### PR TITLE
Infrastructure: fix mNeedsToBeCompiled to be private in TAlias like all other classes

### DIFF
--- a/src/TAlias.h
+++ b/src/TAlias.h
@@ -72,12 +72,14 @@ public:
     QSharedPointer<pcre> mpRegex;
     QString mScript;
     QPointer<Host> mpHost;
-    bool mNeedsToBeCompiled = true;
     bool mModuleMember = false;
     bool mModuleMasterFolder = false;
     QString mFuncName;
     bool exportItem = true;
     bool mRegisteredAnonymousLuaFunction = false;
+
+private:
+    bool mNeedsToBeCompiled = true;
 };
 
 #endif // MUDLET_TALIAS_H


### PR DESCRIPTION
This brings it inline with all other classes

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix mNeedsToBeCompiled to be private in TAlias like all other classes
#### Motivation for adding to Mudlet
Consistency in codebase
#### Other info (issues closed, discussion etc)
