### PR TITLE
Fix: restore generation of `sysWindowsResizeEvent` when borders are changed

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -214,10 +214,6 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mBlockScriptCompile(true)
 , mBlockStopWatchCreation(true)
 , mEchoLuaErrors(false)
-, mBorderBottomHeight(0)
-, mBorderLeftWidth(0)
-, mBorderRightWidth(0)
-, mBorderTopHeight(0)
 , mCommandLineFont(QFont(qsl("Bitstream Vera Sans Mono"), 14, QFont::Normal))
 , mCommandSeparator(qsl(";;"))
 , mEnableGMCP(true)
@@ -4163,4 +4159,19 @@ QPointer<TConsole> Host::parentTConsole(QObject* start) const
         return result;
     }
     return qobject_cast<TConsole*>(ptr);
+}
+
+// The order in this is top, bottom, left, right
+void Host::setBorders(const std::tuple<int, int, int, int> borders)
+{
+    auto original = mBorders;
+    if (borders != original) {
+        mBorders = borders;
+        auto x = mpConsole->width();
+        auto y = mpConsole->height();
+        QSize s = QSize(x, y);
+        QResizeEvent event(s, s);
+        QApplication::sendEvent(mpConsole, &event);
+        mpConsole->raiseMudletSysWindowResizeEvent(x, y);
+    }
 }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -4167,11 +4167,13 @@ void Host::setBorders(const std::tuple<int, int, int, int> borders)
     auto original = mBorders;
     if (borders != original) {
         mBorders = borders;
-        auto x = mpConsole->width();
-        auto y = mpConsole->height();
-        QSize s = QSize(x, y);
-        QResizeEvent event(s, s);
-        QApplication::sendEvent(mpConsole, &event);
-        mpConsole->raiseMudletSysWindowResizeEvent(x, y);
+        if (!mpConsole.isNull()) {
+            auto x = mpConsole->width();
+            auto y = mpConsole->height();
+            QSize s = QSize(x, y);
+            QResizeEvent event(s, s);
+            QApplication::sendEvent(mpConsole, &event);
+            mpConsole->raiseMudletSysWindowResizeEvent(x, y);
+        }
     }
 }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -4165,15 +4165,17 @@ QPointer<TConsole> Host::parentTConsole(QObject* start) const
 void Host::setBorders(const std::tuple<int, int, int, int> borders)
 {
     auto original = mBorders;
-    if (borders != original) {
-        mBorders = borders;
-        if (!mpConsole.isNull()) {
-            auto x = mpConsole->width();
-            auto y = mpConsole->height();
-            QSize s = QSize(x, y);
-            QResizeEvent event(s, s);
-            QApplication::sendEvent(mpConsole, &event);
-            mpConsole->raiseMudletSysWindowResizeEvent(x, y);
-        }
+    if (borders == original) {
+        return;
     }
+    mBorders = borders;
+    if (mpConsole.isNull()) {
+        return;
+    }
+    auto x = mpConsole->width();
+    auto y = mpConsole->height();
+    QSize s = QSize(x, y);
+    QResizeEvent event(s, s);
+    QApplication::sendEvent(mpConsole, &event);
+    mpConsole->raiseMudletSysWindowResizeEvent(x, y);
 }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -4161,8 +4161,7 @@ QPointer<TConsole> Host::parentTConsole(QObject* start) const
     return qobject_cast<TConsole*>(ptr);
 }
 
-// The order in this is top, bottom, left, right
-void Host::setBorders(const std::tuple<int, int, int, int> borders)
+void Host::setBorders(QMargins borders)
 {
     auto original = mBorders;
     if (borders == original) {

--- a/src/Host.h
+++ b/src/Host.h
@@ -43,6 +43,7 @@
 #include <QFile>
 #include <QFont>
 #include <QList>
+#include <QMargins>
 #include <QPointer>
 #include <QStack>
 #include <QTextStream>
@@ -404,8 +405,8 @@ public:
     void recordActiveCommandLine(TCommandLine*);
     void forgetCommandLine(TCommandLine*);
     QPointer<TConsole> parentTConsole(QObject*) const;
-    std::tuple<int, int, int, int> borders() const { return mBorders; }
-    void setBorders(const std::tuple<int, int, int, int>);
+    QMargins borders() const { return mBorders; }
+    void setBorders(const QMargins);
 
 
     cTelnet mTelnet;
@@ -862,7 +863,7 @@ private:
     // return to it when switching between profiles:
     QStack<QPointer<TCommandLine>> mpLastCommandLineUsed;
 
-    std::tuple<int, int, int, int> mBorders{};
+    QMargins mBorders;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(Host::DiscordOptionFlags)

--- a/src/Host.h
+++ b/src/Host.h
@@ -404,6 +404,8 @@ public:
     void recordActiveCommandLine(TCommandLine*);
     void forgetCommandLine(TCommandLine*);
     QPointer<TConsole> parentTConsole(QObject*) const;
+    std::tuple<int, int, int, int> borders() const { return mBorders; }
+    void setBorders(const std::tuple<int, int, int, int>);
 
 
     cTelnet mTelnet;
@@ -424,10 +426,6 @@ public:
     bool mBlockScriptCompile;
     bool mBlockStopWatchCreation;
     bool mEchoLuaErrors;
-    int mBorderBottomHeight;
-    int mBorderLeftWidth;
-    int mBorderRightWidth;
-    int mBorderTopHeight;
     QFont mCommandLineFont;
     QString mCommandSeparator;
     bool mEnableGMCP;
@@ -863,6 +861,8 @@ private:
     // Tracks which command line was last used for this profile so that we can
     // return to it when switching between profiles:
     QStack<QPointer<TCommandLine>> mpLastCommandLineUsed;
+
+    std::tuple<int, int, int, int> mBorders{};
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(Host::DiscordOptionFlags)

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -589,7 +589,7 @@ void TConsole::resizeEvent(QResizeEvent* event)
         mpBaseHFrame->resize(x, y);
         x -= (mpLeftToolBar->width() + mpRightToolBar->width());
         y -= mpTopToolBar->height();
-        // The mBorders will be all zeros for all but the MainConsole:
+        // The mBorders components will be all zeros for all but the MainConsole:
         mpMainDisplay->resize(x - mBorders.left() - mBorders.right(),
                               y - mBorders.top() - mBorders.bottom() - mpCommandLine->height());
     } else {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -83,36 +83,15 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     ps->setKey(Qt::CTRL + Qt::Key_W);
     ps->setContext(Qt::WidgetShortcut);
 
-    if (mType & CentralDebugConsole) {
+    if (mType == CentralDebugConsole) {
         // Probably will not show up as this is used inside a QMainWindow widget
         // which has its own title and icon set.
         setWindowTitle(tr("Debug Console"));
-        // mIsSubConsole was left false for this
         mWrapAt = 50;
-    } else {
-        if (mType & (ErrorConsole|SubConsole|UserWindow)) {
-            // Originally this was for TConsole instances with a parent pointer
-            // This branch for: UserWindows, SubConsole, ErrorConsole
-            // mIsSubConsole was true for these
-            mMainFrameTopHeight = 0;
-            mMainFrameBottomHeight = 0;
-            mMainFrameLeftWidth = 0;
-            mMainFrameRightWidth = 0;
-
-        } else if (mType & (MainConsole|Buffer)) {
-            // Originally this was for TConsole instances without a parent pointer
-            // This branch for: Buffers, MainConsole
-            // mIsSubConsole was false for these
-            mMainFrameTopHeight = mpHost->mBorderTopHeight;
-            mMainFrameBottomHeight = mpHost->mBorderBottomHeight;
-            mMainFrameLeftWidth = mpHost->mBorderLeftWidth;
-            mMainFrameRightWidth = mpHost->mBorderRightWidth;
-            mCommandBgColor = mpHost->mCommandBgColor;
-            mCommandFgColor = mpHost->mCommandFgColor;
-
-        } else {
-            Q_ASSERT_X(false, "TConsole::TConsole(...)", "invalid TConsole type detected");
-        }
+    } else if (mType == MainConsole) {
+        mBorders = mpHost->borders();
+        mCommandBgColor = mpHost->mCommandBgColor;
+        mCommandFgColor = mpHost->mCommandFgColor;
     }
     setContentsMargins(0, 0, 0, 0);
     setAttribute(Qt::WA_DeleteOnClose);
@@ -196,7 +175,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     mpBaseHFrame->setContentsMargins(0, 0, 0, 0);
     centralLayout->setSpacing(0);
     centralLayout->setContentsMargins(0, 0, 0, 0);
-    mpMainDisplay->move(mMainFrameLeftWidth, mMainFrameTopHeight);
+    mpMainDisplay->move(std::get<2>(mBorders), std::get<0>(mBorders));
     mpMainFrame->show();
     mpMainDisplay->show();
     mpMainFrame->setContentsMargins(0, 0, 0, 0);
@@ -570,13 +549,27 @@ void TConsole::resizeConsole()
 }
 
 
+void TConsole::raiseMudletSysWindowResizeEvent(const int overallWidth, const int overallHeight)
+{
+    if (mpHost.isNull()) {
+        return;
+    }
+    TEvent mudletEvent {};
+    mudletEvent.mArgumentList.append(QLatin1String("sysWindowResizeEvent"));
+    mudletEvent.mArgumentList.append(QString::number(overallWidth - std::get<2>(mBorders) - std::get<3>(mBorders)));
+    mudletEvent.mArgumentList.append(QString::number(overallHeight - std::get<0>(mBorders) - std::get<1>(mBorders) - mpCommandLine->height()));
+    mudletEvent.mArgumentList.append(mConsoleName);
+    mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    mpHost->raiseEvent(mudletEvent);
+}
+
 void TConsole::resizeEvent(QResizeEvent* event)
 {
     if (mType & MainConsole) {
-        mMainFrameTopHeight = mpHost->mBorderTopHeight;
-        mMainFrameBottomHeight = mpHost->mBorderBottomHeight;
-        mMainFrameLeftWidth = mpHost->mBorderLeftWidth;
-        mMainFrameRightWidth = mpHost->mBorderRightWidth;
+        mBorders = mpHost->borders();
     }
     int x = event->size().width();
     int y = event->size().height();
@@ -590,18 +583,20 @@ void TConsole::resizeEvent(QResizeEvent* event)
         return;
     }
 
-    if (mType & (MainConsole|Buffer|SubConsole|UserWindow) && mpCommandLine && !mpCommandLine->isHidden()) {
+    if (mType & (MainConsole|SubConsole|UserWindow) && mpCommandLine && !mpCommandLine->isHidden()) {
         mpMainFrame->resize(x, y);
         mpBaseVFrame->resize(x, y);
         mpBaseHFrame->resize(x, y);
-        x = x - mpLeftToolBar->width() - mpRightToolBar->width();
-        y = y - mpTopToolBar->height();
-        mpMainDisplay->resize(x - mMainFrameLeftWidth - mMainFrameRightWidth, y - mMainFrameTopHeight - mMainFrameBottomHeight - mpCommandLine->height());
+        x -= (mpLeftToolBar->width() + mpRightToolBar->width());
+        y -= mpTopToolBar->height();
+        // The mMainFrameXxxxXxxx will be zero for all but the MainConsole:
+        mpMainDisplay->resize(x - std::get<2>(mBorders) - std::get<3>(mBorders),
+                              y - std::get<0>(mBorders) - std::get<1>(mBorders) - mpCommandLine->height());
     } else {
         mpMainFrame->resize(x, y);
-        mpMainDisplay->resize(x, y); //x - mMainFrameLeftWidth - mMainFrameRightWidth, y - mMainFrameTopHeight - mMainFrameBottomHeight );
+        mpMainDisplay->resize(x, y);
     }
-    mpMainDisplay->move(mMainFrameLeftWidth, mMainFrameTopHeight);
+    mpMainDisplay->move(std::get<2>(mBorders), std::get<0>(mBorders));
 
     if (mType & (CentralDebugConsole|ErrorConsole)) {
         layerCommandLine->hide();
@@ -619,24 +614,17 @@ void TConsole::resizeEvent(QResizeEvent* event)
         if (preventLuaEvent) {
             return;
         }
-        TLuaInterpreter* pLua = mpHost->getLuaInterpreter();
-        QString func = "handleWindowResizeEvent";
-        QString n = "WindowResizeEvent";
-        pLua->call(func, n);
+        if (!mpHost.isNull()) {
+            TLuaInterpreter* pLua = mpHost->getLuaInterpreter();
+            QString func = "handleWindowResizeEvent";
+            QString n = "WindowResizeEvent";
+            pLua->call(func, n);
 
-        TEvent mudletEvent {};
-        mudletEvent.mArgumentList.append(QLatin1String("sysWindowResizeEvent"));
-        mudletEvent.mArgumentList.append(QString::number(x - mMainFrameLeftWidth - mMainFrameRightWidth));
-        mudletEvent.mArgumentList.append(QString::number(y - mMainFrameTopHeight - mMainFrameBottomHeight - mpCommandLine->height()));
-        mudletEvent.mArgumentList.append(mConsoleName);
-        mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-        mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-        mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-        mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-        mpHost->raiseEvent(mudletEvent);
+            raiseMudletSysWindowResizeEvent(x, y);
+        }
     }
 //create the sysUserWindowResize Event for automatic resizing with Geyser
-    if (mType & (UserWindow)) {
+    if (mType & (UserWindow) && !mpHost.isNull()) {
         TLuaInterpreter* pLua = mpHost->getLuaInterpreter();
         QString func = "handleWindowResizeEvent";
         QString n = "WindowResizeEvent";
@@ -657,11 +645,8 @@ void TConsole::resizeEvent(QResizeEvent* event)
 
 void TConsole::refresh()
 {
-    if (mType & (ErrorConsole|MainConsole|SubConsole|UserWindow|Buffer)) {
-        mMainFrameTopHeight = mpHost->mBorderTopHeight;
-        mMainFrameBottomHeight = mpHost->mBorderBottomHeight;
-        mMainFrameLeftWidth = mpHost->mBorderLeftWidth;
-        mMainFrameRightWidth = mpHost->mBorderRightWidth;
+    if (mType == MainConsole) {
+        mBorders = mpHost->borders();
     }
 
     int x = width();
@@ -683,13 +668,13 @@ void TConsole::refresh()
         y -= mpTopToolBar->height();
     }
 
-    mpMainDisplay->resize(x - mMainFrameLeftWidth - mMainFrameRightWidth, y - mMainFrameTopHeight - mMainFrameBottomHeight - mpCommandLine->height());
+    mpMainDisplay->resize(x - std::get<2>(mBorders) - std::get<3>(mBorders), y - std::get<0>(mBorders) - std::get<1>(mBorders) - mpCommandLine->height());
 
     if (mType & MainConsole) {
         mpCommandLine->adjustHeight();
     }
 
-    mpMainDisplay->move(mMainFrameLeftWidth, mMainFrameTopHeight);
+    mpMainDisplay->move(std::get<2>(mBorders), std::get<0>(mBorders));
     x = width();
     y = height();
     QSize s = QSize(x, y);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -175,7 +175,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     mpBaseHFrame->setContentsMargins(0, 0, 0, 0);
     centralLayout->setSpacing(0);
     centralLayout->setContentsMargins(0, 0, 0, 0);
-    mpMainDisplay->move(std::get<2>(mBorders), std::get<0>(mBorders));
+    mpMainDisplay->move(mBorders.left(), mBorders.top());
     mpMainFrame->show();
     mpMainDisplay->show();
     mpMainFrame->setContentsMargins(0, 0, 0, 0);
@@ -556,8 +556,8 @@ void TConsole::raiseMudletSysWindowResizeEvent(const int overallWidth, const int
     }
     TEvent mudletEvent {};
     mudletEvent.mArgumentList.append(QLatin1String("sysWindowResizeEvent"));
-    mudletEvent.mArgumentList.append(QString::number(overallWidth - std::get<2>(mBorders) - std::get<3>(mBorders)));
-    mudletEvent.mArgumentList.append(QString::number(overallHeight - std::get<0>(mBorders) - std::get<1>(mBorders) - mpCommandLine->height()));
+    mudletEvent.mArgumentList.append(QString::number(overallWidth - mBorders.left() - mBorders.right()));
+    mudletEvent.mArgumentList.append(QString::number(overallHeight - mBorders.top() - mBorders.bottom() - mpCommandLine->height()));
     mudletEvent.mArgumentList.append(mConsoleName);
     mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
@@ -589,14 +589,14 @@ void TConsole::resizeEvent(QResizeEvent* event)
         mpBaseHFrame->resize(x, y);
         x -= (mpLeftToolBar->width() + mpRightToolBar->width());
         y -= mpTopToolBar->height();
-        // The mMainFrameXxxxXxxx will be zero for all but the MainConsole:
-        mpMainDisplay->resize(x - std::get<2>(mBorders) - std::get<3>(mBorders),
-                              y - std::get<0>(mBorders) - std::get<1>(mBorders) - mpCommandLine->height());
+        // The mBorders will be all zeros for all but the MainConsole:
+        mpMainDisplay->resize(x - mBorders.left() - mBorders.right(),
+                              y - mBorders.top() - mBorders.bottom() - mpCommandLine->height());
     } else {
         mpMainFrame->resize(x, y);
         mpMainDisplay->resize(x, y);
     }
-    mpMainDisplay->move(std::get<2>(mBorders), std::get<0>(mBorders));
+    mpMainDisplay->move(mBorders.left(), mBorders.top());
 
     if (mType & (CentralDebugConsole|ErrorConsole)) {
         layerCommandLine->hide();
@@ -668,13 +668,13 @@ void TConsole::refresh()
         y -= mpTopToolBar->height();
     }
 
-    mpMainDisplay->resize(x - std::get<2>(mBorders) - std::get<3>(mBorders), y - std::get<0>(mBorders) - std::get<1>(mBorders) - mpCommandLine->height());
+    mpMainDisplay->resize(x - mBorders.left() - mBorders.right(), y - mBorders.top() - mBorders.bottom() - mpCommandLine->height());
 
     if (mType & MainConsole) {
         mpCommandLine->adjustHeight();
     }
 
-    mpMainDisplay->move(std::get<2>(mBorders), std::get<0>(mBorders));
+    mpMainDisplay->move(mBorders.left(), mBorders.top());
     x = width();
     y = height();
     QSize s = QSize(x, y);

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -242,7 +242,7 @@ public:
 
     int mIndentCount = 0;
     // Order top, bottom, left, right:
-    std::tuple<int, int, int, int> mBorders{};
+    QMargins mBorders;
     int mOldX = 0;
     int mOldY = 0;
 

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -241,7 +241,6 @@ public:
     int mEngineCursor = -1;
 
     int mIndentCount = 0;
-    // Order top, bottom, left, right:
     QMargins mBorders;
     int mOldX = 0;
     int mOldY = 0;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -205,6 +205,7 @@ public:
     void setCaretMode(bool enabled);
     void setSearchOptions(const SearchOptions);
     void setProxyForFocus(TCommandLine*);
+    void raiseMudletSysWindowResizeEvent(const int overallWidth, const int overallHeight);
 
 
     QPointer<Host> mpHost;
@@ -240,10 +241,8 @@ public:
     int mEngineCursor = -1;
 
     int mIndentCount = 0;
-    int mMainFrameBottomHeight = 0;
-    int mMainFrameLeftWidth = 0;
-    int mMainFrameRightWidth = 0;
-    int mMainFrameTopHeight = 0;
+    // Order top, bottom, left, right:
+    std::tuple<int, int, int, int> mBorders{};
     int mOldX = 0;
     int mOldY = 0;
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3680,14 +3680,14 @@ int TLuaInterpreter::setBorderSizes(lua_State* L)
     case 2: {
         auto height = getVerifiedInt(L, __func__, 1, "new height");
         auto width = getVerifiedInt(L, __func__, 2, "new width");
-        host.setBorders({height, height, width, width});
+        host.setBorders({width, height, width, height});
         break;
     }
     case 3: {
         auto top = getVerifiedInt(L, __func__, 1, "new top size");
         auto width = getVerifiedInt(L, __func__, 2, "new width");
         auto bottom = getVerifiedInt(L, __func__, 3, "new bottom size");
-        host.setBorders({top, bottom, width, width});
+        host.setBorders({width, top, width, bottom});
         break;
         }
     default: {
@@ -3695,7 +3695,7 @@ int TLuaInterpreter::setBorderSizes(lua_State* L)
         auto right = getVerifiedInt(L, __func__, 2, "new right size");
         auto bottom = getVerifiedInt(L, __func__, 3, "new bottom size");
         auto left = getVerifiedInt(L, __func__, 4, "new left size");
-        host.setBorders({top, bottom, left, right});
+        host.setBorders({left, top, right, bottom});
         break;
     }
     }
@@ -3707,7 +3707,7 @@ int TLuaInterpreter::setBorderTop(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     auto sizes = host.borders();
-    std::get<0>(sizes) = getVerifiedInt(L, __func__, 1, "new size");
+    sizes.setTop(getVerifiedInt(L, __func__, 1, "new size"));
     host.setBorders(sizes);
     return 0;
 }
@@ -3717,7 +3717,7 @@ int TLuaInterpreter::setBorderRight(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     auto sizes = host.borders();
-    std::get<3>(sizes) = getVerifiedInt(L, __func__, 1, "new size");
+    sizes.setRight(getVerifiedInt(L, __func__, 1, "new size"));
     host.setBorders(sizes);
     return 0;
 }
@@ -3727,7 +3727,7 @@ int TLuaInterpreter::setBorderBottom(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     auto sizes = host.borders();
-    std::get<1>(sizes) = getVerifiedInt(L, __func__, 1, "new size");
+    sizes.setBottom(getVerifiedInt(L, __func__, 1, "new size"));
     host.setBorders(sizes);
     return 0;
 }
@@ -3737,7 +3737,7 @@ int TLuaInterpreter::setBorderLeft(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     auto sizes = host.borders();
-    std::get<2>(sizes) = getVerifiedInt(L, __func__, 1, "new size");
+    sizes.setLeft(getVerifiedInt(L, __func__, 1, "new size"));
     host.setBorders(sizes);
     return 0;
 }
@@ -3746,7 +3746,7 @@ int TLuaInterpreter::setBorderLeft(lua_State* L)
 int TLuaInterpreter::getBorderTop(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    lua_pushnumber(L, std::get<0>(host.borders()));
+    lua_pushnumber(L, host.borders().top());
     return 1;
 }
 
@@ -3754,7 +3754,7 @@ int TLuaInterpreter::getBorderTop(lua_State* L)
 int TLuaInterpreter::getBorderLeft(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    lua_pushnumber(L, std::get<2>(host.borders()));
+    lua_pushnumber(L, host.borders().left());
     return 1;
 }
 
@@ -3762,7 +3762,7 @@ int TLuaInterpreter::getBorderLeft(lua_State* L)
 int TLuaInterpreter::getBorderBottom(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    lua_pushnumber(L, std::get<1>(host.borders()));
+    lua_pushnumber(L, host.borders().bottom());
     return 1;
 }
 
@@ -3770,7 +3770,7 @@ int TLuaInterpreter::getBorderBottom(lua_State* L)
 int TLuaInterpreter::getBorderRight(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    lua_pushnumber(L, std::get<3>(host.borders()));
+    lua_pushnumber(L, host.borders().right());
     return 1;
 }
 
@@ -3780,13 +3780,13 @@ int TLuaInterpreter::getBorderSizes(lua_State* L)
     Host& host = getHostFromLua(L);
     auto sizes = host.borders();
     lua_createtable(L, 0, 4);
-    lua_pushinteger(L, std::get<0>(sizes));
+    lua_pushinteger(L, sizes.top());
     lua_setfield(L, -2, "top");
-    lua_pushinteger(L, std::get<3>(sizes));
+    lua_pushinteger(L, sizes.right());
     lua_setfield(L, -2, "right");
-    lua_pushinteger(L, std::get<1>(sizes));
+    lua_pushinteger(L, sizes.bottom());
     lua_setfield(L, -2, "bottom");
-    lua_pushinteger(L, std::get<2>(sizes));
+    lua_pushinteger(L, sizes.left());
     lua_setfield(L, -2, "left");
     return 1;
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3664,101 +3664,81 @@ int TLuaInterpreter::hideWindow(lua_State* L)
     return 0;
 }
 
-// No documentation available in wiki - internal function
-void TLuaInterpreter::setBorderSize(lua_State* L, int size, int position, bool resizeMudlet)
-{
-    Host& host = getHostFromLua(L);
-    switch (position) {
-        case Qt::TopSection: host.mBorderTopHeight = size; break;
-        case Qt::RightSection: host.mBorderRightWidth = size; break;
-        case Qt::BottomSection: host.mBorderBottomHeight = size; break;
-        case Qt::LeftSection: host.mBorderLeftWidth = size; break;
-    }
-    if (resizeMudlet) {
-        int x, y;
-        x = host.mpConsole->width();
-        y = host.mpConsole->height();
-        QSize s = QSize(x, y);
-        QResizeEvent event(s, s);
-        QApplication::sendEvent(host.mpConsole, &event);
-    }
-}
-
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderSizes
 int TLuaInterpreter::setBorderSizes(lua_State* L)
 {
+    Host& host = getHostFromLua(L);
     int numberOfArguments = lua_gettop(L);
-    int sizeTop = 0;
-    int sizeRight = 0;
-    int sizeBottom = 0;
-    int sizeLeft = 0;
     switch (numberOfArguments) {
-        case 0: break;
-        case 1: {
-            sizeTop = getVerifiedInt(L, __func__, 1, "new size");
-            sizeRight = sizeTop;
-            sizeBottom = sizeTop;
-            sizeLeft = sizeTop;
-            break;
-        }
-        case 2: {
-            sizeTop = getVerifiedInt(L, __func__, 1, "new height");
-            sizeRight = getVerifiedInt(L, __func__, 2, "new width");
-            sizeBottom = sizeTop;
-            sizeLeft = sizeRight;
-            break;
-        }
-        case 3: {
-            sizeTop = getVerifiedInt(L, __func__, 1, "new top size");
-            sizeRight = getVerifiedInt(L, __func__, 2, "new width");
-            sizeBottom = getVerifiedInt(L, __func__, 3, "new bottom size");
-            sizeLeft = sizeRight;
-            break;
-        }
-        default: {
-            sizeTop = getVerifiedInt(L, __func__, 1, "new top size");
-            sizeRight = getVerifiedInt(L, __func__, 2, "new right size");
-            sizeBottom = getVerifiedInt(L, __func__, 3, "new bottom size");
-            sizeLeft = getVerifiedInt(L, __func__, 4, "new left size");
-            break;
-        }
+    case 0:
+        break;
+    case 1: {
+        auto value = getVerifiedInt(L, __func__, 1, "new size");
+        host.setBorders({value, value, value, value});
+        break;
     }
-    setBorderSize(L, sizeTop, Qt::TopSection, false);
-    setBorderSize(L, sizeRight, Qt::RightSection, false);
-    setBorderSize(L, sizeBottom, Qt::BottomSection, false);
-    setBorderSize(L, sizeLeft, Qt::LeftSection, true); // only now send update event to resize Mudlet window
+    case 2: {
+        auto height = getVerifiedInt(L, __func__, 1, "new height");
+        auto width = getVerifiedInt(L, __func__, 2, "new width");
+        host.setBorders({height, height, width, width});
+        break;
+    }
+    case 3: {
+        auto top = getVerifiedInt(L, __func__, 1, "new top size");
+        auto width = getVerifiedInt(L, __func__, 2, "new width");
+        auto bottom = getVerifiedInt(L, __func__, 3, "new bottom size");
+        host.setBorders({top, bottom, width, width});
+        break;
+        }
+    default: {
+        auto top = getVerifiedInt(L, __func__, 1, "new top size");
+        auto right = getVerifiedInt(L, __func__, 2, "new right size");
+        auto bottom = getVerifiedInt(L, __func__, 3, "new bottom size");
+        auto left = getVerifiedInt(L, __func__, 4, "new left size");
+        host.setBorders({top, bottom, left, right});
+        break;
+    }
+    }
     return 0;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderTop
 int TLuaInterpreter::setBorderTop(lua_State* L)
 {
-    int size = getVerifiedInt(L, __func__, 1, "new size");
-    setBorderSize(L, size, Qt::TopSection);
+    Host& host = getHostFromLua(L);
+    auto sizes = host.borders();
+    std::get<0>(sizes) = getVerifiedInt(L, __func__, 1, "new size");
+    host.setBorders(sizes);
     return 0;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderRight
 int TLuaInterpreter::setBorderRight(lua_State* L)
 {
-    int size = getVerifiedInt(L, __func__, 1, "new size");
-    setBorderSize(L, size, Qt::RightSection);
+    Host& host = getHostFromLua(L);
+    auto sizes = host.borders();
+    std::get<3>(sizes) = getVerifiedInt(L, __func__, 1, "new size");
+    host.setBorders(sizes);
     return 0;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderBottom
 int TLuaInterpreter::setBorderBottom(lua_State* L)
 {
-    int size = getVerifiedInt(L, __func__, 1, "new size");
-    setBorderSize(L, size, Qt::BottomSection);
+    Host& host = getHostFromLua(L);
+    auto sizes = host.borders();
+    std::get<1>(sizes) = getVerifiedInt(L, __func__, 1, "new size");
+    host.setBorders(sizes);
     return 0;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderLeft
 int TLuaInterpreter::setBorderLeft(lua_State* L)
 {
-    int size = getVerifiedInt(L, __func__, 1, "new size");
-    setBorderSize(L, size, Qt::LeftSection);
+    Host& host = getHostFromLua(L);
+    auto sizes = host.borders();
+    std::get<2>(sizes) = getVerifiedInt(L, __func__, 1, "new size");
+    host.setBorders(sizes);
     return 0;
 }
 
@@ -3766,7 +3746,7 @@ int TLuaInterpreter::setBorderLeft(lua_State* L)
 int TLuaInterpreter::getBorderTop(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    lua_pushnumber(L, host.mBorderTopHeight);
+    lua_pushnumber(L, std::get<0>(host.borders()));
     return 1;
 }
 
@@ -3774,7 +3754,7 @@ int TLuaInterpreter::getBorderTop(lua_State* L)
 int TLuaInterpreter::getBorderLeft(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    lua_pushnumber(L, host.mBorderLeftWidth);
+    lua_pushnumber(L, std::get<2>(host.borders()));
     return 1;
 }
 
@@ -3782,7 +3762,7 @@ int TLuaInterpreter::getBorderLeft(lua_State* L)
 int TLuaInterpreter::getBorderBottom(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    lua_pushnumber(L, host.mBorderBottomHeight);
+    lua_pushnumber(L, std::get<1>(host.borders()));
     return 1;
 }
 
@@ -3790,7 +3770,7 @@ int TLuaInterpreter::getBorderBottom(lua_State* L)
 int TLuaInterpreter::getBorderRight(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    lua_pushnumber(L, host.mBorderRightWidth);
+    lua_pushnumber(L, std::get<3>(host.borders()));
     return 1;
 }
 
@@ -3798,14 +3778,15 @@ int TLuaInterpreter::getBorderRight(lua_State* L)
 int TLuaInterpreter::getBorderSizes(lua_State* L)
 {
     Host& host = getHostFromLua(L);
+    auto sizes = host.borders();
     lua_createtable(L, 0, 4);
-    lua_pushinteger(L, host.mBorderTopHeight);
+    lua_pushinteger(L, std::get<0>(sizes));
     lua_setfield(L, -2, "top");
-    lua_pushinteger(L, host.mBorderRightWidth);
+    lua_pushinteger(L, std::get<3>(sizes));
     lua_setfield(L, -2, "right");
-    lua_pushinteger(L, host.mBorderBottomHeight);
+    lua_pushinteger(L, std::get<1>(sizes));
     lua_setfield(L, -2, "bottom");
-    lua_pushinteger(L, host.mBorderLeftWidth);
+    lua_pushinteger(L, std::get<2>(sizes));
     lua_setfield(L, -2, "left");
     return 1;
 }

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -451,7 +451,6 @@ public:
     static int stopMusic(lua_State*);
     static int stopSounds(lua_State*);
     static int purgeMediaCache(lua_State*);
-    static void setBorderSize(lua_State*, int, int, bool resizeMudlet = true);
     static int setBorderSizes(lua_State*);
     static int setBorderTop(lua_State*);
     static int setBorderBottom(lua_State*);

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -522,10 +522,10 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
         host.append_child("serverPackageVersion").text().set(pHost->mServerGUI_Package_version.toUtf8().constData());
         host.append_child("port").text().set(QString::number(pHost->mPort).toUtf8().constData());
         auto borders = pHost->borders();
-        host.append_child("borderTopHeight").text().set(QString::number(std::get<0>(borders)).toUtf8().constData());
-        host.append_child("borderBottomHeight").text().set(QString::number(std::get<1>(borders)).toUtf8().constData());
-        host.append_child("borderLeftWidth").text().set(QString::number(std::get<2>(borders)).toUtf8().constData());
-        host.append_child("borderRightWidth").text().set(QString::number(std::get<3>(borders)).toUtf8().constData());
+        host.append_child("borderTopHeight").text().set(QString::number(borders.top()).toUtf8().constData());
+        host.append_child("borderBottomHeight").text().set(QString::number(borders.bottom()).toUtf8().constData());
+        host.append_child("borderLeftWidth").text().set(QString::number(borders.left()).toUtf8().constData());
+        host.append_child("borderRightWidth").text().set(QString::number(borders.right()).toUtf8().constData());
         host.append_child("wrapAt").text().set(QString::number(pHost->mWrapAt).toUtf8().constData());
         host.append_child("wrapIndentCount").text().set(QString::number(pHost->mWrapIndentCount).toUtf8().constData());
         host.append_child("mFgColor").text().set(pHost->mFgColor.name().toUtf8().constData());

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -521,10 +521,11 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
         host.append_child("serverPackageName").text().set(pHost->mServerGUI_Package_name.toUtf8().constData());
         host.append_child("serverPackageVersion").text().set(pHost->mServerGUI_Package_version.toUtf8().constData());
         host.append_child("port").text().set(QString::number(pHost->mPort).toUtf8().constData());
-        host.append_child("borderTopHeight").text().set(QString::number(pHost->mBorderTopHeight).toUtf8().constData());
-        host.append_child("borderBottomHeight").text().set(QString::number(pHost->mBorderBottomHeight).toUtf8().constData());
-        host.append_child("borderLeftWidth").text().set(QString::number(pHost->mBorderLeftWidth).toUtf8().constData());
-        host.append_child("borderRightWidth").text().set(QString::number(pHost->mBorderRightWidth).toUtf8().constData());
+        auto borders = pHost->borders();
+        host.append_child("borderTopHeight").text().set(QString::number(std::get<0>(borders)).toUtf8().constData());
+        host.append_child("borderBottomHeight").text().set(QString::number(std::get<1>(borders)).toUtf8().constData());
+        host.append_child("borderLeftWidth").text().set(QString::number(std::get<2>(borders)).toUtf8().constData());
+        host.append_child("borderRightWidth").text().set(QString::number(std::get<3>(borders)).toUtf8().constData());
         host.append_child("wrapAt").text().set(QString::number(pHost->mWrapAt).toUtf8().constData());
         host.append_child("wrapIndentCount").text().set(QString::number(pHost->mWrapIndentCount).toUtf8().constData());
         host.append_child("mFgColor").text().set(pHost->mFgColor.name().toUtf8().constData());

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -947,6 +947,7 @@ void XMLimport::readHost(Host* pHost)
         mpHost->mMapInfoContributors.clear();
     }
 
+    std::tuple<int, int, int, int> borders{};
     while (!atEnd()) {
         readNext();
 
@@ -982,15 +983,15 @@ void XMLimport::readHost(Host* pHost)
             } else if (name() == "port") {
                 pHost->mPort = readElementText().toInt();
             } else if (name() == "borderTopHeight") {
-                pHost->mBorderTopHeight = readElementText().toInt();
+                std::get<0>(borders) = readElementText().toInt();
+            } else if (name() == "borderBottomHeight") {
+                std::get<1>(borders) = readElementText().toInt();
+            } else if (name() == "borderLeftWidth") {
+                std::get<2>(borders) = readElementText().toInt();
+            } else if (name() == "borderRightWidth") {
+                std::get<3>(borders) = readElementText().toInt();
             } else if (name() == "commandLineMinimumHeight") {
                 pHost->commandLineMinimumHeight = readElementText().toInt();
-            } else if (name() == "borderBottomHeight") {
-                pHost->mBorderBottomHeight = readElementText().toInt();
-            } else if (name() == "borderLeftWidth") {
-                pHost->mBorderLeftWidth = readElementText().toInt();
-            } else if (name() == "borderRightWidth") {
-                pHost->mBorderRightWidth = readElementText().toInt();
             } else if (name() == "wrapAt") {
                 pHost->mWrapAt = readElementText().toInt();
             } else if (name() == "wrapIndentCount") {
@@ -1125,7 +1126,8 @@ void XMLimport::readHost(Host* pHost)
             }
         }
     }
-    mpHost->loadPackageInfo();
+    pHost->setBorders(borders);
+    pHost->loadPackageInfo();
 }
 
 bool XMLimport::readDefaultTrueBool(QString name) {

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -947,7 +947,7 @@ void XMLimport::readHost(Host* pHost)
         mpHost->mMapInfoContributors.clear();
     }
 
-    std::tuple<int, int, int, int> borders{};
+    QMargins borders;
     while (!atEnd()) {
         readNext();
 
@@ -983,13 +983,13 @@ void XMLimport::readHost(Host* pHost)
             } else if (name() == "port") {
                 pHost->mPort = readElementText().toInt();
             } else if (name() == "borderTopHeight") {
-                std::get<0>(borders) = readElementText().toInt();
+                borders.setTop(readElementText().toInt());
             } else if (name() == "borderBottomHeight") {
-                std::get<1>(borders) = readElementText().toInt();
+                borders.setBottom(readElementText().toInt());
             } else if (name() == "borderLeftWidth") {
-                std::get<2>(borders) = readElementText().toInt();
+                borders.setLeft(readElementText().toInt());
             } else if (name() == "borderRightWidth") {
-                std::get<3>(borders) = readElementText().toInt();
+                borders.setRight(readElementText().toInt());
             } else if (name() == "commandLineMinimumHeight") {
                 pHost->commandLineMinimumHeight = readElementText().toInt();
             } else if (name() == "wrapAt") {

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -815,10 +815,11 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     checkBox_runAllKeyBindings->setChecked(pHost->getKeyUnit()->mRunAllKeyMatches);
 
-    topBorderHeight->setValue(pHost->mBorderTopHeight);
-    bottomBorderHeight->setValue(pHost->mBorderBottomHeight);
-    leftBorderWidth->setValue(pHost->mBorderLeftWidth);
-    rightBorderWidth->setValue(pHost->mBorderRightWidth);
+    auto originalBorders = pHost->borders();
+    topBorderHeight->setValue(std::get<0>(originalBorders));
+    bottomBorderHeight->setValue(std::get<1>(originalBorders));
+    leftBorderWidth->setValue(std::get<2>(originalBorders));
+    rightBorderWidth->setValue(std::get<3>(originalBorders));
 
     // Set the properties in groupBox_logOptions
     mIsLoggingTimestamps->setChecked(pHost->mIsLoggingTimestamps);
@@ -2672,10 +2673,8 @@ void dlgProfilePreferences::slot_saveAndClose()
             pHost->mpMap->mpMapper->mp2dMap->repaint(); // Forceably redraw it as we ARE currently showing default area
             pHost->mpMap->mpMapper->update();
         }
-        pHost->mBorderTopHeight = topBorderHeight->value();
-        pHost->mBorderBottomHeight = bottomBorderHeight->value();
-        pHost->mBorderLeftWidth = leftBorderWidth->value();
-        pHost->mBorderRightWidth = rightBorderWidth->value();
+        std::tuple<int, int, int, int> newBorders{topBorderHeight->value(), bottomBorderHeight->value(), leftBorderWidth->value(), rightBorderWidth->value()};
+        pHost->setBorders(newBorders);
         pHost->commandLineMinimumHeight = commandLineMinimumHeight->value();
         pHost->mFORCE_MXP_NEGOTIATION_OFF = mFORCE_MXP_NEGOTIATION_OFF->isChecked();
         pHost->mFORCE_CHARSET_NEGOTIATION_OFF = mFORCE_CHARSET_NEGOTIATION_OFF->isChecked();

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -816,10 +816,10 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     checkBox_runAllKeyBindings->setChecked(pHost->getKeyUnit()->mRunAllKeyMatches);
 
     auto originalBorders = pHost->borders();
-    topBorderHeight->setValue(std::get<0>(originalBorders));
-    bottomBorderHeight->setValue(std::get<1>(originalBorders));
-    leftBorderWidth->setValue(std::get<2>(originalBorders));
-    rightBorderWidth->setValue(std::get<3>(originalBorders));
+    topBorderHeight->setValue(originalBorders.top());
+    bottomBorderHeight->setValue(originalBorders.bottom());
+    leftBorderWidth->setValue(originalBorders.left());
+    rightBorderWidth->setValue(originalBorders.right());
 
     // Set the properties in groupBox_logOptions
     mIsLoggingTimestamps->setChecked(pHost->mIsLoggingTimestamps);
@@ -2673,7 +2673,7 @@ void dlgProfilePreferences::slot_saveAndClose()
             pHost->mpMap->mpMapper->mp2dMap->repaint(); // Forceably redraw it as we ARE currently showing default area
             pHost->mpMap->mpMapper->update();
         }
-        std::tuple<int, int, int, int> newBorders{topBorderHeight->value(), bottomBorderHeight->value(), leftBorderWidth->value(), rightBorderWidth->value()};
+        QMargins newBorders{leftBorderWidth->value(), topBorderHeight->value(), rightBorderWidth->value(), bottomBorderHeight->value()};
         pHost->setBorders(newBorders);
         pHost->commandLineMinimumHeight = commandLineMinimumHeight->value();
         pHost->mFORCE_MXP_NEGOTIATION_OFF = mFORCE_MXP_NEGOTIATION_OFF->isChecked();


### PR DESCRIPTION
This should close #6614.

Whilst looking through the code-base I was confused to see that the members `(int) mMainFrame{Top|Bottom|Right|Left}{Height|Width}` in the `TConsole` class were directly related to the `(int) mBorder{Top|Bottom|Left|Right}{Height|Width}` members. Also they are often manipulated as a set. I felt that it was constructive to refactor them into a common `std::tuple<int, int, int, int> mBorders`.

This refactoring meant it was also possible to detect when the borders were changed (in the new `(void) Host::setBorders(const std::tuple<int, int, int, int> borders)`) and to raise the missing `sysWindowResizeEvent` as needed.

Signed-off by: Stephen Lyons <slysven@virginmedia.com>