### PR TITLE
Fix: work around Discord user-name & discriminator changes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -467,6 +467,9 @@ add_executable(mudlet ${mudlet_SRCS} ${mudlet_RCCS} ${mudlet_HDRS} ${mudlet_UIS}
 # * Produce all the time the surprise that normally will only occur on the
 #   first day of the fourth month of the Gregorian calendar year:
 # target_compile_definitions(mudlet PRIVATE DEBUG_EASTER_EGGS)
+#
+# * Produce additional details as the Discord-RPC library is used
+# target_compile_definitions(mudlet PRIVATE DEBUG_DISCORD)
 
 target_sources(mudlet PRIVATE "${mudlet_BINARY_DIR}/translations/translated/qm.qrc")
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -4209,7 +4209,7 @@ void Host::slot_discordReadyReceived(const QString& userId, const QString& userN
                        "However Discord are progressively changing the form of the former and removing the\n"
                        "latter from May 2023 onward and Mudlet is changing to use the unique user ID\n"
                        "for each Discord user account instead for this purpose. When you are logged into\n"
-                       "the Discord application with an identy that matches the details stored for this\n"
+                       "the Discord application with an identity that matches the details stored for this\n"
                        "profile a different message will be shown that gives that user ID which you can\n"
                        "then copy to the appropriate field in the 'Chat' tab in the preferences and remove\n"
                        "the user-name and/or user-discriminator enteries there to adapt for this change.\n"

--- a/src/Host.h
+++ b/src/Host.h
@@ -408,6 +408,9 @@ public:
     QMargins borders() const { return mBorders; }
     void setBorders(const QMargins);
     void loadMap();
+    bool inProfileLoadingSequence() const { return mIsProfileLoadingSequence; }
+    void startingProfileLoadingSequence() { mIsProfileLoadingSequence = true; }
+    void completedProfileLoadingSequence();
 
 
     cTelnet mTelnet;
@@ -461,11 +464,6 @@ public:
     QString mProxyPassword;
 
     bool mIsGoingDown;
-    // Used to force the test compilation of the scripts for TActions ("Buttons")
-    // that are pushdown buttons that run when they are "pushed down" during
-    // loading even though the buttons start out with themselves NOT being
-    // pushed down:
-    bool mIsProfileLoadingSequence;
 
     bool mNoAntiAlias;
 
@@ -704,6 +702,7 @@ signals:
 
 private slots:
     void slot_purgeTemps();
+    void slot_discordReadyReceived(const QString& userId, const QString& userName, const QString& userDiscriminator);
 
 private:
     void installPackageFonts(const QString &packageName);
@@ -794,6 +793,14 @@ private:
     // Will be null/empty if they have not set their own invite
     QString mDiscordInviteURL;
 
+    // From 2023/05 Discord are changing the way usernames are handled such
+    // that the Discriminator is going away and the format for usernames is
+    // being severely reduced - but the userId is not changing. This means
+    // that we want to encourage existing users with a non-empty username
+    // or discriminator to change to just use the "snowflake" (long unique
+    // number) form - which will be stored here - and used in preference the
+    // two other values:
+    QString mRequiredDiscordUserId;
     // Will be null/empty if we are not concerned to check the use of Discord
     // Rich Presence against the local user currently logged into Discord -
     // these two will be checked against the values from the Discord instance
@@ -878,6 +885,14 @@ private:
     bool mFocusTimerRunning = false;
 
     QMargins mBorders;
+
+    // Used to force the test compilation of the scripts for TActions ("Buttons")
+    // that are pushdown buttons that run when they are "pushed down" during
+    // loading even though the buttons start out with themselves NOT being
+    // pushed down:
+    // Made private so it requires calls from methods to set/reset and those
+    // can run additional code now desired to be associated with changing it:
+    bool mIsProfileLoadingSequence = false;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(Host::DiscordOptionFlags)

--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -200,7 +200,7 @@ void TAction::expandToolbar(TToolBar* pT)
         /*
          * CHECK: The other expandToolbar(...) has the following in this position:
          *       //FIXME: Heiko April 2012: only run checkbox button scripts, but run them even if unchecked
-         *       if( action->mIsPushDownButton && mpHost->mIsProfileLoadingSequence )
+         *       if( action->mIsPushDownButton && mpHost->inProfileLoadingSequence() )
          *       {
          *          qDebug()<<"expandToolBar() name="<<action->mName<<" executing script";
          *          action->execute();
@@ -290,7 +290,7 @@ void TAction::expandToolbar(TEasyButtonBar* pT)
         button->setStyleSheet(css);
 
         //FIXME: Heiko April 2012: only run checkbox button scripts, but run them even if unchecked
-        if (action->mIsPushDownButton && mpHost->mIsProfileLoadingSequence) {
+        if (action->mIsPushDownButton && mpHost->inProfileLoadingSequence()) {
             qDebug() << "expandToolBar() name=" << action->mName << " executing script";
             action->execute();
         }
@@ -351,7 +351,7 @@ void TAction::fillMenu(TEasyButtonBar* pT, QMenu* menu)
         action->mpEButton = newAction;
 
         //FIXME: Heiko April 2012 -> expandToolBar()
-        if (action->mIsPushDownButton && mpHost->mIsProfileLoadingSequence) {
+        if (action->mIsPushDownButton && mpHost->inProfileLoadingSequence()) {
             action->execute();
         }
 

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -439,8 +439,11 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mSslIgnoreAll") = pHost->mSslIgnoreAll ? "yes" : "no";
     host.append_attribute("mAskTlsAvailable") = pHost->mAskTlsAvailable ? "yes" : "no";
     host.append_attribute("mDiscordAccessFlags") = QString::number(pHost->mDiscordAccessFlags).toUtf8().constData();
-    host.append_attribute("mRequiredDiscordUserName") = pHost->mRequiredDiscordUserName.toUtf8().constData();
-    host.append_attribute("mRequiredDiscordUserDiscriminator") = pHost->mRequiredDiscordUserDiscriminator.toUtf8().constData();
+    host.append_attribute("RequiredDiscordUserId") = pHost->mRequiredDiscordUserId.toUtf8().constData();
+    if (!pHost->mRequiredDiscordUserName.isEmpty() || !pHost->mRequiredDiscordUserDiscriminator.isEmpty()) {
+        host.append_attribute("mRequiredDiscordUserDiscriminator") = pHost->mRequiredDiscordUserDiscriminator.toUtf8().constData();
+        host.append_attribute("mRequiredDiscordUserName") = pHost->mRequiredDiscordUserName.toUtf8().constData();
+    }
     host.append_attribute("mSGRCodeHasColSpaceId") = pHost->getHaveColorSpaceId() ? "yes" : "no";
     host.append_attribute("mServerMayRedefineColors") = pHost->getMayRedefineColors() ? "yes" : "no";
     quint8 styleCode = 0;

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -821,6 +821,12 @@ void XMLimport::readHost(Host* pHost)
         pHost->mDiscordAccessFlags = static_cast<Host::DiscordOptionFlags>(attributes().value(qsl("mDiscordAccessFlags")).toString().toInt());
     }
 
+    if (attributes().hasAttribute(QLatin1String("RequiredDiscordUserId"))) {
+        pHost->mRequiredDiscordUserId = attributes().value(QLatin1String("RequiredDiscordUserId")).toString();
+    } else {
+        pHost->mRequiredDiscordUserId.clear();
+    }
+
     if (attributes().hasAttribute(QLatin1String("mRequiredDiscordUserName"))) {
         pHost->mRequiredDiscordUserName = attributes().value(QLatin1String("mRequiredDiscordUserName")).toString();
     } else {

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -28,8 +28,6 @@
 #include <string.h>
 #include "post_guard.h"
 
-// Uncomment this to provide some additional qDebug() output:
-// #define DEBUG_DISCORD 1
 
 QString Discord::smUserName;
 QString Discord::smUserId;
@@ -259,7 +257,7 @@ void Discord::setParty(Host* pHost, int partySize, int partyMax)
 
 void Discord::timerEvent(QTimerEvent* event)
 {
-    Q_UNUSED(event);
+    Q_UNUSED(event)
 
     if (mLoaded) {
         Discord_RunCallbacks();
@@ -268,16 +266,17 @@ void Discord::timerEvent(QTimerEvent* event)
 
 void Discord::handleDiscordReady(const DiscordUser* request)
 {
-    Discord::smUserName = request->username;
-    Discord::smUserId = request->userId;
-    Discord::smDiscriminator = request->discriminator;
-    Discord::smAvatar = request->avatar;
+    Discord::smUserName = QString::fromUtf8(request->username);
+    Discord::smUserId = QString::fromUtf8(request->userId);
+    Discord::smDiscriminator = QString::fromUtf8(request->discriminator);
+    Discord::smAvatar = QString::fromUtf8(request->avatar);
 
 #if defined(DEBUG_DISCORD)
     qDebug().noquote().nospace() << "Discord Ready callback received - for UserName: \"" << smUserName << "\", ID: \"" << smUserId << "#" << smDiscriminator << "\".";
 #endif
     // don't call UpdatePresence from here - freezes Mudlet deep in the Discord API
     // when profile autostart is enabled
+    emit mudlet::self()->mDiscord.signal_discordReadyReceived(smUserId, smUserName, smDiscriminator);
 }
 
 QStringList Discord::getDiscordUserDetails() const

--- a/src/discord.h
+++ b/src/discord.h
@@ -207,8 +207,11 @@ public:
     bool discordUserIdMatch(Host* pHost) const;
 
 
+    static std::tuple<QString, QString, QString> discordUserDetails() { return {smUserId, smUserName, smDiscriminator}; }
     const static QString mMudletApplicationId;
 
+signals:
+    void signal_discordReadyReceived(const QString& userId, const QString& userName, const QString& userDiscriminator);
 
 private:
     static void handleDiscordReady(const DiscordUser* request);

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -828,6 +828,24 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         checkBox_discordServerAccessToState->setChecked(!(discordFlags & Host::DiscordSetState));
         checkBox_discordServerAccessToPartyInfo->setChecked(!(discordFlags & Host::DiscordSetPartyInfo));
         checkBox_discordServerAccessToTimerInfo->setChecked(!(discordFlags & Host::DiscordSetTimeInfo));
+        lineEdit_discordUserId->setText(pHost->mRequiredDiscordUserId);
+        if (pHost->mRequiredDiscordUserName.isEmpty() && pHost->mRequiredDiscordUserDiscriminator.isEmpty()) {
+            label_discordUserName->hide();
+            lineEdit_discordUserName->hide();
+            label_discordUserDiscriminator->hide();
+            lineEdit_discordUserDiscriminator->hide();
+            //: Text used for the label to introduce the Discord User Id ("snowflake") number when there is no obsolete User Name or User Discriminator stored.
+            label_discordUserId->setText(tr("Restrict to user id:"));
+            // Also tweak the tooltips on the shown elements:
+            label_discordUserId->setToolTip(utils::richText(tr("Mudlet will only send Rich Presence information to your local Discord "
+                                                               "application while you use this Discord user id (useful if you have multiple "
+                                                               "Discord accounts). Leave empty to allow this profile to send information to "
+                                                               "any Discord account you log in with.")));
+            lineEdit_discordUserId->setToolTip(utils::richText(tr("Mudlet will only send Rich Presence information to your local Discord "
+                                                                  "application while you use this Discord user id (useful if you have multiple "
+                                                                  "Discord accounts). Leave empty to allow this profile to send information to "
+                                                                  "any Discord account you log in with.")));
+        }
         lineEdit_discordUserName->setText(pHost->mRequiredDiscordUserName);
         lineEdit_discordUserDiscriminator->setText(pHost->mRequiredDiscordUserDiscriminator);
     }
@@ -3008,6 +3026,7 @@ void dlgProfilePreferences::slot_saveAndClose()
                                          | (checkBox_discordServerAccessToTimerInfo->isChecked() ? Host::DiscordNoOption : Host::DiscordSetTimeInfo)
                                          | (checkBox_discordLuaAPI->isChecked() ? Host::DiscordLuaAccessEnabled : Host::DiscordNoOption));
 
+        pHost->mRequiredDiscordUserId = lineEdit_discordUserId->text().trimmed();
         pHost->mRequiredDiscordUserName = lineEdit_discordUserName->text().trimmed();
         if (lineEdit_discordUserDiscriminator->hasAcceptableInput()) {
             // The input mask specifies 4 digits [0-9]

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2765,7 +2765,7 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
     if (!pHost) {
         return;
     }
-    pHost->mIsProfileLoadingSequence = true;
+    pHost->startingProfileLoadingSequence();
     // The Host instance gets its TMainConsole here:
     addConsoleForNewHost(pHost);
     pHost->mBlockScriptCompile = false;
@@ -2815,12 +2815,7 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
 
     // This marks the end of the profile loading process, so all the aliases
     // triggers and other items are present in the Lua sub-system:
-    pHost->mIsProfileLoadingSequence = false;
-
-    TEvent event {};
-    event.mArgumentList.append(QLatin1String("sysLoadEvent"));
-    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-    pHost->raiseEvent(event);
+    pHost->completedProfileLoadingSequence();
 
     // Now load the default (latest stored) map file:
     pHost->loadMap();

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -251,6 +251,9 @@ isEmpty( MAIN_BUILD_SYSTEM_TEST ) | !equals( MAIN_BUILD_SYSTEM_TEST, "NO" ) {
 # * Produce all the time the surprise that normally will only occur on the first
 # day of the fourth month of the Gregorian calendar year:
 # DEFINES+=DEBUG_EASTER_EGGS
+#
+# * Produce additional details as the Discord-RPC library is used
+# DEFINES+=DEBUG_DISCORD
 
 unix:!macx {
 # Distribution packagers would be using PREFIX = /usr but this is accepted

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -3000,23 +3000,55 @@ you can use it but there could be issues with aligning columns of text</string>
              <bool>true</bool>
             </property>
             <property name="toolTip">
-             <string>&lt;p&gt;Mudlet will only show Rich Presence information while you use this Discord username (useful if you have multiple Discord accounts). Leave empty to show it for any Discord account you log in to.&lt;/p&gt;</string>
+             <string>&lt;p&gt;Mudlet will only show Rich Presence information while your Discord application reports that you are logged in with these Discord user identification details (useful if you have multiple Discord accounts). Leave empty to show it for any Discord account you log in to.&lt;/p&gt;</string>
             </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_widget_discordUser">
-             <item>
-              <widget class="QLabel" name="label_discordUserName">
+            <layout class="QGridLayout" name="gridLayout_widget_discordUser">
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_discordUserId">
+               <property name="toolTip">
+                <string>&lt;p&gt;&lt;b&gt;&lt;i&gt;(Preferred as of May 2023)&lt;/i&gt;&lt;/b&gt; Mudlet will only send Rich Presence information to your local Discord application while you use this Discord user id (useful if you have multiple Discord accounts). Leave empty to allow this profile to send information to any Discord account you log in with.&lt;/p&gt;</string>
+               </property>
                <property name="text">
-                <string>Restrict to:</string>
+                <string comment="Text used for the label to introduce the Discord User Id (&quot;snowflake&quot;) number when there is an obsolete User Name or User Discriminator stored.">(Preferred) Restrict to user id:</string>
+               </property>
+               <property name="buddy">
+                <cstring>lineEdit_discordUserId</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1" colspan="3">
+              <widget class="QLineEdit" name="lineEdit_discordUserId">
+               <property name="toolTip">
+                <string>&lt;p&gt;&lt;b&gt;&lt;i&gt;(Preferred as of May 2023)&lt;/i&gt;&lt;/b&gt; Mudlet will only send Rich Presence information to your local Discord application while you use this Discord user id (useful if you have multiple Discord accounts). Leave empty to allow this profile to send information to any Discord account you log in with.&lt;/p&gt;</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+               <property name="placeholderText">
+                <string>specific Discord user id</string>
+               </property>
+               <property name="clearButtonEnabled">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_discordUserName">
+               <property name="toolTip">
+                <string>&lt;p&gt;&lt;b&gt;&lt;i&gt;(Depreciated as of May 2023)&lt;/i&gt;&lt;/b&gt; Mudlet will only send Rich Presence information to your local Discord application while you use this Discord user name (useful if you have multiple Discord accounts). Leave empty to allow this profile to send information to any Discord account you log in with.&lt;/p&gt;</string>
+               </property>
+               <property name="text">
+                <string>(Depreciated) Restrict to:</string>
                </property>
                <property name="buddy">
                 <cstring>lineEdit_discordUserName</cstring>
                </property>
               </widget>
              </item>
-             <item>
+             <item row="1" column="1">
               <widget class="QLineEdit" name="lineEdit_discordUserName">
                <property name="toolTip">
-                <string>&lt;p&gt;Mudlet will only show Rich Presence information while you use this Discord username (useful if you have multiple Discord accounts). Leave empty to show it for any Discord account you log in to.&lt;/p&gt;</string>
+                <string>&lt;p&gt;&lt;b&gt;&lt;i&gt;(Depreciated as of May 2023)&lt;/i&gt;&lt;/b&gt; Mudlet will only send Rich Presence information to your local Discord application while you use this Discord user name (useful if you have multiple Discord accounts). Leave empty to allow this profile to send information to any Discord account you log in with.&lt;/p&gt;</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -3029,17 +3061,17 @@ you can use it but there could be issues with aligning columns of text</string>
                </property>
               </widget>
              </item>
-             <item>
+             <item row="1" column="2">
               <widget class="QLabel" name="label_discordUserDiscriminator">
                <property name="toolTip">
-                <string>&lt;p&gt;Mudlet will only show Rich Presence information while you use this Discord username (useful if you have multiple Discord accounts). Leave empty to show it for any Discord account you log in to.&lt;/p&gt;</string>
+                <string>&lt;p&gt;&lt;p&gt;&lt;b&gt;&lt;i&gt;(Depreciated as of May 2023)&lt;/i&gt;&lt;/b&gt; Mudlet will only send Rich Presence information to your local Discord application while you use this Discord username discriminator (useful if you have multiple Discord accounts). Leave empty to allow this profile to send information to any Discord account you log in with.&lt;/p&gt;</string>
                </property>
                <property name="text">
                 <string notr="true"> # </string>
                </property>
               </widget>
              </item>
-             <item>
+             <item row="1" column="3">
               <widget class="QLineEdit" name="lineEdit_discordUserDiscriminator">
                <property name="maximumSize">
                 <size>
@@ -3048,7 +3080,7 @@ you can use it but there could be issues with aligning columns of text</string>
                 </size>
                </property>
                <property name="toolTip">
-                <string>&lt;p&gt;Mudlet will only show Rich Presence information while you use this Discord username (useful if you have multiple Discord accounts). Leave empty to show it for any Discord account you log in to.&lt;/p&gt;</string>
+                <string>&lt;p&gt;&lt;p&gt;&lt;b&gt;&lt;i&gt;(Depreciated as of May 2023)&lt;/i&gt;&lt;/b&gt; Mudlet will only send Rich Presence information to your local Discord application while you use this Discord username discriminator (useful if you have multiple Discord accounts). Leave empty to allow this profile to send information to any Discord account you log in with.&lt;/p&gt;</string>
                </property>
                <property name="inputMethodHints">
                 <set>Qt::ImhDigitsOnly</set>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Discord is changing the way that Users are identified (to just lower case alphanumeric characters and '-' and '.) and removing the *discriminator*. However the unique user id (a long number) is not changing.

#### Motivation for adding to Mudlet
This PR encourages the user to migrate from using the first two to limit which profile uses which Discord User-account to the latter. It causes `[ ALERT ] ` messages to be shown on profile startup when the Discord-RPC library is active and has made contact with the user's Discord application and either a user specified user name or discriminator is being used to limit. If they match up to the current Discord account in use the user id number is shown and the user is requested to note it down and copy it to the preferences and to then remove the previously entered name and discriminator. Once this has been done (or if they have not been entered) when a profile starts up a different message is given:
* an `[ INFO ] ` one that confirms that the Discord_RPC library is connected and if a user id has been set nothing else, but if not the id is shown so that it can be used in the future
* an `[ ALERT ] ` one that indicates that the entered id does not match the one in use and what those numbers are

Once any existing preset user name or discriminator has been removed they will be removed from the profile storage and the preference form bits for them hidden and the text/tooltips for the visible id entry modified to remove details about the older, "deprecated" details.

To enable the appropriate message to be give at the right time the way the `(bool) Host::mIsProfileLoadingSequence` flag is accessed has been revised so that it being reset triggers the message AND the `sysLoadEvent` Mudlet event being raised, the latter is still done in the same point in the application but it gets moved from the `mudlet` class to a called method in the `host` class.

For the details of the Discord changes see their blog at:
https://discord.com/blog/usernames
and
https://support.discord.com/hc/en-us/articles/12620128861463

#### Other info (issues closed, discussion etc)
If we do not change this it may not be possible to get the Discord RPC restricted to particular profiles using the existing system. Once any migration has been done Mudlet only has to work with a single string (the id one) rather than a pair (the user name and the discriminator).