### PR TITLE
add html escaping to some labels containing user-defined things such as trigger names

### DIFF
--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -224,7 +224,7 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds)
                 }
                 setError(qsl("<b><font color='blue'>%1</font></b>")
                          .arg(tr(R"(Error: in item %1, perl regex "%2" failed to compile, reason: "%3".)")
-                         .arg(QString::number(i + 1), regexp.constData(), error)));
+                         .arg(QString::number(i + 1), QString(regexp.constData()).toHtmlEscaped(), error)));
                 state = false;
             } else {
                 if (mudlet::smDebugMode) {

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -860,9 +860,7 @@ std::pair<bool, QString> dlgPackageExporter::copyAssetsToTmp(const QStringList& 
         }
         if (asset.isFile()) {
             QFile::remove(filePath);
-            if (!QFile::copy(asset.absoluteFilePath(), filePath)) {
-                return {false, tr("cannot copy %1 to the temporary location %2 - can you double-check it?").arg(asset.absoluteFilePath().toHtmlEscaped(), tempPath.toHtmlEscaped())};
-            }
+            QFile::copy(asset.absoluteFilePath(), filePath);
         } else if (asset.isDir()) {
             copy_directory(asset.absoluteFilePath(), filePath, false);
         }

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -856,11 +856,13 @@ std::pair<bool, QString> dlgPackageExporter::copyAssetsToTmp(const QStringList& 
         QString filePath = tempPath;
         filePath.append(asset.fileName());
         if (!asset.exists()) {
-            return {false, tr("%1 doesn't seem to exist anymore - can you double-check it?").arg(asset.absoluteFilePath())};
+            return {false, tr("%1 doesn't seem to exist anymore - can you double-check it?").arg(asset.absoluteFilePath().toHtmlEscaped())};
         }
         if (asset.isFile()) {
             QFile::remove(filePath);
-            QFile::copy(asset.absoluteFilePath(), filePath);
+            if (!QFile::copy(asset.absoluteFilePath(), filePath)) {
+                return {false, tr("cannot copy %1 to the temporary location %2 - can you double-check it?").arg(asset.absoluteFilePath().toHtmlEscaped(), tempPath.toHtmlEscaped())};
+            }
         } else if (asset.isDir()) {
             copy_directory(asset.absoluteFilePath(), filePath, false);
         }

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -174,7 +174,7 @@ std::pair<bool, QString> dlgPackageExporter::writeFileToZip(const QString& archi
                 tr("Failed to open file \"%1\" to place into package. Error message was: \"%2\".",
                    // Intentional comment to separate arguments
                    "This error message will appear when a file is to be placed into the package but the code cannot open it.")
-                        .arg(fileSystemFileName, zip_strerror(archive))};
+                        .arg(fileSystemFileName.toHtmlEscaped(), zip_strerror(archive))};
     }
 
     if (zip_file_add(archive, archiveFileName.toUtf8().constData(), s, ZIP_FL_ENC_UTF_8 | ZIP_FL_OVERWRITE) == -1) {
@@ -184,7 +184,7 @@ std::pair<bool, QString> dlgPackageExporter::writeFileToZip(const QString& archi
                 tr("Failed to add file \"%1\" to package. Error message was: \"%3\".",
                    // Intentional comment to separate arguments
                    "This error message will appear when a file is to be placed into the package but cannot be done for some reason.")
-                        .arg(archiveFileName, zip_strerror(archive))};
+                        .arg(archiveFileName.toHtmlEscaped(), zip_strerror(archive))};
     }
 
     return {true, QString()};

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -528,7 +528,7 @@ void dlgPackageExporter::slot_exportPackage()
     QFile checkWriteability(mXmlPathFileName);
     if (!checkWriteability.open(QIODevice::WriteOnly)) {
         displayResultMessage(tr("Failed to export. Could not open the folder \"%1\" for writing. Do you have the necessary permissions and free disk-space to write to that folder?")
-                             .arg(mXmlPathFileName), false);
+                             .arg(mXmlPathFileName.toHtmlEscaped()), false);
         assetsFuture.cancel();
         mExportingPackage = false;
         checkToEnableExportButton();
@@ -570,7 +570,7 @@ void dlgPackageExporter::slot_exportPackage()
                     displayResultMessage(errorMsg, false);
                 } else {
                     displayResultMessage(tr("Package \"%1\" exported to: %2")
-                                                 .arg(mPackageName, qsl("<a href=\"file:///%1\">%1</a>")
+                                                 .arg(mPackageName.toHtmlEscaped(), qsl("<a href=\"file:///%1\">%1</a>")
                                                                             .arg(getActualPath().toHtmlEscaped())),
                                          true);
                 }
@@ -785,7 +785,7 @@ void dlgPackageExporter::exportXml(bool& isOk,
         displayResultMessage(tr("Failed to export. Could not write Mudlet items to the file \"%1\".",
                                 // Intentional comment to separate arguments
                                 "This error message is shown when all the Mudlet items cannot be written to the 'packageName'.xml file in the base directory of the place where all the files are staged before being compressed into the package file. The full path and filename are shown in %1 to help the user diagnose what might have happened.")
-                             .arg(mXmlPathFileName), false);
+                             .arg(mXmlPathFileName.toHtmlEscaped()), false);
         // Although we have failed, we must not just abort here. We need to reset
         // the selected "for export or not"-flags first. So note that we have failed:
         isOk = false;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2323,9 +2323,9 @@ void dlgProfilePreferences::loadMap(const QString& fileName)
     if (success) {
         // TMap::audit() is what paints up the "[  OK  ]" message for the map load.
         pHost->mpMap->audit();
-        label_mapFileActionResult->setText(tr("Loaded map from %1.").arg(fileName));
+        label_mapFileActionResult->setText(tr("Loaded map from %1.").arg(fileName.toHtmlEscaped()));
     } else {
-        label_mapFileActionResult->setText(tr("Could not load map from %1.").arg(fileName));
+        label_mapFileActionResult->setText(tr("Could not load map from %1.").arg(fileName.toHtmlEscaped()));
     }
 
     QTimer::singleShot(10s, this, &dlgProfilePreferences::slot_hideActionLabel);
@@ -2425,9 +2425,9 @@ void dlgProfilePreferences::slot_saveMap()
         }
 
         if (success) {
-            label_mapFileActionResult->setText(tr("Saved map to %1.").arg(fileName));
+            label_mapFileActionResult->setText(tr("Saved map to %1.").arg(fileName.toHtmlEscaped()));
         } else {
-            label_mapFileActionResult->setText(tr("Could not save map to %1.").arg(fileName));
+            label_mapFileActionResult->setText(tr("Could not save map to %1.").arg(fileName.toHtmlEscaped()));
         }
         mudlet::self()->setShowMapAuditErrors(showAuditErrors);
 

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -1046,13 +1046,13 @@ QAction* dlgRoomExits::getActionOnExit(QLineEdit* pExitLineEdit) const
         if (exitRoomLocked) {
             if (outOfAreaExit) {
                 return doubleParagraph.arg(tr("Exit to \"%1\" in area: \"%2\".")
-                                               .arg(exitRoomName, exitAreaName),
+                                               .arg(exitRoomName.toHtmlEscaped(), exitAreaName.toHtmlEscaped()),
                                            tr("<b>Room is locked</b>, it will not be used for speed-walks for any exit that leads to it.",
                                               // Intentional comment to separate arguments
                                               "Bold HTML tags are used to emphasis that destination room locked status overrides any weight or lock (\"No route\") setting of any exit that goes to it."));
             }
             return doubleParagraph.arg(tr("Exit to \"%1\".")
-                                           .arg(exitRoomName),
+                                           .arg(exitRoomName.toHtmlEscaped()),
                                        tr("<b>Room is locked</b>, it will not be used for speed-walks for any exit that leads to it.",
                                           // Intentional comment to separate arguments
                                           "Bold HTML tags are used to emphasis that destination room locked status overrides any weight or lock (\"No route\") setting of any exit that goes to it."));
@@ -1060,14 +1060,14 @@ QAction* dlgRoomExits::getActionOnExit(QLineEdit* pExitLineEdit) const
         }
         if (outOfAreaExit) {
             return doubleParagraph.arg(tr("Exit to \"%1\" in area: \"%2\".")
-                                           .arg(exitRoomName, exitAreaName),
+                                           .arg(exitRoomName.toHtmlEscaped(), exitAreaName.toHtmlEscaped()),
                                        tr("<b>Room</b> Weight of destination: %1.",
                                           // Intentional comment to separate arguments
                                           "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
                                            .arg(exitRoomWeight));
         }
         return doubleParagraph.arg(tr("Exit to \"%1\".")
-                                       .arg(exitRoomName),
+                                       .arg(exitRoomName.toHtmlEscaped()),
                                    tr("<b>Room</b> Weight of destination: %1.",
                                       // Intentional comment to separate arguments
                                       "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
@@ -1077,7 +1077,7 @@ QAction* dlgRoomExits::getActionOnExit(QLineEdit* pExitLineEdit) const
     if (exitRoomLocked) {
         if (outOfAreaExit) {
             return doubleParagraph.arg(tr("Exit to unnamed room in area: \"%1\", is valid.")
-                                           .arg(exitAreaName),
+                                           .arg(exitAreaName.toHtmlEscaped()),
                                        tr("<b>Room is locked</b>, it will not be used for speed-walks for any exit that leads to it.",
                                           // Intentional comment to separate arguments
                                           "Bold HTML tags are used to emphasis that destination room locked status overrides any weight or lock (\"No route\") setting of any exit that goes to it."));
@@ -1091,7 +1091,7 @@ QAction* dlgRoomExits::getActionOnExit(QLineEdit* pExitLineEdit) const
 
     if (outOfAreaExit) {
         return doubleParagraph.arg(tr("Exit to unnamed room in area: \"%1\", is valid.")
-                                       .arg(exitAreaName),
+                                       .arg(exitAreaName.toHtmlEscaped()),
                                    tr("<b>Room</b> Weight of destination: %1.",
                                       // Intentional comment to separate arguments
                                       "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -2806,7 +2806,7 @@ void dlgTriggerEditor::activeToggle_trigger()
     } else {
         pT->setIsActive(false);
         showError(tr(R"(<b>Unable to activate a filter or trigger or the part of a module "<tt>%1</tt>" that contains them; reason: %2.</b></p>
-                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)").arg(pT->getName(), pT->getError()));
+                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)").arg(pT->getName().toHtmlEscaped(), pT->getError()));
         icon.addPixmap(QPixmap(qsl(":/icons/tools-report-bug.png")), QIcon::Normal, QIcon::Off);
     }
     pItem->setIcon(0, icon);
@@ -2942,14 +2942,14 @@ void dlgTriggerEditor::activeToggle_timer()
 
     if (pT->state()) {
         if (pT->shouldBeActive()) {
-            showInfo(tr(R"(Trying to activate a timer group, offset timer, timer or the part of a module "<tt>%1</tt>" that contains them <em>succeeded</em>.)").arg(pT->getName()));
+            showInfo(tr(R"(Trying to activate a timer group, offset timer, timer or the part of a module "<tt>%1</tt>" that contains them <em>succeeded</em>.)").arg(pT->getName().toHtmlEscaped()));
         } else {
-            showInfo(tr(R"(Trying to deactivate a timer group, offset timer, timer or the part of a module "<tt>%1</tt>" that contains them <em>succeeded</em>.)").arg(pT->getName()));
+            showInfo(tr(R"(Trying to deactivate a timer group, offset timer, timer or the part of a module "<tt>%1</tt>" that contains them <em>succeeded</em>.)").arg(pT->getName().toHtmlEscaped()));
         }
     } else {
         pT->setIsActive(false);
         showError(tr(R"(<p><b>Unable to activate an offset timer or timer or the part of a module "<tt>%1</tt>" that contains them; reason: %2.</b></p>
-                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)").arg(pT->getName(), pT->getError()));
+                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)").arg(pT->getName().toHtmlEscaped(), pT->getError()));
         icon.addPixmap(QPixmap(qsl(":/icons/tools-report-bug.png")), QIcon::Normal, QIcon::Off);
     }
     pItem->setIcon(0, icon);
@@ -2993,7 +2993,7 @@ void dlgTriggerEditor::activeToggle_alias()
     } else {
         pT->setIsActive(false);
         showError(tr(R"(<p><b>Unable to activate an alias or the part of a module "<tt>%1</tt>" that contains them; reason: %2.</b></p>
-                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)").arg(pT->getName(), pT->getError()));
+                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)").arg(pT->getName().toHtmlEscaped(), pT->getError()));
         icon.addPixmap(QPixmap(qsl(":/icons/tools-report-bug.png")), QIcon::Normal, QIcon::Off);
     }
     pItem->setIcon(0, icon);
@@ -3097,7 +3097,7 @@ void dlgTriggerEditor::activeToggle_script()
     } else {
         pT->setIsActive(false);
         showError(tr(R"(<p><b>Unable to activate a script group or script or the part of a module "<tt>%1</tt>" that contains them; reason: %2.</b></p>
-                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)").arg(pT->getName(), pT->getError()));
+                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)").arg(pT->getName().toHtmlEscaped(), pT->getError()));
         icon.addPixmap(QPixmap(qsl(":/icons/tools-report-bug.png")), QIcon::Normal, QIcon::Off);
     }
     pItem->setIcon(0, icon);
@@ -3168,7 +3168,7 @@ void dlgTriggerEditor::activeToggle_action()
     } else {
         pT->setIsActive(false);
         showError(tr(R"(<p><b>Unable to activate a button/menu/toolbar or the part of a module "<tt>%1</tt>" that contains them; reason: %2.</b></p>
-                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)").arg(pT->getName(), pT->getError()));
+                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)").arg(pT->getName().toHtmlEscaped(), pT->getError()));
         icon.addPixmap(QPixmap(qsl(":/icons/tools-report-bug.png")), QIcon::Normal, QIcon::Off);
     }
     pItem->setIcon(0, icon);
@@ -3215,7 +3215,7 @@ void dlgTriggerEditor::activeToggle_key()
         pItem->setIcon(0, iconError);
     }
     showInfo(
-            QString("Trying to %2 key <em>%1</em> %3.").arg(pT->getName(), pT->shouldBeActive() ? "activate" : "deactivate", pT->state() ? "succeeded" : QString("failed; reason: ") + pT->getError()));
+            QString("Trying to %2 key <em>%1</em> %3.").arg(pT->getName().toHtmlEscaped(), pT->shouldBeActive() ? "activate" : "deactivate", pT->state() ? "succeeded" : QString("failed; reason: ") + pT->getError()));
     if (pItem->childCount() > 0) {
         children_icon_key(pItem);
     }
@@ -4230,7 +4230,7 @@ void dlgTriggerEditor::saveAlias()
         iconError.addPixmap(QPixmap(qsl(":/icons/tools-report-bug.png")), QIcon::Normal, QIcon::Off);
         pItem->setIcon(0, iconError);
         pItem->setText(0, name);
-        showError(tr("Alias <em>%1</em> has an infinite loop - substitution matches its own pattern. Please fix it - this alias isn't good as it'll call itself forever.").arg(name).toHtmlEscaped());
+        showError(tr("Alias <em>%1</em> has an infinite loop - substitution matches its own pattern. Please fix it - this alias isn't good as it'll call itself forever.").arg(name.toHtmlEscaped()));
         return;
     }
 
@@ -7702,7 +7702,7 @@ void dlgTriggerEditor::exportTrigger(const QString& fileName)
     }
     XMLexport writer(pT);
     if (writer.exportTrigger(fileName)) {
-        statusBar()->showMessage(tr("Package %1 saved").arg(name).toHtmlEscaped(), 2000);
+        statusBar()->showMessage(tr("Package %1 saved").arg(name.toHtmlEscaped()), 2000);
     }
 }
 
@@ -7726,7 +7726,7 @@ void dlgTriggerEditor::exportTimer(const QString& fileName)
     }
     XMLexport writer(pT);
     if (writer.exportTimer(fileName)) {
-        statusBar()->showMessage(tr("Package %1 saved").arg(name).toHtmlEscaped(), 2000);
+        statusBar()->showMessage(tr("Package %1 saved").arg(name.toHtmlEscaped()), 2000);
     }
 }
 
@@ -7750,7 +7750,7 @@ void dlgTriggerEditor::exportAlias(const QString& fileName)
     }
     XMLexport writer(pT);
     if (writer.exportAlias(fileName)) {
-        statusBar()->showMessage(tr("Package %1 saved").arg(name).toHtmlEscaped(), 2000);
+        statusBar()->showMessage(tr("Package %1 saved").arg(name.toHtmlEscaped()), 2000);
     }
 }
 
@@ -7774,7 +7774,7 @@ void dlgTriggerEditor::exportAction(const QString& fileName)
     }
     XMLexport writer(pT);
     if (writer.exportAction(fileName)) {
-        statusBar()->showMessage(tr("Package %1 saved").arg(name).toHtmlEscaped(), 2000);
+        statusBar()->showMessage(tr("Package %1 saved").arg(name.toHtmlEscaped()), 2000);
     }
 }
 
@@ -7798,7 +7798,7 @@ void dlgTriggerEditor::exportScript(const QString& fileName)
     }
     XMLexport writer(pT);
     if (writer.exportScript(fileName)) {
-        statusBar()->showMessage(tr("Package %1 saved").arg(name).toHtmlEscaped(), 2000);
+        statusBar()->showMessage(tr("Package %1 saved").arg(name.toHtmlEscaped()), 2000);
     }
 }
 
@@ -7823,7 +7823,7 @@ void dlgTriggerEditor::exportKey(const QString& fileName)
     }
     XMLexport writer(pT);
     if (writer.exportKey(fileName)) {
-        statusBar()->showMessage(tr("Package %1 saved").arg(name).toHtmlEscaped(), 2000);
+        statusBar()->showMessage(tr("Package %1 saved").arg(name.toHtmlEscaped()), 2000);
     }
 }
 
@@ -7847,7 +7847,7 @@ void dlgTriggerEditor::exportTriggerToClipboard()
     }
     XMLexport writer(pT);
     writer.exportToClipboard(pT);
-    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name).toHtmlEscaped(), 2000);
+    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name.toHtmlEscaped()), 2000);
 }
 
 void dlgTriggerEditor::exportTimerToClipboard()
@@ -7870,7 +7870,7 @@ void dlgTriggerEditor::exportTimerToClipboard()
     }
     XMLexport writer(pT);
     writer.exportToClipboard(pT);
-    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name).toHtmlEscaped(), 2000);
+    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name.toHtmlEscaped()), 2000);
 }
 
 void dlgTriggerEditor::exportAliasToClipboard()
@@ -7893,7 +7893,7 @@ void dlgTriggerEditor::exportAliasToClipboard()
     }
     XMLexport writer(pT);
     writer.exportToClipboard(pT);
-    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name).toHtmlEscaped(), 2000);
+    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name.toHtmlEscaped()), 2000);
 }
 
 void dlgTriggerEditor::exportActionToClipboard()
@@ -7916,7 +7916,7 @@ void dlgTriggerEditor::exportActionToClipboard()
     }
     XMLexport writer(pT);
     writer.exportToClipboard(pT);
-    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name).toHtmlEscaped(), 2000);
+    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name.toHtmlEscaped()), 2000);
 }
 
 void dlgTriggerEditor::exportScriptToClipboard()
@@ -7939,7 +7939,7 @@ void dlgTriggerEditor::exportScriptToClipboard()
     }
     XMLexport writer(pT);
     writer.exportToClipboard(pT);
-    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name).toHtmlEscaped(), 2000);
+    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name.toHtmlEscaped()), 2000);
 }
 
 void dlgTriggerEditor::exportKeyToClipboard()
@@ -7963,7 +7963,7 @@ void dlgTriggerEditor::exportKeyToClipboard()
     }
     XMLexport writer(pT);
     writer.exportToClipboard(pT);
-    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name).toHtmlEscaped(), 2000);
+    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name.toHtmlEscaped()), 2000);
 }
 
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -2799,9 +2799,9 @@ void dlgTriggerEditor::activeToggle_trigger()
 
     if (pT->state()) {
         if (pT->shouldBeActive()) {
-            showInfo(tr(R"(Trying to activate a trigger group, filter or trigger or the part of a module "<tt>%1</tt>" that contains them <em>succeeded</em>.)").arg(pT->getName()));
+            showInfo(tr(R"(Trying to activate a trigger group, filter or trigger or the part of a module "<tt>%1</tt>" that contains them <em>succeeded</em>.)").arg(pT->getName().toHtmlEscaped()));
         } else {
-            showInfo(tr(R"(Trying to deactivate a trigger group, filter or trigger or the part of a module "<tt>%1</tt>" that contains them <em>succeeded</em>.)").arg(pT->getName()));
+            showInfo(tr(R"(Trying to deactivate a trigger group, filter or trigger or the part of a module "<tt>%1</tt>" that contains them <em>succeeded</em>.)").arg(pT->getName().toHtmlEscaped()));
         }
     } else {
         pT->setIsActive(false);
@@ -2986,9 +2986,9 @@ void dlgTriggerEditor::activeToggle_alias()
 
     if (pT->state()) {
         if (pT->shouldBeActive()) {
-            showInfo(tr(R"(Trying to activate an alias group, alias or the part of a module "<tt>%1</tt>" that contains them <em>succeeded</em>.)").arg(pT->getName()));
+            showInfo(tr(R"(Trying to activate an alias group, alias or the part of a module "<tt>%1</tt>" that contains them <em>succeeded</em>.)").arg(pT->getName().toHtmlEscaped()));
         } else {
-            showInfo(tr(R"(Trying to deactivate an alias group, alias or the part of a module "<tt>%1</tt>" that contains them <em>succeeded</em>.)").arg(pT->getName()));
+            showInfo(tr(R"(Trying to deactivate an alias group, alias or the part of a module "<tt>%1</tt>" that contains them <em>succeeded</em>.)").arg(pT->getName().toHtmlEscaped()));
         }
     } else {
         pT->setIsActive(false);
@@ -3090,9 +3090,9 @@ void dlgTriggerEditor::activeToggle_script()
 
     if (pT->state()) {
         if (pT->shouldBeActive()) {
-            showInfo(tr(R"(Trying to activate a script group, script or the part of a module "<tt>%1</tt>" that contains them <em>succeeded</em>.)").arg(pT->getName()));
+            showInfo(tr(R"(Trying to activate a script group, script or the part of a module "<tt>%1</tt>" that contains them <em>succeeded</em>.)").arg(pT->getName().toHtmlEscaped()));
         } else {
-            showInfo(tr(R"(Trying to deactivate a script group, script or the part of a module "<tt>%1</tt>" that contains them <em>succeeded</em>.)").arg(pT->getName()));
+            showInfo(tr(R"(Trying to deactivate a script group, script or the part of a module "<tt>%1</tt>" that contains them <em>succeeded</em>.)").arg(pT->getName().toHtmlEscaped()));
         }
     } else {
         pT->setIsActive(false);
@@ -3161,9 +3161,9 @@ void dlgTriggerEditor::activeToggle_action()
 
     if (pT->state()) {
         if (pT->shouldBeActive()) {
-            showInfo(tr(R"(Trying to activate a button/menu/toolbar or the part of a module "<tt>%1</tt>" that contains them <em>succeeded</em>.)").arg(pT->getName()));
+            showInfo(tr(R"(Trying to activate a button/menu/toolbar or the part of a module "<tt>%1</tt>" that contains them <em>succeeded</em>.)").arg(pT->getName().toHtmlEscaped()));
         } else {
-            showInfo(tr(R"(Trying to deactivate a button/menu/toolbar or the part of a module "<tt>%1</tt>" that contains them <em>succeeded</em>.)").arg(pT->getName()));
+            showInfo(tr(R"(Trying to deactivate a button/menu/toolbar or the part of a module "<tt>%1</tt>" that contains them <em>succeeded</em>.)").arg(pT->getName().toHtmlEscaped()));
         }
     } else {
         pT->setIsActive(false);
@@ -4230,7 +4230,7 @@ void dlgTriggerEditor::saveAlias()
         iconError.addPixmap(QPixmap(qsl(":/icons/tools-report-bug.png")), QIcon::Normal, QIcon::Off);
         pItem->setIcon(0, iconError);
         pItem->setText(0, name);
-        showError(tr("Alias <em>%1</em> has an infinite loop - substitution matches its own pattern. Please fix it - this alias isn't good as it'll call itself forever.").arg(name));
+        showError(tr("Alias <em>%1</em> has an infinite loop - substitution matches its own pattern. Please fix it - this alias isn't good as it'll call itself forever.").arg(name).toHtmlEscaped());
         return;
     }
 
@@ -7702,7 +7702,7 @@ void dlgTriggerEditor::exportTrigger(const QString& fileName)
     }
     XMLexport writer(pT);
     if (writer.exportTrigger(fileName)) {
-        statusBar()->showMessage(tr("Package %1 saved").arg(name), 2000);
+        statusBar()->showMessage(tr("Package %1 saved").arg(name).toHtmlEscaped(), 2000);
     }
 }
 
@@ -7726,7 +7726,7 @@ void dlgTriggerEditor::exportTimer(const QString& fileName)
     }
     XMLexport writer(pT);
     if (writer.exportTimer(fileName)) {
-        statusBar()->showMessage(tr("Package %1 saved").arg(name), 2000);
+        statusBar()->showMessage(tr("Package %1 saved").arg(name).toHtmlEscaped(), 2000);
     }
 }
 
@@ -7750,7 +7750,7 @@ void dlgTriggerEditor::exportAlias(const QString& fileName)
     }
     XMLexport writer(pT);
     if (writer.exportAlias(fileName)) {
-        statusBar()->showMessage(tr("Package %1 saved").arg(name), 2000);
+        statusBar()->showMessage(tr("Package %1 saved").arg(name).toHtmlEscaped(), 2000);
     }
 }
 
@@ -7774,7 +7774,7 @@ void dlgTriggerEditor::exportAction(const QString& fileName)
     }
     XMLexport writer(pT);
     if (writer.exportAction(fileName)) {
-        statusBar()->showMessage(tr("Package %1 saved").arg(name), 2000);
+        statusBar()->showMessage(tr("Package %1 saved").arg(name).toHtmlEscaped(), 2000);
     }
 }
 
@@ -7798,7 +7798,7 @@ void dlgTriggerEditor::exportScript(const QString& fileName)
     }
     XMLexport writer(pT);
     if (writer.exportScript(fileName)) {
-        statusBar()->showMessage(tr("Package %1 saved").arg(name), 2000);
+        statusBar()->showMessage(tr("Package %1 saved").arg(name).toHtmlEscaped(), 2000);
     }
 }
 
@@ -7823,7 +7823,7 @@ void dlgTriggerEditor::exportKey(const QString& fileName)
     }
     XMLexport writer(pT);
     if (writer.exportKey(fileName)) {
-        statusBar()->showMessage(tr("Package %1 saved").arg(name), 2000);
+        statusBar()->showMessage(tr("Package %1 saved").arg(name).toHtmlEscaped(), 2000);
     }
 }
 
@@ -7847,7 +7847,7 @@ void dlgTriggerEditor::exportTriggerToClipboard()
     }
     XMLexport writer(pT);
     writer.exportToClipboard(pT);
-    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name), 2000);
+    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name).toHtmlEscaped(), 2000);
 }
 
 void dlgTriggerEditor::exportTimerToClipboard()
@@ -7870,7 +7870,7 @@ void dlgTriggerEditor::exportTimerToClipboard()
     }
     XMLexport writer(pT);
     writer.exportToClipboard(pT);
-    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name), 2000);
+    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name).toHtmlEscaped(), 2000);
 }
 
 void dlgTriggerEditor::exportAliasToClipboard()
@@ -7893,7 +7893,7 @@ void dlgTriggerEditor::exportAliasToClipboard()
     }
     XMLexport writer(pT);
     writer.exportToClipboard(pT);
-    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name), 2000);
+    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name).toHtmlEscaped(), 2000);
 }
 
 void dlgTriggerEditor::exportActionToClipboard()
@@ -7916,7 +7916,7 @@ void dlgTriggerEditor::exportActionToClipboard()
     }
     XMLexport writer(pT);
     writer.exportToClipboard(pT);
-    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name), 2000);
+    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name).toHtmlEscaped(), 2000);
 }
 
 void dlgTriggerEditor::exportScriptToClipboard()
@@ -7939,7 +7939,7 @@ void dlgTriggerEditor::exportScriptToClipboard()
     }
     XMLexport writer(pT);
     writer.exportToClipboard(pT);
-    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name), 2000);
+    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name).toHtmlEscaped(), 2000);
 }
 
 void dlgTriggerEditor::exportKeyToClipboard()
@@ -7963,7 +7963,7 @@ void dlgTriggerEditor::exportKeyToClipboard()
     }
     XMLexport writer(pT);
     writer.exportToClipboard(pT);
-    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name), 2000);
+    statusBar()->showMessage(tr("Copied %1 to clipboard").arg(name).toHtmlEscaped(), 2000);
 }
 
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4629,7 +4629,8 @@ bool mudlet::desktopInDarkMode()
 
 void mudlet::announce(const QString& text, const QString& processing)
 {
-    mpAnnouncer->announce(text, processing);
+    QTextEdit convertor(text);
+    mpAnnouncer->announce(convertor.toPlainText(), processing);
 }
 
 void mudlet::onlyShowProfiles(const QStringList& predefinedProfiles)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4638,8 +4638,7 @@ bool mudlet::desktopInDarkMode()
 
 void mudlet::announce(const QString& text, const QString& processing)
 {
-    QTextEdit convertor(text);
-    mpAnnouncer->announce(convertor.toPlainText(), processing);
+    mpAnnouncer->announce(text, processing);
 }
 
 void mudlet::onlyShowProfiles(const QStringList& predefinedProfiles)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
This adds html escaping to some user defined strings that are fed into labels that process html
#### Motivation for adding to Mudlet
incomplete effort toward #6795
also I'd like to utilize html to plain text conversions for screen reader items, and having potentially invalid html fed into it makes that feel broken
#### Other info (issues closed, discussion etc)
I used VS Code to search for `\.arg\(.*[Nn]ame.*\)` mainly to catch these, so not an exhaustive list.  Here are some screenshots of type of thing that are improved on: 
![image](https://user-images.githubusercontent.com/29287358/235965165-a3911f17-b236-40d0-8522-c26531202d81.png)
![image](https://user-images.githubusercontent.com/29287358/235965234-3ded409a-fc0e-45d3-9daf-86839274dc6a.png)
![image](https://user-images.githubusercontent.com/29287358/235965362-328324c2-13bd-4e38-b930-5852c350be2f.png)
![image](https://user-images.githubusercontent.com/29287358/235990572-6c35418f-894a-4750-bba8-cb3885c05b35.png)
