### PR TITLE
Infrastructure: Remove 🔍 from action name to make clang-tidy action work

### DIFF
--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -1,4 +1,4 @@
-name: "🔍 Check improvements with Mudlet's C++ style guide"
+name: "Check improvements with Mudlet's C++ style guide"
 
 on:
   pull_request_target:

--- a/.github/workflows/clangtidy-post-comments.yml
+++ b/.github/workflows/clangtidy-post-comments.yml
@@ -2,7 +2,7 @@ name: Post clang-tidy review comments
 
 on:
   workflow_run:
-    workflows: ["🔍 Check improvements with Mudlet's C++ style guide"]
+    workflows: ["Check improvements with Mudlet's C++ style guide"]
     types:
       - completed
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove 🔍 from action name to make clang-tidy action work, as otherwise we are spammed with the following:

![image](https://user-images.githubusercontent.com/110988/227268965-8041544a-f3ec-46eb-9da7-8883cad50166.png)
![image](https://user-images.githubusercontent.com/110988/227268976-aedfdc29-7bad-4f30-8a65-99305c0d7780.png)

#### Motivation for adding to Mudlet
Working around a [Github issue](https://github.com/orgs/community/discussions/50835).
#### Other info (issues closed, discussion etc)
