### PR TITLE
fix F6 keybinding

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -233,7 +233,8 @@ bool TCommandLine::event(QEvent* event)
             break;
 
         case Qt::Key_F6:
-            if (mpHost->mCaretShortcut == Host::CaretShortcut::F6) {
+            if ((mpHost->mCaretShortcut == Host::CaretShortcut::F6) &&
+                ((ke->modifiers() & allModifiers) == Qt::NoModifier)) {
                 mpHost->setCaretEnabled(true);
                 ke->accept();
                 return true;

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -238,6 +238,10 @@ bool TCommandLine::event(QEvent* event)
                 ke->accept();
                 return true;
             }
+
+            if (keybindingMatched(ke)) {
+                return true;
+            }
             break;
 
         case Qt::Key_unknown:

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -233,8 +233,7 @@ bool TCommandLine::event(QEvent* event)
             break;
 
         case Qt::Key_F6:
-            if ((mpHost->mCaretShortcut == Host::CaretShortcut::F6) &&
-                ((ke->modifiers() & allModifiers) == Qt::NoModifier)) {
+            if ((mpHost->mCaretShortcut == Host::CaretShortcut::F6) && ((ke->modifiers() & allModifiers) == Qt::NoModifier)) {
                 mpHost->setCaretEnabled(true);
                 ke->accept();
                 return true;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
The accessibility code has special behavior for F6 that is optional, but if the option is off or assigned to something other than F6, it gets interrupted and doesn't run keybinds set by user.  Also I'll make it more strict when it IS enabled, and make it so that modifiers like Ctrl-F6 are not treated as F6.

#### Motivation for adding to Mudlet
Fame and accolades

#### Other info (issues closed, discussion etc)
Fixes #6666