### PR TITLE
Infrastructure: update contributing guide for html escaping

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Check https://www.linguistic-antipatterns.com when naming anything to help ensur
 * use braces {} around all statements (ie, `if`'s and so on), even if they are one line
 * use `qsl()` to wrap Qt strings, this ensures they're created at compile time
 * at the same time, don't use a blank `qsl("")` - use `QString()` in that case ([source](http://blog.qt.io/blog/2014/06/13/qt-weekly-13-qstringliteral/))
-
+* escape dynamic label information with .toHtmlEscaped() to ensure safe display ([example](https://github.com/Mudlet/Mudlet/pull/6807/files)).
 
 # Internationalization do's and don'ts
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Need to escape dynamic information in labels otherwise html strings in trigger/alias/etc names will mess the display up, see https://github.com/Mudlet/Mudlet/pull/6807
#### Motivation for adding to Mudlet
So `<`'s in item names work fine, mainly
#### Other info (issues closed, discussion etc)
Could not think of a better name than "dynamic information"