### PR TITLE
Fix: do not use the profile name, url or port in game save files

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1771,9 +1771,6 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, int modul
         for (auto& entry : entries) {
             file2.setFileName(entry.absoluteFilePath());
             file2.open(QFile::ReadOnly | QFile::Text);
-            QString profileName = getName();
-            QString login = getLogin();
-            QString pass = getPass();
             XMLimport reader(this);
             if (module) {
                 QStringList moduleEntry;
@@ -1785,18 +1782,12 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, int modul
                 mInstalledPackages.append(packageName);
             }
             reader.importPackage(&file2, packageName, module); // TODO: Missing false return value handler
-            setName(profileName);
-            setLogin(login);
-            setPass(pass);
             file2.close();
         }
     } else {
         file2.setFileName(fileName);
         file2.open(QFile::ReadOnly | QFile::Text);
         //mInstalledPackages.append( packageName );
-        QString profileName = getName();
-        QString login = getLogin();
-        QString pass = getPass();
         XMLimport reader(this);
         if (module) {
             QStringList moduleEntry;
@@ -1808,9 +1799,6 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, int modul
             mInstalledPackages.append(packageName);
         }
         reader.importPackage(&file2, packageName, module); // TODO: Missing false return value handler
-        setName(profileName);
-        setLogin(login);
-        setPass(pass);
         file2.close();
     }
     if (mpEditorDialog) {

--- a/src/Host.h
+++ b/src/Host.h
@@ -523,6 +523,10 @@ public:
 
     QString mUrl;
 
+    QString mBackupHostName;
+    int mBackupPort = 23;
+    QString mBackupUrl;
+
     bool mUSE_FORCE_LF_AFTER_PROMPT;
     bool mUSE_IRE_DRIVER_BUGFIX;
     bool mUSE_UNIX_EOL;

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -486,8 +486,6 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     }
 
     { // Blocked so that indentation reflects that of the XML file
-        host.append_child("name").text().set(pHost->mHostName.toUtf8().constData());
-
         auto mInstalledPackages = host.append_child("mInstalledPackages");
 
         for (int i = 0; i < pHost->mInstalledPackages.size(); ++i) {
@@ -517,10 +515,8 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
             }
         }
 
-        host.append_child("url").text().set(pHost->mUrl.toUtf8().constData());
         host.append_child("serverPackageName").text().set(pHost->mServerGUI_Package_name.toUtf8().constData());
         host.append_child("serverPackageVersion").text().set(pHost->mServerGUI_Package_version.toUtf8().constData());
-        host.append_child("port").text().set(QString::number(pHost->mPort).toUtf8().constData());
         auto borders = pHost->borders();
         host.append_child("borderTopHeight").text().set(QString::number(borders.top()).toUtf8().constData());
         host.append_child("borderBottomHeight").text().set(QString::number(borders.bottom()).toUtf8().constData());

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -486,6 +486,8 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     }
 
     { // Blocked so that indentation reflects that of the XML file
+        host.append_child("name").text().set(pHost->mHostName.toUtf8().constData());
+
         auto mInstalledPackages = host.append_child("mInstalledPackages");
 
         for (int i = 0; i < pHost->mInstalledPackages.size(); ++i) {
@@ -515,8 +517,10 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
             }
         }
 
+        host.append_child("url").text().set(pHost->mUrl.toUtf8().constData());
         host.append_child("serverPackageName").text().set(pHost->mServerGUI_Package_name.toUtf8().constData());
         host.append_child("serverPackageVersion").text().set(pHost->mServerGUI_Package_version.toUtf8().constData());
+        host.append_child("port").text().set(QString::number(pHost->mPort).toUtf8().constData());
         auto borders = pHost->borders();
         host.append_child("borderTopHeight").text().set(QString::number(borders.top()).toUtf8().constData());
         host.append_child("borderBottomHeight").text().set(QString::number(borders.bottom()).toUtf8().constData());

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -956,7 +956,13 @@ void XMLimport::readHost(Host* pHost)
         }
         if (isStartElement()) {
             if (name() == qsl("name")) {
-                pHost->mHostName = readElementText();
+                // Ignore this detail it has been removed from the Xml format
+                // as it is actually stored outside of the game save in the
+                // profile base directory but will appear in older files and
+                // trip the QDebug() error reporting associated with the
+                // following readUnknownElement(...) for "anything not otherwise
+                // parsed":
+                Q_UNUSED(readElementText())
             } else if (name() == qsl("mInstalledModules")) {
                 QMap<QString, QStringList> entry;
 
@@ -975,13 +981,25 @@ void XMLimport::readHost(Host* pHost)
             } else if (name() == qsl("mInstalledPackages")) {
                 readStringList(pHost->mInstalledPackages, qsl("Host"));
             } else if (name() == qsl("url")) {
-                pHost->mUrl = readElementText();
+                // Ignore this detail it has been removed from the Xml format
+                // as it is actually stored outside of the game save in the
+                // profile base directory but will appear in older files and
+                // trip the QDebug() error reporting associated with the
+                // following readUnknownElement(...) for "anything not otherwise
+                // parsed":
+                Q_UNUSED(readElementText())
             } else if (name() == qsl("serverPackageName")) {
                 pHost->mServerGUI_Package_name = readElementText();
             } else if (name() == qsl("serverPackageVersion")) {
                 pHost->mServerGUI_Package_version = readElementText();
             } else if (name() == qsl("port")) {
-                pHost->mPort = readElementText().toInt();
+                // Ignore this detail it has been removed from the Xml format
+                // as it is actually stored outside of the game save in the
+                // profile base directory but will appear in older files and
+                // trip the QDebug() error reporting associated with the
+                // following readUnknownElement(...) for "anything not otherwise
+                // parsed":
+                Q_UNUSED(readElementText())
             } else if (name() == qsl("borderTopHeight")) {
                 borders.setTop(readElementText().toInt());
             } else if (name() == qsl("borderBottomHeight")) {
@@ -1057,7 +1075,7 @@ void XMLimport::readHost(Host* pHost)
                 // the Xml format but will appear in older files and trip the
                 // QDebug() error reporting associated with the following
                 // readUnknownElement(...) for "anything not otherwise parsed"
-                Q_UNUSED(readElementText());
+                Q_UNUSED(readElementText())
             } else if (name() == qsl("mFgColor2")) {
                 pHost->mFgColor_2.setNamedColor(readElementText());
             } else if (name() == qsl("mBgColor2")) {

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -956,13 +956,12 @@ void XMLimport::readHost(Host* pHost)
         }
         if (isStartElement()) {
             if (name() == qsl("name")) {
-                // Ignore this detail it has been removed from the Xml format
-                // as it is actually stored outside of the game save in the
-                // profile base directory but will appear in older files and
-                // trip the QDebug() error reporting associated with the
-                // following readUnknownElement(...) for "anything not otherwise
-                // parsed":
-                Q_UNUSED(readElementText())
+                // Only read this detail into a backup location so that it can
+                // be imported without changing the main setting unless it is
+                // needed (intended for use when importing a profile but not
+                // otherwise). In fact this detail is normally stored outside of
+                // the game save in the profile base directory:
+                pHost->mBackupHostName = readElementText();
             } else if (name() == qsl("mInstalledModules")) {
                 QMap<QString, QStringList> entry;
 
@@ -981,25 +980,23 @@ void XMLimport::readHost(Host* pHost)
             } else if (name() == qsl("mInstalledPackages")) {
                 readStringList(pHost->mInstalledPackages, qsl("Host"));
             } else if (name() == qsl("url")) {
-                // Ignore this detail it has been removed from the Xml format
-                // as it is actually stored outside of the game save in the
-                // profile base directory but will appear in older files and
-                // trip the QDebug() error reporting associated with the
-                // following readUnknownElement(...) for "anything not otherwise
-                // parsed":
-                Q_UNUSED(readElementText())
+                // Only read this detail into a backup location so that it can
+                // be imported without changing the main setting unless it is
+                // needed (intended for use when importing a profile but not
+                // otherwise). In fact this detail is normally stored outside of
+                // the game save in the profile base directory:
+                pHost->mBackupUrl = readElementText();
             } else if (name() == qsl("serverPackageName")) {
                 pHost->mServerGUI_Package_name = readElementText();
             } else if (name() == qsl("serverPackageVersion")) {
                 pHost->mServerGUI_Package_version = readElementText();
             } else if (name() == qsl("port")) {
-                // Ignore this detail it has been removed from the Xml format
-                // as it is actually stored outside of the game save in the
-                // profile base directory but will appear in older files and
-                // trip the QDebug() error reporting associated with the
-                // following readUnknownElement(...) for "anything not otherwise
-                // parsed":
-                Q_UNUSED(readElementText())
+                // Only read this detail into a backup location so that it can
+                // be imported without changing the main setting unless it is
+                // needed (intended for use when importing a profile but not
+                // otherwise). In fact this detail is normally stored outside of
+                // the game save in the profile base directory:
+                pHost->mBackupPort = readElementText().toInt();
             } else if (name() == qsl("borderTopHeight")) {
                 borders.setTop(readElementText().toInt());
             } else if (name() == qsl("borderBottomHeight")) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This is counterproductive as the data is supposed to be stored in the base directory of the profile and changes made in the "Connect profile" dialog get overridden by the game save.

#### Motivation for adding to Mudlet
I nearly got banned for multi-playing on a Server because I was working on a separate issue related to multiple auto loading profiles and two of the profiles I normally used had been edited to set the URL to `localhost` but when the profiles were autoloaded they used the stored settings and promptly BOTH connected to the Game server - waking up its anti- multi-playing detection!

As the profile name is not now being stored within the profile save file there is no need to backup and then restore it when installing a package, so code to do that and the same for the character name and login password is also removed from `Host::installPackage(...)`.
