### PR TITLE
Fix: prevent user map menus being deleted prematurely

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2869,8 +2869,9 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
             it.next();
             QStringList menuInfo = it.value();
             QString displayName = menuInfo[1];
-            auto userMenu = new QMenu(displayName, this);
-            userMenu->setAttribute(Qt::WA_DeleteOnClose);
+            // Need to give the top-level context menu as the parent so the
+            // sub-menus get destroyed at the right time:
+            auto userMenu = new QMenu(displayName, popup);
             userMenus.insert(it.key(), userMenu);
         }
         it.toFront();


### PR DESCRIPTION
This will close #6642.

It was happening because the (sub) menus were being set to automatically delete when they are closed - which happens when the user selects an item on them, or, after a delay, if the pointer moves off of them. In the latter case this is what was causing the problem as the parent menu (or even a further up ancestor) does not necessarily go away and it is expected the sub-menu should persist.

The cure is to remove the automatic delete flag from the sub-menus.

However in itself this means that they would persist in memory until the widget that owns them is destroyed, as this is the `T2DMap` instance that could lead to 1000s of them being leaked in this manner.

The solution is to tell them that their parent is the top-level (context) menu so that when it goes they do as well and not before!