### PR TITLE
Infrastructure: setBackgroundColor adjusts a Label's stylesheet rather than palette

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3741,9 +3741,16 @@ bool Host::setBackgroundColor(const QString& name, int r, int g, int b, int alph
         pC->setConsoleBgColor(r, g, b, alpha);
         return true;
     } else if (pL) {
-        QPalette mainPalette;
-        mainPalette.setColor(QPalette::Window, QColor(r, g, b, alpha));
-        pL->setPalette(mainPalette);
+        QString styleSheet = pL->styleSheet();
+        QString newColor = QString("background-color: rgba(%1, %2, %3, %4);").arg(r).arg(g).arg(b).arg(alpha);
+        if (stylesheet.contains(qsl("background-color"))) {
+            QRegularExpression re("background-color: .*;");
+            styleSheet.replace(re, newColor);
+        } else {
+            styleSheet.append(newColor);
+        }
+        
+        pL->setStyleSheet(styleSheet);
         return true;
     }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3743,7 +3743,7 @@ bool Host::setBackgroundColor(const QString& name, int r, int g, int b, int alph
     } else if (pL) {
         QString styleSheet = pL->styleSheet();
         QString newColor = QString("background-color: rgba(%1, %2, %3, %4);").arg(r).arg(g).arg(b).arg(alpha);
-        if (stylesheet.contains(qsl("background-color"))) {
+        if (styleSheet.contains(qsl("background-color"))) {
             QRegularExpression re("background-color: .*;");
             styleSheet.replace(re, newColor);
         } else {


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adjusts setBackgroundColor to use and adjust the stylesheet of a label rather than using setPalette on the object. This should allow you to adjust the background color of a label which uses a stylesheet. 

Currently, once you set a stylesheet on a label setBackgroundColor stops really doing anything. This way it should be a more consistent experience. 

#### Motivation for adding to Mudlet

Discussion with Vadi on discord about how to be able to include better default styles with Geyser objects. 

#### Other info (issues closed, discussion etc)
