### PR TITLE
Infrastructure: update .clang-tidy checks syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,6 @@
 Checks: '-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-implicit-bool-conversion,-readability-qualified-auto,-cppcoreguidelines-owning-memory,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-readability-static-accessed-through-instance,-cppcoreguidelines-pro-type-static-cast-downcast,-bugprone-suspicious-enum-usage,-readability-uppercase-literal-suffix,-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-misc-no-recursion,-readability-isolate-declaration,-cppcoreguidelines-pro-type-vararg,-misc-non-private-member-variables-in-classes,-performance-no-automatic-move,-readability-avoid-const-params-in-decls,-cppcoreguidelines-non-private-member-variables-in-classes'
 # Use .clang-format for formatting
 FormatStyle: file
-IgnoredVariableNames: x, y
+CheckOptions:
+  - key:             readability-identifier-length.IgnoredVariableNames
+    value:           'x|y'


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Update `.clang-tidy` checks syntax to [what is supported](https://clang.llvm.org/extra/clang-tidy/).
#### Motivation for adding to Mudlet
So clang-tidy analyser works.
#### Other info (issues closed, discussion etc)
The syntax we use is [outdated](https://github.com/Mudlet/Mudlet/actions/runs/4520879927/jobs/7962272520?pr=6698#step:13:554).

Also, the workflow-after-workflow trigger finally [works](https://github.com/Mudlet/Mudlet/actions/workflows/clangtidy-post-comments.yml)! `+` was not a legal character to have in the Github action.