### PR TITLE
improve Ctrl-2 and the others to initially focus on item list

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6868,6 +6868,7 @@ void dlgTriggerEditor::slot_showTimers()
         splitter_right->setSizes(sizes);
         mTimerEditorSplitterState = splitter_right->saveState();
     }
+    treeWidget_timers->setFocus();
 }
 
 void dlgTriggerEditor::showCurrentTriggerItem()
@@ -6913,6 +6914,7 @@ void dlgTriggerEditor::slot_showTriggers()
         splitter_right->setSizes(sizes);
         mTriggerEditorSplitterState = splitter_right->saveState();
     }
+    treeWidget_triggers->setFocus();
 }
 
 void dlgTriggerEditor::slot_showScripts()
@@ -6935,6 +6937,7 @@ void dlgTriggerEditor::slot_showScripts()
         splitter_right->setSizes(sizes);
         mScriptEditorSplitterState = splitter_right->saveState();
     }
+    treeWidget_scripts->setFocus();
 }
 
 void dlgTriggerEditor::slot_showKeys()
@@ -6959,6 +6962,7 @@ void dlgTriggerEditor::slot_showKeys()
         splitter_right->setSizes(sizes);
         mKeyEditorSplitterState = splitter_right->saveState();
     }
+    treeWidget_keys->setFocus();
 }
 
 void dlgTriggerEditor::slot_showVariables()
@@ -6987,6 +6991,7 @@ void dlgTriggerEditor::slot_showVariables()
         splitter_right->setSizes(sizes);
         mVarEditorSplitterState = splitter_right->saveState();
     }
+    treeWidget_variables->setFocus();
 }
 
 void dlgTriggerEditor::show_vars()
@@ -7033,6 +7038,7 @@ void dlgTriggerEditor::slot_showAliases()
         splitter_right->setSizes(sizes);
         mAliasEditorSplitterState = splitter_right->saveState();
     }
+    treeWidget_aliases->setFocus();
 }
 
 void dlgTriggerEditor::showError(const QString& error)
@@ -7082,6 +7088,7 @@ void dlgTriggerEditor::slot_showActions()
         splitter_right->setSizes(sizes);
         mActionEditorSplitterState = splitter_right->saveState();
     }
+    treeWidget_actions->setFocus();
 }
 
 void dlgTriggerEditor::slot_saveEdits()


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Entering the trigger editor (clicking button or Alt-E) puts focus on item list, changing views to aliases and the rest (button or Ctrl-2, Ctrl-3, etc) does not, so this edit makes Ctrl-2 similar to Alt-E.
#### Motivation for adding to Mudlet
Keyboard navigation would be more consistent
#### Other info (issues closed, discussion etc)
fix #6796 
