### PR TITLE
Infrastructure: Run danger when PR title is updated

### DIFF
--- a/.github/workflows/dangerjs.yml
+++ b/.github/workflows/dangerjs.yml
@@ -1,6 +1,8 @@
 name: DangerJS
 
-on: pull_request_target
+on: 
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   danger:

--- a/.github/workflows/dangerjs.yml
+++ b/.github/workflows/dangerjs.yml
@@ -1,6 +1,6 @@
 name: DangerJS
 
-on: 
+on:
   pull_request_target:
     types: [opened, synchronize, reopened, edited]
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Run danger when PR title is updated
#### Motivation for adding to Mudlet
Newcomers to the repo often get caught out by PR titles initially - so they edit them, but nothing happens. This should re-run Danger
#### Other info (issues closed, discussion etc)
Not 100% certain it'll work, lets merge and see