### PR TITLE
Fix: get MSYS2/Mingw-w64 builds compiling

### DIFF
--- a/src/uiawrapper.h
+++ b/src/uiawrapper.h
@@ -33,7 +33,7 @@
 #include <uiautomationcore.h>
 #include <uiautomationcoreapi.h>
 
-#if defined(WITH_MAIN_BUILD_SYSTEM)
+#if defined(INCLUDE_MAIN_BUILD_SYSTEM)
 enum NotificationProcessing {
   NotificationProcessing_ImportantAll = 0,
   NotificationProcessing_ImportantMostRecent = 1,
@@ -49,7 +49,7 @@ enum NotificationKind {
   NotificationKind_ActionAborted = 3,
   NotificationKind_Other = 4
 };
-#endif // WITH_MAIN_BUILD_SYSTEM
+#endif // INCLUDE_MAIN_BUILD_SYSTEM
 
 class UiaWrapper {
   UiaWrapper();

--- a/src/uiawrapper.h
+++ b/src/uiawrapper.h
@@ -33,6 +33,7 @@
 #include <uiautomationcore.h>
 #include <uiautomationcoreapi.h>
 
+#if defined(WITH_MAIN_BUILD_SYSTEM)
 enum NotificationProcessing {
   NotificationProcessing_ImportantAll = 0,
   NotificationProcessing_ImportantMostRecent = 1,
@@ -48,6 +49,7 @@ enum NotificationKind {
   NotificationKind_ActionAborted = 3,
   NotificationKind_Other = 4
 };
+#endif // WITH_MAIN_BUILD_SYSTEM
 
 class UiaWrapper {
   UiaWrapper();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
It seems that in an update a couple of `enum`s that we had put in for Windows builds are NOT needed in this build environment and thus need to be kept out of the build in this case.

#### Motivation for adding to Mudlet
This will be needed to test the set of three scripts I have been putting together to setup, build and package Mudlet in that environment.