### PR TITLE
Infrastructure: install Qt in a location clang-tidy can find it

### DIFF
--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -128,8 +128,14 @@ jobs:
         build_dir: 'b/ninja' # path is relative to checkout directory
         exclude: '3rdparty'
         config_file: '.clang-tidy'
-        # the action doesn't see system-level libraries, need to replicate them here
-        apt_packages: 'pkg-config,libzip-dev,libglu1-mesa-dev,libpulse-dev'
+        # the action doesn't see system-level or vcpkg libraries, need to replicate them here
+        apt_packages: 'zlib1g-dev, libhunspell-dev,
+          libpcre3-dev, libzip-dev, libboost-dev, libboost-all-dev, libyajl-dev, libpulse-dev, libpugixml-dev,
+          liblua5.1-0-dev, lua-filesystem, lua-zip, lua-sql-sqlite3, luarocks, ccache, lua5.1,
+          libglu1-mesa-dev, mesa-common-dev, libglib2.0-dev, libgstreamer1.0-dev, libqt5opengl5-dev,
+          qtmultimedia5-dev, qttools5-dev, qt5keychain-dev, libsecret-1-dev,
+          libqt5texttospeech5-dev, qtspeech5-flite-plugin, qtspeech5-speechd-plugin,
+          qtbase5-dev, qtchooser, qt5-qmake, qtbase5-dev-tools, qtmultimedia5-dev'
         split_workflow: true
 
     - name: Upload check results

--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -41,7 +41,7 @@ jobs:
       if: runner.os == 'Windows'
       with:
         version: ${{matrix.qt}}
-        dir: ${{runner.workspace}}
+        dir: ${{github.workspace}}
         arch: win64_mingw73
         cache: true
 
@@ -50,7 +50,7 @@ jobs:
       if: runner.os == 'Linux' || runner.os == 'macOS'
       with:
         version: ${{matrix.qt}}
-        dir: ${{runner.workspace}}
+        dir: ${{github.workspace}}
         cache: true
 
     - name: Restore Boost cache
@@ -128,14 +128,8 @@ jobs:
         build_dir: 'b/ninja' # path is relative to checkout directory
         exclude: '3rdparty'
         config_file: '.clang-tidy'
-        # the action doesn't see system-level or vcpkg libraries, need to replicate them here
-        apt_packages: 'zlib1g-dev, libhunspell-dev,
-          libpcre3-dev, libzip-dev, libboost-dev, libboost-all-dev, libyajl-dev, libpulse-dev, libpugixml-dev,
-          liblua5.1-0-dev, lua-filesystem, lua-zip, lua-sql-sqlite3, luarocks, ccache, lua5.1,
-          libglu1-mesa-dev, mesa-common-dev, libglib2.0-dev, libgstreamer1.0-dev, libqt5opengl5-dev,
-          qtmultimedia5-dev, qttools5-dev, qt5keychain-dev, libsecret-1-dev,
-          libqt5texttospeech5-dev, qtspeech5-flite-plugin, qtspeech5-speechd-plugin,
-          qtbase5-dev, qtchooser, qt5-qmake, qtbase5-dev-tools, qtmultimedia5-dev'
+        # the action doesn't see system-level libraries need to replicate them here
+        apt_packages: 'gettext, pkg-config, libzip-dev, libglu1-mesa-dev, libpulse-dev'
         split_workflow: true
 
     - name: Upload check results


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
The action [can't currently see](https://github.com/Mudlet/Mudlet/actions/runs/4523196244/jobs/7966168328?pr=6698#step:13:561) our Qt headers, probably because they get installed into the runner workspace and not the github workspace where the action [can see them](https://github.com/ZedThree/clang-tidy-review#limitations). 
#### Motivation for adding to Mudlet
Still trying to get the clang-tidy workflow to work.
#### Other info (issues closed, discussion etc)