### PR TITLE
Fix: remove unwanted leading spaces in a couple of multi-line texts

### DIFF
--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -715,15 +715,15 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
     if (!missingAreasNeeded.isEmpty()) {
         if (mudlet::self()->showMapAuditErrors()) {
             QString alertMsg = tr("[ ALERT ] - %n area(s) detected as missing in map: adding it/them in.\n"
-                                  " Look for further messages related to the rooms that are supposed\n"
-                                  " to be in this/these area(s)...",
+                                  "Look for further messages related to the rooms that are supposed\n"
+                                  "to be in this/these area(s)...",
                                   "Making use of %n to allow quantity dependent message form 8-) !",
                                   missingAreasNeeded.count());
             mpMap->postMessage(alertMsg);
         }
         mpMap->appendErrorMsgWithNoLf(tr("[ ALERT ] - %n area(s) detected as missing in map: adding it/them in.\n"
-                                         " Look for further messages related to the rooms that is/are supposed to\n"
-                                         " be in this/these area(s)...",
+                                         "Look for further messages related to the rooms that are supposed to\n"
+                                         "be in this/these area(s)...",
                                          "Making use of %n to allow quantity dependent message form 8-) !",
                                          missingAreasNeeded.count()),
                                       true);


### PR DESCRIPTION
Also revise one of them so that it is the same as the other - so less work for translators.