### PR TITLE
Fix: undo changed 'cannot write file' text

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -7987,7 +7987,7 @@ void dlgTriggerEditor::slot_export()
 
     QFile checkWriteability(fileName);
     if (!checkWriteability.open(QFile::WriteOnly | QFile::Text)) {
-        QMessageBox::warning(this, tr("export package:"), tr("Cannot write checkWriteability %1:\n%2.").arg(fileName, checkWriteability.errorString()));
+        QMessageBox::warning(this, tr("export package:"), tr("Cannot write file %1:\n%2.").arg(fileName, checkWriteability.errorString()));
         return;
     }
     // Should close the checkWriteability that we have confirmed can be opened:


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Undo changed 'cannot write file' text
#### Motivation for adding to Mudlet
`Cannot write checkWriteability` was not meant to be shown to the player
#### Other info (issues closed, discussion etc)
