### PR TITLE
Infrastructure: rename C++ to cpp in analysis action to please Github

### DIFF
--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -1,4 +1,4 @@
-name: "Check improvements with C++ style guide"
+name: "Check improvements with cpp style guide"
 
 on:
   pull_request_target:

--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -6,7 +6,6 @@ on:
     - '**.cpp'
     - '**.h'
     - '.github/workflows/clangtidy-diff-analysis.yml'
-  workflow_dispatch:
 
 jobs:
   compile-mudlet:

--- a/.github/workflows/clangtidy-post-comments.yml
+++ b/.github/workflows/clangtidy-post-comments.yml
@@ -2,7 +2,7 @@ name: Post clang-tidy review comments
 
 on:
   workflow_run:
-    workflows: ["Check improvements with C++ style guide"]
+    workflows: ["Check improvements with cpp style guide"]
     types:
       - completed
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Rename C++ to cpp in analysis action to please Github
#### Motivation for adding to Mudlet
Trying to get the clang-tidy analyser to work
#### Other info (issues closed, discussion etc)
Github still [doesn't want](https://github.com/Mudlet/Mudlet/actions/runs/4515667367) to start the action:

> Encountered an issue parsing workflow trigger(s) "Check improvements with C++ style guide" in a workflow. Please ensure any special characters are escaped.

Also disabled `workflow_dispatch` as the action only makes sense to run in the context of a PR, and errors otherwise:

> review: error: argument --pr: invalid int value: ''