### PR TITLE
Fix: instability when auto-loading multiple profiles

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -4086,11 +4086,11 @@ void Host::setCaretEnabled(bool enabled) {
 
 void Host::setFocusOnHostActiveCommandLine()
 {
-    if (mPendingSetFocusOnCommandLine) {
+    if (mFocusTimerRunning) {
         return;
     }
 
-    mPendingSetFocusOnCommandLine = true;
+    mFocusTimerRunning = true;
     QTimer::singleShot(0, this, [this]() {
         auto pCommandLine = activeCommandLine();
         if (pCommandLine) {
@@ -4106,7 +4106,7 @@ void Host::setFocusOnHostActiveCommandLine()
             mpConsole->repaint();
             mpConsole->mpCommandLine->setFocus(Qt::OtherFocusReason);
         }
-        mPendingSetFocusOnCommandLine = false;
+        mFocusTimerRunning = false;
     });
 }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -4098,6 +4098,11 @@ void Host::setCaretEnabled(bool enabled) {
 
 void Host::setFocusOnHostActiveCommandLine()
 {
+    if (mPendingSetFocusOnCommandLine) {
+        return;
+    }
+
+    mPendingSetFocusOnCommandLine = true;
     QTimer::singleShot(0, this, [this]() {
         auto pCommandLine = activeCommandLine();
         if (pCommandLine) {
@@ -4113,6 +4118,7 @@ void Host::setFocusOnHostActiveCommandLine()
             mpConsole->repaint();
             mpConsole->mpCommandLine->setFocus(Qt::OtherFocusReason);
         }
+        mPendingSetFocusOnCommandLine = false;
     });
 }
 

--- a/src/Host.h
+++ b/src/Host.h
@@ -867,7 +867,10 @@ private:
     // return to it when switching between profiles:
     QStack<QPointer<TCommandLine>> mpLastCommandLineUsed;
 
-    bool mPendingSetFocusOnCommandLine = false;
+    // ensures that only one "zero-time" timer is created by the lambda in
+    // setFocusOnHostActiveCommandLine(), even when it is called multiple
+    // times:
+    bool mFocusTimerRunning = false;
 
     QMargins mBorders;
 };

--- a/src/Host.h
+++ b/src/Host.h
@@ -863,6 +863,8 @@ private:
     // return to it when switching between profiles:
     QStack<QPointer<TCommandLine>> mpLastCommandLineUsed;
 
+    bool mPendingSetFocusOnCommandLine = false;
+
     QMargins mBorders;
 };
 

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -564,8 +564,6 @@ void TCommandLine::focusInEvent(QFocusEvent* event)
         mpHost->recordActiveCommandLine(this);
     }
 
-    mudlet::self()->activateProfile(mpHost);
-
     QPlainTextEdit::focusInEvent(event);
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1440,6 +1440,12 @@ void mudlet::addConsoleForNewHost(Host* pH)
     QResizeEvent event(s, s);
     updateDiscordNamedIcon();
     QApplication::sendEvent(pH->mpConsole, &event);
+    // This is needed to completely show the first autoloaded profile so that
+    // it can be properly hidden by a second one (without it the:
+    // mpCurrentActiveHost->mpConsole->hide() does not work correctly and two
+    // profiles get shown across a split screen - even though mMultiView is NOT
+    // set)!
+    qApp->processEvents();
 }
 
 


### PR DESCRIPTION
This tries to avoid multiple single shot timers from being created to move the focus on the appropriate command line of a particular profile. However the actual fix in the situation of autoloading profiles is to remove the code that generated a call to switch to a profile in the focusInEvent for the `TCommandLine` class - in combination these two changes should prevent the unstable, and continuous, oscillation between two profiles I saw before making these changes. This should close #6669.

Furthermore during the creation of the first profile something was not being completed that meant the profile was not capable of being hidden when a second profile was loaded afterwards. This can be corrected by allowing pending events (such as pending "zero-timers") to complete, this may improve #6392...

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
