### PR TITLE
fix data sent before Z_STREAM_END not shown to user

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2604,7 +2604,12 @@ int cTelnet::decompressBuffer(char*& in_buffer, int& length, char* out_buffer)
         // zval should always be NULL on inflateEnd.  No need for an else block. MCCP Rev. 3 -MH //
         initStreamDecompressor();
         qDebug() << "Listening for new compression sequences";
-        return -1;
+
+        // We shouldn't return -1 or an error here, as that prevents any text
+        // or any telnet negotiation strings from being properly interpreted
+        // by Mudlet, and shown to the user.
+        // Returning outSize ensures anything sent before the Z_STREAM_END is
+        // shown to the user.
     }
     return outSize;
 }


### PR DESCRIPTION
Ought to close https://github.com/Mudlet/Mudlet/issues/6826

Only tested on Linux, but I see the biggest problem on Windows where no data is shown at all instead of "some data".
Making pull request with the hope of getting a Windows build to test it properly.

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->

#### Brief overview of PR changes/additions

See https://github.com/Mudlet/Mudlet/issues/6826

#### Motivation for adding to Mudlet

See https://github.com/Mudlet/Mudlet/issues/6826

#### Other info (issues closed, discussion etc)

Would need a Windows build done from this patch to properly test it solves the issue on Windows, too. I tested it solves it under Linux.