### PR TITLE
Improve: reset 2D map panning buttons autorepeat to default

### DIFF
--- a/src/ui/mapper.ui
+++ b/src/ui/mapper.ui
@@ -204,12 +204,6 @@
               <property name="autoRepeat">
                <bool>true</bool>
               </property>
-              <property name="autoRepeatDelay">
-               <number>100</number>
-              </property>
-              <property name="autoRepeatInterval">
-               <number>1</number>
-              </property>
              </widget>
             </item>
             <item>
@@ -243,12 +237,6 @@
               </property>
               <property name="autoRepeat">
                <bool>true</bool>
-              </property>
-              <property name="autoRepeatDelay">
-               <number>100</number>
-              </property>
-              <property name="autoRepeatInterval">
-               <number>1</number>
               </property>
              </widget>
             </item>
@@ -284,12 +272,6 @@
               <property name="autoRepeat">
                <bool>true</bool>
               </property>
-              <property name="autoRepeatDelay">
-               <number>100</number>
-              </property>
-              <property name="autoRepeatInterval">
-               <number>1</number>
-              </property>
              </widget>
             </item>
             <item>
@@ -323,12 +305,6 @@
               </property>
               <property name="autoRepeat">
                <bool>true</bool>
-              </property>
-              <property name="autoRepeatDelay">
-               <number>100</number>
-              </property>
-              <property name="autoRepeatInterval">
-               <number>1</number>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Reset 2D map panning buttons autorepeat to default
#### Motivation for adding to Mudlet
Player feedback is that they pan uncomfortably fast
#### Other info (issues closed, discussion etc)
