### PR TITLE
Infrastructure: bump clang-tidy-review action to 0.12.2

### DIFF
--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -122,7 +122,7 @@ jobs:
           --target autogen
 
     - name: Check C++ changes against style guide
-      uses: ZedThree/clang-tidy-review@v0.12.1
+      uses: ZedThree/clang-tidy-review@v0.12.2
       id: static_analysis
       with:
         build_dir: 'b/ninja' # path is relative to checkout directory
@@ -133,4 +133,4 @@ jobs:
         split_workflow: true
 
     - name: Upload check results
-      uses: ZedThree/clang-tidy-review/upload@v0.12.1
+      uses: ZedThree/clang-tidy-review/upload@v0.12.2

--- a/.github/workflows/clangtidy-post-comments.yml
+++ b/.github/workflows/clangtidy-post-comments.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: ZedThree/clang-tidy-review/post@v0.12.1
+      - uses: ZedThree/clang-tidy-review/post@v0.12.2


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Bump clang-tidy-review action to 0.12.2
#### Motivation for adding to Mudlet
I fixed a bug in the plugin's parsing that [didn't allow spaces](https://github.com/Mudlet/Mudlet/actions/runs/4525770548/jobs/7970489216?pr=6698#step:13:39) in package configuration
#### Other info (issues closed, discussion etc)
