### PR TITLE
Fix: allow search highlighting to be undone

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2878,6 +2878,9 @@ void TBuffer::shrinkBuffer()
         buffer.pop_front();
         mCursorY--;
     }
+    // We need to adjust the search result line as some lines have now gone
+    // away:
+    mpConsole->mCurrentSearchResult = qMax(0, mpConsole->mCurrentSearchResult - mBatchDeleteSize);
 
     if (mpConsole->getType() & (TConsole::MainConsole|TConsole::UserWindow|TConsole::SubConsole|TConsole::Buffer)) {
         // Signal to lua subsystem that indexes into the Console will need adjusting
@@ -3078,9 +3081,8 @@ bool TBuffer::applyBgColor(const QPoint& P_begin, const QPoint& P_end, const QCo
             }
         }
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 QStringList TBuffer::getEndLines(int n)
@@ -4194,4 +4196,13 @@ int TBuffer::lengthInGraphemes(const QString& text)
 const QList<QByteArray> TBuffer::getEncodingNames()
 {
      return csmEncodingTable.getEncodingNames();
+}
+
+void TBuffer::clearSearchHighlights()
+{
+    for (auto& line : buffer) {
+        for (auto& character : line) {
+            character.mFlags &= ~TChar::AttributeFlag::SearchFind;
+        }
+    }
 }

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2018, 2020, 2022 by Stephen Lyons                        *
+ *   Copyright (C) 2014-2018, 2020, 2022-2023 by Stephen Lyons             *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -4202,7 +4202,7 @@ void TBuffer::clearSearchHighlights()
 {
     for (auto& line : buffer) {
         for (auto& character : line) {
-            character.mFlags &= ~TChar::AttributeFlag::SearchFind;
+            character.mFlags &= ~TChar::AttributeFlag::Found;
         }
     }
 }

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015, 2017-2018, 2020, 2022 by Stephen Lyons            *
+ *   Copyright (C) 2015, 2017-2018, 2020, 2022-2023 by Stephen Lyons       *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -80,7 +80,7 @@ public:
         TestMask = 0x3f,
         // Has been found in a search operation (currently Main Console only)
         // and has been given a highlight to indicate that:
-        SearchFind = 0x40,
+        Found = 0x40,
         // Replaces TCHAR_ECHO 16
         Echo = 0x100
     };
@@ -128,7 +128,7 @@ public:
     bool isOverlined() const { return mFlags & Overline; }
     bool isStruckOut() const { return mFlags & StrikeOut; }
     bool isReversed() const { return mFlags & Reverse; }
-    bool isSearchFind() const { return mFlags & SearchFind; }
+    bool isFound() const { return mFlags & Found; }
 
 private:
     QColor mFgColor;

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -78,6 +78,9 @@ public:
         // The attributes that are currently user settable and what should be
         // consider in HTML generation:
         TestMask = 0x3f,
+        // Has been found in a search operation (currently Main Console only)
+        // and has been given a highlight to indicate that:
+        SearchFind = 0x40,
         // Replaces TCHAR_ECHO 16
         Echo = 0x100
     };
@@ -119,6 +122,13 @@ public:
     void deselect() { mIsSelected = false; }
     bool isSelected() const { return mIsSelected; }
     int linkIndex () const { return mLinkIndex; }
+    bool isBold() const { return mFlags & Bold; }
+    bool isItalic() const { return mFlags & Italic; }
+    bool isUnderlined() const { return mFlags & Underline; }
+    bool isOverlined() const { return mFlags & Overline; }
+    bool isStruckOut() const { return mFlags & StrikeOut; }
+    bool isReversed() const { return mFlags & Reverse; }
+    bool isSearchFind() const { return mFlags & SearchFind; }
 
 private:
     QColor mFgColor;
@@ -191,6 +201,8 @@ public:
     // It would have been nice to do this with Qt's signals and slots but that
     // is apparently incompatible with using a default constructor - sigh!
     void encodingChanged(const QByteArray &);
+    void clearSearchHighlights();
+
     static int lengthInGraphemes(const QString& text);
 
 

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1858,7 +1858,7 @@ void TConsole::slot_searchBufferUp()
         do {
             searchX = buffer.lineBuffer[searchY].indexOf(mSearchQuery, searchX + 1, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive));
             if (searchX > -1) {
-                buffer.applyAttribute(QPoint(searchX, searchY), QPoint(searchX + mSearchQuery.size(), searchY), TChar::SearchFind, true);
+                buffer.applyAttribute(QPoint(searchX, searchY), QPoint(searchX + mSearchQuery.size(), searchY), TChar::Found, true);
                 found = true;
             }
         } while (searchX > -1);
@@ -1893,7 +1893,7 @@ void TConsole::slot_searchBufferDown()
         do {
             searchX = buffer.lineBuffer[searchY].indexOf(mSearchQuery, searchX + 1, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive));
             if (searchX > -1) {
-                buffer.applyAttribute(QPoint(searchX, searchY), QPoint(searchX + mSearchQuery.size(), searchY), TChar::SearchFind, true);
+                buffer.applyAttribute(QPoint(searchX, searchY), QPoint(searchX + mSearchQuery.size(), searchY), TChar::Found, true);
                 found = true;
             }
         } while (searchX > -1);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -371,8 +371,17 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     emergencyStop->setToolTip(utils::richText(tr("Emergency Stop. Stops all timers and triggers.")));
     connect(emergencyStop, &QAbstractButton::clicked, this, &TConsole::slot_stopAllItems);
 
-    mpBufferSearchBox->setMinimumSize(QSize(100, 30));
-    mpBufferSearchBox->setMaximumSize(QSize(150, 30));
+    mpBufferSearchBox->setClearButtonEnabled(true);
+    for (auto child : mpBufferSearchBox->children()) {
+        auto *pAction_clear(qobject_cast<QAction *>(child));
+        if (pAction_clear && pAction_clear->objectName() == QLatin1String("_q_qlineeditclearaction")) {
+            connect(pAction_clear, &QAction::triggered, this, &TConsole::slot_clearSearchResults, Qt::QueuedConnection);
+            break;
+        }
+    }
+
+    mpBufferSearchBox->setMinimumSize(QSize(150, 30));
+    mpBufferSearchBox->setMaximumSize(QSize(250, 30));
     mpBufferSearchBox->setSizePolicy(sizePolicy5);
     mpBufferSearchBox->setFont(mpHost->mCommandLineFont);
     mpBufferSearchBox->setFocusPolicy(Qt::ClickFocus);
@@ -1831,9 +1840,9 @@ void TConsole::slot_searchBufferUp()
     // happen:
     mudlet::self()->activateProfile(mpHost);
 
-    QString _txt = mpBufferSearchBox->text();
-    if (_txt != mSearchQuery) {
-        mSearchQuery = _txt;
+    if (mSearchQuery != mpBufferSearchBox->text()) {
+        mSearchQuery = mpBufferSearchBox->text();
+        buffer.clearSearchHighlights();
         mCurrentSearchResult = buffer.lineBuffer.size();
     } else {
         // make sure the line to search from does not exceed the buffer, which can grow and shrink dynamically
@@ -1842,26 +1851,22 @@ void TConsole::slot_searchBufferUp()
     if (buffer.lineBuffer.empty()) {
         return;
     }
-    bool _found = false;
-    for (int i = mCurrentSearchResult - 1; i >= 0; i--) {
-        int begin = -1;
+
+    bool found = false;
+    for (int searchY = mCurrentSearchResult - 1; searchY >= 0; --searchY) {
+        int searchX = -1;
         do {
-            begin = buffer.lineBuffer[i].indexOf(mSearchQuery, begin + 1, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive));
-            if (begin > -1) {
-                int length = mSearchQuery.size();
-                moveCursor(0, i);
-                selectSection(begin, length);
-                setBgColor(255, 255, 0, 255);
-                setFgColor(0, 0, 0);
-                deselect();
-                reset();
-                _found = true;
+            searchX = buffer.lineBuffer[searchY].indexOf(mSearchQuery, searchX + 1, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive));
+            if (searchX > -1) {
+                buffer.applyAttribute(QPoint(searchX, searchY), QPoint(searchX + mSearchQuery.size(), searchY), TChar::SearchFind, true);
+                found = true;
             }
-        } while (begin > -1);
-        if (_found) {
-            scrollUp(buffer.mCursorY - i - 3);
+        } while (searchX > -1);
+
+        if (found) {
+            scrollUp(buffer.mCursorY - searchY - 3);
             mUpperPane->forceUpdate();
-            mCurrentSearchResult = i;
+            mCurrentSearchResult = searchY;
             return;
         }
     }
@@ -1870,9 +1875,9 @@ void TConsole::slot_searchBufferUp()
 
 void TConsole::slot_searchBufferDown()
 {
-    QString _txt = mpBufferSearchBox->text();
-    if (_txt != mSearchQuery) {
-        mSearchQuery = _txt;
+    if (mSearchQuery != mpBufferSearchBox->text()) {
+        mSearchQuery = mpBufferSearchBox->text();
+        buffer.clearSearchHighlights();
         mCurrentSearchResult = buffer.lineBuffer.size();
     }
     if (buffer.lineBuffer.empty()) {
@@ -1881,26 +1886,22 @@ void TConsole::slot_searchBufferDown()
     if (mCurrentSearchResult >= buffer.lineBuffer.size()) {
         return;
     }
-    bool _found = false;
-    for (int i = mCurrentSearchResult + 1; i < buffer.lineBuffer.size(); i++) {
-        int begin = -1;
+
+    bool found = false;
+    for (int searchY = mCurrentSearchResult + 1; searchY < buffer.lineBuffer.size(); ++searchY) {
+        int searchX = -1;
         do {
-            begin = buffer.lineBuffer[i].indexOf(mSearchQuery, begin + 1, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive));
-            if (begin > -1) {
-                int length = mSearchQuery.size();
-                moveCursor(0, i);
-                selectSection(begin, length);
-                setBgColor(255, 255, 0, 255);
-                setFgColor(0, 0, 0);
-                deselect();
-                reset();
-                _found = true;
+            searchX = buffer.lineBuffer[searchY].indexOf(mSearchQuery, searchX + 1, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive));
+            if (searchX > -1) {
+                buffer.applyAttribute(QPoint(searchX, searchY), QPoint(searchX + mSearchQuery.size(), searchY), TChar::SearchFind, true);
+                found = true;
             }
-        } while (begin > -1);
-        if (_found) {
-            scrollUp(buffer.mCursorY - i - 3);
+        } while (searchX > -1);
+
+        if (found) {
+            scrollUp(buffer.mCursorY - searchY - 3);
             mUpperPane->forceUpdate();
-            mCurrentSearchResult = i;
+            mCurrentSearchResult = searchY;
             return;
         }
     }
@@ -2300,4 +2301,11 @@ void TConsole::slot_toggleSearchCaseSensitivity(const bool state)
         createSearchOptionIcon();
         mpHost->mBufferSearchOptions = mSearchOptions;
     }
+}
+
+void TConsole::slot_clearSearchResults()
+{
+    buffer.clearSearchHighlights();
+    mUpperPane->forceUpdate();
+    mLowerPane->forceUpdate();
 }

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -283,8 +283,13 @@ public:
     QAction* mpAction_searchCaseSensitive = nullptr;
     QToolButton* mpBufferSearchUp = nullptr;
     QToolButton* mpBufferSearchDown = nullptr;
+    // The line on which the current search result has been found, or the next
+    // one is to start (currently only for the main console):
     int mCurrentSearchResult = 0;
-    QList<int> mSearchResults;
+    // Not used:
+    // QList<int> mSearchResults;
+    // The term that is currently being search for (currently only for the main
+    // console):
     QString mSearchQuery;
     QWidget* mpButtonMainLayer = nullptr;
     int mBgImageMode = 0;
@@ -310,8 +315,11 @@ protected:
     void mousePressEvent(QMouseEvent*) override;
 
 
-private:
+private slots:
     void slot_adjustAccessibleNames();
+    void slot_clearSearchResults();
+
+private:
     void createSearchOptionIcon();
 
     ConsoleType mType = UnknownType;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -670,7 +670,7 @@ int TTextEdit::drawGraphemeBackground(QPainter& painter, QVector<QColor>& fgColo
     textRects.append(textRect);
     QColor bgColor;
     bool caretIsHere = mpHost->caretEnabled() && mCaretLine == line && mCaretColumn == column;
-    if (Q_UNLIKELY(charStyle.isSearchFind())) {
+    if (Q_UNLIKELY(charStyle.isFound())) {
         if (Q_UNLIKELY(charStyle.isReversed() != (charStyle.isSelected() != caretIsHere))) {
             fgColors.append(mSearchHighlightBgColor);
             bgColor = mSearchHighlightFgColor;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -663,7 +663,6 @@ int TTextEdit::drawGraphemeBackground(QPainter& painter, QVector<QColor>& fgColo
     } // End of switch
     charWidths.append(charWidth);
 
-    TChar::AttributeFlags attributes = charStyle.allDisplayAttributes();
     QRect textRect;
     if (charWidth > 0) {
         textRect = QRect(mFontWidth * cursor.x(), mFontHeight * cursor.y(), mFontWidth * charWidth, mFontHeight);
@@ -671,19 +670,29 @@ int TTextEdit::drawGraphemeBackground(QPainter& painter, QVector<QColor>& fgColo
     textRects.append(textRect);
     QColor bgColor;
     bool caretIsHere = mpHost->caretEnabled() && mCaretLine == line && mCaretColumn == column;
-    if (Q_UNLIKELY(static_cast<bool>(attributes & TChar::Reverse) != (charStyle.isSelected() != caretIsHere))) {
-        fgColors.append(charStyle.background());
-        bgColor = charStyle.foreground();
+    if (Q_UNLIKELY(charStyle.isSearchFind())) {
+        if (Q_UNLIKELY(charStyle.isReversed() != (charStyle.isSelected() != caretIsHere))) {
+            fgColors.append(mSearchHighlightBgColor);
+            bgColor = mSearchHighlightFgColor;
+        } else {
+            fgColors.append(mSearchHighlightFgColor);
+            bgColor = mSearchHighlightBgColor;
+        }
     } else {
-        fgColors.append(charStyle.foreground());
-        bgColor = charStyle.background();
+        if (Q_UNLIKELY(charStyle.isReversed() != (charStyle.isSelected() != caretIsHere))) {
+            fgColors.append(charStyle.background());
+            bgColor = charStyle.foreground();
+        } else {
+            fgColors.append(charStyle.foreground());
+            bgColor = charStyle.background();
+        }
     }
     if (caretIsHere) {
         bgColor = mCaretColor;
     }
     if (!textRect.isNull()) {
         painter.fillRect(textRect, bgColor);
-}
+    }
     return charWidth;
 }
 

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -170,6 +170,8 @@ private:
     int mFontWidth;
     bool mForceUpdate;
     const QColor mCaretColor = QColorConstants::Gray;
+    const QColor mSearchHighlightFgColor = QColorConstants::Black;
+    const QColor mSearchHighlightBgColor = QColorConstants::Yellow;
 
     // Each TConsole instance uses two instances of this class, one above the
     // other but they need to behave differently in some ways; this flag is set


### PR DESCRIPTION
#### Brief overview of PR changes/additions & motivation for adding to Mudlet
This adds a clear button to the Search widget on the Main Console's command line which also clears all the (yellow on black) highlights used during a search - and entering a different term also clears the highlights ready for the next term.

It also should accommodate when the underlying `TBuffer` is shrunk because it has exceeded the maximum number of lines - which the prior code didn't.

#### Other info (issues closed, discussion etc)
This should close #3759.

There is future scope to speed up the clearing process - I intend to convert the `(QList<bool>) TBuffer::promptBuffer` to a `(QList<LineFlags>) TBuffer::lineFlags` construct where the flag that a line is a "prompt" one is just one bit - and the fact that the line contains something that matches the current search term is another. So that when iterating through the whole buffer to clear the new `TChar::AttributeFlag::SearchFind` flag for those characters that are high- lighted Mudlet instead only has to go over those lines with the line flag set. {Such a line flag structure will also assist in my evil plans to implement flashing text so it is possible to work out which lines contain text that has to be redrawn every so often to make it flash!}