### PR TITLE
Fix: Save new profile host info on lost focus (#2919)

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -499,7 +499,7 @@ void dlgConnectionProfiles::slot_saveName()
     QString newProfileName = profile_name_entry->text().trimmed();
     QString newProfileHost = host_name_entry->text().trimmed();
     QString newProfilePort = port_entry->text().trimmed();
-    int newProfileSslTsl = int(port_ssl_tsl->isChecked()) * 2;
+    int newProfileSslTsl = port_ssl_tsl->isChecked() * 2;
 
     validateProfile();
     if (!validName || newProfileName.isEmpty() || !pItem) {

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -497,6 +497,9 @@ void dlgConnectionProfiles::slot_saveName()
 {
     QListWidgetItem* pItem = profiles_tree_widget->currentItem();
     QString newProfileName = profile_name_entry->text().trimmed();
+    QString newProfileHost = host_name_entry->text().trimmed();
+    QString newProfilePort = port_entry->text().trimmed();
+    int newProfileSslTsl = int(port_ssl_tsl->isChecked()) * 2;
 
     validateProfile();
     if (!validName || newProfileName.isEmpty() || !pItem) {
@@ -544,6 +547,16 @@ void dlgConnectionProfiles::slot_saveName()
         notificationAreaMessageBox->show();
         notificationAreaMessageBox->setText(tr("Could not create the new profile folder on your computer."));
     }
+
+    if (!newProfileHost.isEmpty()) {
+        slot_updateUrl(newProfileHost);
+    }
+
+    if (!newProfilePort.isEmpty()) {
+        slot_updatePort(newProfilePort);
+    }
+
+    slot_updateSslTslPort(newProfileSslTsl);
 
     // if this was a previously deleted profile, restore it
     auto& settings = *mudlet::self()->mpSettings;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Re-runs update functions for host, port, and ssl state in the saveName function to make sure they have a valid place in system memory to write to.

#### Motivation for adding to Mudlet
Better UX

#### Other info (issues closed, discussion etc)
Fixes #2919 

To my mind this could have been solved in one of three ways.

1. Assigning every new profile a unique temporary name, and making sure it's written into storage before any changes can be made to the name and connection settings. This way when host and port are edited first, they have a valid place to write to. This would solve the problem, but would also mean that every single new profile would have to be written to disk upon creation, which from my observation is not how it currently works.

2. Creating a place to hold profile information that can then be saved later in one function, but this would require touching a whole bunch of code and potentially breaking things that I'm not aware of.

3.  My current solution. I'm open to trying to implement one of the other two solutions if that would be preferable.
