### PR TITLE
Infrastructure: remove a couple of old std::tie uses

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1442,7 +1442,7 @@ int TLuaInterpreter::setProfileIcon(lua_State* L)
 
     Host& host = getHostFromLua(L);
 
-    auto[success, message] = mudlet::self()->setProfileIcon(host.getName(), iconPath);
+    auto [success, message] = mudlet::self()->setProfileIcon(host.getName(), iconPath);
     if (!success) {
         return warnArgumentValue(L, __func__, message);
     }
@@ -2385,16 +2385,13 @@ int TLuaInterpreter::selectSection(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getSelection
 int TLuaInterpreter::getSelection(lua_State* L)
 {
-    bool valid;
-    QString text;
-    int start, length;
-
     QString windowName;
     if (lua_gettop(L) > 0) {
         windowName = WINDOW_NAME(L, 1);
     }
     auto console = CONSOLE(L, windowName);
-    std::tie(valid, text, start, length) = console->getSelection();
+
+    auto [valid, text, start, length] = console->getSelection();
 
     if (!valid) {
         return warnArgumentValue(L, __func__, text);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8057,8 +8057,6 @@ void dlgTriggerEditor::slot_copyXml()
 void dlgTriggerEditor::slot_pasteXml()
 {
     XMLimport reader(mpHost);
-    EditorViewType importedItemType = EditorViewType::cmUnknownView;
-    int importedItemID = 0;
 
     switch (mCurrentView) {
     case EditorViewType::cmTriggerView:
@@ -8087,7 +8085,7 @@ void dlgTriggerEditor::slot_pasteXml()
         break;
     }
 
-    std::tie(importedItemType, importedItemID) = reader.importFromClipboard();
+    auto [importedItemType, importedItemID] = reader.importFromClipboard();
 
     // don't reset the view if what we pasted wasn't a Mudlet editor item
     if (importedItemType == EditorViewType::cmUnknownView && importedItemID == 0) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove a couple of old std::tie uses
#### Motivation for adding to Mudlet
Cleaner code and better examples for other developers to c/p from
#### Other info (issues closed, discussion etc)
Now possible thanks to C++17