### PR TITLE
Fix: prevent right clicking in error console moving focus to main window

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1981,7 +1981,12 @@ void TConsole::dropEvent(QDropEvent* e)
 // This is also called from the TTextEdit mouse(Press|Release)Event()s:
 void TConsole::raiseMudletMousePressOrReleaseEvent(QMouseEvent* event, const bool isPressEvent)
 {
+    if (mType & (CentralDebugConsole | ErrorConsole)) {
+        return;
+    }
 
+    // Else if NOT the CentralDebugConsole or the ErrorConsole then bring the
+    // focus to the current profile in the main application window:
     TEvent mudletEvent{};
     mudletEvent.mArgumentList.append(isPressEvent ? qsl("sysWindowMousePressEvent") : qsl("sysWindowMouseReleaseEvent"));
     switch (event->button()) {


### PR DESCRIPTION
This should close #6638 as it prevents that and the Central Debug Console windows from performing the step in the `TTextEdit::mouseReleaseEvent(...)` that was redirecting the focus to the profile's currently used command- line. It also fixes a related matter in that those windows were also possibly raising bogus `sysWindowMousePressEvent` and `sysWindowMouseReleaseEvent` events that a user's GUI system would not want.

For some reason Qt Creator has also taken upon itself to fix up some spacing issues which are in accordance to our preferences so I have left them in the commit.