### PR TITLE
Infrastructure: improve variable names and comments in map drawing classes

### DIFF
--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -82,7 +82,7 @@ public:
     void setExitSize(double);
     void createLabel(QRectF labelRectangle);
     // Clears cache so new symbols are built at next paintEvent():
-    void flushSymbolPixmapCache() {mSymbolPixmapCache.clear();}
+    void flushSymbolPixmapCache() { mSymbolPixmapCache.clear(); }
     void addSymbolToPixmapCache(const QString, const QString, const QColor, const bool);
     void setPlayerRoomStyle(const int style);
 #if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
@@ -100,11 +100,11 @@ public:
     TMap* mpMap = nullptr;
     QPointer<Host> mpHost;
     qreal xyzoom = csmDefaultXYZoom;
-    int mRX = 0;
-    int mRY = 0;
+    int mRoomCenterX = 0;
+    int mRoomCentery = 0;
     QPoint mPHighlight;
     bool mPick = false;
-    int mTarget = 0;
+    int mTargetRoomId = 0;
     bool mStartSpeedWalk = false;
 
 
@@ -137,8 +137,10 @@ public:
     int mFontHeight = 20;
     bool mShowRoomID = false;
     QMap<int, QPixmap> mPixMap;
-    double rSize = 0.5;
-    double eSize = 3.0;
+    // size the room should be drawn on the 2D map
+    double mRoomSize = 0.5;
+    // size of exits on the 2D map
+    double mExitSize = 3.0;
     // When a Lua centerview(...) is called this assigns the room ID value to
     // this member and (switching areas if necessary) pans the map to be
     // centered on this room:
@@ -146,14 +148,11 @@ public:
     // This is the area of the map that is being shown, it need not be that
     // which contains the player room:
     int mAreaID = 0;
-    // These next three represent the room coordinates at the middle of the map
-    // the first pair needs to not be integer types as a more flexible zoom
-    // in/out mechanism was adopted that meant non-integral coordinates were
-    // needed, OTOH a "snap to a fractional (power of 2?) value" might help to
-    // keep the decimal numbers reasonable:
-    qreal mOx = 0.0;
-    qreal mOy = 0.0;
-    int mOz = 0;
+    // These represent the map center coordinates.
+    // The first two are non-integer to enable flexible zooming:
+    qreal mMapCenterX = 0.0;
+    qreal mMapCenterY = 0.0;
+    int mMapZLevel = 0;
     // Gets set when pan controls are used to move the map away from being
     // centered on mRoomID - it seems to be needed if the room concerned
     // is being moved by the mouse as part of a selection:
@@ -269,19 +268,10 @@ private:
         int y;
     } mContextMenuClickPosition;
 
-    // When more than zero rooms are selected this
-    // is either the first (only) room in the set
-    // or if getCenterSelectionId() is used the
-    // room that is selected - this is so that it
-    // can be painted in yellow rather than orange
-    // when more than one room is selected to
-    // indicate the particular room that will be
-    // modified or be the center of those
-    // modifications. {for slot_spread(),
-    // slot_shrink(), slot_setUserData() - if ever
-    // implemented, slot_setExits(),
-    // slot_movePosition(), etc.} - previously have
-    // used -1 but is now reset to 0 if it is not valid.
+    // This holds the ID of the room highlighted in yellow when multiple
+    // rooms are selected. It is either the first selected room, or the
+    // room at the center of the selection. This indicates the room that
+    // will be modified by actions like spread, shrink, set exits, move position, etc.
     int mMultiSelectionHighlightRoomId = 0;
 
     bool mIsSelectionSorting = true;

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -79,42 +79,42 @@ void GLWidget::slot_showAllLevels()
 void GLWidget::slot_shiftDown()
 {
     mShiftMode = true;
-    mOy--;
+    mMapCenterY--;
     update();
 }
 
 void GLWidget::slot_shiftUp()
 {
     mShiftMode = true;
-    mOy++;
+    mMapCenterY++;
     update();
 }
 
 void GLWidget::slot_shiftLeft()
 {
     mShiftMode = true;
-    mOx--;
+    mMapCenterX--;
     update();
 }
 
 void GLWidget::slot_shiftRight()
 {
     mShiftMode = true;
-    mOx++;
+    mMapCenterX++;
     update();
 }
 
 void GLWidget::slot_shiftZup()
 {
     mShiftMode = true;
-    mOz++;
+    mMapZLevel++;
     update();
 }
 
 void GLWidget::slot_shiftZdown()
 {
     mShiftMode = true;
-    mOz--;
+    mMapZLevel--;
     update();
 }
 
@@ -243,9 +243,9 @@ void GLWidget::setViewCenter(int areaId, int xPos, int yPos, int zPos)
 {
     mAID = areaId;
     mShiftMode = true;
-    mOx = xPos;
-    mOy = yPos;
-    mOz = zPos;
+    mMapCenterX = xPos;
+    mMapCenterY = yPos;
+    mMapZLevel = zPos;
     update();
 }
 
@@ -295,14 +295,14 @@ void GLWidget::paintGL()
         ox = pRID->x;
         oy = pRID->y;
         oz = pRID->z;
-        mOx = ox;
-        mOy = oy;
-        mOz = oz;
+        mMapCenterX = ox;
+        mMapCenterY = oy;
+        mMapZLevel = oz;
 
     } else {
-        ox = mOx;
-        oy = mOy;
-        oz = mOz;
+        ox = mMapCenterX;
+        oy = mMapCenterY;
+        oz = mMapZLevel;
     }
     px = static_cast<float>(ox); //mpMap->rooms[mpMap->mRoomId]->x);
     py = static_cast<float>(oy); //mpMap->rooms[mpMap->mRoomId]->y);
@@ -1366,7 +1366,7 @@ void GLWidget::paintGL()
                 glMaterialfv(GL_FRONT, GL_AMBIENT_AND_DIFFUSE, mc3);
                 glMateriali(GL_FRONT, GL_SHININESS, 36);
                 glColor4f(1.0, 0.0, 0.0, 1.0);
-            } else if (currentRoomId == mTarget) {
+            } else if (currentRoomId == mTargetRoomId) {
                 glDisable(GL_BLEND);
                 glEnable(GL_LIGHTING);
                 glDisable(GL_LIGHT1);
@@ -2078,7 +2078,7 @@ void GLWidget::mousePressEvent(QMouseEvent* event)
         gluPerspective(60 * mScale, (GLfloat)width() / (GLfloat)height(), 0.0001, 10000.0);
         glMatrixMode(GL_MODELVIEW);
         doneCurrent();
-        mTarget = -22;
+        mTargetRoomId = -22;
         makeCurrent();
         paintGL();
         doneCurrent();
@@ -2088,7 +2088,7 @@ void GLWidget::mousePressEvent(QMouseEvent* event)
         hits = glRenderMode(GL_RENDER);
 
         for (int i = 0; i < hits; i++) {
-            mTarget = buff[i * 4 + 3];
+            mTargetRoomId = buff[i * 4 + 3];
             //TODO: multiple assignments
             //            unsigned int minZ = buff[i * 4 + 1];
             //            unsigned int maxZ = buff[i * 4 + 2];
@@ -2100,8 +2100,8 @@ void GLWidget::mousePressEvent(QMouseEvent* event)
         glMatrixMode(GL_MODELVIEW);
         doneCurrent();
         update();
-        if (mpMap->mpRoomDB->getRoom(mTarget)) {
-            mpMap->mTargetID = mTarget;
+        if (mpMap->mpRoomDB->getRoom(mTargetRoomId)) {
+            mpMap->mTargetID = mTargetRoomId;
             if (mpMap->mpHost->checkForCustomSpeedwalk()) {
                 mpMap->mpHost->startSpeedWalk(mpMap->mRoomIdHash.value(mpMap->mProfileName), mpMap->mTargetID);
             } else if (mpMap->findPath(mpMap->mRoomIdHash.value(mpMap->mProfileName), mpMap->mTargetID)) {

--- a/src/glwidget.h
+++ b/src/glwidget.h
@@ -97,9 +97,9 @@ private:
 
     int mRID = 0;
     int mAID = 0;
-    int mOx = 0;
-    int mOy = 0;
-    int mOz = 0;
+    int mMapCenterX = 0;
+    int mMapCenterY = 0;
+    int mMapZLevel = 0;
     bool mShiftMode = false;
 
     float xRot = 1.0;
@@ -113,7 +113,7 @@ private:
     int mShowBottomLevels = 999999;
 
     float mScale = 1.0;
-    int mTarget = 0;
+    int mTargetRoomId = 0;
 };
 
 #endif // MUDLET_GLWIDGET_H


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Improve variable names and comments in map drawing classes
#### Motivation for adding to Mudlet
So contributors have an easier time building Mudlet
#### Other info (issues closed, discussion etc)
T2DMap::getCenterSelection() is not just getting a selection as the name implies but is also changing the classes' state, that means the function has [unexpected side-effects](https://www.linguistic-antipatterns.com/?tab=%22Unexpected-side-effects%22): would like to improve that in a follow-up PR.