### PR TITLE
Fix: Make Geyser less picky about object names

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -342,7 +342,7 @@ function Geyser.Container:new(cons, container)
 
   -- If we're not not a class definition then add to a controlling
   -- container.
-  if not string.find(me.name, ".*Class") then
+  if not string.find(me.name, ".+Class$") then
     -- If passed in a container, add me to that container
     if container then
       if me.useAdd2 then


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Someone was having an issue in Discord today and it turned out their object name had "Class" in it, which was causing it to error. This code is meant to filter out the geyser class objects, but was a bit too broad. This will now only filter things out if their name is `<something>Class`. All the Geyser class names match this pattern already but it should reduce confusing errors in future.
#### Motivation for adding to Mudlet
Less unexpected and confusing errors is better.
#### Other info (issues closed, discussion etc)
