### PR TITLE
Add: a placeholder text for aliases

### DIFF
--- a/src/ui/aliases_main_area.ui
+++ b/src/ui/aliases_main_area.ui
@@ -97,6 +97,9 @@
      <property name="toolTip">
       <string>enter a perl regex pattern for your alias; alias are triggers on your input</string>
      </property>
+     <property name="placeholderText">
+      <string>^mycommand$ (example)</string>
+     </property>
     </widget>
    </item>
    <item row="1" column="2" alignment="Qt::AlignRight">


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add a placeholder text for aliases
#### Motivation for adding to Mudlet
I've seen a few incoming folk get confused by alias regexex, hopefully this can steer them in the right direction

![image](https://user-images.githubusercontent.com/110988/230744979-742b9341-b421-4128-a697-5506a6debd5f.png)

#### Other info (issues closed, discussion etc)
