### PR TITLE
Infrastructure: add example benchmark code for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,15 @@ git_submodule_init(
   CHECK_FILE "3rdparty/lcf/lcf-scm-1.rockspec" SUBMODULE_PATH "3rdparty/lcf"
   READABLE_NAME "lua code formatter source code")
 
+include(FetchContent)
+FetchContent_Declare(
+    nanobench
+    GIT_REPOSITORY https://github.com/martinus/nanobench.git
+    GIT_TAG v4.3.11
+    GIT_SHALLOW TRUE)
+
+FetchContent_MakeAvailable(nanobench)
+
 if(USE_UPDATER)
   git_submodule_init(CHECK_FILE "3rdparty/dblsqd/CMakeLists.txt" SUBMODULE_PATH
                      "3rdparty/dblsqd" READABLE_NAME "DBLSQD updater")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,8 +180,7 @@ git_submodule_init(
 #     GIT_REPOSITORY https://github.com/martinus/nanobench.git
 #     GIT_TAG v4.3.11
 #     GIT_SHALLOW TRUE)
-
-FetchContent_MakeAvailable(nanobench)
+# FetchContent_MakeAvailable(nanobench)
 
 if(USE_UPDATER)
   git_submodule_init(CHECK_FILE "3rdparty/dblsqd/CMakeLists.txt" SUBMODULE_PATH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,12 +173,13 @@ git_submodule_init(
   CHECK_FILE "3rdparty/lcf/lcf-scm-1.rockspec" SUBMODULE_PATH "3rdparty/lcf"
   READABLE_NAME "lua code formatter source code")
 
-include(FetchContent)
-FetchContent_Declare(
-    nanobench
-    GIT_REPOSITORY https://github.com/martinus/nanobench.git
-    GIT_TAG v4.3.11
-    GIT_SHALLOW TRUE)
+# PLACEMARKER: sample benchmarking code
+# include(FetchContent)
+# FetchContent_Declare(
+#     nanobench
+#     GIT_REPOSITORY https://github.com/martinus/nanobench.git
+#     GIT_TAG v4.3.11
+#     GIT_SHALLOW TRUE)
 
 FetchContent_MakeAvailable(nanobench)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -525,8 +525,9 @@ target_link_libraries(
         PUGIXML::PUGIXML
         ZIP::ZIP
         ZLIB::ZLIB
-        ${QT_LIBS}
-        nanobench)
+# PLACEMARKER: sample benchmarking code
+#       nanobench
+        ${QT_LIBS})
 
 if(USE_UPDATER)
   target_link_libraries(mudlet dblsqd)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -525,7 +525,8 @@ target_link_libraries(
         PUGIXML::PUGIXML
         ZIP::ZIP
         ZLIB::ZLIB
-        ${QT_LIBS})
+        ${QT_LIBS}
+        nanobench)
 
 if(USE_UPDATER)
   target_link_libraries(mudlet dblsqd)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -611,6 +611,25 @@ mudlet::mudlet()
         mpAnnouncer = new Announcer(this);
         emit signal_adjustAccessibleNames();
     });
+
+    // looking to benchmark old/new code? Use this example
+    // full docs at https://nanobench.ankerl.com
+    ankerl::nanobench::Bench benchmark;
+    benchmark.title("Example benchmark")
+            .minEpochIterations(2000)
+            .warmup(100)
+            .relative(true);
+
+    benchmark.run("new code", [&] {
+        loadMaps();
+    });
+
+    benchmark.run("old code", [&] {
+        for (int = 0; i < 500; i++) {
+            loadMaps();
+        }
+    });
+
 }
 
 QSettings* mudlet::getQSettings()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -99,7 +99,7 @@ namespace coreMacOS {
 }
 #endif
 
-#include <nanobench.h>
+// #include <nanobench.h>
 #include "post_guard.h"
 
 using namespace std::chrono_literals;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -99,6 +99,7 @@ namespace coreMacOS {
 }
 #endif
 
+#include <nanobench.h>
 #include "post_guard.h"
 
 using namespace std::chrono_literals;
@@ -614,22 +615,21 @@ mudlet::mudlet()
 
     // looking to benchmark old/new code? Use this example
     // full docs at https://nanobench.ankerl.com
-    ankerl::nanobench::Bench benchmark;
-    benchmark.title("Example benchmark")
-            .minEpochIterations(2000)
-            .warmup(100)
-            .relative(true);
-
-    benchmark.run("new code", [&] {
-        loadMaps();
-    });
-
-    benchmark.run("old code", [&] {
-        for (int = 0; i < 500; i++) {
-            loadMaps();
-        }
-    });
-
+//    ankerl::nanobench::Bench benchmark;
+//    benchmark.title("Example benchmark")
+//            .minEpochIterations(2000)
+//            .warmup(100)
+//            .relative(true);
+//
+//    benchmark.run("old code", [this] {
+//        loadMaps();
+//    });
+//
+//    benchmark.run("new code", [this] {
+//        for (int i = 0; i < 2; i++) {
+//            loadMaps();
+//        }
+//    });
 }
 
 QSettings* mudlet::getQSettings()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -99,6 +99,7 @@ namespace coreMacOS {
 }
 #endif
 
+// PLACEMARKER: sample benchmarking code
 // #include <nanobench.h>
 #include "post_guard.h"
 
@@ -613,6 +614,7 @@ mudlet::mudlet()
         emit signal_adjustAccessibleNames();
     });
 
+    // PLACEMARKER: sample benchmarking code
     // looking to benchmark old/new code? Use this example
     // full docs at https://nanobench.ankerl.com
 //    ankerl::nanobench::Bench benchmark;
@@ -620,11 +622,11 @@ mudlet::mudlet()
 //            .minEpochIterations(2000)
 //            .warmup(100)
 //            .relative(true);
-//
+
 //    benchmark.run("old code", [this] {
 //        loadMaps();
 //    });
-//
+
 //    benchmark.run("new code", [this] {
 //        for (int i = 0; i < 2; i++) {
 //            loadMaps();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add example benchmark code. Can benchmark whole methods or just part of a method pretty easily.
#### Motivation for adding to Mudlet
So developers have an easy way to compare speed of old/new code and thus have an easier time keeping Mudlet quick.
#### Other info (issues closed, discussion etc)
I also tried adding it to https://wiki.mudlet.org/w/Relevant_Developer_Tutorials but after having spent too long fighting with mediawiki's translatable page, I gave up.