### PR TITLE
Add option to save command history between sessions

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -211,6 +211,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mAllowToSendCommand(true)
 , mAutoClearCommandLineAfterSend(false)
 , mHighlightHistory(true)
+, mSaveHistory(false)
 , mBlockScriptCompile(true)
 , mBlockStopWatchCreation(true)
 , mEchoLuaErrors(false)

--- a/src/Host.h
+++ b/src/Host.h
@@ -420,6 +420,7 @@ public:
     bool mAllowToSendCommand;
     bool mAutoClearCommandLineAfterSend;
     bool mHighlightHistory;
+    bool mSaveHistory;
     // Set in constructor and used in (bool) TScript::setScript(const QString&)
     // to prevent compilation of the script that was being set therein, cleared
     // after the main TConsole for a new profile has been created during the

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1428,7 +1428,7 @@ void TCommandLine::saveHistory()
     }
     int i = mHistoryList.size();
     while (i--) {
-        qDebug()<<"TIM writing line "<<i<<": "<<mHistoryList[i];
+        qDebug() << "TIM writing line " << i << ": " << mHistoryList[i];
         ofs << mHistoryList[i];
     }
     file.close();
@@ -1456,10 +1456,10 @@ void TCommandLine::restoreHistory()
         ifs >> line;
         mHistoryList.push_front(line);
         count++;
-        qDebug()<<"TIM got line: "<<line;
+        qDebug() << "TIM got line: " << line;
     }
     count--; // Empty string at the end
-    qDebug()<<"TIM have read file";
+    qDebug() << "TIM have read file";
     if (!count) {
         return;
     }

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1412,3 +1412,48 @@ void TCommandLine::slot_adjustAccessibleNames()
         Q_UNREACHABLE();
     }
 }
+
+void TCommandLine::saveHistory()
+{
+    QFile file(mudlet::getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), qsl("commandHistory")));
+    if (!file.open(QFile::ReadWrite | QFile::Truncate | QFile::Text)) {
+        qDebug() << "Problem creating commandHistory file";
+        return;
+    }
+    QTextStream output(&file);
+
+    int i = mHistoryList.size();
+    while (i--) {
+        output << mHistoryList[i].toUtf8() << "\n";
+    }
+    file.close();
+}
+
+void TCommandLine::restoreHistory()
+{
+    QFile file(mudlet::getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), qsl("commandHistory")));
+    file.open(QFile::ReadOnly | QFile::Text);
+    QTextStream input(&file);
+    if (!file.exists()) {
+        qDebug() << "Command history file not found";
+        return;
+    } else {
+        qDebug() << "Restoring command history";
+    }
+    int count = 0;
+    QString line;
+    while (!input.atEnd()) {
+        line = input.readLine();
+        if (!line.isEmpty()) {
+            mHistoryList.push_front(line);
+            count++;
+        }
+    }
+    file.close();
+    if (!count) {
+        return;
+    }
+    mHistoryList.push_front(QString());
+    QString infoMsg = tr("[ INFO ]  - Command history restored %1 line(s).").arg(QString::number(count));
+    mpHost->postMessage(infoMsg);
+}

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -75,6 +75,8 @@ public:
     void removeBlacklist(const QString&);
     void clearBlacklist();
     void adjustHeight();
+    void saveHistory();
+    void restoreHistory();
     TConsole* console() const { return mpConsole; }
 
     int mActionFunction = 0;

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -72,6 +72,10 @@ TMainConsole::TMainConsole(Host* pH, QWidget* parent)
 
     // Ensure the QWidget has the profile name embedded into it
     setProperty("HostName", pH->getName());
+
+    if (mpHost->mSaveHistory) {
+        mpCommandLine->restoreHistory();
+    }
 }
 
 TMainConsole::~TMainConsole()

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -376,6 +376,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     // can be used compared to the more complex Utf8 one needed otherwise:
     host.append_attribute("autoClearCommandLineAfterSend") = pHost->mAutoClearCommandLineAfterSend ? "yes" : "no";
     host.append_attribute("HighlightHistory") = pHost->mHighlightHistory ? "yes" : "no";
+    host.append_attribute("saveHistory") = pHost->mSaveHistory ? "yes" : "no";
     host.append_attribute("printCommand") = pHost->mPrintCommand ? "yes" : "no";
     host.append_attribute("USE_IRE_DRIVER_BUGFIX") = pHost->mUSE_IRE_DRIVER_BUGFIX ? "yes" : "no";
     host.append_attribute("mUSE_FORCE_LF_AFTER_PROMPT") = pHost->mUSE_FORCE_LF_AFTER_PROMPT ? "yes" : "no";

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -724,7 +724,7 @@ void XMLimport::readHost(Host* pHost)
     pHost->mNoAntiAlias = attributes().value(qsl("mNoAntiAlias")) == YES;
     pHost->mEchoLuaErrors = attributes().value(qsl("mEchoLuaErrors")) == YES;
     pHost->mHighlightHistory = readDefaultTrueBool(qsl("HighlightHistory"));
-    pHost->mSaveHistory = readDefaultFalseBool(qsl("saveHistory"));
+    pHost->mSaveHistory = attributes().value(qsl("saveHistory")) == YES;
     if (attributes().hasAttribute("AmbigousWidthGlyphsToBeWide")) {
         const QStringView ambiguousWidthSetting(attributes().value(qsl("AmbigousWidthGlyphsToBeWide")));
         if (ambiguousWidthSetting == YES) {
@@ -1148,10 +1148,6 @@ void XMLimport::readHost(Host* pHost)
 
 bool XMLimport::readDefaultTrueBool(QString name) {
     return attributes().value(name) == YES || !attributes().hasAttribute(name);
-}
-
-bool XMLimport::readDefaultFalseBool(QString name) {
-    return attributes().hasAttribute(name) && attributes().value(name) == YES;
 }
 
 // returns the ID of the root imported trigger/group

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -724,6 +724,7 @@ void XMLimport::readHost(Host* pHost)
     pHost->mNoAntiAlias = attributes().value(qsl("mNoAntiAlias")) == YES;
     pHost->mEchoLuaErrors = attributes().value(qsl("mEchoLuaErrors")) == YES;
     pHost->mHighlightHistory = readDefaultTrueBool(qsl("HighlightHistory"));
+    pHost->mSaveHistory = readDefaultFalseBool(qsl("saveHistory"));
     if (attributes().hasAttribute("AmbigousWidthGlyphsToBeWide")) {
         const QStringView ambiguousWidthSetting(attributes().value(qsl("AmbigousWidthGlyphsToBeWide")));
         if (ambiguousWidthSetting == YES) {
@@ -1147,6 +1148,10 @@ void XMLimport::readHost(Host* pHost)
 
 bool XMLimport::readDefaultTrueBool(QString name) {
     return attributes().value(name) == YES || !attributes().hasAttribute(name);
+}
+
+bool XMLimport::readDefaultFalseBool(QString name) {
+    return attributes().hasAttribute(name) && attributes().value(name) == YES;
 }
 
 // returns the ID of the root imported trigger/group

--- a/src/XMLimport.h
+++ b/src/XMLimport.h
@@ -107,6 +107,7 @@ private:
     void remapColorsToAnsiNumber(QStringList&, const QList<int>&);
 
     bool readDefaultTrueBool(QString name);
+    bool readDefaultFalseBool(QString name);
 
     QPointer<Host> mpHost;
     QString mPackageName;

--- a/src/XMLimport.h
+++ b/src/XMLimport.h
@@ -107,7 +107,6 @@ private:
     void remapColorsToAnsiNumber(QStringList&, const QList<int>&);
 
     bool readDefaultTrueBool(QString name);
-    bool readDefaultFalseBool(QString name);
 
     QPointer<Host> mpHost;
     QString mPackageName;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -213,6 +213,9 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
                                               "will be run.</p>"
                                               "<p><i>It is recommended to not enable this option if you need to maintain compatibility "
                                               "with scripts or packages for Mudlet versions prior to <b>3.9.0</b>.</i></p>"));
+    checkBox_saveHistory->setToolTip(tr("<p>If checked then when a profile is closed and reopened, it will retain the history of commands.</p>"
+                                        "<p><i>It is unchecked by default</i></p>"
+                                        "<p>Be aware that it may include private information such as passwords, if they are typed in as input.</p>"));
     checkBox_useWideAmbiguousEastAsianGlyphs->setToolTip(tr("<p>Some East Asian MUDs may use glyphs (characters) that Unicode classifies as being "
                                                             "of <i>Ambiguous</i> width when drawn in a font with a so-called <i>fixed</i> pitch; in "
                                                             "fact such text is <i>duo-spaced</i> when not using a proportional font. These symbols can be "
@@ -777,6 +780,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     show_sent_text_checkbox->setChecked(pHost->mPrintCommand);
     auto_clear_input_line_checkbox->setChecked(pHost->mAutoClearCommandLineAfterSend);
     checkBox_highlightHistory->setChecked(pHost->mHighlightHistory);
+    checkBox_saveHistory->setChecked(pHost->mSaveHistory);
     command_separator_lineedit->setText(pHost->mCommandSeparator);
 
     checkBox_USE_IRE_DRIVER_BUGFIX->setChecked(pHost->mUSE_IRE_DRIVER_BUGFIX);
@@ -2635,6 +2639,15 @@ void dlgProfilePreferences::slot_saveAndClose()
         pHost->mPrintCommand = show_sent_text_checkbox->isChecked();
         pHost->mAutoClearCommandLineAfterSend = auto_clear_input_line_checkbox->isChecked();
         pHost->mHighlightHistory = checkBox_highlightHistory->isChecked();
+        bool newSaveHistory = checkBox_saveHistory->isChecked();
+        if (pHost->mSaveHistory && !newSaveHistory) {
+            // If user stops saving command history, then remove the old file when they click Save.
+            QFile historyFile(mudlet::getMudletPath(mudlet::profileDataItemPath, pHost->getName(), qsl("commandHistory")));
+            if (historyFile.exists()) {
+                historyFile.remove();
+            }
+        }
+        pHost->mSaveHistory = newSaveHistory;
         pHost->mCommandSeparator = command_separator_lineedit->text();
         pHost->mAcceptServerGUI = acceptServerGUI->isChecked();
         pHost->mAcceptServerMedia = acceptServerMedia->isChecked();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1313,6 +1313,10 @@ void mudlet::closeHost(const QString& name)
 
     migrateDebugConsole(pH);
 
+    if (pH->mSaveHistory) {
+        pH->mpConsole->mpCommandLine->saveHistory();
+    }
+
     pH->mpConsole->close();
 
     mpTabBar->removeTab(name);

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -556,6 +556,16 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="1">
+           <widget class="QCheckBox" name="checkBox_saveHistory">
+            <property name="toolTip">
+             <string>placeholder text, not sure where it is used, appears to be changed by cpp file? maybe only in the designer thing?</string>
+            </property>
+            <property name="text">
+             <string>Save command history between sessions</string>
+            </property>
+           </widget>
+          </item>
           <item row="3" column="0" alignment="Qt::AlignRight">
            <widget class="QLabel" name="label_commandSeparator">
             <property name="toolTip">
@@ -4057,6 +4067,7 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>show_sent_text_checkbox</tabstop>
   <tabstop>checkBox_highlightHistory</tabstop>
   <tabstop>checkBox_runAllKeyBindings</tabstop>
+  <tabstop>checkBox_saveHistory</tabstop>
   <tabstop>command_separator_lineedit</tabstop>
   <tabstop>commandLineMinimumHeight</tabstop>
   <tabstop>checkBox_spellCheck</tabstop>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
This will offer an option to save command history to a file and load it in next session.

#### Motivation for adding to Mudlet
Close #2007

#### Other info (issues closed, discussion etc)
Currently it does all that was requested but not to my personal standards.  This is marked as a draft because I don't want it in the program yet for some tangent reasons:
- [ ] Sanity checks in general - I want to make sure that the user placing a badly formed file into that spot will not cause crashes.
- [ ] Get input on any kind of limits, max lines, max total size, timing... I have code locally to impose a limit on how large the file can be, but haven't asked the crew yet if you want to cap at a certain number or lines or bytes.  If the user sets a limit, should the limit also apply to current session and actively clear off old commands even before changing sessions, that kind of thing.
- [ ] I don't think there's anything in existing program to clear out old commands.  There isn't a function similar to `setConsoleBufferSize` but for commands.  On one computer I can go back thousands of commands.  On another computer I can go back only a certain distance which means either a broken linked list or some purge code that I haven't noticed, or a bug in the arrow up keypress action.  I'll want to fix that bug too before submitting even though it's a tangent thing, or at least track down a pattern so that I can report it with repeatable instructions.
- [ ] Will ask the crew if you want to change any current treatment of history, if you might want to change how no-echo works and such since this will start preserving that between sessions, or if mere warning is enough.