### PR TITLE
Infra: switch automatic builds from Ubuntu 18.04 to 20.04

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         include:
           # oldest OS supported for maximum compatibility of built AppImage
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             buildname: 'ubuntu / gcc / lua tests'
             triplet: x64-linux
             compiler: gcc_64


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Change automatic builds to use Ubuntu 20.04.
#### Motivation for adding to Mudlet
GitHub Actions are ending Ubuntu 18.04 runners and Ubuntu itself will stop supporting it soon.  We aren't using any features that require 20.04 yet but we'd have to use an alternative to GitHub Actions to continue building with it.
#### Other info (issues closed, discussion etc)
fix #6231 