### PR TITLE
Infrastructure: remove apostrophe from clangtidy workflow name

### DIFF
--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -6,6 +6,7 @@ on:
     - '**.cpp'
     - '**.h'
     - '.github/workflows/clangtidy-diff-analysis.yml'
+  workflow_dispatch:
 
 jobs:
   compile-mudlet:

--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -122,7 +122,7 @@ jobs:
           --target autogen
 
     - name: Check C++ changes against style guide
-      uses: ZedThree/clang-tidy-review@v0.12.0
+      uses: ZedThree/clang-tidy-review@v0.12.1
       id: static_analysis
       with:
         build_dir: 'b/ninja' # path is relative to checkout directory

--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -6,7 +6,6 @@ on:
     - '**.cpp'
     - '**.h'
     - '.github/workflows/clangtidy-diff-analysis.yml'
-  workflow_dispatch:
 
 jobs:
   compile-mudlet:

--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -123,7 +123,7 @@ jobs:
           --target autogen
 
     - name: Check C++ changes against style guide
-      uses: ZedThree/clang-tidy-review@v0.12.1
+      uses: ZedThree/clang-tidy-review@v0.12.0
       id: static_analysis
       with:
         build_dir: 'b/ninja' # path is relative to checkout directory

--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -1,4 +1,4 @@
-name: "Check improvements with Mudlet's C++ style guide"
+name: "Check improvements with C++ style guide"
 
 on:
   pull_request_target:

--- a/.github/workflows/clangtidy-post-comments.yml
+++ b/.github/workflows/clangtidy-post-comments.yml
@@ -2,7 +2,7 @@ name: Post clang-tidy review comments
 
 on:
   workflow_run:
-    workflows: ["Check improvements with Mudlet's C++ style guide"]
+    workflows: ["Check improvements with C++ style guide"]
     types:
       - completed
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove apostrophe from clangtidy workflow name
#### Motivation for adding to Mudlet
So Github can run this dependant workflow okay
#### Other info (issues closed, discussion etc)
It looks like https://github.com/Mudlet/Mudlet/pull/6689 did not fix the issue and the emoji was not the issue. It's still happening and it's not obvious why - [Github docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run) don't shed any light on this.