### PR TITLE
fix false bold look by removing transparency when copying as image

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1707,7 +1707,9 @@ void TTextEdit::slot_copySelectionToClipboardImage()
     auto widthpx = std::min(65500, largestLine);
     auto rect = QRect(mPA.x(), mPA.y(), widthpx, heightpx);
     auto pixmap = QPixmap(widthpx, heightpx);
-    pixmap.fill(mBgColor);
+    auto solidColor = QColor(mBgColor);
+    solidColor.setAlpha(255);
+    pixmap.fill(solidColor);
 
     QPainter painter(&pixmap);
     if (!painter.isActive()) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
When you copy as image, it retains transparency.  Many programs do not understand transparency.  As a result, it looks as though it is painted as bold.  Currently the first step in building the image is painting background color.  My change will make a copy of the background color and turn off transparency and use that copy instead, when it fills the box with the bottom layer initial color. 
#### Motivation for adding to Mudlet
Fix #5925 
#### Other info (issues closed, discussion etc)
To illustrate the old behavior, I made a button that prints a few lines, ran it on Windows 10 and on Ubuntu.  I pasted the Ubuntu one over to Discord so I could lay this all out on Windows.  Here is screenshot:
![image](https://user-images.githubusercontent.com/29287358/229197014-39eb8495-8644-4d05-8efb-e4c1d6f281bc.png)
I pasted the same thing into Inkscape and Paint on the right there, plus into Discord web client on the top left.  I ran the same thing on Ubuntu and pasted it into Discord native client, that's the second picture in the chat on left.  Opened both of those Discord pics into their own browser windows.  Then I have Mudlet itself in there.

Long story short, the current behavior is sensible and puts transparency onto the clipboard, so it can look good pasted into some stuff.  But it looks bad when fed into other stuff.  Also the web version of Discord (Chrome on Win 10) messes it up while the Discord app (on Ubuntu at least) preserves it properly.  Really this is disabling a feature, but it's a weird feature that I don't know if anyone even utilizes it, and makes it seem broken.