### PR TITLE
Fix: Geyser.MiniConsole now leaves room for scrollbars when auto wrapping

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -406,7 +406,7 @@ end
 --- Set the wrap based on how wide the console is
 function Geyser.MiniConsole:resetAutoWrap()
   if not self.autoWrap then
-    return
+    return nil, "Autowrap is not enabled for " .. self.name
   end
   local fontWidth, fontHeight = calcFontSize(self.name)
   local consoleWidth = self.get_width()

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -112,12 +112,14 @@ end
 function Geyser.MiniConsole:enableScrollBar()
   enableScrollBar(self.name)
   self.scrollBar = true
+  self:resetAutoWrap()
 end
 
 --- Disables the scroll bar for this window
 function Geyser.MiniConsole:disableScrollBar()
   disableScrollBar(self.name)
   self.scrollBar = false
+  self:resetAutoWrap()
 end
 
 --- Enables the horizontal scroll bar for this window

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -111,21 +111,25 @@ end
 --- Enables the scroll bar for this window
 function Geyser.MiniConsole:enableScrollBar()
   enableScrollBar(self.name)
+  self.scrollBar = true
 end
 
 --- Disables the scroll bar for this window
 function Geyser.MiniConsole:disableScrollBar()
   disableScrollBar(self.name)
+  self.scrollBar = false
 end
 
 --- Enables the horizontal scroll bar for this window
 function Geyser.MiniConsole:enableHorizontalScrollBar()
   enableHorizontalScrollBar(self.name)
+  self.horizontalScrollBar = true
 end
 
 --- Disables the horizontal scroll bar for this window
 function Geyser.MiniConsole:disableHorizontalScrollBar()
   disableHorizontalScrollBar(self.name)
+  self.horizontalScrollBar = false
 end
 
 -- Start commandLine functions
@@ -399,8 +403,14 @@ end
 
 --- Set the wrap based on how wide the console is
 function Geyser.MiniConsole:resetAutoWrap()
+  if not self.autoWrap then
+    return
+  end
   local fontWidth, fontHeight = calcFontSize(self.name)
   local consoleWidth = self.get_width()
+  if self.scrollBar then
+    consoleWidth = consoleWidth - 15
+  end
   local charactersWidth = math.floor(consoleWidth / fontWidth)
 
   self.wrapAt = charactersWidth
@@ -554,7 +564,7 @@ function Geyser.MiniConsole:new (cons, container)
   self.__index = self
   -----------------------------------------------------------
   -- Now create the MiniConsole using primitives
-  if not string.find(me.name, ".*Class") then
+  if not string.find(me.name, ".+Class$") then
     me.windowname = me.windowname or me.container.windowname or "main"
     createMiniConsole(me.windowname,me.name, me:get_x(), me:get_y(),
     me:get_width(), me:get_height())
@@ -593,6 +603,9 @@ function Geyser.MiniConsole:new (cons, container)
       me:enableAutoWrap()
     elseif cons.wrapAt then
       me:setWrap(cons.wrapAt)
+    end
+    if cons.autoWrap then
+      me:enableAutoWrap()
     end
     if me.commandLine then
       me:enableCommandLine()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Makes sure the scrollBar property is more strictly tracked and uses that to determine if we should leave 15px of space for the scrollbar.
resets autowrap when you enable or disable the scrollbar
Also improves the handling and tracking of the autoWrap constraint a bit, and sets resetAutoWrap() to return immediately if autoWrap is not true.
#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/6618