### PR TITLE
Fix: ensure map loading occurs at correct point in profile initialiation

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -395,19 +395,6 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
     mErrorLogStream.setCodec(QTextCodec::codecForName("UTF-8"));
 #endif
 
-    QTimer::singleShot(0, this, [this]() {
-        qDebug() << "Host::Host() - restore map case 4 {QTimer::singleShot(0)} lambda.";
-        if (mpMap->restore(QString(), false)) {
-            mpMap->audit();
-            if (mpMap->mpMapper) {
-                mpMap->mpMapper->mp2dMap->init();
-                mpMap->mpMapper->updateAreaComboBox();
-                mpMap->mpMapper->resetAreaComboBoxToPlayerRoomArea();
-                mpMap->mpMapper->show();
-            }
-        }
-    });
-
     mGMCP_merge_table_keys.append("Char.Status");
     mDoubleClickIgnore.insert('"');
     mDoubleClickIgnore.insert('\'');
@@ -471,6 +458,23 @@ Host::~Host()
     mErrorLogStream.flush();
     mErrorLogFile.close();
     TDebug::removeHost(this);
+}
+
+void Host::loadMap()
+{
+    // It is not okay to call TMap::audit() until after the Lua sub-system has
+    // been set up - which is why this has been moved out of a zero-timer in
+    // the constructor:
+    qDebug() << "Host::loadMap() - restore map case 4.";
+    if (mpMap->restore(QString(), false)) {
+        mpMap->audit();
+        if (mpMap->mpMapper) {
+            mpMap->mpMapper->mp2dMap->init();
+            mpMap->mpMapper->updateAreaComboBox();
+            mpMap->mpMapper->resetAreaComboBoxToPlayerRoomArea();
+            mpMap->mpMapper->show();
+        }
+    }
 }
 
 void Host::startMapAutosave()

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -462,9 +462,6 @@ Host::~Host()
 
 void Host::loadMap()
 {
-    // It is not okay to call TMap::audit() until after the Lua sub-system has
-    // been set up - which is why this has been moved out of a zero-timer in
-    // the constructor:
     qDebug() << "Host::loadMap() - restore map case 4.";
     if (mpMap->restore(QString(), false)) {
         mpMap->audit();

--- a/src/Host.h
+++ b/src/Host.h
@@ -407,6 +407,7 @@ public:
     QPointer<TConsole> parentTConsole(QObject*) const;
     QMargins borders() const { return mBorders; }
     void setBorders(const QMargins);
+    void loadMap();
 
 
     cTelnet mTelnet;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2768,7 +2768,7 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
 
     pHost->mBlockStopWatchCreation = false;
     // This will build all the scripts in the collection of script items (but
-    // NOT the other Mudlet item types) - prisumably so that the event handlers
+    // not triggers/aliases/etc) - presumably so that the event handlers
     // are ready for use.
     pHost->getScriptUnit()->compileAll();
     pHost->updateAnsi16ColorsInTable();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2740,8 +2740,12 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
         return;
     }
     pHost->mIsProfileLoadingSequence = true;
+    // The Host instance gets its TMainConsole here:
     addConsoleForNewHost(pHost);
     pHost->mBlockScriptCompile = false;
+    // This uses the external LuaGlobal.lua file to load all the other external
+    // lua files, including the condenseMapLoad() function needed by the
+    // TMap::audit() method:
     pHost->mLuaInterpreter.loadGlobal();
     pHost->hideMudletsVariables();
 
@@ -2763,6 +2767,9 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
     }
 
     pHost->mBlockStopWatchCreation = false;
+    // This will build all the scripts in the collection of script items (but
+    // NOT the other Mudlet item types) - prisumably so that the event handlers
+    // are ready for use.
     pHost->getScriptUnit()->compileAll();
     pHost->updateAnsi16ColorsInTable();
 
@@ -2780,12 +2787,17 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
 
     mPackagesToInstallList.clear();
 
+    // This marks the end of the profile loading process, so all the aliases
+    // triggers and other items are present in the Lua sub-system:
     pHost->mIsProfileLoadingSequence = false;
 
     TEvent event {};
     event.mArgumentList.append(QLatin1String("sysLoadEvent"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     pHost->raiseEvent(event);
+
+    // Now load the default (latest stored) map file:
+    pHost->loadMap();
 
     //NOTE: this is a potential problem if users connect by hand quickly
     //      and one host has a slower response time as the other one, but


### PR DESCRIPTION
#### Brief overview of PR changes/additions

For some time now (years) the loading of the default (last saved) map file was done via a "zero-timer" started at the end of the `Host` constructor. However we are now using several such zero-timers and the Qt documentation does point out that the order of triggering for more that one is arbitrary.

#### Brief overview of PR changes/additions
This PR changes the point at which the map is loaded to a precise point in the profile initialisation sequence to be just after the Lua sub-system is setup but before the connection to the server (if to be done) will occur.

#### Other info (issues closed, discussion etc)
I don't think it has been raised as an issue per se, however @weisluke (who maintains the WoTMUD Mudlet packages) pointed it out in our Discord **# help** channel:
> Weisluke - **[02/04/2023 16:39 UTC](https://www.discord.com/channels/283581582550237184/283582068334526464/1092126254146265129)**:

````>
[  OK  ]  - Auditing of map completed (0.12s). Enjoy your game...
[  LUA  ] - object: <condenseMapLoad> function:<condenseMapLoad>
            <attempt to call a nil value>
[  OK  ]  - Map loaded successfully (0s).
[  OK  ]  - Mudlet-lua API & Geyser Layout manager loaded.
[  OK  ]  - Map loaded successfully (0.33s).```

hmm, anyone else seeing this condenseMapLoad error in 4.17.2?
