### PR TITLE
Infrastructure: restore 🔍 to clang-tidy check workflow name

### DIFF
--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -1,4 +1,4 @@
-name: "🔍 Check improvements with Mudlet's cpp style guide"
+name: "🔍 Check improvements with cpp style guide"
 
 on:
   pull_request_target:

--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -1,4 +1,4 @@
-name: "Check improvements with cpp style guide"
+name: "🔍 Check improvements with Mudlet's cpp style guide"
 
 on:
   pull_request_target:

--- a/.github/workflows/clangtidy-post-comments.yml
+++ b/.github/workflows/clangtidy-post-comments.yml
@@ -2,7 +2,7 @@ name: Post clang-tidy review comments
 
 on:
   workflow_run:
-    workflows: ["🔍 Check improvements with Mudlet's cpp style guide"]
+    workflows: ["🔍 Check improvements with cpp style guide"]
     types:
       - completed
 

--- a/.github/workflows/clangtidy-post-comments.yml
+++ b/.github/workflows/clangtidy-post-comments.yml
@@ -2,7 +2,7 @@ name: Post clang-tidy review comments
 
 on:
   workflow_run:
-    workflows: ["Check improvements with cpp style guide"]
+    workflows: ["🔍 Check improvements with Mudlet's cpp style guide"]
     types:
       - completed
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Restore 🔍 to clang-tidy check workflow name
#### Motivation for adding to Mudlet
So the check workflow can be told apart from others that appear in the big list under a PR.
#### Other info (issues closed, discussion etc)
I suspect the `+` was not allowed because it's part of Github's [filtering syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet), however the docs say filters only apply in path, branch, and tags - nothing about workflows. This seems like a Github bug to me (or an undocumented feature!). Regardless, will stay away from this in case they change their mind on this in the future.