### PR TITLE
Infrastructure: remove build statuses from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,6 @@
   <a href="https://www.codefactor.io/repository/github/mudlet/mudlet">
     <img src="https://www.codefactor.io/repository/github/mudlet/mudlet/badge" alt="CodeFactor" />
   </a>
-  <br>
-  <sup><b>Windows:</b></sup>&nbsp;<a href="http://mudlet.org/download/" rel="nofollow"><img src="https://ci.appveyor.com/api/projects/status/31fqq844br6g6i40/branch/development?svg=true" alt="AppVeyor (Windows) CI Build status" style="max-width:100%;">
-  </a>
-  <sup><b>Linux &amp; MacOS:</b></sup>&nbsp;<a href="http://mudlet.org/download/" rel="nofollow"><img src="https://travis-ci.org/Mudlet/Mudlet.svg?branch=development" alt="Travis (Linux &amp; MacOs) CI Build status" style="max-width:100%;">
-  </a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Travis one hasn't worked for a long while, and after having run the status badges for many years - I'm not seeing the value in them that anyone is getting really.
#### Motivation for adding to Mudlet
A bit of README cleanup.
#### Other info (issues closed, discussion etc)
