### PR TITLE
fix profile tabs bolded by activity staying bold after switching to them

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4486,6 +4486,12 @@ void mudlet::activateProfile(Host* pHost)
         mpTabBar->blockSignals(false);
     }
 
+    // Reset the tab back to "normal" to undo the effect of it having its style
+    // changed on new data:
+    mpTabBar->setTabBold(newActiveTabIndex, false);
+    mpTabBar->setTabItalic(newActiveTabIndex, false);
+    mpTabBar->setTabUnderline(newActiveTabIndex, false);
+
     mpCurrentActiveHost = pHost;
     mpCurrentActiveHost->mpConsole->show();
     mpCurrentActiveHost->mpConsole->repaint();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Profile tabs become bold when there is activity and not looking at that tab.  Switching to that tab is supposed to clear the bold but currently it is not.  This is meant to fix that.
#### Motivation for adding to Mudlet
Fix #6672
#### Other info (issues closed, discussion etc)
The #6267 had a comment `Moved as much as possible to activateProfile` and then found this chunk that got lost.  Just copied and pasted from there.