### PR TITLE
Fix: try and solve crashing when saving profile asynchronously

### DIFF
--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -192,7 +192,7 @@ void XMLexport::writeModuleXML(const QString& moduleName, const QString& fileNam
         helpPackage.append_child("helpURL").text().set("");
     }
     if (async) {
-        auto future = QtConcurrent::run([&]() { return saveXml(fileName); });
+        auto future = QtConcurrent::run([&, fileName]() { return saveXml(fileName); });
         auto watcher = new QFutureWatcher<bool>;
         connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=]() { mpHost->xmlSaved(fileName); });
         watcher->setFuture(future);
@@ -207,7 +207,7 @@ void XMLexport::exportHost(const QString& filename_pugi_xml)
 {
     auto mudletPackage = writeXmlHeader();
     writeHost(mpHost, mudletPackage);
-    auto future = QtConcurrent::run([&]() { return saveXml(filename_pugi_xml); });
+    auto future = QtConcurrent::run([&, filename_pugi_xml]() { return saveXml(filename_pugi_xml); });
 
     auto watcher = new QFutureWatcher<bool>;
     connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=]() { mpHost->xmlSaved(qsl("profile")); });
@@ -765,7 +765,7 @@ bool XMLexport::exportProfile(const QString& exportFileName)
     auto mudletPackage = writeXmlHeader();
 
     if (writeGenericPackage(mpHost, mudletPackage)) {
-        auto future = QtConcurrent::run([&]() { return saveXml(exportFileName); });
+        auto future = QtConcurrent::run([&, exportFileName]() { return saveXml(exportFileName); });
         auto watcher = new QFutureWatcher<bool>;
         QObject::connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=]() { mpHost->xmlSaved(qsl("profile")); });
         watcher->setFuture(future);

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -343,9 +343,9 @@ void Updater::slot_installOrRestartClicked(QAbstractButton* button, const QStrin
 
 // otherwise the button says 'Install', so install the update
 #if defined(Q_OS_LINUX)
-    QFuture<void> future = QtConcurrent::run([&]() { untarOnLinux(filePath); });
+    QFuture<void> future = QtConcurrent::run([&, filePath]() { untarOnLinux(filePath); });
 #elif defined(Q_OS_WIN32)
-    QFuture<void> future = QtConcurrent::run([&]() { prepareSetupOnWindows(filePath); });
+    QFuture<void> future = QtConcurrent::run([&, filePath]() { prepareSetupOnWindows(filePath); });
 #endif
 
     // replace current binary with the unzipped one


### PR DESCRIPTION
#### Brief overview of PR changes/additions
It looks as though this is due to a dangling reference because we never take a copy of the file name when we start the `QConcurrent::run(...)` and the default capture for the lamba is **by-reference** AND the argument being passed is itself a reference - which does not bode well should the source of the reference disappear.

#### Motivation for adding to Mudlet
Hopefully this will cure #6671.
