### PR TITLE
Fix: MXP version/style for better game compatibility 

### DIFF
--- a/src/TMxpClient.h
+++ b/src/TMxpClient.h
@@ -62,6 +62,9 @@ public:
     virtual void setItalic(bool val) = 0;
     virtual void setUnderline(bool val) = 0;
 
+    virtual void setStyle(const QString& val) = 0;
+    virtual const QString &getStyle() = 0;
+
     virtual int setLink(const QStringList& hrefs, const QStringList& hints) = 0;
     virtual bool getLink(int id, QStringList** hrefs, QStringList** hints) = 0;
 

--- a/src/TMxpClient.h
+++ b/src/TMxpClient.h
@@ -67,7 +67,7 @@ public:
     virtual void setUnderline(bool val) = 0;
 
     virtual void setStyle(const QString& val) = 0;
-    virtual const QString &getStyle() = 0;
+    virtual QString getStyle() = 0;
 
     virtual int setLink(const QStringList& hrefs, const QStringList& hints) = 0;
     virtual bool getLink(int id, QStringList** hrefs, QStringList** hints) = 0;

--- a/src/TMxpClient.h
+++ b/src/TMxpClient.h
@@ -40,6 +40,10 @@ public:
 
     virtual void initialize(TMxpContext* context) { mpContext = context; }
 
+    // Declaring the next functions as virtual = 0 makes this an abstract class:
+    // That is, a derived class can only be instantiated when it actually
+    // defines these functions.
+
     virtual QString getVersion() = 0;
 
     virtual void sendToServer(QString& str) = 0;

--- a/src/TMxpMudlet.h
+++ b/src/TMxpMudlet.h
@@ -36,6 +36,8 @@ class TMediaData;
 
 class TMxpMudlet : public TMxpClient
 {
+    QString mxpStyle; // Name/Version of the MXP style sheet uploaded by the mud
+
 public:
     explicit TMxpMudlet(Host* pHost)
     : isBold(false)
@@ -85,6 +87,8 @@ public:
     void setBold(bool bold) override { isBold = bold; }
     void setItalic(bool italic) override { isItalic = italic; }
     void setUnderline(bool underline) override { isUnderline = underline; }
+    void setStyle(const QString& val) override {mxpStyle = val; }
+    const QString &getStyle() override {return mxpStyle;}
 
     void setFlag(const QString& elementName, const QMap<QString, QString>& values, const QString& content) override {
         Q_UNUSED(elementName)

--- a/src/TMxpMudlet.h
+++ b/src/TMxpMudlet.h
@@ -88,7 +88,7 @@ public:
     void setItalic(bool italic) override { isItalic = italic; }
     void setUnderline(bool underline) override { isUnderline = underline; }
     void setStyle(const QString& val) override { mxpStyle = val; }
-    const QString &getStyle() override { return mxpStyle;}
+    QString getStyle() override { return mxpStyle;}
 
     void setFlag(const QString& elementName, const QMap<QString, QString>& values, const QString& content) override {
         Q_UNUSED(elementName)

--- a/src/TMxpMudlet.h
+++ b/src/TMxpMudlet.h
@@ -87,8 +87,8 @@ public:
     void setBold(bool bold) override { isBold = bold; }
     void setItalic(bool italic) override { isItalic = italic; }
     void setUnderline(bool underline) override { isUnderline = underline; }
-    void setStyle(const QString& val) override {mxpStyle = val; }
-    const QString &getStyle() override {return mxpStyle;}
+    void setStyle(const QString& val) override { mxpStyle = val; }
+    const QString &getStyle() override { return mxpStyle;}
 
     void setFlag(const QString& elementName, const QMap<QString, QString>& values, const QString& content) override {
         Q_UNUSED(elementName)

--- a/src/TMxpVersionTagHandler.cpp
+++ b/src/TMxpVersionTagHandler.cpp
@@ -28,7 +28,19 @@ TMxpTagHandlerResult TMxpVersionTagHandler::handleStartTag(TMxpContext& ctx, TMx
     Q_UNUSED(tag)
     const QString& version = client.getVersion();
 
+    if (tag->getAttributesCount() > 0) {
+        // Get the first arg (spaces or = in StyleId must be quoted)
+        client.setStyle(tag->getAttrName(0));
+        // Don't return a version string if there was an argument!
+        return MXP_TAG_HANDLED;
+    }
+
     QString payload = scmVersionString.arg(version);
+    if (!client.getStyle().isNull()) {
+        payload.replace(qsl(">"), qsl(" STYLE=%1>").arg(client.getStyle()));
+    }
+
+
     client.sendToServer(payload);
 
     return MXP_TAG_HANDLED;

--- a/src/TMxpVersionTagHandler.cpp
+++ b/src/TMxpVersionTagHandler.cpp
@@ -25,7 +25,6 @@
 TMxpTagHandlerResult TMxpVersionTagHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
 {
     Q_UNUSED(ctx)
-    Q_UNUSED(tag)
     const QString& version = client.getVersion();
 
     if (tag->getAttributesCount() > 0) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -79,6 +79,8 @@ add_test(NAME TMxpSendTagHandlerTest COMMAND TMxpSendTagHandlerTest)
 add_executable(TMxpEntityTagHandlerTest TMxpEntityTagHandlerTest.cpp ${MXP_SOURCE} ../src/TMxpEntityTagHandler.cpp ../src/TMxpTagParser.cpp ../src/TMxpNodeBuilder.cpp)
 add_test(NAME TMxpEntityTagHandlerTest COMMAND TMxpEntityTagHandlerTest)
 
+add_executable(TMxpVersionTagTest TMxpVersionTagTest.cpp ../src/TMxpVersionTagHandler.cpp ../src/TMxpTagParser.cpp ../src/TMxpNodeBuilder.cpp ../src/MxpTag.cpp ../src/TStringUtils.cpp ../src/TMxpTagHandler.cpp)
+add_test(NAME TMxpVersionTagTest COMMAND TMxpVersionTagTest)
 
 add_executable(TLuaInterfaceTest TLuaInterfaceTest.cpp ../src/LuaInterface.cpp ../src/TVar.cpp ../src/VarUnit.cpp)
 add_test(NAME TLuaInterfaceTest COMMAND TLuaInterfaceTest)

--- a/test/TMxpStubClient.h
+++ b/test/TMxpStubClient.h
@@ -73,8 +73,8 @@ public:
     QStringList mHrefs, mHints;
 
     QString mPublishedEntityName, mPublishedEntityValue;
-	
-	QString style;
+
+    QString style;
 
     QString getVersion() override
     {
@@ -126,14 +126,14 @@ public:
     {
         isUnderline = underline;
     }
-	void setStyle(const QString& val) override
-	{
-	    style = val;
-	}
+    void setStyle(const QString& val) override
+    {
+        style = val;
+    }
     const QString &getStyle() override
-	{
-		return style;
-	}
+    {
+        return style;
+    }
 
     int setLink(const QStringList& hrefs, const QStringList& hints) override
     {

--- a/test/TMxpStubClient.h
+++ b/test/TMxpStubClient.h
@@ -63,7 +63,7 @@ public:
 
 class TMxpStubClient : public TMxpClient {
 public:
-    QString version;
+    QString version = "Stub-1.0";
     bool linkMode;
 
     QString sentToServer;

--- a/test/TMxpStubClient.h
+++ b/test/TMxpStubClient.h
@@ -126,11 +126,12 @@ public:
     {
         isUnderline = underline;
     }
+
     void setStyle(const QString& val) override
     {
         style = val;
     }
-    const QString &getStyle() override
+    QString getStyle() override
     {
         return style;
     }

--- a/test/TMxpStubClient.h
+++ b/test/TMxpStubClient.h
@@ -73,6 +73,8 @@ public:
     QStringList mHrefs, mHints;
 
     QString mPublishedEntityName, mPublishedEntityValue;
+	
+	QString style;
 
     QString getVersion() override
     {
@@ -124,6 +126,14 @@ public:
     {
         isUnderline = underline;
     }
+	void setStyle(const QString& val) override
+	{
+	    style = val;
+	}
+    const QString &getStyle() override
+	{
+		return style;
+	}
 
     int setLink(const QStringList& hrefs, const QStringList& hints) override
     {

--- a/test/TMxpVersionTagTest.cpp
+++ b/test/TMxpVersionTagTest.cpp
@@ -1,0 +1,94 @@
+/***************************************************************************
+ *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2023 by Michael Weller - michael.weller@t-online.de     *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+ 
+#include <QTest>
+#include "TMxpVersionTagHandler.h"
+#include "TMxpStubClient.h"
+#include <TMxpTagParser.h>
+#include <TMxpTagProcessor.h>
+#include <TMxpProcessor.h>
+
+
+
+
+class TMxpVersionTagTest : public QObject {
+    Q_OBJECT
+
+private:
+private slots:
+    QSharedPointer<MxpNode> parseNode(const QString& tagText) const
+    {
+        auto nodes = TMxpTagParser::parseToMxpNodeList(tagText);
+        return nodes.size() > 0 ? nodes.first() : nullptr;
+    }
+
+    void initTestCase()
+    {}
+
+    void testVersionTag()
+    {
+        // Vanilla use of version
+
+        TMxpStubContext ctx;
+        TMxpStubClient stub;
+
+        auto versionTag = parseNode("<Version>");
+
+        TMxpVersionTagHandler versionTagHandler;
+        TMxpTagHandler& tagHandler = versionTagHandler;
+        tagHandler.handleTag(ctx, stub, versionTag->asTag());
+
+        QCOMPARE(stub.sentToServer, "\n\u001B[1z<VERSION MXP=1.0 CLIENT=Mudlet VERSION=Stub-1.0>\n");
+    }
+
+    void testVersionStyle()
+    {
+        // Set a Style (Version of MXP Template of mud)
+
+        TMxpStubContext ctx;
+        TMxpStubClient stub;
+
+        // style is generally just a string, but compared to other implementations we must at least allow
+        // for full 9 digits (which would fit into a 32bit int)
+        auto versionTag = parseNode("<Version 987654321>");
+
+        TMxpVersionTagHandler versionTagHandler;
+        TMxpTagHandler& tagHandler = versionTagHandler;
+        tagHandler.handleTag(ctx, stub, versionTag->asTag());
+
+        // NO return value when setting style (this is a grey area.. but Z/CMUD and mushclient do it this way and
+        // the MXP definition seems to imply this interpretation:
+        // The client caches this version information and returns it when requested by a plain <VERSION> request.
+        // One can interprete this like: it ONLY returns it when using a plain request... but...)
+        QCOMPARE(stub.sentToServer, "");
+
+        // From now on, return it with version
+        versionTag = parseNode("<VERSION>");
+        tagHandler.handleTag(ctx, stub, versionTag->asTag());
+        QCOMPARE(stub.sentToServer, "\n\u001B[1z<VERSION MXP=1.0 CLIENT=Mudlet VERSION=Stub-1.0 STYLE=987654321>\n");
+    }
+
+    void cleanupTestCase()
+    {}
+};
+
+#include "TMxpVersionTagTest.moc"
+QTEST_MAIN(TMxpVersionTagTest)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Parses the style argument of MXP version, like <VERSION StyleID>, and returns the version (and style id) only when an empty <VERSION> tag is send. Cf. https://www.zuggsoft.com/zmud/mxp.htm#Version%20Control   This is also how Zmud, Cmud and Mushclient process the <VERSION> tag.
#### Motivation for adding to Mudlet
Enhance MXP v1.0 compliance
#### Other info (issues closed, discussion etc)
cf. [MXP enhancements, was PR #4200](https://forums.mudlet.org/viewtopic.php?p=47108#p47108)