### PR TITLE
fix package export copying files

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -860,7 +860,9 @@ std::pair<bool, QString> dlgPackageExporter::copyAssetsToTmp(const QStringList& 
         }
         if (asset.isFile()) {
             QFile::remove(filePath);
-            QFile::copy(asset.absoluteFilePath(), filePath);
+            if (!QFile::copy(asset.absoluteFilePath(), filePath)) {
+                return {false, tr("cannot copy %1 to the temporary location %2 - can you double-check it?").arg(asset.absoluteFilePath().toHtmlEscaped(), tempPath.toHtmlEscaped())};
+            }
         } else if (asset.isDir()) {
             copy_directory(asset.absoluteFilePath(), filePath, false);
         }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Copying additional files to the package temporary folder before zipping did not verify that the copy worked.  Then the whole folder was zipped without noticing anything was missing.  With this change, it pays attention to if the copy function returns an error.
#### Motivation for adding to Mudlet
If you try and include an unreadable file, then it should not be quietly skipped, it should have an error message just like if you had picked a file and deleted it.
#### Other info (issues closed, discussion etc)
fixes #6823