### PR TITLE
fix ability to use your own ctrl-F keybinds

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -134,6 +134,10 @@ bool TCommandLine::event(QEvent* event)
         }
 
         if (ke->matches(QKeySequence::Find)){ // Find is Ctrl+F
+            if (keybindingMatched(ke)) { // If user has set up a keybind then do that instead.
+                return true;
+            }
+
             if (mudlet::self()->dactionInputLine->isChecked()) {
                 // If hidden then reveal as if pressed Alt-L
                 mudlet::self()->dactionInputLine->setChecked(false);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
This makes it so if you have a ctrl-F keybind then it will continue to work instead of doing the search that got added in #6353.  Bonus is that you could implement your own version of search like  https://github.com/Mudlet/Mudlet/pull/6406#issuecomment-1314702575
#### Motivation for adding to Mudlet

> keraM — 03/20/2023 5:22 PM
> Is there a way to disable ctrl+f hotkey that seems to be new in the new version? it now takes me to the search field and is ignoring my other hotkey in my profile that I'm used to
> It's not appearing in the shorcuts tab in settings
> gesslar — 03/20/2023 5:23 PM
> i don't see it in the Shortcuts screen. i would suggest an issue to add that, keraM

#### Other info (issues closed, discussion etc)
advice from gesslar was not taken