### PR TITLE
Infrastructure: update the en_US translations to include recent text changes

### DIFF
--- a/translations/translated/mudlet_en_US.ts
+++ b/translations/translated/mudlet_en_US.ts
@@ -27,7 +27,7 @@
 <context>
     <name>T2DMap</name>
     <message numerus="yes">
-        <location filename="../../src/T2DMap.cpp" line="1204"/>
+        <location filename="../../src/T2DMap.cpp" line="1218"/>
         <source>You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.</source>
         <translation>
             <numerusform>You have a map loaded (%n room), but Mudlet does not know where you are at the moment.</numerusform>
@@ -38,7 +38,37 @@
 <context>
     <name>TRoomDB</name>
     <message numerus="yes">
-        <location filename="../../src/TRoomDB.cpp" line="731"/>
+        <location filename="../../src/TRoomDB.cpp" line="717"/>
+        <source>[ ALERT ] - %n area(s) detected as missing in map: adding it/them in.
+Look for further messages related to the rooms that are supposed
+to be in this/these area(s)...</source>
+        <comment>Making use of %n to allow quantity dependent message form 8-) !</comment>
+        <translation>
+            <numerusform>[ ALERT ] - %n area detected as missing in map: adding it in.
+Look for further messages related to the rooms that are supposed
+to be in this area...</numerusform>
+            <numerusform>[ ALERT ] - %n areas detected as missing in map: adding them in.
+Look for further messages related to the rooms that are supposed
+to be in these areas...</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/TRoomDB.cpp" line="724"/>
+        <source>[ ALERT ] - %n area(s) detected as missing in map: adding it/them in.
+Look for further messages related to the rooms that is/are supposed to
+be in this/these area(s)...</source>
+        <comment>Making use of %n to allow quantity dependent message form 8-) !</comment>
+        <translation>
+            <numerusform>[ ALERT ] - %n area detected as missing in map: adding it in.
+Look for further messages related to the rooms that are supposed to
+be in this area...</numerusform>
+            <numerusform>[ ALERT ] - %n areas detected as missing in map: adding them in.
+Look for further messages related to the rooms that are supposed to
+be in these areas...</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/TRoomDB.cpp" line="733"/>
         <source>[ INFO ]  - The missing area(s) are now called:
 (ID) ==&gt; &quot;name&quot;</source>
         <comment>Making use of %n to allow quantity dependent message form 8-) !</comment>
@@ -48,36 +78,6 @@
 (ID) ==&gt; &quot;name&quot;</numerusform>
             <numerusform>[ INFO ]  - The missing %n areas are now called:
 (ID) ==&gt; &quot;name&quot;</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../../src/TRoomDB.cpp" line="715"/>
-        <source>[ ALERT ] - %n area(s) detected as missing in map: adding it/them in.
- Look for further messages related to the rooms that are supposed
- to be in this/these area(s)...</source>
-        <comment>Making use of %n to allow quantity dependent message form 8-) !</comment>
-        <translation>
-            <numerusform>[ ALERT ] - %n area detected as missing in map: adding it in.
- Look for further messages related to the rooms that are supposed
- to be in this area...</numerusform>
-            <numerusform>[ ALERT ] - %n areas detected as missing in map: adding them in.
- Look for further messages related to the rooms that are supposed
- to be in these areas...</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../../src/TRoomDB.cpp" line="722"/>
-        <source>[ ALERT ] - %n area(s) detected as missing in map: adding it/them in.
- Look for further messages related to the rooms that is/are supposed to
- be in this/these area(s)...</source>
-        <comment>Making use of %n to allow quantity dependent message form 8-) !</comment>
-        <translation>
-            <numerusform>[ ALERT ] - %n area detected as missing in map: adding it in.
- Look for further messages related to the rooms that are supposed
- to be in this area...</numerusform>
-            <numerusform>[ ALERT ] - %n areas detected as missing in map: adding them in.
- Look for further messages related to the rooms that are supposed
- to be in these areas...</numerusform>
         </translation>
     </message>
 </context>
@@ -95,7 +95,7 @@
 <context>
     <name>dlgPackageExporter</name>
     <message numerus="yes">
-        <location filename="../../src/dlgPackageExporter.cpp" line="1459"/>
+        <location filename="../../src/dlgPackageExporter.cpp" line="1462"/>
         <source>Select what to export (%n item(s))</source>
         <comment>This is the text shown at the top of a groupbox when there is %n (one or more) items to export in the Package exporter dialogue; the initial (and when there is no items selected) is a separate text.</comment>
         <translation>
@@ -113,6 +113,28 @@
         <translation>
             <numerusform>Remove %n package</numerusform>
             <numerusform>Remove %n packages</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>dlgProfilePreferences</name>
+    <message numerus="yes">
+        <location filename="../../src/dlgProfilePreferences.cpp" line="154"/>
+        <location filename="../../src/dlgProfilePreferences.cpp" line="3102"/>
+        <source>copy to %n destination(s)</source>
+        <comment>text on button to put the map from this profile into the other profiles to receive the map from this profile, %n is the number of other profiles that have already been selected to receive it and will be zero or more. The button will also be disabled (greyed out) in the zero case but the text will still be visible.</comment>
+        <translation>
+            <numerusform>copy to %n destination</numerusform>
+            <numerusform>copy to %n destinations</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/dlgProfilePreferences.cpp" line="3112"/>
+        <source>%n selected - change destinations...</source>
+        <comment>text on button to select other profiles to receive the map from this profile, %n is the number of other profiles that have already been selected to receive it and will always be 1 or more</comment>
+        <translation>
+            <numerusform>%n selected - change destination...</numerusform>
+            <numerusform>%n selected - change destinations...</numerusform>
         </translation>
     </message>
 </context>
@@ -182,7 +204,7 @@
 <context>
     <name>mudlet</name>
     <message numerus="yes">
-        <location filename="../../src/mudlet.cpp" line="3547"/>
+        <location filename="../../src/mudlet.cpp" line="3597"/>
         <source>&lt;p&gt;About Mudlet&lt;/p&gt;&lt;p&gt;&lt;i&gt;%n update(s) is/are now available!&lt;/i&gt;&lt;p&gt;</source>
         <comment>This is the tooltip text for the &apos;About&apos; Mudlet main toolbar button when it has been changed by adding a menu which now contains the original &apos;About Mudlet&apos; action and a new one to access the manual update process</comment>
         <translation>
@@ -191,7 +213,7 @@
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../src/mudlet.cpp" line="3565"/>
+        <location filename="../../src/mudlet.cpp" line="3615"/>
         <source>Review %n update(s)...</source>
         <comment>Review update(s) menu item, %n is the count of how many updates are available</comment>
         <translatorcomment>Could do with the insertion of &quot;the&quot; as a second word!</translatorcomment>
@@ -201,7 +223,7 @@
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../src/mudlet.cpp" line="3570"/>
+        <location filename="../../src/mudlet.cpp" line="3620"/>
         <source>Review the update(s) available...</source>
         <comment>Tool-tip for review update(s) menu item, given that the count of how many updates are available is already shown in the menu, the %n parameter that is that number need not be used here</comment>
         <translation>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This updated the numerus translations for the American (plurals-only) case.

#### Motivation for adding to Mudlet
It replaces the other (draft) PR mentioned as it incorporates changes introduced by #6715 which the automation that produced the former does not cover at present (whether it would have eventually is unclear).

#### Other info (issues closed, discussion etc)
**NOTE: THIS SUPPLANTS/REPLACES/CLOSES #6748**
