### PR TITLE
Infrastructure: don't run separate changelog generation nightly

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -1,8 +1,6 @@
 name: Generate a changelog
 
 on:
-  schedule:
-    - cron: '0 3 * * *'
   workflow_dispatch:
     inputs:
       from:


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Don't run changelog generation nightly. 
#### Motivation for adding to Mudlet
It was never used for PTBs, only intended to just view the changelog from the latest release until now - but it's seldomly used for that purpose and it's more confusing than anything to have it run on a periodic basis.
#### Other info (issues closed, discussion etc)
