### PR TITLE
Infrastructure: update clang-tidy checker to work in forked repos

### DIFF
--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -122,7 +122,7 @@ jobs:
           --target autogen
 
     - name: Check C++ changes against style guide
-      uses: ZedThree/clang-tidy-review@v0.10.1
+      uses: ZedThree/clang-tidy-review@v0.12.0
       id: static_analysis
       with:
         build_dir: 'b/ninja' # path is relative to checkout directory
@@ -130,7 +130,7 @@ jobs:
         config_file: '.clang-tidy'
         # the action doesn't see system-level libraries, need to replicate them here
         apt_packages: 'pkg-config,libzip-dev,libglu1-mesa-dev,libpulse-dev'
+        split_workflow: true
 
-    - name: Passed C++ style guide checks
-      if: steps.static_analysis.outputs.total_comments > 0
-      run: exit 1
+    - name: Upload check results
+      uses: ZedThree/clang-tidy-review/upload@v0.12.0

--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -1,4 +1,4 @@
-name: 🔍 Check improvements with Mudlet's C++ style guide
+name: "🔍 Check improvements with Mudlet's C++ style guide"
 
 on:
   pull_request_target:

--- a/.github/workflows/clangtidy-post-comments.yml
+++ b/.github/workflows/clangtidy-post-comments.yml
@@ -1,0 +1,14 @@
+name: Post clang-tidy review comments
+
+on:
+  workflow_run:
+    workflows: ["🔍 Check improvements with Mudlet's C++ style guide"]
+    types:
+      - completed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: ZedThree/clang-tidy-review/post@v0.12.0


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Update clang-tidy checker to work in forked repos
#### Motivation for adding to Mudlet
Better quality code!
#### Other info (issues closed, discussion etc)
See https://github.com/ZedThree/clang-tidy-review#usage-in-fork-environments-split-workflow