### PR TITLE
improve profile preferences window

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -489,8 +489,16 @@ void dlgProfilePreferences::disableHostDetails()
     // ===== tab_shortcuts =====
     groupBox_main_window_shortcuts->setEnabled(false);
 
+    // ===== tab_accessibility =====
+    label_blankLinesBehaviour->setEnabled(false);
+    label_caretModeKey->setEnabled(false);
+    checkBox_announceIncomingText->setEnabled(false);
+    comboBox_blankLinesBehaviour->setEnabled(false);
+    comboBox_caretModeKey->setEnabled(false);
+
     // ===== tab_specialOptions =====
     groupBox_specialOptions->setEnabled(false);
+    groupBox_purgeMediaCache->setEnabled(false);
     // ----- groupBox_specialOptions -----
     need_reconnect_for_specialoption->hide();
 
@@ -500,12 +508,9 @@ void dlgProfilePreferences::disableHostDetails()
     // This acts on a label within this groupBox:
     slot_hidePasswordMigrationLabel();
     checkBox_debugShowAllCodepointProblems->setEnabled(false);
-    checkBox_announceIncomingText->setEnabled(false);
-    comboBox_blankLinesBehaviour->setEnabled(false);
     widget_timerDebugOutputMinimumInterval->setEnabled(false);
     label_networkPacketTimeout->setEnabled(false);
     doubleSpinBox_networkPacketTimeout->setEnabled(false);
-    comboBox_caretModeKey->setEnabled(false);
 }
 
 void dlgProfilePreferences::enableHostDetails()
@@ -586,8 +591,6 @@ void dlgProfilePreferences::enableHostDetails()
     groupBox_ssl->setEnabled(QSslSocket::supportsSsl());
     checkBox_askTlsAvailable->setEnabled(true);
 #endif
-    checkBox_announceIncomingText->setEnabled(true);
-    comboBox_blankLinesBehaviour->setEnabled(true);
 
     // ===== tab_chat =====
     groupBox_ircOptions->setEnabled(true);
@@ -595,9 +598,16 @@ void dlgProfilePreferences::enableHostDetails()
     // ===== tab_shortcuts =====
     groupBox_main_window_shortcuts->setEnabled(true);
 
+    // ===== tab_accessibility =====
+    label_blankLinesBehaviour->setEnabled(true);
+    label_caretModeKey->setEnabled(true);
+    checkBox_announceIncomingText->setEnabled(true);
+    comboBox_blankLinesBehaviour->setEnabled(true);
+    comboBox_caretModeKey->setEnabled(true);
+
     // ===== tab_specialOptions =====
     groupBox_specialOptions->setEnabled(true);
-
+    groupBox_purgeMediaCache->setEnabled(true);
     groupbox_searchEngineSelection->setEnabled(true);
     // ----- groupBox_debug -----
     checkBox_expectCSpaceIdInColonLessMColorCode->setEnabled(true);
@@ -605,7 +615,6 @@ void dlgProfilePreferences::enableHostDetails()
     checkBox_debugShowAllCodepointProblems->setEnabled(true);
     label_networkPacketTimeout->setEnabled(true);
     doubleSpinBox_networkPacketTimeout->setEnabled(true);
-    comboBox_caretModeKey->setEnabled(true);
 }
 
 void dlgProfilePreferences::initWithHost(Host* pHost)

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -434,6 +434,7 @@ void dlgProfilePreferences::disableHostDetails()
     theme_download_label->hide();
 
     groupBox_autoComplete->setEnabled(false);
+    groupBox_editorDisplayOptions->setEnabled(false);
     groupBox_advancedEditor->setEnabled(false);
 
     // ===== tab_displayColors =====
@@ -556,6 +557,7 @@ void dlgProfilePreferences::enableHostDetails()
     groupbox_codeEditorThemeSelection->setEnabled(true);
 
     groupBox_autoComplete->setEnabled(true);
+    groupBox_editorDisplayOptions->setEnabled(true);
     groupBox_advancedEditor->setEnabled(true);
 
     // ===== tab_displayColors =====
@@ -947,19 +949,19 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         }
     }
     if (pHost->mpMap->mpMapper) {
-        QLabel* pLabel_mapSymbolFontFudge = new QLabel(tr("2D Map Room Symbol scaling factor:"), groupBox_debug);
-        mpDoubleSpinBox_mapSymbolFontFudge = new QDoubleSpinBox(groupBox_debug);
+        QLabel* pLabel_mapSymbolFontFudge = new QLabel(tr("2D Map Room Symbol scaling factor:"), groupBox_mapViewOptions);
+        mpDoubleSpinBox_mapSymbolFontFudge = new QDoubleSpinBox(groupBox_mapViewOptions);
         mpDoubleSpinBox_mapSymbolFontFudge->setValue(pHost->mpMap->mMapSymbolFontFudgeFactor);
         mpDoubleSpinBox_mapSymbolFontFudge->setPrefix(qsl("×"));
         mpDoubleSpinBox_mapSymbolFontFudge->setRange(0.50, 2.00);
         mpDoubleSpinBox_mapSymbolFontFudge->setSingleStep(0.01);
-        auto * pdebugLayout = qobject_cast<QGridLayout*>(groupBox_debug->layout());
-        if (pdebugLayout) {
-            int existingRows = pdebugLayout->rowCount();
-            pdebugLayout->addWidget(pLabel_mapSymbolFontFudge, existingRows, 0);
-            pdebugLayout->addWidget(mpDoubleSpinBox_mapSymbolFontFudge, existingRows, 1);
+        auto * pmapViewLayout = qobject_cast<QGridLayout*>(groupBox_mapViewOptions->layout());
+        if (pmapViewLayout) {
+            int existingRows = pmapViewLayout->rowCount();
+            pmapViewLayout->addWidget(pLabel_mapSymbolFontFudge, existingRows, 0);
+            pmapViewLayout->addWidget(mpDoubleSpinBox_mapSymbolFontFudge, existingRows, 1);
         } else {
-            qWarning() << "dlgProfilePreferences::initWithHost(...) WARNING - Unable to cast groupBox_debug layout to expected QGridLayout - someone has messed with the profile_preferences.ui file and the contents of the groupBox can not be shown...!";
+            qWarning() << "dlgProfilePreferences::initWithHost(...) WARNING - Unable to cast groupBox_mapViewOptions layout to expected QGridLayout - someone has messed with the profile_preferences.ui file and the contents of the groupBox can not be shown...!";
         }
 
         label_mapSymbolsFont->setEnabled(true);

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -3555,6 +3555,111 @@ you can use it but there could be issues with aligning columns of text</string>
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tab_accessibility">
+      <attribute name="title">
+       <string>Accessibility</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="vBoxLayout_tab_accessibility">
+       <item>
+        <widget class="QGroupBox" name="groupBox_accessibility">
+         <property name="title">
+          <string>Accessibility</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="0" column="0" colspan="2">
+           <widget class="QCheckBox" name="checkBox_announceIncomingText">
+            <property name="toolTip">
+             <string>On some platforms, like macOS, the screen reader tool has issues announcing incoming text fully, without skipping. You can opt into disabling announcing new text from the game with this option to use a custom TTS instead which avoids such issues</string>
+            </property>
+            <property name="text">
+             <string>Announce incoming text in screen reader</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="comboBox_blankLinesBehaviour">
+            <item>
+             <property name="text">
+              <string>show them</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>hide them</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>replace with a space</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_blankLinesBehaviour">
+            <property name="text">
+             <string>When the game sends blank lines:</string>
+            </property>
+            <property name="buddy">
+             <cstring>comboBox_blankLinesBehaviour</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_caretModeKey">
+            <property name="text">
+             <string>Switch between input line and main window using:</string>
+            </property>
+            <property name="buddy">
+             <cstring>comboBox_caretModeKey</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="comboBox_caretModeKey">
+            <item>
+             <property name="text">
+              <string>no key</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Tab</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Ctrl+Tab</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>F6</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_accessibility">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Expanding</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="tab_specialOptions">
       <attribute name="title">
        <string>Special Options</string>
@@ -3877,88 +3982,6 @@ you can use it but there could be issues with aligning columns of text</string>
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox">
-         <property name="title">
-          <string>Accessibility</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout">
-          <item row="0" column="0" colspan="2">
-           <widget class="QCheckBox" name="checkBox_announceIncomingText">
-            <property name="toolTip">
-             <string>On some platforms, like macOS, the screen reader tool has issues announcing incoming text fully, without skipping. You can opt into disabling announcing new text from the game with this option to use a custom TTS instead which avoids such issues</string>
-            </property>
-            <property name="text">
-             <string>Announce incoming text in screen reader</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QComboBox" name="comboBox_blankLinesBehaviour">
-            <item>
-             <property name="text">
-              <string>show them</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>hide them</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>replace with a space</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_blankLinesBehaviour">
-            <property name="text">
-             <string>When the game sends blank lines:</string>
-            </property>
-            <property name="buddy">
-             <cstring>comboBox_blankLinesBehaviour</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_caretModeKey">
-            <property name="text">
-             <string>Switch between input line and main window using:</string>
-            </property>
-            <property name="buddy">
-             <cstring>comboBox_caretModeKey</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QComboBox" name="comboBox_caretModeKey">
-            <item>
-             <property name="text">
-              <string>no key</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Tab</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Ctrl+Tab</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>F6</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
         <spacer name="verticalSpacer_specialOptions">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -4182,6 +4205,7 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>mFORCE_CHARSET_NEGOTIATION_OFF</tabstop>
   <tabstop>checkBox_mUSE_FORCE_LF_AFTER_PROMPT</tabstop>
   <tabstop>mFORCE_MXP_NEGOTIATION_OFF</tabstop>
+  <tabstop>buttonPurgeMediaCache</tabstop>
   <tabstop>checkbox_noAutomaticUpdates</tabstop>
   <tabstop>search_engine_combobox</tabstop>
   <tabstop>checkBox_showIconsOnMenus</tabstop>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -1138,12 +1138,9 @@ you can use it but there could be issues with aligning columns of text</string>
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QCheckBox" name="checkBox_showSpacesAndTabs">
-            <property name="toolTip">
-             <string>&lt;body&gt;&lt;p&gt;When displaying Lua contents in the main text editor area of the Editor show tabs and spaces with visible marks instead of whitespace.&lt;/p&gt;</string>
-            </property>
+           <widget class="QCheckBox" name="checkBox_enableTextAnalyzer">
             <property name="text">
-             <string>Show Spaces/Tabs</string>
+             <string>Enable text analyzer</string>
             </property>
            </widget>
           </item>
@@ -1158,12 +1155,12 @@ you can use it but there could be issues with aligning columns of text</string>
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QCheckBox" name="checkBox_showLineFeedsAndParagraphs">
-            <property name="toolTip">
-             <string>&lt;body&gt;&lt;p&gt;When displaying Lua contents in the main text editor area of the Editor show  line and paragraphs ends with visible marks as well as whitespace.&lt;/p&gt;</string>
-            </property>
+           <widget class="QCheckBox" name="checkBox_useWideAmbiguousEastAsianGlyphs">
             <property name="text">
-             <string>Show Line/Paragraphs</string>
+             <string>Make 'Ambiguous' E. Asian width characters wide</string>
+            </property>
+            <property name="tristate">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -1177,31 +1174,14 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QCheckBox" name="checkBox_useWideAmbiguousEastAsianGlyphs">
-            <property name="text">
-             <string>Make 'Ambiguous' E. Asian width characters wide</string>
-            </property>
-            <property name="tristate">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
           <item row="3" column="0">
-           <widget class="QCheckBox" name="checkBox_enableTextAnalyzer">
-            <property name="text">
-             <string>Enable text analyzer</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
            <widget class="QLabel" name="label_controlCharacterHandling">
             <property name="text">
              <string>Display control characters as:</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="3" column="1">
            <widget class="QComboBox" name="comboBox_controlCharacterHandling">
             <property name="currentIndex">
              <number>0</number>
@@ -1337,6 +1317,35 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QCheckBox" name="checkBox_autocompleteLuaCode">
             <property name="text">
              <string>Autocomplete Lua functions in code editor</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_editorDisplayOptions">
+         <property name="title">
+          <string>Display options</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_groupBox_editorDisplayOptions">
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="checkBox_showSpacesAndTabs">
+            <property name="toolTip">
+             <string>&lt;body&gt;&lt;p&gt;When displaying Lua contents in the main text editor area of the Editor show tabs and spaces with visible marks instead of whitespace.&lt;/p&gt;</string>
+            </property>
+            <property name="text">
+             <string>Show Spaces/Tabs</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QCheckBox" name="checkBox_showLineFeedsAndParagraphs">
+            <property name="toolTip">
+             <string>&lt;body&gt;&lt;p&gt;When displaying Lua contents in the main text editor area of the Editor show  line and paragraphs ends with visible marks as well as whitespace.&lt;/p&gt;</string>
+            </property>
+            <property name="text">
+             <string>Show Line/Paragraphs</string>
             </property>
            </widget>
           </item>
@@ -4100,13 +4109,13 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>checkBox_USE_SMALL_SCREEN</tabstop>
   <tabstop>checkBox_echoLuaErrors</tabstop>
   <tabstop>checkBox_enableTextAnalyzer</tabstop>
-  <tabstop>checkBox_showSpacesAndTabs</tabstop>
-  <tabstop>checkBox_showLineFeedsAndParagraphs</tabstop>
   <tabstop>checkBox_useWideAmbiguousEastAsianGlyphs</tabstop>
   <tabstop>comboBox_controlCharacterHandling</tabstop>
   <tabstop>code_editor_theme_selection_combobox</tabstop>
   <tabstop>script_preview_combobox</tabstop>
   <tabstop>checkBox_autocompleteLuaCode</tabstop>
+  <tabstop>checkBox_showSpacesAndTabs</tabstop>
+  <tabstop>checkBox_showLineFeedsAndParagraphs</tabstop>
   <tabstop>checkBox_showBidi</tabstop>
   <tabstop>pushButton_foreground_color</tabstop>
   <tabstop>pushButton_command_line_foreground_color</tabstop>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
It has changes on the preferences window, main thing is moving Accessibility to a new tab.

While I'm at it:
- dim the Clear stored media group when no profile open
- add a tab stop for that same Clear button
- dim the accessibility labels when no profile instead of just the drop boxes
- renamed `groupBox` to `groupBox_accessibility`
- moved `Show Spaces/Tabs` and `Show Line/Paragraphs` from Main Display tab to Editor tab
` moved `2D Room Symbol scaling factor` (visible only when map is opened) from Special Options to Mapper

#### Motivation for adding to Mudlet
The Save button was pushed off the screen on my system because the Special Options tab is so tall and the window is stretched to hold it.
#### Other info (issues closed, discussion etc)
