### PR TITLE
Improve: don't show individual Lua module loading messages

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15111,10 +15111,8 @@ bool TLuaInterpreter::loadLuaModule(QQueue<QString>& resultMsgsQueue, const QStr
         return false;
     }
 
+    // clear out the queue in case any previous attempts to load the module of the same name failed
     QQueue<QString> newMessageQueue;
-    newMessageQueue.enqueue(tr("[  OK  ]  - Lua module %1 loaded.",
-                               "%1 is the name (may specify which variant) of the module.")
-                            .arg(description.isEmpty() ? requirement : description));
     resultMsgsQueue.swap(newMessageQueue);
     return true;
 }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Clean up Mudlet start and just show the overall 'Mudlet-lua API & Geyser' loaded message only.
#### Motivation for adding to Mudlet
Less spam for the first-time players to get distracted by, and a cleaner look for Mudlet.
#### Other info (issues closed, discussion etc)
![image](https://user-images.githubusercontent.com/110988/236525349-f7e51bce-d408-4c76-9c7a-29982dd82e6a.png)
