### PR TITLE
Infrastructure: add some commonly used variable names to .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,37 @@
-Checks: '-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-implicit-bool-conversion,-readability-qualified-auto,-cppcoreguidelines-owning-memory,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-readability-static-accessed-through-instance,-cppcoreguidelines-pro-type-static-cast-downcast,-bugprone-suspicious-enum-usage,-readability-uppercase-literal-suffix,-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-misc-no-recursion,-readability-isolate-declaration,-cppcoreguidelines-pro-type-vararg,-misc-non-private-member-variables-in-classes,-performance-no-automatic-move,-readability-avoid-const-params-in-decls,-cppcoreguidelines-non-private-member-variables-in-classes'
+Checks:  '# disable all checks by default
+          -*
+          readability-identifier-length
+          # and only explicitly enable the ones we need
+          performance-*
+          readability-*
+          bugprone-*
+          clang-analyzer-*
+          cppcoreguidelines-*
+          mpi-*
+          misc-*
+          -readability-implicit-bool-conversion
+          -readability-qualified-auto
+          -cppcoreguidelines-owning-memory
+          -cppcoreguidelines-avoid-magic-numbers
+          -readability-magic-numbers
+          -readability-static-accessed-through-instance
+          -cppcoreguidelines-pro-type-static-cast-downcast
+          -bugprone-suspicious-enum-usage
+          -readability-uppercase-literal-suffix
+          -cppcoreguidelines-avoid-non-const-global-variables
+          -cppcoreguidelines-pro-bounds-array-to-pointer-decay
+          -misc-no-recursion
+          -readability-isolate-declaration
+          -cppcoreguidelines-pro-type-vararg
+          -misc-non-private-member-variables-in-classes
+          -performance-no-automatic-move
+          -readability-avoid-const-params-in-decls
+          -cppcoreguidelines-non-private-member-variables-in-classes
+          '
 # Use .clang-format for formatting
 FormatStyle: file
 CheckOptions:
+  - key:             readability-identifier-length.IgnoredParameterNames
+    value:           'i|r|g|b|a|x|y|z|c|p|L|rr|fg|bg|gg|bb|id|pC|pT|pH|to|it|pW|ch'
   - key:             readability-identifier-length.IgnoredVariableNames
-    value:           'x|y'
+    value:           'i|r|g|b|a|x|y|z|c|p|L|rr|fg|bg|gg|bb|id|pC|pT|pH|to|it|pW|ch'


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add some commonly used, normally too short but in this case still understandable variables to .clang-tidy
#### Motivation for adding to Mudlet
So clang-tidy doesn't complain about them, yet other short variable names which make no sense don't get into the code
#### Other info (issues closed, discussion etc)
