### PR TITLE
Fix: buttons in menus not working (4.17)

### DIFF
--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -336,7 +336,7 @@ void TAction::fillMenu(TEasyButtonBar* pT, QMenu* menu)
             continue;
         }
         mpEasyButtonBar = pT;
-        auto newAction = new EAction(mpHost, QIcon(mIcon), action->mName, mID);
+        auto newAction = new EAction(mpHost, QIcon(mIcon), action->mName, action->mID);
         newAction->setStatusTip(action->mName);
         newAction->setCheckable(action->mIsPushDownButton);
         if (action->mIsPushDownButton) {


### PR DESCRIPTION
This was due to a typo in #6455 where I put the wrong ID number into one instance of the `EAction` constructor.