### PR TITLE
Fix: don't specify DejaVu fonts

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -344,23 +344,29 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     mpLineEdit_networkLatency->setContentsMargins(0, 0, 0, 0);
     mpLineEdit_networkLatency->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
 
-    QFont latencyFont = QFont("Bitstream Vera Sans Mono", 10, QFont::Normal);
-    int width;
-    int maxWidth = 120;
-    width = QFontMetrics(latencyFont).boundingRect(QString("N:0.000 S:0.000")).width();
-    if (width < maxWidth) {
-        mpLineEdit_networkLatency->setFont(latencyFont);
-    } else {
-        QFont latencyFont2 = QFont("Bitstream Vera Sans Mono", 9, QFont::Normal);
-        width = QFontMetrics(latencyFont2).boundingRect(QString("N:0.000 S:0.000")).width();
-        if (width < maxWidth) {
-            mpLineEdit_networkLatency->setFont(latencyFont2);
-        } else {
-            QFont latencyFont3 = QFont("Bitstream Vera Sans Mono", 8, QFont::Normal);
-            width = QFontMetrics(latencyFont3).boundingRect(QString("N:0.000 S:0.000")).width();
-            mpLineEdit_networkLatency->setFont(latencyFont3);
-        }
-    }
+    int latencyFontPointSize = 21;
+    const int latencyFontSizeMargin = 10;
+    QString dummyTextA = tr("N:%1 S:%2",
+                            // intentional comment to separate arguments
+                            "The first argument 'N' represents the 'N'etwork latency; the second 'S' the "
+                            "'S'ystem (processing) time")
+                         .arg(0.0, 0, 'f', 3)
+                         .arg(0.0, 0, 'f', 3);
+    QString dummyTextB = tr("<no GA> S:%1",
+                            // intentional comment to separate arguments
+                            "The argument 'S' represents the 'S'ystem (processing) time, in this situation "
+                            "the Game Server is not sending \"GoAhead\" signals so we cannot deduce the "
+                            "network latency...")
+                         .arg(0.0, 0, 'f', 3);
+    QFont latencyFont = QFont(qsl("Bitstream Vera Sans Mono"), latencyFontPointSize, QFont::Normal);
+    do {
+        latencyFont.setPointSize(--latencyFontPointSize);
+    } while (latencyFontPointSize > 6
+             && qMax(QFontMetrics(latencyFont).boundingRect(dummyTextA).width(),
+                     QFontMetrics(latencyFont).boundingRect(dummyTextB).width()) + latencyFontSizeMargin
+             > mpLineEdit_networkLatency->maximumWidth());
+
+    mpLineEdit_networkLatency->setFont(latencyFont);
 
     emergencyStop->setMinimumSize(QSize(30, 30));
     emergencyStop->setMaximumSize(QSize(30, 30));

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -71,7 +71,6 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
 , mpMainDisplay(new QWidget(mpMainFrame))
 , mpScrollBar(new QScrollBar)
 , mpHScrollBar(new QScrollBar(Qt::Horizontal))
-, mpLineEdit_networkLatency(new QLineEdit)
 , mProfileName(mpHost ? mpHost->getName() : qsl("debug console"))
 , mpBufferSearchBox(new QLineEdit)
 , mpBufferSearchUp(new QToolButton)
@@ -333,40 +332,44 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     logButton->setIcon(logIcon);
     connect(logButton, &QAbstractButton::clicked, this, &TConsole::slot_toggleLogging);
 
-    mpLineEdit_networkLatency->setReadOnly(true);
-    mpLineEdit_networkLatency->setSizePolicy(sizePolicy4);
-    mpLineEdit_networkLatency->setFocusPolicy(Qt::NoFocus);
-    mpLineEdit_networkLatency->setToolTip(utils::richText(tr("<i>N:</i> is the latency of the game server and network (aka ping, in seconds),<br>"
-                                                             "<i>S:</i> is the system processing time - how long your triggers took to process the last line(s).")));
-    mpLineEdit_networkLatency->setMaximumSize(120, 30);
-    mpLineEdit_networkLatency->setMinimumSize(120, 30);
-    mpLineEdit_networkLatency->setAutoFillBackground(true);
-    mpLineEdit_networkLatency->setContentsMargins(0, 0, 0, 0);
-    mpLineEdit_networkLatency->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
+    if (mType == MainConsole) {
+        mpLineEdit_networkLatency = new QLineEdit(this);
+        mpLineEdit_networkLatency->setReadOnly(true);
+        mpLineEdit_networkLatency->setSizePolicy(sizePolicy4);
+        mpLineEdit_networkLatency->setFocusPolicy(Qt::NoFocus);
+        mpLineEdit_networkLatency->setToolTip(utils::richText(tr("<i>N:</i> is the latency of the game server and network (aka ping, in seconds),<br>"
+                                                                 "<i>S:</i> is the system processing time - how long your triggers took to process the last line(s).")));
+        mpLineEdit_networkLatency->setMaximumSize(120, 30);
+        mpLineEdit_networkLatency->setMinimumSize(120, 30);
+        mpLineEdit_networkLatency->setAutoFillBackground(true);
+        mpLineEdit_networkLatency->setContentsMargins(0, 0, 0, 0);
+        mpLineEdit_networkLatency->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
 
-    int latencyFontPointSize = 21;
-    const int latencyFontSizeMargin = 10;
-    QString dummyTextA = tr("N:%1 S:%2",
-                            // intentional comment to separate arguments
-                            "The first argument 'N' represents the 'N'etwork latency; the second 'S' the "
-                            "'S'ystem (processing) time")
-                         .arg(0.0, 0, 'f', 3)
-                         .arg(0.0, 0, 'f', 3);
-    QString dummyTextB = tr("<no GA> S:%1",
-                            // intentional comment to separate arguments
-                            "The argument 'S' represents the 'S'ystem (processing) time, in this situation "
-                            "the Game Server is not sending \"GoAhead\" signals so we cannot deduce the "
-                            "network latency...")
-                         .arg(0.0, 0, 'f', 3);
-    QFont latencyFont = QFont(qsl("Bitstream Vera Sans Mono"), latencyFontPointSize, QFont::Normal);
-    do {
-        latencyFont.setPointSize(--latencyFontPointSize);
-    } while (latencyFontPointSize > 6
-             && qMax(QFontMetrics(latencyFont).boundingRect(dummyTextA).width(),
-                     QFontMetrics(latencyFont).boundingRect(dummyTextB).width()) + latencyFontSizeMargin
-             > mpLineEdit_networkLatency->maximumWidth());
+        int latencyFontPointSize = 21;
+        QFont latencyFont = QFont(qsl("Bitstream Vera Sans Mono"), latencyFontPointSize, QFont::Normal);
+        const int latencyFontSizeMargin = 10;
+        QString dummyTextA = tr("N:%1 S:%2",
+                                // intentional comment to separate arguments
+                                "The first argument 'N' represents the 'N'etwork latency; the second 'S' the "
+                                "'S'ystem (processing) time")
+                                     .arg(0.0, 0, 'f', 3)
+                                     .arg(0.0, 0, 'f', 3);
+        QString dummyTextB = tr("<no GA> S:%1",
+                                // intentional comment to separate arguments
+                                "The argument 'S' represents the 'S'ystem (processing) time, in this situation "
+                                "the Game Server is not sending \"GoAhead\" signals so we cannot deduce the "
+                                "network latency...")
+                                     .arg(0.0, 0, 'f', 3);
+        do {
+            latencyFont.setPointSize(--latencyFontPointSize);
+        } while (latencyFontPointSize > 6
+                 && qMax(QFontMetrics(latencyFont).boundingRect(dummyTextA).width(),
+                         QFontMetrics(latencyFont).boundingRect(dummyTextB).width()) + latencyFontSizeMargin
+                            > mpLineEdit_networkLatency->maximumWidth());
 
-    mpLineEdit_networkLatency->setFont(latencyFont);
+        mpLineEdit_networkLatency->setFont(latencyFont);
+        mpLineEdit_networkLatency->setFrame(false);
+    }
 
     emergencyStop->setMinimumSize(QSize(30, 30));
     emergencyStop->setMaximumSize(QSize(30, 30));
@@ -441,10 +444,12 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     layoutButtonLayer->addWidget(replayButton, 0, 8);
     layoutButtonLayer->addWidget(logButton, 0, 9);
     layoutButtonLayer->addWidget(emergencyStop, 0, 10);
-    layoutButtonLayer->addWidget(mpLineEdit_networkLatency, 0, 11);
+    if (mType == MainConsole) {
+        // In fact a whole lot more could be inside this "if"!
+        layoutButtonLayer->addWidget(mpLineEdit_networkLatency, 0, 11);
+    }
     layoutLayer2->setContentsMargins(0, 0, 0, 0);
     layout->addWidget(layer);
-    mpLineEdit_networkLatency->setFrame(false);
     layerCommandLine->setAutoFillBackground(true);
 
     centralLayout->addWidget(layerCommandLine);

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -1145,6 +1145,7 @@ bool TMainConsole::setTextFormat(const QString& name, const QColor& fgColor, con
 
 void TMainConsole::printOnDisplay(std::string& incomingSocketData, const bool isFromServer)
 {
+    Q_ASSERT_X(mpLineEdit_networkLatency, "TMainConsole::printOnDisplay(...)", "mpLineEdit_networkLatency does not point to a valid QLineEdit");
     mProcessingTimer.restart();
     mTriggerEngineMode = true;
     buffer.translateToPlainText(incomingSocketData, isFromServer);

--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -51,7 +51,7 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent)
 
         bool isWithinSpace = false;
         while (!isWithinSpace) {
-            QFont font(qsl("DejaVu Serif"), fontSize, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
+            QFont font(qsl("Bitstream Vera Serif"), fontSize, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
             QTextLayout versionTextLayout(sourceVersionText, font, painter.device());
             versionTextLayout.beginLayout();
             // Start work in this text item
@@ -86,7 +86,7 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent)
         // Repeat for other text, but we know it will fit at given size
         // PLACEMARKER: Date-stamp needing annual update
         QString sourceCopyrightText = qsl("©️ Mudlet makers 2008-2023");
-        QFont font(qsl("DejaVu Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
+        QFont font(qsl("Bitstream Vera Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
         QTextLayout copyrightTextLayout(sourceCopyrightText, font, painter.device());
         copyrightTextLayout.beginLayout();
         QTextLine copyrightTextline = copyrightTextLayout.createLine();
@@ -117,11 +117,11 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent)
     // clang-format off
     QString htmlHead(qsl(R"(
         <head><style type="text/css">
-        h1 { font-family: "DejaVu Serif"; text-align: center; }
-        h2 { font-family: "DejaVu Serif"; text-align: center; }
-        h3 { font-family: "DejaVu Serif"; text-align: center; white-space: pre-wrap; }
-        h4 { font-family: "DejaVu Serif"; white-space: pre-wrap; }
-        p { font-family: "DejaVu Serif" }
+        h1 { font-family: "Bitstream Vera Serif"; text-align: center; }
+        h2 { font-family: "Bitstream Vera Serif"; text-align: center; }
+        h3 { font-family: "Bitstream Vera Serif"; text-align: center; white-space: pre-wrap; }
+        h4 { font-family: "Bitstream Vera Serif"; white-space: pre-wrap; }
+        p { font-family: "Bitstream Vera Serif" }
         tt { font-family: "Monospace"; white-space: pre-wrap; }
         .container { text-align: center; }
         </style></head>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -384,7 +384,7 @@ int main(int argc, char* argv[])
 
         bool isWithinSpace = false;
         while (!isWithinSpace) {
-            QFont font("DejaVu Serif", fontSize, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
+            QFont font("Bitstream Vera Serif", fontSize, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
             QTextLayout versionTextLayout(sourceVersionText, font, painter.device());
             versionTextLayout.beginLayout();
             // Start work in this text item
@@ -419,7 +419,7 @@ int main(int argc, char* argv[])
         // Repeat for other text, but we know it will fit at given size
         // PLACEMARKER: Date-stamp needing annual update
         QString sourceCopyrightText = qsl("©️ Mudlet makers 2008-2023");
-        QFont font(qsl("DejaVu Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
+        QFont font(qsl("Bitstream Vera Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
         QTextLayout copyrightTextLayout(sourceCopyrightText, font, painter.device());
         copyrightTextLayout.beginLayout();
         QTextLine copyrightTextline = copyrightTextLayout.createLine();

--- a/src/ui/about_dialog.ui
+++ b/src/ui/about_dialog.ui
@@ -30,7 +30,7 @@
   </property>
   <property name="font">
    <font>
-    <family>DejaVu Sans</family>
+    <family>Bitstream Vera Sans</family>
     <pointsize>10</pointsize>
    </font>
   </property>
@@ -47,66 +47,44 @@
   <property name="autoFillBackground">
    <bool>true</bool>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QFrame" name="frame">
+  <layout class="QHBoxLayout" name="horizontalLayout_main" stretch="0,1">
+   <item>
+    <widget class="QLabel" name="mudletTitleLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="minimumSize">
       <size>
        <width>320</width>
        <height>360</height>
       </size>
      </property>
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
+     <property name="font">
+      <font>
+       <pointsize>15</pointsize>
+      </font>
      </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
+     <property name="contextMenuPolicy">
+      <enum>Qt::NoContextMenu</enum>
      </property>
-     <widget class="QLabel" name="mudletTitleLabel">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>320</width>
-        <height>360</height>
-       </rect>
-      </property>
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>320</width>
-        <height>360</height>
-       </size>
-      </property>
-      <property name="font">
-       <font>
-        <pointsize>15</pointsize>
-       </font>
-      </property>
-      <property name="contextMenuPolicy">
-       <enum>Qt::NoContextMenu</enum>
-      </property>
-      <property name="autoFillBackground">
-       <bool>false</bool>
-      </property>
-      <property name="text">
-       <string/>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignBottom|Qt::AlignHCenter</set>
-      </property>
-      <property name="textInteractionFlags">
-       <set>Qt::NoTextInteraction</set>
-      </property>
-     </widget>
+     <property name="autoFillBackground">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignBottom|Qt::AlignHCenter</set>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::NoTextInteraction</set>
+     </property>
     </widget>
    </item>
-   <item row="0" column="1">
+   <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
       <number>0</number>
@@ -121,7 +99,7 @@
       <attribute name="title">
        <string>Mudlet</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0">
+      <layout class="QVBoxLayout" name="verticalLayout_tab_mudlet" stretch="0">
        <property name="spacing">
         <number>0</number>
        </property>
@@ -153,7 +131,6 @@
          </property>
          <property name="font">
           <font>
-           <family>DejaVu Sans</family>
            <pointsize>9</pointsize>
           </font>
          </property>
@@ -184,7 +161,7 @@
       <attribute name="title">
        <string>Supporters</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_4">
+      <layout class="QVBoxLayout" name="verticalLayout_tab_supporters">
        <property name="spacing">
         <number>0</number>
        </property>
@@ -213,7 +190,7 @@
       <attribute name="title">
        <string>License</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout">
+      <layout class="QVBoxLayout" name="verticalLayout_tab_license">
        <property name="spacing">
         <number>0</number>
        </property>
@@ -248,7 +225,7 @@
       <attribute name="title">
        <string>Third Party</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
+      <layout class="QVBoxLayout" name="verticalLayout_tab_license_3rdparty">
        <property name="spacing">
         <number>0</number>
        </property>

--- a/src/ui/actions_main_area.ui
+++ b/src/ui/actions_main_area.ui
@@ -339,7 +339,6 @@
         </property>
         <property name="font">
          <font>
-          <family>Bitstream Vera Sans Mono</family>
           <pointsize>8</pointsize>
          </font>
         </property>

--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -16,6 +16,11 @@
     <height>0</height>
    </size>
   </property>
+  <property name="font">
+   <font>
+    <family>Bitstream Vera Sans</family>
+   </font>
+  </property>
   <property name="windowTitle">
    <string>Select a profile to connect with</string>
   </property>
@@ -127,7 +132,6 @@
            </property>
            <property name="font">
             <font>
-             <family>Arial Black</family>
              <pointsize>16</pointsize>
              <stylestrategy>PreferAntialias</stylestrategy>
             </font>
@@ -278,7 +282,6 @@
               </property>
               <property name="font">
                <font>
-                <family>Arial</family>
                 <pointsize>8</pointsize>
                 <stylestrategy>PreferAntialias</stylestrategy>
                </font>
@@ -499,7 +502,6 @@
                </property>
                <property name="font">
                 <font>
-                 <family>Bitstream Charter</family>
                  <pointsize>9</pointsize>
                 </font>
                </property>
@@ -549,7 +551,6 @@
                </property>
                <property name="font">
                 <font>
-                 <family>Bitstream Charter</family>
                  <pointsize>9</pointsize>
                 </font>
                </property>
@@ -565,7 +566,6 @@
               <widget class="QLineEdit" name="profile_name_entry">
                <property name="font">
                 <font>
-                 <family>Bitstream Charter</family>
                  <pointsize>9</pointsize>
                 </font>
                </property>
@@ -832,7 +832,6 @@
               </property>
               <property name="font">
                <font>
-                <family>DejaVu Sans</family>
                 <pointsize>9</pointsize>
                </font>
               </property>

--- a/src/ui/source_editor_area.ui
+++ b/src/ui/source_editor_area.ui
@@ -49,12 +49,6 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="font">
-      <font>
-       <family>Courier New</family>
-       <pointsize>11</pointsize>
-      </font>
-     </property>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
#### Overview of PR changes/additions & motivation for adding to Mudlet
I spotted on the MUME Discord that they were wondering about why mentions of Deja Vu fonts were occuring in some files (HTML?) that Mudlet was using/ producing on Windows machines. I remembered that we shipped a few fonts but noticed that we bundle the earlier "Bitstream Vera" fonts (which were one of the contributors to the DejaVu ones) and that we do NOT include the latter.  As such it isn't sensible for us to specify (in the places that we do) the DejaVu font when the bundled Bitstream one is suitable. In checking for places where we do mention a font I spotted that there were some probably bogus ones in some Qt Designer forms/dialogs for specific widgets that should probably be removed so that a parent one for the whole dialogue (if provided) was used - leaving a size parameter where that was wanted.

#### Other info (issues closed, discussion etc)
Whilst working on this I spotted some issues with the way the size of the font used to draw the network and system latencies was calculated was done. The "dummy" version of the text used in a three size test was not denoted as translatable texts so the width that the process would decide upon would not match the translated text used in non-en locales and also it only tried three different sizes - which might not be optimum for some locales. I refactored and redesigned this bit of code to use a loop and try more sizes and use the translated form of the text!
