### PR TITLE
Fix: needed/unneeded context for lambdas

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -828,7 +828,7 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
         waitForAsyncXmlSave();
         saveModules(saveName != qsl("autosave"));
     });
-    QObject::connect(watcher, &QFutureWatcher<void>::finished, this, [=]() {
+    connect(watcher, &QFutureWatcher<void>::finished, this, [=]() {
         // reload, or queue module reload for when xml is ready
         if (syncModules) {
             reloadModules();
@@ -2746,19 +2746,19 @@ void Host::loadSecuredPassword()
 
     job->setKey(getName());
 
-    connect(job, &QKeychain::ReadPasswordJob::finished, this, [=](QKeychain::Job* job) {
-        if (job->error()) {
-            const auto error = job->errorString();
+    connect(job, &QKeychain::ReadPasswordJob::finished, this, [=](QKeychain::Job* task) {
+        if (task->error()) {
+            const auto error = task->errorString();
             if (error != qsl("Entry not found") && error != qsl("No match")) {
                 qDebug().nospace().noquote() << "Host::loadSecuredPassword() ERROR - could not retrieve secure password for \"" << getName() << "\", error is: " << error << ".";
             }
 
         } else {
-            auto readJob = static_cast<QKeychain::ReadPasswordJob*>(job);
+            auto readJob = static_cast<QKeychain::ReadPasswordJob*>(task);
             setPass(readJob->textData());
         }
 
-        job->deleteLater();
+        task->deleteLater();
     });
 
     job->start();

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4117,7 +4117,7 @@ void T2DMap::slot_setArea()
         arealist_combobox->addItem(qsl("%1 (%2)").arg(sortedAreaList.at(i), QString::number(areaId)), QString::number(areaId));
     }
 
-    connect(set_room_area_dialog, &QDialog::accepted, [=]() {
+    connect(set_room_area_dialog, &QDialog::accepted, this, [=]() {
         int newAreaId = arealist_combobox->itemData(arealist_combobox->currentIndex()).toInt();
         mMultiRect = QRect(0, 0, 0, 0);
         QSetIterator<int> itSelectedRoom = mMultiSelectionSet;

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -450,7 +450,7 @@ bool TCommandLine::event(QEvent* event)
         case Qt::Key_PageUp:
             if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
                 mpConsole->scrollUp(0);
-                QTimer::singleShot(0, [this]() {  mpConsole->scrollUp(mpConsole->mUpperPane->getScreenHeight()); });
+                QTimer::singleShot(0, this, [this]() {  mpConsole->scrollUp(mpConsole->mUpperPane->getScreenHeight()); });
                 ke->accept();
                 return true;
             }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1067,7 +1067,7 @@ void TConsole::scrollUp(int lines)
     mLowerPane->forceUpdate();
 
     if (lowerAppears) {
-        QTimer::singleShot(0, [this]() {  mUpperPane->scrollUp(mLowerPane->getRowCount()); });
+        QTimer::singleShot(0, this, [this]() {  mUpperPane->scrollUp(mLowerPane->getRowCount()); });
     }
     mUpperPane->scrollUp(lines);
     slot_adjustAccessibleNames();

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4479,7 +4479,7 @@ int TLuaInterpreter::movieFunc(lua_State* L, const QString& funcName)
         }
         movie->setScaledSize(pN->size());
         if (autoScale) {
-            connect(pN, &TLabel::resized, [=] {movie->setScaledSize(pN->size());} );
+            connect(pN, &TLabel::resized, pN, [=] { movie->setScaledSize(pN->size()); });
         } else {
             pN->disconnect(SIGNAL(resized()));
         }
@@ -10382,7 +10382,7 @@ int TLuaInterpreter::downloadFile(lua_State* L)
     host.updateProxySettings(host.mLuaInterpreter.mpFileDownloader);
     QNetworkReply* reply = host.mLuaInterpreter.mpFileDownloader->get(request);
     host.mLuaInterpreter.downloadMap.insert(reply, localFile);
-    connect(reply, &QNetworkReply::downloadProgress, [=](qint64 bytesDownloaded, qint64 totalBytes) {
+    connect(reply, &QNetworkReply::downloadProgress, reply, [=](qint64 bytesDownloaded, qint64 totalBytes) {
         raiseDownloadProgressEvent(L, urlString, bytesDownloaded, totalBytes);
         if (mudlet::smDebugMode) {
             auto& lHost = getHostFromLua(L);
@@ -14918,7 +14918,7 @@ int TLuaInterpreter::unzipAsync(lua_State *L)
 
     auto future = QtConcurrent::run(mudlet::unzip, zipLocation, extractLocation, temporaryDir.path());
     auto watcher = new QFutureWatcher<bool>;
-    QObject::connect(watcher, &QFutureWatcher<bool>::finished, [=]() {
+    connect(watcher, &QFutureWatcher<bool>::finished, watcher, [=]() {
         TEvent event {};
         Host& host = getHostFromLua(L);
 

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -775,16 +775,16 @@ TMediaPlayer TMedia::getMediaPlayer(TMediaData& mediaData)
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     disconnect(pPlayer.getMediaPlayer(), &QMediaPlayer::stateChanged, nullptr, nullptr);
-    connect(pPlayer.getMediaPlayer(), &QMediaPlayer::stateChanged,
+    connect(pPlayer.getMediaPlayer(), &QMediaPlayer::stateChanged, this,
             [&](QMediaPlayerPlaybackState playbackState) { handlePlayerPlaybackStateChanged(playbackState, pPlayer); });
 #else
     disconnect(pPlayer.getMediaPlayer(), &QMediaPlayer::playbackStateChanged, nullptr, nullptr);
-    connect(pPlayer.getMediaPlayer(), &QMediaPlayer::playbackStateChanged,
+    connect(pPlayer.getMediaPlayer(), &QMediaPlayer::playbackStateChanged, this,
             [&](QMediaPlayerPlaybackState playbackState) { handlePlayerPlaybackStateChanged(playbackState, pPlayer); });
 #endif
     disconnect(pPlayer.getMediaPlayer(), &QMediaPlayer::positionChanged, nullptr, nullptr);
 
-    connect(pPlayer.getMediaPlayer(), &QMediaPlayer::positionChanged, [&](qint64 progress) {
+    connect(pPlayer.getMediaPlayer(), &QMediaPlayer::positionChanged, this, [&](qint64 progress) {
         int volume = pPlayer.getMediaData().getMediaVolume();
         int fadeInPosition = pPlayer.getMediaData().getMediaFadeIn();
         int fadeOutPosition = pPlayer.getMediaData().getMediaFadeOut();

--- a/src/TMxpCustomElementTagHandler.cpp
+++ b/src/TMxpCustomElementTagHandler.cpp
@@ -87,7 +87,7 @@ TMxpTagHandlerResult TMxpCustomElementTagHandler::handleEndTag(TMxpContext& ctx,
 //              <send href='help 1024;' hint='Click for help on 1024;' expire=help>
 MxpStartTag TMxpCustomElementTagHandler::resolveElementDefinition(const TMxpElement& element, MxpStartTag* definitionTag, MxpStartTag* customTag) const
 {
-    auto mapping = [this, customTag, element](const MxpTagAttribute& attr) {
+    auto mapping = [customTag, element](const MxpTagAttribute& attr) {
         if (!attr.hasValue()) {
             return MxpTagAttribute(mapAttributes(element, attr.getName(), customTag));
         } else {
@@ -104,8 +104,8 @@ MxpStartTag TMxpCustomElementTagHandler::resolveElementDefinition(const TMxpElem
 
 QString TMxpCustomElementTagHandler::mapAttributes(const TMxpElement& element, const QString& input, MxpStartTag* tag)
 {
-    auto mapEntityNameToTagAttributeValue = [element, tag](const QString& input) {
-        QString attrName = input.mid(1, input.size() - 2);
+    auto mapEntityNameToTagAttributeValue = [element, tag](const QString& text) {
+        QString attrName = text.mid(1, text.size() - 2);
         // get attribute value by NAME
         // <!EL help "<send href='help &desc;' hint='Click for help on &desc;' expire=help>" ATT='desc'>
         // <help desc="1024">1024</help>
@@ -121,7 +121,7 @@ QString TMxpCustomElementTagHandler::mapAttributes(const TMxpElement& element, c
             return tag->getAttribute(attrIndex).getName();
         }
 
-        return input;
+        return text;
     };
 
     return TEntityResolver::interpolate(input, mapEntityNameToTagAttributeValue);

--- a/src/TMxpSupportTagHandler.cpp
+++ b/src/TMxpSupportTagHandler.cpp
@@ -34,30 +34,30 @@ TMxpTagHandlerResult TMxpSupportTagHandler::handleStartTag(TMxpContext& ctx, TMx
 
     return MXP_TAG_HANDLED;
 }
+
 QString TMxpSupportTagHandler::processSupportsRequest(TMxpContext& ctx, MxpStartTag* tag)
 {
     const auto& supportedMxpElements = ctx.getSupportedElements();
     // strip initial SUPPORT and tokenize all of the requested elements
     QStringList result;
-
-    auto reportEntireElement = [](auto element, auto& result, auto& mSupportedMxpElements) {
-        result.append("+" + element);
+    auto reportEntireElement = [](auto element, auto& input, auto& mSupportedMxpElements) {
+        input.append(qsl("+%1").arg(element));
 
         for (const auto& attribute : mSupportedMxpElements.value(element)) {
-            result.append("+" + element + qsl(".") + attribute);
+            input.append(qsl("+%1.%2").arg(element, attribute));
         }
 
-        return result;
+        return input;
     };
 
-    auto reportAllElements = [reportEntireElement](auto& result, auto& mSupportedMxpElements) {
+    auto reportAllElements = [reportEntireElement](auto& input, auto& mSupportedMxpElements) {
         auto elementsIterator = mSupportedMxpElements.constBegin();
         while (elementsIterator != mSupportedMxpElements.constEnd()) {
-            result = reportEntireElement(elementsIterator.key(), result, mSupportedMxpElements);
+            input = reportEntireElement(elementsIterator.key(), input, mSupportedMxpElements);
             ++elementsIterator;
         }
 
-        return result;
+        return input;
     };
 
     // empty <SUPPORT> - report all known elements

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -194,7 +194,7 @@ void XMLexport::writeModuleXML(const QString& moduleName, const QString& fileNam
     if (async) {
         auto future = QtConcurrent::run([&]() { return saveXml(fileName); });
         auto watcher = new QFutureWatcher<bool>;
-        QObject::connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=]() { mpHost->xmlSaved(fileName); });
+        connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=]() { mpHost->xmlSaved(fileName); });
         watcher->setFuture(future);
         saveFutures.append(future);
     } else {
@@ -210,7 +210,7 @@ void XMLexport::exportHost(const QString& filename_pugi_xml)
     auto future = QtConcurrent::run([&]() { return saveXml(filename_pugi_xml); });
 
     auto watcher = new QFutureWatcher<bool>;
-    QObject::connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=]() { mpHost->xmlSaved(qsl("profile")); });
+    connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=]() { mpHost->xmlSaved(qsl("profile")); });
     watcher->setFuture(future);
     saveFutures.append(future);
 }

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -112,7 +112,7 @@ Discord::Discord(QObject* parent)
     Discord_Initialize(mHostApplicationIDs.value(nullptr).toUtf8().constData(), mpHandlers, 0, nullptr);
 
     // mudlet instance is not available in this constructor as it's still being initialised, so postpone the connection
-    QTimer::singleShot(0, [this]() {
+    QTimer::singleShot(0, this, [this]() {
         Q_ASSERT(mudlet::self());
         connect(mudlet::self(), &mudlet::signal_tabChanged, this, &Discord::UpdatePresence);
 

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1163,19 +1163,19 @@ void dlgConnectionProfiles::loadSecuredPassword(const QString& profile, L callba
 
     job->setKey(profile);
 
-    connect(job, &QKeychain::ReadPasswordJob::finished, this, [=](QKeychain::Job* job) {
-        if (job->error()) {
-            const auto error = job->errorString();
+    connect(job, &QKeychain::ReadPasswordJob::finished, this, [=](QKeychain::Job* task) {
+        if (task->error()) {
+            const auto error = task->errorString();
             if (error != qsl("Entry not found") && error != qsl("No match")) {
                 qDebug().nospace().noquote() << "dlgConnectionProfiles::loadSecuredPassword() ERROR - could not retrieve secure password for \"" << profile << "\", error is: " << error << ".";
             }
 
         }
 
-        auto readJob = static_cast<QKeychain::ReadPasswordJob*>(job);
+        auto readJob = static_cast<QKeychain::ReadPasswordJob*>(task);
         callback(readJob->textData());
 
-        job->deleteLater();
+        task->deleteLater();
     });
 
     job->start();
@@ -1327,7 +1327,7 @@ void dlgConnectionProfiles::slot_copyProfile()
     mpCopyProfile->setEnabled(false);
     auto future = QtConcurrent::run(dlgConnectionProfiles::copyFolder, mudlet::getMudletPath(mudlet::profileHomePath, oldname), mudlet::getMudletPath(mudlet::profileHomePath, profile_name));
     auto watcher = new QFutureWatcher<bool>;
-    QObject::connect(watcher, &QFutureWatcher<bool>::finished, [=]() {
+    connect(watcher, &QFutureWatcher<bool>::finished, this, [=]() {
         mProfileList << profile_name;
         slot_itemClicked(pItem);
         // Clear the Discord optin on the copied profile - just because the source

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -277,7 +277,7 @@ void dlgMapper::slot_toggle3DView(const bool is3DMode)
         widget_2DControls->setVisible(false);
     } else {
         // workaround for buttons reloading oddly
-        QTimer::singleShot(100ms, [this]() {
+        QTimer::singleShot(100ms, this, [this]() {
             widget_3DControls->setVisible(false);
             widget_2DControls->setVisible(true);
         });

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -562,7 +562,7 @@ void dlgPackageExporter::slot_exportPackage()
         } else {
             auto future = QtConcurrent::run(dlgPackageExporter::zipPackage, stagingDirName, mPackagePathFileName, mXmlPathFileName, mPackageName, mPackageComment);
             auto watcher = new QFutureWatcher<std::pair<bool, QString>>;
-            QObject::connect(watcher, &QFutureWatcher<std::pair<bool, QString>>::finished, [=]() {
+            connect(watcher, &QFutureWatcher<std::pair<bool, QString>>::finished, this, [=]() {
                 mExportingPackage = false;
                 checkToEnableExportButton();
 
@@ -1067,14 +1067,14 @@ void dlgPackageExporter::slot_addFiles()
     if (dialogListView) {
         dialogListView->setSelectionMode(QAbstractItemView::ExtendedSelection);
         //button would be disabled if no folder is selected
-        connect(dialogListView, &QListView::clicked, [=] { button->setEnabled(true); });
+        connect(dialogListView, &QListView::clicked, this, [=] { button->setEnabled(true); });
     }
     QTreeView* dialogTreeView = fDialog->findChild<QTreeView*>();
     if (dialogTreeView) {
         dialogTreeView->setSelectionMode(QAbstractItemView::ExtendedSelection);
-        connect(dialogTreeView, &QTreeView::clicked, [=] { button->setEnabled(true); });
+        connect(dialogTreeView, &QTreeView::clicked, this, [=] { button->setEnabled(true); });
     }
-    connect(button, &QPushButton::clicked, [=] { fDialog->QDialog::accept(); });
+    connect(button, &QPushButton::clicked, this, [=] { fDialog->QDialog::accept(); });
     if (fDialog->exec()) {
         selectedFiles = fDialog->selectedFiles();
     }

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -349,20 +349,20 @@ void dlgProfilePreferences::setupPasswordsMigration()
     hidePasswordMigrationLabelTimer = std::make_unique<QTimer>(this);
     hidePasswordMigrationLabelTimer->setSingleShot(true);
 
-    connect(hidePasswordMigrationLabelTimer.get(), &QTimer::timeout, this, &dlgProfilePreferences::hidePasswordMigrationLabel);
+    connect(hidePasswordMigrationLabelTimer.get(), &QTimer::timeout, this, &dlgProfilePreferences::slot_hidePasswordMigrationLabel);
 
-    connect(mudlet::self(), &mudlet::signal_passwordsMigratedToSecure, [=]() {
+    connect(mudlet::self(), &mudlet::signal_passwordsMigratedToSecure, this, [=]() {
         label_password_migration_notification->setText(tr("Migrated all passwords to secure storage."));
         comboBox_store_passwords_in->setEnabled(true);
         hidePasswordMigrationLabelTimer->start(10s);
     });
 
-    connect(mudlet::self(), &mudlet::signal_passwordMigratedToSecure, [=](const QString& profile) {
+    connect(mudlet::self(), &mudlet::signal_passwordMigratedToSecure, this, [=](const QString& profile) {
         label_password_migration_notification->setText(
                 tr("Migrated %1...", "This notifies the user that progress is being made on profile migration by saying what profile was just migrated to store passwords securely").arg(profile));
     });
 
-    connect(mudlet::self(), &mudlet::signal_passwordsMigratedToProfiles, [=]() {
+    connect(mudlet::self(), &mudlet::signal_passwordsMigratedToProfiles, this, [=]() {
         label_password_migration_notification->setText(tr("Migrated all passwords to profile storage."));
         comboBox_store_passwords_in->setEnabled(true);
         hidePasswordMigrationLabelTimer->start(10s);
@@ -498,7 +498,7 @@ void dlgProfilePreferences::disableHostDetails()
     // ----- groupBox_debug -----
     checkBox_expectCSpaceIdInColonLessMColorCode->setEnabled(false);
     // This acts on a label within this groupBox:
-    hidePasswordMigrationLabel();
+    slot_hidePasswordMigrationLabel();
     checkBox_debugShowAllCodepointProblems->setEnabled(false);
     checkBox_announceIncomingText->setEnabled(false);
     comboBox_blankLinesBehaviour->setEnabled(false);
@@ -903,7 +903,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     // label to show on successful map file action
     label_mapFileActionResult->hide();
 
-    hidePasswordMigrationLabel();
+    slot_hidePasswordMigrationLabel();
 
     //double-click ignore
     QString ignore;
@@ -1406,7 +1406,7 @@ void dlgProfilePreferences::clearHostDetails()
 
     label_mapFileActionResult->hide();
 
-    hidePasswordMigrationLabel();
+    slot_hidePasswordMigrationLabel();
 
     doubleclick_ignore_lineedit->clear();
 
@@ -2305,7 +2305,7 @@ void dlgProfilePreferences::slot_hideActionLabel()
     label_mapFileActionResult->hide();
 }
 
-void dlgProfilePreferences::hidePasswordMigrationLabel()
+void dlgProfilePreferences::slot_hidePasswordMigrationLabel()
 {
     label_password_migration_notification->hide();
 }
@@ -3238,7 +3238,7 @@ void dlgProfilePreferences::slot_tabChanged(int tabIndex)
                         // perform unzipping in a worker thread so as not to freeze the UI
                         auto future = QtConcurrent::run(mudlet::unzip, tempThemesArchive->fileName(), mudlet::getMudletPath(mudlet::mainDataItemPath, qsl("edbee/")), temporaryDir.path());
                         auto watcher = new QFutureWatcher<bool>;
-                        QObject::connect(watcher, &QFutureWatcher<bool>::finished, this, [=]() {
+                        connect(watcher, &QFutureWatcher<bool>::finished, this, [=]() {
                             if (future.result()) {
                                 populateThemesList();
 
@@ -4193,10 +4193,10 @@ void dlgProfilePreferences::slot_enableDarkEditor(const QString& link)
         }
 
         // in case no theme index is available yet, so it as soon as one is available
-        KDToolBox::connectSingleShot(this, &dlgProfilePreferences::signal_themeUpdateCompleted,  [=]() {
-            auto monokaiIndex = code_editor_theme_selection_combobox->findText(darkTheme);
-            if (monokaiIndex != -1) {
-                code_editor_theme_selection_combobox->setCurrentIndex(monokaiIndex);
+        KDToolBox::connectSingleShot(this, &dlgProfilePreferences::signal_themeUpdateCompleted, this, [=]() {
+            auto index = code_editor_theme_selection_combobox->findText(darkTheme);
+            if (index != -1) {
+                code_editor_theme_selection_combobox->setCurrentIndex(index);
             }
         });
 

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -169,6 +169,7 @@ private slots:
     void slot_toggleMapDeleteButton(const bool);
     void slot_deleteMap();
     void slot_changeLargeAreaExitArrows(const bool);
+    void slot_hidePasswordMigrationLabel();
 
 signals:
     void signal_themeUpdateCompleted();
@@ -197,7 +198,6 @@ private:
     void disconnectHostRelatedControls();
     void generateMapGlyphDisplay();
     void generateDiscordTooltips();
-    void hidePasswordMigrationLabel();
     void setupPasswordsMigration();
     QString mapSaveLoadDirectory(Host* pHost);
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -524,13 +524,13 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     connect(mProfileSaveAsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_profileSaveAsAction);
 
     auto *nextSectionShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Tab), this);
-    QObject::connect(nextSectionShortcut, &QShortcut::activated, this, &dlgTriggerEditor::slot_nextSection);
+    connect(nextSectionShortcut, &QShortcut::activated, this, &dlgTriggerEditor::slot_nextSection);
 
     QShortcut *previousSectionShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Tab), this);
-    QObject::connect(previousSectionShortcut, &QShortcut::activated, this, &dlgTriggerEditor::slot_previousSection);
+    connect(previousSectionShortcut, &QShortcut::activated, this, &dlgTriggerEditor::slot_previousSection);
 
     QShortcut *activateMainWindowAction = new QShortcut(QKeySequence((Qt::ALT | Qt::Key_E)), this);
-    QObject::connect(activateMainWindowAction, &QShortcut::activated, this, &dlgTriggerEditor::slot_activateMainWindow);
+    connect(activateMainWindowAction, &QShortcut::activated, this, &dlgTriggerEditor::slot_activateMainWindow);
 
     toolBar = new QToolBar();
     toolBar2 = new QToolBar();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -475,7 +475,7 @@ mudlet::mudlet()
     connect(dactionDiscord, &QAction::triggered, this, &mudlet::slot_profileDiscord);
     connect(dactionMudletDiscord, &QAction::triggered, this, &mudlet::slot_mudletDiscord);
     connect(dactionLiveHelpChat, &QAction::triggered, this, &mudlet::slot_irc);
-    connect(dactionShowErrors, &QAction::triggered, [=]() {
+    connect(dactionShowErrors, &QAction::triggered, this, [=]() {
         auto host = getActiveHost();
         if (!host) {
             return;
@@ -3599,7 +3599,7 @@ void mudlet::slot_updateInstalled()
     disconnect(dactionUpdate, &QAction::triggered, this, nullptr);
 
     // rejig to restart Mudlet instead
-    QObject::connect(dactionUpdate, &QAction::triggered, this, [=]() {
+    connect(dactionUpdate, &QAction::triggered, this, [=]() {
         forceClose();
         QProcess::startDetached(qApp->arguments()[0], qApp->arguments());
     });
@@ -3822,11 +3822,11 @@ void mudlet::slot_passwordMigratedToPortableStorage(QKeychain::Job* job)
         writeProfileData(profileName, qsl("password"), readJob->textData());
 
         // delete from secure storage
-        auto *job = new QKeychain::DeletePasswordJob(qsl("Mudlet profile"));
-        job->setAutoDelete(true);
-        job->setKey(profileName);
-        job->setProperty("profile", profileName);
-        job->start();
+        auto *deleteJob = new QKeychain::DeletePasswordJob(qsl("Mudlet profile"));
+        deleteJob->setAutoDelete(true);
+        deleteJob->setKey(profileName);
+        deleteJob->setProperty("profile", profileName);
+        deleteJob->start();
     }
     mProfilePasswordsToMigrate.removeAll(profileName);
     job->deleteLater();

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -75,7 +75,7 @@ void Updater::checkUpdatesOnStart()
 #endif
 
     mDailyCheck->setInterval(12h);
-    QObject::connect(mDailyCheck.get(), &QTimer::timeout, this, [this] {
+    connect(mDailyCheck.get(), &QTimer::timeout, this, [this] {
           auto updates = feed->getUpdates(dblsqd::Release::getCurrentRelease());
           qWarning() << "Daily check for updates:" << updates.size() << "update(s) available";
           if (updates.isEmpty()) {
@@ -116,7 +116,7 @@ void Updater::manuallyCheckUpdates()
     msparkleUpdater->checkForUpdates();
 #else
     feed->load();
-    QObject::connect(feed, &dblsqd::Feed::ready, this, &Updater::showDialogManually);
+    connect(feed, &dblsqd::Feed::ready, this, &Updater::showDialogManually);
 #endif
 }
 
@@ -159,7 +159,7 @@ void Updater::setupOnMacOS()
 void Updater::setupOnWindows()
 {
     // Setup to automatically download the new release when an update is available
-    QObject::connect(feed, &dblsqd::Feed::ready, [=]() {
+    connect(feed, &dblsqd::Feed::ready, feed, [=]() {
         if (mudlet::scmIsDevelopmentVersion) {
             return;
         }
@@ -176,7 +176,7 @@ void Updater::setupOnWindows()
     });
 
     // Setup to run setup.exe to replace the old installation
-    QObject::connect(feed, &dblsqd::Feed::downloadFinished, [=]() {
+    connect(feed, &dblsqd::Feed::downloadFinished, this, [=]() {
         // if automatic updates are enabled, and this isn't a manual check, perform the automatic update
         if (!(updateAutomatically() && updateDialog->isHidden())) {
             return;
@@ -222,7 +222,7 @@ void Updater::setupOnLinux()
     // Setup to automatically download the new release when an update is
     // available or wave a flag when it is to be done manually
     // Setup to automatically download the new release when an update is available
-    QObject::connect(feed, &dblsqd::Feed::ready, this, [=]() {
+    connect(feed, &dblsqd::Feed::ready, this, [=]() {
         // don't update development builds to prevent auto-update from overwriting your
         // compiled binary while in development
         if (mudlet::scmIsDevelopmentVersion) {
@@ -242,7 +242,7 @@ void Updater::setupOnLinux()
     });
 
     // Setup to unzip and replace old binary when the download is done
-    QObject::connect(feed, &dblsqd::Feed::downloadFinished, this, [=]() {
+    connect(feed, &dblsqd::Feed::downloadFinished, this, [=]() {
         // if automatic updates are enabled, and this isn't a manual check, perform the automatic update
         if (!(updateAutomatically() && updateDialog->isHidden())) {
             return;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Clazy was picking up "connect-3arg-lambda" warnings, explained as item 3 here: https://www.kdab.com/nailing-13-signal-slot-mistakes-clazy-1-3 .

#### Motivation for adding to Mudlet
It seemed to fix crashes I was getting when I was trying to change the password secure storage setting, see:
https://github.com/Mudlet/Mudlet/issues/6671#issuecomment-1483211392 however those were not happening every time - but that could be down to which threads the two ends of a connect was happening on, which the extra argument helps to determine AFAICT.

I also think it might help in other places where we were getting odd crashes - maybe even #6671 ?

Also:
* remove some redundant `QObject` prepended to `connect(...)` calls
* rename some arguments passed into some lambda so that they do not shadow other variables in the parent methods.
* identify `dlgProfilePreferences::hidePasswordMigrationLabel()` as a Qt SLOT, renamed to `slot_hidePasswordMigrationLabel()`.
