### PR TITLE
Infrastructure: mark read-only variables as const

### DIFF
--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -502,7 +502,7 @@ void ActionUnit::constructToolbar(TAction* pAction, TToolBar* pToolBar)
         mudlet::self()->addDockWidget(((pAction->mToolbarLastDockArea != Qt::NoDockWidgetArea) ? pAction->mToolbarLastDockArea : Qt::LeftDockWidgetArea), pToolBar);
         if (pAction->mToolbarLastFloatingState) {
             pToolBar->setFloating(true);
-            QPoint const pos = QPoint(pAction->mPosX, pAction->mPosY);
+            const QPoint pos = QPoint(pAction->mPosX, pAction->mPosY);
             pToolBar->show();
             pToolBar->move(pos);
         } else {

--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -502,7 +502,7 @@ void ActionUnit::constructToolbar(TAction* pAction, TToolBar* pToolBar)
         mudlet::self()->addDockWidget(((pAction->mToolbarLastDockArea != Qt::NoDockWidgetArea) ? pAction->mToolbarLastDockArea : Qt::LeftDockWidgetArea), pToolBar);
         if (pAction->mToolbarLastFloatingState) {
             pToolBar->setFloating(true);
-            QPoint pos = QPoint(pAction->mPosX, pAction->mPosY);
+            QPoint const pos = QPoint(pAction->mPosX, pAction->mPosY);
             pToolBar->show();
             pToolBar->move(pos);
         } else {

--- a/src/FontManager.cpp
+++ b/src/FontManager.cpp
@@ -56,7 +56,7 @@ void FontManager::loadFonts(const QString& folder)
     dir.setNameFilters(filters);
 
     for (auto fontFile : dir.entryList(QDir::Files | QDir::Readable | QDir::NoDotAndDotDot)) {
-        QString const fontFilePathName = qsl("%1/%2").arg(dir.absolutePath(), fontFile);
+        const QString fontFilePathName = qsl("%1/%2").arg(dir.absolutePath(), fontFile);
         loadFont(fontFilePathName);
     }
 }

--- a/src/FontManager.cpp
+++ b/src/FontManager.cpp
@@ -82,7 +82,7 @@ void FontManager::loadFont(const QString& filePath, const QString& belongsTo)
 
 bool FontManager::fontAlreadyLoaded(const QString& filePath)
 {
-    QFileInfo const fontFile(filePath);
+    const QFileInfo fontFile(filePath);
     auto fileName = fontFile.fileName();
 
     return loadedFontPaths.contains(fileName);
@@ -90,7 +90,7 @@ bool FontManager::fontAlreadyLoaded(const QString& filePath)
 
 void FontManager::rememberFont(const QString& filePath, int fontID, const QString& belongsTo)
 {
-    QFileInfo const fontFile(filePath);
+    const QFileInfo fontFile(filePath);
     auto fileName = fontFile.fileName();
 
     if (loadedFontPaths.contains(fileName)) {

--- a/src/FontManager.cpp
+++ b/src/FontManager.cpp
@@ -31,7 +31,7 @@
 
 void FontManager::addFonts()
 {
-    QDir const dir(mudlet::getMudletPath(mudlet::mainFontsPath));
+    const QDir dir(mudlet::getMudletPath(mudlet::mainFontsPath));
 
     if (!dir.exists()) {
         return;

--- a/src/FontManager.cpp
+++ b/src/FontManager.cpp
@@ -31,7 +31,7 @@
 
 void FontManager::addFonts()
 {
-    QDir dir(mudlet::getMudletPath(mudlet::mainFontsPath));
+    QDir const dir(mudlet::getMudletPath(mudlet::mainFontsPath));
 
     if (!dir.exists()) {
         return;
@@ -56,7 +56,7 @@ void FontManager::loadFonts(const QString& folder)
     dir.setNameFilters(filters);
 
     for (auto fontFile : dir.entryList(QDir::Files | QDir::Readable | QDir::NoDotAndDotDot)) {
-        QString fontFilePathName = qsl("%1/%2").arg(dir.absolutePath(), fontFile);
+        QString const fontFilePathName = qsl("%1/%2").arg(dir.absolutePath(), fontFile);
         loadFont(fontFilePathName);
     }
 }
@@ -82,7 +82,7 @@ void FontManager::loadFont(const QString& filePath, const QString& belongsTo)
 
 bool FontManager::fontAlreadyLoaded(const QString& filePath)
 {
-    QFileInfo fontFile(filePath);
+    QFileInfo const fontFile(filePath);
     auto fileName = fontFile.fileName();
 
     return loadedFontPaths.contains(fileName);
@@ -90,7 +90,7 @@ bool FontManager::fontAlreadyLoaded(const QString& filePath)
 
 void FontManager::rememberFont(const QString& filePath, int fontID, const QString& belongsTo)
 {
-    QFileInfo fontFile(filePath);
+    QFileInfo const fontFile(filePath);
     auto fileName = fontFile.fileName();
 
     if (loadedFontPaths.contains(fileName)) {

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -376,8 +376,8 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
     mLuaInterpreter.updateAnsi16ColorsInTable();
     mLuaInterpreter.updateExtendedAnsiColorsInTable();
 
-    QString const directoryLogFile = mudlet::getMudletPath(mudlet::profileDataItemPath, mHostName, qsl("log"));
-    QString const logFileName = qsl("%1/errors.txt").arg(directoryLogFile);
+    const QString directoryLogFile = mudlet::getMudletPath(mudlet::profileDataItemPath, mHostName, qsl("log"));
+    const QString logFileName = qsl("%1/errors.txt").arg(directoryLogFile);
     QDir const dirLogFile;
     if (!dirLogFile.exists(directoryLogFile)) {
         dirLogFile.mkpath(directoryLogFile);
@@ -514,7 +514,7 @@ void Host::loadPackageInfo()
 {
     QStringList const packages = mInstalledPackages;
     for (int i = 0; i < packages.size(); i++) {
-        QString const packagePath{mudlet::self()->getMudletPath(mudlet::profilePackagePath, getName(), packages.at(i))};
+        const QString packagePath{mudlet::self()->getMudletPath(mudlet::profilePackagePath, getName(), packages.at(i))};
         QDir const dir(packagePath);
         if (dir.exists(qsl("config.lua"))) {
             getPackageConfig(dir.absoluteFilePath(qsl("config.lua")));
@@ -524,7 +524,7 @@ void Host::loadPackageInfo()
 
 void Host::createModuleBackup(const QString &filename, const QString &saveName)
 {
-    QString const time = QDateTime::currentDateTime().toString("yyyy-MM-dd#HH-mm-ss");
+    const QString time = QDateTime::currentDateTime().toString("yyyy-MM-dd#HH-mm-ss");
     QFile::copy(filename, saveName + time);
 }
 
@@ -556,7 +556,7 @@ void Host::saveModules(bool backup)
 {
     QMapIterator<QString, QStringList> it(modulesToWrite);
     mModulesToSync.clear();
-    QString const savePath = mudlet::getMudletPath(mudlet::moduleBackupsPath);
+    const QString savePath = mudlet::getMudletPath(mudlet::moduleBackupsPath);
     auto savePathDir = QDir(savePath);
     if (!savePathDir.exists()) {
         savePathDir.mkpath(savePath);
@@ -564,8 +564,8 @@ void Host::saveModules(bool backup)
     while (it.hasNext()) {
         it.next();
         QStringList entry = it.value();
-        QString const moduleName = it.key();
-        QString const filename = entry[0];
+        const QString moduleName = it.key();
+        const QString filename = entry[0];
 
         if (backup) {
             createModuleBackup(filename, savePath + moduleName);
@@ -614,8 +614,8 @@ void Host::updateModuleZips(const QString& zipName, const QString& moduleName)
         return;
     }
     zip* zipFile = nullptr;
-    QString const packagePathName = mudlet::getMudletPath(mudlet::profilePackagePath, mHostName, moduleName);
-    QString const filename_xml = mudlet::getMudletPath(mudlet::profilePackagePathFileName, mHostName, moduleName);
+    const QString packagePathName = mudlet::getMudletPath(mudlet::profilePackagePath, mHostName, moduleName);
+    const QString filename_xml = mudlet::getMudletPath(mudlet::profilePackagePathFileName, mHostName, moduleName);
     int err = 0;
     zipFile = zip_open(zipName.toStdString().c_str(), ZIP_CREATE, &err);
     if (!zipFile) {
@@ -1008,14 +1008,14 @@ unsigned int Host::assemblePath()
     unsigned int totalWeight = 0;
     QStringList pathList;
     for (int const i : qAsConst(mpMap->mPathList)) {
-        QString const n = QString::number(i);
+        const QString n = QString::number(i);
         pathList.append(n);
     }
     QStringList directionList = mpMap->mDirList;
     QStringList weightList;
     for (int const stepWeight : qAsConst(mpMap->mWeightList)) {
         totalWeight += stepWeight;
-        QString const n = QString::number(stepWeight);
+        const QString n = QString::number(stepWeight);
         weightList.append(n);
     }
     QString tableName = qsl("speedWalkPath");
@@ -1070,19 +1070,19 @@ void Host::startSpeedWalk()
 {
     int const totalWeight = assemblePath();
     Q_UNUSED(totalWeight);
-    QString const f = qsl("doSpeedWalk");
-    QString const n = QString();
+    const QString f = qsl("doSpeedWalk");
+    const QString n = QString();
     mLuaInterpreter.call(f, n);
 }
 
 void Host::startSpeedWalk(int sourceRoom, int targetRoom)
 {
-    QString const sourceName = qsl("speedWalkFrom");
+    const QString sourceName = qsl("speedWalkFrom");
     mLuaInterpreter.set_lua_integer(sourceName, sourceRoom);
-    QString const targetName = qsl("speedWalkTo");
+    const QString targetName = qsl("speedWalkTo");
     mLuaInterpreter.set_lua_integer(targetName, targetRoom);
-    QString const f = qsl("doSpeedWalk");
-    QString const n = QString();
+    const QString f = qsl("doSpeedWalk");
+    const QString n = QString();
     mLuaInterpreter.call(f, n);
 }
 
@@ -1564,7 +1564,7 @@ void Host::raiseEvent(const TEvent& pE)
         return;
     }
 
-    static QString const star = qsl("*");
+    static const QString star = qsl("*");
 
     if (mEventHandlerMap.contains(pE.mArgumentList.at(0))) {
         QList<TScript*> scriptList = mEventHandlerMap.value(pE.mArgumentList.at(0));
@@ -1699,8 +1699,8 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, int modul
     }
     QFile file2;
     if (fileName.endsWith(qsl(".zip"), Qt::CaseInsensitive) || fileName.endsWith(qsl(".mpackage"), Qt::CaseInsensitive)) {
-        QString const _home = mudlet::getMudletPath(mudlet::profileHomePath, getName());
-        QString const _dest = mudlet::getMudletPath(mudlet::profilePackagePath, getName(), packageName);
+        const QString _home = mudlet::getMudletPath(mudlet::profileHomePath, getName());
+        const QString _dest = mudlet::getMudletPath(mudlet::profilePackagePath, getName(), packageName);
         // home directory for the PROFILE
         QDir const _tmpDir(_home);
         // directory to store the expanded archive file contents
@@ -1767,7 +1767,7 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, int modul
                 }
             }
             // continuing, so update the folder name on disk
-            QString const newpath(qsl("%1/%2").arg(_home, packageName));
+            const QString newpath(qsl("%1/%2").arg(_home, packageName));
             _dir.rename(_dir.absolutePath(), newpath);
             _dir = QDir(newpath);
         }
@@ -2014,7 +2014,7 @@ bool Host::uninstallPackage(const QString& packageName, int module)
 
     getActionUnit()->updateToolbar();
 
-    QString const dest = mudlet::getMudletPath(mudlet::profilePackagePath, getName(), packageName);
+    const QString dest = mudlet::getMudletPath(mudlet::profilePackagePath, getName(), packageName);
     removeDir(dest, dest);
 
     // ensure only one timer is running in case multiple modules are uninstalled at once
@@ -2042,7 +2042,7 @@ bool Host::uninstallPackage(const QString& packageName, int module)
 
 void Host::readPackageConfig(const QString& luaConfig, QString& packageName, bool isModule)
 {
-    QString const newName = getPackageConfig(luaConfig, isModule);
+    const QString newName = getPackageConfig(luaConfig, isModule);
     if (!newName.isEmpty()) {
         packageName = sanitizePackageName(newName);
     }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -625,7 +625,7 @@ void Host::updateModuleZips(const QString& zipName, const QString& moduleName)
     if (!packageDir.exists()) {
         packageDir.mkpath(packagePathName);
     }
-    int const xmlIndex = zip_name_locate(zipFile, qsl("%1.xml").arg(moduleName).toUtf8().constData(), ZIP_FL_ENC_GUESS);
+    const int xmlIndex = zip_name_locate(zipFile, qsl("%1.xml").arg(moduleName).toUtf8().constData(), ZIP_FL_ENC_GUESS);
     zip_delete(zipFile, xmlIndex);
     struct zip_source* s = zip_source_file(zipFile, filename_xml.toUtf8().constData(), 0, -1);
     if (mudlet::smDebugMode && s == nullptr) {
@@ -1007,13 +1007,13 @@ unsigned int Host::assemblePath()
 {
     unsigned int totalWeight = 0;
     QStringList pathList;
-    for (int const i : qAsConst(mpMap->mPathList)) {
+    for (const int i : qAsConst(mpMap->mPathList)) {
         const QString n = QString::number(i);
         pathList.append(n);
     }
     QStringList directionList = mpMap->mDirList;
     QStringList weightList;
-    for (int const stepWeight : qAsConst(mpMap->mWeightList)) {
+    for (const int stepWeight : qAsConst(mpMap->mWeightList)) {
         totalWeight += stepWeight;
         const QString n = QString::number(stepWeight);
         weightList.append(n);
@@ -1068,7 +1068,7 @@ bool Host::checkForCustomSpeedwalk()
 
 void Host::startSpeedWalk()
 {
-    int const totalWeight = assemblePath();
+    const int totalWeight = assemblePath();
     Q_UNUSED(totalWeight);
     const QString f = qsl("doSpeedWalk");
     const QString n = QString();
@@ -1230,7 +1230,7 @@ int Host::findStopWatchId(const QString& name) const
 {
     // Scan through existing names, in ascending id order
     QList<int> stopWatchIdList = mStopWatchMap.keys();
-    int const total = stopWatchIdList.size();
+    const int total = stopWatchIdList.size();
     if (total > 1) {
         std::sort(stopWatchIdList.begin(), stopWatchIdList.end());
     }
@@ -1446,7 +1446,7 @@ QPair<bool, QString> Host::setStopWatchName(const QString& currentName, const QS
     stopWatch* pStopWatch = nullptr;
     // Scan through existing names, in ascending id order
     QList<int> stopWatchIdList = mStopWatchMap.keys();
-    int const total = stopWatchIdList.size();
+    const int total = stopWatchIdList.size();
     if (total > 1) {
         std::sort(stopWatchIdList.begin(), stopWatchIdList.end());
     }
@@ -2293,16 +2293,16 @@ QColor Host::getAnsiColor(const int ansiCode, const bool isBackground) const
         } else if (ansiCode >= 16 && ansiCode <= 231) {
             // because color 1-15 behave like normal ANSI colors we need to subtract 16
             // 6x6 RGB color space
-            int const r = (ansiCode - 16) / 36;
-            int const g = (ansiCode - 16 - (r * 36)) / 6;
-            int const b = (ansiCode - 16 - (r * 36)) - (g * 6);
+            const int r = (ansiCode - 16) / 36;
+            const int g = (ansiCode - 16 - (r * 36)) / 6;
+            const int b = (ansiCode - 16 - (r * 36)) - (g * 6);
             // Values are scaled according to the standard Xterm color palette
             // http://jonasjacek.github.io/colors/
             return QColor(r == 0 ? 0 : (r - 1) * 40 + 95,
                           g == 0 ? 0 : (g - 1) * 40 + 95,
                           b == 0 ? 0 : (b - 1) * 40 + 95);
         } else if (ansiCode < 256) {
-            int const k = (ansiCode - 232) * 10 + 8;
+            const int k = (ansiCode - 232) * 10 + 8;
             return QColor(k, k, k);
         } else {
             return QColor(); // No-op

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -378,7 +378,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 
     const QString directoryLogFile = mudlet::getMudletPath(mudlet::profileDataItemPath, mHostName, qsl("log"));
     const QString logFileName = qsl("%1/errors.txt").arg(directoryLogFile);
-    QDir const dirLogFile;
+    const QDir dirLogFile;
     if (!dirLogFile.exists(directoryLogFile)) {
         dirLogFile.mkpath(directoryLogFile);
     }
@@ -515,7 +515,7 @@ void Host::loadPackageInfo()
     QStringList const packages = mInstalledPackages;
     for (int i = 0; i < packages.size(); i++) {
         const QString packagePath{mudlet::self()->getMudletPath(mudlet::profilePackagePath, getName(), packages.at(i))};
-        QDir const dir(packagePath);
+        const QDir dir(packagePath);
         if (dir.exists(qsl("config.lua"))) {
             getPackageConfig(dir.absoluteFilePath(qsl("config.lua")));
         }
@@ -621,7 +621,7 @@ void Host::updateModuleZips(const QString& zipName, const QString& moduleName)
     if (!zipFile) {
         return;
     }
-    QDir const packageDir = QDir(packagePathName);
+    const QDir packageDir = QDir(packagePathName);
     if (!packageDir.exists()) {
         packageDir.mkpath(packagePathName);
     }
@@ -811,7 +811,7 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
         return std::make_tuple(false, filename_xml, qsl("profile loading is in progress"));
     }
 
-    QDir const dir_xml;
+    const QDir dir_xml;
     if (!dir_xml.exists(directory_xml)) {
         dir_xml.mkpath(directory_xml);
     }
@@ -1702,7 +1702,7 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, int modul
         const QString _home = mudlet::getMudletPath(mudlet::profileHomePath, getName());
         const QString _dest = mudlet::getMudletPath(mudlet::profilePackagePath, getName(), packageName);
         // home directory for the PROFILE
-        QDir const _tmpDir(_home);
+        const QDir _tmpDir(_home);
         // directory to store the expanded archive file contents
         const bool mkpathSuccessful = _tmpDir.mkpath(_dest);
         if (!mkpathSuccessful) {
@@ -1877,7 +1877,7 @@ QString Host::sanitizePackageName(const QString packageName) const {
 bool Host::removeDir(const QString& dirName, const QString& originalPath)
 {
     bool result = true;
-    QDir const dir(dirName);
+    const QDir dir(dirName);
     if (dir.exists(dirName)) {
         for (QFileInfo  const&info : dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden | QDir::AllDirs | QDir::Files, QDir::DirsFirst)) {
             // prevent recursion outside of the original branch

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1032,7 +1032,7 @@ bool Host::checkForMappingScript()
     // the mapper script reminder is only shown once
     // because it is too difficult and error prone (->proper script sequence)
     // to disable this message
-    bool const ret = (mLuaInterpreter.check_for_mappingscript() || mHaveMapperScript);
+    const bool ret = (mLuaInterpreter.check_for_mappingscript() || mHaveMapperScript);
     mHaveMapperScript = true;
     return ret;
 }
@@ -1062,7 +1062,7 @@ void Host::check_for_mappingscript()
 
 bool Host::checkForCustomSpeedwalk()
 {
-    bool const ret = mLuaInterpreter.check_for_custom_speedwalk();
+    const bool ret = mLuaInterpreter.check_for_custom_speedwalk();
     return ret;
 }
 
@@ -1704,7 +1704,7 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, int modul
         // home directory for the PROFILE
         QDir const _tmpDir(_home);
         // directory to store the expanded archive file contents
-        bool const mkpathSuccessful = _tmpDir.mkpath(_dest);
+        const bool mkpathSuccessful = _tmpDir.mkpath(_dest);
         if (!mkpathSuccessful) {
             return {false, qsl("could not create destination folder")};
         }
@@ -2171,7 +2171,7 @@ QPair<bool, QString> Host::writeProfileData(const QString& item, const QString& 
 QString Host::readProfileData(const QString& item)
 {
     QFile file(mudlet::getMudletPath(mudlet::profileDataItemPath, getName(), item));
-    bool const success = file.open(QIODevice::ReadOnly);
+    const bool success = file.open(QIODevice::ReadOnly);
     QString ret;
     if (success) {
         QDataStream ifs(&file);
@@ -2603,10 +2603,10 @@ void Host::setSpellDic(const QString& newDict)
 void Host::setUserDictionaryOptions(const bool _useDictionary, const bool useShared)
 {
     Q_UNUSED(_useDictionary);
-    bool const useDictionary = true;
+    const bool useDictionary = true;
     bool dictionaryChanged {};
     // Copy the value while we have the lock:
-    bool const isSpellCheckingEnabled = mEnableSpellCheck;
+    const bool isSpellCheckingEnabled = mEnableSpellCheck;
     if (mEnableUserDictionary != useDictionary) {
         mEnableUserDictionary = useDictionary;
         dictionaryChanged = true;
@@ -3873,7 +3873,7 @@ void Host::showHideOrCreateMapper(const bool loadDefaultMap)
 void Host::toggleMapperVisibility()
 {
     auto pMap = mpMap.data();
-    bool const visStatus = mpMap->mpMapper->isVisible();
+    const bool visStatus = mpMap->mpMapper->isVisible();
     if (pMap->mpMapper->isFloatAndDockable()) {
         // If we are using a floating/dockable widget we must show/hide that
         // only and not the mapper widget (otherwise it messes up {shrinks

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -190,14 +190,14 @@ QString stopWatch::getElapsedDayTimeString() const
         elapsed *= -1;
     }
 
-    qint64 days = elapsed / std::chrono::milliseconds(24h).count();
+    qint64 const days = elapsed / std::chrono::milliseconds(24h).count();
     qint64 remainder = elapsed - (days * std::chrono::milliseconds(24h).count());
-    quint8 hours = static_cast<quint8>(remainder / std::chrono::milliseconds(1h).count());
+    quint8 const hours = static_cast<quint8>(remainder / std::chrono::milliseconds(1h).count());
     remainder = remainder - (hours * std::chrono::milliseconds(1h).count());
-    quint8 minutes = static_cast<quint8>(remainder / std::chrono::milliseconds(1min).count());
+    quint8 const minutes = static_cast<quint8>(remainder / std::chrono::milliseconds(1min).count());
     remainder = remainder - (minutes * std::chrono::milliseconds(1min).count());
-    quint8 seconds = static_cast<quint8>(remainder / std::chrono::milliseconds(1s).count());
-    quint16 milliSeconds = static_cast<quint16>(remainder - (seconds * std::chrono::milliseconds(1s).count()));
+    quint8 const seconds = static_cast<quint8>(remainder / std::chrono::milliseconds(1s).count());
+    quint16 const milliSeconds = static_cast<quint16>(remainder - (seconds * std::chrono::milliseconds(1s).count()));
     return qsl("%1:%2:%3:%4:%5:%6").arg((isNegative ? QLatin1String("-") : QLatin1String("+")), QString::number(days), QString::number(hours), QString::number(minutes), QString::number(seconds), QString::number(milliSeconds));
 }
 
@@ -376,9 +376,9 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
     mLuaInterpreter.updateAnsi16ColorsInTable();
     mLuaInterpreter.updateExtendedAnsiColorsInTable();
 
-    QString directoryLogFile = mudlet::getMudletPath(mudlet::profileDataItemPath, mHostName, qsl("log"));
-    QString logFileName = qsl("%1/errors.txt").arg(directoryLogFile);
-    QDir dirLogFile;
+    QString const directoryLogFile = mudlet::getMudletPath(mudlet::profileDataItemPath, mHostName, qsl("log"));
+    QString const logFileName = qsl("%1/errors.txt").arg(directoryLogFile);
+    QDir const dirLogFile;
     if (!dirLogFile.exists(directoryLogFile)) {
         dirLogFile.mkpath(directoryLogFile);
     }
@@ -512,10 +512,10 @@ void Host::autoSaveMap()
 
 void Host::loadPackageInfo()
 {
-    QStringList packages = mInstalledPackages;
+    QStringList const packages = mInstalledPackages;
     for (int i = 0; i < packages.size(); i++) {
-        QString packagePath{mudlet::self()->getMudletPath(mudlet::profilePackagePath, getName(), packages.at(i))};
-        QDir dir(packagePath);
+        QString const packagePath{mudlet::self()->getMudletPath(mudlet::profilePackagePath, getName(), packages.at(i))};
+        QDir const dir(packagePath);
         if (dir.exists(qsl("config.lua"))) {
             getPackageConfig(dir.absoluteFilePath(qsl("config.lua")));
         }
@@ -524,7 +524,7 @@ void Host::loadPackageInfo()
 
 void Host::createModuleBackup(const QString &filename, const QString &saveName)
 {
-    QString time = QDateTime::currentDateTime().toString("yyyy-MM-dd#HH-mm-ss");
+    QString const time = QDateTime::currentDateTime().toString("yyyy-MM-dd#HH-mm-ss");
     QFile::copy(filename, saveName + time);
 }
 
@@ -556,7 +556,7 @@ void Host::saveModules(bool backup)
 {
     QMapIterator<QString, QStringList> it(modulesToWrite);
     mModulesToSync.clear();
-    QString savePath = mudlet::getMudletPath(mudlet::moduleBackupsPath);
+    QString const savePath = mudlet::getMudletPath(mudlet::moduleBackupsPath);
     auto savePathDir = QDir(savePath);
     if (!savePathDir.exists()) {
         savePathDir.mkpath(savePath);
@@ -564,8 +564,8 @@ void Host::saveModules(bool backup)
     while (it.hasNext()) {
         it.next();
         QStringList entry = it.value();
-        QString moduleName = it.key();
-        QString filename = entry[0];
+        QString const moduleName = it.key();
+        QString const filename = entry[0];
 
         if (backup) {
             createModuleBackup(filename, savePath + moduleName);
@@ -585,7 +585,7 @@ void Host::reloadModules()
         if (otherHost == this || !otherHost->mpConsole) {
             continue;
         }
-        QMap<QString, int>& modulePri = otherHost->mModulePriorities;
+        QMap<QString, int> const& modulePri = otherHost->mModulePriorities;
         QMap<int, QStringList> moduleOrder;
 
         auto modulePrioritiesIt = modulePri.constBegin();
@@ -597,7 +597,7 @@ void Host::reloadModules()
         QMapIterator<int, QStringList> it(moduleOrder);
         while (it.hasNext()) {
             it.next();
-            QStringList moduleList = it.value();
+            QStringList const moduleList = it.value();
             for (auto moduleName : moduleList) {
                 if (mModulesToSync.contains(moduleName)) {
                     otherHost->reloadModule(moduleName, mHostName);
@@ -614,18 +614,18 @@ void Host::updateModuleZips(const QString& zipName, const QString& moduleName)
         return;
     }
     zip* zipFile = nullptr;
-    QString packagePathName = mudlet::getMudletPath(mudlet::profilePackagePath, mHostName, moduleName);
-    QString filename_xml = mudlet::getMudletPath(mudlet::profilePackagePathFileName, mHostName, moduleName);
+    QString const packagePathName = mudlet::getMudletPath(mudlet::profilePackagePath, mHostName, moduleName);
+    QString const filename_xml = mudlet::getMudletPath(mudlet::profilePackagePathFileName, mHostName, moduleName);
     int err = 0;
     zipFile = zip_open(zipName.toStdString().c_str(), ZIP_CREATE, &err);
     if (!zipFile) {
         return;
     }
-    QDir packageDir = QDir(packagePathName);
+    QDir const packageDir = QDir(packagePathName);
     if (!packageDir.exists()) {
         packageDir.mkpath(packagePathName);
     }
-    int xmlIndex = zip_name_locate(zipFile, qsl("%1.xml").arg(moduleName).toUtf8().constData(), ZIP_FL_ENC_GUESS);
+    int const xmlIndex = zip_name_locate(zipFile, qsl("%1.xml").arg(moduleName).toUtf8().constData(), ZIP_FL_ENC_GUESS);
     zip_delete(zipFile, xmlIndex);
     struct zip_source* s = zip_source_file(zipFile, filename_xml.toUtf8().constData(), 0, -1);
     if (mudlet::smDebugMode && s == nullptr) {
@@ -692,7 +692,7 @@ void Host::reloadModule(const QString& syncModuleName, const QString& syncingFro
     moduleIterator.toFront();
     while (moduleIterator.hasNext()) {
         moduleIterator.next();
-        QStringList entry = installedModules[moduleIterator.key()];
+        QStringList const entry = installedModules[moduleIterator.key()];
         mInstalledModules[moduleIterator.key()] = entry;
     }
 }
@@ -811,7 +811,7 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
         return std::make_tuple(false, filename_xml, qsl("profile loading is in progress"));
     }
 
-    QDir dir_xml;
+    QDir const dir_xml;
     if (!dir_xml.exists(directory_xml)) {
         dir_xml.mkpath(directory_xml);
     }
@@ -941,7 +941,7 @@ void Host::thankForUsingPTB()
 
 void Host::setMediaLocationGMCP(const QString& mediaUrl)
 {
-    QUrl url = QUrl(mediaUrl);
+    QUrl const url = QUrl(mediaUrl);
 
     if (!url.isValid()) {
         return;
@@ -957,7 +957,7 @@ QString Host::getMediaLocationGMCP() const
 
 void Host::setMediaLocationMSP(const QString& mediaUrl)
 {
-    QUrl url = QUrl(mediaUrl);
+    QUrl const url = QUrl(mediaUrl);
 
     if (!url.isValid()) {
         return;
@@ -1007,15 +1007,15 @@ unsigned int Host::assemblePath()
 {
     unsigned int totalWeight = 0;
     QStringList pathList;
-    for (int i : qAsConst(mpMap->mPathList)) {
-        QString n = QString::number(i);
+    for (int const i : qAsConst(mpMap->mPathList)) {
+        QString const n = QString::number(i);
         pathList.append(n);
     }
     QStringList directionList = mpMap->mDirList;
     QStringList weightList;
-    for (int stepWeight : qAsConst(mpMap->mWeightList)) {
+    for (int const stepWeight : qAsConst(mpMap->mWeightList)) {
         totalWeight += stepWeight;
-        QString n = QString::number(stepWeight);
+        QString const n = QString::number(stepWeight);
         weightList.append(n);
     }
     QString tableName = qsl("speedWalkPath");
@@ -1032,7 +1032,7 @@ bool Host::checkForMappingScript()
     // the mapper script reminder is only shown once
     // because it is too difficult and error prone (->proper script sequence)
     // to disable this message
-    bool ret = (mLuaInterpreter.check_for_mappingscript() || mHaveMapperScript);
+    bool const ret = (mLuaInterpreter.check_for_mappingscript() || mHaveMapperScript);
     mHaveMapperScript = true;
     return ret;
 }
@@ -1062,27 +1062,27 @@ void Host::check_for_mappingscript()
 
 bool Host::checkForCustomSpeedwalk()
 {
-    bool ret = mLuaInterpreter.check_for_custom_speedwalk();
+    bool const ret = mLuaInterpreter.check_for_custom_speedwalk();
     return ret;
 }
 
 void Host::startSpeedWalk()
 {
-    int totalWeight = assemblePath();
+    int const totalWeight = assemblePath();
     Q_UNUSED(totalWeight);
-    QString f = qsl("doSpeedWalk");
-    QString n = QString();
+    QString const f = qsl("doSpeedWalk");
+    QString const n = QString();
     mLuaInterpreter.call(f, n);
 }
 
 void Host::startSpeedWalk(int sourceRoom, int targetRoom)
 {
-    QString sourceName = qsl("speedWalkFrom");
+    QString const sourceName = qsl("speedWalkFrom");
     mLuaInterpreter.set_lua_integer(sourceName, sourceRoom);
-    QString targetName = qsl("speedWalkTo");
+    QString const targetName = qsl("speedWalkTo");
     mLuaInterpreter.set_lua_integer(targetName, targetRoom);
-    QString f = qsl("doSpeedWalk");
-    QString n = QString();
+    QString const f = qsl("doSpeedWalk");
+    QString const n = QString();
     mLuaInterpreter.call(f, n);
 }
 
@@ -1230,7 +1230,7 @@ int Host::findStopWatchId(const QString& name) const
 {
     // Scan through existing names, in ascending id order
     QList<int> stopWatchIdList = mStopWatchMap.keys();
-    int total = stopWatchIdList.size();
+    int const total = stopWatchIdList.size();
     if (total > 1) {
         std::sort(stopWatchIdList.begin(), stopWatchIdList.end());
     }
@@ -1446,7 +1446,7 @@ QPair<bool, QString> Host::setStopWatchName(const QString& currentName, const QS
     stopWatch* pStopWatch = nullptr;
     // Scan through existing names, in ascending id order
     QList<int> stopWatchIdList = mStopWatchMap.keys();
-    int total = stopWatchIdList.size();
+    int const total = stopWatchIdList.size();
     if (total > 1) {
         std::sort(stopWatchIdList.begin(), stopWatchIdList.end());
     }
@@ -1564,7 +1564,7 @@ void Host::raiseEvent(const TEvent& pE)
         return;
     }
 
-    static QString star = qsl("*");
+    static QString const star = qsl("*");
 
     if (mEventHandlerMap.contains(pE.mArgumentList.at(0))) {
         QList<TScript*> scriptList = mEventHandlerMap.value(pE.mArgumentList.at(0));
@@ -1580,13 +1580,13 @@ void Host::raiseEvent(const TEvent& pE)
     }
 
     if (mAnonymousEventHandlerFunctions.contains(pE.mArgumentList.at(0))) {
-        QStringList functionsList = mAnonymousEventHandlerFunctions.value(pE.mArgumentList.at(0));
+        QStringList const functionsList = mAnonymousEventHandlerFunctions.value(pE.mArgumentList.at(0));
         for (int i = 0, total = functionsList.size(); i < total; ++i) {
             mLuaInterpreter.callEventHandler(functionsList.at(i), pE);
         }
     }
     if (mAnonymousEventHandlerFunctions.contains(star)) {
-        QStringList functionsList = mAnonymousEventHandlerFunctions.value(star);
+        QStringList const functionsList = mAnonymousEventHandlerFunctions.value(star);
         for (int i = 0, total = functionsList.size(); i < total; ++i) {
             mLuaInterpreter.callEventHandler(functionsList.at(i), pE);
         }
@@ -1699,12 +1699,12 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, int modul
     }
     QFile file2;
     if (fileName.endsWith(qsl(".zip"), Qt::CaseInsensitive) || fileName.endsWith(qsl(".mpackage"), Qt::CaseInsensitive)) {
-        QString _home = mudlet::getMudletPath(mudlet::profileHomePath, getName());
-        QString _dest = mudlet::getMudletPath(mudlet::profilePackagePath, getName(), packageName);
+        QString const _home = mudlet::getMudletPath(mudlet::profileHomePath, getName());
+        QString const _dest = mudlet::getMudletPath(mudlet::profilePackagePath, getName(), packageName);
         // home directory for the PROFILE
-        QDir _tmpDir(_home);
+        QDir const _tmpDir(_home);
         // directory to store the expanded archive file contents
-        bool mkpathSuccessful = _tmpDir.mkpath(_dest);
+        bool const mkpathSuccessful = _tmpDir.mkpath(_dest);
         if (!mkpathSuccessful) {
             return {false, qsl("could not create destination folder")};
         }
@@ -1767,13 +1767,13 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, int modul
                 }
             }
             // continuing, so update the folder name on disk
-            QString newpath(qsl("%1/%2").arg(_home, packageName));
+            QString const newpath(qsl("%1/%2").arg(_home, packageName));
             _dir.rename(_dir.absolutePath(), newpath);
             _dir = QDir(newpath);
         }
         QStringList _filterList;
         _filterList << qsl("*.xml") << qsl("*.trigger");
-        QFileInfoList entries = _dir.entryInfoList(_filterList, QDir::Files);
+        QFileInfoList const entries = _dir.entryInfoList(_filterList, QDir::Files);
         for (auto& entry : entries) {
             file2.setFileName(entry.absoluteFilePath());
             file2.open(QFile::ReadOnly | QFile::Text);
@@ -1877,9 +1877,9 @@ QString Host::sanitizePackageName(const QString packageName) const {
 bool Host::removeDir(const QString& dirName, const QString& originalPath)
 {
     bool result = true;
-    QDir dir(dirName);
+    QDir const dir(dirName);
     if (dir.exists(dirName)) {
-        for (QFileInfo &info : dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden | QDir::AllDirs | QDir::Files, QDir::DirsFirst)) {
+        for (QFileInfo  const&info : dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden | QDir::AllDirs | QDir::Files, QDir::DirsFirst)) {
             // prevent recursion outside of the original branch
             if (info.isDir() && info.absoluteFilePath().startsWith(originalPath)) {
                 result = removeDir(info.absoluteFilePath(), originalPath);
@@ -2014,7 +2014,7 @@ bool Host::uninstallPackage(const QString& packageName, int module)
 
     getActionUnit()->updateToolbar();
 
-    QString dest = mudlet::getMudletPath(mudlet::profilePackagePath, getName(), packageName);
+    QString const dest = mudlet::getMudletPath(mudlet::profilePackagePath, getName(), packageName);
     removeDir(dest, dest);
 
     // ensure only one timer is running in case multiple modules are uninstalled at once
@@ -2042,7 +2042,7 @@ bool Host::uninstallPackage(const QString& packageName, int module)
 
 void Host::readPackageConfig(const QString& luaConfig, QString& packageName, bool isModule)
 {
-    QString newName = getPackageConfig(luaConfig, isModule);
+    QString const newName = getPackageConfig(luaConfig, isModule);
     if (!newName.isEmpty()) {
         packageName = sanitizePackageName(newName);
     }
@@ -2171,7 +2171,7 @@ QPair<bool, QString> Host::writeProfileData(const QString& item, const QString& 
 QString Host::readProfileData(const QString& item)
 {
     QFile file(mudlet::getMudletPath(mudlet::profileDataItemPath, getName(), item));
-    bool success = file.open(QIODevice::ReadOnly);
+    bool const success = file.open(QIODevice::ReadOnly);
     QString ret;
     if (success) {
         QDataStream ifs(&file);
@@ -2293,16 +2293,16 @@ QColor Host::getAnsiColor(const int ansiCode, const bool isBackground) const
         } else if (ansiCode >= 16 && ansiCode <= 231) {
             // because color 1-15 behave like normal ANSI colors we need to subtract 16
             // 6x6 RGB color space
-            int r = (ansiCode - 16) / 36;
-            int g = (ansiCode - 16 - (r * 36)) / 6;
-            int b = (ansiCode - 16 - (r * 36)) - (g * 6);
+            int const r = (ansiCode - 16) / 36;
+            int const g = (ansiCode - 16 - (r * 36)) / 6;
+            int const b = (ansiCode - 16 - (r * 36)) - (g * 6);
             // Values are scaled according to the standard Xterm color palette
             // http://jonasjacek.github.io/colors/
             return QColor(r == 0 ? 0 : (r - 1) * 40 + 95,
                           g == 0 ? 0 : (g - 1) * 40 + 95,
                           b == 0 ? 0 : (b - 1) * 40 + 95);
         } else if (ansiCode < 256) {
-            int k = (ansiCode - 232) * 10 + 8;
+            int const k = (ansiCode - 232) * 10 + 8;
             return QColor(k, k, k);
         } else {
             return QColor(); // No-op
@@ -2390,7 +2390,7 @@ void Host::processGMCPDiscordStatus(const QJsonObject& discordInfo)
     if (gameName != QJsonValue::Undefined) {
         setDiscordGameName(gameName.toString());
         pMudlet->updateDiscordNamedIcon();
-        QPair<bool, QString> richPresenceSupported = pMudlet->mDiscord.gameIntegrationSupported(getUrl());
+        QPair<bool, QString> const richPresenceSupported = pMudlet->mDiscord.gameIntegrationSupported(getUrl());
         if (richPresenceSupported.first && pMudlet->mDiscord.usingMudletsDiscordID(this)) {
             pMudlet->mDiscord.setDetailText(this, tr("Playing %1").arg(richPresenceSupported.second));
             pMudlet->mDiscord.setLargeImage(this, richPresenceSupported.second);
@@ -2603,10 +2603,10 @@ void Host::setSpellDic(const QString& newDict)
 void Host::setUserDictionaryOptions(const bool _useDictionary, const bool useShared)
 {
     Q_UNUSED(_useDictionary);
-    bool useDictionary = true;
+    bool const useDictionary = true;
     bool dictionaryChanged {};
     // Copy the value while we have the lock:
-    bool isSpellCheckingEnabled = mEnableSpellCheck;
+    bool const isSpellCheckingEnabled = mEnableSpellCheck;
     if (mEnableUserDictionary != useDictionary) {
         mEnableUserDictionary = useDictionary;
         dictionaryChanged = true;
@@ -3788,7 +3788,7 @@ bool Host::setBackgroundImage(const QString& name, QString& imgPath, int mode)
 
     auto pL = mpConsole->mLabelMap.value(name);
     if (pL) {
-        QPixmap bgPixmap(imgPath);
+        QPixmap const bgPixmap(imgPath);
         pL->setPixmap(bgPixmap);
         return true;
     }
@@ -3873,7 +3873,7 @@ void Host::showHideOrCreateMapper(const bool loadDefaultMap)
 void Host::toggleMapperVisibility()
 {
     auto pMap = mpMap.data();
-    bool visStatus = mpMap->mpMapper->isVisible();
+    bool const visStatus = mpMap->mpMapper->isVisible();
     if (pMap->mpMapper->isFloatAndDockable()) {
         // If we are using a floating/dockable widget we must show/hide that
         // only and not the mapper widget (otherwise it messes up {shrinks
@@ -3907,7 +3907,7 @@ void Host::createMapper(const bool loadDefaultMap)
     if (loadDefaultMap && pMap->mpRoomDB->isEmpty()) {
         qDebug() << "Host::create_mapper() - restore map case 3.";
         pMap->pushErrorMessagesToFile(tr("Pre-Map loading(3) report"), true);
-        QDateTime now(QDateTime::currentDateTime());
+        QDateTime const now(QDateTime::currentDateTime());
         if (pMap->restore(QString())) {
             pMap->audit();
             pMap->mpMapper->mp2dMap->init();
@@ -4002,7 +4002,7 @@ void Host::setupIreDriverBugfix()
     // but other games implementing GA don't. Thus, only enable the workaround
     // for the former only
 
-    QStringList ireGameUrls{"achaea.com", "lusternia.com", "imperian.com", "aetolia.com", "starmourn.com"};
+    QStringList const ireGameUrls{"achaea.com", "lusternia.com", "imperian.com", "aetolia.com", "starmourn.com"};
     if (ireGameUrls.contains(getUrl(), Qt::CaseInsensitive)) {
         set_USE_IRE_DRIVER_BUGFIX(true);
     }
@@ -4180,7 +4180,7 @@ void Host::setBorders(QMargins borders)
     }
     auto x = mpConsole->width();
     auto y = mpConsole->height();
-    QSize s = QSize(x, y);
+    QSize const s = QSize(x, y);
     QResizeEvent event(s, s);
     QApplication::sendEvent(mpConsole, &event);
     mpConsole->raiseMudletSysWindowResizeEvent(x, y);

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -512,7 +512,7 @@ void Host::autoSaveMap()
 
 void Host::loadPackageInfo()
 {
-    QStringList const packages = mInstalledPackages;
+    const QStringList packages = mInstalledPackages;
     for (int i = 0; i < packages.size(); i++) {
         const QString packagePath{mudlet::self()->getMudletPath(mudlet::profilePackagePath, getName(), packages.at(i))};
         const QDir dir(packagePath);
@@ -597,7 +597,7 @@ void Host::reloadModules()
         QMapIterator<int, QStringList> it(moduleOrder);
         while (it.hasNext()) {
             it.next();
-            QStringList const moduleList = it.value();
+            const QStringList moduleList = it.value();
             for (auto moduleName : moduleList) {
                 if (mModulesToSync.contains(moduleName)) {
                     otherHost->reloadModule(moduleName, mHostName);
@@ -692,7 +692,7 @@ void Host::reloadModule(const QString& syncModuleName, const QString& syncingFro
     moduleIterator.toFront();
     while (moduleIterator.hasNext()) {
         moduleIterator.next();
-        QStringList const entry = installedModules[moduleIterator.key()];
+        const QStringList entry = installedModules[moduleIterator.key()];
         mInstalledModules[moduleIterator.key()] = entry;
     }
 }
@@ -1580,13 +1580,13 @@ void Host::raiseEvent(const TEvent& pE)
     }
 
     if (mAnonymousEventHandlerFunctions.contains(pE.mArgumentList.at(0))) {
-        QStringList const functionsList = mAnonymousEventHandlerFunctions.value(pE.mArgumentList.at(0));
+        const QStringList functionsList = mAnonymousEventHandlerFunctions.value(pE.mArgumentList.at(0));
         for (int i = 0, total = functionsList.size(); i < total; ++i) {
             mLuaInterpreter.callEventHandler(functionsList.at(i), pE);
         }
     }
     if (mAnonymousEventHandlerFunctions.contains(star)) {
-        QStringList const functionsList = mAnonymousEventHandlerFunctions.value(star);
+        const QStringList functionsList = mAnonymousEventHandlerFunctions.value(star);
         for (int i = 0, total = functionsList.size(); i < total; ++i) {
             mLuaInterpreter.callEventHandler(functionsList.at(i), pE);
         }
@@ -4002,7 +4002,7 @@ void Host::setupIreDriverBugfix()
     // but other games implementing GA don't. Thus, only enable the workaround
     // for the former only
 
-    QStringList const ireGameUrls{"achaea.com", "lusternia.com", "imperian.com", "aetolia.com", "starmourn.com"};
+    const QStringList ireGameUrls{"achaea.com", "lusternia.com", "imperian.com", "aetolia.com", "starmourn.com"};
     if (ireGameUrls.contains(getUrl(), Qt::CaseInsensitive)) {
         set_USE_IRE_DRIVER_BUGFIX(true);
     }

--- a/src/Host.h
+++ b/src/Host.h
@@ -123,7 +123,7 @@ private:
 #ifndef QT_NO_DEBUG_STREAM
 inline QDebug& operator<<(QDebug& debug, const stopWatch& stopwatch)
 {
-    QDebugStateSaver saver(debug);
+    QDebugStateSaver const saver(debug);
     Q_UNUSED(saver);
     debug.nospace() << qsl("stopwatch(mIsRunning: %1 mInitialised: %2 mIsPersistent: %3 mEffectiveStartDateTime: %4 mElapsedTime: %5)")
                        .arg((stopwatch.running() ? QLatin1String("true") : QLatin1String("false")),

--- a/src/HostManager.cpp
+++ b/src/HostManager.cpp
@@ -32,7 +32,7 @@ bool HostManager::deleteHost(const QString& hostname)
         qDebug() << "HostManager::deleteHost(" << hostname.toUtf8().constData() << ") ERROR: not a member of host pool... aborting!";
         return false;
     } else {
-        int ret = mHostPool.remove(hostname);
+        int const ret = mHostPool.remove(hostname);
         return ret;
     }
 }
@@ -54,8 +54,8 @@ bool HostManager::addHost(const QString& hostname, const QString& port, const QS
         return false;
     }
 
-    int id = mHostPool.size() + 1;
-    QSharedPointer<Host> pNewHost(new Host(portnumber, hostname, login, pass, id));
+    int const id = mHostPool.size() + 1;
+    QSharedPointer<Host> const pNewHost(new Host(portnumber, hostname, login, pass, id));
 
     if (Q_UNLIKELY(!pNewHost)) {
         qDebug() << "HostManager::addHost(" << hostname.toUtf8().constData() << ") ERROR: failed to create new Host for the host pool... aborting!";
@@ -118,7 +118,7 @@ void HostManager::postInterHostEvent(const Host* pHost, const TEvent& event, con
     allValidHosts = afterSendingHost;
     allValidHosts.append(beforeSendingHost);
 
-    for (int validHost : qAsConst(allValidHosts)) {
+    for (int const validHost : qAsConst(allValidHosts)) {
         hostList.at(validHost)->raiseEvent(event);
     }
 }

--- a/src/HostManager.cpp
+++ b/src/HostManager.cpp
@@ -32,7 +32,7 @@ bool HostManager::deleteHost(const QString& hostname)
         qDebug() << "HostManager::deleteHost(" << hostname.toUtf8().constData() << ") ERROR: not a member of host pool... aborting!";
         return false;
     } else {
-        int const ret = mHostPool.remove(hostname);
+        const int ret = mHostPool.remove(hostname);
         return ret;
     }
 }
@@ -54,7 +54,7 @@ bool HostManager::addHost(const QString& hostname, const QString& port, const QS
         return false;
     }
 
-    int const id = mHostPool.size() + 1;
+    const int id = mHostPool.size() + 1;
     QSharedPointer<Host> const pNewHost(new Host(portnumber, hostname, login, pass, id));
 
     if (Q_UNLIKELY(!pNewHost)) {
@@ -118,7 +118,7 @@ void HostManager::postInterHostEvent(const Host* pHost, const TEvent& event, con
     allValidHosts = afterSendingHost;
     allValidHosts.append(beforeSendingHost);
 
-    for (int const validHost : qAsConst(allValidHosts)) {
+    for (const int validHost : qAsConst(allValidHosts)) {
         hostList.at(validHost)->raiseEvent(event);
     }
 }

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -107,7 +107,7 @@ void LuaInterface::getAllChildren(TVar* var, QList<TVar*>* list)
 bool LuaInterface::loadKey(lua_State* L, TVar* var)
 {
     if (setjmp(buf) == 0) {
-        int const keyType = var->getKeyType();
+        const int keyType = var->getKeyType();
         if (var->isReference()) {
             lua_rawgeti(L, LUA_REGISTRYINDEX, var->getName().toInt());
         } else {
@@ -161,7 +161,7 @@ bool LuaInterface::reparentCVariable(TVar* from, TVar* to, TVar* curVar)
             // moving from global to global or nowhere
             return true;
         }
-        int const stackSize = lua_gettop(mL);
+        const int stackSize = lua_gettop(mL);
         bool const isSaved = varUnit->isSaved(curVar);
         if (isSaved) {
             QList<TVar*> list;
@@ -317,7 +317,7 @@ bool LuaInterface::setCValue(QList<TVar*> vars)
     //make the new stack
     TVar* var = vars.back();
     if (setjmp(buf) == 0) {
-        int const stackSize = lua_gettop(mL);
+        const int stackSize = lua_gettop(mL);
         lua_getglobal(mL, (vars[0]->getName()).toUtf8().constData());
         int i = 1;
         for (; i < vars.size() - 1; i++) {
@@ -558,8 +558,8 @@ bool LuaInterface::loadVar(TVar* var)
     //puts the value of a variable on the -1 position of the stack
     if (setjmp(buf) == 0) {
 
-        int const kType = var->getKeyType();
-        int const vType = var->getValueType();
+        const int kType = var->getKeyType();
+        const int vType = var->getValueType();
         if (vType == LUA_TTABLE) {
             if (kType == LUA_TNUMBER) {
                 lua_pushnumber(mL, QString(var->getName()).toInt());
@@ -603,7 +603,7 @@ void LuaInterface::renameVar(TVar* var)
     }
 
     for (int i = 1; i < vars.size(); i++) {
-        int const kType = vars[i]->getKeyType();
+        const int kType = vars[i]->getKeyType();
         if (kType == LUA_TNUMBER) {
             oldVariable.append(qsl("[%1]").arg(vars.at(i)->getName()));
             if (i < vars.size() - 1) {
@@ -682,7 +682,7 @@ QString LuaInterface::getValue(TVar* var)
         if (vars.empty()) {
             return {};
         }
-        int const pCount = vars.size(); //how many things we need to pop from the stack at the end
+        const int pCount = vars.size(); //how many things we need to pop from the stack at the end
         //load from _G first
         auto firstVariable = vars.constFirst();
         if (firstVariable->getKeyType() == LUA_TSTRING) {
@@ -691,8 +691,8 @@ QString LuaInterface::getValue(TVar* var)
             lua_rawgeti(mL, LUA_GLOBALSINDEX, firstVariable->getName().toInt());
         }
         if (lua_isnoneornil(mL, lua_gettop(mL))) {
-            qDebug() << "LuaInterface::getValue: Couldn't put root value" << firstVariable->getName() 
-                << "onto the Lua stack in order to get value of" << var->getName() 
+            qDebug() << "LuaInterface::getValue: Couldn't put root value" << firstVariable->getName()
+                << "onto the Lua stack in order to get value of" << var->getName()
                 << ", perhaps the key type isn't supported?";
             return {};
         }
@@ -701,7 +701,7 @@ QString LuaInterface::getValue(TVar* var)
                 return {};
             }
         }
-        int const valueType = lua_type(mL, -1);
+        const int valueType = lua_type(mL, -1);
         QString value;
         if (valueType == LUA_TBOOLEAN) {
             value = lua_toboolean(mL, -1) == 0 ? QLatin1String("false") : QLatin1String("true");
@@ -718,8 +718,8 @@ void LuaInterface::iterateTable(lua_State* L, int index, TVar* tVar, bool hide)
 {
     depth++;
     while (lua_next(L, index)) {
-        int const vType = lua_type(L, -1);
-        int const kType = lua_type(L, -2);
+        const int vType = lua_type(L, -1);
+        const int kType = lua_type(L, -2);
         lua_pushvalue(L, -2); //we do this because extracting the key with tostring changes it
         QString keyName;
         QString valueName;
@@ -807,7 +807,7 @@ void LuaInterface::getVars(bool hide)
     global->setValue("{}", LUA_TTABLE);
     QListIterator<int> it(lrefs);
     while (it.hasNext()) {
-        int const ref = it.next();
+        const int ref = it.next();
         luaL_unref(mL, LUA_REGISTRYINDEX, ref);
     }
     varUnit->clear();

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -107,7 +107,7 @@ void LuaInterface::getAllChildren(TVar* var, QList<TVar*>* list)
 bool LuaInterface::loadKey(lua_State* L, TVar* var)
 {
     if (setjmp(buf) == 0) {
-        int keyType = var->getKeyType();
+        int const keyType = var->getKeyType();
         if (var->isReference()) {
             lua_rawgeti(L, LUA_REGISTRYINDEX, var->getName().toInt());
         } else {
@@ -161,8 +161,8 @@ bool LuaInterface::reparentCVariable(TVar* from, TVar* to, TVar* curVar)
             // moving from global to global or nowhere
             return true;
         }
-        int stackSize = lua_gettop(mL);
-        bool isSaved = varUnit->isSaved(curVar);
+        int const stackSize = lua_gettop(mL);
+        bool const isSaved = varUnit->isSaved(curVar);
         if (isSaved) {
             QList<TVar*> list;
             getAllChildren(curVar, &list);
@@ -317,7 +317,7 @@ bool LuaInterface::setCValue(QList<TVar*> vars)
     //make the new stack
     TVar* var = vars.back();
     if (setjmp(buf) == 0) {
-        int stackSize = lua_gettop(mL);
+        int const stackSize = lua_gettop(mL);
         lua_getglobal(mL, (vars[0]->getName()).toUtf8().constData());
         int i = 1;
         for (; i < vars.size() - 1; i++) {
@@ -558,8 +558,8 @@ bool LuaInterface::loadVar(TVar* var)
     //puts the value of a variable on the -1 position of the stack
     if (setjmp(buf) == 0) {
 
-        int kType = var->getKeyType();
-        int vType = var->getValueType();
+        int const kType = var->getKeyType();
+        int const vType = var->getValueType();
         if (vType == LUA_TTABLE) {
             if (kType == LUA_TNUMBER) {
                 lua_pushnumber(mL, QString(var->getName()).toInt());
@@ -603,7 +603,7 @@ void LuaInterface::renameVar(TVar* var)
     }
 
     for (int i = 1; i < vars.size(); i++) {
-        int kType = vars[i]->getKeyType();
+        int const kType = vars[i]->getKeyType();
         if (kType == LUA_TNUMBER) {
             oldVariable.append(qsl("[%1]").arg(vars.at(i)->getName()));
             if (i < vars.size() - 1) {
@@ -678,11 +678,11 @@ void LuaInterface::renameVar(TVar* var)
 QString LuaInterface::getValue(TVar* var)
 {
     if (setjmp(buf) == 0) {
-        QList<TVar*> vars = varOrder(var);
+        QList<TVar*> const vars = varOrder(var);
         if (vars.empty()) {
             return {};
         }
-        int pCount = vars.size(); //how many things we need to pop from the stack at the end
+        int const pCount = vars.size(); //how many things we need to pop from the stack at the end
         //load from _G first
         auto firstVariable = vars.constFirst();
         if (firstVariable->getKeyType() == LUA_TSTRING) {
@@ -701,7 +701,7 @@ QString LuaInterface::getValue(TVar* var)
                 return {};
             }
         }
-        int valueType = lua_type(mL, -1);
+        int const valueType = lua_type(mL, -1);
         QString value;
         if (valueType == LUA_TBOOLEAN) {
             value = lua_toboolean(mL, -1) == 0 ? QLatin1String("false") : QLatin1String("true");
@@ -718,8 +718,8 @@ void LuaInterface::iterateTable(lua_State* L, int index, TVar* tVar, bool hide)
 {
     depth++;
     while (lua_next(L, index)) {
-        int vType = lua_type(L, -1);
-        int kType = lua_type(L, -2);
+        int const vType = lua_type(L, -1);
+        int const kType = lua_type(L, -2);
         lua_pushvalue(L, -2); //we do this because extracting the key with tostring changes it
         QString keyName;
         QString valueName;
@@ -807,7 +807,7 @@ void LuaInterface::getVars(bool hide)
     global->setValue("{}", LUA_TTABLE);
     QListIterator<int> it(lrefs);
     while (it.hasNext()) {
-        int ref = it.next();
+        int const ref = it.next();
         luaL_unref(mL, LUA_REGISTRYINDEX, ref);
     }
     varUnit->clear();

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -162,7 +162,7 @@ bool LuaInterface::reparentCVariable(TVar* from, TVar* to, TVar* curVar)
             return true;
         }
         const int stackSize = lua_gettop(mL);
-        bool const isSaved = varUnit->isSaved(curVar);
+        const bool isSaved = varUnit->isSaved(curVar);
         if (isSaved) {
             QList<TVar*> list;
             getAllChildren(curVar, &list);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -97,7 +97,7 @@ T2DMap::T2DMap(QWidget* parent)
     mMultiSelectionListWidget.setItemsExpandable(false);
     mMultiSelectionListWidget.setSelectionMode(QAbstractItemView::MultiSelection); // Was ExtendedSelection
     mMultiSelectionListWidget.setRootIsDecorated(false);
-    QSizePolicy multiSelectionSizePolicy(QSizePolicy::Maximum, QSizePolicy::Expanding);
+    QSizePolicy const multiSelectionSizePolicy(QSizePolicy::Maximum, QSizePolicy::Expanding);
     mMultiSelectionListWidget.setSizePolicy(multiSelectionSizePolicy);
     mMultiSelectionListWidget.setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
     mMultiSelectionListWidget.setFrameShape(QFrame::NoFrame);
@@ -190,7 +190,7 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
         return;
     }
 
-    int playerRoomId = mpMap->mRoomIdHash.value(mpMap->mProfileName);
+    int const playerRoomId = mpMap->mRoomIdHash.value(mpMap->mProfileName);
     TRoom* pPlayerRoom = mpMap->mpRoomDB->getRoom(playerRoomId);
     int playerAreaID = -2; // Cannot be valid (but -1 can be)!
     if (pPlayerRoom) {
@@ -201,7 +201,7 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
     TEvent areaViewedChangedEvent{};
     while (it.hasNext()) {
         it.next();
-        int areaID = it.key();
+        int const areaID = it.key();
         auto areaName = it.value();
         TArea* area = mpMap->mpRoomDB->getArea(areaID);
         if (area && newAreaName == areaName) {
@@ -255,7 +255,7 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
                 // key is z-coordinate, value is count of rooms on that level
                 QMap<int, int> roomsCountLevelMap;
                 while (itRoom.hasNext()) {
-                    int checkRoomID = itRoom.next();
+                    int const checkRoomID = itRoom.next();
                     TRoom* room = mpMap->mpRoomDB->getRoom(checkRoomID);
                     if (room) {
                         validRoomFound = true;
@@ -315,7 +315,7 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
                     TRoom* closestCenterRoom = nullptr;
                     while (itpRoom.hasNext()) {
                         TRoom* room = itpRoom.next();
-                        QVector2D meanToRoom(static_cast<float>(room->x) - mean_x, static_cast<float>(room->y) - mean_y);
+                        QVector2D const meanToRoom(static_cast<float>(room->x) - mean_x, static_cast<float>(room->y) - mean_y);
                         if (closestSquareDistance < -0.5) {
                             // Test for first time around loop - for initialisation
                             // Don't use an equality to zero test, we are using
@@ -324,7 +324,7 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
                             closestSquareDistance = meanToRoom.lengthSquared();
                             closestCenterRoom = room;
                         } else {
-                            float currentRoomSquareDistance = meanToRoom.lengthSquared();
+                            float const currentRoomSquareDistance = meanToRoom.lengthSquared();
                             if (closestSquareDistance > currentRoomSquareDistance) {
                                 closestSquareDistance = currentRoomSquareDistance;
                                 closestCenterRoom = room;
@@ -378,7 +378,7 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
                 TRoom* closestCenterRoom = nullptr;
                 while (itpRoom.hasNext()) {
                     TRoom* room = itpRoom.next();
-                    QVector2D meanToRoom(static_cast<float>(room->x) - mean_x, static_cast<float>(room->y) - mean_y);
+                    QVector2D const meanToRoom(static_cast<float>(room->x) - mean_x, static_cast<float>(room->y) - mean_y);
                     if (closestSquareDistance < -0.5) {
                         // Test for first time around loop - for initialisation
                         // Don't use an equality to zero test, we are using
@@ -387,7 +387,7 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
                         closestSquareDistance = meanToRoom.lengthSquared();
                         closestCenterRoom = room;
                     } else {
-                        float currentRoomSquareDistance = meanToRoom.lengthSquared();
+                        float const currentRoomSquareDistance = meanToRoom.lengthSquared();
                         if (closestSquareDistance > currentRoomSquareDistance) {
                             closestSquareDistance = currentRoomSquareDistance;
                             closestCenterRoom = room;
@@ -417,8 +417,8 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
 void T2DMap::addSymbolToPixmapCache(const QString key, const QString text, const QColor symbolColor, const bool gridMode)
 {
     // Some constants used to prevent small, unreadable symbols:
-    static float symbolLowerSizeLimit = 8.0;
-    static unsigned int minimumUsableFontSize = 8;
+    static float const symbolLowerSizeLimit = 8.0;
+    static unsigned int const minimumUsableFontSize = 8;
 
     // Draw onto a rectangle that will fit the room symbol rectangle,
     // Must tweak the size so it fits within circle when round room symbols are
@@ -451,15 +451,15 @@ void T2DMap::addSymbolToPixmapCache(const QString key, const QString text, const
     symbolPainter.setFont(mpMap->mMapSymbolFont);
     symbolPainter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing | QPainter::SmoothPixmapTransform, true);
 
-    QFontMetrics mapSymbolFontMetrics = symbolPainter.fontMetrics();
-    QVector<quint32> codePoints = symbolString.toUcs4();
+    QFontMetrics const mapSymbolFontMetrics = symbolPainter.fontMetrics();
+    QVector<quint32> const codePoints = symbolString.toUcs4();
     QVector<bool> isUsable;
     for (int i = 0; i < codePoints.size(); ++i) {
         isUsable.append(mapSymbolFontMetrics.inFontUcs4(codePoints.at(i)));
     }
 
     QFont fontForThisSymbol = mpMap->mMapSymbolFont;
-    bool needToFallback = isUsable.contains(false);
+    bool const needToFallback = isUsable.contains(false);
     // Oh dear at least one grapheme is not represented in either the selected
     // or any font as set elsewhere
     if (needToFallback) {
@@ -469,7 +469,7 @@ void T2DMap::addSymbolToPixmapCache(const QString key, const QString text, const
         fontForThisSymbol.setStyleStrategy(static_cast<QFont::StyleStrategy>(mpMap->mMapSymbolFont.styleStrategy() & ~(QFont::NoFontMerging)));
     }
 
-    qreal fudgeFactor = symbolRectangle.toRect().width() * mpMap->mMapSymbolFontFudgeFactor;
+    qreal const fudgeFactor = symbolRectangle.toRect().width() * mpMap->mMapSymbolFontFudgeFactor;
     QRectF testRectangle(0, 0, fudgeFactor, fudgeFactor);
     testRectangle.moveCenter(pixmap->rect().center());
     QRectF boundaryRect;
@@ -521,7 +521,7 @@ bool T2DMap::sizeFontToFitTextInRect( QFont & font, const QRectF & boundaryRect,
     }
 
     qreal fontSize = qMax(minFontSize, font.pointSizeF());  // protect against too-small initial value
-    QRectF testRect(boundaryRect.width() * (100 - percentageMargin) / 200.0,
+    QRectF const testRect(boundaryRect.width() * (100 - percentageMargin) / 200.0,
                     boundaryRect.height() * (100 - percentageMargin) / 200.0,
                     boundaryRect.width() * (100 - percentageMargin) / 100.0,
                     boundaryRect.height() * (100 - percentageMargin) / 100.);
@@ -603,8 +603,8 @@ inline void T2DMap::drawRoom(QPainter& painter,
     QRectF roomRectangle;
     QRectF roomNameRectangle;
     double realHeight;
-    int borderWidth = 1 / eSize * mRoomWidth * rSize;
-    bool shouldDrawBorder = mpHost->mMapperShowRoomBorders && !isGridMode;
+    int const borderWidth = 1 / eSize * mRoomWidth * rSize;
+    bool const shouldDrawBorder = mpHost->mMapperShowRoomBorders && !isGridMode;
     bool showThisRoomName = showRoomName;
     if (isGridMode) {
         realHeight = mRoomHeight;
@@ -667,7 +667,7 @@ inline void T2DMap::drawRoom(QPainter& painter,
             roomColor = mpMap->mCustomEnvColors[roomEnvironment];
         } else {
             if (16 < roomEnvironment && roomEnvironment < 232) {
-                quint8 base = roomEnvironment - 16;
+                quint8 const base = roomEnvironment - 16;
                 quint8 r = base / 36;
                 quint8 g = (base - (r * 36)) / 6;
                 quint8 b = (base - (r * 36)) - (g * 6);
@@ -677,13 +677,13 @@ inline void T2DMap::drawRoom(QPainter& painter,
                 b = b == 0 ? 0 : (b - 1) * 40 + 95;
                 roomColor = QColor(r, g, b, 255);
             } else if (231 < roomEnvironment && roomEnvironment < 256) {
-                quint8 k = ((roomEnvironment - 232) * 10) + 8;
+                quint8 const k = ((roomEnvironment - 232) * 10) + 8;
                 roomColor = QColor(k, k, k, 255);
             }
         }
     }
 
-    bool isRoomSelected = (mPick && roomClickTestRectangle.contains(mPHighlight)) || mMultiSelectionSet.contains(currentRoomId);
+    bool const isRoomSelected = (mPick && roomClickTestRectangle.contains(mPHighlight)) || mMultiSelectionSet.contains(currentRoomId);
     QLinearGradient selectionBg(roomRectangle.topLeft(), roomRectangle.bottomRight());
     selectionBg.setColorAt(0.25, roomColor);
     selectionBg.setColorAt(1, Qt::blue);
@@ -711,8 +711,8 @@ inline void T2DMap::drawRoom(QPainter& painter,
     painter.setPen(roomPen);
 
     if (mBubbleMode) {
-        float roomRadius = 0.5 * rSize * mRoomWidth;
-        QPointF roomCenter = QPointF(rx, ry);
+        float const roomRadius = 0.5 * rSize * mRoomWidth;
+        QPointF const roomCenter = QPointF(rx, ry);
         if (!isRoomSelected) {
             // CHECK: The use of a gradient fill to a white center on round
             // rooms might look nice in some situations but not in all:
@@ -739,15 +739,15 @@ inline void T2DMap::drawRoom(QPainter& painter,
             // within the area - there is a separate block of code further down
             // in this method that handles clicking on the out of area exit so
             // that a speed walk is done to the room in the OTHER area:
-            float roomRadius = 0.4 * mRoomWidth;
-            QPointF roomCenter = QPointF(rx, ry);
+            float const roomRadius = 0.4 * mRoomWidth;
+            QPointF const roomCenter = QPointF(rx, ry);
             QRadialGradient gradient(roomCenter, roomRadius);
             gradient.setColorAt(0.95, QColor(255, 0, 0, 150));
             gradient.setColorAt(0.80, QColor(150, 100, 100, 150));
             gradient.setColorAt(0.799, QColor(150, 100, 100, 100));
             gradient.setColorAt(0.7, QColor(255, 0, 0, 200));
             gradient.setColorAt(0, Qt::white);
-            QPen transparentPen(Qt::transparent);
+            QPen const transparentPen(Qt::transparent);
             QPainterPath diameterPath;
             painter.setBrush(gradient);
             painter.setPen(transparentPen);
@@ -811,12 +811,12 @@ inline void T2DMap::drawRoom(QPainter& painter,
 
     // Do we need to draw the custom (user specified) highlight
     if (pRoom->highlight) {
-        float roomRadius = (pRoom->highlightRadius * mRoomWidth) / 2.0;
-        QPointF roomCenter = QPointF(rx, ry);
+        float const roomRadius = (pRoom->highlightRadius * mRoomWidth) / 2.0;
+        QPointF const roomCenter = QPointF(rx, ry);
         QRadialGradient gradient(roomCenter, roomRadius);
         gradient.setColorAt(0.85, pRoom->highlightColor);
         gradient.setColorAt(0, pRoom->highlightColor2);
-        QPen transparentPen(Qt::transparent);
+        QPen const transparentPen(Qt::transparent);
         QPainterPath diameterPath;
         painter.setBrush(gradient);
         painter.setPen(transparentPen);
@@ -843,7 +843,7 @@ inline void T2DMap::drawRoom(QPainter& painter,
     if (showRoomName) {
         painter.save();
 
-        QString namePosData = pRoom->userData.value(ROOM_UI_NAMEPOS);
+        QString const namePosData = pRoom->userData.value(ROOM_UI_NAMEPOS);
         if (!namePosData.isEmpty()) {
             QPointF nameOffset {0, 0};
             QStringList posXY = namePosData.split(" ");
@@ -1101,8 +1101,8 @@ inline void T2DMap::drawRoom(QPainter& painter,
         QMapIterator<int, QPointF> it(areaExitsMap);
         while (it.hasNext()) {
             it.next();
-            QPointF roomCenter = it.value();
-            QRectF dr = QRectF(roomCenter.x(), roomCenter.y(), mRoomWidth * rSize, mRoomHeight * rSize);
+            QPointF const roomCenter = it.value();
+            QRectF const dr = QRectF(roomCenter.x(), roomCenter.y(), mRoomWidth * rSize, mRoomHeight * rSize);
 
             // clang-format off
             if ((mPick
@@ -1120,14 +1120,14 @@ inline void T2DMap::drawRoom(QPainter& painter,
                 // that it is useful, note that there is similar code for a
                 // room being clicked on that is WITHIN the area, that is
                 // above this point in the source code:
-                float roomRadius = (0.8 * mRoomWidth) / 2.0;
+                float const roomRadius = (0.8 * mRoomWidth) / 2.0;
                 QRadialGradient gradient(roomCenter, roomRadius);
                 gradient.setColorAt(0.95, QColor(255, 0, 0, 150));
                 gradient.setColorAt(0.80, QColor(150, 100, 100, 150));
                 gradient.setColorAt(0.799, QColor(150, 100, 100, 100));
                 gradient.setColorAt(0.7, QColor(255, 0, 0, 200));
                 gradient.setColorAt(0, Qt::white);
-                QPen transparentPen(Qt::transparent);
+                QPen const transparentPen(Qt::transparent);
                 QPainterPath myPath;
                 painter.setBrush(gradient);
                 painter.setPen(transparentPen);
@@ -1186,7 +1186,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
     // the room name's font defaults to the symbol's
     // but may be overridden
     auto mapNameFont = mpMap->mMapSymbolFont;
-    QString fontName = mpMap->mUserData.value(ROOM_UI_NAMEFONT);
+    QString const fontName = mpMap->mUserData.value(ROOM_UI_NAMEFONT);
     if (!fontName.isEmpty()) {
         QFont font;
         if (font.fromString(fontName)) {
@@ -1201,7 +1201,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
 
     QList<int> exitList;
     QList<int> oneWayExits;
-    int playerRoomId = mpMap->mRoomIdHash.value(mpMap->mProfileName);
+    int const playerRoomId = mpMap->mRoomIdHash.value(mpMap->mProfileName);
     TRoom* pPlayerRoom = mpMap->mpRoomDB->getRoom(playerRoomId);
     if (!pPlayerRoom) {
         painter.save();
@@ -1308,7 +1308,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
         } else {
             roomTestRect = QRectF(0, 0, static_cast<qreal>(mRoomWidth) * rSize, static_cast<qreal>(mRoomHeight) * rSize);
         }
-        static quint8 roomVnumMargin = 10;
+        static quint8 const roomVnumMargin = 10;
         roomVNumFont.setBold(true);
 
         // QFont::PreferOutline will help to select a font that will scale to any
@@ -1329,14 +1329,14 @@ void T2DMap::paintEvent(QPaintEvent* e)
 
         mapNameFont.setStyleStrategy(QFont::StyleStrategy(QFont::PreferNoShaping|QFont::PreferAntialias|QFont::PreferOutline));
 
-        double sizeAdjust = 0; // TODO: add userdata setting to adjust this
+        double const sizeAdjust = 0; // TODO: add userdata setting to adjust this
         mapNameFont.setPointSizeF(static_cast<qreal>(mRoomWidth) * rSize * pow(1.1, sizeAdjust) / 2.0);
         showRoomNames = (mapNameFont.pointSizeF() > 3.0);
     }
 
-    int zLevel = mOz;
+    int const zLevel = mOz;
 
-    float exitWidth = 1 / eSize * mRoomWidth * rSize;
+    float const exitWidth = 1 / eSize * mRoomWidth * rSize;
 
     painter.fillRect(0, 0, width(), height(), mpHost->mBgColor_2);
 
@@ -1359,13 +1359,13 @@ void T2DMap::paintEvent(QPaintEvent* e)
             pDrawnArea->mMapLabels[itMapLabel.key()] = mapLabel;
         }
         QPointF labelPosition;
-        int labelX = mapLabel.pos.x() * mRoomWidth + mRX;
-        int labelY = mapLabel.pos.y() * mRoomHeight * -1 + mRY;
+        int const labelX = mapLabel.pos.x() * mRoomWidth + mRX;
+        int const labelY = mapLabel.pos.y() * mRoomHeight * -1 + mRY;
 
         labelPosition.setX(labelX);
         labelPosition.setY(labelY);
-        int labelWidth = abs(qRound(mapLabel.size.width() * mRoomWidth));
-        int labelHeight = abs(qRound(mapLabel.size.height() * mRoomHeight));
+        int const labelWidth = abs(qRound(mapLabel.size.width() * mRoomWidth));
+        int const labelHeight = abs(qRound(mapLabel.size.height() * mRoomHeight));
         if (!((0 < labelX || 0 < labelX + labelWidth) && (widgetWidth > labelX || widgetWidth > labelX + labelWidth))) {
             continue;
         }
@@ -1407,7 +1407,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
     // Draw the rooms:
     QSetIterator<int> itRoom(pDrawnArea->getAreaRooms());
     while (itRoom.hasNext()) {
-        int currentAreaRoom = itRoom.next();
+        int const currentAreaRoom = itRoom.next();
         TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
         if (!room) {
             continue;
@@ -1417,8 +1417,8 @@ void T2DMap::paintEvent(QPaintEvent* e)
             continue;
         }
 
-        float rx = room->x *       mRoomWidth + static_cast<float>(mRX);
-        float ry = room->y * -1 * mRoomHeight + static_cast<float>(mRY);
+        float const rx = room->x *       mRoomWidth + static_cast<float>(mRX);
+        float const ry = room->y * -1 * mRoomHeight + static_cast<float>(mRY);
         if (rx < 0 || ry < 0 || rx > widgetWidth || ry > widgetHeight) {
             continue;
         }
@@ -1436,14 +1436,14 @@ void T2DMap::paintEvent(QPaintEvent* e)
     if (isPlayerRoomVisible) {
         drawRoom(painter, roomVNumFont, mapNameFont, pen, pPlayerRoom, pDrawnArea->gridMode, isFontBigEnoughToShowRoomVnum, showRoomNames, playerRoomId, static_cast<float>(playerRoomOnWidgetCoordinates.x()), static_cast<float>(playerRoomOnWidgetCoordinates.y()), areaExitsMap);
         painter.save();
-        QPen transparentPen(Qt::transparent);
+        QPen const transparentPen(Qt::transparent);
         QPainterPath myPath;
-        double roomRadius = (mpMap->mPlayerRoomOuterDiameterPercentage / 200.0) * static_cast<double>(mRoomWidth);
+        double const roomRadius = (mpMap->mPlayerRoomOuterDiameterPercentage / 200.0) * static_cast<double>(mRoomWidth);
         QRadialGradient gradient(playerRoomOnWidgetCoordinates, roomRadius);
         if (mpHost->mMapStrongHighlight) {
             // Never set, no means to except via XMLImport, as dlgMapper class's
             // slot_toggleStrongHighlight is not wired up to anything
-            QRectF dr = QRectF(playerRoomOnWidgetCoordinates.x() - (static_cast<double>(mRoomWidth) * rSize) / 2.0,
+            QRectF const dr = QRectF(playerRoomOnWidgetCoordinates.x() - (static_cast<double>(mRoomWidth) * rSize) / 2.0,
                                playerRoomOnWidgetCoordinates.y() - (static_cast<double>(mRoomHeight) * rSize) / 2.0,
                                static_cast<double>(mRoomWidth) * rSize, static_cast<double>(mRoomHeight) * rSize);
             painter.fillRect(dr, QColor(255, 0, 0, 150));
@@ -1480,13 +1480,13 @@ void T2DMap::paintEvent(QPaintEvent* e)
             pDrawnArea->mMapLabels[itMapLabel.key()] = mapLabel;
         }
         QPointF labelPosition;
-        int labelX = mapLabel.pos.x() * mRoomWidth + mRX;
-        int labelY = mapLabel.pos.y() * mRoomHeight * -1 + mRY;
+        int const labelX = mapLabel.pos.x() * mRoomWidth + mRX;
+        int const labelY = mapLabel.pos.y() * mRoomHeight * -1 + mRY;
 
         labelPosition.setX(labelX);
         labelPosition.setY(labelY);
-        int labelWidth = abs(qRound(mapLabel.size.width() * mRoomWidth));
-        int labelHeight = abs(qRound(mapLabel.size.height() * mRoomHeight));
+        int const labelWidth = abs(qRound(mapLabel.size.width() * mRoomWidth));
+        int const labelHeight = abs(qRound(mapLabel.size.height() * mRoomHeight));
 
         if (!((0 < labelX || 0 < labelX + labelWidth) && (widgetWidth > labelX || widgetWidth > labelX + labelWidth))) {
             continue;
@@ -1518,13 +1518,13 @@ void T2DMap::paintEvent(QPaintEvent* e)
     if (mMultiSelectionHighlightRoomId > 0 && mMultiSelectionSet.size() > 1) {
         TRoom* pR_multiSelectionHighlight = mpMap->mpRoomDB->getRoom(mMultiSelectionHighlightRoomId);
         if (pR_multiSelectionHighlight) {
-            float r_mSx = pR_multiSelectionHighlight->x * mRoomWidth + mRX;
-            float r_mSy = pR_multiSelectionHighlight->y * -1 * mRoomHeight + mRY;
-            QPen savePen = painter.pen();
-            QBrush saveBrush = painter.brush();
-            float roomRadius = mRoomWidth * 1.2;
-            float roomDiagonal = mRoomWidth * 1.2;
-            QPointF roomCenter = QPointF(r_mSx, r_mSy);
+            float const r_mSx = pR_multiSelectionHighlight->x * mRoomWidth + mRX;
+            float const r_mSy = pR_multiSelectionHighlight->y * -1 * mRoomHeight + mRY;
+            QPen const savePen = painter.pen();
+            QBrush const saveBrush = painter.brush();
+            float const roomRadius = mRoomWidth * 1.2;
+            float const roomDiagonal = mRoomWidth * 1.2;
+            QPointF const roomCenter = QPointF(r_mSx, r_mSy);
 
             QPen yellowPen(QColor(255, 255, 50, 192)); // Quarter opaque yellow pen
             yellowPen.setWidth(mRoomWidth * 0.1);
@@ -1582,11 +1582,11 @@ void T2DMap::paintEvent(QPaintEvent* e)
     if (!mHelpMsg.isEmpty()) {
         painter.setPen(QColor(255, 155, 50));
         QFont _f = painter.font();
-        QFont _f2 = _f;
+        QFont const _f2 = _f;
         _f.setPointSize(12); // 20 was a little large
         _f.setBold(true);
         painter.setFont(_f);
-        QRect _r = QRect(0, 0, widgetWidth, widgetHeight);
+        QRect const _r = QRect(0, 0, widgetWidth, widgetHeight);
         painter.drawText(_r, Qt::AlignHCenter | Qt::AlignBottom | Qt::TextWordWrap, mHelpMsg);
         // Now draw text centered at bottom, so it does not clash with info window
         painter.setFont(_f2);
@@ -1619,8 +1619,8 @@ void T2DMap::drawDoor(QPainter& painter, const TRoom& room, const QString& dirKe
     const double endAngleFactor = 150.0;
     const double endFiddleFactor = 0.50;
     const float doorWidthFactor = 1.5;
-    bool isShortLine = ((exitLine.length() / (mRoomWidth + mRoomHeight)) < innerThresholdFactor);
-    bool isLongLine = ((exitLine.length() / (mRoomWidth + mRoomHeight)) > outerThresholdFactor);
+    bool const isShortLine = ((exitLine.length() / (mRoomWidth + mRoomHeight)) < innerThresholdFactor);
+    bool const isLongLine = ((exitLine.length() / (mRoomWidth + mRoomHeight)) > outerThresholdFactor);
     QLineF line{exitLine};
     if (isShortLine) {
         line.setLength(shortPositionFactor * (mRoomWidth + mRoomHeight));
@@ -1658,7 +1658,7 @@ void T2DMap::drawDoor(QPainter& painter, const TRoom& room, const QString& dirKe
     doorPen.setStyle(Qt::SolidLine);
     doorPen.setCapStyle(Qt::RoundCap);
 
-    int doorStatus = room.doors.value(dirKey);
+    int const doorStatus = room.doors.value(dirKey);
     if (doorStatus == 1) {
         doorPen.setColor(mOpenDoorColor);
     } else if (doorStatus == 2) {
@@ -1715,7 +1715,7 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
     }
     QSetIterator<int> itRoom2(pArea->getAreaRooms());
     while (itRoom2.hasNext()) {
-        int _id = itRoom2.next();
+        int const _id = itRoom2.next();
         TRoom* room = mpMap->mpRoomDB->getRoom(_id);
         if (!room) {
             continue;
@@ -1931,7 +1931,7 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
 
                 const float ex = room->x * mRoomWidth + mRX;
                 const float ey = room->y * mRoomHeight * -1 + mRY;
-                QPointF origin = QPointF(ex, ey);
+                QPointF const origin = QPointF(ex, ey);
                 // The following sets a point offset from the room center
                 // that depends on the exit direction that the custom line
                 // heads to from the room center - it forms a fixed segment
@@ -1974,7 +1974,7 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 customLinePen.setStyle(room->customLinesStyle.value(itk.key()));
 
                 QVector<QPointF> polyLinePoints;
-                QList<QPointF> customLinePoints = itk.value();
+                QList<QPointF> const customLinePoints = itk.value();
                 QLineF doorLineSegment;
                 if (!customLinePoints.empty()) {
                     painter.setPen(customLinePen);
@@ -2000,17 +2000,17 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                     if (room->customLinesArrow.value(itk.key())) {
                         QLineF l0 = QLineF(polyLinePoints.last(), polyLinePoints.at(polyLinePoints.size() - 2));
                         l0.setLength(exitWidth * 5.0);
-                        QPointF _p1 = l0.p1();
-                        QPointF _p2 = l0.p2();
-                        QLineF l1 = QLineF(l0);
-                        qreal w1 = l1.angle() - 90.0;
+                        QPointF const _p1 = l0.p1();
+                        QPointF const _p2 = l0.p2();
+                        QLineF const l1 = QLineF(l0);
+                        qreal const w1 = l1.angle() - 90.0;
                         QLineF l2;
                         l2.setP1(_p2);
                         l2.setAngle(w1);
                         l2.setLength(exitWidth * 2.0);
-                        QPointF _p3 = l2.p2();
+                        QPointF const _p3 = l2.p2();
                         l2.setAngle(l2.angle() + 180.0);
-                        QPointF _p4 = l2.p2();
+                        QPointF const _p4 = l2.p2();
                         QPolygonF _poly;
                         _poly.append(_p1);
                         _poly.append(_p3);
@@ -2027,9 +2027,9 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                     }
 
                     if (_id == mCustomLineSelectedRoom && itk.key() == mCustomLineSelectedExit) {
-                        QPen _savedPen = painter.pen();
+                        QPen const _savedPen = painter.pen();
                         QPen _pen;
-                        QBrush _brush = painter.brush();
+                        QBrush const _brush = painter.brush();
                         painter.setBrush(Qt::NoBrush);
                         // The first two points in the polyLinePoints are
                         // fixed for all exit directions and do not get
@@ -2058,12 +2058,12 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
         }
 
         // draw exit stubs
-        for (int direction : qAsConst(room->exitStubs)) {
+        for (int const direction : qAsConst(room->exitStubs)) {
             if (direction >= DIR_NORTH && direction <= DIR_SOUTHWEST) {
                 // Stubs on non-XY plane exits are handled differently and we
                 // do not support special exit stubs (yet?)
-                QVector3D uDirection = mpMap->scmUnitVectors.value(direction);
-                QLineF stubLine(rx, ry, rx + uDirection.x() * 0.5 * mRoomWidth, ry + uDirection.y() * 0.5 * mRoomHeight);
+                QVector3D const uDirection = mpMap->scmUnitVectors.value(direction);
+                QLineF const stubLine(rx, ry, rx + uDirection.x() * 0.5 * mRoomWidth, ry + uDirection.y() * 0.5 * mRoomHeight);
                 const QString doorKey{TRoom::dirCodeToShortString(direction)};
                 // Draw the door lines before we draw the stub or the filled
                 // circle on the end - so that the latter overlays the doors
@@ -2078,7 +2078,7 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 // And turn off drawing the border (outline):
                 painter.setPen(Qt::NoPen);
                 QPainterPath stubMarkingCirclePath;
-                QRectF surroundingRectF(stubLine.p2().x() - 0.1 * mRoomWidth, stubLine.p2().y() - 0.1 * mRoomHeight, 0.2 * mRoomWidth, 0.2 * mRoomHeight);
+                QRectF const surroundingRectF(stubLine.p2().x() - 0.1 * mRoomWidth, stubLine.p2().y() - 0.1 * mRoomHeight, 0.2 * mRoomWidth, 0.2 * mRoomHeight);
                 stubMarkingCirclePath.arcTo(surroundingRectF, 0.0, 360.0);
                 // So this should draw a solid filled circle whose diameter
                 // is fixed and not dependent on the exit line thickness:
@@ -2087,8 +2087,8 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
             }
         }
 
-        for (int& k : exitList) {
-            int rID = k;
+        for (int const& k : exitList) {
+            int const rID = k;
             if (rID <= 0) {
                 continue;
             }
@@ -2105,8 +2105,8 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
             const float ey = pE->y * mRoomHeight * -1 + mRY;
             const int ez = pE->z;
 
-            QVector3D p1(ex, ey, ez);
-            QVector3D p2(rx, ry, rz);
+            QVector3D const p1(ex, ey, ez);
+            QVector3D const p2(rx, ry, rz);
             // This was a QLine (so used integer coordinates), but lets
             // try with a QLineF as we are using floating point numbers:
             QLineF line;
@@ -2114,7 +2114,7 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 // Non-area exit:
                 if (!oneWayExits.contains(rID)) {
                     // Two way exit
-                    QLineF l0 = QLineF(p2.toPointF(), p1.toPointF());
+                    QLineF const l0 = QLineF(p2.toPointF(), p1.toPointF());
                     painter.save();
                     QPen exitPen = painter.pen();
                     // We need the line not to extend past the actual end point:
@@ -2126,8 +2126,8 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                     QLineF l0 = QLineF(p2.toPointF(), p1.toPointF());
                     QLineF k0 = l0;
                     k0.setLength((l0.length() - exitWidth * 5.0) / 2.0);
-                    qreal dx = k0.dx();
-                    qreal dy = k0.dy();
+                    qreal const dx = k0.dx();
+                    qreal const dy = k0.dy();
                     painter.save();
                     QPen arrowPen = painter.pen();
                     QPen oneWayLinePen = painter.pen();
@@ -2139,17 +2139,17 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                     painter.drawLine(l0);
 
                     l0.setLength(exitWidth * 5.0);
-                    QPointF _p1 = l0.p2();
-                    QPointF _p2 = l0.p1();
-                    QLineF l1 = QLineF(l0);
-                    qreal w1 = l1.angle() - 90.0;
+                    QPointF const _p1 = l0.p2();
+                    QPointF const _p2 = l0.p1();
+                    QLineF const l1 = QLineF(l0);
+                    qreal const w1 = l1.angle() - 90.0;
                     QLineF l2;
                     l2.setP1(_p2);
                     l2.setAngle(w1);
                     l2.setLength(exitWidth * 2.0);
-                    QPointF _p3 = l2.p2();
+                    QPointF const _p3 = l2.p2();
                     l2.setAngle(l2.angle() + 180.0);
-                    QPointF _p4 = l2.p2();
+                    QPointF const _p4 = l2.p2();
                     QPolygonF poly;
                     poly.append(_p1);
                     poly.append(_p3);
@@ -2220,10 +2220,10 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 } else {
                     l0.setLength(exitWidth * 5.0);
                 }
-                QPointF p1 = l0.p1();
-                QPointF p2 = l0.p2();
-                QLineF l1 = QLineF(l0);
-                qreal w1 = l1.angle() - 90.0;
+                QPointF const p1 = l0.p1();
+                QPointF const p2 = l0.p2();
+                QLineF const l1 = QLineF(l0);
+                qreal const w1 = l1.angle() - 90.0;
                 QLineF l2;
                 l2.setP1(p2);
                 l2.setAngle(w1);
@@ -2232,9 +2232,9 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 } else {
                     l2.setLength(exitWidth * 2.0);
                 }
-                QPointF p3 = l2.p2();
+                QPointF const p3 = l2.p2();
                 l2.setAngle(l2.angle() + 180.0);
-                QPointF p4 = l2.p2();
+                QPointF const p4 = l2.p2();
                 QPolygonF polygon;
                 polygon.append(p1);
                 polygon.append(p3);
@@ -2303,11 +2303,11 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
         // have been drawn otherwise later drawn rooms will overwrite the
         // mark, especially on areas in gridmode.
         if (customLineDestinationTarget > 0 && customLineDestinationTarget == _id) {
-            QPen savePen = painter.pen();
-            QBrush saveBrush = painter.brush();
+            QPen const savePen = painter.pen();
+            QBrush const saveBrush = painter.brush();
             const float roomRadius = mRoomWidth * 1.2;
             const float roomDiagonal = mRoomWidth * 1.2;
-            QPointF roomCenter = QPointF(rx, ry);
+            QPointF const roomCenter = QPointF(rx, ry);
 
             QPen yellowPen(QColor(255, 255, 50, 192)); // Quarter opaque yellow pen
             yellowPen.setWidth(mRoomWidth * 0.1);
@@ -2331,7 +2331,7 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
 void T2DMap::paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, const int displayAreaId, QColor& infoColor)
 {
     QList<QString> contributorList = mpMap->mMapInfoContributorManager->getContributorKeys();
-    QSet<QString> contributorKeys{contributorList.begin(), contributorList.end()};
+    QSet<QString> const contributorKeys{contributorList.begin(), contributorList.end()};
     if (!contributorKeys.intersects(mpHost->mMapInfoContributors)) {
         return;
     }
@@ -2349,7 +2349,7 @@ void T2DMap::paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, c
         return;
     }
     int yOffset = 20;
-    int initialYOffset = yOffset;
+    int const initialYOffset = yOffset;
     // Left margin for info widget:
     int xOffset = 10;
     if (mMultiSelectionListWidget.isVisible()) {
@@ -2405,7 +2405,7 @@ int T2DMap::paintMapInfoContributor(QPainter& painter, int xOffset, int yOffset,
     font.setItalic(properties.isItalic);
     painter.setFont(font);
 
-    int infoHeight = mFontHeight; // Account for first iteration
+    int const infoHeight = mFontHeight; // Account for first iteration
     QRect testRect;
     // infoRect has a 10 margin on either side and on top to widget frame.
     mMapInfoRect = QRect(xOffset, yOffset, width() - 10 - xOffset, infoHeight);
@@ -2450,7 +2450,7 @@ void T2DMap::createLabel(QRectF labelRectangle)
     if (!pArea) {
         return;
     }
-    int labelId = pArea->createLabelId();
+    int const labelId = pArea->createLabelId();
 
     connect(mpDlgMapLabel, &dlgMapLabel::updated, this, [=]() {
         updateMapLabel(labelRectangle, labelId, pArea);
@@ -2497,18 +2497,18 @@ void T2DMap::updateMapLabel(QRectF labelRectangle, int labelId, TArea* pArea)
     if (mpDlgMapLabel->isTextLabel()) {
         labelPainter.drawText(drawRectangle, Qt::AlignHCenter | Qt::AlignCenter, label.text, nullptr);
     } else {
-        QPixmap imagePixmap = QPixmap(imagePath).scaled(drawRectangle.size(), mpDlgMapLabel->stretchImage() ? Qt::IgnoreAspectRatio : Qt::KeepAspectRatio);
+        QPixmap const imagePixmap = QPixmap(imagePath).scaled(drawRectangle.size(), mpDlgMapLabel->stretchImage() ? Qt::IgnoreAspectRatio : Qt::KeepAspectRatio);
         auto point = mpDlgMapLabel->stretchImage() ? QPoint(0, 0) : pixmap.rect().center() - imagePixmap.rect().center();
         labelPainter.drawPixmap(point, imagePixmap);
     }
 
     label.pix = pixmap.copy(drawRectangle);
     auto normalizedLabelRectangle = labelRectangle.normalized();
-    float mx = (normalizedLabelRectangle.topLeft().x() / mRoomWidth) + mOx - (xspan / 2.0);
-    float my = (yspan / 2.0) - (labelRectangle.topLeft().y() / mRoomHeight) - mOy;
+    float const mx = (normalizedLabelRectangle.topLeft().x() / mRoomWidth) + mOx - (xspan / 2.0);
+    float const my = (yspan / 2.0) - (labelRectangle.topLeft().y() / mRoomHeight) - mOy;
 
-    float mx2 = (normalizedLabelRectangle.bottomRight().x() / mRoomWidth) + mOx - (xspan / 2.0);
-    float my2 = (yspan / 2.0) - (labelRectangle.bottomRight().y() / mRoomHeight) - mOy;
+    float const mx2 = (normalizedLabelRectangle.bottomRight().x() / mRoomWidth) + mOx - (xspan / 2.0);
+    float const my2 = (yspan / 2.0) - (labelRectangle.bottomRight().y() / mRoomHeight) - mOy;
     label.pos = QVector3D(mx, my, mOz);
     label.size = QRectF(QPointF(mx, my), QPointF(mx2, my2)).normalized().size();
 
@@ -2543,7 +2543,7 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
         mHelpMsg.clear();
         if (mSizeLabel) {
             mSizeLabel = false;
-            QRectF labelRect = mMultiRect;
+            QRectF const labelRect = mMultiRect;
             createLabel(labelRect);
         }
         mMultiRect = QRect(0, 0, 0, 0);
@@ -2596,24 +2596,24 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
         auto pArea = mpMap->mpRoomDB->getArea(mAreaID);
         if (!mLabelHighlighted && mCustomLineSelectedRoom == 0) {
             mMultiRect = QRect(event->pos(), event->pos());
-            float fx = ((xspan / 2.0) - mOx) * mRoomWidth;
-            float fy = ((yspan / 2.0) - mOy) * mRoomHeight;
+            float const fx = ((xspan / 2.0) - mOx) * mRoomWidth;
+            float const fy = ((yspan / 2.0) - mOy) * mRoomHeight;
 
             if (pArea) {
                 QSetIterator<int> itRoom(pArea->getAreaRooms());
                 while (itRoom.hasNext()) { // Scan to find rooms in selection
-                    int currentAreaRoom = itRoom.next();
+                    int const currentAreaRoom = itRoom.next();
                     TRoom *room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
                     if (!room) {
                         continue;
                     }
-                    int rx = room->x * mRoomWidth + fx;
-                    int ry = room->y * -1 * mRoomHeight + fy;
-                    int rz = room->z;
+                    int const rx = room->x * mRoomWidth + fx;
+                    int const ry = room->y * -1 * mRoomHeight + fy;
+                    int const rz = room->z;
 
-                    int mx = event->pos().x();
-                    int my = event->pos().y();
-                    int mz = mOz;
+                    int const mx = event->pos().x();
+                    int const my = event->pos().y();
+                    int const mz = mOz;
                     if ((abs(mx - rx) < qRound(mRoomWidth * rSize / 2.0)) && (abs(my - ry) < qRound(mRoomHeight * rSize / 2.0)) && (mz == rz)) {
                         if (mMultiSelectionSet.contains(currentAreaRoom) && event->modifiers().testFlag(Qt::ControlModifier)) {
                             mMultiSelectionSet.remove(currentAreaRoom);
@@ -2628,7 +2628,7 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
                 }
             }
 
-            int selectionSize = mMultiSelectionSet.size();
+            int const selectionSize = mMultiSelectionSet.size();
             switch (selectionSize) {
                 case 0:
                     mMultiSelectionHighlightRoomId = 0;
@@ -2749,7 +2749,7 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
 
             popup->addSeparator();
 
-            QString viewModeItem = mMapViewOnly ? tr("Switch to editing mode", "2D Mapper context menu (room) item") : tr("Switch to viewing mode", "2D Mapper context menu (room) item");
+            QString const viewModeItem = mMapViewOnly ? tr("Switch to editing mode", "2D Mapper context menu (room) item") : tr("Switch to viewing mode", "2D Mapper context menu (room) item");
             auto setMapViewOnly = new QAction(viewModeItem, this);
             connect(setMapViewOnly, &QAction::triggered, this, &T2DMap::slot_toggleMapViewOnly);
             popup->addAction(setMapViewOnly);
@@ -2838,7 +2838,7 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
         while (it.hasNext()) {
             it.next();
             QStringList menuInfo = it.value();
-            QString displayName = menuInfo[1];
+            QString const displayName = menuInfo[1];
             // Need to give the top-level context menu as the parent so the
             // sub-menus get destroyed at the right time:
             auto userMenu = new QMenu(displayName, popup);
@@ -2849,7 +2849,7 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
             //take care of nested menus now since they're all made
             it.next();
             QStringList menuInfo = it.value();
-            QString menuParent = menuInfo[0];
+            QString const menuParent = menuInfo[0];
             if (menuParent == "") { //parentless
                 popup->addMenu(userMenus[it.key()]);
             } else { //has a parent
@@ -2938,8 +2938,8 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
 
             TRoom* room = mpMap->mpRoomDB->getRoom(mCustomLinesRoomFrom);
             if (room) {
-                float mx = (event->pos().x() / mRoomWidth) + mOx - (xspan / 2.0);
-                float my = (yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy;
+                float const mx = (event->pos().x() / mRoomWidth) + mOx - (xspan / 2.0);
+                float const my = (yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy;
                 // might be useful to have a snap to grid type option
                 room->customLines[mCustomLinesRoomExit].push_back(QPointF(mx, my));
                 room->calcRoomDimensions();
@@ -2953,12 +2953,12 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
             // But NOT if got one or more rooms already selected!
             TArea* pA = mpMap->mpRoomDB->getArea(mAreaID);
             if (pA) {
-                float mx = (event->pos().x() / mRoomWidth) + mOx - (xspan / 2.0);
-                float my = (yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy;
-                QPointF pc = QPointF(mx, my);
+                float const mx = (event->pos().x() / mRoomWidth) + mOx - (xspan / 2.0);
+                float const my = (yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy;
+                QPointF const pc = QPointF(mx, my);
                 QSetIterator<int> itRoom = pA->rooms;
                 while (itRoom.hasNext()) {
-                    int currentRoomId = itRoom.next();
+                    int const currentRoomId = itRoom.next();
                     TRoom* room = mpMap->mpRoomDB->getRoom(currentRoomId);
                     if (!room) {
                         continue;
@@ -3002,8 +3002,8 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                                 }
 
                                 // We have not previously chosen a line to edit
-                                QLineF line = QLineF(olx, oly, lx, ly);
-                                QLineF normal = line.normalVector();
+                                QLineF const line = QLineF(olx, oly, lx, ly);
+                                QLineF const normal = line.normalVector();
                                 QLineF tl;
                                 tl.setP1(pc);
                                 tl.setAngle(normal.angle());
@@ -3047,8 +3047,8 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
             if (!pArea) {
                 return;
             }
-            float fx = ((xspan / 2.0) - mOx) * mRoomWidth;
-            float fy = ((yspan / 2.0) - mOy) * mRoomHeight;
+            float const fx = ((xspan / 2.0) - mOx) * mRoomWidth;
+            float const fy = ((yspan / 2.0) - mOy) * mRoomHeight;
 
             if (!event->modifiers().testFlag(Qt::ControlModifier)) {
                 if (!mMapViewOnly) {
@@ -3060,18 +3060,18 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
 
             QSetIterator<int> itRoom(pArea->getAreaRooms());
             while (itRoom.hasNext()) { // Scan to find rooms in selection
-                int currentAreaRoom = itRoom.next();
+                int const currentAreaRoom = itRoom.next();
                 TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
                 if (!room) {
                     continue;
                 }
-                int rx = room->x * mRoomWidth + fx;
-                int ry = room->y * -1 * mRoomHeight + fy;
-                int rz = room->z;
+                int const rx = room->x * mRoomWidth + fx;
+                int const ry = room->y * -1 * mRoomHeight + fy;
+                int const rz = room->z;
 
-                int mx = event->pos().x();
-                int my = event->pos().y();
-                int mz = mOz;
+                int const mx = event->pos().x();
+                int const my = event->pos().y();
+                int const mz = mOz;
                 if ((abs(mx - rx) < qRound(mRoomWidth * rSize / 2.0)) && (abs(my - ry) < qRound(mRoomHeight * rSize / 2.0)) && (mz == rz)) {
                     if (mMultiSelectionSet.contains(currentAreaRoom) && event->modifiers().testFlag(Qt::ControlModifier)) {
                         mMultiSelectionSet.remove(currentAreaRoom);
@@ -3110,15 +3110,15 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                     }
 
                     QPointF labelPosition;
-                    float labelX = mapLabel.pos.x() * mRoomWidth + mRX;
-                    float labelY = mapLabel.pos.y() * mRoomHeight * -1 + mRY;
+                    float const labelX = mapLabel.pos.x() * mRoomWidth + mRX;
+                    float const labelY = mapLabel.pos.y() * mRoomHeight * -1 + mRY;
 
                     labelPosition.setX(labelX);
                     labelPosition.setY(labelY);
-                    int mx = event->pos().x();
-                    int my = event->pos().y();
-                    QPoint click = QPoint(mx, my);
-                    QRectF br = QRect(labelX, labelY, mapLabel.clickSize.width(), mapLabel.clickSize.height());
+                    int const mx = event->pos().x();
+                    int const my = event->pos().y();
+                    QPoint const click = QPoint(mx, my);
+                    QRectF const br = QRect(labelX, labelY, mapLabel.clickSize.width(), mapLabel.clickSize.height());
                     if (br.contains(click)) {
                         mapLabel.highlight = !mapLabel.highlight;
                         mLabelHighlighted = mapLabel.highlight;
@@ -3166,12 +3166,12 @@ void T2DMap::updateSelectionWidget()
         mIsSelectionUsingNames = false;
         while (itRoom.hasNext()) {
             auto _item = new QTreeWidgetItem;
-            int multiSelectionRoomId = itRoom.next();
+            int const multiSelectionRoomId = itRoom.next();
             _item->setText(0, key_plain.arg(multiSelectionRoomId, mMaxRoomIdDigits));
             _item->setTextAlignment(0, Qt::AlignRight);
             TRoom *pR_multiSelection = mpMap->mpRoomDB->getRoom(multiSelectionRoomId);
             if (pR_multiSelection) {
-                QString multiSelectionRoomName = pR_multiSelection->name;
+                QString const multiSelectionRoomName = pR_multiSelection->name;
                 if (!multiSelectionRoomName.isEmpty()) {
                     _item->setText(1, multiSelectionRoomName);
                     _item->setTextAlignment(1, Qt::AlignLeft);
@@ -3200,10 +3200,10 @@ void T2DMap::updateSelectionWidget()
 // returns the current mouse position as X, Y coordinates on the map
 std::pair<int, int> T2DMap::getMousePosition()
 {
-    QPoint mousePosition = this->mapFromGlobal(QCursor::pos());
+    QPoint const mousePosition = this->mapFromGlobal(QCursor::pos());
 
-    float mx = (mousePosition.x() / mRoomWidth) + mOx - (xspan / 2.0);
-    float my = (yspan / 2.0) - (mousePosition.y() / mRoomHeight) - mOy;
+    float const mx = (mousePosition.x() / mRoomWidth) + mOx - (xspan / 2.0);
+    float const my = (yspan / 2.0) - (mousePosition.y() / mRoomHeight) - mOy;
 
     return {std::round(mx), std::round(my)};
 }
@@ -3316,7 +3316,7 @@ void T2DMap::slot_customLineProperties()
             mpCurrentLineStyle->addItem(QIcon(QPixmap(key_icon_line_dash)), tr("Dash line"), static_cast<int>(Qt::DashLine));
             mpCurrentLineStyle->addItem(QIcon(QPixmap(key_icon_line_dashDot)), tr("Dash-dot line"), static_cast<int>(Qt::DashDotLine));
             mpCurrentLineStyle->addItem(QIcon(QPixmap(key_icon_line_dashDotDot)), tr("Dash-dot-dot line"), static_cast<int>(Qt::DashDotDotLine));
-            Qt::PenStyle lineStyle = room->customLinesStyle.value(exit);
+            Qt::PenStyle const lineStyle = room->customLinesStyle.value(exit);
             mpCurrentLineStyle->setCurrentIndex(mpCurrentLineStyle->findData(static_cast<int>(lineStyle)));
 
             mpCurrentLineArrow->setChecked(room->customLinesArrow.value(exit));
@@ -3528,7 +3528,7 @@ void T2DMap::slot_setPlayerLocation()
         return; // Was <= 1 but that can't be right, and >1 doesn't seem right either
     }
 
-    int _newRoomId = *(mMultiSelectionSet.constBegin());
+    int const _newRoomId = *(mMultiSelectionSet.constBegin());
     if (mpMap->mpRoomDB->getRoom(_newRoomId)) {
         // No need to check it is a DIFFERENT room - that is taken care of by en/dis-abling the control
         mpMap->mRoomIdHash[mpMap->mProfileName] = _newRoomId;
@@ -3653,9 +3653,9 @@ void T2DMap::slot_movePosition()
     }
 
     if (dialog->exec() == QDialog::Accepted) {
-        int dx = pLEx->text().toInt() - pR_start->x;
-        int dy = pLEy->text().toInt() - pR_start->y;
-        int dz = pLEz->text().toInt() - pR_start->z;
+        int const dx = pLEx->text().toInt() - pR_start->x;
+        int const dy = pLEy->text().toInt() - pR_start->y;
+        int const dz = pLEz->text().toInt() - pR_start->z;
 
         mMultiRect = QRect(0, 0, 0, 0);
 
@@ -3719,7 +3719,7 @@ void T2DMap::slot_showPropertiesDialog()
 
         // Scan and count all the different names used
         if (!room->name.isEmpty()) {
-            QString thisName = QString(room->name);
+            QString const thisName = QString(room->name);
             if (!thisName.isEmpty()) {
                 if (usedNames.contains(thisName)) {
                     (usedNames[thisName])++;
@@ -3730,7 +3730,7 @@ void T2DMap::slot_showPropertiesDialog()
         }
 
         // Scan and count all the different room colors used
-        int thisColor = room->environment;
+        int const thisColor = room->environment;
         if (usedColors.contains(thisColor)) {
             (usedColors[thisColor])++;
         } else {
@@ -3738,7 +3738,7 @@ void T2DMap::slot_showPropertiesDialog()
         }
 
         // Scan and count all the different symbols used
-        QString thisSymbol = QString(room->mSymbol);
+        QString const thisSymbol = QString(room->mSymbol);
         if (usedSymbols.contains(thisSymbol)) {
             (usedSymbols[thisSymbol])++;
         } else {
@@ -3746,7 +3746,7 @@ void T2DMap::slot_showPropertiesDialog()
         }
 
         // Scan and count all the different weights used
-        int thisWeight = room->getWeight();
+        int const thisWeight = room->getWeight();
         if (thisWeight > 0) {
             if (usedWeights.contains(thisWeight)) {
                 (usedWeights[thisWeight])++;
@@ -3756,7 +3756,7 @@ void T2DMap::slot_showPropertiesDialog()
         }
 
         // Scan and count all the different lock status used
-        bool thisLockStatus = room->isLocked;
+        bool const thisLockStatus = room->isLocked;
         if (usedLockStatus.contains(thisLockStatus)) {
             (usedLockStatus[thisLockStatus])++;
         } else {
@@ -3872,7 +3872,7 @@ void T2DMap::slot_spread()
     // Move the dialog down to here so it doesn't fire up for some already
     // determined to be null (no change) case, also handle "Cancel" being pressed
     bool isOk = false;
-    int spread = QInputDialog::getInt(this,
+    int const spread = QInputDialog::getInt(this,
                                       tr("Spread out rooms"),
                                       tr("Increase the spacing of\n"
                                          "the selected rooms,\n"
@@ -3889,8 +3889,8 @@ void T2DMap::slot_spread()
     }
 
     mMultiRect = QRect(0, 0, 0, 0);
-    int dx = pR_centerRoom->x;
-    int dy = pR_centerRoom->y;
+    int const dx = pR_centerRoom->x;
+    int const dy = pR_centerRoom->y;
     QSetIterator<int> itSelectionRoom = mMultiSelectionSet;
     while (itSelectionRoom.hasNext()) {
         TRoom* pMovingR = mpMap->mpRoomDB->getRoom(itSelectionRoom.next());
@@ -3906,7 +3906,7 @@ void T2DMap::slot_spread()
             itCustomLine.next();
             QList<QPointF> customLinePoints = itCustomLine.value();
             for (auto& customLinePoint : customLinePoints) {
-                QPointF movingPoint = customLinePoint;
+                QPointF const movingPoint = customLinePoint;
                 customLinePoint.setX(static_cast<float>((movingPoint.x() - dx) * spread + dx));
                 customLinePoint.setY(static_cast<float>((movingPoint.y() - dx) * spread + dy));
             }
@@ -3933,7 +3933,7 @@ void T2DMap::slot_shrink()
     // Move the dialog down to here so it doesn't fire up for some already
     // determined to be null (no change) case, also handle "Cancel" being pressed
     bool isOk = false;
-    int spread = QInputDialog::getInt(this,
+    int const spread = QInputDialog::getInt(this,
                                       tr("Shrink in rooms"),
                                       tr("Decrease the spacing of\n"
                                          "the selected rooms,\n"
@@ -3950,8 +3950,8 @@ void T2DMap::slot_shrink()
     }
 
     mMultiRect = QRect(0, 0, 0, 0);
-    int dx = pR_centerRoom->x;
-    int dy = pR_centerRoom->y;
+    int const dx = pR_centerRoom->x;
+    int const dy = pR_centerRoom->y;
 
     QSetIterator<int> itSelectionRoom(mMultiSelectionSet);
     while (itSelectionRoom.hasNext()) {
@@ -3967,7 +3967,7 @@ void T2DMap::slot_shrink()
             itCustomLine.next();
             QList<QPointF> customLinePoints = itCustomLine.value();
             for (auto& customLinePoint : customLinePoints) {
-                QPointF movingPoint = customLinePoint;
+                QPointF const movingPoint = customLinePoint;
                 customLinePoint.setX(static_cast<float>((movingPoint.x() - dx) / spread + dx));
                 customLinePoint.setY(static_cast<float>((movingPoint.y() - dx) / spread + dy));
             }
@@ -4003,7 +4003,7 @@ void T2DMap::slot_loadMap() {
         return;
     }
 
-    QString fileName = QFileDialog::getOpenFileName(
+    QString const fileName = QFileDialog::getOpenFileName(
                            this,
                            tr("Load Mudlet map"),
                            mudlet::getMudletPath(mudlet::profileMapsPath, mpMap->mProfileName),
@@ -4089,7 +4089,7 @@ void T2DMap::slot_setArea()
 
     const QMap<int, QString>& areaNamesMap = mpMap->mpRoomDB->getAreaNamesMap();
     for (int i = 0, total = sortedAreaList.count(); i < total; ++i) {
-        int areaId = areaNamesMap.key(sortedAreaList.at(i));
+        int const areaId = areaNamesMap.key(sortedAreaList.at(i));
         arealist_combobox->addItem(qsl("%1 (%2)").arg(sortedAreaList.at(i), QString::number(areaId)), QString::number(areaId));
     }
 
@@ -4130,7 +4130,7 @@ void T2DMap::slot_setArea()
         mMultiRect = QRect(0, 0, 0, 0);
         QSetIterator<int> itSelectedRoom = mMultiSelectionSet;
         while (itSelectedRoom.hasNext()) {
-            int currentRoomId = itSelectedRoom.next();
+            int const currentRoomId = itSelectedRoom.next();
             if (itSelectedRoom.hasNext()) { // NOT the last room in set -  so defer some area related recalculations
                 mpMap->setRoomArea(currentRoomId, newAreaId, true);
             } else {
@@ -4141,7 +4141,7 @@ void T2DMap::slot_setArea()
                     // Failed on the last of multiple room area move so do the missed
                     // out recalculations for the dirtied areas
                     auto areaPtrsList{mpMap->mpRoomDB->getAreaPtrList()};
-                    QSet<TArea*> areaPtrsSet{areaPtrsList.begin(), areaPtrsList.end()};
+                    QSet<TArea*> const areaPtrsSet{areaPtrsList.begin(), areaPtrsList.end()};
                     QSetIterator<TArea*> itpArea{areaPtrsSet};
                     while (itpArea.hasNext()) {
                         TArea* pArea = itpArea.next();
@@ -4185,12 +4185,12 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
     }
     if (mpMap->m2DPanMode) {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-        QPointF panNewPosition = event->localPos();
+        QPointF const panNewPosition = event->localPos();
 #else
         QPointF panNewPosition = event->position();
 #endif
         mShiftMode = true;
-        QPointF movement = mpMap->m2DPanStart - panNewPosition;
+        QPointF const movement = mpMap->m2DPanStart - panNewPosition;
         mOx += movement.x() / mRoomWidth;
         mOy += movement.y() / mRoomHeight;
         mpMap->m2DPanStart = panNewPosition;
@@ -4203,9 +4203,9 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
         if (room) {
             if (room->customLines.contains(mCustomLineSelectedExit)) {
                 if (room->customLines[mCustomLineSelectedExit].size() > mCustomLineSelectedPoint) {
-                    qreal mx = static_cast<qreal>(event->pos().x()) / static_cast<qreal>(mRoomWidth) + mOx - static_cast<qreal>(xspan / 2.0f);
-                    qreal my = static_cast<qreal>(yspan / 2.0f) - static_cast<qreal>(event->pos().y()) / static_cast<qreal>(mRoomHeight) - mOy;
-                    QPointF pc = QPointF(mx, my);
+                    qreal const mx = static_cast<qreal>(event->pos().x()) / static_cast<qreal>(mRoomWidth) + mOx - static_cast<qreal>(xspan / 2.0f);
+                    qreal const my = static_cast<qreal>(yspan / 2.0f) - static_cast<qreal>(event->pos().y()) / static_cast<qreal>(mRoomHeight) - mOy;
+                    QPointF const pc = QPointF(mx, my);
                     room->customLines[mCustomLineSelectedExit][mCustomLineSelectedPoint] = pc;
                     room->calcRoomDimensions();
                     repaint();
@@ -4235,8 +4235,8 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
                 if (!mapLabel.highlight) {
                     continue;
                 }
-                float mx = (static_cast<float>(event->pos().x()) / mRoomWidth) + static_cast<float>(mOx) -(xspan / 2.0f);
-                float my = (yspan / 2.0f) - (static_cast<float>(event->pos().y()) / mRoomHeight) - static_cast<float>(mOy);
+                float const mx = (static_cast<float>(event->pos().x()) / mRoomWidth) + static_cast<float>(mOx) -(xspan / 2.0f);
+                float const my = (yspan / 2.0f) - (static_cast<float>(event->pos().y()) / mRoomHeight) - static_cast<float>(mOy);
                 mapLabel.pos = QVector3D(mx, my, static_cast<float>(mOz));
                 pA->mMapLabels[itMapLabel.key()] = mapLabel;
                 needUpdate = true;
@@ -4275,11 +4275,11 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
 
         if (!mSizeLabel) { // NOT sizing a label
             mMultiSelectionSet.clear();
-            float fx = xspan / 2.0f * mRoomWidth - mRoomWidth * static_cast<float>(mOx);
-            float fy = yspan / 2.0f * mRoomHeight - mRoomHeight * static_cast<float>(mOy);
+            float const fx = xspan / 2.0f * mRoomWidth - mRoomWidth * static_cast<float>(mOx);
+            float const fy = yspan / 2.0f * mRoomHeight - mRoomHeight * static_cast<float>(mOy);
             QSetIterator<int> itSelectedRoom(pArea->getAreaRooms());
             while (itSelectedRoom.hasNext()) {
-                int currentRoomId = itSelectedRoom.next();
+                int const currentRoomId = itSelectedRoom.next();
                 TRoom* room = mpMap->mpRoomDB->getRoom(currentRoomId);
                 if (!room) {
                     continue;
@@ -4291,8 +4291,8 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
                     continue;
                 }
 
-                float rx = static_cast<float>(room->x) * mRoomWidth  + fx;
-                float ry = static_cast<float>(room->y * -1) * mRoomHeight + fy;
+                float const rx = static_cast<float>(room->x) * mRoomWidth  + fx;
+                float const ry = static_cast<float>(room->y * -1) * mRoomHeight + fy;
                 QRectF dr;
                 if (pArea->gridMode) {
                     dr = QRectF(static_cast<qreal>(rx - (mRoomWidth / 2.0f)), static_cast<qreal>(ry - (mRoomHeight / 2.0f)), static_cast<qreal>(mRoomWidth), static_cast<qreal>(mRoomHeight));
@@ -4327,12 +4327,12 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
                 mIsSelectionUsingNames = false;
                 while (itRoom.hasNext()) {
                     auto item = new QTreeWidgetItem;
-                    int multiSelectionRoomId = itRoom.next();
+                    int const multiSelectionRoomId = itRoom.next();
                     item->setText(0, qsl("%1").arg(multiSelectionRoomId, mMaxRoomIdDigits));
                     item->setTextAlignment(0, Qt::AlignRight);
                     TRoom* pR_multiSelection = mpMap->mpRoomDB->getRoom(multiSelectionRoomId);
                     if (pR_multiSelection) {
-                        QString multiSelectionRoomName = pR_multiSelection->name;
+                        QString const multiSelectionRoomName = pR_multiSelection->name;
                         if (!multiSelectionRoomName.isEmpty()) {
                             item->setText(1, multiSelectionRoomName);
                             item->setTextAlignment(1, Qt::AlignLeft);
@@ -4380,8 +4380,8 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
             return;
         }
 
-        int dx = qRound((event->pos().x() / mRoomWidth) + mOx - (xspan / 2.0)) - room->x;
-        int dy = qRound((yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy) - room->y;
+        int const dx = qRound((event->pos().x() / mRoomWidth) + mOx - (xspan / 2.0)) - room->x;
+        int const dy = qRound((yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy) - room->y;
         QSetIterator<int> itRoom = mMultiSelectionSet;
         while (itRoom.hasNext()) {
             room = mpMap->mpRoomDB->getRoom(itRoom.next());
@@ -4396,7 +4396,7 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
                     itk.next();
                     QList<QPointF> _pL = itk.value();
                     for (auto& point : _pL) {
-                        QPointF op = point;
+                        QPointF const op = point;
                         point.setX(static_cast<float>(op.x() + dx));
                         point.setY(static_cast<float>(op.y() + dy));
                     }
@@ -4428,7 +4428,7 @@ bool T2DMap::getCenterSelection()
     float mean_z = 0.0;
     uint processedRoomCount = 0;
     while (itRoom.hasNext()) {
-        int currentRoomId = itRoom.next();
+        int const currentRoomId = itRoom.next();
         TRoom* room = mpMap->mpRoomDB->getRoom(currentRoomId);
         if (!room) {
             continue;
@@ -4443,20 +4443,20 @@ bool T2DMap::getCenterSelection()
         itRoom.toFront();
         float closestSquareDistance = -1.0;
         while (itRoom.hasNext()) {
-            int currentRoomId = itRoom.next();
+            int const currentRoomId = itRoom.next();
             TRoom* room = mpMap->mpRoomDB->getRoom(currentRoomId);
             if (!room) {
                 continue;
             }
 
-            QVector3D meanToRoom(static_cast<float>(room->x) - mean_x, static_cast<float>(room->y) - mean_y, static_cast<float>(room->z) - mean_z);
+            QVector3D const meanToRoom(static_cast<float>(room->x) - mean_x, static_cast<float>(room->y) - mean_y, static_cast<float>(room->z) - mean_z);
             if (closestSquareDistance < -0.5) {
                 // Don't use an equality to zero test, we are using floats so
                 // need to allow for a little bit of fuzzzyness!
                 closestSquareDistance = meanToRoom.lengthSquared();
                 mMultiSelectionHighlightRoomId = currentRoomId;
             } else {
-                float currentRoomSquareDistance = meanToRoom.lengthSquared();
+                float const currentRoomSquareDistance = meanToRoom.lengthSquared();
                 if (closestSquareDistance > currentRoomSquareDistance) {
                     closestSquareDistance = currentRoomSquareDistance;
                     mMultiSelectionHighlightRoomId = currentRoomId;
@@ -4480,7 +4480,7 @@ void T2DMap::wheelEvent(QWheelEvent* e)
     // However the event "pos()" depends on the widget it came from so we have
     // to use "globalPos()" instead and see how it lies in relation to the child
     // widget:
-    QRect selectionListWidgetGlobalRect = QRect(mapToGlobal(mMultiSelectionListWidget.frameRect().topLeft()), mapToGlobal(mMultiSelectionListWidget.frameRect().bottomRight()));
+    QRect const selectionListWidgetGlobalRect = QRect(mapToGlobal(mMultiSelectionListWidget.frameRect().topLeft()), mapToGlobal(mMultiSelectionListWidget.frameRect().bottomRight()));
     if (mMultiSelectionListWidget.isVisible() && selectionListWidgetGlobalRect.contains(e->globalPosition().toPoint())) {
         e->accept();
         return;
@@ -4498,7 +4498,7 @@ void T2DMap::wheelEvent(QWheelEvent* e)
     const int yDelta = qRound(delta.y() * (e->modifiers() & Qt::ControlModifier ? 5.0 : 1.0) / (8.0 * 15.0));
     if (yDelta) {
         mPick = false;
-        qreal oldZoom = xyzoom;
+        qreal const oldZoom = xyzoom;
         xyzoom = qMax(csmMinXYZoom, xyzoom * pow(1.07, yDelta));
         mpMap->mpRoomDB->getArea(mAreaID)->set2DMapZoom(xyzoom);
 
@@ -4798,8 +4798,8 @@ void T2DMap::slot_setCustomLine()
     QMapIterator<QString, int> it(room->getSpecialExits());
     while (it.hasNext()) {
         it.next();
-        int id_to = it.value();
-        QString dir = it.key();
+        int const id_to = it.value();
+        QString const dir = it.key();
         auto pI = new QTreeWidgetItem(specialExits);
         if (room->customLines.contains(dir)) {
             pI->setCheckState(0, Qt::Checked);
@@ -4954,7 +4954,7 @@ void T2DMap::slot_setCustomLine2()
         return;
     }
 
-    QList<QPointF> list;
+    QList<QPointF> const list;
     room->customLines[mCustomLinesRoomExit] = list;
     //    qDebug("T2DMap::slot_setCustomLine2() NORMAL EXIT: %s", qPrintable(exitKey));
     room->customLinesColor[mCustomLinesRoomExit] = mCurrentLineColor;
@@ -4979,7 +4979,7 @@ void T2DMap::slot_setCustomLine2B(QTreeWidgetItem* special_exit, int column)
     if (!special_exit) {
         return;
     }
-    QString exit = special_exit->text(2);
+    QString const exit = special_exit->text(2);
     mpCustomLinesDialog->hide(); // Hide but don't delete until done the custom line
     mCustomLinesRoomExit = exit;
     mCustomLinesRoomTo = special_exit->text(1).toInt(); // Wasn't being set !
@@ -4988,7 +4988,7 @@ void T2DMap::slot_setCustomLine2B(QTreeWidgetItem* special_exit, int column)
     if (!room) {
         return;
     }
-    QList<QPointF> _list;
+    QList<QPointF> const _list;
     room->customLines[exit] = _list;
     //    qDebug("T2DMap::slot_setCustomLine2B() SPECIAL EXIT: %s", qPrintable(exit));
     room->customLinesColor[exit] = mCurrentLineColor;
@@ -5020,10 +5020,10 @@ void T2DMap::slot_createLabel()
 
 void T2DMap::slot_roomSelectionChanged()
 {
-    QList<QTreeWidgetItem*> selection = mMultiSelectionListWidget.selectedItems();
+    QList<QTreeWidgetItem*> const selection = mMultiSelectionListWidget.selectedItems();
     mMultiSelectionSet.clear();
     for (auto treeWidgetItem : selection) {
-        int currentRoomId = treeWidgetItem->text(0).toInt();
+        int const currentRoomId = treeWidgetItem->text(0).toInt();
         mMultiSelectionSet.insert(currentRoomId);
     }
     switch (mMultiSelectionSet.size()) {
@@ -5063,8 +5063,8 @@ void T2DMap::resizeMultiSelectionWidget()
         // The following factors are tweaks to ensure that the widget shows all
         // the rows, as the header seems bigger than the value returned, static values
         // used to enable values to be changed by debugger at runtime!
-        static float headerFactor = 1.2;
-        static float rowFactor = 1.0;
+        static float const headerFactor = 1.2;
+        static float const rowFactor = 1.0;
         _newHeight = headerFactor * mMultiSelectionListWidget.header()->height();
         if (rowItem) { // Have some data rows - and we have forced them to be the same height:
             _newHeight += rowFactor * mMultiSelectionListWidget.topLevelItemCount() * mMultiSelectionListWidget.visualItemRect(rowItem).height();
@@ -5088,8 +5088,8 @@ void T2DMap::setPlayerRoomStyle(const int type)
     // Indicate the LARGEST size we will need
     mPlayerRoomColorGradentStops.reserve(5);
 
-    double factor = mpMap->mPlayerRoomInnerDiameterPercentage / 100.0;
-    bool solid = (mpMap->mPlayerRoomInnerDiameterPercentage == 0);
+    double const factor = mpMap->mPlayerRoomInnerDiameterPercentage / 100.0;
+    bool const solid = (mpMap->mPlayerRoomInnerDiameterPercentage == 0);
     switch (type) {
     case 1: // Simple(?) shaded red ring:
         if (solid) {

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -843,7 +843,7 @@ inline void T2DMap::drawRoom(QPainter& painter,
     if (showRoomName) {
         painter.save();
 
-        QString const namePosData = pRoom->userData.value(ROOM_UI_NAMEPOS);
+        const QString namePosData = pRoom->userData.value(ROOM_UI_NAMEPOS);
         if (!namePosData.isEmpty()) {
             QPointF nameOffset {0, 0};
             QStringList posXY = namePosData.split(" ");
@@ -1186,7 +1186,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
     // the room name's font defaults to the symbol's
     // but may be overridden
     auto mapNameFont = mpMap->mMapSymbolFont;
-    QString const fontName = mpMap->mUserData.value(ROOM_UI_NAMEFONT);
+    const QString fontName = mpMap->mUserData.value(ROOM_UI_NAMEFONT);
     if (!fontName.isEmpty()) {
         QFont font;
         if (font.fromString(fontName)) {
@@ -2749,7 +2749,7 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
 
             popup->addSeparator();
 
-            QString const viewModeItem = mMapViewOnly ? tr("Switch to editing mode", "2D Mapper context menu (room) item") : tr("Switch to viewing mode", "2D Mapper context menu (room) item");
+            const QString viewModeItem = mMapViewOnly ? tr("Switch to editing mode", "2D Mapper context menu (room) item") : tr("Switch to viewing mode", "2D Mapper context menu (room) item");
             auto setMapViewOnly = new QAction(viewModeItem, this);
             connect(setMapViewOnly, &QAction::triggered, this, &T2DMap::slot_toggleMapViewOnly);
             popup->addAction(setMapViewOnly);
@@ -2838,7 +2838,7 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
         while (it.hasNext()) {
             it.next();
             QStringList menuInfo = it.value();
-            QString const displayName = menuInfo[1];
+            const QString displayName = menuInfo[1];
             // Need to give the top-level context menu as the parent so the
             // sub-menus get destroyed at the right time:
             auto userMenu = new QMenu(displayName, popup);
@@ -2849,7 +2849,7 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
             //take care of nested menus now since they're all made
             it.next();
             QStringList menuInfo = it.value();
-            QString const menuParent = menuInfo[0];
+            const QString menuParent = menuInfo[0];
             if (menuParent == "") { //parentless
                 popup->addMenu(userMenus[it.key()]);
             } else { //has a parent
@@ -3171,7 +3171,7 @@ void T2DMap::updateSelectionWidget()
             _item->setTextAlignment(0, Qt::AlignRight);
             TRoom *pR_multiSelection = mpMap->mpRoomDB->getRoom(multiSelectionRoomId);
             if (pR_multiSelection) {
-                QString const multiSelectionRoomName = pR_multiSelection->name;
+                const QString multiSelectionRoomName = pR_multiSelection->name;
                 if (!multiSelectionRoomName.isEmpty()) {
                     _item->setText(1, multiSelectionRoomName);
                     _item->setTextAlignment(1, Qt::AlignLeft);
@@ -3719,7 +3719,7 @@ void T2DMap::slot_showPropertiesDialog()
 
         // Scan and count all the different names used
         if (!room->name.isEmpty()) {
-            QString const thisName = QString(room->name);
+            const QString thisName = QString(room->name);
             if (!thisName.isEmpty()) {
                 if (usedNames.contains(thisName)) {
                     (usedNames[thisName])++;
@@ -3738,7 +3738,7 @@ void T2DMap::slot_showPropertiesDialog()
         }
 
         // Scan and count all the different symbols used
-        QString const thisSymbol = QString(room->mSymbol);
+        const QString thisSymbol = QString(room->mSymbol);
         if (usedSymbols.contains(thisSymbol)) {
             (usedSymbols[thisSymbol])++;
         } else {
@@ -4003,7 +4003,7 @@ void T2DMap::slot_loadMap() {
         return;
     }
 
-    QString const fileName = QFileDialog::getOpenFileName(
+    const QString fileName = QFileDialog::getOpenFileName(
                            this,
                            tr("Load Mudlet map"),
                            mudlet::getMudletPath(mudlet::profileMapsPath, mpMap->mProfileName),
@@ -4332,7 +4332,7 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
                     item->setTextAlignment(0, Qt::AlignRight);
                     TRoom* pR_multiSelection = mpMap->mpRoomDB->getRoom(multiSelectionRoomId);
                     if (pR_multiSelection) {
-                        QString const multiSelectionRoomName = pR_multiSelection->name;
+                        const QString multiSelectionRoomName = pR_multiSelection->name;
                         if (!multiSelectionRoomName.isEmpty()) {
                             item->setText(1, multiSelectionRoomName);
                             item->setTextAlignment(1, Qt::AlignLeft);
@@ -4799,7 +4799,7 @@ void T2DMap::slot_setCustomLine()
     while (it.hasNext()) {
         it.next();
         int const id_to = it.value();
-        QString const dir = it.key();
+        const QString dir = it.key();
         auto pI = new QTreeWidgetItem(specialExits);
         if (room->customLines.contains(dir)) {
             pI->setCheckState(0, Qt::Checked);
@@ -4979,7 +4979,7 @@ void T2DMap::slot_setCustomLine2B(QTreeWidgetItem* special_exit, int column)
     if (!special_exit) {
         return;
     }
-    QString const exit = special_exit->text(2);
+    const QString exit = special_exit->text(2);
     mpCustomLinesDialog->hide(); // Hide but don't delete until done the custom line
     mCustomLinesRoomExit = exit;
     mCustomLinesRoomTo = special_exit->text(1).toInt(); // Wasn't being set !

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -324,7 +324,7 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
                             closestSquareDistance = meanToRoom.lengthSquared();
                             closestCenterRoom = room;
                         } else {
-                            float const currentRoomSquareDistance = meanToRoom.lengthSquared();
+                            const float currentRoomSquareDistance = meanToRoom.lengthSquared();
                             if (closestSquareDistance > currentRoomSquareDistance) {
                                 closestSquareDistance = currentRoomSquareDistance;
                                 closestCenterRoom = room;
@@ -387,7 +387,7 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
                         closestSquareDistance = meanToRoom.lengthSquared();
                         closestCenterRoom = room;
                     } else {
-                        float const currentRoomSquareDistance = meanToRoom.lengthSquared();
+                        const float currentRoomSquareDistance = meanToRoom.lengthSquared();
                         if (closestSquareDistance > currentRoomSquareDistance) {
                             closestSquareDistance = currentRoomSquareDistance;
                             closestCenterRoom = room;
@@ -417,7 +417,7 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
 void T2DMap::addSymbolToPixmapCache(const QString key, const QString text, const QColor symbolColor, const bool gridMode)
 {
     // Some constants used to prevent small, unreadable symbols:
-    static float const symbolLowerSizeLimit = 8.0;
+    static const float symbolLowerSizeLimit = 8.0;
     static unsigned const int minimumUsableFontSize = 8;
 
     // Draw onto a rectangle that will fit the room symbol rectangle,
@@ -711,7 +711,7 @@ inline void T2DMap::drawRoom(QPainter& painter,
     painter.setPen(roomPen);
 
     if (mBubbleMode) {
-        float const roomRadius = 0.5 * rSize * mRoomWidth;
+        const float roomRadius = 0.5 * rSize * mRoomWidth;
         QPointF const roomCenter = QPointF(rx, ry);
         if (!isRoomSelected) {
             // CHECK: The use of a gradient fill to a white center on round
@@ -739,7 +739,7 @@ inline void T2DMap::drawRoom(QPainter& painter,
             // within the area - there is a separate block of code further down
             // in this method that handles clicking on the out of area exit so
             // that a speed walk is done to the room in the OTHER area:
-            float const roomRadius = 0.4 * mRoomWidth;
+            const float roomRadius = 0.4 * mRoomWidth;
             QPointF const roomCenter = QPointF(rx, ry);
             QRadialGradient gradient(roomCenter, roomRadius);
             gradient.setColorAt(0.95, QColor(255, 0, 0, 150));
@@ -811,7 +811,7 @@ inline void T2DMap::drawRoom(QPainter& painter,
 
     // Do we need to draw the custom (user specified) highlight
     if (pRoom->highlight) {
-        float const roomRadius = (pRoom->highlightRadius * mRoomWidth) / 2.0;
+        const float roomRadius = (pRoom->highlightRadius * mRoomWidth) / 2.0;
         QPointF const roomCenter = QPointF(rx, ry);
         QRadialGradient gradient(roomCenter, roomRadius);
         gradient.setColorAt(0.85, pRoom->highlightColor);
@@ -1120,7 +1120,7 @@ inline void T2DMap::drawRoom(QPainter& painter,
                 // that it is useful, note that there is similar code for a
                 // room being clicked on that is WITHIN the area, that is
                 // above this point in the source code:
-                float const roomRadius = (0.8 * mRoomWidth) / 2.0;
+                const float roomRadius = (0.8 * mRoomWidth) / 2.0;
                 QRadialGradient gradient(roomCenter, roomRadius);
                 gradient.setColorAt(0.95, QColor(255, 0, 0, 150));
                 gradient.setColorAt(0.80, QColor(150, 100, 100, 150));
@@ -1336,7 +1336,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
 
     const int zLevel = mOz;
 
-    float const exitWidth = 1 / eSize * mRoomWidth * rSize;
+    const float exitWidth = 1 / eSize * mRoomWidth * rSize;
 
     painter.fillRect(0, 0, width(), height(), mpHost->mBgColor_2);
 
@@ -1417,8 +1417,8 @@ void T2DMap::paintEvent(QPaintEvent* e)
             continue;
         }
 
-        float const rx = room->x *       mRoomWidth + static_cast<float>(mRX);
-        float const ry = room->y * -1 * mRoomHeight + static_cast<float>(mRY);
+        const float rx = room->x *       mRoomWidth + static_cast<float>(mRX);
+        const float ry = room->y * -1 * mRoomHeight + static_cast<float>(mRY);
         if (rx < 0 || ry < 0 || rx > widgetWidth || ry > widgetHeight) {
             continue;
         }
@@ -1518,12 +1518,12 @@ void T2DMap::paintEvent(QPaintEvent* e)
     if (mMultiSelectionHighlightRoomId > 0 && mMultiSelectionSet.size() > 1) {
         TRoom* pR_multiSelectionHighlight = mpMap->mpRoomDB->getRoom(mMultiSelectionHighlightRoomId);
         if (pR_multiSelectionHighlight) {
-            float const r_mSx = pR_multiSelectionHighlight->x * mRoomWidth + mRX;
-            float const r_mSy = pR_multiSelectionHighlight->y * -1 * mRoomHeight + mRY;
+            const float r_mSx = pR_multiSelectionHighlight->x * mRoomWidth + mRX;
+            const float r_mSy = pR_multiSelectionHighlight->y * -1 * mRoomHeight + mRY;
             QPen const savePen = painter.pen();
             QBrush const saveBrush = painter.brush();
-            float const roomRadius = mRoomWidth * 1.2;
-            float const roomDiagonal = mRoomWidth * 1.2;
+            const float roomRadius = mRoomWidth * 1.2;
+            const float roomDiagonal = mRoomWidth * 1.2;
             QPointF const roomCenter = QPointF(r_mSx, r_mSy);
 
             QPen yellowPen(QColor(255, 255, 50, 192)); // Quarter opaque yellow pen
@@ -2504,11 +2504,11 @@ void T2DMap::updateMapLabel(QRectF labelRectangle, int labelId, TArea* pArea)
 
     label.pix = pixmap.copy(drawRectangle);
     auto normalizedLabelRectangle = labelRectangle.normalized();
-    float const mx = (normalizedLabelRectangle.topLeft().x() / mRoomWidth) + mOx - (xspan / 2.0);
-    float const my = (yspan / 2.0) - (labelRectangle.topLeft().y() / mRoomHeight) - mOy;
+    const float mx = (normalizedLabelRectangle.topLeft().x() / mRoomWidth) + mOx - (xspan / 2.0);
+    const float my = (yspan / 2.0) - (labelRectangle.topLeft().y() / mRoomHeight) - mOy;
 
-    float const mx2 = (normalizedLabelRectangle.bottomRight().x() / mRoomWidth) + mOx - (xspan / 2.0);
-    float const my2 = (yspan / 2.0) - (labelRectangle.bottomRight().y() / mRoomHeight) - mOy;
+    const float mx2 = (normalizedLabelRectangle.bottomRight().x() / mRoomWidth) + mOx - (xspan / 2.0);
+    const float my2 = (yspan / 2.0) - (labelRectangle.bottomRight().y() / mRoomHeight) - mOy;
     label.pos = QVector3D(mx, my, mOz);
     label.size = QRectF(QPointF(mx, my), QPointF(mx2, my2)).normalized().size();
 
@@ -2596,8 +2596,8 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
         auto pArea = mpMap->mpRoomDB->getArea(mAreaID);
         if (!mLabelHighlighted && mCustomLineSelectedRoom == 0) {
             mMultiRect = QRect(event->pos(), event->pos());
-            float const fx = ((xspan / 2.0) - mOx) * mRoomWidth;
-            float const fy = ((yspan / 2.0) - mOy) * mRoomHeight;
+            const float fx = ((xspan / 2.0) - mOx) * mRoomWidth;
+            const float fy = ((yspan / 2.0) - mOy) * mRoomHeight;
 
             if (pArea) {
                 QSetIterator<int> itRoom(pArea->getAreaRooms());
@@ -2938,8 +2938,8 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
 
             TRoom* room = mpMap->mpRoomDB->getRoom(mCustomLinesRoomFrom);
             if (room) {
-                float const mx = (event->pos().x() / mRoomWidth) + mOx - (xspan / 2.0);
-                float const my = (yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy;
+                const float mx = (event->pos().x() / mRoomWidth) + mOx - (xspan / 2.0);
+                const float my = (yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy;
                 // might be useful to have a snap to grid type option
                 room->customLines[mCustomLinesRoomExit].push_back(QPointF(mx, my));
                 room->calcRoomDimensions();
@@ -2953,8 +2953,8 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
             // But NOT if got one or more rooms already selected!
             TArea* pA = mpMap->mpRoomDB->getArea(mAreaID);
             if (pA) {
-                float const mx = (event->pos().x() / mRoomWidth) + mOx - (xspan / 2.0);
-                float const my = (yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy;
+                const float mx = (event->pos().x() / mRoomWidth) + mOx - (xspan / 2.0);
+                const float my = (yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy;
                 QPointF const pc = QPointF(mx, my);
                 QSetIterator<int> itRoom = pA->rooms;
                 while (itRoom.hasNext()) {
@@ -3047,8 +3047,8 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
             if (!pArea) {
                 return;
             }
-            float const fx = ((xspan / 2.0) - mOx) * mRoomWidth;
-            float const fy = ((yspan / 2.0) - mOy) * mRoomHeight;
+            const float fx = ((xspan / 2.0) - mOx) * mRoomWidth;
+            const float fy = ((yspan / 2.0) - mOy) * mRoomHeight;
 
             if (!event->modifiers().testFlag(Qt::ControlModifier)) {
                 if (!mMapViewOnly) {
@@ -3110,8 +3110,8 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                     }
 
                     QPointF labelPosition;
-                    float const labelX = mapLabel.pos.x() * mRoomWidth + mRX;
-                    float const labelY = mapLabel.pos.y() * mRoomHeight * -1 + mRY;
+                    const float labelX = mapLabel.pos.x() * mRoomWidth + mRX;
+                    const float labelY = mapLabel.pos.y() * mRoomHeight * -1 + mRY;
 
                     labelPosition.setX(labelX);
                     labelPosition.setY(labelY);
@@ -3202,8 +3202,8 @@ std::pair<int, int> T2DMap::getMousePosition()
 {
     const QPoint mousePosition = this->mapFromGlobal(QCursor::pos());
 
-    float const mx = (mousePosition.x() / mRoomWidth) + mOx - (xspan / 2.0);
-    float const my = (yspan / 2.0) - (mousePosition.y() / mRoomHeight) - mOy;
+    const float mx = (mousePosition.x() / mRoomWidth) + mOx - (xspan / 2.0);
+    const float my = (yspan / 2.0) - (mousePosition.y() / mRoomHeight) - mOy;
 
     return {std::round(mx), std::round(my)};
 }
@@ -4235,8 +4235,8 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
                 if (!mapLabel.highlight) {
                     continue;
                 }
-                float const mx = (static_cast<float>(event->pos().x()) / mRoomWidth) + static_cast<float>(mOx) -(xspan / 2.0f);
-                float const my = (yspan / 2.0f) - (static_cast<float>(event->pos().y()) / mRoomHeight) - static_cast<float>(mOy);
+                const float mx = (static_cast<float>(event->pos().x()) / mRoomWidth) + static_cast<float>(mOx) -(xspan / 2.0f);
+                const float my = (yspan / 2.0f) - (static_cast<float>(event->pos().y()) / mRoomHeight) - static_cast<float>(mOy);
                 mapLabel.pos = QVector3D(mx, my, static_cast<float>(mOz));
                 pA->mMapLabels[itMapLabel.key()] = mapLabel;
                 needUpdate = true;
@@ -4275,8 +4275,8 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
 
         if (!mSizeLabel) { // NOT sizing a label
             mMultiSelectionSet.clear();
-            float const fx = xspan / 2.0f * mRoomWidth - mRoomWidth * static_cast<float>(mOx);
-            float const fy = yspan / 2.0f * mRoomHeight - mRoomHeight * static_cast<float>(mOy);
+            const float fx = xspan / 2.0f * mRoomWidth - mRoomWidth * static_cast<float>(mOx);
+            const float fy = yspan / 2.0f * mRoomHeight - mRoomHeight * static_cast<float>(mOy);
             QSetIterator<int> itSelectedRoom(pArea->getAreaRooms());
             while (itSelectedRoom.hasNext()) {
                 const int currentRoomId = itSelectedRoom.next();
@@ -4291,8 +4291,8 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
                     continue;
                 }
 
-                float const rx = static_cast<float>(room->x) * mRoomWidth  + fx;
-                float const ry = static_cast<float>(room->y * -1) * mRoomHeight + fy;
+                const float rx = static_cast<float>(room->x) * mRoomWidth  + fx;
+                const float ry = static_cast<float>(room->y * -1) * mRoomHeight + fy;
                 QRectF dr;
                 if (pArea->gridMode) {
                     dr = QRectF(static_cast<qreal>(rx - (mRoomWidth / 2.0f)), static_cast<qreal>(ry - (mRoomHeight / 2.0f)), static_cast<qreal>(mRoomWidth), static_cast<qreal>(mRoomHeight));
@@ -4456,7 +4456,7 @@ bool T2DMap::getCenterSelection()
                 closestSquareDistance = meanToRoom.lengthSquared();
                 mMultiSelectionHighlightRoomId = currentRoomId;
             } else {
-                float const currentRoomSquareDistance = meanToRoom.lengthSquared();
+                const float currentRoomSquareDistance = meanToRoom.lengthSquared();
                 if (closestSquareDistance > currentRoomSquareDistance) {
                     closestSquareDistance = currentRoomSquareDistance;
                     mMultiSelectionHighlightRoomId = currentRoomId;
@@ -5063,8 +5063,8 @@ void T2DMap::resizeMultiSelectionWidget()
         // The following factors are tweaks to ensure that the widget shows all
         // the rows, as the header seems bigger than the value returned, static values
         // used to enable values to be changed by debugger at runtime!
-        static float const headerFactor = 1.2;
-        static float const rowFactor = 1.0;
+        static const float headerFactor = 1.2;
+        static const float rowFactor = 1.0;
         _newHeight = headerFactor * mMultiSelectionListWidget.header()->height();
         if (rowItem) { // Have some data rows - and we have forced them to be the same height:
             _newHeight += rowFactor * mMultiSelectionListWidget.topLevelItemCount() * mMultiSelectionListWidget.visualItemRect(rowItem).height();

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -190,7 +190,7 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
         return;
     }
 
-    int const playerRoomId = mpMap->mRoomIdHash.value(mpMap->mProfileName);
+    const int playerRoomId = mpMap->mRoomIdHash.value(mpMap->mProfileName);
     TRoom* pPlayerRoom = mpMap->mpRoomDB->getRoom(playerRoomId);
     int playerAreaID = -2; // Cannot be valid (but -1 can be)!
     if (pPlayerRoom) {
@@ -201,7 +201,7 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
     TEvent areaViewedChangedEvent{};
     while (it.hasNext()) {
         it.next();
-        int const areaID = it.key();
+        const int areaID = it.key();
         auto areaName = it.value();
         TArea* area = mpMap->mpRoomDB->getArea(areaID);
         if (area && newAreaName == areaName) {
@@ -255,7 +255,7 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
                 // key is z-coordinate, value is count of rooms on that level
                 QMap<int, int> roomsCountLevelMap;
                 while (itRoom.hasNext()) {
-                    int const checkRoomID = itRoom.next();
+                    const int checkRoomID = itRoom.next();
                     TRoom* room = mpMap->mpRoomDB->getRoom(checkRoomID);
                     if (room) {
                         validRoomFound = true;
@@ -418,7 +418,7 @@ void T2DMap::addSymbolToPixmapCache(const QString key, const QString text, const
 {
     // Some constants used to prevent small, unreadable symbols:
     static float const symbolLowerSizeLimit = 8.0;
-    static unsigned int const minimumUsableFontSize = 8;
+    static unsigned const int minimumUsableFontSize = 8;
 
     // Draw onto a rectangle that will fit the room symbol rectangle,
     // Must tweak the size so it fits within circle when round room symbols are
@@ -603,7 +603,7 @@ inline void T2DMap::drawRoom(QPainter& painter,
     QRectF roomRectangle;
     QRectF roomNameRectangle;
     double realHeight;
-    int const borderWidth = 1 / eSize * mRoomWidth * rSize;
+    const int borderWidth = 1 / eSize * mRoomWidth * rSize;
     bool const shouldDrawBorder = mpHost->mMapperShowRoomBorders && !isGridMode;
     bool showThisRoomName = showRoomName;
     if (isGridMode) {
@@ -1201,7 +1201,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
 
     QList<int> exitList;
     QList<int> oneWayExits;
-    int const playerRoomId = mpMap->mRoomIdHash.value(mpMap->mProfileName);
+    const int playerRoomId = mpMap->mRoomIdHash.value(mpMap->mProfileName);
     TRoom* pPlayerRoom = mpMap->mpRoomDB->getRoom(playerRoomId);
     if (!pPlayerRoom) {
         painter.save();
@@ -1334,7 +1334,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
         showRoomNames = (mapNameFont.pointSizeF() > 3.0);
     }
 
-    int const zLevel = mOz;
+    const int zLevel = mOz;
 
     float const exitWidth = 1 / eSize * mRoomWidth * rSize;
 
@@ -1359,13 +1359,13 @@ void T2DMap::paintEvent(QPaintEvent* e)
             pDrawnArea->mMapLabels[itMapLabel.key()] = mapLabel;
         }
         QPointF labelPosition;
-        int const labelX = mapLabel.pos.x() * mRoomWidth + mRX;
-        int const labelY = mapLabel.pos.y() * mRoomHeight * -1 + mRY;
+        const int labelX = mapLabel.pos.x() * mRoomWidth + mRX;
+        const int labelY = mapLabel.pos.y() * mRoomHeight * -1 + mRY;
 
         labelPosition.setX(labelX);
         labelPosition.setY(labelY);
-        int const labelWidth = abs(qRound(mapLabel.size.width() * mRoomWidth));
-        int const labelHeight = abs(qRound(mapLabel.size.height() * mRoomHeight));
+        const int labelWidth = abs(qRound(mapLabel.size.width() * mRoomWidth));
+        const int labelHeight = abs(qRound(mapLabel.size.height() * mRoomHeight));
         if (!((0 < labelX || 0 < labelX + labelWidth) && (widgetWidth > labelX || widgetWidth > labelX + labelWidth))) {
             continue;
         }
@@ -1407,7 +1407,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
     // Draw the rooms:
     QSetIterator<int> itRoom(pDrawnArea->getAreaRooms());
     while (itRoom.hasNext()) {
-        int const currentAreaRoom = itRoom.next();
+        const int currentAreaRoom = itRoom.next();
         TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
         if (!room) {
             continue;
@@ -1480,13 +1480,13 @@ void T2DMap::paintEvent(QPaintEvent* e)
             pDrawnArea->mMapLabels[itMapLabel.key()] = mapLabel;
         }
         QPointF labelPosition;
-        int const labelX = mapLabel.pos.x() * mRoomWidth + mRX;
-        int const labelY = mapLabel.pos.y() * mRoomHeight * -1 + mRY;
+        const int labelX = mapLabel.pos.x() * mRoomWidth + mRX;
+        const int labelY = mapLabel.pos.y() * mRoomHeight * -1 + mRY;
 
         labelPosition.setX(labelX);
         labelPosition.setY(labelY);
-        int const labelWidth = abs(qRound(mapLabel.size.width() * mRoomWidth));
-        int const labelHeight = abs(qRound(mapLabel.size.height() * mRoomHeight));
+        const int labelWidth = abs(qRound(mapLabel.size.width() * mRoomWidth));
+        const int labelHeight = abs(qRound(mapLabel.size.height() * mRoomHeight));
 
         if (!((0 < labelX || 0 < labelX + labelWidth) && (widgetWidth > labelX || widgetWidth > labelX + labelWidth))) {
             continue;
@@ -1658,7 +1658,7 @@ void T2DMap::drawDoor(QPainter& painter, const TRoom& room, const QString& dirKe
     doorPen.setStyle(Qt::SolidLine);
     doorPen.setCapStyle(Qt::RoundCap);
 
-    int const doorStatus = room.doors.value(dirKey);
+    const int doorStatus = room.doors.value(dirKey);
     if (doorStatus == 1) {
         doorPen.setColor(mOpenDoorColor);
     } else if (doorStatus == 2) {
@@ -1715,7 +1715,7 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
     }
     QSetIterator<int> itRoom2(pArea->getAreaRooms());
     while (itRoom2.hasNext()) {
-        int const _id = itRoom2.next();
+        const int _id = itRoom2.next();
         TRoom* room = mpMap->mpRoomDB->getRoom(_id);
         if (!room) {
             continue;
@@ -2058,7 +2058,7 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
         }
 
         // draw exit stubs
-        for (int const direction : qAsConst(room->exitStubs)) {
+        for (const int direction : qAsConst(room->exitStubs)) {
             if (direction >= DIR_NORTH && direction <= DIR_SOUTHWEST) {
                 // Stubs on non-XY plane exits are handled differently and we
                 // do not support special exit stubs (yet?)
@@ -2087,8 +2087,8 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
             }
         }
 
-        for (int const& k : exitList) {
-            int const rID = k;
+        for (const int& k : exitList) {
+            const int rID = k;
             if (rID <= 0) {
                 continue;
             }
@@ -2349,7 +2349,7 @@ void T2DMap::paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, c
         return;
     }
     int yOffset = 20;
-    int const initialYOffset = yOffset;
+    const int initialYOffset = yOffset;
     // Left margin for info widget:
     int xOffset = 10;
     if (mMultiSelectionListWidget.isVisible()) {
@@ -2405,7 +2405,7 @@ int T2DMap::paintMapInfoContributor(QPainter& painter, int xOffset, int yOffset,
     font.setItalic(properties.isItalic);
     painter.setFont(font);
 
-    int const infoHeight = mFontHeight; // Account for first iteration
+    const int infoHeight = mFontHeight; // Account for first iteration
     QRect testRect;
     // infoRect has a 10 margin on either side and on top to widget frame.
     mMapInfoRect = QRect(xOffset, yOffset, width() - 10 - xOffset, infoHeight);
@@ -2450,7 +2450,7 @@ void T2DMap::createLabel(QRectF labelRectangle)
     if (!pArea) {
         return;
     }
-    int const labelId = pArea->createLabelId();
+    const int labelId = pArea->createLabelId();
 
     connect(mpDlgMapLabel, &dlgMapLabel::updated, this, [=]() {
         updateMapLabel(labelRectangle, labelId, pArea);
@@ -2602,18 +2602,18 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
             if (pArea) {
                 QSetIterator<int> itRoom(pArea->getAreaRooms());
                 while (itRoom.hasNext()) { // Scan to find rooms in selection
-                    int const currentAreaRoom = itRoom.next();
+                    const int currentAreaRoom = itRoom.next();
                     TRoom *room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
                     if (!room) {
                         continue;
                     }
-                    int const rx = room->x * mRoomWidth + fx;
-                    int const ry = room->y * -1 * mRoomHeight + fy;
-                    int const rz = room->z;
+                    const int rx = room->x * mRoomWidth + fx;
+                    const int ry = room->y * -1 * mRoomHeight + fy;
+                    const int rz = room->z;
 
-                    int const mx = event->pos().x();
-                    int const my = event->pos().y();
-                    int const mz = mOz;
+                    const int mx = event->pos().x();
+                    const int my = event->pos().y();
+                    const int mz = mOz;
                     if ((abs(mx - rx) < qRound(mRoomWidth * rSize / 2.0)) && (abs(my - ry) < qRound(mRoomHeight * rSize / 2.0)) && (mz == rz)) {
                         if (mMultiSelectionSet.contains(currentAreaRoom) && event->modifiers().testFlag(Qt::ControlModifier)) {
                             mMultiSelectionSet.remove(currentAreaRoom);
@@ -2628,7 +2628,7 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
                 }
             }
 
-            int const selectionSize = mMultiSelectionSet.size();
+            const int selectionSize = mMultiSelectionSet.size();
             switch (selectionSize) {
                 case 0:
                     mMultiSelectionHighlightRoomId = 0;
@@ -2958,7 +2958,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                 QPointF const pc = QPointF(mx, my);
                 QSetIterator<int> itRoom = pA->rooms;
                 while (itRoom.hasNext()) {
-                    int const currentRoomId = itRoom.next();
+                    const int currentRoomId = itRoom.next();
                     TRoom* room = mpMap->mpRoomDB->getRoom(currentRoomId);
                     if (!room) {
                         continue;
@@ -3060,18 +3060,18 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
 
             QSetIterator<int> itRoom(pArea->getAreaRooms());
             while (itRoom.hasNext()) { // Scan to find rooms in selection
-                int const currentAreaRoom = itRoom.next();
+                const int currentAreaRoom = itRoom.next();
                 TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
                 if (!room) {
                     continue;
                 }
-                int const rx = room->x * mRoomWidth + fx;
-                int const ry = room->y * -1 * mRoomHeight + fy;
-                int const rz = room->z;
+                const int rx = room->x * mRoomWidth + fx;
+                const int ry = room->y * -1 * mRoomHeight + fy;
+                const int rz = room->z;
 
-                int const mx = event->pos().x();
-                int const my = event->pos().y();
-                int const mz = mOz;
+                const int mx = event->pos().x();
+                const int my = event->pos().y();
+                const int mz = mOz;
                 if ((abs(mx - rx) < qRound(mRoomWidth * rSize / 2.0)) && (abs(my - ry) < qRound(mRoomHeight * rSize / 2.0)) && (mz == rz)) {
                     if (mMultiSelectionSet.contains(currentAreaRoom) && event->modifiers().testFlag(Qt::ControlModifier)) {
                         mMultiSelectionSet.remove(currentAreaRoom);
@@ -3115,8 +3115,8 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
 
                     labelPosition.setX(labelX);
                     labelPosition.setY(labelY);
-                    int const mx = event->pos().x();
-                    int const my = event->pos().y();
+                    const int mx = event->pos().x();
+                    const int my = event->pos().y();
                     QPoint const click = QPoint(mx, my);
                     QRectF const br = QRect(labelX, labelY, mapLabel.clickSize.width(), mapLabel.clickSize.height());
                     if (br.contains(click)) {
@@ -3166,7 +3166,7 @@ void T2DMap::updateSelectionWidget()
         mIsSelectionUsingNames = false;
         while (itRoom.hasNext()) {
             auto _item = new QTreeWidgetItem;
-            int const multiSelectionRoomId = itRoom.next();
+            const int multiSelectionRoomId = itRoom.next();
             _item->setText(0, key_plain.arg(multiSelectionRoomId, mMaxRoomIdDigits));
             _item->setTextAlignment(0, Qt::AlignRight);
             TRoom *pR_multiSelection = mpMap->mpRoomDB->getRoom(multiSelectionRoomId);
@@ -3528,7 +3528,7 @@ void T2DMap::slot_setPlayerLocation()
         return; // Was <= 1 but that can't be right, and >1 doesn't seem right either
     }
 
-    int const _newRoomId = *(mMultiSelectionSet.constBegin());
+    const int _newRoomId = *(mMultiSelectionSet.constBegin());
     if (mpMap->mpRoomDB->getRoom(_newRoomId)) {
         // No need to check it is a DIFFERENT room - that is taken care of by en/dis-abling the control
         mpMap->mRoomIdHash[mpMap->mProfileName] = _newRoomId;
@@ -3653,9 +3653,9 @@ void T2DMap::slot_movePosition()
     }
 
     if (dialog->exec() == QDialog::Accepted) {
-        int const dx = pLEx->text().toInt() - pR_start->x;
-        int const dy = pLEy->text().toInt() - pR_start->y;
-        int const dz = pLEz->text().toInt() - pR_start->z;
+        const int dx = pLEx->text().toInt() - pR_start->x;
+        const int dy = pLEy->text().toInt() - pR_start->y;
+        const int dz = pLEz->text().toInt() - pR_start->z;
 
         mMultiRect = QRect(0, 0, 0, 0);
 
@@ -3730,7 +3730,7 @@ void T2DMap::slot_showPropertiesDialog()
         }
 
         // Scan and count all the different room colors used
-        int const thisColor = room->environment;
+        const int thisColor = room->environment;
         if (usedColors.contains(thisColor)) {
             (usedColors[thisColor])++;
         } else {
@@ -3746,7 +3746,7 @@ void T2DMap::slot_showPropertiesDialog()
         }
 
         // Scan and count all the different weights used
-        int const thisWeight = room->getWeight();
+        const int thisWeight = room->getWeight();
         if (thisWeight > 0) {
             if (usedWeights.contains(thisWeight)) {
                 (usedWeights[thisWeight])++;
@@ -3872,7 +3872,7 @@ void T2DMap::slot_spread()
     // Move the dialog down to here so it doesn't fire up for some already
     // determined to be null (no change) case, also handle "Cancel" being pressed
     bool isOk = false;
-    int const spread = QInputDialog::getInt(this,
+    const int spread = QInputDialog::getInt(this,
                                       tr("Spread out rooms"),
                                       tr("Increase the spacing of\n"
                                          "the selected rooms,\n"
@@ -3889,8 +3889,8 @@ void T2DMap::slot_spread()
     }
 
     mMultiRect = QRect(0, 0, 0, 0);
-    int const dx = pR_centerRoom->x;
-    int const dy = pR_centerRoom->y;
+    const int dx = pR_centerRoom->x;
+    const int dy = pR_centerRoom->y;
     QSetIterator<int> itSelectionRoom = mMultiSelectionSet;
     while (itSelectionRoom.hasNext()) {
         TRoom* pMovingR = mpMap->mpRoomDB->getRoom(itSelectionRoom.next());
@@ -3933,7 +3933,7 @@ void T2DMap::slot_shrink()
     // Move the dialog down to here so it doesn't fire up for some already
     // determined to be null (no change) case, also handle "Cancel" being pressed
     bool isOk = false;
-    int const spread = QInputDialog::getInt(this,
+    const int spread = QInputDialog::getInt(this,
                                       tr("Shrink in rooms"),
                                       tr("Decrease the spacing of\n"
                                          "the selected rooms,\n"
@@ -3950,8 +3950,8 @@ void T2DMap::slot_shrink()
     }
 
     mMultiRect = QRect(0, 0, 0, 0);
-    int const dx = pR_centerRoom->x;
-    int const dy = pR_centerRoom->y;
+    const int dx = pR_centerRoom->x;
+    const int dy = pR_centerRoom->y;
 
     QSetIterator<int> itSelectionRoom(mMultiSelectionSet);
     while (itSelectionRoom.hasNext()) {
@@ -4089,7 +4089,7 @@ void T2DMap::slot_setArea()
 
     const QMap<int, QString>& areaNamesMap = mpMap->mpRoomDB->getAreaNamesMap();
     for (int i = 0, total = sortedAreaList.count(); i < total; ++i) {
-        int const areaId = areaNamesMap.key(sortedAreaList.at(i));
+        const int areaId = areaNamesMap.key(sortedAreaList.at(i));
         arealist_combobox->addItem(qsl("%1 (%2)").arg(sortedAreaList.at(i), QString::number(areaId)), QString::number(areaId));
     }
 
@@ -4130,7 +4130,7 @@ void T2DMap::slot_setArea()
         mMultiRect = QRect(0, 0, 0, 0);
         QSetIterator<int> itSelectedRoom = mMultiSelectionSet;
         while (itSelectedRoom.hasNext()) {
-            int const currentRoomId = itSelectedRoom.next();
+            const int currentRoomId = itSelectedRoom.next();
             if (itSelectedRoom.hasNext()) { // NOT the last room in set -  so defer some area related recalculations
                 mpMap->setRoomArea(currentRoomId, newAreaId, true);
             } else {
@@ -4279,7 +4279,7 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
             float const fy = yspan / 2.0f * mRoomHeight - mRoomHeight * static_cast<float>(mOy);
             QSetIterator<int> itSelectedRoom(pArea->getAreaRooms());
             while (itSelectedRoom.hasNext()) {
-                int const currentRoomId = itSelectedRoom.next();
+                const int currentRoomId = itSelectedRoom.next();
                 TRoom* room = mpMap->mpRoomDB->getRoom(currentRoomId);
                 if (!room) {
                     continue;
@@ -4327,7 +4327,7 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
                 mIsSelectionUsingNames = false;
                 while (itRoom.hasNext()) {
                     auto item = new QTreeWidgetItem;
-                    int const multiSelectionRoomId = itRoom.next();
+                    const int multiSelectionRoomId = itRoom.next();
                     item->setText(0, qsl("%1").arg(multiSelectionRoomId, mMaxRoomIdDigits));
                     item->setTextAlignment(0, Qt::AlignRight);
                     TRoom* pR_multiSelection = mpMap->mpRoomDB->getRoom(multiSelectionRoomId);
@@ -4380,8 +4380,8 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
             return;
         }
 
-        int const dx = qRound((event->pos().x() / mRoomWidth) + mOx - (xspan / 2.0)) - room->x;
-        int const dy = qRound((yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy) - room->y;
+        const int dx = qRound((event->pos().x() / mRoomWidth) + mOx - (xspan / 2.0)) - room->x;
+        const int dy = qRound((yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy) - room->y;
         QSetIterator<int> itRoom = mMultiSelectionSet;
         while (itRoom.hasNext()) {
             room = mpMap->mpRoomDB->getRoom(itRoom.next());
@@ -4428,7 +4428,7 @@ bool T2DMap::getCenterSelection()
     float mean_z = 0.0;
     uint processedRoomCount = 0;
     while (itRoom.hasNext()) {
-        int const currentRoomId = itRoom.next();
+        const int currentRoomId = itRoom.next();
         TRoom* room = mpMap->mpRoomDB->getRoom(currentRoomId);
         if (!room) {
             continue;
@@ -4443,7 +4443,7 @@ bool T2DMap::getCenterSelection()
         itRoom.toFront();
         float closestSquareDistance = -1.0;
         while (itRoom.hasNext()) {
-            int const currentRoomId = itRoom.next();
+            const int currentRoomId = itRoom.next();
             TRoom* room = mpMap->mpRoomDB->getRoom(currentRoomId);
             if (!room) {
                 continue;
@@ -4798,7 +4798,7 @@ void T2DMap::slot_setCustomLine()
     QMapIterator<QString, int> it(room->getSpecialExits());
     while (it.hasNext()) {
         it.next();
-        int const id_to = it.value();
+        const int id_to = it.value();
         const QString dir = it.key();
         auto pI = new QTreeWidgetItem(specialExits);
         if (room->customLines.contains(dir)) {
@@ -5023,7 +5023,7 @@ void T2DMap::slot_roomSelectionChanged()
     QList<QTreeWidgetItem*> const selection = mMultiSelectionListWidget.selectedItems();
     mMultiSelectionSet.clear();
     for (auto treeWidgetItem : selection) {
-        int const currentRoomId = treeWidgetItem->text(0).toInt();
+        const int currentRoomId = treeWidgetItem->text(0).toInt();
         mMultiSelectionSet.insert(currentRoomId);
     }
     switch (mMultiSelectionSet.size()) {

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3117,7 +3117,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                     labelPosition.setY(labelY);
                     const int mx = event->pos().x();
                     const int my = event->pos().y();
-                    QPoint const click = QPoint(mx, my);
+                    const QPoint click = QPoint(mx, my);
                     QRectF const br = QRect(labelX, labelY, mapLabel.clickSize.width(), mapLabel.clickSize.height());
                     if (br.contains(click)) {
                         mapLabel.highlight = !mapLabel.highlight;
@@ -3200,7 +3200,7 @@ void T2DMap::updateSelectionWidget()
 // returns the current mouse position as X, Y coordinates on the map
 std::pair<int, int> T2DMap::getMousePosition()
 {
-    QPoint const mousePosition = this->mapFromGlobal(QCursor::pos());
+    const QPoint mousePosition = this->mapFromGlobal(QCursor::pos());
 
     float const mx = (mousePosition.x() / mRoomWidth) + mOx - (xspan / 2.0);
     float const my = (yspan / 2.0) - (mousePosition.y() / mRoomHeight) - mOy;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1329,7 +1329,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
 
         mapNameFont.setStyleStrategy(QFont::StyleStrategy(QFont::PreferNoShaping|QFont::PreferAntialias|QFont::PreferOutline));
 
-        double const sizeAdjust = 0; // TODO: add userdata setting to adjust this
+        double const sizeAdjust = 0;
         mapNameFont.setPointSizeF(static_cast<qreal>(mRoomWidth) * rSize * pow(1.1, sizeAdjust) / 2.0);
         showRoomNames = (mapNameFont.pointSizeF() > 3.0);
     }

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -459,7 +459,7 @@ void T2DMap::addSymbolToPixmapCache(const QString key, const QString text, const
     }
 
     QFont fontForThisSymbol = mpMap->mMapSymbolFont;
-    bool const needToFallback = isUsable.contains(false);
+    const bool needToFallback = isUsable.contains(false);
     // Oh dear at least one grapheme is not represented in either the selected
     // or any font as set elsewhere
     if (needToFallback) {
@@ -604,7 +604,7 @@ inline void T2DMap::drawRoom(QPainter& painter,
     QRectF roomNameRectangle;
     double realHeight;
     const int borderWidth = 1 / eSize * mRoomWidth * rSize;
-    bool const shouldDrawBorder = mpHost->mMapperShowRoomBorders && !isGridMode;
+    const bool shouldDrawBorder = mpHost->mMapperShowRoomBorders && !isGridMode;
     bool showThisRoomName = showRoomName;
     if (isGridMode) {
         realHeight = mRoomHeight;
@@ -683,7 +683,7 @@ inline void T2DMap::drawRoom(QPainter& painter,
         }
     }
 
-    bool const isRoomSelected = (mPick && roomClickTestRectangle.contains(mPHighlight)) || mMultiSelectionSet.contains(currentRoomId);
+    const bool isRoomSelected = (mPick && roomClickTestRectangle.contains(mPHighlight)) || mMultiSelectionSet.contains(currentRoomId);
     QLinearGradient selectionBg(roomRectangle.topLeft(), roomRectangle.bottomRight());
     selectionBg.setColorAt(0.25, roomColor);
     selectionBg.setColorAt(1, Qt::blue);
@@ -1619,8 +1619,8 @@ void T2DMap::drawDoor(QPainter& painter, const TRoom& room, const QString& dirKe
     const double endAngleFactor = 150.0;
     const double endFiddleFactor = 0.50;
     const float doorWidthFactor = 1.5;
-    bool const isShortLine = ((exitLine.length() / (mRoomWidth + mRoomHeight)) < innerThresholdFactor);
-    bool const isLongLine = ((exitLine.length() / (mRoomWidth + mRoomHeight)) > outerThresholdFactor);
+    const bool isShortLine = ((exitLine.length() / (mRoomWidth + mRoomHeight)) < innerThresholdFactor);
+    const bool isLongLine = ((exitLine.length() / (mRoomWidth + mRoomHeight)) > outerThresholdFactor);
     QLineF line{exitLine};
     if (isShortLine) {
         line.setLength(shortPositionFactor * (mRoomWidth + mRoomHeight));
@@ -3756,7 +3756,7 @@ void T2DMap::slot_showPropertiesDialog()
         }
 
         // Scan and count all the different lock status used
-        bool const thisLockStatus = room->isLocked;
+        const bool thisLockStatus = room->isLocked;
         if (usedLockStatus.contains(thisLockStatus)) {
             (usedLockStatus[thisLockStatus])++;
         } else {
@@ -5089,7 +5089,7 @@ void T2DMap::setPlayerRoomStyle(const int type)
     mPlayerRoomColorGradentStops.reserve(5);
 
     double const factor = mpMap->mPlayerRoomInnerDiameterPercentage / 100.0;
-    bool const solid = (mpMap->mPlayerRoomInnerDiameterPercentage == 0);
+    const bool solid = (mpMap->mPlayerRoomInnerDiameterPercentage == 0);
     switch (type) {
     case 1: // Simple(?) shaded red ring:
         if (solid) {

--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -121,7 +121,7 @@ bool TAction::setScript(const QString& script)
 bool TAction::compileScript()
 {
     mFuncName = QString("Action") + QString::number(mID);
-    QString const code = QString("function ") + mFuncName + QString("()\n") + mScript + QString("\nend\n");
+    const QString code = QString("function ") + mFuncName + QString("()\n") + mScript + QString("\nend\n");
     QString error;
     if (mpHost->mLuaInterpreter.compile(code, error, QString("Button: ") + getName())) {
         mNeedsToBeCompiled = false;
@@ -179,7 +179,7 @@ void TAction::expandToolbar(TToolBar* pT)
             continue;
         }
         QIcon const icon(action->mIcon);
-        QString const name = action->getName();
+        const QString name = action->getName();
         auto button = new TFlipButton(action, mpHost);
         button->setIcon(icon);
         button->setText(name);
@@ -271,7 +271,7 @@ void TAction::expandToolbar(TEasyButtonBar* pT)
             continue;
         }
         QIcon const icon(action->mIcon);
-        QString const name = action->getName();
+        const QString name = action->getName();
         auto button = new TFlipButton(action, mpHost);
         button->setIcon(icon);
         button->setText(name);

--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -121,7 +121,7 @@ bool TAction::setScript(const QString& script)
 bool TAction::compileScript()
 {
     mFuncName = QString("Action") + QString::number(mID);
-    QString code = QString("function ") + mFuncName + QString("()\n") + mScript + QString("\nend\n");
+    QString const code = QString("function ") + mFuncName + QString("()\n") + mScript + QString("\nend\n");
     QString error;
     if (mpHost->mLuaInterpreter.compile(code, error, QString("Button: ") + getName())) {
         mNeedsToBeCompiled = false;
@@ -178,8 +178,8 @@ void TAction::expandToolbar(TToolBar* pT)
             // buttons show in a "greyed-out" state... - Slysven
             continue;
         }
-        QIcon icon(action->mIcon);
-        QString name = action->getName();
+        QIcon const icon(action->mIcon);
+        QString const name = action->getName();
         auto button = new TFlipButton(action, mpHost);
         button->setIcon(icon);
         button->setText(name);
@@ -270,8 +270,8 @@ void TAction::expandToolbar(TEasyButtonBar* pT)
         if (!action->isActive()) {
             continue;
         }
-        QIcon icon(action->mIcon);
-        QString name = action->getName();
+        QIcon const icon(action->mIcon);
+        QString const name = action->getName();
         auto button = new TFlipButton(action, mpHost);
         button->setIcon(icon);
         button->setText(name);

--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -178,7 +178,7 @@ void TAction::expandToolbar(TToolBar* pT)
             // buttons show in a "greyed-out" state... - Slysven
             continue;
         }
-        QIcon const icon(action->mIcon);
+        const QIcon icon(action->mIcon);
         const QString name = action->getName();
         auto button = new TFlipButton(action, mpHost);
         button->setIcon(icon);
@@ -270,7 +270,7 @@ void TAction::expandToolbar(TEasyButtonBar* pT)
         if (!action->isActive()) {
             continue;
         }
-        QIcon const icon(action->mIcon);
+        const QIcon icon(action->mIcon);
         const QString name = action->getName();
         auto button = new TFlipButton(action, mpHost);
         button->setIcon(icon);

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -77,14 +77,14 @@ int TArea::getAreaID()
 QMap<int, QMap<int, QMultiMap<int, int>>> TArea::koordinatenSystem()
 {
     QMap<int, QMap<int, QMultiMap<int, int>>> kS;
-    QList<TRoom*> roomList = mpRoomDB->getRoomPtrList();
+    QList<TRoom*> const roomList = mpRoomDB->getRoomPtrList();
     for (auto room : roomList) {
-        int id = room->getId();
-        int x = room->x;
-        int y = room->y;
-        int z = room->z;
-        QMap<int, QMultiMap<int, int>> _y;
-        QMultiMap<int, int> _z;
+        int const id = room->getId();
+        int const x = room->x;
+        int const y = room->y;
+        int const z = room->z;
+        QMap<int, QMultiMap<int, int>> const _y;
+        QMultiMap<int, int> const _z;
         if (!kS.contains(x)) {
             kS[x] = _y;
         }
@@ -101,7 +101,7 @@ QList<int> TArea::getRoomsByPosition(int x, int y, int z)
     QList<int> dL;
     QSetIterator<int> itAreaRoom(rooms);
     while (itAreaRoom.hasNext()) {
-        int roomId = itAreaRoom.next();
+        int const roomId = itAreaRoom.next();
         TRoom* pR = mpRoomDB->getRoom(roomId);
         if (pR) {
             if (pR->x == x && pR->y == y && pR->z == z) {
@@ -120,11 +120,11 @@ QList<int> TArea::getRoomsByPosition(int x, int y, int z)
 QList<int> TArea::getCollisionNodes()
 {
     QList<int> problems;
-    QMap<int, QMap<int, QMultiMap<int, int>>> kS = koordinatenSystem();
+    QMap<int, QMap<int, QMultiMap<int, int>>> const kS = koordinatenSystem();
     QMapIterator<int, QMap<int, QMultiMap<int, int>>> it(kS);
     while (it.hasNext()) {
         it.next();
-        QMap<int, QMultiMap<int, int>> x_val = it.value();
+        QMap<int, QMultiMap<int, int>> const x_val = it.value();
         QMapIterator<int, QMultiMap<int, int>> it2(x_val);
         while (it2.hasNext()) {
             it2.next();
@@ -133,8 +133,8 @@ QList<int> TArea::getCollisionNodes()
             QList<int> z_coordinates;
             while (it3.hasNext()) {
                 it3.next();
-                int z = it3.key();
-                int node = it3.value();
+                int const z = it3.key();
+                int const node = it3.value();
 
                 if (!z_coordinates.contains(node)) {
                     z_coordinates.append(node);
@@ -168,62 +168,62 @@ void TArea::determineAreaExitsOfRoom(int id)
     // instance's own list of rooms which will fail (with a -1 if it is NOT in
     // the list and hence the area.
     if (exitId > 0 && !rooms.contains(exitId)) {
-        QPair<int, int> p = QPair<int, int>(exitId, DIR_NORTH);
+        QPair<int, int> const p = QPair<int, int>(exitId, DIR_NORTH);
         mAreaExits.insert(id, p);
     }
     exitId = pR->getNortheast();
     if (exitId > 0 && !rooms.contains(exitId)) {
-        QPair<int, int> p = QPair<int, int>(exitId, DIR_NORTHEAST);
+        QPair<int, int> const p = QPair<int, int>(exitId, DIR_NORTHEAST);
         mAreaExits.insert(id, p);
     }
     exitId = pR->getEast();
     if (exitId > 0 && !rooms.contains(exitId)) {
-        QPair<int, int> p = QPair<int, int>(exitId, DIR_EAST);
+        QPair<int, int> const p = QPair<int, int>(exitId, DIR_EAST);
         mAreaExits.insert(id, p);
     }
     exitId = pR->getSoutheast();
     if (exitId > 0 && !rooms.contains(exitId)) {
-        QPair<int, int> p = QPair<int, int>(exitId, DIR_SOUTHEAST);
+        QPair<int, int> const p = QPair<int, int>(exitId, DIR_SOUTHEAST);
         mAreaExits.insert(id, p);
     }
     exitId = pR->getSouth();
     if (exitId > 0 && !rooms.contains(exitId)) {
-        QPair<int, int> p = QPair<int, int>(exitId, DIR_SOUTH);
+        QPair<int, int> const p = QPair<int, int>(exitId, DIR_SOUTH);
         mAreaExits.insert(id, p);
     }
     exitId = pR->getSouthwest();
     if (exitId > 0 && !rooms.contains(exitId)) {
-        QPair<int, int> p = QPair<int, int>(exitId, DIR_SOUTHWEST);
+        QPair<int, int> const p = QPair<int, int>(exitId, DIR_SOUTHWEST);
         mAreaExits.insert(id, p);
     }
     exitId = pR->getWest();
     if (exitId > 0 && !rooms.contains(exitId)) {
-        QPair<int, int> p = QPair<int, int>(exitId, DIR_WEST);
+        QPair<int, int> const p = QPair<int, int>(exitId, DIR_WEST);
         mAreaExits.insert(id, p);
     }
     exitId = pR->getNorthwest();
     if (exitId > 0 && !rooms.contains(exitId)) {
-        QPair<int, int> p = QPair<int, int>(exitId, DIR_NORTHWEST);
+        QPair<int, int> const p = QPair<int, int>(exitId, DIR_NORTHWEST);
         mAreaExits.insert(id, p);
     }
     exitId = pR->getUp();
     if (exitId > 0 && !rooms.contains(exitId)) {
-        QPair<int, int> p = QPair<int, int>(exitId, DIR_UP);
+        QPair<int, int> const p = QPair<int, int>(exitId, DIR_UP);
         mAreaExits.insert(id, p);
     }
     exitId = pR->getDown();
     if (exitId > 0 && !rooms.contains(exitId)) {
-        QPair<int, int> p = QPair<int, int>(exitId, DIR_DOWN);
+        QPair<int, int> const p = QPair<int, int>(exitId, DIR_DOWN);
         mAreaExits.insert(id, p);
     }
     exitId = pR->getIn();
     if (exitId > 0 && !rooms.contains(exitId)) {
-        QPair<int, int> p = QPair<int, int>(exitId, DIR_IN);
+        QPair<int, int> const p = QPair<int, int>(exitId, DIR_IN);
         mAreaExits.insert(id, p);
     }
     exitId = pR->getOut();
     if (exitId > 0 && !rooms.contains(exitId)) {
-        QPair<int, int> p = QPair<int, int>(exitId, DIR_OUT);
+        QPair<int, int> const p = QPair<int, int>(exitId, DIR_OUT);
         mAreaExits.insert(id, p);
     }
     QMapIterator<QString, int> it(pR->getSpecialExits());
@@ -232,7 +232,7 @@ void TArea::determineAreaExitsOfRoom(int id)
         TRoom* pO = mpRoomDB->getRoom(it.value());
         if (pO) {
             if (pO->getArea() != getAreaID()) {
-                QPair<int, int> p = QPair<int, int>(pO->getId(), DIR_OTHER);
+                QPair<int, int> const p = QPair<int, int>(pO->getId(), DIR_OTHER);
                 mAreaExits.insert(id, p);
             }
         }
@@ -244,7 +244,7 @@ void TArea::determineAreaExits()
     mAreaExits.clear();
     QSetIterator<int> itRoom(rooms);
     while (itRoom.hasNext()) {
-        int id = itRoom.next();
+        int const id = itRoom.next();
         TRoom* pR = mpRoomDB->getRoom(id);
         if (!pR) {
             continue;
@@ -252,62 +252,62 @@ void TArea::determineAreaExits()
 
         int exitId = pR->getNorth();
         if (exitId > 0 && !rooms.contains(exitId)) {
-            QPair<int, int> p = QPair<int, int>(exitId, DIR_NORTH);
+            QPair<int, int> const p = QPair<int, int>(exitId, DIR_NORTH);
             mAreaExits.insert(id, p);
         }
         exitId = pR->getNortheast();
         if (exitId > 0 && !rooms.contains(exitId)) {
-            QPair<int, int> p = QPair<int, int>(exitId, DIR_NORTHEAST);
+            QPair<int, int> const p = QPair<int, int>(exitId, DIR_NORTHEAST);
             mAreaExits.insert(id, p);
         }
         exitId = pR->getEast();
         if (exitId > 0 && !rooms.contains(exitId)) {
-            QPair<int, int> p = QPair<int, int>(exitId, DIR_EAST);
+            QPair<int, int> const p = QPair<int, int>(exitId, DIR_EAST);
             mAreaExits.insert(id, p);
         }
         exitId = pR->getSoutheast();
         if (exitId > 0 && !rooms.contains(exitId)) {
-            QPair<int, int> p = QPair<int, int>(exitId, DIR_SOUTHEAST);
+            QPair<int, int> const p = QPair<int, int>(exitId, DIR_SOUTHEAST);
             mAreaExits.insert(id, p);
         }
         exitId = pR->getSouth();
         if (exitId > 0 && !rooms.contains(exitId)) {
-            QPair<int, int> p = QPair<int, int>(exitId, DIR_SOUTH);
+            QPair<int, int> const p = QPair<int, int>(exitId, DIR_SOUTH);
             mAreaExits.insert(id, p);
         }
         exitId = pR->getSouthwest();
         if (exitId > 0 && !rooms.contains(exitId)) {
-            QPair<int, int> p = QPair<int, int>(exitId, DIR_SOUTHWEST);
+            QPair<int, int> const p = QPair<int, int>(exitId, DIR_SOUTHWEST);
             mAreaExits.insert(id, p);
         }
         exitId = pR->getWest();
         if (exitId > 0 && !rooms.contains(exitId)) {
-            QPair<int, int> p = QPair<int, int>(exitId, DIR_WEST);
+            QPair<int, int> const p = QPair<int, int>(exitId, DIR_WEST);
             mAreaExits.insert(id, p);
         }
         exitId = pR->getNorthwest();
         if (exitId > 0 && !rooms.contains(exitId)) {
-            QPair<int, int> p = QPair<int, int>(exitId, DIR_NORTHWEST);
+            QPair<int, int> const p = QPair<int, int>(exitId, DIR_NORTHWEST);
             mAreaExits.insert(id, p);
         }
         exitId = pR->getUp();
         if (exitId > 0 && !rooms.contains(exitId)) {
-            QPair<int, int> p = QPair<int, int>(exitId, DIR_UP);
+            QPair<int, int> const p = QPair<int, int>(exitId, DIR_UP);
             mAreaExits.insert(id, p);
         }
         exitId = pR->getDown();
         if (exitId > 0 && !rooms.contains(exitId)) {
-            QPair<int, int> p = QPair<int, int>(exitId, DIR_DOWN);
+            QPair<int, int> const p = QPair<int, int>(exitId, DIR_DOWN);
             mAreaExits.insert(id, p);
         }
         exitId = pR->getIn();
         if (exitId > 0 && !rooms.contains(exitId)) {
-            QPair<int, int> p = QPair<int, int>(exitId, DIR_IN);
+            QPair<int, int> const p = QPair<int, int>(exitId, DIR_IN);
             mAreaExits.insert(id, p);
         }
         exitId = pR->getOut();
         if (exitId > 0 && !rooms.contains(exitId)) {
-            QPair<int, int> p = QPair<int, int>(exitId, DIR_OUT);
+            QPair<int, int> const p = QPair<int, int>(exitId, DIR_OUT);
             mAreaExits.insert(id, p);
         }
         QMapIterator<QString, int> itSpecialExit(pR->getSpecialExits());
@@ -317,7 +317,7 @@ void TArea::determineAreaExits()
 
             if (pO) {
                 if (pO->getArea() != getAreaID()) {
-                    QPair<int, int> p = QPair<int, int>(pO->getId(), DIR_OTHER);
+                    QPair<int, int> const p = QPair<int, int>(pO->getId(), DIR_OTHER);
                     mAreaExits.insert(id, p);
                 }
             }
@@ -332,9 +332,9 @@ void TArea::fast_calcSpan(int id)
         return;
     }
 
-    int x = pR->x;
-    int y = pR->y;
-    int z = pR->z;
+    int const x = pR->x;
+    int const y = pR->y;
+    int const z = pR->z;
     if (x > max_x) {
         max_x = x;
     }
@@ -365,7 +365,7 @@ void TArea::addRoom(int id)
             qDebug() << "TArea::addRoom(" << id << ") No creation! room already exists";
         }
     } else {
-        QString error = tr("roomID=%1 does not exist, can not set properties of a non-existent room!").arg(id);
+        QString const error = tr("roomID=%1 does not exist, can not set properties of a non-existent room!").arg(id);
         mpMap->mpHost->mpConsole->printSystemMessage(error);
     }
 }
@@ -381,7 +381,7 @@ void TArea::calcSpan()
     bool isFirstDone = false;
     QSetIterator<int> itRoom(rooms);
     while (itRoom.hasNext()) {
-        int id = itRoom.next();
+        int const id = itRoom.next();
         TRoom* pR = mpRoomDB->getRoom(id);
         if (!pR) {
             continue;
@@ -505,7 +505,7 @@ void TArea::removeRoom(int room, bool isToDeferAreaRelatedRecalculations)
     if (isOnExtreme) {
         calcSpan();
     }
-    quint64 thisTime = timer.nsecsElapsed();
+    quint64 const thisTime = timer.nsecsElapsed();
     cumulativeMean += (((thisTime * 1.0e-9) - cumulativeMean) / ++runCount);
     if (runCount % 1000 == 0) {
         qDebug() << "TArea::removeRoom(" << room << ") from Area took" << thisTime * 1.0e-9 << "sec. this time and after" << runCount << "times the average is" << cumulativeMean << "sec.";
@@ -552,7 +552,7 @@ const QMultiMap<int, QPair<QString, int>> TArea::getAreaExitRoomData() const
     // IS one
     QSetIterator<int> itRoomWithOtherAreaSpecialExit = roomsWithOtherAreaSpecialExits;
     while (itRoomWithOtherAreaSpecialExit.hasNext()) {
-        int fromRoomId = itRoomWithOtherAreaSpecialExit.next();
+        int const fromRoomId = itRoomWithOtherAreaSpecialExit.next();
         TRoom* pFromRoom = mpRoomDB->getRoom(fromRoomId);
         if (pFromRoom) {
             QMapIterator<QString, int> itSpecialExit(pFromRoom->getSpecialExits());
@@ -600,7 +600,7 @@ void TArea::writeJsonArea(QJsonArray& array) const
     writeJsonUserData(areaObj);
 
     QList<int> roomList{rooms.begin(), rooms.end()};
-    int roomCount = roomList.count();
+    int const roomCount = roomList.count();
     if (roomCount > 1) {
         std::sort(roomList.begin(), roomList.end());
     }
@@ -625,14 +625,14 @@ void TArea::writeJsonArea(QJsonArray& array) const
         // Must add on any remainder otherwise the total will be wrong:
         mpMap->incrementJsonProgressDialog(true, true, currentRoomCount % 10);
     }
-    QJsonValue roomsValue{roomsArray};
+    QJsonValue const roomsValue{roomsArray};
     areaObj.insert(QLatin1String("rooms"), roomsValue);
 
     // Process the labels after the rooms so that the first area shows something
     // quickly (from the rooms) even if it has a number of labels to do.
 
     writeJsonLabels(areaObj);
-    QJsonValue areaValue{areaObj};
+    QJsonValue const areaValue{areaObj};
     array.append(areaValue);
 }
 
@@ -646,7 +646,7 @@ std::pair<int, QString> TArea::readJsonArea(const QJsonArray& array, const int a
     int roomCount = 0;
     for (int roomIndex = 0, total = areaObj.value(QLatin1String("rooms")).toArray().count(); roomIndex < total; ++roomIndex) {
         TRoom* pR = new TRoom(mpRoomDB);
-        int roomId = pR->readJsonRoom(areaObj.value(QLatin1String("rooms")).toArray(), roomIndex, id);
+        int const roomId = pR->readJsonRoom(areaObj.value(QLatin1String("rooms")).toArray(), roomIndex, id);
         rooms.insert(roomId);
         // This also sets the room id for the TRoom:
         mpRoomDB->addRoom(roomId, pR, true);
@@ -678,7 +678,7 @@ void TArea::writeJsonUserData(QJsonObject& obj) const
     QMapIterator<QString, QString> itDataItem(mUserData);
     while (itDataItem.hasNext()) {
         itDataItem.next();
-        QJsonValue userDataValue{itDataItem.value()};
+        QJsonValue const userDataValue{itDataItem.value()};
         userDataObj.insert(itDataItem.key(), userDataValue);
     }
     const QJsonValue userDatasValue{userDataObj};
@@ -719,7 +719,7 @@ void TArea::writeJsonLabels(QJsonObject& obj) const
             }
         }
     }
-    QJsonValue labelsValue{labelArray};
+    QJsonValue const labelsValue{labelArray};
     obj.insert(QLatin1String("labels"), labelsValue);
 }
 
@@ -754,7 +754,7 @@ void TArea::writeJsonLabel(QJsonArray& array, const int id, const TMapLabel* pLa
 
     if (!(pLabel->text.isEmpty() || !pLabel->text.compare(tr("no text", "Default text if a label is created in mapper with no text")))) {
         // Don't include the text if it is am image:
-        QJsonValue textValue{pLabel->text};
+        QJsonValue const textValue{pLabel->text};
         labelObj.insert(QLatin1String("text"), textValue);
     }
 
@@ -777,15 +777,15 @@ void TArea::writeJsonLabel(QJsonArray& array, const int id, const TMapLabel* pLa
         QJsonObject backgroundColorObj;
         TMap::writeJsonColor(foregroundColorObj, pLabel->fgColor);
         TMap::writeJsonColor(backgroundColorObj, pLabel->bgColor);
-        QJsonValue foregroundColorValue{foregroundColorObj};
-        QJsonValue backgroundColorValue{backgroundColorObj};
+        QJsonValue const foregroundColorValue{foregroundColorObj};
+        QJsonValue const backgroundColorValue{backgroundColorObj};
         colorsArray.append(foregroundColorValue);
         colorsArray.append(backgroundColorValue);
-        QJsonValue colorsValue{colorsArray};
+        QJsonValue const colorsValue{colorsArray};
         labelObj.insert(QLatin1String("colors"), colorsValue);
     }
 
-    QList<QByteArray> pixmapData = convertImageToBase64Data(pLabel->pix);
+    QList<QByteArray> const pixmapData = convertImageToBase64Data(pLabel->pix);
     QJsonArray imageArray;
     for (auto imageLine : pixmapData) {
         const QJsonValue imageLineValue{imageLine.data()};
@@ -807,7 +807,7 @@ void TArea::readJsonLabel(const QJsonObject& labelObj)
 {
     TMapLabel label;
 
-    int labelId = labelObj.value(QLatin1String("id")).toInt();
+    int const labelId = labelObj.value(QLatin1String("id")).toInt();
 
     label.pos = readJson3DCoordinates(labelObj, QLatin1String("coordinates"));
 
@@ -823,7 +823,7 @@ void TArea::readJsonLabel(const QJsonObject& labelObj)
         // assembled the operator== is too picky for our purposes as even the
         // way the colour was put together (color spec type) can make them NOT
         // seem to be the same when we'd think they were...
-        QJsonArray colorsArray = labelObj.value(QLatin1String("colors")).toArray();
+        QJsonArray const colorsArray = labelObj.value(QLatin1String("colors")).toArray();
         label.fgColor = TMap::readJsonColor(colorsArray.at(0).toObject());
         label.bgColor = TMap::readJsonColor(colorsArray.at(1).toObject());
     } else {
@@ -831,7 +831,7 @@ void TArea::readJsonLabel(const QJsonObject& labelObj)
         label.bgColor = defaultLabelBackground;
     }
 
-    QJsonArray imageArray = labelObj.value(QLatin1String("image")).toArray();
+    QJsonArray const imageArray = labelObj.value(QLatin1String("image")).toArray();
     QList<QByteArray> pixmapData;
     for (int i = 0, total = imageArray.size(); i < total; ++i) {
         pixmapData.append(imageArray.at(i).toString().toLatin1());
@@ -870,7 +870,7 @@ QSizeF TArea::readJsonSize(const QJsonObject& obj, const QString& title) const
         return size;
     }
 
-    QJsonArray valueArray = obj.value(title).toArray();
+    QJsonArray const valueArray = obj.value(title).toArray();
     if (valueArray.at(0).isDouble()) {
         size.setWidth(valueArray.at(0).toDouble());
     }
@@ -897,7 +897,7 @@ QVector3D TArea::readJson3DCoordinates(const QJsonObject& obj, const QString& ti
         return position;
     }
 
-    QJsonArray valueArray = obj.value(title).toArray();
+    QJsonArray const valueArray = obj.value(title).toArray();
     if (valueArray.at(0).isDouble()) {
         position.setX(valueArray.at(0).toDouble());
     }
@@ -942,7 +942,7 @@ QList<QByteArray> TArea::convertImageToBase64Data(const QPixmap& pixmap) const
 
 QPixmap TArea::convertBase64DataToImage(const QList<QByteArray>& pixmapArray) const
 {
-    QByteArray decodedImageArray = QByteArray::fromBase64(pixmapArray.join());
+    QByteArray const decodedImageArray = QByteArray::fromBase64(pixmapArray.join());
     QPixmap pixmap;
     pixmap.loadFromData(decodedImageArray);
 

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -365,7 +365,7 @@ void TArea::addRoom(int id)
             qDebug() << "TArea::addRoom(" << id << ") No creation! room already exists";
         }
     } else {
-        QString const error = tr("roomID=%1 does not exist, can not set properties of a non-existent room!").arg(id);
+        const QString error = tr("roomID=%1 does not exist, can not set properties of a non-existent room!").arg(id);
         mpMap->mpHost->mpConsole->printSystemMessage(error);
     }
 }

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -79,10 +79,10 @@ QMap<int, QMap<int, QMultiMap<int, int>>> TArea::koordinatenSystem()
     QMap<int, QMap<int, QMultiMap<int, int>>> kS;
     QList<TRoom*> const roomList = mpRoomDB->getRoomPtrList();
     for (auto room : roomList) {
-        int const id = room->getId();
-        int const x = room->x;
-        int const y = room->y;
-        int const z = room->z;
+        const int id = room->getId();
+        const int x = room->x;
+        const int y = room->y;
+        const int z = room->z;
         QMap<int, QMultiMap<int, int>> const _y;
         QMultiMap<int, int> const _z;
         if (!kS.contains(x)) {
@@ -101,7 +101,7 @@ QList<int> TArea::getRoomsByPosition(int x, int y, int z)
     QList<int> dL;
     QSetIterator<int> itAreaRoom(rooms);
     while (itAreaRoom.hasNext()) {
-        int const roomId = itAreaRoom.next();
+        const int roomId = itAreaRoom.next();
         TRoom* pR = mpRoomDB->getRoom(roomId);
         if (pR) {
             if (pR->x == x && pR->y == y && pR->z == z) {
@@ -133,8 +133,8 @@ QList<int> TArea::getCollisionNodes()
             QList<int> z_coordinates;
             while (it3.hasNext()) {
                 it3.next();
-                int const z = it3.key();
-                int const node = it3.value();
+                const int z = it3.key();
+                const int node = it3.value();
 
                 if (!z_coordinates.contains(node)) {
                     z_coordinates.append(node);
@@ -244,7 +244,7 @@ void TArea::determineAreaExits()
     mAreaExits.clear();
     QSetIterator<int> itRoom(rooms);
     while (itRoom.hasNext()) {
-        int const id = itRoom.next();
+        const int id = itRoom.next();
         TRoom* pR = mpRoomDB->getRoom(id);
         if (!pR) {
             continue;
@@ -332,9 +332,9 @@ void TArea::fast_calcSpan(int id)
         return;
     }
 
-    int const x = pR->x;
-    int const y = pR->y;
-    int const z = pR->z;
+    const int x = pR->x;
+    const int y = pR->y;
+    const int z = pR->z;
     if (x > max_x) {
         max_x = x;
     }
@@ -381,7 +381,7 @@ void TArea::calcSpan()
     bool isFirstDone = false;
     QSetIterator<int> itRoom(rooms);
     while (itRoom.hasNext()) {
-        int const id = itRoom.next();
+        const int id = itRoom.next();
         TRoom* pR = mpRoomDB->getRoom(id);
         if (!pR) {
             continue;
@@ -552,7 +552,7 @@ const QMultiMap<int, QPair<QString, int>> TArea::getAreaExitRoomData() const
     // IS one
     QSetIterator<int> itRoomWithOtherAreaSpecialExit = roomsWithOtherAreaSpecialExits;
     while (itRoomWithOtherAreaSpecialExit.hasNext()) {
-        int const fromRoomId = itRoomWithOtherAreaSpecialExit.next();
+        const int fromRoomId = itRoomWithOtherAreaSpecialExit.next();
         TRoom* pFromRoom = mpRoomDB->getRoom(fromRoomId);
         if (pFromRoom) {
             QMapIterator<QString, int> itSpecialExit(pFromRoom->getSpecialExits());
@@ -600,7 +600,7 @@ void TArea::writeJsonArea(QJsonArray& array) const
     writeJsonUserData(areaObj);
 
     QList<int> roomList{rooms.begin(), rooms.end()};
-    int const roomCount = roomList.count();
+    const int roomCount = roomList.count();
     if (roomCount > 1) {
         std::sort(roomList.begin(), roomList.end());
     }
@@ -646,7 +646,7 @@ std::pair<int, QString> TArea::readJsonArea(const QJsonArray& array, const int a
     int roomCount = 0;
     for (int roomIndex = 0, total = areaObj.value(QLatin1String("rooms")).toArray().count(); roomIndex < total; ++roomIndex) {
         TRoom* pR = new TRoom(mpRoomDB);
-        int const roomId = pR->readJsonRoom(areaObj.value(QLatin1String("rooms")).toArray(), roomIndex, id);
+        const int roomId = pR->readJsonRoom(areaObj.value(QLatin1String("rooms")).toArray(), roomIndex, id);
         rooms.insert(roomId);
         // This also sets the room id for the TRoom:
         mpRoomDB->addRoom(roomId, pR, true);
@@ -807,7 +807,7 @@ void TArea::readJsonLabel(const QJsonObject& labelObj)
 {
     TMapLabel label;
 
-    int const labelId = labelObj.value(QLatin1String("id")).toInt();
+    const int labelId = labelObj.value(QLatin1String("id")).toInt();
 
     label.pos = readJson3DCoordinates(labelObj, QLatin1String("coordinates"));
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -106,7 +106,7 @@ TChar::TChar(const TChar& copy)
 const QString timeStampFormat = qsl("hh:mm:ss.zzz ");
 const QString blankTimeStamp  = qsl("------------ ");
 
-// Store for text and attributes (such as character color) to be drawn on screen 
+// Store for text and attributes (such as character color) to be drawn on screen
 // Contents are rendered by a TTextEdit
 TBuffer::TBuffer(Host* pH, TConsole* pConsole)
 : mpConsole(pConsole)
@@ -524,7 +524,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                     if (!mpHost->mFORCE_MXP_NEGOTIATION_OFF && mpHost->mServerMXPenabled && isFromServer) {
                         mGotCSI = false;
 
-                        QString const code = QString(localBuffer.substr(localBufferPosition, spanEnd - spanStart).c_str());
+                        const QString code = QString(localBuffer.substr(localBufferPosition, spanEnd - spanStart).c_str());
                         mpHost->mMxpProcessor.setMode(code);
                     }
                     // end of if (!mpHost->mFORCE_MXP_NEGOTIATION_OFF)
@@ -1198,7 +1198,7 @@ void TBuffer::decodeSGR(const QString& sequence)
 
     QStringList const parameterStrings = sequence.split(QChar(';'));
     for (int paraIndex = 0, total = parameterStrings.count(); paraIndex < total; ++paraIndex) {
-        QString const allParameterElements = parameterStrings.at(paraIndex);
+        const QString allParameterElements = parameterStrings.at(paraIndex);
         if (allParameterElements.contains(QLatin1String(":"))) {
             /******************************************************************
              * Parameter string with colon separated Parameter (sub) elements *
@@ -2117,8 +2117,8 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
             for (int i = lineBuffer.back().size() - 1; i >= 0; --i) {
                 if (lineBreaks.indexOf(lineBuffer.back().at(i)) > -1) {
                     const int linebreakPos = (i != 0) ? i + 1 : lineBuffer.back().size();
-                    QString const tmp = lineBuffer.back().mid(0, linebreakPos);
-                    QString const lineRest = lineBuffer.back().mid(linebreakPos);
+                    const QString tmp = lineBuffer.back().mid(0, linebreakPos);
+                    const QString lineRest = lineBuffer.back().mid(linebreakPos);
                     lineBuffer.back() = tmp;
                     std::deque<TChar> newLine;
 
@@ -2210,8 +2210,8 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
                 // insert linebreak either at linebreaking character location or at last character of line
                 if (lineBreaks.indexOf(lineBuffer.back().at(i)) > -1 || i == 0) {
                     const int linebreakPos = (i != 0) ? i + 1 : lineBuffer.back().size();
-                    QString const tmp = lineBuffer.back().mid(0, linebreakPos);
-                    QString const lineRest = lineBuffer.back().mid(linebreakPos);
+                    const QString tmp = lineBuffer.back().mid(0, linebreakPos);
+                    const QString lineRest = lineBuffer.back().mid(linebreakPos);
                     lineBuffer.back() = tmp;
                     std::deque<TChar> newLine;
 
@@ -2352,7 +2352,7 @@ TBuffer TBuffer::copy(QPoint& P1, QPoint& P2)
             id = 0;
         }
         // This is rather inefficient as s is only ever one QChar long
-        QString const s(lineBuffer.at(y).at(x));
+        const QString s(lineBuffer.at(y).at(x));
         slice.append(s, 0, 1, buffer.at(y).at(x).mFgColor, buffer.at(y).at(x).mBgColor, buffer.at(y).at(x).mFlags, id);
     }
     return slice;
@@ -2394,11 +2394,11 @@ void TBuffer::paste(QPoint& P, const TBuffer& chunk)
         QPoint P_current(cx, y);
         if ((y < getLastLineNumber()) && (!needAppend)) {
             const TChar& format = chunk.buffer.at(0).at(cx);
-            QString const s = QString(chunk.lineBuffer.at(0).at(cx));
+            const QString s = QString(chunk.lineBuffer.at(0).at(cx));
             insertInLine(P_current, s, format);
         } else {
             hasAppended = true;
-            QString const s(chunk.lineBuffer.at(0).at(cx));
+            const QString s(chunk.lineBuffer.at(0).at(cx));
             append(s, 0, 1, chunk.buffer.at(0).at(cx).mFgColor, chunk.buffer.at(0).at(cx).mBgColor, chunk.buffer.at(0).at(cx).mFlags);
         }
     }
@@ -2425,7 +2425,7 @@ void TBuffer::appendBuffer(const TBuffer& chunk)
         if (!linkId) {
             id = 0;
         }
-        QString const s(chunk.lineBuffer.at(0).at(cx));
+        const QString s(chunk.lineBuffer.at(0).at(cx));
         append(s, 0, 1, chunk.buffer.at(0).at(cx).mFgColor, chunk.buffer.at(0).at(cx).mBgColor, chunk.buffer.at(0).at(cx).mFlags, id);
     }
 
@@ -2486,7 +2486,7 @@ inline int TBuffer::wrap(int startLine)
         bool const isPrompt = promptBuffer[i];
         std::deque<TChar> newLine;
         QString lineText = "";
-        QString const time = timeBuffer[i];
+        const QString time = timeBuffer[i];
         int indent = 0;
         if (static_cast<int>(buffer[i].size()) >= mWrapAt) {
             for (int i3 = 0; i3 < mWrapIndent; ++i3) {
@@ -2709,7 +2709,7 @@ int TBuffer::wrapLine(int startLine, int screenWidth, int indentSize, TChar& for
 
     buffer.erase(buffer.begin() + startLine);
     lineBuffer.removeAt(startLine);
-    QString const time = timeBuffer.at(startLine);
+    const QString time = timeBuffer.at(startLine);
     timeBuffer.removeAt(startLine);
     bool const isPrompt = promptBuffer.at(startLine);
     promptBuffer.removeAt(startLine);
@@ -3416,7 +3416,7 @@ bool TBuffer::processUtf8Sequence(const std::string& bufferData, const bool isFr
 
         // Will be one (BMP codepoint) or two (non-BMP codepoints) QChar(s)
         if (isValid) {
-            QString const codePoint = QString(bufferData.substr(pos, utf8SequenceLength).c_str());
+            const QString codePoint = QString(bufferData.substr(pos, utf8SequenceLength).c_str());
             switch (codePoint.size()) {
             default:
                 Q_UNREACHABLE(); // This can't happen, unless we got start or length wrong in std::string::substr()

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -240,7 +240,7 @@ int TBuffer::getLastLineNumber()
 
 void TBuffer::addLink(bool trigMode, const QString& text, QStringList& command, QStringList& hint, TChar format, QVector<int> luaReference)
 {
-    int const id = mLinkStore.addLinks(command, hint, mpHost, luaReference);
+    const int id = mLinkStore.addLinks(command, hint, mpHost, luaReference);
 
     if (!trigMode) {
         append(text, 0, text.length(), format.mFgColor, format.mBgColor, format.mFlags, id);
@@ -539,7 +539,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                     const int dataLength = spanEnd - spanStart;
                     QByteArray const temp = QByteArray::fromRawData(localBuffer.substr(localBufferPosition, dataLength).c_str(), dataLength);
                     bool isOk = false;
-                    int const spacesNeeded = temp.toInt(&isOk);
+                    const int spacesNeeded = temp.toInt(&isOk);
                     if (isOk && spacesNeeded > 0) {
                         const TChar::AttributeFlags attributeFlags =
                                 ((mIsDefaultColor ? mBold : false) ? TChar::Bold : TChar::None)
@@ -579,7 +579,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                     const int dataLength = spanEnd - spanStart;
                     QByteArray const temp = QByteArray::fromRawData(localBuffer.substr(localBufferPosition, dataLength).c_str(), dataLength);
                     bool isOk = false;
-                    int const argValue = temp.toInt(&isOk);
+                    const int argValue = temp.toInt(&isOk);
                     if (isOk) {
                         if (argValue >= 0 && argValue < 3) {
                             qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - ED (erase in display) sequence of form CSI" << temp << "J received,\nrejecting as incompatible with Mudlet.";
@@ -751,7 +751,7 @@ COMMIT_LINE:
 
             mMudLine.clear();
             mMudBuffer.clear();
-            int const line = lineBuffer.size() - 1;
+            const int line = lineBuffer.size() - 1;
             mpHost->mpConsole->runTriggers(line);
             // Only use of TBuffer::wrap(), breaks up new text
             // NOTE: it MAY have been clobbered by the trigger engine!
@@ -955,7 +955,7 @@ void TBuffer::decodeSGR38(const QStringList& parameters, bool isColonSeparated)
             mForeGroundColorLight = mForeGroundColor;
 
         } else {
-            int const value = (tag - 232) * 10 + 8;
+            const int value = (tag - 232) * 10 + 8;
             mForeGroundColor = QColor(value, value, value);
             mForeGroundColorLight = mForeGroundColor;
         }
@@ -1118,7 +1118,7 @@ void TBuffer::decodeSGR48(const QStringList& parameters, bool isColonSeparated)
                                       b == 0 ? 0 : (b - 1) * 40 + 95);
 
         } else {
-            int const value = (tag - 232) * 10 + 8;
+            const int value = (tag - 232) * 10 + 8;
             mBackGroundColor = QColor(value, value, value);
         }
 
@@ -1226,7 +1226,7 @@ void TBuffer::decodeSGR(const QString& sequence)
                     madeElements << parameterStrings.at(paraIndex); // "38"
                     madeElements << parameterStrings.at(paraIndex + 1); // "2" or "5" hopefully
                     bool isOk = false;
-                    int const sgr38_type = madeElements.at(1).toInt(&isOk);
+                    const int sgr38_type = madeElements.at(1).toInt(&isOk);
                     if (madeElements.at(1).isEmpty() || !isOk || sgr38_type == 0) {
                         // Oh dear that parameter is empty or equivalent to zero
                         // so we cannot do anything more
@@ -1323,7 +1323,7 @@ void TBuffer::decodeSGR(const QString& sequence)
                     madeElements << parameterStrings.at(paraIndex);
                     madeElements << parameterStrings.at(paraIndex + 1);
                     bool isOk = false;
-                    int const sgr48_type = madeElements.at(1).toInt(&isOk);
+                    const int sgr48_type = madeElements.at(1).toInt(&isOk);
                     if (madeElements.at(1).isEmpty() || !isOk || sgr48_type == 0) {
                         // Oh dear that parameter is empty or equivalent to zero
                         // so we cannot do anything more
@@ -1402,7 +1402,7 @@ void TBuffer::decodeSGR(const QString& sequence)
             } else if (parameterElements.at(0) == QLatin1String("4")) {
                 // New way of controlling underline
                 bool isOk = false;
-                int const value = parameterElements.at(1).toInt(&isOk);
+                const int value = parameterElements.at(1).toInt(&isOk);
                 if (!isOk) {
                     // missing value
                     qDebug().noquote().nospace() << "TBuffer::decodeSGR(\"" << sequence << "\") ERROR - failed to detect underline parameter element (the second part) in a SGR...;4:?;..m sequence assuming it is a zero!";
@@ -1428,7 +1428,7 @@ void TBuffer::decodeSGR(const QString& sequence)
             } else if (parameterElements.at(0) == QLatin1String("3")) {
                 // New way of controlling italics
                 bool isOk = false;
-                int const value = parameterElements.at(1).toInt(&isOk);
+                const int value = parameterElements.at(1).toInt(&isOk);
                 if (!isOk) {
                     // missing value
                     qDebug().noquote().nospace() << "TBuffer::decodeSGR(\"" << sequence << "\") ERROR - failed to detect italic parameter element (the second part) in a SGR...;3:?;../m sequence assuming it is a zero!";
@@ -1609,7 +1609,7 @@ void TBuffer::decodeSGR(const QString& sequence)
                     madeElements << parameterStrings.at(paraIndex);
                     madeElements << parameterStrings.at(paraIndex + 1);
                     bool isOk = false;
-                    int const sgr38_type = madeElements.at(1).toInt(&isOk);
+                    const int sgr38_type = madeElements.at(1).toInt(&isOk);
                     if (madeElements.at(1).isEmpty() || !isOk || sgr38_type == 0) {
                         // Oh dear that parameter is empty or equivalent to zero
                         // so we cannot do anything more
@@ -1728,7 +1728,7 @@ void TBuffer::decodeSGR(const QString& sequence)
                     madeElements << parameterStrings.at(paraIndex);
                     madeElements << parameterStrings.at(paraIndex + 1);
                     bool isOk = false;
-                    int const sgr48_type = madeElements.at(1).toInt(&isOk);
+                    const int sgr48_type = madeElements.at(1).toInt(&isOk);
                     if (madeElements.at(1).isEmpty() || !isOk || sgr48_type == 0) {
                         // Oh dear that parameter is empty or equivalent to zero
                         // so we cannot do anything more
@@ -2302,8 +2302,8 @@ bool TBuffer::insertInLine(QPoint& P, const QString& text, const TChar& format)
     if (text.isEmpty()) {
         return false;
     }
-    int const x = P.x();
-    int const y = P.y();
+    const int x = P.x();
+    const int y = P.y();
     if ((y >= 0) && (y < static_cast<int>(buffer.size()))) {
         if (x < 0) {
             return false;
@@ -2331,7 +2331,7 @@ TBuffer TBuffer::copy(QPoint& P1, QPoint& P2)
 {
     TBuffer slice(mpHost);
     slice.clear();
-    int const y = P1.y();
+    const int y = P1.y();
     int x = P1.x();
     if (y < 0 || y >= static_cast<int>(buffer.size())) {
         return slice;
@@ -2341,8 +2341,8 @@ TBuffer TBuffer::copy(QPoint& P1, QPoint& P2)
         x = 0;
     }
     int oldLinkId{}, id{};
-    for (int const total = P2.x(); x < total; ++x) {
-        int const linkId = buffer.at(y).at(x).linkIndex();
+    for (const int total = P2.x(); x < total; ++x) {
+        const int linkId = buffer.at(y).at(x).linkIndex();
         if (linkId && (linkId != oldLinkId)) {
             id = slice.mLinkStore.addLinks(mLinkStore.getLinksConst(linkId), mLinkStore.getHintsConst(linkId), mpHost);
             oldLinkId = linkId;
@@ -2373,7 +2373,7 @@ void TBuffer::paste(QPoint& P, const TBuffer& chunk)
     bool const needAppend = false;
     bool hasAppended = false;
     int y = P.y();
-    int const x = P.x();
+    const int x = P.x();
     if (chunk.buffer.empty()) {
         return;
     }
@@ -2417,7 +2417,7 @@ void TBuffer::appendBuffer(const TBuffer& chunk)
     }
     int oldLinkId{}, id{};
     for (int cx = 0, total = static_cast<int>(chunk.buffer.at(0).size()); cx < total; ++cx) {
-        int const linkId = chunk.buffer.at(0).at(cx).linkIndex();
+        const int linkId = chunk.buffer.at(0).at(cx).linkIndex();
         if (linkId && (oldLinkId != linkId)) {
             id = mLinkStore.addLinks(chunk.mLinkStore.getLinksConst(linkId), chunk.mLinkStore.getHintsConst(linkId), mpHost);
             oldLinkId = linkId;
@@ -2438,7 +2438,7 @@ int TBuffer::calculateWrapPosition(int lineNumber, int begin, int end)
     if (lineBuffer.size() < lineNumber) {
         return 0;
     }
-    int const lineSize = static_cast<int>(lineBuffer[lineNumber].size()) - 1;
+    const int lineSize = static_cast<int>(lineBuffer[lineNumber].size()) - 1;
     if (lineSize < end) {
         end = lineSize;
     }
@@ -2456,7 +2456,7 @@ inline int TBuffer::skipSpacesAtBeginOfLine(const int row, const int column)
 {
     int offset = 0;
     int position = column;
-    int const endOfLinePosition = lineBuffer.at(row).size();
+    const int endOfLinePosition = lineBuffer.at(row).size();
     while (position < endOfLinePosition) {
         if (buffer.at(row).at(position).mFlags & TChar::Echo) {
             break;
@@ -2497,7 +2497,7 @@ inline int TBuffer::wrap(int startLine)
         }
         int lastSpace = 0;
         int wrapPos = 0;
-        int const length = buffer[i].size();
+        const int length = buffer[i].size();
         if (length == 0) {
             tempList.append(QString());
             std::deque<TChar> const emptyLine;
@@ -2511,7 +2511,7 @@ inline int TBuffer::wrap(int startLine)
             } else {
                 lastSpace = 0;
             }
-            int const wrapPosition = (lastSpace) ? lastSpace : (mWrapAt - indent);
+            const int wrapPosition = (lastSpace) ? lastSpace : (mWrapAt - indent);
             for (int i3 = 0; i3 < wrapPosition; ++i3) {
                 if (lastSpace > 0) {
                     if (i2 > lastSpace) {
@@ -2555,7 +2555,7 @@ inline int TBuffer::wrap(int startLine)
         promptBuffer.pop_back();
     }
 
-    int const insertedLines = queue.size() - 1;
+    const int insertedLines = queue.size() - 1;
     while (!queue.empty()) {
         buffer.push_back(queue.front());
         queue.pop();
@@ -2714,7 +2714,7 @@ int TBuffer::wrapLine(int startLine, int screenWidth, int indentSize, TChar& for
     bool const isPrompt = promptBuffer.at(startLine);
     promptBuffer.removeAt(startLine);
 
-    int const insertedLines = queue.size() - 1;
+    const int insertedLines = queue.size() - 1;
     int i = 0;
     while (!queue.empty()) {
         buffer.insert(buffer.begin() + startLine + i, queue.front());
@@ -2733,8 +2733,8 @@ int TBuffer::wrapLine(int startLine, int screenWidth, int indentSize, TChar& for
 
 bool TBuffer::moveCursor(QPoint& where)
 {
-    int const x = where.x();
-    int const y = where.y();
+    const int x = where.x();
+    const int y = where.y();
     if (y < 0) {
         return false;
     }
@@ -2794,7 +2794,7 @@ QStringList TBuffer::split(int line, const QRegularExpression& splitter)
 
 void TBuffer::expandLine(int y, int count, TChar& pC)
 {
-    int const size = buffer[y].size() - 1;
+    const int size = buffer[y].size() - 1;
     for (int i = size, total = size + count; i < total; ++i) {
         buffer[y].push_back(pC);
         lineBuffer[y].append(QChar::Space);
@@ -2803,10 +2803,10 @@ void TBuffer::expandLine(int y, int count, TChar& pC)
 
 bool TBuffer::replaceInLine(QPoint& P_begin, QPoint& P_end, const QString& with, TChar& format)
 {
-    int const x1 = P_begin.x();
-    int const x2 = P_end.x();
-    int const y1 = P_begin.y();
-    int const y2 = P_end.y();
+    const int x1 = P_begin.x();
+    const int x2 = P_end.x();
+    const int y1 = P_begin.y();
+    const int y2 = P_end.y();
     if ((y1 >= static_cast<int>(buffer.size())) || (y2 >= static_cast<int>(buffer.size()))) {
         return false;
     }
@@ -2898,7 +2898,7 @@ void TBuffer::shrinkBuffer()
 bool TBuffer::deleteLines(int from, int to)
 {
     if ((from >= 0) && (from < static_cast<int>(buffer.size())) && (from <= to) && (to >= 0) && (to < static_cast<int>(buffer.size()))) {
-        int const delta = to - from + 1;
+        const int delta = to - from + 1;
 
         for (int i = from, total = from + delta; i < total; ++i) {
             lineBuffer.removeAt(i);
@@ -2915,10 +2915,10 @@ bool TBuffer::deleteLines(int from, int to)
 
 bool TBuffer::applyLink(const QPoint& P_begin, const QPoint& P_end, const QStringList& linkFunction, const QStringList& linkHint, QVector<int> luaReference)
 {
-    int const x1 = P_begin.x();
-    int const x2 = P_end.x();
-    int const y1 = P_begin.y();
-    int const y2 = P_end.y();
+    const int x1 = P_begin.x();
+    const int x2 = P_end.x();
+    const int y1 = P_begin.y();
+    const int y2 = P_end.y();
     int linkID = 0;
 
     // clang-format off
@@ -2962,10 +2962,10 @@ bool TBuffer::applyLink(const QPoint& P_begin, const QPoint& P_end, const QStrin
 // Can set multiple attributes to given state
 bool TBuffer::applyAttribute(const QPoint& P_begin, const QPoint& P_end, const TChar::AttributeFlags attributes, const bool state)
 {
-    int const x1 = P_begin.x();
-    int const x2 = P_end.x();
-    int const y1 = P_begin.y();
-    int const y2 = P_end.y();
+    const int x1 = P_begin.x();
+    const int x2 = P_end.x();
+    const int y1 = P_begin.y();
+    const int y2 = P_end.y();
 
     // clang-format off
     if ((x1 >= 0)
@@ -3004,10 +3004,10 @@ bool TBuffer::applyAttribute(const QPoint& P_begin, const QPoint& P_end, const T
 
 bool TBuffer::applyFgColor(const QPoint& P_begin, const QPoint& P_end, const QColor& newColor)
 {
-    int const x1 = P_begin.x();
-    int const x2 = P_end.x();
-    int const y1 = P_begin.y();
-    int const y2 = P_end.y();
+    const int x1 = P_begin.x();
+    const int x2 = P_end.x();
+    const int y1 = P_begin.y();
+    const int y2 = P_end.y();
 
     // clang-format off
     if ((x1 >= 0)
@@ -3046,10 +3046,10 @@ bool TBuffer::applyFgColor(const QPoint& P_begin, const QPoint& P_end, const QCo
 
 bool TBuffer::applyBgColor(const QPoint& P_begin, const QPoint& P_end, const QColor& newColor)
 {
-    int const x1 = P_begin.x();
-    int const x2 = P_end.x();
-    int const y1 = P_begin.y();
-    int const y2 = P_end.y();
+    const int x1 = P_begin.x();
+    const int x2 = P_end.x();
+    const int y1 = P_begin.y();
+    const int y2 = P_end.y();
 
     // clang-format off
     if ((x1 >= 0)

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -240,7 +240,7 @@ int TBuffer::getLastLineNumber()
 
 void TBuffer::addLink(bool trigMode, const QString& text, QStringList& command, QStringList& hint, TChar format, QVector<int> luaReference)
 {
-    int id = mLinkStore.addLinks(command, hint, mpHost, luaReference);
+    int const id = mLinkStore.addLinks(command, hint, mpHost, luaReference);
 
     if (!trigMode) {
         append(text, 0, text.length(), format.mFgColor, format.mBgColor, format.mFlags, id);
@@ -353,7 +353,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
     }
 
     // Check this each packet
-    QByteArray usedEncoding = mpHost->mTelnet.getEncoding();
+    QByteArray const usedEncoding = mpHost->mTelnet.getEncoding();
     if (mEncoding != usedEncoding) {
         encodingChanged(usedEncoding);
         // Will have to dump any stored bytes as they will be in the old
@@ -401,7 +401,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
     // repeated switch(...) and branch to one of a series of decoding methods
     // each with another up to 128 value switch()
 
-    size_t localBufferLength = localBuffer.length();
+    size_t const localBufferLength = localBuffer.length();
     size_t localBufferPosition = 0;
     if (!localBufferLength) {
         return;
@@ -443,7 +443,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
             // specifications..
             // After the first character the remaining characters of the
             // parameter string will be in the range "0-9:;" only
-            size_t spanStart = localBufferPosition;
+            size_t const spanStart = localBufferPosition;
             size_t spanEnd = spanStart;
             while (spanEnd < localBufferLength
                    && ((((spanStart < spanEnd) && cParameterInitial.indexOf(localBuffer[spanEnd]) >= 0))
@@ -524,7 +524,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                     if (!mpHost->mFORCE_MXP_NEGOTIATION_OFF && mpHost->mServerMXPenabled && isFromServer) {
                         mGotCSI = false;
 
-                        QString code = QString(localBuffer.substr(localBufferPosition, spanEnd - spanStart).c_str());
+                        QString const code = QString(localBuffer.substr(localBufferPosition, spanEnd - spanStart).c_str());
                         mpHost->mMxpProcessor.setMode(code);
                     }
                     // end of if (!mpHost->mFORCE_MXP_NEGOTIATION_OFF)
@@ -537,9 +537,9 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                     // Needed for mud.durismud.com see forum message topic:
                     // https://forums.mudlet.org/viewtopic.php?f=9&t=22887
                     const int dataLength = spanEnd - spanStart;
-                    QByteArray temp = QByteArray::fromRawData(localBuffer.substr(localBufferPosition, dataLength).c_str(), dataLength);
+                    QByteArray const temp = QByteArray::fromRawData(localBuffer.substr(localBufferPosition, dataLength).c_str(), dataLength);
                     bool isOk = false;
-                    int spacesNeeded = temp.toInt(&isOk);
+                    int const spacesNeeded = temp.toInt(&isOk);
                     if (isOk && spacesNeeded > 0) {
                         const TChar::AttributeFlags attributeFlags =
                                 ((mIsDefaultColor ? mBold : false) ? TChar::Bold : TChar::None)
@@ -551,7 +551,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
 
                         // Note: we are using the background color for the
                         // foreground color as well so that we are transparent:
-                        TChar c(mBackGroundColor, mBackGroundColor, attributeFlags);
+                        TChar const c(mBackGroundColor, mBackGroundColor, attributeFlags);
                         for (int spaceCount = 0; spaceCount < spacesNeeded; ++spaceCount) {
                             mMudLine.append(QChar::Space);
                             mMudBuffer.push_back(c);
@@ -577,9 +577,9 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                      *   scrollback buffer - which is again a NWIH for us...!
                      */
                     const int dataLength = spanEnd - spanStart;
-                    QByteArray temp = QByteArray::fromRawData(localBuffer.substr(localBufferPosition, dataLength).c_str(), dataLength);
+                    QByteArray const temp = QByteArray::fromRawData(localBuffer.substr(localBufferPosition, dataLength).c_str(), dataLength);
                     bool isOk = false;
-                    int argValue = temp.toInt(&isOk);
+                    int const argValue = temp.toInt(&isOk);
                     if (isOk) {
                         if (argValue >= 0 && argValue < 3) {
                             qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - ED (erase in display) sequence of form CSI" << temp << "J received,\nrejecting as incompatible with Mudlet.";
@@ -620,7 +620,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
             // of String (SOS) or String Terminator (ST) and the latter is ESC
             // followed by '\\' (a single \ BTW) in the 7-bit code case (the
             // former is encoded as ESC followed by 'X'):
-            size_t spanStart = localBufferPosition;
+            size_t const spanStart = localBufferPosition;
             size_t spanEnd = spanStart;
             // It is safe to look at spanEnd-1 even at the starting position
             // because we already know that the localBuffer extends backwards
@@ -653,7 +653,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
         if (mpHost->mMxpProcessor.isEnabled()) {
             if (mpHost->mServerMXPenabled) {
                 if (mpHost->mMxpProcessor.mode() != MXP_MODE_LOCKED) {
-                    TMxpProcessingResult result = mpHost->mMxpProcessor.processMxpInput(ch);
+                    TMxpProcessingResult const result = mpHost->mMxpProcessor.processMxpInput(ch);
                     if (result == HANDLER_NEXT_CHAR) {
                         localBufferPosition++;
                         continue;
@@ -751,7 +751,7 @@ COMMIT_LINE:
 
             mMudLine.clear();
             mMudBuffer.clear();
-            int line = lineBuffer.size() - 1;
+            int const line = lineBuffer.size() - 1;
             mpHost->mpConsole->runTriggers(line);
             // Only use of TBuffer::wrap(), breaks up new text
             // NOTE: it MAY have been clobbered by the trigger engine!
@@ -759,7 +759,7 @@ COMMIT_LINE:
 
             // Start a new, but empty line in the various buffers
             ++localBufferPosition;
-            std::deque<TChar> newLine;
+            std::deque<TChar> const newLine;
             buffer.push_back(newLine);
             lineBuffer.push_back(QString());
             timeBuffer.push_back(QString());
@@ -942,9 +942,9 @@ void TBuffer::decodeSGR38(const QStringList& parameters, bool isColonSeparated)
             // because color 1-15 behave like normal ANSI colors
            tag -= 16;
             // 6x6x6 RGB color space
-            quint8 r = tag / 36;
-            quint8 g = (tag - (r * 36)) / 6;
-            quint8 b = (tag - (r * 36)) - (g * 6);
+            quint8 const r = tag / 36;
+            quint8 const g = (tag - (r * 36)) / 6;
+            quint8 const b = (tag - (r * 36)) - (g * 6);
             // Adjusted from previously linear gradient for the blocks.
             // To match the common terminal palettes, the values are
             // scaled as follows:
@@ -955,7 +955,7 @@ void TBuffer::decodeSGR38(const QStringList& parameters, bool isColonSeparated)
             mForeGroundColorLight = mForeGroundColor;
 
         } else {
-            int value = (tag - 232) * 10 + 8;
+            int const value = (tag - 232) * 10 + 8;
             mForeGroundColor = QColor(value, value, value);
             mForeGroundColorLight = mForeGroundColor;
         }
@@ -1106,9 +1106,9 @@ void TBuffer::decodeSGR48(const QStringList& parameters, bool isColonSeparated)
             // because color 1-15 behave like normal ANSI colors
             tag -= 16;
             // 6x6x6 RGB color space
-            quint8 r = tag / 36;
-            quint8 g = (tag - (r * 36)) / 6;
-            quint8 b = (tag - (r * 36)) - (g * 6);
+            quint8 const r = tag / 36;
+            quint8 const g = (tag - (r * 36)) / 6;
+            quint8 const b = (tag - (r * 36)) - (g * 6);
             // Adjusted from previously linear gradient for the blocks.
             // To match the common terminal palettes, the values are
             // scaled as follows:
@@ -1118,7 +1118,7 @@ void TBuffer::decodeSGR48(const QStringList& parameters, bool isColonSeparated)
                                       b == 0 ? 0 : (b - 1) * 40 + 95);
 
         } else {
-            int value = (tag - 232) * 10 + 8;
+            int const value = (tag - 232) * 10 + 8;
             mBackGroundColor = QColor(value, value, value);
         }
 
@@ -1194,17 +1194,17 @@ void TBuffer::decodeSGR(const QString& sequence)
         return;
     }
 
-    bool haveColorSpaceId = pHost->getHaveColorSpaceId();
+    bool const haveColorSpaceId = pHost->getHaveColorSpaceId();
 
-    QStringList parameterStrings = sequence.split(QChar(';'));
+    QStringList const parameterStrings = sequence.split(QChar(';'));
     for (int paraIndex = 0, total = parameterStrings.count(); paraIndex < total; ++paraIndex) {
-        QString allParameterElements = parameterStrings.at(paraIndex);
+        QString const allParameterElements = parameterStrings.at(paraIndex);
         if (allParameterElements.contains(QLatin1String(":"))) {
             /******************************************************************
              * Parameter string with colon separated Parameter (sub) elements *
              ******************************************************************/
             // We have colon separated parameter elements, so we must have at least 2 members
-            QStringList parameterElements(allParameterElements.split(QChar(':')));
+            QStringList const parameterElements(allParameterElements.split(QChar(':')));
             if (parameterElements.at(0) == QLatin1String("38")) {
                 if (parameterElements.count() >= 2) {
                     decodeSGR38(parameterElements, true);
@@ -1226,7 +1226,7 @@ void TBuffer::decodeSGR(const QString& sequence)
                     madeElements << parameterStrings.at(paraIndex); // "38"
                     madeElements << parameterStrings.at(paraIndex + 1); // "2" or "5" hopefully
                     bool isOk = false;
-                    int sgr38_type = madeElements.at(1).toInt(&isOk);
+                    int const sgr38_type = madeElements.at(1).toInt(&isOk);
                     if (madeElements.at(1).isEmpty() || !isOk || sgr38_type == 0) {
                         // Oh dear that parameter is empty or equivalent to zero
                         // so we cannot do anything more
@@ -1323,7 +1323,7 @@ void TBuffer::decodeSGR(const QString& sequence)
                     madeElements << parameterStrings.at(paraIndex);
                     madeElements << parameterStrings.at(paraIndex + 1);
                     bool isOk = false;
-                    int sgr48_type = madeElements.at(1).toInt(&isOk);
+                    int const sgr48_type = madeElements.at(1).toInt(&isOk);
                     if (madeElements.at(1).isEmpty() || !isOk || sgr48_type == 0) {
                         // Oh dear that parameter is empty or equivalent to zero
                         // so we cannot do anything more
@@ -1402,7 +1402,7 @@ void TBuffer::decodeSGR(const QString& sequence)
             } else if (parameterElements.at(0) == QLatin1String("4")) {
                 // New way of controlling underline
                 bool isOk = false;
-                int value = parameterElements.at(1).toInt(&isOk);
+                int const value = parameterElements.at(1).toInt(&isOk);
                 if (!isOk) {
                     // missing value
                     qDebug().noquote().nospace() << "TBuffer::decodeSGR(\"" << sequence << "\") ERROR - failed to detect underline parameter element (the second part) in a SGR...;4:?;..m sequence assuming it is a zero!";
@@ -1428,7 +1428,7 @@ void TBuffer::decodeSGR(const QString& sequence)
             } else if (parameterElements.at(0) == QLatin1String("3")) {
                 // New way of controlling italics
                 bool isOk = false;
-                int value = parameterElements.at(1).toInt(&isOk);
+                int const value = parameterElements.at(1).toInt(&isOk);
                 if (!isOk) {
                     // missing value
                     qDebug().noquote().nospace() << "TBuffer::decodeSGR(\"" << sequence << "\") ERROR - failed to detect italic parameter element (the second part) in a SGR...;3:?;../m sequence assuming it is a zero!";
@@ -1609,7 +1609,7 @@ void TBuffer::decodeSGR(const QString& sequence)
                     madeElements << parameterStrings.at(paraIndex);
                     madeElements << parameterStrings.at(paraIndex + 1);
                     bool isOk = false;
-                    int sgr38_type = madeElements.at(1).toInt(&isOk);
+                    int const sgr38_type = madeElements.at(1).toInt(&isOk);
                     if (madeElements.at(1).isEmpty() || !isOk || sgr38_type == 0) {
                         // Oh dear that parameter is empty or equivalent to zero
                         // so we cannot do anything more
@@ -1728,7 +1728,7 @@ void TBuffer::decodeSGR(const QString& sequence)
                     madeElements << parameterStrings.at(paraIndex);
                     madeElements << parameterStrings.at(paraIndex + 1);
                     bool isOk = false;
-                    int sgr48_type = madeElements.at(1).toInt(&isOk);
+                    int const sgr48_type = madeElements.at(1).toInt(&isOk);
                     if (madeElements.at(1).isEmpty() || !isOk || sgr48_type == 0) {
                         // Oh dear that parameter is empty or equivalent to zero
                         // so we cannot do anything more
@@ -1911,11 +1911,11 @@ void TBuffer::decodeOSC(const QString& sequence)
         return;
     }
 
-    bool serverMayRedefineDefaultColors = pHost->getMayRedefineColors();
+    bool const serverMayRedefineDefaultColors = pHost->getMayRedefineColors();
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug().nospace().noquote() << "    Consider the OSC sequence: \"" << sequence << "\"";
 #endif
-    unsigned short character = sequence.at(0).unicode();
+    unsigned short const character = sequence.at(0).unicode();
     switch (character) {
     case static_cast<quint8>('P'):
         if (serverMayRedefineDefaultColors) {
@@ -1925,7 +1925,7 @@ void TBuffer::decodeOSC(const QString& sequence)
                 // Uses mid(...) rather than at(...) because we want the return to
                 // be a (single character) QString and not a QChar so we can use
                 // QString::toUInt(...):
-                quint8 colorNumber = sequence.mid(1, 1).toUInt(&isOk, 16);
+                quint8 const colorNumber = sequence.mid(1, 1).toUInt(&isOk, 16);
                 quint8 rr = 0;
                 if (isOk) {
                     rr = sequence.mid(2, 2).toUInt(&isOk, 16);
@@ -2076,7 +2076,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
         // buffer is completely empty
         std::deque<TChar> newLine;
         // The ternary operator is used here to set/reset only the TChar::Echo bit in the flags:
-        TChar c(format.mFgColor,
+        TChar const c(format.mFgColor,
                 format.mBgColor,
                 (mEchoingText ? (TChar::Echo | (format.mFlags & TChar::TestMask))
                  : (format.mFlags & TChar::TestMask)));
@@ -2101,7 +2101,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
         //FIXME <=substart+sub_end must check whether sub-ranges are still needed
         if (text.at(i) == QChar::LineFeed) {
             log(size() - 1, size() - 1);
-            std::deque<TChar> newLine;
+            std::deque<TChar> const newLine;
             buffer.push_back(newLine);
             lineBuffer.push_back(QString());
             timeBuffer << blankTimeStamp;
@@ -2117,8 +2117,8 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
             for (int i = lineBuffer.back().size() - 1; i >= 0; --i) {
                 if (lineBreaks.indexOf(lineBuffer.back().at(i)) > -1) {
                     const int linebreakPos = (i != 0) ? i + 1 : lineBuffer.back().size();
-                    QString tmp = lineBuffer.back().mid(0, linebreakPos);
-                    QString lineRest = lineBuffer.back().mid(linebreakPos);
+                    QString const tmp = lineBuffer.back().mid(0, linebreakPos);
+                    QString const lineRest = lineBuffer.back().mid(linebreakPos);
                     lineBuffer.back() = tmp;
                     std::deque<TChar> newLine;
 
@@ -2148,7 +2148,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
             }
         }
         lineBuffer.back().append(text.at(i));
-        TChar c(format.mFgColor,
+        TChar const c(format.mFgColor,
                 format.mBgColor,
                 (mEchoingText ? (TChar::Echo | (format.mFlags & TChar::TestMask))
                  : (format.mFlags & TChar::TestMask)),
@@ -2172,7 +2172,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
     int last = buffer.size() - 1;
     if (last < 0) {
         std::deque<TChar> newLine;
-        TChar c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags));
+        TChar const c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags));
         newLine.push_back(c);
         buffer.push_back(newLine);
         lineBuffer.push_back(QString());
@@ -2193,7 +2193,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
     for (int i = sub_start; i < length; ++i) {
         if (text.at(i) == '\n') {
             log(size() - 1, size() - 1);
-            std::deque<TChar> newLine;
+            std::deque<TChar> const newLine;
             buffer.push_back(newLine);
             lineBuffer.push_back(QString());
             timeBuffer << blankTimeStamp;
@@ -2210,8 +2210,8 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
                 // insert linebreak either at linebreaking character location or at last character of line
                 if (lineBreaks.indexOf(lineBuffer.back().at(i)) > -1 || i == 0) {
                     const int linebreakPos = (i != 0) ? i + 1 : lineBuffer.back().size();
-                    QString tmp = lineBuffer.back().mid(0, linebreakPos);
-                    QString lineRest = lineBuffer.back().mid(linebreakPos);
+                    QString const tmp = lineBuffer.back().mid(0, linebreakPos);
+                    QString const lineRest = lineBuffer.back().mid(linebreakPos);
                     lineBuffer.back() = tmp;
                     std::deque<TChar> newLine;
 
@@ -2241,7 +2241,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
             }
         }
         lineBuffer.back().append(text.at(i));
-        TChar c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags), linkID);
+        TChar const c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags), linkID);
         buffer.back().push_back(c);
         if (firstChar) {
             timeBuffer.back() = QTime::currentTime().toString(timeStampFormat);
@@ -2264,7 +2264,7 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
     if (Q_UNLIKELY(lastLine < 0)) {
         // There are NO lines in the buffer - so initialize with a new empty line
         std::deque<TChar> newLine;
-        TChar c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags));
+        TChar const c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags));
         newLine.push_back(c);
         buffer.push_back(newLine);
         lineBuffer.push_back(QString());
@@ -2286,7 +2286,7 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
 
     for (int i = sub_start; i <= (sub_start + lineEndPos); i++) {
         lineBuffer.back().append(text.at(i));
-        TChar c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags), linkID);
+        TChar const c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags), linkID);
         buffer.back().push_back(c);
         if (firstChar) {
             timeBuffer.back() = QTime::currentTime().toString(timeStampFormat);
@@ -2302,8 +2302,8 @@ bool TBuffer::insertInLine(QPoint& P, const QString& text, const TChar& format)
     if (text.isEmpty()) {
         return false;
     }
-    int x = P.x();
-    int y = P.y();
+    int const x = P.x();
+    int const y = P.y();
     if ((y >= 0) && (y < static_cast<int>(buffer.size()))) {
         if (x < 0) {
             return false;
@@ -2314,7 +2314,7 @@ bool TBuffer::insertInLine(QPoint& P, const QString& text, const TChar& format)
         }
         for (int i = 0, total = text.size(); i < total; ++i) {
             lineBuffer[y].insert(x + i, text.at(i));
-            TChar c = format;
+            TChar const c = format;
             auto it = buffer[y].begin();
             buffer[y].insert(it + x + i, c);
         }
@@ -2331,7 +2331,7 @@ TBuffer TBuffer::copy(QPoint& P1, QPoint& P2)
 {
     TBuffer slice(mpHost);
     slice.clear();
-    int y = P1.y();
+    int const y = P1.y();
     int x = P1.x();
     if (y < 0 || y >= static_cast<int>(buffer.size())) {
         return slice;
@@ -2341,8 +2341,8 @@ TBuffer TBuffer::copy(QPoint& P1, QPoint& P2)
         x = 0;
     }
     int oldLinkId{}, id{};
-    for (int total = P2.x(); x < total; ++x) {
-        int linkId = buffer.at(y).at(x).linkIndex();
+    for (int const total = P2.x(); x < total; ++x) {
+        int const linkId = buffer.at(y).at(x).linkIndex();
         if (linkId && (linkId != oldLinkId)) {
             id = slice.mLinkStore.addLinks(mLinkStore.getLinksConst(linkId), mLinkStore.getHintsConst(linkId), mpHost);
             oldLinkId = linkId;
@@ -2352,7 +2352,7 @@ TBuffer TBuffer::copy(QPoint& P1, QPoint& P2)
             id = 0;
         }
         // This is rather inefficient as s is only ever one QChar long
-        QString s(lineBuffer.at(y).at(x));
+        QString const s(lineBuffer.at(y).at(x));
         slice.append(s, 0, 1, buffer.at(y).at(x).mFgColor, buffer.at(y).at(x).mBgColor, buffer.at(y).at(x).mFlags, id);
     }
     return slice;
@@ -2370,10 +2370,10 @@ TBuffer TBuffer::cut(QPoint& P1, QPoint& P2)
 // This only copies the first line of chunk's contents:
 void TBuffer::paste(QPoint& P, const TBuffer& chunk)
 {
-    bool needAppend = false;
+    bool const needAppend = false;
     bool hasAppended = false;
     int y = P.y();
-    int x = P.x();
+    int const x = P.x();
     if (chunk.buffer.empty()) {
         return;
     }
@@ -2394,11 +2394,11 @@ void TBuffer::paste(QPoint& P, const TBuffer& chunk)
         QPoint P_current(cx, y);
         if ((y < getLastLineNumber()) && (!needAppend)) {
             const TChar& format = chunk.buffer.at(0).at(cx);
-            QString s = QString(chunk.lineBuffer.at(0).at(cx));
+            QString const s = QString(chunk.lineBuffer.at(0).at(cx));
             insertInLine(P_current, s, format);
         } else {
             hasAppended = true;
-            QString s(chunk.lineBuffer.at(0).at(cx));
+            QString const s(chunk.lineBuffer.at(0).at(cx));
             append(s, 0, 1, chunk.buffer.at(0).at(cx).mFgColor, chunk.buffer.at(0).at(cx).mBgColor, chunk.buffer.at(0).at(cx).mFlags);
         }
     }
@@ -2417,7 +2417,7 @@ void TBuffer::appendBuffer(const TBuffer& chunk)
     }
     int oldLinkId{}, id{};
     for (int cx = 0, total = static_cast<int>(chunk.buffer.at(0).size()); cx < total; ++cx) {
-        int linkId = chunk.buffer.at(0).at(cx).linkIndex();
+        int const linkId = chunk.buffer.at(0).at(cx).linkIndex();
         if (linkId && (oldLinkId != linkId)) {
             id = mLinkStore.addLinks(chunk.mLinkStore.getLinksConst(linkId), chunk.mLinkStore.getHintsConst(linkId), mpHost);
             oldLinkId = linkId;
@@ -2425,7 +2425,7 @@ void TBuffer::appendBuffer(const TBuffer& chunk)
         if (!linkId) {
             id = 0;
         }
-        QString s(chunk.lineBuffer.at(0).at(cx));
+        QString const s(chunk.lineBuffer.at(0).at(cx));
         append(s, 0, 1, chunk.buffer.at(0).at(cx).mFgColor, chunk.buffer.at(0).at(cx).mBgColor, chunk.buffer.at(0).at(cx).mFlags, id);
     }
 
@@ -2438,7 +2438,7 @@ int TBuffer::calculateWrapPosition(int lineNumber, int begin, int end)
     if (lineBuffer.size() < lineNumber) {
         return 0;
     }
-    int lineSize = static_cast<int>(lineBuffer[lineNumber].size()) - 1;
+    int const lineSize = static_cast<int>(lineBuffer[lineNumber].size()) - 1;
     if (lineSize < end) {
         end = lineSize;
     }
@@ -2456,7 +2456,7 @@ inline int TBuffer::skipSpacesAtBeginOfLine(const int row, const int column)
 {
     int offset = 0;
     int position = column;
-    int endOfLinePosition = lineBuffer.at(row).size();
+    int const endOfLinePosition = lineBuffer.at(row).size();
     while (position < endOfLinePosition) {
         if (buffer.at(row).at(position).mFlags & TChar::Echo) {
             break;
@@ -2481,12 +2481,12 @@ inline int TBuffer::wrap(int startLine)
     QStringList timeList;
     QList<bool> promptList;
     int lineCount = 0;
-    TChar pSpace(mpConsole);
+    TChar const pSpace(mpConsole);
     for (int i = startLine, total = static_cast<int>(buffer.size()); i < total; ++i) {
-        bool isPrompt = promptBuffer[i];
+        bool const isPrompt = promptBuffer[i];
         std::deque<TChar> newLine;
         QString lineText = "";
-        QString time = timeBuffer[i];
+        QString const time = timeBuffer[i];
         int indent = 0;
         if (static_cast<int>(buffer[i].size()) >= mWrapAt) {
             for (int i3 = 0; i3 < mWrapIndent; ++i3) {
@@ -2497,10 +2497,10 @@ inline int TBuffer::wrap(int startLine)
         }
         int lastSpace = 0;
         int wrapPos = 0;
-        int length = buffer[i].size();
+        int const length = buffer[i].size();
         if (length == 0) {
             tempList.append(QString());
-            std::deque<TChar> emptyLine;
+            std::deque<TChar> const emptyLine;
             queue.push(emptyLine);
             timeList.append(time);
         }
@@ -2511,7 +2511,7 @@ inline int TBuffer::wrap(int startLine)
             } else {
                 lastSpace = 0;
             }
-            int wrapPosition = (lastSpace) ? lastSpace : (mWrapAt - indent);
+            int const wrapPosition = (lastSpace) ? lastSpace : (mWrapAt - indent);
             for (int i3 = 0; i3 < wrapPosition; ++i3) {
                 if (lastSpace > 0) {
                     if (i2 > lastSpace) {
@@ -2531,7 +2531,7 @@ inline int TBuffer::wrap(int startLine)
             }
             if (newLine.empty()) {
                 tempList.append(QString());
-                std::deque<TChar> emptyLine;
+                std::deque<TChar> const emptyLine;
                 queue.push(emptyLine);
                 timeList.append(QString());
                 promptList.append(false);
@@ -2555,7 +2555,7 @@ inline int TBuffer::wrap(int startLine)
         promptBuffer.pop_back();
     }
 
-    int insertedLines = queue.size() - 1;
+    int const insertedLines = queue.size() - 1;
     while (!queue.empty()) {
         buffer.push_back(queue.front());
         queue.pop();
@@ -2647,7 +2647,7 @@ int TBuffer::wrapLine(int startLine, int screenWidth, int indentSize, TChar& for
         int indent = 0;
         if (static_cast<int>(buffer[line].size()) >= screenWidth) {
             for (int prependSpaces = 0; prependSpaces < indentSize; ++prependSpaces) {
-                TChar pSpace = format;
+                TChar const pSpace = format;
                 newLine.push_back(pSpace);
                 lineText.append(QChar::Space);
             }
@@ -2679,7 +2679,7 @@ int TBuffer::wrapLine(int startLine, int screenWidth, int indentSize, TChar& for
 
                     if (newLine.empty()) {
                         tempList.append(QString());
-                        std::deque<TChar> emptyLine;
+                        std::deque<TChar> const emptyLine;
                         queue.push(emptyLine);
                     } else {
                         queue.push(newLine);
@@ -2709,12 +2709,12 @@ int TBuffer::wrapLine(int startLine, int screenWidth, int indentSize, TChar& for
 
     buffer.erase(buffer.begin() + startLine);
     lineBuffer.removeAt(startLine);
-    QString time = timeBuffer.at(startLine);
+    QString const time = timeBuffer.at(startLine);
     timeBuffer.removeAt(startLine);
-    bool isPrompt = promptBuffer.at(startLine);
+    bool const isPrompt = promptBuffer.at(startLine);
     promptBuffer.removeAt(startLine);
 
-    int insertedLines = queue.size() - 1;
+    int const insertedLines = queue.size() - 1;
     int i = 0;
     while (!queue.empty()) {
         buffer.insert(buffer.begin() + startLine + i, queue.front());
@@ -2733,8 +2733,8 @@ int TBuffer::wrapLine(int startLine, int screenWidth, int indentSize, TChar& for
 
 bool TBuffer::moveCursor(QPoint& where)
 {
-    int x = where.x();
-    int y = where.y();
+    int const x = where.x();
+    int const y = where.y();
     if (y < 0) {
         return false;
     }
@@ -2794,7 +2794,7 @@ QStringList TBuffer::split(int line, const QRegularExpression& splitter)
 
 void TBuffer::expandLine(int y, int count, TChar& pC)
 {
-    int size = buffer[y].size() - 1;
+    int const size = buffer[y].size() - 1;
     for (int i = size, total = size + count; i < total; ++i) {
         buffer[y].push_back(pC);
         lineBuffer[y].append(QChar::Space);
@@ -2803,10 +2803,10 @@ void TBuffer::expandLine(int y, int count, TChar& pC)
 
 bool TBuffer::replaceInLine(QPoint& P_begin, QPoint& P_end, const QString& with, TChar& format)
 {
-    int x1 = P_begin.x();
-    int x2 = P_end.x();
-    int y1 = P_begin.y();
-    int y2 = P_end.y();
+    int const x1 = P_begin.x();
+    int const x2 = P_end.x();
+    int const y1 = P_begin.y();
+    int const y2 = P_end.y();
     if ((y1 >= static_cast<int>(buffer.size())) || (y2 >= static_cast<int>(buffer.size()))) {
         return false;
     }
@@ -2857,7 +2857,7 @@ void TBuffer::clear()
             break;
         }
     }
-    std::deque<TChar> newLine;
+    std::deque<TChar> const newLine;
     buffer.push_back(newLine);
     lineBuffer << QString();
     timeBuffer << QString();
@@ -2898,7 +2898,7 @@ void TBuffer::shrinkBuffer()
 bool TBuffer::deleteLines(int from, int to)
 {
     if ((from >= 0) && (from < static_cast<int>(buffer.size())) && (from <= to) && (to >= 0) && (to < static_cast<int>(buffer.size()))) {
-        int delta = to - from + 1;
+        int const delta = to - from + 1;
 
         for (int i = from, total = from + delta; i < total; ++i) {
             lineBuffer.removeAt(i);
@@ -2915,10 +2915,10 @@ bool TBuffer::deleteLines(int from, int to)
 
 bool TBuffer::applyLink(const QPoint& P_begin, const QPoint& P_end, const QStringList& linkFunction, const QStringList& linkHint, QVector<int> luaReference)
 {
-    int x1 = P_begin.x();
-    int x2 = P_end.x();
-    int y1 = P_begin.y();
-    int y2 = P_end.y();
+    int const x1 = P_begin.x();
+    int const x2 = P_end.x();
+    int const y1 = P_begin.y();
+    int const y2 = P_end.y();
     int linkID = 0;
 
     // clang-format off
@@ -2962,10 +2962,10 @@ bool TBuffer::applyLink(const QPoint& P_begin, const QPoint& P_end, const QStrin
 // Can set multiple attributes to given state
 bool TBuffer::applyAttribute(const QPoint& P_begin, const QPoint& P_end, const TChar::AttributeFlags attributes, const bool state)
 {
-    int x1 = P_begin.x();
-    int x2 = P_end.x();
-    int y1 = P_begin.y();
-    int y2 = P_end.y();
+    int const x1 = P_begin.x();
+    int const x2 = P_end.x();
+    int const y1 = P_begin.y();
+    int const y2 = P_end.y();
 
     // clang-format off
     if ((x1 >= 0)
@@ -3004,10 +3004,10 @@ bool TBuffer::applyAttribute(const QPoint& P_begin, const QPoint& P_end, const T
 
 bool TBuffer::applyFgColor(const QPoint& P_begin, const QPoint& P_end, const QColor& newColor)
 {
-    int x1 = P_begin.x();
-    int x2 = P_end.x();
-    int y1 = P_begin.y();
-    int y2 = P_end.y();
+    int const x1 = P_begin.x();
+    int const x2 = P_end.x();
+    int const y1 = P_begin.y();
+    int const y2 = P_end.y();
 
     // clang-format off
     if ((x1 >= 0)
@@ -3046,10 +3046,10 @@ bool TBuffer::applyFgColor(const QPoint& P_begin, const QPoint& P_end, const QCo
 
 bool TBuffer::applyBgColor(const QPoint& P_begin, const QPoint& P_end, const QColor& newColor)
 {
-    int x1 = P_begin.x();
-    int x2 = P_end.x();
-    int y1 = P_begin.y();
-    int y2 = P_end.y();
+    int const x1 = P_begin.x();
+    int const x2 = P_end.x();
+    int const y1 = P_begin.y();
+    int const y2 = P_end.y();
 
     // clang-format off
     if ((x1 >= 0)
@@ -3416,7 +3416,7 @@ bool TBuffer::processUtf8Sequence(const std::string& bufferData, const bool isFr
 
         // Will be one (BMP codepoint) or two (non-BMP codepoints) QChar(s)
         if (isValid) {
-            QString codePoint = QString(bufferData.substr(pos, utf8SequenceLength).c_str());
+            QString const codePoint = QString(bufferData.substr(pos, utf8SequenceLength).c_str());
             switch (codePoint.size()) {
             default:
                 Q_UNREACHABLE(); // This can't happen, unless we got start or length wrong in std::string::substr()

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1196,7 +1196,7 @@ void TBuffer::decodeSGR(const QString& sequence)
 
     const bool haveColorSpaceId = pHost->getHaveColorSpaceId();
 
-    QStringList const parameterStrings = sequence.split(QChar(';'));
+    const QStringList parameterStrings = sequence.split(QChar(';'));
     for (int paraIndex = 0, total = parameterStrings.count(); paraIndex < total; ++paraIndex) {
         const QString allParameterElements = parameterStrings.at(paraIndex);
         if (allParameterElements.contains(QLatin1String(":"))) {
@@ -1204,7 +1204,7 @@ void TBuffer::decodeSGR(const QString& sequence)
              * Parameter string with colon separated Parameter (sub) elements *
              ******************************************************************/
             // We have colon separated parameter elements, so we must have at least 2 members
-            QStringList const parameterElements(allParameterElements.split(QChar(':')));
+            const QStringList parameterElements(allParameterElements.split(QChar(':')));
             if (parameterElements.at(0) == QLatin1String("38")) {
                 if (parameterElements.count() >= 2) {
                     decodeSGR38(parameterElements, true);

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -551,7 +551,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
 
                         // Note: we are using the background color for the
                         // foreground color as well so that we are transparent:
-                        TChar const c(mBackGroundColor, mBackGroundColor, attributeFlags);
+                        const TChar c(mBackGroundColor, mBackGroundColor, attributeFlags);
                         for (int spaceCount = 0; spaceCount < spacesNeeded; ++spaceCount) {
                             mMudLine.append(QChar::Space);
                             mMudBuffer.push_back(c);
@@ -2076,7 +2076,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
         // buffer is completely empty
         std::deque<TChar> newLine;
         // The ternary operator is used here to set/reset only the TChar::Echo bit in the flags:
-        TChar const c(format.mFgColor,
+        const TChar c(format.mFgColor,
                 format.mBgColor,
                 (mEchoingText ? (TChar::Echo | (format.mFlags & TChar::TestMask))
                  : (format.mFlags & TChar::TestMask)));
@@ -2148,7 +2148,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
             }
         }
         lineBuffer.back().append(text.at(i));
-        TChar const c(format.mFgColor,
+        const TChar c(format.mFgColor,
                 format.mBgColor,
                 (mEchoingText ? (TChar::Echo | (format.mFlags & TChar::TestMask))
                  : (format.mFlags & TChar::TestMask)),
@@ -2172,7 +2172,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
     int last = buffer.size() - 1;
     if (last < 0) {
         std::deque<TChar> newLine;
-        TChar const c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags));
+        const TChar c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags));
         newLine.push_back(c);
         buffer.push_back(newLine);
         lineBuffer.push_back(QString());
@@ -2241,7 +2241,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
             }
         }
         lineBuffer.back().append(text.at(i));
-        TChar const c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags), linkID);
+        const TChar c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags), linkID);
         buffer.back().push_back(c);
         if (firstChar) {
             timeBuffer.back() = QTime::currentTime().toString(timeStampFormat);
@@ -2264,7 +2264,7 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
     if (Q_UNLIKELY(lastLine < 0)) {
         // There are NO lines in the buffer - so initialize with a new empty line
         std::deque<TChar> newLine;
-        TChar const c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags));
+        const TChar c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags));
         newLine.push_back(c);
         buffer.push_back(newLine);
         lineBuffer.push_back(QString());
@@ -2286,7 +2286,7 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
 
     for (int i = sub_start; i <= (sub_start + lineEndPos); i++) {
         lineBuffer.back().append(text.at(i));
-        TChar const c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags), linkID);
+        const TChar c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags), linkID);
         buffer.back().push_back(c);
         if (firstChar) {
             timeBuffer.back() = QTime::currentTime().toString(timeStampFormat);
@@ -2314,7 +2314,7 @@ bool TBuffer::insertInLine(QPoint& P, const QString& text, const TChar& format)
         }
         for (int i = 0, total = text.size(); i < total; ++i) {
             lineBuffer[y].insert(x + i, text.at(i));
-            TChar const c = format;
+            const TChar c = format;
             auto it = buffer[y].begin();
             buffer[y].insert(it + x + i, c);
         }
@@ -2481,7 +2481,7 @@ inline int TBuffer::wrap(int startLine)
     QStringList timeList;
     QList<bool> promptList;
     int lineCount = 0;
-    TChar const pSpace(mpConsole);
+    const TChar pSpace(mpConsole);
     for (int i = startLine, total = static_cast<int>(buffer.size()); i < total; ++i) {
         const bool isPrompt = promptBuffer[i];
         std::deque<TChar> newLine;
@@ -2647,7 +2647,7 @@ int TBuffer::wrapLine(int startLine, int screenWidth, int indentSize, TChar& for
         int indent = 0;
         if (static_cast<int>(buffer[line].size()) >= screenWidth) {
             for (int prependSpaces = 0; prependSpaces < indentSize; ++prependSpaces) {
-                TChar const pSpace = format;
+                const TChar pSpace = format;
                 newLine.push_back(pSpace);
                 lineText.append(QChar::Space);
             }

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1194,7 +1194,7 @@ void TBuffer::decodeSGR(const QString& sequence)
         return;
     }
 
-    bool const haveColorSpaceId = pHost->getHaveColorSpaceId();
+    const bool haveColorSpaceId = pHost->getHaveColorSpaceId();
 
     QStringList const parameterStrings = sequence.split(QChar(';'));
     for (int paraIndex = 0, total = parameterStrings.count(); paraIndex < total; ++paraIndex) {
@@ -1911,7 +1911,7 @@ void TBuffer::decodeOSC(const QString& sequence)
         return;
     }
 
-    bool const serverMayRedefineDefaultColors = pHost->getMayRedefineColors();
+    const bool serverMayRedefineDefaultColors = pHost->getMayRedefineColors();
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug().nospace().noquote() << "    Consider the OSC sequence: \"" << sequence << "\"";
 #endif
@@ -2370,7 +2370,7 @@ TBuffer TBuffer::cut(QPoint& P1, QPoint& P2)
 // This only copies the first line of chunk's contents:
 void TBuffer::paste(QPoint& P, const TBuffer& chunk)
 {
-    bool const needAppend = false;
+    const bool needAppend = false;
     bool hasAppended = false;
     int y = P.y();
     const int x = P.x();
@@ -2483,7 +2483,7 @@ inline int TBuffer::wrap(int startLine)
     int lineCount = 0;
     TChar const pSpace(mpConsole);
     for (int i = startLine, total = static_cast<int>(buffer.size()); i < total; ++i) {
-        bool const isPrompt = promptBuffer[i];
+        const bool isPrompt = promptBuffer[i];
         std::deque<TChar> newLine;
         QString lineText = "";
         const QString time = timeBuffer[i];
@@ -2711,7 +2711,7 @@ int TBuffer::wrapLine(int startLine, int screenWidth, int indentSize, TChar& for
     lineBuffer.removeAt(startLine);
     const QString time = timeBuffer.at(startLine);
     timeBuffer.removeAt(startLine);
-    bool const isPrompt = promptBuffer.at(startLine);
+    const bool isPrompt = promptBuffer.at(startLine);
     promptBuffer.removeAt(startLine);
 
     const int insertedLines = queue.size() - 1;

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -314,7 +314,7 @@ private:
 // Note "inline" is REQUIRED:
 inline QDebug& operator<<(QDebug& debug, const TChar::AttributeFlags& attributes)
 {
-    QDebugStateSaver saver(debug);
+    QDebugStateSaver const saver(debug);
     QString result = QLatin1String("TChar::AttributeFlags(");
     QStringList presentAttributes;
     if (attributes & TChar::Bold) {

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -64,7 +64,7 @@ TCommandLine::TCommandLine(Host* pHost, const QString& name, CommandLineType typ
     //style subCommandLines by stylesheet
     if (mType != MainCommandLine) {
         QColor const c = mpHost->mCommandLineBgColor;
-        QString const styleSheet{qsl("QPlainTextEdit{background-color: rgb(%1, %2, %3);}").arg(c.red()).arg(c.green()).arg(c.blue())};
+        const QString styleSheet{qsl("QPlainTextEdit{background-color: rgb(%1, %2, %3);}").arg(c.red()).arg(c.green()).arg(c.blue())};
         setStyleSheet(styleSheet);
     }
 
@@ -651,7 +651,7 @@ void TCommandLine::slot_popupMenu()
 #if defined(Q_OS_FREEBSD)
     QString t = pA->data().toString();
 #else
-    QString const t = pA->text();
+    const QString t = pA->text();
 #endif
     QTextCursor c = cursorForPosition(mPopupPosition);
     c.select(QTextCursor::WordUnderCursor);
@@ -902,7 +902,7 @@ void TCommandLine::mouseReleaseEvent(QMouseEvent* event)
 void TCommandLine::enterCommand(QKeyEvent* event)
 {
     Q_UNUSED(event)
-    QString const _t = toPlainText();
+    const QString _t = toPlainText();
     mTabCompletionCount = -1;
     mAutoCompletionCount = -1;
     mTabCompletionTyped.clear();
@@ -984,7 +984,7 @@ void TCommandLine::handleTabCompletion(bool direction)
     buffer.replace(QChar::LineFeed, QChar::Space);
 
     QStringList wordList = buffer.split(QRegularExpression(qsl(R"(\b)"), QRegularExpression::UseUnicodePropertiesOption), Qt::SkipEmptyParts);
-    wordList.append(commandLineSuggestions.values()); // hindsight 20/20 I do not need to split this to a separate table, a check to not append buffer to this table and only append suggested list does same thing for far less overhead. 
+    wordList.append(commandLineSuggestions.values()); // hindsight 20/20 I do not need to split this to a separate table, a check to not append buffer to this table and only append suggested list does same thing for far less overhead.
     QStringList const blacklist = tabCompleteBlacklist.values();
     QStringList toDelete;
 
@@ -1023,7 +1023,7 @@ void TCommandLine::handleTabCompletion(bool direction)
         }
         int offset = 0;
         forever {
-            QString const tmp = filterList.back();
+            const QString tmp = filterList.back();
             filterList.removeAll(tmp);
             filterList.insert(offset, tmp);
             ++offset;
@@ -1039,8 +1039,8 @@ void TCommandLine::handleTabCompletion(bool direction)
             if (mTabCompletionCount < 0) {
                 mTabCompletionCount = 0;
             }
-            QString const proposal = filterList[mTabCompletionCount];
-            QString const userWords = mTabCompletionTyped.left(typePosition);
+            const QString proposal = filterList[mTabCompletionCount];
+            const QString userWords = mTabCompletionTyped.left(typePosition);
             setPlainText(QString(userWords + proposal));
             moveCursor(QTextCursor::End, QTextCursor::MoveAnchor);
             mTabCompletionOld = toPlainText();
@@ -1068,7 +1068,7 @@ void TCommandLine::handleAutoCompletion()
         mAutoCompletionCount = 0;
     }
     for (int i = mAutoCompletionCount; i < mHistoryList.size(); i++) {
-        QString const h = mHistoryList[i].mid(0, neu.size());
+        const QString h = mHistoryList[i].mid(0, neu.size());
         if (neu == h) {
             mAutoCompletionCount = i;
             mLastCompletion = mHistoryList[i];

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -63,8 +63,8 @@ TCommandLine::TCommandLine(Host* pHost, const QString& name, CommandLineType typ
     setPalette(mRegularPalette);
     //style subCommandLines by stylesheet
     if (mType != MainCommandLine) {
-        QColor c = mpHost->mCommandLineBgColor;
-        QString styleSheet{qsl("QPlainTextEdit{background-color: rgb(%1, %2, %3);}").arg(c.red()).arg(c.green()).arg(c.blue())};
+        QColor const c = mpHost->mCommandLineBgColor;
+        QString const styleSheet{qsl("QPlainTextEdit{background-color: rgb(%1, %2, %3);}").arg(c.red()).arg(c.green()).arg(c.blue())};
         setStyleSheet(styleSheet);
     }
 
@@ -183,7 +183,7 @@ bool TCommandLine::event(QEvent* event)
                 // implicit <SHIFT>):
                 const int currentIndex = mudlet::self()->mpTabBar->currentIndex();
                 const int count = mudlet::self()->mpTabBar->count();
-                int newIndex = (currentIndex - 1 < 0) ? (count - 1) : (currentIndex - 1);
+                int const newIndex = (currentIndex - 1 < 0) ? (count - 1) : (currentIndex - 1);
                 mudlet::self()->slot_tabChanged(newIndex);
                 ke->accept();
                 return true;
@@ -216,7 +216,7 @@ bool TCommandLine::event(QEvent* event)
                 // Switch to NEXT profile tab
                 const int currentIndex = mudlet::self()->mpTabBar->currentIndex();
                 const int count = mudlet::self()->mpTabBar->count();
-                int newIndex = (currentIndex + 1 < count) ? (currentIndex + 1) : 0;
+                int const newIndex = (currentIndex + 1 < count) ? (currentIndex + 1) : 0;
                 mudlet::self()->slot_tabChanged(newIndex);
                 ke->accept();
                 return true;
@@ -606,7 +606,7 @@ void TCommandLine::adjustHeight()
     if (lines > 10) {
         lines = 10;
     }
-    int fontH = QFontMetrics(font()).height();
+    int const fontH = QFontMetrics(font()).height();
     // Adjust height margin based on font size and if it is more than one row
     int marginH = lines > 1 ? 2+fontH/3 : 5;
     if (lines > 1 && marginH < 8) {
@@ -619,9 +619,9 @@ void TCommandLine::adjustHeight()
     if (_height > height() || _height < height()) {
         mpConsole->layerCommandLine->setMinimumHeight(_height);
         mpConsole->layerCommandLine->setMaximumHeight(_height);
-        int x = mpConsole->width();
-        int y = mpConsole->height();
-        QSize s = QSize(x, y);
+        int const x = mpConsole->width();
+        int const y = mpConsole->height();
+        QSize const s = QSize(x, y);
         QResizeEvent event(s, s);
         QApplication::sendEvent(mpConsole, &event);
     }
@@ -651,7 +651,7 @@ void TCommandLine::slot_popupMenu()
 #if defined(Q_OS_FREEBSD)
     QString t = pA->data().toString();
 #else
-    QString t = pA->text();
+    QString const t = pA->text();
 #endif
     QTextCursor c = cursorForPosition(mPopupPosition);
     c.select(QTextCursor::WordUnderCursor);
@@ -731,7 +731,7 @@ void TCommandLine::mousePressEvent(QMouseEvent* event)
             QList<QAction*> spellings_system;
             QList<QAction*> spellings_profile;
             if (handle_system && codec) {
-                QByteArray encodedText = codec->fromUnicode(mSpellCheckedWord);
+                QByteArray const encodedText = codec->fromUnicode(mSpellCheckedWord);
 
                 if (!Hunspell_spell(handle_system, encodedText.constData())) {
                     // The word is NOT in the main system dictionary:
@@ -902,7 +902,7 @@ void TCommandLine::mouseReleaseEvent(QMouseEvent* event)
 void TCommandLine::enterCommand(QKeyEvent* event)
 {
     Q_UNUSED(event)
-    QString _t = toPlainText();
+    QString const _t = toPlainText();
     mTabCompletionCount = -1;
     mAutoCompletionCount = -1;
     mTabCompletionTyped.clear();
@@ -977,7 +977,7 @@ void TCommandLine::handleTabCompletion(bool direction)
         amount = 500;
     }
 
-    QStringList bufferList = mpHost->mpConsole->buffer.getEndLines(amount);
+    QStringList const bufferList = mpHost->mpConsole->buffer.getEndLines(amount);
     QString buffer = bufferList.join(QChar::Space);
 
     buffer.replace(QChar(0x21af), QChar::LineFeed);
@@ -985,7 +985,7 @@ void TCommandLine::handleTabCompletion(bool direction)
 
     QStringList wordList = buffer.split(QRegularExpression(qsl(R"(\b)"), QRegularExpression::UseUnicodePropertiesOption), Qt::SkipEmptyParts);
     wordList.append(commandLineSuggestions.values()); // hindsight 20/20 I do not need to split this to a separate table, a check to not append buffer to this table and only append suggested list does same thing for far less overhead. 
-    QStringList blacklist = tabCompleteBlacklist.values(); 
+    QStringList const blacklist = tabCompleteBlacklist.values();
     QStringList toDelete;
 
     for (const QString& wstr : qAsConst(wordList)) {
@@ -1007,9 +1007,9 @@ void TCommandLine::handleTabCompletion(bool direction)
             return;
         }
         QString lastWord;
-        QRegularExpression reg = QRegularExpression(qsl(R"(\b(\w+)$)"), QRegularExpression::UseUnicodePropertiesOption);
-        QRegularExpressionMatch match = reg.match(mTabCompletionTyped);
-        int typePosition = match.capturedStart();
+        QRegularExpression const reg = QRegularExpression(qsl(R"(\b(\w+)$)"), QRegularExpression::UseUnicodePropertiesOption);
+        QRegularExpressionMatch const match = reg.match(mTabCompletionTyped);
+        int const typePosition = match.capturedStart();
         if (reg.captureCount() >= 1) {
             lastWord = match.captured(1);
         } else {
@@ -1023,7 +1023,7 @@ void TCommandLine::handleTabCompletion(bool direction)
         }
         int offset = 0;
         forever {
-            QString tmp = filterList.back();
+            QString const tmp = filterList.back();
             filterList.removeAll(tmp);
             filterList.insert(offset, tmp);
             ++offset;
@@ -1039,8 +1039,8 @@ void TCommandLine::handleTabCompletion(bool direction)
             if (mTabCompletionCount < 0) {
                 mTabCompletionCount = 0;
             }
-            QString proposal = filterList[mTabCompletionCount];
-            QString userWords = mTabCompletionTyped.left(typePosition);
+            QString const proposal = filterList[mTabCompletionCount];
+            QString const userWords = mTabCompletionTyped.left(typePosition);
             setPlainText(QString(userWords + proposal));
             moveCursor(QTextCursor::End, QTextCursor::MoveAnchor);
             mTabCompletionOld = toPlainText();
@@ -1060,7 +1060,7 @@ void TCommandLine::handleAutoCompletion()
     neu.chop(textCursor().selectedText().size());
     setPlainText(neu);
     mTabCompletionOld = neu;
-    int oldLength = toPlainText().size();
+    int const oldLength = toPlainText().size();
     if (mAutoCompletionCount >= mHistoryList.size()) {
         mAutoCompletionCount = mHistoryList.size() - 1;
     }
@@ -1068,7 +1068,7 @@ void TCommandLine::handleAutoCompletion()
         mAutoCompletionCount = 0;
     }
     for (int i = mAutoCompletionCount; i < mHistoryList.size(); i++) {
-        QString h = mHistoryList[i].mid(0, neu.size());
+        QString const h = mHistoryList[i].mid(0, neu.size());
         if (neu == h) {
             mAutoCompletionCount = i;
             mLastCompletion = mHistoryList[i];
@@ -1095,7 +1095,7 @@ void TCommandLine::historyMove(MoveDirection direction)
     if (mHistoryList.empty()) {
         return;
     }
-    int shift = (direction == MOVE_UP ? 1 : -1);
+    int const shift = (direction == MOVE_UP ? 1 : -1);
     if ((textCursor().selectedText().size() == toPlainText().size()) || (toPlainText().isEmpty()) || !mpHost->mHighlightHistory) {
         mHistoryBuffer += shift;
         if (mHistoryBuffer >= mHistoryList.size()) {
@@ -1160,7 +1160,7 @@ void TCommandLine::spellCheckWord(QTextCursor& c)
     QTextCharFormat f;
     mSpellChecking = true;
     c.select(QTextCursor::WordUnderCursor);
-    QByteArray encodedText = mpHost->mpConsole->getHunspellCodec_system()->fromUnicode(c.selectedText());
+    QByteArray const encodedText = mpHost->mpConsole->getHunspellCodec_system()->fromUnicode(c.selectedText());
     if (!Hunspell_spell(systemDictionaryHandle, encodedText.constData())) {
         // Word is not in selected system dictionary
         Hunhandle* userDictionaryhandle = mpHost->mpConsole->getHunspellHandle_user();
@@ -1225,9 +1225,9 @@ void TCommandLine::recheckWholeLine()
     }
 
     // Save the current position
-    QTextCursor oldCursor = textCursor();
+    QTextCursor const oldCursor = textCursor();
 
-    QTextCharFormat f;
+    QTextCharFormat const f;
     QTextCursor c = textCursor();
     // Move Cursor AND selection anchor to start:
     c.movePosition(QTextCursor::Start);
@@ -1316,7 +1316,7 @@ void TCommandLine::clearBlacklist()
 
 void TCommandLine::slot_adjustAccessibleNames()
 {
-    bool multipleProfilesActive = (mudlet::self()->getHostManager().getHostCount() > 1);
+    bool const multipleProfilesActive = (mudlet::self()->getHostManager().getHostCount() > 1);
     const QString hostName{mpHost ? mpHost->getName() : QString()};
     switch (mType) {
     case MainCommandLine:

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1316,7 +1316,7 @@ void TCommandLine::clearBlacklist()
 
 void TCommandLine::slot_adjustAccessibleNames()
 {
-    bool const multipleProfilesActive = (mudlet::self()->getHostManager().getHostCount() > 1);
+    const bool multipleProfilesActive = (mudlet::self()->getHostManager().getHostCount() > 1);
     const QString hostName{mpHost ? mpHost->getName() : QString()};
     switch (mType) {
     case MainCommandLine:

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -977,7 +977,7 @@ void TCommandLine::handleTabCompletion(bool direction)
         amount = 500;
     }
 
-    QStringList const bufferList = mpHost->mpConsole->buffer.getEndLines(amount);
+    const QStringList bufferList = mpHost->mpConsole->buffer.getEndLines(amount);
     QString buffer = bufferList.join(QChar::Space);
 
     buffer.replace(QChar(0x21af), QChar::LineFeed);
@@ -985,7 +985,7 @@ void TCommandLine::handleTabCompletion(bool direction)
 
     QStringList wordList = buffer.split(QRegularExpression(qsl(R"(\b)"), QRegularExpression::UseUnicodePropertiesOption), Qt::SkipEmptyParts);
     wordList.append(commandLineSuggestions.values()); // hindsight 20/20 I do not need to split this to a separate table, a check to not append buffer to this table and only append suggested list does same thing for far less overhead.
-    QStringList const blacklist = tabCompleteBlacklist.values();
+    const QStringList blacklist = tabCompleteBlacklist.values();
     QStringList toDelete;
 
     for (const QString& wstr : qAsConst(wordList)) {

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -183,7 +183,7 @@ bool TCommandLine::event(QEvent* event)
                 // implicit <SHIFT>):
                 const int currentIndex = mudlet::self()->mpTabBar->currentIndex();
                 const int count = mudlet::self()->mpTabBar->count();
-                int const newIndex = (currentIndex - 1 < 0) ? (count - 1) : (currentIndex - 1);
+                const int newIndex = (currentIndex - 1 < 0) ? (count - 1) : (currentIndex - 1);
                 mudlet::self()->slot_tabChanged(newIndex);
                 ke->accept();
                 return true;
@@ -216,7 +216,7 @@ bool TCommandLine::event(QEvent* event)
                 // Switch to NEXT profile tab
                 const int currentIndex = mudlet::self()->mpTabBar->currentIndex();
                 const int count = mudlet::self()->mpTabBar->count();
-                int const newIndex = (currentIndex + 1 < count) ? (currentIndex + 1) : 0;
+                const int newIndex = (currentIndex + 1 < count) ? (currentIndex + 1) : 0;
                 mudlet::self()->slot_tabChanged(newIndex);
                 ke->accept();
                 return true;
@@ -606,7 +606,7 @@ void TCommandLine::adjustHeight()
     if (lines > 10) {
         lines = 10;
     }
-    int const fontH = QFontMetrics(font()).height();
+    const int fontH = QFontMetrics(font()).height();
     // Adjust height margin based on font size and if it is more than one row
     int marginH = lines > 1 ? 2+fontH/3 : 5;
     if (lines > 1 && marginH < 8) {
@@ -619,8 +619,8 @@ void TCommandLine::adjustHeight()
     if (_height > height() || _height < height()) {
         mpConsole->layerCommandLine->setMinimumHeight(_height);
         mpConsole->layerCommandLine->setMaximumHeight(_height);
-        int const x = mpConsole->width();
-        int const y = mpConsole->height();
+        const int x = mpConsole->width();
+        const int y = mpConsole->height();
         QSize const s = QSize(x, y);
         QResizeEvent event(s, s);
         QApplication::sendEvent(mpConsole, &event);
@@ -1009,7 +1009,7 @@ void TCommandLine::handleTabCompletion(bool direction)
         QString lastWord;
         QRegularExpression const reg = QRegularExpression(qsl(R"(\b(\w+)$)"), QRegularExpression::UseUnicodePropertiesOption);
         QRegularExpressionMatch const match = reg.match(mTabCompletionTyped);
-        int const typePosition = match.capturedStart();
+        const int typePosition = match.capturedStart();
         if (reg.captureCount() >= 1) {
             lastWord = match.captured(1);
         } else {
@@ -1060,7 +1060,7 @@ void TCommandLine::handleAutoCompletion()
     neu.chop(textCursor().selectedText().size());
     setPlainText(neu);
     mTabCompletionOld = neu;
-    int const oldLength = toPlainText().size();
+    const int oldLength = toPlainText().size();
     if (mAutoCompletionCount >= mHistoryList.size()) {
         mAutoCompletionCount = mHistoryList.size() - 1;
     }
@@ -1095,7 +1095,7 @@ void TCommandLine::historyMove(MoveDirection direction)
     if (mHistoryList.empty()) {
         return;
     }
-    int const shift = (direction == MOVE_UP ? 1 : -1);
+    const int shift = (direction == MOVE_UP ? 1 : -1);
     if ((textCursor().selectedText().size() == toPlainText().size()) || (toPlainText().isEmpty()) || !mpHost->mHighlightHistory) {
         mHistoryBuffer += shift;
         if (mHistoryBuffer >= mHistoryList.size()) {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -785,7 +785,7 @@ void TConsole::closeEvent(QCloseEvent* event)
 
         if (mpHost->mpMap && mpHost->mpMap->mpRoomDB) {
             // There is a map loaded - but it *could* have no rooms at all!
-            QDir const dir_map;
+            const QDir dir_map;
             const QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
             const QString filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString("yyyy-MM-dd#HH-mm-ss"));
             if (!dir_map.exists(directory_map)) {
@@ -828,7 +828,7 @@ void TConsole::closeEvent(QCloseEvent* event)
                 goto ASK;
             } else if (mpHost->mpMap && mpHost->mpMap->mpRoomDB) {
                 // There is a map loaded - but it *could* have no rooms at all!
-                QDir const dir_map;
+                const QDir dir_map;
                 const QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
                 const QString filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
                 if (!dir_map.exists(directory_map)) {
@@ -901,7 +901,7 @@ void TConsole::slot_toggleReplayRecording()
     if (mRecordReplay) {
         const QString directoryLogFile = mudlet::getMudletPath(mudlet::profileReplayAndLogFilesPath, mProfileName);
         const QString mLogFileName = qsl("%1/%2.dat").arg(directoryLogFile, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
-        QDir const dirLogFile;
+        const QDir dirLogFile;
         if (!dirLogFile.exists(directoryLogFile)) {
             dirLogFile.mkpath(directoryLogFile);
         }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1963,7 +1963,7 @@ void TConsole::dropEvent(QDropEvent* e)
 {
     for (const auto& url : e->mimeData()->urls()) {
         const QString fname = url.toLocalFile();
-        QFileInfo const info(fname);
+        const QFileInfo info(fname);
         if (info.exists()) {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
             const QPoint pos = e->pos();

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -348,13 +348,13 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
         int latencyFontPointSize = 21;
         QFont latencyFont = QFont(qsl("Bitstream Vera Sans Mono"), latencyFontPointSize, QFont::Normal);
         const int latencyFontSizeMargin = 10;
-        QString const dummyTextA = tr("N:%1 S:%2",
+        const QString dummyTextA = tr("N:%1 S:%2",
                                 // intentional comment to separate arguments
                                 "The first argument 'N' represents the 'N'etwork latency; the second 'S' the "
                                 "'S'ystem (processing) time")
                                      .arg(0.0, 0, 'f', 3)
                                      .arg(0.0, 0, 'f', 3);
-        QString const dummyTextB = tr("<no GA> S:%1",
+        const QString dummyTextB = tr("<no GA> S:%1",
                                 // intentional comment to separate arguments
                                 "The argument 'S' represents the 'S'ystem (processing) time, in this situation "
                                 "the Game Server is not sending \"GoAhead\" signals so we cannot deduce the "
@@ -636,8 +636,8 @@ void TConsole::resizeEvent(QResizeEvent* event)
         }
         if (!mpHost.isNull()) {
             TLuaInterpreter* pLua = mpHost->getLuaInterpreter();
-            QString const func = "handleWindowResizeEvent";
-            QString const n = "WindowResizeEvent";
+            const QString func = "handleWindowResizeEvent";
+            const QString n = "WindowResizeEvent";
             pLua->call(func, n);
 
             raiseMudletSysWindowResizeEvent(x, y);
@@ -646,8 +646,8 @@ void TConsole::resizeEvent(QResizeEvent* event)
 //create the sysUserWindowResize Event for automatic resizing with Geyser
     if (mType & (UserWindow) && !mpHost.isNull()) {
         TLuaInterpreter* pLua = mpHost->getLuaInterpreter();
-        QString const func = "handleWindowResizeEvent";
-        QString const n = "WindowResizeEvent";
+        const QString func = "handleWindowResizeEvent";
+        const QString n = "WindowResizeEvent";
         pLua->call(func, n);
 
         TEvent mudletEvent {};
@@ -786,8 +786,8 @@ void TConsole::closeEvent(QCloseEvent* event)
         if (mpHost->mpMap && mpHost->mpMap->mpRoomDB) {
             // There is a map loaded - but it *could* have no rooms at all!
             QDir const dir_map;
-            QString const directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
-            QString const filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString("yyyy-MM-dd#HH-mm-ss"));
+            const QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
+            const QString filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString("yyyy-MM-dd#HH-mm-ss"));
             if (!dir_map.exists(directory_map)) {
                 dir_map.mkpath(directory_map);
             }
@@ -829,8 +829,8 @@ void TConsole::closeEvent(QCloseEvent* event)
             } else if (mpHost->mpMap && mpHost->mpMap->mpRoomDB) {
                 // There is a map loaded - but it *could* have no rooms at all!
                 QDir const dir_map;
-                QString const directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
-                QString const filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
+                const QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
+                const QString filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
                 if (!dir_map.exists(directory_map)) {
                     dir_map.mkpath(directory_map);
                 }
@@ -899,8 +899,8 @@ void TConsole::slot_toggleReplayRecording()
     }
     mRecordReplay = !mRecordReplay;
     if (mRecordReplay) {
-        QString const directoryLogFile = mudlet::getMudletPath(mudlet::profileReplayAndLogFilesPath, mProfileName);
-        QString const mLogFileName = qsl("%1/%2.dat").arg(directoryLogFile, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
+        const QString directoryLogFile = mudlet::getMudletPath(mudlet::profileReplayAndLogFilesPath, mProfileName);
+        const QString mLogFileName = qsl("%1/%2.dat").arg(directoryLogFile, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
         QDir const dirLogFile;
         if (!dirLogFile.exists(directoryLogFile)) {
             dirLogFile.mkpath(directoryLogFile);
@@ -1097,7 +1097,7 @@ void TConsole::scrollUp(int lines)
     if (lowerAppears) {
         QTimer::singleShot(0, this, [this]() {  mUpperPane->scrollUp(mLowerPane->getRowCount()); });
         if (!mpHost->mTutorialForSplitscreenScrollbackAlreadyShown) {
-            QString const infoMsg = tr("[ INFO ]  - Split-screen scrollback activated. Press CTRL-ENTER to cancel.");
+            const QString infoMsg = tr("[ INFO ]  - Split-screen scrollback activated. Press CTRL-ENTER to cancel.");
             mpHost->postMessage(infoMsg);
             mpHost->mTutorialForSplitscreenScrollbackAlreadyShown = true;
         }
@@ -1556,7 +1556,7 @@ int TConsole::select(const QString& text, int numOfMatch)
 
     int begin = -1;
     for (int i = 0; i < numOfMatch; i++) {
-        QString const li = buffer.line(mUserCursor.y());
+        const QString li = buffer.line(mUserCursor.y());
         if (li.isEmpty()) {
             continue;
         }
@@ -1759,7 +1759,7 @@ void TConsole::echoLink(const QString& text, QStringList& func, QStringList& hin
 // An overload of print(const QString& msg):
 void TConsole::print(const char* txt)
 {
-    QString const msg(txt);
+    const QString msg(txt);
     print(msg);
 }
 
@@ -1790,7 +1790,7 @@ void TConsole::print(const QString& msg, const QColor fgColor, const QColor bgCo
 
 void TConsole::printSystemMessage(const QString& msg)
 {
-    QString const txt = tr("System Message: %1").arg(msg);
+    const QString txt = tr("System Message: %1").arg(msg);
     print(txt, mSystemMessageFgColor, mSystemMessageBgColor);
 }
 
@@ -1962,7 +1962,7 @@ void TConsole::dragEnterEvent(QDragEnterEvent* e)
 void TConsole::dropEvent(QDropEvent* e)
 {
     for (const auto& url : e->mimeData()->urls()) {
-        QString const fname = url.toLocalFile();
+        const QString fname = url.toLocalFile();
         QFileInfo const info(fname);
         if (info.exists()) {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -629,7 +629,7 @@ void TConsole::resizeEvent(QResizeEvent* event)
 
     if (mType & MainConsole) {
         // don't call event in lua if size didn't change
-        bool const preventLuaEvent = (getMainWindowSize() == mOldSize);
+        const bool preventLuaEvent = (getMainWindowSize() == mOldSize);
         mOldSize = getMainWindowSize();
         if (preventLuaEvent) {
             return;
@@ -1088,7 +1088,7 @@ void TConsole::scrollDown(int lines)
 
 void TConsole::scrollUp(int lines)
 {
-    bool const lowerAppears = mLowerPane->isHidden();
+    const bool lowerAppears = mLowerPane->isHidden();
     mLowerPane->mCursorY = buffer.size();
     mLowerPane->show();
     mLowerPane->updateScreenView();
@@ -2077,7 +2077,7 @@ void TConsole::mousePressEvent(QMouseEvent* event)
 
 void TConsole::slot_adjustAccessibleNames()
 {
-    bool const multipleProfilesActive = (mudlet::self()->getHostManager().getHostCount() > 1);
+    const bool multipleProfilesActive = (mudlet::self()->getHostManager().getHostCount() > 1);
     switch (mType) {
     case CentralDebugConsole:
         setAccessibleName(tr("Debug Console."));

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1966,7 +1966,7 @@ void TConsole::dropEvent(QDropEvent* e)
         QFileInfo const info(fname);
         if (info.exists()) {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-            QPoint const pos = e->pos();
+            const QPoint pos = e->pos();
 #else
             QPoint pos = e->position().toPoint();
 #endif
@@ -1989,7 +1989,7 @@ void TConsole::dropEvent(QDropEvent* e)
     if (e->mimeData()->hasText()) {
         if (QUrl const url(e->mimeData()->text()); url.isValid()) {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-            QPoint const pos = e->pos();
+            const QPoint pos = e->pos();
 #else
             QPoint pos = e->position().toPoint();
 #endif
@@ -2053,7 +2053,7 @@ void TConsole::raiseMudletMousePressOrReleaseEvent(QMouseEvent* event, const boo
     default:                mudletEvent.mArgumentList.append(QString::number(0));
     }
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    QPoint const pos = event->pos();
+    const QPoint pos = event->pos();
 #else
     QPoint pos = event->position().toPoint();
 #endif

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -96,11 +96,11 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     setAttribute(Qt::WA_DeleteOnClose);
     setAttribute(Qt::WA_OpaquePaintEvent); //was disabled
 
-    QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    QSizePolicy sizePolicy3(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    QSizePolicy sizePolicy2(QSizePolicy::Expanding, QSizePolicy::Fixed);
-    QSizePolicy sizePolicy4(QSizePolicy::Fixed, QSizePolicy::Expanding);
-    QSizePolicy sizePolicy5(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    QSizePolicy const sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    QSizePolicy const sizePolicy3(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    QSizePolicy const sizePolicy2(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    QSizePolicy const sizePolicy4(QSizePolicy::Fixed, QSizePolicy::Expanding);
+    QSizePolicy const sizePolicy5(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
     mpMainFrame->setContentsMargins(0, 0, 0, 0);
 
@@ -348,13 +348,13 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
         int latencyFontPointSize = 21;
         QFont latencyFont = QFont(qsl("Bitstream Vera Sans Mono"), latencyFontPointSize, QFont::Normal);
         const int latencyFontSizeMargin = 10;
-        QString dummyTextA = tr("N:%1 S:%2",
+        QString const dummyTextA = tr("N:%1 S:%2",
                                 // intentional comment to separate arguments
                                 "The first argument 'N' represents the 'N'etwork latency; the second 'S' the "
                                 "'S'ystem (processing) time")
                                      .arg(0.0, 0, 'f', 3)
                                      .arg(0.0, 0, 'f', 3);
-        QString dummyTextB = tr("<no GA> S:%1",
+        QString const dummyTextB = tr("<no GA> S:%1",
                                 // intentional comment to separate arguments
                                 "The argument 'S' represents the 'S'ystem (processing) time, in this situation "
                                 "the Game Server is not sending \"GoAhead\" signals so we cannot deduce the "
@@ -563,7 +563,7 @@ Host* TConsole::getHost()
 
 void TConsole::resizeConsole()
 {
-    QSize size = QSize(width(), height());
+    QSize const size = QSize(width(), height());
     QResizeEvent event(size, size);
     QApplication::sendEvent(this, &event);
 }
@@ -629,15 +629,15 @@ void TConsole::resizeEvent(QResizeEvent* event)
 
     if (mType & MainConsole) {
         // don't call event in lua if size didn't change
-        bool preventLuaEvent = (getMainWindowSize() == mOldSize);
+        bool const preventLuaEvent = (getMainWindowSize() == mOldSize);
         mOldSize = getMainWindowSize();
         if (preventLuaEvent) {
             return;
         }
         if (!mpHost.isNull()) {
             TLuaInterpreter* pLua = mpHost->getLuaInterpreter();
-            QString func = "handleWindowResizeEvent";
-            QString n = "WindowResizeEvent";
+            QString const func = "handleWindowResizeEvent";
+            QString const n = "WindowResizeEvent";
             pLua->call(func, n);
 
             raiseMudletSysWindowResizeEvent(x, y);
@@ -646,8 +646,8 @@ void TConsole::resizeEvent(QResizeEvent* event)
 //create the sysUserWindowResize Event for automatic resizing with Geyser
     if (mType & (UserWindow) && !mpHost.isNull()) {
         TLuaInterpreter* pLua = mpHost->getLuaInterpreter();
-        QString func = "handleWindowResizeEvent";
-        QString n = "WindowResizeEvent";
+        QString const func = "handleWindowResizeEvent";
+        QString const n = "WindowResizeEvent";
         pLua->call(func, n);
 
         TEvent mudletEvent {};
@@ -697,7 +697,7 @@ void TConsole::refresh()
     mpMainDisplay->move(mBorders.left(), mBorders.top());
     x = width();
     y = height();
-    QSize s = QSize(x, y);
+    QSize const s = QSize(x, y);
     QResizeEvent event(s, s);
     QApplication::sendEvent(this, &event);
 }
@@ -785,9 +785,9 @@ void TConsole::closeEvent(QCloseEvent* event)
 
         if (mpHost->mpMap && mpHost->mpMap->mpRoomDB) {
             // There is a map loaded - but it *could* have no rooms at all!
-            QDir dir_map;
-            QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
-            QString filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString("yyyy-MM-dd#HH-mm-ss"));
+            QDir const dir_map;
+            QString const directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
+            QString const filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString("yyyy-MM-dd#HH-mm-ss"));
             if (!dir_map.exists(directory_map)) {
                 dir_map.mkpath(directory_map);
             }
@@ -811,7 +811,7 @@ void TConsole::closeEvent(QCloseEvent* event)
 
     if (!mUserAgreedToCloseConsole) {
     ASK:
-        int choice = QMessageBox::question(this, tr("Save profile?"), tr("Do you want to save the profile %1?").arg(mProfileName), QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+        int const choice = QMessageBox::question(this, tr("Save profile?"), tr("Do you want to save the profile %1?").arg(mProfileName), QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
         if (choice == QMessageBox::Cancel) {
             event->setAccepted(false);
             event->ignore();
@@ -828,9 +828,9 @@ void TConsole::closeEvent(QCloseEvent* event)
                 goto ASK;
             } else if (mpHost->mpMap && mpHost->mpMap->mpRoomDB) {
                 // There is a map loaded - but it *could* have no rooms at all!
-                QDir dir_map;
-                QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
-                QString filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
+                QDir const dir_map;
+                QString const directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
+                QString const filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
                 if (!dir_map.exists(directory_map)) {
                     dir_map.mkpath(directory_map);
                 }
@@ -899,9 +899,9 @@ void TConsole::slot_toggleReplayRecording()
     }
     mRecordReplay = !mRecordReplay;
     if (mRecordReplay) {
-        QString directoryLogFile = mudlet::getMudletPath(mudlet::profileReplayAndLogFilesPath, mProfileName);
-        QString mLogFileName = qsl("%1/%2.dat").arg(directoryLogFile, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
-        QDir dirLogFile;
+        QString const directoryLogFile = mudlet::getMudletPath(mudlet::profileReplayAndLogFilesPath, mProfileName);
+        QString const mLogFileName = qsl("%1/%2.dat").arg(directoryLogFile, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
+        QDir const dirLogFile;
         if (!dirLogFile.exists(directoryLogFile)) {
             dirLogFile.mkpath(directoryLogFile);
         }
@@ -1088,7 +1088,7 @@ void TConsole::scrollDown(int lines)
 
 void TConsole::scrollUp(int lines)
 {
-    bool lowerAppears = mLowerPane->isHidden();
+    bool const lowerAppears = mLowerPane->isHidden();
     mLowerPane->mCursorY = buffer.size();
     mLowerPane->show();
     mLowerPane->updateScreenView();
@@ -1097,7 +1097,7 @@ void TConsole::scrollUp(int lines)
     if (lowerAppears) {
         QTimer::singleShot(0, this, [this]() {  mUpperPane->scrollUp(mLowerPane->getRowCount()); });
         if (!mpHost->mTutorialForSplitscreenScrollbackAlreadyShown) {
-            QString infoMsg = tr("[ INFO ]  - Split-screen scrollback activated. Press CTRL-ENTER to cancel.");
+            QString const infoMsg = tr("[ INFO ]  - Split-screen scrollback activated. Press CTRL-ENTER to cancel.");
             mpHost->postMessage(infoMsg);
             mpHost->mTutorialForSplitscreenScrollbackAlreadyShown = true;
         }
@@ -1148,12 +1148,12 @@ void TConsole::reset()
 
 void TConsole::insertLink(const QString& text, QStringList& func, QStringList& hint, QPoint P, bool customFormat, QVector<int> luaReference)
 {
-    int x = P.x();
-    int y = P.y();
+    int const x = P.x();
+    int const y = P.y();
     QPoint P2 = P;
     P2.setX(x + text.size());
 
-    TChar standardLinkFormat = TChar(Qt::blue, mBgColor, TChar::Underline);
+    TChar const standardLinkFormat = TChar(Qt::blue, mBgColor, TChar::Underline);
     if (mTriggerEngineMode) {
         mpHost->getLuaInterpreter()->adjustCaptureGroups(x, text.size());
 
@@ -1190,11 +1190,11 @@ void TConsole::insertLink(const QString& text, QStringList& func, QStringList& h
 
             buffer.applyLink(P, P2, func, hint, luaReference);
             if (text.indexOf("\n") != -1) {
-                int y_tmp = mUserCursor.y();
-                int down = buffer.wrapLine(mUserCursor.y(), mpHost->mScreenWidth, mpHost->mWrapIndentCount, mFormatCurrent);
+                int const y_tmp = mUserCursor.y();
+                int const down = buffer.wrapLine(mUserCursor.y(), mpHost->mScreenWidth, mpHost->mWrapIndentCount, mFormatCurrent);
                 mUpperPane->needUpdate(y_tmp, y_tmp + down + 1);
-                int y_neu = y_tmp + down;
-                int x_adjust = text.lastIndexOf("\n");
+                int const y_neu = y_tmp + down;
+                int const x_adjust = text.lastIndexOf("\n");
                 int x_neu = 0;
                 if (x_adjust != -1) {
                     x_neu = text.size() - x_adjust - 1 > 0 ? text.size() - x_adjust - 1 : 0;
@@ -1210,8 +1210,8 @@ void TConsole::insertLink(const QString& text, QStringList& func, QStringList& h
 
 void TConsole::insertText(const QString& text, QPoint P)
 {
-    int x = P.x();
-    int y = P.y();
+    int const x = P.x();
+    int const y = P.y();
     if (mTriggerEngineMode) {
         mpHost->getLuaInterpreter()->adjustCaptureGroups(x, text.size());
         buffer.insertInLine(P, text, mFormatCurrent);
@@ -1226,9 +1226,9 @@ void TConsole::insertText(const QString& text, QPoint P)
             mLowerPane->showNewLines();
         } else {
             buffer.insertInLine(mUserCursor, text, mFormatCurrent);
-            int y_tmp = mUserCursor.y();
+            int const y_tmp = mUserCursor.y();
             if (text.indexOf(QChar::LineFeed) != -1) {
-                int down = buffer.wrapLine(y_tmp, mpHost->mScreenWidth, mpHost->mWrapIndentCount, mFormatCurrent);
+                int const down = buffer.wrapLine(y_tmp, mpHost->mScreenWidth, mpHost->mWrapIndentCount, mFormatCurrent);
                 mUpperPane->needUpdate(y_tmp, y_tmp + down + 1);
             } else {
                 mUpperPane->needUpdate(y_tmp, y_tmp + 1);
@@ -1241,18 +1241,18 @@ void TConsole::insertText(const QString& text, QPoint P)
 
 void TConsole::replace(const QString& text)
 {
-    int x = P_begin.x();
-    int o = P_end.x() - P_begin.x();
-    int r = text.size();
+    int const x = P_begin.x();
+    int const o = P_end.x() - P_begin.x();
+    int const r = text.size();
 
     if (mTriggerEngineMode) {
         if (hasSelection()) {
             if (r < o) {
-                int a = -1 * (o - r);
+                int const a = -1 * (o - r);
                 mpHost->getLuaInterpreter()->adjustCaptureGroups(x, a);
             }
             if (r > o) {
-                int a = r - o;
+                int const a = r - o;
                 mpHost->getLuaInterpreter()->adjustCaptureGroups(x, a);
             }
         } else {
@@ -1320,7 +1320,7 @@ int TConsole::getLineCount()
 QStringList TConsole::getLines(int from, int to)
 {
     QStringList ret;
-    int delta = abs(from - to);
+    int const delta = abs(from - to);
     for (int i = 0; i < delta; i++) {
         ret << buffer.line(from + i);
     }
@@ -1335,8 +1335,8 @@ void TConsole::selectCurrentLine()
 std::list<int> TConsole::getFgColor()
 {
     std::list<int> result;
-    int x = P_begin.x();
-    int y = P_begin.y();
+    int const x = P_begin.x();
+    int const y = P_begin.y();
     if (y < 0) {
         return result;
     }
@@ -1348,9 +1348,9 @@ std::list<int> TConsole::getFgColor()
     }
 
     auto line = buffer.buffer.at(y);
-    int len = static_cast<int>(line.size());
+    int const len = static_cast<int>(line.size());
     if (len - 1 >= x) {
-        QColor color(line.at(x).foreground());
+        QColor const color(line.at(x).foreground());
         result.push_back(color.red());
         result.push_back(color.green());
         result.push_back(color.blue());
@@ -1362,8 +1362,8 @@ std::list<int> TConsole::getFgColor()
 std::list<int> TConsole::getBgColor()
 {
     std::list<int> result;
-    int x = P_begin.x();
-    int y = P_begin.y();
+    int const x = P_begin.x();
+    int const y = P_begin.y();
     if (y < 0) {
         return result;
     }
@@ -1375,9 +1375,9 @@ std::list<int> TConsole::getBgColor()
     }
 
     auto line = buffer.buffer.at(y);
-    int len = static_cast<int>(line.size());
+    int const len = static_cast<int>(line.size());
     if (len - 1 >= x) {
-        QColor color(line.at(x).background());
+        QColor const color(line.at(x).background());
         result.push_back(color.red());
         result.push_back(color.green());
         result.push_back(color.blue());
@@ -1388,8 +1388,8 @@ std::list<int> TConsole::getBgColor()
 
 QPair<quint8, TChar> TConsole::getTextAttributes() const
 {
-    int x = P_begin.x();
-    int y = P_begin.y();
+    int const x = P_begin.x();
+    int const y = P_begin.y();
     if (y < 0 || x < 0 || y >= static_cast<int>(buffer.buffer.size()) || x >= (static_cast<int>(buffer.buffer.at(y).size()) - 1)) {
         return qMakePair(2, TChar());
     }
@@ -1453,7 +1453,7 @@ bool TConsole::resetConsoleBackgroundImage()
 
 void TConsole::setCmdVisible(bool isVisible)
 {
-    QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    QSizePolicy const sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     // create MiniConsole commandline if it's not existing
     if (!mpCommandLine) {
         mpCommandLine = new TCommandLine(mpHost, mConsoleName, TCommandLine::ConsoleCommandLine, this, mpMainDisplay);
@@ -1521,7 +1521,7 @@ int TConsole::getLastLineNumber()
 
 void TConsole::moveCursorEnd()
 {
-    int y = buffer.getLastLineNumber();
+    int const y = buffer.getLastLineNumber();
     int x = buffer.line(y).size() - 1;
     x = x >= 0 ? x : 0;
     moveCursor(x, y);
@@ -1556,7 +1556,7 @@ int TConsole::select(const QString& text, int numOfMatch)
 
     int begin = -1;
     for (int i = 0; i < numOfMatch; i++) {
-        QString li = buffer.line(mUserCursor.y());
+        QString const li = buffer.line(mUserCursor.y());
         if (li.isEmpty()) {
             continue;
         }
@@ -1571,7 +1571,7 @@ int TConsole::select(const QString& text, int numOfMatch)
         }
     }
 
-    int end = begin + text.size();
+    int const end = begin + text.size();
     P_begin.setX(begin);
     P_begin.setY(mUserCursor.y());
     P_end.setX(end);
@@ -1596,7 +1596,7 @@ bool TConsole::selectSection(int from, int to)
     if (mUserCursor.y() >= static_cast<int>(buffer.buffer.size())) {
         return false;
     }
-    int s = buffer.buffer[mUserCursor.y()].size();
+    int const s = buffer.buffer[mUserCursor.y()].size();
     if (from > s || from + to > s) {
         return false;
     }
@@ -1713,7 +1713,7 @@ void TConsole::printCommand(QString& msg)
 {
     if (mTriggerEngineMode) {
         msg.append(QChar::LineFeed);
-        int lineBeforeNewContent = buffer.getLastLineNumber();
+        int const lineBeforeNewContent = buffer.getLastLineNumber();
         if (lineBeforeNewContent >= 0) {
             if (buffer.lineBuffer.at(lineBeforeNewContent).right(1) != QChar(QChar::LineFeed)) {
                 msg.prepend(QChar::LineFeed);
@@ -1721,7 +1721,7 @@ void TConsole::printCommand(QString& msg)
         }
         buffer.appendLine(msg, 0, msg.size() - 1, mCommandFgColor, mCommandBgColor);
     } else {
-        int lineBeforeNewContent = buffer.size() - 2;
+        int const lineBeforeNewContent = buffer.size() - 2;
         if (lineBeforeNewContent >= 0) {
             int promptEnd = buffer.buffer.at(lineBeforeNewContent).size();
             if (promptEnd < 0) {
@@ -1729,9 +1729,9 @@ void TConsole::printCommand(QString& msg)
             }
             if (buffer.promptBuffer[lineBeforeNewContent]) {
                 QPoint P(promptEnd, lineBeforeNewContent);
-                TChar format(mCommandFgColor, mCommandBgColor);
+                TChar const format(mCommandFgColor, mCommandBgColor);
                 buffer.insertInLine(P, msg, format);
-                int down = buffer.wrapLine(lineBeforeNewContent, mpHost->mScreenWidth, mpHost->mWrapIndentCount, mFormatCurrent);
+                int const down = buffer.wrapLine(lineBeforeNewContent, mpHost->mScreenWidth, mpHost->mWrapIndentCount, mFormatCurrent);
 
                 mUpperPane->needUpdate(lineBeforeNewContent, lineBeforeNewContent + 1 + down);
                 mLowerPane->needUpdate(lineBeforeNewContent, lineBeforeNewContent + 1 + down);
@@ -1749,7 +1749,7 @@ void TConsole::echoLink(const QString& text, QStringList& func, QStringList& hin
     if (customFormat) {
         buffer.addLink(mTriggerEngineMode, text, func, hint, mFormatCurrent, luaReference);
     } else {
-        TChar f = TChar(Qt::blue, (mType == MainConsole ? mpHost->mBgColor : mBgColor), TChar::Underline);
+        TChar const f = TChar(Qt::blue, (mType == MainConsole ? mpHost->mBgColor : mBgColor), TChar::Underline);
         buffer.addLink(mTriggerEngineMode, text, func, hint, f, luaReference);
     }
     mUpperPane->showNewLines();
@@ -1759,7 +1759,7 @@ void TConsole::echoLink(const QString& text, QStringList& func, QStringList& hin
 // An overload of print(const QString& msg):
 void TConsole::print(const char* txt)
 {
-    QString msg(txt);
+    QString const msg(txt);
     print(msg);
 }
 
@@ -1790,7 +1790,7 @@ void TConsole::print(const QString& msg, const QColor fgColor, const QColor bgCo
 
 void TConsole::printSystemMessage(const QString& msg)
 {
-    QString txt = tr("System Message: %1").arg(msg);
+    QString const txt = tr("System Message: %1").arg(msg);
     print(txt, mSystemMessageFgColor, mSystemMessageBgColor);
 }
 
@@ -1937,10 +1937,10 @@ QSize TConsole::getMainWindowSize() const
     if (isHidden()) {
         return mOldSize;
     }
-    QSize consoleSize = size();
-    int toolbarWidth = mpLeftToolBar->width() + mpRightToolBar->width();
-    int toolbarHeight = mpTopToolBar->height();
-    int commandLineHeight = mpCommandLine->height();
+    QSize const consoleSize = size();
+    int const toolbarWidth = mpLeftToolBar->width() + mpRightToolBar->width();
+    int const toolbarHeight = mpTopToolBar->height();
+    int const commandLineHeight = mpCommandLine->height();
     QSize mainWindowSize(consoleSize.width() - toolbarWidth, consoleSize.height() - (commandLineHeight + toolbarHeight));
     return mainWindowSize;
 }
@@ -1962,11 +1962,11 @@ void TConsole::dragEnterEvent(QDragEnterEvent* e)
 void TConsole::dropEvent(QDropEvent* e)
 {
     for (const auto& url : e->mimeData()->urls()) {
-        QString fname = url.toLocalFile();
-        QFileInfo info(fname);
+        QString const fname = url.toLocalFile();
+        QFileInfo const info(fname);
         if (info.exists()) {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-            QPoint pos = e->pos();
+            QPoint const pos = e->pos();
 #else
             QPoint pos = e->position().toPoint();
 #endif
@@ -1987,9 +1987,9 @@ void TConsole::dropEvent(QDropEvent* e)
         }
     }
     if (e->mimeData()->hasText()) {
-        if (QUrl url(e->mimeData()->text()); url.isValid()) {
+        if (QUrl const url(e->mimeData()->text()); url.isValid()) {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-            QPoint pos = e->pos();
+            QPoint const pos = e->pos();
 #else
             QPoint pos = e->position().toPoint();
 #endif
@@ -2053,7 +2053,7 @@ void TConsole::raiseMudletMousePressOrReleaseEvent(QMouseEvent* event, const boo
     default:                mudletEvent.mArgumentList.append(QString::number(0));
     }
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    QPoint pos = event->pos();
+    QPoint const pos = event->pos();
 #else
     QPoint pos = event->position().toPoint();
 #endif
@@ -2077,7 +2077,7 @@ void TConsole::mousePressEvent(QMouseEvent* event)
 
 void TConsole::slot_adjustAccessibleNames()
 {
-    bool multipleProfilesActive = (mudlet::self()->getHostManager().getHostCount() > 1);
+    bool const multipleProfilesActive = (mudlet::self()->getHostManager().getHostCount() > 1);
     switch (mType) {
     case CentralDebugConsole:
         setAccessibleName(tr("Debug Console."));

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -811,7 +811,7 @@ void TConsole::closeEvent(QCloseEvent* event)
 
     if (!mUserAgreedToCloseConsole) {
     ASK:
-        int const choice = QMessageBox::question(this, tr("Save profile?"), tr("Do you want to save the profile %1?").arg(mProfileName), QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+        const int choice = QMessageBox::question(this, tr("Save profile?"), tr("Do you want to save the profile %1?").arg(mProfileName), QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
         if (choice == QMessageBox::Cancel) {
             event->setAccepted(false);
             event->ignore();
@@ -1148,8 +1148,8 @@ void TConsole::reset()
 
 void TConsole::insertLink(const QString& text, QStringList& func, QStringList& hint, QPoint P, bool customFormat, QVector<int> luaReference)
 {
-    int const x = P.x();
-    int const y = P.y();
+    const int x = P.x();
+    const int y = P.y();
     QPoint P2 = P;
     P2.setX(x + text.size());
 
@@ -1190,11 +1190,11 @@ void TConsole::insertLink(const QString& text, QStringList& func, QStringList& h
 
             buffer.applyLink(P, P2, func, hint, luaReference);
             if (text.indexOf("\n") != -1) {
-                int const y_tmp = mUserCursor.y();
-                int const down = buffer.wrapLine(mUserCursor.y(), mpHost->mScreenWidth, mpHost->mWrapIndentCount, mFormatCurrent);
+                const int y_tmp = mUserCursor.y();
+                const int down = buffer.wrapLine(mUserCursor.y(), mpHost->mScreenWidth, mpHost->mWrapIndentCount, mFormatCurrent);
                 mUpperPane->needUpdate(y_tmp, y_tmp + down + 1);
-                int const y_neu = y_tmp + down;
-                int const x_adjust = text.lastIndexOf("\n");
+                const int y_neu = y_tmp + down;
+                const int x_adjust = text.lastIndexOf("\n");
                 int x_neu = 0;
                 if (x_adjust != -1) {
                     x_neu = text.size() - x_adjust - 1 > 0 ? text.size() - x_adjust - 1 : 0;
@@ -1210,8 +1210,8 @@ void TConsole::insertLink(const QString& text, QStringList& func, QStringList& h
 
 void TConsole::insertText(const QString& text, QPoint P)
 {
-    int const x = P.x();
-    int const y = P.y();
+    const int x = P.x();
+    const int y = P.y();
     if (mTriggerEngineMode) {
         mpHost->getLuaInterpreter()->adjustCaptureGroups(x, text.size());
         buffer.insertInLine(P, text, mFormatCurrent);
@@ -1226,9 +1226,9 @@ void TConsole::insertText(const QString& text, QPoint P)
             mLowerPane->showNewLines();
         } else {
             buffer.insertInLine(mUserCursor, text, mFormatCurrent);
-            int const y_tmp = mUserCursor.y();
+            const int y_tmp = mUserCursor.y();
             if (text.indexOf(QChar::LineFeed) != -1) {
-                int const down = buffer.wrapLine(y_tmp, mpHost->mScreenWidth, mpHost->mWrapIndentCount, mFormatCurrent);
+                const int down = buffer.wrapLine(y_tmp, mpHost->mScreenWidth, mpHost->mWrapIndentCount, mFormatCurrent);
                 mUpperPane->needUpdate(y_tmp, y_tmp + down + 1);
             } else {
                 mUpperPane->needUpdate(y_tmp, y_tmp + 1);
@@ -1241,18 +1241,18 @@ void TConsole::insertText(const QString& text, QPoint P)
 
 void TConsole::replace(const QString& text)
 {
-    int const x = P_begin.x();
-    int const o = P_end.x() - P_begin.x();
-    int const r = text.size();
+    const int x = P_begin.x();
+    const int o = P_end.x() - P_begin.x();
+    const int r = text.size();
 
     if (mTriggerEngineMode) {
         if (hasSelection()) {
             if (r < o) {
-                int const a = -1 * (o - r);
+                const int a = -1 * (o - r);
                 mpHost->getLuaInterpreter()->adjustCaptureGroups(x, a);
             }
             if (r > o) {
-                int const a = r - o;
+                const int a = r - o;
                 mpHost->getLuaInterpreter()->adjustCaptureGroups(x, a);
             }
         } else {
@@ -1320,7 +1320,7 @@ int TConsole::getLineCount()
 QStringList TConsole::getLines(int from, int to)
 {
     QStringList ret;
-    int const delta = abs(from - to);
+    const int delta = abs(from - to);
     for (int i = 0; i < delta; i++) {
         ret << buffer.line(from + i);
     }
@@ -1335,8 +1335,8 @@ void TConsole::selectCurrentLine()
 std::list<int> TConsole::getFgColor()
 {
     std::list<int> result;
-    int const x = P_begin.x();
-    int const y = P_begin.y();
+    const int x = P_begin.x();
+    const int y = P_begin.y();
     if (y < 0) {
         return result;
     }
@@ -1348,7 +1348,7 @@ std::list<int> TConsole::getFgColor()
     }
 
     auto line = buffer.buffer.at(y);
-    int const len = static_cast<int>(line.size());
+    const int len = static_cast<int>(line.size());
     if (len - 1 >= x) {
         QColor const color(line.at(x).foreground());
         result.push_back(color.red());
@@ -1362,8 +1362,8 @@ std::list<int> TConsole::getFgColor()
 std::list<int> TConsole::getBgColor()
 {
     std::list<int> result;
-    int const x = P_begin.x();
-    int const y = P_begin.y();
+    const int x = P_begin.x();
+    const int y = P_begin.y();
     if (y < 0) {
         return result;
     }
@@ -1375,7 +1375,7 @@ std::list<int> TConsole::getBgColor()
     }
 
     auto line = buffer.buffer.at(y);
-    int const len = static_cast<int>(line.size());
+    const int len = static_cast<int>(line.size());
     if (len - 1 >= x) {
         QColor const color(line.at(x).background());
         result.push_back(color.red());
@@ -1388,8 +1388,8 @@ std::list<int> TConsole::getBgColor()
 
 QPair<quint8, TChar> TConsole::getTextAttributes() const
 {
-    int const x = P_begin.x();
-    int const y = P_begin.y();
+    const int x = P_begin.x();
+    const int y = P_begin.y();
     if (y < 0 || x < 0 || y >= static_cast<int>(buffer.buffer.size()) || x >= (static_cast<int>(buffer.buffer.at(y).size()) - 1)) {
         return qMakePair(2, TChar());
     }
@@ -1521,7 +1521,7 @@ int TConsole::getLastLineNumber()
 
 void TConsole::moveCursorEnd()
 {
-    int const y = buffer.getLastLineNumber();
+    const int y = buffer.getLastLineNumber();
     int x = buffer.line(y).size() - 1;
     x = x >= 0 ? x : 0;
     moveCursor(x, y);
@@ -1571,7 +1571,7 @@ int TConsole::select(const QString& text, int numOfMatch)
         }
     }
 
-    int const end = begin + text.size();
+    const int end = begin + text.size();
     P_begin.setX(begin);
     P_begin.setY(mUserCursor.y());
     P_end.setX(end);
@@ -1596,7 +1596,7 @@ bool TConsole::selectSection(int from, int to)
     if (mUserCursor.y() >= static_cast<int>(buffer.buffer.size())) {
         return false;
     }
-    int const s = buffer.buffer[mUserCursor.y()].size();
+    const int s = buffer.buffer[mUserCursor.y()].size();
     if (from > s || from + to > s) {
         return false;
     }
@@ -1713,7 +1713,7 @@ void TConsole::printCommand(QString& msg)
 {
     if (mTriggerEngineMode) {
         msg.append(QChar::LineFeed);
-        int const lineBeforeNewContent = buffer.getLastLineNumber();
+        const int lineBeforeNewContent = buffer.getLastLineNumber();
         if (lineBeforeNewContent >= 0) {
             if (buffer.lineBuffer.at(lineBeforeNewContent).right(1) != QChar(QChar::LineFeed)) {
                 msg.prepend(QChar::LineFeed);
@@ -1721,7 +1721,7 @@ void TConsole::printCommand(QString& msg)
         }
         buffer.appendLine(msg, 0, msg.size() - 1, mCommandFgColor, mCommandBgColor);
     } else {
-        int const lineBeforeNewContent = buffer.size() - 2;
+        const int lineBeforeNewContent = buffer.size() - 2;
         if (lineBeforeNewContent >= 0) {
             int promptEnd = buffer.buffer.at(lineBeforeNewContent).size();
             if (promptEnd < 0) {
@@ -1731,7 +1731,7 @@ void TConsole::printCommand(QString& msg)
                 QPoint P(promptEnd, lineBeforeNewContent);
                 TChar const format(mCommandFgColor, mCommandBgColor);
                 buffer.insertInLine(P, msg, format);
-                int const down = buffer.wrapLine(lineBeforeNewContent, mpHost->mScreenWidth, mpHost->mWrapIndentCount, mFormatCurrent);
+                const int down = buffer.wrapLine(lineBeforeNewContent, mpHost->mScreenWidth, mpHost->mWrapIndentCount, mFormatCurrent);
 
                 mUpperPane->needUpdate(lineBeforeNewContent, lineBeforeNewContent + 1 + down);
                 mLowerPane->needUpdate(lineBeforeNewContent, lineBeforeNewContent + 1 + down);
@@ -1938,9 +1938,9 @@ QSize TConsole::getMainWindowSize() const
         return mOldSize;
     }
     QSize const consoleSize = size();
-    int const toolbarWidth = mpLeftToolBar->width() + mpRightToolBar->width();
-    int const toolbarHeight = mpTopToolBar->height();
-    int const commandLineHeight = mpCommandLine->height();
+    const int toolbarWidth = mpLeftToolBar->width() + mpRightToolBar->width();
+    const int toolbarHeight = mpTopToolBar->height();
+    const int commandLineHeight = mpCommandLine->height();
     QSize mainWindowSize(consoleSize.width() - toolbarWidth, consoleSize.height() - (commandLineHeight + toolbarHeight));
     return mainWindowSize;
 }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1153,7 +1153,7 @@ void TConsole::insertLink(const QString& text, QStringList& func, QStringList& h
     QPoint P2 = P;
     P2.setX(x + text.size());
 
-    TChar const standardLinkFormat = TChar(Qt::blue, mBgColor, TChar::Underline);
+    const TChar standardLinkFormat = TChar(Qt::blue, mBgColor, TChar::Underline);
     if (mTriggerEngineMode) {
         mpHost->getLuaInterpreter()->adjustCaptureGroups(x, text.size());
 
@@ -1729,7 +1729,7 @@ void TConsole::printCommand(QString& msg)
             }
             if (buffer.promptBuffer[lineBeforeNewContent]) {
                 QPoint P(promptEnd, lineBeforeNewContent);
-                TChar const format(mCommandFgColor, mCommandBgColor);
+                const TChar format(mCommandFgColor, mCommandBgColor);
                 buffer.insertInLine(P, msg, format);
                 const int down = buffer.wrapLine(lineBeforeNewContent, mpHost->mScreenWidth, mpHost->mWrapIndentCount, mFormatCurrent);
 
@@ -1749,7 +1749,7 @@ void TConsole::echoLink(const QString& text, QStringList& func, QStringList& hin
     if (customFormat) {
         buffer.addLink(mTriggerEngineMode, text, func, hint, mFormatCurrent, luaReference);
     } else {
-        TChar const f = TChar(Qt::blue, (mType == MainConsole ? mpHost->mBgColor : mBgColor), TChar::Underline);
+        const TChar f = TChar(Qt::blue, (mType == MainConsole ? mpHost->mBgColor : mBgColor), TChar::Underline);
         buffer.addLink(mTriggerEngineMode, text, func, hint, f, luaReference);
     }
     mUpperPane->showNewLines();

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -336,7 +336,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS(TConsole::ConsoleType)
 inline QDebug& operator<<(QDebug& debug, const TConsole::ConsoleType& type)
 {
     QString text;
-    QDebugStateSaver saver(debug);
+    QDebugStateSaver const saver(debug);
     switch (type) {
     case TConsole::UnknownType:           text = qsl("Unknown"); break;
     case TConsole::CentralDebugConsole:   text = qsl("Central Debug Console"); break;

--- a/src/TDebug.cpp
+++ b/src/TDebug.cpp
@@ -44,7 +44,7 @@ TDebug& TDebug::operator>>(Host* pHost)
         if (Q_LIKELY(!msg.isEmpty())) {
             // Don't enqueue empty messages
             auto tag = deduceProfileTag(msg, pHost);
-            TDebugMessage newMessage(msg, tag, fgColor, bgColor);
+            TDebugMessage const newMessage(msg, tag, fgColor, bgColor);
             smMessageQueue.enqueue(newMessage);
         }
 

--- a/src/TEasyButtonBar.cpp
+++ b/src/TEasyButtonBar.cpp
@@ -49,7 +49,7 @@ TEasyButtonBar::TEasyButtonBar(TAction* pA, QString name, QWidget* pW)
         setContentsMargins(0, 0, 0, 0);
         mpLayout->setContentsMargins(0, 0, 0, 0);
         mpLayout->setSpacing(0);
-        QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+        QSizePolicy const sizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
         mpWidget->setSizePolicy(sizePolicy);
     } else {
         mpWidget->setMinimumHeight(mpTAction->mSizeY);
@@ -76,7 +76,7 @@ void TEasyButtonBar::addButton(TFlipButton* pB)
         }
     } else {
         qDebug() << "setting up custom sizes";
-        QSize size = QSize(pB->mpTAction->mSizeX, pB->mpTAction->mSizeY);
+        QSize const size = QSize(pB->mpTAction->mSizeX, pB->mpTAction->mSizeY);
         pB->setMaximumSize(size);
         pB->setMinimumSize(size);
         pB->setParent(mpWidget);
@@ -85,7 +85,7 @@ void TEasyButtonBar::addButton(TFlipButton* pB)
 
     pB->setStyleSheet(pB->mpTAction->css);
     pB->setFlat(pB->mpTAction->getButtonFlat());
-    int rotation = pB->mpTAction->getButtonRotation();
+    int const rotation = pB->mpTAction->getButtonRotation();
     switch (rotation) {
     case 0:
         pB->setOrientation(Qt::Horizontal);
@@ -108,8 +108,8 @@ void TEasyButtonBar::addButton(TFlipButton* pB)
         }
         if (columns > 0) {
             mItemCount++;
-            int row = mItemCount / columns;
-            int col = mItemCount % columns;
+            int const row = mItemCount / columns;
+            int const col = mItemCount % columns;
             if (mVerticalOrientation) {
                 mpLayout->addWidget(pB, row, col);
             } else {
@@ -136,14 +136,14 @@ void TEasyButtonBar::finalize()
     }
     auto fillerWidget = new QWidget;
 
-    QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    QSizePolicy const sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     fillerWidget->setSizePolicy(sizePolicy);
     int columns = mpTAction->getButtonColumns();
     if (columns <= 0) {
         columns = 1;
     }
-    int row = (++mItemCount) / columns;
-    int column = mItemCount % columns;
+    int const row = (++mItemCount) / columns;
+    int const column = mItemCount % columns;
     if (mpLayout) {
         mpLayout->addWidget(fillerWidget, row, column);
     }
@@ -200,7 +200,7 @@ void TEasyButtonBar::clear()
         mpWidget->setLayout(mpLayout);
         mpLayout->setContentsMargins(0, 0, 0, 0);
         mpLayout->setSpacing(0);
-        QSizePolicy sizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+        QSizePolicy const sizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
         mpWidget->setSizePolicy(sizePolicy);
 
         mpWidget->setContentsMargins(0, 0, 0, 0);

--- a/src/TEasyButtonBar.cpp
+++ b/src/TEasyButtonBar.cpp
@@ -85,7 +85,7 @@ void TEasyButtonBar::addButton(TFlipButton* pB)
 
     pB->setStyleSheet(pB->mpTAction->css);
     pB->setFlat(pB->mpTAction->getButtonFlat());
-    int const rotation = pB->mpTAction->getButtonRotation();
+    const int rotation = pB->mpTAction->getButtonRotation();
     switch (rotation) {
     case 0:
         pB->setOrientation(Qt::Horizontal);
@@ -108,8 +108,8 @@ void TEasyButtonBar::addButton(TFlipButton* pB)
         }
         if (columns > 0) {
             mItemCount++;
-            int const row = mItemCount / columns;
-            int const col = mItemCount % columns;
+            const int row = mItemCount / columns;
+            const int col = mItemCount % columns;
             if (mVerticalOrientation) {
                 mpLayout->addWidget(pB, row, col);
             } else {
@@ -142,8 +142,8 @@ void TEasyButtonBar::finalize()
     if (columns <= 0) {
         columns = 1;
     }
-    int const row = (++mItemCount) / columns;
-    int const column = mItemCount % columns;
+    const int row = (++mItemCount) / columns;
+    const int column = mItemCount % columns;
     if (mpLayout) {
         mpLayout->addWidget(fillerWidget, row, column);
     }

--- a/src/TEncodingTable.cpp
+++ b/src/TEncodingTable.cpp
@@ -35,7 +35,7 @@ QList<QByteArray> TEncodingTable::getEncodingNames() const
 
         QMutableByteArrayListIterator itEncoding(results);
         while (itEncoding.hasNext()) {
-            QByteArray encoding{itEncoding.next()};
+            QByteArray const encoding{itEncoding.next()};
             QTextCodec* pEncoding = QTextCodec::codecForName(encoding);
             if (!pEncoding) {
                 // We do not have that encoder available after all

--- a/src/TEntityResolver.cpp
+++ b/src/TEntityResolver.cpp
@@ -63,7 +63,7 @@ QString TEntityResolver::resolveCode(const QString& entityValue)
 QString TEntityResolver::resolveCode(const QString& entityValue, int base)
 {
     bool isNum = false;
-    ushort code = entityValue.toUShort(&isNum, base);
+    ushort const code = entityValue.toUShort(&isNum, base);
     return isNum ? resolveCode(code) : entityValue;
 }
 

--- a/src/TEvent.h
+++ b/src/TEvent.h
@@ -47,7 +47,7 @@ public:
 // Note "inline" is REQUIRED:
 inline QDebug& operator<<(QDebug& debug, const TEvent& event)
 {
-    QDebugStateSaver saver(debug);
+    QDebugStateSaver const saver(debug);
     const int argCount = event.mArgumentList.count();
     const int typeCount = event.mArgumentTypeList.count();
     int i = 0;

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -166,7 +166,7 @@ bool TKey::setScript(const QString& script)
 bool TKey::compileScript()
 {
     mFuncName = QString("Key") + QString::number(mID);
-    QString code = QString("function ") + mFuncName + QString("()\n") + mScript + QString("\nend\n");
+    QString const code = QString("function ") + mFuncName + QString("()\n") + mScript + QString("\nend\n");
     QString error;
     if (mpHost->mLuaInterpreter.compile(code, error, QString("Key: ") + getName())) {
         mNeedsToBeCompiled = false;

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -166,7 +166,7 @@ bool TKey::setScript(const QString& script)
 bool TKey::compileScript()
 {
     mFuncName = QString("Key") + QString::number(mID);
-    QString const code = QString("function ") + mFuncName + QString("()\n") + mScript + QString("\nend\n");
+    const QString code = QString("function ") + mFuncName + QString("()\n") + mScript + QString("\nend\n");
     QString error;
     if (mpHost->mLuaInterpreter.compile(code, error, QString("Key: ") + getName())) {
         mNeedsToBeCompiled = false;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -8925,7 +8925,7 @@ int TLuaInterpreter::highlightRoom(lua_State* L)
     const int bgr = getVerifiedInt(L, __func__, 5, "color2Red");
     const int bgg = getVerifiedInt(L, __func__, 6, "color2Green");
     const int bgb = getVerifiedInt(L, __func__, 7, "color2Blue");
-    float const radius = getVerifiedFloat(L, __func__, 8, "highlightRadius");
+    const float radius = getVerifiedFloat(L, __func__, 8, "highlightRadius");
     const int alpha1 = getVerifiedInt(L, __func__, 9, "color1Alpha");
     const int alpha2 = getVerifiedInt(L, __func__, 10, "color2Alpha");
 
@@ -8966,9 +8966,9 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
     const int args = lua_gettop(L);
     const int area = getVerifiedInt(L, __func__, 1, "areaID");
     const QString text = getVerifiedString(L, __func__, 2, "text");
-    float const posx = getVerifiedFloat(L, __func__, 3, "posX");
-    float const posy = getVerifiedFloat(L, __func__, 4, "posY");
-    float const posz = getVerifiedFloat(L, __func__, 5, "posZ");
+    const float posx = getVerifiedFloat(L, __func__, 3, "posX");
+    const float posy = getVerifiedFloat(L, __func__, 4, "posY");
+    const float posz = getVerifiedFloat(L, __func__, 5, "posZ");
     const int fgr = getVerifiedInt(L, __func__, 6, "fgRed");
     const int fgg = getVerifiedInt(L, __func__, 7, "fgGreen");
     const int fgb = getVerifiedInt(L, __func__, 8, "fgBlue");
@@ -9056,12 +9056,12 @@ int TLuaInterpreter::createMapImageLabel(lua_State* L)
     const int args = lua_gettop(L);
     const int area = getVerifiedInt(L, __func__, 1, "areaID");
     const QString imagePathFileName = getVerifiedString(L, __func__, 2, "imagePathFileName");
-    float const posx = getVerifiedFloat(L, __func__, 3, "posX");
-    float const posy = getVerifiedFloat(L, __func__, 4, "posY");
-    float const posz = getVerifiedFloat(L, __func__, 5, "posZ");
-    float const width = getVerifiedFloat(L, __func__, 6, "width");
-    float const height = getVerifiedFloat(L, __func__, 7, "height");
-    float const zoom = getVerifiedFloat(L, __func__, 8, "zoom");
+    const float posx = getVerifiedFloat(L, __func__, 3, "posX");
+    const float posy = getVerifiedFloat(L, __func__, 4, "posY");
+    const float posz = getVerifiedFloat(L, __func__, 5, "posZ");
+    const float width = getVerifiedFloat(L, __func__, 6, "width");
+    const float height = getVerifiedFloat(L, __func__, 7, "height");
+    const float zoom = getVerifiedFloat(L, __func__, 8, "zoom");
     const bool showOnTop = getVerifiedBool(L, __func__, 9, "showOnTop");
     bool temporary = false;
     if (args > 9) {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -525,7 +525,7 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
         break;
 
     case QNetworkAccessManager::GetOperation:
-        QString const localFileName = downloadMap.value(reply);
+        const QString localFileName = downloadMap.value(reply);
         downloadMap.remove(reply);
 
         // If the user did not give us a file path, we're not going to
@@ -980,7 +980,7 @@ int TLuaInterpreter::selectString(lua_State* L)
         windowName = WINDOW_NAME(L, s++);
     }
 
-    QString const searchText = getVerifiedString(L, __func__, s++, "text to select");
+    const QString searchText = getVerifiedString(L, __func__, s++, "text to select");
     // CHECK: Do we need to qualify this for a non-blank string?
 
     qint64 const numOfMatch = static_cast <qint64> (getVerifiedInt(L, __func__, s, "match count {1 for first}"));
@@ -1432,7 +1432,7 @@ int TLuaInterpreter::getLines(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#loadReplay
 int TLuaInterpreter::loadReplay(lua_State* L)
 {
-    QString const replayFileName = getVerifiedString(L, __func__, 1, "replay file name");
+    const QString replayFileName = getVerifiedString(L, __func__, 1, "replay file name");
     if (replayFileName.isEmpty()) {
         return warnArgumentValue(L, __func__, "a blank string is not a valid replay file name");
     }
@@ -1452,7 +1452,7 @@ int TLuaInterpreter::loadReplay(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setProfileIcon
 int TLuaInterpreter::setProfileIcon(lua_State* L)
 {
-    QString const iconPath = getVerifiedString(L, __func__, 1, "icon file path");
+    const QString iconPath = getVerifiedString(L, __func__, 1, "icon file path");
     if (iconPath.isEmpty()) {
         return warnArgumentValue(L, __func__, "a blank string is not a valid icon file path");
     }
@@ -1486,7 +1486,7 @@ int TLuaInterpreter::resetProfileIcon(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getCurrentLine
 int TLuaInterpreter::getCurrentLine(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     auto console = getHostFromLua(L).findConsole(windowName);
     if (!console) {
         // the next line should be "pushnil"; compatibility with old bugs and all that
@@ -1494,7 +1494,7 @@ int TLuaInterpreter::getCurrentLine(lua_State* L)
         lua_pushfstring(L, bad_window_value, windowName.toUtf8().constData());
         return 2;
     }
-    QString const line = console->getCurrentLine();
+    const QString line = console->getCurrentLine();
     lua_pushstring(L, line.toUtf8().constData());
     return 1;
 }
@@ -1502,7 +1502,7 @@ int TLuaInterpreter::getCurrentLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMiniConsoleFontSize
 int TLuaInterpreter::setMiniConsoleFontSize(lua_State* L)
 {
-    QString const windowName = getVerifiedString(L, __func__, 1, "miniconsole name");
+    const QString windowName = getVerifiedString(L, __func__, 1, "miniconsole name");
     int const size = getVerifiedInt(L, __func__, 2, "font size");
     auto console = CONSOLE(L, windowName);
     if (console->setFontSize(size)) {
@@ -1543,7 +1543,7 @@ int TLuaInterpreter::addMapMenu(lua_State* L)
 {
     //    first arg = unique name, second arg= parent name, third arg = display name (=unique name if not provided)
     QStringList menuList;
-    QString const uniqueName = getVerifiedString(L, __func__, 1, "uniquename");
+    const QString uniqueName = getVerifiedString(L, __func__, 1, "uniquename");
 
     if (!lua_isstring(L, 2)) {
         menuList << "";
@@ -1569,7 +1569,7 @@ int TLuaInterpreter::addMapMenu(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#removeMapMenu
 int TLuaInterpreter::removeMapMenu(lua_State* L)
 {
-    QString const uniqueName = getVerifiedString(L, __func__, 1, "Menu name");
+    const QString uniqueName = getVerifiedString(L, __func__, 1, "Menu name");
     if (uniqueName.isEmpty()) {
         return 0;
     }
@@ -1588,7 +1588,7 @@ int TLuaInterpreter::removeMapMenu(lua_State* L)
                     while (it.hasNext()) {
                         it.next();
                         QStringList menuInfo = it.value();
-                        QString const parent = menuInfo[0];
+                        const QString parent = menuInfo[0];
                         if (removeList.contains(parent)) {
                             host.mpMap->mpMapper->mp2dMap->mUserMenus.remove(it.key());
                             if (it.key() != "" && !removeList.contains(it.key())) {
@@ -1602,7 +1602,7 @@ int TLuaInterpreter::removeMapMenu(lua_State* L)
                 QMapIterator<QString, QStringList> it2(host.mpMap->mpMapper->mp2dMap->mUserActions);
                 while (it2.hasNext()) {
                     it2.next();
-                    QString const actParent = it2.value()[1];
+                    const QString actParent = it2.value()[1];
                     if (removeList.contains(actParent)) {
                         host.mpMap->mpMapper->mp2dMap->mUserActions.remove(it2.key());
                     }
@@ -1642,7 +1642,7 @@ int TLuaInterpreter::getMapMenus(lua_State* L)
 int TLuaInterpreter::addMapEvent(lua_State* L)
 {
     QStringList actionInfo;
-    QString const uniqueName = getVerifiedString(L, __func__, 1, "uniquename");
+    const QString uniqueName = getVerifiedString(L, __func__, 1, "uniquename");
     actionInfo << getVerifiedString(L, __func__, 2, "event name");
 
     if (!lua_isstring(L, 3)) {
@@ -1673,7 +1673,7 @@ int TLuaInterpreter::addMapEvent(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#removeMapEvent
 int TLuaInterpreter::removeMapEvent(lua_State* L)
 {
-    QString const displayName = getVerifiedString(L, __func__, 1, "event name");
+    const QString displayName = getVerifiedString(L, __func__, 1, "event name");
     Host const& host = getHostFromLua(L);
     if (host.mpMap) {
         if (host.mpMap->mpMapper) {
@@ -1835,7 +1835,7 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
             lua_pushboolean(L, true);
             return 1;
         }
-        QString const dataQString{data};
+        const QString dataQString{data};
         // else
             // We need to transcode it from UTF-8 into the current Game Server
             // encoding - this can fail if it includes any characters (as UTF-8)
@@ -1915,7 +1915,7 @@ int TLuaInterpreter::setWindowWrap(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getWindowWrap
 int TLuaInterpreter::getWindowWrap(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
 
     auto console = CONSOLE(L, windowName);
     lua_pushnumber(L, console->getWrapAt());
@@ -1925,7 +1925,7 @@ int TLuaInterpreter::getWindowWrap(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setWindowWrapIndent
 int TLuaInterpreter::setWindowWrapIndent(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     int const luaFrom = getVerifiedInt(L, __func__, 2, "wrapTo");
     auto console = CONSOLE(L, windowName);
     console->setIndentCount(luaFrom);
@@ -1977,7 +1977,7 @@ int TLuaInterpreter::getStopWatchTime(lua_State* L)
         }
 
     } else {
-        QString const name{lua_tostring(L, 1)};
+        const QString name{lua_tostring(L, 1)};
         // Using an empty string will return the first unnamed stopwatch:
         watchId = host.findStopWatchId(name);
         if (!watchId) {
@@ -2060,7 +2060,7 @@ int TLuaInterpreter::stopStopWatch(lua_State* L)
         }
 
     } else {
-        QString const name{lua_tostring(L, 1)};
+        const QString name{lua_tostring(L, 1)};
         QPair<bool, QString> const result = host.stopStopWatch(name);
         if (!result.first) {
             return warnArgumentValue(L, __func__, result.second);
@@ -2161,7 +2161,7 @@ std::tuple<bool, int> TLuaInterpreter::getWatchId(lua_State* L, Host& h)
         return std::make_tuple(true, static_cast<int>(lua_tointeger(L, 1)));
     }
 
-    QString const name{lua_tostring(L, 1)};
+    const QString name{lua_tostring(L, 1)};
     // Using an empty string will return the first unnamed stopwatch:
     int const watchId = h.findStopWatchId(name);
     if (!watchId) {
@@ -2269,7 +2269,7 @@ int TLuaInterpreter::setStopWatchName(lua_State* L)
         currentName = lua_tostring(L, 1);
     }
 
-    QString const newName = getVerifiedString(L, __func__, 2, "stopwatch new name");
+    const QString newName = getVerifiedString(L, __func__, 2, "stopwatch new name");
 
     QPair<bool, QString> result;
     if (currentName.isNull()) {
@@ -2483,7 +2483,7 @@ int TLuaInterpreter::getConsoleBufferSize(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableScrollBar
 int TLuaInterpreter::enableScrollBar(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->setScrollBarVisible(true);
     return 0;
@@ -2492,7 +2492,7 @@ int TLuaInterpreter::enableScrollBar(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableScrollBar
 int TLuaInterpreter::disableScrollBar(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->setScrollBarVisible(false);
     return 0;
@@ -2501,7 +2501,7 @@ int TLuaInterpreter::disableScrollBar(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableHorizontalScrollBar
 int TLuaInterpreter::enableHorizontalScrollBar(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->setHorizontalScrollBar(true);
     return 0;
@@ -2510,7 +2510,7 @@ int TLuaInterpreter::enableHorizontalScrollBar(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableHorizontalScrollBar
 int TLuaInterpreter::disableHorizontalScrollBar(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->setHorizontalScrollBar(false);
     return 0;
@@ -2519,7 +2519,7 @@ int TLuaInterpreter::disableHorizontalScrollBar(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableCommandLine
 int TLuaInterpreter::enableCommandLine(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->setCmdVisible(true);
     return 0;
@@ -2528,7 +2528,7 @@ int TLuaInterpreter::enableCommandLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableCommandLine
 int TLuaInterpreter::disableCommandLine(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->setCmdVisible(false);
     return 0;
@@ -2544,7 +2544,7 @@ int TLuaInterpreter::replace(lua_State* L)
     if (n > 1) {
         windowName = WINDOW_NAME(L, s++);
     }
-    QString const text = getVerifiedString(L, __func__, s, "with");
+    const QString text = getVerifiedString(L, __func__, s, "with");
 
     auto console = CONSOLE(L, windowName);
     console->replace(text);
@@ -2554,7 +2554,7 @@ int TLuaInterpreter::replace(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#deleteLine
 int TLuaInterpreter::deleteLine(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->skipLine();
     return 0;
@@ -2766,11 +2766,11 @@ int TLuaInterpreter::getExitStubs1(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getModulePath
 int TLuaInterpreter::getModulePath(lua_State* L)
 {
-    QString const moduleName = getVerifiedString(L, __func__, 1, "module name");
+    const QString moduleName = getVerifiedString(L, __func__, 1, "module name");
     Host const& host = getHostFromLua(L);
     QMap<QString, QStringList> modules = host.mInstalledModules;
     if (modules.contains(moduleName)) {
-        QString const modPath = modules[moduleName][0];
+        const QString modPath = modules[moduleName][0];
         lua_pushstring(L, modPath.toUtf8().constData());
         return 1;
     }
@@ -2780,7 +2780,7 @@ int TLuaInterpreter::getModulePath(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getModulePriority
 int TLuaInterpreter::getModulePriority(lua_State* L)
 {
-    QString const moduleName = getVerifiedString(L, __func__, 1, "module name");
+    const QString moduleName = getVerifiedString(L, __func__, 1, "module name");
     Host& host = getHostFromLua(L);
     if (host.mModulePriorities.contains(moduleName)) {
         int const priority = host.mModulePriorities[moduleName];
@@ -2796,7 +2796,7 @@ int TLuaInterpreter::getModulePriority(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setModulePriority
 int TLuaInterpreter::setModulePriority(lua_State* L)
 {
-    QString const moduleName = getVerifiedString(L, __func__, 1, "module name");
+    const QString moduleName = getVerifiedString(L, __func__, 1, "module name");
     int const modulePriority = getVerifiedInt(L, __func__, 2, "module priority");
 
     Host& host = getHostFromLua(L);
@@ -2843,7 +2843,7 @@ int TLuaInterpreter::loadMap(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableTimer
 int TLuaInterpreter::enableTimer(lua_State* L)
 {
-    QString const text = getVerifiedString(L, __func__, 1, "name");
+    const QString text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
     bool const error = host.getTimerUnit()->enableTimer(text);
     lua_pushboolean(L, error);
@@ -2853,7 +2853,7 @@ int TLuaInterpreter::enableTimer(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableTimer
 int TLuaInterpreter::disableTimer(lua_State* L)
 {
-    QString const text = getVerifiedString(L, __func__, 1, "name");
+    const QString text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
     bool const error = host.getTimerUnit()->disableTimer(text);
     lua_pushboolean(L, error);
@@ -2863,7 +2863,7 @@ int TLuaInterpreter::disableTimer(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableKey
 int TLuaInterpreter::enableKey(lua_State* L)
 {
-    QString const keyName = getVerifiedString(L, __func__, 1, "key name");
+    const QString keyName = getVerifiedString(L, __func__, 1, "key name");
     Host& host = getHostFromLua(L);
     bool const error = host.getKeyUnit()->enableKey(keyName);
     lua_pushboolean(L, error);
@@ -2873,7 +2873,7 @@ int TLuaInterpreter::enableKey(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableKey
 int TLuaInterpreter::disableKey(lua_State* L)
 {
-    QString const keyName = getVerifiedString(L, __func__, 1, "key name");
+    const QString keyName = getVerifiedString(L, __func__, 1, "key name");
     Host& host = getHostFromLua(L);
     bool const error = host.getKeyUnit()->disableKey(keyName);
     lua_pushboolean(L, error);
@@ -2893,7 +2893,7 @@ int TLuaInterpreter::killKey(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableAlias
 int TLuaInterpreter::enableAlias(lua_State* L)
 {
-    QString const text = getVerifiedString(L, __func__, 1, "name");
+    const QString text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
     bool const error = host.getAliasUnit()->enableAlias(text);
     lua_pushboolean(L, error);
@@ -2903,7 +2903,7 @@ int TLuaInterpreter::enableAlias(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableAlias
 int TLuaInterpreter::disableAlias(lua_State* L)
 {
-    QString const text = getVerifiedString(L, __func__, 1, "name");
+    const QString text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
     bool const error = host.getAliasUnit()->disableAlias(text);
     lua_pushboolean(L, error);
@@ -2913,7 +2913,7 @@ int TLuaInterpreter::disableAlias(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#killAlias
 int TLuaInterpreter::killAlias(lua_State* L)
 {
-    QString const text = getVerifiedString(L, __func__, 1, "name");
+    const QString text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.getAliasUnit()->killAlias(text));
     return 1;
@@ -2922,7 +2922,7 @@ int TLuaInterpreter::killAlias(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableTrigger
 int TLuaInterpreter::enableTrigger(lua_State* L)
 {
-    QString const text = getVerifiedString(L, __func__, 1, "name");
+    const QString text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
     bool const error = host.getTriggerUnit()->enableTrigger(text);
     lua_pushboolean(L, error);
@@ -2932,7 +2932,7 @@ int TLuaInterpreter::enableTrigger(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableTrigger
 int TLuaInterpreter::disableTrigger(lua_State* L)
 {
-    QString const text = getVerifiedString(L, __func__, 1, "name");
+    const QString text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
     bool const error = host.getTriggerUnit()->disableTrigger(text);
     lua_pushboolean(L, error);
@@ -2942,7 +2942,7 @@ int TLuaInterpreter::disableTrigger(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableScript
 int TLuaInterpreter::enableScript(lua_State* L)
 {
-    QString const name = getVerifiedString(L, __func__, 1, "script name");
+    const QString name = getVerifiedString(L, __func__, 1, "script name");
 
     Host& host = getHostFromLua(L);
     int cnt = 0;
@@ -2964,7 +2964,7 @@ int TLuaInterpreter::enableScript(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableScript
 int TLuaInterpreter::disableScript(lua_State* L)
 {
-    QString const name = getVerifiedString(L, __func__, 1, "script name");
+    const QString name = getVerifiedString(L, __func__, 1, "script name");
 
     Host& host = getHostFromLua(L);
     int cnt = 0;
@@ -2986,7 +2986,7 @@ int TLuaInterpreter::disableScript(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#killTimer
 int TLuaInterpreter::killTimer(lua_State* L)
 {
-    QString const text = getVerifiedString(L, __func__, 1, "ID");
+    const QString text = getVerifiedString(L, __func__, 1, "ID");
     Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.killTimer(text));
     return 1;
@@ -2995,7 +2995,7 @@ int TLuaInterpreter::killTimer(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#killTrigger
 int TLuaInterpreter::killTrigger(lua_State* L)
 {
-    QString const text = getVerifiedString(L, __func__, 1, "ID");
+    const QString text = getVerifiedString(L, __func__, 1, "ID");
     Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.killTrigger(text));
     return 1;
@@ -3094,7 +3094,7 @@ int TLuaInterpreter::setFont(lua_State* L)
         windowName = WINDOW_NAME(L, s++);
     }
 
-    QString const font = getVerifiedString(L, __func__, s, "name");
+    const QString font = getVerifiedString(L, __func__, s, "name");
 
     if (!mudlet::self()->getAvailableFonts().contains(font, Qt::CaseInsensitive)) {
         return warnArgumentValue(L, __func__, qsl("font '%1' is not available").arg(font));
@@ -3167,7 +3167,7 @@ int TLuaInterpreter::getFontSize(lua_State* L)
 {
     Host const& host = getHostFromLua(L);
     int rval = -1;
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     if (console == host.mpConsole) {
         rval = host.getDisplayFont().pointSize();
@@ -3191,7 +3191,7 @@ int TLuaInterpreter::openUserWindow(lua_State* L)
         lua_pushfstring(L, "openUserWindow:  bad argument #1 type (name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString const name{lua_tostring(L, 1)};
+    const QString name{lua_tostring(L, 1)};
 
     bool loadLayout = true;
     if (n > 1) {
@@ -3223,7 +3223,7 @@ int TLuaInterpreter::openUserWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setUserWindowTitle
 int TLuaInterpreter::setUserWindowTitle(lua_State* L)
 {
-    QString const name = getVerifiedString(L, __func__, 1, "name");
+    const QString name = getVerifiedString(L, __func__, 1, "name");
     QString title;
     if (lua_gettop(L) > 1) {
         title = getVerifiedString(L, __func__, 2, "title", true);
@@ -3443,7 +3443,7 @@ int TLuaInterpreter::createLabelUserWindow(lua_State* L, const QString& windowNa
 // Internal Function create Label in MainWindow
 int TLuaInterpreter::createLabelMainWindow(lua_State* L, const QString& labelName)
 {
-    QString const windowName = QLatin1String("main");
+    const QString windowName = QLatin1String("main");
     int const n = lua_gettop(L);
     int const x = getVerifiedInt(L, "createLabel", 2, "label x-coordinate");
     int const y = getVerifiedInt(L, "createLabel", 3, "label y-coordinate");
@@ -3487,7 +3487,7 @@ int TLuaInterpreter::createLabelMainWindow(lua_State* L, const QString& labelNam
 
 int TLuaInterpreter::deleteLabel(lua_State* L)
 {
-    QString const labelName = getVerifiedString(L, __func__, 1, "label name");
+    const QString labelName = getVerifiedString(L, __func__, 1, "label name");
     Host const& host = getHostFromLua(L);
     if (auto [success, message] = host.mpConsole->deleteLabel(labelName); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -3499,8 +3499,8 @@ int TLuaInterpreter::deleteLabel(lua_State* L)
 
 int TLuaInterpreter::setLabelToolTip(lua_State* L)
 {
-    QString const labelName = getVerifiedString(L, __func__, 1, "label name");
-    QString const labelToolTip = getVerifiedString(L, __func__, 2, "text");
+    const QString labelName = getVerifiedString(L, __func__, 1, "label name");
+    const QString labelToolTip = getVerifiedString(L, __func__, 2, "text");
     double duration = 0;
     if (lua_gettop(L) > 2) {
         duration = getVerifiedDouble(L, __func__, 3, "duration");
@@ -3518,7 +3518,7 @@ int TLuaInterpreter::setLabelToolTip(lua_State* L)
 
 int TLuaInterpreter::setLabelCursor(lua_State* L)
 {
-    QString const labelName = getVerifiedString(L, __func__, 1, "label name");
+    const QString labelName = getVerifiedString(L, __func__, 1, "label name");
     int const labelCursor = getVerifiedInt(L, __func__, 2, "cursortype");
     Host const& host = getHostFromLua(L);
 
@@ -3534,8 +3534,8 @@ int TLuaInterpreter::setLabelCustomCursor(lua_State* L)
 {
     int const n = lua_gettop(L);
     int hotX = -1, hotY = -1;
-    QString const labelName = getVerifiedString(L, __func__, 1, "label name");
-    QString const pixmapLocation = getVerifiedString(L, __func__, 2, "custom cursor location");
+    const QString labelName = getVerifiedString(L, __func__, 1, "label name");
+    const QString pixmapLocation = getVerifiedString(L, __func__, 2, "custom cursor location");
 
     if (n > 2) {
         hotX = getVerifiedInt(L, __func__, 3, "hot spot x-coordinate");
@@ -3613,7 +3613,7 @@ int TLuaInterpreter::createCommandLine(lua_State* L)
         lua_pushfstring(L, "createCommandLine: bad argument #%d type (commandLine name as string expected, got %s!)", counter, luaL_typename(L, counter));
         return lua_error(L);
     }
-    QString const commandLineName{lua_tostring(L, counter)};
+    const QString commandLineName{lua_tostring(L, counter)};
     counter++;
     int const x = getVerifiedInt(L, __func__, counter, "commandline x-coordinate");
     counter++;
@@ -3636,7 +3636,7 @@ int TLuaInterpreter::createCommandLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#createBuffer
 int TLuaInterpreter::createBuffer(lua_State* L)
 {
-    QString const text = getVerifiedString(L, __func__, 1, "name");
+    const QString text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
     host.createBuffer(text);
     return 0;
@@ -3653,7 +3653,7 @@ int TLuaInterpreter::clearUserWindow(lua_State* L)
         //host.mpConsole->mUpperPane->forceUpdate();
         return 0;
     }
-    QString const text = lua_tostring(L, 1);
+    const QString text = lua_tostring(L, 1);
 
     Host& host = getHostFromLua(L);
     host.clearWindow(text);
@@ -3664,7 +3664,7 @@ int TLuaInterpreter::clearUserWindow(lua_State* L)
 // Documentation: ? - public function but should stay undocumented -- compare https://github.com/Mudlet/Mudlet/issues/1149
 int TLuaInterpreter::closeUserWindow(lua_State* L)
 {
-    QString const text = getVerifiedString(L, __func__, 1, "name");
+    const QString text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
     host.closeWindow(text);
     return 0;
@@ -3673,7 +3673,7 @@ int TLuaInterpreter::closeUserWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#hideWindow
 int TLuaInterpreter::hideWindow(lua_State* L)
 {
-    QString const text = getVerifiedString(L, __func__, 1, "name");
+    const QString text = getVerifiedString(L, __func__, 1, "name");
 
     Host& host = getHostFromLua(L);
     host.hideWindow(text);
@@ -3811,7 +3811,7 @@ int TLuaInterpreter::getBorderSizes(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#resizeWindow
 int TLuaInterpreter::resizeWindow(lua_State* L)
 {
-    QString const text = getVerifiedString(L, __func__, 1, "windowName");
+    const QString text = getVerifiedString(L, __func__, 1, "windowName");
     double const x1 = getVerifiedDouble(L, __func__, 2, "width");
     double const y1 = getVerifiedDouble(L, __func__, 3, "height");
     Host& host = getHostFromLua(L);
@@ -3822,7 +3822,7 @@ int TLuaInterpreter::resizeWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#moveWindow
 int TLuaInterpreter::moveWindow(lua_State* L)
 {
-    QString const text = getVerifiedString(L, __func__, 1, "name");
+    const QString text = getVerifiedString(L, __func__, 1, "name");
     double const x1 = getVerifiedDouble(L, __func__, 2, "x");
     double const y1 = getVerifiedDouble(L, __func__, 3, "y");
     Host& host = getHostFromLua(L);
@@ -3837,13 +3837,13 @@ int TLuaInterpreter::setWindow(lua_State* L)
     int x = 0, y = 0;
     bool show = true;
 
-    QString const windowname {WINDOW_NAME(L, 1)};
+    const QString windowname {WINDOW_NAME(L, 1)};
 
     if (lua_type(L, 2) != LUA_TSTRING) {
         lua_pushfstring(L, "setWindow: bad argument #2 type (element name as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString const name{lua_tostring(L, 2)};
+    const QString name{lua_tostring(L, 2)};
 
     if (n > 2) {
         x = getVerifiedInt(L, __func__, 3, "x-coordinate");
@@ -4251,7 +4251,7 @@ int TLuaInterpreter::resetBackgroundImage(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getImageSize
 int TLuaInterpreter::getImageSize(lua_State* L)
 {
-    QString const imageLocation = getVerifiedString(L, __func__, 1, "image location");
+    const QString imageLocation = getVerifiedString(L, __func__, 1, "image location");
     if (imageLocation.isEmpty()) {
         return warnArgumentValue(L, __func__, "image location cannot be an empty string");
     }
@@ -4268,7 +4268,7 @@ int TLuaInterpreter::getImageSize(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getLabelSizeHint
 int TLuaInterpreter::getLabelSizeHint(lua_State* L)
 {
-    QString const labelName = getVerifiedString(L, __func__, 1, "label name");
+    const QString labelName = getVerifiedString(L, __func__, 1, "label name");
     Host const& host = getHostFromLua(L);
     if (labelName.isEmpty()) {
         return warnArgumentValue(L, __func__, "label name cannot be an empty string");
@@ -4287,7 +4287,7 @@ int TLuaInterpreter::getLabelSizeHint(lua_State* L)
 int TLuaInterpreter::setCmdLineAction(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    QString const name = getVerifiedString(L, __func__, 1, "command line name");
+    const QString name = getVerifiedString(L, __func__, 1, "command line name");
     if (name.isEmpty()) {
         return warnArgumentValue(L, __func__, "command line name cannot be an empty string");
     }
@@ -4310,7 +4310,7 @@ int TLuaInterpreter::setCmdLineAction(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#resetCmdLineAction
 int TLuaInterpreter::resetCmdLineAction(lua_State* L){
     Host& host = getHostFromLua(L);
-    QString const name = getVerifiedString(L, __func__, 1, "command line name");
+    const QString name = getVerifiedString(L, __func__, 1, "command line name");
     if (name.isEmpty()) {
         return warnArgumentValue(L, __func__, "command line name cannot be an empty string");
     }
@@ -4333,7 +4333,7 @@ int TLuaInterpreter::setCmdLineStyleSheet(lua_State* L)
     if (n > 1) {
         name = getVerifiedString(L, __func__, 1, "command line name", true);
     }
-    QString const styleSheet = getVerifiedString(L, __func__, n, "StyleSheet");
+    const QString styleSheet = getVerifiedString(L, __func__, n, "StyleSheet");
     Host const& host = getHostFromLua(L);
 
     if (auto [success, message] = host.mpConsole->setCmdLineStyleSheet(name, styleSheet); !success) {
@@ -4348,7 +4348,7 @@ int TLuaInterpreter::setCmdLineStyleSheet(lua_State* L)
 int TLuaInterpreter::setLabelCallback(lua_State* L, const QString& funcName)
 {
     Host& host = getHostFromLua(L);
-    QString const labelName = getVerifiedString(L, funcName.toUtf8().constData(), 1, "label name");
+    const QString labelName = getVerifiedString(L, funcName.toUtf8().constData(), 1, "label name");
     if (labelName.isEmpty()) {
         return warnArgumentValue(L, __func__, "label name cannot be an empty string");
     }
@@ -4431,11 +4431,11 @@ int TLuaInterpreter::setLabelOnLeave(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMovie
 int TLuaInterpreter::setMovie(lua_State* L)
 {
-    QString const labelName = getVerifiedString(L, __func__, 1, "label name");
+    const QString labelName = getVerifiedString(L, __func__, 1, "label name");
     if (labelName.isEmpty()) {
         return warnArgumentValue(L, __func__, "label name cannot be an empty string");
     }
-    QString const moviePath = getVerifiedString(L, __func__, 2, "movie (gif) path");
+    const QString moviePath = getVerifiedString(L, __func__, 2, "movie (gif) path");
 
     Host& host = getHostFromLua(L);
     if (auto [success, message] = host.setMovie(labelName, moviePath); !success) {
@@ -4448,7 +4448,7 @@ int TLuaInterpreter::setMovie(lua_State* L)
 // No documentation available in wiki - internal function
 int TLuaInterpreter::movieFunc(lua_State* L, const QString& funcName)
 {
-    QString const labelName = getVerifiedString(L, funcName.toUtf8().constData(), 1, "label name");
+    const QString labelName = getVerifiedString(L, funcName.toUtf8().constData(), 1, "label name");
     if (labelName.isEmpty()) {
         return warnArgumentValue(L, __func__, "label name cannot be an empty string");
     }
@@ -4526,7 +4526,7 @@ int TLuaInterpreter::setTextFormat(lua_State* L)
 
     int const n = lua_gettop(L);
 
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
 
     QVector<int> colorComponents(6); // 0-2 RGB background, 3-5 RGB foreground
     colorComponents[0] = qRound(qBound(0.0, getVerifiedDouble(L, __func__, 2, "red background color component"), 255.0));
@@ -4634,7 +4634,7 @@ int TLuaInterpreter::setTextFormat(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#raiseWindow
 int TLuaInterpreter::raiseWindow(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     Host const& host = getHostFromLua(L);
     lua_pushboolean(L, host.mpConsole->raiseWindow(windowName));
     return 1;
@@ -4643,7 +4643,7 @@ int TLuaInterpreter::raiseWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#lowerWindow
 int TLuaInterpreter::lowerWindow(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     Host const& host = getHostFromLua(L);
     lua_pushboolean(L, host.mpConsole->lowerWindow(windowName));
     return 1;
@@ -4652,7 +4652,7 @@ int TLuaInterpreter::lowerWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#showWindow
 int TLuaInterpreter::showWindow(lua_State* L)
 {
-    QString const text = getVerifiedString(L, __func__, 1, "name");
+    const QString text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.showWindow(text));
     return 1;
@@ -4684,7 +4684,7 @@ int TLuaInterpreter::setRoomName(lua_State* L)
     }
 
     int const id = getVerifiedInt(L, __func__, 1, "roomID");
-    QString const name = getVerifiedString(L, __func__, 2, "room name", true);
+    const QString name = getVerifiedString(L, __func__, 2, "room name", true);
 
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
@@ -4744,7 +4744,7 @@ int TLuaInterpreter::connectToServer(lua_State* L)
     bool isToSaveToProfile = false;
 
     Host& host = getHostFromLua(L);
-    QString const url = getVerifiedString(L, __func__, 1, "url");
+    const QString url = getVerifiedString(L, __func__, 1, "url");
 
     if (!lua_isnoneornil(L, 2)) {
         port = getVerifiedInt(L, __func__, 2, "port number {default = 23}", true);
@@ -4781,7 +4781,7 @@ int TLuaInterpreter::connectToServer(lua_State* L)
 int TLuaInterpreter::setRoomIDbyHash(lua_State* L)
 {
     int const id = getVerifiedInt(L, __func__, 1, "roomID");
-    QString const hash = getVerifiedString(L, __func__, 2, "hash");
+    const QString hash = getVerifiedString(L, __func__, 2, "hash");
     Host const& host = getHostFromLua(L);
     if (host.mpMap->mpRoomDB->roomIDToHash.contains(id)) {
         host.mpMap->mpRoomDB->hashToRoomID.remove(host.mpMap->mpRoomDB->roomIDToHash[id]);
@@ -4797,7 +4797,7 @@ int TLuaInterpreter::setRoomIDbyHash(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomIDbyHash
 int TLuaInterpreter::getRoomIDbyHash(lua_State* L)
 {
-    QString const hash = getVerifiedString(L, __func__, 1, "hash");
+    const QString hash = getVerifiedString(L, __func__, 1, "hash");
     Host const& host = getHostFromLua(L);
     int const retID = host.mpMap->mpRoomDB->hashToRoomID.value(hash, -1);
     lua_pushnumber(L, retID);
@@ -4812,7 +4812,7 @@ int TLuaInterpreter::getRoomHashByID(lua_State* L)
     if (!host.mpMap->mpRoomDB->roomIDToHash.contains(id)) {
         return warnArgumentValue(L, __func__, qsl("no hash for room %1").arg(id));
     }
-    QString const retHash = host.mpMap->mpRoomDB->roomIDToHash[id];
+    const QString retHash = host.mpMap->mpRoomDB->roomIDToHash[id];
     lua_pushstring(L, retHash.toUtf8().constData());
     return 1;
 }
@@ -4878,7 +4878,7 @@ int TLuaInterpreter::lockSpecialExit(lua_State* L)
 {
     int const fromRoomID = getVerifiedInt(L, __func__, 1, "exit roomID");
     // The second argument (was the toRoomID) is now ignored as it is not required/considered in any way
-    QString const dir = getVerifiedString(L, __func__, 3, "special exit name/command");
+    const QString dir = getVerifiedString(L, __func__, 3, "special exit name/command");
     if (dir.isEmpty()) {
         return warnArgumentValue(L, __func__, "the special exit name/command cannot be empty");
     }
@@ -4905,7 +4905,7 @@ int TLuaInterpreter::hasSpecialExitLock(lua_State* L)
 {
     int const fromRoomID = getVerifiedInt(L, __func__, 1, "exit roomID");
     // Second argument was the entrance roomID but it is not needed any more and is ignored
-    QString const dir = getVerifiedString(L, __func__, 3, "special exit name/command");
+    const QString dir = getVerifiedString(L, __func__, 3, "special exit name/command");
     if (dir.isEmpty()) {
         return warnArgumentValue(L, __func__, "the special exit name/command cannot be empty");
     }
@@ -5120,7 +5120,7 @@ int TLuaInterpreter::searchRoom(lua_State* L)
                 // This test is to keep Coverity happy as it thinks pR could be
                 // a nullptr in some odd situation {CID 1415023}:
                 if (pR) {
-                    QString const name = pR->name;
+                    const QString name = pR->name;
                     int const roomID = pR->getId();
                     lua_pushnumber(L, roomID);
                     lua_pushstring(L, name.toUtf8().constData());
@@ -5184,7 +5184,7 @@ int TLuaInterpreter::searchRoomUserData(lua_State* L)
         QSet<QString> valuesSet; // Use a set as it automatically eliminates duplicates
         while (itRoom.hasNext()) {
             itRoom.next();
-            QString const roomValueForKey = itRoom.value()->userData.value(key, QString());
+            const QString roomValueForKey = itRoom.value()->userData.value(key, QString());
             // If the key is NOT present, will return second argument which is a
             // null QString which is NOT the same as an empty QString.
             if (!roomValueForKey.isNull()) {
@@ -5207,7 +5207,7 @@ int TLuaInterpreter::searchRoomUserData(lua_State* L)
         while (itRoom.hasNext()) {
             itRoom.next();
 
-            QString const roomDataValue = itRoom.value()->userData.value(key, QString());
+            const QString roomDataValue = itRoom.value()->userData.value(key, QString());
             if ((!roomDataValue.isNull()) && (!value.compare(roomDataValue, Qt::CaseSensitive))) {
                 roomIdsSet.insert(itRoom.key());
             }
@@ -5276,7 +5276,7 @@ int TLuaInterpreter::searchAreaUserData(lua_State* L)
         QSet<QString> valuesSet; // Use a set as it automatically eliminates duplicates
         while (itArea.hasNext()) {
             itArea.next();
-            QString const areaValueForKey = itArea.value()->mUserData.value(key, QString());
+            const QString areaValueForKey = itArea.value()->mUserData.value(key, QString());
             // If the key is NOT present, will return second argument which is a
             // null QString which is NOT the same as an empty QString.
             if (!areaValueForKey.isNull()) {
@@ -5299,7 +5299,7 @@ int TLuaInterpreter::searchAreaUserData(lua_State* L)
         while (itArea.hasNext()) { // Find all areas with a particular key AND value
             itArea.next();
 
-            QString const areaDataValue = itArea.value()->mUserData.value(key, QString());
+            const QString areaDataValue = itArea.value()->mUserData.value(key, QString());
             if ((!areaDataValue.isNull()) && (!value.compare(areaDataValue, Qt::CaseSensitive))) {
                 areaIdsSet.insert(itArea.key());
             }
@@ -5333,7 +5333,7 @@ int TLuaInterpreter::getAreaTable(lua_State* L)
     while (it.hasNext()) {
         it.next();
         int const areaId = it.key();
-        QString const name = it.value();
+        const QString name = it.value();
         lua_pushstring(L, name.toUtf8().constData());
         lua_pushnumber(L, areaId);
         lua_settable(L, -3);
@@ -5354,7 +5354,7 @@ int TLuaInterpreter::getAreaTableSwap(lua_State* L)
     while (it.hasNext()) {
         it.next();
         int const areaId = it.key();
-        QString const name = it.value();
+        const QString name = it.value();
         lua_pushnumber(L, areaId);
         lua_pushstring(L, name.toUtf8().constData());
         lua_settable(L, -3);
@@ -5530,7 +5530,7 @@ int TLuaInterpreter::getPath(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#deselect
 int TLuaInterpreter::deselect(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->deselect();
     lua_pushboolean(L, true);
@@ -5540,7 +5540,7 @@ int TLuaInterpreter::deselect(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#resetFormat
 int TLuaInterpreter::resetFormat(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->reset();
     lua_pushboolean(L, true);
@@ -5558,8 +5558,8 @@ int TLuaInterpreter::hasFocus(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#echoUserWindow
 int TLuaInterpreter::echoUserWindow(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
-    QString const text = getVerifiedString(L, __func__, 2, "text");
+    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString text = getVerifiedString(L, __func__, 2, "text");
     Host& host = getHostFromLua(L);
     host.echoWindow(windowName, text);
     return 0;
@@ -5593,7 +5593,7 @@ int TLuaInterpreter::setAppStyleSheet(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setAppStyleSheet
 int TLuaInterpreter::setProfileStyleSheet(lua_State* L)
 {
-    QString const styleSheet = getVerifiedString(L, __func__, 1, "style sheet");
+    const QString styleSheet = getVerifiedString(L, __func__, 1, "style sheet");
     Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.setProfileStyleSheet(styleSheet));
     return 1;
@@ -6484,7 +6484,7 @@ int TLuaInterpreter::purgeMediaCache(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#moveCursorEnd
 int TLuaInterpreter::moveCursorEnd(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->moveCursorEnd();
     return 0;
@@ -6493,7 +6493,7 @@ int TLuaInterpreter::moveCursorEnd(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getLastLineNumber
 int TLuaInterpreter::getLastLineNumber(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE_NIL(L, windowName);
     int const number = console ? console->getLastLineNumber() : -1;
     lua_pushnumber(L, number);
@@ -6504,7 +6504,7 @@ int TLuaInterpreter::getLastLineNumber(lua_State* L)
 int TLuaInterpreter::getMudletHomeDir(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    QString const nativeHomeDirectory = mudlet::getMudletPath(mudlet::profileHomePath, host.getName());
+    const QString nativeHomeDirectory = mudlet::getMudletPath(mudlet::profileHomePath, host.getName());
     lua_pushstring(L, nativeHomeDirectory.toUtf8().constData());
     return 1;
 }
@@ -6560,7 +6560,7 @@ int TLuaInterpreter::setLink(lua_State* L)
         linkFunction = lua_tostring(L, s++);
     }
 
-    QString const linkHint = getVerifiedString(L, __func__, s++, "tooltip");
+    const QString linkHint = getVerifiedString(L, __func__, s++, "tooltip");
 
     Host const& host = getHostFromLua(L);
     QStringList _linkFunction;
@@ -6602,7 +6602,7 @@ int TLuaInterpreter::setPopup(lua_State* L)
     while (lua_next(L, s) != 0) {
         // key at index -2 and value at index -1
         if (lua_type(L, -1) == LUA_TSTRING) {
-            QString const cmd = lua_tostring(L, -1);
+            const QString cmd = lua_tostring(L, -1);
             _commandList << cmd;
             luaReference << 0;
         }
@@ -6623,7 +6623,7 @@ int TLuaInterpreter::setPopup(lua_State* L)
     while (lua_next(L, s) != 0) {
         // key at index -2 and value at index -1
         if (lua_type(L, -1) == LUA_TSTRING) {
-            QString const hint = lua_tostring(L, -1);
+            const QString hint = lua_tostring(L, -1);
             _hintList << hint;
         }
         // removes value, but keeps key for next iteration
@@ -6806,8 +6806,8 @@ int TLuaInterpreter::debug(lua_State* L)
 int TLuaInterpreter::showHandlerError(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    QString const event = getVerifiedString(L, __func__, 1, "event name");
-    QString const error = getVerifiedString(L, __func__, 2, "error message");
+    const QString event = getVerifiedString(L, __func__, 1, "event name");
+    const QString error = getVerifiedString(L, __func__, 2, "error message");
     host.mLuaInterpreter.logEventError(event, error);
     return 0;
 }
@@ -6815,7 +6815,7 @@ int TLuaInterpreter::showHandlerError(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#hideToolBar
 int TLuaInterpreter::hideToolBar(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
 
     Host& host = getHostFromLua(L);
     host.getActionUnit()->hideToolBar(windowName);
@@ -6825,7 +6825,7 @@ int TLuaInterpreter::hideToolBar(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#showToolBar
 int TLuaInterpreter::showToolBar(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
 
     Host& host = getHostFromLua(L);
     host.getActionUnit()->showToolBar(windowName);
@@ -7028,7 +7028,7 @@ std::pair<int, TAction*> TLuaInterpreter::getTActionFromIdOrName(lua_State* L, c
     }
 
     if (argType == LUA_TSTRING) {
-        QString const name = lua_tostring(L, index);
+        const QString name = lua_tostring(L, index);
         if (name.isEmpty()) {
             return {warnArgumentValue(L, func, "item name must not be an empty string"), pItem};
         }
@@ -7136,7 +7136,7 @@ int TLuaInterpreter::getMainWindowSize(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getUserWindowSize
 int TLuaInterpreter::getUserWindowSize(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
 
     Host const& host = getHostFromLua(L);
     QSize const userWindowSize = host.mpConsole->getUserWindowSize(windowName);
@@ -7191,7 +7191,7 @@ int TLuaInterpreter::tempTimer(lua_State* L)
         return 1;
     }
 
-    QString const luaCode = getVerifiedString(L, __func__, 2, "script or function name");
+    const QString luaCode = getVerifiedString(L, __func__, 2, "script or function name");
     if (n > 2) {
         repeating = getVerifiedBool(L, __func__, 3, "repeating", true);
     }
@@ -7212,7 +7212,7 @@ int TLuaInterpreter::tempExactMatchTrigger(lua_State* L)
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
     int triggerID;
     int expiryCount = -1;
-    QString const exactMatchPattern = getVerifiedString(L, __func__, 1, "exact match pattern");
+    const QString exactMatchPattern = getVerifiedString(L, __func__, 1, "exact match pattern");
 
     if (lua_isnumber(L, 3)) {
         expiryCount = lua_tonumber(L, 3);
@@ -7252,7 +7252,7 @@ int TLuaInterpreter::tempBeginOfLineTrigger(lua_State* L)
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
     int triggerID;
     int expiryCount = -1;
-    QString const pattern = getVerifiedString(L, __func__, 1, "pattern");
+    const QString pattern = getVerifiedString(L, __func__, 1, "pattern");
 
     if (lua_isnumber(L, 3)) {
         expiryCount = lua_tonumber(L, 3);
@@ -7292,7 +7292,7 @@ int TLuaInterpreter::tempTrigger(lua_State* L)
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
     int triggerID;
     int expiryCount = -1;
-    QString const substringPattern = getVerifiedString(L, __func__, 1, "substring pattern");
+    const QString substringPattern = getVerifiedString(L, __func__, 1, "substring pattern");
 
     if (lua_isnumber(L, 3)) {
         expiryCount = lua_tonumber(L, 3);
@@ -7607,8 +7607,8 @@ int TLuaInterpreter::tempLineTrigger(lua_State* L)
 int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    QString const triggerName = getVerifiedString(L, __func__, 1, "trigger name create or add to");
-    QString const pattern = getVerifiedString(L, __func__, 2, "regex pattern to match");
+    const QString triggerName = getVerifiedString(L, __func__, 1, "trigger name create or add to");
+    const QString pattern = getVerifiedString(L, __func__, 2, "regex pattern to match");
 
     if (!lua_isstring(L, 3) && !lua_isfunction(L, 3)) {
         lua_pushfstring(L, "tempComplexRegexTrigger: bad argument #3 type (code to run as a string or a function expected, got %s!)", luaL_typename(L, 3));
@@ -7745,15 +7745,15 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
 int TLuaInterpreter::tempButton(lua_State* L)
 {
     //args: parent, name, orientation
-    QString const cmdButtonUp = "";
-    QString const cmdButtonDown = "";
-    QString const script = "";
+    const QString cmdButtonUp = "";
+    const QString cmdButtonDown = "";
+    const QString script = "";
     QString toolbar;
     QStringList nameL;
     nameL << toolbar;
 
     toolbar = getVerifiedString(L, __func__, 1, "toolbar name");
-    QString const name = getVerifiedString(L, __func__, 2, "button text");
+    const QString name = getVerifiedString(L, __func__, 2, "button text");
     int const orientation = getVerifiedInt(L, __func__, 3, "orientation");
 
     Host& host = getHostFromLua(L);
@@ -7803,8 +7803,8 @@ int TLuaInterpreter::tempButton(lua_State* L)
 int TLuaInterpreter::setButtonStyleSheet(lua_State* L)
 {
     //args: name, css text
-    QString const name = getVerifiedString(L, __func__, 1, "name");
-    QString const css = getVerifiedString(L, __func__, 2, "css");
+    const QString name = getVerifiedString(L, __func__, 1, "name");
+    const QString css = getVerifiedString(L, __func__, 2, "css");
     Host& host = getHostFromLua(L);
     auto actionsList = host.getActionUnit()->findActionsByName(name);
     if (actionsList.empty()) {
@@ -7822,9 +7822,9 @@ int TLuaInterpreter::setButtonStyleSheet(lua_State* L)
 int TLuaInterpreter::tempButtonToolbar(lua_State* L)
 {
     QString name;
-    QString const cmdButtonUp = "";
-    QString const cmdButtonDown = "";
-    QString const script = "";
+    const QString cmdButtonUp = "";
+    const QString cmdButtonDown = "";
+    const QString script = "";
     QStringList nameL;
     nameL << name;
 
@@ -7873,7 +7873,7 @@ int TLuaInterpreter::tempRegexTrigger(lua_State* L)
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
     int triggerID;
     int expiryCount = -1;
-    QString const regexPattern = getVerifiedString(L, __func__, 1, "regex pattern");
+    const QString regexPattern = getVerifiedString(L, __func__, 1, "regex pattern");
 
     if (lua_isnumber(L, 3)) {
         expiryCount = lua_tonumber(L, 3);
@@ -7909,7 +7909,7 @@ int TLuaInterpreter::tempRegexTrigger(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#tempAlias
 int TLuaInterpreter::tempAlias(lua_State* L)
 {
-    QString const regex = getVerifiedString(L, __func__, 1, "regex-type pattern");
+    const QString regex = getVerifiedString(L, __func__, 1, "regex-type pattern");
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
 
@@ -7937,7 +7937,7 @@ int TLuaInterpreter::tempAlias(lua_State* L)
         lua_pushfstring(L, "tempAlias: bad argument #2 type (lua script as string or function expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString const script{lua_tostring(L, 2)};
+    const QString script{lua_tostring(L, 2)};
 
     lua_pushnumber(L, pLuaInterpreter->startTempAlias(regex, script));
     return 1;
@@ -8028,7 +8028,7 @@ int TLuaInterpreter::isActive(lua_State* L)
     auto [isId, nameOrId] = getVerifiedStringOrInteger(L, __func__, 1, "item name or ID");
     // Although we only use 4 ASCII strings the user may not enter a purely
     // ASCII value which we might have to report...
-    QString const type = getVerifiedString(L, __func__, 2, "item type");
+    const QString type = getVerifiedString(L, __func__, 2, "item type");
     bool isOk = false;
     int const id = nameOrId.toInt(&isOk);
     if (isId && (!isOk || id < 0)) {
@@ -8135,9 +8135,9 @@ int TLuaInterpreter::isActive(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#permAlias
 int TLuaInterpreter::permAlias(lua_State* L)
 {
-    QString const name = getVerifiedString(L, __func__, 1, "alias name");
-    QString const parent = getVerifiedString(L, __func__, 2, "alias group/parent");
-    QString const regex = getVerifiedString(L, __func__, 3, "regexp pattern");
+    const QString name = getVerifiedString(L, __func__, 1, "alias name");
+    const QString parent = getVerifiedString(L, __func__, 2, "alias group/parent");
+    const QString regex = getVerifiedString(L, __func__, 3, "regexp pattern");
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
     if (auto [validationResult, validationMessage] = pLuaInterpreter->validateLuaCodeParam(4); !validationResult) {
@@ -8145,7 +8145,7 @@ int TLuaInterpreter::permAlias(lua_State* L)
         return lua_error(L);
     }
 
-    QString const script{lua_tostring(L, 4)};
+    const QString script{lua_tostring(L, 4)};
     auto [aliasId, message] = pLuaInterpreter->startPermAlias(name, parent, regex, script);
     if (aliasId == -1) {
         lua_pushfstring(L, "permAlias: cannot create alias (%s)", message.toUtf8().constData());
@@ -8160,7 +8160,7 @@ int TLuaInterpreter::getScript(lua_State* L)
 {
     int const n = lua_gettop(L);
     int pos = 1;
-    QString const name = getVerifiedString(L, __func__, 1, "script name");
+    const QString name = getVerifiedString(L, __func__, 1, "script name");
     if (n > 1) {
         pos = getVerifiedInt(L, __func__, 2, "script position");
     }
@@ -8193,7 +8193,7 @@ int TLuaInterpreter::setScript(lua_State* L)
         lua_pushfstring(L, "setScript: bad argument #%d (%s)", 2, validationMessage.toUtf8().constData());
         return lua_error(L);
     }
-    QString const luaCode{lua_tostring(L, 2)};
+    const QString luaCode{lua_tostring(L, 2)};
 
     if (n > 2) {
         pos = getVerifiedInt(L, __func__, 3, "script position");
@@ -8213,15 +8213,15 @@ int TLuaInterpreter::setScript(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#permScript
 int TLuaInterpreter::permScript(lua_State* L)
 {
-    QString const name = getVerifiedString(L, __func__, 1, "script name");
-    QString const parent = getVerifiedString(L, __func__, 2, "script parent name");
+    const QString name = getVerifiedString(L, __func__, 1, "script name");
+    const QString parent = getVerifiedString(L, __func__, 2, "script parent name");
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
     if (auto [validationResult, validationMessage] = pLuaInterpreter->validateLuaCodeParam(3); !validationResult) {
         lua_pushfstring(L, "permScript: bad argument #%d (%s)", 3, validationMessage.toUtf8().constData());
         return lua_error(L);
     }
-    QString const luaCode{lua_tostring(L, 3)};
+    const QString luaCode{lua_tostring(L, 3)};
     auto [id, message] = pLuaInterpreter->createPermScript(name, parent, luaCode);
     if (id == -1) {
         lua_pushfstring(L, "permScript: cannot create script (%s)", message.toUtf8().constData());
@@ -8234,8 +8234,8 @@ int TLuaInterpreter::permScript(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#permTimer
 int TLuaInterpreter::permTimer(lua_State* L)
 {
-    QString const name = getVerifiedString(L, __func__, 1, "timer name");
-    QString const parent = getVerifiedString(L, __func__, 2, "timer parent name");
+    const QString name = getVerifiedString(L, __func__, 1, "timer name");
+    const QString parent = getVerifiedString(L, __func__, 2, "timer parent name");
     double const time = getVerifiedDouble(L, __func__, 3, "time in seconds");
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
@@ -8243,7 +8243,7 @@ int TLuaInterpreter::permTimer(lua_State* L)
         lua_pushfstring(L, "permTimer: bad argument #%d (%s)", 4, validationMessage.toUtf8().constData());
         return lua_error(L);
     }
-    QString const luaCode{lua_tostring(L, 4)};
+    const QString luaCode{lua_tostring(L, 4)};
     auto [id, message] = pLuaInterpreter->startPermTimer(name, parent, time, luaCode);
     if (id == -1) {
         lua_pushfstring(L, "permTimer: cannot create timer (%s)", message.toUtf8().constData());
@@ -8256,8 +8256,8 @@ int TLuaInterpreter::permTimer(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#permSubstringTrigger
 int TLuaInterpreter::permSubstringTrigger(lua_State* L)
 {
-    QString const name = getVerifiedString(L, __func__, 1, "trigger name");
-    QString const parent = getVerifiedString(L, __func__, 2, "trigger parent");
+    const QString name = getVerifiedString(L, __func__, 1, "trigger name");
+    const QString parent = getVerifiedString(L, __func__, 2, "trigger parent");
     QStringList regList;
     if (!lua_istable(L, 3)) {
         lua_pushfstring(L, "permSubstringTrigger: bad argument #3 type (sub-strings list as table expected, got %s!)",
@@ -8281,7 +8281,7 @@ int TLuaInterpreter::permSubstringTrigger(lua_State* L)
         return lua_error(L);
     }
 
-    QString const script{lua_tostring(L, 4)};
+    const QString script{lua_tostring(L, 4)};
     auto [triggerID, message] = pLuaInterpreter->startPermSubstringTrigger(name, parent, regList, script);
     if(triggerID == - 1) {
         lua_pushfstring(L, "permSubstringTrigger: cannot create trigger (%s)", message.toUtf8().constData());
@@ -8296,13 +8296,13 @@ int TLuaInterpreter::permPromptTrigger(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    QString const triggerName = getVerifiedString(L, __func__, 1, "trigger name");
-    QString const parentName = getVerifiedString(L, __func__, 2, "parent trigger name");
+    const QString triggerName = getVerifiedString(L, __func__, 1, "trigger name");
+    const QString parentName = getVerifiedString(L, __func__, 2, "parent trigger name");
     if (auto [validationResult, validationMessage] = pLuaInterpreter->validateLuaCodeParam(3); !validationResult) {
         lua_pushfstring(L, "permPromptTrigger: bad argument #%d (%s)", 3, validationMessage.toUtf8().constData());
         return lua_error(L);
     }
-    QString const luaFunction = lua_tostring(L, 3);
+    const QString luaFunction = lua_tostring(L, 3);
 
     auto [triggerID, message] = pLuaInterpreter->startPermPromptTrigger(triggerName, parentName, luaFunction);
     if(triggerID == - 1) {
@@ -8382,7 +8382,7 @@ int TLuaInterpreter::tempKey(lua_State* L)
         lua_pushfstring(L, "tempKey: bad argument #%d type (lua script as string or function expected, got %s!)", argIndex, luaL_typename(L, argIndex));
         return lua_error(L);
     }
-    QString const luaFunction{lua_tostring(L, argIndex)};
+    const QString luaFunction{lua_tostring(L, argIndex)};
 
     int const timerID = pLuaInterpreter->startTempKey(keyModifier, keyCode, luaFunction);
     lua_pushnumber(L, timerID);
@@ -8392,8 +8392,8 @@ int TLuaInterpreter::tempKey(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#permBeginOfLineStringTrigger
 int TLuaInterpreter::permBeginOfLineStringTrigger(lua_State* L)
 {
-    QString const name = getVerifiedString(L, __func__, 1, "trigger name");
-    QString const parent = getVerifiedString(L, __func__, 2, "trigger parent");
+    const QString name = getVerifiedString(L, __func__, 1, "trigger name");
+    const QString parent = getVerifiedString(L, __func__, 2, "trigger parent");
 
     QStringList regList;
     if (!lua_istable(L, 3)) {
@@ -8418,7 +8418,7 @@ int TLuaInterpreter::permBeginOfLineStringTrigger(lua_State* L)
         return lua_error(L);
     }
 
-    QString const script{lua_tostring(L, 4)};
+    const QString script{lua_tostring(L, 4)};
     auto [triggerId, message] = pLuaInterpreter->startPermBeginOfLineStringTrigger(name, parent, regList, script);
     if (triggerId == -1) {
         lua_pushfstring(L, "permRegexTrigger: cannot create trigger (%s)", message.toUtf8().constData());
@@ -8431,8 +8431,8 @@ int TLuaInterpreter::permBeginOfLineStringTrigger(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#permRegexTrigger
 int TLuaInterpreter::permRegexTrigger(lua_State* L)
 {
-    QString const name = getVerifiedString(L, __func__, 1, "trigger name");
-    QString const parent = getVerifiedString(L, __func__, 2, "trigger parent");
+    const QString name = getVerifiedString(L, __func__, 1, "trigger name");
+    const QString parent = getVerifiedString(L, __func__, 2, "trigger parent");
 
     QStringList regList;
     if (!lua_istable(L, 3)) {
@@ -8457,7 +8457,7 @@ int TLuaInterpreter::permRegexTrigger(lua_State* L)
         return lua_error(L);
     }
 
-    QString const script{lua_tostring(L, 4)};
+    const QString script{lua_tostring(L, 4)};
     auto [triggerId, message] = pLuaInterpreter->startPermRegexTrigger(name, parent, regList, script);
     if (triggerId == -1) {
         lua_pushfstring(L, "permRegexTrigger: cannot create trigger (%s)", message.toUtf8().constData());
@@ -8471,14 +8471,14 @@ int TLuaInterpreter::permRegexTrigger(lua_State* L)
 int TLuaInterpreter::invokeFileDialog(lua_State* L)
 {
     bool const luaDir = getVerifiedBool(L, __func__, 1, "fileOrFolder");
-    QString const title = getVerifiedString(L, __func__, 2, "dialogTitle");
+    const QString title = getVerifiedString(L, __func__, 2, "dialogTitle");
 
     if (!luaDir) {
-        QString const fileName = QFileDialog::getExistingDirectory(nullptr, title, QDir::currentPath());
+        const QString fileName = QFileDialog::getExistingDirectory(nullptr, title, QDir::currentPath());
         lua_pushstring(L, fileName.toUtf8().constData());
         return 1;
     } else {
-        QString const fileName = QFileDialog::getOpenFileName(nullptr, title, QDir::currentPath());
+        const QString fileName = QFileDialog::getOpenFileName(nullptr, title, QDir::currentPath());
         lua_pushstring(L, fileName.toUtf8().constData());
         return 1;
     }
@@ -8610,7 +8610,7 @@ int TLuaInterpreter::setAreaName(lua_State* L)
         return lua_error(L);
     }
 
-    QString const newName = getVerifiedString(L, __func__, 2, "area name").trimmed();
+    const QString newName = getVerifiedString(L, __func__, 2, "area name").trimmed();
     // Now allow non-Ascii names but eliminate any leading or trailing spaces
 
     if (newName.isEmpty()) {
@@ -8700,7 +8700,7 @@ int TLuaInterpreter::getRoomAreaName(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addAreaName
 int TLuaInterpreter::addAreaName(lua_State* L)
 {
-    QString const name = getVerifiedString(L, __func__, 1, "area name").trimmed();
+    const QString name = getVerifiedString(L, __func__, 1, "area name").trimmed();
 
     Host const& host = getHostFromLua(L);
     if ((!host.mpMap) || (!host.mpMap->mpRoomDB)) {
@@ -8965,7 +8965,7 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
 
     int const args = lua_gettop(L);
     int const area = getVerifiedInt(L, __func__, 1, "areaID");
-    QString const text = getVerifiedString(L, __func__, 2, "text");
+    const QString text = getVerifiedString(L, __func__, 2, "text");
     float const posx = getVerifiedFloat(L, __func__, 3, "posX");
     float const posy = getVerifiedFloat(L, __func__, 4, "posY");
     float const posz = getVerifiedFloat(L, __func__, 5, "posZ");
@@ -9055,7 +9055,7 @@ int TLuaInterpreter::createMapImageLabel(lua_State* L)
 {
     int const args = lua_gettop(L);
     int const area = getVerifiedInt(L, __func__, 1, "areaID");
-    QString const imagePathFileName = getVerifiedString(L, __func__, 2, "imagePathFileName");
+    const QString imagePathFileName = getVerifiedString(L, __func__, 2, "imagePathFileName");
     float const posx = getVerifiedFloat(L, __func__, 3, "posX");
     float const posy = getVerifiedFloat(L, __func__, 4, "posY");
     float const posz = getVerifiedFloat(L, __func__, 5, "posZ");
@@ -9086,7 +9086,7 @@ int TLuaInterpreter::setDoor(lua_State* L)
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
     }
-    QString const exitCmd = getVerifiedString(L, __func__, 2, "door command");
+    const QString exitCmd = getVerifiedString(L, __func__, 2, "door command");
 
     if (exitCmd.compare(qsl("n")) && exitCmd.compare(qsl("e")) && exitCmd.compare(qsl("s")) && exitCmd.compare(qsl("w"))
         && exitCmd.compare(qsl("ne"))
@@ -9180,7 +9180,7 @@ int TLuaInterpreter::setExitWeight(lua_State* L)
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomID));
     }
 
-    QString const direction(dirToString(L, 2));
+    const QString direction(dirToString(L, 2));
     if (direction.isEmpty()) {
         lua_pushfstring(L, "setExitWeight: bad argument #2 type (direction as string or number {between 1 and 12 inclusive} expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
@@ -9325,7 +9325,7 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
             .arg(QString::number(id_from), lua_tostring(L, 3)));
     }
 
-    QString const lineStyleString = getVerifiedString(L, __func__, 4, "line style");
+    const QString lineStyleString = getVerifiedString(L, __func__, 4, "line style");
     if (!lineStyleString.compare(QLatin1String("solid line"))) {
         line_style = Qt::SolidLine;
     } else if (!lineStyleString.compare(QLatin1String("dot line"))) {
@@ -9432,7 +9432,7 @@ int TLuaInterpreter::removeCustomLine(lua_State* L)
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
     }
 
-    QString const direction = dirToString(L, 2);
+    const QString direction = dirToString(L, 2);
     if (direction.isEmpty()) {
         lua_pushfstring(L, "removeCustomLine: bad argument #2 type (direction as string or number (between 1 and 12 inclusive) expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
@@ -9642,7 +9642,7 @@ int TLuaInterpreter::deleteMapLabel(lua_State* L)
 int TLuaInterpreter::windowType(lua_State* L)
 {
     Host const& host = getHostFromLua(L);
-    QString const windowName = getVerifiedString(L, __func__, 1, "window name");
+    const QString windowName = getVerifiedString(L, __func__, 1, "window name");
 
     if (auto kind = host.windowType(windowName)) {
         lua_pushstring(L, kind->toUtf8().constData());
@@ -9813,7 +9813,7 @@ int TLuaInterpreter::addSpecialExit(lua_State* L)
         return warnArgumentValue(L, __func__, qsl("number %1 is not a valid entrance roomID").arg(toRoomID));
     }
 
-    QString const dir = getVerifiedString(L, __func__, 3, "special exit name/command");
+    const QString dir = getVerifiedString(L, __func__, 3, "special exit name/command");
     if (dir.isEmpty()) {
         return warnArgumentValue(L, __func__, "the special exit name/command cannot be empty");
     }
@@ -9833,7 +9833,7 @@ int TLuaInterpreter::removeSpecialExit(lua_State* L)
         return warnArgumentValue(L, __func__, csmInvalidExitRoomID.arg(fromRoomID));
     }
 
-    QString const dir = getVerifiedString(L, __func__, 2, "special exit name/command");
+    const QString dir = getVerifiedString(L, __func__, 2, "special exit name/command");
     if (dir.isEmpty()) {
         return warnArgumentValue(L, __func__, "the exit command cannot be empty");
     }
@@ -9879,7 +9879,7 @@ int TLuaInterpreter::clearRoomUserDataItem(lua_State* L)
     }
 
     int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
-    QString const key = getVerifiedString(L, __func__, 2, "key");
+    const QString key = getVerifiedString(L, __func__, 2, "key");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
@@ -9932,7 +9932,7 @@ int TLuaInterpreter::clearAreaUserDataItem(lua_State* L)
     }
 
     int const areaId = getVerifiedInt(L, __func__, 1, "areaID");
-    QString const key = getVerifiedString(L, __func__, 2, "key");
+    const QString key = getVerifiedString(L, __func__, 2, "key");
     TArea* pA = host.mpMap->mpRoomDB->getArea(areaId);
     if (!pA) {
         return warnArgumentValue(L, __func__, csmInvalidAreaID.arg(areaId));
@@ -9971,7 +9971,7 @@ int TLuaInterpreter::clearMapUserDataItem(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    QString const key = getVerifiedString(L, __func__, 1, "key");
+    const QString key = getVerifiedString(L, __func__, 1, "key");
     if (key.isEmpty()) {
         return warnArgumentValue(L, __func__, "key can not be an empty string");
     }
@@ -10129,7 +10129,7 @@ int TLuaInterpreter::getRoomUserData(lua_State* L)
     }
 
     int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
-    QString const key = getVerifiedString(L, __func__, 2, "key");
+    const QString key = getVerifiedString(L, __func__, 2, "key");
     bool isBackwardCompatibilityRequired = true;
     if (lua_gettop(L) > 2) {
         isBackwardCompatibilityRequired = !getVerifiedBool(L, __func__, 3, "enableFullErrorReporting {default = false}", true);
@@ -10159,7 +10159,7 @@ int TLuaInterpreter::getRoomUserData(lua_State* L)
 int TLuaInterpreter::getAreaUserData(lua_State* L)
 {
     int const areaId = getVerifiedInt(L, __func__, 1, "areaID");
-    QString const key = getVerifiedString(L, __func__, 2, "key");
+    const QString key = getVerifiedString(L, __func__, 2, "key");
     if (key.isEmpty()) {
         return warnArgumentValue(L, __func__, "key is not allowed to be an empty string");
     }
@@ -10187,7 +10187,7 @@ int TLuaInterpreter::getMapUserData(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    QString const key = getVerifiedString(L, __func__, 1, "key");
+    const QString key = getVerifiedString(L, __func__, 1, "key");
     if (!host.mpMap->mUserData.contains(key)) {
         return warnArgumentValue(L, __func__, qsl("no user data with key '%1' in map").arg(key));
     }
@@ -10204,9 +10204,9 @@ int TLuaInterpreter::setRoomUserData(lua_State* L)
     }
 
     int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
-    QString const key = getVerifiedString(L, __func__, 2, "key");
+    const QString key = getVerifiedString(L, __func__, 2, "key");
     // Ideally should reject empty keys but this could break existing scripts so we can't
-    QString const value = getVerifiedString(L, __func__, 3, "value");
+    const QString value = getVerifiedString(L, __func__, 3, "value");
 
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
@@ -10222,11 +10222,11 @@ int TLuaInterpreter::setRoomUserData(lua_State* L)
 int TLuaInterpreter::setAreaUserData(lua_State* L)
 {
     int const areaId = getVerifiedInt(L, __func__, 1, "areaID");
-    QString const key = getVerifiedString(L, __func__, 2, "key");
+    const QString key = getVerifiedString(L, __func__, 2, "key");
     if (key.isEmpty()) {
         return warnArgumentValue(L, __func__, "key is not allowed to be an empty string");
     }
-    QString const value = getVerifiedString(L, __func__, 3, "value");
+    const QString value = getVerifiedString(L, __func__, 3, "value");
 
     Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
@@ -10251,11 +10251,11 @@ int TLuaInterpreter::setMapUserData(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    QString const key = getVerifiedString(L, __func__, 1, "key");
+    const QString key = getVerifiedString(L, __func__, 1, "key");
     if (key.isEmpty()) {
         return warnArgumentValue(L, __func__, "key is not allowed to be an empty string");
     }
-    QString const value = getVerifiedString(L, __func__, 2, "value");
+    const QString value = getVerifiedString(L, __func__, 2, "value");
 
     host.mpMap->mUserData[key] = value;
     host.mpMap->setUnsaved(__func__);
@@ -10367,8 +10367,8 @@ int TLuaInterpreter::getAllMapUserData(lua_State* L)
 int TLuaInterpreter::downloadFile(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    QString const localFile = getVerifiedString(L, __func__, 1, "local filename");
-    QString const urlString = getVerifiedString(L, __func__, 2, "remote url");
+    const QString localFile = getVerifiedString(L, __func__, 1, "local filename");
+    const QString urlString = getVerifiedString(L, __func__, 2, "remote url");
     QUrl const url = QUrl::fromUserInput(urlString);
     if (!url.isValid()) {
         return warnArgumentValue(L, __func__, qsl("url is invalid, reason: %1").arg(url.errorString()));
@@ -10495,7 +10495,7 @@ int TLuaInterpreter::resetRoomArea(lua_State* L)
 int TLuaInterpreter::setRoomChar(lua_State* L)
 {
     int const id = getVerifiedInt(L, __func__, 1, "roomID");
-    QString const symbol = getVerifiedString(L, __func__, 2, "room symbol");
+    const QString symbol = getVerifiedString(L, __func__, 2, "room symbol");
 
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
@@ -10862,7 +10862,7 @@ int TLuaInterpreter::insertPopup(lua_State* L)
     if (n >= 4) {
         windowName = WINDOW_NAME(L, s++);
     }
-    QString const txt = getVerifiedString(L, __func__, s++, "text");
+    const QString txt = getVerifiedString(L, __func__, s++, "text");
 
     if (!lua_istable(L, s)) {
         lua_pushfstring(L, "insertPopup: bad argument #%d type (commands as table expected, got %s!)", s, luaL_typename(L, s));
@@ -10872,7 +10872,7 @@ int TLuaInterpreter::insertPopup(lua_State* L)
     while (lua_next(L, s) != 0) {
         // key at index -2 and value at index -1
         if (lua_type(L, -1) == LUA_TSTRING) {
-            QString const cmd = lua_tostring(L, -1);
+            const QString cmd = lua_tostring(L, -1);
             _commandList << cmd;
             luaReference << 0;
         }
@@ -10894,7 +10894,7 @@ int TLuaInterpreter::insertPopup(lua_State* L)
     while (lua_next(L, s) != 0) {
         // key at index -2 and value at index -1
         if (lua_type(L, -1) == LUA_TSTRING) {
-            QString const hint = lua_tostring(L, -1);
+            const QString hint = lua_tostring(L, -1);
             _hintList << hint;
         }
         // removes value, but keeps key for next iteration
@@ -10924,7 +10924,7 @@ int TLuaInterpreter::insertText(lua_State* L)
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
         windowName = WINDOW_NAME(L, ++s);
     }
-    QString const text = getVerifiedString(L, __func__, ++s, "text");
+    const QString text = getVerifiedString(L, __func__, ++s, "text");
 
     auto console = CONSOLE(L, windowName);
     console->insertText(text);
@@ -10935,7 +10935,7 @@ int TLuaInterpreter::insertText(lua_State* L)
 // No Documentation - public function but should stay undocumented -- compare https://github.com/Mudlet/Mudlet/issues/1149
 int TLuaInterpreter::insertHTML(lua_State* L)
 {
-    QString const sendText = getVerifiedString(L, __func__, 1, "sendText");
+    const QString sendText = getVerifiedString(L, __func__, 1, "sendText");
     Host const& host = getHostFromLua(L);
     host.mpConsole->insertHTML(sendText);
     return 0;
@@ -10963,7 +10963,7 @@ int TLuaInterpreter::echo(lua_State* L)
         consoleName = getVerifiedString(L, __func__, s++, "console name", true);
     }
 
-    QString const displayText = getVerifiedString(L, __func__, s, "text to display");
+    const QString displayText = getVerifiedString(L, __func__, s, "text to display");
 
     if (isMain(consoleName)) {
         host.mpConsole->buffer.mEchoingText = true;
@@ -10995,7 +10995,7 @@ int TLuaInterpreter::echoPopup(lua_State* L)
     if (n >= 4) {
         windowName = WINDOW_NAME(L, s++);
     }
-    QString const text = getVerifiedString(L, __func__, s++, "text as string");
+    const QString text = getVerifiedString(L, __func__, s++, "text as string");
 
     if (!lua_istable(L, s)) {
         lua_pushfstring(L, "echoPopup: bad argument #%d type (command list as table expected, got %s!)", s, luaL_typename(L, s));
@@ -11005,7 +11005,7 @@ int TLuaInterpreter::echoPopup(lua_State* L)
     while (lua_next(L, s) != 0) {
         // key at index -2 and value at index -1
         if (lua_type(L, -1) == LUA_TSTRING) {
-            QString const cmd = lua_tostring(L, -1);
+            const QString cmd = lua_tostring(L, -1);
             commandList << cmd;
             luaReference << 0;
         }
@@ -11026,7 +11026,7 @@ int TLuaInterpreter::echoPopup(lua_State* L)
     while (lua_next(L, s) != 0) {
         // key at index -2 and value at index -1
         if (lua_type(L, -1) == LUA_TSTRING) {
-            QString const hint = lua_tostring(L, -1);
+            const QString hint = lua_tostring(L, -1);
             hintList << hint;
         }
         // removes value, but keeps key for next iteration
@@ -11158,7 +11158,7 @@ int TLuaInterpreter::pasteWindow(lua_State* L)
         lua_pushfstring(L, "pasteWindow: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     Host& host = getHostFromLua(L);
     host.pasteWindow(windowName);
     return 0;
@@ -11167,7 +11167,7 @@ int TLuaInterpreter::pasteWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#openUrl
 int TLuaInterpreter::openUrl(lua_State* L)
 {
-    QString const url = getVerifiedString(L, __func__, 1, "url");
+    const QString url = getVerifiedString(L, __func__, 1, "url");
     QDesktopServices::openUrl(url);
     return 0;
 }
@@ -11185,7 +11185,7 @@ int TLuaInterpreter::setLabelStyleSheet(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getLabelStyleSheet
 int TLuaInterpreter::getLabelStyleSheet(lua_State* L)
 {
-    QString const label = getVerifiedString(L, __func__, 1, "label");
+    const QString label = getVerifiedString(L, __func__, 1, "label");
     Host const& host = getHostFromLua(L);
     if (auto stylesheet = host.mpConsole->getLabelStyleSheet(label)) {
         lua_pushstring(L, stylesheet->toUtf8().constData());
@@ -11200,8 +11200,8 @@ int TLuaInterpreter::getLabelStyleSheet(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setUserWindowStyleSheet
 int TLuaInterpreter::setUserWindowStyleSheet(lua_State* L)
 {
-    QString const userWindowName = getVerifiedString(L, __func__, 1, "userwindow name");
-    QString const userWindowStyleSheet = getVerifiedString(L, __func__, 2, "StyleSheet");
+    const QString userWindowName = getVerifiedString(L, __func__, 1, "userwindow name");
+    const QString userWindowStyleSheet = getVerifiedString(L, __func__, 2, "StyleSheet");
     Host const& host = getHostFromLua(L);
 
     if (auto [success, message] = host.mpConsole->setUserWindowStyleSheet(userWindowName, userWindowStyleSheet); !success) {
@@ -11291,7 +11291,7 @@ int TLuaInterpreter::getMudletVersion(lua_State* L)
     int const n = lua_gettop(L);
 
     if (n == 1) {
-        QString const tidiedWhat = getVerifiedString(L, __func__, 1, "style", true).toLower().trimmed();
+        const QString tidiedWhat = getVerifiedString(L, __func__, 1, "style", true).toLower().trimmed();
         if (tidiedWhat.contains("major")) {
             lua_pushinteger(L, major);
         } else if (tidiedWhat.contains("minor")) {
@@ -11352,7 +11352,7 @@ int TLuaInterpreter::getMudletVersion(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#openWebPage
 int TLuaInterpreter::openWebPage(lua_State* L)
 {
-    QString const url = getVerifiedString(L, __func__, 1, "URL");
+    const QString url = getVerifiedString(L, __func__, 1, "URL");
     lua_pushboolean(L, mudlet::self()->openWebPage(url));
     return 1;
 }
@@ -11373,7 +11373,7 @@ int TLuaInterpreter::setDiscordApplicationID(lua_State* L)
         lua_pushboolean(L, true);
         return 1;
     }
-    QString const inputText = getVerifiedString(L, __func__, 1, "Discord application ID").trimmed();
+    const QString inputText = getVerifiedString(L, __func__, 1, "Discord application ID").trimmed();
     // Treat it as a UTF-8 string because although it is likely to be an
     // unsigned long long integer (0 to 18446744073709551615) we want to
     // be able to handle any input so we can report bad input strings back.
@@ -11388,7 +11388,7 @@ int TLuaInterpreter::setDiscordApplicationID(lua_State* L)
     bool isOk = false;
     quint64 const numericEquivalent = inputText.toULongLong(&isOk);
     if (numericEquivalent && isOk) {
-        QString const appID = QString::number(numericEquivalent);
+        const QString appID = QString::number(numericEquivalent);
         if (pMudlet->mDiscord.setApplicationID(&host, appID)) {
             lua_pushboolean(L, true);
             return 1;
@@ -11654,7 +11654,7 @@ int TLuaInterpreter::setDiscordGame(lua_State* L)
         return warnArgumentValue(L, __func__, "access to Discord large icon is disabled in settings for privacy");
     }
 
-    QString const gamename = getVerifiedString(L, __func__, 1, "game name");
+    const QString gamename = getVerifiedString(L, __func__, 1, "game name");
     pMudlet->mDiscord.setDetailText(&host, tr("Playing %1").arg(gamename));
     pMudlet->mDiscord.setLargeImage(&host, gamename.toLower());
     lua_pushboolean(L, true);
@@ -11883,7 +11883,7 @@ int TLuaInterpreter::getEpoch(lua_State *L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#appendBuffer
 int TLuaInterpreter::appendBuffer(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->appendBuffer();
     return 0;
@@ -11898,10 +11898,10 @@ int TLuaInterpreter::appendCmdLine(lua_State* L)
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
     }
-    QString const text = getVerifiedString(L, __func__, n, "text to set on command line");
+    const QString text = getVerifiedString(L, __func__, n, "text to set on command line");
     auto pN = COMMANDLINE(L, name);
 
-    QString const curText = pN->toPlainText();
+    const QString curText = pN->toPlainText();
     pN->setPlainText(curText + text);
     QTextCursor cur = pN->textCursor();
     cur.clearSelection();
@@ -11933,7 +11933,7 @@ int TLuaInterpreter::getCmdLine(lua_State* L)
         name = CMDLINE_NAME(L, 1);
     }
     auto commandline = COMMANDLINE(L, name);
-    QString const text = commandline->toPlainText();
+    const QString text = commandline->toPlainText();
     lua_pushstring(L, text.toUtf8().constData());
     return 1;
 }
@@ -11946,7 +11946,7 @@ int TLuaInterpreter::addCmdLineSuggestion(lua_State* L)
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
     }
-    QString const text = getVerifiedString(L, __func__, n, "suggestion text");
+    const QString text = getVerifiedString(L, __func__, n, "suggestion text");
     auto pN = COMMANDLINE(L, name);
     pN->addSuggestion(text);
     return 0;
@@ -11960,7 +11960,7 @@ int TLuaInterpreter::removeCmdLineSuggestion(lua_State* L)
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
     }
-    QString const text = getVerifiedString(L, __func__, n, "suggestion text");
+    const QString text = getVerifiedString(L, __func__, n, "suggestion text");
     auto pN = COMMANDLINE(L, name);
     pN->removeSuggestion(text);
     return 0;
@@ -11986,7 +11986,7 @@ int TLuaInterpreter::addCmdLineBlacklist(lua_State* L)
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
     }
-    QString const text = getVerifiedString(L, __func__, n, "suggestion text");
+    const QString text = getVerifiedString(L, __func__, n, "suggestion text");
     auto pN = COMMANDLINE(L, name);
     pN->addBlacklist(text);
     return 0;
@@ -11999,7 +11999,7 @@ int TLuaInterpreter::removeCmdLineBlacklist(lua_State* L)
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
     }
-    QString const text = getVerifiedString(L, __func__, n, "suggestion text");
+    const QString text = getVerifiedString(L, __func__, n, "suggestion text");
     auto pN = COMMANDLINE(L, name);
     pN->removeBlacklist(text);
     return 0;
@@ -12020,7 +12020,7 @@ int TLuaInterpreter::clearCmdLineBlacklist(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#installPackage
 int TLuaInterpreter::installPackage(lua_State* L)
 {
-    QString const location = getVerifiedString(L, __func__, 1, "package location path and file name");
+    const QString location = getVerifiedString(L, __func__, 1, "package location path and file name");
     Host& host = getHostFromLua(L);
     if (auto [success, message] = host.installPackage(location, 0); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -12031,7 +12031,7 @@ int TLuaInterpreter::installPackage(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#uninstallPackage
 int TLuaInterpreter::uninstallPackage(lua_State* L)
 {
-    QString const packageName = getVerifiedString(L, __func__, 1, "package name");
+    const QString packageName = getVerifiedString(L, __func__, 1, "package name");
     Host& host = getHostFromLua(L);
     host.uninstallPackage(packageName, 0);
     return 0;
@@ -12040,9 +12040,9 @@ int TLuaInterpreter::uninstallPackage(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#installModule
 int TLuaInterpreter::installModule(lua_State* L)
 {
-    QString const modName = getVerifiedString(L, __func__, 1, "module location");
+    const QString modName = getVerifiedString(L, __func__, 1, "module location");
     Host& host = getHostFromLua(L);
-    QString const module = QDir::fromNativeSeparators(modName);
+    const QString module = QDir::fromNativeSeparators(modName);
 
     if (auto [success, message] = host.installPackage(module, 3); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -12058,7 +12058,7 @@ int TLuaInterpreter::installModule(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#uninstallModule
 int TLuaInterpreter::uninstallModule(lua_State* L)
 {
-    QString const module = getVerifiedString(L, __func__, 1, "module name");
+    const QString module = getVerifiedString(L, __func__, 1, "module name");
     Host& host = getHostFromLua(L);
     if (!host.uninstallPackage(module, 3)) {
         lua_pushboolean(L, false);
@@ -12075,7 +12075,7 @@ int TLuaInterpreter::uninstallModule(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#reloadModule
 int TLuaInterpreter::reloadModule(lua_State* L)
 {
-    QString const module = getVerifiedString(L, __func__, 1, "module name");
+    const QString module = getVerifiedString(L, __func__, 1, "module name");
     Host& host = getHostFromLua(L);
     host.reloadModule(module);
     return 0;
@@ -12084,7 +12084,7 @@ int TLuaInterpreter::reloadModule(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableModuleSync
 int TLuaInterpreter::enableModuleSync(lua_State* L)
 {
-    QString const module = getVerifiedString(L, __func__, 1, "module name");
+    const QString module = getVerifiedString(L, __func__, 1, "module name");
     Host& host = getHostFromLua(L);
     if (auto [success, message] = host.changeModuleSync(module, QLatin1String("1")); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -12104,7 +12104,7 @@ int TLuaInterpreter::enableModuleSync(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableModuleSync
 int TLuaInterpreter::disableModuleSync(lua_State* L)
 {
-    QString const module = getVerifiedString(L, __func__, 1, "module name");
+    const QString module = getVerifiedString(L, __func__, 1, "module name");
     Host& host = getHostFromLua(L);
     if (auto [success, message] = host.changeModuleSync(module, QLatin1String("0")); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -12124,7 +12124,7 @@ int TLuaInterpreter::disableModuleSync(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getModuleSync
 int TLuaInterpreter::getModuleSync(lua_State* L)
 {
-    QString const module = getVerifiedString(L, __func__, 1, "module name");
+    const QString module = getVerifiedString(L, __func__, 1, "module name");
     Host& host = getHostFromLua(L);
     if (auto [success, message] = host.getModuleSync(module); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -12175,7 +12175,7 @@ int TLuaInterpreter::getModuleInfo(lua_State* L)
     Host const& host = getHostFromLua(L);
     auto infoMap = host.mModuleInfo;
     int const n = lua_gettop(L);
-    QString const name = getVerifiedString(L, __func__, 1, "module name");
+    const QString name = getVerifiedString(L, __func__, 1, "module name");
     QString info;
     if (n > 1) {
         info = getVerifiedString(L, __func__, 2, "info", true);
@@ -12201,7 +12201,7 @@ int TLuaInterpreter::getPackageInfo(lua_State* L)
     Host const& host = getHostFromLua(L);
     auto infoMap = host.mPackageInfo;
     int const n = lua_gettop(L);
-    QString const name = getVerifiedString(L, __func__, 1, "package name");
+    const QString name = getVerifiedString(L, __func__, 1, "package name");
     QString info;
     if (n > 1) {
         info = getVerifiedString(L, __func__, 2, "info", true);
@@ -12225,9 +12225,9 @@ int TLuaInterpreter::getPackageInfo(lua_State* L)
 int TLuaInterpreter::setModuleInfo(lua_State* L)
 {
   Host& host = getHostFromLua(L);
-  QString const moduleName = getVerifiedString(L, __func__, 1, "module name");
-  QString const info = getVerifiedString(L, __func__, 2, "info");
-  QString const value = getVerifiedString(L, __func__, 3, "value");
+  const QString moduleName = getVerifiedString(L, __func__, 1, "module name");
+  const QString info = getVerifiedString(L, __func__, 2, "info");
+  const QString value = getVerifiedString(L, __func__, 3, "value");
   host.mModuleInfo[moduleName][info] = value;
   lua_pushboolean(L, true);
   return 1;
@@ -12237,9 +12237,9 @@ int TLuaInterpreter::setModuleInfo(lua_State* L)
 int TLuaInterpreter::setPackageInfo(lua_State* L)
 {
   Host& host = getHostFromLua(L);
-  QString const packageName = getVerifiedString(L, __func__, 1, "package name");
-  QString const info = getVerifiedString(L, __func__, 2, "info");
-  QString const value = getVerifiedString(L, __func__, 3, "value");
+  const QString packageName = getVerifiedString(L, __func__, 1, "package name");
+  const QString info = getVerifiedString(L, __func__, 2, "info");
+  const QString value = getVerifiedString(L, __func__, 3, "value");
   host.mPackageInfo[packageName][info] = value;
   lua_pushboolean(L, true);
   return 1;
@@ -12283,8 +12283,8 @@ int TLuaInterpreter::setDefaultAreaVisible(lua_State* L)
 // this function to get called events.
 int TLuaInterpreter::registerAnonymousEventHandler(lua_State* L)
 {
-    QString const event = getVerifiedString(L, __func__, 1, "event name");
-    QString const func = getVerifiedString(L, __func__, 2, "function name");
+    const QString event = getVerifiedString(L, __func__, 1, "event name");
+    const QString func = getVerifiedString(L, __func__, 2, "function name");
     Host& host = getHostFromLua(L);
     host.registerAnonymousEventHandler(event, func);
     return 0;
@@ -12293,7 +12293,7 @@ int TLuaInterpreter::registerAnonymousEventHandler(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#expandAlias
 int TLuaInterpreter::expandAlias(lua_State* L)
 {
-    QString const payload = getVerifiedString(L, __func__, 1, "text to parse");
+    const QString payload = getVerifiedString(L, __func__, 1, "text to parse");
     bool wantPrint = true;
     if (lua_gettop(L) > 1) {
         // check if the 2nd argument is a 'false', but don't match if it is 'nil'
@@ -12320,7 +12320,7 @@ int TLuaInterpreter::printCmdLine(lua_State* L)
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
     }
-    QString const text = getVerifiedString(L, __func__, n, "text to set on command line");
+    const QString text = getVerifiedString(L, __func__, n, "text to set on command line");
 
     auto pN = COMMANDLINE(L, name);
     pN->setPlainText(text);
@@ -12350,7 +12350,7 @@ int TLuaInterpreter::clearCmdLine(lua_State* L)
 // encoded in the required Mud Server encoding.
 int TLuaInterpreter::sendRaw(lua_State* L)
 {
-    QString const text = getVerifiedString(L, __func__, 1, "command");
+    const QString text = getVerifiedString(L, __func__, 1, "command");
     bool wantPrint = true;
     if (lua_gettop(L) > 1) {
         wantPrint = getVerifiedBool(L, __func__, 2, "showOnScreen", true);
@@ -12382,8 +12382,8 @@ int TLuaInterpreter::sendSocket(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#sendIrc
 int TLuaInterpreter::sendIrc(lua_State* L)
 {
-    QString const target = getVerifiedString(L, __func__, 1, "target");
-    QString const msg = getVerifiedString(L, __func__, 2, "message");
+    const QString target = getVerifiedString(L, __func__, 1, "target");
+    const QString msg = getVerifiedString(L, __func__, 2, "message");
 
     Host* pHost = &getHostFromLua(L);
     if (!pHost->mpDlgIRC) {
@@ -12493,7 +12493,7 @@ int TLuaInterpreter::getIrcConnectedHost(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setIrcNick
 int TLuaInterpreter::setIrcNick(lua_State* L)
 {
-    QString const nick = getVerifiedString(L, __func__, 1, "nick");
+    const QString nick = getVerifiedString(L, __func__, 1, "nick");
     if (nick.isEmpty()) {
         return warnArgumentValue(L, __func__, "nick must not be empty");
     }
@@ -12570,7 +12570,7 @@ int TLuaInterpreter::setIrcChannels(lua_State* L)
     while (lua_next(L, 1) != 0) {
         // key at index -2 and value at index -1
         if (lua_type(L, -1) == LUA_TSTRING) {
-            QString const c = lua_tostring(L, -1);
+            const QString c = lua_tostring(L, -1);
             if (!c.isEmpty() && (c.startsWith(QLatin1String("#")) || c.startsWith(QLatin1String("&")) || c.startsWith(QLatin1String("+")))) {
                 newchannels << c;
             }
@@ -12780,7 +12780,7 @@ int TLuaInterpreter::ttsGetVoices(lua_State* L)
 int TLuaInterpreter::ttsGetCurrentVoice(lua_State* L)
 {
     TLuaInterpreter::ttsBuild();
-    QString const currentVoice = speechUnit->voice().name();
+    const QString currentVoice = speechUnit->voice().name();
     lua_pushstring(L, currentVoice.toUtf8().constData());
     return 1;
 }
@@ -12789,7 +12789,7 @@ int TLuaInterpreter::ttsGetCurrentVoice(lua_State* L)
 int TLuaInterpreter::ttsSetVoiceByName(lua_State* L)
 {
     TLuaInterpreter::ttsBuild();
-    QString const nextVoice = getVerifiedString(L, __func__, 1, "voice");
+    const QString nextVoice = getVerifiedString(L, __func__, 1, "voice");
 
     QVector<QVoice> const speechVoices = speechUnit->availableVoices();
     for (auto voice : speechVoices) {
@@ -13214,8 +13214,8 @@ bool TLuaInterpreter::compileAndExecuteScript(const QString& code)
         if (mudlet::smDebugMode) {
             qDebug() << "LUA ERROR: code did not compile: ERROR:" << e.c_str();
         }
-        QString const _n = "error in Lua code";
-        QString const _n2 = "no debug data available";
+        const QString _n = "error in Lua code";
+        const QString _n2 = "no debug data available";
         logError(e, _n, _n2);
     }
 
@@ -13251,7 +13251,7 @@ QString TLuaInterpreter::formatLuaCode(const QString &code)
     // escape newlines so they don't interpreted as newlines, but instead get passed onto the function
     escapedCode.replace(QLatin1String("\n"), QLatin1String("\\n"));
 
-    QString const thing = QString(R"(return get_formatted_code(get_ast("%1"), {indent_chunk = '  ', right_margin = 100, max_text_width = 160, keep_comments = true}))").arg(escapedCode);
+    const QString thing = QString(R"(return get_formatted_code(get_ast("%1"), {indent_chunk = '  ', right_margin = 100, max_text_width = 160, keep_comments = true}))").arg(escapedCode);
     int const error = luaL_dostring(L, thing.toUtf8().constData());
     if (error) {
         std::string e = "no error message available from Lua";
@@ -13262,8 +13262,8 @@ QString TLuaInterpreter::formatLuaCode(const QString &code)
         if (mudlet::smDebugMode) {
             qDebug() << "LUA ERROR: code did not compile: ERROR:" << e.c_str();
         }
-        QString const objectName = "error in Lua code";
-        QString const functionName = "no debug data available";
+        const QString objectName = "error in Lua code";
+        const QString functionName = "no debug data available";
         logError(e, objectName, functionName);
         lua_pop(L, lua_gettop(L));
         return code;
@@ -13315,7 +13315,7 @@ std::pair<bool, QString> TLuaInterpreter::validateLuaCodeParam(int index)
     if (!lua_isstring(L, index)) {
         return {false, qsl("lua script as string expected, got %1!").arg(luaL_typename(L, index))};
     }
-    QString const script{lua_tostring(L, index)};
+    const QString script{lua_tostring(L, index)};
     return validLuaCode(script);
 }
 
@@ -13510,7 +13510,7 @@ TLuaInterpreter::signalMXPEvent(const QString &type, const QMap<QString, QString
 
     Host &host = getHostFromLua(L);
     if (mudlet::smDebugMode) {
-        QString const msg = qsl("\n%1 event <%2> display(%1) to see the full content\n").arg("mxp", token);
+        const QString msg = qsl("\n%1 event <%2> display(%1) to see the full content\n").arg("mxp", token);
         host.mpConsole->printSystemMessage(msg);
     }
     host.raiseEvent(event);
@@ -13643,8 +13643,8 @@ void TLuaInterpreter::parseJSON(QString& key, const QString& string_data, const 
                 e = "Lua error:";
                 e += lua_tostring(L, -1);
             }
-            QString const _n = "JSON decoder error:";
-            QString const _f = "json_to_value";
+            const QString _n = "JSON decoder error:";
+            const QString _f = "json_to_value";
             logError(e, _n, _f);
         }
     }
@@ -13669,7 +13669,7 @@ void TLuaInterpreter::parseJSON(QString& key, const QString& string_data, const 
         event.mArgumentList.append(key);
         event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         if (mudlet::smDebugMode) {
-            QString const msg = qsl("\n%1 event <%2> display(%1) to see the full content\n").arg(protocol, token);
+            const QString msg = qsl("\n%1 event <%2> display(%1) to see the full content\n").arg(protocol, token);
             host.mpConsole->printSystemMessage(msg);
         }
         host.raiseEvent(event);
@@ -13680,7 +13680,7 @@ void TLuaInterpreter::parseJSON(QString& key, const QString& string_data, const 
         QRegularExpressionMatch const match = rx.match(string_data);
 
         if (match.capturedStart() != -1) {
-            QString const title = match.captured(1);
+            const QString title = match.captured(1);
             QString initialText = match.captured(2);
             QRegularExpression const codeRegex(qsl(R"lit(\\n|\\t|\\"|\\\\|\\u[0-9a-cA-C][0-9a-fA-F]{3}|\\u[dD][0-7][0-9a-fA-F]{2}|\\u[efEF][0-9a-fA-F]{3}|\\u[dD][89abAB][0-9a-fA-F]{2}\\u[dD][c-fC-F][0-9a-fA-F]{2})lit"));
             // We are about to search for 8 escape code strings within the initial text that the game gave us, patterns are:
@@ -13763,8 +13763,8 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
                 continue;
             }
 
-            QString const msspVAR = payloadList[0];
-            QString const msspVAL = payloadList[1];
+            const QString msspVAR = payloadList[0];
+            const QString msspVAL = payloadList[1];
 
             lua_getglobal(L, "mssp");
             lua_pushstring(L, msspVAR.toUtf8().constData());
@@ -13773,7 +13773,7 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
             lua_rawset(L, -3);
 
             // Raise an event
-            QString const protocol = qsl("mssp");
+            const QString protocol = qsl("mssp");
             QString token = protocol;
             token.append(".");
             token.append(msspVAR);
@@ -13784,7 +13784,7 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
             event.mArgumentList.append(token);
             event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
             if (mudlet::smDebugMode) {
-                QString const msg = qsl("\n%1 event <%2> display(%1) to see the full content\n").arg(protocol, token);
+                const QString msg = qsl("\n%1 event <%2> display(%1) to see the full content\n").arg(protocol, token);
                 host.mpConsole->printSystemMessage(msg);
             }
             host.raiseEvent(event);
@@ -13986,8 +13986,8 @@ bool TLuaInterpreter::call_luafunction(void* pT)
                 if (lua_isstring(L, i)) {
                     e = "Lua error:";
                     e += lua_tostring(L, i);
-                    QString const _n = "error in anonymous Lua function";
-                    QString const _n2 = "no debug data available";
+                    const QString _n = "error in anonymous Lua function";
+                    const QString _n2 = "no debug data available";
                     logError(e, _n, _n2);
                     if (mudlet::smDebugMode) {
                         auto& host = getHostFromLua(L);
@@ -14007,8 +14007,8 @@ bool TLuaInterpreter::call_luafunction(void* pT)
 
     }
 
-    QString const _n = "error in anonymous Lua function";
-    QString const _n2 = "func reference not found by Lua, func cannot be called";
+    const QString _n = "error in anonymous Lua function";
+    const QString _n2 = "func reference not found by Lua, func cannot be called";
     std::string e = "Lua error:";
     logError(e, _n, _n2);
     return false;
@@ -14058,8 +14058,8 @@ std::pair<bool, bool> TLuaInterpreter::callLuaFunctionReturnBool(void* pT)
                 if (lua_isstring(L, i)) {
                     e = "Lua error:";
                     e += lua_tostring(L, i);
-                    QString const _n = "error in anonymous Lua function";
-                    QString const _n2 = "no debug data available";
+                    const QString _n = "error in anonymous Lua function";
+                    const QString _n2 = "no debug data available";
                     logError(e, _n, _n2);
                     if (mudlet::smDebugMode) {
                         auto& host = getHostFromLua(L);
@@ -14082,8 +14082,8 @@ std::pair<bool, bool> TLuaInterpreter::callLuaFunctionReturnBool(void* pT)
         return {!error , returnValue};
     }
 
-    QString const _n = "error in anonymous Lua function";
-    QString const _n2 = "func reference not found by Lua, func cannot be called";
+    const QString _n = "error in anonymous Lua function";
+    const QString _n2 = "func reference not found by Lua, func cannot be called";
     std::string e = "Lua error:";
     logError(e, _n, _n2);
 
@@ -14220,7 +14220,7 @@ bool TLuaInterpreter::callConditionFunction(std::string& function, const QString
             std::string e = "";
             if (lua_isstring(L, i)) {
                 e += lua_tostring(L, i);
-                QString const _f = function.c_str();
+                const QString _f = function.c_str();
                 logError(e, mName, _f);
                 if (mudlet::smDebugMode) {
                     auto& host = getHostFromLua(L);
@@ -14396,7 +14396,7 @@ bool TLuaInterpreter::callLabelCallbackEvent(const int func, const QEvent* qE)
 {
     lua_State* L = pGlobalLua;
     lua_rawgeti(L, LUA_REGISTRYINDEX, func);
-    QString const name = qsl("label callback event");
+    const QString name = qsl("label callback event");
 
     if (qE) {
         // Create Lua table with QEvent data if needed
@@ -14564,7 +14564,7 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
             err = "Lua error: ";
             err += lua_tostring(L, 1);
         }
-        QString const name = "event handler function";
+        const QString name = "event handler function";
         logError(err, name, function);
         return false;
     }
@@ -14611,7 +14611,7 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
         if (lua_isstring(L, -1)) {
             err += lua_tostring(L, -1);
         }
-        QString const name = "event handler function";
+        const QString name = "event handler function";
         logError(err, name, function);
         if (mudlet::smDebugMode) {
             auto& host = getHostFromLua(L);
@@ -14626,7 +14626,7 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
 // No documentation available in wiki - internal function
 double TLuaInterpreter::condenseMapLoad()
 {
-    QString const luaFunction = qsl("condenseMapLoad");
+    const QString luaFunction = qsl("condenseMapLoad");
     double loadTime = -1.0;
 
     lua_State* L = pGlobalLua;
@@ -14639,7 +14639,7 @@ double TLuaInterpreter::condenseMapLoad()
             std::string e = "";
             if (lua_isstring(L, i)) {
                 e += lua_tostring(L, i);
-                QString const _f = luaFunction.toUtf8().constData();
+                const QString _f = luaFunction.toUtf8().constData();
                 logError(e, luaFunction, _f);
                 if (mudlet::smDebugMode) {
                     auto& host = getHostFromLua(L);
@@ -14703,7 +14703,7 @@ int TLuaInterpreter::performHttpRequest(lua_State *L, const char* functionName, 
         dataToPost = lua_tostring(L, pos + 1);
     }
 
-    QString const urlString = getVerifiedString(L, functionName, pos + 2, "remote url");
+    const QString urlString = getVerifiedString(L, functionName, pos + 2, "remote url");
     QUrl const url = QUrl::fromUserInput(urlString);
 
     if (!url.isValid()) {
@@ -14784,7 +14784,7 @@ int TLuaInterpreter::performHttpRequest(lua_State *L, const char* functionName, 
 int TLuaInterpreter::getHTTP(lua_State* L)
 {
     auto& host = getHostFromLua(L);
-    QString const urlString = getVerifiedString(L, __func__, 1, "remote url");
+    const QString urlString = getVerifiedString(L, __func__, 1, "remote url");
     QUrl const url = QUrl::fromUserInput(urlString);
     if (!url.isValid()) {
         return warnArgumentValue(L, __func__, qsl("url is invalid, reason: %1").arg(url.errorString()));
@@ -14837,7 +14837,7 @@ int TLuaInterpreter::postHTTP(lua_State* L)
 int TLuaInterpreter::deleteHTTP(lua_State *L)
 {
     auto& host = getHostFromLua(L);
-    QString const urlString = getVerifiedString(L, __func__, 1, "remote url");
+    const QString urlString = getVerifiedString(L, __func__, 1, "remote url");
     QUrl const url = QUrl::fromUserInput(urlString);
     if (!url.isValid()) {
         return warnArgumentValue(L, __func__, qsl("url is invalid, reason: %1").arg(url.errorString()));
@@ -14896,7 +14896,7 @@ int TLuaInterpreter::getConnectionInfo(lua_State *L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Networking_Functions#unzipAsync
 int TLuaInterpreter::unzipAsync(lua_State *L)
 {
-    QString const zipLocation = getVerifiedString(L, __func__, 1, "zip location");
+    const QString zipLocation = getVerifiedString(L, __func__, 1, "zip location");
     QString extractLocation = getVerifiedString(L, __func__, 2, "extract location");
 
     QTemporaryDir const temporaryDir;
@@ -16130,7 +16130,7 @@ std::pair<int, QString> TLuaInterpreter::createPermScript(const QString& name, c
     // This will lead to the generation of the ID number:
     mpHost->getScriptUnit()->registerScript(pS);
     if (!pS->setScript(luaCode)) {
-        QString const errMsg = pS->getError();
+        const QString errMsg = pS->getError();
         delete pS;
         return {-1, qsl("unable to compile \"%1\", reason: %2").arg(luaCode, errMsg)};
     }
@@ -16155,7 +16155,7 @@ std::pair<int, QString> TLuaInterpreter::setScriptCode(QString& name, const QStr
     }
     auto oldCode = pS->getScript();
     if (!pS->setScript(luaCode)) {
-        QString const errMsg = pS->getError();
+        const QString errMsg = pS->getError();
         pS->setScript(oldCode);
         return {-1, qsl("unable to compile \"%1\" at position \"%2\", reason: %3").arg(luaCode).arg(++pos).arg(errMsg)};
     }
@@ -16191,7 +16191,7 @@ std::pair<int, QString> TLuaInterpreter::startPermTimer(const QString& name, con
     // This will lead to the generation of the ID number:
     mpHost->getTimerUnit()->registerTimer(pT);
     if (!pT->setScript(function)) {
-        QString const errMsg = pT->getError();
+        const QString errMsg = pT->getError();
         // Apparently this will call the TTimer::unregisterTimer(...) method:
         delete pT;
         return {-1, qsl("unable to compile \"%1\", reason: %2").arg(function, errMsg)};
@@ -16214,7 +16214,7 @@ QPair<int, QString> TLuaInterpreter::startTempTimer(double timeout, const QStrin
     // name for temporary timers:
     mpHost->getTimerUnit()->registerTimer(pT);
     if (!pT->setScript(function)) {
-        QString const errMsg = pT->getError();
+        const QString errMsg = pT->getError();
         // Apparently this will call the TTimer::unregisterTimer(...) method:
         delete pT;
         return qMakePair(-1, qsl("unable to compile \"%1\", reason: %2").arg(function, errMsg));
@@ -16604,7 +16604,7 @@ Host& getHostFromLua(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getColumnCount
 int TLuaInterpreter::getColumnCount(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
 
     int columns;
     auto console = CONSOLE(L, windowName);
@@ -16616,7 +16616,7 @@ int TLuaInterpreter::getColumnCount(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRowCount
 int TLuaInterpreter::getRowCount(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
 
     int rows;
     auto console = CONSOLE(L, windowName);
@@ -16683,7 +16683,7 @@ int TLuaInterpreter::getMapSelection(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableClickthrough
 int TLuaInterpreter::enableClickthrough(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
 
     Host& host = getHostFromLua(L);
 
@@ -16694,7 +16694,7 @@ int TLuaInterpreter::enableClickthrough(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableClickthrough
 int TLuaInterpreter::disableClickthrough(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
 
     Host& host = getHostFromLua(L);
 
@@ -16713,7 +16713,7 @@ int TLuaInterpreter::addWordToDictionary(lua_State* L)
         return warnArgumentValue(L, __func__, "no user dictionary enabled in the preferences for this profile");
     }
 
-    QString const text = getVerifiedString(L, __func__, 1, "word");
+    const QString text = getVerifiedString(L, __func__, 1, "word");
     QPair<bool, QString> const result = host.mpConsole->addWordToSet(text);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
@@ -16733,7 +16733,7 @@ int TLuaInterpreter::removeWordFromDictionary(lua_State* L)
         return warnArgumentValue(L, __func__, "no user dictionary enabled in the preferences for this profile");
     }
 
-    QString const text = getVerifiedString(L, __func__, 1, "word");
+    const QString text = getVerifiedString(L, __func__, 1, "word");
     QPair<bool, QString> const result = host.mpConsole->removeWordFromSet(text);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
@@ -16750,7 +16750,7 @@ int TLuaInterpreter::spellCheckWord(lua_State* L)
     bool hasSharedDictionary = false;
     host.getUserDictionaryOptions(hasUserDictionary, hasSharedDictionary);
 
-    QString const text = getVerifiedString(L, __func__, 1, "word");
+    const QString text = getVerifiedString(L, __func__, 1, "word");
 
     bool useUserDictionary = false;
     if (lua_gettop(L) > 1) {
@@ -16787,7 +16787,7 @@ int TLuaInterpreter::spellSuggestWord(lua_State* L)
     bool hasSharedDictionary = false;
     host.getUserDictionaryOptions(hasUserDictionary, hasSharedDictionary);
 
-    QString const text = getVerifiedString(L, __func__, 1, "word");
+    const QString text = getVerifiedString(L, __func__, 1, "word");
 
     bool useUserDictionary = false;
     if (lua_gettop(L) > 1) {
@@ -17049,7 +17049,7 @@ void TLuaInterpreter::updateExtendedAnsiColorsInTable()
         lua_getfield(L, LUA_GLOBALSINDEX, "color_table");
         lua_insert(L, -2);
 
-        QString const name = qsl("ansi_%1").arg(i + 16, 3, 10, QLatin1Char('0'));
+        const QString name = qsl("ansi_%1").arg(i + 16, 3, 10, QLatin1Char('0'));
         lua_pushstring(L, name.toUtf8().constData());
         lua_insert(L, -2);
         lua_settable(L, -3);
@@ -17074,7 +17074,7 @@ void TLuaInterpreter::updateExtendedAnsiColorsInTable()
         lua_getfield(L, LUA_GLOBALSINDEX, "color_table");
         lua_insert(L, -2);
 
-        QString const name = qsl("ansi_%1").arg(i, 3, 10, QLatin1Char('0'));
+        const QString name = qsl("ansi_%1").arg(i, 3, 10, QLatin1Char('0'));
         lua_pushstring(L, name.toUtf8().constData());
         lua_insert(L, -2);
         lua_settable(L, -3);
@@ -17237,7 +17237,7 @@ int TLuaInterpreter::setMapRoomExitsColor(lua_State* L)
 int TLuaInterpreter::showNotification(lua_State* L)
 {
     int const n = lua_gettop(L);
-    QString const title = getVerifiedString(L, __func__, 1, "title");
+    const QString title = getVerifiedString(L, __func__, 1, "title");
     QString text = title;
     if (n >= 2) {
         text = getVerifiedString(L, __func__, 2, "message");
@@ -17349,7 +17349,7 @@ int TLuaInterpreter::registerMapInfo(lua_State* L)
 
         auto nResult = lua_gettop(L);
         auto index = -nResult;
-        QString const text = lua_tostring(L, index);
+        const QString text = lua_tostring(L, index);
         bool const isBold = lua_toboolean(L, ++index);
         bool const isItalic = lua_toboolean(L, ++index);
         int r = -1;
@@ -17443,7 +17443,7 @@ int TLuaInterpreter::addMouseEvent(lua_State * L)
 {
     Host& host = getHostFromLua(L);
     QStringList actionInfo;
-    QString const uniqueName = getVerifiedString(L, __func__, 1, "uniquename");
+    const QString uniqueName = getVerifiedString(L, __func__, 1, "uniquename");
     if (host.mConsoleActions.contains(uniqueName)) {
         return warnArgumentValue(L, __func__, qsl("mouse event '%1' already exists").arg(uniqueName));
     }
@@ -17473,7 +17473,7 @@ int TLuaInterpreter::addMouseEvent(lua_State * L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#removeMouseEvent
 int TLuaInterpreter::removeMouseEvent(lua_State * L)
 {
-    QString const uniqueName = getVerifiedString(L, __func__, 1, "event name");
+    const QString uniqueName = getVerifiedString(L, __func__, 1, "event name");
     Host& host = getHostFromLua(L);
     if (host.mConsoleActions.remove(uniqueName) == 0) {
         return warnArgumentValue(L, __func__, qsl("mouse event '%1' does not exist").arg(uniqueName));
@@ -17968,10 +17968,10 @@ int TLuaInterpreter::getScroll(lua_State* L)
 // Please use same options with same names in setConfig and getConfig and keep them in sync
 // The no args case that returns a table is handled by getConfig in Other.lua
 // that runs a loop with a list of these properties, please update that list.
-int TLuaInterpreter::getConfig(lua_State *L) 
+int TLuaInterpreter::getConfig(lua_State *L)
 {
     auto &host = getHostFromLua(L);
-    QString const key = getVerifiedString(L, __func__, 1, "key");
+    const QString key = getVerifiedString(L, __func__, 1, "key");
     if (key.isEmpty()) {
         return warnArgumentValue(L, __func__, "you must provide a key");
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -525,7 +525,7 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
         break;
 
     case QNetworkAccessManager::GetOperation:
-        QString localFileName = downloadMap.value(reply);
+        QString const localFileName = downloadMap.value(reply);
         downloadMap.remove(reply);
 
         // If the user did not give us a file path, we're not going to
@@ -556,7 +556,7 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
             break;
         }
 
-        qint64 bytesWritten = localFile.write(reply->readAll());
+        qint64 const bytesWritten = localFile.write(reply->readAll());
         if (bytesWritten == -1) {
             event.mArgumentList << QLatin1String("sysDownloadError");
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
@@ -661,13 +661,13 @@ void TLuaInterpreter::slot_purge()
 // No documentation available in wiki - internal function
 int TLuaInterpreter::Wait(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     if (n != 1) {
         lua_pushstring(L, "Wait: wrong number of arguments");
         return lua_error(L);
     }
 
-    int luaSleepMsec = getVerifiedInt(L, __func__, 1, "sleep time in msec");
+    int const luaSleepMsec = getVerifiedInt(L, __func__, 1, "sleep time in msec");
     msleep(luaSleepMsec); // FIXME thread::sleep()
     return 0;
 }
@@ -686,7 +686,7 @@ int TLuaInterpreter::Wait(lua_State* L)
 QString TLuaInterpreter::dirToString(lua_State* L, int position)
 {
     if (lua_isnumber(L, position)) {
-        qint64 dirNum = lua_tonumber(L, position);
+        qint64 const dirNum = lua_tonumber(L, position);
         switch (dirNum) {
         // breaks not needed - all handled cases end in a return!
         case 1:
@@ -823,7 +823,7 @@ int TLuaInterpreter::raiseEvent(lua_State* L)
 
     TEvent event {};
 
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     // We go from the top of the stack down, because luaL_ref will
     // only reference the object at the top of the stack
     for (int i = n; i >= 1; i--) {
@@ -910,7 +910,7 @@ int TLuaInterpreter::raiseGlobalEvent(lua_State* L)
 {
     Host& host = getHostFromLua(L);
 
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     if (!n) {
         lua_pushstring(L, "raiseGlobalEvent: missing argument #1 (eventName as, probably, a string expected!)");
         return lua_error(L);
@@ -980,10 +980,10 @@ int TLuaInterpreter::selectString(lua_State* L)
         windowName = WINDOW_NAME(L, s++);
     }
 
-    QString searchText = getVerifiedString(L, __func__, s++, "text to select");
+    QString const searchText = getVerifiedString(L, __func__, s++, "text to select");
     // CHECK: Do we need to qualify this for a non-blank string?
 
-    qint64 numOfMatch = static_cast <qint64> (getVerifiedInt(L, __func__, s, "match count {1 for first}"));
+    qint64 const numOfMatch = static_cast <qint64> (getVerifiedInt(L, __func__, s, "match count {1 for first}"));
 
     auto console = CONSOLE(L, windowName);
     lua_pushnumber(L, console->select(searchText, numOfMatch));
@@ -1007,10 +1007,10 @@ int TLuaInterpreter::selectCurrentLine(lua_State* L)
 int TLuaInterpreter::isAnsiFgColor(lua_State* L)
 {
     std::string windowName = "main";
-    int ansiFg = getVerifiedInt(L, __func__, 1, "ANSI color");
+    int const ansiFg = getVerifiedInt(L, __func__, 1, "ANSI color");
 
     std::list<int> result;
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     result = host.mpConsole->getFgColor(windowName);
     auto it = result.begin();
     if (result.size() < 3) {
@@ -1101,10 +1101,10 @@ int TLuaInterpreter::isAnsiFgColor(lua_State* L)
 int TLuaInterpreter::isAnsiBgColor(lua_State* L)
 {
     std::string windowName = "main";
-    int ansiBg = getVerifiedInt(L, __func__, 1, "ANSI color");
+    int const ansiBg = getVerifiedInt(L, __func__, 1, "ANSI color");
 
     std::list<int> result;
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     result = host.mpConsole->getBgColor(windowName);
     auto it = result.begin();
     if (result.size() < 3) {
@@ -1199,9 +1199,9 @@ int TLuaInterpreter::getFgColor(lua_State* L)
         windowName = getVerifiedString(L, __func__, 1, "window name", true).toStdString();
     }
 
-    Host& host = getHostFromLua(L);
-    std::list<int> result = host.mpConsole->getFgColor(windowName);
-    for (int pos : result) {
+    Host const& host = getHostFromLua(L);
+    std::list<int> const result = host.mpConsole->getFgColor(windowName);
+    for (int const pos : result) {
         lua_pushnumber(L, pos);
     }
     return result.size();
@@ -1215,9 +1215,9 @@ int TLuaInterpreter::getBgColor(lua_State* L)
         windowName = getVerifiedString(L, __func__, 1, "window name", true).toStdString();
     }
 
-    Host& host = getHostFromLua(L);
-    std::list<int> result = host.mpConsole->getBgColor(windowName);
-    for (int pos : result) {
+    Host const& host = getHostFromLua(L);
+    std::list<int> const result = host.mpConsole->getBgColor(windowName);
+    for (int const pos : result) {
         lua_pushnumber(L, pos);
     }
     return result.size();
@@ -1231,8 +1231,8 @@ int TLuaInterpreter::getTextFormat(lua_State* L)
         windowName = getVerifiedString(L, __func__, 1, "window name", true);
     }
 
-    Host& host = getHostFromLua(L);
-    QPair<quint8, TChar> result = host.mpConsole->getTextAttributes(windowName);
+    Host const& host = getHostFromLua(L);
+    QPair<quint8, TChar> const result = host.mpConsole->getTextAttributes(windowName);
     if (result.first == 1) {
         return warnArgumentValue(L, __func__, qsl("window '%1' not found").arg(windowName));
     }
@@ -1243,7 +1243,7 @@ int TLuaInterpreter::getTextFormat(lua_State* L)
 
     lua_newtable(L);
 
-    TChar::AttributeFlags format = result.second.allDisplayAttributes();
+    TChar::AttributeFlags const format = result.second.allDisplayAttributes();
     lua_pushstring(L, "bold");
     lua_pushboolean(L, format & TChar::Bold);
     lua_settable(L, -3);
@@ -1268,7 +1268,7 @@ int TLuaInterpreter::getTextFormat(lua_State* L)
     lua_pushboolean(L, format & TChar::Underline);
     lua_settable(L, -3);
 
-    QColor foreground(result.second.foreground());
+    QColor const foreground(result.second.foreground());
     lua_pushstring(L, "foreground");
     lua_newtable(L);
     lua_pushnumber(L, 1);
@@ -1284,7 +1284,7 @@ int TLuaInterpreter::getTextFormat(lua_State* L)
     lua_settable(L, -3);
     lua_settable(L, -3);
 
-    QColor background(result.second.background());
+    QColor const background(result.second.background());
     lua_pushstring(L, "background");
     lua_newtable(L);
     lua_pushnumber(L, 1);
@@ -1325,9 +1325,9 @@ int TLuaInterpreter::wrapLine(lua_State* L)
     if (lua_gettop(L)) {
         windowName = getVerifiedString(L, __func__, s++, "window name").toStdString();
     }
-    int lineNumber = getVerifiedInt(L, __func__, s, "line");
+    int const lineNumber = getVerifiedInt(L, __func__, s, "line");
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     host.mpConsole->luaWrapLine(windowName, lineNumber);
     return 0;
 }
@@ -1394,7 +1394,7 @@ int TLuaInterpreter::selectCaptureGroup(lua_State *L)
         }
     }
     if (length > 0) {
-        int pos = host.mpConsole->selectSection(begin, length);
+        int const pos = host.mpConsole->selectSection(begin, length);
         lua_pushnumber(L, pos);
     } else {
         lua_pushnumber(L, -1);
@@ -1405,17 +1405,17 @@ int TLuaInterpreter::selectCaptureGroup(lua_State *L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getLines
 int TLuaInterpreter::getLines(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     int s = 1;
     QString windowName;
     if (n > 2) {
         windowName = getVerifiedString(L, __func__, s++, "mini console, user window or buffer name {may be omitted for the \"main\" console}", true);
     }
-    int lineFrom = getVerifiedInt(L, __func__, s++, "start line");
-    int lineTo = getVerifiedInt(L, __func__, s, "end line");
+    int const lineFrom = getVerifiedInt(L, __func__, s++, "start line");
+    int const lineTo = getVerifiedInt(L, __func__, s, "end line");
 
     Host& host = getHostFromLua(L);
-    QPair<bool, QStringList> result = host.getLines(windowName, lineFrom, lineTo);
+    QPair<bool, QStringList> const result = host.getLines(windowName, lineFrom, lineTo);
     if (!result.first) {
         // Only one QString in .second - the error message
         return warnArgumentValue(L, __func__, result.second.at(0));
@@ -1432,7 +1432,7 @@ int TLuaInterpreter::getLines(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#loadReplay
 int TLuaInterpreter::loadReplay(lua_State* L)
 {
-    QString replayFileName = getVerifiedString(L, __func__, 1, "replay file name");
+    QString const replayFileName = getVerifiedString(L, __func__, 1, "replay file name");
     if (replayFileName.isEmpty()) {
         return warnArgumentValue(L, __func__, "a blank string is not a valid replay file name");
     }
@@ -1452,7 +1452,7 @@ int TLuaInterpreter::loadReplay(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setProfileIcon
 int TLuaInterpreter::setProfileIcon(lua_State* L)
 {
-    QString iconPath = getVerifiedString(L, __func__, 1, "icon file path");
+    QString const iconPath = getVerifiedString(L, __func__, 1, "icon file path");
     if (iconPath.isEmpty()) {
         return warnArgumentValue(L, __func__, "a blank string is not a valid icon file path");
     }
@@ -1486,7 +1486,7 @@ int TLuaInterpreter::resetProfileIcon(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getCurrentLine
 int TLuaInterpreter::getCurrentLine(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
     auto console = getHostFromLua(L).findConsole(windowName);
     if (!console) {
         // the next line should be "pushnil"; compatibility with old bugs and all that
@@ -1494,7 +1494,7 @@ int TLuaInterpreter::getCurrentLine(lua_State* L)
         lua_pushfstring(L, bad_window_value, windowName.toUtf8().constData());
         return 2;
     }
-    QString line = console->getCurrentLine();
+    QString const line = console->getCurrentLine();
     lua_pushstring(L, line.toUtf8().constData());
     return 1;
 }
@@ -1502,8 +1502,8 @@ int TLuaInterpreter::getCurrentLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMiniConsoleFontSize
 int TLuaInterpreter::setMiniConsoleFontSize(lua_State* L)
 {
-    QString windowName = getVerifiedString(L, __func__, 1, "miniconsole name");
-    int size = getVerifiedInt(L, __func__, 2, "font size");
+    QString const windowName = getVerifiedString(L, __func__, 1, "miniconsole name");
+    int const size = getVerifiedInt(L, __func__, 2, "font size");
     auto console = CONSOLE(L, windowName);
     if (console->setFontSize(size)) {
         lua_pushboolean(L, true);
@@ -1531,7 +1531,7 @@ int TLuaInterpreter::getLineNumber(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#updateMap
 int TLuaInterpreter::updateMap(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (host.mpMap) {
         host.mpMap->update();
     }
@@ -1543,7 +1543,7 @@ int TLuaInterpreter::addMapMenu(lua_State* L)
 {
     //    first arg = unique name, second arg= parent name, third arg = display name (=unique name if not provided)
     QStringList menuList;
-    QString uniqueName = getVerifiedString(L, __func__, 1, "uniquename");
+    QString const uniqueName = getVerifiedString(L, __func__, 1, "uniquename");
 
     if (!lua_isstring(L, 2)) {
         menuList << "";
@@ -1555,7 +1555,7 @@ int TLuaInterpreter::addMapMenu(lua_State* L)
     } else {
         menuList << lua_tostring(L, 3);
     }
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (host.mpMap) {
         if (host.mpMap->mpMapper) {
             if (host.mpMap->mpMapper->mp2dMap) {
@@ -1569,11 +1569,11 @@ int TLuaInterpreter::addMapMenu(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#removeMapMenu
 int TLuaInterpreter::removeMapMenu(lua_State* L)
 {
-    QString uniqueName = getVerifiedString(L, __func__, 1, "Menu name");
+    QString const uniqueName = getVerifiedString(L, __func__, 1, "Menu name");
     if (uniqueName.isEmpty()) {
         return 0;
     }
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (host.mpMap) {
         if (host.mpMap->mpMapper) {
             if (host.mpMap->mpMapper->mp2dMap) {
@@ -1588,7 +1588,7 @@ int TLuaInterpreter::removeMapMenu(lua_State* L)
                     while (it.hasNext()) {
                         it.next();
                         QStringList menuInfo = it.value();
-                        QString parent = menuInfo[0];
+                        QString const parent = menuInfo[0];
                         if (removeList.contains(parent)) {
                             host.mpMap->mpMapper->mp2dMap->mUserMenus.remove(it.key());
                             if (it.key() != "" && !removeList.contains(it.key())) {
@@ -1602,7 +1602,7 @@ int TLuaInterpreter::removeMapMenu(lua_State* L)
                 QMapIterator<QString, QStringList> it2(host.mpMap->mpMapper->mp2dMap->mUserActions);
                 while (it2.hasNext()) {
                     it2.next();
-                    QString actParent = it2.value()[1];
+                    QString const actParent = it2.value()[1];
                     if (removeList.contains(actParent)) {
                         host.mpMap->mpMapper->mp2dMap->mUserActions.remove(it2.key());
                     }
@@ -1616,7 +1616,7 @@ int TLuaInterpreter::removeMapMenu(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMapMenus
 int TLuaInterpreter::getMapMenus(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!(host.mpMap && host.mpMap->mpMapper && host.mpMap->mpMapper->mp2dMap)) {
         return warnArgumentValue(L, __func__, "you haven't opened a map yet");
     }
@@ -1642,7 +1642,7 @@ int TLuaInterpreter::getMapMenus(lua_State* L)
 int TLuaInterpreter::addMapEvent(lua_State* L)
 {
     QStringList actionInfo;
-    QString uniqueName = getVerifiedString(L, __func__, 1, "uniquename");
+    QString const uniqueName = getVerifiedString(L, __func__, 1, "uniquename");
     actionInfo << getVerifiedString(L, __func__, 2, "event name");
 
     if (!lua_isstring(L, 3)) {
@@ -1659,7 +1659,7 @@ int TLuaInterpreter::addMapEvent(lua_State* L)
     for (int i = 5; i <= lua_gettop(L); i++) {
         actionInfo << lua_tostring(L, i);
     }
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (host.mpMap) {
         if (host.mpMap->mpMapper) {
             if (host.mpMap->mpMapper->mp2dMap) {
@@ -1673,8 +1673,8 @@ int TLuaInterpreter::addMapEvent(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#removeMapEvent
 int TLuaInterpreter::removeMapEvent(lua_State* L)
 {
-    QString displayName = getVerifiedString(L, __func__, 1, "event name");
-    Host& host = getHostFromLua(L);
+    QString const displayName = getVerifiedString(L, __func__, 1, "event name");
+    Host const& host = getHostFromLua(L);
     if (host.mpMap) {
         if (host.mpMap->mpMapper) {
             if (host.mpMap->mpMapper->mp2dMap) {
@@ -1688,7 +1688,7 @@ int TLuaInterpreter::removeMapEvent(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMapEvents
 int TLuaInterpreter::getMapEvents(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (host.mpMap) {
         if (host.mpMap->mpMapper) {
             if (host.mpMap->mpMapper->mp2dMap) {
@@ -1697,7 +1697,7 @@ int TLuaInterpreter::getMapEvents(lua_State* L)
                 QMapIterator<QString, QStringList> it(host.mpMap->mpMapper->mp2dMap->mUserActions);
                 while (it.hasNext()) {
                     it.next();
-                    QStringList eventInfo = it.value();
+                    QStringList const eventInfo = it.value();
                     lua_createtable(L, 0, 4);
                     lua_pushstring(L, eventInfo.at(0).toUtf8().constData());
                     lua_setfield(L, -2, "event name");
@@ -1732,7 +1732,7 @@ int TLuaInterpreter::centerview(lua_State* L)
         return warnArgumentValue(L, __func__, "you haven't opened a map yet");
     }
 
-    int roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
 
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (pR) {
@@ -1790,7 +1790,7 @@ int TLuaInterpreter::copy(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#cut
 int TLuaInterpreter::cut(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     host.mpConsole->cut();
     return 0;
 }
@@ -1811,7 +1811,7 @@ int TLuaInterpreter::paste(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#feedTriggers
 int TLuaInterpreter::feedTriggers(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L,
                         "feedTriggers: bad argument #1 type (imitation game server text as string\n"
@@ -1819,13 +1819,13 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
                         luaL_typename(L, 1));
         return lua_error(L);
     }
-    QByteArray data{lua_tostring(L, 1)};
+    QByteArray const data{lua_tostring(L, 1)};
     bool dataIsUtf8Encoded = true;
     if (lua_gettop(L) > 1) {
         dataIsUtf8Encoded = getVerifiedBool(L, __func__, 2, "Utf8Encoded", true);
     }
 
-    QByteArray currentEncoding = host.mTelnet.getEncoding();
+    QByteArray const currentEncoding = host.mTelnet.getEncoding();
     if (dataIsUtf8Encoded) {
         // We can convert the data from a QByteArray to a QString:
         if (currentEncoding == "UTF-8") {
@@ -1835,7 +1835,7 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
             lua_pushboolean(L, true);
             return 1;
         }
-        QString dataQString{data};
+        QString const dataQString{data};
         // else
             // We need to transcode it from UTF-8 into the current Game Server
             // encoding - this can fail if it includes any characters (as UTF-8)
@@ -1883,8 +1883,8 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#isPrompt
 int TLuaInterpreter::isPrompt(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
-    int userCursorY = host.mpConsole->getLineNumber();
+    Host const& host = getHostFromLua(L);
+    int const userCursorY = host.mpConsole->getLineNumber();
     if (userCursorY < host.mpConsole->buffer.promptBuffer.size() && userCursorY >= 0) {
         lua_pushboolean(L, host.mpConsole->buffer.promptBuffer.at(userCursorY));
         return 1;
@@ -1906,7 +1906,7 @@ int TLuaInterpreter::setWindowWrap(lua_State* L)
     if (lua_gettop(L) > 1) {
         windowName = WINDOW_NAME(L, s++);
     }
-    int luaFrom = getVerifiedInt(L, __func__, s, "wrapAt");
+    int const luaFrom = getVerifiedInt(L, __func__, s, "wrapAt");
     auto console = CONSOLE(L, windowName);
     console->setWrapAt(luaFrom);
     return 0;
@@ -1915,7 +1915,7 @@ int TLuaInterpreter::setWindowWrap(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getWindowWrap
 int TLuaInterpreter::getWindowWrap(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
 
     auto console = CONSOLE(L, windowName);
     lua_pushnumber(L, console->getWrapAt());
@@ -1925,8 +1925,8 @@ int TLuaInterpreter::getWindowWrap(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setWindowWrapIndent
 int TLuaInterpreter::setWindowWrapIndent(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
-    int luaFrom = getVerifiedInt(L, __func__, 2, "wrapTo");
+    QString const windowName {WINDOW_NAME(L, 1)};
+    int const luaFrom = getVerifiedInt(L, __func__, 2, "wrapTo");
     auto console = CONSOLE(L, windowName);
     console->setIndentCount(luaFrom);
     return 0;
@@ -1968,7 +1968,7 @@ int TLuaInterpreter::getStopWatchTime(lua_State* L)
 
     int watchId = 0;
     QPair<bool, double> result;
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (lua_type(L, 1) == LUA_TNUMBER) {
         watchId = static_cast<int>(lua_tointeger(L, 1));
         result = host.getStopWatchTime(watchId);
@@ -1977,7 +1977,7 @@ int TLuaInterpreter::getStopWatchTime(lua_State* L)
         }
 
     } else {
-        QString name{lua_tostring(L, 1)};
+        QString const name{lua_tostring(L, 1)};
         // Using an empty string will return the first unnamed stopwatch:
         watchId = host.findStopWatchId(name);
         if (!watchId) {
@@ -2006,7 +2006,7 @@ int TLuaInterpreter::createStopWatch(lua_State* L)
 {
     QString name;
     bool autoStart = true;
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     int s = 1;
     if (n) {
         if (lua_type(L, s) == LUA_TBOOLEAN) {
@@ -2029,7 +2029,7 @@ int TLuaInterpreter::createStopWatch(lua_State* L)
 
 
     Host& host = getHostFromLua(L);
-    QPair<int, QString> result = host.createStopWatch(name);
+    QPair<int, QString> const result = host.createStopWatch(name);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second);
     }
@@ -2054,14 +2054,14 @@ int TLuaInterpreter::stopStopWatch(lua_State* L)
     int watchId = 0;
     if (lua_type(L, 1) == LUA_TNUMBER) {
         watchId = static_cast<int>(lua_tointeger(L, 1));
-        QPair<bool, QString> result = host.stopStopWatch(watchId);
+        QPair<bool, QString> const result = host.stopStopWatch(watchId);
         if (!result.first) {
             return warnArgumentValue(L, __func__, result.second);
         }
 
     } else {
-        QString name{lua_tostring(L, 1)};
-        QPair<bool, QString> result = host.stopStopWatch(name);
+        QString const name{lua_tostring(L, 1)};
+        QPair<bool, QString> const result = host.stopStopWatch(name);
         if (!result.first) {
             return warnArgumentValue(L, __func__, result.second);
         }
@@ -2115,7 +2115,7 @@ int TLuaInterpreter::startStopWatch(lua_State* L)
         return 1;
     }
 
-    QPair<bool, QString> result = host.startStopWatch(lua_tostring(L, 1));
+    QPair<bool, QString> const result = host.startStopWatch(lua_tostring(L, 1));
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second);
     }
@@ -2134,7 +2134,7 @@ int TLuaInterpreter::resetStopWatch(lua_State* L)
 
     Host& host = getHostFromLua(L);
     if (lua_type(L, 1) == LUA_TNUMBER) {
-        QPair<bool, QString> result = host.resetStopWatch(static_cast<int>(lua_tointeger(L, 1)));
+        QPair<bool, QString> const result = host.resetStopWatch(static_cast<int>(lua_tointeger(L, 1)));
         if (!result.first) {
             return warnArgumentValue(L, __func__, result.second);
         }
@@ -2143,7 +2143,7 @@ int TLuaInterpreter::resetStopWatch(lua_State* L)
         return 1;
     }
 
-    QPair<bool, QString> result = host.resetStopWatch(lua_tostring(L, 1));
+    QPair<bool, QString> const result = host.resetStopWatch(lua_tostring(L, 1));
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second);
     }
@@ -2161,9 +2161,9 @@ std::tuple<bool, int> TLuaInterpreter::getWatchId(lua_State* L, Host& h)
         return std::make_tuple(true, static_cast<int>(lua_tointeger(L, 1)));
     }
 
-    QString name{lua_tostring(L, 1)};
+    QString const name{lua_tostring(L, 1)};
     // Using an empty string will return the first unnamed stopwatch:
-    int watchId = h.findStopWatchId(name);
+    int const watchId = h.findStopWatchId(name);
     if (!watchId) {
         lua_pushnil(L);
         if (name.isEmpty()) {
@@ -2191,8 +2191,8 @@ int TLuaInterpreter::adjustStopWatch(lua_State* L)
         return 2;
     }
 
-    double adjustment = getVerifiedDouble(L, __func__, 2, "modification in seconds");
-    bool result = host.adjustStopWatch(watchId, qRound(adjustment * 1000.0));
+    double const adjustment = getVerifiedDouble(L, __func__, 2, "modification in seconds");
+    bool const result = host.adjustStopWatch(watchId, qRound(adjustment * 1000.0));
     // This is only likely to fail when a numeric first argument was given:
     if (!result) {
         return warnArgumentValue(L, __func__, csmInvalidStopWatchID.arg(watchId));
@@ -2216,7 +2216,7 @@ int TLuaInterpreter::deleteStopWatch(lua_State* L)
         return 2;
     }
 
-    bool result = host.destroyStopWatch(watchId);
+    bool const result = host.destroyStopWatch(watchId);
     // This is only likely to fail when a numeric first argument was given:
     if (!result) {
         return warnArgumentValue(L, __func__, csmInvalidStopWatchID.arg(watchId));
@@ -2240,7 +2240,7 @@ int TLuaInterpreter::setStopWatchPersistence(lua_State* L)
         return 2;
     }
 
-    bool isPersistent = getVerifiedBool(L, __func__, 2, "persistence");
+    bool const isPersistent = getVerifiedBool(L, __func__, 2, "persistence");
 
     // This is only likely to fail when a numeric first argument was given:
     if (!host.makeStopWatchPersistent(watchId, isPersistent)) {
@@ -2269,7 +2269,7 @@ int TLuaInterpreter::setStopWatchName(lua_State* L)
         currentName = lua_tostring(L, 1);
     }
 
-    QString newName = getVerifiedString(L, __func__, 2, "stopwatch new name");
+    QString const newName = getVerifiedString(L, __func__, 2, "stopwatch new name");
 
     QPair<bool, QString> result;
     if (currentName.isNull()) {
@@ -2338,7 +2338,7 @@ int TLuaInterpreter::getStopWatchBrokenDownTime(lua_State* L)
         return 2;
     }
 
-    QPair<bool, QString> result = host.getBrokenDownStopWatchTime(watchId);
+    QPair<bool, QString> const result = host.getBrokenDownStopWatchTime(watchId);
     // This is only likely to fail when a numeric first argument was given:
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second);
@@ -2352,11 +2352,11 @@ int TLuaInterpreter::getStopWatchBrokenDownTime(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getStopWatches
 int TLuaInterpreter::getStopWatches(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     const QList<int> stopWatchIds = host.getStopWatchIds();
     lua_newtable(L);
     for (int index = 0, total = stopWatchIds.count(); index < total; ++index) {
-        int watchId = stopWatchIds.at(index);
+        int const watchId = stopWatchIds.at(index);
         lua_pushnumber(L, watchId);
         auto pStopWatch = host.getStopWatch(watchId);
         lua_newtable(L);
@@ -2393,11 +2393,11 @@ int TLuaInterpreter::selectSection(lua_State* L)
     if (lua_gettop(L) > 2) {
         windowName = WINDOW_NAME(L, s++);
     }
-    int from = getVerifiedInt(L, __func__, s++, "from position");
-    int to = getVerifiedInt(L, __func__, s, "length");
+    int const from = getVerifiedInt(L, __func__, s++, "from position");
+    int const to = getVerifiedInt(L, __func__, s, "length");
 
     auto console = CONSOLE(L, windowName);
-    int ret = console->selectSection(from, to);
+    int const ret = console->selectSection(from, to);
     lua_pushboolean(L, ret != -1);
     return 1;
 }
@@ -2427,14 +2427,14 @@ int TLuaInterpreter::getSelection(lua_State* L)
 int TLuaInterpreter::moveCursor(lua_State* L)
 {
     int s = 1;
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     QString windowName;
     if (n > 2) {
         windowName = WINDOW_NAME(L, s++);
     }
 
-    int luaFrom = getVerifiedInt(L, __func__, s++, "x");
-    int luaTo = getVerifiedInt(L, __func__, s, "y");
+    int const luaFrom = getVerifiedInt(L, __func__, s++, "x");
+    int const luaTo = getVerifiedInt(L, __func__, s, "y");
 
     auto console = CONSOLE(L, windowName);
     lua_pushboolean(L, console->moveCursor(luaFrom, luaTo));
@@ -2445,7 +2445,7 @@ int TLuaInterpreter::moveCursor(lua_State* L)
 int TLuaInterpreter::setConsoleBufferSize(lua_State* L)
 {
     int s = 1;
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     QString windowName;
     if (n > 2) {
         windowName = WINDOW_NAME(L, s++);
@@ -2483,7 +2483,7 @@ int TLuaInterpreter::getConsoleBufferSize(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableScrollBar
 int TLuaInterpreter::enableScrollBar(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->setScrollBarVisible(true);
     return 0;
@@ -2492,7 +2492,7 @@ int TLuaInterpreter::enableScrollBar(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableScrollBar
 int TLuaInterpreter::disableScrollBar(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->setScrollBarVisible(false);
     return 0;
@@ -2501,7 +2501,7 @@ int TLuaInterpreter::disableScrollBar(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableHorizontalScrollBar
 int TLuaInterpreter::enableHorizontalScrollBar(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->setHorizontalScrollBar(true);
     return 0;
@@ -2510,7 +2510,7 @@ int TLuaInterpreter::enableHorizontalScrollBar(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableHorizontalScrollBar
 int TLuaInterpreter::disableHorizontalScrollBar(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->setHorizontalScrollBar(false);
     return 0;
@@ -2519,7 +2519,7 @@ int TLuaInterpreter::disableHorizontalScrollBar(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableCommandLine
 int TLuaInterpreter::enableCommandLine(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->setCmdVisible(true);
     return 0;
@@ -2528,7 +2528,7 @@ int TLuaInterpreter::enableCommandLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableCommandLine
 int TLuaInterpreter::disableCommandLine(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->setCmdVisible(false);
     return 0;
@@ -2537,14 +2537,14 @@ int TLuaInterpreter::disableCommandLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#replace
 int TLuaInterpreter::replace(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     int s = 1;
     QString windowName;
 
     if (n > 1) {
         windowName = WINDOW_NAME(L, s++);
     }
-    QString text = getVerifiedString(L, __func__, s, "with");
+    QString const text = getVerifiedString(L, __func__, s, "with");
 
     auto console = CONSOLE(L, windowName);
     console->replace(text);
@@ -2554,7 +2554,7 @@ int TLuaInterpreter::replace(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#deleteLine
 int TLuaInterpreter::deleteLine(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->skipLine();
     return 0;
@@ -2573,8 +2573,8 @@ int TLuaInterpreter::saveMap(lua_State* L)
         }
     }
 
-    Host& host = getHostFromLua(L);
-    bool error = host.mpConsole->saveMap(location, saveVersion);
+    Host const& host = getHostFromLua(L);
+    bool const error = host.mpConsole->saveMap(location, saveVersion);
     lua_pushboolean(L, error);
     return 1;
 }
@@ -2582,17 +2582,17 @@ int TLuaInterpreter::saveMap(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setExitStub
 int TLuaInterpreter::setExitStub(lua_State* L)
 {
-    int roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
 
-    int dir = dirToNumber(L, 2);
+    int const dir = dirToNumber(L, 2);
     if (!dir) {
         lua_pushfstring(L, "setExitStub: bad argument #2 type (direction as number or string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
 
-    bool status = getVerifiedBool(L, __func__, 3, "set/unset");
+    bool const status = getVerifiedBool(L, __func__, 3, "set/unset");
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap) {
         return 0;
     }
@@ -2615,9 +2615,9 @@ int TLuaInterpreter::connectExitStub(lua_State* L)
     int toRoom = 0;
     bool hasDirection = false;
     bool hasToRoomId = false;
-    int fromRoom = getVerifiedInt(L, __func__, 1, "fromID");
+    int const fromRoom = getVerifiedInt(L, __func__, 1, "fromID");
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -2637,13 +2637,13 @@ int TLuaInterpreter::connectExitStub(lua_State* L)
             // It is a string so it is (we will assume) a direction
             hasDirection = true;
         } else if (lua_type(L, 2) == LUA_TNUMBER) {
-            int value = qRound(lua_tonumber(L, 2));
+            int const value = qRound(lua_tonumber(L, 2));
             if (value >= DIR_OUT || value <= DIR_NORTH) {
                 // Ambiguous - look in more detail and check whether there is a
                 // a room with the given number and/or an exit stub:
-                bool hasRoomWithNumberAsId = static_cast<bool>(host.mpMap->mpRoomDB->getRoom(value));
+                bool const hasRoomWithNumberAsId = static_cast<bool>(host.mpMap->mpRoomDB->getRoom(value));
                 auto pR = host.mpMap->mpRoomDB->getRoom(fromRoom);
-                bool hasExitStubWithNumberAsDirection = (pR && pR->exitStubs.contains(value));
+                bool const hasExitStubWithNumberAsDirection = (pR && pR->exitStubs.contains(value));
                 if (hasRoomWithNumberAsId) {
                     if (hasExitStubWithNumberAsDirection) {
                         return warnArgumentValue(
@@ -2677,7 +2677,7 @@ int TLuaInterpreter::connectExitStub(lua_State* L)
     // or an (English) STRING of one of the directions
     int dirType = 0;
     if (hasDirection) {
-        int argNumber = hasToRoomId ? 3 : 2;
+        int const argNumber = hasToRoomId ? 3 : 2;
         dirType = dirToNumber(L, argNumber);
         if (!dirType) {
             return warnArgumentValue(L, __func__, qsl("argument %1 as '%2' cannot be parsed as a valid direction").arg(QString::number(argNumber), QString::fromUtf8(lua_tostring(L, argNumber))));
@@ -2716,19 +2716,19 @@ int TLuaInterpreter::connectExitStub(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getExitStubs
 int TLuaInterpreter::getExitStubs(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
 
     // Previously threw a Lua error on non-existent room!
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
     }
-    QList<int> stubs = pR->exitStubs;
+    QList<int> const stubs = pR->exitStubs;
     lua_newtable(L);
     for (int i = 0, total = stubs.size(); i < total; ++i) {
         lua_pushnumber(L, i);
@@ -2741,19 +2741,19 @@ int TLuaInterpreter::getExitStubs(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getExitStubs1
 int TLuaInterpreter::getExitStubs1(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
 
     // Previously threw a Lua error on non-existent room!
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
     }
-    QList<int> stubs = pR->exitStubs;
+    QList<int> const stubs = pR->exitStubs;
     lua_newtable(L);
     for (int i = 0, total = stubs.size(); i < total; ++i) {
         lua_pushnumber(L, i + 1);
@@ -2766,11 +2766,11 @@ int TLuaInterpreter::getExitStubs1(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getModulePath
 int TLuaInterpreter::getModulePath(lua_State* L)
 {
-    QString moduleName = getVerifiedString(L, __func__, 1, "module name");
-    Host& host = getHostFromLua(L);
+    QString const moduleName = getVerifiedString(L, __func__, 1, "module name");
+    Host const& host = getHostFromLua(L);
     QMap<QString, QStringList> modules = host.mInstalledModules;
     if (modules.contains(moduleName)) {
-        QString modPath = modules[moduleName][0];
+        QString const modPath = modules[moduleName][0];
         lua_pushstring(L, modPath.toUtf8().constData());
         return 1;
     }
@@ -2780,10 +2780,10 @@ int TLuaInterpreter::getModulePath(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getModulePriority
 int TLuaInterpreter::getModulePriority(lua_State* L)
 {
-    QString moduleName = getVerifiedString(L, __func__, 1, "module name");
+    QString const moduleName = getVerifiedString(L, __func__, 1, "module name");
     Host& host = getHostFromLua(L);
     if (host.mModulePriorities.contains(moduleName)) {
-        int priority = host.mModulePriorities[moduleName];
+        int const priority = host.mModulePriorities[moduleName];
         lua_pushnumber(L, priority);
         return 1;
     } else {
@@ -2796,8 +2796,8 @@ int TLuaInterpreter::getModulePriority(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setModulePriority
 int TLuaInterpreter::setModulePriority(lua_State* L)
 {
-    QString moduleName = getVerifiedString(L, __func__, 1, "module name");
-    int modulePriority = getVerifiedInt(L, __func__, 2, "module priority");
+    QString const moduleName = getVerifiedString(L, __func__, 1, "module name");
+    int const modulePriority = getVerifiedInt(L, __func__, 2, "module priority");
 
     Host& host = getHostFromLua(L);
     if (!host.mInstalledModules.contains(moduleName)) {
@@ -2810,7 +2810,7 @@ int TLuaInterpreter::setModulePriority(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#loadMap
 int TLuaInterpreter::loadMap(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
 
     QString location;
     if (lua_gettop(L)) {
@@ -2843,9 +2843,9 @@ int TLuaInterpreter::loadMap(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableTimer
 int TLuaInterpreter::enableTimer(lua_State* L)
 {
-    QString text = getVerifiedString(L, __func__, 1, "name");
+    QString const text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
-    bool error = host.getTimerUnit()->enableTimer(text);
+    bool const error = host.getTimerUnit()->enableTimer(text);
     lua_pushboolean(L, error);
     return 1;
 }
@@ -2853,9 +2853,9 @@ int TLuaInterpreter::enableTimer(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableTimer
 int TLuaInterpreter::disableTimer(lua_State* L)
 {
-    QString text = getVerifiedString(L, __func__, 1, "name");
+    QString const text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
-    bool error = host.getTimerUnit()->disableTimer(text);
+    bool const error = host.getTimerUnit()->disableTimer(text);
     lua_pushboolean(L, error);
     return 1;
 }
@@ -2863,9 +2863,9 @@ int TLuaInterpreter::disableTimer(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableKey
 int TLuaInterpreter::enableKey(lua_State* L)
 {
-    QString keyName = getVerifiedString(L, __func__, 1, "key name");
+    QString const keyName = getVerifiedString(L, __func__, 1, "key name");
     Host& host = getHostFromLua(L);
-    bool error = host.getKeyUnit()->enableKey(keyName);
+    bool const error = host.getKeyUnit()->enableKey(keyName);
     lua_pushboolean(L, error);
     return 1;
 }
@@ -2873,9 +2873,9 @@ int TLuaInterpreter::enableKey(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableKey
 int TLuaInterpreter::disableKey(lua_State* L)
 {
-    QString keyName = getVerifiedString(L, __func__, 1, "key name");
+    QString const keyName = getVerifiedString(L, __func__, 1, "key name");
     Host& host = getHostFromLua(L);
-    bool error = host.getKeyUnit()->disableKey(keyName);
+    bool const error = host.getKeyUnit()->disableKey(keyName);
     lua_pushboolean(L, error);
     return 1;
 }
@@ -2885,7 +2885,7 @@ int TLuaInterpreter::killKey(lua_State* L)
 {
     QString keyName = getVerifiedString(L, __func__, 1, "key name");
     Host& host = getHostFromLua(L);
-    bool error = host.getKeyUnit()->killKey(keyName);
+    bool const error = host.getKeyUnit()->killKey(keyName);
     lua_pushboolean(L, error);
     return 1;
 }
@@ -2893,9 +2893,9 @@ int TLuaInterpreter::killKey(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableAlias
 int TLuaInterpreter::enableAlias(lua_State* L)
 {
-    QString text = getVerifiedString(L, __func__, 1, "name");
+    QString const text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
-    bool error = host.getAliasUnit()->enableAlias(text);
+    bool const error = host.getAliasUnit()->enableAlias(text);
     lua_pushboolean(L, error);
     return 1;
 }
@@ -2903,9 +2903,9 @@ int TLuaInterpreter::enableAlias(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableAlias
 int TLuaInterpreter::disableAlias(lua_State* L)
 {
-    QString text = getVerifiedString(L, __func__, 1, "name");
+    QString const text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
-    bool error = host.getAliasUnit()->disableAlias(text);
+    bool const error = host.getAliasUnit()->disableAlias(text);
     lua_pushboolean(L, error);
     return 1;
 }
@@ -2913,7 +2913,7 @@ int TLuaInterpreter::disableAlias(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#killAlias
 int TLuaInterpreter::killAlias(lua_State* L)
 {
-    QString text = getVerifiedString(L, __func__, 1, "name");
+    QString const text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.getAliasUnit()->killAlias(text));
     return 1;
@@ -2922,9 +2922,9 @@ int TLuaInterpreter::killAlias(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableTrigger
 int TLuaInterpreter::enableTrigger(lua_State* L)
 {
-    QString text = getVerifiedString(L, __func__, 1, "name");
+    QString const text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
-    bool error = host.getTriggerUnit()->enableTrigger(text);
+    bool const error = host.getTriggerUnit()->enableTrigger(text);
     lua_pushboolean(L, error);
     return 1;
 }
@@ -2932,9 +2932,9 @@ int TLuaInterpreter::enableTrigger(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableTrigger
 int TLuaInterpreter::disableTrigger(lua_State* L)
 {
-    QString text = getVerifiedString(L, __func__, 1, "name");
+    QString const text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
-    bool error = host.getTriggerUnit()->disableTrigger(text);
+    bool const error = host.getTriggerUnit()->disableTrigger(text);
     lua_pushboolean(L, error);
     return 1;
 }
@@ -2942,11 +2942,11 @@ int TLuaInterpreter::disableTrigger(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableScript
 int TLuaInterpreter::enableScript(lua_State* L)
 {
-    QString name = getVerifiedString(L, __func__, 1, "script name");
+    QString const name = getVerifiedString(L, __func__, 1, "script name");
 
     Host& host = getHostFromLua(L);
     int cnt = 0;
-    QMap<int, TScript*> scripts = host.getScriptUnit()->getScriptList();
+    QMap<int, TScript*> const scripts = host.getScriptUnit()->getScriptList();
     for (auto script : scripts) {
         if (script->getName() == name) {
             cnt++;
@@ -2964,11 +2964,11 @@ int TLuaInterpreter::enableScript(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableScript
 int TLuaInterpreter::disableScript(lua_State* L)
 {
-    QString name = getVerifiedString(L, __func__, 1, "script name");
+    QString const name = getVerifiedString(L, __func__, 1, "script name");
 
     Host& host = getHostFromLua(L);
     int cnt = 0;
-    QMap<int, TScript*> scripts = host.getScriptUnit()->getScriptList();
+    QMap<int, TScript*> const scripts = host.getScriptUnit()->getScriptList();
     for (auto script : scripts) {
         if (script->getName() == name) {
             cnt++;
@@ -2986,7 +2986,7 @@ int TLuaInterpreter::disableScript(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#killTimer
 int TLuaInterpreter::killTimer(lua_State* L)
 {
-    QString text = getVerifiedString(L, __func__, 1, "ID");
+    QString const text = getVerifiedString(L, __func__, 1, "ID");
     Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.killTimer(text));
     return 1;
@@ -2995,7 +2995,7 @@ int TLuaInterpreter::killTimer(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#killTrigger
 int TLuaInterpreter::killTrigger(lua_State* L)
 {
-    QString text = getVerifiedString(L, __func__, 1, "ID");
+    QString const text = getVerifiedString(L, __func__, 1, "ID");
     Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.killTrigger(text));
     return 1;
@@ -3094,7 +3094,7 @@ int TLuaInterpreter::setFont(lua_State* L)
         windowName = WINDOW_NAME(L, s++);
     }
 
-    QString font = getVerifiedString(L, __func__, s, "name");
+    QString const font = getVerifiedString(L, __func__, s, "name");
 
     if (!mudlet::self()->getAvailableFonts().contains(font, Qt::CaseInsensitive)) {
         return warnArgumentValue(L, __func__, qsl("font '%1' is not available").arg(font));
@@ -3145,7 +3145,7 @@ int TLuaInterpreter::setFontSize(lua_State* L)
         windowName = WINDOW_NAME(L, s++);
     }
 
-    int size = getVerifiedInt(L, __func__, s, "size");
+    int const size = getVerifiedInt(L, __func__, s, "size");
     if (size <= 0) {
         // just throw an error, no default needed.
         return warnArgumentValue(L, __func__, "size cannot be 0 or negative");
@@ -3165,9 +3165,9 @@ int TLuaInterpreter::setFontSize(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getFontSize
 int TLuaInterpreter::getFontSize(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     int rval = -1;
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     if (console == host.mpConsole) {
         rval = host.getDisplayFont().pointSize();
@@ -3186,12 +3186,12 @@ int TLuaInterpreter::getFontSize(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#openUserWindow
 int TLuaInterpreter::openUserWindow(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     if (lua_type(L, 1) != LUA_TSTRING) {
         lua_pushfstring(L, "openUserWindow:  bad argument #1 type (name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString name{lua_tostring(L, 1)};
+    QString const name{lua_tostring(L, 1)};
 
     bool loadLayout = true;
     if (n > 1) {
@@ -3223,13 +3223,13 @@ int TLuaInterpreter::openUserWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setUserWindowTitle
 int TLuaInterpreter::setUserWindowTitle(lua_State* L)
 {
-    QString name = getVerifiedString(L, __func__, 1, "name");
+    QString const name = getVerifiedString(L, __func__, 1, "name");
     QString title;
     if (lua_gettop(L) > 1) {
         title = getVerifiedString(L, __func__, 2, "title", true);
     }
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (auto [success, message] = host.mpConsole->setUserWindowTitle(name, title); !success) {
         return warnArgumentValue(L, __func__, message);
     }
@@ -3316,13 +3316,13 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
         counter = 2;
     }
 
-    int x = getVerifiedInt(L, __func__, counter, "miniconsole x-coordinate");
+    int const x = getVerifiedInt(L, __func__, counter, "miniconsole x-coordinate");
     counter++;
-    int y = getVerifiedInt(L, __func__, counter, "miniconsole y-coordinate");
+    int const y = getVerifiedInt(L, __func__, counter, "miniconsole y-coordinate");
     counter++;
-    int width = getVerifiedInt(L, __func__, counter, "miniconsole width");
+    int const width = getVerifiedInt(L, __func__, counter, "miniconsole width");
     counter++;
-    int height = getVerifiedInt(L, __func__, counter, "miniconsole height");
+    int const height = getVerifiedInt(L, __func__, counter, "miniconsole height");
 
     Host& host = getHostFromLua(L);
     if (auto [success, message] = host.createMiniConsole(windowName, name, x, y, width, height); !success) {
@@ -3379,15 +3379,15 @@ int TLuaInterpreter::createScrollBox(lua_State* L)
         counter = 2;
     }
 
-    int x = getVerifiedInt(L, __func__, counter, "scrollBox x-coordinate");
+    int const x = getVerifiedInt(L, __func__, counter, "scrollBox x-coordinate");
     counter++;
-    int y = getVerifiedInt(L, __func__, counter, "scrollBox y-coordinate");
+    int const y = getVerifiedInt(L, __func__, counter, "scrollBox y-coordinate");
     counter++;
-    int width = getVerifiedInt(L, __func__, counter, "scrollBox width");
+    int const width = getVerifiedInt(L, __func__, counter, "scrollBox width");
     counter++;
-    int height = getVerifiedInt(L, __func__, counter, "scrollBox height");
+    int const height = getVerifiedInt(L, __func__, counter, "scrollBox height");
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (auto [success, message] = host.createScrollBox(windowName, name, x, y, width, height); !success) {
         return warnArgumentValue(L, __func__, message, true);
     }
@@ -3399,11 +3399,11 @@ int TLuaInterpreter::createScrollBox(lua_State* L)
 // Internal Function createLabel in an UserWindow
 int TLuaInterpreter::createLabelUserWindow(lua_State* L, const QString& windowName, const QString& labelName)
 {
-    int n = lua_gettop(L);
-    int x = getVerifiedInt(L, "createLabel", 3, "label x-coordinate");
-    int y = getVerifiedInt(L, "createLabel", 4, "label y-coordinate");
-    int width = getVerifiedInt(L, "createLabel", 5, "label width");
-    int height = getVerifiedInt(L, "createLabel", 6, "label height");
+    int const n = lua_gettop(L);
+    int const x = getVerifiedInt(L, "createLabel", 3, "label x-coordinate");
+    int const y = getVerifiedInt(L, "createLabel", 4, "label y-coordinate");
+    int const width = getVerifiedInt(L, "createLabel", 5, "label width");
+    int const height = getVerifiedInt(L, "createLabel", 6, "label height");
 
     bool fillBackground = false;
     if ((!lua_isnumber(L, 7)) && (!lua_isboolean(L, 7))) {
@@ -3443,12 +3443,12 @@ int TLuaInterpreter::createLabelUserWindow(lua_State* L, const QString& windowNa
 // Internal Function create Label in MainWindow
 int TLuaInterpreter::createLabelMainWindow(lua_State* L, const QString& labelName)
 {
-    QString windowName = QLatin1String("main");
-    int n = lua_gettop(L);
-    int x = getVerifiedInt(L, "createLabel", 2, "label x-coordinate");
-    int y = getVerifiedInt(L, "createLabel", 3, "label y-coordinate");
-    int width = getVerifiedInt(L, "createLabel", 4, "label width");
-    int height = getVerifiedInt(L, "createLabel", 5, "label height");
+    QString const windowName = QLatin1String("main");
+    int const n = lua_gettop(L);
+    int const x = getVerifiedInt(L, "createLabel", 2, "label x-coordinate");
+    int const y = getVerifiedInt(L, "createLabel", 3, "label y-coordinate");
+    int const width = getVerifiedInt(L, "createLabel", 4, "label width");
+    int const height = getVerifiedInt(L, "createLabel", 5, "label height");
 
     bool fillBackground = false;
     if ((!lua_isnumber(L, 6)) && (!lua_isboolean(L, 6))) {
@@ -3487,8 +3487,8 @@ int TLuaInterpreter::createLabelMainWindow(lua_State* L, const QString& labelNam
 
 int TLuaInterpreter::deleteLabel(lua_State* L)
 {
-    QString labelName = getVerifiedString(L, __func__, 1, "label name");
-    Host& host = getHostFromLua(L);
+    QString const labelName = getVerifiedString(L, __func__, 1, "label name");
+    Host const& host = getHostFromLua(L);
     if (auto [success, message] = host.mpConsole->deleteLabel(labelName); !success) {
         return warnArgumentValue(L, __func__, message);
     }
@@ -3499,14 +3499,14 @@ int TLuaInterpreter::deleteLabel(lua_State* L)
 
 int TLuaInterpreter::setLabelToolTip(lua_State* L)
 {
-    QString labelName = getVerifiedString(L, __func__, 1, "label name");
-    QString labelToolTip = getVerifiedString(L, __func__, 2, "text");
+    QString const labelName = getVerifiedString(L, __func__, 1, "label name");
+    QString const labelToolTip = getVerifiedString(L, __func__, 2, "text");
     double duration = 0;
     if (lua_gettop(L) > 2) {
         duration = getVerifiedDouble(L, __func__, 3, "duration");
     }
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
 
     if (auto [success, message] = host.mpConsole->setLabelToolTip(labelName, labelToolTip, duration); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -3518,9 +3518,9 @@ int TLuaInterpreter::setLabelToolTip(lua_State* L)
 
 int TLuaInterpreter::setLabelCursor(lua_State* L)
 {
-    QString labelName = getVerifiedString(L, __func__, 1, "label name");
-    int labelCursor = getVerifiedInt(L, __func__, 2, "cursortype");
-    Host& host = getHostFromLua(L);
+    QString const labelName = getVerifiedString(L, __func__, 1, "label name");
+    int const labelCursor = getVerifiedInt(L, __func__, 2, "cursortype");
+    Host const& host = getHostFromLua(L);
 
     if (auto [success, message] = host.mpConsole->setLabelCursor(labelName, labelCursor); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -3532,17 +3532,17 @@ int TLuaInterpreter::setLabelCursor(lua_State* L)
 
 int TLuaInterpreter::setLabelCustomCursor(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     int hotX = -1, hotY = -1;
-    QString labelName = getVerifiedString(L, __func__, 1, "label name");
-    QString pixmapLocation = getVerifiedString(L, __func__, 2, "custom cursor location");
+    QString const labelName = getVerifiedString(L, __func__, 1, "label name");
+    QString const pixmapLocation = getVerifiedString(L, __func__, 2, "custom cursor location");
 
     if (n > 2) {
         hotX = getVerifiedInt(L, __func__, 3, "hot spot x-coordinate");
         hotY = getVerifiedInt(L, __func__, 4, "hot spot y-coordinate");
     }
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
 
     if (auto [success, message] = host.mpConsole->setLabelCustomCursor(labelName, pixmapLocation, hotX, hotY); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -3555,7 +3555,7 @@ int TLuaInterpreter::setLabelCustomCursor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#createMapper
 int TLuaInterpreter::createMapper(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     QString windowName = "";
     int counter = 1;
 
@@ -3572,15 +3572,15 @@ int TLuaInterpreter::createMapper(lua_State* L)
         }
     }
 
-    int x = getVerifiedInt(L, __func__, counter, "mapper x-coordinate");
+    int const x = getVerifiedInt(L, __func__, counter, "mapper x-coordinate");
     counter++;
-    int y = getVerifiedInt(L, __func__, counter, "mapper y-coordinate");
+    int const y = getVerifiedInt(L, __func__, counter, "mapper y-coordinate");
     counter++;
-    int width = getVerifiedInt(L, __func__, counter, "mapper width");
+    int const width = getVerifiedInt(L, __func__, counter, "mapper width");
     counter++;
-    int height = getVerifiedInt(L, __func__, counter, "mapper height");
+    int const height = getVerifiedInt(L, __func__, counter, "mapper height");
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (auto [success, message] = host.mpConsole->createMapper(windowName, x, y, width, height); !success) {
         return warnArgumentValue(L, __func__, message);
     }
@@ -3593,7 +3593,7 @@ int TLuaInterpreter::createMapper(lua_State* L)
 int TLuaInterpreter::createCommandLine(lua_State* L)
 {
     QString windowName = QLatin1String("main");
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     int counter = 1;
 
     if (n > 5) {
@@ -3613,18 +3613,18 @@ int TLuaInterpreter::createCommandLine(lua_State* L)
         lua_pushfstring(L, "createCommandLine: bad argument #%d type (commandLine name as string expected, got %s!)", counter, luaL_typename(L, counter));
         return lua_error(L);
     }
-    QString commandLineName{lua_tostring(L, counter)};
+    QString const commandLineName{lua_tostring(L, counter)};
     counter++;
-    int x = getVerifiedInt(L, __func__, counter, "commandline x-coordinate");
+    int const x = getVerifiedInt(L, __func__, counter, "commandline x-coordinate");
     counter++;
-    int y = getVerifiedInt(L, __func__, counter, "commandline y-coordinate");
+    int const y = getVerifiedInt(L, __func__, counter, "commandline y-coordinate");
     counter++;
-    int width = getVerifiedInt(L, __func__, counter, "commandline width");
+    int const width = getVerifiedInt(L, __func__, counter, "commandline width");
     counter++;
-    int height = getVerifiedInt(L, __func__, counter, "commandline height");
+    int const height = getVerifiedInt(L, __func__, counter, "commandline height");
     counter++;
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (auto [success, message] = host.mpConsole->createCommandLine(windowName, commandLineName, x, y, width, height); !success) {
         return warnArgumentValue(L, __func__, message);
     }
@@ -3636,7 +3636,7 @@ int TLuaInterpreter::createCommandLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#createBuffer
 int TLuaInterpreter::createBuffer(lua_State* L)
 {
-    QString text = getVerifiedString(L, __func__, 1, "name");
+    QString const text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
     host.createBuffer(text);
     return 0;
@@ -3646,14 +3646,14 @@ int TLuaInterpreter::createBuffer(lua_State* L)
 int TLuaInterpreter::clearUserWindow(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
-        Host& host = getHostFromLua(L);
+        Host const& host = getHostFromLua(L);
         host.mpConsole->mUpperPane->resetHScrollbar();
         host.mpConsole->buffer.clear();
         host.mpConsole->mUpperPane->showNewLines();
         //host.mpConsole->mUpperPane->forceUpdate();
         return 0;
     }
-    QString text = lua_tostring(L, 1);
+    QString const text = lua_tostring(L, 1);
 
     Host& host = getHostFromLua(L);
     host.clearWindow(text);
@@ -3664,7 +3664,7 @@ int TLuaInterpreter::clearUserWindow(lua_State* L)
 // Documentation: ? - public function but should stay undocumented -- compare https://github.com/Mudlet/Mudlet/issues/1149
 int TLuaInterpreter::closeUserWindow(lua_State* L)
 {
-    QString text = getVerifiedString(L, __func__, 1, "name");
+    QString const text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
     host.closeWindow(text);
     return 0;
@@ -3673,7 +3673,7 @@ int TLuaInterpreter::closeUserWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#hideWindow
 int TLuaInterpreter::hideWindow(lua_State* L)
 {
-    QString text = getVerifiedString(L, __func__, 1, "name");
+    QString const text = getVerifiedString(L, __func__, 1, "name");
 
     Host& host = getHostFromLua(L);
     host.hideWindow(text);
@@ -3685,7 +3685,7 @@ int TLuaInterpreter::hideWindow(lua_State* L)
 int TLuaInterpreter::setBorderSizes(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    int numberOfArguments = lua_gettop(L);
+    int const numberOfArguments = lua_gettop(L);
     switch (numberOfArguments) {
     case 0:
         break;
@@ -3762,7 +3762,7 @@ int TLuaInterpreter::setBorderLeft(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderTop
 int TLuaInterpreter::getBorderTop(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     lua_pushnumber(L, host.borders().top());
     return 1;
 }
@@ -3770,7 +3770,7 @@ int TLuaInterpreter::getBorderTop(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderLeft
 int TLuaInterpreter::getBorderLeft(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     lua_pushnumber(L, host.borders().left());
     return 1;
 }
@@ -3778,7 +3778,7 @@ int TLuaInterpreter::getBorderLeft(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderBottom
 int TLuaInterpreter::getBorderBottom(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     lua_pushnumber(L, host.borders().bottom());
     return 1;
 }
@@ -3786,7 +3786,7 @@ int TLuaInterpreter::getBorderBottom(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderRight
 int TLuaInterpreter::getBorderRight(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     lua_pushnumber(L, host.borders().right());
     return 1;
 }
@@ -3794,7 +3794,7 @@ int TLuaInterpreter::getBorderRight(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderSizes
 int TLuaInterpreter::getBorderSizes(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     auto sizes = host.borders();
     lua_createtable(L, 0, 4);
     lua_pushinteger(L, sizes.top());
@@ -3811,9 +3811,9 @@ int TLuaInterpreter::getBorderSizes(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#resizeWindow
 int TLuaInterpreter::resizeWindow(lua_State* L)
 {
-    QString text = getVerifiedString(L, __func__, 1, "windowName");
-    double x1 = getVerifiedDouble(L, __func__, 2, "width");
-    double y1 = getVerifiedDouble(L, __func__, 3, "height");
+    QString const text = getVerifiedString(L, __func__, 1, "windowName");
+    double const x1 = getVerifiedDouble(L, __func__, 2, "width");
+    double const y1 = getVerifiedDouble(L, __func__, 3, "height");
     Host& host = getHostFromLua(L);
     host.resizeWindow(text, static_cast<int>(x1), static_cast<int>(y1));
     return 0;
@@ -3822,9 +3822,9 @@ int TLuaInterpreter::resizeWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#moveWindow
 int TLuaInterpreter::moveWindow(lua_State* L)
 {
-    QString text = getVerifiedString(L, __func__, 1, "name");
-    double x1 = getVerifiedDouble(L, __func__, 2, "x");
-    double y1 = getVerifiedDouble(L, __func__, 3, "y");
+    QString const text = getVerifiedString(L, __func__, 1, "name");
+    double const x1 = getVerifiedDouble(L, __func__, 2, "x");
+    double const y1 = getVerifiedDouble(L, __func__, 3, "y");
     Host& host = getHostFromLua(L);
     host.moveWindow(text, static_cast<int>(x1), static_cast<int>(y1));
     return 0;
@@ -3833,17 +3833,17 @@ int TLuaInterpreter::moveWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setWindow
 int TLuaInterpreter::setWindow(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     int x = 0, y = 0;
     bool show = true;
 
-    QString windowname {WINDOW_NAME(L, 1)};
+    QString const windowname {WINDOW_NAME(L, 1)};
 
     if (lua_type(L, 2) != LUA_TSTRING) {
         lua_pushfstring(L, "setWindow: bad argument #2 type (element name as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString name{lua_tostring(L, 2)};
+    QString const name{lua_tostring(L, 2)};
 
     if (n > 2) {
         x = getVerifiedInt(L, __func__, 3, "x-coordinate");
@@ -3861,7 +3861,7 @@ int TLuaInterpreter::setWindow(lua_State* L)
 
 int TLuaInterpreter::openMapWidget(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     QString area = QString();
     int x = -1, y = -1, width = -1, height = -1;
     if (n == 1) {
@@ -3903,8 +3903,8 @@ int TLuaInterpreter::closeMapWidget(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMainWindowSize
 int TLuaInterpreter::setMainWindowSize(lua_State* L)
 {
-    int x1 = getVerifiedInt(L, __func__, 1, "mainWidth");
-    int y1 = getVerifiedInt(L, __func__, 2, "mainHeight");
+    int const x1 = getVerifiedInt(L, __func__, 1, "mainWidth");
+    int const y1 = getVerifiedInt(L, __func__, 2, "mainHeight");
     mudlet::self()->resize(x1, y1);
     return 0;
 }
@@ -3937,12 +3937,12 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
         return lua_error(L);
     }
 
-    int g = getVerifiedInt(L, __func__, ++s, "green value 0-255");
+    int const g = getVerifiedInt(L, __func__, ++s, "green value 0-255");
     if (!validRange(g)) {
         return warnArgumentValue(L, __func__, csmInvalidGreenValue.arg(g));
     }
 
-    int b = getVerifiedInt(L, __func__, ++s, "blue value 0-255");
+    int const b = getVerifiedInt(L, __func__, ++s, "blue value 0-255");
     if (!validRange(b)) {
         return warnArgumentValue(L, __func__, csmInvalidBlueValue.arg(b));
     }
@@ -3970,11 +3970,11 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBackgroundColor
 int TLuaInterpreter::getBackgroundColor(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     QColor color;
 
     QString windowName = qsl("main");
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     if (n > 0) {
         windowName = getVerifiedString(L, __func__, 1, "window name");
     }
@@ -4022,12 +4022,12 @@ int TLuaInterpreter::setCommandBackgroundColor(lua_State* L)
         return lua_error(L);
     }
 
-    int g = getVerifiedInt(L, __func__, ++s, "green value 0-255");
+    int const g = getVerifiedInt(L, __func__, ++s, "green value 0-255");
     if (!validRange(g)) {
         return warnArgumentValue(L, __func__, csmInvalidGreenValue.arg(g));
     }
 
-    int b = getVerifiedInt(L, __func__, ++s, "blue value 0-255");
+    int const b = getVerifiedInt(L, __func__, ++s, "blue value 0-255");
     if (!validRange(b)) {
         return warnArgumentValue(L, __func__, csmInvalidBlueValue.arg(b));
     }
@@ -4079,12 +4079,12 @@ int TLuaInterpreter::setCommandForegroundColor(lua_State* L)
         return lua_error(L);
     }
 
-    int g = getVerifiedInt(L, __func__, ++s, "green value 0-255");
+    int const g = getVerifiedInt(L, __func__, ++s, "green value 0-255");
     if (!validRange(g)) {
         return warnArgumentValue(L, __func__, csmInvalidGreenValue.arg(g));
     }
 
-    int b = getVerifiedInt(L, __func__, ++s, "blue value 0-255");
+    int const b = getVerifiedInt(L, __func__, ++s, "blue value 0-255");
     if (!validRange(b)) {
         return warnArgumentValue(L, __func__, csmInvalidBlueValue.arg(b));
     }
@@ -4153,8 +4153,8 @@ int TLuaInterpreter::calcFontSize(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#startLogging
 int TLuaInterpreter::startLogging(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
-    bool logOn = getVerifiedBool(L, __func__, 1, "turn logging on/off");
+    Host const& host = getHostFromLua(L);
+    bool const logOn = getVerifiedBool(L, __func__, 1, "turn logging on/off");
 
     QString savedLogFileName;
     if (host.mpConsole->mLogToLogFile) {
@@ -4204,7 +4204,7 @@ int TLuaInterpreter::setBackgroundImage(lua_State* L)
     QString imgPath;
     int mode = 1;
     int counter = 1;
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     if (n > 1 && lua_type(L, 2) == LUA_TSTRING) {
         windowName = getVerifiedString(L, __func__, 1, "console or label name");
         counter++;
@@ -4235,7 +4235,7 @@ int TLuaInterpreter::setBackgroundImage(lua_State* L)
 int TLuaInterpreter::resetBackgroundImage(lua_State* L)
 {
     QString windowName = qsl("main");
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     if (n > 0) {
         windowName = getVerifiedString(L, __func__, 1, "console name");
     }
@@ -4251,7 +4251,7 @@ int TLuaInterpreter::resetBackgroundImage(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getImageSize
 int TLuaInterpreter::getImageSize(lua_State* L)
 {
-    QString imageLocation = getVerifiedString(L, __func__, 1, "image location");
+    QString const imageLocation = getVerifiedString(L, __func__, 1, "image location");
     if (imageLocation.isEmpty()) {
         return warnArgumentValue(L, __func__, "image location cannot be an empty string");
     }
@@ -4268,8 +4268,8 @@ int TLuaInterpreter::getImageSize(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getLabelSizeHint
 int TLuaInterpreter::getLabelSizeHint(lua_State* L)
 {
-    QString labelName = getVerifiedString(L, __func__, 1, "label name");
-    Host& host = getHostFromLua(L);
+    QString const labelName = getVerifiedString(L, __func__, 1, "label name");
+    Host const& host = getHostFromLua(L);
     if (labelName.isEmpty()) {
         return warnArgumentValue(L, __func__, "label name cannot be an empty string");
     }
@@ -4287,7 +4287,7 @@ int TLuaInterpreter::getLabelSizeHint(lua_State* L)
 int TLuaInterpreter::setCmdLineAction(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    QString name = getVerifiedString(L, __func__, 1, "command line name");
+    QString const name = getVerifiedString(L, __func__, 1, "command line name");
     if (name.isEmpty()) {
         return warnArgumentValue(L, __func__, "command line name cannot be an empty string");
     }
@@ -4297,7 +4297,7 @@ int TLuaInterpreter::setCmdLineAction(lua_State* L)
         lua_pushfstring(L, "setCmdLineAction: bad argument #2 type (function expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    int func = luaL_ref(L, LUA_REGISTRYINDEX);
+    int const func = luaL_ref(L, LUA_REGISTRYINDEX);
 
     if (!host.setCmdLineAction(name, func)) {
         return warnArgumentValue(L, __func__, qsl("command line name '%1' not found").arg(name));
@@ -4310,7 +4310,7 @@ int TLuaInterpreter::setCmdLineAction(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#resetCmdLineAction
 int TLuaInterpreter::resetCmdLineAction(lua_State* L){
     Host& host = getHostFromLua(L);
-    QString name = getVerifiedString(L, __func__, 1, "command line name");
+    QString const name = getVerifiedString(L, __func__, 1, "command line name");
     if (name.isEmpty()) {
         return warnArgumentValue(L, __func__, "command line name cannot be an empty string");
     }
@@ -4328,13 +4328,13 @@ int TLuaInterpreter::resetCmdLineAction(lua_State* L){
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setCmdLineStyleSheet
 int TLuaInterpreter::setCmdLineStyleSheet(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     QString name = "main";
     if (n > 1) {
         name = getVerifiedString(L, __func__, 1, "command line name", true);
     }
-    QString styleSheet = getVerifiedString(L, __func__, n, "StyleSheet");
-    Host& host = getHostFromLua(L);
+    QString const styleSheet = getVerifiedString(L, __func__, n, "StyleSheet");
+    Host const& host = getHostFromLua(L);
 
     if (auto [success, message] = host.mpConsole->setCmdLineStyleSheet(name, styleSheet); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -4348,7 +4348,7 @@ int TLuaInterpreter::setCmdLineStyleSheet(lua_State* L)
 int TLuaInterpreter::setLabelCallback(lua_State* L, const QString& funcName)
 {
     Host& host = getHostFromLua(L);
-    QString labelName = getVerifiedString(L, funcName.toUtf8().constData(), 1, "label name");
+    QString const labelName = getVerifiedString(L, funcName.toUtf8().constData(), 1, "label name");
     if (labelName.isEmpty()) {
         return warnArgumentValue(L, __func__, "label name cannot be an empty string");
     }
@@ -4358,7 +4358,7 @@ int TLuaInterpreter::setLabelCallback(lua_State* L, const QString& funcName)
         lua_pushfstring(L, "%s: bad argument #2 type (function expected, got %s!)", funcName.toUtf8().constData(), luaL_typename(L, 1));
         return lua_error(L);
     }
-    int func = luaL_ref(L, LUA_REGISTRYINDEX);
+    int const func = luaL_ref(L, LUA_REGISTRYINDEX);
 
     bool lua_result = false;
     if (funcName == qsl("setLabelClickCallback")) {
@@ -4431,11 +4431,11 @@ int TLuaInterpreter::setLabelOnLeave(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMovie
 int TLuaInterpreter::setMovie(lua_State* L)
 {
-    QString labelName = getVerifiedString(L, __func__, 1, "label name");
+    QString const labelName = getVerifiedString(L, __func__, 1, "label name");
     if (labelName.isEmpty()) {
         return warnArgumentValue(L, __func__, "label name cannot be an empty string");
     }
-    QString moviePath = getVerifiedString(L, __func__, 2, "movie (gif) path");
+    QString const moviePath = getVerifiedString(L, __func__, 2, "movie (gif) path");
 
     Host& host = getHostFromLua(L);
     if (auto [success, message] = host.setMovie(labelName, moviePath); !success) {
@@ -4448,7 +4448,7 @@ int TLuaInterpreter::setMovie(lua_State* L)
 // No documentation available in wiki - internal function
 int TLuaInterpreter::movieFunc(lua_State* L, const QString& funcName)
 {
-    QString labelName = getVerifiedString(L, funcName.toUtf8().constData(), 1, "label name");
+    QString const labelName = getVerifiedString(L, funcName.toUtf8().constData(), 1, "label name");
     if (labelName.isEmpty()) {
         return warnArgumentValue(L, __func__, "label name cannot be an empty string");
     }
@@ -4463,15 +4463,15 @@ int TLuaInterpreter::movieFunc(lua_State* L, const QString& funcName)
     } else if (funcName == qsl("pauseMovie")) {
         movie->setPaused(true);
     } else if (funcName == qsl("setMovieFrame")) {
-        int frame = getVerifiedInt(L, funcName.toUtf8().constData(), 2, "movie frame number");
+        int const frame = getVerifiedInt(L, funcName.toUtf8().constData(), 2, "movie frame number");
         lua_pushboolean(L, movie->jumpToFrame(frame));
         return 1;
     } else if (funcName == qsl("setMovieSpeed")) {
-        int speed = getVerifiedInt(L, funcName.toUtf8().constData(), 2, "movie playback speed in %");
+        int const speed = getVerifiedInt(L, funcName.toUtf8().constData(), 2, "movie playback speed in %");
         movie->setSpeed(speed);
     } else if (funcName == qsl("scaleMovie")) {
         bool autoScale{true};
-        int n = lua_gettop(L);
+        int const n = lua_gettop(L);
         if (n > 1) {
             autoScale = getVerifiedBool(L, funcName.toUtf8().constData(), 2, "activate/deactivate scaling movie", true);
         }
@@ -4522,11 +4522,11 @@ int TLuaInterpreter::scaleMovie(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setTextFormat
 int TLuaInterpreter::setTextFormat(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
 
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
 
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
 
     QVector<int> colorComponents(6); // 0-2 RGB background, 3-5 RGB foreground
     colorComponents[0] = qRound(qBound(0.0, getVerifiedDouble(L, __func__, 2, "red background color component"), 255.0));
@@ -4613,7 +4613,7 @@ int TLuaInterpreter::setTextFormat(lua_State* L)
         }
     }
 
-    TChar::AttributeFlags flags = (bold ? TChar::Bold : TChar::None)
+    TChar::AttributeFlags const flags = (bold ? TChar::Bold : TChar::None)
             | (italics ? TChar::Italic : TChar::None)
             | (overline ? TChar::Overline : TChar::None)
             | (reverse ? TChar::Reverse : TChar::None)
@@ -4634,8 +4634,8 @@ int TLuaInterpreter::setTextFormat(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#raiseWindow
 int TLuaInterpreter::raiseWindow(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
-    Host& host = getHostFromLua(L);
+    QString const windowName {WINDOW_NAME(L, 1)};
+    Host const& host = getHostFromLua(L);
     lua_pushboolean(L, host.mpConsole->raiseWindow(windowName));
     return 1;
 }
@@ -4643,8 +4643,8 @@ int TLuaInterpreter::raiseWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#lowerWindow
 int TLuaInterpreter::lowerWindow(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
-    Host& host = getHostFromLua(L);
+    QString const windowName {WINDOW_NAME(L, 1)};
+    Host const& host = getHostFromLua(L);
     lua_pushboolean(L, host.mpConsole->lowerWindow(windowName));
     return 1;
 }
@@ -4652,7 +4652,7 @@ int TLuaInterpreter::lowerWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#showWindow
 int TLuaInterpreter::showWindow(lua_State* L)
 {
-    QString text = getVerifiedString(L, __func__, 1, "name");
+    QString const text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.showWindow(text));
     return 1;
@@ -4661,10 +4661,10 @@ int TLuaInterpreter::showWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setRoomEnv
 int TLuaInterpreter::setRoomEnv(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
-    int env = getVerifiedInt(L, __func__, 2, "environmentID");
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    int const env = getVerifiedInt(L, __func__, 2, "environmentID");
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
@@ -4678,13 +4678,13 @@ int TLuaInterpreter::setRoomEnv(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setRoomName
 int TLuaInterpreter::setRoomName(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
-    QString name = getVerifiedString(L, __func__, 2, "room name", true);
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    QString const name = getVerifiedString(L, __func__, 2, "room name", true);
 
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
@@ -4700,12 +4700,12 @@ int TLuaInterpreter::setRoomName(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomName
 int TLuaInterpreter::getRoomName(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
 
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
@@ -4718,10 +4718,10 @@ int TLuaInterpreter::getRoomName(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setRoomWeight
 int TLuaInterpreter::setRoomWeight(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
-    int w = getVerifiedInt(L, __func__, 2, "weight");
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    int const w = getVerifiedInt(L, __func__, 2, "weight");
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
@@ -4744,7 +4744,7 @@ int TLuaInterpreter::connectToServer(lua_State* L)
     bool isToSaveToProfile = false;
 
     Host& host = getHostFromLua(L);
-    QString url = getVerifiedString(L, __func__, 1, "url");
+    QString const url = getVerifiedString(L, __func__, 1, "url");
 
     if (!lua_isnoneornil(L, 2)) {
         port = getVerifiedInt(L, __func__, 2, "port number {default = 23}", true);
@@ -4780,9 +4780,9 @@ int TLuaInterpreter::connectToServer(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setRoomIDbyHash
 int TLuaInterpreter::setRoomIDbyHash(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
-    QString hash = getVerifiedString(L, __func__, 2, "hash");
-    Host& host = getHostFromLua(L);
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    QString const hash = getVerifiedString(L, __func__, 2, "hash");
+    Host const& host = getHostFromLua(L);
     if (host.mpMap->mpRoomDB->roomIDToHash.contains(id)) {
         host.mpMap->mpRoomDB->hashToRoomID.remove(host.mpMap->mpRoomDB->roomIDToHash[id]);
     }
@@ -4797,9 +4797,9 @@ int TLuaInterpreter::setRoomIDbyHash(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomIDbyHash
 int TLuaInterpreter::getRoomIDbyHash(lua_State* L)
 {
-    QString hash = getVerifiedString(L, __func__, 1, "hash");
-    Host& host = getHostFromLua(L);
-    int retID = host.mpMap->mpRoomDB->hashToRoomID.value(hash, -1);
+    QString const hash = getVerifiedString(L, __func__, 1, "hash");
+    Host const& host = getHostFromLua(L);
+    int const retID = host.mpMap->mpRoomDB->hashToRoomID.value(hash, -1);
     lua_pushnumber(L, retID);
     return 1;
 }
@@ -4807,12 +4807,12 @@ int TLuaInterpreter::getRoomIDbyHash(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomHashByID
 int TLuaInterpreter::getRoomHashByID(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
-    Host& host = getHostFromLua(L);
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap->mpRoomDB->roomIDToHash.contains(id)) {
         return warnArgumentValue(L, __func__, qsl("no hash for room %1").arg(id));
     }
-    QString retHash = host.mpMap->mpRoomDB->roomIDToHash[id];
+    QString const retHash = host.mpMap->mpRoomDB->roomIDToHash[id];
     lua_pushstring(L, retHash.toUtf8().constData());
     return 1;
 }
@@ -4820,11 +4820,11 @@ int TLuaInterpreter::getRoomHashByID(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#roomLocked
 int TLuaInterpreter::roomLocked(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
-    Host& host = getHostFromLua(L);
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
-        bool r = pR->isLocked;
+        bool const r = pR->isLocked;
         lua_pushboolean(L, r);
     } else {
         lua_pushboolean(L, false);
@@ -4835,9 +4835,9 @@ int TLuaInterpreter::roomLocked(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#lockRoom
 int TLuaInterpreter::lockRoom(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
-    bool b = getVerifiedBool(L, __func__, 2, "lockIfTrue");
-    Host& host = getHostFromLua(L);
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    bool const b = getVerifiedBool(L, __func__, 2, "lockIfTrue");
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
         pR->isLocked = b;
@@ -4853,17 +4853,17 @@ int TLuaInterpreter::lockRoom(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#lockExit
 int TLuaInterpreter::lockExit(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
 
-    int dir = dirToNumber(L, 2);
+    int const dir = dirToNumber(L, 2);
     if (!dir) {
         lua_pushfstring(L, "lockExit: bad argument #2 type (direction as number or string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
 
-    bool b = getVerifiedBool(L, __func__, 3, "lockIfTrue");
+    bool const b = getVerifiedBool(L, __func__, 3, "lockIfTrue");
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
         pR->setExitLock(dir, b);
@@ -4876,15 +4876,15 @@ int TLuaInterpreter::lockExit(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#lockSpecialExit
 int TLuaInterpreter::lockSpecialExit(lua_State* L)
 {
-    int fromRoomID = getVerifiedInt(L, __func__, 1, "exit roomID");
+    int const fromRoomID = getVerifiedInt(L, __func__, 1, "exit roomID");
     // The second argument (was the toRoomID) is now ignored as it is not required/considered in any way
-    QString dir = getVerifiedString(L, __func__, 3, "special exit name/command");
+    QString const dir = getVerifiedString(L, __func__, 3, "special exit name/command");
     if (dir.isEmpty()) {
         return warnArgumentValue(L, __func__, "the special exit name/command cannot be empty");
     }
-    bool b = getVerifiedBool(L, __func__, 4, "special exit lock state");
+    bool const b = getVerifiedBool(L, __func__, 4, "special exit lock state");
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(fromRoomID);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidExitRoomID.arg(fromRoomID));
@@ -4903,14 +4903,14 @@ int TLuaInterpreter::lockSpecialExit(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#hasSpecialExitLock
 int TLuaInterpreter::hasSpecialExitLock(lua_State* L)
 {
-    int fromRoomID = getVerifiedInt(L, __func__, 1, "exit roomID");
+    int const fromRoomID = getVerifiedInt(L, __func__, 1, "exit roomID");
     // Second argument was the entrance roomID but it is not needed any more and is ignored
-    QString dir = getVerifiedString(L, __func__, 3, "special exit name/command");
+    QString const dir = getVerifiedString(L, __func__, 3, "special exit name/command");
     if (dir.isEmpty()) {
         return warnArgumentValue(L, __func__, "the special exit name/command cannot be empty");
     }
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(fromRoomID);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidExitRoomID.arg(fromRoomID));
@@ -4927,15 +4927,15 @@ int TLuaInterpreter::hasSpecialExitLock(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#hasExitLock
 int TLuaInterpreter::hasExitLock(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
 
-    int dir = dirToNumber(L, 2);
+    int const dir = dirToNumber(L, 2);
     if (!dir) {
         lua_pushfstring(L, "hasExitLock: bad argument #2 type (direction as number or string expected, got %s!)");
         return lua_error(L);
     }
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
         lua_pushboolean(L, pR->hasExitLock(dir));
@@ -4947,9 +4947,9 @@ int TLuaInterpreter::hasExitLock(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomExits
 int TLuaInterpreter::getRoomExits(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
         lua_newtable(L);
@@ -5022,8 +5022,8 @@ int TLuaInterpreter::getRoomExits(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getAllRoomEntrances
 int TLuaInterpreter::getAllRoomEntrances(lua_State* L)
 {
-    int roomId = getVerifiedInt(L, __func__, 1, "roomID");
-    Host& host = getHostFromLua(L);
+    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -5048,13 +5048,13 @@ int TLuaInterpreter::getAllRoomEntrances(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#searchRoom
 int TLuaInterpreter::searchRoom(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
     int room_id = 0;
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     bool gotRoomID = false;
     bool caseSensitive = false;
     bool exactMatch = false;
@@ -5097,7 +5097,7 @@ int TLuaInterpreter::searchRoom(lua_State* L)
             return 1;
         }
     } else {
-        QList<TRoom*> roomList = host.mpMap->mpRoomDB->getRoomPtrList();
+        QList<TRoom*> const roomList = host.mpMap->mpRoomDB->getRoomPtrList();
         lua_newtable(L);
         QList<int> roomIdsFound;
         for (auto pR : roomList) {
@@ -5115,13 +5115,13 @@ int TLuaInterpreter::searchRoom(lua_State* L)
             }
         }
         if (!roomIdsFound.isEmpty()) {
-            for (int i : roomIdsFound) {
+            for (int const i : roomIdsFound) {
                 TRoom* pR = host.mpMap->mpRoomDB->getRoom(i);
                 // This test is to keep Coverity happy as it thinks pR could be
                 // a nullptr in some odd situation {CID 1415023}:
                 if (pR) {
-                    QString name = pR->name;
-                    int roomID = pR->getId();
+                    QString const name = pR->name;
+                    int const roomID = pR->getId();
                     lua_pushnumber(L, roomID);
                     lua_pushstring(L, name.toUtf8().constData());
                     lua_settable(L, -3);
@@ -5135,7 +5135,7 @@ int TLuaInterpreter::searchRoom(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#searchRoomUserData
 int TLuaInterpreter::searchRoomUserData(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -5184,7 +5184,7 @@ int TLuaInterpreter::searchRoomUserData(lua_State* L)
         QSet<QString> valuesSet; // Use a set as it automatically eliminates duplicates
         while (itRoom.hasNext()) {
             itRoom.next();
-            QString roomValueForKey = itRoom.value()->userData.value(key, QString());
+            QString const roomValueForKey = itRoom.value()->userData.value(key, QString());
             // If the key is NOT present, will return second argument which is a
             // null QString which is NOT the same as an empty QString.
             if (!roomValueForKey.isNull()) {
@@ -5207,7 +5207,7 @@ int TLuaInterpreter::searchRoomUserData(lua_State* L)
         while (itRoom.hasNext()) {
             itRoom.next();
 
-            QString roomDataValue = itRoom.value()->userData.value(key, QString());
+            QString const roomDataValue = itRoom.value()->userData.value(key, QString());
             if ((!roomDataValue.isNull()) && (!value.compare(roomDataValue, Qt::CaseSensitive))) {
                 roomIdsSet.insert(itRoom.key());
             }
@@ -5231,7 +5231,7 @@ int TLuaInterpreter::searchRoomUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#searchAreaUserData
 int TLuaInterpreter::searchAreaUserData(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -5276,7 +5276,7 @@ int TLuaInterpreter::searchAreaUserData(lua_State* L)
         QSet<QString> valuesSet; // Use a set as it automatically eliminates duplicates
         while (itArea.hasNext()) {
             itArea.next();
-            QString areaValueForKey = itArea.value()->mUserData.value(key, QString());
+            QString const areaValueForKey = itArea.value()->mUserData.value(key, QString());
             // If the key is NOT present, will return second argument which is a
             // null QString which is NOT the same as an empty QString.
             if (!areaValueForKey.isNull()) {
@@ -5299,7 +5299,7 @@ int TLuaInterpreter::searchAreaUserData(lua_State* L)
         while (itArea.hasNext()) { // Find all areas with a particular key AND value
             itArea.next();
 
-            QString areaDataValue = itArea.value()->mUserData.value(key, QString());
+            QString const areaDataValue = itArea.value()->mUserData.value(key, QString());
             if ((!areaDataValue.isNull()) && (!value.compare(areaDataValue, Qt::CaseSensitive))) {
                 areaIdsSet.insert(itArea.key());
             }
@@ -5323,7 +5323,7 @@ int TLuaInterpreter::searchAreaUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getAreaTable
 int TLuaInterpreter::getAreaTable(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -5332,8 +5332,8 @@ int TLuaInterpreter::getAreaTable(lua_State* L)
     lua_newtable(L);
     while (it.hasNext()) {
         it.next();
-        int areaId = it.key();
-        QString name = it.value();
+        int const areaId = it.key();
+        QString const name = it.value();
         lua_pushstring(L, name.toUtf8().constData());
         lua_pushnumber(L, areaId);
         lua_settable(L, -3);
@@ -5344,7 +5344,7 @@ int TLuaInterpreter::getAreaTable(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getAreaTableSwap
 int TLuaInterpreter::getAreaTableSwap(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -5353,8 +5353,8 @@ int TLuaInterpreter::getAreaTableSwap(lua_State* L)
     lua_newtable(L);
     while (it.hasNext()) {
         it.next();
-        int areaId = it.key();
-        QString name = it.value();
+        int const areaId = it.key();
+        QString const name = it.value();
         lua_pushnumber(L, areaId);
         lua_pushstring(L, name.toUtf8().constData());
         lua_settable(L, -3);
@@ -5365,8 +5365,8 @@ int TLuaInterpreter::getAreaTableSwap(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getAreaRooms
 int TLuaInterpreter::getAreaRooms(lua_State* L)
 {
-    int area = getVerifiedInt(L, __func__, 1, "areaID");
-    Host& host = getHostFromLua(L);
+    int const area = getVerifiedInt(L, __func__, 1, "areaID");
+    Host const& host = getHostFromLua(L);
     TArea* pA = host.mpMap->mpRoomDB->getArea(area);
     if (!pA) {
         lua_pushnil(L);
@@ -5389,7 +5389,7 @@ int TLuaInterpreter::getAreaRooms(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRooms
 int TLuaInterpreter::getRooms(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     lua_newtable(L);
     QHashIterator<int, TRoom*> it(host.mpMap->mpRoomDB->getRoomMap());
     while (it.hasNext()) {
@@ -5404,15 +5404,15 @@ int TLuaInterpreter::getRooms(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getAreaExits
 int TLuaInterpreter::getAreaExits(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     bool isFullDataRequired = false;
-    int area = getVerifiedInt(L, __func__, 1, "areaID");
+    int const area = getVerifiedInt(L, __func__, 1, "areaID");
 
     if (n > 1) {
         isFullDataRequired = getVerifiedBool(L, __func__, 2, "full data wanted", true);
     }
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TArea* pA = host.mpMap->mpRoomDB->getArea(area);
     if (!pA) {
         return warnArgumentValue(L, __func__, csmInvalidAreaID.arg(area));
@@ -5431,12 +5431,12 @@ int TLuaInterpreter::getAreaExits(lua_State* L)
             lua_settable(L, -3);
         }
     } else {
-        QMultiMap<int, QPair<QString, int>> areaExits = pA->getAreaExitRoomData();
-        QList<int> fromRooms = areaExits.uniqueKeys();
-        for (int fromRoom : fromRooms) {
+        QMultiMap<int, QPair<QString, int>> const areaExits = pA->getAreaExitRoomData();
+        QList<int> const fromRooms = areaExits.uniqueKeys();
+        for (int const fromRoom : fromRooms) {
             lua_pushnumber(L, fromRoom);
             lua_newtable(L);
-            QList<QPair<QString, int>> toRoomsData = areaExits.values(fromRoom);
+            QList<QPair<QString, int>> const toRoomsData = areaExits.values(fromRoom);
             for (const auto& j : toRoomsData) {
                 lua_pushstring(L, j.first.toUtf8().constData());
                 lua_pushnumber(L, j.second);
@@ -5451,7 +5451,7 @@ int TLuaInterpreter::getAreaExits(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#auditAreas
 int TLuaInterpreter::auditAreas(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     host.mpMap->audit();
     return 0;
 }
@@ -5479,7 +5479,7 @@ int TLuaInterpreter::getRoomWeight(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#gotoRoom
 int TLuaInterpreter::gotoRoom(lua_State* L)
 {
-    int targetRoomId = getVerifiedInt(L, __func__, 1, "target roomID");
+    int const targetRoomId = getVerifiedInt(L, __func__, 1, "target roomID");
 
     Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
@@ -5489,7 +5489,7 @@ int TLuaInterpreter::gotoRoom(lua_State* L)
     }
 
     if (!host.mpMap->gotoRoom(targetRoomId)) {
-        int totalWeight = host.assemblePath(); // Needed if unsuccessful to clear lua speedwalk tables
+        int const totalWeight = host.assemblePath(); // Needed if unsuccessful to clear lua speedwalk tables
         Q_UNUSED(totalWeight);
         return warnArgumentValue(L, __func__, qsl("no path found from current room to room with id %1").arg(targetRoomId), true);
     }
@@ -5501,8 +5501,8 @@ int TLuaInterpreter::gotoRoom(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getPath
 int TLuaInterpreter::getPath(lua_State* L)
 {
-    int originRoomId = getVerifiedInt(L, __func__, 1, "starting roomID");
-    int targetRoomId = getVerifiedInt(L, __func__, 2, "target roomID");
+    int const originRoomId = getVerifiedInt(L, __func__, 1, "starting roomID");
+    int const targetRoomId = getVerifiedInt(L, __func__, 2, "target roomID");
 
     Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
@@ -5513,8 +5513,8 @@ int TLuaInterpreter::getPath(lua_State* L)
         return warnArgumentValue(L, __func__, qsl("number %1 is not a valid target roomID").arg(targetRoomId));
     }
 
-    bool ret = host.mpMap->gotoRoom(originRoomId, targetRoomId);
-    int totalWeight = host.assemblePath(); // Needed even if unsuccessful, to clear lua tables then
+    bool const ret = host.mpMap->gotoRoom(originRoomId, targetRoomId);
+    int const totalWeight = host.assemblePath(); // Needed even if unsuccessful, to clear lua tables then
     if (ret) {
         lua_pushboolean(L, true);
         lua_pushnumber(L, totalWeight);
@@ -5530,7 +5530,7 @@ int TLuaInterpreter::getPath(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#deselect
 int TLuaInterpreter::deselect(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->deselect();
     lua_pushboolean(L, true);
@@ -5540,7 +5540,7 @@ int TLuaInterpreter::deselect(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#resetFormat
 int TLuaInterpreter::resetFormat(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->reset();
     lua_pushboolean(L, true);
@@ -5550,7 +5550,7 @@ int TLuaInterpreter::resetFormat(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#hasFocus
 int TLuaInterpreter::hasFocus(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     lua_pushboolean(L, host.mpConsole->hasFocus()); //FIXME
     return 1;
 }
@@ -5558,8 +5558,8 @@ int TLuaInterpreter::hasFocus(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#echoUserWindow
 int TLuaInterpreter::echoUserWindow(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
-    QString text = getVerifiedString(L, __func__, 2, "text");
+    QString const windowName {WINDOW_NAME(L, 1)};
+    QString const text = getVerifiedString(L, __func__, 2, "text");
     Host& host = getHostFromLua(L);
     host.echoWindow(windowName, text);
     return 0;
@@ -5570,7 +5570,7 @@ int TLuaInterpreter::setAppStyleSheet(lua_State* L)
 {
     QString styleSheet;
     QString tag;
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     styleSheet = getVerifiedString(L, __func__, 1, "style sheet");
     if (n > 1) {
         tag = getVerifiedString(L, __func__, 2, "tag");
@@ -5593,7 +5593,7 @@ int TLuaInterpreter::setAppStyleSheet(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setAppStyleSheet
 int TLuaInterpreter::setProfileStyleSheet(lua_State* L)
 {
-    QString styleSheet = getVerifiedString(L, __func__, 1, "style sheet");
+    QString const styleSheet = getVerifiedString(L, __func__, 1, "style sheet");
     Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.setProfileStyleSheet(styleSheet));
     return 1;
@@ -5632,9 +5632,9 @@ int TLuaInterpreter::receiveMSP(lua_State* L)
 // Private
 int TLuaInterpreter::loadMediaFileAsOrderedArguments(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TMediaData mediaData{};
-    int numArgs = lua_gettop(L);
+    int const numArgs = lua_gettop(L);
     QString stringValue;
 
     // name[,url])
@@ -5677,7 +5677,7 @@ int TLuaInterpreter::loadMediaFileAsOrderedArguments(lua_State* L)
 // Private
 int TLuaInterpreter::loadMediaFileAsTableArgument(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TMediaData mediaData{};
 
     lua_pushnil(L);
@@ -5752,9 +5752,9 @@ int TLuaInterpreter::loadSoundFile(lua_State* L)
 // Private
 int TLuaInterpreter::playMusicFileAsOrderedArguments(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TMediaData mediaData{};
-    int numArgs = lua_gettop(L);
+    int const numArgs = lua_gettop(L);
     QString stringValue;
     int intValue = 0;
     bool boolValue = 0;
@@ -5863,7 +5863,7 @@ int TLuaInterpreter::playMusicFileAsOrderedArguments(lua_State* L)
 // Private
 int TLuaInterpreter::playMusicFileAsTableArgument(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TMediaData mediaData{};
 
     lua_pushnil(L);
@@ -5946,7 +5946,7 @@ int TLuaInterpreter::playMusicFileAsTableArgument(lua_State* L)
                 mediaData.setMediaLoops(value);
             }
         } else if (key == QLatin1String("continue")) {
-            bool value = getVerifiedBool(L, __func__, -1, "value for continue must be boolean");
+            bool const value = getVerifiedBool(L, __func__, -1, "value for continue must be boolean");
             mediaData.setMediaContinue(value);
         }
 
@@ -5984,9 +5984,9 @@ int TLuaInterpreter::playMusicFile(lua_State* L)
 // Private
 int TLuaInterpreter::playSoundFileAsOrderedArguments(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TMediaData mediaData{};
-    int numArgs = lua_gettop(L);
+    int const numArgs = lua_gettop(L);
     QString stringValue;
     int intValue = 0;
 
@@ -6102,7 +6102,7 @@ int TLuaInterpreter::playSoundFileAsOrderedArguments(lua_State* L)
 // Private
 int TLuaInterpreter::playSoundFileAsTableArgument(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TMediaData mediaData{};
 
     lua_pushnil(L);
@@ -6231,9 +6231,9 @@ int TLuaInterpreter::playSoundFile(lua_State* L)
 // Private
 int TLuaInterpreter::stopMusicAsOrderedArguments(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TMediaData mediaData{};
-    int numArgs = lua_gettop(L);
+    int const numArgs = lua_gettop(L);
     QString stringValue;
 
     // values as ordered args: name[,key][,tag])
@@ -6276,7 +6276,7 @@ int TLuaInterpreter::stopMusicAsOrderedArguments(lua_State* L)
 // Private
 int TLuaInterpreter::stopMusicAsTableArgument(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TMediaData mediaData{};
 
     lua_pushnil(L);
@@ -6318,7 +6318,7 @@ int TLuaInterpreter::stopMusicAsTableArgument(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#stopMusic
 int TLuaInterpreter::stopMusic(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TMediaData mediaData{};
 
     if (lua_gettop(L)) {
@@ -6341,9 +6341,9 @@ int TLuaInterpreter::stopMusic(lua_State* L)
 // Private
 int TLuaInterpreter::stopSoundsAsOrderedArguments(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TMediaData mediaData{};
-    int numArgs = lua_gettop(L);
+    int const numArgs = lua_gettop(L);
     QString stringValue;
     int intValue = 0;
 
@@ -6398,7 +6398,7 @@ int TLuaInterpreter::stopSoundsAsOrderedArguments(lua_State* L)
 // Private
 int TLuaInterpreter::stopSoundsAsTableArgument(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TMediaData mediaData{};
 
     lua_pushnil(L);
@@ -6452,7 +6452,7 @@ int TLuaInterpreter::stopSoundsAsTableArgument(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#stopSounds
 int TLuaInterpreter::stopSounds(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TMediaData mediaData{};
 
     if (lua_gettop(L)) {
@@ -6484,7 +6484,7 @@ int TLuaInterpreter::purgeMediaCache(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#moveCursorEnd
 int TLuaInterpreter::moveCursorEnd(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->moveCursorEnd();
     return 0;
@@ -6493,9 +6493,9 @@ int TLuaInterpreter::moveCursorEnd(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getLastLineNumber
 int TLuaInterpreter::getLastLineNumber(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE_NIL(L, windowName);
-    int number = console ? console->getLastLineNumber() : -1;
+    int const number = console ? console->getLastLineNumber() : -1;
     lua_pushnumber(L, number);
     return 1;
 }
@@ -6504,7 +6504,7 @@ int TLuaInterpreter::getLastLineNumber(lua_State* L)
 int TLuaInterpreter::getMudletHomeDir(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    QString nativeHomeDirectory = mudlet::getMudletPath(mudlet::profileHomePath, host.getName());
+    QString const nativeHomeDirectory = mudlet::getMudletPath(mudlet::profileHomePath, host.getName());
     lua_pushstring(L, nativeHomeDirectory.toUtf8().constData());
     return 1;
 }
@@ -6533,7 +6533,7 @@ int TLuaInterpreter::setTriggerStayOpen(lua_State* L)
     if (lua_gettop(L) > 1) {
         windowName = WINDOW_NAME(L, s++);
     }
-    double b = getVerifiedDouble(L, __func__, s, "number of lines");
+    double const b = getVerifiedDouble(L, __func__, s, "number of lines");
     Host& host = getHostFromLua(L);
     host.getTriggerUnit()->setTriggerStayOpen(windowName, static_cast<int>(b));
     return 0;
@@ -6560,9 +6560,9 @@ int TLuaInterpreter::setLink(lua_State* L)
         linkFunction = lua_tostring(L, s++);
     }
 
-    QString linkHint = getVerifiedString(L, __func__, s++, "tooltip");
+    QString const linkHint = getVerifiedString(L, __func__, s++, "tooltip");
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     QStringList _linkFunction;
     _linkFunction << linkFunction;
     QStringList _linkHint;
@@ -6587,7 +6587,7 @@ int TLuaInterpreter::setPopup(lua_State* L)
     QStringList _commandList;
     QVector<int> luaReference;
     int s = 1;
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
 
     // console name is an optional first argument
     if (n > 2) {
@@ -6602,7 +6602,7 @@ int TLuaInterpreter::setPopup(lua_State* L)
     while (lua_next(L, s) != 0) {
         // key at index -2 and value at index -1
         if (lua_type(L, -1) == LUA_TSTRING) {
-            QString cmd = lua_tostring(L, -1);
+            QString const cmd = lua_tostring(L, -1);
             _commandList << cmd;
             luaReference << 0;
         }
@@ -6623,14 +6623,14 @@ int TLuaInterpreter::setPopup(lua_State* L)
     while (lua_next(L, s) != 0) {
         // key at index -2 and value at index -1
         if (lua_type(L, -1) == LUA_TSTRING) {
-            QString hint = lua_tostring(L, -1);
+            QString const hint = lua_tostring(L, -1);
             _hintList << hint;
         }
         // removes value, but keeps key for next iteration
         lua_pop(L, 1);
     }
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (_commandList.size() != _hintList.size()) {
         lua_pushstring(L, "setPopup: commands and hints list aren't the same size");
         return lua_error(L);
@@ -6654,7 +6654,7 @@ int TLuaInterpreter::setBold(lua_State* L)
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
         windowName = WINDOW_NAME(L, s++);
     }
-    bool isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable bold attribute");
+    bool const isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable bold attribute");
     auto console = CONSOLE(L, windowName);
     console->setDisplayAttributes(TChar::Bold, isAttributeEnabled);
     lua_pushboolean(L, true);
@@ -6669,7 +6669,7 @@ int TLuaInterpreter::setItalics(lua_State* L)
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
         windowName = WINDOW_NAME(L, s++);
     }
-    bool isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable italic attribute");
+    bool const isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable italic attribute");
     auto console = CONSOLE(L, windowName);
     console->setDisplayAttributes(TChar::Italic, isAttributeEnabled);
     lua_pushboolean(L, true);
@@ -6684,7 +6684,7 @@ int TLuaInterpreter::setOverline(lua_State* L)
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
         windowName = WINDOW_NAME(L, s++);
     }
-    bool isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable overline attribute");
+    bool const isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable overline attribute");
     auto console = CONSOLE(L, windowName);
     console->setDisplayAttributes(TChar::Overline, isAttributeEnabled);
     lua_pushboolean(L, true);
@@ -6699,7 +6699,7 @@ int TLuaInterpreter::setReverse(lua_State* L)
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
         windowName = WINDOW_NAME(L, s++);
     }
-    bool isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable reverse attribute");
+    bool const isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable reverse attribute");
     auto console = CONSOLE(L, windowName);
     console->setDisplayAttributes(TChar::Reverse, isAttributeEnabled);
     lua_pushboolean(L, true);
@@ -6714,7 +6714,7 @@ int TLuaInterpreter::setStrikeOut(lua_State* L)
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
         windowName = WINDOW_NAME(L, s++);
     }
-    bool isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable strikeout attribute");
+    bool const isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable strikeout attribute");
     auto console = CONSOLE(L, windowName);
     console->setDisplayAttributes(TChar::StrikeOut, isAttributeEnabled);
     lua_pushboolean(L, true);
@@ -6729,7 +6729,7 @@ int TLuaInterpreter::setUnderline(lua_State* L)
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
         windowName = WINDOW_NAME(L, s++);
     }
-    bool isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable underline attribute");
+    bool const isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable underline attribute");
     auto console = CONSOLE(L, windowName);
     console->setDisplayAttributes(TChar::Underline, isAttributeEnabled);
     lua_pushboolean(L, true);
@@ -6740,7 +6740,7 @@ int TLuaInterpreter::setUnderline(lua_State* L)
 int TLuaInterpreter::errorc(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     if (!n) {
         // Nothing to show
         return 0;
@@ -6776,8 +6776,8 @@ int TLuaInterpreter::errorc(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#debugc -- not #debug - compare GlobalLua
 int TLuaInterpreter::debug(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
-    int n = lua_gettop(L);
+    Host const& host = getHostFromLua(L);
+    int const n = lua_gettop(L);
     if (!n) {
         // Nothing to show
         return 0;
@@ -6806,8 +6806,8 @@ int TLuaInterpreter::debug(lua_State* L)
 int TLuaInterpreter::showHandlerError(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    QString event = getVerifiedString(L, __func__, 1, "event name");
-    QString error = getVerifiedString(L, __func__, 2, "error message");
+    QString const event = getVerifiedString(L, __func__, 1, "event name");
+    QString const error = getVerifiedString(L, __func__, 2, "error message");
     host.mLuaInterpreter.logEventError(event, error);
     return 0;
 }
@@ -6815,7 +6815,7 @@ int TLuaInterpreter::showHandlerError(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#hideToolBar
 int TLuaInterpreter::hideToolBar(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
 
     Host& host = getHostFromLua(L);
     host.getActionUnit()->hideToolBar(windowName);
@@ -6825,7 +6825,7 @@ int TLuaInterpreter::hideToolBar(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#showToolBar
 int TLuaInterpreter::showToolBar(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
 
     Host& host = getHostFromLua(L);
     host.getActionUnit()->showToolBar(windowName);
@@ -6840,7 +6840,7 @@ int TLuaInterpreter::sendATCP(lua_State* L)
         lua_pushfstring(L, "sendATCP: bad argument #1 type (message as string expected, got %1!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    std::string msg = host.mTelnet.encodeAndCookBytes(lua_tostring(L, 1));
+    std::string const msg = host.mTelnet.encodeAndCookBytes(lua_tostring(L, 1));
 
     std::string what;
     if (lua_gettop(L) > 1) {
@@ -6884,7 +6884,7 @@ int TLuaInterpreter::sendGMCP(lua_State* L)
         lua_pushfstring(L, "sendGMCP: bad argument #1 type (message as string expected, got %1!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    std::string msg = host.mTelnet.encodeAndCookBytes(lua_tostring(L, 1));
+    std::string const msg = host.mTelnet.encodeAndCookBytes(lua_tostring(L, 1));
 
     std::string what;
     if (lua_gettop(L) > 1) {
@@ -6924,7 +6924,7 @@ int TLuaInterpreter::sendGMCP(lua_State* L)
 int TLuaInterpreter::sendMSDP(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
 
     if (n < 1) {
         lua_pushstring(L, "sendMSDP: bad argument #1 type (variable name as string expected, got nil!)");
@@ -6938,7 +6938,7 @@ int TLuaInterpreter::sendMSDP(lua_State* L)
         }
     }
 
-    std::string variable = host.mTelnet.encodeAndCookBytes(lua_tostring(L, 1));
+    std::string const variable = host.mTelnet.encodeAndCookBytes(lua_tostring(L, 1));
 
     std::string output;
     output += TN_IAC;
@@ -6968,7 +6968,7 @@ int TLuaInterpreter::sendTelnetChannel102(lua_State* L)
                         luaL_typename(L, 1));
         return lua_error(L);
     }
-    std::string msg = lua_tostring(L, 1);
+    std::string const msg = lua_tostring(L, 1);
     if (msg.length() != 2) {
         return warnArgumentValue(L, __func__, qsl(
             "invalid message of length %1 supplied, it should be two bytes (may use lua \\### for each byte where ### is a number between 1 and 254)")
@@ -7013,7 +7013,7 @@ std::pair<int, TAction*> TLuaInterpreter::getTActionFromIdOrName(lua_State* L, c
     auto argType = lua_type(L, index);
     TAction* pItem = nullptr;
     if (argType == LUA_TNUMBER) {
-        int id = qRound(lua_tonumber(L, index));
+        int const id = qRound(lua_tonumber(L, index));
         if (id < 0) {
             return {warnArgumentValue(L, func, qsl("item ID (%1) invalid, it must be equal or greater than zero").arg(id).toUtf8().constData()), pItem};
         }
@@ -7028,7 +7028,7 @@ std::pair<int, TAction*> TLuaInterpreter::getTActionFromIdOrName(lua_State* L, c
     }
 
     if (argType == LUA_TSTRING) {
-        QString name = lua_tostring(L, index);
+        QString const name = lua_tostring(L, index);
         if (name.isEmpty()) {
             return {warnArgumentValue(L, func, "item name must not be an empty string"), pItem};
         }
@@ -7106,7 +7106,7 @@ int TLuaInterpreter::setButtonState(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getNetworkLatency
 int TLuaInterpreter::getNetworkLatency(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     lua_pushnumber(L, host.mTelnet.networkLatencyTime);
     return 1;
 }
@@ -7114,7 +7114,7 @@ int TLuaInterpreter::getNetworkLatency(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMainConsoleWidth
 int TLuaInterpreter::getMainConsoleWidth(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     int fw = QFontMetrics(host.getDisplayFont()).averageCharWidth();
     fw *= host.mWrapAt + 1;
     lua_pushnumber(L, fw);
@@ -7124,8 +7124,8 @@ int TLuaInterpreter::getMainConsoleWidth(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMainWindowSize
 int TLuaInterpreter::getMainWindowSize(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
-    QSize mainWindowSize = host.mpConsole->getMainWindowSize();
+    Host const& host = getHostFromLua(L);
+    QSize const mainWindowSize = host.mpConsole->getMainWindowSize();
 
     lua_pushnumber(L, mainWindowSize.width());
     lua_pushnumber(L, mainWindowSize.height());
@@ -7136,10 +7136,10 @@ int TLuaInterpreter::getMainWindowSize(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getUserWindowSize
 int TLuaInterpreter::getUserWindowSize(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
 
-    Host& host = getHostFromLua(L);
-    QSize userWindowSize = host.mpConsole->getUserWindowSize(windowName);
+    Host const& host = getHostFromLua(L);
+    QSize const userWindowSize = host.mpConsole->getUserWindowSize(windowName);
     lua_pushnumber(L, userWindowSize.width());
     lua_pushnumber(L, userWindowSize.height());
 
@@ -7149,9 +7149,9 @@ int TLuaInterpreter::getUserWindowSize(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMousePosition
 int TLuaInterpreter::getMousePosition(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
 
-    QPoint pos = host.mpConsole->mapFromGlobal(QCursor::pos());
+    QPoint const pos = host.mpConsole->mapFromGlobal(QCursor::pos());
 
     lua_pushnumber(L, pos.x());
     lua_pushnumber(L, pos.y());
@@ -7163,8 +7163,8 @@ int TLuaInterpreter::getMousePosition(lua_State* L)
 int TLuaInterpreter::tempTimer(lua_State* L)
 {
     bool repeating{};
-    double time = getVerifiedDouble(L, __func__, 1, "time in seconds {maybe decimal}");
-    int n = lua_gettop(L);
+    double const time = getVerifiedDouble(L, __func__, 1, "time in seconds {maybe decimal}");
+    int const n = lua_gettop(L);
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
@@ -7172,7 +7172,7 @@ int TLuaInterpreter::tempTimer(lua_State* L)
         if (n > 2) {
             repeating = getVerifiedBool(L, __func__, 3, "repeating", true);
         }
-        QPair<int, QString> result = pLuaInterpreter->startTempTimer(time, QString(), repeating);
+        QPair<int, QString> const result = pLuaInterpreter->startTempTimer(time, QString(), repeating);
         if (result.first == -1) {
             lua_pushnumber(L, -1);
             lua_pushstring(L, result.second.toUtf8().constData());
@@ -7191,11 +7191,11 @@ int TLuaInterpreter::tempTimer(lua_State* L)
         return 1;
     }
 
-    QString luaCode = getVerifiedString(L, __func__, 2, "script or function name");
+    QString const luaCode = getVerifiedString(L, __func__, 2, "script or function name");
     if (n > 2) {
         repeating = getVerifiedBool(L, __func__, 3, "repeating", true);
     }
-    QPair<int, QString> result = pLuaInterpreter->startTempTimer(time, luaCode, repeating);
+    QPair<int, QString> const result = pLuaInterpreter->startTempTimer(time, luaCode, repeating);
     lua_pushnumber(L, result.first);
     if (result.first == -1) {
         lua_pushstring(L, result.second.toUtf8().constData());
@@ -7212,7 +7212,7 @@ int TLuaInterpreter::tempExactMatchTrigger(lua_State* L)
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
     int triggerID;
     int expiryCount = -1;
-    QString exactMatchPattern = getVerifiedString(L, __func__, 1, "exact match pattern");
+    QString const exactMatchPattern = getVerifiedString(L, __func__, 1, "exact match pattern");
 
     if (lua_isnumber(L, 3)) {
         expiryCount = lua_tonumber(L, 3);
@@ -7252,7 +7252,7 @@ int TLuaInterpreter::tempBeginOfLineTrigger(lua_State* L)
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
     int triggerID;
     int expiryCount = -1;
-    QString pattern = getVerifiedString(L, __func__, 1, "pattern");
+    QString const pattern = getVerifiedString(L, __func__, 1, "pattern");
 
     if (lua_isnumber(L, 3)) {
         expiryCount = lua_tonumber(L, 3);
@@ -7292,7 +7292,7 @@ int TLuaInterpreter::tempTrigger(lua_State* L)
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
     int triggerID;
     int expiryCount = -1;
-    QString substringPattern = getVerifiedString(L, __func__, 1, "substring pattern");
+    QString const substringPattern = getVerifiedString(L, __func__, 1, "substring pattern");
 
     if (lua_isnumber(L, 3)) {
         expiryCount = lua_tonumber(L, 3);
@@ -7494,7 +7494,7 @@ int TLuaInterpreter::tempAnsiColorTrigger(lua_State* L)
         return lua_error(L);
     }
     {   // separate block so that "value" is not scoped to the whole function
-        int value = lua_tointeger(L, s);
+        int const value = lua_tointeger(L, s);
         if (value == TTrigger::scmIgnored && lua_gettop(L) < 2) {
             return warnArgumentValue(L, __func__, qsl(
                 "invalid ANSI color number %1, it cannot be used (to ignore the foreground color) if the background color is omitted")
@@ -7525,7 +7525,7 @@ int TLuaInterpreter::tempAnsiColorTrigger(lua_State* L)
                         s, TTrigger::scmIgnored, TTrigger::scmDefault, luaL_typename(L, s));
         return lua_error(L);
     } else {
-        int value = lua_tointeger(L, s);
+        int const value = lua_tointeger(L, s);
         if (!(value == TTrigger::scmIgnored || value == TTrigger::scmDefault || (value >= 0 && value <= 255))) {
             return warnArgumentValue(L, __func__, qsl(
                 "invalid ANSI color number %1, only %2 (ignore background color), %3 (default background color) or 0 to 255 recognised")
@@ -7560,7 +7560,7 @@ int TLuaInterpreter::tempAnsiColorTrigger(lua_State* L)
         return lua_error(L);
     }
 
-    int triggerID = pLuaInterpreter->startTempColorTrigger(ansiFgColor, ansiBgColor, code, expiryCount);
+    int const triggerID = pLuaInterpreter->startTempColorTrigger(ansiFgColor, ansiBgColor, code, expiryCount);
     if (code.isNull()) {
         auto trigger = host.getTriggerUnit()->getTrigger(triggerID);
         trigger->mRegisteredAnonymousLuaFunction = true;
@@ -7578,11 +7578,11 @@ int TLuaInterpreter::tempLineTrigger(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    int from = getVerifiedInt(L, __func__, 1, "line to start matching from");
-    int howMany  = getVerifiedInt(L, __func__, 2, "how many lines to match for");
+    int const from = getVerifiedInt(L, __func__, 1, "line to start matching from");
+    int const howMany  = getVerifiedInt(L, __func__, 2, "how many lines to match for");
     int triggerID;
     // temp line triggers expire naturally on their own, thus don't need the expiry mechanism applicable to all other triggers
-    int dontExpire = -1;
+    int const dontExpire = -1;
 
     if (lua_isstring(L, 3)) {
         triggerID = pLuaInterpreter->startTempLineTrigger(from, howMany, QString(lua_tostring(L, 3)), dontExpire);
@@ -7607,8 +7607,8 @@ int TLuaInterpreter::tempLineTrigger(lua_State* L)
 int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    QString triggerName = getVerifiedString(L, __func__, 1, "trigger name create or add to");
-    QString pattern = getVerifiedString(L, __func__, 2, "regex pattern to match");
+    QString const triggerName = getVerifiedString(L, __func__, 1, "trigger name create or add to");
+    QString const pattern = getVerifiedString(L, __func__, 2, "regex pattern to match");
 
     if (!lua_isstring(L, 3) && !lua_isfunction(L, 3)) {
         lua_pushfstring(L, "tempComplexRegexTrigger: bad argument #3 type (code to run as a string or a function expected, got %s!)", luaL_typename(L, 3));
@@ -7619,22 +7619,22 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
         lua_pushfstring(L, "tempComplexRegexTrigger: bad argument #4 type (multiline flag as number expected, got %s!)", luaL_typename(L, 4));
         return lua_error(L);
     }
-    bool multiLine = lua_tonumber(L, 4);
+    bool const multiLine = lua_tonumber(L, 4);
 
     if (!lua_isnumber(L, 7)) {
         lua_pushfstring(L, "tempComplexRegexTrigger: bad argument #7 type (filter flag as number expected, got %s!)", luaL_typename(L, 7));
         return lua_error(L);
     }
-    bool filter = lua_tonumber(L, 7);
+    bool const filter = lua_tonumber(L, 7);
 
     if (!lua_isnumber(L, 8)) {
         lua_pushfstring(L, "tempComplexRegexTrigger: bad argument #8 type (match all flag as number expected, got %s!)", luaL_typename(L, 8));
         return lua_error(L);
     }
-    bool matchAll = lua_tonumber(L, 8);
+    bool const matchAll = lua_tonumber(L, 8);
 
-    int fireLength = getVerifiedInt(L, __func__, 12, "fire length");
-    int lineDelta = getVerifiedInt(L, __func__, 13, "line delta");
+    int const fireLength = getVerifiedInt(L, __func__, 12, "fire length");
+    int const lineDelta = getVerifiedInt(L, __func__, 13, "line delta");
 
     bool colorTrigger;
     QString fgColor;
@@ -7745,16 +7745,16 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
 int TLuaInterpreter::tempButton(lua_State* L)
 {
     //args: parent, name, orientation
-    QString cmdButtonUp = "";
-    QString cmdButtonDown = "";
-    QString script = "";
+    QString const cmdButtonUp = "";
+    QString const cmdButtonDown = "";
+    QString const script = "";
     QString toolbar;
     QStringList nameL;
     nameL << toolbar;
 
     toolbar = getVerifiedString(L, __func__, 1, "toolbar name");
-    QString name = getVerifiedString(L, __func__, 2, "button text");
-    int orientation = getVerifiedInt(L, __func__, 3, "orientation");
+    QString const name = getVerifiedString(L, __func__, 2, "button text");
+    int const orientation = getVerifiedInt(L, __func__, 3, "orientation");
 
     Host& host = getHostFromLua(L);
     TAction* pP = host.getActionUnit()->findAction(toolbar);
@@ -7803,8 +7803,8 @@ int TLuaInterpreter::tempButton(lua_State* L)
 int TLuaInterpreter::setButtonStyleSheet(lua_State* L)
 {
     //args: name, css text
-    QString name = getVerifiedString(L, __func__, 1, "name");
-    QString css = getVerifiedString(L, __func__, 2, "css");
+    QString const name = getVerifiedString(L, __func__, 1, "name");
+    QString const css = getVerifiedString(L, __func__, 2, "css");
     Host& host = getHostFromLua(L);
     auto actionsList = host.getActionUnit()->findActionsByName(name);
     if (actionsList.empty()) {
@@ -7822,15 +7822,15 @@ int TLuaInterpreter::setButtonStyleSheet(lua_State* L)
 int TLuaInterpreter::tempButtonToolbar(lua_State* L)
 {
     QString name;
-    QString cmdButtonUp = "";
-    QString cmdButtonDown = "";
-    QString script = "";
+    QString const cmdButtonUp = "";
+    QString const cmdButtonDown = "";
+    QString const script = "";
     QStringList nameL;
     nameL << name;
 
     name = getVerifiedString(L, __func__, 1, "name");
     int location = getVerifiedInt(L, __func__, 2, "location");
-    int orientation = getVerifiedInt(L, __func__, 3, "orientation");
+    int const orientation = getVerifiedInt(L, __func__, 3, "orientation");
 
     if (location > 0) {
         location++;
@@ -7873,7 +7873,7 @@ int TLuaInterpreter::tempRegexTrigger(lua_State* L)
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
     int triggerID;
     int expiryCount = -1;
-    QString regexPattern = getVerifiedString(L, __func__, 1, "regex pattern");
+    QString const regexPattern = getVerifiedString(L, __func__, 1, "regex pattern");
 
     if (lua_isnumber(L, 3)) {
         expiryCount = lua_tonumber(L, 3);
@@ -7909,13 +7909,13 @@ int TLuaInterpreter::tempRegexTrigger(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#tempAlias
 int TLuaInterpreter::tempAlias(lua_State* L)
 {
-    QString regex = getVerifiedString(L, __func__, 1, "regex-type pattern");
+    QString const regex = getVerifiedString(L, __func__, 1, "regex-type pattern");
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
 
     if (lua_isfunction(L, 2)) {
 
-        int result = pLuaInterpreter->startTempAlias(regex, QString());
+        int const result = pLuaInterpreter->startTempAlias(regex, QString());
         if (result == -1) {
             lua_pushnumber(L, -1);
             return 2;
@@ -7937,7 +7937,7 @@ int TLuaInterpreter::tempAlias(lua_State* L)
         lua_pushfstring(L, "tempAlias: bad argument #2 type (lua script as string or function expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString script{lua_tostring(L, 2)};
+    QString const script{lua_tostring(L, 2)};
 
     lua_pushnumber(L, pLuaInterpreter->startTempAlias(regex, script));
     return 1;
@@ -7951,7 +7951,7 @@ int TLuaInterpreter::exists(lua_State* L)
     // ASCII value which we might have to report...
     QString type = getVerifiedString(L, __func__, 2, "item type").toLower();
     bool isOk = false;
-    int id = nameOrId.toInt(&isOk);
+    int const id = nameOrId.toInt(&isOk);
     if (isId && (!isOk || id < 0)) {
         // Must be zero or more but doesn't seem to be, must return the
         // original supplied argument as a string (rather than the nameOrId
@@ -8028,9 +8028,9 @@ int TLuaInterpreter::isActive(lua_State* L)
     auto [isId, nameOrId] = getVerifiedStringOrInteger(L, __func__, 1, "item name or ID");
     // Although we only use 4 ASCII strings the user may not enter a purely
     // ASCII value which we might have to report...
-    QString type = getVerifiedString(L, __func__, 2, "item type");
+    QString const type = getVerifiedString(L, __func__, 2, "item type");
     bool isOk = false;
-    int id = nameOrId.toInt(&isOk);
+    int const id = nameOrId.toInt(&isOk);
     if (isId && (!isOk || id < 0)) {
         // Must be zero or more but doesn't seem to be, must return the
         // original supplied argument as a string (rather than the nameOrId
@@ -8103,7 +8103,7 @@ int TLuaInterpreter::isActive(lua_State* L)
             auto pT = host.getActionUnit()->getAction(id);
             cnt = (static_cast<bool>(pT) && pT->isActive()) ? 1 : 0;
         } else {
-            QMap<int, TAction*> actions = host.getActionUnit()->getActionList();
+            QMap<int, TAction*> const actions = host.getActionUnit()->getActionList();
             for (auto action : actions) {
                 if (action->getName() == nameOrId && action->isActive()) {
                     ++cnt;
@@ -8116,7 +8116,7 @@ int TLuaInterpreter::isActive(lua_State* L)
             auto pT = host.getScriptUnit()->getScript(id);
             cnt = (static_cast<bool>(pT) && pT->isActive()) ? 1 : 0;
         } else {
-            QMap<int, TScript*> scripts = host.getScriptUnit()->getScriptList();
+            QMap<int, TScript*> const scripts = host.getScriptUnit()->getScriptList();
             for (auto script : scripts) {
                 if (script->getName() == nameOrId && script->isActive()) {
                     ++cnt;
@@ -8135,9 +8135,9 @@ int TLuaInterpreter::isActive(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#permAlias
 int TLuaInterpreter::permAlias(lua_State* L)
 {
-    QString name = getVerifiedString(L, __func__, 1, "alias name");
-    QString parent = getVerifiedString(L, __func__, 2, "alias group/parent");
-    QString regex = getVerifiedString(L, __func__, 3, "regexp pattern");
+    QString const name = getVerifiedString(L, __func__, 1, "alias name");
+    QString const parent = getVerifiedString(L, __func__, 2, "alias group/parent");
+    QString const regex = getVerifiedString(L, __func__, 3, "regexp pattern");
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
     if (auto [validationResult, validationMessage] = pLuaInterpreter->validateLuaCodeParam(4); !validationResult) {
@@ -8145,7 +8145,7 @@ int TLuaInterpreter::permAlias(lua_State* L)
         return lua_error(L);
     }
 
-    QString script{lua_tostring(L, 4)};
+    QString const script{lua_tostring(L, 4)};
     auto [aliasId, message] = pLuaInterpreter->startPermAlias(name, parent, regex, script);
     if (aliasId == -1) {
         lua_pushfstring(L, "permAlias: cannot create alias (%s)", message.toUtf8().constData());
@@ -8158,9 +8158,9 @@ int TLuaInterpreter::permAlias(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getScript
 int TLuaInterpreter::getScript(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     int pos = 1;
-    QString name = getVerifiedString(L, __func__, 1, "script name");
+    QString const name = getVerifiedString(L, __func__, 1, "script name");
     if (n > 1) {
         pos = getVerifiedInt(L, __func__, 2, "script position");
     }
@@ -8174,7 +8174,7 @@ int TLuaInterpreter::getScript(lua_State* L)
         return 2;
     }
 
-    int id = pS->getID();
+    int const id = pS->getID();
     lua_pushstring(L, pS->getScript().toUtf8().constData());
     lua_pushnumber(L, id);
     return 2;
@@ -8183,7 +8183,7 @@ int TLuaInterpreter::getScript(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setScript
 int TLuaInterpreter::setScript(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     int pos = 1;
     QString name = getVerifiedString(L, __func__, 1, "script name");
 
@@ -8193,7 +8193,7 @@ int TLuaInterpreter::setScript(lua_State* L)
         lua_pushfstring(L, "setScript: bad argument #%d (%s)", 2, validationMessage.toUtf8().constData());
         return lua_error(L);
     }
-    QString luaCode{lua_tostring(L, 2)};
+    QString const luaCode{lua_tostring(L, 2)};
 
     if (n > 2) {
         pos = getVerifiedInt(L, __func__, 3, "script position");
@@ -8213,15 +8213,15 @@ int TLuaInterpreter::setScript(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#permScript
 int TLuaInterpreter::permScript(lua_State* L)
 {
-    QString name = getVerifiedString(L, __func__, 1, "script name");
-    QString parent = getVerifiedString(L, __func__, 2, "script parent name");
+    QString const name = getVerifiedString(L, __func__, 1, "script name");
+    QString const parent = getVerifiedString(L, __func__, 2, "script parent name");
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
     if (auto [validationResult, validationMessage] = pLuaInterpreter->validateLuaCodeParam(3); !validationResult) {
         lua_pushfstring(L, "permScript: bad argument #%d (%s)", 3, validationMessage.toUtf8().constData());
         return lua_error(L);
     }
-    QString luaCode{lua_tostring(L, 3)};
+    QString const luaCode{lua_tostring(L, 3)};
     auto [id, message] = pLuaInterpreter->createPermScript(name, parent, luaCode);
     if (id == -1) {
         lua_pushfstring(L, "permScript: cannot create script (%s)", message.toUtf8().constData());
@@ -8234,16 +8234,16 @@ int TLuaInterpreter::permScript(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#permTimer
 int TLuaInterpreter::permTimer(lua_State* L)
 {
-    QString name = getVerifiedString(L, __func__, 1, "timer name");
-    QString parent = getVerifiedString(L, __func__, 2, "timer parent name");
-    double time = getVerifiedDouble(L, __func__, 3, "time in seconds");
+    QString const name = getVerifiedString(L, __func__, 1, "timer name");
+    QString const parent = getVerifiedString(L, __func__, 2, "timer parent name");
+    double const time = getVerifiedDouble(L, __func__, 3, "time in seconds");
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
     if (auto [validationResult, validationMessage] = pLuaInterpreter->validateLuaCodeParam(4); !validationResult) {
         lua_pushfstring(L, "permTimer: bad argument #%d (%s)", 4, validationMessage.toUtf8().constData());
         return lua_error(L);
     }
-    QString luaCode{lua_tostring(L, 4)};
+    QString const luaCode{lua_tostring(L, 4)};
     auto [id, message] = pLuaInterpreter->startPermTimer(name, parent, time, luaCode);
     if (id == -1) {
         lua_pushfstring(L, "permTimer: cannot create timer (%s)", message.toUtf8().constData());
@@ -8256,8 +8256,8 @@ int TLuaInterpreter::permTimer(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#permSubstringTrigger
 int TLuaInterpreter::permSubstringTrigger(lua_State* L)
 {
-    QString name = getVerifiedString(L, __func__, 1, "trigger name");
-    QString parent = getVerifiedString(L, __func__, 2, "trigger parent");
+    QString const name = getVerifiedString(L, __func__, 1, "trigger name");
+    QString const parent = getVerifiedString(L, __func__, 2, "trigger parent");
     QStringList regList;
     if (!lua_istable(L, 3)) {
         lua_pushfstring(L, "permSubstringTrigger: bad argument #3 type (sub-strings list as table expected, got %s!)",
@@ -8281,7 +8281,7 @@ int TLuaInterpreter::permSubstringTrigger(lua_State* L)
         return lua_error(L);
     }
 
-    QString script{lua_tostring(L, 4)};
+    QString const script{lua_tostring(L, 4)};
     auto [triggerID, message] = pLuaInterpreter->startPermSubstringTrigger(name, parent, regList, script);
     if(triggerID == - 1) {
         lua_pushfstring(L, "permSubstringTrigger: cannot create trigger (%s)", message.toUtf8().constData());
@@ -8296,13 +8296,13 @@ int TLuaInterpreter::permPromptTrigger(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    QString triggerName = getVerifiedString(L, __func__, 1, "trigger name");
-    QString parentName = getVerifiedString(L, __func__, 2, "parent trigger name");
+    QString const triggerName = getVerifiedString(L, __func__, 1, "trigger name");
+    QString const parentName = getVerifiedString(L, __func__, 2, "parent trigger name");
     if (auto [validationResult, validationMessage] = pLuaInterpreter->validateLuaCodeParam(3); !validationResult) {
         lua_pushfstring(L, "permPromptTrigger: bad argument #%d (%s)", 3, validationMessage.toUtf8().constData());
         return lua_error(L);
     }
-    QString luaFunction = lua_tostring(L, 3);
+    QString const luaFunction = lua_tostring(L, 3);
 
     auto [triggerID, message] = pLuaInterpreter->startPermPromptTrigger(triggerName, parentName, luaFunction);
     if(triggerID == - 1) {
@@ -8360,7 +8360,7 @@ int TLuaInterpreter::tempKey(lua_State* L)
 
     if (lua_isfunction(L, ++argIndex)) {
 
-        int result = pLuaInterpreter->startTempKey(keyModifier, keyCode, QString());
+        int const result = pLuaInterpreter->startTempKey(keyModifier, keyCode, QString());
         if (result == -1) {
             lua_pushnumber(L, -1);
             return 2;
@@ -8382,9 +8382,9 @@ int TLuaInterpreter::tempKey(lua_State* L)
         lua_pushfstring(L, "tempKey: bad argument #%d type (lua script as string or function expected, got %s!)", argIndex, luaL_typename(L, argIndex));
         return lua_error(L);
     }
-    QString luaFunction{lua_tostring(L, argIndex)};
+    QString const luaFunction{lua_tostring(L, argIndex)};
 
-    int timerID = pLuaInterpreter->startTempKey(keyModifier, keyCode, luaFunction);
+    int const timerID = pLuaInterpreter->startTempKey(keyModifier, keyCode, luaFunction);
     lua_pushnumber(L, timerID);
     return 1;
 }
@@ -8392,8 +8392,8 @@ int TLuaInterpreter::tempKey(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#permBeginOfLineStringTrigger
 int TLuaInterpreter::permBeginOfLineStringTrigger(lua_State* L)
 {
-    QString name = getVerifiedString(L, __func__, 1, "trigger name");
-    QString parent = getVerifiedString(L, __func__, 2, "trigger parent");
+    QString const name = getVerifiedString(L, __func__, 1, "trigger name");
+    QString const parent = getVerifiedString(L, __func__, 2, "trigger parent");
 
     QStringList regList;
     if (!lua_istable(L, 3)) {
@@ -8418,7 +8418,7 @@ int TLuaInterpreter::permBeginOfLineStringTrigger(lua_State* L)
         return lua_error(L);
     }
 
-    QString script{lua_tostring(L, 4)};
+    QString const script{lua_tostring(L, 4)};
     auto [triggerId, message] = pLuaInterpreter->startPermBeginOfLineStringTrigger(name, parent, regList, script);
     if (triggerId == -1) {
         lua_pushfstring(L, "permRegexTrigger: cannot create trigger (%s)", message.toUtf8().constData());
@@ -8431,8 +8431,8 @@ int TLuaInterpreter::permBeginOfLineStringTrigger(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#permRegexTrigger
 int TLuaInterpreter::permRegexTrigger(lua_State* L)
 {
-    QString name = getVerifiedString(L, __func__, 1, "trigger name");
-    QString parent = getVerifiedString(L, __func__, 2, "trigger parent");
+    QString const name = getVerifiedString(L, __func__, 1, "trigger name");
+    QString const parent = getVerifiedString(L, __func__, 2, "trigger parent");
 
     QStringList regList;
     if (!lua_istable(L, 3)) {
@@ -8457,7 +8457,7 @@ int TLuaInterpreter::permRegexTrigger(lua_State* L)
         return lua_error(L);
     }
 
-    QString script{lua_tostring(L, 4)};
+    QString const script{lua_tostring(L, 4)};
     auto [triggerId, message] = pLuaInterpreter->startPermRegexTrigger(name, parent, regList, script);
     if (triggerId == -1) {
         lua_pushfstring(L, "permRegexTrigger: cannot create trigger (%s)", message.toUtf8().constData());
@@ -8470,15 +8470,15 @@ int TLuaInterpreter::permRegexTrigger(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#invokeFileDialog
 int TLuaInterpreter::invokeFileDialog(lua_State* L)
 {
-    bool luaDir = getVerifiedBool(L, __func__, 1, "fileOrFolder");
-    QString title = getVerifiedString(L, __func__, 2, "dialogTitle");
+    bool const luaDir = getVerifiedBool(L, __func__, 1, "fileOrFolder");
+    QString const title = getVerifiedString(L, __func__, 2, "dialogTitle");
 
     if (!luaDir) {
-        QString fileName = QFileDialog::getExistingDirectory(nullptr, title, QDir::currentPath());
+        QString const fileName = QFileDialog::getExistingDirectory(nullptr, title, QDir::currentPath());
         lua_pushstring(L, fileName.toUtf8().constData());
         return 1;
     } else {
-        QString fileName = QFileDialog::getOpenFileName(nullptr, title, QDir::currentPath());
+        QString const fileName = QFileDialog::getOpenFileName(nullptr, title, QDir::currentPath());
         lua_pushstring(L, fileName.toUtf8().constData());
         return 1;
     }
@@ -8487,7 +8487,7 @@ int TLuaInterpreter::invokeFileDialog(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getTimestamp
 int TLuaInterpreter::getTimestamp(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     int s = 1;
     QString name;
     if (n > 1) {
@@ -8498,13 +8498,13 @@ int TLuaInterpreter::getTimestamp(lua_State* L)
         }
     }
 
-    qint64 luaLine = getVerifiedInt(L, __func__, s, "line number");
+    qint64 const luaLine = getVerifiedInt(L, __func__, s, "line number");
     if (luaLine < 1) {
         return warnArgumentValue(L, __func__, qsl(
             "line number %1 invalid, it should be greater than zero").arg(luaLine));
     }
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (name.isEmpty()) {
         if (luaLine > 0 && luaLine < host.mpConsole->buffer.timeBuffer.size()) {
             // CHECK: Lua starts counting at 1 but we are indexing into a C/C++
@@ -8531,10 +8531,10 @@ int TLuaInterpreter::getTimestamp(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderColor
 int TLuaInterpreter::setBorderColor(lua_State* L)
 {
-    int luaRed = getVerifiedInt(L, __func__, 1, "red");
-    int luaGreen = getVerifiedInt(L, __func__, 2, "green");
-    int luaBlue = getVerifiedInt(L, __func__, 3, "blue");
-    Host& host = getHostFromLua(L);
+    int const luaRed = getVerifiedInt(L, __func__, 1, "red");
+    int const luaGreen = getVerifiedInt(L, __func__, 2, "green");
+    int const luaBlue = getVerifiedInt(L, __func__, 3, "blue");
+    Host const& host = getHostFromLua(L);
     QPalette framePalette;
     framePalette.setColor(QPalette::Text, QColor(Qt::black));
     framePalette.setColor(QPalette::Highlight, QColor(55, 55, 255));
@@ -8546,11 +8546,11 @@ int TLuaInterpreter::setBorderColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setRoomCoordinates
 int TLuaInterpreter::setRoomCoordinates(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
-    int x = getVerifiedInt(L, __func__, 2, "x");
-    int y = getVerifiedInt(L, __func__, 3, "y");
-    int z = getVerifiedInt(L, __func__, 4, "z");
-    Host& host = getHostFromLua(L);
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    int const x = getVerifiedInt(L, __func__, 2, "x");
+    int const y = getVerifiedInt(L, __func__, 3, "y");
+    int const z = getVerifiedInt(L, __func__, 4, "z");
+    Host const& host = getHostFromLua(L);
     lua_pushboolean(L, host.mpMap->setRoomCoordinates(id, x, y, z));
     return 1;
 }
@@ -8558,12 +8558,12 @@ int TLuaInterpreter::setRoomCoordinates(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setCustomEnvColor
 int TLuaInterpreter::setCustomEnvColor(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "environmentID");
-    int r = getVerifiedInt(L, __func__, 2, "r");
-    int g = getVerifiedInt(L, __func__, 3, "g");
-    int b = getVerifiedInt(L, __func__, 4, "b");
-    int alpha = getVerifiedInt(L, __func__, 5, "a");
-    Host& host = getHostFromLua(L);
+    int const id = getVerifiedInt(L, __func__, 1, "environmentID");
+    int const r = getVerifiedInt(L, __func__, 2, "r");
+    int const g = getVerifiedInt(L, __func__, 3, "g");
+    int const b = getVerifiedInt(L, __func__, 4, "b");
+    int const alpha = getVerifiedInt(L, __func__, 5, "a");
+    Host const& host = getHostFromLua(L);
     host.mpMap->mCustomEnvColors[id] = QColor(r, g, b, alpha);
     host.mpMap->setUnsaved(__func__);
     return 0;
@@ -8574,7 +8574,7 @@ int TLuaInterpreter::setAreaName(lua_State* L)
 {
     int id = -1;
     QString existingName;
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -8610,7 +8610,7 @@ int TLuaInterpreter::setAreaName(lua_State* L)
         return lua_error(L);
     }
 
-    QString newName = getVerifiedString(L, __func__, 2, "area name").trimmed();
+    QString const newName = getVerifiedString(L, __func__, 2, "area name").trimmed();
     // Now allow non-Ascii names but eliminate any leading or trailing spaces
 
     if (newName.isEmpty()) {
@@ -8638,7 +8638,7 @@ int TLuaInterpreter::setAreaName(lua_State* L)
         }
     }
 
-    bool result = host.mpMap->mpRoomDB->setAreaName(id, newName);
+    bool const result = host.mpMap->mpRoomDB->setAreaName(id, newName);
     if (result) {
         host.mpMap->setUnsaved(__func__);
         if (host.mpMap->mpMapper) {
@@ -8656,7 +8656,7 @@ int TLuaInterpreter::setAreaName(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomAreaName
 int TLuaInterpreter::getRoomAreaName(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -8677,7 +8677,7 @@ int TLuaInterpreter::getRoomAreaName(lua_State* L)
     }
 
     if (!name.isNull()) {
-        int result = host.mpMap->mpRoomDB->getAreaNamesMap().key(name, -1);
+        int const result = host.mpMap->mpRoomDB->getAreaNamesMap().key(name, -1);
         lua_pushnumber(L, result);
         if (result != -1) {
             return 1;
@@ -8700,9 +8700,9 @@ int TLuaInterpreter::getRoomAreaName(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addAreaName
 int TLuaInterpreter::addAreaName(lua_State* L)
 {
-    QString name = getVerifiedString(L, __func__, 1, "area name").trimmed();
+    QString const name = getVerifiedString(L, __func__, 1, "area name").trimmed();
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if ((!host.mpMap) || (!host.mpMap->mpRoomDB)) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     } else if (name.isEmpty()) {
@@ -8731,7 +8731,7 @@ int TLuaInterpreter::deleteArea(lua_State* L)
     int id = 0;
     QString name;
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -8783,11 +8783,11 @@ int TLuaInterpreter::deleteArea(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#deleteRoom
 int TLuaInterpreter::deleteRoom(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
     if (id <= 0) {
         return 0;
     }
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     lua_pushboolean(L, host.mpMap->mpRoomDB->removeRoom(id));
     host.mpMap->setUnsaved(__func__);
     return 1;
@@ -8796,16 +8796,16 @@ int TLuaInterpreter::deleteRoom(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setExit
 int TLuaInterpreter::setExit(lua_State* L)
 {
-    int from = getVerifiedInt(L, __func__, 1, "from roomID");
-    int to = getVerifiedInt(L, __func__, 2, "to roomID");
+    int const from = getVerifiedInt(L, __func__, 1, "from roomID");
+    int const to = getVerifiedInt(L, __func__, 2, "to roomID");
 
-    int dir = dirToNumber(L, 3);
+    int const dir = dirToNumber(L, 3);
     if (!dir) {
         lua_pushfstring(L, "setExit: bad argument #3 type (direction as number or string expected, got %s!)", luaL_typename(L, 3));
         return lua_error(L);
     }
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     lua_pushboolean(L, host.mpMap->setExit(from, to, dir));
     host.mpMap->mMapGraphNeedsUpdate = true;
     return 1;
@@ -8814,8 +8814,8 @@ int TLuaInterpreter::setExit(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomCoordinates
 int TLuaInterpreter::getRoomCoordinates(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
-    Host& host = getHostFromLua(L);
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
         lua_pushnil(L);
@@ -8833,8 +8833,8 @@ int TLuaInterpreter::getRoomCoordinates(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomArea
 int TLuaInterpreter::getRoomArea(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
-    Host& host = getHostFromLua(L);
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
         lua_pushnil(L);
@@ -8847,8 +8847,8 @@ int TLuaInterpreter::getRoomArea(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#roomExists
 int TLuaInterpreter::roomExists(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
-    Host& host = getHostFromLua(L);
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
         lua_pushboolean(L, true);
@@ -8861,9 +8861,9 @@ int TLuaInterpreter::roomExists(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addRoom
 int TLuaInterpreter::addRoom(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
-    Host& host = getHostFromLua(L);
-    bool added = host.mpMap->addRoom(id);
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    Host const& host = getHostFromLua(L);
+    bool const added = host.mpMap->addRoom(id);
     lua_pushboolean(L, added);
     if (added) {
         host.mpMap->setRoomArea(id, -1, false);
@@ -8876,13 +8876,13 @@ int TLuaInterpreter::addRoom(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#createRoomID
 int TLuaInterpreter::createRoomID(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
     if (lua_gettop(L) > 0) {
-        int minId = getVerifiedInt(L, __func__, 1, "minimum room Id", true);
+        int const minId = getVerifiedInt(L, __func__, 1, "minimum room Id", true);
         if (minId < 1) {
             return warnArgumentValue(L, __func__, qsl(
                 "minimum roomID %1 is an optional value but if provided it must be greater than zero").arg(minId));
@@ -8897,9 +8897,9 @@ int TLuaInterpreter::createRoomID(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#unHighlightRoom
 int TLuaInterpreter::unHighlightRoom(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
         pR->highlight = false;
@@ -8918,18 +8918,18 @@ int TLuaInterpreter::unHighlightRoom(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#highlightRoom
 int TLuaInterpreter::highlightRoom(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
-    int fgr = getVerifiedInt(L, __func__, 2, "color1Red");
-    int fgg = getVerifiedInt(L, __func__, 3, "color1Green");
-    int fgb = getVerifiedInt(L, __func__, 4, "color1Blue");
-    int bgr = getVerifiedInt(L, __func__, 5, "color2Red");
-    int bgg = getVerifiedInt(L, __func__, 6, "color2Green");
-    int bgb = getVerifiedInt(L, __func__, 7, "color2Blue");
-    float radius = getVerifiedFloat(L, __func__, 8, "highlightRadius");
-    int alpha1 = getVerifiedInt(L, __func__, 9, "color1Alpha");
-    int alpha2 = getVerifiedInt(L, __func__, 10, "color2Alpha");
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    int const fgr = getVerifiedInt(L, __func__, 2, "color1Red");
+    int const fgg = getVerifiedInt(L, __func__, 3, "color1Green");
+    int const fgb = getVerifiedInt(L, __func__, 4, "color1Blue");
+    int const bgr = getVerifiedInt(L, __func__, 5, "color2Red");
+    int const bgg = getVerifiedInt(L, __func__, 6, "color2Green");
+    int const bgb = getVerifiedInt(L, __func__, 7, "color2Blue");
+    float const radius = getVerifiedFloat(L, __func__, 8, "highlightRadius");
+    int const alpha1 = getVerifiedInt(L, __func__, 9, "color1Alpha");
+    int const alpha2 = getVerifiedInt(L, __func__, 10, "color2Alpha");
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
         auto fg = QColor(fgr, fgg, fgb, alpha1);
@@ -8963,18 +8963,18 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
     int foregroundTransparency = 255;
     int backgroundTransparency = 50;
 
-    int args = lua_gettop(L);
-    int area = getVerifiedInt(L, __func__, 1, "areaID");
-    QString text = getVerifiedString(L, __func__, 2, "text");
-    float posx = getVerifiedFloat(L, __func__, 3, "posX");
-    float posy = getVerifiedFloat(L, __func__, 4, "posY");
-    float posz = getVerifiedFloat(L, __func__, 5, "posZ");
-    int fgr = getVerifiedInt(L, __func__, 6, "fgRed");
-    int fgg = getVerifiedInt(L, __func__, 7, "fgGreen");
-    int fgb = getVerifiedInt(L, __func__, 8, "fgBlue");
-    int bgr = getVerifiedInt(L, __func__, 9, "bgRed");
-    int bgg = getVerifiedInt(L, __func__, 10, "bgGreen");
-    int bgb = getVerifiedInt(L, __func__, 11, "bgBlue");
+    int const args = lua_gettop(L);
+    int const area = getVerifiedInt(L, __func__, 1, "areaID");
+    QString const text = getVerifiedString(L, __func__, 2, "text");
+    float const posx = getVerifiedFloat(L, __func__, 3, "posX");
+    float const posy = getVerifiedFloat(L, __func__, 4, "posY");
+    float const posz = getVerifiedFloat(L, __func__, 5, "posZ");
+    int const fgr = getVerifiedInt(L, __func__, 6, "fgRed");
+    int const fgg = getVerifiedInt(L, __func__, 7, "fgGreen");
+    int const fgb = getVerifiedInt(L, __func__, 8, "fgBlue");
+    int const bgr = getVerifiedInt(L, __func__, 9, "bgRed");
+    int const bgg = getVerifiedInt(L, __func__, 10, "bgGreen");
+    int const bgb = getVerifiedInt(L, __func__, 11, "bgBlue");
     if (args > 11) {
         zoom = getVerifiedFloat(L, __func__, 12, "zoom", true);
         fontSize = getVerifiedInt(L, __func__, 13, "fontSize", true);
@@ -8998,7 +8998,7 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
         temporary = getVerifiedBool(L, __func__, 19, "temporary", true);
     }
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     lua_pushinteger(L, host.mpMap->createMapLabel(area, text, posx, posy, posz, QColor(fgr, fgg, fgb, foregroundTransparency), QColor(bgr, bgg, bgb, backgroundTransparency), showOnTop, noScaling, temporary, zoom, fontSize, fontName));
     return 1;
 }
@@ -9006,12 +9006,12 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMapZoom
 int TLuaInterpreter::setMapZoom(lua_State* L)
 {
-    qreal zoom = getVerifiedDouble(L, __func__, 1, "zoom");
+    qreal const zoom = getVerifiedDouble(L, __func__, 1, "zoom");
     int areaID = 0;
     if (lua_gettop(L) > 1) {
         areaID = getVerifiedInt(L, __func__, 2, "area id", true);
     }
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (host.mpMap.isNull() || host.mpMap->mpMapper.isNull()) {
         return warnArgumentValue(L, __func__, "no map loaded or no active mapper");
     }
@@ -9032,7 +9032,7 @@ int TLuaInterpreter::getMapZoom(lua_State* L)
     if (lua_gettop(L)) {
         areaID = getVerifiedInt(L, __func__, 1, "area id", true);
     }
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (host.mpMap.isNull() || host.mpMap->mpMapper.isNull()) {
         return warnArgumentValue(L, __func__, "no map loaded or no active mapper");
     }
@@ -9053,22 +9053,22 @@ int TLuaInterpreter::getMapZoom(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#createMapImageLabel
 int TLuaInterpreter::createMapImageLabel(lua_State* L)
 {
-    int args = lua_gettop(L);
-    int area = getVerifiedInt(L, __func__, 1, "areaID");
-    QString imagePathFileName = getVerifiedString(L, __func__, 2, "imagePathFileName");
-    float posx = getVerifiedFloat(L, __func__, 3, "posX");
-    float posy = getVerifiedFloat(L, __func__, 4, "posY");
-    float posz = getVerifiedFloat(L, __func__, 5, "posZ");
-    float width = getVerifiedFloat(L, __func__, 6, "width");
-    float height = getVerifiedFloat(L, __func__, 7, "height");
-    float zoom = getVerifiedFloat(L, __func__, 8, "zoom");
-    bool showOnTop = getVerifiedBool(L, __func__, 9, "showOnTop");
+    int const args = lua_gettop(L);
+    int const area = getVerifiedInt(L, __func__, 1, "areaID");
+    QString const imagePathFileName = getVerifiedString(L, __func__, 2, "imagePathFileName");
+    float const posx = getVerifiedFloat(L, __func__, 3, "posX");
+    float const posy = getVerifiedFloat(L, __func__, 4, "posY");
+    float const posz = getVerifiedFloat(L, __func__, 5, "posZ");
+    float const width = getVerifiedFloat(L, __func__, 6, "width");
+    float const height = getVerifiedFloat(L, __func__, 7, "height");
+    float const zoom = getVerifiedFloat(L, __func__, 8, "zoom");
+    bool const showOnTop = getVerifiedBool(L, __func__, 9, "showOnTop");
     bool temporary = false;
     if (args > 9) {
         temporary = getVerifiedBool(L, __func__, 10, "showOnTop", true);
     }
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     lua_pushinteger(L, host.mpMap->createMapImageLabel(area, imagePathFileName, posx, posy, posz, width, height, zoom, showOnTop, temporary));
     return 1;
 }
@@ -9076,17 +9076,17 @@ int TLuaInterpreter::createMapImageLabel(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setDoor
 int TLuaInterpreter::setDoor(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
     }
-    QString exitCmd = getVerifiedString(L, __func__, 2, "door command");
+    QString const exitCmd = getVerifiedString(L, __func__, 2, "door command");
 
     if (exitCmd.compare(qsl("n")) && exitCmd.compare(qsl("e")) && exitCmd.compare(qsl("s")) && exitCmd.compare(qsl("w"))
         && exitCmd.compare(qsl("ne"))
@@ -9129,13 +9129,13 @@ int TLuaInterpreter::setDoor(lua_State* L)
         // else IS a valid stub or real normal exit -fall through to continue
     }
 
-    int doorStatus = getVerifiedInt(L, __func__, 3, "door type  {0='none', 1='open', 2='closed' or 3='locked'}");
+    int const doorStatus = getVerifiedInt(L, __func__, 3, "door type  {0='none', 1='open', 2='closed' or 3='locked'}");
     if (doorStatus < 0 || doorStatus > 3) {
         return warnArgumentValue(L, __func__, qsl(
             "door type %1 is not one of 0='none', 1='open', 2='closed' or 3='locked'").arg(doorStatus));
     }
 
-    bool result = pR->setDoor(exitCmd, doorStatus);
+    bool const result = pR->setDoor(exitCmd, doorStatus);
     if (result) {
         host.mpMap->setUnsaved(__func__);
         if (host.mpMap->mpMapper && host.mpMap->mpMapper->mp2dMap) {
@@ -9149,19 +9149,19 @@ int TLuaInterpreter::setDoor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getDoors
 int TLuaInterpreter::getDoors(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
     }
 
     lua_newtable(L);
-    QStringList keys = pR->doors.keys();
+    QStringList const keys = pR->doors.keys();
     for (unsigned int i = 0, total = keys.size(); i < total; ++i) {
         lua_pushstring(L, keys.at(i).toUtf8().constData());
         lua_pushnumber(L, pR->doors.value(keys.at(i)));
@@ -9173,14 +9173,14 @@ int TLuaInterpreter::getDoors(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setExitWeight
 int TLuaInterpreter::setExitWeight(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
-    int roomID = getVerifiedInt(L, __func__, 1, "roomID");
+    Host const& host = getHostFromLua(L);
+    int const roomID = getVerifiedInt(L, __func__, 1, "roomID");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomID));
     }
 
-    QString direction(dirToString(L, 2));
+    QString const direction(dirToString(L, 2));
     if (direction.isEmpty()) {
         lua_pushfstring(L, "setExitWeight: bad argument #2 type (direction as string or number {between 1 and 12 inclusive} expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
@@ -9190,7 +9190,7 @@ int TLuaInterpreter::setExitWeight(lua_State* L)
             .arg(QString::number(roomID), lua_tostring(L, 2)));
     }
 
-    qint64 weight = getVerifiedInt(L, __func__, 3, "exit weight");
+    qint64 const weight = getVerifiedInt(L, __func__, 3, "exit weight");
     if (weight < 0 || weight > std::numeric_limits<int>::max()) {
         return warnArgumentValue(L, __func__, qsl(
             "weight %1 is outside of the usable range of 0 (which resets the weight back to that of the destination room) to %2")
@@ -9205,7 +9205,7 @@ int TLuaInterpreter::setExitWeight(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addCustomLine
 int TLuaInterpreter::addCustomLine(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
 
     //args: id_from, id_to, direction, style, line color, arrow (bool)
     int id_to = 0;
@@ -9217,7 +9217,7 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
     QList<qreal> x;
     QList<qreal> y;
     QList<int> z;
-    int id_from = getVerifiedInt(L, __func__, 1, "roomID");
+    int const id_from = getVerifiedInt(L, __func__, 1, "roomID");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id_from);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id_from));
@@ -9233,8 +9233,8 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
         if (!pR_to) {
             return warnArgumentValue(L, __func__, qsl("number %1 is not a valid target roomID").arg(id_to));
         }
-        int area = pR->getArea();
-        int area_to = pR_to->getArea();
+        int const area = pR->getArea();
+        int const area_to = pR_to->getArea();
         if (area != area_to) {
             return warnArgumentValue(L, __func__, qsl(
                 "target room is in area '%1' (ID: %2) which is not the one '%3' (ID: %4) in which this custom line is to be drawn")
@@ -9325,7 +9325,7 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
             .arg(QString::number(id_from), lua_tostring(L, 3)));
     }
 
-    QString lineStyleString = getVerifiedString(L, __func__, 4, "line style");
+    QString const lineStyleString = getVerifiedString(L, __func__, 4, "line style");
     if (!lineStyleString.compare(QLatin1String("solid line"))) {
         line_style = Qt::SolidLine;
     } else if (!lineStyleString.compare(QLatin1String("dot line"))) {
@@ -9359,7 +9359,7 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
                     return lua_error(L);
                 }
 
-                qint64 component = lua_tointeger(L, -1);
+                qint64 const component = lua_tointeger(L, -1);
                 if (component < 0 || component > 255) {
                     return warnArgumentValue(L, __func__, qsl(
                         "%1 color component in the table of the fifth argument is %2 which is out of the valid range (0 to 255)")
@@ -9383,8 +9383,8 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
         }
     }
 
-    bool arrow = getVerifiedBool(L, __func__, 6, "end with arrow");
-    int lz = z.at(0);
+    bool const arrow = getVerifiedBool(L, __func__, 6, "end with arrow");
+    int const lz = z.at(0);
     QList<QPointF> points;
     // TODO: make provision for 3D custom lines (and store the z coordinates and allow them to vary)
     points.append(QPointF(x.at(0), y.at(0)));
@@ -9423,16 +9423,16 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#removeCustomLine
 int TLuaInterpreter::removeCustomLine(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
 
     //args: room_id, direction
-    int roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
     }
 
-    QString direction = dirToString(L, 2);
+    QString const direction = dirToString(L, 2);
     if (direction.isEmpty()) {
         lua_pushfstring(L, "removeCustomLine: bad argument #2 type (direction as string or number (between 1 and 12 inclusive) expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
@@ -9463,14 +9463,14 @@ int TLuaInterpreter::removeCustomLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getCustomLines
 int TLuaInterpreter::getCustomLines(lua_State* L)
 {
-    int roomID = getVerifiedInt(L, __func__, 1, "roomID");
-    Host& host = getHostFromLua(L);
+    int const roomID = getVerifiedInt(L, __func__, 1, "roomID");
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
     if (!pR) { //if the room doesn't exist return nil
         return warnArgumentValue(L, __func__, qsl("room %1 doesn't exist").arg(roomID));
     }
     lua_newtable(L); //return table customLines[]
-    QStringList exits = pR->customLines.keys();
+    QStringList const exits = pR->customLines.keys();
     for (int i = 0, iTotal = exits.size(); i < iTotal; ++i) {
         lua_pushstring(L, exits.at(i).toUtf8().constData());
         lua_newtable(L); //customLines[direction]
@@ -9514,7 +9514,7 @@ int TLuaInterpreter::getCustomLines(lua_State* L)
         lua_settable(L, -3); //customLines[direction]["attributes"]
         lua_pushstring(L, "points");
         lua_newtable(L); //customLines[direction][points]
-        QList<QPointF> pointL = pR->customLines.value(exits.at(i));
+        QList<QPointF> const pointL = pR->customLines.value(exits.at(i));
         for (int k = 0, kTotal = pointL.size(); k < kTotal; ++k) {
             lua_pushnumber(L, k);
             lua_newtable(L);
@@ -9535,14 +9535,14 @@ int TLuaInterpreter::getCustomLines(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getCustomLines1
 int TLuaInterpreter::getCustomLines1(lua_State* L)
 {
-    int roomID = getVerifiedInt(L, __func__, 1, "roomID");
-    Host& host = getHostFromLua(L);
+    int const roomID = getVerifiedInt(L, __func__, 1, "roomID");
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
     if (!pR) { //if the room doesn't exist return nil
         return warnArgumentValue(L, __func__, qsl("room %1 doesn't exist").arg(roomID));
     }
     lua_newtable(L); //return table customLines[]
-    QStringList exits = pR->customLines.keys();
+    QStringList const exits = pR->customLines.keys();
     for (int i = 0, iTotal = exits.size(); i < iTotal; ++i) {
         lua_pushstring(L, exits.at(i).toUtf8().constData());
         lua_newtable(L); //customLines[direction]
@@ -9586,7 +9586,7 @@ int TLuaInterpreter::getCustomLines1(lua_State* L)
         lua_settable(L, -3); //customLines[direction]["attributes"]
         lua_pushstring(L, "points");
         lua_newtable(L); //customLines[direction]["points"]
-        QList<QPointF> pointL = pR->customLines.value(exits.at(i));
+        QList<QPointF> const pointL = pR->customLines.value(exits.at(i));
         for (int k = 0, kTotal = pointL.size(); k < kTotal; ++k) {
             // To allow the output from here to be fed back into addCustomLine
             // we need to start the numbering from the Lua standard of 1 and
@@ -9613,12 +9613,12 @@ int TLuaInterpreter::getCustomLines1(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getExitWeights
 int TLuaInterpreter::getExitWeights(lua_State* L)
 {
-    int roomID = getVerifiedInt(L, __func__, 1, "roomID");
-    Host& host = getHostFromLua(L);
+    int const roomID = getVerifiedInt(L, __func__, 1, "roomID");
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
     lua_newtable(L);
     if (pR) {
-        QStringList keys = pR->getExitWeights().keys();
+        QStringList const keys = pR->getExitWeights().keys();
         for (int i = 0; i < keys.size(); i++) {
             lua_pushstring(L, keys.at(i).toUtf8().constData());
             lua_pushnumber(L, pR->getExitWeight(keys.at(i)));
@@ -9631,9 +9631,9 @@ int TLuaInterpreter::getExitWeights(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#deleteMapLabel
 int TLuaInterpreter::deleteMapLabel(lua_State* L)
 {
-    int area = getVerifiedInt(L, __func__, 1, "areaID");
-    int labelID = getVerifiedInt(L, __func__, 2, "labelID");
-    Host& host = getHostFromLua(L);
+    int const area = getVerifiedInt(L, __func__, 1, "areaID");
+    int const labelID = getVerifiedInt(L, __func__, 2, "labelID");
+    Host const& host = getHostFromLua(L);
     host.mpMap->deleteMapLabel(area, labelID);
     return 0;
 }
@@ -9641,8 +9641,8 @@ int TLuaInterpreter::deleteMapLabel(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#windowType
 int TLuaInterpreter::windowType(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
-    QString windowName = getVerifiedString(L, __func__, 1, "window name");
+    Host const& host = getHostFromLua(L);
+    QString const windowName = getVerifiedString(L, __func__, 1, "window name");
 
     if (auto kind = host.windowType(windowName)) {
         lua_pushstring(L, kind->toUtf8().constData());
@@ -9658,8 +9658,8 @@ int TLuaInterpreter::windowType(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMapLabels
 int TLuaInterpreter::getMapLabels(lua_State* L)
 {
-    int area = getVerifiedInt(L, __func__, 1, "areaID");
-    Host& host = getHostFromLua(L);
+    int const area = getVerifiedInt(L, __func__, 1, "areaID");
+    Host const& host = getHostFromLua(L);
     lua_newtable(L);
     auto pA = host.mpMap->mpRoomDB->getArea(area);
     if (pA && !pA->mMapLabels.isEmpty()) {
@@ -9677,7 +9677,7 @@ int TLuaInterpreter::getMapLabels(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMapLabel
 int TLuaInterpreter::getMapLabel(lua_State* L)
 {
-    int areaId = getVerifiedInt(L, __func__, 1, "areaID");
+    int const areaId = getVerifiedInt(L, __func__, 1, "areaID");
 
     if (!lua_isstring(L, 2) && !lua_isnumber(L, 2)) {
         lua_pushfstring(L, "getMapLabel: bad argument #2 type (labelID as number or labelText as string expected, got %s!)", luaL_typename(L, 2));
@@ -9695,7 +9695,7 @@ int TLuaInterpreter::getMapLabel(lua_State* L)
         // Can be an empty string as image labels have no text!
     }
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     auto pA = host.mpMap->mpRoomDB->getArea(areaId);
     if (!pA) {
         return warnArgumentValue(L, __func__, qsl("areaID %1 does not exist").arg(areaId));
@@ -9800,20 +9800,20 @@ void TLuaInterpreter::pushMapLabelPropertiesToLua(lua_State* L, const TMapLabel&
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addSpecialExit
 int TLuaInterpreter::addSpecialExit(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
-    int fromRoomID = getVerifiedInt(L, __func__, 1, "exit roomID");
+    Host const& host = getHostFromLua(L);
+    int const fromRoomID = getVerifiedInt(L, __func__, 1, "exit roomID");
     TRoom* pR_from = host.mpMap->mpRoomDB->getRoom(fromRoomID);
     if (!pR_from) {
         return warnArgumentValue(L, __func__, csmInvalidExitRoomID.arg(fromRoomID));
     }
 
-    int toRoomID = getVerifiedInt(L, __func__, 2, "entrance roomID");
+    int const toRoomID = getVerifiedInt(L, __func__, 2, "entrance roomID");
     TRoom* pR_to = host.mpMap->mpRoomDB->getRoom(toRoomID);
     if (!pR_to) {
         return warnArgumentValue(L, __func__, qsl("number %1 is not a valid entrance roomID").arg(toRoomID));
     }
 
-    QString dir = getVerifiedString(L, __func__, 3, "special exit name/command");
+    QString const dir = getVerifiedString(L, __func__, 3, "special exit name/command");
     if (dir.isEmpty()) {
         return warnArgumentValue(L, __func__, "the special exit name/command cannot be empty");
     }
@@ -9826,14 +9826,14 @@ int TLuaInterpreter::addSpecialExit(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#removeSpecialExit
 int TLuaInterpreter::removeSpecialExit(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
-    int fromRoomID = getVerifiedInt(L, __func__, 1, "exit roomID");
+    Host const& host = getHostFromLua(L);
+    int const fromRoomID = getVerifiedInt(L, __func__, 1, "exit roomID");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(fromRoomID);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidExitRoomID.arg(fromRoomID));
     }
 
-    QString dir = getVerifiedString(L, __func__, 2, "special exit name/command");
+    QString const dir = getVerifiedString(L, __func__, 2, "special exit name/command");
     if (dir.isEmpty()) {
         return warnArgumentValue(L, __func__, "the exit command cannot be empty");
     }
@@ -9850,12 +9850,12 @@ int TLuaInterpreter::removeSpecialExit(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearRoomUserData
 int TLuaInterpreter::clearRoomUserData(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
@@ -9873,13 +9873,13 @@ int TLuaInterpreter::clearRoomUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearRoomUserDataItem
 int TLuaInterpreter::clearRoomUserDataItem(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int roomId = getVerifiedInt(L, __func__, 1, "roomID");
-    QString key = getVerifiedString(L, __func__, 2, "key");
+    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    QString const key = getVerifiedString(L, __func__, 2, "key");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
@@ -9903,12 +9903,12 @@ int TLuaInterpreter::clearRoomUserDataItem(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearAreaUserData
 int TLuaInterpreter::clearAreaUserData(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int areaId = getVerifiedInt(L, __func__, 1, "areaID");
+    int const areaId = getVerifiedInt(L, __func__, 1, "areaID");
     TArea* pA = host.mpMap->mpRoomDB->getArea(areaId);
     if (!pA) {
         return warnArgumentValue(L, __func__, csmInvalidAreaID.arg(areaId));
@@ -9926,13 +9926,13 @@ int TLuaInterpreter::clearAreaUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearAreaUserDataItem
 int TLuaInterpreter::clearAreaUserDataItem(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int areaId = getVerifiedInt(L, __func__, 1, "areaID");
-    QString key = getVerifiedString(L, __func__, 2, "key");
+    int const areaId = getVerifiedInt(L, __func__, 1, "areaID");
+    QString const key = getVerifiedString(L, __func__, 2, "key");
     TArea* pA = host.mpMap->mpRoomDB->getArea(areaId);
     if (!pA) {
         return warnArgumentValue(L, __func__, csmInvalidAreaID.arg(areaId));
@@ -9948,7 +9948,7 @@ int TLuaInterpreter::clearAreaUserDataItem(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearMapUserData
 int TLuaInterpreter::clearMapUserData(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -9966,12 +9966,12 @@ int TLuaInterpreter::clearMapUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearMapUserDataItem
 int TLuaInterpreter::clearMapUserDataItem(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    QString key = getVerifiedString(L, __func__, 1, "key");
+    QString const key = getVerifiedString(L, __func__, 1, "key");
     if (key.isEmpty()) {
         return warnArgumentValue(L, __func__, "key can not be an empty string");
     }
@@ -9982,8 +9982,8 @@ int TLuaInterpreter::clearMapUserDataItem(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearSpecialExits
 int TLuaInterpreter::clearSpecialExits(lua_State* L)
 {
-    int id_from = getVerifiedInt(L, __func__, 1, "roomID");
-    Host& host = getHostFromLua(L);
+    int const id_from = getVerifiedInt(L, __func__, 1, "roomID");
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id_from);
     if (pR) {
         pR->clearSpecialExits();
@@ -10000,8 +10000,8 @@ int TLuaInterpreter::clearSpecialExits(lua_State* L)
 // documented in the wiki!
 int TLuaInterpreter::getSpecialExits(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
-    int id_from = getVerifiedInt(L, __func__, 1, "exit roomID");
+    Host const& host = getHostFromLua(L);
+    int const id_from = getVerifiedInt(L, __func__, 1, "exit roomID");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id_from);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id_from));
@@ -10019,18 +10019,18 @@ int TLuaInterpreter::getSpecialExits(lua_State* L)
         specialExitsByExitId.insert(itSpecialExit.value(), itSpecialExit.key());
     }
 
-    QList<int> exitRoomIdList = specialExitsByExitId.keys();
+    QList<int> const exitRoomIdList = specialExitsByExitId.keys();
     lua_newtable(L);
     for (int i = 0, exitRoomIdCount = exitRoomIdList.count(); i < exitRoomIdCount; ++i) {
         lua_pushnumber(L, exitRoomIdList.at(i));
         lua_newtable(L);
         {
-            QStringList exitCommandsToThisRoomId = specialExitsByExitId.values(exitRoomIdList.at(i));
+            QStringList const exitCommandsToThisRoomId = specialExitsByExitId.values(exitRoomIdList.at(i));
             int bestUnlockedExitIndex = -1;
             int bestUnlockedExitWeight = -1;
             int bestLockedExitIndex = -1;
             int bestLockedExitWeight = -1;
-            int exitCommandsCount = exitCommandsToThisRoomId.count();
+            int const exitCommandsCount = exitCommandsToThisRoomId.count();
             for (int j = 0; j < exitCommandsCount; ++j) {
                 if (showAllExits || exitCommandsCount == 1) {
                     // The simpler case - show all exits (or the only exit) to
@@ -10045,7 +10045,7 @@ int TLuaInterpreter::getSpecialExits(lua_State* L)
                 // The more complex (but highly unlikely in most MUDs) case
                 // - find the best exit to this room when there are more than
                 // one:
-                int thisExitWeight = pR->getExitWeight(exitCommandsToThisRoomId.at(j));
+                int const thisExitWeight = pR->getExitWeight(exitCommandsToThisRoomId.at(j));
                 if (pR->hasSpecialExitLock(exitCommandsToThisRoomId.at(j))) {
                     if (bestLockedExitIndex == -1) {
                         bestLockedExitIndex = j;
@@ -10070,7 +10070,7 @@ int TLuaInterpreter::getSpecialExits(lua_State* L)
             if (!showAllExits && (exitCommandsCount > 1)) {
                 // Produce the best exit to this room given that there IS more
                 // than one and we haven't been asked to show them all:
-                int bestExitIndex = (bestUnlockedExitIndex != -1) ? bestUnlockedExitIndex : bestLockedExitIndex;
+                int const bestExitIndex = (bestUnlockedExitIndex != -1) ? bestUnlockedExitIndex : bestLockedExitIndex;
                 lua_pushstring(L, exitCommandsToThisRoomId.at(bestExitIndex).toUtf8().constData());
                 lua_pushstring(L, pR->hasSpecialExitLock(exitCommandsToThisRoomId.at(bestExitIndex)) ? "1" : "0");
                 lua_settable(L, -3);
@@ -10085,12 +10085,12 @@ int TLuaInterpreter::getSpecialExits(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getSpecialExitsSwap
 int TLuaInterpreter::getSpecialExitsSwap(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "getSpecialExitsSwap: bad argument #1 type (exit roomID as number expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    int id_from = lua_tointeger(L, 1);
+    int const id_from = lua_tointeger(L, 1);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id_from);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id_from));
@@ -10110,8 +10110,8 @@ int TLuaInterpreter::getSpecialExitsSwap(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomEnv
 int TLuaInterpreter::getRoomEnv(lua_State* L)
 {
-    int roomID = getVerifiedInt(L, __func__, 1, "roomID");
-    Host& host = getHostFromLua(L);
+    int const roomID = getVerifiedInt(L, __func__, 1, "roomID");
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
     if (pR) {
         lua_pushnumber(L, pR->environment);
@@ -10123,13 +10123,13 @@ int TLuaInterpreter::getRoomEnv(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomUserData
 int TLuaInterpreter::getRoomUserData(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int roomId = getVerifiedInt(L, __func__, 1, "roomID");
-    QString key = getVerifiedString(L, __func__, 2, "key");
+    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    QString const key = getVerifiedString(L, __func__, 2, "key");
     bool isBackwardCompatibilityRequired = true;
     if (lua_gettop(L) > 2) {
         isBackwardCompatibilityRequired = !getVerifiedBool(L, __func__, 3, "enableFullErrorReporting {default = false}", true);
@@ -10158,13 +10158,13 @@ int TLuaInterpreter::getRoomUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getAreaUserData
 int TLuaInterpreter::getAreaUserData(lua_State* L)
 {
-    int areaId = getVerifiedInt(L, __func__, 1, "areaID");
-    QString key = getVerifiedString(L, __func__, 2, "key");
+    int const areaId = getVerifiedInt(L, __func__, 1, "areaID");
+    QString const key = getVerifiedString(L, __func__, 2, "key");
     if (key.isEmpty()) {
         return warnArgumentValue(L, __func__, "key is not allowed to be an empty string");
     }
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -10182,12 +10182,12 @@ int TLuaInterpreter::getAreaUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMapUserData
 int TLuaInterpreter::getMapUserData(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    QString key = getVerifiedString(L, __func__, 1, "key");
+    QString const key = getVerifiedString(L, __func__, 1, "key");
     if (!host.mpMap->mUserData.contains(key)) {
         return warnArgumentValue(L, __func__, qsl("no user data with key '%1' in map").arg(key));
     }
@@ -10198,15 +10198,15 @@ int TLuaInterpreter::getMapUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setRoomUserData
 int TLuaInterpreter::setRoomUserData(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int roomId = getVerifiedInt(L, __func__, 1, "roomID");
-    QString key = getVerifiedString(L, __func__, 2, "key");
+    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    QString const key = getVerifiedString(L, __func__, 2, "key");
     // Ideally should reject empty keys but this could break existing scripts so we can't
-    QString value = getVerifiedString(L, __func__, 3, "value");
+    QString const value = getVerifiedString(L, __func__, 3, "value");
 
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
@@ -10221,14 +10221,14 @@ int TLuaInterpreter::setRoomUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setAreaUserData
 int TLuaInterpreter::setAreaUserData(lua_State* L)
 {
-    int areaId = getVerifiedInt(L, __func__, 1, "areaID");
-    QString key = getVerifiedString(L, __func__, 2, "key");
+    int const areaId = getVerifiedInt(L, __func__, 1, "areaID");
+    QString const key = getVerifiedString(L, __func__, 2, "key");
     if (key.isEmpty()) {
         return warnArgumentValue(L, __func__, "key is not allowed to be an empty string");
     }
-    QString value = getVerifiedString(L, __func__, 3, "value");
+    QString const value = getVerifiedString(L, __func__, 3, "value");
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -10246,16 +10246,16 @@ int TLuaInterpreter::setAreaUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMapUserData
 int TLuaInterpreter::setMapUserData(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    QString key = getVerifiedString(L, __func__, 1, "key");
+    QString const key = getVerifiedString(L, __func__, 1, "key");
     if (key.isEmpty()) {
         return warnArgumentValue(L, __func__, "key is not allowed to be an empty string");
     }
-    QString value = getVerifiedString(L, __func__, 2, "value");
+    QString const value = getVerifiedString(L, __func__, 2, "value");
 
     host.mpMap->mUserData[key] = value;
     host.mpMap->setUnsaved(__func__);
@@ -10266,12 +10266,12 @@ int TLuaInterpreter::setMapUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomUserDataKeys
 int TLuaInterpreter::getRoomUserDataKeys(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
 
     QStringList keys;
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
@@ -10291,12 +10291,12 @@ int TLuaInterpreter::getRoomUserDataKeys(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getAllRoomUserData
 int TLuaInterpreter::getAllRoomUserData(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
 
     QStringList keys;
     QStringList values;
@@ -10318,12 +10318,12 @@ int TLuaInterpreter::getAllRoomUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getAllAreaUserData
 int TLuaInterpreter::getAllAreaUserData(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int areaId = getVerifiedInt(L, __func__, 1, "areaID");
+    int const areaId = getVerifiedInt(L, __func__, 1, "areaID");
 
     QStringList keys;
     QStringList values;
@@ -10345,7 +10345,7 @@ int TLuaInterpreter::getAllAreaUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getAllMapUserData
 int TLuaInterpreter::getAllMapUserData(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -10367,9 +10367,9 @@ int TLuaInterpreter::getAllMapUserData(lua_State* L)
 int TLuaInterpreter::downloadFile(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    QString localFile = getVerifiedString(L, __func__, 1, "local filename");
-    QString urlString = getVerifiedString(L, __func__, 2, "remote url");
-    QUrl url = QUrl::fromUserInput(urlString);
+    QString const localFile = getVerifiedString(L, __func__, 1, "local filename");
+    QString const urlString = getVerifiedString(L, __func__, 2, "remote url");
+    QUrl const url = QUrl::fromUserInput(urlString);
     if (!url.isValid()) {
         return warnArgumentValue(L, __func__, qsl("url is invalid, reason: %1").arg(url.errorString()));
     }
@@ -10401,12 +10401,12 @@ int TLuaInterpreter::downloadFile(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setRoomArea
 int TLuaInterpreter::setRoomArea(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
     if (!host.mpMap->mpRoomDB->getRoomIDList().contains(id)) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
     }
@@ -10443,7 +10443,7 @@ int TLuaInterpreter::setRoomArea(lua_State* L)
 
     // Can set the room to an area which does not have a TArea instance but does
     // appear in the TRoomDB::areaNamesMap...
-    bool result = host.mpMap->setRoomArea(id, areaId, false);
+    bool const result = host.mpMap->setRoomArea(id, areaId, false);
     if (result) {
         // As a successful result WILL change the area a room is in then the map
         // should be updated.  The GUI code that modifies room(s) areas already
@@ -10465,15 +10465,15 @@ int TLuaInterpreter::setRoomArea(lua_State* L)
 int TLuaInterpreter::resetRoomArea(lua_State* L)
 {
     //will reset the room area to our void area
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     } else if (!host.mpMap->mpRoomDB->getRoomIDList().contains(id)) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
     }
-    bool result = host.mpMap->setRoomArea(id, -1, false);
+    bool const result = host.mpMap->setRoomArea(id, -1, false);
     if (result) {
         // As a successful result WILL change the area a room is in then the map
         // should be updated.  The GUI code that modifies room(s) areas already
@@ -10494,10 +10494,10 @@ int TLuaInterpreter::resetRoomArea(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setRoomChar
 int TLuaInterpreter::setRoomChar(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
-    QString symbol = getVerifiedString(L, __func__, 2, "room symbol");
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    QString const symbol = getVerifiedString(L, __func__, 2, "room symbol");
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
@@ -10519,8 +10519,8 @@ int TLuaInterpreter::setRoomChar(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomChar
 int TLuaInterpreter::getRoomChar(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
-    Host& host = getHostFromLua(L);
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
@@ -10533,24 +10533,24 @@ int TLuaInterpreter::getRoomChar(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setRoomCharColor
 int TLuaInterpreter::setRoomCharColor(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
-    int r = getVerifiedInt(L, __func__, 2, "red component");
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    int const r = getVerifiedInt(L, __func__, 2, "red component");
     if (r < 0 || r > 255) {
         lua_pushfstring(L, "setRoomCharColor: bad argument #2 type (red component value %d out of range (0 to 255)", r);
         return lua_error(L);
     }
-    int g = getVerifiedInt(L, __func__, 3, "green component");
+    int const g = getVerifiedInt(L, __func__, 3, "green component");
     if (g < 0 || g > 255) {
         lua_pushfstring(L, "setRoomCharColor: bad argument #3 type (red component value %d out of range (0 to 255)", r);
         return lua_error(L);
     }
-    int b = getVerifiedInt(L, __func__, 4, "blue component");
+    int const b = getVerifiedInt(L, __func__, 4, "blue component");
     if (b < 0 || b > 255) {
         lua_pushfstring(L, "setRoomCharColor: bad argument #4 type (blue component value %d out of range (0 to 255)", r);
         return lua_error(L);
     }
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
@@ -10568,9 +10568,9 @@ int TLuaInterpreter::setRoomCharColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#unsetRoomCharColor
 int TLuaInterpreter::unsetRoomCharColor(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
@@ -10589,8 +10589,8 @@ int TLuaInterpreter::unsetRoomCharColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomCharColor
 int TLuaInterpreter::getRoomCharColor(lua_State* L)
 {
-    int id = getVerifiedInt(L, __func__, 1, "roomID");
-    Host& host = getHostFromLua(L);
+    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
@@ -10605,12 +10605,12 @@ int TLuaInterpreter::getRoomCharColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomsByPosition
 int TLuaInterpreter::getRoomsByPosition(lua_State* L)
 {
-    int area = getVerifiedInt(L, __func__, 1, "areaID");
-    int x = getVerifiedInt(L, __func__, 2, "x");
-    int y = getVerifiedInt(L, __func__, 3, "y");
-    int z = getVerifiedInt(L, __func__, 4, "z");
+    int const area = getVerifiedInt(L, __func__, 1, "areaID");
+    int const x = getVerifiedInt(L, __func__, 2, "x");
+    int const y = getVerifiedInt(L, __func__, 3, "y");
+    int const z = getVerifiedInt(L, __func__, 4, "z");
 
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     TArea* pA = host.mpMap->mpRoomDB->getArea(area);
     if (!pA) {
         lua_pushnil(L);
@@ -10630,12 +10630,12 @@ int TLuaInterpreter::getRoomsByPosition(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getGridMode
 int TLuaInterpreter::getGridMode(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int id = getVerifiedInt(L, __func__, 1, "areaID");
+    int const id = getVerifiedInt(L, __func__, 1, "areaID");
 
     TArea* area = host.mpMap->mpRoomDB->getArea(id);
     if (!area) {
@@ -10649,9 +10649,9 @@ int TLuaInterpreter::getGridMode(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setGridMode
 int TLuaInterpreter::setGridMode(lua_State* L)
 {
-    int area = getVerifiedInt(L, __func__, 1, "areaID");
-    bool gridMode = getVerifiedBool(L, __func__, 2, "true/false");
-    Host& host = getHostFromLua(L);
+    int const area = getVerifiedInt(L, __func__, 1, "areaID");
+    bool const gridMode = getVerifiedBool(L, __func__, 2, "true/false");
+    Host const& host = getHostFromLua(L);
     TArea* pA = host.mpMap->mpRoomDB->getArea(area);
     if (!pA) {
         lua_pushboolean(L, false);
@@ -10678,21 +10678,21 @@ int TLuaInterpreter::setGridMode(lua_State* L)
 int TLuaInterpreter::setFgColor(lua_State* L)
 {
     int s = 0;
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     auto validRange = [](int number) { return number >= 0 && number <= 255; };
     QString windowName;
     if (n > 3) {
         windowName = WINDOW_NAME(L, ++s);
     }
-    int luaRed = getVerifiedInt(L, __func__, ++s, "red component value");
+    int const luaRed = getVerifiedInt(L, __func__, ++s, "red component value");
     if (!validRange(luaRed)) {
         return warnArgumentValue(L, __func__, csmInvalidRedValue.arg(luaRed));
     }
-    int luaGreen = getVerifiedInt(L, __func__, ++s, "green component value");
+    int const luaGreen = getVerifiedInt(L, __func__, ++s, "green component value");
     if (!validRange(luaGreen)) {
         return warnArgumentValue(L, __func__, csmInvalidGreenValue.arg(luaGreen));
     }
-    int luaBlue = getVerifiedInt(L, __func__, ++s, "blue component value");
+    int const luaBlue = getVerifiedInt(L, __func__, ++s, "blue component value");
     if (!validRange(luaBlue)) {
         return warnArgumentValue(L, __func__, csmInvalidBlueValue.arg(luaBlue));
     }
@@ -10762,7 +10762,7 @@ int TLuaInterpreter::setBgColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#insertLink
 int TLuaInterpreter::insertLink(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     int funcRef{0};
     bool useCurrentFormat{false};
     QString windowName{qsl("main")};
@@ -10856,13 +10856,13 @@ int TLuaInterpreter::insertPopup(lua_State* L)
     QVector<int> luaReference;
     bool customFormat = false;
     int s = 1;
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
 
     // console name is an optional first argument
     if (n >= 4) {
         windowName = WINDOW_NAME(L, s++);
     }
-    QString txt = getVerifiedString(L, __func__, s++, "text");
+    QString const txt = getVerifiedString(L, __func__, s++, "text");
 
     if (!lua_istable(L, s)) {
         lua_pushfstring(L, "insertPopup: bad argument #%d type (commands as table expected, got %s!)", s, luaL_typename(L, s));
@@ -10872,7 +10872,7 @@ int TLuaInterpreter::insertPopup(lua_State* L)
     while (lua_next(L, s) != 0) {
         // key at index -2 and value at index -1
         if (lua_type(L, -1) == LUA_TSTRING) {
-            QString cmd = lua_tostring(L, -1);
+            QString const cmd = lua_tostring(L, -1);
             _commandList << cmd;
             luaReference << 0;
         }
@@ -10894,7 +10894,7 @@ int TLuaInterpreter::insertPopup(lua_State* L)
     while (lua_next(L, s) != 0) {
         // key at index -2 and value at index -1
         if (lua_type(L, -1) == LUA_TSTRING) {
-            QString hint = lua_tostring(L, -1);
+            QString const hint = lua_tostring(L, -1);
             _hintList << hint;
         }
         // removes value, but keeps key for next iteration
@@ -10924,7 +10924,7 @@ int TLuaInterpreter::insertText(lua_State* L)
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
         windowName = WINDOW_NAME(L, ++s);
     }
-    QString text = getVerifiedString(L, __func__, ++s, "text");
+    QString const text = getVerifiedString(L, __func__, ++s, "text");
 
     auto console = CONSOLE(L, windowName);
     console->insertText(text);
@@ -10935,8 +10935,8 @@ int TLuaInterpreter::insertText(lua_State* L)
 // No Documentation - public function but should stay undocumented -- compare https://github.com/Mudlet/Mudlet/issues/1149
 int TLuaInterpreter::insertHTML(lua_State* L)
 {
-    QString sendText = getVerifiedString(L, __func__, 1, "sendText");
-    Host& host = getHostFromLua(L);
+    QString const sendText = getVerifiedString(L, __func__, 1, "sendText");
+    Host const& host = getHostFromLua(L);
     host.mpConsole->insertHTML(sendText);
     return 0;
 }
@@ -10944,7 +10944,7 @@ int TLuaInterpreter::insertHTML(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addSupportedTelnetOption
 int TLuaInterpreter::addSupportedTelnetOption(lua_State* L)
 {
-    int option = getVerifiedInt(L, __func__, 1, "option");
+    int const option = getVerifiedInt(L, __func__, 1, "option");
     Host& host = getHostFromLua(L);
     host.mTelnet.supportedTelnetOptions[option] = true;
     return 0;
@@ -10956,14 +10956,14 @@ int TLuaInterpreter::echo(lua_State* L)
     Host& host = getHostFromLua(L);
 
     QString consoleName;
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     int s = 1;
 
     if (n > 1) {
         consoleName = getVerifiedString(L, __func__, s++, "console name", true);
     }
 
-    QString displayText = getVerifiedString(L, __func__, s, "text to display");
+    QString const displayText = getVerifiedString(L, __func__, s, "text to display");
 
     if (isMain(consoleName)) {
         host.mpConsole->buffer.mEchoingText = true;
@@ -10990,12 +10990,12 @@ int TLuaInterpreter::echoPopup(lua_State* L)
     QVector<int> luaReference;
     bool customFormat = false;
     int s = 1;
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     // console name is an optional first argument
     if (n >= 4) {
         windowName = WINDOW_NAME(L, s++);
     }
-    QString text = getVerifiedString(L, __func__, s++, "text as string");
+    QString const text = getVerifiedString(L, __func__, s++, "text as string");
 
     if (!lua_istable(L, s)) {
         lua_pushfstring(L, "echoPopup: bad argument #%d type (command list as table expected, got %s!)", s, luaL_typename(L, s));
@@ -11005,7 +11005,7 @@ int TLuaInterpreter::echoPopup(lua_State* L)
     while (lua_next(L, s) != 0) {
         // key at index -2 and value at index -1
         if (lua_type(L, -1) == LUA_TSTRING) {
-            QString cmd = lua_tostring(L, -1);
+            QString const cmd = lua_tostring(L, -1);
             commandList << cmd;
             luaReference << 0;
         }
@@ -11026,7 +11026,7 @@ int TLuaInterpreter::echoPopup(lua_State* L)
     while (lua_next(L, s) != 0) {
         // key at index -2 and value at index -1
         if (lua_type(L, -1) == LUA_TSTRING) {
-            QString hint = lua_tostring(L, -1);
+            QString const hint = lua_tostring(L, -1);
             hintList << hint;
         }
         // removes value, but keeps key for next iteration
@@ -11050,7 +11050,7 @@ int TLuaInterpreter::echoPopup(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#echoLink
 int TLuaInterpreter::echoLink(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     int funcRef{0};
     bool useCurrentFormat{false};
     QString windowName{qsl("main")};
@@ -11140,7 +11140,7 @@ int TLuaInterpreter::setMergeTables(lua_State* L)
     Host& host = getHostFromLua(L);
 
     QStringList modulesList;
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     for (int i = 1; i <= n; i++) {
         modulesList << getVerifiedString(L, __func__, i, "module");
     }
@@ -11158,7 +11158,7 @@ int TLuaInterpreter::pasteWindow(lua_State* L)
         lua_pushfstring(L, "pasteWindow: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
     Host& host = getHostFromLua(L);
     host.pasteWindow(windowName);
     return 0;
@@ -11167,7 +11167,7 @@ int TLuaInterpreter::pasteWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#openUrl
 int TLuaInterpreter::openUrl(lua_State* L)
 {
-    QString url = getVerifiedString(L, __func__, 1, "url");
+    QString const url = getVerifiedString(L, __func__, 1, "url");
     QDesktopServices::openUrl(url);
     return 0;
 }
@@ -11177,7 +11177,7 @@ int TLuaInterpreter::setLabelStyleSheet(lua_State* L)
 {
     std::string label = getVerifiedString(L, __func__, 1, "label").toStdString();
     std::string markup = getVerifiedString(L, __func__, 2, "markup").toStdString();
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     host.mpConsole->setLabelStyleSheet(label, markup);
     return 0;
 }
@@ -11185,8 +11185,8 @@ int TLuaInterpreter::setLabelStyleSheet(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getLabelStyleSheet
 int TLuaInterpreter::getLabelStyleSheet(lua_State* L)
 {
-    QString label = getVerifiedString(L, __func__, 1, "label");
-    Host& host = getHostFromLua(L);
+    QString const label = getVerifiedString(L, __func__, 1, "label");
+    Host const& host = getHostFromLua(L);
     if (auto stylesheet = host.mpConsole->getLabelStyleSheet(label)) {
         lua_pushstring(L, stylesheet->toUtf8().constData());
         return 1;
@@ -11200,9 +11200,9 @@ int TLuaInterpreter::getLabelStyleSheet(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setUserWindowStyleSheet
 int TLuaInterpreter::setUserWindowStyleSheet(lua_State* L)
 {
-    QString userWindowName = getVerifiedString(L, __func__, 1, "userwindow name");
-    QString userWindowStyleSheet = getVerifiedString(L, __func__, 2, "StyleSheet");
-    Host& host = getHostFromLua(L);
+    QString const userWindowName = getVerifiedString(L, __func__, 1, "userwindow name");
+    QString const userWindowStyleSheet = getVerifiedString(L, __func__, 2, "StyleSheet");
+    Host const& host = getHostFromLua(L);
 
     if (auto [success, message] = host.mpConsole->setUserWindowStyleSheet(userWindowName, userWindowStyleSheet); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -11215,10 +11215,10 @@ int TLuaInterpreter::setUserWindowStyleSheet(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getCustomEnvColorTable
 int TLuaInterpreter::getCustomEnvColorTable(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap->mCustomEnvColors.empty()) {
         lua_newtable(L);
-        QList<int> colorList = host.mpMap->mCustomEnvColors.keys();
+        QList<int> const colorList = host.mpMap->mCustomEnvColors.keys();
         for (auto idx : colorList) {
             lua_pushnumber(L, idx);
             lua_newtable(L);
@@ -11258,9 +11258,9 @@ int TLuaInterpreter::getCustomEnvColorTable(lua_State* L)
 int TLuaInterpreter::getMudletVersion(lua_State* L)
 {
     QByteArray version = QByteArray(APP_VERSION).trimmed();
-    QByteArray build = QByteArray(APP_BUILD).trimmed();
+    QByteArray const build = QByteArray(APP_BUILD).trimmed();
 
-    QList<QByteArray> versionData = version.split('.');
+    QList<QByteArray> const versionData = version.split('.');
     if (versionData.size() != 3) {
         qWarning() << "TLuaInterpreter::getMudletVersion(): ERROR: Version data not correctly set on compilation,\n"
                    << "   is the VERSION value in the project file present?";
@@ -11288,10 +11288,10 @@ int TLuaInterpreter::getMudletVersion(lua_State* L)
         return lua_error(L);
     }
 
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
 
     if (n == 1) {
-        QString tidiedWhat = getVerifiedString(L, __func__, 1, "style", true).toLower().trimmed();
+        QString const tidiedWhat = getVerifiedString(L, __func__, 1, "style", true).toLower().trimmed();
         if (tidiedWhat.contains("major")) {
             lua_pushinteger(L, major);
         } else if (tidiedWhat.contains("minor")) {
@@ -11352,7 +11352,7 @@ int TLuaInterpreter::getMudletVersion(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#openWebPage
 int TLuaInterpreter::openWebPage(lua_State* L)
 {
-    QString url = getVerifiedString(L, __func__, 1, "URL");
+    QString const url = getVerifiedString(L, __func__, 1, "URL");
     lua_pushboolean(L, mudlet::self()->openWebPage(url));
     return 1;
 }
@@ -11373,7 +11373,7 @@ int TLuaInterpreter::setDiscordApplicationID(lua_State* L)
         lua_pushboolean(L, true);
         return 1;
     }
-    QString inputText = getVerifiedString(L, __func__, 1, "Discord application ID").trimmed();
+    QString const inputText = getVerifiedString(L, __func__, 1, "Discord application ID").trimmed();
     // Treat it as a UTF-8 string because although it is likely to be an
     // unsigned long long integer (0 to 18446744073709551615) we want to
     // be able to handle any input so we can report bad input strings back.
@@ -11386,9 +11386,9 @@ int TLuaInterpreter::setDiscordApplicationID(lua_State* L)
         return 1;
     }
     bool isOk = false;
-    quint64 numericEquivalent = inputText.toULongLong(&isOk);
+    quint64 const numericEquivalent = inputText.toULongLong(&isOk);
     if (numericEquivalent && isOk) {
-        QString appID = QString::number(numericEquivalent);
+        QString const appID = QString::number(numericEquivalent);
         if (pMudlet->mDiscord.setApplicationID(&host, appID)) {
             lua_pushboolean(L, true);
             return 1;
@@ -11407,8 +11407,8 @@ int TLuaInterpreter::setDiscordGameUrl(lua_State* L)
     // in order to respect privacy.
     mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
-    bool isActiveHost = (pMudlet->mpCurrentActiveHost == &host);
-    int args = lua_gettop(L);
+    bool const isActiveHost = (pMudlet->mpCurrentActiveHost == &host);
+    int const args = lua_gettop(L);
 
     if (!args) { // no args, blank the invite URL and game name
         host.setDiscordInviteURL(QString());
@@ -11654,7 +11654,7 @@ int TLuaInterpreter::setDiscordGame(lua_State* L)
         return warnArgumentValue(L, __func__, "access to Discord large icon is disabled in settings for privacy");
     }
 
-    QString gamename = getVerifiedString(L, __func__, 1, "game name");
+    QString const gamename = getVerifiedString(L, __func__, 1, "game name");
     pMudlet->mDiscord.setDetailText(&host, tr("Playing %1").arg(gamename));
     pMudlet->mDiscord.setLargeImage(&host, gamename.toLower());
     lua_pushboolean(L, true);
@@ -11713,7 +11713,7 @@ int TLuaInterpreter::setDiscordElapsedStartTime(lua_State* L)
         return warnArgumentValue(L, __func__, "access to Discord time is disabled in settings for privacy");
     }
 
-    int64_t timeStamp = getVerifiedInt(L, __func__, 1, "epoch time");
+    int64_t const timeStamp = getVerifiedInt(L, __func__, 1, "epoch time");
     if (timeStamp < 0) {
         return warnArgumentValue(L, __func__, "the timestamp must be zero to clear the 'elapsed:' time or an epoch time value from the recent past");
     }
@@ -11735,7 +11735,7 @@ int TLuaInterpreter::setDiscordRemainingEndTime(lua_State* L)
         return warnArgumentValue(L, __func__, "access to Discord time is disabled in settings for privacy");
     }
 
-    int64_t timeStamp = getVerifiedInt(L, __func__, 1, "epoch time");
+    int64_t const timeStamp = getVerifiedInt(L, __func__, 1, "epoch time");
 
     if (timeStamp < 0) {
         return warnArgumentValue(L, __func__, "the timestamp must be zero to clear the 'remaining:' time or an epoch time value in the recent future");
@@ -11757,7 +11757,7 @@ int TLuaInterpreter::getDiscordTimeStamps(lua_State* L)
         return warnArgumentValue(L, __func__, "access to Discord time is disabled in settings for privacy");
     }
 
-    QPair<int64_t, int64_t> timeStamps = mudlet::self()->mDiscord.getTimeStamps(&host);
+    QPair<int64_t, int64_t> const timeStamps = mudlet::self()->mDiscord.getTimeStamps(&host);
     lua_pushnumber(L, timeStamps.first);
     lua_pushnumber(L, timeStamps.second);
     return 2;
@@ -11776,7 +11776,7 @@ int TLuaInterpreter::setDiscordParty(lua_State* L)
         return warnArgumentValue(L, __func__, "access to Discord party info is disabled in settings for privacy");
     }
 
-    int64_t partySize = getVerifiedInt(L, __func__, 1, "current party size");
+    int64_t const partySize = getVerifiedInt(L, __func__, 1, "current party size");
     if (partySize < 0) {
         return warnArgumentValue(L, __func__, "the current party size must be zero or more");
     }
@@ -11810,7 +11810,7 @@ int TLuaInterpreter::getDiscordParty(lua_State* L)
         return warnArgumentValue(L, __func__, "access to Discord party info is disabled in settings for privacy");
     }
 
-    QPair<int, int> partyValues = pMudlet->mDiscord.getParty(&host);
+    QPair<int, int> const partyValues = pMudlet->mDiscord.getParty(&host);
     lua_pushnumber(L, partyValues.first);
     lua_pushnumber(L, partyValues.second);
     return 2;
@@ -11830,7 +11830,7 @@ int TLuaInterpreter::resetDiscordData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getTime
 int TLuaInterpreter::getTime(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     bool return_string = false;
     QString format = qsl("yyyy.MM.dd hh:mm:ss.zzz");
     QString tm;
@@ -11840,13 +11840,13 @@ int TLuaInterpreter::getTime(lua_State* L)
             format = getVerifiedString(L, __func__, 2, "custom time format");
         }
     }
-    QDateTime time = QDateTime::currentDateTime();
+    QDateTime const time = QDateTime::currentDateTime();
     if (return_string) {
         tm = time.toString(format);
         lua_pushstring(L, tm.toUtf8().constData());
     } else {
-        QDate dt = time.date();
-        QTime tm = time.time();
+        QDate const dt = time.date();
+        QTime const tm = time.time();
         lua_createtable(L, 0, 4);
         lua_pushstring(L, "hour");
         lua_pushinteger(L, tm.hour());
@@ -11883,7 +11883,7 @@ int TLuaInterpreter::getEpoch(lua_State *L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#appendBuffer
 int TLuaInterpreter::appendBuffer(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->appendBuffer();
     return 0;
@@ -11892,16 +11892,16 @@ int TLuaInterpreter::appendBuffer(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#appendCmdLine
 int TLuaInterpreter::appendCmdLine(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     QString name = "main";
 
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
     }
-    QString text = getVerifiedString(L, __func__, n, "text to set on command line");
+    QString const text = getVerifiedString(L, __func__, n, "text to set on command line");
     auto pN = COMMANDLINE(L, name);
 
-    QString curText = pN->toPlainText();
+    QString const curText = pN->toPlainText();
     pN->setPlainText(curText + text);
     QTextCursor cur = pN->textCursor();
     cur.clearSelection();
@@ -11914,7 +11914,7 @@ int TLuaInterpreter::appendCmdLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#selectCmdLineText
 int TLuaInterpreter::selectCmdLineText(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     QString name = "main";
     if (n >= 1) {
         name = CMDLINE_NAME(L, 1);
@@ -11927,13 +11927,13 @@ int TLuaInterpreter::selectCmdLineText(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getCmdLine
 int TLuaInterpreter::getCmdLine(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     QString name = "main";
     if (n >= 1) {
         name = CMDLINE_NAME(L, 1);
     }
     auto commandline = COMMANDLINE(L, name);
-    QString text = commandline->toPlainText();
+    QString const text = commandline->toPlainText();
     lua_pushstring(L, text.toUtf8().constData());
     return 1;
 }
@@ -11941,12 +11941,12 @@ int TLuaInterpreter::getCmdLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addCmdLineSuggestion
 int TLuaInterpreter::addCmdLineSuggestion(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     QString name = "main";
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
     }
-    QString text = getVerifiedString(L, __func__, n, "suggestion text");
+    QString const text = getVerifiedString(L, __func__, n, "suggestion text");
     auto pN = COMMANDLINE(L, name);
     pN->addSuggestion(text);
     return 0;
@@ -11955,12 +11955,12 @@ int TLuaInterpreter::addCmdLineSuggestion(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#removeCmdLineSuggestion
 int TLuaInterpreter::removeCmdLineSuggestion(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     QString name = "main";
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
     }
-    QString text = getVerifiedString(L, __func__, n, "suggestion text");
+    QString const text = getVerifiedString(L, __func__, n, "suggestion text");
     auto pN = COMMANDLINE(L, name);
     pN->removeSuggestion(text);
     return 0;
@@ -11969,7 +11969,7 @@ int TLuaInterpreter::removeCmdLineSuggestion(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearCmdLineSuggestions
 int TLuaInterpreter::clearCmdLineSuggestions(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     QString name = "main";
     if (n == 1) {
         name = CMDLINE_NAME(L, 1);
@@ -11981,12 +11981,12 @@ int TLuaInterpreter::clearCmdLineSuggestions(lua_State* L)
 
 int TLuaInterpreter::addCmdLineBlacklist(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     QString name = "main";
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
     }
-    QString text = getVerifiedString(L, __func__, n, "suggestion text");
+    QString const text = getVerifiedString(L, __func__, n, "suggestion text");
     auto pN = COMMANDLINE(L, name);
     pN->addBlacklist(text);
     return 0;
@@ -11994,12 +11994,12 @@ int TLuaInterpreter::addCmdLineBlacklist(lua_State* L)
 
 int TLuaInterpreter::removeCmdLineBlacklist(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     QString name = "main";
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
     }
-    QString text = getVerifiedString(L, __func__, n, "suggestion text");
+    QString const text = getVerifiedString(L, __func__, n, "suggestion text");
     auto pN = COMMANDLINE(L, name);
     pN->removeBlacklist(text);
     return 0;
@@ -12007,7 +12007,7 @@ int TLuaInterpreter::removeCmdLineBlacklist(lua_State* L)
 
 int TLuaInterpreter::clearCmdLineBlacklist(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     QString name = "main";
     if (n == 1) {
         name = CMDLINE_NAME(L, 1);
@@ -12020,7 +12020,7 @@ int TLuaInterpreter::clearCmdLineBlacklist(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#installPackage
 int TLuaInterpreter::installPackage(lua_State* L)
 {
-    QString location = getVerifiedString(L, __func__, 1, "package location path and file name");
+    QString const location = getVerifiedString(L, __func__, 1, "package location path and file name");
     Host& host = getHostFromLua(L);
     if (auto [success, message] = host.installPackage(location, 0); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -12031,7 +12031,7 @@ int TLuaInterpreter::installPackage(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#uninstallPackage
 int TLuaInterpreter::uninstallPackage(lua_State* L)
 {
-    QString packageName = getVerifiedString(L, __func__, 1, "package name");
+    QString const packageName = getVerifiedString(L, __func__, 1, "package name");
     Host& host = getHostFromLua(L);
     host.uninstallPackage(packageName, 0);
     return 0;
@@ -12040,9 +12040,9 @@ int TLuaInterpreter::uninstallPackage(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#installModule
 int TLuaInterpreter::installModule(lua_State* L)
 {
-    QString modName = getVerifiedString(L, __func__, 1, "module location");
+    QString const modName = getVerifiedString(L, __func__, 1, "module location");
     Host& host = getHostFromLua(L);
-    QString module = QDir::fromNativeSeparators(modName);
+    QString const module = QDir::fromNativeSeparators(modName);
 
     if (auto [success, message] = host.installPackage(module, 3); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -12058,7 +12058,7 @@ int TLuaInterpreter::installModule(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#uninstallModule
 int TLuaInterpreter::uninstallModule(lua_State* L)
 {
-    QString module = getVerifiedString(L, __func__, 1, "module name");
+    QString const module = getVerifiedString(L, __func__, 1, "module name");
     Host& host = getHostFromLua(L);
     if (!host.uninstallPackage(module, 3)) {
         lua_pushboolean(L, false);
@@ -12075,7 +12075,7 @@ int TLuaInterpreter::uninstallModule(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#reloadModule
 int TLuaInterpreter::reloadModule(lua_State* L)
 {
-    QString module = getVerifiedString(L, __func__, 1, "module name");
+    QString const module = getVerifiedString(L, __func__, 1, "module name");
     Host& host = getHostFromLua(L);
     host.reloadModule(module);
     return 0;
@@ -12084,7 +12084,7 @@ int TLuaInterpreter::reloadModule(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableModuleSync
 int TLuaInterpreter::enableModuleSync(lua_State* L)
 {
-    QString module = getVerifiedString(L, __func__, 1, "module name");
+    QString const module = getVerifiedString(L, __func__, 1, "module name");
     Host& host = getHostFromLua(L);
     if (auto [success, message] = host.changeModuleSync(module, QLatin1String("1")); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -12092,7 +12092,7 @@ int TLuaInterpreter::enableModuleSync(lua_State* L)
 
     auto moduleManager = host.mpModuleManager;
     if (moduleManager && !moduleManager->moduleTable->findItems(module, Qt::MatchExactly).isEmpty()) {
-        int row = moduleManager->moduleTable->findItems(module, Qt::MatchExactly)[0]->row();
+        int const row = moduleManager->moduleTable->findItems(module, Qt::MatchExactly)[0]->row();
         auto checkItem = moduleManager->moduleTable->item(row, 2);
         checkItem->setCheckState(Qt::Checked);
     }
@@ -12104,7 +12104,7 @@ int TLuaInterpreter::enableModuleSync(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableModuleSync
 int TLuaInterpreter::disableModuleSync(lua_State* L)
 {
-    QString module = getVerifiedString(L, __func__, 1, "module name");
+    QString const module = getVerifiedString(L, __func__, 1, "module name");
     Host& host = getHostFromLua(L);
     if (auto [success, message] = host.changeModuleSync(module, QLatin1String("0")); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -12112,7 +12112,7 @@ int TLuaInterpreter::disableModuleSync(lua_State* L)
 
     auto moduleManager = host.mpModuleManager;
     if (moduleManager && !moduleManager->moduleTable->findItems(module, Qt::MatchExactly).isEmpty()) {
-        int row = moduleManager->moduleTable->findItems(module, Qt::MatchExactly)[0]->row();
+        int const row = moduleManager->moduleTable->findItems(module, Qt::MatchExactly)[0]->row();
         auto checkItem = moduleManager->moduleTable->item(row, 2);
         checkItem->setCheckState(Qt::Unchecked);
     }
@@ -12124,7 +12124,7 @@ int TLuaInterpreter::disableModuleSync(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getModuleSync
 int TLuaInterpreter::getModuleSync(lua_State* L)
 {
-    QString module = getVerifiedString(L, __func__, 1, "module name");
+    QString const module = getVerifiedString(L, __func__, 1, "module name");
     Host& host = getHostFromLua(L);
     if (auto [success, message] = host.getModuleSync(module); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -12141,7 +12141,7 @@ int TLuaInterpreter::getModuleSync(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getPackages
 int TLuaInterpreter::getPackages(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     auto packages = host.mInstalledPackages;
     lua_newtable(L);
     for (int i = 0; i < packages.size(); i++) {
@@ -12155,7 +12155,7 @@ int TLuaInterpreter::getPackages(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getModules
 int TLuaInterpreter::getModules(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     auto modules = host.mInstalledModules;
     int counter = 0;
     QMap<QString, QStringList>::const_iterator iter = modules.constBegin();
@@ -12172,10 +12172,10 @@ int TLuaInterpreter::getModules(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getModuleInfo
 int TLuaInterpreter::getModuleInfo(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     auto infoMap = host.mModuleInfo;
-    int n = lua_gettop(L);
-    QString name = getVerifiedString(L, __func__, 1, "module name");
+    int const n = lua_gettop(L);
+    QString const name = getVerifiedString(L, __func__, 1, "module name");
     QString info;
     if (n > 1) {
         info = getVerifiedString(L, __func__, 2, "info", true);
@@ -12198,10 +12198,10 @@ int TLuaInterpreter::getModuleInfo(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getPackageInfo
 int TLuaInterpreter::getPackageInfo(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     auto infoMap = host.mPackageInfo;
-    int n = lua_gettop(L);
-    QString name = getVerifiedString(L, __func__, 1, "package name");
+    int const n = lua_gettop(L);
+    QString const name = getVerifiedString(L, __func__, 1, "package name");
     QString info;
     if (n > 1) {
         info = getVerifiedString(L, __func__, 2, "info", true);
@@ -12225,9 +12225,9 @@ int TLuaInterpreter::getPackageInfo(lua_State* L)
 int TLuaInterpreter::setModuleInfo(lua_State* L)
 {
   Host& host = getHostFromLua(L);
-  QString moduleName = getVerifiedString(L, __func__, 1, "module name");
-  QString info = getVerifiedString(L, __func__, 2, "info");
-  QString value = getVerifiedString(L, __func__, 3, "value");
+  QString const moduleName = getVerifiedString(L, __func__, 1, "module name");
+  QString const info = getVerifiedString(L, __func__, 2, "info");
+  QString const value = getVerifiedString(L, __func__, 3, "value");
   host.mModuleInfo[moduleName][info] = value;
   lua_pushboolean(L, true);
   return 1;
@@ -12237,9 +12237,9 @@ int TLuaInterpreter::setModuleInfo(lua_State* L)
 int TLuaInterpreter::setPackageInfo(lua_State* L)
 {
   Host& host = getHostFromLua(L);
-  QString packageName = getVerifiedString(L, __func__, 1, "package name");
-  QString info = getVerifiedString(L, __func__, 2, "info");
-  QString value = getVerifiedString(L, __func__, 3, "value");
+  QString const packageName = getVerifiedString(L, __func__, 1, "package name");
+  QString const info = getVerifiedString(L, __func__, 2, "info");
+  QString const value = getVerifiedString(L, __func__, 3, "value");
   host.mPackageInfo[packageName][info] = value;
   lua_pushboolean(L, true);
   return 1;
@@ -12248,12 +12248,12 @@ int TLuaInterpreter::setPackageInfo(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setDefaultAreaVisible
 int TLuaInterpreter::setDefaultAreaVisible(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    bool isToShowDefaultArea = getVerifiedBool(L, __func__, 1, "isToShowDefaultArea");
+    bool const isToShowDefaultArea = getVerifiedBool(L, __func__, 1, "isToShowDefaultArea");
     if (host.mpMap->mpMapper) {
         // If we are re-enabling the display of the default area
         // AND the mapper was showing the default area
@@ -12283,8 +12283,8 @@ int TLuaInterpreter::setDefaultAreaVisible(lua_State* L)
 // this function to get called events.
 int TLuaInterpreter::registerAnonymousEventHandler(lua_State* L)
 {
-    QString event = getVerifiedString(L, __func__, 1, "event name");
-    QString func = getVerifiedString(L, __func__, 2, "function name");
+    QString const event = getVerifiedString(L, __func__, 1, "event name");
+    QString const func = getVerifiedString(L, __func__, 2, "function name");
     Host& host = getHostFromLua(L);
     host.registerAnonymousEventHandler(event, func);
     return 0;
@@ -12293,7 +12293,7 @@ int TLuaInterpreter::registerAnonymousEventHandler(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#expandAlias
 int TLuaInterpreter::expandAlias(lua_State* L)
 {
-    QString payload = getVerifiedString(L, __func__, 1, "text to parse");
+    QString const payload = getVerifiedString(L, __func__, 1, "text to parse");
     bool wantPrint = true;
     if (lua_gettop(L) > 1) {
         // check if the 2nd argument is a 'false', but don't match if it is 'nil'
@@ -12315,12 +12315,12 @@ int TLuaInterpreter::expandAlias(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#printCmdLine
 int TLuaInterpreter::printCmdLine(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     QString name = "main";
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
     }
-    QString text = getVerifiedString(L, __func__, n, "text to set on command line");
+    QString const text = getVerifiedString(L, __func__, n, "text to set on command line");
 
     auto pN = COMMANDLINE(L, name);
     pN->setPlainText(text);
@@ -12334,7 +12334,7 @@ int TLuaInterpreter::printCmdLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearCmdLine
 int TLuaInterpreter::clearCmdLine(lua_State* L)
 {
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     QString name = "main";
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
@@ -12350,7 +12350,7 @@ int TLuaInterpreter::clearCmdLine(lua_State* L)
 // encoded in the required Mud Server encoding.
 int TLuaInterpreter::sendRaw(lua_State* L)
 {
-    QString text = getVerifiedString(L, __func__, 1, "command");
+    QString const text = getVerifiedString(L, __func__, 1, "command");
     bool wantPrint = true;
     if (lua_gettop(L) > 1) {
         wantPrint = getVerifiedBool(L, __func__, 2, "showOnScreen", true);
@@ -12382,8 +12382,8 @@ int TLuaInterpreter::sendSocket(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#sendIrc
 int TLuaInterpreter::sendIrc(lua_State* L)
 {
-    QString target = getVerifiedString(L, __func__, 1, "target");
-    QString msg = getVerifiedString(L, __func__, 2, "message");
+    QString const target = getVerifiedString(L, __func__, 1, "target");
+    QString const msg = getVerifiedString(L, __func__, 2, "message");
 
     Host* pHost = &getHostFromLua(L);
     if (!pHost->mpDlgIRC) {
@@ -12398,7 +12398,7 @@ int TLuaInterpreter::sendIrc(lua_State* L)
         return warnArgumentValue(L, __func__, "not ready to send just yet");
     }
 
-    QPair<bool, QString> result = pHost->mpDlgIRC->sendMsg(target, msg);
+    QPair<bool, QString> const result = pHost->mpDlgIRC->sendMsg(target, msg);
 
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
@@ -12458,7 +12458,7 @@ int TLuaInterpreter::getIrcChannels(lua_State* L)
     }
 
     lua_newtable(L);
-    int total = channels.count();
+    int const total = channels.count();
     for (int i = 0; i < total; ++i) {
         lua_pushnumber(L, i + 1);
         lua_pushstring(L, channels[i].toUtf8().data());
@@ -12493,13 +12493,13 @@ int TLuaInterpreter::getIrcConnectedHost(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setIrcNick
 int TLuaInterpreter::setIrcNick(lua_State* L)
 {
-    QString nick = getVerifiedString(L, __func__, 1, "nick");
+    QString const nick = getVerifiedString(L, __func__, 1, "nick");
     if (nick.isEmpty()) {
         return warnArgumentValue(L, __func__, "nick must not be empty");
     }
 
     Host* pHost = &getHostFromLua(L);
-    QPair<bool, QString> result = dlgIRC::writeIrcNickName(pHost, nick);
+    QPair<bool, QString> const result = dlgIRC::writeIrcNickName(pHost, nick);
     if (!result.first) {
         return warnArgumentValue(L, __func__, qsl("unable to save nick name, reason: %1").arg(result.second));
     }
@@ -12511,11 +12511,11 @@ int TLuaInterpreter::setIrcNick(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setIrcServer
 int TLuaInterpreter::setIrcServer(lua_State* L)
 {
-    int args = lua_gettop(L);
+    int const args = lua_gettop(L);
     int secure = false;
     int port = 6667;
     QString password;
-    std::string addr = getVerifiedString(L, __func__, 1, "hostname").toStdString();
+    std::string const addr = getVerifiedString(L, __func__, 1, "hostname").toStdString();
     if (addr.empty()) {
         return warnArgumentValue(L, __func__, "hostname must not be empty");
     }
@@ -12570,7 +12570,7 @@ int TLuaInterpreter::setIrcChannels(lua_State* L)
     while (lua_next(L, 1) != 0) {
         // key at index -2 and value at index -1
         if (lua_type(L, -1) == LUA_TSTRING) {
-            QString c = lua_tostring(L, -1);
+            QString const c = lua_tostring(L, -1);
             if (!c.isEmpty() && (c.startsWith(QLatin1String("#")) || c.startsWith(QLatin1String("&")) || c.startsWith(QLatin1String("+")))) {
                 newchannels << c;
             }
@@ -12583,7 +12583,7 @@ int TLuaInterpreter::setIrcChannels(lua_State* L)
     }
 
     Host* pHost = &getHostFromLua(L);
-    QPair<bool, QString> result = dlgIRC::writeIrcChannels(pHost, newchannels);
+    QPair<bool, QString> const result = dlgIRC::writeIrcChannels(pHost, newchannels);
     if (!result.first) {
         return warnArgumentValue(L, __func__, qsl("unable to save channels, reason: %1").arg(result.second));
     }
@@ -12617,7 +12617,7 @@ int TLuaInterpreter::ttsSpeak(lua_State* L)
         return warnArgumentValue(L, __func__, qsl("skipped empty text to speak (TTS)"));
     }
 
-    std::vector<QString> dontSpeak = {"<", ">", "&lt;", "&gt;"}; // discussion: https://github.com/Mudlet/Mudlet/issues/4689
+    std::vector<QString> const dontSpeak = {"<", ">", "&lt;", "&gt;"}; // discussion: https://github.com/Mudlet/Mudlet/issues/4689
     for (const QString& dropThis : dontSpeak) {
         if (textToSay.contains(dropThis)) {
             textToSay.replace(dropThis, QString());
@@ -12765,7 +12765,7 @@ int TLuaInterpreter::ttsGetPitch(lua_State* L)
 int TLuaInterpreter::ttsGetVoices(lua_State* L)
 {
     TLuaInterpreter::ttsBuild();
-    QVector<QVoice> speechVoices = speechUnit->availableVoices();
+    QVector<QVoice> const speechVoices = speechUnit->availableVoices();
     int i = 0;
     lua_newtable(L);
     for (const QVoice& voice : speechVoices) {
@@ -12780,7 +12780,7 @@ int TLuaInterpreter::ttsGetVoices(lua_State* L)
 int TLuaInterpreter::ttsGetCurrentVoice(lua_State* L)
 {
     TLuaInterpreter::ttsBuild();
-    QString currentVoice = speechUnit->voice().name();
+    QString const currentVoice = speechUnit->voice().name();
     lua_pushstring(L, currentVoice.toUtf8().constData());
     return 1;
 }
@@ -12789,9 +12789,9 @@ int TLuaInterpreter::ttsGetCurrentVoice(lua_State* L)
 int TLuaInterpreter::ttsSetVoiceByName(lua_State* L)
 {
     TLuaInterpreter::ttsBuild();
-    QString nextVoice = getVerifiedString(L, __func__, 1, "voice");
+    QString const nextVoice = getVerifiedString(L, __func__, 1, "voice");
 
-    QVector<QVoice> speechVoices = speechUnit->availableVoices();
+    QVector<QVoice> const speechVoices = speechUnit->availableVoices();
     for (auto voice : speechVoices) {
         if (voice.name() == nextVoice) {
             speechUnit->setVoice(voice);
@@ -12891,7 +12891,7 @@ int TLuaInterpreter::ttsQueue(lua_State* L)
         return warnArgumentValue(L, __func__, qsl("skipped empty text to speak (TTS)"));
     }
 
-    std::vector<QString> dontSpeak = {"<", ">", "&lt;", "&gt;"}; // discussion: https://github.com/Mudlet/Mudlet/issues/4689
+    std::vector<QString> const dontSpeak = {"<", ">", "&lt;", "&gt;"}; // discussion: https://github.com/Mudlet/Mudlet/issues/4689
     for (const QString& dropThis : dontSpeak) {
         if (inputText.contains(dropThis)) {
             inputText.replace(dropThis, QString());
@@ -13057,8 +13057,8 @@ int TLuaInterpreter::setServerEncoding(lua_State* L)
         lua_pushfstring(L, "setServerEncoding: bad argument #1 type (newEncoding as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QByteArray newEncoding = lua_tostring(L, 1);
-    QPair<bool, QString> results = host.mTelnet.setEncoding(newEncoding);
+    QByteArray const newEncoding = lua_tostring(L, 1);
+    QPair<bool, QString> const results = host.mTelnet.setEncoding(newEncoding);
 
     if (!results.first) {
         return warnArgumentValue(L, __func__, results.second);
@@ -13071,7 +13071,7 @@ int TLuaInterpreter::setServerEncoding(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getServerEncoding
 int TLuaInterpreter::getServerEncoding(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
 
     // don't leak if we're using a Mudlet or a Qt-supplied codec to Lua
     auto sanitizeEncoding = [] (auto encodingName) {
@@ -13092,7 +13092,7 @@ int TLuaInterpreter::getServerEncoding(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getServerEncodingsList
 int TLuaInterpreter::getServerEncodingsList(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
 
     // don't leak if we're using a Mudlet or a Qt-supplied codec to Lua
     auto sanitizeEncoding = [] (auto encodingName) {
@@ -13204,7 +13204,7 @@ bool TLuaInterpreter::compileAndExecuteScript(const QString& code)
     }
     lua_State* L = pGlobalLua;
 
-    int error = luaL_dostring(L, code.toUtf8().constData());
+    int const error = luaL_dostring(L, code.toUtf8().constData());
     if (error) {
         std::string e = "no error message available from Lua";
         if (lua_isstring(L, 1)) {
@@ -13214,8 +13214,8 @@ bool TLuaInterpreter::compileAndExecuteScript(const QString& code)
         if (mudlet::smDebugMode) {
             qDebug() << "LUA ERROR: code did not compile: ERROR:" << e.c_str();
         }
-        QString _n = "error in Lua code";
-        QString _n2 = "no debug data available";
+        QString const _n = "error in Lua code";
+        QString const _n2 = "no debug data available";
         logError(e, _n, _n2);
     }
 
@@ -13251,8 +13251,8 @@ QString TLuaInterpreter::formatLuaCode(const QString &code)
     // escape newlines so they don't interpreted as newlines, but instead get passed onto the function
     escapedCode.replace(QLatin1String("\n"), QLatin1String("\\n"));
 
-    QString thing = QString(R"(return get_formatted_code(get_ast("%1"), {indent_chunk = '  ', right_margin = 100, max_text_width = 160, keep_comments = true}))").arg(escapedCode);
-    int error = luaL_dostring(L, thing.toUtf8().constData());
+    QString const thing = QString(R"(return get_formatted_code(get_ast("%1"), {indent_chunk = '  ', right_margin = 100, max_text_width = 160, keep_comments = true}))").arg(escapedCode);
+    int const error = luaL_dostring(L, thing.toUtf8().constData());
     if (error) {
         std::string e = "no error message available from Lua";
         if (lua_isstring(L, 1)) {
@@ -13262,8 +13262,8 @@ QString TLuaInterpreter::formatLuaCode(const QString &code)
         if (mudlet::smDebugMode) {
             qDebug() << "LUA ERROR: code did not compile: ERROR:" << e.c_str();
         }
-        QString objectName = "error in Lua code";
-        QString functionName = "no debug data available";
+        QString const objectName = "error in Lua code";
+        QString const functionName = "no debug data available";
         logError(e, objectName, functionName);
         lua_pop(L, lua_gettop(L));
         return code;
@@ -13279,7 +13279,7 @@ bool TLuaInterpreter::compile(const QString& code, QString& errorMsg, const QStr
 {
     lua_State* L = pGlobalLua;
 
-    int error = (luaL_loadbuffer(L, code.toUtf8().constData(),
+    int const error = (luaL_loadbuffer(L, code.toUtf8().constData(),
                                  strlen(code.toUtf8().constData()),
                                  name.toUtf8().constData()) || lua_pcall(L, 0, 0, 0));
 
@@ -13315,7 +13315,7 @@ std::pair<bool, QString> TLuaInterpreter::validateLuaCodeParam(int index)
     if (!lua_isstring(L, index)) {
         return {false, qsl("lua script as string expected, got %1!").arg(luaL_typename(L, index))};
     }
-    QString script{lua_tostring(L, index)};
+    QString const script{lua_tostring(L, index)};
     return validLuaCode(script);
 }
 
@@ -13325,8 +13325,8 @@ std::pair<bool, QString> TLuaInterpreter::validateLuaCodeParam(int index)
 std::pair<bool, QString> TLuaInterpreter::validLuaCode(const QString &code)
 {
     lua_State* L = pGlobalLua;
-    int error = luaL_loadbuffer(L, code.toUtf8().constData(), strlen(code.toUtf8().constData()), code.toUtf8().data());
-    int topElementIndex = lua_gettop(L);
+    int const error = luaL_loadbuffer(L, code.toUtf8().constData(), strlen(code.toUtf8().constData()), code.toUtf8().data());
+    int const topElementIndex = lua_gettop(L);
     QString e = "invalid Lua code: ";
     if (error) {
         if (lua_isstring(L, topElementIndex)) {
@@ -13510,7 +13510,7 @@ TLuaInterpreter::signalMXPEvent(const QString &type, const QMap<QString, QString
 
     Host &host = getHostFromLua(L);
     if (mudlet::smDebugMode) {
-        QString msg = qsl("\n%1 event <%2> display(%1) to see the full content\n").arg("mxp", token);
+        QString const msg = qsl("\n%1 event <%2> display(%1) to see the full content\n").arg("mxp", token);
         host.mpConsole->printSystemMessage(msg);
     }
     host.raiseEvent(event);
@@ -13579,7 +13579,7 @@ void TLuaInterpreter::parseJSON(QString& key, const QString& string_data, const 
         return;
     }
     int i = 0;
-    for (int total = tokenList.size() - 1; i < total; ++i) {
+    for (int const total = tokenList.size() - 1; i < total; ++i) {
         lua_getfield(L, -1, tokenList.at(i).toUtf8().constData());
         if (!lua_istable(L, -1)) {
             lua_pop(L, 1);
@@ -13615,7 +13615,7 @@ void TLuaInterpreter::parseJSON(QString& key, const QString& string_data, const 
     }
     auto dataInUtf8 = string_data.toUtf8();
     lua_pushlstring(L, dataInUtf8.constData(), dataInUtf8.length());
-    int error = lua_pcall(L, 1, 1, 0);
+    int const error = lua_pcall(L, 1, 1, 0);
     if (!error) {
         // Top of stack should now contain the lua representation of json.
         lua_rawset(L, -3);
@@ -13629,7 +13629,7 @@ void TLuaInterpreter::parseJSON(QString& key, const QString& string_data, const 
             }
             lua_getglobal(L, "gmcp");
             i = 0;
-            for (int total = tokenList.size() - 1; i < total; ++i) {
+            for (int const total = tokenList.size() - 1; i < total; ++i) {
                 lua_getfield(L, -1, tokenList.at(i).toUtf8().constData());
                 lua_remove(L, -2);
             }
@@ -13643,8 +13643,8 @@ void TLuaInterpreter::parseJSON(QString& key, const QString& string_data, const 
                 e = "Lua error:";
                 e += lua_tostring(L, -1);
             }
-            QString _n = "JSON decoder error:";
-            QString _f = "json_to_value";
+            QString const _n = "JSON decoder error:";
+            QString const _f = "json_to_value";
             logError(e, _n, _f);
         }
     }
@@ -13669,20 +13669,20 @@ void TLuaInterpreter::parseJSON(QString& key, const QString& string_data, const 
         event.mArgumentList.append(key);
         event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         if (mudlet::smDebugMode) {
-            QString msg = qsl("\n%1 event <%2> display(%1) to see the full content\n").arg(protocol, token);
+            QString const msg = qsl("\n%1 event <%2> display(%1) to see the full content\n").arg(protocol, token);
             host.mpConsole->printSystemMessage(msg);
         }
         host.raiseEvent(event);
     }
     // auto-detect IRE composer
     if (tokenList.size() == 3 && tokenList.at(0).toLower() == "ire" && tokenList.at(1).toLower() == "composer" && tokenList.at(2).toLower() == "edit") {
-        QRegularExpression rx(qsl(R"lit(\{ ?"title": ?"(.*)", ?"text": ?"(.*)" ?\})lit"));
-        QRegularExpressionMatch match = rx.match(string_data);
+        QRegularExpression const rx(qsl(R"lit(\{ ?"title": ?"(.*)", ?"text": ?"(.*)" ?\})lit"));
+        QRegularExpressionMatch const match = rx.match(string_data);
 
         if (match.capturedStart() != -1) {
-            QString title = match.captured(1);
+            QString const title = match.captured(1);
             QString initialText = match.captured(2);
-            QRegularExpression codeRegex(qsl(R"lit(\\n|\\t|\\"|\\\\|\\u[0-9a-cA-C][0-9a-fA-F]{3}|\\u[dD][0-7][0-9a-fA-F]{2}|\\u[efEF][0-9a-fA-F]{3}|\\u[dD][89abAB][0-9a-fA-F]{2}\\u[dD][c-fC-F][0-9a-fA-F]{2})lit"));
+            QRegularExpression const codeRegex(qsl(R"lit(\\n|\\t|\\"|\\\\|\\u[0-9a-cA-C][0-9a-fA-F]{3}|\\u[dD][0-7][0-9a-fA-F]{2}|\\u[efEF][0-9a-fA-F]{3}|\\u[dD][89abAB][0-9a-fA-F]{2}\\u[dD][c-fC-F][0-9a-fA-F]{2})lit"));
             // We are about to search for 8 escape code strings within the initial text that the game gave us, patterns are:
             // \n  \t  \"  \\ - new line, tab, quote, backslash
             // Then there are three patterns for \uXXXX where XXXX is a 4-digit hexadecimal value
@@ -13763,8 +13763,8 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
                 continue;
             }
 
-            QString msspVAR = payloadList[0];
-            QString msspVAL = payloadList[1];
+            QString const msspVAR = payloadList[0];
+            QString const msspVAL = payloadList[1];
 
             lua_getglobal(L, "mssp");
             lua_pushstring(L, msspVAR.toUtf8().constData());
@@ -13773,7 +13773,7 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
             lua_rawset(L, -3);
 
             // Raise an event
-            QString protocol = qsl("mssp");
+            QString const protocol = qsl("mssp");
             QString token = protocol;
             token.append(".");
             token.append(msspVAR);
@@ -13784,7 +13784,7 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
             event.mArgumentList.append(token);
             event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
             if (mudlet::smDebugMode) {
-                QString msg = qsl("\n%1 event <%2> display(%1) to see the full content\n").arg(protocol, token);
+                QString const msg = qsl("\n%1 event <%2> display(%1) to see the full content\n").arg(protocol, token);
                 host.mpConsole->printSystemMessage(msg);
             }
             host.raiseEvent(event);
@@ -13809,10 +13809,10 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
 void TLuaInterpreter::msdp2Lua(const char* src)
 {
     Host& host = getHostFromLua(pGlobalLua);
-    QByteArray transcodedSrc = host.mTelnet.decodeBytes(src);
+    QByteArray const transcodedSrc = host.mTelnet.decodeBytes(src);
     QStringList varList;
     QByteArray lastVar;
-    int textLength = transcodedSrc.length();
+    int const textLength = transcodedSrc.length();
     int nest = 0;
     quint8 last = 0;
 
@@ -13978,16 +13978,16 @@ bool TLuaInterpreter::call_luafunction(void* pT)
     lua_gettable(L, LUA_REGISTRYINDEX);
     if (lua_isfunction(L, -1)) {
         setMatches(L);
-        int error = lua_pcall(L, 0, LUA_MULTRET, 0);
+        int const error = lua_pcall(L, 0, LUA_MULTRET, 0);
         if (error) {
-            int nbpossible_errors = lua_gettop(L);
+            int const nbpossible_errors = lua_gettop(L);
             for (int i = 1; i <= nbpossible_errors; i++) {
                 std::string e = "";
                 if (lua_isstring(L, i)) {
                     e = "Lua error:";
                     e += lua_tostring(L, i);
-                    QString _n = "error in anonymous Lua function";
-                    QString _n2 = "no debug data available";
+                    QString const _n = "error in anonymous Lua function";
+                    QString const _n2 = "no debug data available";
                     logError(e, _n, _n2);
                     if (mudlet::smDebugMode) {
                         auto& host = getHostFromLua(L);
@@ -14007,8 +14007,8 @@ bool TLuaInterpreter::call_luafunction(void* pT)
 
     }
 
-    QString _n = "error in anonymous Lua function";
-    QString _n2 = "func reference not found by Lua, func cannot be called";
+    QString const _n = "error in anonymous Lua function";
+    QString const _n2 = "func reference not found by Lua, func cannot be called";
     std::string e = "Lua error:";
     logError(e, _n, _n2);
     return false;
@@ -14050,16 +14050,16 @@ std::pair<bool, bool> TLuaInterpreter::callLuaFunctionReturnBool(void* pT)
 
     if (lua_isfunction(L, -1)) {
         setMatches(L);
-        int error = lua_pcall(L, 0, LUA_MULTRET, 0);
+        int const error = lua_pcall(L, 0, LUA_MULTRET, 0);
         if (error) {
-            int nbpossible_errors = lua_gettop(L);
+            int const nbpossible_errors = lua_gettop(L);
             for (int i = 1; i <= nbpossible_errors; i++) {
                 std::string e = "";
                 if (lua_isstring(L, i)) {
                     e = "Lua error:";
                     e += lua_tostring(L, i);
-                    QString _n = "error in anonymous Lua function";
-                    QString _n2 = "no debug data available";
+                    QString const _n = "error in anonymous Lua function";
+                    QString const _n2 = "no debug data available";
                     logError(e, _n, _n2);
                     if (mudlet::smDebugMode) {
                         auto& host = getHostFromLua(L);
@@ -14082,8 +14082,8 @@ std::pair<bool, bool> TLuaInterpreter::callLuaFunctionReturnBool(void* pT)
         return {!error , returnValue};
     }
 
-    QString _n = "error in anonymous Lua function";
-    QString _n2 = "func reference not found by Lua, func cannot be called";
+    QString const _n = "error in anonymous Lua function";
+    QString const _n2 = "func reference not found by Lua, func cannot be called";
     std::string e = "Lua error:";
     logError(e, _n, _n2);
 
@@ -14099,9 +14099,9 @@ bool TLuaInterpreter::call(const QString& function, const QString& mName, const 
     setMatches(L);
 
     lua_getglobal(L, function.toUtf8().constData());
-    int error = lua_pcall(L, 0, LUA_MULTRET, 0);
+    int const error = lua_pcall(L, 0, LUA_MULTRET, 0);
     if (error) {
-        int nbpossible_errors = lua_gettop(L);
+        int const nbpossible_errors = lua_gettop(L);
         for (int i = 1; i <= nbpossible_errors; i++) {
             std::string e = "";
             if (lua_isstring(L, i)) {
@@ -14133,9 +14133,9 @@ std::pair<bool, bool> TLuaInterpreter::callReturnBool(const QString& function, c
     setMatches(L);
 
     lua_getglobal(L, function.toUtf8().constData());
-    int error = lua_pcall(L, 0, LUA_MULTRET, 0);
+    int const error = lua_pcall(L, 0, LUA_MULTRET, 0);
     if (error) {
-        int nbpossible_errors = lua_gettop(L);
+        int const nbpossible_errors = lua_gettop(L);
         for (int i = 1; i <= nbpossible_errors; i++) {
             std::string e = "";
             if (lua_isstring(L, i)) {
@@ -14213,14 +14213,14 @@ bool TLuaInterpreter::callConditionFunction(std::string& function, const QString
     lua_State* L = pGlobalLua;
 
     lua_getfield(L, LUA_GLOBALSINDEX, function.c_str());
-    int error = lua_pcall(L, 0, 1, 0);
+    int const error = lua_pcall(L, 0, 1, 0);
     if (error) {
-        int nbpossible_errors = lua_gettop(L);
+        int const nbpossible_errors = lua_gettop(L);
         for (int i = 1; i <= nbpossible_errors; i++) {
             std::string e = "";
             if (lua_isstring(L, i)) {
                 e += lua_tostring(L, i);
-                QString _f = function.c_str();
+                QString const _f = function.c_str();
                 logError(e, mName, _f);
                 if (mudlet::smDebugMode) {
                     auto& host = getHostFromLua(L);
@@ -14236,7 +14236,7 @@ bool TLuaInterpreter::callConditionFunction(std::string& function, const QString
     }
 
     bool ret = false;
-    int returnValues = lua_gettop(L);
+    int const returnValues = lua_gettop(L);
     if (returnValues > 0) {
         // Lua docs: Like all tests in Lua, lua_toboolean returns 1 for any Lua value different from false and nil; otherwise it returns 0
         // This means trigger patterns don't have to strictly return true or false, as it is accepted in Lua
@@ -14275,9 +14275,9 @@ bool TLuaInterpreter::callMulti(const QString& function, const QString& mName)
     }
 
     lua_getglobal(L, function.toUtf8().constData());
-    int error = lua_pcall(L, 0, LUA_MULTRET, 0);
+    int const error = lua_pcall(L, 0, LUA_MULTRET, 0);
     if (error) {
-        int nbpossible_errors = lua_gettop(L);
+        int const nbpossible_errors = lua_gettop(L);
         for (int i = 1; i <= nbpossible_errors; i++) {
             std::string e = "";
             if (lua_isstring(L, i)) {
@@ -14325,9 +14325,9 @@ std::pair<bool, bool> TLuaInterpreter::callMultiReturnBool(const QString& functi
     }
 
     lua_getglobal(L, function.toUtf8().constData());
-    int error = lua_pcall(L, 0, LUA_MULTRET, 0);
+    int const error = lua_pcall(L, 0, LUA_MULTRET, 0);
     if (error) {
-        int nbpossible_errors = lua_gettop(L);
+        int const nbpossible_errors = lua_gettop(L);
         for (int i = 1; i <= nbpossible_errors; i++) {
             std::string e = "";
             if (lua_isstring(L, i)) {
@@ -14396,7 +14396,7 @@ bool TLuaInterpreter::callLabelCallbackEvent(const int func, const QEvent* qE)
 {
     lua_State* L = pGlobalLua;
     lua_rawgeti(L, LUA_REGISTRYINDEX, func);
-    QString name = qsl("label callback event");
+    QString const name = qsl("label callback event");
 
     if (qE) {
         // Create Lua table with QEvent data if needed
@@ -14564,7 +14564,7 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
             err = "Lua error: ";
             err += lua_tostring(L, 1);
         }
-        QString name = "event handler function";
+        QString const name = "event handler function";
         logError(err, name, function);
         return false;
     }
@@ -14611,7 +14611,7 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
         if (lua_isstring(L, -1)) {
             err += lua_tostring(L, -1);
         }
-        QString name = "event handler function";
+        QString const name = "event handler function";
         logError(err, name, function);
         if (mudlet::smDebugMode) {
             auto& host = getHostFromLua(L);
@@ -14626,20 +14626,20 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
 // No documentation available in wiki - internal function
 double TLuaInterpreter::condenseMapLoad()
 {
-    QString luaFunction = qsl("condenseMapLoad");
+    QString const luaFunction = qsl("condenseMapLoad");
     double loadTime = -1.0;
 
     lua_State* L = pGlobalLua;
 
     lua_getfield(L, LUA_GLOBALSINDEX, "condenseMapLoad");
-    int error = lua_pcall(L, 0, 1, 0);
+    int const error = lua_pcall(L, 0, 1, 0);
     if (error) {
-        int nbpossible_errors = lua_gettop(L);
+        int const nbpossible_errors = lua_gettop(L);
         for (int i = 1; i <= nbpossible_errors; i++) {
             std::string e = "";
             if (lua_isstring(L, i)) {
                 e += lua_tostring(L, i);
-                QString _f = luaFunction.toUtf8().constData();
+                QString const _f = luaFunction.toUtf8().constData();
                 logError(e, luaFunction, _f);
                 if (mudlet::smDebugMode) {
                     auto& host = getHostFromLua(L);
@@ -14654,7 +14654,7 @@ double TLuaInterpreter::condenseMapLoad()
         }
     }
 
-    int returnValues = lua_gettop(L);
+    int const returnValues = lua_gettop(L);
     if (returnValues > 0 && !lua_isnoneornil(L, 1)) {
         loadTime = lua_tonumber(L, 1);
     }
@@ -14703,8 +14703,8 @@ int TLuaInterpreter::performHttpRequest(lua_State *L, const char* functionName, 
         dataToPost = lua_tostring(L, pos + 1);
     }
 
-    QString urlString = getVerifiedString(L, functionName, pos + 2, "remote url");
-    QUrl url = QUrl::fromUserInput(urlString);
+    QString const urlString = getVerifiedString(L, functionName, pos + 2, "remote url");
+    QUrl const url = QUrl::fromUserInput(urlString);
 
     if (!url.isValid()) {
         return warnArgumentValue(L, __func__, qsl("url is invalid, reason: %1.").arg(url.errorString()));
@@ -14784,8 +14784,8 @@ int TLuaInterpreter::performHttpRequest(lua_State *L, const char* functionName, 
 int TLuaInterpreter::getHTTP(lua_State* L)
 {
     auto& host = getHostFromLua(L);
-    QString urlString = getVerifiedString(L, __func__, 1, "remote url");
-    QUrl url = QUrl::fromUserInput(urlString);
+    QString const urlString = getVerifiedString(L, __func__, 1, "remote url");
+    QUrl const url = QUrl::fromUserInput(urlString);
     if (!url.isValid()) {
         return warnArgumentValue(L, __func__, qsl("url is invalid, reason: %1").arg(url.errorString()));
     }
@@ -14837,8 +14837,8 @@ int TLuaInterpreter::postHTTP(lua_State* L)
 int TLuaInterpreter::deleteHTTP(lua_State *L)
 {
     auto& host = getHostFromLua(L);
-    QString urlString = getVerifiedString(L, __func__, 1, "remote url");
-    QUrl url = QUrl::fromUserInput(urlString);
+    QString const urlString = getVerifiedString(L, __func__, 1, "remote url");
+    QUrl const url = QUrl::fromUserInput(urlString);
     if (!url.isValid()) {
         return warnArgumentValue(L, __func__, qsl("url is invalid, reason: %1").arg(url.errorString()));
     }
@@ -14884,7 +14884,7 @@ int TLuaInterpreter::deleteHTTP(lua_State *L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getConnectionInfo
 int TLuaInterpreter::getConnectionInfo(lua_State *L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
 
     auto [hostName, hostPort, connected] = host.mTelnet.getConnectionInfo();
     lua_pushstring(L, hostName.toUtf8().constData());
@@ -14896,10 +14896,10 @@ int TLuaInterpreter::getConnectionInfo(lua_State *L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Networking_Functions#unzipAsync
 int TLuaInterpreter::unzipAsync(lua_State *L)
 {
-    QString zipLocation = getVerifiedString(L, __func__, 1, "zip location");
+    QString const zipLocation = getVerifiedString(L, __func__, 1, "zip location");
     QString extractLocation = getVerifiedString(L, __func__, 2, "extract location");
 
-    QTemporaryDir temporaryDir;
+    QTemporaryDir const temporaryDir;
     if (!temporaryDir.isValid()) {
         return warnArgumentValue(L, __func__, "couldn't create temporary directory to extract the zip into");
     }
@@ -14909,7 +14909,7 @@ int TLuaInterpreter::unzipAsync(lua_State *L)
         extractLocation.append(QLatin1String("/"));
     }
 
-    QDir dir;
+    QDir const dir;
     if (!dir.mkpath(extractLocation)) {
         return warnArgumentValue(L, __func__, "couldn't create output directory to put the extracted files into");
     }
@@ -14968,7 +14968,7 @@ void TLuaInterpreter::set_lua_string(const QString& varName, const QString& varV
 void TLuaInterpreter::set_lua_integer(const QString& varName, int varValue)
 {
     lua_State* L = pGlobalLua;
-    int top = lua_gettop(L);
+    int const top = lua_gettop(L);
 
     lua_pushnumber(L, varValue);
     lua_setglobal(L, varName.toUtf8().constData());
@@ -14980,7 +14980,7 @@ QString TLuaInterpreter::getLuaString(const QString& stringName)
 {
     lua_State* L = pGlobalLua;
 
-    int error = luaL_dostring(L, qsl("return %1").arg(stringName).toUtf8().constData());
+    int const error = luaL_dostring(L, qsl("return %1").arg(stringName).toUtf8().constData());
     if (!error) {
         return lua_tostring(L, 1);
     } else {
@@ -15013,7 +15013,7 @@ int TLuaInterpreter::check_for_mappingscript()
         return 0;
     }
 
-    int r = lua_toboolean(L, -1);
+    int const r = lua_toboolean(L, -1);
     lua_pop(L, 2);
     return r;
 }
@@ -15033,7 +15033,7 @@ int TLuaInterpreter::check_for_custom_speedwalk()
         lua_pop(L, 2);
         return 0;
     }
-    int r = lua_toboolean(L, -1);
+    int const r = lua_toboolean(L, -1);
     lua_pop(L, 2);
     return r;
 }
@@ -15091,7 +15091,7 @@ static void storeHostInLua(lua_State* L, Host* h);
 // with its success message, on failure will just append...
 bool TLuaInterpreter::loadLuaModule(QQueue<QString>& resultMsgsQueue, const QString& requirement, const QString& failureConsequence, const QString& description, const QString& luaModuleId)
 {
-    int error = luaL_dostring(pGlobalLua, qsl("%1require \"%2\"")
+    int const error = luaL_dostring(pGlobalLua, qsl("%1require \"%2\"")
                               .arg(luaModuleId.isEmpty() ? QString() : qsl("%1 =").arg(luaModuleId),
                                    requirement).toUtf8().constData());
     if (error) {
@@ -16130,12 +16130,12 @@ std::pair<int, QString> TLuaInterpreter::createPermScript(const QString& name, c
     // This will lead to the generation of the ID number:
     mpHost->getScriptUnit()->registerScript(pS);
     if (!pS->setScript(luaCode)) {
-        QString errMsg = pS->getError();
+        QString const errMsg = pS->getError();
         delete pS;
         return {-1, qsl("unable to compile \"%1\", reason: %2").arg(luaCode, errMsg)};
     }
 
-    int id = pS->getID();
+    int const id = pS->getID();
     pS->setIsActive(false);
     mpHost->mpEditorDialog->mNeedUpdateData = true;
     return {id, QString()};
@@ -16155,11 +16155,11 @@ std::pair<int, QString> TLuaInterpreter::setScriptCode(QString& name, const QStr
     }
     auto oldCode = pS->getScript();
     if (!pS->setScript(luaCode)) {
-        QString errMsg = pS->getError();
+        QString const errMsg = pS->getError();
         pS->setScript(oldCode);
         return {-1, qsl("unable to compile \"%1\" at position \"%2\", reason: %3").arg(luaCode).arg(++pos).arg(errMsg)};
     }
-    int id = pS->getID();
+    int const id = pS->getID();
     mpHost->mpEditorDialog->writeScript(id);
     return {id, QString()};
 }
@@ -16167,7 +16167,7 @@ std::pair<int, QString> TLuaInterpreter::setScriptCode(QString& name, const QStr
 // No documentation available in wiki - internal function
 std::pair<int, QString> TLuaInterpreter::startPermTimer(const QString& name, const QString& parent, double timeout, const QString& function)
 {
-    QTime time = QTime(0, 0, 0, 0).addMSecs(qRound(timeout * 1000));
+    QTime const time = QTime(0, 0, 0, 0).addMSecs(qRound(timeout * 1000));
     TTimer* pT;
     if (parent.isEmpty()) {
         pT = new TTimer(qsl("newPermTimerWithoutAnId"), time, mpHost);
@@ -16191,7 +16191,7 @@ std::pair<int, QString> TLuaInterpreter::startPermTimer(const QString& name, con
     // This will lead to the generation of the ID number:
     mpHost->getTimerUnit()->registerTimer(pT);
     if (!pT->setScript(function)) {
-        QString errMsg = pT->getError();
+        QString const errMsg = pT->getError();
         // Apparently this will call the TTimer::unregisterTimer(...) method:
         delete pT;
         return {-1, qsl("unable to compile \"%1\", reason: %2").arg(function, errMsg)};
@@ -16205,7 +16205,7 @@ std::pair<int, QString> TLuaInterpreter::startPermTimer(const QString& name, con
 // No documentation available in wiki - internal function
 QPair<int, QString> TLuaInterpreter::startTempTimer(double timeout, const QString& function, const bool repeating)
 {
-    QTime time = QTime(0,0,0,0).addMSecs(qRound(timeout * 1000));
+    QTime const time = QTime(0,0,0,0).addMSecs(qRound(timeout * 1000));
     auto* pT = new TTimer(qsl("newTempTimerWithoutAnId"), time, mpHost, repeating);
     pT->setTime(time);
     pT->setIsFolder(false);
@@ -16214,13 +16214,13 @@ QPair<int, QString> TLuaInterpreter::startTempTimer(double timeout, const QStrin
     // name for temporary timers:
     mpHost->getTimerUnit()->registerTimer(pT);
     if (!pT->setScript(function)) {
-        QString errMsg = pT->getError();
+        QString const errMsg = pT->getError();
         // Apparently this will call the TTimer::unregisterTimer(...) method:
         delete pT;
         return qMakePair(-1, qsl("unable to compile \"%1\", reason: %2").arg(function, errMsg));
     }
 
-    int id = pT->getID();
+    int const id = pT->getID();
     pT->setIsActive(true);
     pT->enableTimer(id);
     return qMakePair(id, QString());
@@ -16264,7 +16264,7 @@ int TLuaInterpreter::startTempAlias(const QString& regex, const QString& functio
     if (!function.isEmpty()) {
         pT->setScript(function);
     }
-    int id = pT->getID();
+    int const id = pT->getID();
     pT->setName(QString::number(id));
     return id;
 }
@@ -16310,7 +16310,7 @@ int TLuaInterpreter::startTempKey(int& modifier, int& keycode, const QString& fu
     if (!function.isEmpty()) {
         pT->setScript(function);
     }
-    int id = pT->getID();
+    int const id = pT->getID();
     pT->setName(QString::number(id));
     return id;
 }
@@ -16319,15 +16319,15 @@ int TLuaInterpreter::startTempKey(int& modifier, int& keycode, const QString& fu
 int TLuaInterpreter::startTempExactMatchTrigger(const QString& regex, const QString& function, int expiryCount)
 {
     TTrigger* pT = nullptr;
-    QStringList sList {regex};
-    QList<int> propertyList {REGEX_EXACT_MATCH};
+    QStringList const sList {regex};
+    QList<int> const propertyList {REGEX_EXACT_MATCH};
     pT = new TTrigger("a", sList, propertyList, false, mpHost);
     pT->setIsFolder(false);
     pT->setIsActive(true);
     pT->setTemporary(true);
     pT->registerTrigger();
     pT->setScript(function);
-    int id = pT->getID();
+    int const id = pT->getID();
     pT->setName(QString::number(id));
     pT->setExpiryCount(expiryCount);
     return id;
@@ -16337,15 +16337,15 @@ int TLuaInterpreter::startTempExactMatchTrigger(const QString& regex, const QStr
 int TLuaInterpreter::startTempBeginOfLineTrigger(const QString& regex, const QString& function, int expiryCount)
 {
     TTrigger* pT = nullptr;
-    QStringList sList {regex};
-    QList<int> propertyList {REGEX_BEGIN_OF_LINE_SUBSTRING};
+    QStringList const sList {regex};
+    QList<int> const propertyList {REGEX_BEGIN_OF_LINE_SUBSTRING};
     pT = new TTrigger("a", sList, propertyList, false, mpHost);
     pT->setIsFolder(false);
     pT->setIsActive(true);
     pT->setTemporary(true);
     pT->registerTrigger();
     pT->setScript(function);
-    int id = pT->getID();
+    int const id = pT->getID();
     pT->setName(QString::number(id));
     pT->setExpiryCount(expiryCount);
     return id;
@@ -16355,15 +16355,15 @@ int TLuaInterpreter::startTempBeginOfLineTrigger(const QString& regex, const QSt
 int TLuaInterpreter::startTempTrigger(const QString& regex, const QString& function, int expiryCount)
 {
     TTrigger* pT = nullptr;
-    QStringList sList {regex};
-    QList<int> propertyList {REGEX_SUBSTRING};
+    QStringList const sList {regex};
+    QList<int> const propertyList {REGEX_SUBSTRING};
     pT = new TTrigger("a", sList, propertyList, false, mpHost);
     pT->setIsFolder(false);
     pT->setIsActive(true);
     pT->setTemporary(true);
     pT->registerTrigger();
     pT->setScript(function);
-    int id = pT->getID();
+    int const id = pT->getID();
     pT->setName(QString::number(id));
     pT->setExpiryCount(expiryCount);
     return id;
@@ -16373,15 +16373,15 @@ int TLuaInterpreter::startTempTrigger(const QString& regex, const QString& funct
 int TLuaInterpreter::startTempPromptTrigger(const QString& function, int expiryCount)
 {
     TTrigger* pT;
-    QStringList sList = {QString()};
-    QList<int> propertyList = {REGEX_PROMPT};
+    QStringList const sList = {QString()};
+    QList<int> const propertyList = {REGEX_PROMPT};
     pT = new TTrigger("a", sList, propertyList, false, mpHost);
     pT->setIsFolder(false);
     pT->setIsActive(true);
     pT->setTemporary(true);
     pT->registerTrigger();
     pT->setScript(function);
-    int id = pT->getID();
+    int const id = pT->getID();
     pT->setName(QString::number(id));
     pT->setExpiryCount(expiryCount);
     return id;
@@ -16404,7 +16404,7 @@ int TLuaInterpreter::startTempLineTrigger(int from, int howmany, const QString& 
     pT->setLineDelta(howmany);
     pT->registerTrigger();
     pT->setScript(function);
-    int id = pT->getID();
+    int const id = pT->getID();
     pT->setName(QString::number(id));
     pT->setExpiryCount(expiryCount);
     return id;
@@ -16426,7 +16426,7 @@ int TLuaInterpreter::startTempColorTrigger(int fg, int bg, const QString& functi
 
     pT->registerTrigger();
     pT->setScript(function);
-    int id = pT->getID();
+    int const id = pT->getID();
     pT->setName(QString::number(id));
     pT->setExpiryCount(expiryCount);
     return id;
@@ -16436,15 +16436,15 @@ int TLuaInterpreter::startTempColorTrigger(int fg, int bg, const QString& functi
 int TLuaInterpreter::startTempRegexTrigger(const QString& regex, const QString& function, int expiryCount)
 {
     TTrigger* pT = nullptr;
-    QStringList sList {regex};
-    QList<int> propertyList {REGEX_PERL};
+    QStringList const sList {regex};
+    QList<int> const propertyList {REGEX_PERL};
     pT = new TTrigger("a", sList, propertyList, false, mpHost);
     pT->setIsFolder(false);
     pT->setIsActive(true);
     pT->setTemporary(true);
     pT->registerTrigger();
     pT->setScript(function);
-    int id = pT->getID();
+    int const id = pT->getID();
     pT->setName(QString::number(id));
     pT->setExpiryCount(expiryCount);
     return id;
@@ -16538,8 +16538,8 @@ std::pair<int, QString> TLuaInterpreter::startPermSubstringTrigger(const QString
 std::pair<int, QString> TLuaInterpreter::startPermPromptTrigger(const QString& name, const QString& parent, const QString& function)
 {
     TTrigger* pT;
-    QList<int> propertyList = {REGEX_PROMPT};
-    QStringList patterns = {QString()};
+    QList<int> const propertyList = {REGEX_PROMPT};
+    QStringList const patterns = {QString()};
 
     if (parent.isEmpty()) {
         pT = new TTrigger("a", patterns, propertyList, false, mpHost);
@@ -16604,7 +16604,7 @@ Host& getHostFromLua(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getColumnCount
 int TLuaInterpreter::getColumnCount(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
 
     int columns;
     auto console = CONSOLE(L, windowName);
@@ -16616,7 +16616,7 @@ int TLuaInterpreter::getColumnCount(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRowCount
 int TLuaInterpreter::getRowCount(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
 
     int rows;
     auto console = CONSOLE(L, windowName);
@@ -16683,7 +16683,7 @@ int TLuaInterpreter::getMapSelection(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableClickthrough
 int TLuaInterpreter::enableClickthrough(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
 
     Host& host = getHostFromLua(L);
 
@@ -16694,7 +16694,7 @@ int TLuaInterpreter::enableClickthrough(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableClickthrough
 int TLuaInterpreter::disableClickthrough(lua_State* L)
 {
-    QString windowName {WINDOW_NAME(L, 1)};
+    QString const windowName {WINDOW_NAME(L, 1)};
 
     Host& host = getHostFromLua(L);
 
@@ -16713,8 +16713,8 @@ int TLuaInterpreter::addWordToDictionary(lua_State* L)
         return warnArgumentValue(L, __func__, "no user dictionary enabled in the preferences for this profile");
     }
 
-    QString text = getVerifiedString(L, __func__, 1, "word");
-    QPair<bool, QString> result = host.mpConsole->addWordToSet(text);
+    QString const text = getVerifiedString(L, __func__, 1, "word");
+    QPair<bool, QString> const result = host.mpConsole->addWordToSet(text);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
     }
@@ -16733,8 +16733,8 @@ int TLuaInterpreter::removeWordFromDictionary(lua_State* L)
         return warnArgumentValue(L, __func__, "no user dictionary enabled in the preferences for this profile");
     }
 
-    QString text = getVerifiedString(L, __func__, 1, "word");
-    QPair<bool, QString> result = host.mpConsole->removeWordFromSet(text);
+    QString const text = getVerifiedString(L, __func__, 1, "word");
+    QPair<bool, QString> const result = host.mpConsole->removeWordFromSet(text);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
     }
@@ -16750,7 +16750,7 @@ int TLuaInterpreter::spellCheckWord(lua_State* L)
     bool hasSharedDictionary = false;
     host.getUserDictionaryOptions(hasUserDictionary, hasSharedDictionary);
 
-    QString text = getVerifiedString(L, __func__, 1, "word");
+    QString const text = getVerifiedString(L, __func__, 1, "word");
 
     bool useUserDictionary = false;
     if (lua_gettop(L) > 1) {
@@ -16787,7 +16787,7 @@ int TLuaInterpreter::spellSuggestWord(lua_State* L)
     bool hasSharedDictionary = false;
     host.getUserDictionaryOptions(hasUserDictionary, hasSharedDictionary);
 
-    QString text = getVerifiedString(L, __func__, 1, "word");
+    QString const text = getVerifiedString(L, __func__, 1, "word");
 
     bool useUserDictionary = false;
     if (lua_gettop(L) > 1) {
@@ -16844,7 +16844,7 @@ int TLuaInterpreter::getDictionaryWordList(lua_State* L)
     // is fatally dangerous if used in a range based initialiser:
     QSet<QString> wordSet{host.mpConsole->getWordSet()};
     QStringList wordList{wordSet.begin(), wordSet.end()};
-    int wordCount = wordList.size();
+    int const wordCount = wordList.size();
     if (wordCount > 1) {
         QCollator sorter;
         sorter.setCaseSensitivity(Qt::CaseInsensitive);
@@ -17031,9 +17031,9 @@ void TLuaInterpreter::updateExtendedAnsiColorsInTable()
 
     // And insert the 6x6x6 RGB colours
     for (int i = 0; i < 216; ++i) {
-        int r = i / 36;
-        int g = (i - (r * 36)) / 6;
-        int b = (i - (r * 36)) - (g * 6);
+        int const r = i / 36;
+        int const g = (i - (r * 36)) / 6;
+        int const b = (i - (r * 36)) - (g * 6);
 
         lua_createtable(L, 3, 0);
 
@@ -17049,7 +17049,7 @@ void TLuaInterpreter::updateExtendedAnsiColorsInTable()
         lua_getfield(L, LUA_GLOBALSINDEX, "color_table");
         lua_insert(L, -2);
 
-        QString name = qsl("ansi_%1").arg(i + 16, 3, 10, QLatin1Char('0'));
+        QString const name = qsl("ansi_%1").arg(i + 16, 3, 10, QLatin1Char('0'));
         lua_pushstring(L, name.toUtf8().constData());
         lua_insert(L, -2);
         lua_settable(L, -3);
@@ -17060,7 +17060,7 @@ void TLuaInterpreter::updateExtendedAnsiColorsInTable()
     for (int i = 232; i < 256; ++i) {
         lua_createtable(L, 3, 0);
 
-        int value = (i - 232) * 10 + 8;
+        int const value = (i - 232) * 10 + 8;
 
         lua_pushnumber(L, value);
         lua_rawseti(L, -2, 1);
@@ -17074,7 +17074,7 @@ void TLuaInterpreter::updateExtendedAnsiColorsInTable()
         lua_getfield(L, LUA_GLOBALSINDEX, "color_table");
         lua_insert(L, -2);
 
-        QString name = qsl("ansi_%1").arg(i, 3, 10, QLatin1Char('0'));
+        QString const name = qsl("ansi_%1").arg(i, 3, 10, QLatin1Char('0'));
         lua_pushstring(L, name.toUtf8().constData());
         lua_insert(L, -2);
         lua_settable(L, -3);
@@ -17116,7 +17116,7 @@ void TLuaInterpreter::createHttpHeadersTable(lua_State* L, QNetworkReply* reply)
 
     // Parse headers, add them as key-value pairs to the empty table
     const QList<QByteArray> headerList = reply->rawHeaderList();
-    for (QByteArray header : headerList) {
+    for (QByteArray const header : headerList) {
         // Push header key onto stack
         lua_pushstring(L, header.constData());
         // Push header value onto stack
@@ -17145,10 +17145,10 @@ void TLuaInterpreter::createCookiesTable(lua_State* L, QNetworkReply* reply)
     lua_newtable(L);
 
     // Parse cookies, add them as key-value pairs to the empty table
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     QNetworkCookieJar* cookieJar = host.mLuaInterpreter.mpFileDownloader->cookieJar();
-    QList<QNetworkCookie> cookies = cookieJar->cookiesForUrl(reply->url());
-    for (QNetworkCookie cookie : cookies) {
+    QList<QNetworkCookie> const cookies = cookieJar->cookiesForUrl(reply->url());
+    for (QNetworkCookie const cookie : cookies) {
         // Push cookie name onto stack
         lua_pushstring(L, cookie.name().constData());
         // Push cookie value onto stack
@@ -17175,17 +17175,17 @@ int TLuaInterpreter::getMapBackgroundColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMapBackgroundColor
 int TLuaInterpreter::setMapBackgroundColor(lua_State* L)
 {
-    int r = getVerifiedInt(L, __func__, 1, "red component");
+    int const r = getVerifiedInt(L, __func__, 1, "red component");
     if (r < 0 || r > 255) {
         return warnArgumentValue(L, __func__, csmInvalidRedValue.arg(r));
     }
 
-    int g = getVerifiedInt(L, __func__, 2, "green component");
+    int const g = getVerifiedInt(L, __func__, 2, "green component");
     if (g < 0 || g > 255) {
         return warnArgumentValue(L, __func__, csmInvalidGreenValue.arg(g));
     }
 
-    int b = getVerifiedInt(L, __func__, 3, "blue component");
+    int const b = getVerifiedInt(L, __func__, 3, "blue component");
     if (b < 0 || b > 255) {
         return warnArgumentValue(L, __func__, csmInvalidBlueValue.arg(b));
     }
@@ -17211,17 +17211,17 @@ int TLuaInterpreter::getMapRoomExitsColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMapRoomExitsColor
 int TLuaInterpreter::setMapRoomExitsColor(lua_State* L)
 {
-    int r = getVerifiedInt(L, __func__, 1, "red component");
+    int const r = getVerifiedInt(L, __func__, 1, "red component");
     if (r < 0 || r > 255) {
         return warnArgumentValue(L, __func__, csmInvalidRedValue.arg(r));
     }
 
-    int g = getVerifiedInt(L, __func__, 2, "green component");
+    int const g = getVerifiedInt(L, __func__, 2, "green component");
     if (g < 0 || g > 255) {
         return warnArgumentValue(L, __func__, csmInvalidGreenValue.arg(g));
     }
 
-    int b = getVerifiedInt(L, __func__, 3, "blue component");
+    int const b = getVerifiedInt(L, __func__, 3, "blue component");
     if (b < 0 || b > 255) {
         return warnArgumentValue(L, __func__, csmInvalidBlueValue.arg(b));
     }
@@ -17236,8 +17236,8 @@ int TLuaInterpreter::setMapRoomExitsColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#showNotification
 int TLuaInterpreter::showNotification(lua_State* L)
 {
-    int n = lua_gettop(L);
-    QString title = getVerifiedString(L, __func__, 1, "title");
+    int const n = lua_gettop(L);
+    QString const title = getVerifiedString(L, __func__, 1, "title");
     QString text = title;
     if (n >= 2) {
         text = getVerifiedString(L, __func__, 2, "message");
@@ -17317,7 +17317,7 @@ int TLuaInterpreter::registerMapInfo(lua_State* L)
         lua_pushfstring(L, "registerMapInfo: bad argument #2 type (callback as function expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    int callback = luaL_ref(L, LUA_REGISTRYINDEX);
+    int const callback = luaL_ref(L, LUA_REGISTRYINDEX);
 
     auto& host = getHostFromLua(L);
     host.mpMap->mMapInfoContributorManager->registerContributor(name, [=](int roomID, int selectionSize, int areaId, int displayAreaId, QColor& infoColor) {
@@ -17332,9 +17332,9 @@ int TLuaInterpreter::registerMapInfo(lua_State* L)
         lua_pushinteger(L, areaId);
         lua_pushinteger(L, displayAreaId);
 
-        int error = lua_pcall(L, 4, 6, 0);
+        int const error = lua_pcall(L, 4, 6, 0);
         if (error) {
-            int errorCount = lua_gettop(L);
+            int const errorCount = lua_gettop(L);
             if (mudlet::smDebugMode) {
                 for (int i = 1; i <= errorCount; i++) {
                     if (lua_isstring(L, i)) {
@@ -17349,9 +17349,9 @@ int TLuaInterpreter::registerMapInfo(lua_State* L)
 
         auto nResult = lua_gettop(L);
         auto index = -nResult;
-        QString text = lua_tostring(L, index);
-        bool isBold = lua_toboolean(L, ++index);
-        bool isItalic = lua_toboolean(L, ++index);
+        QString const text = lua_tostring(L, index);
+        bool const isBold = lua_toboolean(L, ++index);
+        bool const isItalic = lua_toboolean(L, ++index);
         int r = -1;
         int g = -1;
         int b = -1;
@@ -17419,7 +17419,7 @@ int TLuaInterpreter::addFileWatch(lua_State * L)
     auto path = getVerifiedString(L, __func__, 1, "path");
     auto& host = getHostFromLua(L);
 
-    QFileInfo fileInfo(path);
+    QFileInfo const fileInfo(path);
     if (!fileInfo.exists()) {
         return warnArgumentValue(L, __func__, qsl("path '%1' does not exist").arg(path));
     }
@@ -17443,7 +17443,7 @@ int TLuaInterpreter::addMouseEvent(lua_State * L)
 {
     Host& host = getHostFromLua(L);
     QStringList actionInfo;
-    QString uniqueName = getVerifiedString(L, __func__, 1, "uniquename");
+    QString const uniqueName = getVerifiedString(L, __func__, 1, "uniquename");
     if (host.mConsoleActions.contains(uniqueName)) {
         return warnArgumentValue(L, __func__, qsl("mouse event '%1' already exists").arg(uniqueName));
     }
@@ -17473,7 +17473,7 @@ int TLuaInterpreter::addMouseEvent(lua_State * L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#removeMouseEvent
 int TLuaInterpreter::removeMouseEvent(lua_State * L)
 {
-    QString uniqueName = getVerifiedString(L, __func__, 1, "event name");
+    QString const uniqueName = getVerifiedString(L, __func__, 1, "event name");
     Host& host = getHostFromLua(L);
     if (host.mConsoleActions.remove(uniqueName) == 0) {
         return warnArgumentValue(L, __func__, qsl("mouse event '%1' does not exist").arg(uniqueName));
@@ -17486,13 +17486,13 @@ int TLuaInterpreter::removeMouseEvent(lua_State * L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMouseEvents
 int TLuaInterpreter::getMouseEvents(lua_State * L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
     // create the result table
     lua_newtable(L);
     QMapIterator<QString, QStringList> it(host.mConsoleActions);
     while (it.hasNext()) {
         it.next();
-        QStringList eventInfo = it.value();
+        QStringList const eventInfo = it.value();
         lua_createtable(L, 0, 3);
         lua_pushstring(L, eventInfo.at(0).toUtf8().constData());
         lua_setfield(L, -2, "event name");
@@ -17685,7 +17685,7 @@ int TLuaInterpreter::setConfig(lua_State * L)
 int TLuaInterpreter::addCommandLineMenuEvent(lua_State * L)
 {
     int args = 1;
-    int argsCount = lua_gettop(L);
+    int const argsCount = lua_gettop(L);
 
     QString commandLineName;
     if (argsCount >= 3) {
@@ -17707,7 +17707,7 @@ int TLuaInterpreter::addCommandLineMenuEvent(lua_State * L)
 int TLuaInterpreter::removeCommandLineMenuEvent(lua_State * L)
 {
     int args = 1;
-    int argsCount = lua_gettop(L);
+    int const argsCount = lua_gettop(L);
 
     QString commandLineName;
     if (argsCount >= 2) {
@@ -17730,7 +17730,7 @@ int TLuaInterpreter::removeCommandLineMenuEvent(lua_State * L)
 
 int TLuaInterpreter::deleteMap(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
+    Host const& host = getHostFromLua(L);
 
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         // These tests pass even if the map is empty, however there can still
@@ -17866,7 +17866,7 @@ int TLuaInterpreter::announce(lua_State *L) {
     static const QStringList processingKinds{"importantall", "importantmostrecent", "all", "mostrecent", "currentthenmostrecent"};
     QString processing;
 
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     if (n > 1) {
         // while this only has effect on Windows, it should fail silently in order not to spam
         processing = getVerifiedString(L, __func__, 2, "processing style");
@@ -17889,7 +17889,7 @@ int TLuaInterpreter::scrollTo(lua_State* L)
     int targetLine = -1;
     bool stopScrolling = false;
 
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     if (n == 2) {
         windowName = getVerifiedString(L, __func__, 1, "window name", true);
         targetLine = getVerifiedInt(L, __func__, 2, "line to scroll to");
@@ -17913,7 +17913,7 @@ int TLuaInterpreter::scrollTo(lua_State* L)
         return 2;
     }
 
-    int numLines = console->getLastLineNumber();
+    int const numLines = console->getLastLineNumber();
     if (targetLine >= numLines) { // larger than buffer or at end
         stopScrolling = true;
     } else if (targetLine < 0) { // negative, count from end of buffer
@@ -17943,7 +17943,7 @@ int TLuaInterpreter::getScroll(lua_State* L)
 {
     QString windowName;
 
-    int n = lua_gettop(L);
+    int const n = lua_gettop(L);
     if (n == 1) {
         windowName = getVerifiedString(L, __func__, 1, "window name", true);
     } else {
@@ -17971,7 +17971,7 @@ int TLuaInterpreter::getScroll(lua_State* L)
 int TLuaInterpreter::getConfig(lua_State *L) 
 {
     auto &host = getHostFromLua(L);
-    QString key = getVerifiedString(L, __func__, 1, "key");
+    QString const key = getVerifiedString(L, __func__, 1, "key");
     if (key.isEmpty()) {
         return warnArgumentValue(L, __func__, "you must provide a key");
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14909,7 +14909,7 @@ int TLuaInterpreter::unzipAsync(lua_State *L)
         extractLocation.append(QLatin1String("/"));
     }
 
-    QDir const dir;
+    const QDir dir;
     if (!dir.mkpath(extractLocation)) {
         return warnArgumentValue(L, __func__, "couldn't create output directory to put the extracted files into");
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -17419,7 +17419,7 @@ int TLuaInterpreter::addFileWatch(lua_State * L)
     auto path = getVerifiedString(L, __func__, 1, "path");
     auto& host = getHostFromLua(L);
 
-    QFileInfo const fileInfo(path);
+    const QFileInfo fileInfo(path);
     if (!fileInfo.exists()) {
         return warnArgumentValue(L, __func__, qsl("path '%1' does not exist").arg(path));
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -661,13 +661,13 @@ void TLuaInterpreter::slot_purge()
 // No documentation available in wiki - internal function
 int TLuaInterpreter::Wait(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     if (n != 1) {
         lua_pushstring(L, "Wait: wrong number of arguments");
         return lua_error(L);
     }
 
-    int const luaSleepMsec = getVerifiedInt(L, __func__, 1, "sleep time in msec");
+    const int luaSleepMsec = getVerifiedInt(L, __func__, 1, "sleep time in msec");
     msleep(luaSleepMsec); // FIXME thread::sleep()
     return 0;
 }
@@ -823,7 +823,7 @@ int TLuaInterpreter::raiseEvent(lua_State* L)
 
     TEvent event {};
 
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     // We go from the top of the stack down, because luaL_ref will
     // only reference the object at the top of the stack
     for (int i = n; i >= 1; i--) {
@@ -910,7 +910,7 @@ int TLuaInterpreter::raiseGlobalEvent(lua_State* L)
 {
     Host& host = getHostFromLua(L);
 
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     if (!n) {
         lua_pushstring(L, "raiseGlobalEvent: missing argument #1 (eventName as, probably, a string expected!)");
         return lua_error(L);
@@ -1007,7 +1007,7 @@ int TLuaInterpreter::selectCurrentLine(lua_State* L)
 int TLuaInterpreter::isAnsiFgColor(lua_State* L)
 {
     std::string windowName = "main";
-    int const ansiFg = getVerifiedInt(L, __func__, 1, "ANSI color");
+    const int ansiFg = getVerifiedInt(L, __func__, 1, "ANSI color");
 
     std::list<int> result;
     Host const& host = getHostFromLua(L);
@@ -1101,7 +1101,7 @@ int TLuaInterpreter::isAnsiFgColor(lua_State* L)
 int TLuaInterpreter::isAnsiBgColor(lua_State* L)
 {
     std::string windowName = "main";
-    int const ansiBg = getVerifiedInt(L, __func__, 1, "ANSI color");
+    const int ansiBg = getVerifiedInt(L, __func__, 1, "ANSI color");
 
     std::list<int> result;
     Host const& host = getHostFromLua(L);
@@ -1201,7 +1201,7 @@ int TLuaInterpreter::getFgColor(lua_State* L)
 
     Host const& host = getHostFromLua(L);
     std::list<int> const result = host.mpConsole->getFgColor(windowName);
-    for (int const pos : result) {
+    for (const int pos : result) {
         lua_pushnumber(L, pos);
     }
     return result.size();
@@ -1217,7 +1217,7 @@ int TLuaInterpreter::getBgColor(lua_State* L)
 
     Host const& host = getHostFromLua(L);
     std::list<int> const result = host.mpConsole->getBgColor(windowName);
-    for (int const pos : result) {
+    for (const int pos : result) {
         lua_pushnumber(L, pos);
     }
     return result.size();
@@ -1325,7 +1325,7 @@ int TLuaInterpreter::wrapLine(lua_State* L)
     if (lua_gettop(L)) {
         windowName = getVerifiedString(L, __func__, s++, "window name").toStdString();
     }
-    int const lineNumber = getVerifiedInt(L, __func__, s, "line");
+    const int lineNumber = getVerifiedInt(L, __func__, s, "line");
 
     Host const& host = getHostFromLua(L);
     host.mpConsole->luaWrapLine(windowName, lineNumber);
@@ -1394,7 +1394,7 @@ int TLuaInterpreter::selectCaptureGroup(lua_State *L)
         }
     }
     if (length > 0) {
-        int const pos = host.mpConsole->selectSection(begin, length);
+        const int pos = host.mpConsole->selectSection(begin, length);
         lua_pushnumber(L, pos);
     } else {
         lua_pushnumber(L, -1);
@@ -1405,14 +1405,14 @@ int TLuaInterpreter::selectCaptureGroup(lua_State *L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getLines
 int TLuaInterpreter::getLines(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     int s = 1;
     QString windowName;
     if (n > 2) {
         windowName = getVerifiedString(L, __func__, s++, "mini console, user window or buffer name {may be omitted for the \"main\" console}", true);
     }
-    int const lineFrom = getVerifiedInt(L, __func__, s++, "start line");
-    int const lineTo = getVerifiedInt(L, __func__, s, "end line");
+    const int lineFrom = getVerifiedInt(L, __func__, s++, "start line");
+    const int lineTo = getVerifiedInt(L, __func__, s, "end line");
 
     Host& host = getHostFromLua(L);
     QPair<bool, QStringList> const result = host.getLines(windowName, lineFrom, lineTo);
@@ -1503,7 +1503,7 @@ int TLuaInterpreter::getCurrentLine(lua_State* L)
 int TLuaInterpreter::setMiniConsoleFontSize(lua_State* L)
 {
     const QString windowName = getVerifiedString(L, __func__, 1, "miniconsole name");
-    int const size = getVerifiedInt(L, __func__, 2, "font size");
+    const int size = getVerifiedInt(L, __func__, 2, "font size");
     auto console = CONSOLE(L, windowName);
     if (console->setFontSize(size)) {
         lua_pushboolean(L, true);
@@ -1732,7 +1732,7 @@ int TLuaInterpreter::centerview(lua_State* L)
         return warnArgumentValue(L, __func__, "you haven't opened a map yet");
     }
 
-    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
 
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (pR) {
@@ -1884,7 +1884,7 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
 int TLuaInterpreter::isPrompt(lua_State* L)
 {
     Host const& host = getHostFromLua(L);
-    int const userCursorY = host.mpConsole->getLineNumber();
+    const int userCursorY = host.mpConsole->getLineNumber();
     if (userCursorY < host.mpConsole->buffer.promptBuffer.size() && userCursorY >= 0) {
         lua_pushboolean(L, host.mpConsole->buffer.promptBuffer.at(userCursorY));
         return 1;
@@ -1906,7 +1906,7 @@ int TLuaInterpreter::setWindowWrap(lua_State* L)
     if (lua_gettop(L) > 1) {
         windowName = WINDOW_NAME(L, s++);
     }
-    int const luaFrom = getVerifiedInt(L, __func__, s, "wrapAt");
+    const int luaFrom = getVerifiedInt(L, __func__, s, "wrapAt");
     auto console = CONSOLE(L, windowName);
     console->setWrapAt(luaFrom);
     return 0;
@@ -1926,7 +1926,7 @@ int TLuaInterpreter::getWindowWrap(lua_State* L)
 int TLuaInterpreter::setWindowWrapIndent(lua_State* L)
 {
     const QString windowName {WINDOW_NAME(L, 1)};
-    int const luaFrom = getVerifiedInt(L, __func__, 2, "wrapTo");
+    const int luaFrom = getVerifiedInt(L, __func__, 2, "wrapTo");
     auto console = CONSOLE(L, windowName);
     console->setIndentCount(luaFrom);
     return 0;
@@ -2006,7 +2006,7 @@ int TLuaInterpreter::createStopWatch(lua_State* L)
 {
     QString name;
     bool autoStart = true;
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     int s = 1;
     if (n) {
         if (lua_type(L, s) == LUA_TBOOLEAN) {
@@ -2163,7 +2163,7 @@ std::tuple<bool, int> TLuaInterpreter::getWatchId(lua_State* L, Host& h)
 
     const QString name{lua_tostring(L, 1)};
     // Using an empty string will return the first unnamed stopwatch:
-    int const watchId = h.findStopWatchId(name);
+    const int watchId = h.findStopWatchId(name);
     if (!watchId) {
         lua_pushnil(L);
         if (name.isEmpty()) {
@@ -2356,7 +2356,7 @@ int TLuaInterpreter::getStopWatches(lua_State* L)
     const QList<int> stopWatchIds = host.getStopWatchIds();
     lua_newtable(L);
     for (int index = 0, total = stopWatchIds.count(); index < total; ++index) {
-        int const watchId = stopWatchIds.at(index);
+        const int watchId = stopWatchIds.at(index);
         lua_pushnumber(L, watchId);
         auto pStopWatch = host.getStopWatch(watchId);
         lua_newtable(L);
@@ -2393,11 +2393,11 @@ int TLuaInterpreter::selectSection(lua_State* L)
     if (lua_gettop(L) > 2) {
         windowName = WINDOW_NAME(L, s++);
     }
-    int const from = getVerifiedInt(L, __func__, s++, "from position");
-    int const to = getVerifiedInt(L, __func__, s, "length");
+    const int from = getVerifiedInt(L, __func__, s++, "from position");
+    const int to = getVerifiedInt(L, __func__, s, "length");
 
     auto console = CONSOLE(L, windowName);
-    int const ret = console->selectSection(from, to);
+    const int ret = console->selectSection(from, to);
     lua_pushboolean(L, ret != -1);
     return 1;
 }
@@ -2427,14 +2427,14 @@ int TLuaInterpreter::getSelection(lua_State* L)
 int TLuaInterpreter::moveCursor(lua_State* L)
 {
     int s = 1;
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     QString windowName;
     if (n > 2) {
         windowName = WINDOW_NAME(L, s++);
     }
 
-    int const luaFrom = getVerifiedInt(L, __func__, s++, "x");
-    int const luaTo = getVerifiedInt(L, __func__, s, "y");
+    const int luaFrom = getVerifiedInt(L, __func__, s++, "x");
+    const int luaTo = getVerifiedInt(L, __func__, s, "y");
 
     auto console = CONSOLE(L, windowName);
     lua_pushboolean(L, console->moveCursor(luaFrom, luaTo));
@@ -2445,7 +2445,7 @@ int TLuaInterpreter::moveCursor(lua_State* L)
 int TLuaInterpreter::setConsoleBufferSize(lua_State* L)
 {
     int s = 1;
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     QString windowName;
     if (n > 2) {
         windowName = WINDOW_NAME(L, s++);
@@ -2537,7 +2537,7 @@ int TLuaInterpreter::disableCommandLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#replace
 int TLuaInterpreter::replace(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     int s = 1;
     QString windowName;
 
@@ -2582,9 +2582,9 @@ int TLuaInterpreter::saveMap(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setExitStub
 int TLuaInterpreter::setExitStub(lua_State* L)
 {
-    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
 
-    int const dir = dirToNumber(L, 2);
+    const int dir = dirToNumber(L, 2);
     if (!dir) {
         lua_pushfstring(L, "setExitStub: bad argument #2 type (direction as number or string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
@@ -2615,7 +2615,7 @@ int TLuaInterpreter::connectExitStub(lua_State* L)
     int toRoom = 0;
     bool hasDirection = false;
     bool hasToRoomId = false;
-    int const fromRoom = getVerifiedInt(L, __func__, 1, "fromID");
+    const int fromRoom = getVerifiedInt(L, __func__, 1, "fromID");
 
     Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
@@ -2637,7 +2637,7 @@ int TLuaInterpreter::connectExitStub(lua_State* L)
             // It is a string so it is (we will assume) a direction
             hasDirection = true;
         } else if (lua_type(L, 2) == LUA_TNUMBER) {
-            int const value = qRound(lua_tonumber(L, 2));
+            const int value = qRound(lua_tonumber(L, 2));
             if (value >= DIR_OUT || value <= DIR_NORTH) {
                 // Ambiguous - look in more detail and check whether there is a
                 // a room with the given number and/or an exit stub:
@@ -2677,7 +2677,7 @@ int TLuaInterpreter::connectExitStub(lua_State* L)
     // or an (English) STRING of one of the directions
     int dirType = 0;
     if (hasDirection) {
-        int const argNumber = hasToRoomId ? 3 : 2;
+        const int argNumber = hasToRoomId ? 3 : 2;
         dirType = dirToNumber(L, argNumber);
         if (!dirType) {
             return warnArgumentValue(L, __func__, qsl("argument %1 as '%2' cannot be parsed as a valid direction").arg(QString::number(argNumber), QString::fromUtf8(lua_tostring(L, argNumber))));
@@ -2721,7 +2721,7 @@ int TLuaInterpreter::getExitStubs(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
 
     // Previously threw a Lua error on non-existent room!
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
@@ -2746,7 +2746,7 @@ int TLuaInterpreter::getExitStubs1(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
 
     // Previously threw a Lua error on non-existent room!
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
@@ -2783,7 +2783,7 @@ int TLuaInterpreter::getModulePriority(lua_State* L)
     const QString moduleName = getVerifiedString(L, __func__, 1, "module name");
     Host& host = getHostFromLua(L);
     if (host.mModulePriorities.contains(moduleName)) {
-        int const priority = host.mModulePriorities[moduleName];
+        const int priority = host.mModulePriorities[moduleName];
         lua_pushnumber(L, priority);
         return 1;
     } else {
@@ -2797,7 +2797,7 @@ int TLuaInterpreter::getModulePriority(lua_State* L)
 int TLuaInterpreter::setModulePriority(lua_State* L)
 {
     const QString moduleName = getVerifiedString(L, __func__, 1, "module name");
-    int const modulePriority = getVerifiedInt(L, __func__, 2, "module priority");
+    const int modulePriority = getVerifiedInt(L, __func__, 2, "module priority");
 
     Host& host = getHostFromLua(L);
     if (!host.mInstalledModules.contains(moduleName)) {
@@ -3145,7 +3145,7 @@ int TLuaInterpreter::setFontSize(lua_State* L)
         windowName = WINDOW_NAME(L, s++);
     }
 
-    int const size = getVerifiedInt(L, __func__, s, "size");
+    const int size = getVerifiedInt(L, __func__, s, "size");
     if (size <= 0) {
         // just throw an error, no default needed.
         return warnArgumentValue(L, __func__, "size cannot be 0 or negative");
@@ -3186,7 +3186,7 @@ int TLuaInterpreter::getFontSize(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#openUserWindow
 int TLuaInterpreter::openUserWindow(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     if (lua_type(L, 1) != LUA_TSTRING) {
         lua_pushfstring(L, "openUserWindow:  bad argument #1 type (name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
@@ -3316,13 +3316,13 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
         counter = 2;
     }
 
-    int const x = getVerifiedInt(L, __func__, counter, "miniconsole x-coordinate");
+    const int x = getVerifiedInt(L, __func__, counter, "miniconsole x-coordinate");
     counter++;
-    int const y = getVerifiedInt(L, __func__, counter, "miniconsole y-coordinate");
+    const int y = getVerifiedInt(L, __func__, counter, "miniconsole y-coordinate");
     counter++;
-    int const width = getVerifiedInt(L, __func__, counter, "miniconsole width");
+    const int width = getVerifiedInt(L, __func__, counter, "miniconsole width");
     counter++;
-    int const height = getVerifiedInt(L, __func__, counter, "miniconsole height");
+    const int height = getVerifiedInt(L, __func__, counter, "miniconsole height");
 
     Host& host = getHostFromLua(L);
     if (auto [success, message] = host.createMiniConsole(windowName, name, x, y, width, height); !success) {
@@ -3379,13 +3379,13 @@ int TLuaInterpreter::createScrollBox(lua_State* L)
         counter = 2;
     }
 
-    int const x = getVerifiedInt(L, __func__, counter, "scrollBox x-coordinate");
+    const int x = getVerifiedInt(L, __func__, counter, "scrollBox x-coordinate");
     counter++;
-    int const y = getVerifiedInt(L, __func__, counter, "scrollBox y-coordinate");
+    const int y = getVerifiedInt(L, __func__, counter, "scrollBox y-coordinate");
     counter++;
-    int const width = getVerifiedInt(L, __func__, counter, "scrollBox width");
+    const int width = getVerifiedInt(L, __func__, counter, "scrollBox width");
     counter++;
-    int const height = getVerifiedInt(L, __func__, counter, "scrollBox height");
+    const int height = getVerifiedInt(L, __func__, counter, "scrollBox height");
 
     Host const& host = getHostFromLua(L);
     if (auto [success, message] = host.createScrollBox(windowName, name, x, y, width, height); !success) {
@@ -3399,11 +3399,11 @@ int TLuaInterpreter::createScrollBox(lua_State* L)
 // Internal Function createLabel in an UserWindow
 int TLuaInterpreter::createLabelUserWindow(lua_State* L, const QString& windowName, const QString& labelName)
 {
-    int const n = lua_gettop(L);
-    int const x = getVerifiedInt(L, "createLabel", 3, "label x-coordinate");
-    int const y = getVerifiedInt(L, "createLabel", 4, "label y-coordinate");
-    int const width = getVerifiedInt(L, "createLabel", 5, "label width");
-    int const height = getVerifiedInt(L, "createLabel", 6, "label height");
+    const int n = lua_gettop(L);
+    const int x = getVerifiedInt(L, "createLabel", 3, "label x-coordinate");
+    const int y = getVerifiedInt(L, "createLabel", 4, "label y-coordinate");
+    const int width = getVerifiedInt(L, "createLabel", 5, "label width");
+    const int height = getVerifiedInt(L, "createLabel", 6, "label height");
 
     bool fillBackground = false;
     if ((!lua_isnumber(L, 7)) && (!lua_isboolean(L, 7))) {
@@ -3444,11 +3444,11 @@ int TLuaInterpreter::createLabelUserWindow(lua_State* L, const QString& windowNa
 int TLuaInterpreter::createLabelMainWindow(lua_State* L, const QString& labelName)
 {
     const QString windowName = QLatin1String("main");
-    int const n = lua_gettop(L);
-    int const x = getVerifiedInt(L, "createLabel", 2, "label x-coordinate");
-    int const y = getVerifiedInt(L, "createLabel", 3, "label y-coordinate");
-    int const width = getVerifiedInt(L, "createLabel", 4, "label width");
-    int const height = getVerifiedInt(L, "createLabel", 5, "label height");
+    const int n = lua_gettop(L);
+    const int x = getVerifiedInt(L, "createLabel", 2, "label x-coordinate");
+    const int y = getVerifiedInt(L, "createLabel", 3, "label y-coordinate");
+    const int width = getVerifiedInt(L, "createLabel", 4, "label width");
+    const int height = getVerifiedInt(L, "createLabel", 5, "label height");
 
     bool fillBackground = false;
     if ((!lua_isnumber(L, 6)) && (!lua_isboolean(L, 6))) {
@@ -3519,7 +3519,7 @@ int TLuaInterpreter::setLabelToolTip(lua_State* L)
 int TLuaInterpreter::setLabelCursor(lua_State* L)
 {
     const QString labelName = getVerifiedString(L, __func__, 1, "label name");
-    int const labelCursor = getVerifiedInt(L, __func__, 2, "cursortype");
+    const int labelCursor = getVerifiedInt(L, __func__, 2, "cursortype");
     Host const& host = getHostFromLua(L);
 
     if (auto [success, message] = host.mpConsole->setLabelCursor(labelName, labelCursor); !success) {
@@ -3532,7 +3532,7 @@ int TLuaInterpreter::setLabelCursor(lua_State* L)
 
 int TLuaInterpreter::setLabelCustomCursor(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     int hotX = -1, hotY = -1;
     const QString labelName = getVerifiedString(L, __func__, 1, "label name");
     const QString pixmapLocation = getVerifiedString(L, __func__, 2, "custom cursor location");
@@ -3555,7 +3555,7 @@ int TLuaInterpreter::setLabelCustomCursor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#createMapper
 int TLuaInterpreter::createMapper(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     QString windowName = "";
     int counter = 1;
 
@@ -3572,13 +3572,13 @@ int TLuaInterpreter::createMapper(lua_State* L)
         }
     }
 
-    int const x = getVerifiedInt(L, __func__, counter, "mapper x-coordinate");
+    const int x = getVerifiedInt(L, __func__, counter, "mapper x-coordinate");
     counter++;
-    int const y = getVerifiedInt(L, __func__, counter, "mapper y-coordinate");
+    const int y = getVerifiedInt(L, __func__, counter, "mapper y-coordinate");
     counter++;
-    int const width = getVerifiedInt(L, __func__, counter, "mapper width");
+    const int width = getVerifiedInt(L, __func__, counter, "mapper width");
     counter++;
-    int const height = getVerifiedInt(L, __func__, counter, "mapper height");
+    const int height = getVerifiedInt(L, __func__, counter, "mapper height");
 
     Host const& host = getHostFromLua(L);
     if (auto [success, message] = host.mpConsole->createMapper(windowName, x, y, width, height); !success) {
@@ -3593,7 +3593,7 @@ int TLuaInterpreter::createMapper(lua_State* L)
 int TLuaInterpreter::createCommandLine(lua_State* L)
 {
     QString windowName = QLatin1String("main");
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     int counter = 1;
 
     if (n > 5) {
@@ -3615,13 +3615,13 @@ int TLuaInterpreter::createCommandLine(lua_State* L)
     }
     const QString commandLineName{lua_tostring(L, counter)};
     counter++;
-    int const x = getVerifiedInt(L, __func__, counter, "commandline x-coordinate");
+    const int x = getVerifiedInt(L, __func__, counter, "commandline x-coordinate");
     counter++;
-    int const y = getVerifiedInt(L, __func__, counter, "commandline y-coordinate");
+    const int y = getVerifiedInt(L, __func__, counter, "commandline y-coordinate");
     counter++;
-    int const width = getVerifiedInt(L, __func__, counter, "commandline width");
+    const int width = getVerifiedInt(L, __func__, counter, "commandline width");
     counter++;
-    int const height = getVerifiedInt(L, __func__, counter, "commandline height");
+    const int height = getVerifiedInt(L, __func__, counter, "commandline height");
     counter++;
 
     Host const& host = getHostFromLua(L);
@@ -3685,7 +3685,7 @@ int TLuaInterpreter::hideWindow(lua_State* L)
 int TLuaInterpreter::setBorderSizes(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    int const numberOfArguments = lua_gettop(L);
+    const int numberOfArguments = lua_gettop(L);
     switch (numberOfArguments) {
     case 0:
         break;
@@ -3833,7 +3833,7 @@ int TLuaInterpreter::moveWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setWindow
 int TLuaInterpreter::setWindow(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     int x = 0, y = 0;
     bool show = true;
 
@@ -3861,7 +3861,7 @@ int TLuaInterpreter::setWindow(lua_State* L)
 
 int TLuaInterpreter::openMapWidget(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     QString area = QString();
     int x = -1, y = -1, width = -1, height = -1;
     if (n == 1) {
@@ -3903,8 +3903,8 @@ int TLuaInterpreter::closeMapWidget(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMainWindowSize
 int TLuaInterpreter::setMainWindowSize(lua_State* L)
 {
-    int const x1 = getVerifiedInt(L, __func__, 1, "mainWidth");
-    int const y1 = getVerifiedInt(L, __func__, 2, "mainHeight");
+    const int x1 = getVerifiedInt(L, __func__, 1, "mainWidth");
+    const int y1 = getVerifiedInt(L, __func__, 2, "mainHeight");
     mudlet::self()->resize(x1, y1);
     return 0;
 }
@@ -3937,12 +3937,12 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
         return lua_error(L);
     }
 
-    int const g = getVerifiedInt(L, __func__, ++s, "green value 0-255");
+    const int g = getVerifiedInt(L, __func__, ++s, "green value 0-255");
     if (!validRange(g)) {
         return warnArgumentValue(L, __func__, csmInvalidGreenValue.arg(g));
     }
 
-    int const b = getVerifiedInt(L, __func__, ++s, "blue value 0-255");
+    const int b = getVerifiedInt(L, __func__, ++s, "blue value 0-255");
     if (!validRange(b)) {
         return warnArgumentValue(L, __func__, csmInvalidBlueValue.arg(b));
     }
@@ -3974,7 +3974,7 @@ int TLuaInterpreter::getBackgroundColor(lua_State* L)
     QColor color;
 
     QString windowName = qsl("main");
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     if (n > 0) {
         windowName = getVerifiedString(L, __func__, 1, "window name");
     }
@@ -4022,12 +4022,12 @@ int TLuaInterpreter::setCommandBackgroundColor(lua_State* L)
         return lua_error(L);
     }
 
-    int const g = getVerifiedInt(L, __func__, ++s, "green value 0-255");
+    const int g = getVerifiedInt(L, __func__, ++s, "green value 0-255");
     if (!validRange(g)) {
         return warnArgumentValue(L, __func__, csmInvalidGreenValue.arg(g));
     }
 
-    int const b = getVerifiedInt(L, __func__, ++s, "blue value 0-255");
+    const int b = getVerifiedInt(L, __func__, ++s, "blue value 0-255");
     if (!validRange(b)) {
         return warnArgumentValue(L, __func__, csmInvalidBlueValue.arg(b));
     }
@@ -4079,12 +4079,12 @@ int TLuaInterpreter::setCommandForegroundColor(lua_State* L)
         return lua_error(L);
     }
 
-    int const g = getVerifiedInt(L, __func__, ++s, "green value 0-255");
+    const int g = getVerifiedInt(L, __func__, ++s, "green value 0-255");
     if (!validRange(g)) {
         return warnArgumentValue(L, __func__, csmInvalidGreenValue.arg(g));
     }
 
-    int const b = getVerifiedInt(L, __func__, ++s, "blue value 0-255");
+    const int b = getVerifiedInt(L, __func__, ++s, "blue value 0-255");
     if (!validRange(b)) {
         return warnArgumentValue(L, __func__, csmInvalidBlueValue.arg(b));
     }
@@ -4204,7 +4204,7 @@ int TLuaInterpreter::setBackgroundImage(lua_State* L)
     QString imgPath;
     int mode = 1;
     int counter = 1;
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     if (n > 1 && lua_type(L, 2) == LUA_TSTRING) {
         windowName = getVerifiedString(L, __func__, 1, "console or label name");
         counter++;
@@ -4235,7 +4235,7 @@ int TLuaInterpreter::setBackgroundImage(lua_State* L)
 int TLuaInterpreter::resetBackgroundImage(lua_State* L)
 {
     QString windowName = qsl("main");
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     if (n > 0) {
         windowName = getVerifiedString(L, __func__, 1, "console name");
     }
@@ -4297,7 +4297,7 @@ int TLuaInterpreter::setCmdLineAction(lua_State* L)
         lua_pushfstring(L, "setCmdLineAction: bad argument #2 type (function expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    int const func = luaL_ref(L, LUA_REGISTRYINDEX);
+    const int func = luaL_ref(L, LUA_REGISTRYINDEX);
 
     if (!host.setCmdLineAction(name, func)) {
         return warnArgumentValue(L, __func__, qsl("command line name '%1' not found").arg(name));
@@ -4328,7 +4328,7 @@ int TLuaInterpreter::resetCmdLineAction(lua_State* L){
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setCmdLineStyleSheet
 int TLuaInterpreter::setCmdLineStyleSheet(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     QString name = "main";
     if (n > 1) {
         name = getVerifiedString(L, __func__, 1, "command line name", true);
@@ -4358,7 +4358,7 @@ int TLuaInterpreter::setLabelCallback(lua_State* L, const QString& funcName)
         lua_pushfstring(L, "%s: bad argument #2 type (function expected, got %s!)", funcName.toUtf8().constData(), luaL_typename(L, 1));
         return lua_error(L);
     }
-    int const func = luaL_ref(L, LUA_REGISTRYINDEX);
+    const int func = luaL_ref(L, LUA_REGISTRYINDEX);
 
     bool lua_result = false;
     if (funcName == qsl("setLabelClickCallback")) {
@@ -4463,15 +4463,15 @@ int TLuaInterpreter::movieFunc(lua_State* L, const QString& funcName)
     } else if (funcName == qsl("pauseMovie")) {
         movie->setPaused(true);
     } else if (funcName == qsl("setMovieFrame")) {
-        int const frame = getVerifiedInt(L, funcName.toUtf8().constData(), 2, "movie frame number");
+        const int frame = getVerifiedInt(L, funcName.toUtf8().constData(), 2, "movie frame number");
         lua_pushboolean(L, movie->jumpToFrame(frame));
         return 1;
     } else if (funcName == qsl("setMovieSpeed")) {
-        int const speed = getVerifiedInt(L, funcName.toUtf8().constData(), 2, "movie playback speed in %");
+        const int speed = getVerifiedInt(L, funcName.toUtf8().constData(), 2, "movie playback speed in %");
         movie->setSpeed(speed);
     } else if (funcName == qsl("scaleMovie")) {
         bool autoScale{true};
-        int const n = lua_gettop(L);
+        const int n = lua_gettop(L);
         if (n > 1) {
             autoScale = getVerifiedBool(L, funcName.toUtf8().constData(), 2, "activate/deactivate scaling movie", true);
         }
@@ -4524,7 +4524,7 @@ int TLuaInterpreter::setTextFormat(lua_State* L)
 {
     Host const& host = getHostFromLua(L);
 
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
 
     const QString windowName {WINDOW_NAME(L, 1)};
 
@@ -4661,8 +4661,8 @@ int TLuaInterpreter::showWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setRoomEnv
 int TLuaInterpreter::setRoomEnv(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
-    int const env = getVerifiedInt(L, __func__, 2, "environmentID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int env = getVerifiedInt(L, __func__, 2, "environmentID");
 
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
@@ -4683,7 +4683,7 @@ int TLuaInterpreter::setRoomName(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
     const QString name = getVerifiedString(L, __func__, 2, "room name", true);
 
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
@@ -4705,7 +4705,7 @@ int TLuaInterpreter::getRoomName(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
 
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
@@ -4718,8 +4718,8 @@ int TLuaInterpreter::getRoomName(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setRoomWeight
 int TLuaInterpreter::setRoomWeight(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
-    int const w = getVerifiedInt(L, __func__, 2, "weight");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int w = getVerifiedInt(L, __func__, 2, "weight");
 
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
@@ -4780,7 +4780,7 @@ int TLuaInterpreter::connectToServer(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setRoomIDbyHash
 int TLuaInterpreter::setRoomIDbyHash(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
     const QString hash = getVerifiedString(L, __func__, 2, "hash");
     Host const& host = getHostFromLua(L);
     if (host.mpMap->mpRoomDB->roomIDToHash.contains(id)) {
@@ -4799,7 +4799,7 @@ int TLuaInterpreter::getRoomIDbyHash(lua_State* L)
 {
     const QString hash = getVerifiedString(L, __func__, 1, "hash");
     Host const& host = getHostFromLua(L);
-    int const retID = host.mpMap->mpRoomDB->hashToRoomID.value(hash, -1);
+    const int retID = host.mpMap->mpRoomDB->hashToRoomID.value(hash, -1);
     lua_pushnumber(L, retID);
     return 1;
 }
@@ -4807,7 +4807,7 @@ int TLuaInterpreter::getRoomIDbyHash(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomHashByID
 int TLuaInterpreter::getRoomHashByID(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
     Host const& host = getHostFromLua(L);
     if (!host.mpMap->mpRoomDB->roomIDToHash.contains(id)) {
         return warnArgumentValue(L, __func__, qsl("no hash for room %1").arg(id));
@@ -4820,7 +4820,7 @@ int TLuaInterpreter::getRoomHashByID(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#roomLocked
 int TLuaInterpreter::roomLocked(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
@@ -4835,7 +4835,7 @@ int TLuaInterpreter::roomLocked(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#lockRoom
 int TLuaInterpreter::lockRoom(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
     bool const b = getVerifiedBool(L, __func__, 2, "lockIfTrue");
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
@@ -4853,9 +4853,9 @@ int TLuaInterpreter::lockRoom(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#lockExit
 int TLuaInterpreter::lockExit(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
 
-    int const dir = dirToNumber(L, 2);
+    const int dir = dirToNumber(L, 2);
     if (!dir) {
         lua_pushfstring(L, "lockExit: bad argument #2 type (direction as number or string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
@@ -4876,7 +4876,7 @@ int TLuaInterpreter::lockExit(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#lockSpecialExit
 int TLuaInterpreter::lockSpecialExit(lua_State* L)
 {
-    int const fromRoomID = getVerifiedInt(L, __func__, 1, "exit roomID");
+    const int fromRoomID = getVerifiedInt(L, __func__, 1, "exit roomID");
     // The second argument (was the toRoomID) is now ignored as it is not required/considered in any way
     const QString dir = getVerifiedString(L, __func__, 3, "special exit name/command");
     if (dir.isEmpty()) {
@@ -4903,7 +4903,7 @@ int TLuaInterpreter::lockSpecialExit(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#hasSpecialExitLock
 int TLuaInterpreter::hasSpecialExitLock(lua_State* L)
 {
-    int const fromRoomID = getVerifiedInt(L, __func__, 1, "exit roomID");
+    const int fromRoomID = getVerifiedInt(L, __func__, 1, "exit roomID");
     // Second argument was the entrance roomID but it is not needed any more and is ignored
     const QString dir = getVerifiedString(L, __func__, 3, "special exit name/command");
     if (dir.isEmpty()) {
@@ -4927,9 +4927,9 @@ int TLuaInterpreter::hasSpecialExitLock(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#hasExitLock
 int TLuaInterpreter::hasExitLock(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
 
-    int const dir = dirToNumber(L, 2);
+    const int dir = dirToNumber(L, 2);
     if (!dir) {
         lua_pushfstring(L, "hasExitLock: bad argument #2 type (direction as number or string expected, got %s!)");
         return lua_error(L);
@@ -4947,7 +4947,7 @@ int TLuaInterpreter::hasExitLock(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomExits
 int TLuaInterpreter::getRoomExits(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
 
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
@@ -5022,7 +5022,7 @@ int TLuaInterpreter::getRoomExits(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getAllRoomEntrances
 int TLuaInterpreter::getAllRoomEntrances(lua_State* L)
 {
-    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
     Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
@@ -5054,7 +5054,7 @@ int TLuaInterpreter::searchRoom(lua_State* L)
     }
 
     int room_id = 0;
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     bool gotRoomID = false;
     bool caseSensitive = false;
     bool exactMatch = false;
@@ -5115,13 +5115,13 @@ int TLuaInterpreter::searchRoom(lua_State* L)
             }
         }
         if (!roomIdsFound.isEmpty()) {
-            for (int const i : roomIdsFound) {
+            for (const int i : roomIdsFound) {
                 TRoom* pR = host.mpMap->mpRoomDB->getRoom(i);
                 // This test is to keep Coverity happy as it thinks pR could be
                 // a nullptr in some odd situation {CID 1415023}:
                 if (pR) {
                     const QString name = pR->name;
-                    int const roomID = pR->getId();
+                    const int roomID = pR->getId();
                     lua_pushnumber(L, roomID);
                     lua_pushstring(L, name.toUtf8().constData());
                     lua_settable(L, -3);
@@ -5332,7 +5332,7 @@ int TLuaInterpreter::getAreaTable(lua_State* L)
     lua_newtable(L);
     while (it.hasNext()) {
         it.next();
-        int const areaId = it.key();
+        const int areaId = it.key();
         const QString name = it.value();
         lua_pushstring(L, name.toUtf8().constData());
         lua_pushnumber(L, areaId);
@@ -5353,7 +5353,7 @@ int TLuaInterpreter::getAreaTableSwap(lua_State* L)
     lua_newtable(L);
     while (it.hasNext()) {
         it.next();
-        int const areaId = it.key();
+        const int areaId = it.key();
         const QString name = it.value();
         lua_pushnumber(L, areaId);
         lua_pushstring(L, name.toUtf8().constData());
@@ -5365,7 +5365,7 @@ int TLuaInterpreter::getAreaTableSwap(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getAreaRooms
 int TLuaInterpreter::getAreaRooms(lua_State* L)
 {
-    int const area = getVerifiedInt(L, __func__, 1, "areaID");
+    const int area = getVerifiedInt(L, __func__, 1, "areaID");
     Host const& host = getHostFromLua(L);
     TArea* pA = host.mpMap->mpRoomDB->getArea(area);
     if (!pA) {
@@ -5404,9 +5404,9 @@ int TLuaInterpreter::getRooms(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getAreaExits
 int TLuaInterpreter::getAreaExits(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     bool isFullDataRequired = false;
-    int const area = getVerifiedInt(L, __func__, 1, "areaID");
+    const int area = getVerifiedInt(L, __func__, 1, "areaID");
 
     if (n > 1) {
         isFullDataRequired = getVerifiedBool(L, __func__, 2, "full data wanted", true);
@@ -5433,7 +5433,7 @@ int TLuaInterpreter::getAreaExits(lua_State* L)
     } else {
         QMultiMap<int, QPair<QString, int>> const areaExits = pA->getAreaExitRoomData();
         QList<int> const fromRooms = areaExits.uniqueKeys();
-        for (int const fromRoom : fromRooms) {
+        for (const int fromRoom : fromRooms) {
             lua_pushnumber(L, fromRoom);
             lua_newtable(L);
             QList<QPair<QString, int>> const toRoomsData = areaExits.values(fromRoom);
@@ -5479,7 +5479,7 @@ int TLuaInterpreter::getRoomWeight(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#gotoRoom
 int TLuaInterpreter::gotoRoom(lua_State* L)
 {
-    int const targetRoomId = getVerifiedInt(L, __func__, 1, "target roomID");
+    const int targetRoomId = getVerifiedInt(L, __func__, 1, "target roomID");
 
     Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
@@ -5489,7 +5489,7 @@ int TLuaInterpreter::gotoRoom(lua_State* L)
     }
 
     if (!host.mpMap->gotoRoom(targetRoomId)) {
-        int const totalWeight = host.assemblePath(); // Needed if unsuccessful to clear lua speedwalk tables
+        const int totalWeight = host.assemblePath(); // Needed if unsuccessful to clear lua speedwalk tables
         Q_UNUSED(totalWeight);
         return warnArgumentValue(L, __func__, qsl("no path found from current room to room with id %1").arg(targetRoomId), true);
     }
@@ -5501,8 +5501,8 @@ int TLuaInterpreter::gotoRoom(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getPath
 int TLuaInterpreter::getPath(lua_State* L)
 {
-    int const originRoomId = getVerifiedInt(L, __func__, 1, "starting roomID");
-    int const targetRoomId = getVerifiedInt(L, __func__, 2, "target roomID");
+    const int originRoomId = getVerifiedInt(L, __func__, 1, "starting roomID");
+    const int targetRoomId = getVerifiedInt(L, __func__, 2, "target roomID");
 
     Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
@@ -5514,7 +5514,7 @@ int TLuaInterpreter::getPath(lua_State* L)
     }
 
     bool const ret = host.mpMap->gotoRoom(originRoomId, targetRoomId);
-    int const totalWeight = host.assemblePath(); // Needed even if unsuccessful, to clear lua tables then
+    const int totalWeight = host.assemblePath(); // Needed even if unsuccessful, to clear lua tables then
     if (ret) {
         lua_pushboolean(L, true);
         lua_pushnumber(L, totalWeight);
@@ -5570,7 +5570,7 @@ int TLuaInterpreter::setAppStyleSheet(lua_State* L)
 {
     QString styleSheet;
     QString tag;
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     styleSheet = getVerifiedString(L, __func__, 1, "style sheet");
     if (n > 1) {
         tag = getVerifiedString(L, __func__, 2, "tag");
@@ -5634,7 +5634,7 @@ int TLuaInterpreter::loadMediaFileAsOrderedArguments(lua_State* L)
 {
     Host const& host = getHostFromLua(L);
     TMediaData mediaData{};
-    int const numArgs = lua_gettop(L);
+    const int numArgs = lua_gettop(L);
     QString stringValue;
 
     // name[,url])
@@ -5754,7 +5754,7 @@ int TLuaInterpreter::playMusicFileAsOrderedArguments(lua_State* L)
 {
     Host const& host = getHostFromLua(L);
     TMediaData mediaData{};
-    int const numArgs = lua_gettop(L);
+    const int numArgs = lua_gettop(L);
     QString stringValue;
     int intValue = 0;
     bool boolValue = 0;
@@ -5986,7 +5986,7 @@ int TLuaInterpreter::playSoundFileAsOrderedArguments(lua_State* L)
 {
     Host const& host = getHostFromLua(L);
     TMediaData mediaData{};
-    int const numArgs = lua_gettop(L);
+    const int numArgs = lua_gettop(L);
     QString stringValue;
     int intValue = 0;
 
@@ -6233,7 +6233,7 @@ int TLuaInterpreter::stopMusicAsOrderedArguments(lua_State* L)
 {
     Host const& host = getHostFromLua(L);
     TMediaData mediaData{};
-    int const numArgs = lua_gettop(L);
+    const int numArgs = lua_gettop(L);
     QString stringValue;
 
     // values as ordered args: name[,key][,tag])
@@ -6343,7 +6343,7 @@ int TLuaInterpreter::stopSoundsAsOrderedArguments(lua_State* L)
 {
     Host const& host = getHostFromLua(L);
     TMediaData mediaData{};
-    int const numArgs = lua_gettop(L);
+    const int numArgs = lua_gettop(L);
     QString stringValue;
     int intValue = 0;
 
@@ -6495,7 +6495,7 @@ int TLuaInterpreter::getLastLineNumber(lua_State* L)
 {
     const QString windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE_NIL(L, windowName);
-    int const number = console ? console->getLastLineNumber() : -1;
+    const int number = console ? console->getLastLineNumber() : -1;
     lua_pushnumber(L, number);
     return 1;
 }
@@ -6587,7 +6587,7 @@ int TLuaInterpreter::setPopup(lua_State* L)
     QStringList _commandList;
     QVector<int> luaReference;
     int s = 1;
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
 
     // console name is an optional first argument
     if (n > 2) {
@@ -6740,7 +6740,7 @@ int TLuaInterpreter::setUnderline(lua_State* L)
 int TLuaInterpreter::errorc(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     if (!n) {
         // Nothing to show
         return 0;
@@ -6777,7 +6777,7 @@ int TLuaInterpreter::errorc(lua_State* L)
 int TLuaInterpreter::debug(lua_State* L)
 {
     Host const& host = getHostFromLua(L);
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     if (!n) {
         // Nothing to show
         return 0;
@@ -6924,7 +6924,7 @@ int TLuaInterpreter::sendGMCP(lua_State* L)
 int TLuaInterpreter::sendMSDP(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
 
     if (n < 1) {
         lua_pushstring(L, "sendMSDP: bad argument #1 type (variable name as string expected, got nil!)");
@@ -7013,7 +7013,7 @@ std::pair<int, TAction*> TLuaInterpreter::getTActionFromIdOrName(lua_State* L, c
     auto argType = lua_type(L, index);
     TAction* pItem = nullptr;
     if (argType == LUA_TNUMBER) {
-        int const id = qRound(lua_tonumber(L, index));
+        const int id = qRound(lua_tonumber(L, index));
         if (id < 0) {
             return {warnArgumentValue(L, func, qsl("item ID (%1) invalid, it must be equal or greater than zero").arg(id).toUtf8().constData()), pItem};
         }
@@ -7164,7 +7164,7 @@ int TLuaInterpreter::tempTimer(lua_State* L)
 {
     bool repeating{};
     double const time = getVerifiedDouble(L, __func__, 1, "time in seconds {maybe decimal}");
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
@@ -7494,7 +7494,7 @@ int TLuaInterpreter::tempAnsiColorTrigger(lua_State* L)
         return lua_error(L);
     }
     {   // separate block so that "value" is not scoped to the whole function
-        int const value = lua_tointeger(L, s);
+        const int value = lua_tointeger(L, s);
         if (value == TTrigger::scmIgnored && lua_gettop(L) < 2) {
             return warnArgumentValue(L, __func__, qsl(
                 "invalid ANSI color number %1, it cannot be used (to ignore the foreground color) if the background color is omitted")
@@ -7525,7 +7525,7 @@ int TLuaInterpreter::tempAnsiColorTrigger(lua_State* L)
                         s, TTrigger::scmIgnored, TTrigger::scmDefault, luaL_typename(L, s));
         return lua_error(L);
     } else {
-        int const value = lua_tointeger(L, s);
+        const int value = lua_tointeger(L, s);
         if (!(value == TTrigger::scmIgnored || value == TTrigger::scmDefault || (value >= 0 && value <= 255))) {
             return warnArgumentValue(L, __func__, qsl(
                 "invalid ANSI color number %1, only %2 (ignore background color), %3 (default background color) or 0 to 255 recognised")
@@ -7560,7 +7560,7 @@ int TLuaInterpreter::tempAnsiColorTrigger(lua_State* L)
         return lua_error(L);
     }
 
-    int const triggerID = pLuaInterpreter->startTempColorTrigger(ansiFgColor, ansiBgColor, code, expiryCount);
+    const int triggerID = pLuaInterpreter->startTempColorTrigger(ansiFgColor, ansiBgColor, code, expiryCount);
     if (code.isNull()) {
         auto trigger = host.getTriggerUnit()->getTrigger(triggerID);
         trigger->mRegisteredAnonymousLuaFunction = true;
@@ -7578,11 +7578,11 @@ int TLuaInterpreter::tempLineTrigger(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    int const from = getVerifiedInt(L, __func__, 1, "line to start matching from");
-    int const howMany  = getVerifiedInt(L, __func__, 2, "how many lines to match for");
+    const int from = getVerifiedInt(L, __func__, 1, "line to start matching from");
+    const int howMany  = getVerifiedInt(L, __func__, 2, "how many lines to match for");
     int triggerID;
     // temp line triggers expire naturally on their own, thus don't need the expiry mechanism applicable to all other triggers
-    int const dontExpire = -1;
+    const int dontExpire = -1;
 
     if (lua_isstring(L, 3)) {
         triggerID = pLuaInterpreter->startTempLineTrigger(from, howMany, QString(lua_tostring(L, 3)), dontExpire);
@@ -7633,8 +7633,8 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
     }
     bool const matchAll = lua_tonumber(L, 8);
 
-    int const fireLength = getVerifiedInt(L, __func__, 12, "fire length");
-    int const lineDelta = getVerifiedInt(L, __func__, 13, "line delta");
+    const int fireLength = getVerifiedInt(L, __func__, 12, "fire length");
+    const int lineDelta = getVerifiedInt(L, __func__, 13, "line delta");
 
     bool colorTrigger;
     QString fgColor;
@@ -7754,7 +7754,7 @@ int TLuaInterpreter::tempButton(lua_State* L)
 
     toolbar = getVerifiedString(L, __func__, 1, "toolbar name");
     const QString name = getVerifiedString(L, __func__, 2, "button text");
-    int const orientation = getVerifiedInt(L, __func__, 3, "orientation");
+    const int orientation = getVerifiedInt(L, __func__, 3, "orientation");
 
     Host& host = getHostFromLua(L);
     TAction* pP = host.getActionUnit()->findAction(toolbar);
@@ -7830,7 +7830,7 @@ int TLuaInterpreter::tempButtonToolbar(lua_State* L)
 
     name = getVerifiedString(L, __func__, 1, "name");
     int location = getVerifiedInt(L, __func__, 2, "location");
-    int const orientation = getVerifiedInt(L, __func__, 3, "orientation");
+    const int orientation = getVerifiedInt(L, __func__, 3, "orientation");
 
     if (location > 0) {
         location++;
@@ -7915,7 +7915,7 @@ int TLuaInterpreter::tempAlias(lua_State* L)
 
     if (lua_isfunction(L, 2)) {
 
-        int const result = pLuaInterpreter->startTempAlias(regex, QString());
+        const int result = pLuaInterpreter->startTempAlias(regex, QString());
         if (result == -1) {
             lua_pushnumber(L, -1);
             return 2;
@@ -7951,7 +7951,7 @@ int TLuaInterpreter::exists(lua_State* L)
     // ASCII value which we might have to report...
     QString type = getVerifiedString(L, __func__, 2, "item type").toLower();
     bool isOk = false;
-    int const id = nameOrId.toInt(&isOk);
+    const int id = nameOrId.toInt(&isOk);
     if (isId && (!isOk || id < 0)) {
         // Must be zero or more but doesn't seem to be, must return the
         // original supplied argument as a string (rather than the nameOrId
@@ -8030,7 +8030,7 @@ int TLuaInterpreter::isActive(lua_State* L)
     // ASCII value which we might have to report...
     const QString type = getVerifiedString(L, __func__, 2, "item type");
     bool isOk = false;
-    int const id = nameOrId.toInt(&isOk);
+    const int id = nameOrId.toInt(&isOk);
     if (isId && (!isOk || id < 0)) {
         // Must be zero or more but doesn't seem to be, must return the
         // original supplied argument as a string (rather than the nameOrId
@@ -8158,7 +8158,7 @@ int TLuaInterpreter::permAlias(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getScript
 int TLuaInterpreter::getScript(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     int pos = 1;
     const QString name = getVerifiedString(L, __func__, 1, "script name");
     if (n > 1) {
@@ -8174,7 +8174,7 @@ int TLuaInterpreter::getScript(lua_State* L)
         return 2;
     }
 
-    int const id = pS->getID();
+    const int id = pS->getID();
     lua_pushstring(L, pS->getScript().toUtf8().constData());
     lua_pushnumber(L, id);
     return 2;
@@ -8183,7 +8183,7 @@ int TLuaInterpreter::getScript(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setScript
 int TLuaInterpreter::setScript(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     int pos = 1;
     QString name = getVerifiedString(L, __func__, 1, "script name");
 
@@ -8360,7 +8360,7 @@ int TLuaInterpreter::tempKey(lua_State* L)
 
     if (lua_isfunction(L, ++argIndex)) {
 
-        int const result = pLuaInterpreter->startTempKey(keyModifier, keyCode, QString());
+        const int result = pLuaInterpreter->startTempKey(keyModifier, keyCode, QString());
         if (result == -1) {
             lua_pushnumber(L, -1);
             return 2;
@@ -8384,7 +8384,7 @@ int TLuaInterpreter::tempKey(lua_State* L)
     }
     const QString luaFunction{lua_tostring(L, argIndex)};
 
-    int const timerID = pLuaInterpreter->startTempKey(keyModifier, keyCode, luaFunction);
+    const int timerID = pLuaInterpreter->startTempKey(keyModifier, keyCode, luaFunction);
     lua_pushnumber(L, timerID);
     return 1;
 }
@@ -8487,7 +8487,7 @@ int TLuaInterpreter::invokeFileDialog(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getTimestamp
 int TLuaInterpreter::getTimestamp(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     int s = 1;
     QString name;
     if (n > 1) {
@@ -8531,9 +8531,9 @@ int TLuaInterpreter::getTimestamp(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderColor
 int TLuaInterpreter::setBorderColor(lua_State* L)
 {
-    int const luaRed = getVerifiedInt(L, __func__, 1, "red");
-    int const luaGreen = getVerifiedInt(L, __func__, 2, "green");
-    int const luaBlue = getVerifiedInt(L, __func__, 3, "blue");
+    const int luaRed = getVerifiedInt(L, __func__, 1, "red");
+    const int luaGreen = getVerifiedInt(L, __func__, 2, "green");
+    const int luaBlue = getVerifiedInt(L, __func__, 3, "blue");
     Host const& host = getHostFromLua(L);
     QPalette framePalette;
     framePalette.setColor(QPalette::Text, QColor(Qt::black));
@@ -8546,10 +8546,10 @@ int TLuaInterpreter::setBorderColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setRoomCoordinates
 int TLuaInterpreter::setRoomCoordinates(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
-    int const x = getVerifiedInt(L, __func__, 2, "x");
-    int const y = getVerifiedInt(L, __func__, 3, "y");
-    int const z = getVerifiedInt(L, __func__, 4, "z");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int x = getVerifiedInt(L, __func__, 2, "x");
+    const int y = getVerifiedInt(L, __func__, 3, "y");
+    const int z = getVerifiedInt(L, __func__, 4, "z");
     Host const& host = getHostFromLua(L);
     lua_pushboolean(L, host.mpMap->setRoomCoordinates(id, x, y, z));
     return 1;
@@ -8558,11 +8558,11 @@ int TLuaInterpreter::setRoomCoordinates(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setCustomEnvColor
 int TLuaInterpreter::setCustomEnvColor(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "environmentID");
-    int const r = getVerifiedInt(L, __func__, 2, "r");
-    int const g = getVerifiedInt(L, __func__, 3, "g");
-    int const b = getVerifiedInt(L, __func__, 4, "b");
-    int const alpha = getVerifiedInt(L, __func__, 5, "a");
+    const int id = getVerifiedInt(L, __func__, 1, "environmentID");
+    const int r = getVerifiedInt(L, __func__, 2, "r");
+    const int g = getVerifiedInt(L, __func__, 3, "g");
+    const int b = getVerifiedInt(L, __func__, 4, "b");
+    const int alpha = getVerifiedInt(L, __func__, 5, "a");
     Host const& host = getHostFromLua(L);
     host.mpMap->mCustomEnvColors[id] = QColor(r, g, b, alpha);
     host.mpMap->setUnsaved(__func__);
@@ -8677,7 +8677,7 @@ int TLuaInterpreter::getRoomAreaName(lua_State* L)
     }
 
     if (!name.isNull()) {
-        int const result = host.mpMap->mpRoomDB->getAreaNamesMap().key(name, -1);
+        const int result = host.mpMap->mpRoomDB->getAreaNamesMap().key(name, -1);
         lua_pushnumber(L, result);
         if (result != -1) {
             return 1;
@@ -8783,7 +8783,7 @@ int TLuaInterpreter::deleteArea(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#deleteRoom
 int TLuaInterpreter::deleteRoom(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
     if (id <= 0) {
         return 0;
     }
@@ -8796,10 +8796,10 @@ int TLuaInterpreter::deleteRoom(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setExit
 int TLuaInterpreter::setExit(lua_State* L)
 {
-    int const from = getVerifiedInt(L, __func__, 1, "from roomID");
-    int const to = getVerifiedInt(L, __func__, 2, "to roomID");
+    const int from = getVerifiedInt(L, __func__, 1, "from roomID");
+    const int to = getVerifiedInt(L, __func__, 2, "to roomID");
 
-    int const dir = dirToNumber(L, 3);
+    const int dir = dirToNumber(L, 3);
     if (!dir) {
         lua_pushfstring(L, "setExit: bad argument #3 type (direction as number or string expected, got %s!)", luaL_typename(L, 3));
         return lua_error(L);
@@ -8814,7 +8814,7 @@ int TLuaInterpreter::setExit(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomCoordinates
 int TLuaInterpreter::getRoomCoordinates(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
@@ -8833,7 +8833,7 @@ int TLuaInterpreter::getRoomCoordinates(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomArea
 int TLuaInterpreter::getRoomArea(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
@@ -8847,7 +8847,7 @@ int TLuaInterpreter::getRoomArea(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#roomExists
 int TLuaInterpreter::roomExists(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
@@ -8861,7 +8861,7 @@ int TLuaInterpreter::roomExists(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addRoom
 int TLuaInterpreter::addRoom(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
     Host const& host = getHostFromLua(L);
     bool const added = host.mpMap->addRoom(id);
     lua_pushboolean(L, added);
@@ -8882,7 +8882,7 @@ int TLuaInterpreter::createRoomID(lua_State* L)
     }
 
     if (lua_gettop(L) > 0) {
-        int const minId = getVerifiedInt(L, __func__, 1, "minimum room Id", true);
+        const int minId = getVerifiedInt(L, __func__, 1, "minimum room Id", true);
         if (minId < 1) {
             return warnArgumentValue(L, __func__, qsl(
                 "minimum roomID %1 is an optional value but if provided it must be greater than zero").arg(minId));
@@ -8897,7 +8897,7 @@ int TLuaInterpreter::createRoomID(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#unHighlightRoom
 int TLuaInterpreter::unHighlightRoom(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
 
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
@@ -8918,16 +8918,16 @@ int TLuaInterpreter::unHighlightRoom(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#highlightRoom
 int TLuaInterpreter::highlightRoom(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
-    int const fgr = getVerifiedInt(L, __func__, 2, "color1Red");
-    int const fgg = getVerifiedInt(L, __func__, 3, "color1Green");
-    int const fgb = getVerifiedInt(L, __func__, 4, "color1Blue");
-    int const bgr = getVerifiedInt(L, __func__, 5, "color2Red");
-    int const bgg = getVerifiedInt(L, __func__, 6, "color2Green");
-    int const bgb = getVerifiedInt(L, __func__, 7, "color2Blue");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int fgr = getVerifiedInt(L, __func__, 2, "color1Red");
+    const int fgg = getVerifiedInt(L, __func__, 3, "color1Green");
+    const int fgb = getVerifiedInt(L, __func__, 4, "color1Blue");
+    const int bgr = getVerifiedInt(L, __func__, 5, "color2Red");
+    const int bgg = getVerifiedInt(L, __func__, 6, "color2Green");
+    const int bgb = getVerifiedInt(L, __func__, 7, "color2Blue");
     float const radius = getVerifiedFloat(L, __func__, 8, "highlightRadius");
-    int const alpha1 = getVerifiedInt(L, __func__, 9, "color1Alpha");
-    int const alpha2 = getVerifiedInt(L, __func__, 10, "color2Alpha");
+    const int alpha1 = getVerifiedInt(L, __func__, 9, "color1Alpha");
+    const int alpha2 = getVerifiedInt(L, __func__, 10, "color2Alpha");
 
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
@@ -8963,18 +8963,18 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
     int foregroundTransparency = 255;
     int backgroundTransparency = 50;
 
-    int const args = lua_gettop(L);
-    int const area = getVerifiedInt(L, __func__, 1, "areaID");
+    const int args = lua_gettop(L);
+    const int area = getVerifiedInt(L, __func__, 1, "areaID");
     const QString text = getVerifiedString(L, __func__, 2, "text");
     float const posx = getVerifiedFloat(L, __func__, 3, "posX");
     float const posy = getVerifiedFloat(L, __func__, 4, "posY");
     float const posz = getVerifiedFloat(L, __func__, 5, "posZ");
-    int const fgr = getVerifiedInt(L, __func__, 6, "fgRed");
-    int const fgg = getVerifiedInt(L, __func__, 7, "fgGreen");
-    int const fgb = getVerifiedInt(L, __func__, 8, "fgBlue");
-    int const bgr = getVerifiedInt(L, __func__, 9, "bgRed");
-    int const bgg = getVerifiedInt(L, __func__, 10, "bgGreen");
-    int const bgb = getVerifiedInt(L, __func__, 11, "bgBlue");
+    const int fgr = getVerifiedInt(L, __func__, 6, "fgRed");
+    const int fgg = getVerifiedInt(L, __func__, 7, "fgGreen");
+    const int fgb = getVerifiedInt(L, __func__, 8, "fgBlue");
+    const int bgr = getVerifiedInt(L, __func__, 9, "bgRed");
+    const int bgg = getVerifiedInt(L, __func__, 10, "bgGreen");
+    const int bgb = getVerifiedInt(L, __func__, 11, "bgBlue");
     if (args > 11) {
         zoom = getVerifiedFloat(L, __func__, 12, "zoom", true);
         fontSize = getVerifiedInt(L, __func__, 13, "fontSize", true);
@@ -9053,8 +9053,8 @@ int TLuaInterpreter::getMapZoom(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#createMapImageLabel
 int TLuaInterpreter::createMapImageLabel(lua_State* L)
 {
-    int const args = lua_gettop(L);
-    int const area = getVerifiedInt(L, __func__, 1, "areaID");
+    const int args = lua_gettop(L);
+    const int area = getVerifiedInt(L, __func__, 1, "areaID");
     const QString imagePathFileName = getVerifiedString(L, __func__, 2, "imagePathFileName");
     float const posx = getVerifiedFloat(L, __func__, 3, "posX");
     float const posy = getVerifiedFloat(L, __func__, 4, "posY");
@@ -9081,7 +9081,7 @@ int TLuaInterpreter::setDoor(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
@@ -9129,7 +9129,7 @@ int TLuaInterpreter::setDoor(lua_State* L)
         // else IS a valid stub or real normal exit -fall through to continue
     }
 
-    int const doorStatus = getVerifiedInt(L, __func__, 3, "door type  {0='none', 1='open', 2='closed' or 3='locked'}");
+    const int doorStatus = getVerifiedInt(L, __func__, 3, "door type  {0='none', 1='open', 2='closed' or 3='locked'}");
     if (doorStatus < 0 || doorStatus > 3) {
         return warnArgumentValue(L, __func__, qsl(
             "door type %1 is not one of 0='none', 1='open', 2='closed' or 3='locked'").arg(doorStatus));
@@ -9154,7 +9154,7 @@ int TLuaInterpreter::getDoors(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
@@ -9174,7 +9174,7 @@ int TLuaInterpreter::getDoors(lua_State* L)
 int TLuaInterpreter::setExitWeight(lua_State* L)
 {
     Host const& host = getHostFromLua(L);
-    int const roomID = getVerifiedInt(L, __func__, 1, "roomID");
+    const int roomID = getVerifiedInt(L, __func__, 1, "roomID");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomID));
@@ -9217,7 +9217,7 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
     QList<qreal> x;
     QList<qreal> y;
     QList<int> z;
-    int const id_from = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id_from = getVerifiedInt(L, __func__, 1, "roomID");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id_from);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id_from));
@@ -9233,8 +9233,8 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
         if (!pR_to) {
             return warnArgumentValue(L, __func__, qsl("number %1 is not a valid target roomID").arg(id_to));
         }
-        int const area = pR->getArea();
-        int const area_to = pR_to->getArea();
+        const int area = pR->getArea();
+        const int area_to = pR_to->getArea();
         if (area != area_to) {
             return warnArgumentValue(L, __func__, qsl(
                 "target room is in area '%1' (ID: %2) which is not the one '%3' (ID: %4) in which this custom line is to be drawn")
@@ -9384,7 +9384,7 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
     }
 
     bool const arrow = getVerifiedBool(L, __func__, 6, "end with arrow");
-    int const lz = z.at(0);
+    const int lz = z.at(0);
     QList<QPointF> points;
     // TODO: make provision for 3D custom lines (and store the z coordinates and allow them to vary)
     points.append(QPointF(x.at(0), y.at(0)));
@@ -9426,7 +9426,7 @@ int TLuaInterpreter::removeCustomLine(lua_State* L)
     Host const& host = getHostFromLua(L);
 
     //args: room_id, direction
-    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
@@ -9463,7 +9463,7 @@ int TLuaInterpreter::removeCustomLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getCustomLines
 int TLuaInterpreter::getCustomLines(lua_State* L)
 {
-    int const roomID = getVerifiedInt(L, __func__, 1, "roomID");
+    const int roomID = getVerifiedInt(L, __func__, 1, "roomID");
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
     if (!pR) { //if the room doesn't exist return nil
@@ -9535,7 +9535,7 @@ int TLuaInterpreter::getCustomLines(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getCustomLines1
 int TLuaInterpreter::getCustomLines1(lua_State* L)
 {
-    int const roomID = getVerifiedInt(L, __func__, 1, "roomID");
+    const int roomID = getVerifiedInt(L, __func__, 1, "roomID");
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
     if (!pR) { //if the room doesn't exist return nil
@@ -9613,7 +9613,7 @@ int TLuaInterpreter::getCustomLines1(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getExitWeights
 int TLuaInterpreter::getExitWeights(lua_State* L)
 {
-    int const roomID = getVerifiedInt(L, __func__, 1, "roomID");
+    const int roomID = getVerifiedInt(L, __func__, 1, "roomID");
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
     lua_newtable(L);
@@ -9631,8 +9631,8 @@ int TLuaInterpreter::getExitWeights(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#deleteMapLabel
 int TLuaInterpreter::deleteMapLabel(lua_State* L)
 {
-    int const area = getVerifiedInt(L, __func__, 1, "areaID");
-    int const labelID = getVerifiedInt(L, __func__, 2, "labelID");
+    const int area = getVerifiedInt(L, __func__, 1, "areaID");
+    const int labelID = getVerifiedInt(L, __func__, 2, "labelID");
     Host const& host = getHostFromLua(L);
     host.mpMap->deleteMapLabel(area, labelID);
     return 0;
@@ -9658,7 +9658,7 @@ int TLuaInterpreter::windowType(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMapLabels
 int TLuaInterpreter::getMapLabels(lua_State* L)
 {
-    int const area = getVerifiedInt(L, __func__, 1, "areaID");
+    const int area = getVerifiedInt(L, __func__, 1, "areaID");
     Host const& host = getHostFromLua(L);
     lua_newtable(L);
     auto pA = host.mpMap->mpRoomDB->getArea(area);
@@ -9677,7 +9677,7 @@ int TLuaInterpreter::getMapLabels(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMapLabel
 int TLuaInterpreter::getMapLabel(lua_State* L)
 {
-    int const areaId = getVerifiedInt(L, __func__, 1, "areaID");
+    const int areaId = getVerifiedInt(L, __func__, 1, "areaID");
 
     if (!lua_isstring(L, 2) && !lua_isnumber(L, 2)) {
         lua_pushfstring(L, "getMapLabel: bad argument #2 type (labelID as number or labelText as string expected, got %s!)", luaL_typename(L, 2));
@@ -9801,13 +9801,13 @@ void TLuaInterpreter::pushMapLabelPropertiesToLua(lua_State* L, const TMapLabel&
 int TLuaInterpreter::addSpecialExit(lua_State* L)
 {
     Host const& host = getHostFromLua(L);
-    int const fromRoomID = getVerifiedInt(L, __func__, 1, "exit roomID");
+    const int fromRoomID = getVerifiedInt(L, __func__, 1, "exit roomID");
     TRoom* pR_from = host.mpMap->mpRoomDB->getRoom(fromRoomID);
     if (!pR_from) {
         return warnArgumentValue(L, __func__, csmInvalidExitRoomID.arg(fromRoomID));
     }
 
-    int const toRoomID = getVerifiedInt(L, __func__, 2, "entrance roomID");
+    const int toRoomID = getVerifiedInt(L, __func__, 2, "entrance roomID");
     TRoom* pR_to = host.mpMap->mpRoomDB->getRoom(toRoomID);
     if (!pR_to) {
         return warnArgumentValue(L, __func__, qsl("number %1 is not a valid entrance roomID").arg(toRoomID));
@@ -9827,7 +9827,7 @@ int TLuaInterpreter::addSpecialExit(lua_State* L)
 int TLuaInterpreter::removeSpecialExit(lua_State* L)
 {
     Host const& host = getHostFromLua(L);
-    int const fromRoomID = getVerifiedInt(L, __func__, 1, "exit roomID");
+    const int fromRoomID = getVerifiedInt(L, __func__, 1, "exit roomID");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(fromRoomID);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidExitRoomID.arg(fromRoomID));
@@ -9855,7 +9855,7 @@ int TLuaInterpreter::clearRoomUserData(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
@@ -9878,7 +9878,7 @@ int TLuaInterpreter::clearRoomUserDataItem(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
     const QString key = getVerifiedString(L, __func__, 2, "key");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
@@ -9908,7 +9908,7 @@ int TLuaInterpreter::clearAreaUserData(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int const areaId = getVerifiedInt(L, __func__, 1, "areaID");
+    const int areaId = getVerifiedInt(L, __func__, 1, "areaID");
     TArea* pA = host.mpMap->mpRoomDB->getArea(areaId);
     if (!pA) {
         return warnArgumentValue(L, __func__, csmInvalidAreaID.arg(areaId));
@@ -9931,7 +9931,7 @@ int TLuaInterpreter::clearAreaUserDataItem(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int const areaId = getVerifiedInt(L, __func__, 1, "areaID");
+    const int areaId = getVerifiedInt(L, __func__, 1, "areaID");
     const QString key = getVerifiedString(L, __func__, 2, "key");
     TArea* pA = host.mpMap->mpRoomDB->getArea(areaId);
     if (!pA) {
@@ -9982,7 +9982,7 @@ int TLuaInterpreter::clearMapUserDataItem(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearSpecialExits
 int TLuaInterpreter::clearSpecialExits(lua_State* L)
 {
-    int const id_from = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id_from = getVerifiedInt(L, __func__, 1, "roomID");
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id_from);
     if (pR) {
@@ -10001,7 +10001,7 @@ int TLuaInterpreter::clearSpecialExits(lua_State* L)
 int TLuaInterpreter::getSpecialExits(lua_State* L)
 {
     Host const& host = getHostFromLua(L);
-    int const id_from = getVerifiedInt(L, __func__, 1, "exit roomID");
+    const int id_from = getVerifiedInt(L, __func__, 1, "exit roomID");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id_from);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id_from));
@@ -10030,7 +10030,7 @@ int TLuaInterpreter::getSpecialExits(lua_State* L)
             int bestUnlockedExitWeight = -1;
             int bestLockedExitIndex = -1;
             int bestLockedExitWeight = -1;
-            int const exitCommandsCount = exitCommandsToThisRoomId.count();
+            const int exitCommandsCount = exitCommandsToThisRoomId.count();
             for (int j = 0; j < exitCommandsCount; ++j) {
                 if (showAllExits || exitCommandsCount == 1) {
                     // The simpler case - show all exits (or the only exit) to
@@ -10045,7 +10045,7 @@ int TLuaInterpreter::getSpecialExits(lua_State* L)
                 // The more complex (but highly unlikely in most MUDs) case
                 // - find the best exit to this room when there are more than
                 // one:
-                int const thisExitWeight = pR->getExitWeight(exitCommandsToThisRoomId.at(j));
+                const int thisExitWeight = pR->getExitWeight(exitCommandsToThisRoomId.at(j));
                 if (pR->hasSpecialExitLock(exitCommandsToThisRoomId.at(j))) {
                     if (bestLockedExitIndex == -1) {
                         bestLockedExitIndex = j;
@@ -10070,7 +10070,7 @@ int TLuaInterpreter::getSpecialExits(lua_State* L)
             if (!showAllExits && (exitCommandsCount > 1)) {
                 // Produce the best exit to this room given that there IS more
                 // than one and we haven't been asked to show them all:
-                int const bestExitIndex = (bestUnlockedExitIndex != -1) ? bestUnlockedExitIndex : bestLockedExitIndex;
+                const int bestExitIndex = (bestUnlockedExitIndex != -1) ? bestUnlockedExitIndex : bestLockedExitIndex;
                 lua_pushstring(L, exitCommandsToThisRoomId.at(bestExitIndex).toUtf8().constData());
                 lua_pushstring(L, pR->hasSpecialExitLock(exitCommandsToThisRoomId.at(bestExitIndex)) ? "1" : "0");
                 lua_settable(L, -3);
@@ -10090,7 +10090,7 @@ int TLuaInterpreter::getSpecialExitsSwap(lua_State* L)
         lua_pushfstring(L, "getSpecialExitsSwap: bad argument #1 type (exit roomID as number expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    int const id_from = lua_tointeger(L, 1);
+    const int id_from = lua_tointeger(L, 1);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id_from);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id_from));
@@ -10110,7 +10110,7 @@ int TLuaInterpreter::getSpecialExitsSwap(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomEnv
 int TLuaInterpreter::getRoomEnv(lua_State* L)
 {
-    int const roomID = getVerifiedInt(L, __func__, 1, "roomID");
+    const int roomID = getVerifiedInt(L, __func__, 1, "roomID");
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
     if (pR) {
@@ -10128,7 +10128,7 @@ int TLuaInterpreter::getRoomUserData(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
     const QString key = getVerifiedString(L, __func__, 2, "key");
     bool isBackwardCompatibilityRequired = true;
     if (lua_gettop(L) > 2) {
@@ -10158,7 +10158,7 @@ int TLuaInterpreter::getRoomUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getAreaUserData
 int TLuaInterpreter::getAreaUserData(lua_State* L)
 {
-    int const areaId = getVerifiedInt(L, __func__, 1, "areaID");
+    const int areaId = getVerifiedInt(L, __func__, 1, "areaID");
     const QString key = getVerifiedString(L, __func__, 2, "key");
     if (key.isEmpty()) {
         return warnArgumentValue(L, __func__, "key is not allowed to be an empty string");
@@ -10203,7 +10203,7 @@ int TLuaInterpreter::setRoomUserData(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
     const QString key = getVerifiedString(L, __func__, 2, "key");
     // Ideally should reject empty keys but this could break existing scripts so we can't
     const QString value = getVerifiedString(L, __func__, 3, "value");
@@ -10221,7 +10221,7 @@ int TLuaInterpreter::setRoomUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setAreaUserData
 int TLuaInterpreter::setAreaUserData(lua_State* L)
 {
-    int const areaId = getVerifiedInt(L, __func__, 1, "areaID");
+    const int areaId = getVerifiedInt(L, __func__, 1, "areaID");
     const QString key = getVerifiedString(L, __func__, 2, "key");
     if (key.isEmpty()) {
         return warnArgumentValue(L, __func__, "key is not allowed to be an empty string");
@@ -10271,7 +10271,7 @@ int TLuaInterpreter::getRoomUserDataKeys(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
 
     QStringList keys;
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
@@ -10296,7 +10296,7 @@ int TLuaInterpreter::getAllRoomUserData(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int const roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
 
     QStringList keys;
     QStringList values;
@@ -10323,7 +10323,7 @@ int TLuaInterpreter::getAllAreaUserData(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int const areaId = getVerifiedInt(L, __func__, 1, "areaID");
+    const int areaId = getVerifiedInt(L, __func__, 1, "areaID");
 
     QStringList keys;
     QStringList values;
@@ -10406,7 +10406,7 @@ int TLuaInterpreter::setRoomArea(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
     if (!host.mpMap->mpRoomDB->getRoomIDList().contains(id)) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
     }
@@ -10465,7 +10465,7 @@ int TLuaInterpreter::setRoomArea(lua_State* L)
 int TLuaInterpreter::resetRoomArea(lua_State* L)
 {
     //will reset the room area to our void area
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
 
     Host const& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
@@ -10494,7 +10494,7 @@ int TLuaInterpreter::resetRoomArea(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setRoomChar
 int TLuaInterpreter::setRoomChar(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
     const QString symbol = getVerifiedString(L, __func__, 2, "room symbol");
 
     Host const& host = getHostFromLua(L);
@@ -10519,7 +10519,7 @@ int TLuaInterpreter::setRoomChar(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomChar
 int TLuaInterpreter::getRoomChar(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
@@ -10533,18 +10533,18 @@ int TLuaInterpreter::getRoomChar(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setRoomCharColor
 int TLuaInterpreter::setRoomCharColor(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
-    int const r = getVerifiedInt(L, __func__, 2, "red component");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int r = getVerifiedInt(L, __func__, 2, "red component");
     if (r < 0 || r > 255) {
         lua_pushfstring(L, "setRoomCharColor: bad argument #2 type (red component value %d out of range (0 to 255)", r);
         return lua_error(L);
     }
-    int const g = getVerifiedInt(L, __func__, 3, "green component");
+    const int g = getVerifiedInt(L, __func__, 3, "green component");
     if (g < 0 || g > 255) {
         lua_pushfstring(L, "setRoomCharColor: bad argument #3 type (red component value %d out of range (0 to 255)", r);
         return lua_error(L);
     }
-    int const b = getVerifiedInt(L, __func__, 4, "blue component");
+    const int b = getVerifiedInt(L, __func__, 4, "blue component");
     if (b < 0 || b > 255) {
         lua_pushfstring(L, "setRoomCharColor: bad argument #4 type (blue component value %d out of range (0 to 255)", r);
         return lua_error(L);
@@ -10568,7 +10568,7 @@ int TLuaInterpreter::setRoomCharColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#unsetRoomCharColor
 int TLuaInterpreter::unsetRoomCharColor(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
 
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
@@ -10589,7 +10589,7 @@ int TLuaInterpreter::unsetRoomCharColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomCharColor
 int TLuaInterpreter::getRoomCharColor(lua_State* L)
 {
-    int const id = getVerifiedInt(L, __func__, 1, "roomID");
+    const int id = getVerifiedInt(L, __func__, 1, "roomID");
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
@@ -10605,10 +10605,10 @@ int TLuaInterpreter::getRoomCharColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomsByPosition
 int TLuaInterpreter::getRoomsByPosition(lua_State* L)
 {
-    int const area = getVerifiedInt(L, __func__, 1, "areaID");
-    int const x = getVerifiedInt(L, __func__, 2, "x");
-    int const y = getVerifiedInt(L, __func__, 3, "y");
-    int const z = getVerifiedInt(L, __func__, 4, "z");
+    const int area = getVerifiedInt(L, __func__, 1, "areaID");
+    const int x = getVerifiedInt(L, __func__, 2, "x");
+    const int y = getVerifiedInt(L, __func__, 3, "y");
+    const int z = getVerifiedInt(L, __func__, 4, "z");
 
     Host const& host = getHostFromLua(L);
     TArea* pA = host.mpMap->mpRoomDB->getArea(area);
@@ -10635,7 +10635,7 @@ int TLuaInterpreter::getGridMode(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    int const id = getVerifiedInt(L, __func__, 1, "areaID");
+    const int id = getVerifiedInt(L, __func__, 1, "areaID");
 
     TArea* area = host.mpMap->mpRoomDB->getArea(id);
     if (!area) {
@@ -10649,7 +10649,7 @@ int TLuaInterpreter::getGridMode(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setGridMode
 int TLuaInterpreter::setGridMode(lua_State* L)
 {
-    int const area = getVerifiedInt(L, __func__, 1, "areaID");
+    const int area = getVerifiedInt(L, __func__, 1, "areaID");
     bool const gridMode = getVerifiedBool(L, __func__, 2, "true/false");
     Host const& host = getHostFromLua(L);
     TArea* pA = host.mpMap->mpRoomDB->getArea(area);
@@ -10678,21 +10678,21 @@ int TLuaInterpreter::setGridMode(lua_State* L)
 int TLuaInterpreter::setFgColor(lua_State* L)
 {
     int s = 0;
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     auto validRange = [](int number) { return number >= 0 && number <= 255; };
     QString windowName;
     if (n > 3) {
         windowName = WINDOW_NAME(L, ++s);
     }
-    int const luaRed = getVerifiedInt(L, __func__, ++s, "red component value");
+    const int luaRed = getVerifiedInt(L, __func__, ++s, "red component value");
     if (!validRange(luaRed)) {
         return warnArgumentValue(L, __func__, csmInvalidRedValue.arg(luaRed));
     }
-    int const luaGreen = getVerifiedInt(L, __func__, ++s, "green component value");
+    const int luaGreen = getVerifiedInt(L, __func__, ++s, "green component value");
     if (!validRange(luaGreen)) {
         return warnArgumentValue(L, __func__, csmInvalidGreenValue.arg(luaGreen));
     }
-    int const luaBlue = getVerifiedInt(L, __func__, ++s, "blue component value");
+    const int luaBlue = getVerifiedInt(L, __func__, ++s, "blue component value");
     if (!validRange(luaBlue)) {
         return warnArgumentValue(L, __func__, csmInvalidBlueValue.arg(luaBlue));
     }
@@ -10762,7 +10762,7 @@ int TLuaInterpreter::setBgColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#insertLink
 int TLuaInterpreter::insertLink(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     int funcRef{0};
     bool useCurrentFormat{false};
     QString windowName{qsl("main")};
@@ -10856,7 +10856,7 @@ int TLuaInterpreter::insertPopup(lua_State* L)
     QVector<int> luaReference;
     bool customFormat = false;
     int s = 1;
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
 
     // console name is an optional first argument
     if (n >= 4) {
@@ -10944,7 +10944,7 @@ int TLuaInterpreter::insertHTML(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addSupportedTelnetOption
 int TLuaInterpreter::addSupportedTelnetOption(lua_State* L)
 {
-    int const option = getVerifiedInt(L, __func__, 1, "option");
+    const int option = getVerifiedInt(L, __func__, 1, "option");
     Host& host = getHostFromLua(L);
     host.mTelnet.supportedTelnetOptions[option] = true;
     return 0;
@@ -10956,7 +10956,7 @@ int TLuaInterpreter::echo(lua_State* L)
     Host& host = getHostFromLua(L);
 
     QString consoleName;
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     int s = 1;
 
     if (n > 1) {
@@ -10990,7 +10990,7 @@ int TLuaInterpreter::echoPopup(lua_State* L)
     QVector<int> luaReference;
     bool customFormat = false;
     int s = 1;
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     // console name is an optional first argument
     if (n >= 4) {
         windowName = WINDOW_NAME(L, s++);
@@ -11050,7 +11050,7 @@ int TLuaInterpreter::echoPopup(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#echoLink
 int TLuaInterpreter::echoLink(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     int funcRef{0};
     bool useCurrentFormat{false};
     QString windowName{qsl("main")};
@@ -11140,7 +11140,7 @@ int TLuaInterpreter::setMergeTables(lua_State* L)
     Host& host = getHostFromLua(L);
 
     QStringList modulesList;
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     for (int i = 1; i <= n; i++) {
         modulesList << getVerifiedString(L, __func__, i, "module");
     }
@@ -11288,7 +11288,7 @@ int TLuaInterpreter::getMudletVersion(lua_State* L)
         return lua_error(L);
     }
 
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
 
     if (n == 1) {
         const QString tidiedWhat = getVerifiedString(L, __func__, 1, "style", true).toLower().trimmed();
@@ -11408,7 +11408,7 @@ int TLuaInterpreter::setDiscordGameUrl(lua_State* L)
     mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
     bool const isActiveHost = (pMudlet->mpCurrentActiveHost == &host);
-    int const args = lua_gettop(L);
+    const int args = lua_gettop(L);
 
     if (!args) { // no args, blank the invite URL and game name
         host.setDiscordInviteURL(QString());
@@ -11830,7 +11830,7 @@ int TLuaInterpreter::resetDiscordData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getTime
 int TLuaInterpreter::getTime(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     bool return_string = false;
     QString format = qsl("yyyy.MM.dd hh:mm:ss.zzz");
     QString tm;
@@ -11892,7 +11892,7 @@ int TLuaInterpreter::appendBuffer(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#appendCmdLine
 int TLuaInterpreter::appendCmdLine(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     QString name = "main";
 
     if (n > 1) {
@@ -11914,7 +11914,7 @@ int TLuaInterpreter::appendCmdLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#selectCmdLineText
 int TLuaInterpreter::selectCmdLineText(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     QString name = "main";
     if (n >= 1) {
         name = CMDLINE_NAME(L, 1);
@@ -11927,7 +11927,7 @@ int TLuaInterpreter::selectCmdLineText(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getCmdLine
 int TLuaInterpreter::getCmdLine(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     QString name = "main";
     if (n >= 1) {
         name = CMDLINE_NAME(L, 1);
@@ -11941,7 +11941,7 @@ int TLuaInterpreter::getCmdLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addCmdLineSuggestion
 int TLuaInterpreter::addCmdLineSuggestion(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     QString name = "main";
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
@@ -11955,7 +11955,7 @@ int TLuaInterpreter::addCmdLineSuggestion(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#removeCmdLineSuggestion
 int TLuaInterpreter::removeCmdLineSuggestion(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     QString name = "main";
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
@@ -11969,7 +11969,7 @@ int TLuaInterpreter::removeCmdLineSuggestion(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearCmdLineSuggestions
 int TLuaInterpreter::clearCmdLineSuggestions(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     QString name = "main";
     if (n == 1) {
         name = CMDLINE_NAME(L, 1);
@@ -11981,7 +11981,7 @@ int TLuaInterpreter::clearCmdLineSuggestions(lua_State* L)
 
 int TLuaInterpreter::addCmdLineBlacklist(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     QString name = "main";
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
@@ -11994,7 +11994,7 @@ int TLuaInterpreter::addCmdLineBlacklist(lua_State* L)
 
 int TLuaInterpreter::removeCmdLineBlacklist(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     QString name = "main";
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
@@ -12007,7 +12007,7 @@ int TLuaInterpreter::removeCmdLineBlacklist(lua_State* L)
 
 int TLuaInterpreter::clearCmdLineBlacklist(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     QString name = "main";
     if (n == 1) {
         name = CMDLINE_NAME(L, 1);
@@ -12092,7 +12092,7 @@ int TLuaInterpreter::enableModuleSync(lua_State* L)
 
     auto moduleManager = host.mpModuleManager;
     if (moduleManager && !moduleManager->moduleTable->findItems(module, Qt::MatchExactly).isEmpty()) {
-        int const row = moduleManager->moduleTable->findItems(module, Qt::MatchExactly)[0]->row();
+        const int row = moduleManager->moduleTable->findItems(module, Qt::MatchExactly)[0]->row();
         auto checkItem = moduleManager->moduleTable->item(row, 2);
         checkItem->setCheckState(Qt::Checked);
     }
@@ -12112,7 +12112,7 @@ int TLuaInterpreter::disableModuleSync(lua_State* L)
 
     auto moduleManager = host.mpModuleManager;
     if (moduleManager && !moduleManager->moduleTable->findItems(module, Qt::MatchExactly).isEmpty()) {
-        int const row = moduleManager->moduleTable->findItems(module, Qt::MatchExactly)[0]->row();
+        const int row = moduleManager->moduleTable->findItems(module, Qt::MatchExactly)[0]->row();
         auto checkItem = moduleManager->moduleTable->item(row, 2);
         checkItem->setCheckState(Qt::Unchecked);
     }
@@ -12174,7 +12174,7 @@ int TLuaInterpreter::getModuleInfo(lua_State* L)
 {
     Host const& host = getHostFromLua(L);
     auto infoMap = host.mModuleInfo;
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     const QString name = getVerifiedString(L, __func__, 1, "module name");
     QString info;
     if (n > 1) {
@@ -12200,7 +12200,7 @@ int TLuaInterpreter::getPackageInfo(lua_State* L)
 {
     Host const& host = getHostFromLua(L);
     auto infoMap = host.mPackageInfo;
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     const QString name = getVerifiedString(L, __func__, 1, "package name");
     QString info;
     if (n > 1) {
@@ -12315,7 +12315,7 @@ int TLuaInterpreter::expandAlias(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#printCmdLine
 int TLuaInterpreter::printCmdLine(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     QString name = "main";
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
@@ -12334,7 +12334,7 @@ int TLuaInterpreter::printCmdLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearCmdLine
 int TLuaInterpreter::clearCmdLine(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     QString name = "main";
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
@@ -12458,7 +12458,7 @@ int TLuaInterpreter::getIrcChannels(lua_State* L)
     }
 
     lua_newtable(L);
-    int const total = channels.count();
+    const int total = channels.count();
     for (int i = 0; i < total; ++i) {
         lua_pushnumber(L, i + 1);
         lua_pushstring(L, channels[i].toUtf8().data());
@@ -12511,7 +12511,7 @@ int TLuaInterpreter::setIrcNick(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setIrcServer
 int TLuaInterpreter::setIrcServer(lua_State* L)
 {
-    int const args = lua_gettop(L);
+    const int args = lua_gettop(L);
     int secure = false;
     int port = 6667;
     QString password;
@@ -13204,7 +13204,7 @@ bool TLuaInterpreter::compileAndExecuteScript(const QString& code)
     }
     lua_State* L = pGlobalLua;
 
-    int const error = luaL_dostring(L, code.toUtf8().constData());
+    const int error = luaL_dostring(L, code.toUtf8().constData());
     if (error) {
         std::string e = "no error message available from Lua";
         if (lua_isstring(L, 1)) {
@@ -13252,7 +13252,7 @@ QString TLuaInterpreter::formatLuaCode(const QString &code)
     escapedCode.replace(QLatin1String("\n"), QLatin1String("\\n"));
 
     const QString thing = QString(R"(return get_formatted_code(get_ast("%1"), {indent_chunk = '  ', right_margin = 100, max_text_width = 160, keep_comments = true}))").arg(escapedCode);
-    int const error = luaL_dostring(L, thing.toUtf8().constData());
+    const int error = luaL_dostring(L, thing.toUtf8().constData());
     if (error) {
         std::string e = "no error message available from Lua";
         if (lua_isstring(L, 1)) {
@@ -13279,7 +13279,7 @@ bool TLuaInterpreter::compile(const QString& code, QString& errorMsg, const QStr
 {
     lua_State* L = pGlobalLua;
 
-    int const error = (luaL_loadbuffer(L, code.toUtf8().constData(),
+    const int error = (luaL_loadbuffer(L, code.toUtf8().constData(),
                                  strlen(code.toUtf8().constData()),
                                  name.toUtf8().constData()) || lua_pcall(L, 0, 0, 0));
 
@@ -13325,8 +13325,8 @@ std::pair<bool, QString> TLuaInterpreter::validateLuaCodeParam(int index)
 std::pair<bool, QString> TLuaInterpreter::validLuaCode(const QString &code)
 {
     lua_State* L = pGlobalLua;
-    int const error = luaL_loadbuffer(L, code.toUtf8().constData(), strlen(code.toUtf8().constData()), code.toUtf8().data());
-    int const topElementIndex = lua_gettop(L);
+    const int error = luaL_loadbuffer(L, code.toUtf8().constData(), strlen(code.toUtf8().constData()), code.toUtf8().data());
+    const int topElementIndex = lua_gettop(L);
     QString e = "invalid Lua code: ";
     if (error) {
         if (lua_isstring(L, topElementIndex)) {
@@ -13579,7 +13579,7 @@ void TLuaInterpreter::parseJSON(QString& key, const QString& string_data, const 
         return;
     }
     int i = 0;
-    for (int const total = tokenList.size() - 1; i < total; ++i) {
+    for (const int total = tokenList.size() - 1; i < total; ++i) {
         lua_getfield(L, -1, tokenList.at(i).toUtf8().constData());
         if (!lua_istable(L, -1)) {
             lua_pop(L, 1);
@@ -13615,7 +13615,7 @@ void TLuaInterpreter::parseJSON(QString& key, const QString& string_data, const 
     }
     auto dataInUtf8 = string_data.toUtf8();
     lua_pushlstring(L, dataInUtf8.constData(), dataInUtf8.length());
-    int const error = lua_pcall(L, 1, 1, 0);
+    const int error = lua_pcall(L, 1, 1, 0);
     if (!error) {
         // Top of stack should now contain the lua representation of json.
         lua_rawset(L, -3);
@@ -13629,7 +13629,7 @@ void TLuaInterpreter::parseJSON(QString& key, const QString& string_data, const 
             }
             lua_getglobal(L, "gmcp");
             i = 0;
-            for (int const total = tokenList.size() - 1; i < total; ++i) {
+            for (const int total = tokenList.size() - 1; i < total; ++i) {
                 lua_getfield(L, -1, tokenList.at(i).toUtf8().constData());
                 lua_remove(L, -2);
             }
@@ -13812,7 +13812,7 @@ void TLuaInterpreter::msdp2Lua(const char* src)
     QByteArray const transcodedSrc = host.mTelnet.decodeBytes(src);
     QStringList varList;
     QByteArray lastVar;
-    int const textLength = transcodedSrc.length();
+    const int textLength = transcodedSrc.length();
     int nest = 0;
     quint8 last = 0;
 
@@ -13978,9 +13978,9 @@ bool TLuaInterpreter::call_luafunction(void* pT)
     lua_gettable(L, LUA_REGISTRYINDEX);
     if (lua_isfunction(L, -1)) {
         setMatches(L);
-        int const error = lua_pcall(L, 0, LUA_MULTRET, 0);
+        const int error = lua_pcall(L, 0, LUA_MULTRET, 0);
         if (error) {
-            int const nbpossible_errors = lua_gettop(L);
+            const int nbpossible_errors = lua_gettop(L);
             for (int i = 1; i <= nbpossible_errors; i++) {
                 std::string e = "";
                 if (lua_isstring(L, i)) {
@@ -14050,9 +14050,9 @@ std::pair<bool, bool> TLuaInterpreter::callLuaFunctionReturnBool(void* pT)
 
     if (lua_isfunction(L, -1)) {
         setMatches(L);
-        int const error = lua_pcall(L, 0, LUA_MULTRET, 0);
+        const int error = lua_pcall(L, 0, LUA_MULTRET, 0);
         if (error) {
-            int const nbpossible_errors = lua_gettop(L);
+            const int nbpossible_errors = lua_gettop(L);
             for (int i = 1; i <= nbpossible_errors; i++) {
                 std::string e = "";
                 if (lua_isstring(L, i)) {
@@ -14099,9 +14099,9 @@ bool TLuaInterpreter::call(const QString& function, const QString& mName, const 
     setMatches(L);
 
     lua_getglobal(L, function.toUtf8().constData());
-    int const error = lua_pcall(L, 0, LUA_MULTRET, 0);
+    const int error = lua_pcall(L, 0, LUA_MULTRET, 0);
     if (error) {
-        int const nbpossible_errors = lua_gettop(L);
+        const int nbpossible_errors = lua_gettop(L);
         for (int i = 1; i <= nbpossible_errors; i++) {
             std::string e = "";
             if (lua_isstring(L, i)) {
@@ -14133,9 +14133,9 @@ std::pair<bool, bool> TLuaInterpreter::callReturnBool(const QString& function, c
     setMatches(L);
 
     lua_getglobal(L, function.toUtf8().constData());
-    int const error = lua_pcall(L, 0, LUA_MULTRET, 0);
+    const int error = lua_pcall(L, 0, LUA_MULTRET, 0);
     if (error) {
-        int const nbpossible_errors = lua_gettop(L);
+        const int nbpossible_errors = lua_gettop(L);
         for (int i = 1; i <= nbpossible_errors; i++) {
             std::string e = "";
             if (lua_isstring(L, i)) {
@@ -14213,9 +14213,9 @@ bool TLuaInterpreter::callConditionFunction(std::string& function, const QString
     lua_State* L = pGlobalLua;
 
     lua_getfield(L, LUA_GLOBALSINDEX, function.c_str());
-    int const error = lua_pcall(L, 0, 1, 0);
+    const int error = lua_pcall(L, 0, 1, 0);
     if (error) {
-        int const nbpossible_errors = lua_gettop(L);
+        const int nbpossible_errors = lua_gettop(L);
         for (int i = 1; i <= nbpossible_errors; i++) {
             std::string e = "";
             if (lua_isstring(L, i)) {
@@ -14236,7 +14236,7 @@ bool TLuaInterpreter::callConditionFunction(std::string& function, const QString
     }
 
     bool ret = false;
-    int const returnValues = lua_gettop(L);
+    const int returnValues = lua_gettop(L);
     if (returnValues > 0) {
         // Lua docs: Like all tests in Lua, lua_toboolean returns 1 for any Lua value different from false and nil; otherwise it returns 0
         // This means trigger patterns don't have to strictly return true or false, as it is accepted in Lua
@@ -14275,9 +14275,9 @@ bool TLuaInterpreter::callMulti(const QString& function, const QString& mName)
     }
 
     lua_getglobal(L, function.toUtf8().constData());
-    int const error = lua_pcall(L, 0, LUA_MULTRET, 0);
+    const int error = lua_pcall(L, 0, LUA_MULTRET, 0);
     if (error) {
-        int const nbpossible_errors = lua_gettop(L);
+        const int nbpossible_errors = lua_gettop(L);
         for (int i = 1; i <= nbpossible_errors; i++) {
             std::string e = "";
             if (lua_isstring(L, i)) {
@@ -14325,9 +14325,9 @@ std::pair<bool, bool> TLuaInterpreter::callMultiReturnBool(const QString& functi
     }
 
     lua_getglobal(L, function.toUtf8().constData());
-    int const error = lua_pcall(L, 0, LUA_MULTRET, 0);
+    const int error = lua_pcall(L, 0, LUA_MULTRET, 0);
     if (error) {
-        int const nbpossible_errors = lua_gettop(L);
+        const int nbpossible_errors = lua_gettop(L);
         for (int i = 1; i <= nbpossible_errors; i++) {
             std::string e = "";
             if (lua_isstring(L, i)) {
@@ -14632,9 +14632,9 @@ double TLuaInterpreter::condenseMapLoad()
     lua_State* L = pGlobalLua;
 
     lua_getfield(L, LUA_GLOBALSINDEX, "condenseMapLoad");
-    int const error = lua_pcall(L, 0, 1, 0);
+    const int error = lua_pcall(L, 0, 1, 0);
     if (error) {
-        int const nbpossible_errors = lua_gettop(L);
+        const int nbpossible_errors = lua_gettop(L);
         for (int i = 1; i <= nbpossible_errors; i++) {
             std::string e = "";
             if (lua_isstring(L, i)) {
@@ -14654,7 +14654,7 @@ double TLuaInterpreter::condenseMapLoad()
         }
     }
 
-    int const returnValues = lua_gettop(L);
+    const int returnValues = lua_gettop(L);
     if (returnValues > 0 && !lua_isnoneornil(L, 1)) {
         loadTime = lua_tonumber(L, 1);
     }
@@ -14968,7 +14968,7 @@ void TLuaInterpreter::set_lua_string(const QString& varName, const QString& varV
 void TLuaInterpreter::set_lua_integer(const QString& varName, int varValue)
 {
     lua_State* L = pGlobalLua;
-    int const top = lua_gettop(L);
+    const int top = lua_gettop(L);
 
     lua_pushnumber(L, varValue);
     lua_setglobal(L, varName.toUtf8().constData());
@@ -14980,7 +14980,7 @@ QString TLuaInterpreter::getLuaString(const QString& stringName)
 {
     lua_State* L = pGlobalLua;
 
-    int const error = luaL_dostring(L, qsl("return %1").arg(stringName).toUtf8().constData());
+    const int error = luaL_dostring(L, qsl("return %1").arg(stringName).toUtf8().constData());
     if (!error) {
         return lua_tostring(L, 1);
     } else {
@@ -15013,7 +15013,7 @@ int TLuaInterpreter::check_for_mappingscript()
         return 0;
     }
 
-    int const r = lua_toboolean(L, -1);
+    const int r = lua_toboolean(L, -1);
     lua_pop(L, 2);
     return r;
 }
@@ -15033,7 +15033,7 @@ int TLuaInterpreter::check_for_custom_speedwalk()
         lua_pop(L, 2);
         return 0;
     }
-    int const r = lua_toboolean(L, -1);
+    const int r = lua_toboolean(L, -1);
     lua_pop(L, 2);
     return r;
 }
@@ -15091,7 +15091,7 @@ static void storeHostInLua(lua_State* L, Host* h);
 // with its success message, on failure will just append...
 bool TLuaInterpreter::loadLuaModule(QQueue<QString>& resultMsgsQueue, const QString& requirement, const QString& failureConsequence, const QString& description, const QString& luaModuleId)
 {
-    int const error = luaL_dostring(pGlobalLua, qsl("%1require \"%2\"")
+    const int error = luaL_dostring(pGlobalLua, qsl("%1require \"%2\"")
                               .arg(luaModuleId.isEmpty() ? QString() : qsl("%1 =").arg(luaModuleId),
                                    requirement).toUtf8().constData());
     if (error) {
@@ -16135,7 +16135,7 @@ std::pair<int, QString> TLuaInterpreter::createPermScript(const QString& name, c
         return {-1, qsl("unable to compile \"%1\", reason: %2").arg(luaCode, errMsg)};
     }
 
-    int const id = pS->getID();
+    const int id = pS->getID();
     pS->setIsActive(false);
     mpHost->mpEditorDialog->mNeedUpdateData = true;
     return {id, QString()};
@@ -16159,7 +16159,7 @@ std::pair<int, QString> TLuaInterpreter::setScriptCode(QString& name, const QStr
         pS->setScript(oldCode);
         return {-1, qsl("unable to compile \"%1\" at position \"%2\", reason: %3").arg(luaCode).arg(++pos).arg(errMsg)};
     }
-    int const id = pS->getID();
+    const int id = pS->getID();
     mpHost->mpEditorDialog->writeScript(id);
     return {id, QString()};
 }
@@ -16220,7 +16220,7 @@ QPair<int, QString> TLuaInterpreter::startTempTimer(double timeout, const QStrin
         return qMakePair(-1, qsl("unable to compile \"%1\", reason: %2").arg(function, errMsg));
     }
 
-    int const id = pT->getID();
+    const int id = pT->getID();
     pT->setIsActive(true);
     pT->enableTimer(id);
     return qMakePair(id, QString());
@@ -16264,7 +16264,7 @@ int TLuaInterpreter::startTempAlias(const QString& regex, const QString& functio
     if (!function.isEmpty()) {
         pT->setScript(function);
     }
-    int const id = pT->getID();
+    const int id = pT->getID();
     pT->setName(QString::number(id));
     return id;
 }
@@ -16310,7 +16310,7 @@ int TLuaInterpreter::startTempKey(int& modifier, int& keycode, const QString& fu
     if (!function.isEmpty()) {
         pT->setScript(function);
     }
-    int const id = pT->getID();
+    const int id = pT->getID();
     pT->setName(QString::number(id));
     return id;
 }
@@ -16327,7 +16327,7 @@ int TLuaInterpreter::startTempExactMatchTrigger(const QString& regex, const QStr
     pT->setTemporary(true);
     pT->registerTrigger();
     pT->setScript(function);
-    int const id = pT->getID();
+    const int id = pT->getID();
     pT->setName(QString::number(id));
     pT->setExpiryCount(expiryCount);
     return id;
@@ -16345,7 +16345,7 @@ int TLuaInterpreter::startTempBeginOfLineTrigger(const QString& regex, const QSt
     pT->setTemporary(true);
     pT->registerTrigger();
     pT->setScript(function);
-    int const id = pT->getID();
+    const int id = pT->getID();
     pT->setName(QString::number(id));
     pT->setExpiryCount(expiryCount);
     return id;
@@ -16363,7 +16363,7 @@ int TLuaInterpreter::startTempTrigger(const QString& regex, const QString& funct
     pT->setTemporary(true);
     pT->registerTrigger();
     pT->setScript(function);
-    int const id = pT->getID();
+    const int id = pT->getID();
     pT->setName(QString::number(id));
     pT->setExpiryCount(expiryCount);
     return id;
@@ -16381,7 +16381,7 @@ int TLuaInterpreter::startTempPromptTrigger(const QString& function, int expiryC
     pT->setTemporary(true);
     pT->registerTrigger();
     pT->setScript(function);
-    int const id = pT->getID();
+    const int id = pT->getID();
     pT->setName(QString::number(id));
     pT->setExpiryCount(expiryCount);
     return id;
@@ -16404,7 +16404,7 @@ int TLuaInterpreter::startTempLineTrigger(int from, int howmany, const QString& 
     pT->setLineDelta(howmany);
     pT->registerTrigger();
     pT->setScript(function);
-    int const id = pT->getID();
+    const int id = pT->getID();
     pT->setName(QString::number(id));
     pT->setExpiryCount(expiryCount);
     return id;
@@ -16426,7 +16426,7 @@ int TLuaInterpreter::startTempColorTrigger(int fg, int bg, const QString& functi
 
     pT->registerTrigger();
     pT->setScript(function);
-    int const id = pT->getID();
+    const int id = pT->getID();
     pT->setName(QString::number(id));
     pT->setExpiryCount(expiryCount);
     return id;
@@ -16444,7 +16444,7 @@ int TLuaInterpreter::startTempRegexTrigger(const QString& regex, const QString& 
     pT->setTemporary(true);
     pT->registerTrigger();
     pT->setScript(function);
-    int const id = pT->getID();
+    const int id = pT->getID();
     pT->setName(QString::number(id));
     pT->setExpiryCount(expiryCount);
     return id;
@@ -16844,7 +16844,7 @@ int TLuaInterpreter::getDictionaryWordList(lua_State* L)
     // is fatally dangerous if used in a range based initialiser:
     QSet<QString> wordSet{host.mpConsole->getWordSet()};
     QStringList wordList{wordSet.begin(), wordSet.end()};
-    int const wordCount = wordList.size();
+    const int wordCount = wordList.size();
     if (wordCount > 1) {
         QCollator sorter;
         sorter.setCaseSensitivity(Qt::CaseInsensitive);
@@ -17031,9 +17031,9 @@ void TLuaInterpreter::updateExtendedAnsiColorsInTable()
 
     // And insert the 6x6x6 RGB colours
     for (int i = 0; i < 216; ++i) {
-        int const r = i / 36;
-        int const g = (i - (r * 36)) / 6;
-        int const b = (i - (r * 36)) - (g * 6);
+        const int r = i / 36;
+        const int g = (i - (r * 36)) / 6;
+        const int b = (i - (r * 36)) - (g * 6);
 
         lua_createtable(L, 3, 0);
 
@@ -17060,7 +17060,7 @@ void TLuaInterpreter::updateExtendedAnsiColorsInTable()
     for (int i = 232; i < 256; ++i) {
         lua_createtable(L, 3, 0);
 
-        int const value = (i - 232) * 10 + 8;
+        const int value = (i - 232) * 10 + 8;
 
         lua_pushnumber(L, value);
         lua_rawseti(L, -2, 1);
@@ -17175,17 +17175,17 @@ int TLuaInterpreter::getMapBackgroundColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMapBackgroundColor
 int TLuaInterpreter::setMapBackgroundColor(lua_State* L)
 {
-    int const r = getVerifiedInt(L, __func__, 1, "red component");
+    const int r = getVerifiedInt(L, __func__, 1, "red component");
     if (r < 0 || r > 255) {
         return warnArgumentValue(L, __func__, csmInvalidRedValue.arg(r));
     }
 
-    int const g = getVerifiedInt(L, __func__, 2, "green component");
+    const int g = getVerifiedInt(L, __func__, 2, "green component");
     if (g < 0 || g > 255) {
         return warnArgumentValue(L, __func__, csmInvalidGreenValue.arg(g));
     }
 
-    int const b = getVerifiedInt(L, __func__, 3, "blue component");
+    const int b = getVerifiedInt(L, __func__, 3, "blue component");
     if (b < 0 || b > 255) {
         return warnArgumentValue(L, __func__, csmInvalidBlueValue.arg(b));
     }
@@ -17211,17 +17211,17 @@ int TLuaInterpreter::getMapRoomExitsColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMapRoomExitsColor
 int TLuaInterpreter::setMapRoomExitsColor(lua_State* L)
 {
-    int const r = getVerifiedInt(L, __func__, 1, "red component");
+    const int r = getVerifiedInt(L, __func__, 1, "red component");
     if (r < 0 || r > 255) {
         return warnArgumentValue(L, __func__, csmInvalidRedValue.arg(r));
     }
 
-    int const g = getVerifiedInt(L, __func__, 2, "green component");
+    const int g = getVerifiedInt(L, __func__, 2, "green component");
     if (g < 0 || g > 255) {
         return warnArgumentValue(L, __func__, csmInvalidGreenValue.arg(g));
     }
 
-    int const b = getVerifiedInt(L, __func__, 3, "blue component");
+    const int b = getVerifiedInt(L, __func__, 3, "blue component");
     if (b < 0 || b > 255) {
         return warnArgumentValue(L, __func__, csmInvalidBlueValue.arg(b));
     }
@@ -17236,7 +17236,7 @@ int TLuaInterpreter::setMapRoomExitsColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#showNotification
 int TLuaInterpreter::showNotification(lua_State* L)
 {
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     const QString title = getVerifiedString(L, __func__, 1, "title");
     QString text = title;
     if (n >= 2) {
@@ -17317,7 +17317,7 @@ int TLuaInterpreter::registerMapInfo(lua_State* L)
         lua_pushfstring(L, "registerMapInfo: bad argument #2 type (callback as function expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    int const callback = luaL_ref(L, LUA_REGISTRYINDEX);
+    const int callback = luaL_ref(L, LUA_REGISTRYINDEX);
 
     auto& host = getHostFromLua(L);
     host.mpMap->mMapInfoContributorManager->registerContributor(name, [=](int roomID, int selectionSize, int areaId, int displayAreaId, QColor& infoColor) {
@@ -17332,9 +17332,9 @@ int TLuaInterpreter::registerMapInfo(lua_State* L)
         lua_pushinteger(L, areaId);
         lua_pushinteger(L, displayAreaId);
 
-        int const error = lua_pcall(L, 4, 6, 0);
+        const int error = lua_pcall(L, 4, 6, 0);
         if (error) {
-            int const errorCount = lua_gettop(L);
+            const int errorCount = lua_gettop(L);
             if (mudlet::smDebugMode) {
                 for (int i = 1; i <= errorCount; i++) {
                     if (lua_isstring(L, i)) {
@@ -17685,7 +17685,7 @@ int TLuaInterpreter::setConfig(lua_State * L)
 int TLuaInterpreter::addCommandLineMenuEvent(lua_State * L)
 {
     int args = 1;
-    int const argsCount = lua_gettop(L);
+    const int argsCount = lua_gettop(L);
 
     QString commandLineName;
     if (argsCount >= 3) {
@@ -17707,7 +17707,7 @@ int TLuaInterpreter::addCommandLineMenuEvent(lua_State * L)
 int TLuaInterpreter::removeCommandLineMenuEvent(lua_State * L)
 {
     int args = 1;
-    int const argsCount = lua_gettop(L);
+    const int argsCount = lua_gettop(L);
 
     QString commandLineName;
     if (argsCount >= 2) {
@@ -17866,7 +17866,7 @@ int TLuaInterpreter::announce(lua_State *L) {
     static const QStringList processingKinds{"importantall", "importantmostrecent", "all", "mostrecent", "currentthenmostrecent"};
     QString processing;
 
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     if (n > 1) {
         // while this only has effect on Windows, it should fail silently in order not to spam
         processing = getVerifiedString(L, __func__, 2, "processing style");
@@ -17889,7 +17889,7 @@ int TLuaInterpreter::scrollTo(lua_State* L)
     int targetLine = -1;
     bool stopScrolling = false;
 
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     if (n == 2) {
         windowName = getVerifiedString(L, __func__, 1, "window name", true);
         targetLine = getVerifiedInt(L, __func__, 2, "line to scroll to");
@@ -17913,7 +17913,7 @@ int TLuaInterpreter::scrollTo(lua_State* L)
         return 2;
     }
 
-    int const numLines = console->getLastLineNumber();
+    const int numLines = console->getLastLineNumber();
     if (targetLine >= numLines) { // larger than buffer or at end
         stopScrolling = true;
     } else if (targetLine < 0) { // negative, count from end of buffer
@@ -17943,7 +17943,7 @@ int TLuaInterpreter::getScroll(lua_State* L)
 {
     QString windowName;
 
-    int const n = lua_gettop(L);
+    const int n = lua_gettop(L);
     if (n == 1) {
         windowName = getVerifiedString(L, __func__, 1, "window name", true);
     } else {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1697,7 +1697,7 @@ int TLuaInterpreter::getMapEvents(lua_State* L)
                 QMapIterator<QString, QStringList> it(host.mpMap->mpMapper->mp2dMap->mUserActions);
                 while (it.hasNext()) {
                     it.next();
-                    QStringList const eventInfo = it.value();
+                    const QStringList eventInfo = it.value();
                     lua_createtable(L, 0, 4);
                     lua_pushstring(L, eventInfo.at(0).toUtf8().constData());
                     lua_setfield(L, -2, "event name");
@@ -9161,7 +9161,7 @@ int TLuaInterpreter::getDoors(lua_State* L)
     }
 
     lua_newtable(L);
-    QStringList const keys = pR->doors.keys();
+    const QStringList keys = pR->doors.keys();
     for (unsigned int i = 0, total = keys.size(); i < total; ++i) {
         lua_pushstring(L, keys.at(i).toUtf8().constData());
         lua_pushnumber(L, pR->doors.value(keys.at(i)));
@@ -9470,7 +9470,7 @@ int TLuaInterpreter::getCustomLines(lua_State* L)
         return warnArgumentValue(L, __func__, qsl("room %1 doesn't exist").arg(roomID));
     }
     lua_newtable(L); //return table customLines[]
-    QStringList const exits = pR->customLines.keys();
+    const QStringList exits = pR->customLines.keys();
     for (int i = 0, iTotal = exits.size(); i < iTotal; ++i) {
         lua_pushstring(L, exits.at(i).toUtf8().constData());
         lua_newtable(L); //customLines[direction]
@@ -9542,7 +9542,7 @@ int TLuaInterpreter::getCustomLines1(lua_State* L)
         return warnArgumentValue(L, __func__, qsl("room %1 doesn't exist").arg(roomID));
     }
     lua_newtable(L); //return table customLines[]
-    QStringList const exits = pR->customLines.keys();
+    const QStringList exits = pR->customLines.keys();
     for (int i = 0, iTotal = exits.size(); i < iTotal; ++i) {
         lua_pushstring(L, exits.at(i).toUtf8().constData());
         lua_newtable(L); //customLines[direction]
@@ -9618,7 +9618,7 @@ int TLuaInterpreter::getExitWeights(lua_State* L)
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
     lua_newtable(L);
     if (pR) {
-        QStringList const keys = pR->getExitWeights().keys();
+        const QStringList keys = pR->getExitWeights().keys();
         for (int i = 0; i < keys.size(); i++) {
             lua_pushstring(L, keys.at(i).toUtf8().constData());
             lua_pushnumber(L, pR->getExitWeight(keys.at(i)));
@@ -10025,7 +10025,7 @@ int TLuaInterpreter::getSpecialExits(lua_State* L)
         lua_pushnumber(L, exitRoomIdList.at(i));
         lua_newtable(L);
         {
-            QStringList const exitCommandsToThisRoomId = specialExitsByExitId.values(exitRoomIdList.at(i));
+            const QStringList exitCommandsToThisRoomId = specialExitsByExitId.values(exitRoomIdList.at(i));
             int bestUnlockedExitIndex = -1;
             int bestUnlockedExitWeight = -1;
             int bestLockedExitIndex = -1;
@@ -16319,7 +16319,7 @@ int TLuaInterpreter::startTempKey(int& modifier, int& keycode, const QString& fu
 int TLuaInterpreter::startTempExactMatchTrigger(const QString& regex, const QString& function, int expiryCount)
 {
     TTrigger* pT = nullptr;
-    QStringList const sList {regex};
+    const QStringList sList {regex};
     QList<int> const propertyList {REGEX_EXACT_MATCH};
     pT = new TTrigger("a", sList, propertyList, false, mpHost);
     pT->setIsFolder(false);
@@ -16337,7 +16337,7 @@ int TLuaInterpreter::startTempExactMatchTrigger(const QString& regex, const QStr
 int TLuaInterpreter::startTempBeginOfLineTrigger(const QString& regex, const QString& function, int expiryCount)
 {
     TTrigger* pT = nullptr;
-    QStringList const sList {regex};
+    const QStringList sList {regex};
     QList<int> const propertyList {REGEX_BEGIN_OF_LINE_SUBSTRING};
     pT = new TTrigger("a", sList, propertyList, false, mpHost);
     pT->setIsFolder(false);
@@ -16355,7 +16355,7 @@ int TLuaInterpreter::startTempBeginOfLineTrigger(const QString& regex, const QSt
 int TLuaInterpreter::startTempTrigger(const QString& regex, const QString& function, int expiryCount)
 {
     TTrigger* pT = nullptr;
-    QStringList const sList {regex};
+    const QStringList sList {regex};
     QList<int> const propertyList {REGEX_SUBSTRING};
     pT = new TTrigger("a", sList, propertyList, false, mpHost);
     pT->setIsFolder(false);
@@ -16373,7 +16373,7 @@ int TLuaInterpreter::startTempTrigger(const QString& regex, const QString& funct
 int TLuaInterpreter::startTempPromptTrigger(const QString& function, int expiryCount)
 {
     TTrigger* pT;
-    QStringList const sList = {QString()};
+    const QStringList sList = {QString()};
     QList<int> const propertyList = {REGEX_PROMPT};
     pT = new TTrigger("a", sList, propertyList, false, mpHost);
     pT->setIsFolder(false);
@@ -16436,7 +16436,7 @@ int TLuaInterpreter::startTempColorTrigger(int fg, int bg, const QString& functi
 int TLuaInterpreter::startTempRegexTrigger(const QString& regex, const QString& function, int expiryCount)
 {
     TTrigger* pT = nullptr;
-    QStringList const sList {regex};
+    const QStringList sList {regex};
     QList<int> const propertyList {REGEX_PERL};
     pT = new TTrigger("a", sList, propertyList, false, mpHost);
     pT->setIsFolder(false);
@@ -16539,7 +16539,7 @@ std::pair<int, QString> TLuaInterpreter::startPermPromptTrigger(const QString& n
 {
     TTrigger* pT;
     QList<int> const propertyList = {REGEX_PROMPT};
-    QStringList const patterns = {QString()};
+    const QStringList patterns = {QString()};
 
     if (parent.isEmpty()) {
         pT = new TTrigger("a", patterns, propertyList, false, mpHost);
@@ -17492,7 +17492,7 @@ int TLuaInterpreter::getMouseEvents(lua_State * L)
     QMapIterator<QString, QStringList> it(host.mConsoleActions);
     while (it.hasNext()) {
         it.next();
-        QStringList const eventInfo = it.value();
+        const QStringList eventInfo = it.value();
         lua_createtable(L, 0, 3);
         lua_pushstring(L, eventInfo.at(0).toUtf8().constData());
         lua_setfield(L, -2, "event name");

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1010,7 +1010,7 @@ int TLuaInterpreter::isAnsiFgColor(lua_State* L)
     const int ansiFg = getVerifiedInt(L, __func__, 1, "ANSI color");
 
     std::list<int> result;
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     result = host.mpConsole->getFgColor(windowName);
     auto it = result.begin();
     if (result.size() < 3) {
@@ -1104,7 +1104,7 @@ int TLuaInterpreter::isAnsiBgColor(lua_State* L)
     const int ansiBg = getVerifiedInt(L, __func__, 1, "ANSI color");
 
     std::list<int> result;
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     result = host.mpConsole->getBgColor(windowName);
     auto it = result.begin();
     if (result.size() < 3) {
@@ -1199,7 +1199,7 @@ int TLuaInterpreter::getFgColor(lua_State* L)
         windowName = getVerifiedString(L, __func__, 1, "window name", true).toStdString();
     }
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     std::list<int> const result = host.mpConsole->getFgColor(windowName);
     for (const int pos : result) {
         lua_pushnumber(L, pos);
@@ -1215,7 +1215,7 @@ int TLuaInterpreter::getBgColor(lua_State* L)
         windowName = getVerifiedString(L, __func__, 1, "window name", true).toStdString();
     }
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     std::list<int> const result = host.mpConsole->getBgColor(windowName);
     for (const int pos : result) {
         lua_pushnumber(L, pos);
@@ -1231,7 +1231,7 @@ int TLuaInterpreter::getTextFormat(lua_State* L)
         windowName = getVerifiedString(L, __func__, 1, "window name", true);
     }
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     QPair<quint8, TChar> const result = host.mpConsole->getTextAttributes(windowName);
     if (result.first == 1) {
         return warnArgumentValue(L, __func__, qsl("window '%1' not found").arg(windowName));
@@ -1327,7 +1327,7 @@ int TLuaInterpreter::wrapLine(lua_State* L)
     }
     const int lineNumber = getVerifiedInt(L, __func__, s, "line");
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     host.mpConsole->luaWrapLine(windowName, lineNumber);
     return 0;
 }
@@ -1531,7 +1531,7 @@ int TLuaInterpreter::getLineNumber(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#updateMap
 int TLuaInterpreter::updateMap(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (host.mpMap) {
         host.mpMap->update();
     }
@@ -1555,7 +1555,7 @@ int TLuaInterpreter::addMapMenu(lua_State* L)
     } else {
         menuList << lua_tostring(L, 3);
     }
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (host.mpMap) {
         if (host.mpMap->mpMapper) {
             if (host.mpMap->mpMapper->mp2dMap) {
@@ -1573,7 +1573,7 @@ int TLuaInterpreter::removeMapMenu(lua_State* L)
     if (uniqueName.isEmpty()) {
         return 0;
     }
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (host.mpMap) {
         if (host.mpMap->mpMapper) {
             if (host.mpMap->mpMapper->mp2dMap) {
@@ -1616,7 +1616,7 @@ int TLuaInterpreter::removeMapMenu(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMapMenus
 int TLuaInterpreter::getMapMenus(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!(host.mpMap && host.mpMap->mpMapper && host.mpMap->mpMapper->mp2dMap)) {
         return warnArgumentValue(L, __func__, "you haven't opened a map yet");
     }
@@ -1659,7 +1659,7 @@ int TLuaInterpreter::addMapEvent(lua_State* L)
     for (int i = 5; i <= lua_gettop(L); i++) {
         actionInfo << lua_tostring(L, i);
     }
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (host.mpMap) {
         if (host.mpMap->mpMapper) {
             if (host.mpMap->mpMapper->mp2dMap) {
@@ -1674,7 +1674,7 @@ int TLuaInterpreter::addMapEvent(lua_State* L)
 int TLuaInterpreter::removeMapEvent(lua_State* L)
 {
     const QString displayName = getVerifiedString(L, __func__, 1, "event name");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (host.mpMap) {
         if (host.mpMap->mpMapper) {
             if (host.mpMap->mpMapper->mp2dMap) {
@@ -1688,7 +1688,7 @@ int TLuaInterpreter::removeMapEvent(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMapEvents
 int TLuaInterpreter::getMapEvents(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (host.mpMap) {
         if (host.mpMap->mpMapper) {
             if (host.mpMap->mpMapper->mp2dMap) {
@@ -1790,7 +1790,7 @@ int TLuaInterpreter::copy(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#cut
 int TLuaInterpreter::cut(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     host.mpConsole->cut();
     return 0;
 }
@@ -1811,7 +1811,7 @@ int TLuaInterpreter::paste(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#feedTriggers
 int TLuaInterpreter::feedTriggers(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L,
                         "feedTriggers: bad argument #1 type (imitation game server text as string\n"
@@ -1883,7 +1883,7 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#isPrompt
 int TLuaInterpreter::isPrompt(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     const int userCursorY = host.mpConsole->getLineNumber();
     if (userCursorY < host.mpConsole->buffer.promptBuffer.size() && userCursorY >= 0) {
         lua_pushboolean(L, host.mpConsole->buffer.promptBuffer.at(userCursorY));
@@ -1968,7 +1968,7 @@ int TLuaInterpreter::getStopWatchTime(lua_State* L)
 
     int watchId = 0;
     QPair<bool, double> result;
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (lua_type(L, 1) == LUA_TNUMBER) {
         watchId = static_cast<int>(lua_tointeger(L, 1));
         result = host.getStopWatchTime(watchId);
@@ -2352,7 +2352,7 @@ int TLuaInterpreter::getStopWatchBrokenDownTime(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getStopWatches
 int TLuaInterpreter::getStopWatches(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     const QList<int> stopWatchIds = host.getStopWatchIds();
     lua_newtable(L);
     for (int index = 0, total = stopWatchIds.count(); index < total; ++index) {
@@ -2573,7 +2573,7 @@ int TLuaInterpreter::saveMap(lua_State* L)
         }
     }
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     const bool error = host.mpConsole->saveMap(location, saveVersion);
     lua_pushboolean(L, error);
     return 1;
@@ -2592,7 +2592,7 @@ int TLuaInterpreter::setExitStub(lua_State* L)
 
     const bool status = getVerifiedBool(L, __func__, 3, "set/unset");
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap) {
         return 0;
     }
@@ -2617,7 +2617,7 @@ int TLuaInterpreter::connectExitStub(lua_State* L)
     bool hasToRoomId = false;
     const int fromRoom = getVerifiedInt(L, __func__, 1, "fromID");
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -2716,7 +2716,7 @@ int TLuaInterpreter::connectExitStub(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getExitStubs
 int TLuaInterpreter::getExitStubs(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -2741,7 +2741,7 @@ int TLuaInterpreter::getExitStubs(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getExitStubs1
 int TLuaInterpreter::getExitStubs1(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -2767,7 +2767,7 @@ int TLuaInterpreter::getExitStubs1(lua_State* L)
 int TLuaInterpreter::getModulePath(lua_State* L)
 {
     const QString moduleName = getVerifiedString(L, __func__, 1, "module name");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     QMap<QString, QStringList> modules = host.mInstalledModules;
     if (modules.contains(moduleName)) {
         const QString modPath = modules[moduleName][0];
@@ -2810,7 +2810,7 @@ int TLuaInterpreter::setModulePriority(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#loadMap
 int TLuaInterpreter::loadMap(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
 
     QString location;
     if (lua_gettop(L)) {
@@ -3165,7 +3165,7 @@ int TLuaInterpreter::setFontSize(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getFontSize
 int TLuaInterpreter::getFontSize(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     int rval = -1;
     const QString windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
@@ -3229,7 +3229,7 @@ int TLuaInterpreter::setUserWindowTitle(lua_State* L)
         title = getVerifiedString(L, __func__, 2, "title", true);
     }
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (auto [success, message] = host.mpConsole->setUserWindowTitle(name, title); !success) {
         return warnArgumentValue(L, __func__, message);
     }
@@ -3387,7 +3387,7 @@ int TLuaInterpreter::createScrollBox(lua_State* L)
     counter++;
     const int height = getVerifiedInt(L, __func__, counter, "scrollBox height");
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (auto [success, message] = host.createScrollBox(windowName, name, x, y, width, height); !success) {
         return warnArgumentValue(L, __func__, message, true);
     }
@@ -3488,7 +3488,7 @@ int TLuaInterpreter::createLabelMainWindow(lua_State* L, const QString& labelNam
 int TLuaInterpreter::deleteLabel(lua_State* L)
 {
     const QString labelName = getVerifiedString(L, __func__, 1, "label name");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (auto [success, message] = host.mpConsole->deleteLabel(labelName); !success) {
         return warnArgumentValue(L, __func__, message);
     }
@@ -3506,7 +3506,7 @@ int TLuaInterpreter::setLabelToolTip(lua_State* L)
         duration = getVerifiedDouble(L, __func__, 3, "duration");
     }
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
 
     if (auto [success, message] = host.mpConsole->setLabelToolTip(labelName, labelToolTip, duration); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -3520,7 +3520,7 @@ int TLuaInterpreter::setLabelCursor(lua_State* L)
 {
     const QString labelName = getVerifiedString(L, __func__, 1, "label name");
     const int labelCursor = getVerifiedInt(L, __func__, 2, "cursortype");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
 
     if (auto [success, message] = host.mpConsole->setLabelCursor(labelName, labelCursor); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -3542,7 +3542,7 @@ int TLuaInterpreter::setLabelCustomCursor(lua_State* L)
         hotY = getVerifiedInt(L, __func__, 4, "hot spot y-coordinate");
     }
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
 
     if (auto [success, message] = host.mpConsole->setLabelCustomCursor(labelName, pixmapLocation, hotX, hotY); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -3580,7 +3580,7 @@ int TLuaInterpreter::createMapper(lua_State* L)
     counter++;
     const int height = getVerifiedInt(L, __func__, counter, "mapper height");
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (auto [success, message] = host.mpConsole->createMapper(windowName, x, y, width, height); !success) {
         return warnArgumentValue(L, __func__, message);
     }
@@ -3624,7 +3624,7 @@ int TLuaInterpreter::createCommandLine(lua_State* L)
     const int height = getVerifiedInt(L, __func__, counter, "commandline height");
     counter++;
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (auto [success, message] = host.mpConsole->createCommandLine(windowName, commandLineName, x, y, width, height); !success) {
         return warnArgumentValue(L, __func__, message);
     }
@@ -3646,7 +3646,7 @@ int TLuaInterpreter::createBuffer(lua_State* L)
 int TLuaInterpreter::clearUserWindow(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
-        Host const& host = getHostFromLua(L);
+        const Host& host = getHostFromLua(L);
         host.mpConsole->mUpperPane->resetHScrollbar();
         host.mpConsole->buffer.clear();
         host.mpConsole->mUpperPane->showNewLines();
@@ -3762,7 +3762,7 @@ int TLuaInterpreter::setBorderLeft(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderTop
 int TLuaInterpreter::getBorderTop(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     lua_pushnumber(L, host.borders().top());
     return 1;
 }
@@ -3770,7 +3770,7 @@ int TLuaInterpreter::getBorderTop(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderLeft
 int TLuaInterpreter::getBorderLeft(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     lua_pushnumber(L, host.borders().left());
     return 1;
 }
@@ -3778,7 +3778,7 @@ int TLuaInterpreter::getBorderLeft(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderBottom
 int TLuaInterpreter::getBorderBottom(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     lua_pushnumber(L, host.borders().bottom());
     return 1;
 }
@@ -3786,7 +3786,7 @@ int TLuaInterpreter::getBorderBottom(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderRight
 int TLuaInterpreter::getBorderRight(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     lua_pushnumber(L, host.borders().right());
     return 1;
 }
@@ -3794,7 +3794,7 @@ int TLuaInterpreter::getBorderRight(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderSizes
 int TLuaInterpreter::getBorderSizes(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     auto sizes = host.borders();
     lua_createtable(L, 0, 4);
     lua_pushinteger(L, sizes.top());
@@ -3970,7 +3970,7 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBackgroundColor
 int TLuaInterpreter::getBackgroundColor(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     QColor color;
 
     QString windowName = qsl("main");
@@ -4153,7 +4153,7 @@ int TLuaInterpreter::calcFontSize(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#startLogging
 int TLuaInterpreter::startLogging(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     const bool logOn = getVerifiedBool(L, __func__, 1, "turn logging on/off");
 
     QString savedLogFileName;
@@ -4269,7 +4269,7 @@ int TLuaInterpreter::getImageSize(lua_State* L)
 int TLuaInterpreter::getLabelSizeHint(lua_State* L)
 {
     const QString labelName = getVerifiedString(L, __func__, 1, "label name");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (labelName.isEmpty()) {
         return warnArgumentValue(L, __func__, "label name cannot be an empty string");
     }
@@ -4334,7 +4334,7 @@ int TLuaInterpreter::setCmdLineStyleSheet(lua_State* L)
         name = getVerifiedString(L, __func__, 1, "command line name", true);
     }
     const QString styleSheet = getVerifiedString(L, __func__, n, "StyleSheet");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
 
     if (auto [success, message] = host.mpConsole->setCmdLineStyleSheet(name, styleSheet); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -4522,7 +4522,7 @@ int TLuaInterpreter::scaleMovie(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setTextFormat
 int TLuaInterpreter::setTextFormat(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
 
     const int n = lua_gettop(L);
 
@@ -4635,7 +4635,7 @@ int TLuaInterpreter::setTextFormat(lua_State* L)
 int TLuaInterpreter::raiseWindow(lua_State* L)
 {
     const QString windowName {WINDOW_NAME(L, 1)};
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.mpConsole->raiseWindow(windowName));
     return 1;
 }
@@ -4644,7 +4644,7 @@ int TLuaInterpreter::raiseWindow(lua_State* L)
 int TLuaInterpreter::lowerWindow(lua_State* L)
 {
     const QString windowName {WINDOW_NAME(L, 1)};
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.mpConsole->lowerWindow(windowName));
     return 1;
 }
@@ -4664,7 +4664,7 @@ int TLuaInterpreter::setRoomEnv(lua_State* L)
     const int id = getVerifiedInt(L, __func__, 1, "roomID");
     const int env = getVerifiedInt(L, __func__, 2, "environmentID");
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
@@ -4678,7 +4678,7 @@ int TLuaInterpreter::setRoomEnv(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setRoomName
 int TLuaInterpreter::setRoomName(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -4700,7 +4700,7 @@ int TLuaInterpreter::setRoomName(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomName
 int TLuaInterpreter::getRoomName(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -4721,7 +4721,7 @@ int TLuaInterpreter::setRoomWeight(lua_State* L)
     const int id = getVerifiedInt(L, __func__, 1, "roomID");
     const int w = getVerifiedInt(L, __func__, 2, "weight");
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
@@ -4782,7 +4782,7 @@ int TLuaInterpreter::setRoomIDbyHash(lua_State* L)
 {
     const int id = getVerifiedInt(L, __func__, 1, "roomID");
     const QString hash = getVerifiedString(L, __func__, 2, "hash");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (host.mpMap->mpRoomDB->roomIDToHash.contains(id)) {
         host.mpMap->mpRoomDB->hashToRoomID.remove(host.mpMap->mpRoomDB->roomIDToHash[id]);
     }
@@ -4798,7 +4798,7 @@ int TLuaInterpreter::setRoomIDbyHash(lua_State* L)
 int TLuaInterpreter::getRoomIDbyHash(lua_State* L)
 {
     const QString hash = getVerifiedString(L, __func__, 1, "hash");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     const int retID = host.mpMap->mpRoomDB->hashToRoomID.value(hash, -1);
     lua_pushnumber(L, retID);
     return 1;
@@ -4808,7 +4808,7 @@ int TLuaInterpreter::getRoomIDbyHash(lua_State* L)
 int TLuaInterpreter::getRoomHashByID(lua_State* L)
 {
     const int id = getVerifiedInt(L, __func__, 1, "roomID");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap->mpRoomDB->roomIDToHash.contains(id)) {
         return warnArgumentValue(L, __func__, qsl("no hash for room %1").arg(id));
     }
@@ -4821,7 +4821,7 @@ int TLuaInterpreter::getRoomHashByID(lua_State* L)
 int TLuaInterpreter::roomLocked(lua_State* L)
 {
     const int id = getVerifiedInt(L, __func__, 1, "roomID");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
         const bool r = pR->isLocked;
@@ -4837,7 +4837,7 @@ int TLuaInterpreter::lockRoom(lua_State* L)
 {
     const int id = getVerifiedInt(L, __func__, 1, "roomID");
     const bool b = getVerifiedBool(L, __func__, 2, "lockIfTrue");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
         pR->isLocked = b;
@@ -4863,7 +4863,7 @@ int TLuaInterpreter::lockExit(lua_State* L)
 
     const bool b = getVerifiedBool(L, __func__, 3, "lockIfTrue");
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
         pR->setExitLock(dir, b);
@@ -4884,7 +4884,7 @@ int TLuaInterpreter::lockSpecialExit(lua_State* L)
     }
     const bool b = getVerifiedBool(L, __func__, 4, "special exit lock state");
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(fromRoomID);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidExitRoomID.arg(fromRoomID));
@@ -4910,7 +4910,7 @@ int TLuaInterpreter::hasSpecialExitLock(lua_State* L)
         return warnArgumentValue(L, __func__, "the special exit name/command cannot be empty");
     }
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(fromRoomID);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidExitRoomID.arg(fromRoomID));
@@ -4935,7 +4935,7 @@ int TLuaInterpreter::hasExitLock(lua_State* L)
         return lua_error(L);
     }
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
         lua_pushboolean(L, pR->hasExitLock(dir));
@@ -4949,7 +4949,7 @@ int TLuaInterpreter::getRoomExits(lua_State* L)
 {
     const int id = getVerifiedInt(L, __func__, 1, "roomID");
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
         lua_newtable(L);
@@ -5023,7 +5023,7 @@ int TLuaInterpreter::getRoomExits(lua_State* L)
 int TLuaInterpreter::getAllRoomEntrances(lua_State* L)
 {
     const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -5048,7 +5048,7 @@ int TLuaInterpreter::getAllRoomEntrances(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#searchRoom
 int TLuaInterpreter::searchRoom(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -5135,7 +5135,7 @@ int TLuaInterpreter::searchRoom(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#searchRoomUserData
 int TLuaInterpreter::searchRoomUserData(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -5231,7 +5231,7 @@ int TLuaInterpreter::searchRoomUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#searchAreaUserData
 int TLuaInterpreter::searchAreaUserData(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -5323,7 +5323,7 @@ int TLuaInterpreter::searchAreaUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getAreaTable
 int TLuaInterpreter::getAreaTable(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -5344,7 +5344,7 @@ int TLuaInterpreter::getAreaTable(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getAreaTableSwap
 int TLuaInterpreter::getAreaTableSwap(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -5366,7 +5366,7 @@ int TLuaInterpreter::getAreaTableSwap(lua_State* L)
 int TLuaInterpreter::getAreaRooms(lua_State* L)
 {
     const int area = getVerifiedInt(L, __func__, 1, "areaID");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TArea* pA = host.mpMap->mpRoomDB->getArea(area);
     if (!pA) {
         lua_pushnil(L);
@@ -5389,7 +5389,7 @@ int TLuaInterpreter::getAreaRooms(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRooms
 int TLuaInterpreter::getRooms(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     lua_newtable(L);
     QHashIterator<int, TRoom*> it(host.mpMap->mpRoomDB->getRoomMap());
     while (it.hasNext()) {
@@ -5412,7 +5412,7 @@ int TLuaInterpreter::getAreaExits(lua_State* L)
         isFullDataRequired = getVerifiedBool(L, __func__, 2, "full data wanted", true);
     }
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TArea* pA = host.mpMap->mpRoomDB->getArea(area);
     if (!pA) {
         return warnArgumentValue(L, __func__, csmInvalidAreaID.arg(area));
@@ -5451,7 +5451,7 @@ int TLuaInterpreter::getAreaExits(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#auditAreas
 int TLuaInterpreter::auditAreas(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     host.mpMap->audit();
     return 0;
 }
@@ -5550,7 +5550,7 @@ int TLuaInterpreter::resetFormat(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#hasFocus
 int TLuaInterpreter::hasFocus(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.mpConsole->hasFocus()); //FIXME
     return 1;
 }
@@ -5632,7 +5632,7 @@ int TLuaInterpreter::receiveMSP(lua_State* L)
 // Private
 int TLuaInterpreter::loadMediaFileAsOrderedArguments(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TMediaData mediaData{};
     const int numArgs = lua_gettop(L);
     QString stringValue;
@@ -5677,7 +5677,7 @@ int TLuaInterpreter::loadMediaFileAsOrderedArguments(lua_State* L)
 // Private
 int TLuaInterpreter::loadMediaFileAsTableArgument(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TMediaData mediaData{};
 
     lua_pushnil(L);
@@ -5752,7 +5752,7 @@ int TLuaInterpreter::loadSoundFile(lua_State* L)
 // Private
 int TLuaInterpreter::playMusicFileAsOrderedArguments(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TMediaData mediaData{};
     const int numArgs = lua_gettop(L);
     QString stringValue;
@@ -5863,7 +5863,7 @@ int TLuaInterpreter::playMusicFileAsOrderedArguments(lua_State* L)
 // Private
 int TLuaInterpreter::playMusicFileAsTableArgument(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TMediaData mediaData{};
 
     lua_pushnil(L);
@@ -5984,7 +5984,7 @@ int TLuaInterpreter::playMusicFile(lua_State* L)
 // Private
 int TLuaInterpreter::playSoundFileAsOrderedArguments(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TMediaData mediaData{};
     const int numArgs = lua_gettop(L);
     QString stringValue;
@@ -6102,7 +6102,7 @@ int TLuaInterpreter::playSoundFileAsOrderedArguments(lua_State* L)
 // Private
 int TLuaInterpreter::playSoundFileAsTableArgument(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TMediaData mediaData{};
 
     lua_pushnil(L);
@@ -6231,7 +6231,7 @@ int TLuaInterpreter::playSoundFile(lua_State* L)
 // Private
 int TLuaInterpreter::stopMusicAsOrderedArguments(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TMediaData mediaData{};
     const int numArgs = lua_gettop(L);
     QString stringValue;
@@ -6276,7 +6276,7 @@ int TLuaInterpreter::stopMusicAsOrderedArguments(lua_State* L)
 // Private
 int TLuaInterpreter::stopMusicAsTableArgument(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TMediaData mediaData{};
 
     lua_pushnil(L);
@@ -6318,7 +6318,7 @@ int TLuaInterpreter::stopMusicAsTableArgument(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#stopMusic
 int TLuaInterpreter::stopMusic(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TMediaData mediaData{};
 
     if (lua_gettop(L)) {
@@ -6341,7 +6341,7 @@ int TLuaInterpreter::stopMusic(lua_State* L)
 // Private
 int TLuaInterpreter::stopSoundsAsOrderedArguments(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TMediaData mediaData{};
     const int numArgs = lua_gettop(L);
     QString stringValue;
@@ -6398,7 +6398,7 @@ int TLuaInterpreter::stopSoundsAsOrderedArguments(lua_State* L)
 // Private
 int TLuaInterpreter::stopSoundsAsTableArgument(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TMediaData mediaData{};
 
     lua_pushnil(L);
@@ -6452,7 +6452,7 @@ int TLuaInterpreter::stopSoundsAsTableArgument(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#stopSounds
 int TLuaInterpreter::stopSounds(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TMediaData mediaData{};
 
     if (lua_gettop(L)) {
@@ -6562,7 +6562,7 @@ int TLuaInterpreter::setLink(lua_State* L)
 
     const QString linkHint = getVerifiedString(L, __func__, s++, "tooltip");
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     QStringList _linkFunction;
     _linkFunction << linkFunction;
     QStringList _linkHint;
@@ -6630,7 +6630,7 @@ int TLuaInterpreter::setPopup(lua_State* L)
         lua_pop(L, 1);
     }
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (_commandList.size() != _hintList.size()) {
         lua_pushstring(L, "setPopup: commands and hints list aren't the same size");
         return lua_error(L);
@@ -6776,7 +6776,7 @@ int TLuaInterpreter::errorc(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#debugc -- not #debug - compare GlobalLua
 int TLuaInterpreter::debug(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     const int n = lua_gettop(L);
     if (!n) {
         // Nothing to show
@@ -7106,7 +7106,7 @@ int TLuaInterpreter::setButtonState(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getNetworkLatency
 int TLuaInterpreter::getNetworkLatency(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     lua_pushnumber(L, host.mTelnet.networkLatencyTime);
     return 1;
 }
@@ -7114,7 +7114,7 @@ int TLuaInterpreter::getNetworkLatency(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMainConsoleWidth
 int TLuaInterpreter::getMainConsoleWidth(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     int fw = QFontMetrics(host.getDisplayFont()).averageCharWidth();
     fw *= host.mWrapAt + 1;
     lua_pushnumber(L, fw);
@@ -7124,7 +7124,7 @@ int TLuaInterpreter::getMainConsoleWidth(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMainWindowSize
 int TLuaInterpreter::getMainWindowSize(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     QSize const mainWindowSize = host.mpConsole->getMainWindowSize();
 
     lua_pushnumber(L, mainWindowSize.width());
@@ -7138,7 +7138,7 @@ int TLuaInterpreter::getUserWindowSize(lua_State* L)
 {
     const QString windowName {WINDOW_NAME(L, 1)};
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     QSize const userWindowSize = host.mpConsole->getUserWindowSize(windowName);
     lua_pushnumber(L, userWindowSize.width());
     lua_pushnumber(L, userWindowSize.height());
@@ -7149,7 +7149,7 @@ int TLuaInterpreter::getUserWindowSize(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMousePosition
 int TLuaInterpreter::getMousePosition(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
 
     const QPoint pos = host.mpConsole->mapFromGlobal(QCursor::pos());
 
@@ -8504,7 +8504,7 @@ int TLuaInterpreter::getTimestamp(lua_State* L)
             "line number %1 invalid, it should be greater than zero").arg(luaLine));
     }
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (name.isEmpty()) {
         if (luaLine > 0 && luaLine < host.mpConsole->buffer.timeBuffer.size()) {
             // CHECK: Lua starts counting at 1 but we are indexing into a C/C++
@@ -8534,7 +8534,7 @@ int TLuaInterpreter::setBorderColor(lua_State* L)
     const int luaRed = getVerifiedInt(L, __func__, 1, "red");
     const int luaGreen = getVerifiedInt(L, __func__, 2, "green");
     const int luaBlue = getVerifiedInt(L, __func__, 3, "blue");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     QPalette framePalette;
     framePalette.setColor(QPalette::Text, QColor(Qt::black));
     framePalette.setColor(QPalette::Highlight, QColor(55, 55, 255));
@@ -8550,7 +8550,7 @@ int TLuaInterpreter::setRoomCoordinates(lua_State* L)
     const int x = getVerifiedInt(L, __func__, 2, "x");
     const int y = getVerifiedInt(L, __func__, 3, "y");
     const int z = getVerifiedInt(L, __func__, 4, "z");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.mpMap->setRoomCoordinates(id, x, y, z));
     return 1;
 }
@@ -8563,7 +8563,7 @@ int TLuaInterpreter::setCustomEnvColor(lua_State* L)
     const int g = getVerifiedInt(L, __func__, 3, "g");
     const int b = getVerifiedInt(L, __func__, 4, "b");
     const int alpha = getVerifiedInt(L, __func__, 5, "a");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     host.mpMap->mCustomEnvColors[id] = QColor(r, g, b, alpha);
     host.mpMap->setUnsaved(__func__);
     return 0;
@@ -8574,7 +8574,7 @@ int TLuaInterpreter::setAreaName(lua_State* L)
 {
     int id = -1;
     QString existingName;
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -8656,7 +8656,7 @@ int TLuaInterpreter::setAreaName(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomAreaName
 int TLuaInterpreter::getRoomAreaName(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -8702,7 +8702,7 @@ int TLuaInterpreter::addAreaName(lua_State* L)
 {
     const QString name = getVerifiedString(L, __func__, 1, "area name").trimmed();
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if ((!host.mpMap) || (!host.mpMap->mpRoomDB)) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     } else if (name.isEmpty()) {
@@ -8731,7 +8731,7 @@ int TLuaInterpreter::deleteArea(lua_State* L)
     int id = 0;
     QString name;
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -8787,7 +8787,7 @@ int TLuaInterpreter::deleteRoom(lua_State* L)
     if (id <= 0) {
         return 0;
     }
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.mpMap->mpRoomDB->removeRoom(id));
     host.mpMap->setUnsaved(__func__);
     return 1;
@@ -8805,7 +8805,7 @@ int TLuaInterpreter::setExit(lua_State* L)
         return lua_error(L);
     }
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.mpMap->setExit(from, to, dir));
     host.mpMap->mMapGraphNeedsUpdate = true;
     return 1;
@@ -8815,7 +8815,7 @@ int TLuaInterpreter::setExit(lua_State* L)
 int TLuaInterpreter::getRoomCoordinates(lua_State* L)
 {
     const int id = getVerifiedInt(L, __func__, 1, "roomID");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
         lua_pushnil(L);
@@ -8834,7 +8834,7 @@ int TLuaInterpreter::getRoomCoordinates(lua_State* L)
 int TLuaInterpreter::getRoomArea(lua_State* L)
 {
     const int id = getVerifiedInt(L, __func__, 1, "roomID");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
         lua_pushnil(L);
@@ -8848,7 +8848,7 @@ int TLuaInterpreter::getRoomArea(lua_State* L)
 int TLuaInterpreter::roomExists(lua_State* L)
 {
     const int id = getVerifiedInt(L, __func__, 1, "roomID");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
         lua_pushboolean(L, true);
@@ -8862,7 +8862,7 @@ int TLuaInterpreter::roomExists(lua_State* L)
 int TLuaInterpreter::addRoom(lua_State* L)
 {
     const int id = getVerifiedInt(L, __func__, 1, "roomID");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     const bool added = host.mpMap->addRoom(id);
     lua_pushboolean(L, added);
     if (added) {
@@ -8876,7 +8876,7 @@ int TLuaInterpreter::addRoom(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#createRoomID
 int TLuaInterpreter::createRoomID(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -8899,7 +8899,7 @@ int TLuaInterpreter::unHighlightRoom(lua_State* L)
 {
     const int id = getVerifiedInt(L, __func__, 1, "roomID");
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
         pR->highlight = false;
@@ -8929,7 +8929,7 @@ int TLuaInterpreter::highlightRoom(lua_State* L)
     const int alpha1 = getVerifiedInt(L, __func__, 9, "color1Alpha");
     const int alpha2 = getVerifiedInt(L, __func__, 10, "color2Alpha");
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
         auto fg = QColor(fgr, fgg, fgb, alpha1);
@@ -8998,7 +8998,7 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
         temporary = getVerifiedBool(L, __func__, 19, "temporary", true);
     }
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     lua_pushinteger(L, host.mpMap->createMapLabel(area, text, posx, posy, posz, QColor(fgr, fgg, fgb, foregroundTransparency), QColor(bgr, bgg, bgb, backgroundTransparency), showOnTop, noScaling, temporary, zoom, fontSize, fontName));
     return 1;
 }
@@ -9011,7 +9011,7 @@ int TLuaInterpreter::setMapZoom(lua_State* L)
     if (lua_gettop(L) > 1) {
         areaID = getVerifiedInt(L, __func__, 2, "area id", true);
     }
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (host.mpMap.isNull() || host.mpMap->mpMapper.isNull()) {
         return warnArgumentValue(L, __func__, "no map loaded or no active mapper");
     }
@@ -9032,7 +9032,7 @@ int TLuaInterpreter::getMapZoom(lua_State* L)
     if (lua_gettop(L)) {
         areaID = getVerifiedInt(L, __func__, 1, "area id", true);
     }
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (host.mpMap.isNull() || host.mpMap->mpMapper.isNull()) {
         return warnArgumentValue(L, __func__, "no map loaded or no active mapper");
     }
@@ -9068,7 +9068,7 @@ int TLuaInterpreter::createMapImageLabel(lua_State* L)
         temporary = getVerifiedBool(L, __func__, 10, "showOnTop", true);
     }
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     lua_pushinteger(L, host.mpMap->createMapImageLabel(area, imagePathFileName, posx, posy, posz, width, height, zoom, showOnTop, temporary));
     return 1;
 }
@@ -9076,7 +9076,7 @@ int TLuaInterpreter::createMapImageLabel(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setDoor
 int TLuaInterpreter::setDoor(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -9149,7 +9149,7 @@ int TLuaInterpreter::setDoor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getDoors
 int TLuaInterpreter::getDoors(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -9173,7 +9173,7 @@ int TLuaInterpreter::getDoors(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setExitWeight
 int TLuaInterpreter::setExitWeight(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     const int roomID = getVerifiedInt(L, __func__, 1, "roomID");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
     if (!pR) {
@@ -9205,7 +9205,7 @@ int TLuaInterpreter::setExitWeight(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addCustomLine
 int TLuaInterpreter::addCustomLine(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
 
     //args: id_from, id_to, direction, style, line color, arrow (bool)
     int id_to = 0;
@@ -9423,7 +9423,7 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#removeCustomLine
 int TLuaInterpreter::removeCustomLine(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
 
     //args: room_id, direction
     const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
@@ -9464,7 +9464,7 @@ int TLuaInterpreter::removeCustomLine(lua_State* L)
 int TLuaInterpreter::getCustomLines(lua_State* L)
 {
     const int roomID = getVerifiedInt(L, __func__, 1, "roomID");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
     if (!pR) { //if the room doesn't exist return nil
         return warnArgumentValue(L, __func__, qsl("room %1 doesn't exist").arg(roomID));
@@ -9536,7 +9536,7 @@ int TLuaInterpreter::getCustomLines(lua_State* L)
 int TLuaInterpreter::getCustomLines1(lua_State* L)
 {
     const int roomID = getVerifiedInt(L, __func__, 1, "roomID");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
     if (!pR) { //if the room doesn't exist return nil
         return warnArgumentValue(L, __func__, qsl("room %1 doesn't exist").arg(roomID));
@@ -9614,7 +9614,7 @@ int TLuaInterpreter::getCustomLines1(lua_State* L)
 int TLuaInterpreter::getExitWeights(lua_State* L)
 {
     const int roomID = getVerifiedInt(L, __func__, 1, "roomID");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
     lua_newtable(L);
     if (pR) {
@@ -9633,7 +9633,7 @@ int TLuaInterpreter::deleteMapLabel(lua_State* L)
 {
     const int area = getVerifiedInt(L, __func__, 1, "areaID");
     const int labelID = getVerifiedInt(L, __func__, 2, "labelID");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     host.mpMap->deleteMapLabel(area, labelID);
     return 0;
 }
@@ -9641,7 +9641,7 @@ int TLuaInterpreter::deleteMapLabel(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#windowType
 int TLuaInterpreter::windowType(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     const QString windowName = getVerifiedString(L, __func__, 1, "window name");
 
     if (auto kind = host.windowType(windowName)) {
@@ -9659,7 +9659,7 @@ int TLuaInterpreter::windowType(lua_State* L)
 int TLuaInterpreter::getMapLabels(lua_State* L)
 {
     const int area = getVerifiedInt(L, __func__, 1, "areaID");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     lua_newtable(L);
     auto pA = host.mpMap->mpRoomDB->getArea(area);
     if (pA && !pA->mMapLabels.isEmpty()) {
@@ -9695,7 +9695,7 @@ int TLuaInterpreter::getMapLabel(lua_State* L)
         // Can be an empty string as image labels have no text!
     }
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     auto pA = host.mpMap->mpRoomDB->getArea(areaId);
     if (!pA) {
         return warnArgumentValue(L, __func__, qsl("areaID %1 does not exist").arg(areaId));
@@ -9800,7 +9800,7 @@ void TLuaInterpreter::pushMapLabelPropertiesToLua(lua_State* L, const TMapLabel&
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addSpecialExit
 int TLuaInterpreter::addSpecialExit(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     const int fromRoomID = getVerifiedInt(L, __func__, 1, "exit roomID");
     TRoom* pR_from = host.mpMap->mpRoomDB->getRoom(fromRoomID);
     if (!pR_from) {
@@ -9826,7 +9826,7 @@ int TLuaInterpreter::addSpecialExit(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#removeSpecialExit
 int TLuaInterpreter::removeSpecialExit(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     const int fromRoomID = getVerifiedInt(L, __func__, 1, "exit roomID");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(fromRoomID);
     if (!pR) {
@@ -9850,7 +9850,7 @@ int TLuaInterpreter::removeSpecialExit(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearRoomUserData
 int TLuaInterpreter::clearRoomUserData(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -9873,7 +9873,7 @@ int TLuaInterpreter::clearRoomUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearRoomUserDataItem
 int TLuaInterpreter::clearRoomUserDataItem(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -9903,7 +9903,7 @@ int TLuaInterpreter::clearRoomUserDataItem(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearAreaUserData
 int TLuaInterpreter::clearAreaUserData(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -9926,7 +9926,7 @@ int TLuaInterpreter::clearAreaUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearAreaUserDataItem
 int TLuaInterpreter::clearAreaUserDataItem(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -9948,7 +9948,7 @@ int TLuaInterpreter::clearAreaUserDataItem(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearMapUserData
 int TLuaInterpreter::clearMapUserData(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -9966,7 +9966,7 @@ int TLuaInterpreter::clearMapUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearMapUserDataItem
 int TLuaInterpreter::clearMapUserDataItem(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -9983,7 +9983,7 @@ int TLuaInterpreter::clearMapUserDataItem(lua_State* L)
 int TLuaInterpreter::clearSpecialExits(lua_State* L)
 {
     const int id_from = getVerifiedInt(L, __func__, 1, "roomID");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id_from);
     if (pR) {
         pR->clearSpecialExits();
@@ -10000,7 +10000,7 @@ int TLuaInterpreter::clearSpecialExits(lua_State* L)
 // documented in the wiki!
 int TLuaInterpreter::getSpecialExits(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     const int id_from = getVerifiedInt(L, __func__, 1, "exit roomID");
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id_from);
     if (!pR) {
@@ -10085,7 +10085,7 @@ int TLuaInterpreter::getSpecialExits(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getSpecialExitsSwap
 int TLuaInterpreter::getSpecialExitsSwap(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "getSpecialExitsSwap: bad argument #1 type (exit roomID as number expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
@@ -10111,7 +10111,7 @@ int TLuaInterpreter::getSpecialExitsSwap(lua_State* L)
 int TLuaInterpreter::getRoomEnv(lua_State* L)
 {
     const int roomID = getVerifiedInt(L, __func__, 1, "roomID");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
     if (pR) {
         lua_pushnumber(L, pR->environment);
@@ -10123,7 +10123,7 @@ int TLuaInterpreter::getRoomEnv(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomUserData
 int TLuaInterpreter::getRoomUserData(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -10164,7 +10164,7 @@ int TLuaInterpreter::getAreaUserData(lua_State* L)
         return warnArgumentValue(L, __func__, "key is not allowed to be an empty string");
     }
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -10182,7 +10182,7 @@ int TLuaInterpreter::getAreaUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMapUserData
 int TLuaInterpreter::getMapUserData(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -10198,7 +10198,7 @@ int TLuaInterpreter::getMapUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setRoomUserData
 int TLuaInterpreter::setRoomUserData(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -10228,7 +10228,7 @@ int TLuaInterpreter::setAreaUserData(lua_State* L)
     }
     const QString value = getVerifiedString(L, __func__, 3, "value");
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -10246,7 +10246,7 @@ int TLuaInterpreter::setAreaUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMapUserData
 int TLuaInterpreter::setMapUserData(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -10266,7 +10266,7 @@ int TLuaInterpreter::setMapUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomUserDataKeys
 int TLuaInterpreter::getRoomUserDataKeys(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -10291,7 +10291,7 @@ int TLuaInterpreter::getRoomUserDataKeys(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getAllRoomUserData
 int TLuaInterpreter::getAllRoomUserData(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -10318,7 +10318,7 @@ int TLuaInterpreter::getAllRoomUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getAllAreaUserData
 int TLuaInterpreter::getAllAreaUserData(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -10345,7 +10345,7 @@ int TLuaInterpreter::getAllAreaUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getAllMapUserData
 int TLuaInterpreter::getAllMapUserData(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -10401,7 +10401,7 @@ int TLuaInterpreter::downloadFile(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setRoomArea
 int TLuaInterpreter::setRoomArea(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -10467,7 +10467,7 @@ int TLuaInterpreter::resetRoomArea(lua_State* L)
     //will reset the room area to our void area
     const int id = getVerifiedInt(L, __func__, 1, "roomID");
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     } else if (!host.mpMap->mpRoomDB->getRoomIDList().contains(id)) {
@@ -10497,7 +10497,7 @@ int TLuaInterpreter::setRoomChar(lua_State* L)
     const int id = getVerifiedInt(L, __func__, 1, "roomID");
     const QString symbol = getVerifiedString(L, __func__, 2, "room symbol");
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
@@ -10520,7 +10520,7 @@ int TLuaInterpreter::setRoomChar(lua_State* L)
 int TLuaInterpreter::getRoomChar(lua_State* L)
 {
     const int id = getVerifiedInt(L, __func__, 1, "roomID");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
@@ -10550,7 +10550,7 @@ int TLuaInterpreter::setRoomCharColor(lua_State* L)
         return lua_error(L);
     }
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
@@ -10570,7 +10570,7 @@ int TLuaInterpreter::unsetRoomCharColor(lua_State* L)
 {
     const int id = getVerifiedInt(L, __func__, 1, "roomID");
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
@@ -10590,7 +10590,7 @@ int TLuaInterpreter::unsetRoomCharColor(lua_State* L)
 int TLuaInterpreter::getRoomCharColor(lua_State* L)
 {
     const int id = getVerifiedInt(L, __func__, 1, "roomID");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
@@ -10610,7 +10610,7 @@ int TLuaInterpreter::getRoomsByPosition(lua_State* L)
     const int y = getVerifiedInt(L, __func__, 3, "y");
     const int z = getVerifiedInt(L, __func__, 4, "z");
 
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TArea* pA = host.mpMap->mpRoomDB->getArea(area);
     if (!pA) {
         lua_pushnil(L);
@@ -10630,7 +10630,7 @@ int TLuaInterpreter::getRoomsByPosition(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getGridMode
 int TLuaInterpreter::getGridMode(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -10651,7 +10651,7 @@ int TLuaInterpreter::setGridMode(lua_State* L)
 {
     const int area = getVerifiedInt(L, __func__, 1, "areaID");
     const bool gridMode = getVerifiedBool(L, __func__, 2, "true/false");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     TArea* pA = host.mpMap->mpRoomDB->getArea(area);
     if (!pA) {
         lua_pushboolean(L, false);
@@ -10936,7 +10936,7 @@ int TLuaInterpreter::insertText(lua_State* L)
 int TLuaInterpreter::insertHTML(lua_State* L)
 {
     const QString sendText = getVerifiedString(L, __func__, 1, "sendText");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     host.mpConsole->insertHTML(sendText);
     return 0;
 }
@@ -11177,7 +11177,7 @@ int TLuaInterpreter::setLabelStyleSheet(lua_State* L)
 {
     std::string label = getVerifiedString(L, __func__, 1, "label").toStdString();
     std::string markup = getVerifiedString(L, __func__, 2, "markup").toStdString();
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     host.mpConsole->setLabelStyleSheet(label, markup);
     return 0;
 }
@@ -11186,7 +11186,7 @@ int TLuaInterpreter::setLabelStyleSheet(lua_State* L)
 int TLuaInterpreter::getLabelStyleSheet(lua_State* L)
 {
     const QString label = getVerifiedString(L, __func__, 1, "label");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (auto stylesheet = host.mpConsole->getLabelStyleSheet(label)) {
         lua_pushstring(L, stylesheet->toUtf8().constData());
         return 1;
@@ -11202,7 +11202,7 @@ int TLuaInterpreter::setUserWindowStyleSheet(lua_State* L)
 {
     const QString userWindowName = getVerifiedString(L, __func__, 1, "userwindow name");
     const QString userWindowStyleSheet = getVerifiedString(L, __func__, 2, "StyleSheet");
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
 
     if (auto [success, message] = host.mpConsole->setUserWindowStyleSheet(userWindowName, userWindowStyleSheet); !success) {
         return warnArgumentValue(L, __func__, message);
@@ -11215,7 +11215,7 @@ int TLuaInterpreter::setUserWindowStyleSheet(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getCustomEnvColorTable
 int TLuaInterpreter::getCustomEnvColorTable(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap->mCustomEnvColors.empty()) {
         lua_newtable(L);
         QList<int> const colorList = host.mpMap->mCustomEnvColors.keys();
@@ -12141,7 +12141,7 @@ int TLuaInterpreter::getModuleSync(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getPackages
 int TLuaInterpreter::getPackages(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     auto packages = host.mInstalledPackages;
     lua_newtable(L);
     for (int i = 0; i < packages.size(); i++) {
@@ -12155,7 +12155,7 @@ int TLuaInterpreter::getPackages(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getModules
 int TLuaInterpreter::getModules(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     auto modules = host.mInstalledModules;
     int counter = 0;
     QMap<QString, QStringList>::const_iterator iter = modules.constBegin();
@@ -12172,7 +12172,7 @@ int TLuaInterpreter::getModules(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getModuleInfo
 int TLuaInterpreter::getModuleInfo(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     auto infoMap = host.mModuleInfo;
     const int n = lua_gettop(L);
     const QString name = getVerifiedString(L, __func__, 1, "module name");
@@ -12198,7 +12198,7 @@ int TLuaInterpreter::getModuleInfo(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getPackageInfo
 int TLuaInterpreter::getPackageInfo(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     auto infoMap = host.mPackageInfo;
     const int n = lua_gettop(L);
     const QString name = getVerifiedString(L, __func__, 1, "package name");
@@ -12248,7 +12248,7 @@ int TLuaInterpreter::setPackageInfo(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setDefaultAreaVisible
 int TLuaInterpreter::setDefaultAreaVisible(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
@@ -13071,7 +13071,7 @@ int TLuaInterpreter::setServerEncoding(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getServerEncoding
 int TLuaInterpreter::getServerEncoding(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
 
     // don't leak if we're using a Mudlet or a Qt-supplied codec to Lua
     auto sanitizeEncoding = [] (auto encodingName) {
@@ -13092,7 +13092,7 @@ int TLuaInterpreter::getServerEncoding(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getServerEncodingsList
 int TLuaInterpreter::getServerEncodingsList(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
 
     // don't leak if we're using a Mudlet or a Qt-supplied codec to Lua
     auto sanitizeEncoding = [] (auto encodingName) {
@@ -14884,7 +14884,7 @@ int TLuaInterpreter::deleteHTTP(lua_State *L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getConnectionInfo
 int TLuaInterpreter::getConnectionInfo(lua_State *L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
 
     auto [hostName, hostPort, connected] = host.mTelnet.getConnectionInfo();
     lua_pushstring(L, hostName.toUtf8().constData());
@@ -17145,7 +17145,7 @@ void TLuaInterpreter::createCookiesTable(lua_State* L, QNetworkReply* reply)
     lua_newtable(L);
 
     // Parse cookies, add them as key-value pairs to the empty table
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     QNetworkCookieJar* cookieJar = host.mLuaInterpreter.mpFileDownloader->cookieJar();
     QList<QNetworkCookie> const cookies = cookieJar->cookiesForUrl(reply->url());
     for (QNetworkCookie const cookie : cookies) {
@@ -17486,7 +17486,7 @@ int TLuaInterpreter::removeMouseEvent(lua_State * L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMouseEvents
 int TLuaInterpreter::getMouseEvents(lua_State * L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
     // create the result table
     lua_newtable(L);
     QMapIterator<QString, QStringList> it(host.mConsoleActions);
@@ -17730,7 +17730,7 @@ int TLuaInterpreter::removeCommandLineMenuEvent(lua_State * L)
 
 int TLuaInterpreter::deleteMap(lua_State* L)
 {
-    Host const& host = getHostFromLua(L);
+    const Host& host = getHostFromLua(L);
 
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         // These tests pass even if the map is empty, however there can still

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2192,7 +2192,7 @@ int TLuaInterpreter::adjustStopWatch(lua_State* L)
     }
 
     double const adjustment = getVerifiedDouble(L, __func__, 2, "modification in seconds");
-    bool const result = host.adjustStopWatch(watchId, qRound(adjustment * 1000.0));
+    const bool result = host.adjustStopWatch(watchId, qRound(adjustment * 1000.0));
     // This is only likely to fail when a numeric first argument was given:
     if (!result) {
         return warnArgumentValue(L, __func__, csmInvalidStopWatchID.arg(watchId));
@@ -2216,7 +2216,7 @@ int TLuaInterpreter::deleteStopWatch(lua_State* L)
         return 2;
     }
 
-    bool const result = host.destroyStopWatch(watchId);
+    const bool result = host.destroyStopWatch(watchId);
     // This is only likely to fail when a numeric first argument was given:
     if (!result) {
         return warnArgumentValue(L, __func__, csmInvalidStopWatchID.arg(watchId));
@@ -2240,7 +2240,7 @@ int TLuaInterpreter::setStopWatchPersistence(lua_State* L)
         return 2;
     }
 
-    bool const isPersistent = getVerifiedBool(L, __func__, 2, "persistence");
+    const bool isPersistent = getVerifiedBool(L, __func__, 2, "persistence");
 
     // This is only likely to fail when a numeric first argument was given:
     if (!host.makeStopWatchPersistent(watchId, isPersistent)) {
@@ -2574,7 +2574,7 @@ int TLuaInterpreter::saveMap(lua_State* L)
     }
 
     Host const& host = getHostFromLua(L);
-    bool const error = host.mpConsole->saveMap(location, saveVersion);
+    const bool error = host.mpConsole->saveMap(location, saveVersion);
     lua_pushboolean(L, error);
     return 1;
 }
@@ -2590,7 +2590,7 @@ int TLuaInterpreter::setExitStub(lua_State* L)
         return lua_error(L);
     }
 
-    bool const status = getVerifiedBool(L, __func__, 3, "set/unset");
+    const bool status = getVerifiedBool(L, __func__, 3, "set/unset");
 
     Host const& host = getHostFromLua(L);
     if (!host.mpMap) {
@@ -2641,9 +2641,9 @@ int TLuaInterpreter::connectExitStub(lua_State* L)
             if (value >= DIR_OUT || value <= DIR_NORTH) {
                 // Ambiguous - look in more detail and check whether there is a
                 // a room with the given number and/or an exit stub:
-                bool const hasRoomWithNumberAsId = static_cast<bool>(host.mpMap->mpRoomDB->getRoom(value));
+                const bool hasRoomWithNumberAsId = static_cast<bool>(host.mpMap->mpRoomDB->getRoom(value));
                 auto pR = host.mpMap->mpRoomDB->getRoom(fromRoom);
-                bool const hasExitStubWithNumberAsDirection = (pR && pR->exitStubs.contains(value));
+                const bool hasExitStubWithNumberAsDirection = (pR && pR->exitStubs.contains(value));
                 if (hasRoomWithNumberAsId) {
                     if (hasExitStubWithNumberAsDirection) {
                         return warnArgumentValue(
@@ -2845,7 +2845,7 @@ int TLuaInterpreter::enableTimer(lua_State* L)
 {
     const QString text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
-    bool const error = host.getTimerUnit()->enableTimer(text);
+    const bool error = host.getTimerUnit()->enableTimer(text);
     lua_pushboolean(L, error);
     return 1;
 }
@@ -2855,7 +2855,7 @@ int TLuaInterpreter::disableTimer(lua_State* L)
 {
     const QString text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
-    bool const error = host.getTimerUnit()->disableTimer(text);
+    const bool error = host.getTimerUnit()->disableTimer(text);
     lua_pushboolean(L, error);
     return 1;
 }
@@ -2865,7 +2865,7 @@ int TLuaInterpreter::enableKey(lua_State* L)
 {
     const QString keyName = getVerifiedString(L, __func__, 1, "key name");
     Host& host = getHostFromLua(L);
-    bool const error = host.getKeyUnit()->enableKey(keyName);
+    const bool error = host.getKeyUnit()->enableKey(keyName);
     lua_pushboolean(L, error);
     return 1;
 }
@@ -2875,7 +2875,7 @@ int TLuaInterpreter::disableKey(lua_State* L)
 {
     const QString keyName = getVerifiedString(L, __func__, 1, "key name");
     Host& host = getHostFromLua(L);
-    bool const error = host.getKeyUnit()->disableKey(keyName);
+    const bool error = host.getKeyUnit()->disableKey(keyName);
     lua_pushboolean(L, error);
     return 1;
 }
@@ -2885,7 +2885,7 @@ int TLuaInterpreter::killKey(lua_State* L)
 {
     QString keyName = getVerifiedString(L, __func__, 1, "key name");
     Host& host = getHostFromLua(L);
-    bool const error = host.getKeyUnit()->killKey(keyName);
+    const bool error = host.getKeyUnit()->killKey(keyName);
     lua_pushboolean(L, error);
     return 1;
 }
@@ -2895,7 +2895,7 @@ int TLuaInterpreter::enableAlias(lua_State* L)
 {
     const QString text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
-    bool const error = host.getAliasUnit()->enableAlias(text);
+    const bool error = host.getAliasUnit()->enableAlias(text);
     lua_pushboolean(L, error);
     return 1;
 }
@@ -2905,7 +2905,7 @@ int TLuaInterpreter::disableAlias(lua_State* L)
 {
     const QString text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
-    bool const error = host.getAliasUnit()->disableAlias(text);
+    const bool error = host.getAliasUnit()->disableAlias(text);
     lua_pushboolean(L, error);
     return 1;
 }
@@ -2924,7 +2924,7 @@ int TLuaInterpreter::enableTrigger(lua_State* L)
 {
     const QString text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
-    bool const error = host.getTriggerUnit()->enableTrigger(text);
+    const bool error = host.getTriggerUnit()->enableTrigger(text);
     lua_pushboolean(L, error);
     return 1;
 }
@@ -2934,7 +2934,7 @@ int TLuaInterpreter::disableTrigger(lua_State* L)
 {
     const QString text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
-    bool const error = host.getTriggerUnit()->disableTrigger(text);
+    const bool error = host.getTriggerUnit()->disableTrigger(text);
     lua_pushboolean(L, error);
     return 1;
 }
@@ -4154,7 +4154,7 @@ int TLuaInterpreter::calcFontSize(lua_State* L)
 int TLuaInterpreter::startLogging(lua_State* L)
 {
     Host const& host = getHostFromLua(L);
-    bool const logOn = getVerifiedBool(L, __func__, 1, "turn logging on/off");
+    const bool logOn = getVerifiedBool(L, __func__, 1, "turn logging on/off");
 
     QString savedLogFileName;
     if (host.mpConsole->mLogToLogFile) {
@@ -4824,7 +4824,7 @@ int TLuaInterpreter::roomLocked(lua_State* L)
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
-        bool const r = pR->isLocked;
+        const bool r = pR->isLocked;
         lua_pushboolean(L, r);
     } else {
         lua_pushboolean(L, false);
@@ -4836,7 +4836,7 @@ int TLuaInterpreter::roomLocked(lua_State* L)
 int TLuaInterpreter::lockRoom(lua_State* L)
 {
     const int id = getVerifiedInt(L, __func__, 1, "roomID");
-    bool const b = getVerifiedBool(L, __func__, 2, "lockIfTrue");
+    const bool b = getVerifiedBool(L, __func__, 2, "lockIfTrue");
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
@@ -4861,7 +4861,7 @@ int TLuaInterpreter::lockExit(lua_State* L)
         return lua_error(L);
     }
 
-    bool const b = getVerifiedBool(L, __func__, 3, "lockIfTrue");
+    const bool b = getVerifiedBool(L, __func__, 3, "lockIfTrue");
 
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
@@ -4882,7 +4882,7 @@ int TLuaInterpreter::lockSpecialExit(lua_State* L)
     if (dir.isEmpty()) {
         return warnArgumentValue(L, __func__, "the special exit name/command cannot be empty");
     }
-    bool const b = getVerifiedBool(L, __func__, 4, "special exit lock state");
+    const bool b = getVerifiedBool(L, __func__, 4, "special exit lock state");
 
     Host const& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(fromRoomID);
@@ -5513,7 +5513,7 @@ int TLuaInterpreter::getPath(lua_State* L)
         return warnArgumentValue(L, __func__, qsl("number %1 is not a valid target roomID").arg(targetRoomId));
     }
 
-    bool const ret = host.mpMap->gotoRoom(originRoomId, targetRoomId);
+    const bool ret = host.mpMap->gotoRoom(originRoomId, targetRoomId);
     const int totalWeight = host.assemblePath(); // Needed even if unsuccessful, to clear lua tables then
     if (ret) {
         lua_pushboolean(L, true);
@@ -5946,7 +5946,7 @@ int TLuaInterpreter::playMusicFileAsTableArgument(lua_State* L)
                 mediaData.setMediaLoops(value);
             }
         } else if (key == QLatin1String("continue")) {
-            bool const value = getVerifiedBool(L, __func__, -1, "value for continue must be boolean");
+            const bool value = getVerifiedBool(L, __func__, -1, "value for continue must be boolean");
             mediaData.setMediaContinue(value);
         }
 
@@ -6654,7 +6654,7 @@ int TLuaInterpreter::setBold(lua_State* L)
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
         windowName = WINDOW_NAME(L, s++);
     }
-    bool const isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable bold attribute");
+    const bool isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable bold attribute");
     auto console = CONSOLE(L, windowName);
     console->setDisplayAttributes(TChar::Bold, isAttributeEnabled);
     lua_pushboolean(L, true);
@@ -6669,7 +6669,7 @@ int TLuaInterpreter::setItalics(lua_State* L)
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
         windowName = WINDOW_NAME(L, s++);
     }
-    bool const isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable italic attribute");
+    const bool isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable italic attribute");
     auto console = CONSOLE(L, windowName);
     console->setDisplayAttributes(TChar::Italic, isAttributeEnabled);
     lua_pushboolean(L, true);
@@ -6684,7 +6684,7 @@ int TLuaInterpreter::setOverline(lua_State* L)
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
         windowName = WINDOW_NAME(L, s++);
     }
-    bool const isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable overline attribute");
+    const bool isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable overline attribute");
     auto console = CONSOLE(L, windowName);
     console->setDisplayAttributes(TChar::Overline, isAttributeEnabled);
     lua_pushboolean(L, true);
@@ -6699,7 +6699,7 @@ int TLuaInterpreter::setReverse(lua_State* L)
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
         windowName = WINDOW_NAME(L, s++);
     }
-    bool const isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable reverse attribute");
+    const bool isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable reverse attribute");
     auto console = CONSOLE(L, windowName);
     console->setDisplayAttributes(TChar::Reverse, isAttributeEnabled);
     lua_pushboolean(L, true);
@@ -6714,7 +6714,7 @@ int TLuaInterpreter::setStrikeOut(lua_State* L)
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
         windowName = WINDOW_NAME(L, s++);
     }
-    bool const isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable strikeout attribute");
+    const bool isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable strikeout attribute");
     auto console = CONSOLE(L, windowName);
     console->setDisplayAttributes(TChar::StrikeOut, isAttributeEnabled);
     lua_pushboolean(L, true);
@@ -6729,7 +6729,7 @@ int TLuaInterpreter::setUnderline(lua_State* L)
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
         windowName = WINDOW_NAME(L, s++);
     }
-    bool const isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable underline attribute");
+    const bool isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable underline attribute");
     auto console = CONSOLE(L, windowName);
     console->setDisplayAttributes(TChar::Underline, isAttributeEnabled);
     lua_pushboolean(L, true);
@@ -7619,19 +7619,19 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
         lua_pushfstring(L, "tempComplexRegexTrigger: bad argument #4 type (multiline flag as number expected, got %s!)", luaL_typename(L, 4));
         return lua_error(L);
     }
-    bool const multiLine = lua_tonumber(L, 4);
+    const bool multiLine = lua_tonumber(L, 4);
 
     if (!lua_isnumber(L, 7)) {
         lua_pushfstring(L, "tempComplexRegexTrigger: bad argument #7 type (filter flag as number expected, got %s!)", luaL_typename(L, 7));
         return lua_error(L);
     }
-    bool const filter = lua_tonumber(L, 7);
+    const bool filter = lua_tonumber(L, 7);
 
     if (!lua_isnumber(L, 8)) {
         lua_pushfstring(L, "tempComplexRegexTrigger: bad argument #8 type (match all flag as number expected, got %s!)", luaL_typename(L, 8));
         return lua_error(L);
     }
-    bool const matchAll = lua_tonumber(L, 8);
+    const bool matchAll = lua_tonumber(L, 8);
 
     const int fireLength = getVerifiedInt(L, __func__, 12, "fire length");
     const int lineDelta = getVerifiedInt(L, __func__, 13, "line delta");
@@ -8470,7 +8470,7 @@ int TLuaInterpreter::permRegexTrigger(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#invokeFileDialog
 int TLuaInterpreter::invokeFileDialog(lua_State* L)
 {
-    bool const luaDir = getVerifiedBool(L, __func__, 1, "fileOrFolder");
+    const bool luaDir = getVerifiedBool(L, __func__, 1, "fileOrFolder");
     const QString title = getVerifiedString(L, __func__, 2, "dialogTitle");
 
     if (!luaDir) {
@@ -8638,7 +8638,7 @@ int TLuaInterpreter::setAreaName(lua_State* L)
         }
     }
 
-    bool const result = host.mpMap->mpRoomDB->setAreaName(id, newName);
+    const bool result = host.mpMap->mpRoomDB->setAreaName(id, newName);
     if (result) {
         host.mpMap->setUnsaved(__func__);
         if (host.mpMap->mpMapper) {
@@ -8863,7 +8863,7 @@ int TLuaInterpreter::addRoom(lua_State* L)
 {
     const int id = getVerifiedInt(L, __func__, 1, "roomID");
     Host const& host = getHostFromLua(L);
-    bool const added = host.mpMap->addRoom(id);
+    const bool added = host.mpMap->addRoom(id);
     lua_pushboolean(L, added);
     if (added) {
         host.mpMap->setRoomArea(id, -1, false);
@@ -9062,7 +9062,7 @@ int TLuaInterpreter::createMapImageLabel(lua_State* L)
     float const width = getVerifiedFloat(L, __func__, 6, "width");
     float const height = getVerifiedFloat(L, __func__, 7, "height");
     float const zoom = getVerifiedFloat(L, __func__, 8, "zoom");
-    bool const showOnTop = getVerifiedBool(L, __func__, 9, "showOnTop");
+    const bool showOnTop = getVerifiedBool(L, __func__, 9, "showOnTop");
     bool temporary = false;
     if (args > 9) {
         temporary = getVerifiedBool(L, __func__, 10, "showOnTop", true);
@@ -9135,7 +9135,7 @@ int TLuaInterpreter::setDoor(lua_State* L)
             "door type %1 is not one of 0='none', 1='open', 2='closed' or 3='locked'").arg(doorStatus));
     }
 
-    bool const result = pR->setDoor(exitCmd, doorStatus);
+    const bool result = pR->setDoor(exitCmd, doorStatus);
     if (result) {
         host.mpMap->setUnsaved(__func__);
         if (host.mpMap->mpMapper && host.mpMap->mpMapper->mp2dMap) {
@@ -9383,7 +9383,7 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
         }
     }
 
-    bool const arrow = getVerifiedBool(L, __func__, 6, "end with arrow");
+    const bool arrow = getVerifiedBool(L, __func__, 6, "end with arrow");
     const int lz = z.at(0);
     QList<QPointF> points;
     // TODO: make provision for 3D custom lines (and store the z coordinates and allow them to vary)
@@ -10443,7 +10443,7 @@ int TLuaInterpreter::setRoomArea(lua_State* L)
 
     // Can set the room to an area which does not have a TArea instance but does
     // appear in the TRoomDB::areaNamesMap...
-    bool const result = host.mpMap->setRoomArea(id, areaId, false);
+    const bool result = host.mpMap->setRoomArea(id, areaId, false);
     if (result) {
         // As a successful result WILL change the area a room is in then the map
         // should be updated.  The GUI code that modifies room(s) areas already
@@ -10473,7 +10473,7 @@ int TLuaInterpreter::resetRoomArea(lua_State* L)
     } else if (!host.mpMap->mpRoomDB->getRoomIDList().contains(id)) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
     }
-    bool const result = host.mpMap->setRoomArea(id, -1, false);
+    const bool result = host.mpMap->setRoomArea(id, -1, false);
     if (result) {
         // As a successful result WILL change the area a room is in then the map
         // should be updated.  The GUI code that modifies room(s) areas already
@@ -10650,7 +10650,7 @@ int TLuaInterpreter::getGridMode(lua_State* L)
 int TLuaInterpreter::setGridMode(lua_State* L)
 {
     const int area = getVerifiedInt(L, __func__, 1, "areaID");
-    bool const gridMode = getVerifiedBool(L, __func__, 2, "true/false");
+    const bool gridMode = getVerifiedBool(L, __func__, 2, "true/false");
     Host const& host = getHostFromLua(L);
     TArea* pA = host.mpMap->mpRoomDB->getArea(area);
     if (!pA) {
@@ -11407,7 +11407,7 @@ int TLuaInterpreter::setDiscordGameUrl(lua_State* L)
     // in order to respect privacy.
     mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
-    bool const isActiveHost = (pMudlet->mpCurrentActiveHost == &host);
+    const bool isActiveHost = (pMudlet->mpCurrentActiveHost == &host);
     const int args = lua_gettop(L);
 
     if (!args) { // no args, blank the invite URL and game name
@@ -12253,7 +12253,7 @@ int TLuaInterpreter::setDefaultAreaVisible(lua_State* L)
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    bool const isToShowDefaultArea = getVerifiedBool(L, __func__, 1, "isToShowDefaultArea");
+    const bool isToShowDefaultArea = getVerifiedBool(L, __func__, 1, "isToShowDefaultArea");
     if (host.mpMap->mpMapper) {
         // If we are re-enabling the display of the default area
         // AND the mapper was showing the default area
@@ -17350,8 +17350,8 @@ int TLuaInterpreter::registerMapInfo(lua_State* L)
         auto nResult = lua_gettop(L);
         auto index = -nResult;
         const QString text = lua_tostring(L, index);
-        bool const isBold = lua_toboolean(L, ++index);
-        bool const isItalic = lua_toboolean(L, ++index);
+        const bool isBold = lua_toboolean(L, ++index);
+        const bool isItalic = lua_toboolean(L, ++index);
         int r = -1;
         int g = -1;
         int b = -1;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7151,7 +7151,7 @@ int TLuaInterpreter::getMousePosition(lua_State* L)
 {
     Host const& host = getHostFromLua(L);
 
-    QPoint const pos = host.mpConsole->mapFromGlobal(QCursor::pos());
+    const QPoint pos = host.mpConsole->mapFromGlobal(QCursor::pos());
 
     lua_pushnumber(L, pos.x());
     lua_pushnumber(L, pos.y());

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -1016,8 +1016,8 @@ void TMainConsole::setSystemSpellDictionary(const QString& newDict)
     mSpellDic = newDict;
 
     QString const path = mudlet::getMudletPath(mudlet::hunspellDictionaryPath, mpHost->getSpellDic());
-    QString const spell_aff = qsl("%1%2.aff").arg(path, newDict);
-    QString const spell_dic = qsl("%1%2.dic").arg(path, newDict);
+    QString spell_aff = qsl("%1%2.aff").arg(path, newDict);
+    QString spell_dic = qsl("%1%2.dic").arg(path, newDict);
 
     if (mpHunspell_system) {
         Hunspell_destroy(mpHunspell_system);

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -91,8 +91,8 @@ TMainConsole::~TMainConsole()
 
 void TMainConsole::setLabelStyleSheet(std::string& buf, std::string& stylesheet)
 {
-    QString const key{buf.c_str()};
-    QString const sheet{stylesheet.c_str()};
+    const QString key{buf.c_str()};
+    const QString sheet{stylesheet.c_str()};
     if (mLabelMap.find(key) != mLabelMap.end()) {
         QLabel* pC = mLabelMap[key];
         if (!pC) {
@@ -218,7 +218,7 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
         out.setCodec(QTextCodec::codecForName("UTF-8"));
 #endif
         if (isMessageEnabled) {
-            QString const message = qsl("%1\n").arg(tr("Logging has started. Log file is %1").arg(mLogFile.fileName()));
+            const QString message = qsl("%1\n").arg(tr("Logging has started. Log file is %1").arg(mLogFile.fileName()));
             printSystemMessage(message);
             // This puts text onto console that is IMMEDIATELY POSTED into log file so
             // must be done BEFORE logging starts - or actually mLogToLogFile gets set!
@@ -228,7 +228,7 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
         QFile::remove(loggingPath);
         mLogToLogFile = false;
         if (isMessageEnabled) {
-            QString const message = qsl("%1\n").arg(tr("Logging has been stopped. Log file is %1").arg(mLogFile.fileName()));
+            const QString message = qsl("%1\n").arg(tr("Logging has been stopped. Log file is %1").arg(mLogFile.fileName()));
             printSystemMessage(message);
             // This puts text onto console that is IMMEDIATELY POSTED into log file so
             // must be done AFTER logging ends - or actually mLogToLogFile gets reset!
@@ -273,7 +273,7 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
             bool isAtBody = false;
             bool foundBody = false;
             while (!mLogStream.atEnd()) {
-                QString const line = mLogStream.readLine();
+                const QString line = mLogStream.readLine();
                 if (line.contains("<body><div>")) {
                     // Begin writing old log to the current log when the body is
                     // found.
@@ -326,7 +326,7 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
     } else {
         // Logging is being turned off
         buffer.logRemainingOutput();
-        QString const endDateTimeLine = logDateTime.toString(tr("'Log session ending at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'.",
+        const QString endDateTimeLine = logDateTime.toString(tr("'Log session ending at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'.",
                                              "This is the format argument to QDateTime::toString(...) and needs to follow the rules for that function {literal text must be single quoted} as well as being suitable for the translation locale"));
         if (mpHost->mIsCurrentLogFileInHtmlFormat) {
             mLogStream << qsl("<p>%1</p>\n").arg(endDateTimeLine);
@@ -344,7 +344,7 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
 
 void TMainConsole::selectCurrentLine(std::string& buf)
 {
-    QString const key = buf.c_str();
+    const QString key = buf.c_str();
     if (key.isEmpty() || key == QLatin1String("main")) {
         TConsole::selectCurrentLine();
         return;
@@ -357,7 +357,7 @@ void TMainConsole::selectCurrentLine(std::string& buf)
 
 std::list<int> TMainConsole::getFgColor(std::string& buf)
 {
-    QString const key = buf.c_str();
+    const QString key = buf.c_str();
     if (key.isEmpty() || key == QLatin1String("main")) {
         return TConsole::getFgColor();
     }
@@ -371,7 +371,7 @@ std::list<int> TMainConsole::getFgColor(std::string& buf)
 
 std::list<int> TMainConsole::getBgColor(std::string& buf)
 {
-    QString const key = buf.c_str();
+    const QString key = buf.c_str();
     if (key.isEmpty() || key == QLatin1String("main")) {
         return TConsole::getBgColor();
     }
@@ -399,7 +399,7 @@ QPair<quint8, TChar> TMainConsole::getTextAttributes(const QString& name) const
 
 void TMainConsole::luaWrapLine(std::string& buf, int line)
 {
-    QString const key = buf.c_str();
+    const QString key = buf.c_str();
     if (key.isEmpty() || key == QLatin1String("main")) {
         TConsole::luaWrapLine(line);
         return;
@@ -412,7 +412,7 @@ void TMainConsole::luaWrapLine(std::string& buf, int line)
 
 QString TMainConsole::getCurrentLine(std::string& buf)
 {
-    QString const key = buf.c_str();
+    const QString key = buf.c_str();
     if (key.isEmpty() || key == QLatin1String("main")) {
         return TConsole::getCurrentLine();
     }
@@ -930,7 +930,7 @@ QSize TMainConsole::getUserWindowSize(const QString& windowname) const
 
 QPair<bool, QString> TMainConsole::addWordToSet(const QString& word)
 {
-    QString const errMsg = qsl("the word \"%1\" already seems to be in the user dictionary");
+    const QString errMsg = qsl("the word \"%1\" already seems to be in the user dictionary");
     QPair<bool, QString> result{};
     if (!mEnableUserDictionary) {
         return qMakePair(false, QLatin1String("a user dictionary is not enable for this profile"));
@@ -970,7 +970,7 @@ QPair<bool, QString> TMainConsole::addWordToSet(const QString& word)
 
 QPair<bool, QString> TMainConsole::removeWordFromSet(const QString& word)
 {
-    QString const errMsg = qsl("the word \"%1\" does not seem to be in the user dictionary");
+    const QString errMsg = qsl("the word \"%1\" does not seem to be in the user dictionary");
     QPair<bool, QString> result{};
     if (!mEnableUserDictionary) {
         return qMakePair(false, QLatin1String("a user dictionary is not enable for this profile"));
@@ -1015,7 +1015,7 @@ void TMainConsole::setSystemSpellDictionary(const QString& newDict)
 
     mSpellDic = newDict;
 
-    QString const path = mudlet::getMudletPath(mudlet::hunspellDictionaryPath, mpHost->getSpellDic());
+    const QString path = mudlet::getMudletPath(mudlet::hunspellDictionaryPath, mpHost->getSpellDic());
     QString spell_aff = qsl("%1%2.aff").arg(path, newDict);
     QString spell_dic = qsl("%1%2.dic").arg(path, newDict);
 
@@ -1214,7 +1214,7 @@ void TMainConsole::finalize()
 // to the TMap class...?
 bool TMainConsole::saveMap(const QString& location, int saveVersion)
 {
-    QString const filename_map = location.isEmpty() ?
+    const QString filename_map = location.isEmpty() ?
         mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss"))) :
         location;
 
@@ -1358,7 +1358,7 @@ bool TMainConsole::importMap(const QString& location, QString* errMsg)
     QFile file(filePathNameString);
     if (!file.exists()) {
         if (!errMsg) {
-            QString const infoMsg = tr("[ ERROR ]  - Map file not found, path and name used was:\n"
+            const QString infoMsg = tr("[ ERROR ]  - Map file not found, path and name used was:\n"
                                  "%1.")
                                       .arg(filePathNameString);
             pHost->postMessage(infoMsg);
@@ -1373,7 +1373,7 @@ bool TMainConsole::importMap(const QString& location, QString* errMsg)
 
     if (file.open(QFile::ReadOnly | QFile::Text)) {
         if (!errMsg) {
-            QString const infoMsg = tr("[ INFO ]  - Map file located and opened, now parsing it...");
+            const QString infoMsg = tr("[ INFO ]  - Map file located and opened, now parsing it...");
             pHost->postMessage(infoMsg);
         }
 
@@ -1383,7 +1383,7 @@ bool TMainConsole::importMap(const QString& location, QString* errMsg)
         pHost->mpMap->pushErrorMessagesToFile(tr(R"(Importing map(1) "%1" at %2 report)").arg(location, now.toString(Qt::ISODate)));
     } else {
         if (!errMsg) {
-            QString const infoMsg = tr(R"([ INFO ]  - Map file located but it could not opened, please check permissions on:"%1".)").arg(filePathNameString);
+            const QString infoMsg = tr(R"([ INFO ]  - Map file located but it could not opened, please check permissions on:"%1".)").arg(filePathNameString);
             pHost->postMessage(infoMsg);
         } else {
             *errMsg = tr("loadMap: bad argument #1 value (filename used: \n"
@@ -1410,7 +1410,7 @@ void TMainConsole::slot_reloadMap(QList<QString> profilesList)
         return;
     }
 
-    QString const infoMsg = tr("[ INFO ]  - Map reload request received from system...");
+    const QString infoMsg = tr("[ INFO ]  - Map reload request received from system...");
     pHost->postMessage(infoMsg);
 
     QString outcomeMsg;
@@ -1444,7 +1444,7 @@ void TMainConsole::showStatistics()
         return;
     }
 
-    QString const header = qsl("%1\n").arg(tr(
+    const QString header = qsl("%1\n").arg(tr(
         "+--------------------------------------------------------------+\n"
         "|                      system statistics                       |\n"
         "+--------------------------------------------------------------+",
@@ -1503,7 +1503,7 @@ void TMainConsole::showStatistics()
     print(itemMsg, QColor(150, 120, 0), Qt::black);
 
     // Footer for the system's statistics information displayed in the console, it should be 64 'narrow' characters wide
-    QString const footer = qsl("\n+--------------------------------------------------------------+\n");
+    const QString footer = qsl("\n+--------------------------------------------------------------+\n");
     mpHost->mpConsole->print(footer, QColor(150, 120, 0), Qt::black);
 
     mpHost->mLuaInterpreter.compileAndExecuteScript(QLatin1String("resetFormat();"));

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -91,8 +91,8 @@ TMainConsole::~TMainConsole()
 
 void TMainConsole::setLabelStyleSheet(std::string& buf, std::string& stylesheet)
 {
-    QString key{buf.c_str()};
-    QString sheet{stylesheet.c_str()};
+    QString const key{buf.c_str()};
+    QString const sheet{stylesheet.c_str()};
     if (mLabelMap.find(key) != mLabelMap.end()) {
         QLabel* pC = mLabelMap[key];
         if (!pC) {
@@ -105,7 +105,7 @@ void TMainConsole::setLabelStyleSheet(std::string& buf, std::string& stylesheet)
 
 std::optional<QString> TMainConsole::getLabelStyleSheet(const QString& name) const
 {
-    QMap<QString, TLabel*>::const_iterator it = mLabelMap.constFind(name);
+    QMap<QString, TLabel*>::const_iterator const it = mLabelMap.constFind(name);
     if (it != mLabelMap.cend() && it.key() == name) {
         return it.value()->styleSheet();
     }
@@ -115,7 +115,7 @@ std::optional<QString> TMainConsole::getLabelStyleSheet(const QString& name) con
 
 std::optional<QSize> TMainConsole::getLabelSizeHint(const QString& name) const
 {
-    QMap<QString, TLabel*>::const_iterator it = mLabelMap.constFind(name);
+    QMap<QString, TLabel*>::const_iterator const it = mLabelMap.constFind(name);
     if (it != mLabelMap.cend() && it.key() == name) {
         return it.value()->sizeHint();
     }
@@ -157,7 +157,7 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
 {
     const auto loggingPath = mudlet::getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), qsl("autolog"));
     QFile file(loggingPath);
-    QDateTime logDateTime = QDateTime::currentDateTime();
+    QDateTime const logDateTime = QDateTime::currentDateTime();
     if (!mLogToLogFile) {
         file.open(QIODevice::WriteOnly | QIODevice::Text);
         QTextStream out(&file);
@@ -187,7 +187,7 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
 
         // The preset file name formats are derived from date/times so that
         // alphabetical filename and date sort order are the same...
-        QDir dirLogFile;
+        QDir const dirLogFile;
         if (!dirLogFile.exists(directoryLogFile)) {
             dirLogFile.mkpath(directoryLogFile);
         }
@@ -218,7 +218,7 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
         out.setCodec(QTextCodec::codecForName("UTF-8"));
 #endif
         if (isMessageEnabled) {
-            QString message = qsl("%1\n").arg(tr("Logging has started. Log file is %1").arg(mLogFile.fileName()));
+            QString const message = qsl("%1\n").arg(tr("Logging has started. Log file is %1").arg(mLogFile.fileName()));
             printSystemMessage(message);
             // This puts text onto console that is IMMEDIATELY POSTED into log file so
             // must be done BEFORE logging starts - or actually mLogToLogFile gets set!
@@ -228,7 +228,7 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
         QFile::remove(loggingPath);
         mLogToLogFile = false;
         if (isMessageEnabled) {
-            QString message = qsl("%1\n").arg(tr("Logging has been stopped. Log file is %1").arg(mLogFile.fileName()));
+            QString const message = qsl("%1\n").arg(tr("Logging has been stopped. Log file is %1").arg(mLogFile.fileName()));
             printSystemMessage(message);
             // This puts text onto console that is IMMEDIATELY POSTED into log file so
             // must be done AFTER logging ends - or actually mLogToLogFile gets reset!
@@ -273,7 +273,7 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
             bool isAtBody = false;
             bool foundBody = false;
             while (!mLogStream.atEnd()) {
-                QString line = mLogStream.readLine();
+                QString const line = mLogStream.readLine();
                 if (line.contains("<body><div>")) {
                     // Begin writing old log to the current log when the body is
                     // found.
@@ -326,7 +326,7 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
     } else {
         // Logging is being turned off
         buffer.logRemainingOutput();
-        QString endDateTimeLine = logDateTime.toString(tr("'Log session ending at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'.",
+        QString const endDateTimeLine = logDateTime.toString(tr("'Log session ending at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'.",
                                              "This is the format argument to QDateTime::toString(...) and needs to follow the rules for that function {literal text must be single quoted} as well as being suitable for the translation locale"));
         if (mpHost->mIsCurrentLogFileInHtmlFormat) {
             mLogStream << qsl("<p>%1</p>\n").arg(endDateTimeLine);
@@ -344,7 +344,7 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
 
 void TMainConsole::selectCurrentLine(std::string& buf)
 {
-    QString key = buf.c_str();
+    QString const key = buf.c_str();
     if (key.isEmpty() || key == QLatin1String("main")) {
         TConsole::selectCurrentLine();
         return;
@@ -357,7 +357,7 @@ void TMainConsole::selectCurrentLine(std::string& buf)
 
 std::list<int> TMainConsole::getFgColor(std::string& buf)
 {
-    QString key = buf.c_str();
+    QString const key = buf.c_str();
     if (key.isEmpty() || key == QLatin1String("main")) {
         return TConsole::getFgColor();
     }
@@ -371,7 +371,7 @@ std::list<int> TMainConsole::getFgColor(std::string& buf)
 
 std::list<int> TMainConsole::getBgColor(std::string& buf)
 {
-    QString key = buf.c_str();
+    QString const key = buf.c_str();
     if (key.isEmpty() || key == QLatin1String("main")) {
         return TConsole::getBgColor();
     }
@@ -399,7 +399,7 @@ QPair<quint8, TChar> TMainConsole::getTextAttributes(const QString& name) const
 
 void TMainConsole::luaWrapLine(std::string& buf, int line)
 {
-    QString key = buf.c_str();
+    QString const key = buf.c_str();
     if (key.isEmpty() || key == QLatin1String("main")) {
         TConsole::luaWrapLine(line);
         return;
@@ -412,7 +412,7 @@ void TMainConsole::luaWrapLine(std::string& buf, int line)
 
 QString TMainConsole::getCurrentLine(std::string& buf)
 {
-    QString key = buf.c_str();
+    QString const key = buf.c_str();
     if (key.isEmpty() || key == QLatin1String("main")) {
         return TConsole::getCurrentLine();
     }
@@ -652,11 +652,11 @@ std::pair<bool, QString> TMainConsole::setLabelCustomCursor(const QString& name,
 
     auto pL = mLabelMap.value(name);
     if (pL) {
-        QPixmap cursor_pixmap = QPixmap(pixMapLocation);
+        QPixmap const cursor_pixmap = QPixmap(pixMapLocation);
         if (cursor_pixmap.isNull()) {
             return {false, qsl("couldn't find custom cursor, is the location \"%1\" correct?").arg(pixMapLocation)};
         }
-        QCursor custom_cursor = QCursor(cursor_pixmap, hotX, hotY);
+        QCursor const custom_cursor = QCursor(cursor_pixmap, hotX, hotY);
         pL->setCursor(custom_cursor);
         return {true, QString()};
     }
@@ -691,7 +691,7 @@ std::pair<bool, QString> TMainConsole::createMapper(const QString& windowname, i
         mpHost->mpMap->mpMapper = mpMapper;
         qDebug() << "TConsole::createMapper() - restore map case 2.";
         mpHost->mpMap->pushErrorMessagesToFile(tr("Pre-Map loading(2) report"), true);
-        QDateTime now(QDateTime::currentDateTime());
+        QDateTime const now(QDateTime::currentDateTime());
 
         if (mpHost->mpMap->restore(QString())) {
             mpHost->mpMap->audit();
@@ -760,7 +760,7 @@ bool TMainConsole::setBackgroundImage(const QString& name, const QString& path)
 {
     auto pL = mLabelMap.value(name);
     if (pL) {
-        QPixmap bgPixmap(path);
+        QPixmap const bgPixmap(path);
         pL->setPixmap(bgPixmap);
         return true;
     } else {
@@ -921,7 +921,7 @@ QSize TMainConsole::getUserWindowSize(const QString& windowname) const
 {
     auto pW = mDockWidgetMap.value(windowname);
     if (pW){
-        QSize windowSize = pW->widget()->size();
+        QSize const windowSize = pW->widget()->size();
         QSize userWindowSize(windowSize.width(), windowSize.height());
         return userWindowSize;
     }
@@ -930,7 +930,7 @@ QSize TMainConsole::getUserWindowSize(const QString& windowname) const
 
 QPair<bool, QString> TMainConsole::addWordToSet(const QString& word)
 {
-    QString errMsg = qsl("the word \"%1\" already seems to be in the user dictionary");
+    QString const errMsg = qsl("the word \"%1\" already seems to be in the user dictionary");
     QPair<bool, QString> result{};
     if (!mEnableUserDictionary) {
         return qMakePair(false, QLatin1String("a user dictionary is not enable for this profile"));
@@ -970,7 +970,7 @@ QPair<bool, QString> TMainConsole::addWordToSet(const QString& word)
 
 QPair<bool, QString> TMainConsole::removeWordFromSet(const QString& word)
 {
-    QString errMsg = qsl("the word \"%1\" does not seem to be in the user dictionary");
+    QString const errMsg = qsl("the word \"%1\" does not seem to be in the user dictionary");
     QPair<bool, QString> result{};
     if (!mEnableUserDictionary) {
         return qMakePair(false, QLatin1String("a user dictionary is not enable for this profile"));
@@ -1015,9 +1015,9 @@ void TMainConsole::setSystemSpellDictionary(const QString& newDict)
 
     mSpellDic = newDict;
 
-    QString path = mudlet::getMudletPath(mudlet::hunspellDictionaryPath, mpHost->getSpellDic());
-    QString spell_aff = qsl("%1%2.aff").arg(path, newDict);
-    QString spell_dic = qsl("%1%2.dic").arg(path, newDict);
+    QString const path = mudlet::getMudletPath(mudlet::hunspellDictionaryPath, mpHost->getSpellDic());
+    QString const spell_aff = qsl("%1%2.aff").arg(path, newDict);
+    QString const spell_dic = qsl("%1%2.dic").arg(path, newDict);
 
     if (mpHunspell_system) {
         Hunspell_destroy(mpHunspell_system);
@@ -1160,7 +1160,7 @@ void TMainConsole::printOnDisplay(std::string& incomingSocketData, const bool is
         mpHost->mLuaInterpreter.signalMXPEvent(event.name, event.attrs, event.actions);
     }
 
-    double processT = mProcessingTimer.elapsed() / 1000.0;
+    double const processT = mProcessingTimer.elapsed() / 1000.0;
     if (mpHost->mTelnet.mGA_Driver) {
         mpLineEdit_networkLatency->setText(tr("N:%1 S:%2",
                                               // intentional comment to separate arguments
@@ -1214,11 +1214,11 @@ void TMainConsole::finalize()
 // to the TMap class...?
 bool TMainConsole::saveMap(const QString& location, int saveVersion)
 {
-    QString filename_map = location.isEmpty() ?
+    QString const filename_map = location.isEmpty() ?
         mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss"))) :
         location;
 
-    QDir dir_map(mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName));
+    QDir const dir_map(mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName));
     if (!dir_map.exists() && !dir_map.mkpath(dir_map.path())) {
         return false;
     }
@@ -1272,7 +1272,7 @@ bool TMainConsole::loadMap(const QString& location)
 
     qDebug() << "TMainConsole::loadMap() - restore map case 1.";
     pHost->mpMap->pushErrorMessagesToFile(tr("Pre-Map loading(1) report"), true);
-    QDateTime now(QDateTime::currentDateTime());
+    QDateTime const now(QDateTime::currentDateTime());
 
     bool result = false;
     if (pHost->mpMap->restore(location)) {
@@ -1336,11 +1336,11 @@ bool TMainConsole::importMap(const QString& location, QString* errMsg)
     // been logged...
     qDebug() << "TMainConsole::importingMap() - importing map case 1.";
     pHost->mpMap->pushErrorMessagesToFile(tr("Pre-Map importing(1) report"), true);
-    QDateTime now(QDateTime::currentDateTime());
+    QDateTime const now(QDateTime::currentDateTime());
 
     bool result = false;
 
-    QFileInfo fileInfo(location);
+    QFileInfo const fileInfo(location);
     QString filePathNameString;
     if (!fileInfo.filePath().isEmpty()) {
         if (fileInfo.isRelative()) {
@@ -1358,7 +1358,7 @@ bool TMainConsole::importMap(const QString& location, QString* errMsg)
     QFile file(filePathNameString);
     if (!file.exists()) {
         if (!errMsg) {
-            QString infoMsg = tr("[ ERROR ]  - Map file not found, path and name used was:\n"
+            QString const infoMsg = tr("[ ERROR ]  - Map file not found, path and name used was:\n"
                                  "%1.")
                                       .arg(filePathNameString);
             pHost->postMessage(infoMsg);
@@ -1373,7 +1373,7 @@ bool TMainConsole::importMap(const QString& location, QString* errMsg)
 
     if (file.open(QFile::ReadOnly | QFile::Text)) {
         if (!errMsg) {
-            QString infoMsg = tr("[ INFO ]  - Map file located and opened, now parsing it...");
+            QString const infoMsg = tr("[ INFO ]  - Map file located and opened, now parsing it...");
             pHost->postMessage(infoMsg);
         }
 
@@ -1383,7 +1383,7 @@ bool TMainConsole::importMap(const QString& location, QString* errMsg)
         pHost->mpMap->pushErrorMessagesToFile(tr(R"(Importing map(1) "%1" at %2 report)").arg(location, now.toString(Qt::ISODate)));
     } else {
         if (!errMsg) {
-            QString infoMsg = tr(R"([ INFO ]  - Map file located but it could not opened, please check permissions on:"%1".)").arg(filePathNameString);
+            QString const infoMsg = tr(R"([ INFO ]  - Map file located but it could not opened, please check permissions on:"%1".)").arg(filePathNameString);
             pHost->postMessage(infoMsg);
         } else {
             *errMsg = tr("loadMap: bad argument #1 value (filename used: \n"
@@ -1410,7 +1410,7 @@ void TMainConsole::slot_reloadMap(QList<QString> profilesList)
         return;
     }
 
-    QString infoMsg = tr("[ INFO ]  - Map reload request received from system...");
+    QString const infoMsg = tr("[ INFO ]  - Map reload request received from system...");
     pHost->postMessage(infoMsg);
 
     QString outcomeMsg;
@@ -1444,7 +1444,7 @@ void TMainConsole::showStatistics()
         return;
     }
 
-    QString header = qsl("%1\n").arg(tr(
+    QString const header = qsl("%1\n").arg(tr(
         "+--------------------------------------------------------------+\n"
         "|                      system statistics                       |\n"
         "+--------------------------------------------------------------+",
@@ -1503,7 +1503,7 @@ void TMainConsole::showStatistics()
     print(itemMsg, QColor(150, 120, 0), Qt::black);
 
     // Footer for the system's statistics information displayed in the console, it should be 64 'narrow' characters wide
-    QString footer = qsl("\n+--------------------------------------------------------------+\n");
+    QString const footer = qsl("\n+--------------------------------------------------------------+\n");
     mpHost->mpConsole->print(footer, QColor(150, 120, 0), Qt::black);
 
     mpHost->mLuaInterpreter.compileAndExecuteScript(QLatin1String("resetFormat();"));

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -1340,7 +1340,7 @@ bool TMainConsole::importMap(const QString& location, QString* errMsg)
 
     bool result = false;
 
-    QFileInfo const fileInfo(location);
+    const QFileInfo fileInfo(location);
     QString filePathNameString;
     if (!fileInfo.filePath().isEmpty()) {
         if (fileInfo.isRelative()) {

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -187,7 +187,7 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
 
         // The preset file name formats are derived from date/times so that
         // alphabetical filename and date sort order are the same...
-        QDir const dirLogFile;
+        const QDir dirLogFile;
         if (!dirLogFile.exists(directoryLogFile)) {
             dirLogFile.mkpath(directoryLogFile);
         }
@@ -1218,7 +1218,7 @@ bool TMainConsole::saveMap(const QString& location, int saveVersion)
         mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss"))) :
         location;
 
-    QDir const dir_map(mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName));
+    const QDir dir_map(mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName));
     if (!dir_map.exists() && !dir_map.mkpath(dir_map.path())) {
         return false;
     }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -155,7 +155,7 @@ bool TMap::setRoomArea(int id, int area, bool isToDeferAreaRelatedRecalculations
         // to retain the API for the lua subsystem...
     }
 
-    bool const result = pR->setArea(area, isToDeferAreaRelatedRecalculations);
+    const bool result = pR->setArea(area, isToDeferAreaRelatedRecalculations);
     if (result) {
         mMapGraphNeedsUpdate = true;
         setUnsaved(__func__);
@@ -2544,7 +2544,7 @@ bool TMap::importMap(QFile& file, QString* errMsg)
     mImportRunning = true;
     // MUST clear this flag when done under ALL circumstances
 
-    bool const result = readXmlMapFile(file, errMsg);
+    const bool result = readXmlMapFile(file, errMsg);
     mImportRunning = false;
 
     return result;
@@ -3142,7 +3142,7 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
     }
     const QString mapSymbolFontText = mapObj[QLatin1String("mapSymbolFontDetails")].toString();
     float const mapSymbolFontFudgeFactor = (qRound(mapObj[QLatin1String("mapSymbolFontFudgeFactor")].toDouble() * 1000.0)) / 1000;
-    bool const isOnlyMapSymbolFontToBeUsed = mapObj[QLatin1String("onlyMapSymbolFontToBeUsed")].toBool();
+    const bool isOnlyMapSymbolFontToBeUsed = mapObj[QLatin1String("onlyMapSymbolFontToBeUsed")].toBool();
     const int playerRoomStyle = qRound(mapObj[QLatin1String("playerRoomStyle")].toDouble());
     quint8 const playerRoomOuterDiameterPercentage = qRound(mapObj[QLatin1String("playerRoomOuterDiameterPercentage")].toDouble());
     quint8 const playerRoomInnerDiameterPercentage = qRound(mapObj[QLatin1String("playerRoomInnerDiameterPercentage")].toDouble());

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -524,7 +524,7 @@ void TMap::audit()
     _time.start();
 
     { // Blocked - just to limit the scope of infoMsg...!
-        QString const infoMsg = tr("[ INFO ]  - Map audit starting...");
+        const QString infoMsg = tr("[ INFO ]  - Map audit starting...");
         postMessage(infoMsg);
     }
 
@@ -554,7 +554,7 @@ void TMap::audit()
                         int const newID = createMapLabel(areaID, l.text, l.pos.x(), l.pos.y(), l.pos.z(), l.fgColor, l.bgColor, true, false, false, 40.0, 50, std::nullopt);
                         if (newID > -1) {
                             if (mudlet::self()->showMapAuditErrors()) {
-                                QString const msg = tr("[ INFO ] - CONVERTING: old style label, areaID:%1 labelID:%2.").arg(areaID).arg(i);
+                                const QString msg = tr("[ INFO ] - CONVERTING: old style label, areaID:%1 labelID:%2.").arg(areaID).arg(i);
                                 postMessage(msg);
                             }
                             appendAreaErrorMsg(areaID, tr("[ INFO ] - Converting old style label id: %1.").arg(i));
@@ -562,7 +562,7 @@ void TMap::audit()
 
                         } else {
                             if (mudlet::self()->showMapAuditErrors()) {
-                                QString const msg = tr("[ WARN ] - CONVERTING: cannot convert old style label in area with id: %1,  label id is: %2.").arg(areaID).arg(i);
+                                const QString msg = tr("[ WARN ] - CONVERTING: cannot convert old style label in area with id: %1,  label id is: %2.").arg(areaID).arg(i);
                                 postMessage(msg);
                             }
                             appendAreaErrorMsg(areaID, tr("[ WARN ] - CONVERTING: cannot convert old style label with id: %1.").arg(i));
@@ -594,14 +594,14 @@ void TMap::audit()
     }
 
     { // Blocked - just to limit the scope of infoMsg...!
-        QString const infoMsg = tr("[  OK  ]  - Auditing of map completed (%1s). Enjoy your game...").arg(_time.nsecsElapsed() * 1.0e-9, 0, 'f', 2);
+        const QString infoMsg = tr("[  OK  ]  - Auditing of map completed (%1s). Enjoy your game...").arg(_time.nsecsElapsed() * 1.0e-9, 0, 'f', 2);
         postMessage(infoMsg);
         appendErrorMsg(infoMsg);
     }
 
     auto loadTime = mpHost->getLuaInterpreter()->condenseMapLoad();
     if (loadTime != -1.0) {
-        QString const msg = tr("[  OK  ]  - Map loaded successfully (%1s).").arg(loadTime);
+        const QString msg = tr("[  OK  ]  - Map loaded successfully (%1s).").arg(loadTime);
         postMessage(msg);
     }
 }
@@ -1106,7 +1106,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
         saveVersion = 0;
     } else if (saveVersion > mMaxVersion) {
         saveVersion = mMaxVersion;
-         QString const errMsg = tr("[ ERROR ] - The format version \"%1\" you are trying to save the map with is too new\n"
+         const QString errMsg = tr("[ ERROR ] - The format version \"%1\" you are trying to save the map with is too new\n"
                              "for this version of Mudlet. Supported are only formats up to version %2.")
                                  .arg(QString::number(saveVersion), QString::number(mMaxVersion));
         appendErrorMsgWithNoLf(errMsg, false);
@@ -1122,7 +1122,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
     }
 
     if (mSaveVersion != mVersion) {
-        QString const message = tr("[ ALERT ] - Saving map in format version \"%1\" that is different than \"%2\" which\n"
+        const QString message = tr("[ ALERT ] - Saving map in format version \"%1\" that is different than \"%2\" which\n"
                              "it was loaded as. This may be an issue if you want to share the resulting\n"
                              "map with others relying on the original format.")
                                   .arg(mSaveVersion)
@@ -1132,7 +1132,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
     }
 
     if (mSaveVersion != mDefaultVersion) {
-        QString const message = tr("[ WARN ]  - Saving map in format version \"%1\" different from the\n"
+        const QString message = tr("[ WARN ]  - Saving map in format version \"%1\" different from the\n"
                              "recommended map version %2 for this version of Mudlet.")
                                   .arg(mSaveVersion)
                                   .arg(mDefaultVersion);
@@ -1366,7 +1366,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
             QMapIterator<QString, QList<QPointF>> itCustomLine(pR->customLines);
             while (itCustomLine.hasNext()) {
                 itCustomLine.next();
-                QString const direction(itCustomLine.key());
+                const QString direction(itCustomLine.key());
                 if (direction == QLatin1String("n") || direction == QLatin1String("e") || direction == QLatin1String("s") || direction == QLatin1String("w") || direction == QLatin1String("up")
                     || direction == QLatin1String("down")
                     || direction == QLatin1String("ne")
@@ -1386,7 +1386,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
             QMapIterator<QString, bool> itCustomLineArrow(pR->customLinesArrow);
             while (itCustomLineArrow.hasNext()) {
                 itCustomLineArrow.next();
-                QString const direction(itCustomLineArrow.key());
+                const QString direction(itCustomLineArrow.key());
                 if (direction == QLatin1String("n") || direction == QLatin1String("e") || direction == QLatin1String("s") || direction == QLatin1String("w") || direction == QLatin1String("up")
                     || direction == QLatin1String("down")
                     || direction == QLatin1String("ne")
@@ -1406,7 +1406,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
             QMapIterator<QString, QColor> itCustomLineColor(pR->customLinesColor);
             while (itCustomLineColor.hasNext()) {
                 itCustomLineColor.next();
-                QString const direction(itCustomLineColor.key());
+                const QString direction(itCustomLineColor.key());
                 QList<int> colorComponents;
                 colorComponents << itCustomLineColor.value().red() << itCustomLineColor.value().green() << itCustomLineColor.value().blue();
                 if (direction == QLatin1String("n") || direction == QLatin1String("e") || direction == QLatin1String("s") || direction == QLatin1String("w") || direction == QLatin1String("up")
@@ -1482,7 +1482,7 @@ bool TMap::validatePotentialMapFile(QFile& file, QDataStream& ifs)
 {
     int version = 0;
     if (!file.open(QFile::ReadOnly)) {
-        QString const errMsg = tr(R"([ ERROR ] - Unable to open map file for reading: "%1"!)").arg(file.fileName());
+        const QString errMsg = tr(R"([ ERROR ] - Unable to open map file for reading: "%1"!)").arg(file.fileName());
         appendErrorMsg(errMsg, false);
         postMessage(errMsg);
         return false;
@@ -1504,14 +1504,14 @@ bool TMap::validatePotentialMapFile(QFile& file, QDataStream& ifs)
     }
     ifs >> version;
     if ((version < 1) || (version > 127)) {
-        QString const errMsg = tr("[ ALERT ] - File does not seem to be a Mudlet Map file. The part that indicates\n"
+        const QString errMsg = tr("[ ALERT ] - File does not seem to be a Mudlet Map file. The part that indicates\n"
                             "its format version seems to be \"%1\" and that doesn't make sense. The file is:\n"
                             "\"%2\".")
                                  .arg(version)
                                  .arg(file.fileName());
         appendErrorMsgWithNoLf(errMsg);
         postMessage(errMsg);
-        QString const infoMsg = tr("[ INFO ]  - Ignoring this unlikely map file.");
+        const QString infoMsg = tr("[ INFO ]  - Ignoring this unlikely map file.");
         appendErrorMsgWithNoLf(infoMsg);
         postMessage(infoMsg);
         ifs.setDevice(nullptr);
@@ -1519,14 +1519,14 @@ bool TMap::validatePotentialMapFile(QFile& file, QDataStream& ifs)
         return false;
     }
     if (version > mMaxVersion) {
-        QString const errMsg = tr("[ ALERT ] - Map file is too new. Its format version \"%1\" is higher than this version of\n"
+        const QString errMsg = tr("[ ALERT ] - Map file is too new. Its format version \"%1\" is higher than this version of\n"
                             "Mudlet can handle (%2)! The file is:\n\"%3\".")
                                  .arg(version)
                                  .arg(mMaxVersion)
                                  .arg(file.fileName());
         appendErrorMsgWithNoLf(errMsg);
         postMessage(errMsg);
-        QString const infoMsg = tr("[ INFO ]  - You will need to update your Mudlet to read the map file.");
+        const QString infoMsg = tr("[ INFO ]  - You will need to update your Mudlet to read the map file.");
         appendErrorMsgWithNoLf(infoMsg);
         postMessage(infoMsg);
         ifs.setDevice(nullptr);
@@ -1535,21 +1535,21 @@ bool TMap::validatePotentialMapFile(QFile& file, QDataStream& ifs)
     }
 
     if (version < 4) {
-        QString const alertMsg = tr("[ ALERT ] - Map file is really old. Its format version \"%1\" is so ancient that\n"
+        const QString alertMsg = tr("[ ALERT ] - Map file is really old. Its format version \"%1\" is so ancient that\n"
                               "this version of Mudlet may not gain enough information from\n"
                               "it but it will try! The file is: \"%2\".")
                                    .arg(version)
                                    .arg(file.fileName());
         appendErrorMsgWithNoLf(alertMsg, false);
         postMessage(alertMsg);
-        QString const infoMsg = tr("[ INFO ]  - You might wish to donate THIS map file to the Mudlet Museum!\n"
+        const QString infoMsg = tr("[ INFO ]  - You might wish to donate THIS map file to the Mudlet Museum!\n"
                              "There is so much data that it DOES NOT have that you could be\n"
                              "better off starting again...");
         appendErrorMsgWithNoLf(infoMsg, false);
         postMessage(infoMsg);
     } else {
         // Less than (but not less than 4) or equal to default version
-        QString const infoMsg = tr("[ INFO ]  - Reading map. Format version: %1. File:\n"
+        const QString infoMsg = tr("[ INFO ]  - Reading map. Format version: %1. File:\n"
                              "\"%2\",\n"
                              "please wait...").arg(version).arg(file.fileName());
         appendErrorMsg(tr(R"([ INFO ]  - Reading map. Format version: %1. File: "%2".)").arg(version).arg(file.fileName()), false);
@@ -1605,12 +1605,12 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
             } else {
                 if (auto [isOk, message] = readJsonMapFile(fileName, true); !isOk) {
                    // Failed to read the JSON file
-                   QString const errMsg = tr("[ ALERT ] - Failed to load a Mudlet JSON Map file, reason:\n"
+                   const QString errMsg = tr("[ ALERT ] - Failed to load a Mudlet JSON Map file, reason:\n"
                                        "%1; the file is:\n"
                                        "\"%2\".").arg(message, fileName);
                    appendErrorMsgWithNoLf(errMsg);
                    postMessage(errMsg);
-                   QString const infoMsg = tr("[ INFO ]  - Ignoring this map file.");
+                   const QString infoMsg = tr("[ INFO ]  - Ignoring this map file.");
                    appendErrorMsgWithNoLf(infoMsg);
                    postMessage(infoMsg);
                } else {
@@ -1683,9 +1683,9 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
                 // we CAN fix past mistakes by only considering the first ten
                 // elements:
                 QStringList const fontStrings{mUserData.take(qsl("system.fallback_mapSymbolFont")).split(QLatin1Char(','))};
-                QString const fontString{fontStrings.mid(0, 10).join(QLatin1Char(','))};
-                QString const fontFudgeFactorString = mUserData.take(qsl("system.fallback_mapSymbolFontFudgeFactor"));
-                QString const onlyUseSymbolFontString = mUserData.take(qsl("system.fallback_onlyUseMapSymbolFont"));
+                const QString fontString{fontStrings.mid(0, 10).join(QLatin1Char(','))};
+                const QString fontFudgeFactorString = mUserData.take(qsl("system.fallback_mapSymbolFontFudgeFactor"));
+                const QString onlyUseSymbolFontString = mUserData.take(qsl("system.fallback_onlyUseMapSymbolFont"));
                 if (!fontString.isEmpty()) {
                     mMapSymbolFont.fromString(fontString);
                 }
@@ -1781,7 +1781,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
         if (!mpRoomDB->getAreaMap().keys().contains(-1)) {
             auto pDefaultA = new TArea(this, mpRoomDB);
             mpRoomDB->restoreSingleArea(-1, pDefaultA);
-            QString const defaultAreaInsertionMsg = tr("[ INFO ]  - Default (reset) area (for rooms that have not been assigned to an\n"
+            const QString defaultAreaInsertionMsg = tr("[ INFO ]  - Default (reset) area (for rooms that have not been assigned to an\n"
                                                  "area) not found, adding reserved -1 id.");
             appendErrorMsgWithNoLf(defaultAreaInsertionMsg, false);
             if (mudlet::self()->showMapAuditErrors()) {
@@ -1860,7 +1860,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
 
         restore16ColorSet();
 
-        QString const okMsg = tr("[ INFO ]  - Successfully read the map file (%1s), checking some\n"
+        const QString okMsg = tr("[ INFO ]  - Successfully read the map file (%1s), checking some\n"
                            "consistency details..." )
                                 .arg(_time.nsecsElapsed() * 1.0e-9, 0, 'f', 2);
 
@@ -1919,7 +1919,7 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
     QFile file(qsl("%1/%2").arg(folder, entries.at(0)));
 
     if (!file.open(QFile::ReadOnly)) {
-        QString const errMsg = tr(R"([ ERROR ] - Unable to open map file for reading: "%1"!)").arg(file.fileName());
+        const QString errMsg = tr(R"([ ERROR ] - Unable to open map file for reading: "%1"!)").arg(file.fileName());
         appendErrorMsg(errMsg, false);
         postMessage(errMsg);
         return false;
@@ -1935,7 +1935,7 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
     }
     ifs >> otherProfileVersion;
 
-    QString const infoMsg = tr(R"([ INFO ]  - Checking map file "%1", format version "%2".)").arg(file.fileName()).arg(otherProfileVersion);
+    const QString infoMsg = tr(R"([ INFO ]  - Checking map file "%1", format version "%2".)").arg(file.fileName()).arg(otherProfileVersion);
     appendErrorMsg(infoMsg, false);
     if (mudlet::self()->showMapAuditErrors()) {
         postMessage(infoMsg);
@@ -2428,7 +2428,7 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
 
     // Incidentally this should address: https://bugs.launchpad.net/mudlet/+bug/852861
     if (mImportRunning) {
-        QString const warnMsg = tr("[ WARN ]  - Attempt made to download an XML map when one has already been\n"
+        const QString warnMsg = tr("[ WARN ]  - Attempt made to download an XML map when one has already been\n"
                                          "requested or is being imported from a local file - wait for that\n"
                                          "operation to complete (if it cannot be canceled) before retrying!");
         postMessage(warnMsg);
@@ -2449,7 +2449,7 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     }
 
     if (!url.isValid()) {
-        QString const errMsg = tr("[ WARN ]  - Attempt made to download an XML from an invalid URL.  The URL was:\n"
+        const QString errMsg = tr("[ WARN ]  - Attempt made to download an XML from an invalid URL.  The URL was:\n"
                                         "%1\n"
                                         "and the error message (may contain technical details) was:"
                                         "\"%2\".")
@@ -2461,9 +2461,9 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
 
     // Check to ensure we have a map directory to save the map files to.
     QDir const toProfileDir;
-    QString const toProfileDirPathString = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
+    const QString toProfileDirPathString = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
     if (!toProfileDir.mkpath(toProfileDirPathString)) {
-        QString const errMsg = tr("[ ERROR ] - Unable to use or create directory to store map.\n"
+        const QString errMsg = tr("[ ERROR ] - Unable to use or create directory to store map.\n"
                             "Please check that you have permissions/access to:\n"
                             "\"%1\"\n"
                             "and there is enough space. The download operation has failed.")
@@ -2489,7 +2489,7 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
 
     mExpectedFileSize = 4000000;
 
-    QString const infoMsg = tr("[ INFO ]  - Map download initiated, please wait...");
+    const QString infoMsg = tr("[ INFO ]  - Map download initiated, please wait...");
     postMessage(infoMsg);
     qApp->processEvents();
     // Attempts to ensure INFO message gets shown before download is initiated!
@@ -2534,7 +2534,7 @@ bool TMap::importMap(QFile& file, QString* errMsg)
             *errMsg = tr("loadMap: unable to perform request, a map is already being downloaded or\n"
                          "imported at user request.");
         } else {
-            QString const warnMsg = qsl("[ WARN ]  - Attempt made to import an XML map when one is already being\n"
+            const QString warnMsg = qsl("[ WARN ]  - Attempt made to import an XML map when one is already being\n"
                                              "downloaded or is being imported from a local file - wait for that\n"
                                              "operation to complete (if it cannot be canceled) before retrying!");
             postMessage(warnMsg);
@@ -2635,7 +2635,7 @@ void TMap::slot_setDownloadProgress(qint64 got, qint64 total)
 
 void TMap::slot_downloadCancel()
 {
-    QString const alertMsg = tr("[ ALERT ] - Map download was canceled, on user's request.");
+    const QString alertMsg = tr("[ ALERT ] - Map download was canceled, on user's request.");
     postMessage(alertMsg);
     if (mpProgressDialog) {
         mpProgressDialog->deleteLater();
@@ -2654,7 +2654,7 @@ void TMap::slot_downloadError(QNetworkReply::NetworkError error)
 
     if (error != QNetworkReply::OperationCanceledError) {
         // No point in reporting Cancel as that is handled elsewhere
-        QString const errMsg = tr("[ ERROR ] - Map download encountered an error:\n%1.").arg(mpNetworkReply->errorString());
+        const QString errMsg = tr("[ ERROR ] - Map download encountered an error:\n%1.").arg(mpNetworkReply->errorString());
         postMessage(errMsg);
     }
 }
@@ -2685,7 +2685,7 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
     if (reply->error() != QNetworkReply::NoError) {
         if (reply->error() != QNetworkReply::OperationCanceledError) {
             // Don't post an error for the cancel case - it has already been done
-            QString const alertMsg = tr("[ ALERT ] - Map download failed, error reported was:\n%1.").arg(reply->errorString());
+            const QString alertMsg = tr("[ ALERT ] - Map download failed, error reported was:\n%1.").arg(reply->errorString());
             postMessage(alertMsg);
             cleanup();
             return;
@@ -2697,14 +2697,14 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
     QSaveFile writeFile(mLocalMapFileName);
     QFile readFile(mLocalMapFileName);
     if (!writeFile.open(QFile::WriteOnly)) {
-        QString const alertMsg = tr("[ ALERT ] - Map download failed, unable to open destination file:\n%1.").arg(mLocalMapFileName);
+        const QString alertMsg = tr("[ ALERT ] - Map download failed, unable to open destination file:\n%1.").arg(mLocalMapFileName);
         postMessage(alertMsg);
         cleanup();
         return;
     }
     // The QNetworkReply is Ok here:
     if (writeFile.write(reply->readAll()) == -1) {
-        QString const alertMsg = tr("[ ALERT ] - Map download failed, unable to write destination file:\n%1.").arg(mLocalMapFileName);
+        const QString alertMsg = tr("[ ALERT ] - Map download failed, unable to write destination file:\n%1.").arg(mLocalMapFileName);
         postMessage(alertMsg);
         cleanup();
         return;
@@ -2720,7 +2720,7 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
         return;
     }
 
-    QString const infoMsg = tr("[ INFO ]  - ... map downloaded and stored, now parsing it...");
+    const QString infoMsg = tr("[ INFO ]  - ... map downloaded and stored, now parsing it...");
     postMessage(infoMsg);
 
     // Since the download is complete but we do not offer to
@@ -2736,7 +2736,7 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
     } else {
         parsingFileName = mLocalMapFileName;
         if (!readFile.open(QFile::OpenMode(QFile::ReadOnly | QFile::Text))) {
-            QString const alertMsg = tr("[ ERROR ] - Map download problem, unable to read destination file:\n%1.").arg(parsingFileName);
+            const QString alertMsg = tr("[ ERROR ] - Map download problem, unable to read destination file:\n%1.").arg(parsingFileName);
             postMessage(alertMsg);
             cleanup();
             return;
@@ -2756,7 +2756,7 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
         pHost->raiseEvent(mapDownloadEvent);
     } else {
         // Failure in parse file...
-        QString const alertMsg = tr("[ ERROR ] - Map download problem, failure in parsing destination file:\n%1.").arg(parsingFileName);
+        const QString alertMsg = tr("[ ERROR ] - Map download problem, failure in parsing destination file:\n%1.").arg(parsingFileName);
         postMessage(alertMsg);
     }
     cleanup();
@@ -2851,7 +2851,7 @@ std::pair<bool, QString> TMap::writeJsonMapFile(const QString& dest)
     QString destination{dest};
 
     if (destination.isEmpty()) {
-        QString const destFolder = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
+        const QString destFolder = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
         QDir const destDir(destFolder);
         if (!destDir.exists()) {
             destDir.mkdir(destFolder);
@@ -3140,7 +3140,7 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
     if (mapObj.contains(QLatin1String("userData"))) {
         readJsonUserData(mapObj[QLatin1String("userData")].toObject());
     }
-    QString const mapSymbolFontText = mapObj[QLatin1String("mapSymbolFontDetails")].toString();
+    const QString mapSymbolFontText = mapObj[QLatin1String("mapSymbolFontDetails")].toString();
     float const mapSymbolFontFudgeFactor = (qRound(mapObj[QLatin1String("mapSymbolFontFudgeFactor")].toDouble() * 1000.0)) / 1000;
     bool const isOnlyMapSymbolFontToBeUsed = mapObj[QLatin1String("onlyMapSymbolFontToBeUsed")].toBool();
     int const playerRoomStyle = qRound(mapObj[QLatin1String("playerRoomStyle")].toDouble());

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1682,7 +1682,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
                 // this suggests that only one or ten elements are accepted so
                 // we CAN fix past mistakes by only considering the first ten
                 // elements:
-                QStringList const fontStrings{mUserData.take(qsl("system.fallback_mapSymbolFont")).split(QLatin1Char(','))};
+                const QStringList fontStrings{mUserData.take(qsl("system.fallback_mapSymbolFont")).split(QLatin1Char(','))};
                 const QString fontString{fontStrings.mid(0, 10).join(QLatin1Char(','))};
                 const QString fontFudgeFactorString = mUserData.take(qsl("system.fallback_mapSymbolFontFudgeFactor"));
                 const QString onlyUseSymbolFontString = mUserData.take(qsl("system.fallback_onlyUseMapSymbolFont"));

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -3141,7 +3141,7 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
         readJsonUserData(mapObj[QLatin1String("userData")].toObject());
     }
     const QString mapSymbolFontText = mapObj[QLatin1String("mapSymbolFontDetails")].toString();
-    float const mapSymbolFontFudgeFactor = (qRound(mapObj[QLatin1String("mapSymbolFontFudgeFactor")].toDouble() * 1000.0)) / 1000;
+    const float mapSymbolFontFudgeFactor = (qRound(mapObj[QLatin1String("mapSymbolFontFudgeFactor")].toDouble() * 1000.0)) / 1000;
     const bool isOnlyMapSymbolFontToBeUsed = mapObj[QLatin1String("onlyMapSymbolFontToBeUsed")].toBool();
     const int playerRoomStyle = qRound(mapObj[QLatin1String("playerRoomStyle")].toDouble());
     quint8 const playerRoomOuterDiameterPercentage = qRound(mapObj[QLatin1String("playerRoomOuterDiameterPercentage")].toDouble());

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -207,7 +207,7 @@ QString TMap::connectExitStubByDirection(const int fromRoomId, const int dirType
     if (!pFromR) {
         return qsl("fromID (%1) does not exist").arg(fromRoomId);
     }
-    int const area = pFromR->getArea();
+    const int area = pFromR->getArea();
     // This will get converted to a positive value on first use:
     int minDistance = -1;
     int minDistanceRoom = 0;
@@ -218,16 +218,16 @@ QString TMap::connectExitStubByDirection(const int fromRoomId, const int dirType
                 .arg(QString::number(fromRoomId), TRoom::dirCodeToString(dirType), QString::number(dirType));
     }
 
-    int const reverseDir = scmReverseDirections.value(dirType);
+    const int reverseDir = scmReverseDirections.value(dirType);
     QVector3D const unitVector = scmUnitVectors.value(dirType);
     // QVector3D is composed of floating point values so we need to round them
     // if we want to assign them to integral variables without compiler warnings!
-    int const ux = qRound(unitVector.x());
-    int const uy = qRound(unitVector.y());
-    int const uz = qRound(unitVector.z());
-    int const rx = pFromR->x;
-    int const ry = pFromR->y;
-    int const rz = pFromR->z;
+    const int ux = qRound(unitVector.x());
+    const int uy = qRound(unitVector.y());
+    const int uz = qRound(unitVector.z());
+    const int rx = pFromR->x;
+    const int ry = pFromR->y;
+    const int rz = pFromR->z;
     int dx = 0;
     int dy = 0;
     int dz = 0;
@@ -380,7 +380,7 @@ QString TMap::connectExitStubByToId(const int fromRoomId, const int toRoomId)
     }
 
     // else we must have just one direction:
-    int const usableStubDirection = *(usableStubDirections.constBegin());
+    const int usableStubDirection = *(usableStubDirections.constBegin());
     setExit(fromRoomId, toRoomId, usableStubDirection);
     setExit(toRoomId, fromRoomId, scmReverseDirections.value(usableStubDirection));
     setUnsaved(__func__);
@@ -541,17 +541,17 @@ void TMap::audit()
         QMapIterator<int, TArea*> itArea(mpRoomDB->getAreaMap());
         while (itArea.hasNext()) {
             itArea.next();
-            int const areaID = itArea.key();
+            const int areaID = itArea.key();
             TArea* pArea = mpRoomDB->getArea(areaID);
             if (!pArea->mMapLabels.isEmpty()) {
                 QList<int> const labelIDList = pArea->mMapLabels.keys();
-                for (int const& i : labelIDList) {
+                for (const int& i : labelIDList) {
                     TMapLabel const l = pArea->mMapLabels.value(i);
                     if (l.pix.isNull()) {
                         // Note that two of the last three arguments here
                         // (false, 40.0) are not the defaults (true, 30.0) used
                         // now:
-                        int const newID = createMapLabel(areaID, l.text, l.pos.x(), l.pos.y(), l.pos.z(), l.fgColor, l.bgColor, true, false, false, 40.0, 50, std::nullopt);
+                        const int newID = createMapLabel(areaID, l.text, l.pos.x(), l.pos.y(), l.pos.z(), l.fgColor, l.bgColor, true, false, false, 40.0, 50, std::nullopt);
                         if (newID > -1) {
                             if (mudlet::self()->showMapAuditErrors()) {
                                 const QString msg = tr("[ INFO ] - CONVERTING: old style label, areaID:%1 labelID:%2.").arg(areaID).arg(i);
@@ -613,10 +613,10 @@ QList<int> TMap::detectRoomCollisions(int id)
     if (!pR) {
         return collList;
     }
-    int const area = pR->getArea();
-    int const x = pR->x;
-    int const y = pR->y;
-    int const z = pR->z;
+    const int area = pR->getArea();
+    const int x = pR->x;
+    const int y = pR->y;
+    const int z = pR->z;
     TArea* pA = mpRoomDB->getArea(area);
     if (!pA) {
         return collList;
@@ -624,7 +624,7 @@ QList<int> TMap::detectRoomCollisions(int id)
 
     QSetIterator<int> itRoom(pA->getAreaRooms());
     while (itRoom.hasNext()) {
-        int const checkRoomId = itRoom.next();
+        const int checkRoomId = itRoom.next();
         pR = mpRoomDB->getRoom(checkRoomId);
         if (!pR) {
             continue;
@@ -709,7 +709,7 @@ void TMap::initGraph()
 
     // Now identify the routes between rooms, and pick out the best edges of parallel ones
     for (auto l : locations) {
-        unsigned int const source = l.id;
+        unsigned const int source = l.id;
         TRoom* pSourceR = l.pR;
         QHash<unsigned int, route> bestRoutes;
         // key is target (destination room),
@@ -1059,7 +1059,7 @@ bool TMap::findPath(int from, int to)
                 mWeightList.clear(); // Reset any partial results...
                 return false;
             }
-            unsigned int const previousRoomId = (locations.at(previousVertex)).id;
+            unsigned const int previousRoomId = (locations.at(previousVertex)).id;
             QPair<unsigned int, unsigned int> const edgeRoomIdPair = qMakePair(previousRoomId, currentRoomId);
             route const r = edgeHash.value(edgeRoomIdPair);
             mPathList.prepend(currentRoomId);
@@ -1164,7 +1164,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
     QMapIterator<int, TArea*> itAreaList(mpRoomDB->getAreaMap());
     while (itAreaList.hasNext()) {
         itAreaList.next();
-        int const areaID = itAreaList.key();
+        const int areaID = itAreaList.key();
         TArea* pA = itAreaList.value();
         ofs << areaID;
         if (mSaveVersion >= 18) {
@@ -2184,7 +2184,7 @@ int TMap::createMapLabel(int area, const QString& text, float x, float y, float 
     label.size = s;
     label.clickSize = s;
 
-    int const labelId = pA->createLabelId();
+    const int labelId = pA->createLabelId();
     if (Q_LIKELY(labelId >= 0)) {
         pA->mMapLabels.insert(labelId, label);
         if (mpMapper) {
@@ -2223,7 +2223,7 @@ int TMap::createMapImageLabel(int area, QString imagePath, float x, float y, flo
     label.size = QSizeF(width, height);
     label.pix = pix;
 
-    int const labelId = pA->createLabelId();
+    const int labelId = pA->createLabelId();
     if (Q_LIKELY(labelId >=0)) {
         pA->mMapLabels.insert(labelId, label);
         if (mpMapper) {
@@ -3143,7 +3143,7 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
     const QString mapSymbolFontText = mapObj[QLatin1String("mapSymbolFontDetails")].toString();
     float const mapSymbolFontFudgeFactor = (qRound(mapObj[QLatin1String("mapSymbolFontFudgeFactor")].toDouble() * 1000.0)) / 1000;
     bool const isOnlyMapSymbolFontToBeUsed = mapObj[QLatin1String("onlyMapSymbolFontToBeUsed")].toBool();
-    int const playerRoomStyle = qRound(mapObj[QLatin1String("playerRoomStyle")].toDouble());
+    const int playerRoomStyle = qRound(mapObj[QLatin1String("playerRoomStyle")].toDouble());
     quint8 const playerRoomOuterDiameterPercentage = qRound(mapObj[QLatin1String("playerRoomOuterDiameterPercentage")].toDouble());
     quint8 const playerRoomInnerDiameterPercentage = qRound(mapObj[QLatin1String("playerRoomInnerDiameterPercentage")].toDouble());
     QColor playerRoomOuterColor;
@@ -3163,9 +3163,9 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
         if (!envColorObj.isEmpty()) {
             for (auto& key : envColorObj.keys()) {
                 bool isOk = false;
-                int const index = key.toInt(&isOk);
+                const int index = key.toInt(&isOk);
                 if (isOk && envColorObj.value(key).isDouble()) {
-                    int const value = envColorObj.value(key).toInt();
+                    const int value = envColorObj.value(key).toInt();
                     envColors.insert(index, value);
                 }
             }
@@ -3335,7 +3335,7 @@ QColor TMap::readJsonColor(const QJsonObject& obj)
     } else {
         colorRGBAArray = obj.value(QLatin1String("color24RGB")).toArray();
     }
-    int const size = colorRGBAArray.size();
+    const int size = colorRGBAArray.size();
     if ((size == 3 || size == 4)
         && colorRGBAArray.at(0).isDouble()
         && colorRGBAArray.at(1).isDouble()

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1572,7 +1572,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
 
     if (location.isEmpty()) {
         folder = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
-        QDir const dir(folder);
+        const QDir dir(folder);
         QStringList filters;
         filters << qsl("*.[dD][aA][tT]");
         filters << qsl("*.[jJ][sS][oO][nN]");
@@ -2460,7 +2460,7 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     }
 
     // Check to ensure we have a map directory to save the map files to.
-    QDir const toProfileDir;
+    const QDir toProfileDir;
     const QString toProfileDirPathString = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
     if (!toProfileDir.mkpath(toProfileDirPathString)) {
         const QString errMsg = tr("[ ERROR ] - Unable to use or create directory to store map.\n"
@@ -2852,7 +2852,7 @@ std::pair<bool, QString> TMap::writeJsonMapFile(const QString& dest)
 
     if (destination.isEmpty()) {
         const QString destFolder = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
-        QDir const destDir(destFolder);
+        const QDir destDir(destFolder);
         if (!destDir.exists()) {
             destDir.mkdir(destFolder);
         }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -155,7 +155,7 @@ bool TMap::setRoomArea(int id, int area, bool isToDeferAreaRelatedRecalculations
         // to retain the API for the lua subsystem...
     }
 
-    bool result = pR->setArea(area, isToDeferAreaRelatedRecalculations);
+    bool const result = pR->setArea(area, isToDeferAreaRelatedRecalculations);
     if (result) {
         mMapGraphNeedsUpdate = true;
         setUnsaved(__func__);
@@ -207,7 +207,7 @@ QString TMap::connectExitStubByDirection(const int fromRoomId, const int dirType
     if (!pFromR) {
         return qsl("fromID (%1) does not exist").arg(fromRoomId);
     }
-    int area = pFromR->getArea();
+    int const area = pFromR->getArea();
     // This will get converted to a positive value on first use:
     int minDistance = -1;
     int minDistanceRoom = 0;
@@ -218,16 +218,16 @@ QString TMap::connectExitStubByDirection(const int fromRoomId, const int dirType
                 .arg(QString::number(fromRoomId), TRoom::dirCodeToString(dirType), QString::number(dirType));
     }
 
-    int reverseDir = scmReverseDirections.value(dirType);
-    QVector3D unitVector = scmUnitVectors.value(dirType);
+    int const reverseDir = scmReverseDirections.value(dirType);
+    QVector3D const unitVector = scmUnitVectors.value(dirType);
     // QVector3D is composed of floating point values so we need to round them
     // if we want to assign them to integral variables without compiler warnings!
-    int ux = qRound(unitVector.x());
-    int uy = qRound(unitVector.y());
-    int uz = qRound(unitVector.z());
-    int rx = pFromR->x;
-    int ry = pFromR->y;
-    int rz = pFromR->z;
+    int const ux = qRound(unitVector.x());
+    int const uy = qRound(unitVector.y());
+    int const uz = qRound(unitVector.z());
+    int const rx = pFromR->x;
+    int const ry = pFromR->y;
+    int const rz = pFromR->z;
     int dx = 0;
     int dy = 0;
     int dz = 0;
@@ -352,7 +352,7 @@ QString TMap::connectExitStubByToId(const int fromRoomId, const int toRoomId)
         return qsl("toID (%1) does not have any stub exits").arg(toRoomId);
     }
 
-    QSet<int> fromRoomStubs{pFromR->exitStubs.cbegin(), pFromR->exitStubs.cend()};
+    QSet<int> const fromRoomStubs{pFromR->exitStubs.cbegin(), pFromR->exitStubs.cend()};
     QListIterator<int> itToRoomStubs{pToR->exitStubs};
     QSet<int> toReverseStubDirections;
     while (itToRoomStubs.hasNext()) {
@@ -380,7 +380,7 @@ QString TMap::connectExitStubByToId(const int fromRoomId, const int toRoomId)
     }
 
     // else we must have just one direction:
-    int usableStubDirection = *(usableStubDirections.constBegin());
+    int const usableStubDirection = *(usableStubDirections.constBegin());
     setExit(fromRoomId, toRoomId, usableStubDirection);
     setExit(toRoomId, fromRoomId, scmReverseDirections.value(usableStubDirection));
     setUnsaved(__func__);
@@ -524,7 +524,7 @@ void TMap::audit()
     _time.start();
 
     { // Blocked - just to limit the scope of infoMsg...!
-        QString infoMsg = tr("[ INFO ]  - Map audit starting...");
+        QString const infoMsg = tr("[ INFO ]  - Map audit starting...");
         postMessage(infoMsg);
     }
 
@@ -541,20 +541,20 @@ void TMap::audit()
         QMapIterator<int, TArea*> itArea(mpRoomDB->getAreaMap());
         while (itArea.hasNext()) {
             itArea.next();
-            int areaID = itArea.key();
+            int const areaID = itArea.key();
             TArea* pArea = mpRoomDB->getArea(areaID);
             if (!pArea->mMapLabels.isEmpty()) {
-                QList<int> labelIDList = pArea->mMapLabels.keys();
-                for (int& i : labelIDList) {
-                    TMapLabel l = pArea->mMapLabels.value(i);
+                QList<int> const labelIDList = pArea->mMapLabels.keys();
+                for (int const& i : labelIDList) {
+                    TMapLabel const l = pArea->mMapLabels.value(i);
                     if (l.pix.isNull()) {
                         // Note that two of the last three arguments here
                         // (false, 40.0) are not the defaults (true, 30.0) used
                         // now:
-                        int newID = createMapLabel(areaID, l.text, l.pos.x(), l.pos.y(), l.pos.z(), l.fgColor, l.bgColor, true, false, false, 40.0, 50, std::nullopt);
+                        int const newID = createMapLabel(areaID, l.text, l.pos.x(), l.pos.y(), l.pos.z(), l.fgColor, l.bgColor, true, false, false, 40.0, 50, std::nullopt);
                         if (newID > -1) {
                             if (mudlet::self()->showMapAuditErrors()) {
-                                QString msg = tr("[ INFO ] - CONVERTING: old style label, areaID:%1 labelID:%2.").arg(areaID).arg(i);
+                                QString const msg = tr("[ INFO ] - CONVERTING: old style label, areaID:%1 labelID:%2.").arg(areaID).arg(i);
                                 postMessage(msg);
                             }
                             appendAreaErrorMsg(areaID, tr("[ INFO ] - Converting old style label id: %1.").arg(i));
@@ -562,7 +562,7 @@ void TMap::audit()
 
                         } else {
                             if (mudlet::self()->showMapAuditErrors()) {
-                                QString msg = tr("[ WARN ] - CONVERTING: cannot convert old style label in area with id: %1,  label id is: %2.").arg(areaID).arg(i);
+                                QString const msg = tr("[ WARN ] - CONVERTING: cannot convert old style label in area with id: %1,  label id is: %2.").arg(areaID).arg(i);
                                 postMessage(msg);
                             }
                             appendAreaErrorMsg(areaID, tr("[ WARN ] - CONVERTING: cannot convert old style label with id: %1.").arg(i));
@@ -594,14 +594,14 @@ void TMap::audit()
     }
 
     { // Blocked - just to limit the scope of infoMsg...!
-        QString infoMsg = tr("[  OK  ]  - Auditing of map completed (%1s). Enjoy your game...").arg(_time.nsecsElapsed() * 1.0e-9, 0, 'f', 2);
+        QString const infoMsg = tr("[  OK  ]  - Auditing of map completed (%1s). Enjoy your game...").arg(_time.nsecsElapsed() * 1.0e-9, 0, 'f', 2);
         postMessage(infoMsg);
         appendErrorMsg(infoMsg);
     }
 
     auto loadTime = mpHost->getLuaInterpreter()->condenseMapLoad();
     if (loadTime != -1.0) {
-        QString msg = tr("[  OK  ]  - Map loaded successfully (%1s).").arg(loadTime);
+        QString const msg = tr("[  OK  ]  - Map loaded successfully (%1s).").arg(loadTime);
         postMessage(msg);
     }
 }
@@ -613,10 +613,10 @@ QList<int> TMap::detectRoomCollisions(int id)
     if (!pR) {
         return collList;
     }
-    int area = pR->getArea();
-    int x = pR->x;
-    int y = pR->y;
-    int z = pR->z;
+    int const area = pR->getArea();
+    int const x = pR->x;
+    int const y = pR->y;
+    int const z = pR->z;
     TArea* pA = mpRoomDB->getArea(area);
     if (!pA) {
         return collList;
@@ -624,7 +624,7 @@ QList<int> TMap::detectRoomCollisions(int id)
 
     QSetIterator<int> itRoom(pA->getAreaRooms());
     while (itRoom.hasNext()) {
-        int checkRoomId = itRoom.next();
+        int const checkRoomId = itRoom.next();
         pR = mpRoomDB->getRoom(checkRoomId);
         if (!pR) {
             continue;
@@ -709,12 +709,12 @@ void TMap::initGraph()
 
     // Now identify the routes between rooms, and pick out the best edges of parallel ones
     for (auto l : locations) {
-        unsigned int source = l.id;
+        unsigned int const source = l.id;
         TRoom* pSourceR = l.pR;
         QHash<unsigned int, route> bestRoutes;
         // key is target (destination room),
         // value is data we will need to store later,
-        QMap<QString, int> exitWeights = pSourceR->getExitWeights();
+        QMap<QString, int> const exitWeights = pSourceR->getExitWeights();
 
         int target = pSourceR->getNorth();
         TRoom* pTargetR;
@@ -1019,7 +1019,7 @@ bool TMap::findPath(int from, int to)
         // The start room is NOT one that has been included in the BGL graph
         // probably because it is locked - so no route finding can be done
     }
-    vertex start = roomidToIndex.value(from);
+    vertex const start = roomidToIndex.value(from);
 
     if (!roomidToIndex.contains(to)) {
         qDebug() << "TMap::findPath(" << from << "," << to << ") FAIL: target room not in map graph!";
@@ -1027,7 +1027,7 @@ bool TMap::findPath(int from, int to)
         // The target room is NOT one that has been included in the BGL graph
         // probably because it is locked - so no route finding can be done
     }
-    vertex goal = roomidToIndex.value(to);
+    vertex const goal = roomidToIndex.value(to);
 
     std::vector<vertex> p(num_vertices(g));
     // Somehow p is an ascending, monotonic series of numbers start at 0, it
@@ -1059,9 +1059,9 @@ bool TMap::findPath(int from, int to)
                 mWeightList.clear(); // Reset any partial results...
                 return false;
             }
-            unsigned int previousRoomId = (locations.at(previousVertex)).id;
-            QPair<unsigned int, unsigned int> edgeRoomIdPair = qMakePair(previousRoomId, currentRoomId);
-            route r = edgeHash.value(edgeRoomIdPair);
+            unsigned int const previousRoomId = (locations.at(previousVertex)).id;
+            QPair<unsigned int, unsigned int> const edgeRoomIdPair = qMakePair(previousRoomId, currentRoomId);
+            route const r = edgeHash.value(edgeRoomIdPair);
             mPathList.prepend(currentRoomId);
             Q_ASSERT_X(r.cost > 0, "TMap::findPath()", "broken path {QPair made from source and target roomIds for a path step NOT found in QHash table of all possible steps.}");
             // Above was found to be triggered by the situation described in:
@@ -1106,7 +1106,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
         saveVersion = 0;
     } else if (saveVersion > mMaxVersion) {
         saveVersion = mMaxVersion;
-         QString errMsg = tr("[ ERROR ] - The format version \"%1\" you are trying to save the map with is too new\n"
+         QString const errMsg = tr("[ ERROR ] - The format version \"%1\" you are trying to save the map with is too new\n"
                              "for this version of Mudlet. Supported are only formats up to version %2.")
                                  .arg(QString::number(saveVersion), QString::number(mMaxVersion));
         appendErrorMsgWithNoLf(errMsg, false);
@@ -1122,7 +1122,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
     }
 
     if (mSaveVersion != mVersion) {
-        QString message = tr("[ ALERT ] - Saving map in format version \"%1\" that is different than \"%2\" which\n"
+        QString const message = tr("[ ALERT ] - Saving map in format version \"%1\" that is different than \"%2\" which\n"
                              "it was loaded as. This may be an issue if you want to share the resulting\n"
                              "map with others relying on the original format.")
                                   .arg(mSaveVersion)
@@ -1132,7 +1132,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
     }
 
     if (mSaveVersion != mDefaultVersion) {
-        QString message = tr("[ WARN ]  - Saving map in format version \"%1\" different from the\n"
+        QString const message = tr("[ WARN ]  - Saving map in format version \"%1\" different from the\n"
                              "recommended map version %2 for this version of Mudlet.")
                                   .arg(mSaveVersion)
                                   .arg(mDefaultVersion);
@@ -1164,14 +1164,14 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
     QMapIterator<int, TArea*> itAreaList(mpRoomDB->getAreaMap());
     while (itAreaList.hasNext()) {
         itAreaList.next();
-        int areaID = itAreaList.key();
+        int const areaID = itAreaList.key();
         TArea* pA = itAreaList.value();
         ofs << areaID;
         if (mSaveVersion >= 18) {
             ofs << pA->rooms;
         } else {
             // Switched to a (faster) QSet<int> from a QList<int> in version 18
-            QList<int> _oldList = pA->rooms.values();
+            QList<int> const _oldList = pA->rooms.values();
             ofs << _oldList;
         }
         ofs << pA->zLevels;
@@ -1260,7 +1260,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
             while (itPerminentMapLabelIds.hasNext()) {
                 auto labelID = itPerminentMapLabelIds.next();
                 ofs << labelID; //label ID
-                TMapLabel label = pArea->mMapLabels.value(labelID);
+                TMapLabel const label = pArea->mMapLabels.value(labelID);
                 ofs << label.pos;
                 ofs << QPointF(); // dummy value - not actually used
                 ofs << label.size;
@@ -1330,7 +1330,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
             qint8 oldCharacterCode = 0;
             if (pR->mSymbol.length()) {
                 // There is something for a symbol
-                QChar firstChar = pR->mSymbol.at(0);
+                QChar const firstChar = pR->mSymbol.at(0);
                 if (pR->mSymbol.length() == 1 && firstChar.row() == 0 && firstChar.cell() > 32) {
                     // It is something that can be represented by the past unsigned short
                     oldCharacterCode = firstChar.toLatin1();
@@ -1366,7 +1366,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
             QMapIterator<QString, QList<QPointF>> itCustomLine(pR->customLines);
             while (itCustomLine.hasNext()) {
                 itCustomLine.next();
-                QString direction(itCustomLine.key());
+                QString const direction(itCustomLine.key());
                 if (direction == QLatin1String("n") || direction == QLatin1String("e") || direction == QLatin1String("s") || direction == QLatin1String("w") || direction == QLatin1String("up")
                     || direction == QLatin1String("down")
                     || direction == QLatin1String("ne")
@@ -1386,7 +1386,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
             QMapIterator<QString, bool> itCustomLineArrow(pR->customLinesArrow);
             while (itCustomLineArrow.hasNext()) {
                 itCustomLineArrow.next();
-                QString direction(itCustomLineArrow.key());
+                QString const direction(itCustomLineArrow.key());
                 if (direction == QLatin1String("n") || direction == QLatin1String("e") || direction == QLatin1String("s") || direction == QLatin1String("w") || direction == QLatin1String("up")
                     || direction == QLatin1String("down")
                     || direction == QLatin1String("ne")
@@ -1406,7 +1406,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
             QMapIterator<QString, QColor> itCustomLineColor(pR->customLinesColor);
             while (itCustomLineColor.hasNext()) {
                 itCustomLineColor.next();
-                QString direction(itCustomLineColor.key());
+                QString const direction(itCustomLineColor.key());
                 QList<int> colorComponents;
                 colorComponents << itCustomLineColor.value().red() << itCustomLineColor.value().green() << itCustomLineColor.value().blue();
                 if (direction == QLatin1String("n") || direction == QLatin1String("e") || direction == QLatin1String("s") || direction == QLatin1String("w") || direction == QLatin1String("up")
@@ -1482,7 +1482,7 @@ bool TMap::validatePotentialMapFile(QFile& file, QDataStream& ifs)
 {
     int version = 0;
     if (!file.open(QFile::ReadOnly)) {
-        QString errMsg = tr(R"([ ERROR ] - Unable to open map file for reading: "%1"!)").arg(file.fileName());
+        QString const errMsg = tr(R"([ ERROR ] - Unable to open map file for reading: "%1"!)").arg(file.fileName());
         appendErrorMsg(errMsg, false);
         postMessage(errMsg);
         return false;
@@ -1504,14 +1504,14 @@ bool TMap::validatePotentialMapFile(QFile& file, QDataStream& ifs)
     }
     ifs >> version;
     if ((version < 1) || (version > 127)) {
-        QString errMsg = tr("[ ALERT ] - File does not seem to be a Mudlet Map file. The part that indicates\n"
+        QString const errMsg = tr("[ ALERT ] - File does not seem to be a Mudlet Map file. The part that indicates\n"
                             "its format version seems to be \"%1\" and that doesn't make sense. The file is:\n"
                             "\"%2\".")
                                  .arg(version)
                                  .arg(file.fileName());
         appendErrorMsgWithNoLf(errMsg);
         postMessage(errMsg);
-        QString infoMsg = tr("[ INFO ]  - Ignoring this unlikely map file.");
+        QString const infoMsg = tr("[ INFO ]  - Ignoring this unlikely map file.");
         appendErrorMsgWithNoLf(infoMsg);
         postMessage(infoMsg);
         ifs.setDevice(nullptr);
@@ -1519,14 +1519,14 @@ bool TMap::validatePotentialMapFile(QFile& file, QDataStream& ifs)
         return false;
     }
     if (version > mMaxVersion) {
-        QString errMsg = tr("[ ALERT ] - Map file is too new. Its format version \"%1\" is higher than this version of\n"
+        QString const errMsg = tr("[ ALERT ] - Map file is too new. Its format version \"%1\" is higher than this version of\n"
                             "Mudlet can handle (%2)! The file is:\n\"%3\".")
                                  .arg(version)
                                  .arg(mMaxVersion)
                                  .arg(file.fileName());
         appendErrorMsgWithNoLf(errMsg);
         postMessage(errMsg);
-        QString infoMsg = tr("[ INFO ]  - You will need to update your Mudlet to read the map file.");
+        QString const infoMsg = tr("[ INFO ]  - You will need to update your Mudlet to read the map file.");
         appendErrorMsgWithNoLf(infoMsg);
         postMessage(infoMsg);
         ifs.setDevice(nullptr);
@@ -1535,21 +1535,21 @@ bool TMap::validatePotentialMapFile(QFile& file, QDataStream& ifs)
     }
 
     if (version < 4) {
-        QString alertMsg = tr("[ ALERT ] - Map file is really old. Its format version \"%1\" is so ancient that\n"
+        QString const alertMsg = tr("[ ALERT ] - Map file is really old. Its format version \"%1\" is so ancient that\n"
                               "this version of Mudlet may not gain enough information from\n"
                               "it but it will try! The file is: \"%2\".")
                                    .arg(version)
                                    .arg(file.fileName());
         appendErrorMsgWithNoLf(alertMsg, false);
         postMessage(alertMsg);
-        QString infoMsg = tr("[ INFO ]  - You might wish to donate THIS map file to the Mudlet Museum!\n"
+        QString const infoMsg = tr("[ INFO ]  - You might wish to donate THIS map file to the Mudlet Museum!\n"
                              "There is so much data that it DOES NOT have that you could be\n"
                              "better off starting again...");
         appendErrorMsgWithNoLf(infoMsg, false);
         postMessage(infoMsg);
     } else {
         // Less than (but not less than 4) or equal to default version
-        QString infoMsg = tr("[ INFO ]  - Reading map. Format version: %1. File:\n"
+        QString const infoMsg = tr("[ INFO ]  - Reading map. Format version: %1. File:\n"
                              "\"%2\",\n"
                              "please wait...").arg(version).arg(file.fileName());
         appendErrorMsg(tr(R"([ INFO ]  - Reading map. Format version: %1. File: "%2".)").arg(version).arg(file.fileName()), false);
@@ -1572,7 +1572,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
 
     if (location.isEmpty()) {
         folder = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
-        QDir dir(folder);
+        QDir const dir(folder);
         QStringList filters;
         filters << qsl("*.[dD][aA][tT]");
         filters << qsl("*.[jJ][sS][oO][nN]");
@@ -1605,12 +1605,12 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
             } else {
                 if (auto [isOk, message] = readJsonMapFile(fileName, true); !isOk) {
                    // Failed to read the JSON file
-                   QString errMsg = tr("[ ALERT ] - Failed to load a Mudlet JSON Map file, reason:\n"
+                   QString const errMsg = tr("[ ALERT ] - Failed to load a Mudlet JSON Map file, reason:\n"
                                        "%1; the file is:\n"
                                        "\"%2\".").arg(message, fileName);
                    appendErrorMsgWithNoLf(errMsg);
                    postMessage(errMsg);
-                   QString infoMsg = tr("[ INFO ]  - Ignoring this map file.");
+                   QString const infoMsg = tr("[ INFO ]  - Ignoring this map file.");
                    appendErrorMsgWithNoLf(infoMsg);
                    postMessage(infoMsg);
                } else {
@@ -1682,10 +1682,10 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
                 // this suggests that only one or ten elements are accepted so
                 // we CAN fix past mistakes by only considering the first ten
                 // elements:
-                QStringList fontStrings{mUserData.take(qsl("system.fallback_mapSymbolFont")).split(QLatin1Char(','))};
-                QString fontString{fontStrings.mid(0, 10).join(QLatin1Char(','))};
-                QString fontFudgeFactorString = mUserData.take(qsl("system.fallback_mapSymbolFontFudgeFactor"));
-                QString onlyUseSymbolFontString = mUserData.take(qsl("system.fallback_onlyUseMapSymbolFont"));
+                QStringList const fontStrings{mUserData.take(qsl("system.fallback_mapSymbolFont")).split(QLatin1Char(','))};
+                QString const fontString{fontStrings.mid(0, 10).join(QLatin1Char(','))};
+                QString const fontFudgeFactorString = mUserData.take(qsl("system.fallback_mapSymbolFontFudgeFactor"));
+                QString const onlyUseSymbolFontString = mUserData.take(qsl("system.fallback_onlyUseMapSymbolFont"));
                 if (!fontString.isEmpty()) {
                     mMapSymbolFont.fromString(fontString);
                 }
@@ -1754,7 +1754,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
                     ifs >> pA->mUserData;
                 } else if (mVersion >= 17) {
                     ifs >> pA->mUserData;
-                    qreal fallback_map2DZoom = pA->mUserData.take(QLatin1String("system.fallback_map2DZoom")).toDouble();
+                    qreal const fallback_map2DZoom = pA->mUserData.take(QLatin1String("system.fallback_map2DZoom")).toDouble();
                     pA->mLast2DMapZoom = (fallback_map2DZoom >= T2DMap::csmMinXYZoom) ? fallback_map2DZoom : T2DMap::csmDefaultXYZoom;
                 }
                 if (mVersion >= 21) {
@@ -1781,7 +1781,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
         if (!mpRoomDB->getAreaMap().keys().contains(-1)) {
             auto pDefaultA = new TArea(this, mpRoomDB);
             mpRoomDB->restoreSingleArea(-1, pDefaultA);
-            QString defaultAreaInsertionMsg = tr("[ INFO ]  - Default (reset) area (for rooms that have not been assigned to an\n"
+            QString const defaultAreaInsertionMsg = tr("[ INFO ]  - Default (reset) area (for rooms that have not been assigned to an\n"
                                                  "area) not found, adding reserved -1 id.");
             appendErrorMsgWithNoLf(defaultAreaInsertionMsg, false);
             if (mudlet::self()->showMapAuditErrors()) {
@@ -1860,7 +1860,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
 
         restore16ColorSet();
 
-        QString okMsg = tr("[ INFO ]  - Successfully read the map file (%1s), checking some\n"
+        QString const okMsg = tr("[ INFO ]  - Successfully read the map file (%1s), checking some\n"
                            "consistency details..." )
                                 .arg(_time.nsecsElapsed() * 1.0e-9, 0, 'f', 2);
 
@@ -1919,7 +1919,7 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
     QFile file(qsl("%1/%2").arg(folder, entries.at(0)));
 
     if (!file.open(QFile::ReadOnly)) {
-        QString errMsg = tr(R"([ ERROR ] - Unable to open map file for reading: "%1"!)").arg(file.fileName());
+        QString const errMsg = tr(R"([ ERROR ] - Unable to open map file for reading: "%1"!)").arg(file.fileName());
         appendErrorMsg(errMsg, false);
         postMessage(errMsg);
         return false;
@@ -1935,7 +1935,7 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
     }
     ifs >> otherProfileVersion;
 
-    QString infoMsg = tr(R"([ INFO ]  - Checking map file "%1", format version "%2".)").arg(file.fileName()).arg(otherProfileVersion);
+    QString const infoMsg = tr(R"([ INFO ]  - Checking map file "%1", format version "%2".)").arg(file.fileName()).arg(otherProfileVersion);
     appendErrorMsg(infoMsg, false);
     if (mudlet::self()->showMapAuditErrors()) {
         postMessage(infoMsg);
@@ -2164,14 +2164,14 @@ int TMap::createMapLabel(int area, const QString& text, float x, float y, float 
     label.noScaling = noScaling;
     label.temporary = temporary;
 
-    QRectF lr = QRectF(0, 0, 1000, 1000);
+    QRectF const lr = QRectF(0, 0, 1000, 1000);
     QPixmap pix(lr.size().toSize());
     pix.fill(Qt::transparent);
     QPainter lp(&pix);
     lp.fillRect(lr, label.bgColor);
     QPen lpen;
     lpen.setColor(label.fgColor);
-    QFont font(fontName.has_value() ? fontName.value() : QString(), fontSize);
+    QFont const font(fontName.has_value() ? fontName.value() : QString(), fontSize);
     lp.setRenderHint(QPainter::TextAntialiasing, true);
     lp.setPen(lpen);
     lp.setFont(font);
@@ -2180,11 +2180,11 @@ int TMap::createMapLabel(int area, const QString& text, float x, float y, float 
 
     label.size = br.normalized().size();
     label.pix = pix.copy(br.normalized().topLeft().x(), br.normalized().topLeft().y(), br.normalized().width(), br.normalized().height());
-    QSizeF s = QSizeF(label.size.width() / zoom, label.size.height() / zoom);
+    QSizeF const s = QSizeF(label.size.width() / zoom, label.size.height() / zoom);
     label.size = s;
     label.clickSize = s;
 
-    int labelId = pA->createLabelId();
+    int const labelId = pA->createLabelId();
     if (Q_LIKELY(labelId >= 0)) {
         pA->mMapLabels.insert(labelId, label);
         if (mpMapper) {
@@ -2214,8 +2214,8 @@ int TMap::createMapImageLabel(int area, QString imagePath, float x, float y, flo
     label.noScaling = false;
     label.temporary = temporary;
 
-    QRectF drawRect = QRectF(0, 0, static_cast<qreal>(width * zoom), static_cast<qreal>(height * zoom));
-    QPixmap imagePixmap = QPixmap(imagePath);
+    QRectF const drawRect = QRectF(0, 0, static_cast<qreal>(width * zoom), static_cast<qreal>(height * zoom));
+    QPixmap const imagePixmap = QPixmap(imagePath);
     QPixmap pix = QPixmap(drawRect.size().toSize());
     pix.fill(Qt::transparent);
     QPainter lp(&pix);
@@ -2223,7 +2223,7 @@ int TMap::createMapImageLabel(int area, QString imagePath, float x, float y, flo
     label.size = QSizeF(width, height);
     label.pix = pix;
 
-    int labelId = pA->createLabelId();
+    int const labelId = pA->createLabelId();
     if (Q_LIKELY(labelId >=0)) {
         pA->mMapLabels.insert(labelId, label);
         if (mpMapper) {
@@ -2428,7 +2428,7 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
 
     // Incidentally this should address: https://bugs.launchpad.net/mudlet/+bug/852861
     if (mImportRunning) {
-        QString warnMsg = tr("[ WARN ]  - Attempt made to download an XML map when one has already been\n"
+        QString const warnMsg = tr("[ WARN ]  - Attempt made to download an XML map when one has already been\n"
                                          "requested or is being imported from a local file - wait for that\n"
                                          "operation to complete (if it cannot be canceled) before retrying!");
         postMessage(warnMsg);
@@ -2449,7 +2449,7 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     }
 
     if (!url.isValid()) {
-        QString errMsg = tr("[ WARN ]  - Attempt made to download an XML from an invalid URL.  The URL was:\n"
+        QString const errMsg = tr("[ WARN ]  - Attempt made to download an XML from an invalid URL.  The URL was:\n"
                                         "%1\n"
                                         "and the error message (may contain technical details) was:"
                                         "\"%2\".")
@@ -2460,10 +2460,10 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     }
 
     // Check to ensure we have a map directory to save the map files to.
-    QDir toProfileDir;
-    QString toProfileDirPathString = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
+    QDir const toProfileDir;
+    QString const toProfileDirPathString = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
     if (!toProfileDir.mkpath(toProfileDirPathString)) {
-        QString errMsg = tr("[ ERROR ] - Unable to use or create directory to store map.\n"
+        QString const errMsg = tr("[ ERROR ] - Unable to use or create directory to store map.\n"
                             "Please check that you have permissions/access to:\n"
                             "\"%1\"\n"
                             "and there is enough space. The download operation has failed.")
@@ -2489,7 +2489,7 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
 
     mExpectedFileSize = 4000000;
 
-    QString infoMsg = tr("[ INFO ]  - Map download initiated, please wait...");
+    QString const infoMsg = tr("[ INFO ]  - Map download initiated, please wait...");
     postMessage(infoMsg);
     qApp->processEvents();
     // Attempts to ensure INFO message gets shown before download is initiated!
@@ -2534,7 +2534,7 @@ bool TMap::importMap(QFile& file, QString* errMsg)
             *errMsg = tr("loadMap: unable to perform request, a map is already being downloaded or\n"
                          "imported at user request.");
         } else {
-            QString warnMsg = qsl("[ WARN ]  - Attempt made to import an XML map when one is already being\n"
+            QString const warnMsg = qsl("[ WARN ]  - Attempt made to import an XML map when one is already being\n"
                                              "downloaded or is being imported from a local file - wait for that\n"
                                              "operation to complete (if it cannot be canceled) before retrying!");
             postMessage(warnMsg);
@@ -2544,7 +2544,7 @@ bool TMap::importMap(QFile& file, QString* errMsg)
     mImportRunning = true;
     // MUST clear this flag when done under ALL circumstances
 
-    bool result = readXmlMapFile(file, errMsg);
+    bool const result = readXmlMapFile(file, errMsg);
     mImportRunning = false;
 
     return result;
@@ -2635,7 +2635,7 @@ void TMap::slot_setDownloadProgress(qint64 got, qint64 total)
 
 void TMap::slot_downloadCancel()
 {
-    QString alertMsg = tr("[ ALERT ] - Map download was canceled, on user's request.");
+    QString const alertMsg = tr("[ ALERT ] - Map download was canceled, on user's request.");
     postMessage(alertMsg);
     if (mpProgressDialog) {
         mpProgressDialog->deleteLater();
@@ -2654,7 +2654,7 @@ void TMap::slot_downloadError(QNetworkReply::NetworkError error)
 
     if (error != QNetworkReply::OperationCanceledError) {
         // No point in reporting Cancel as that is handled elsewhere
-        QString errMsg = tr("[ ERROR ] - Map download encountered an error:\n%1.").arg(mpNetworkReply->errorString());
+        QString const errMsg = tr("[ ERROR ] - Map download encountered an error:\n%1.").arg(mpNetworkReply->errorString());
         postMessage(errMsg);
     }
 }
@@ -2685,7 +2685,7 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
     if (reply->error() != QNetworkReply::NoError) {
         if (reply->error() != QNetworkReply::OperationCanceledError) {
             // Don't post an error for the cancel case - it has already been done
-            QString alertMsg = tr("[ ALERT ] - Map download failed, error reported was:\n%1.").arg(reply->errorString());
+            QString const alertMsg = tr("[ ALERT ] - Map download failed, error reported was:\n%1.").arg(reply->errorString());
             postMessage(alertMsg);
             cleanup();
             return;
@@ -2697,14 +2697,14 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
     QSaveFile writeFile(mLocalMapFileName);
     QFile readFile(mLocalMapFileName);
     if (!writeFile.open(QFile::WriteOnly)) {
-        QString alertMsg = tr("[ ALERT ] - Map download failed, unable to open destination file:\n%1.").arg(mLocalMapFileName);
+        QString const alertMsg = tr("[ ALERT ] - Map download failed, unable to open destination file:\n%1.").arg(mLocalMapFileName);
         postMessage(alertMsg);
         cleanup();
         return;
     }
     // The QNetworkReply is Ok here:
     if (writeFile.write(reply->readAll()) == -1) {
-        QString alertMsg = tr("[ ALERT ] - Map download failed, unable to write destination file:\n%1.").arg(mLocalMapFileName);
+        QString const alertMsg = tr("[ ALERT ] - Map download failed, unable to write destination file:\n%1.").arg(mLocalMapFileName);
         postMessage(alertMsg);
         cleanup();
         return;
@@ -2720,7 +2720,7 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
         return;
     }
 
-    QString infoMsg = tr("[ INFO ]  - ... map downloaded and stored, now parsing it...");
+    QString const infoMsg = tr("[ INFO ]  - ... map downloaded and stored, now parsing it...");
     postMessage(infoMsg);
 
     // Since the download is complete but we do not offer to
@@ -2736,7 +2736,7 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
     } else {
         parsingFileName = mLocalMapFileName;
         if (!readFile.open(QFile::OpenMode(QFile::ReadOnly | QFile::Text))) {
-            QString alertMsg = tr("[ ERROR ] - Map download problem, unable to read destination file:\n%1.").arg(parsingFileName);
+            QString const alertMsg = tr("[ ERROR ] - Map download problem, unable to read destination file:\n%1.").arg(parsingFileName);
             postMessage(alertMsg);
             cleanup();
             return;
@@ -2756,7 +2756,7 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
         pHost->raiseEvent(mapDownloadEvent);
     } else {
         // Failure in parse file...
-        QString alertMsg = tr("[ ERROR ] - Map download problem, failure in parsing destination file:\n%1.").arg(parsingFileName);
+        QString const alertMsg = tr("[ ERROR ] - Map download problem, failure in parsing destination file:\n%1.").arg(parsingFileName);
         postMessage(alertMsg);
     }
     cleanup();
@@ -2851,8 +2851,8 @@ std::pair<bool, QString> TMap::writeJsonMapFile(const QString& dest)
     QString destination{dest};
 
     if (destination.isEmpty()) {
-        QString destFolder = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
-        QDir destDir(destFolder);
+        QString const destFolder = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
+        QDir const destDir(destFolder);
         if (!destDir.exists()) {
             destDir.mkdir(destFolder);
         }
@@ -2998,7 +2998,7 @@ std::pair<bool, QString> TMap::writeJsonMapFile(const QString& dest)
     }
     // Convert the array of all the mCustomEnvColors into a QJsonValue so we
     // can add it to the map object:
-    QJsonValue mCustomEnvColorsValue{customEnvColorArray};
+    QJsonValue const mCustomEnvColorsValue{customEnvColorArray};
     mapObj.insert(QLatin1String("customEnvColors"), mCustomEnvColorsValue);
 
     mapObj.insert(QLatin1String("mapSymbolFontDetails"), mMapSymbolFont.toString());
@@ -3010,11 +3010,11 @@ std::pair<bool, QString> TMap::writeJsonMapFile(const QString& dest)
     QJsonObject playerRoomInnerColorObj;
     writeJsonColor(playerRoomOuterColorObj, mPlayerRoomOuterColor);
     writeJsonColor(playerRoomInnerColorObj, mPlayerRoomInnerColor);
-    QJsonValue playerRoomOuterColorValue{playerRoomOuterColorObj};
-    QJsonValue playerRoomInnerColorValue{playerRoomInnerColorObj};
+    QJsonValue const playerRoomOuterColorValue{playerRoomOuterColorObj};
+    QJsonValue const playerRoomInnerColorValue{playerRoomInnerColorObj};
     playerRoomColorsArray.append(playerRoomOuterColorValue);
     playerRoomColorsArray.append(playerRoomInnerColorValue);
-    QJsonValue playerRoomColorsValue{playerRoomColorsArray};
+    QJsonValue const playerRoomColorsValue{playerRoomColorsArray};
     mapObj.insert(QLatin1String("playerRoomColors"), playerRoomColorsValue);
     mapObj.insert(QLatin1String("playerRoomStyle"), static_cast<double>(mPlayerRoomStyle));
     mapObj.insert(QLatin1String("playerRoomOuterDiameterPercentage"), static_cast<double>(mPlayerRoomOuterDiameterPercentage));
@@ -3060,10 +3060,10 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
                     : qsl("could not open file \"%1\"").arg(source))};
     }
 
-    QByteArray mapData = file.readAll();
+    QByteArray const mapData = file.readAll();
     file.close();
     QJsonParseError jsonErr;
-    QJsonDocument doc(QJsonDocument::fromJson(mapData, &jsonErr));
+    QJsonDocument const doc(QJsonDocument::fromJson(mapData, &jsonErr));
     if (jsonErr.error != QJsonParseError::NoError) {
         return {false, (translatableTexts
                     ? tr("could not parse file, reason: \"%1\" at offset %2")
@@ -3140,17 +3140,17 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
     if (mapObj.contains(QLatin1String("userData"))) {
         readJsonUserData(mapObj[QLatin1String("userData")].toObject());
     }
-    QString mapSymbolFontText = mapObj[QLatin1String("mapSymbolFontDetails")].toString();
-    float mapSymbolFontFudgeFactor = (qRound(mapObj[QLatin1String("mapSymbolFontFudgeFactor")].toDouble() * 1000.0)) / 1000;
-    bool isOnlyMapSymbolFontToBeUsed = mapObj[QLatin1String("onlyMapSymbolFontToBeUsed")].toBool();
-    int playerRoomStyle = qRound(mapObj[QLatin1String("playerRoomStyle")].toDouble());
-    quint8 playerRoomOuterDiameterPercentage = qRound(mapObj[QLatin1String("playerRoomOuterDiameterPercentage")].toDouble());
-    quint8 playerRoomInnerDiameterPercentage = qRound(mapObj[QLatin1String("playerRoomInnerDiameterPercentage")].toDouble());
+    QString const mapSymbolFontText = mapObj[QLatin1String("mapSymbolFontDetails")].toString();
+    float const mapSymbolFontFudgeFactor = (qRound(mapObj[QLatin1String("mapSymbolFontFudgeFactor")].toDouble() * 1000.0)) / 1000;
+    bool const isOnlyMapSymbolFontToBeUsed = mapObj[QLatin1String("onlyMapSymbolFontToBeUsed")].toBool();
+    int const playerRoomStyle = qRound(mapObj[QLatin1String("playerRoomStyle")].toDouble());
+    quint8 const playerRoomOuterDiameterPercentage = qRound(mapObj[QLatin1String("playerRoomOuterDiameterPercentage")].toDouble());
+    quint8 const playerRoomInnerDiameterPercentage = qRound(mapObj[QLatin1String("playerRoomInnerDiameterPercentage")].toDouble());
     QColor playerRoomOuterColor;
     QColor playerRoomInnerColor;
 
     if (mapObj.contains(QLatin1String("playerRoomColors")) && mapObj.value(QLatin1String("playerRoomColors")).isArray()) {
-        QJsonArray playerRoomColorArray = mapObj.value(QLatin1String("playerRoomColors")).toArray();
+        QJsonArray const playerRoomColorArray = mapObj.value(QLatin1String("playerRoomColors")).toArray();
         if (playerRoomColorArray.size() == 2 && playerRoomColorArray.at(0).isObject() && playerRoomColorArray.at(1).isObject()) {
             playerRoomOuterColor = readJsonColor(playerRoomColorArray.at(0).toObject());
             playerRoomInnerColor = readJsonColor(playerRoomColorArray.at(1).toObject());
@@ -3163,9 +3163,9 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
         if (!envColorObj.isEmpty()) {
             for (auto& key : envColorObj.keys()) {
                 bool isOk = false;
-                int index = key.toInt(&isOk);
+                int const index = key.toInt(&isOk);
                 if (isOk && envColorObj.value(key).isDouble()) {
-                    int value = envColorObj.value(key).toInt();
+                    int const value = envColorObj.value(key).toInt();
                     envColors.insert(index, value);
                 }
             }
@@ -3307,10 +3307,10 @@ void TMap::writeJsonColor(QJsonObject& obj, const QColor& color)
     colorRGBAArray.append(static_cast<double>(color.blue()));
     if (color.alpha() < 255) {
         colorRGBAArray.append(static_cast<double>(color.alpha()));
-        QJsonValue colorRGBAValue{colorRGBAArray};
+        QJsonValue const colorRGBAValue{colorRGBAArray};
         obj.insert(QLatin1String("color32RGBA"), colorRGBAValue);
     } else {
-        QJsonValue colorRGBAValue{colorRGBAArray};
+        QJsonValue const colorRGBAValue{colorRGBAArray};
         obj.insert(QLatin1String("color24RGB"), colorRGBAValue);
     }
 }
@@ -3335,7 +3335,7 @@ QColor TMap::readJsonColor(const QJsonObject& obj)
     } else {
         colorRGBAArray = obj.value(QLatin1String("color24RGB")).toArray();
     }
-    int size = colorRGBAArray.size();
+    int const size = colorRGBAArray.size();
     if ((size == 3 || size == 4)
         && colorRGBAArray.at(0).isDouble()
         && colorRGBAArray.at(1).isDouble()
@@ -3445,7 +3445,7 @@ QColor TMap::getColor(int id)
     default: //user defined room color
         if (!mCustomEnvColors.contains(env)) {
             if (16 < env && env < 232) {
-                quint8 base = env - 16;
+                quint8 const base = env - 16;
                 quint8 r = base / 36;
                 quint8 g = (base - (r * 36)) / 6;
                 quint8 b = (base - (r * 36)) - (g * 6);
@@ -3455,7 +3455,7 @@ QColor TMap::getColor(int id)
                 b = b == 0 ? 0 : (b - 1) * 40 + 95;
                 color = QColor(r, g, b, 255);
             } else if (231 < env && env < 256) {
-                quint8 k = ((env - 232) * 10) + 8;
+                quint8 const k = ((env - 232) * 10) + 8;
                 color = QColor(k, k, k, 255);
             }
             break;

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -84,7 +84,7 @@ void TMedia::playMedia(TMediaData& mediaData)
             TMedia::transitionNonRelativeFile(mediaData);
         }
 
-        QString const absolutePathFileName = TMedia::setupMediaAbsolutePathFileName(mediaData);
+        const QString absolutePathFileName = TMedia::setupMediaAbsolutePathFileName(mediaData);
         QFile const mediaFile(absolutePathFileName);
 
         if (!mediaFile.exists()) {
@@ -221,7 +221,7 @@ void TMedia::parseGMCP(QString& packageMessage, QString& gmcp)
     // This is JSON
     auto json = document.object();
 
-    QString const package = packageMessage.toLower(); // Don't change original variable
+    const QString package = packageMessage.toLower(); // Don't change original variable
 
     if (package == "client.media.stop") {
         TMedia::parseJSONForMediaStop(json);
@@ -243,7 +243,7 @@ void TMedia::parseGMCP(QString& packageMessage, QString& gmcp)
 
 bool TMedia::purgeMediaCache()
 {
-    QString const mediaPath = mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName());
+    const QString mediaPath = mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName());
     QDir mediaDir(mediaPath);
 
     if (!mediaDir.mkpath(mediaPath)) {
@@ -271,13 +271,13 @@ void TMedia::stopAllMediaPlayers()
 
 void TMedia::transitionNonRelativeFile(TMediaData& mediaData)
 {
-    QString const mediaPath = mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName());
+    const QString mediaPath = mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName());
     QDir const mediaDir(mediaPath);
 
     if (!mediaDir.mkpath(mediaPath)) {
         qWarning() << qsl("TMedia::playMedia() WARNING - attempt made to create a directory failed: %1").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()));
     } else {
-        QString const mediaFilePath = qsl("%1/%2").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()), mediaData.getMediaFileName().section('/', -1));
+        const QString mediaFilePath = qsl("%1/%2").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()), mediaData.getMediaFileName().section('/', -1));
         QFile const mediaFile(mediaFilePath);
 
         if (!mediaFile.exists() && !QFile::copy(mediaData.getMediaFileName(), mediaFilePath)) {
@@ -381,7 +381,7 @@ QStringList TMedia::getFileNameList(TMediaData& mediaData)
 {
     QStringList fileNameList;
 
-    QString const mediaPath = mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName());
+    const QString mediaPath = mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName());
     QDir mediaDir(mediaPath);
 
     if (!mediaDir.mkpath(mediaPath)) {
@@ -390,7 +390,7 @@ QStringList TMedia::getFileNameList(TMediaData& mediaData)
     }
 
     if (!mediaData.getMediaFileName().isEmpty() && mediaData.getMediaFileName().contains('/')) {
-        QString const mediaSubPath = qsl("%1/%2").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()), mediaData.getMediaFileName().section('/', 0, -2));
+        const QString mediaSubPath = qsl("%1/%2").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()), mediaData.getMediaFileName().section('/', 0, -2));
         QDir mediaSubDir(mediaSubPath);
 
         if (!mediaSubDir.mkpath(mediaSubPath)) {
@@ -561,7 +561,7 @@ void TMedia::slot_writeFile(QNetworkReply* reply)
 
 void TMedia::downloadFile(TMediaData& mediaData)
 {
-    QString const mediaPath = mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName());
+    const QString mediaPath = mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName());
     QDir const mediaDir(mediaPath);
 
     if (!mediaDir.mkpath(mediaPath)) {
@@ -570,7 +570,7 @@ void TMedia::downloadFile(TMediaData& mediaData)
     }
 
     if (!mediaData.getMediaFileName().isEmpty() && mediaData.getMediaFileName().contains('/')) {
-        QString const mediaSubPath = qsl("%1/%2").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()), mediaData.getMediaFileName().section('/', 0, -2));
+        const QString mediaSubPath = qsl("%1/%2").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()), mediaData.getMediaFileName().section('/', 0, -2));
         QDir const mediaSubDir(mediaSubPath);
 
         if (!mediaSubDir.mkpath(mediaSubPath)) {
@@ -581,7 +581,7 @@ void TMedia::downloadFile(TMediaData& mediaData)
     }
 
     QDir const dir;
-    QString const cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    const QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
 
     if (!dir.mkpath(cacheDir)) {
         qWarning() << "TMedia::downloadFile() WARNING - couldn't create cache directory for sound file(s): " << cacheDir;
@@ -1326,7 +1326,7 @@ void TMedia::parseJSONForMediaLoad(QJsonObject& json)
         return;
     }
 
-    QString const absolutePathFileName = TMedia::setupMediaAbsolutePathFileName(mediaData);
+    const QString absolutePathFileName = TMedia::setupMediaAbsolutePathFileName(mediaData);
 
     QFile const mediaFile(absolutePathFileName);
 

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -272,7 +272,7 @@ void TMedia::stopAllMediaPlayers()
 void TMedia::transitionNonRelativeFile(TMediaData& mediaData)
 {
     const QString mediaPath = mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName());
-    QDir const mediaDir(mediaPath);
+    const QDir mediaDir(mediaPath);
 
     if (!mediaDir.mkpath(mediaPath)) {
         qWarning() << qsl("TMedia::playMedia() WARNING - attempt made to create a directory failed: %1").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()));
@@ -562,7 +562,7 @@ void TMedia::slot_writeFile(QNetworkReply* reply)
 void TMedia::downloadFile(TMediaData& mediaData)
 {
     const QString mediaPath = mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName());
-    QDir const mediaDir(mediaPath);
+    const QDir mediaDir(mediaPath);
 
     if (!mediaDir.mkpath(mediaPath)) {
         qWarning() << qsl("TMedia::downloadFile() WARNING - attempt made to create a directory failed: %1").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()));
@@ -571,7 +571,7 @@ void TMedia::downloadFile(TMediaData& mediaData)
 
     if (!mediaData.getMediaFileName().isEmpty() && mediaData.getMediaFileName().contains('/')) {
         const QString mediaSubPath = qsl("%1/%2").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()), mediaData.getMediaFileName().section('/', 0, -2));
-        QDir const mediaSubDir(mediaSubPath);
+        const QDir mediaSubDir(mediaSubPath);
 
         if (!mediaSubDir.mkpath(mediaSubPath)) {
             qWarning() << qsl("TMedia::downloadFile() WARNING - attempt made to create a directory failed: %1")
@@ -580,7 +580,7 @@ void TMedia::downloadFile(TMediaData& mediaData)
         }
     }
 
-    QDir const dir;
+    const QDir dir;
     const QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
 
     if (!dir.mkpath(cacheDir)) {

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -944,7 +944,7 @@ void TMedia::play(TMediaData& mediaData)
         return;
     }
 
-    QStringList const fileNameList = TMedia::getFileNameList(mediaData);
+    const QStringList fileNameList = TMedia::getFileNameList(mediaData);
 
     if (fileNameList.isEmpty()) { // This should not happen.
         qWarning() << qsl("TMedia::play() WARNING - could not generate a list of media file names.");

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -787,10 +787,10 @@ TMediaPlayer TMedia::getMediaPlayer(TMediaData& mediaData)
     disconnect(pPlayer.getMediaPlayer(), &QMediaPlayer::positionChanged, nullptr, nullptr);
 
     connect(pPlayer.getMediaPlayer(), &QMediaPlayer::positionChanged, this, [&](qint64 progress) {
-        int const volume = pPlayer.getMediaData().getMediaVolume();
-        int const fadeInPosition = pPlayer.getMediaData().getMediaFadeIn();
-        int const fadeOutPosition = pPlayer.getMediaData().getMediaFadeOut();
-        int const startPosition = pPlayer.getMediaData().getMediaStart();
+        const int volume = pPlayer.getMediaData().getMediaVolume();
+        const int fadeInPosition = pPlayer.getMediaData().getMediaFadeIn();
+        const int fadeOutPosition = pPlayer.getMediaData().getMediaFadeOut();
+        const int startPosition = pPlayer.getMediaData().getMediaStart();
         bool const fadeInUsed = fadeInPosition != TMediaData::MediaFadeNotSet;
         bool const fadeOutUsed = fadeOutPosition != TMediaData::MediaFadeNotSet;
         bool actionTaken = false;
@@ -808,7 +808,7 @@ TMediaPlayer TMedia::getMediaPlayer(TMediaData& mediaData)
         }
 
         if (!actionTaken && fadeOutUsed && progress > 0) {
-            int const duration = pPlayer.getMediaPlayer()->duration();
+            const int duration = pPlayer.getMediaPlayer()->duration();
 
             if (progress > duration - fadeOutPosition) {
                 double const fadeOutVolume = static_cast<double>(volume * (duration - progress)) / static_cast<double>(fadeOutPosition * 1.0);

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -62,7 +62,7 @@ void TMedia::playMedia(TMediaData& mediaData)
         return;
     }
 
-    bool fileRelative = TMedia::isFileRelative(mediaData);
+    bool const fileRelative = TMedia::isFileRelative(mediaData);
 
     if (!fileRelative && (mediaData.getMediaProtocol() == TMediaData::MediaProtocolMSP || mediaData.getMediaProtocol() == TMediaData::MediaProtocolGMCP)) {
         return; // MSP and MCMP files will not have absolute paths. Something is wrong.
@@ -84,8 +84,8 @@ void TMedia::playMedia(TMediaData& mediaData)
             TMedia::transitionNonRelativeFile(mediaData);
         }
 
-        QString absolutePathFileName = TMedia::setupMediaAbsolutePathFileName(mediaData);
-        QFile mediaFile(absolutePathFileName);
+        QString const absolutePathFileName = TMedia::setupMediaAbsolutePathFileName(mediaData);
+        QFile const mediaFile(absolutePathFileName);
 
         if (!mediaFile.exists()) {
             if (fileRelative) {
@@ -165,7 +165,7 @@ void TMedia::stopMedia(TMediaData& mediaData)
     }
 
     if (!mediaData.getMediaFileName().isEmpty()) {
-        bool fileRelative = TMedia::isFileRelative(mediaData);
+        bool const fileRelative = TMedia::isFileRelative(mediaData);
 
         if (!fileRelative && (mediaData.getMediaProtocol() == TMediaData::MediaProtocolMSP || mediaData.getMediaProtocol() == TMediaData::MediaProtocolGMCP)) {
             return; // MSP and MCMP files will not have absolute paths. Something is wrong.
@@ -180,7 +180,7 @@ void TMedia::stopMedia(TMediaData& mediaData)
     QListIterator<TMediaPlayer> itTMediaPlayer(mTMediaPlayerList);
 
     while (itTMediaPlayer.hasNext()) {
-        TMediaPlayer pPlayer = itTMediaPlayer.next();
+        TMediaPlayer const pPlayer = itTMediaPlayer.next();
 
         if (mediaData.getMediaProtocol() == TMediaData::MediaProtocolGMCP || mediaData.getMediaProtocol() == TMediaData::MediaProtocolAPI) {
             if (!mediaData.getMediaKey().isEmpty() && !pPlayer.getMediaData().getMediaKey().isEmpty() && pPlayer.getMediaData().getMediaKey() != mediaData.getMediaKey()) {
@@ -221,7 +221,7 @@ void TMedia::parseGMCP(QString& packageMessage, QString& gmcp)
     // This is JSON
     auto json = document.object();
 
-    QString package = packageMessage.toLower(); // Don't change original variable
+    QString const package = packageMessage.toLower(); // Don't change original variable
 
     if (package == "client.media.stop") {
         TMedia::parseJSONForMediaStop(json);
@@ -243,7 +243,7 @@ void TMedia::parseGMCP(QString& packageMessage, QString& gmcp)
 
 bool TMedia::purgeMediaCache()
 {
-    QString mediaPath = mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName());
+    QString const mediaPath = mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName());
     QDir mediaDir(mediaPath);
 
     if (!mediaDir.mkpath(mediaPath)) {
@@ -260,25 +260,25 @@ bool TMedia::purgeMediaCache()
 // Private
 void TMedia::stopAllMediaPlayers()
 {
-    QList<TMediaPlayer> mTMediaPlayerList = (mMSPSoundList + mMSPMusicList + mGMCPSoundList + mGMCPMusicList + mAPISoundList + mAPIMusicList);
+    QList<TMediaPlayer> const mTMediaPlayerList = (mMSPSoundList + mMSPMusicList + mGMCPSoundList + mGMCPMusicList + mAPISoundList + mAPIMusicList);
     QListIterator<TMediaPlayer> itTMediaPlayer(mTMediaPlayerList);
 
     while (itTMediaPlayer.hasNext()) {
-        TMediaPlayer pPlayer = itTMediaPlayer.next();
+        TMediaPlayer const pPlayer = itTMediaPlayer.next();
         pPlayer.getMediaPlayer()->stop();
     }
 }
 
 void TMedia::transitionNonRelativeFile(TMediaData& mediaData)
 {
-    QString mediaPath = mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName());
-    QDir mediaDir(mediaPath);
+    QString const mediaPath = mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName());
+    QDir const mediaDir(mediaPath);
 
     if (!mediaDir.mkpath(mediaPath)) {
         qWarning() << qsl("TMedia::playMedia() WARNING - attempt made to create a directory failed: %1").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()));
     } else {
-        QString mediaFilePath = qsl("%1/%2").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()), mediaData.getMediaFileName().section('/', -1));
-        QFile mediaFile(mediaFilePath);
+        QString const mediaFilePath = qsl("%1/%2").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()), mediaData.getMediaFileName().section('/', -1));
+        QFile const mediaFile(mediaFilePath);
 
         if (!mediaFile.exists() && !QFile::copy(mediaData.getMediaFileName(), mediaFilePath)) {
             qWarning() << qsl("TMedia::playMedia() WARNING - attempt made to copy file %1 to a directory %2 failed.").arg(mediaData.getMediaFileName(), mediaFilePath);
@@ -381,7 +381,7 @@ QStringList TMedia::getFileNameList(TMediaData& mediaData)
 {
     QStringList fileNameList;
 
-    QString mediaPath = mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName());
+    QString const mediaPath = mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName());
     QDir mediaDir(mediaPath);
 
     if (!mediaDir.mkpath(mediaPath)) {
@@ -390,7 +390,7 @@ QStringList TMedia::getFileNameList(TMediaData& mediaData)
     }
 
     if (!mediaData.getMediaFileName().isEmpty() && mediaData.getMediaFileName().contains('/')) {
-        QString mediaSubPath = qsl("%1/%2").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()), mediaData.getMediaFileName().section('/', 0, -2));
+        QString const mediaSubPath = qsl("%1/%2").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()), mediaData.getMediaFileName().section('/', 0, -2));
         QDir mediaSubDir(mediaSubPath);
 
         if (!mediaSubDir.mkpath(mediaSubPath)) {
@@ -431,7 +431,7 @@ QUrl TMedia::getFileUrl(TMediaData& mediaData)
     }
 
     if (!mediaLocation.isEmpty()) {
-        bool endsWithSlash = mediaLocation.endsWith('/');
+        bool const endsWithSlash = mediaLocation.endsWith('/');
 
         if (!endsWithSlash) {
             fileUrl = QUrl::fromUserInput(qsl("%1/%2").arg(mediaLocation, mediaData.getMediaFileName()));
@@ -509,7 +509,7 @@ void TMedia::slot_writeFile(QNetworkReply* reply)
             mpHost->raiseEvent(event);
         }
 
-        qint64 bytesWritten = localFile.write(reply->readAll());
+        qint64 const bytesWritten = localFile.write(reply->readAll());
 
         if (bytesWritten == -1) {
             event.mArgumentList << QLatin1String("sysDownloadError");
@@ -561,8 +561,8 @@ void TMedia::slot_writeFile(QNetworkReply* reply)
 
 void TMedia::downloadFile(TMediaData& mediaData)
 {
-    QString mediaPath = mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName());
-    QDir mediaDir(mediaPath);
+    QString const mediaPath = mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName());
+    QDir const mediaDir(mediaPath);
 
     if (!mediaDir.mkpath(mediaPath)) {
         qWarning() << qsl("TMedia::downloadFile() WARNING - attempt made to create a directory failed: %1").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()));
@@ -570,8 +570,8 @@ void TMedia::downloadFile(TMediaData& mediaData)
     }
 
     if (!mediaData.getMediaFileName().isEmpty() && mediaData.getMediaFileName().contains('/')) {
-        QString mediaSubPath = qsl("%1/%2").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()), mediaData.getMediaFileName().section('/', 0, -2));
-        QDir mediaSubDir(mediaSubPath);
+        QString const mediaSubPath = qsl("%1/%2").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()), mediaData.getMediaFileName().section('/', 0, -2));
+        QDir const mediaSubDir(mediaSubPath);
 
         if (!mediaSubDir.mkpath(mediaSubPath)) {
             qWarning() << qsl("TMedia::downloadFile() WARNING - attempt made to create a directory failed: %1")
@@ -580,8 +580,8 @@ void TMedia::downloadFile(TMediaData& mediaData)
         }
     }
 
-    QDir dir;
-    QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    QDir const dir;
+    QString const cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
 
     if (!dir.mkpath(cacheDir)) {
         qWarning() << "TMedia::downloadFile() WARNING - couldn't create cache directory for sound file(s): " << cacheDir;
@@ -598,7 +598,7 @@ void TMedia::downloadFile(TMediaData& mediaData)
         request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
 #if !defined(QT_NO_SSL)
         if (fileUrl.scheme() == qsl("https")) {
-            QSslConfiguration config(QSslConfiguration::defaultConfiguration());
+            QSslConfiguration const config(QSslConfiguration::defaultConfiguration());
             request.setSslConfiguration(config);
         }
 #endif
@@ -673,10 +673,10 @@ void TMedia::updateMediaPlayerList(TMediaPlayer& player)
 {
     int matchedMediaPlayerIndex = -1;
     TMediaData mediaData = player.getMediaData();
-    QList<TMediaPlayer> mTMediaPlayerList = TMedia::getMediaPlayerList(mediaData);
+    QList<TMediaPlayer> const mTMediaPlayerList = TMedia::getMediaPlayerList(mediaData);
 
     for (int i = 0; i < mTMediaPlayerList.size(); ++i) {
-        TMediaPlayer pTestPlayer = mTMediaPlayerList.at(i);
+        TMediaPlayer const pTestPlayer = mTMediaPlayerList.at(i);
 
         if (pTestPlayer.getMediaPlayer() == player.getMediaPlayer()) {
             matchedMediaPlayerIndex = i;
@@ -747,11 +747,11 @@ void TMedia::updateMediaPlayerList(TMediaPlayer& player)
 TMediaPlayer TMedia::getMediaPlayer(TMediaData& mediaData)
 {
     TMediaPlayer pPlayer{};
-    QList<TMediaPlayer> mTMediaPlayerList = TMedia::getMediaPlayerList(mediaData);
+    QList<TMediaPlayer> const mTMediaPlayerList = TMedia::getMediaPlayerList(mediaData);
     QListIterator<TMediaPlayer> itTMediaPlayer(mTMediaPlayerList);
 
     while (itTMediaPlayer.hasNext()) { // Find first available inactive QMediaPlayer
-        TMediaPlayer pTestPlayer = itTMediaPlayer.next();
+        TMediaPlayer const pTestPlayer = itTMediaPlayer.next();
 
         if (pTestPlayer.getPlaybackState() != QMediaPlayer::PlayingState && pTestPlayer.getMediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
             pPlayer = pTestPlayer;
@@ -787,17 +787,17 @@ TMediaPlayer TMedia::getMediaPlayer(TMediaData& mediaData)
     disconnect(pPlayer.getMediaPlayer(), &QMediaPlayer::positionChanged, nullptr, nullptr);
 
     connect(pPlayer.getMediaPlayer(), &QMediaPlayer::positionChanged, this, [&](qint64 progress) {
-        int volume = pPlayer.getMediaData().getMediaVolume();
-        int fadeInPosition = pPlayer.getMediaData().getMediaFadeIn();
-        int fadeOutPosition = pPlayer.getMediaData().getMediaFadeOut();
-        int startPosition = pPlayer.getMediaData().getMediaStart();
-        bool fadeInUsed = fadeInPosition != TMediaData::MediaFadeNotSet;
-        bool fadeOutUsed = fadeOutPosition != TMediaData::MediaFadeNotSet;
+        int const volume = pPlayer.getMediaData().getMediaVolume();
+        int const fadeInPosition = pPlayer.getMediaData().getMediaFadeIn();
+        int const fadeOutPosition = pPlayer.getMediaData().getMediaFadeOut();
+        int const startPosition = pPlayer.getMediaData().getMediaStart();
+        bool const fadeInUsed = fadeInPosition != TMediaData::MediaFadeNotSet;
+        bool const fadeOutUsed = fadeOutPosition != TMediaData::MediaFadeNotSet;
         bool actionTaken = false;
 
         if (fadeInUsed) {
             if (progress < fadeInPosition) {
-                double fadeInVolume = static_cast<double>(volume * (progress - startPosition)) / static_cast<double>((fadeInPosition - startPosition) * 1.0);
+                double const fadeInVolume = static_cast<double>(volume * (progress - startPosition)) / static_cast<double>((fadeInPosition - startPosition) * 1.0);
 
                 pPlayer.setVolume(qRound(fadeInVolume));
                 actionTaken = true;
@@ -808,10 +808,10 @@ TMediaPlayer TMedia::getMediaPlayer(TMediaData& mediaData)
         }
 
         if (!actionTaken && fadeOutUsed && progress > 0) {
-            int duration = pPlayer.getMediaPlayer()->duration();
+            int const duration = pPlayer.getMediaPlayer()->duration();
 
             if (progress > duration - fadeOutPosition) {
-                double fadeOutVolume = static_cast<double>(volume * (duration - progress)) / static_cast<double>(fadeOutPosition * 1.0);
+                double const fadeOutVolume = static_cast<double>(volume * (duration - progress)) / static_cast<double>(fadeOutPosition * 1.0);
 
                 pPlayer.setVolume(qRound(fadeOutVolume));
                 actionTaken = true;
@@ -831,7 +831,7 @@ void TMedia::handlePlayerPlaybackStateChanged(QMediaPlayerPlaybackState playback
         TEvent mediaFinished{};
         mediaFinished.mArgumentList.append("sysMediaFinished");
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-        QUrl mediaUrl = pPlayer.getMediaPlayer()->media().request().url();
+        QUrl const mediaUrl = pPlayer.getMediaPlayer()->media().request().url();
 #else
         QUrl mediaUrl = pPlayer.getMediaPlayer()->source();
 #endif
@@ -852,11 +852,11 @@ void TMedia::handlePlayerPlaybackStateChanged(QMediaPlayerPlaybackState playback
 TMediaPlayer TMedia::matchMediaPlayer(TMediaData& mediaData, const QString& absolutePathFileName)
 {
     TMediaPlayer pPlayer{};
-    QList<TMediaPlayer> mTMediaPlayerList = TMedia::getMediaPlayerList(mediaData);
+    QList<TMediaPlayer> const mTMediaPlayerList = TMedia::getMediaPlayerList(mediaData);
     QListIterator<TMediaPlayer> itTMediaPlayer(mTMediaPlayerList);
 
     while (itTMediaPlayer.hasNext()) {
-        TMediaPlayer pTestPlayer = itTMediaPlayer.next();
+        TMediaPlayer const pTestPlayer = itTMediaPlayer.next();
 
         if (pTestPlayer.getPlaybackState() == QMediaPlayer::PlayingState && pTestPlayer.getMediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
             if (pTestPlayer.getMediaData().getMediaAbsolutePathFileName().endsWith(absolutePathFileName)) { // Is the same sound or music playing?
@@ -882,11 +882,11 @@ bool TMedia::doesMediaHavePriorityToPlay(TMediaData& mediaData, const QString& a
 
     int maxMediaPriority = 0;
 
-    QList<TMediaPlayer> mTMediaPlayerList = TMedia::getMediaPlayerList(mediaData);
+    QList<TMediaPlayer> const mTMediaPlayerList = TMedia::getMediaPlayerList(mediaData);
     QListIterator<TMediaPlayer> itTMediaPlayer(mTMediaPlayerList);
 
     while (itTMediaPlayer.hasNext()) { // Find the maximum priority of all playing sounds
-        TMediaPlayer pTestPlayer = itTMediaPlayer.next();
+        TMediaPlayer const pTestPlayer = itTMediaPlayer.next();
 
         if (pTestPlayer.getPlaybackState() == QMediaPlayer::PlayingState && pTestPlayer.getMediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
             if (!pTestPlayer.getMediaData().getMediaAbsolutePathFileName().endsWith(absolutePathFileName)) { // Is it a different sound or music than specified?
@@ -913,11 +913,11 @@ bool TMedia::doesMediaHavePriorityToPlay(TMediaData& mediaData, const QString& a
 // Documentation: https://wiki.mudlet.org/w/Manual:Scripting#key
 void TMedia::matchMediaKeyAndStopMediaVariants(TMediaData& mediaData, const QString& absolutePathFileName)
 {
-    QList<TMediaPlayer> mTMediaPlayerList = TMedia::getMediaPlayerList(mediaData);
+    QList<TMediaPlayer> const mTMediaPlayerList = TMedia::getMediaPlayerList(mediaData);
     QListIterator<TMediaPlayer> itTMediaPlayer(mTMediaPlayerList);
 
     while (itTMediaPlayer.hasNext()) {
-        TMediaPlayer pTestPlayer = itTMediaPlayer.next();
+        TMediaPlayer const pTestPlayer = itTMediaPlayer.next();
 
         if (pTestPlayer.getPlaybackState() == QMediaPlayer::PlayingState && pTestPlayer.getMediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
             if (!mediaData.getMediaKey().isEmpty() && !pTestPlayer.getMediaData().getMediaKey().isEmpty()
@@ -944,7 +944,7 @@ void TMedia::play(TMediaData& mediaData)
         return;
     }
 
-    QStringList fileNameList = TMedia::getFileNameList(mediaData);
+    QStringList const fileNameList = TMedia::getFileNameList(mediaData);
 
     if (fileNameList.isEmpty()) { // This should not happen.
         qWarning() << qsl("TMedia::play() WARNING - could not generate a list of media file names.");
@@ -1007,7 +1007,7 @@ void TMedia::play(TMediaData& mediaData)
             TMedia::matchMediaKeyAndStopMediaVariants(mediaData, absolutePathFileName); // If mediaKey matches, check for uniqueness.
         }
 
-        QUrl mediaSource = QUrl::fromLocalFile(absolutePathFileName);
+        QUrl const mediaSource = QUrl::fromLocalFile(absolutePathFileName);
         pPlayer.getMediaPlayer()->setMedia(mediaSource);
     } else {
         if (mediaData.getMediaLoops() == TMediaData::MediaLoopsRepeat) { // Repeat indefinitely
@@ -1326,9 +1326,9 @@ void TMedia::parseJSONForMediaLoad(QJsonObject& json)
         return;
     }
 
-    QString absolutePathFileName = TMedia::setupMediaAbsolutePathFileName(mediaData);
+    QString const absolutePathFileName = TMedia::setupMediaAbsolutePathFileName(mediaData);
 
-    QFile mediaFile(absolutePathFileName);
+    QFile const mediaFile(absolutePathFileName);
 
     if (!mediaFile.exists()) {
         TMedia::downloadFile(mediaData);

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -62,7 +62,7 @@ void TMedia::playMedia(TMediaData& mediaData)
         return;
     }
 
-    bool const fileRelative = TMedia::isFileRelative(mediaData);
+    const bool fileRelative = TMedia::isFileRelative(mediaData);
 
     if (!fileRelative && (mediaData.getMediaProtocol() == TMediaData::MediaProtocolMSP || mediaData.getMediaProtocol() == TMediaData::MediaProtocolGMCP)) {
         return; // MSP and MCMP files will not have absolute paths. Something is wrong.
@@ -165,7 +165,7 @@ void TMedia::stopMedia(TMediaData& mediaData)
     }
 
     if (!mediaData.getMediaFileName().isEmpty()) {
-        bool const fileRelative = TMedia::isFileRelative(mediaData);
+        const bool fileRelative = TMedia::isFileRelative(mediaData);
 
         if (!fileRelative && (mediaData.getMediaProtocol() == TMediaData::MediaProtocolMSP || mediaData.getMediaProtocol() == TMediaData::MediaProtocolGMCP)) {
             return; // MSP and MCMP files will not have absolute paths. Something is wrong.
@@ -431,7 +431,7 @@ QUrl TMedia::getFileUrl(TMediaData& mediaData)
     }
 
     if (!mediaLocation.isEmpty()) {
-        bool const endsWithSlash = mediaLocation.endsWith('/');
+        const bool endsWithSlash = mediaLocation.endsWith('/');
 
         if (!endsWithSlash) {
             fileUrl = QUrl::fromUserInput(qsl("%1/%2").arg(mediaLocation, mediaData.getMediaFileName()));
@@ -791,8 +791,8 @@ TMediaPlayer TMedia::getMediaPlayer(TMediaData& mediaData)
         const int fadeInPosition = pPlayer.getMediaData().getMediaFadeIn();
         const int fadeOutPosition = pPlayer.getMediaData().getMediaFadeOut();
         const int startPosition = pPlayer.getMediaData().getMediaStart();
-        bool const fadeInUsed = fadeInPosition != TMediaData::MediaFadeNotSet;
-        bool const fadeOutUsed = fadeOutPosition != TMediaData::MediaFadeNotSet;
+        const bool fadeInUsed = fadeInPosition != TMediaData::MediaFadeNotSet;
+        const bool fadeOutUsed = fadeOutPosition != TMediaData::MediaFadeNotSet;
         bool actionTaken = false;
 
         if (fadeInUsed) {

--- a/src/TMxpColorTagHandler.cpp
+++ b/src/TMxpColorTagHandler.cpp
@@ -29,8 +29,8 @@ bool TMxpColorTagHandler::supports(TMxpContext& ctx, TMxpClient& client, MxpTag*
 TMxpTagHandlerResult TMxpColorTagHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
 {
     Q_UNUSED(ctx)
-    QString fg = tag->getAttributeByNameOrIndex("FORE", 0);
-    QString bg = tag->getAttributeByNameOrIndex("BACK", 1);
+    QString const fg = tag->getAttributeByNameOrIndex("FORE", 0);
+    QString const bg = tag->getAttributeByNameOrIndex("BACK", 1);
 
     client.pushColor(fg, bg);
 

--- a/src/TMxpColorTagHandler.cpp
+++ b/src/TMxpColorTagHandler.cpp
@@ -29,8 +29,8 @@ bool TMxpColorTagHandler::supports(TMxpContext& ctx, TMxpClient& client, MxpTag*
 TMxpTagHandlerResult TMxpColorTagHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
 {
     Q_UNUSED(ctx)
-    QString const fg = tag->getAttributeByNameOrIndex("FORE", 0);
-    QString const bg = tag->getAttributeByNameOrIndex("BACK", 1);
+    const QString fg = tag->getAttributeByNameOrIndex("FORE", 0);
+    const QString bg = tag->getAttributeByNameOrIndex("BACK", 1);
 
     client.pushColor(fg, bg);
 

--- a/src/TMxpEntityTagHandler.cpp
+++ b/src/TMxpEntityTagHandler.cpp
@@ -36,12 +36,12 @@ TMxpTagHandlerResult TMxpEntityTagHandler::handleStartTag(TMxpContext& ctx, TMxp
     } else if (!boolOptions.contains(tag->getAttrName(1), Qt::CaseInsensitive)) { // 2nd attribute is actually the value
         const QString& value = tag->getAttrName(1);
         if (tag->hasAttribute("ADD")) {
-            QString prevDefinition = resolver.getResolution(entity);
+            QString const prevDefinition = resolver.getResolution(entity);
             QStringList definitionList = prevDefinition.split('|');
             definitionList.push_back(value);
             resolver.registerEntity(entity, definitionList.join('|'));
         } else if (tag->hasAttribute("REMOVE")) {
-            QString prevDefinition = resolver.getResolution(entity);
+            QString const prevDefinition = resolver.getResolution(entity);
             QStringList definitionList = prevDefinition.split('|');
             definitionList.removeOne(value);
             resolver.registerEntity(entity, definitionList.join('|'));

--- a/src/TMxpEntityTagHandler.cpp
+++ b/src/TMxpEntityTagHandler.cpp
@@ -36,12 +36,12 @@ TMxpTagHandlerResult TMxpEntityTagHandler::handleStartTag(TMxpContext& ctx, TMxp
     } else if (!boolOptions.contains(tag->getAttrName(1), Qt::CaseInsensitive)) { // 2nd attribute is actually the value
         const QString& value = tag->getAttrName(1);
         if (tag->hasAttribute("ADD")) {
-            QString const prevDefinition = resolver.getResolution(entity);
+            const QString prevDefinition = resolver.getResolution(entity);
             QStringList definitionList = prevDefinition.split('|');
             definitionList.push_back(value);
             resolver.registerEntity(entity, definitionList.join('|'));
         } else if (tag->hasAttribute("REMOVE")) {
-            QString const prevDefinition = resolver.getResolution(entity);
+            const QString prevDefinition = resolver.getResolution(entity);
             QStringList definitionList = prevDefinition.split('|');
             definitionList.removeOne(value);
             resolver.registerEntity(entity, definitionList.join('|'));

--- a/src/TMxpFontTagHandler.cpp
+++ b/src/TMxpFontTagHandler.cpp
@@ -24,12 +24,12 @@
 TMxpTagHandlerResult TMxpFontTagHandler::handleStartTag(TMxpContext& context, TMxpClient& client, MxpStartTag* tag)
 {
     Q_UNUSED(context)
-    QString fontFace = tag->getAttributeByNameOrIndex("FACE", 0);
-    QString fontSize = tag->getAttributeByNameOrIndex("SIZE", 1);
+    QString const fontFace = tag->getAttributeByNameOrIndex("FACE", 0);
+    QString const fontSize = tag->getAttributeByNameOrIndex("SIZE", 1);
     client.pushFont(fontFace, fontSize);
 
-    QString fgColor = tag->getAttributeByNameOrIndex("COLOR", 2);
-    QString bgColor = tag->getAttributeByNameOrIndex("BACK", 3);
+    QString const fgColor = tag->getAttributeByNameOrIndex("COLOR", 2);
+    QString const bgColor = tag->getAttributeByNameOrIndex("BACK", 3);
     client.pushColor(fgColor, bgColor);
 
     return MXP_TAG_HANDLED;

--- a/src/TMxpFontTagHandler.cpp
+++ b/src/TMxpFontTagHandler.cpp
@@ -24,12 +24,12 @@
 TMxpTagHandlerResult TMxpFontTagHandler::handleStartTag(TMxpContext& context, TMxpClient& client, MxpStartTag* tag)
 {
     Q_UNUSED(context)
-    QString const fontFace = tag->getAttributeByNameOrIndex("FACE", 0);
-    QString const fontSize = tag->getAttributeByNameOrIndex("SIZE", 1);
+    const QString fontFace = tag->getAttributeByNameOrIndex("FACE", 0);
+    const QString fontSize = tag->getAttributeByNameOrIndex("SIZE", 1);
     client.pushFont(fontFace, fontSize);
 
-    QString const fgColor = tag->getAttributeByNameOrIndex("COLOR", 2);
-    QString const bgColor = tag->getAttributeByNameOrIndex("BACK", 3);
+    const QString fgColor = tag->getAttributeByNameOrIndex("COLOR", 2);
+    const QString bgColor = tag->getAttributeByNameOrIndex("BACK", 3);
     client.pushColor(fgColor, bgColor);
 
     return MXP_TAG_HANDLED;

--- a/src/TMxpLinkTagHandler.cpp
+++ b/src/TMxpLinkTagHandler.cpp
@@ -34,7 +34,7 @@ TMxpTagHandlerResult TMxpLinkTagHandler::handleStartTag(TMxpContext& ctx, TMxpCl
         return MXP_TAG_NOT_HANDLED;
     }
 
-    QString hint = tag->hasAttribute("hint") ? tag->getAttributeValue("hint") : href;
+    QString const hint = tag->hasAttribute("hint") ? tag->getAttributeValue("hint") : href;
 
     href = qsl("openUrl([[%1]])").arg(href);
 

--- a/src/TMxpLinkTagHandler.cpp
+++ b/src/TMxpLinkTagHandler.cpp
@@ -34,7 +34,7 @@ TMxpTagHandlerResult TMxpLinkTagHandler::handleStartTag(TMxpContext& ctx, TMxpCl
         return MXP_TAG_NOT_HANDLED;
     }
 
-    QString const hint = tag->hasAttribute("hint") ? tag->getAttributeValue("hint") : href;
+    const QString hint = tag->hasAttribute("hint") ? tag->getAttributeValue("hint") : href;
 
     href = qsl("openUrl([[%1]])").arg(href);
 

--- a/src/TMxpMusicTagHandler.cpp
+++ b/src/TMxpMusicTagHandler.cpp
@@ -26,14 +26,14 @@ TMxpTagHandlerResult TMxpMusicTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
 {
     Q_UNUSED(ctx)
 
-    QString const fileName = extractFileName(tag);
+    const QString fileName = extractFileName(tag);
 
     if (!fileName.isEmpty()) {
-        QString const volume = extractVolume(tag);
-        QString const loops = extractLoops(tag);
-        QString const musicContinue = extractMusicContinue(tag);
-        QString const type = extractType(tag);
-        QString const url = extractUrl(tag);
+        const QString volume = extractVolume(tag);
+        const QString loops = extractLoops(tag);
+        const QString musicContinue = extractMusicContinue(tag);
+        const QString type = extractType(tag);
+        const QString url = extractUrl(tag);
 
         TMediaData mediaData {};
 

--- a/src/TMxpMusicTagHandler.cpp
+++ b/src/TMxpMusicTagHandler.cpp
@@ -26,14 +26,14 @@ TMxpTagHandlerResult TMxpMusicTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
 {
     Q_UNUSED(ctx)
 
-    QString fileName = extractFileName(tag);
+    QString const fileName = extractFileName(tag);
 
     if (!fileName.isEmpty()) {
-        QString volume = extractVolume(tag);
-        QString loops = extractLoops(tag);
-        QString musicContinue = extractMusicContinue(tag);
-        QString type = extractType(tag);
-        QString url = extractUrl(tag);
+        QString const volume = extractVolume(tag);
+        QString const loops = extractLoops(tag);
+        QString const musicContinue = extractMusicContinue(tag);
+        QString const type = extractType(tag);
+        QString const url = extractUrl(tag);
 
         TMediaData mediaData {};
 

--- a/src/TMxpProcessor.cpp
+++ b/src/TMxpProcessor.cpp
@@ -28,7 +28,7 @@
 bool TMxpProcessor::setMode(const QString& code)
 {
     bool isOk = false;
-    int const modeCode = code.toInt(&isOk);
+    const int modeCode = code.toInt(&isOk);
     if (isOk) {
         return setMode(modeCode);
     } else {

--- a/src/TMxpProcessor.cpp
+++ b/src/TMxpProcessor.cpp
@@ -28,7 +28,7 @@
 bool TMxpProcessor::setMode(const QString& code)
 {
     bool isOk = false;
-    int modeCode = code.toInt(&isOk);
+    int const modeCode = code.toInt(&isOk);
     if (isOk) {
         return setMode(modeCode);
     } else {
@@ -131,14 +131,14 @@ TMxpProcessingResult TMxpProcessor::processMxpInput(char& ch)
     }
 
     if (mMxpTagBuilder.hasTag()) {
-        QScopedPointer<MxpTag> tag(mMxpTagBuilder.buildTag());
+        QScopedPointer<MxpTag> const tag(mMxpTagBuilder.buildTag());
 
         //        qDebug() << "TAG RECEIVED: " << tag->asString();
         if (mMXP_MODE == MXP_MODE_TEMP_SECURE) {
             mMXP_MODE = mMXP_DEFAULT;
         }
 
-        TMxpTagHandlerResult result = mMxpTagProcessor.handleTag(mMxpTagProcessor, *mpMxpClient, tag.get());
+        TMxpTagHandlerResult const result = mMxpTagProcessor.handleTag(mMxpTagProcessor, *mpMxpClient, tag.get());
         return result == MXP_TAG_COMMIT_LINE ? HANDLER_COMMIT_LINE : HANDLER_NEXT_CHAR;
     }
 

--- a/src/TMxpSoundTagHandler.cpp
+++ b/src/TMxpSoundTagHandler.cpp
@@ -26,14 +26,14 @@ TMxpTagHandlerResult TMxpSoundTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
 {
     Q_UNUSED(ctx)
 
-    QString fileName = extractFileName(tag);
+    QString const fileName = extractFileName(tag);
 
     if (!fileName.isEmpty()) {
-        QString volume = extractVolume(tag);
-        QString loops = extractLoops(tag);
-        QString priority = extractPriority(tag);
-        QString type = extractType(tag);
-        QString url = extractUrl(tag);
+        QString const volume = extractVolume(tag);
+        QString const loops = extractLoops(tag);
+        QString const priority = extractPriority(tag);
+        QString const type = extractType(tag);
+        QString const url = extractUrl(tag);
 
         TMediaData mediaData {};
 

--- a/src/TMxpSoundTagHandler.cpp
+++ b/src/TMxpSoundTagHandler.cpp
@@ -26,14 +26,14 @@ TMxpTagHandlerResult TMxpSoundTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
 {
     Q_UNUSED(ctx)
 
-    QString const fileName = extractFileName(tag);
+    const QString fileName = extractFileName(tag);
 
     if (!fileName.isEmpty()) {
-        QString const volume = extractVolume(tag);
-        QString const loops = extractLoops(tag);
-        QString const priority = extractPriority(tag);
-        QString const type = extractType(tag);
-        QString const url = extractUrl(tag);
+        const QString volume = extractVolume(tag);
+        const QString loops = extractLoops(tag);
+        const QString priority = extractPriority(tag);
+        const QString type = extractType(tag);
+        const QString url = extractUrl(tag);
 
         TMediaData mediaData {};
 

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -730,7 +730,7 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
         QMultiMapIterator<int, QString> itOldSpecialExit(oldSpecialExits);
         while (itOldSpecialExit.hasNext()) {
             itOldSpecialExit.next();
-            QString const cmd{itOldSpecialExit.value()};
+            const QString cmd{itOldSpecialExit.value()};
             if (cmd.startsWith(QLatin1String("1"))) {
                 // Is locked:
                 mSpecialExits.insert(cmd.mid(1), itOldSpecialExit.key());
@@ -763,7 +763,7 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
         ifs >> userData;
         if (version < 19) {
             // Recover and remove backup values from the user data
-            QString const symbolString = userData.take(QLatin1String("system.fallback_symbol"));
+            const QString symbolString = userData.take(QLatin1String("system.fallback_symbol"));
             if (!symbolString.isEmpty()) {
                 // There is a fallback in the user data
                 mSymbol = symbolString;
@@ -797,7 +797,7 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
             QMapIterator<QString, QList<QPointF>> itCustomLine(oldLinesData);
             while (itCustomLine.hasNext()) {
                 itCustomLine.next();
-                QString const direction(itCustomLine.key());
+                const QString direction(itCustomLine.key());
                 if (direction == QLatin1String("N") || direction == QLatin1String("E") || direction == QLatin1String("S") || direction == QLatin1String("W") || direction == QLatin1String("UP")
                     || direction == QLatin1String("DOWN")
                     || direction == QLatin1String("NE")
@@ -817,7 +817,7 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
             QMapIterator<QString, bool> itCustomLineArrow(oldLinesArrowData);
             while (itCustomLineArrow.hasNext()) {
                 itCustomLineArrow.next();
-                QString const direction(itCustomLineArrow.key());
+                const QString direction(itCustomLineArrow.key());
                 if (direction == QLatin1String("N") || direction == QLatin1String("E") || direction == QLatin1String("S") || direction == QLatin1String("W") || direction == QLatin1String("UP")
                     || direction == QLatin1String("DOWN")
                     || direction == QLatin1String("NE")
@@ -837,7 +837,7 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
             QMapIterator<QString, QList<int>> itCustomLineColor(oldLinesColorData);
             while (itCustomLineColor.hasNext()) {
                 itCustomLineColor.next();
-                QString const direction(itCustomLineColor.key());
+                const QString direction(itCustomLineColor.key());
                 if (direction == QLatin1String("N") || direction == QLatin1String("E") || direction == QLatin1String("S") || direction == QLatin1String("W") || direction == QLatin1String("UP")
                     || direction == QLatin1String("DOWN")
                     || direction == QLatin1String("NE")
@@ -1135,11 +1135,11 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
         QMutableMapIterator<QString, int> it(mSpecialExits);
         while (it.hasNext()) {
             it.next();
-            QString const exitName = it.key();
+            const QString exitName = it.key();
             int const exitRoomId = it.value();
             if (exitName.isEmpty()) {
                 if (mudlet::self()->showMapAuditErrors()) {
-                    QString const warnMsg = tr("[ WARN ]  - In room id:%1 removing invalid (special) exit to %2 {with no name!}").arg(id, 6, QLatin1Char('0')).arg(exitRoomId, 6, QLatin1Char('0'));
+                    const QString warnMsg = tr("[ WARN ]  - In room id:%1 removing invalid (special) exit to %2 {with no name!}").arg(id, 6, QLatin1Char('0')).arg(exitRoomId, 6, QLatin1Char('0'));
                     // If size is less than or equal to 0 then there is nothing to print!!!
                     mpRoomDB->mpMap->postMessage(warnMsg);
                 }
@@ -1149,10 +1149,10 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
             }
 
             if (roomRemapping.contains(exitRoomId)) {
-                QString const auditKey = qsl("audit.remapped_special_exit.%1").arg(exitName);
+                const QString auditKey = qsl("audit.remapped_special_exit.%1").arg(exitName);
                 userData.insert(auditKey, QString::number(exitRoomId));
                 if (mudlet::self()->showMapAuditErrors()) {
-                    QString const infoMsg = tr("[ INFO ]  - In room with id: %1 correcting special exit \"%2\" that\n"
+                    const QString infoMsg = tr("[ INFO ]  - In room with id: %1 correcting special exit \"%2\" that\n"
                                          "was to room with an exit to invalid room: %3 to now go\n"
                                          "to: %4.")
                                               .arg(id)
@@ -1179,15 +1179,15 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
         while (it.hasNext()) {
             it.next();
             int const exitRoomId = it.value();
-            QString const exitName = it.key();
+            const QString exitName = it.key();
 
             if (exitRoomId > 0) {
                 // A real exit - should have a real destination
                 if (Q_UNLIKELY(!mpRoomDB->getRoom(exitRoomId))) {
                     // But it doesn't exist
-                    QString const auditKey = qsl("audit.removed_valid_but_missing_special_exit.%1").arg(exitName);
+                    const QString auditKey = qsl("audit.removed_valid_but_missing_special_exit.%1").arg(exitName);
                     if (mudlet::self()->showMapAuditErrors()) {
-                        QString const warnMsg = tr("[ WARN ]  - Room with id: %1 has a special exit \"%2\" with an\n"
+                        const QString warnMsg = tr("[ WARN ]  - Room with id: %1 has a special exit \"%2\" with an\n"
                                              "exit to: %3 but that room does not exist.  The exit will\n"
                                              "be removed (but the destination room id will be stored in\n"
                                              "the room user data under a key:\n"
@@ -1236,10 +1236,10 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
                 }
             } else {
                 // < 1 and not renumbered because the bad room Id DID NOT exist
-                QString const auditKey = qsl("audit.removed_invalid_special_exit.%1").arg(exitName);
+                const QString auditKey = qsl("audit.removed_invalid_special_exit.%1").arg(exitName);
                 userData.insert(auditKey, QString::number(exitRoomId));
                 if (mudlet::self()->showMapAuditErrors()) {
-                    QString const infoMsg = tr("[ INFO ]  - In room with id: %1 special exit \"%2\"\n"
+                    const QString infoMsg = tr("[ INFO ]  - In room with id: %1 special exit \"%2\"\n"
                                          "that was to room with an invalid room: %3 that does not exist.\n"
                                          "The exit will be removed (the bad destination room id will be stored in the\n"
                                          "room user data under a key:\n"
@@ -1301,7 +1301,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
             }
         }
         if (mudlet::self()->showMapAuditErrors()) {
-            QString const infoMsg = tr("[ INFO ]  - In room with id: %1 found one or more surplus door items that were removed:\n"
+            const QString infoMsg = tr("[ INFO ]  - In room with id: %1 found one or more surplus door items that were removed:\n"
                                  "%2.")
                                       .arg(id)
                                       .arg(extras.join(QLatin1String(", ")));
@@ -1324,7 +1324,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
             extras << qsl("\"%1\"(%2)").arg(itSpareExitWeight.key()).arg(itSpareExitWeight.value());
         }
         if (mudlet::self()->showMapAuditErrors()) {
-            QString const infoMsg = tr("[ INFO ]  - In room with id: %1 found one or more surplus weight items that were removed:\n"
+            const QString infoMsg = tr("[ INFO ]  - In room with id: %1 found one or more surplus weight items that were removed:\n"
                                  "%2.")
                                       .arg(id)
                                       .arg(extras.join(QLatin1String(", ")));
@@ -1347,7 +1347,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
             exitLocks.removeAll(dirCode);
         }
         if (mudlet::self()->showMapAuditErrors()) {
-            QString const infoMsg = tr("[ INFO ]  - In room with id: %1 found one or more surplus exit lock items that were removed:\n"
+            const QString infoMsg = tr("[ INFO ]  - In room with id: %1 found one or more surplus exit lock items that were removed:\n"
                                  "%2.")
                                       .arg(id)
                                       .arg(extras.join(QLatin1String(", ")));
@@ -1433,7 +1433,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
 
         if (!extras.isEmpty()) {
             if (mudlet::self()->showMapAuditErrors()) {
-                QString const infoMsg = tr("[ INFO ]  - In room with id: %1 found one or more surplus custom line elements that\n"
+                const QString infoMsg = tr("[ INFO ]  - In room with id: %1 found one or more surplus custom line elements that\n"
                                      "were removed: %2.")
                                           .arg(id)
                                           .arg(extras.join(QLatin1String(", ")));
@@ -1459,10 +1459,10 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
                       const QHash<int, int> roomRemapping)
 {
     if (roomRemapping.contains(exitRoomId)) {
-        QString const auditKey = qsl("audit.remapped_exit.%1").arg(dirCode);
+        const QString auditKey = qsl("audit.remapped_exit.%1").arg(dirCode);
         userData.insert(auditKey, QString::number(exitRoomId));
         if (mudlet::self()->showMapAuditErrors()) {
-            QString const infoMsg = tr("[ INFO ]  - In room with id: %1 correcting exit \"%2\" that was to room with\n"
+            const QString infoMsg = tr("[ INFO ]  - In room with id: %1 correcting exit \"%2\" that was to room with\n"
                                  "an exit to invalid room: %3 to now go to: %4.")
                                       .arg(id)
                                       .arg(displayName)
@@ -1480,9 +1480,9 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
         // A real exit - should have a real destination, and NOT have a stub
         if (Q_UNLIKELY(!mpRoomDB->getRoom(exitRoomId))) {
             // But it doesn't exist
-            QString const auditKey = qsl("audit.made_stub_of_valid_but_missing_exit.%1").arg(dirCode);
+            const QString auditKey = qsl("audit.made_stub_of_valid_but_missing_exit.%1").arg(dirCode);
             if (mudlet::self()->showMapAuditErrors()) {
-                QString const warnMsg = tr("[ WARN ]  - Room with id: %1 has an exit \"%2\" to: %3 but that room\n"
+                const QString warnMsg = tr("[ WARN ]  - Room with id: %1 has an exit \"%2\" to: %3 but that room\n"
                                      "does not exist.  The exit will be removed (but the destination room\n"
                                      "Id will be stored in the room user data under a key:\n"
                                      "\"%4\")\n"
@@ -1539,7 +1539,7 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
             // We cannot allow a stub exit at the same time as a real exit:
             if (exitStubs.contains(dirCode)) {
                 if (mudlet::self()->showMapAuditErrors()) {
-                    QString const warnMsg = tr("[ ALERT ] - Room with id: %1 has an exit \"%2\" to: %3 but also\n"
+                    const QString warnMsg = tr("[ ALERT ] - Room with id: %1 has an exit \"%2\" to: %3 but also\n"
                                          "has a stub exit!  As a real exit precludes a stub, the latter will\n"
                                          "be removed.")
                                               .arg(id)
@@ -1601,7 +1601,7 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
         // either 0 or < -1 and not renumbered because the bad room Id DID NOT
         // exist, there could be a "double fault" in that there is also a stub
         // exit, but that will be masked as we turn the exit into a stub anyhow.
-        QString const auditKey = qsl("audit.made_stub_of_invalid_exit.%1").arg(dirCode);
+        const QString auditKey = qsl("audit.made_stub_of_invalid_exit.%1").arg(dirCode);
         userData.insert(auditKey, QString::number(exitRoomId));
         QString infoMsg;
         if (mudlet::self()->showMapAuditErrors()) {
@@ -1629,7 +1629,7 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
         exitStubsPool.remove(dirCode); // Remove the stub in this direction from check pool as we have handled it
 
         if (exitLocks.contains(dirCode)) {
-            QString const auditKeyLocked = qsl("audit.invalid_exit.%1.isLocked").arg(dirCode);
+            const QString auditKeyLocked = qsl("audit.invalid_exit.%1.isLocked").arg(dirCode);
             userData.insert(auditKeyLocked, qsl("true"));
             if (mudlet::self()->showMapAuditErrors()) {
                 infoMsg.append(
@@ -1642,7 +1642,7 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
         }
 
         if (exitWeights.contains(exitKey)) {
-            QString const auditKeyWeight = qsl("audit.invalid_exit.%1.weight").arg(dirCode);
+            const QString auditKeyWeight = qsl("audit.invalid_exit.%1.weight").arg(dirCode);
             userData.insert(auditKeyWeight, QString::number(exitWeights.value(exitKey)));
             if (mudlet::self()->showMapAuditErrors()) {
                 infoMsg.append(
@@ -1661,7 +1661,7 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
 
         if (customLines.contains(exitKey)) {
             if (mudlet::self()->showMapAuditErrors()) {
-                QString const warnMsg = tr("[ WARN ]  - There was a custom exit line associated with the invalid exit but\n"
+                const QString warnMsg = tr("[ WARN ]  - There was a custom exit line associated with the invalid exit but\n"
                                      "it has not been possible to salvage this, it has been lost!");
                 mpRoomDB->mpMap->postMessage(warnMsg);
             }
@@ -1868,9 +1868,9 @@ bool TRoom::readJsonExits(const QJsonObject& obj)
 void TRoom::writeJsonNormalExit(QJsonArray& array, const int dir) const
 {
     QJsonObject exitObj;
-    QString const directionString = dirCodeToString(dir);
+    const QString directionString = dirCodeToString(dir);
     int const exitId = getExit(dir);
-    QString const directionKey = dirCodeToShortString(dir);
+    const QString directionKey = dirCodeToShortString(dir);
     // Skip any unreal exits:
     if (exitId < 1) {
         return;
@@ -2170,7 +2170,7 @@ void TRoom::readJsonCustomExitLine(const QJsonObject& exitObj, const QString& di
     }
 
     if (customLineObj.contains(QLatin1String("style")) && customLineObj.value(QLatin1String("style")).isString()) {
-        QString const lineStyle{customLineObj.value(QLatin1String("style")).toString()};
+        const QString lineStyle{customLineObj.value(QLatin1String("style")).toString()};
         if (lineStyle == QLatin1String("dash line")) {
             customLinesStyle.insert(directionString, Qt::DashLine);
         } else if (lineStyle == QLatin1String("dash dot dot line")) {

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -663,8 +663,8 @@ void TRoom::calcRoomDimensions()
             continue;
         }
         for (auto pointInLine : pointsInLine) {
-            qreal pointX = pointInLine.x();
-            qreal pointY = pointInLine.y();
+            qreal const pointX = pointInLine.x();
+            qreal const pointY = pointInLine.y();
             if (pointX < min_x) {
                 min_x = pointX;
             }
@@ -730,7 +730,7 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
         QMultiMapIterator<int, QString> itOldSpecialExit(oldSpecialExits);
         while (itOldSpecialExit.hasNext()) {
             itOldSpecialExit.next();
-            QString cmd{itOldSpecialExit.value()};
+            QString const cmd{itOldSpecialExit.value()};
             if (cmd.startsWith(QLatin1String("1"))) {
                 // Is locked:
                 mSpecialExits.insert(cmd.mid(1), itOldSpecialExit.key());
@@ -763,7 +763,7 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
         ifs >> userData;
         if (version < 19) {
             // Recover and remove backup values from the user data
-            QString symbolString = userData.take(QLatin1String("system.fallback_symbol"));
+            QString const symbolString = userData.take(QLatin1String("system.fallback_symbol"));
             if (!symbolString.isEmpty()) {
                 // There is a fallback in the user data
                 mSymbol = symbolString;
@@ -797,7 +797,7 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
             QMapIterator<QString, QList<QPointF>> itCustomLine(oldLinesData);
             while (itCustomLine.hasNext()) {
                 itCustomLine.next();
-                QString direction(itCustomLine.key());
+                QString const direction(itCustomLine.key());
                 if (direction == QLatin1String("N") || direction == QLatin1String("E") || direction == QLatin1String("S") || direction == QLatin1String("W") || direction == QLatin1String("UP")
                     || direction == QLatin1String("DOWN")
                     || direction == QLatin1String("NE")
@@ -817,7 +817,7 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
             QMapIterator<QString, bool> itCustomLineArrow(oldLinesArrowData);
             while (itCustomLineArrow.hasNext()) {
                 itCustomLineArrow.next();
-                QString direction(itCustomLineArrow.key());
+                QString const direction(itCustomLineArrow.key());
                 if (direction == QLatin1String("N") || direction == QLatin1String("E") || direction == QLatin1String("S") || direction == QLatin1String("W") || direction == QLatin1String("UP")
                     || direction == QLatin1String("DOWN")
                     || direction == QLatin1String("NE")
@@ -837,7 +837,7 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
             QMapIterator<QString, QList<int>> itCustomLineColor(oldLinesColorData);
             while (itCustomLineColor.hasNext()) {
                 itCustomLineColor.next();
-                QString direction(itCustomLineColor.key());
+                QString const direction(itCustomLineColor.key());
                 if (direction == QLatin1String("N") || direction == QLatin1String("E") || direction == QLatin1String("S") || direction == QLatin1String("W") || direction == QLatin1String("UP")
                     || direction == QLatin1String("DOWN")
                     || direction == QLatin1String("NE")
@@ -876,7 +876,7 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
             QSet<QString> missingKeys{customLineKeys.begin(), customLineKeys.end()};
             if (!customLinesColor.isEmpty()) {
                 auto customLinesColorKeys = customLinesColor.keys();
-                QSet<QString> customLinesColorKeysSet{customLinesColorKeys.begin(), customLinesColorKeys.end()};
+                QSet<QString> const customLinesColorKeysSet{customLinesColorKeys.begin(), customLinesColorKeys.end()};
                 missingKeys.subtract(customLinesColorKeysSet);
             }
             QSetIterator<QString> itMissingCustomLineColourKey(missingKeys);
@@ -1135,11 +1135,11 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
         QMutableMapIterator<QString, int> it(mSpecialExits);
         while (it.hasNext()) {
             it.next();
-            QString exitName = it.key();
-            int exitRoomId = it.value();
+            QString const exitName = it.key();
+            int const exitRoomId = it.value();
             if (exitName.isEmpty()) {
                 if (mudlet::self()->showMapAuditErrors()) {
-                    QString warnMsg = tr("[ WARN ]  - In room id:%1 removing invalid (special) exit to %2 {with no name!}").arg(id, 6, QLatin1Char('0')).arg(exitRoomId, 6, QLatin1Char('0'));
+                    QString const warnMsg = tr("[ WARN ]  - In room id:%1 removing invalid (special) exit to %2 {with no name!}").arg(id, 6, QLatin1Char('0')).arg(exitRoomId, 6, QLatin1Char('0'));
                     // If size is less than or equal to 0 then there is nothing to print!!!
                     mpRoomDB->mpMap->postMessage(warnMsg);
                 }
@@ -1149,10 +1149,10 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
             }
 
             if (roomRemapping.contains(exitRoomId)) {
-                QString auditKey = qsl("audit.remapped_special_exit.%1").arg(exitName);
+                QString const auditKey = qsl("audit.remapped_special_exit.%1").arg(exitName);
                 userData.insert(auditKey, QString::number(exitRoomId));
                 if (mudlet::self()->showMapAuditErrors()) {
-                    QString infoMsg = tr("[ INFO ]  - In room with id: %1 correcting special exit \"%2\" that\n"
+                    QString const infoMsg = tr("[ INFO ]  - In room with id: %1 correcting special exit \"%2\" that\n"
                                          "was to room with an exit to invalid room: %3 to now go\n"
                                          "to: %4.")
                                               .arg(id)
@@ -1178,16 +1178,16 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
         QMutableMapIterator<QString, int> it(mSpecialExits);
         while (it.hasNext()) {
             it.next();
-            int exitRoomId = it.value();
-            QString exitName = it.key();
+            int const exitRoomId = it.value();
+            QString const exitName = it.key();
 
             if (exitRoomId > 0) {
                 // A real exit - should have a real destination
                 if (Q_UNLIKELY(!mpRoomDB->getRoom(exitRoomId))) {
                     // But it doesn't exist
-                    QString auditKey = qsl("audit.removed_valid_but_missing_special_exit.%1").arg(exitName);
+                    QString const auditKey = qsl("audit.removed_valid_but_missing_special_exit.%1").arg(exitName);
                     if (mudlet::self()->showMapAuditErrors()) {
-                        QString warnMsg = tr("[ WARN ]  - Room with id: %1 has a special exit \"%2\" with an\n"
+                        QString const warnMsg = tr("[ WARN ]  - Room with id: %1 has a special exit \"%2\" with an\n"
                                              "exit to: %3 but that room does not exist.  The exit will\n"
                                              "be removed (but the destination room id will be stored in\n"
                                              "the room user data under a key:\n"
@@ -1236,10 +1236,10 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
                 }
             } else {
                 // < 1 and not renumbered because the bad room Id DID NOT exist
-                QString auditKey = qsl("audit.removed_invalid_special_exit.%1").arg(exitName);
+                QString const auditKey = qsl("audit.removed_invalid_special_exit.%1").arg(exitName);
                 userData.insert(auditKey, QString::number(exitRoomId));
                 if (mudlet::self()->showMapAuditErrors()) {
-                    QString infoMsg = tr("[ INFO ]  - In room with id: %1 special exit \"%2\"\n"
+                    QString const infoMsg = tr("[ INFO ]  - In room with id: %1 special exit \"%2\"\n"
                                          "that was to room with an invalid room: %3 that does not exist.\n"
                                          "The exit will be removed (the bad destination room id will be stored in the\n"
                                          "room user data under a key:\n"
@@ -1301,7 +1301,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
             }
         }
         if (mudlet::self()->showMapAuditErrors()) {
-            QString infoMsg = tr("[ INFO ]  - In room with id: %1 found one or more surplus door items that were removed:\n"
+            QString const infoMsg = tr("[ INFO ]  - In room with id: %1 found one or more surplus door items that were removed:\n"
                                  "%2.")
                                       .arg(id)
                                       .arg(extras.join(QLatin1String(", ")));
@@ -1324,7 +1324,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
             extras << qsl("\"%1\"(%2)").arg(itSpareExitWeight.key()).arg(itSpareExitWeight.value());
         }
         if (mudlet::self()->showMapAuditErrors()) {
-            QString infoMsg = tr("[ INFO ]  - In room with id: %1 found one or more surplus weight items that were removed:\n"
+            QString const infoMsg = tr("[ INFO ]  - In room with id: %1 found one or more surplus weight items that were removed:\n"
                                  "%2.")
                                       .arg(id)
                                       .arg(extras.join(QLatin1String(", ")));
@@ -1342,12 +1342,12 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
         QStringList extras;
         QSetIterator<int> itSpareExitLock(exitLocksCopy);
         while (itSpareExitLock.hasNext()) {
-            int dirCode = itSpareExitLock.next();
+            int const dirCode = itSpareExitLock.next();
             extras.append(dirCodeToDisplayName(dirCode));
             exitLocks.removeAll(dirCode);
         }
         if (mudlet::self()->showMapAuditErrors()) {
-            QString infoMsg = tr("[ INFO ]  - In room with id: %1 found one or more surplus exit lock items that were removed:\n"
+            QString const infoMsg = tr("[ INFO ]  - In room with id: %1 found one or more surplus exit lock items that were removed:\n"
                                  "%2.")
                                       .arg(id)
                                       .arg(extras.join(QLatin1String(", ")));
@@ -1433,7 +1433,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
 
         if (!extras.isEmpty()) {
             if (mudlet::self()->showMapAuditErrors()) {
-                QString infoMsg = tr("[ INFO ]  - In room with id: %1 found one or more surplus custom line elements that\n"
+                QString const infoMsg = tr("[ INFO ]  - In room with id: %1 found one or more surplus custom line elements that\n"
                                      "were removed: %2.")
                                           .arg(id)
                                           .arg(extras.join(QLatin1String(", ")));
@@ -1459,10 +1459,10 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
                       const QHash<int, int> roomRemapping)
 {
     if (roomRemapping.contains(exitRoomId)) {
-        QString auditKey = qsl("audit.remapped_exit.%1").arg(dirCode);
+        QString const auditKey = qsl("audit.remapped_exit.%1").arg(dirCode);
         userData.insert(auditKey, QString::number(exitRoomId));
         if (mudlet::self()->showMapAuditErrors()) {
-            QString infoMsg = tr("[ INFO ]  - In room with id: %1 correcting exit \"%2\" that was to room with\n"
+            QString const infoMsg = tr("[ INFO ]  - In room with id: %1 correcting exit \"%2\" that was to room with\n"
                                  "an exit to invalid room: %3 to now go to: %4.")
                                       .arg(id)
                                       .arg(displayName)
@@ -1480,9 +1480,9 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
         // A real exit - should have a real destination, and NOT have a stub
         if (Q_UNLIKELY(!mpRoomDB->getRoom(exitRoomId))) {
             // But it doesn't exist
-            QString auditKey = qsl("audit.made_stub_of_valid_but_missing_exit.%1").arg(dirCode);
+            QString const auditKey = qsl("audit.made_stub_of_valid_but_missing_exit.%1").arg(dirCode);
             if (mudlet::self()->showMapAuditErrors()) {
-                QString warnMsg = tr("[ WARN ]  - Room with id: %1 has an exit \"%2\" to: %3 but that room\n"
+                QString const warnMsg = tr("[ WARN ]  - Room with id: %1 has an exit \"%2\" to: %3 but that room\n"
                                      "does not exist.  The exit will be removed (but the destination room\n"
                                      "Id will be stored in the room user data under a key:\n"
                                      "\"%4\")\n"
@@ -1539,7 +1539,7 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
             // We cannot allow a stub exit at the same time as a real exit:
             if (exitStubs.contains(dirCode)) {
                 if (mudlet::self()->showMapAuditErrors()) {
-                    QString warnMsg = tr("[ ALERT ] - Room with id: %1 has an exit \"%2\" to: %3 but also\n"
+                    QString const warnMsg = tr("[ ALERT ] - Room with id: %1 has an exit \"%2\" to: %3 but also\n"
                                          "has a stub exit!  As a real exit precludes a stub, the latter will\n"
                                          "be removed.")
                                               .arg(id)
@@ -1601,7 +1601,7 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
         // either 0 or < -1 and not renumbered because the bad room Id DID NOT
         // exist, there could be a "double fault" in that there is also a stub
         // exit, but that will be masked as we turn the exit into a stub anyhow.
-        QString auditKey = qsl("audit.made_stub_of_invalid_exit.%1").arg(dirCode);
+        QString const auditKey = qsl("audit.made_stub_of_invalid_exit.%1").arg(dirCode);
         userData.insert(auditKey, QString::number(exitRoomId));
         QString infoMsg;
         if (mudlet::self()->showMapAuditErrors()) {
@@ -1629,7 +1629,7 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
         exitStubsPool.remove(dirCode); // Remove the stub in this direction from check pool as we have handled it
 
         if (exitLocks.contains(dirCode)) {
-            QString auditKeyLocked = qsl("audit.invalid_exit.%1.isLocked").arg(dirCode);
+            QString const auditKeyLocked = qsl("audit.invalid_exit.%1.isLocked").arg(dirCode);
             userData.insert(auditKeyLocked, qsl("true"));
             if (mudlet::self()->showMapAuditErrors()) {
                 infoMsg.append(
@@ -1642,7 +1642,7 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
         }
 
         if (exitWeights.contains(exitKey)) {
-            QString auditKeyWeight = qsl("audit.invalid_exit.%1.weight").arg(dirCode);
+            QString const auditKeyWeight = qsl("audit.invalid_exit.%1.weight").arg(dirCode);
             userData.insert(auditKeyWeight, QString::number(exitWeights.value(exitKey)));
             if (mudlet::self()->showMapAuditErrors()) {
                 infoMsg.append(
@@ -1661,7 +1661,7 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
 
         if (customLines.contains(exitKey)) {
             if (mudlet::self()->showMapAuditErrors()) {
-                QString warnMsg = tr("[ WARN ]  - There was a custom exit line associated with the invalid exit but\n"
+                QString const warnMsg = tr("[ WARN ]  - There was a custom exit line associated with the invalid exit but\n"
                                      "it has not been possible to salvage this, it has been lost!");
                 mpRoomDB->mpMap->postMessage(warnMsg);
             }
@@ -1693,7 +1693,7 @@ void TRoom::writeJsonRoom(QJsonArray& obj) const
     roomObj.insert(QLatin1String("id"), static_cast<double>(id));
 
     if (!name.isEmpty()) {
-        QJsonValue nameValue{name};
+        QJsonValue const nameValue{name};
         roomObj.insert(QLatin1String("name"), nameValue);
     }
 
@@ -1743,7 +1743,7 @@ int TRoom::readJsonRoom(const QJsonArray& array, const int index, const int area
     const QJsonObject roomObj{array.at(index).toObject()};
     // This is not needed to be stored into id as that is done when the room is
     // added to the TRoomDB via a TRoomDB::addRoom(...) call:
-    int roomId = roomObj.value(QLatin1String("id")).toInt();
+    int const roomId = roomObj.value(QLatin1String("id")).toInt();
     name = roomObj.value(QLatin1String("name")).toString();
     area = areaId;
     readJsonUserData(roomObj.value(QLatin1String("userData")).toObject());
@@ -1868,9 +1868,9 @@ bool TRoom::readJsonExits(const QJsonObject& obj)
 void TRoom::writeJsonNormalExit(QJsonArray& array, const int dir) const
 {
     QJsonObject exitObj;
-    QString directionString = dirCodeToString(dir);
-    int exitId = getExit(dir);
-    QString directionKey = dirCodeToShortString(dir);
+    QString const directionString = dirCodeToString(dir);
+    int const exitId = getExit(dir);
+    QString const directionKey = dirCodeToShortString(dir);
     // Skip any unreal exits:
     if (exitId < 1) {
         return;
@@ -1903,7 +1903,7 @@ void TRoom::writeJsonNormalExit(QJsonArray& array, const int dir) const
 
 bool TRoom::readJsonNormalExit(const QJsonObject& exitObj, const int dir)
 {
-    int exitRoomId = exitObj.value(QLatin1String("exitId")).toInt();
+    int const exitRoomId = exitObj.value(QLatin1String("exitId")).toInt();
     bool hasCustomExit = false;
     if (exitRoomId < 1) {
         qDebug().nospace().noquote() << "TRoom::readJsonNormalExit(...) INFO - when reading exits for room id: " << id << " the normal \"" << dirCodeToString(dir)
@@ -1978,7 +1978,7 @@ bool TRoom::readJsonNormalExit(const QJsonObject& exitObj, const int dir)
 void TRoom::writeJsonSpecialExit(QJsonArray& array, const QString& dir, const int exitId) const
 {
     QJsonObject exitObj;
-    bool exitLocked = mSpecialExitLocks.contains(dir);
+    bool const exitLocked = mSpecialExitLocks.contains(dir);
 
     // Safety step to avoid insertion of any unreal exits:
     if (exitId < 1 || dir.isEmpty()) {
@@ -2011,7 +2011,7 @@ void TRoom::writeJsonSpecialExit(QJsonArray& array, const QString& dir, const in
 
 bool TRoom::readJsonSpecialExit(const QJsonObject& exitObj, const QString& dir)
 {
-    int exitRoomId = exitObj.value(QLatin1String("exitId")).toInt();
+    int const exitRoomId = exitObj.value(QLatin1String("exitId")).toInt();
     bool hasCustomExit = false;
     if (exitRoomId < 1) {
         qDebug().nospace().noquote() << "TRoom::readJsonSpecialExit(...) INFO - when reading exits for room id: " << id << " the special \"" << dir
@@ -2143,16 +2143,16 @@ void TRoom::readJsonCustomExitLine(const QJsonObject& exitObj, const QString& di
         return;
     }
 
-    QJsonArray customLinePointsArray = customLineObj.value(QLatin1String("coordinates")).toArray();
+    QJsonArray const customLinePointsArray = customLineObj.value(QLatin1String("coordinates")).toArray();
     if (customLinePointsArray.isEmpty()) {
         return;
     }
 
     QList<QPointF> points;
     for (int i = 0, total = customLinePointsArray.count(); i < total; ++i) {
-        QJsonArray customLinePointCoordinateArray = customLinePointsArray.at(i).toArray();
+        QJsonArray const customLinePointCoordinateArray = customLinePointsArray.at(i).toArray();
         if (customLinePointCoordinateArray.size() == 2 && customLinePointCoordinateArray.at(0).isDouble() && customLinePointCoordinateArray.at(1).isDouble()) {
-            QPointF point{customLinePointCoordinateArray.at(0).toDouble(), customLinePointCoordinateArray.at(1).toDouble()};
+            QPointF const point{customLinePointCoordinateArray.at(0).toDouble(), customLinePointCoordinateArray.at(1).toDouble()};
 
             // We might wish to consider if there is a z in the future to
             // accommodate 3D custom lines...!
@@ -2170,7 +2170,7 @@ void TRoom::readJsonCustomExitLine(const QJsonObject& exitObj, const QString& di
     }
 
     if (customLineObj.contains(QLatin1String("style")) && customLineObj.value(QLatin1String("style")).isString()) {
-        QString lineStyle{customLineObj.value(QLatin1String("style")).toString()};
+        QString const lineStyle{customLineObj.value(QLatin1String("style")).toString()};
         if (lineStyle == QLatin1String("dash line")) {
             customLinesStyle.insert(directionString, Qt::DashLine);
         } else if (lineStyle == QLatin1String("dash dot dot line")) {
@@ -2266,7 +2266,7 @@ void TRoom::readJsonExitStubs(const QJsonObject& obj)
     for (const auto exitStubValue : exitStubsArray) {
         const QJsonObject exitStubObj{exitStubValue.toObject()};
         const QString direction{exitStubObj.value(QLatin1String("name")).toString()};
-        int dir = stringToDirCode(direction);
+        int const dir = stringToDirCode(direction);
         QString doorKey;
         if (dir != DIR_OTHER) {
             doorKey = dirCodeToShortString(dir);
@@ -2290,7 +2290,7 @@ void TRoom::readJsonExitStubs(const QJsonObject& obj)
 // does get used then no change to the format is needed:
 void TRoom::writeJsonHighlight(QJsonObject& obj) const
 {
-    bool noColor = (highlightColor == scDefaultHighlightForeground) && (highlightColor2 == scDefaultHighlightBackground);
+    bool const noColor = (highlightColor == scDefaultHighlightForeground) && (highlightColor2 == scDefaultHighlightBackground);
     if (!highlight && qFuzzyCompare(1.0f + highlightRadius, 1.0f) && noColor) {
         // The default case so no need to include it:
         return;
@@ -2314,7 +2314,7 @@ void TRoom::writeJsonHighlight(QJsonObject& obj) const
     }
 
     highlightObj.insert(QLatin1String("radius"), static_cast<double>(highlightRadius));
-    QJsonValue highlightValue{highlightObj};
+    QJsonValue const highlightValue{highlightObj};
     obj.insert(QLatin1String("highlight"), highlightValue);
 }
 
@@ -2358,7 +2358,7 @@ void TRoom::readJsonSymbol(const QJsonObject& roomObj)
         mSymbol = symbolObj.value(QLatin1String("text")).toString();
     }
 
-    QColor color = TMap::readJsonColor(symbolObj);
+    QColor const color = TMap::readJsonColor(symbolObj);
     if (color.isValid()) {
         mSymbolColor = color;
     }

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -1136,7 +1136,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
         while (it.hasNext()) {
             it.next();
             const QString exitName = it.key();
-            int const exitRoomId = it.value();
+            const int exitRoomId = it.value();
             if (exitName.isEmpty()) {
                 if (mudlet::self()->showMapAuditErrors()) {
                     const QString warnMsg = tr("[ WARN ]  - In room id:%1 removing invalid (special) exit to %2 {with no name!}").arg(id, 6, QLatin1Char('0')).arg(exitRoomId, 6, QLatin1Char('0'));
@@ -1178,7 +1178,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
         QMutableMapIterator<QString, int> it(mSpecialExits);
         while (it.hasNext()) {
             it.next();
-            int const exitRoomId = it.value();
+            const int exitRoomId = it.value();
             const QString exitName = it.key();
 
             if (exitRoomId > 0) {
@@ -1342,7 +1342,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
         QStringList extras;
         QSetIterator<int> itSpareExitLock(exitLocksCopy);
         while (itSpareExitLock.hasNext()) {
-            int const dirCode = itSpareExitLock.next();
+            const int dirCode = itSpareExitLock.next();
             extras.append(dirCodeToDisplayName(dirCode));
             exitLocks.removeAll(dirCode);
         }
@@ -1743,7 +1743,7 @@ int TRoom::readJsonRoom(const QJsonArray& array, const int index, const int area
     const QJsonObject roomObj{array.at(index).toObject()};
     // This is not needed to be stored into id as that is done when the room is
     // added to the TRoomDB via a TRoomDB::addRoom(...) call:
-    int const roomId = roomObj.value(QLatin1String("id")).toInt();
+    const int roomId = roomObj.value(QLatin1String("id")).toInt();
     name = roomObj.value(QLatin1String("name")).toString();
     area = areaId;
     readJsonUserData(roomObj.value(QLatin1String("userData")).toObject());
@@ -1869,7 +1869,7 @@ void TRoom::writeJsonNormalExit(QJsonArray& array, const int dir) const
 {
     QJsonObject exitObj;
     const QString directionString = dirCodeToString(dir);
-    int const exitId = getExit(dir);
+    const int exitId = getExit(dir);
     const QString directionKey = dirCodeToShortString(dir);
     // Skip any unreal exits:
     if (exitId < 1) {
@@ -1903,7 +1903,7 @@ void TRoom::writeJsonNormalExit(QJsonArray& array, const int dir) const
 
 bool TRoom::readJsonNormalExit(const QJsonObject& exitObj, const int dir)
 {
-    int const exitRoomId = exitObj.value(QLatin1String("exitId")).toInt();
+    const int exitRoomId = exitObj.value(QLatin1String("exitId")).toInt();
     bool hasCustomExit = false;
     if (exitRoomId < 1) {
         qDebug().nospace().noquote() << "TRoom::readJsonNormalExit(...) INFO - when reading exits for room id: " << id << " the normal \"" << dirCodeToString(dir)
@@ -2011,7 +2011,7 @@ void TRoom::writeJsonSpecialExit(QJsonArray& array, const QString& dir, const in
 
 bool TRoom::readJsonSpecialExit(const QJsonObject& exitObj, const QString& dir)
 {
-    int const exitRoomId = exitObj.value(QLatin1String("exitId")).toInt();
+    const int exitRoomId = exitObj.value(QLatin1String("exitId")).toInt();
     bool hasCustomExit = false;
     if (exitRoomId < 1) {
         qDebug().nospace().noquote() << "TRoom::readJsonSpecialExit(...) INFO - when reading exits for room id: " << id << " the special \"" << dir
@@ -2266,7 +2266,7 @@ void TRoom::readJsonExitStubs(const QJsonObject& obj)
     for (const auto exitStubValue : exitStubsArray) {
         const QJsonObject exitStubObj{exitStubValue.toObject()};
         const QString direction{exitStubObj.value(QLatin1String("name")).toString()};
-        int const dir = stringToDirCode(direction);
+        const int dir = stringToDirCode(direction);
         QString doorKey;
         if (dir != DIR_OTHER) {
             doorKey = dirCodeToShortString(dir);

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -1978,7 +1978,7 @@ bool TRoom::readJsonNormalExit(const QJsonObject& exitObj, const int dir)
 void TRoom::writeJsonSpecialExit(QJsonArray& array, const QString& dir, const int exitId) const
 {
     QJsonObject exitObj;
-    bool const exitLocked = mSpecialExitLocks.contains(dir);
+    const bool exitLocked = mSpecialExitLocks.contains(dir);
 
     // Safety step to avoid insertion of any unreal exits:
     if (exitId < 1 || dir.isEmpty()) {
@@ -2290,7 +2290,7 @@ void TRoom::readJsonExitStubs(const QJsonObject& obj)
 // does get used then no change to the format is needed:
 void TRoom::writeJsonHighlight(QJsonObject& obj) const
 {
-    bool const noColor = (highlightColor == scDefaultHighlightForeground) && (highlightColor2 == scDefaultHighlightBackground);
+    const bool noColor = (highlightColor == scDefaultHighlightForeground) && (highlightColor2 == scDefaultHighlightBackground);
     if (!highlight && qFuzzyCompare(1.0f + highlightRadius, 1.0f) && noColor) {
         // The default case so no need to include it:
         return;

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -260,7 +260,7 @@ bool TRoomDB::__removeRoom(int id)
         }
         rooms.remove(id);
         if (roomIDToHash.contains(id)) {
-            QString const hash = roomIDToHash[id];
+            const QString hash = roomIDToHash[id];
             roomIDToHash.remove(id);
             hashToRoomID.remove(hash);
         }
@@ -625,7 +625,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             TRoom* pR = itRoom.value();
             if (!pR) {
                 if (mudlet::self()->showMapAuditErrors()) {
-                    QString const warnMsg = tr("[ WARN ]  - Problem with data structure associated with room id: %1 - that\n"
+                    const QString warnMsg = tr("[ WARN ]  - Problem with data structure associated with room id: %1 - that\n"
                                          "room's data has been lost so the id is now being deleted.  This\n"
                                          "suggests serious problems with the currently running version of\n"
                                          "Mudlet - is your system running out of memory?")
@@ -682,7 +682,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
 
         if (!areas.contains(usedAreaId)) {
             if (mudlet::self()->showMapAuditErrors()) {
-                QString const warnMsg = tr("[ ALERT ] - Area with id: %1 expected but not found, will be created.").arg(usedAreaId);
+                const QString warnMsg = tr("[ ALERT ] - Area with id: %1 expected but not found, will be created.").arg(usedAreaId);
                 mpMap->postMessage(warnMsg);
             }
             mpMap->appendAreaErrorMsg(usedAreaId, tr("[ ALERT ] - Area with this id expected but not found, will be created."), true);
@@ -714,7 +714,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
     // bit of the task being addressed here is fixing
     if (!missingAreasNeeded.isEmpty()) {
         if (mudlet::self()->showMapAuditErrors()) {
-            QString const alertMsg = tr("[ ALERT ] - %n area(s) detected as missing in map: adding it/them in.\n"
+            const QString alertMsg = tr("[ ALERT ] - %n area(s) detected as missing in map: adding it/them in.\n"
                                   "Look for further messages related to the rooms that are supposed\n"
                                   "to be in this/these area(s)...",
                                   "Making use of %n to allow quantity dependent message form 8-) !",
@@ -765,7 +765,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
     // Now process problem areaIds
     if (!areaRemapping.isEmpty()) {
         if (mudlet::self()->showMapAuditErrors()) {
-            QString const alertMsg = tr("[ ALERT ] - Bad, (less than +1 and not the reserved -1) area ids found (count: %1)\n"
+            const QString alertMsg = tr("[ ALERT ] - Bad, (less than +1 and not the reserved -1) area ids found (count: %1)\n"
                                   "in map, now working out what new id numbers to use...")
                                        .arg(areaRemapping.count());
             mpMap->postMessage(alertMsg);
@@ -805,7 +805,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                 pA = new TArea(mpMap, this);
             }
             if (areaNamesMap.contains(faultyAreaId)) {
-                QString const areaName = areaNamesMap.value(faultyAreaId);
+                const QString areaName = areaNamesMap.value(faultyAreaId);
                 areaNamesMap.remove(faultyAreaId);
                 areaNamesMap.insert(replacementAreaId, areaName);
             } else {
@@ -833,7 +833,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
         }
     } else {
         if (mudlet::self()->showMapAuditErrors()) {
-            QString const infoMsg = tr("[ INFO ]  - Area id numbering is satisfactory.");
+            const QString infoMsg = tr("[ INFO ]  - Area id numbering is satisfactory.");
             mpMap->postMessage(infoMsg);
         }
         mpMap->appendErrorMsg(tr("[ INFO ]  - Area id numbering is satisfactory."), false);
@@ -844,7 +844,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
     // Now complete TASK 1 - find the new room Ids to use
     if (!roomRemapping.isEmpty()) {
         if (mudlet::self()->showMapAuditErrors()) {
-            QString const alertMsg = tr("[ ALERT ] - Bad, (less than +1) room ids found (count: %1) in map, now working\n"
+            const QString alertMsg = tr("[ ALERT ] - Bad, (less than +1) room ids found (count: %1) in map, now working\n"
                                   "out what new id numbers to use.")
                                        .arg(roomRemapping.count());
             mpMap->postMessage(alertMsg);
@@ -909,7 +909,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
         }
     } else {
         if (mudlet::self()->showMapAuditErrors()) {
-            QString const infoMsg = tr("[ INFO ]  - Room id numbering is satisfactory.");
+            const QString infoMsg = tr("[ INFO ]  - Room id numbering is satisfactory.");
             mpMap->postMessage(infoMsg);
         }
         mpMap->appendErrorMsg(tr("[ INFO ]  - Room id numbering is satisfactory."), false);
@@ -932,7 +932,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             QSet<int> _set{pR->exitStubs.begin(), pR->exitStubs.end()};
             if (_set.count() < _listCount) {
                 if (mudlet::self()->showMapAuditErrors()) {
-                    QString const infoMsg = tr("[ INFO ]  - Duplicate exit stub identifiers found in room id: %1, this is an\n"
+                    const QString infoMsg = tr("[ INFO ]  - Duplicate exit stub identifiers found in room id: %1, this is an\n"
                                          "anomaly but has been cleaned up easily.")
                                               .arg(itRoom.key());
                     mpMap->postMessage(infoMsg);
@@ -946,7 +946,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             _set = QSet<int>{pR->exitLocks.begin(), pR->exitLocks.end()};
             if (_set.count() < _listCount) {
                 if (mudlet::self()->showMapAuditErrors()) {
-                    QString const infoMsg = tr("[ INFO ]  - Duplicate exit lock identifiers found in room id: %1, this is an\n"
+                    const QString infoMsg = tr("[ INFO ]  - Duplicate exit lock identifiers found in room id: %1, this is an\n"
                                          "anomaly but has been cleaned up easily.")
                                               .arg(itRoom.key());
                     mpMap->postMessage(infoMsg);
@@ -1030,7 +1030,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                                               true);
                 }
                 if (mudlet::self()->showMapAuditErrors()) {
-                    QString const infoMsg = tr("[ INFO ]  - In area with id: %1 there were %2 rooms missing from those it\n"
+                    const QString infoMsg = tr("[ INFO ]  - In area with id: %1 there were %2 rooms missing from those it\n"
                                          "should be recording as possessing, they were:\n%3\nthey have been added.")
                                               .arg(itArea.key())
                                               .arg(missingRooms.count())
@@ -1065,7 +1065,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                                               true);
                 }
                 if (mudlet::self()->showMapAuditErrors()) {
-                    QString const infoMsg = tr("[ INFO ]  - In area with id: %1 there were %2 extra rooms compared to those it\n"
+                    const QString infoMsg = tr("[ INFO ]  - In area with id: %1 there were %2 extra rooms compared to those it\n"
                                          "should be recording as possessing, they were:\n%3\nthey have been removed.")
                                               .arg(itArea.key())
                                               .arg(extraRooms.count())
@@ -1183,7 +1183,7 @@ void TRoomDB::restoreAreaMap(QDataStream& ifs)
             // Seems to look better if we iterate through backwards!
             while (itRemappedNames.hasPrevious()) {
                 itRemappedNames.previous();
-                QString const oldName = itRemappedNames.key().isEmpty() ? tr("<nothing>") : itRemappedNames.key();
+                const QString oldName = itRemappedNames.key().isEmpty() ? tr("<nothing>") : itRemappedNames.key();
                 detailText.append(qsl("(%1) \"%2\" ==> \"%3\"\n").arg(areaNamesMap.key(itRemappedNames.value())).arg(oldName, itRemappedNames.value()));
                 mpMap->appendAreaErrorMsg(areaNamesMap.key(itRemappedNames.value()),
                                           tr(R"([ INFO ]  - Area name changed to prevent duplicates or unnamed ones; old name: "%1", new name: "%2".)").arg(oldName, itRemappedNames.value()),
@@ -1247,7 +1247,7 @@ void TRoomDB::restoreAreaMap(QDataStream& ifs)
 
     if (!areaNamesMap.contains(-1)) {
         areaNamesMap.insert(-1, mpMap->getDefaultAreaName());
-        QString const defaultAreaNameInsertionMsg = tr("[ INFO ]  - Default (reset) area name (for rooms that have not been assigned to an\n"
+        const QString defaultAreaNameInsertionMsg = tr("[ INFO ]  - Default (reset) area name (for rooms that have not been assigned to an\n"
                                                  "area) not found, adding \"%1\" against the reserved -1 id.")
                                                       .arg(mpMap->getDefaultAreaName());
         mpMap->mpHost->postMessage(defaultAreaNameInsertionMsg);

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -115,7 +115,7 @@ void TRoomDB::deleteValuesFromEntranceMap(QSet<int>& valueSet)
             index = valueList.indexOf(roomId, index + 1);
         }
     }
-    for (unsigned int const entry : deleteEntries) {
+    for (unsigned const int entry : deleteEntries) {
         entranceMap.remove(keyList.at(entry), valueList.at(entry));
     }
     qDebug() << "TRoomDB::deleteValuesFromEntranceMap() with a list of:" << valueSet.size() << "items, run time:" << timer.nsecsElapsed() * 1.0e-9 << "sec.";
@@ -137,7 +137,7 @@ void TRoomDB::updateEntranceMap(TRoom* pR, bool isMapLoading)
     // So we create a mapping like: {room_a: room_b, room_a: room_c}. This allows us to delete
     // rooms and know which other rooms are impacted by this change in a single lookup.
     if (pR) {
-        int const id = pR->getId();
+        const int id = pR->getId();
         QHash<int, int> const exits = pR->getExits();
         QList<int> const toExits = exits.keys();
         QString values;
@@ -152,7 +152,7 @@ void TRoomDB::updateEntranceMap(TRoom* pR, bool isMapLoading)
         if (!isMapLoading) {
             deleteValuesFromEntranceMap(id); // When LOADING a map, will never need to do this
         }
-        for (int const toExit : toExits) {
+        for (const int toExit : toExits) {
             if (showDebug) {
                 values.append(qsl("%1,").arg(toExit));
             }
@@ -264,7 +264,7 @@ bool TRoomDB::__removeRoom(int id)
             roomIDToHash.remove(id);
             hashToRoomID.remove(hash);
         }
-        int const areaID = pR->getArea();
+        const int areaID = pR->getArea();
         TArea* pA = getArea(areaID);
         if (pA) {
             pA->removeRoom(id);
@@ -317,7 +317,7 @@ void TRoomDB::removeRoom(QSet<int>& ids)
                                   // for each room that is removed
     quint64 const roomcount = mpTempRoomDeletionSet->size();
     while (!mpTempRoomDeletionSet->isEmpty()) {
-        int const deleteRoomId = *(mpTempRoomDeletionSet->constBegin());
+        const int deleteRoomId = *(mpTempRoomDeletionSet->constBegin());
         TRoom* pR = getRoom(deleteRoomId);
         if (pR) {
             deletedRoomIds.insert(deleteRoomId);
@@ -376,7 +376,7 @@ void TRoomDB::removeArea(TArea* pA)
         return;
     }
 
-    int const areaId = areas.key(pA, 0);
+    const int areaId = areas.key(pA, 0);
     if (areaId == areas.key(pA, -1)) {
         // By testing twice with different default keys to return if value NOT
         // found, we can be certain we have an actual valid value
@@ -398,7 +398,7 @@ void TRoomDB::buildAreas()
     QHashIterator<int, TRoom*> it(rooms);
     while (it.hasNext()) {
         it.next();
-        int const id = it.key();
+        const int id = it.key();
         TRoom* pR = getRoom(id);
         if (!pR) {
             continue;
@@ -413,7 +413,7 @@ void TRoomDB::buildAreas()
     QMapIterator<int, QString> it2(areaNamesMap);
     while (it2.hasNext()) {
         it2.next();
-        int const id = it2.key();
+        const int id = it2.key();
         if (!areas.contains(id)) {
             areas[id] = new TArea(mpMap, this);
         }
@@ -531,7 +531,7 @@ int TRoomDB::addArea(QString name)
         return 0;
     }
 
-    int const areaID = createNewAreaID();
+    const int areaID = createNewAreaID();
     if (addArea(areaID)) {
         areaNamesMap[areaID] = name;
         // This will overwrite the "Unnamed Area_###" that addArea( areaID )
@@ -649,7 +649,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                 // set of good ones already used
             }
 
-            int const areaId = pR->getArea();
+            const int areaId = pR->getArea();
             areaRoomMultiHash.insert(areaId, itRoom.key());
             roomAreaHash.insert(itRoom.key(), areaId);
         }
@@ -673,7 +673,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
     // (and thus valid) but absent:
     QList<int> missingAreasNeeded;
     while (itUsedArea.hasNext()) {
-        int const usedAreaId = itUsedArea.next();
+        const int usedAreaId = itUsedArea.next();
         if (usedAreaId < -1 || !usedAreaId) {
             areaRemapping.insert(usedAreaId, usedAreaId); // Will find new value to use later
         } else {
@@ -695,7 +695,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
     QMapIterator<int, TArea*> itArea(areas);
     while (itArea.hasNext()) {
         itArea.next();
-        int const areaId = itArea.key();
+        const int areaId = itArea.key();
         if (areaId < -1 || !areaId) {
             areaRemapping.insert(areaId, areaId); // Will find new value to use later
         } else {
@@ -742,7 +742,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             std::sort(missingAreasNeeded.begin(), missingAreasNeeded.end());
         }
 
-        for (int const newAreaId : missingAreasNeeded) {
+        for (const int newAreaId : missingAreasNeeded) {
             // This will create a new "Default" area name if there is not one
             // already for this id - and we do not anticipate that it could ever
             // fail and return false...
@@ -784,7 +784,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
         QMutableHashIterator<int, int> itRemappedArea(areaRemapping);
         while (itRemappedArea.hasNext()) {
             itRemappedArea.next();
-            int const faultyAreaId = itRemappedArea.key();
+            const int faultyAreaId = itRemappedArea.key();
             int replacementAreaId = 0;
             do {
                 ; // No-op, increment done in test
@@ -904,7 +904,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
         QSetIterator<TRoom*> itModifiedRoom(holdingSet);
         while (itModifiedRoom.hasNext()) {
             TRoom* pR = itModifiedRoom.next();
-            int const newRoomId = pR->getId();
+            const int newRoomId = pR->getId();
             rooms.insert(newRoomId, pR);
         }
     } else {
@@ -972,7 +972,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                 QMutableSetIterator<int> itAreaRoom(pA->rooms);
                 if (!roomRemapping.isEmpty()) {
                     while (itAreaRoom.hasNext()) {
-                        int const originalRoomId = itAreaRoom.next();
+                        const int originalRoomId = itAreaRoom.next();
                         if (roomRemapping.contains(originalRoomId)) {
                             itAreaRoom.remove();
                             replacementRoomsSet.insert(roomRemapping.value(originalRoomId));
@@ -1021,7 +1021,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                 }
                 QListIterator<int> itMissingRoom(missingRoomsList);
                 while (itMissingRoom.hasNext()) {
-                    int const missingRoomId = itMissingRoom.next();
+                    const int missingRoomId = itMissingRoom.next();
                     roomList.append(QString::number(missingRoomId));
                     mpMap->appendRoomErrorMsg(missingRoomId,
                                               tr("[ INFO ]  - This room claims to be in area id: %1, but that did not have a record of it."
@@ -1056,7 +1056,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                 }
                 QListIterator<int> itExtraRoom(extraRoomsList);
                 while (itExtraRoom.hasNext()) {
-                    int const extraRoomId = itExtraRoom.next();
+                    const int extraRoomId = itExtraRoom.next();
                     roomList.append(QString::number(extraRoomId));
                     mpMap->appendRoomErrorMsg(extraRoomId,
                                               tr("[ INFO ]  - This room was claimed by area id: %1, but it does not belong there."

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -129,7 +129,7 @@ void TRoomDB::updateEntranceMap(int id)
 
 void TRoomDB::updateEntranceMap(TRoom* pR, bool isMapLoading)
 {
-    static bool const showDebug = false; // Enable this at runtime (set a breakpoint on it) for debugging!
+    static const bool showDebug = false; // Enable this at runtime (set a breakpoint on it) for debugging!
 
     // entranceMap maps the room to rooms it has a viable exit to. So if room b and c both have
     // an exit to room a, upon deleting room a we want a map that allows us to find

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -88,8 +88,8 @@ bool TRoomDB::addRoom(int id, TRoom* pR, bool isMapLoading)
 
 void TRoomDB::deleteValuesFromEntranceMap(int value)
 {
-    QList<int> keyList = entranceMap.keys();
-    QList<int> valueList = entranceMap.values();
+    QList<int> const keyList = entranceMap.keys();
+    QList<int> const valueList = entranceMap.values();
     QList<uint> deleteEntries;
     int index = valueList.indexOf(value);
     while (index != -1) {
@@ -105,8 +105,8 @@ void TRoomDB::deleteValuesFromEntranceMap(QSet<int>& valueSet)
 {
     QElapsedTimer timer;
     timer.start();
-    QList<int> keyList = entranceMap.keys();
-    QList<int> valueList = entranceMap.values();
+    QList<int> const keyList = entranceMap.keys();
+    QList<int> const valueList = entranceMap.values();
     QList<uint> deleteEntries;
     for (auto roomId : valueSet) {
         int index = valueList.indexOf(roomId);
@@ -115,7 +115,7 @@ void TRoomDB::deleteValuesFromEntranceMap(QSet<int>& valueSet)
             index = valueList.indexOf(roomId, index + 1);
         }
     }
-    for (unsigned int entry : deleteEntries) {
+    for (unsigned int const entry : deleteEntries) {
         entranceMap.remove(keyList.at(entry), valueList.at(entry));
     }
     qDebug() << "TRoomDB::deleteValuesFromEntranceMap() with a list of:" << valueSet.size() << "items, run time:" << timer.nsecsElapsed() * 1.0e-9 << "sec.";
@@ -129,7 +129,7 @@ void TRoomDB::updateEntranceMap(int id)
 
 void TRoomDB::updateEntranceMap(TRoom* pR, bool isMapLoading)
 {
-    static bool showDebug = false; // Enable this at runtime (set a breakpoint on it) for debugging!
+    static bool const showDebug = false; // Enable this at runtime (set a breakpoint on it) for debugging!
 
     // entranceMap maps the room to rooms it has a viable exit to. So if room b and c both have
     // an exit to room a, upon deleting room a we want a map that allows us to find
@@ -137,9 +137,9 @@ void TRoomDB::updateEntranceMap(TRoom* pR, bool isMapLoading)
     // So we create a mapping like: {room_a: room_b, room_a: room_c}. This allows us to delete
     // rooms and know which other rooms are impacted by this change in a single lookup.
     if (pR) {
-        int id = pR->getId();
-        QHash<int, int> exits = pR->getExits();
-        QList<int> toExits = exits.keys();
+        int const id = pR->getId();
+        QHash<int, int> const exits = pR->getExits();
+        QList<int> const toExits = exits.keys();
         QString values;
         // to update this we need to iterate the entire entranceMap and remove invalid
         // connections. I'm not sure if this is efficient for every update, and given
@@ -152,7 +152,7 @@ void TRoomDB::updateEntranceMap(TRoom* pR, bool isMapLoading)
         if (!isMapLoading) {
             deleteValuesFromEntranceMap(id); // When LOADING a map, will never need to do this
         }
-        for (int toExit : toExits) {
+        for (int const toExit : toExits) {
             if (showDebug) {
                 values.append(qsl("%1,").arg(toExit));
             }
@@ -260,11 +260,11 @@ bool TRoomDB::__removeRoom(int id)
         }
         rooms.remove(id);
         if (roomIDToHash.contains(id)) {
-            QString hash = roomIDToHash[id];
+            QString const hash = roomIDToHash[id];
             roomIDToHash.remove(id);
             hashToRoomID.remove(hash);
         }
-        int areaID = pR->getArea();
+        int const areaID = pR->getArea();
         TArea* pA = getArea(areaID);
         if (pA) {
             pA->removeRoom(id);
@@ -288,7 +288,7 @@ bool TRoomDB::removeRoom(int id)
         if (mpMap->mRoomIdHash.value(mpMap->mProfileName) == id) {
             // Now we store mRoomId for each profile, we must remove any where
             // this room was used
-            QList<QString> profilesWithUserInThisRoom = mpMap->mRoomIdHash.keys(id);
+            QList<QString> const profilesWithUserInThisRoom = mpMap->mRoomIdHash.keys(id);
             for (auto key : profilesWithUserInThisRoom) {
                 mpMap->mRoomIdHash[key] = 0;
             }
@@ -315,9 +315,9 @@ void TRoomDB::removeRoom(QSet<int>& ids)
                                   // type argument IS NOT CONSTANT - it is
                                   // ALTERED by TArea::removeRoom( int room )
                                   // for each room that is removed
-    quint64 roomcount = mpTempRoomDeletionSet->size();
+    quint64 const roomcount = mpTempRoomDeletionSet->size();
     while (!mpTempRoomDeletionSet->isEmpty()) {
-        int deleteRoomId = *(mpTempRoomDeletionSet->constBegin());
+        int const deleteRoomId = *(mpTempRoomDeletionSet->constBegin());
         TRoom* pR = getRoom(deleteRoomId);
         if (pR) {
             deletedRoomIds.insert(deleteRoomId);
@@ -376,7 +376,7 @@ void TRoomDB::removeArea(TArea* pA)
         return;
     }
 
-    int areaId = areas.key(pA, 0);
+    int const areaId = areas.key(pA, 0);
     if (areaId == areas.key(pA, -1)) {
         // By testing twice with different default keys to return if value NOT
         // found, we can be certain we have an actual valid value
@@ -398,7 +398,7 @@ void TRoomDB::buildAreas()
     QHashIterator<int, TRoom*> it(rooms);
     while (it.hasNext()) {
         it.next();
-        int id = it.key();
+        int const id = it.key();
         TRoom* pR = getRoom(id);
         if (!pR) {
             continue;
@@ -413,7 +413,7 @@ void TRoomDB::buildAreas()
     QMapIterator<int, QString> it2(areaNamesMap);
     while (it2.hasNext()) {
         it2.next();
-        int id = it2.key();
+        int const id = it2.key();
         if (!areas.contains(id)) {
             areas[id] = new TArea(mpMap, this);
         }
@@ -531,7 +531,7 @@ int TRoomDB::addArea(QString name)
         return 0;
     }
 
-    int areaID = createNewAreaID();
+    int const areaID = createNewAreaID();
     if (addArea(areaID)) {
         areaNamesMap[areaID] = name;
         // This will overwrite the "Unnamed Area_###" that addArea( areaID )
@@ -625,7 +625,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             TRoom* pR = itRoom.value();
             if (!pR) {
                 if (mudlet::self()->showMapAuditErrors()) {
-                    QString warnMsg = tr("[ WARN ]  - Problem with data structure associated with room id: %1 - that\n"
+                    QString const warnMsg = tr("[ WARN ]  - Problem with data structure associated with room id: %1 - that\n"
                                          "room's data has been lost so the id is now being deleted.  This\n"
                                          "suggests serious problems with the currently running version of\n"
                                          "Mudlet - is your system running out of memory?")
@@ -649,7 +649,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                 // set of good ones already used
             }
 
-            int areaId = pR->getArea();
+            int const areaId = pR->getArea();
             areaRoomMultiHash.insert(areaId, itRoom.key());
             roomAreaHash.insert(itRoom.key(), areaId);
         }
@@ -663,7 +663,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
     // Throw in the area Ids from the areaNamesMap:
     if (!areaNamesMap.isEmpty()) {
         QList<int> areaIdsFromAreaNamesList{areaNamesMap.keys()};
-        QSet<int> areaIdsFromAreaNamesSet{areaIdsFromAreaNamesList.begin(), areaIdsFromAreaNamesList.end()};
+        QSet<int> const areaIdsFromAreaNamesSet{areaIdsFromAreaNamesList.begin(), areaIdsFromAreaNamesList.end()};
         areaIdSet.unite(areaIdsFromAreaNamesSet);
     }
 
@@ -673,7 +673,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
     // (and thus valid) but absent:
     QList<int> missingAreasNeeded;
     while (itUsedArea.hasNext()) {
-        int usedAreaId = itUsedArea.next();
+        int const usedAreaId = itUsedArea.next();
         if (usedAreaId < -1 || !usedAreaId) {
             areaRemapping.insert(usedAreaId, usedAreaId); // Will find new value to use later
         } else {
@@ -682,7 +682,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
 
         if (!areas.contains(usedAreaId)) {
             if (mudlet::self()->showMapAuditErrors()) {
-                QString warnMsg = tr("[ ALERT ] - Area with id: %1 expected but not found, will be created.").arg(usedAreaId);
+                QString const warnMsg = tr("[ ALERT ] - Area with id: %1 expected but not found, will be created.").arg(usedAreaId);
                 mpMap->postMessage(warnMsg);
             }
             mpMap->appendAreaErrorMsg(usedAreaId, tr("[ ALERT ] - Area with this id expected but not found, will be created."), true);
@@ -695,7 +695,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
     QMapIterator<int, TArea*> itArea(areas);
     while (itArea.hasNext()) {
         itArea.next();
-        int areaId = itArea.key();
+        int const areaId = itArea.key();
         if (areaId < -1 || !areaId) {
             areaRemapping.insert(areaId, areaId); // Will find new value to use later
         } else {
@@ -714,7 +714,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
     // bit of the task being addressed here is fixing
     if (!missingAreasNeeded.isEmpty()) {
         if (mudlet::self()->showMapAuditErrors()) {
-            QString alertMsg = tr("[ ALERT ] - %n area(s) detected as missing in map: adding it/them in.\n"
+            QString const alertMsg = tr("[ ALERT ] - %n area(s) detected as missing in map: adding it/them in.\n"
                                   "Look for further messages related to the rooms that are supposed\n"
                                   "to be in this/these area(s)...",
                                   "Making use of %n to allow quantity dependent message form 8-) !",
@@ -742,7 +742,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             std::sort(missingAreasNeeded.begin(), missingAreasNeeded.end());
         }
 
-        for (int newAreaId : missingAreasNeeded) {
+        for (int const newAreaId : missingAreasNeeded) {
             // This will create a new "Default" area name if there is not one
             // already for this id - and we do not anticipate that it could ever
             // fail and return false...
@@ -765,7 +765,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
     // Now process problem areaIds
     if (!areaRemapping.isEmpty()) {
         if (mudlet::self()->showMapAuditErrors()) {
-            QString alertMsg = tr("[ ALERT ] - Bad, (less than +1 and not the reserved -1) area ids found (count: %1)\n"
+            QString const alertMsg = tr("[ ALERT ] - Bad, (less than +1 and not the reserved -1) area ids found (count: %1)\n"
                                   "in map, now working out what new id numbers to use...")
                                        .arg(areaRemapping.count());
             mpMap->postMessage(alertMsg);
@@ -784,7 +784,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
         QMutableHashIterator<int, int> itRemappedArea(areaRemapping);
         while (itRemappedArea.hasNext()) {
             itRemappedArea.next();
-            int faultyAreaId = itRemappedArea.key();
+            int const faultyAreaId = itRemappedArea.key();
             int replacementAreaId = 0;
             do {
                 ; // No-op, increment done in test
@@ -805,7 +805,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                 pA = new TArea(mpMap, this);
             }
             if (areaNamesMap.contains(faultyAreaId)) {
-                QString areaName = areaNamesMap.value(faultyAreaId);
+                QString const areaName = areaNamesMap.value(faultyAreaId);
                 areaNamesMap.remove(faultyAreaId);
                 areaNamesMap.insert(replacementAreaId, areaName);
             } else {
@@ -833,7 +833,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
         }
     } else {
         if (mudlet::self()->showMapAuditErrors()) {
-            QString infoMsg = tr("[ INFO ]  - Area id numbering is satisfactory.");
+            QString const infoMsg = tr("[ INFO ]  - Area id numbering is satisfactory.");
             mpMap->postMessage(infoMsg);
         }
         mpMap->appendErrorMsg(tr("[ INFO ]  - Area id numbering is satisfactory."), false);
@@ -844,7 +844,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
     // Now complete TASK 1 - find the new room Ids to use
     if (!roomRemapping.isEmpty()) {
         if (mudlet::self()->showMapAuditErrors()) {
-            QString alertMsg = tr("[ ALERT ] - Bad, (less than +1) room ids found (count: %1) in map, now working\n"
+            QString const alertMsg = tr("[ ALERT ] - Bad, (less than +1) room ids found (count: %1) in map, now working\n"
                                   "out what new id numbers to use.")
                                        .arg(roomRemapping.count());
             mpMap->postMessage(alertMsg);
@@ -904,12 +904,12 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
         QSetIterator<TRoom*> itModifiedRoom(holdingSet);
         while (itModifiedRoom.hasNext()) {
             TRoom* pR = itModifiedRoom.next();
-            int newRoomId = pR->getId();
+            int const newRoomId = pR->getId();
             rooms.insert(newRoomId, pR);
         }
     } else {
         if (mudlet::self()->showMapAuditErrors()) {
-            QString infoMsg = tr("[ INFO ]  - Room id numbering is satisfactory.");
+            QString const infoMsg = tr("[ INFO ]  - Room id numbering is satisfactory.");
             mpMap->postMessage(infoMsg);
         }
         mpMap->appendErrorMsg(tr("[ INFO ]  - Room id numbering is satisfactory."), false);
@@ -932,7 +932,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             QSet<int> _set{pR->exitStubs.begin(), pR->exitStubs.end()};
             if (_set.count() < _listCount) {
                 if (mudlet::self()->showMapAuditErrors()) {
-                    QString infoMsg = tr("[ INFO ]  - Duplicate exit stub identifiers found in room id: %1, this is an\n"
+                    QString const infoMsg = tr("[ INFO ]  - Duplicate exit stub identifiers found in room id: %1, this is an\n"
                                          "anomaly but has been cleaned up easily.")
                                               .arg(itRoom.key());
                     mpMap->postMessage(infoMsg);
@@ -946,7 +946,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             _set = QSet<int>{pR->exitLocks.begin(), pR->exitLocks.end()};
             if (_set.count() < _listCount) {
                 if (mudlet::self()->showMapAuditErrors()) {
-                    QString infoMsg = tr("[ INFO ]  - Duplicate exit lock identifiers found in room id: %1, this is an\n"
+                    QString const infoMsg = tr("[ INFO ]  - Duplicate exit lock identifiers found in room id: %1, this is an\n"
                                          "anomaly but has been cleaned up easily.")
                                               .arg(itRoom.key());
                     mpMap->postMessage(infoMsg);
@@ -972,7 +972,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                 QMutableSetIterator<int> itAreaRoom(pA->rooms);
                 if (!roomRemapping.isEmpty()) {
                     while (itAreaRoom.hasNext()) {
-                        int originalRoomId = itAreaRoom.next();
+                        int const originalRoomId = itAreaRoom.next();
                         if (roomRemapping.contains(originalRoomId)) {
                             itAreaRoom.remove();
                             replacementRoomsSet.insert(roomRemapping.value(originalRoomId));
@@ -987,7 +987,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
 
             // Now compare pA->rooms to areaRoomMultiHash.values(itArea.key())
             QList<int> roomIdsInAreaList{areaRoomMultiHash.values(itArea.key())};
-            QSet<int> foundRooms{roomIdsInAreaList.begin(), roomIdsInAreaList.end()};
+            QSet<int> const foundRooms{roomIdsInAreaList.begin(), roomIdsInAreaList.end()};
 
             QSetIterator<int> itFoundRoom(foundRooms);
             // Original form of code which was slower because the two sets of rooms were
@@ -1021,7 +1021,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                 }
                 QListIterator<int> itMissingRoom(missingRoomsList);
                 while (itMissingRoom.hasNext()) {
-                    int missingRoomId = itMissingRoom.next();
+                    int const missingRoomId = itMissingRoom.next();
                     roomList.append(QString::number(missingRoomId));
                     mpMap->appendRoomErrorMsg(missingRoomId,
                                               tr("[ INFO ]  - This room claims to be in area id: %1, but that did not have a record of it."
@@ -1030,7 +1030,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                                               true);
                 }
                 if (mudlet::self()->showMapAuditErrors()) {
-                    QString infoMsg = tr("[ INFO ]  - In area with id: %1 there were %2 rooms missing from those it\n"
+                    QString const infoMsg = tr("[ INFO ]  - In area with id: %1 there were %2 rooms missing from those it\n"
                                          "should be recording as possessing, they were:\n%3\nthey have been added.")
                                               .arg(itArea.key())
                                               .arg(missingRooms.count())
@@ -1056,7 +1056,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                 }
                 QListIterator<int> itExtraRoom(extraRoomsList);
                 while (itExtraRoom.hasNext()) {
-                    int extraRoomId = itExtraRoom.next();
+                    int const extraRoomId = itExtraRoom.next();
                     roomList.append(QString::number(extraRoomId));
                     mpMap->appendRoomErrorMsg(extraRoomId,
                                               tr("[ INFO ]  - This room was claimed by area id: %1, but it does not belong there."
@@ -1065,7 +1065,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                                               true);
                 }
                 if (mudlet::self()->showMapAuditErrors()) {
-                    QString infoMsg = tr("[ INFO ]  - In area with id: %1 there were %2 extra rooms compared to those it\n"
+                    QString const infoMsg = tr("[ INFO ]  - In area with id: %1 there were %2 extra rooms compared to those it\n"
                                          "should be recording as possessing, they were:\n%3\nthey have been removed.")
                                               .arg(itArea.key())
                                               .arg(extraRooms.count())
@@ -1091,7 +1091,7 @@ void TRoomDB::clearMapDB()
 {
     QElapsedTimer timer;
     timer.start();
-    QList<TRoom*> rPtrL = getRoomPtrList();
+    QList<TRoom*> const rPtrL = getRoomPtrList();
     rooms.clear(); // Prevents any further use of TRoomDB::getRoom(int) !!!
     entranceMap.clear();
     areaNamesMap.clear();
@@ -1103,7 +1103,7 @@ void TRoomDB::clearMapDB()
     }
     //    assert(!rooms.size()); // Pointless as rooms.clear() will have achieved the test condition
 
-    QList<TArea*> areaList = getAreaPtrList();
+    QList<TArea*> const areaList = getAreaPtrList();
     for (auto area : areaList) {
         delete area;
     }
@@ -1183,7 +1183,7 @@ void TRoomDB::restoreAreaMap(QDataStream& ifs)
             // Seems to look better if we iterate through backwards!
             while (itRemappedNames.hasPrevious()) {
                 itRemappedNames.previous();
-                QString oldName = itRemappedNames.key().isEmpty() ? tr("<nothing>") : itRemappedNames.key();
+                QString const oldName = itRemappedNames.key().isEmpty() ? tr("<nothing>") : itRemappedNames.key();
                 detailText.append(qsl("(%1) \"%2\" ==> \"%3\"\n").arg(areaNamesMap.key(itRemappedNames.value())).arg(oldName, itRemappedNames.value()));
                 mpMap->appendAreaErrorMsg(areaNamesMap.key(itRemappedNames.value()),
                                           tr(R"([ INFO ]  - Area name changed to prevent duplicates or unnamed ones; old name: "%1", new name: "%2".)").arg(oldName, itRemappedNames.value()),
@@ -1247,7 +1247,7 @@ void TRoomDB::restoreAreaMap(QDataStream& ifs)
 
     if (!areaNamesMap.contains(-1)) {
         areaNamesMap.insert(-1, mpMap->getDefaultAreaName());
-        QString defaultAreaNameInsertionMsg = tr("[ INFO ]  - Default (reset) area name (for rooms that have not been assigned to an\n"
+        QString const defaultAreaNameInsertionMsg = tr("[ INFO ]  - Default (reset) area name (for rooms that have not been assigned to an\n"
                                                  "area) not found, adding \"%1\" against the reserved -1 id.")
                                                       .arg(mpMap->getDefaultAreaName());
         mpMap->mpHost->postMessage(defaultAreaNameInsertionMsg);

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -148,7 +148,7 @@ void TTabBar::removeTab(int index)
 
 void TTabBar::removeTab(const QString& tabName)
 {
-    int index = tabIndex(tabName);
+    int const index = tabIndex(tabName);
     if (index > -1) {
         setTabBold(index, false);
         setTabItalic(index, false);
@@ -169,7 +169,7 @@ QStringList TTabBar::tabNames() const
 
 void TTabBar::applyPrefixToDisplayedText(const QString& tabName, const QString& prefix)
 {
-    int index = tabIndex(tabName);
+    int const index = tabIndex(tabName);
     if (index > -1) {
         QTabBar::setTabText(index, qsl("%1%2").arg(prefix, tabData(index).toString()));
     }

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -148,7 +148,7 @@ void TTabBar::removeTab(int index)
 
 void TTabBar::removeTab(const QString& tabName)
 {
-    int const index = tabIndex(tabName);
+    const int index = tabIndex(tabName);
     if (index > -1) {
         setTabBold(index, false);
         setTabItalic(index, false);
@@ -169,7 +169,7 @@ QStringList TTabBar::tabNames() const
 
 void TTabBar::applyPrefixToDisplayedText(const QString& tabName, const QString& prefix)
 {
-    int const index = tabIndex(tabName);
+    const int index = tabIndex(tabName);
     if (index > -1) {
         QTabBar::setTabText(index, qsl("%1%2").arg(prefix, tabData(index).toString()));
     }

--- a/src/TTextCodec.cpp
+++ b/src/TTextCodec.cpp
@@ -195,7 +195,7 @@ QString TTextCodec_437::convertToUnicode(const char *in, int length, ConverterSt
         result += QChar::ByteOrderMark;
     }
     for (int i = 0; i < length; ++i) {
-        unsigned char ch = in[i];
+        unsigned char const ch = in[i];
         if (ch < 0x80) {
             // ASCII - which is the same as Latin1 when the MS Bit is not set:
             result += QLatin1Char(ch);
@@ -227,7 +227,7 @@ QString TTextCodec_667::convertToUnicode(const char *in, int length, ConverterSt
         result += QChar::ByteOrderMark;
     }
     for (int i = 0; i < length; ++i) {
-        unsigned char ch = in[i];
+        unsigned char const ch = in[i];
         if (ch < 0x80) {
             // ASCII - which is the same as Latin1 when the MS Bit is not set:
             result += QLatin1Char(ch);
@@ -259,7 +259,7 @@ QString TTextCodec_737::convertToUnicode(const char *in, int length, ConverterSt
         result += QChar::ByteOrderMark;
     }
     for (int i = 0; i < length; ++i) {
-        unsigned char ch = in[i];
+        unsigned char const ch = in[i];
         if (ch < 0x80) {
             // ASCII - which is the same as Latin1 when the MS Bit is not set:
             result += QLatin1Char(ch);
@@ -295,7 +295,7 @@ QString TTextCodec_869::convertToUnicode(const char *in, int length, ConverterSt
         result += QChar::ByteOrderMark;
     }
     for (int i = 0; i < length; ++i) {
-        unsigned char ch = in[i];
+        unsigned char const ch = in[i];
         if (ch < 0x80) {
             // ASCII - which is the same as Latin1 when the MS Bit is not set:
             result += QLatin1Char(ch);
@@ -405,7 +405,7 @@ QByteArray TTextCodec_437::convertFromUnicode(const QChar *in, int length, Conve
         } else {
             // In range of Extended ASCII \x80 up to end of BMP \xffff so let's
             // find out if it is in the lookup table.
-            int pos = CptoUnicode.indexOf(in[i]);
+            int const pos = CptoUnicode.indexOf(in[i]);
             // Protect against a bogus index that will break the use of an
             // quint8 afterwards:
             Q_ASSERT_X(pos < 128, "TTextCodec_437", "lookup table is malformed and oversized so that a bogus index of 128 or more was found");
@@ -509,7 +509,7 @@ QByteArray TTextCodec_667::convertFromUnicode(const QChar *in, int length, Conve
         } else {
             // In range of Extended ASCII \x80 up to end of BMP \xffff so let's
             // find out if it is in the lookup table.
-            int pos = CptoUnicode.indexOf(in[i]);
+            int const pos = CptoUnicode.indexOf(in[i]);
             // Protect against a bogus index that will break the use of an
             // quint8 afterwards:
             Q_ASSERT_X(pos < 128, "TTextCodec_667", "lookup table is malformed and oversized so that a bogus index of 128 or more was found");
@@ -613,7 +613,7 @@ QByteArray TTextCodec_737::convertFromUnicode(const QChar *in, int length, Conve
         } else {
             // In range of Extended ASCII \x80 up to end of BMP \xffff so let's
             // find out if it is in the lookup table.
-            int pos = CptoUnicode.indexOf(in[i]);
+            int const pos = CptoUnicode.indexOf(in[i]);
             // Protect against a bogus index that will break the use of an
             // quint8 afterwards:
             Q_ASSERT_X(pos < 128, "TTextCodec_737", "lookup table is malformed and oversized so that a bogus index of 128 or more was found");
@@ -717,7 +717,7 @@ QByteArray TTextCodec_869::convertFromUnicode(const QChar *in, int length, Conve
         } else {
             // In range of Extended ASCII \x80 up to end of BMP \xffff so let's
             // find out if it is in the lookup table.
-            int pos = CptoUnicode.indexOf(in[i]);
+            int const pos = CptoUnicode.indexOf(in[i]);
             // Protect against a bogus index that will break the use of an
             // quint8 afterwards:
             Q_ASSERT_X(pos < 128, "TTextCodec_869", "lookup table is malformed and oversized so that a bogus index of 128 or more was found");

--- a/src/TTextCodec.cpp
+++ b/src/TTextCodec.cpp
@@ -405,7 +405,7 @@ QByteArray TTextCodec_437::convertFromUnicode(const QChar *in, int length, Conve
         } else {
             // In range of Extended ASCII \x80 up to end of BMP \xffff so let's
             // find out if it is in the lookup table.
-            int const pos = CptoUnicode.indexOf(in[i]);
+            const int pos = CptoUnicode.indexOf(in[i]);
             // Protect against a bogus index that will break the use of an
             // quint8 afterwards:
             Q_ASSERT_X(pos < 128, "TTextCodec_437", "lookup table is malformed and oversized so that a bogus index of 128 or more was found");
@@ -509,7 +509,7 @@ QByteArray TTextCodec_667::convertFromUnicode(const QChar *in, int length, Conve
         } else {
             // In range of Extended ASCII \x80 up to end of BMP \xffff so let's
             // find out if it is in the lookup table.
-            int const pos = CptoUnicode.indexOf(in[i]);
+            const int pos = CptoUnicode.indexOf(in[i]);
             // Protect against a bogus index that will break the use of an
             // quint8 afterwards:
             Q_ASSERT_X(pos < 128, "TTextCodec_667", "lookup table is malformed and oversized so that a bogus index of 128 or more was found");
@@ -613,7 +613,7 @@ QByteArray TTextCodec_737::convertFromUnicode(const QChar *in, int length, Conve
         } else {
             // In range of Extended ASCII \x80 up to end of BMP \xffff so let's
             // find out if it is in the lookup table.
-            int const pos = CptoUnicode.indexOf(in[i]);
+            const int pos = CptoUnicode.indexOf(in[i]);
             // Protect against a bogus index that will break the use of an
             // quint8 afterwards:
             Q_ASSERT_X(pos < 128, "TTextCodec_737", "lookup table is malformed and oversized so that a bogus index of 128 or more was found");
@@ -717,7 +717,7 @@ QByteArray TTextCodec_869::convertFromUnicode(const QChar *in, int length, Conve
         } else {
             // In range of Extended ASCII \x80 up to end of BMP \xffff so let's
             // find out if it is in the lookup table.
-            int const pos = CptoUnicode.indexOf(in[i]);
+            const int pos = CptoUnicode.indexOf(in[i]);
             // Protect against a bogus index that will break the use of an
             // quint8 afterwards:
             Q_ASSERT_X(pos < 128, "TTextCodec_869", "lookup table is malformed and oversized so that a bogus index of 128 or more was found");

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -120,8 +120,8 @@ bool TTimer::isOffsetTimer()
 
 bool TTimer::setIsActive(bool b)
 {
-    bool condition1 = Tree<TTimer>::setIsActive(b);
-    bool condition2 = canBeUnlocked();
+    bool const condition1 = Tree<TTimer>::setIsActive(b);
+    bool const condition2 = canBeUnlocked();
     if (condition1 && condition2) {
         start();
     } else {
@@ -193,7 +193,7 @@ bool TTimer::setScript(const QString& script)
 bool TTimer::compileScript()
 {
     mFuncName = QString("Timer") + QString::number(mID);
-    QString code = QString("function ") + mFuncName + QString("()\n") + mScript + QString("\nend\n");
+    QString const code = QString("function ") + mFuncName + QString("()\n") + mScript + QString("\nend\n");
     QString error;
     if (mpHost->mLuaInterpreter.compile(code, error, "Timer: " + getName())) {
         mNeedsToBeCompiled = false;

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -193,7 +193,7 @@ bool TTimer::setScript(const QString& script)
 bool TTimer::compileScript()
 {
     mFuncName = QString("Timer") + QString::number(mID);
-    QString const code = QString("function ") + mFuncName + QString("()\n") + mScript + QString("\nend\n");
+    const QString code = QString("function ") + mFuncName + QString("()\n") + mScript + QString("\nend\n");
     QString error;
     if (mpHost->mLuaInterpreter.compile(code, error, "Timer: " + getName())) {
         mNeedsToBeCompiled = false;

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -120,8 +120,8 @@ bool TTimer::isOffsetTimer()
 
 bool TTimer::setIsActive(bool b)
 {
-    bool const condition1 = Tree<TTimer>::setIsActive(b);
-    bool const condition2 = canBeUnlocked();
+    const bool condition1 = Tree<TTimer>::setIsActive(b);
+    const bool condition2 = canBeUnlocked();
     if (condition1 && condition2) {
         start();
     } else {

--- a/src/TToolBar.cpp
+++ b/src/TToolBar.cpp
@@ -68,7 +68,7 @@ void TToolBar::resizeEvent(QResizeEvent* e)
 void TToolBar::setName(const QString& name)
 {
     mName = name;
-    QString const hostName(mpHost->getName());
+    const QString hostName(mpHost->getName());
     setObjectName(qsl("dockToolBar_%1_%2").arg(hostName, name));
     // Actually put something in as the title so that the main window context
     // menu no longer has empty entries which are disabled:

--- a/src/TToolBar.cpp
+++ b/src/TToolBar.cpp
@@ -68,7 +68,7 @@ void TToolBar::resizeEvent(QResizeEvent* e)
 void TToolBar::setName(const QString& name)
 {
     mName = name;
-    QString hostName(mpHost->getName());
+    QString const hostName(mpHost->getName());
     setObjectName(qsl("dockToolBar_%1_%2").arg(hostName, name));
     // Actually put something in as the title so that the main window context
     // menu no longer has empty entries which are disabled:
@@ -114,7 +114,7 @@ void TToolBar::addButton(TFlipButton* pB)
         pB->setMaximumSize(size);
         pB->setMinimumSize(size);
     } else {
-        QSize size = QSize(pB->mpTAction->mSizeX, pB->mpTAction->mSizeY);
+        QSize const size = QSize(pB->mpTAction->mSizeX, pB->mpTAction->mSizeY);
         pB->setMaximumSize(size);
         pB->setMinimumSize(size);
         pB->setParent(mpWidget);
@@ -123,7 +123,7 @@ void TToolBar::addButton(TFlipButton* pB)
 
     pB->setStyleSheet(pB->mpTAction->css);
     pB->setFlat(pB->mpTAction->getButtonFlat());
-    int rotation = pB->mpTAction->getButtonRotation();
+    int const rotation = pB->mpTAction->getButtonRotation();
     switch (rotation) {
     case 0:
         pB->setOrientation(Qt::Horizontal);
@@ -146,8 +146,8 @@ void TToolBar::addButton(TFlipButton* pB)
         }
         if (columns > 0) {
             mItemCount++;
-            int row = mItemCount / columns;
-            int col = mItemCount % columns;
+            int const row = mItemCount / columns;
+            int const col = mItemCount % columns;
             if (mVerticalOrientation) {
                 mpLayout->addWidget(pB, row, col);
             } else {
@@ -169,14 +169,14 @@ void TToolBar::finalize()
         return;
     }
     auto fillerWidget = new QWidget;
-    QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    QSizePolicy const sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     fillerWidget->setSizePolicy(sizePolicy);
     int columns = mpTAction->getButtonColumns();
     if (columns <= 0) {
         columns = 1;
     }
-    int row = (++mItemCount) / columns;
-    int column = (mItemCount - 1) % columns;
+    int const row = (++mItemCount) / columns;
+    int const column = (mItemCount - 1) % columns;
     mpLayout->addWidget(fillerWidget, row, column);
     // 3 lines above are to avoid order of operations problem of original line
     // (-Wsequence-point warning on mItemCount) NEEDS TO BE CHECKED:
@@ -224,7 +224,7 @@ void TToolBar::clear()
         mpLayout = new QGridLayout(mpWidget);
         mpLayout->setContentsMargins(0, 0, 0, 0);
         mpLayout->setSpacing(0);
-        QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+        QSizePolicy const sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
         mpWidget->setSizePolicy(sizePolicy);
     } else {
         mpLayout = nullptr;

--- a/src/TToolBar.cpp
+++ b/src/TToolBar.cpp
@@ -123,7 +123,7 @@ void TToolBar::addButton(TFlipButton* pB)
 
     pB->setStyleSheet(pB->mpTAction->css);
     pB->setFlat(pB->mpTAction->getButtonFlat());
-    int const rotation = pB->mpTAction->getButtonRotation();
+    const int rotation = pB->mpTAction->getButtonRotation();
     switch (rotation) {
     case 0:
         pB->setOrientation(Qt::Horizontal);
@@ -146,8 +146,8 @@ void TToolBar::addButton(TFlipButton* pB)
         }
         if (columns > 0) {
             mItemCount++;
-            int const row = mItemCount / columns;
-            int const col = mItemCount % columns;
+            const int row = mItemCount / columns;
+            const int col = mItemCount % columns;
             if (mVerticalOrientation) {
                 mpLayout->addWidget(pB, row, col);
             } else {
@@ -175,8 +175,8 @@ void TToolBar::finalize()
     if (columns <= 0) {
         columns = 1;
     }
-    int const row = (++mItemCount) / columns;
-    int const column = (mItemCount - 1) % columns;
+    const int row = (++mItemCount) / columns;
+    const int column = (mItemCount - 1) % columns;
     mpLayout->addWidget(fillerWidget, row, column);
     // 3 lines above are to avoid order of operations problem of original line
     // (-Wsequence-point warning on mItemCount) NEEDS TO BE CHECKED:

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -215,7 +215,7 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds)
 
             // PCRE_UTF8 needed to run compile in UTF-8 mode
             // PCRE_UCP needed for \d, \w etc. to use Unicode properties:
-            QSharedPointer<pcre> re(pcre_compile(regexp.constData(), PCRE_UTF8 | PCRE_UCP, &error, &erroffset, nullptr), pcre_deleter);
+            QSharedPointer<pcre> const re(pcre_compile(regexp.constData(), PCRE_UTF8 | PCRE_UCP, &error, &erroffset, nullptr), pcre_deleter);
 
             if (!re) {
                 if (mudlet::smDebugMode) {
@@ -240,7 +240,7 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds)
             std::stringstream func;
             func << "trigger" << mID << "condition" << i;
             funcName = func.str();
-            QString code = qsl("function %1()\n%2\nend\n").arg(funcName.c_str(), patterns[i]);
+            QString const code = qsl("function %1()\n%2\nend\n").arg(funcName.c_str(), patterns[i]);
             QString error;
             if (!mpLua->compile(code, error, QString::fromStdString(funcName))) {
                 setError(qsl("<b><font color='blue'>%1</font></b>")
@@ -290,7 +290,7 @@ bool TTrigger::match_perl(char* haystackC, const QString& haystack, int patternN
 {
     assert(mRegexMap.contains(patternNumber));
 
-    QSharedPointer<pcre> re = mRegexMap[patternNumber];
+    QSharedPointer<pcre> const re = mRegexMap[patternNumber];
 
     if (!re) {
         if (mudlet::smDebugMode) {
@@ -302,7 +302,7 @@ bool TTrigger::match_perl(char* haystackC, const QString& haystack, int patternN
         return false; //regex compile error
     }
 
-    int haystackCLength = strlen(haystackC);
+    int const haystackCLength = strlen(haystackC);
     int rc = -1;
     int ovector[MAX_CAPTURE_GROUPS * 3];
 
@@ -342,8 +342,8 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
     NameGroupMatches nameGroups;
     for (i = 0; i < rc; i++) {
         const char *substring_start = haystackC + ovector[2 * i];
-        int substring_length = ovector[2 * i + 1] - ovector[2 * i];
-        int utf16_pos = haystack.indexOf(QString(substring_start));
+        int const substring_length = ovector[2 * i + 1] - ovector[2 * i];
+        int const utf16_pos = haystack.indexOf(QString(substring_start));
         std::string match;
         if (substring_length < 1) {
             captureList.push_back(match);
@@ -372,7 +372,7 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
         pcre_fullinfo(re.data(), nullptr, PCRE_INFO_NAMETABLE, &tabptr);
         pcre_fullinfo(re.data(), nullptr, PCRE_INFO_NAMEENTRYSIZE, &name_entry_size);
         for (i = 0; i < namecount; i++) {
-            int n = (tabptr[0] << 8) | tabptr[1];
+            int const n = (tabptr[0] << 8) | tabptr[1];
             auto name = QString::fromUtf8(&tabptr[2]).trimmed(); //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)
             auto* substring_start = haystackC + ovector[2*n]; //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)
             auto substring_length = ovector[2*n+1] - ovector[2*n]; //NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
@@ -388,7 +388,7 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
     }
     for (; mPerlSlashGOption;) {
         int options = 0;
-        int start_offset = ovector[1];
+        int const start_offset = ovector[1];
 
         if (ovector[0] == ovector[1]) {
             if (ovector[0] >= haystackCLength) {
@@ -416,8 +416,8 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
 
         for (i = 0; i < rc; i++) {
             const char *substring_start = haystackC + ovector[2 * i];
-            int substring_length = ovector[2 * i + 1] - ovector[2 * i];
-            int utf16_pos = haystack.indexOf(QString(substring_start));
+            int const substring_length = ovector[2 * i + 1] - ovector[2 * i];
+            int const utf16_pos = haystack.indexOf(QString(substring_start));
 
             std::string match;
             if (substring_length < 1) {
@@ -437,13 +437,13 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
 
     END : {
         if (mIsColorizerTrigger) {
-            int r1 = mBgColor.red();
-            int g1 = mBgColor.green();
-            int b1 = mBgColor.blue();
-            int r2 = mFgColor.red();
-            int g2 = mFgColor.green();
-            int b2 = mFgColor.blue();
-            int total = captureList.size();
+            int const r1 = mBgColor.red();
+            int const g1 = mBgColor.green();
+            int const b1 = mBgColor.blue();
+            int const r2 = mFgColor.red();
+            int const g2 = mFgColor.green();
+            int const b2 = mFgColor.blue();
+            int const total = captureList.size();
             TConsole* pC = mpHost->mpConsole;
             if (Q_UNLIKELY(!pC)) {
                 return;
@@ -452,9 +452,9 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
             auto its = captureList.begin();
             auto iti = posList.begin();
             for (int position = 1; iti != posList.end(); ++iti, ++its, position++) {
-                int begin = *iti;
-                std::string& s = *its;
-                int length = QString::fromStdString(s).size();
+                int const begin = *iti;
+                std::string const& s = *its;
+                int const length = QString::fromStdString(s).size();
                 if (total > 1) {
                     // skip complete match in Perl /g option type of triggers
                     // to enable people to highlight capture groups if there are any
@@ -487,7 +487,7 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
             pL->clearCaptureGroups();
             if (mFilterTrigger) {
                 if (captureList.size() > 1) {
-                    int total = captureList.size();
+                    int const total = captureList.size();
                     auto its = captureList.begin();
                     auto iti = posList.begin();
                     for (int filterPosition = 1; iti != posList.end(); ++iti, ++its, filterPosition++) {
@@ -530,21 +530,21 @@ void TTrigger::processBeginOfLine(const QString& needle, int patternNumber, int 
         TDebug(Qt::darkCyan, Qt::black) << "Trigger name=" << mName << "(" << mPatterns.value(patternNumber) << ") matched.\n" >> mpHost;
     }
     if (mIsColorizerTrigger) {
-        int r1 = mBgColor.red();
-        int g1 = mBgColor.green();
-        int b1 = mBgColor.blue();
-        int r2 = mFgColor.red();
-        int g2 = mFgColor.green();
-        int b2 = mFgColor.blue();
+        int const r1 = mBgColor.red();
+        int const g1 = mBgColor.green();
+        int const b1 = mBgColor.blue();
+        int const r2 = mFgColor.red();
+        int const g2 = mFgColor.green();
+        int const b2 = mFgColor.blue();
         TConsole* pC = mpHost->mpConsole;
         if (Q_UNLIKELY(!pC)) {
             return;
         }
         auto its = captureList.begin();
         for (auto iti = posList.begin(); iti != posList.end(); ++iti, ++its) {
-            int begin = *iti;
-            std::string& s = *its;
-            int length = QString::fromStdString(s).size();
+            int const begin = *iti;
+            std::string const& s = *its;
+            int const length = QString::fromStdString(s).size();
             pC->selectSection(begin, length);
             if (mBgColor != QColorConstants::Transparent) {
                 pC->setBgColor(r1, g1, b1, 255);
@@ -623,7 +623,7 @@ inline void TTrigger::filter(std::string& capture, int& posOffset)
     } else {
         return;
     }
-    QString text = capture.c_str();
+    QString const text = capture.c_str();
     for (auto& trigger : *mpMyChildrenList) {
         trigger->match(filterSubject, text, -1, posOffset);
     }
@@ -642,7 +642,7 @@ void TTrigger::setExpiryCount(int expiryCount)
 
 bool TTrigger::match_substring(const QString& haystack, const QString& needle, int patternNumber, int posOffset)
 {
-    int where = haystack.indexOf(needle);
+    int const where = haystack.indexOf(needle);
     if (where != -1) {
         processSubstringMatch(haystack, needle, patternNumber, posOffset, where);
         return true;
@@ -667,12 +667,12 @@ void TTrigger::processSubstringMatch(const QString& haystack, const QString& nee
         TDebug(Qt::cyan, Qt::black) << "Trigger name=" << mName << "(" << mPatterns.value(regexNumber) << ") matched.\n" >> mpHost;
     }
     if (mIsColorizerTrigger) {
-        int r1 = mBgColor.red();
-        int g1 = mBgColor.green();
-        int b1 = mBgColor.blue();
-        int r2 = mFgColor.red();
-        int g2 = mFgColor.green();
-        int b2 = mFgColor.blue();
+        int const r1 = mBgColor.red();
+        int const g1 = mBgColor.green();
+        int const b1 = mBgColor.blue();
+        int const r2 = mFgColor.red();
+        int const g2 = mFgColor.green();
+        int const b2 = mFgColor.blue();
         TConsole* pC = mpHost->mpConsole;
         if (Q_UNLIKELY(!pC)) {
             return;
@@ -680,9 +680,9 @@ void TTrigger::processSubstringMatch(const QString& haystack, const QString& nee
         pC->deselect();
         auto its = captureList.begin();
         for (auto iti = posList.begin(); iti != posList.end(); ++iti, ++its) {
-            int begin = *iti;
-            std::string& s = *its;
-            int length = QString::fromStdString(s).size();
+            int const begin = *iti;
+            std::string const& s = *its;
+            int const length = QString::fromStdString(s).size();
             pC->selectSection(begin, length);
             if (mBgColor != QColorConstants::Transparent) {
                 pC->setBgColor(r1, g1, b1, 255);
@@ -726,7 +726,7 @@ bool TTrigger::match_color_pattern(int line, int patternNumber)
         return false;
     }
     std::deque<TChar>& bufferLine = mpHost->mpConsole->buffer.buffer[line];
-    QString& lineBuffer = mpHost->mpConsole->buffer.lineBuffer[line];
+    QString const& lineBuffer = mpHost->mpConsole->buffer.lineBuffer[line];
     int pos = 0;
     int matchBegin = -1;
     bool matching = false;
@@ -786,12 +786,12 @@ bool TTrigger::match_color_pattern(int line, int patternNumber)
 void TTrigger::processColorPattern(int patternNumber, std::list<std::string>& captureList, std::list<int>& posList)
 {
     if (mIsColorizerTrigger) {
-        int r1 = mBgColor.red();
-        int g1 = mBgColor.green();
-        int b1 = mBgColor.blue();
-        int r2 = mFgColor.red();
-        int g2 = mFgColor.green();
-        int b2 = mFgColor.blue();
+        int const r1 = mBgColor.red();
+        int const g1 = mBgColor.green();
+        int const b1 = mBgColor.blue();
+        int const r2 = mFgColor.red();
+        int const g2 = mFgColor.green();
+        int const b2 = mFgColor.blue();
         TConsole* pC = mpHost->mpConsole;
         if (Q_UNLIKELY(!pC)) {
             return;
@@ -799,10 +799,10 @@ void TTrigger::processColorPattern(int patternNumber, std::list<std::string>& ca
         pC->deselect();
         auto its = captureList.begin();
         for (auto iti = posList.begin(); iti != posList.end(); ++iti, ++its) {
-            int begin = *iti;
+            int const begin = *iti;
             //                qDebug() << "TTrigger::match_color_pattern(" << line << "," << patternNumber << ") INFO - match found: " << (*its).c_str() << " size is:" << (*its).size();
-            std::string& s = *its;
-            int length = QString::fromStdString(s).size();
+            std::string const& s = *its;
+            int const length = QString::fromStdString(s).size();
             pC->selectSection(begin, length);
             if (mBgColor != QColorConstants::Transparent) {
                 pC->setBgColor(r1, g1, b1, 255);
@@ -850,8 +850,8 @@ bool TTrigger::match_line_spacer(int patternNumber)
                                                           >> mpHost;
                     }
                     matchStatePair.second->conditionMatched();
-                    std::list<std::string> captureList;
-                    std::list<int> posList;
+                    std::list<std::string> const captureList;
+                    std::list<int> const posList;
                     matchStatePair.second->multiCaptureList.push_back(captureList);
                     matchStatePair.second->multiCapturePosList.push_back(posList);
                 }
@@ -931,21 +931,21 @@ void TTrigger::processExactMatch(const QString& line, int patternNumber, int pos
         TDebug(Qt::yellow, Qt::black) << "Trigger name=" << mName << "(" << mPatterns.value(patternNumber) << ") matched.\n" >> mpHost;
     }
     if (mIsColorizerTrigger) {
-        int r1 = mBgColor.red();
-        int g1 = mBgColor.green();
-        int b1 = mBgColor.blue();
-        int r2 = mFgColor.red();
-        int g2 = mFgColor.green();
-        int b2 = mFgColor.blue();
+        int const r1 = mBgColor.red();
+        int const g1 = mBgColor.green();
+        int const b1 = mBgColor.blue();
+        int const r2 = mFgColor.red();
+        int const g2 = mFgColor.green();
+        int const b2 = mFgColor.blue();
         TConsole* pC = mpHost->mpConsole;
         if (Q_UNLIKELY(!pC)) {
             return;
         }
         auto its = captureList.begin();
         for (auto iti = posList.begin(); iti != posList.end(); ++iti, ++its) {
-            int begin = *iti;
-            std::string& s = *its;
-            int length = QString::fromStdString(s).size();
+            int const begin = *iti;
+            std::string const& s = *its;
+            int const length = QString::fromStdString(s).size();
             pC->selectSection(begin, length);
             if (mBgColor != QColorConstants::Transparent) {
                 pC->setBgColor(r1, g1, b1, 255);
@@ -1003,14 +1003,14 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
         if (mIsMultiline) {
             for (auto& matchStatePair : mConditionMap) {
                 matchStatePair.second->newLineArrived();
-                int next = matchStatePair.second->nextCondition();
+                int const next = matchStatePair.second->nextCondition();
                 if (next > highestCondition) {
                     highestCondition = next;
                 }
             }
         }
 
-        int size = mPatternKinds.size();
+        int const size = mPatternKinds.size();
         for (int patternNumber = 0;; patternNumber++) {
             if (patternNumber >= size) {
                 break;
@@ -1088,7 +1088,7 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
                         multiCaptureList = matchStatePair.second->multiCaptureList;
                         if (!multiCaptureList.empty()) {
                             for (auto mit = multiCaptureList.begin(); mit != multiCaptureList.end(); mit++, k++) {
-                                int total = (*mit).size();
+                                int const total = (*mit).size();
                                 auto its = (*mit).begin();
                                 for (int i = 1; its != (*mit).end(); ++its, i++) {
                                     std::string s = *its;
@@ -1207,8 +1207,8 @@ TColorTable* TTrigger::createColorPattern(int ansiFg, int ansiBg)
      * 16 dark white          ->  7
      */
 
-    QColor fgColor = mpHost->getAnsiColor(ansiFg, false);
-    QColor bgColor = mpHost->getAnsiColor(ansiBg, true);
+    QColor const fgColor = mpHost->getAnsiColor(ansiFg, false);
+    QColor const bgColor = mpHost->getAnsiColor(ansiBg, true);
 
     // If BOTH ansiFg AND ansiBg are scmIgnored then the color pattern is
     // totally unset
@@ -1324,7 +1324,7 @@ bool TTrigger::setScript(const QString& script)
 bool TTrigger::compileScript()
 {
     mFuncName = qsl("Trigger%1").arg(QString::number(mID));
-    QString code = qsl("function %1()\n%2\nend\n").arg(mFuncName, mScript);
+    QString const code = qsl("function %1()\n%2\nend\n").arg(mFuncName, mScript);
     QString error;
     if (mpLua->compile(code, error, qsl("Trigger: %1").arg(getName()))) {
         mNeedsToBeCompiled = false;
@@ -1468,9 +1468,9 @@ void TTrigger::decodeColorPatternText(const QString& patternText, int& fgColorCo
 {
     // The numbers used for the text have changed - see table in:
     // TColorTable* TTrigger::createColorPattern(int ansiFg, int ansiBg)
-    QRegularExpression regex = QRegularExpression(qsl("^ANSI_COLORS_F{(\\d+|DEFAULT|IGNORE)}_B{(\\d+|DEFAULT|IGNORE)}$"));
+    QRegularExpression const regex = QRegularExpression(qsl("^ANSI_COLORS_F{(\\d+|DEFAULT|IGNORE)}_B{(\\d+|DEFAULT|IGNORE)}$"));
     // Was QRegularExpression regex = QRegularExpression(qsl(R"(FG(\d+)BG(\d+))"));
-    QRegularExpressionMatch match = regex.match(patternText);
+    QRegularExpressionMatch const match = regex.match(patternText);
     // scmDefault is the new code for "default" colour (as 0 is a valid ANSI color number!)
     // scmIgnored is the new code for "reset" i.e. NOT set color trigger (i.e. don't
     // bother with checking this part of the colour)

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -302,7 +302,7 @@ bool TTrigger::match_perl(char* haystackC, const QString& haystack, int patternN
         return false; //regex compile error
     }
 
-    int const haystackCLength = strlen(haystackC);
+    const int haystackCLength = strlen(haystackC);
     int rc = -1;
     int ovector[MAX_CAPTURE_GROUPS * 3];
 
@@ -342,8 +342,8 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
     NameGroupMatches nameGroups;
     for (i = 0; i < rc; i++) {
         const char *substring_start = haystackC + ovector[2 * i];
-        int const substring_length = ovector[2 * i + 1] - ovector[2 * i];
-        int const utf16_pos = haystack.indexOf(QString(substring_start));
+        const int substring_length = ovector[2 * i + 1] - ovector[2 * i];
+        const int utf16_pos = haystack.indexOf(QString(substring_start));
         std::string match;
         if (substring_length < 1) {
             captureList.push_back(match);
@@ -372,7 +372,7 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
         pcre_fullinfo(re.data(), nullptr, PCRE_INFO_NAMETABLE, &tabptr);
         pcre_fullinfo(re.data(), nullptr, PCRE_INFO_NAMEENTRYSIZE, &name_entry_size);
         for (i = 0; i < namecount; i++) {
-            int const n = (tabptr[0] << 8) | tabptr[1];
+            const int n = (tabptr[0] << 8) | tabptr[1];
             auto name = QString::fromUtf8(&tabptr[2]).trimmed(); //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)
             auto* substring_start = haystackC + ovector[2*n]; //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)
             auto substring_length = ovector[2*n+1] - ovector[2*n]; //NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
@@ -388,7 +388,7 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
     }
     for (; mPerlSlashGOption;) {
         int options = 0;
-        int const start_offset = ovector[1];
+        const int start_offset = ovector[1];
 
         if (ovector[0] == ovector[1]) {
             if (ovector[0] >= haystackCLength) {
@@ -416,8 +416,8 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
 
         for (i = 0; i < rc; i++) {
             const char *substring_start = haystackC + ovector[2 * i];
-            int const substring_length = ovector[2 * i + 1] - ovector[2 * i];
-            int const utf16_pos = haystack.indexOf(QString(substring_start));
+            const int substring_length = ovector[2 * i + 1] - ovector[2 * i];
+            const int utf16_pos = haystack.indexOf(QString(substring_start));
 
             std::string match;
             if (substring_length < 1) {
@@ -437,13 +437,13 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
 
     END : {
         if (mIsColorizerTrigger) {
-            int const r1 = mBgColor.red();
-            int const g1 = mBgColor.green();
-            int const b1 = mBgColor.blue();
-            int const r2 = mFgColor.red();
-            int const g2 = mFgColor.green();
-            int const b2 = mFgColor.blue();
-            int const total = captureList.size();
+            const int r1 = mBgColor.red();
+            const int g1 = mBgColor.green();
+            const int b1 = mBgColor.blue();
+            const int r2 = mFgColor.red();
+            const int g2 = mFgColor.green();
+            const int b2 = mFgColor.blue();
+            const int total = captureList.size();
             TConsole* pC = mpHost->mpConsole;
             if (Q_UNLIKELY(!pC)) {
                 return;
@@ -452,9 +452,9 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
             auto its = captureList.begin();
             auto iti = posList.begin();
             for (int position = 1; iti != posList.end(); ++iti, ++its, position++) {
-                int const begin = *iti;
+                const int begin = *iti;
                 std::string const& s = *its;
-                int const length = QString::fromStdString(s).size();
+                const int length = QString::fromStdString(s).size();
                 if (total > 1) {
                     // skip complete match in Perl /g option type of triggers
                     // to enable people to highlight capture groups if there are any
@@ -487,7 +487,7 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
             pL->clearCaptureGroups();
             if (mFilterTrigger) {
                 if (captureList.size() > 1) {
-                    int const total = captureList.size();
+                    const int total = captureList.size();
                     auto its = captureList.begin();
                     auto iti = posList.begin();
                     for (int filterPosition = 1; iti != posList.end(); ++iti, ++its, filterPosition++) {
@@ -530,21 +530,21 @@ void TTrigger::processBeginOfLine(const QString& needle, int patternNumber, int 
         TDebug(Qt::darkCyan, Qt::black) << "Trigger name=" << mName << "(" << mPatterns.value(patternNumber) << ") matched.\n" >> mpHost;
     }
     if (mIsColorizerTrigger) {
-        int const r1 = mBgColor.red();
-        int const g1 = mBgColor.green();
-        int const b1 = mBgColor.blue();
-        int const r2 = mFgColor.red();
-        int const g2 = mFgColor.green();
-        int const b2 = mFgColor.blue();
+        const int r1 = mBgColor.red();
+        const int g1 = mBgColor.green();
+        const int b1 = mBgColor.blue();
+        const int r2 = mFgColor.red();
+        const int g2 = mFgColor.green();
+        const int b2 = mFgColor.blue();
         TConsole* pC = mpHost->mpConsole;
         if (Q_UNLIKELY(!pC)) {
             return;
         }
         auto its = captureList.begin();
         for (auto iti = posList.begin(); iti != posList.end(); ++iti, ++its) {
-            int const begin = *iti;
+            const int begin = *iti;
             std::string const& s = *its;
-            int const length = QString::fromStdString(s).size();
+            const int length = QString::fromStdString(s).size();
             pC->selectSection(begin, length);
             if (mBgColor != QColorConstants::Transparent) {
                 pC->setBgColor(r1, g1, b1, 255);
@@ -642,7 +642,7 @@ void TTrigger::setExpiryCount(int expiryCount)
 
 bool TTrigger::match_substring(const QString& haystack, const QString& needle, int patternNumber, int posOffset)
 {
-    int const where = haystack.indexOf(needle);
+    const int where = haystack.indexOf(needle);
     if (where != -1) {
         processSubstringMatch(haystack, needle, patternNumber, posOffset, where);
         return true;
@@ -667,12 +667,12 @@ void TTrigger::processSubstringMatch(const QString& haystack, const QString& nee
         TDebug(Qt::cyan, Qt::black) << "Trigger name=" << mName << "(" << mPatterns.value(regexNumber) << ") matched.\n" >> mpHost;
     }
     if (mIsColorizerTrigger) {
-        int const r1 = mBgColor.red();
-        int const g1 = mBgColor.green();
-        int const b1 = mBgColor.blue();
-        int const r2 = mFgColor.red();
-        int const g2 = mFgColor.green();
-        int const b2 = mFgColor.blue();
+        const int r1 = mBgColor.red();
+        const int g1 = mBgColor.green();
+        const int b1 = mBgColor.blue();
+        const int r2 = mFgColor.red();
+        const int g2 = mFgColor.green();
+        const int b2 = mFgColor.blue();
         TConsole* pC = mpHost->mpConsole;
         if (Q_UNLIKELY(!pC)) {
             return;
@@ -680,9 +680,9 @@ void TTrigger::processSubstringMatch(const QString& haystack, const QString& nee
         pC->deselect();
         auto its = captureList.begin();
         for (auto iti = posList.begin(); iti != posList.end(); ++iti, ++its) {
-            int const begin = *iti;
+            const int begin = *iti;
             std::string const& s = *its;
-            int const length = QString::fromStdString(s).size();
+            const int length = QString::fromStdString(s).size();
             pC->selectSection(begin, length);
             if (mBgColor != QColorConstants::Transparent) {
                 pC->setBgColor(r1, g1, b1, 255);
@@ -786,12 +786,12 @@ bool TTrigger::match_color_pattern(int line, int patternNumber)
 void TTrigger::processColorPattern(int patternNumber, std::list<std::string>& captureList, std::list<int>& posList)
 {
     if (mIsColorizerTrigger) {
-        int const r1 = mBgColor.red();
-        int const g1 = mBgColor.green();
-        int const b1 = mBgColor.blue();
-        int const r2 = mFgColor.red();
-        int const g2 = mFgColor.green();
-        int const b2 = mFgColor.blue();
+        const int r1 = mBgColor.red();
+        const int g1 = mBgColor.green();
+        const int b1 = mBgColor.blue();
+        const int r2 = mFgColor.red();
+        const int g2 = mFgColor.green();
+        const int b2 = mFgColor.blue();
         TConsole* pC = mpHost->mpConsole;
         if (Q_UNLIKELY(!pC)) {
             return;
@@ -799,10 +799,10 @@ void TTrigger::processColorPattern(int patternNumber, std::list<std::string>& ca
         pC->deselect();
         auto its = captureList.begin();
         for (auto iti = posList.begin(); iti != posList.end(); ++iti, ++its) {
-            int const begin = *iti;
+            const int begin = *iti;
             //                qDebug() << "TTrigger::match_color_pattern(" << line << "," << patternNumber << ") INFO - match found: " << (*its).c_str() << " size is:" << (*its).size();
             std::string const& s = *its;
-            int const length = QString::fromStdString(s).size();
+            const int length = QString::fromStdString(s).size();
             pC->selectSection(begin, length);
             if (mBgColor != QColorConstants::Transparent) {
                 pC->setBgColor(r1, g1, b1, 255);
@@ -931,21 +931,21 @@ void TTrigger::processExactMatch(const QString& line, int patternNumber, int pos
         TDebug(Qt::yellow, Qt::black) << "Trigger name=" << mName << "(" << mPatterns.value(patternNumber) << ") matched.\n" >> mpHost;
     }
     if (mIsColorizerTrigger) {
-        int const r1 = mBgColor.red();
-        int const g1 = mBgColor.green();
-        int const b1 = mBgColor.blue();
-        int const r2 = mFgColor.red();
-        int const g2 = mFgColor.green();
-        int const b2 = mFgColor.blue();
+        const int r1 = mBgColor.red();
+        const int g1 = mBgColor.green();
+        const int b1 = mBgColor.blue();
+        const int r2 = mFgColor.red();
+        const int g2 = mFgColor.green();
+        const int b2 = mFgColor.blue();
         TConsole* pC = mpHost->mpConsole;
         if (Q_UNLIKELY(!pC)) {
             return;
         }
         auto its = captureList.begin();
         for (auto iti = posList.begin(); iti != posList.end(); ++iti, ++its) {
-            int const begin = *iti;
+            const int begin = *iti;
             std::string const& s = *its;
-            int const length = QString::fromStdString(s).size();
+            const int length = QString::fromStdString(s).size();
             pC->selectSection(begin, length);
             if (mBgColor != QColorConstants::Transparent) {
                 pC->setBgColor(r1, g1, b1, 255);
@@ -1003,14 +1003,14 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
         if (mIsMultiline) {
             for (auto& matchStatePair : mConditionMap) {
                 matchStatePair.second->newLineArrived();
-                int const next = matchStatePair.second->nextCondition();
+                const int next = matchStatePair.second->nextCondition();
                 if (next > highestCondition) {
                     highestCondition = next;
                 }
             }
         }
 
-        int const size = mPatternKinds.size();
+        const int size = mPatternKinds.size();
         for (int patternNumber = 0;; patternNumber++) {
             if (patternNumber >= size) {
                 break;
@@ -1088,7 +1088,7 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
                         multiCaptureList = matchStatePair.second->multiCaptureList;
                         if (!multiCaptureList.empty()) {
                             for (auto mit = multiCaptureList.begin(); mit != multiCaptureList.end(); mit++, k++) {
-                                int const total = (*mit).size();
+                                const int total = (*mit).size();
                                 auto its = (*mit).begin();
                                 for (int i = 1; its != (*mit).end(); ++its, i++) {
                                     std::string s = *its;

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -240,7 +240,7 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds)
             std::stringstream func;
             func << "trigger" << mID << "condition" << i;
             funcName = func.str();
-            QString const code = qsl("function %1()\n%2\nend\n").arg(funcName.c_str(), patterns[i]);
+            const QString code = qsl("function %1()\n%2\nend\n").arg(funcName.c_str(), patterns[i]);
             QString error;
             if (!mpLua->compile(code, error, QString::fromStdString(funcName))) {
                 setError(qsl("<b><font color='blue'>%1</font></b>")
@@ -623,7 +623,7 @@ inline void TTrigger::filter(std::string& capture, int& posOffset)
     } else {
         return;
     }
-    QString const text = capture.c_str();
+    const QString text = capture.c_str();
     for (auto& trigger : *mpMyChildrenList) {
         trigger->match(filterSubject, text, -1, posOffset);
     }
@@ -726,7 +726,7 @@ bool TTrigger::match_color_pattern(int line, int patternNumber)
         return false;
     }
     std::deque<TChar>& bufferLine = mpHost->mpConsole->buffer.buffer[line];
-    QString const& lineBuffer = mpHost->mpConsole->buffer.lineBuffer[line];
+    const QString& lineBuffer = mpHost->mpConsole->buffer.lineBuffer[line];
     int pos = 0;
     int matchBegin = -1;
     bool matching = false;
@@ -1324,7 +1324,7 @@ bool TTrigger::setScript(const QString& script)
 bool TTrigger::compileScript()
 {
     mFuncName = qsl("Trigger%1").arg(QString::number(mID));
-    QString const code = qsl("function %1()\n%2\nend\n").arg(mFuncName, mScript);
+    const QString code = qsl("function %1()\n%2\nend\n").arg(mFuncName, mScript);
     QString error;
     if (mpLua->compile(code, error, qsl("Trigger: %1").arg(getName()))) {
         mNeedsToBeCompiled = false;

--- a/src/TVar.cpp
+++ b/src/TVar.cpp
@@ -102,8 +102,8 @@ QString TVar::getName()
 
 bool TVarLessThan(TVar* varA, TVar* varB)
 {
-    QString a = varA->getName();
-    QString b = varB->getName();
+    QString const a = varA->getName();
+    QString const b = varB->getName();
     bool isAOk = false;
     bool isBOk = false;
 

--- a/src/TVar.cpp
+++ b/src/TVar.cpp
@@ -102,8 +102,8 @@ QString TVar::getName()
 
 bool TVarLessThan(TVar* varA, TVar* varB)
 {
-    QString const a = varA->getName();
-    QString const b = varB->getName();
+    const QString a = varA->getName();
+    const QString b = varB->getName();
     bool isAOk = false;
     bool isBOk = false;
 

--- a/src/VarUnit.cpp
+++ b/src/VarUnit.cpp
@@ -189,7 +189,7 @@ QStringList VarUnit::shortVarName(TVar* var)
 
 void VarUnit::addVariable(TVar* var)
 {
-    QString fullName = varName(var).join(qsl("."));
+    QString const fullName = varName(var).join(qsl("."));
     // pointers.insert(var->pointer);
     variableSet.insert(fullName);
     if (var->hidden) {
@@ -214,7 +214,7 @@ void VarUnit::addHidden(const QString& var)
 
 void VarUnit::removeHidden(TVar* var)
 {
-    QString fullName = shortVarName(var).join(qsl("."));
+    QString const fullName = shortVarName(var).join(qsl("."));
     hidden.remove(fullName);
     hiddenByUser.remove(fullName);
     var->hidden = false;
@@ -229,21 +229,21 @@ void VarUnit::removeHidden(const QString& name)
 
 void VarUnit::addSavedVar(TVar* var)
 {
-    QString fullName = shortVarName(var).join(qsl("."));
+    QString const fullName = shortVarName(var).join(qsl("."));
     var->saved = true;
     savedVars.insert(fullName);
 }
 
 void VarUnit::removeSavedVar(TVar* var)
 {
-    QString fullName = shortVarName(var).join(qsl("."));
+    QString const fullName = shortVarName(var).join(qsl("."));
     savedVars.remove(fullName);
     var->saved = false;
 }
 
 bool VarUnit::isSaved(TVar* var)
 {
-    QString fullName = shortVarName(var).join(qsl("."));
+    QString const fullName = shortVarName(var).join(qsl("."));
     return (savedVars.contains(fullName) || var->saved);
 }
 

--- a/src/VarUnit.cpp
+++ b/src/VarUnit.cpp
@@ -189,7 +189,7 @@ QStringList VarUnit::shortVarName(TVar* var)
 
 void VarUnit::addVariable(TVar* var)
 {
-    QString const fullName = varName(var).join(qsl("."));
+    const QString fullName = varName(var).join(qsl("."));
     // pointers.insert(var->pointer);
     variableSet.insert(fullName);
     if (var->hidden) {
@@ -214,7 +214,7 @@ void VarUnit::addHidden(const QString& var)
 
 void VarUnit::removeHidden(TVar* var)
 {
-    QString const fullName = shortVarName(var).join(qsl("."));
+    const QString fullName = shortVarName(var).join(qsl("."));
     hidden.remove(fullName);
     hiddenByUser.remove(fullName);
     var->hidden = false;
@@ -229,21 +229,21 @@ void VarUnit::removeHidden(const QString& name)
 
 void VarUnit::addSavedVar(TVar* var)
 {
-    QString const fullName = shortVarName(var).join(qsl("."));
+    const QString fullName = shortVarName(var).join(qsl("."));
     var->saved = true;
     savedVars.insert(fullName);
 }
 
 void VarUnit::removeSavedVar(TVar* var)
 {
-    QString const fullName = shortVarName(var).join(qsl("."));
+    const QString fullName = shortVarName(var).join(qsl("."));
     savedVars.remove(fullName);
     var->saved = false;
 }
 
 bool VarUnit::isSaved(TVar* var)
 {
-    QString const fullName = shortVarName(var).join(qsl("."));
+    const QString fullName = shortVarName(var).join(qsl("."));
     return (savedVars.contains(fullName) || var->saved);
 }
 

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -470,7 +470,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("blankLineBehaviour") = QMetaEnum::fromType<Host::BlankLineBehaviour>().valueToKey(
             static_cast<int>(pHost->mBlankLineBehaviour));
     host.append_attribute("NetworkPacketTimeout") = pHost->mTelnet.getPostingTimeout();
-    if (int mode = static_cast<int>(pHost->getControlCharacterMode()); mode) {
+    if (int const mode = static_cast<int>(pHost->getControlCharacterMode()); mode) {
         // Don't bother to include the attribute if ignoreIterator is the default (zero)
         // value - and as ignoreIterator is an ASCII digit ignoreIterator only needs
         // QString::toLatin1() encoding:
@@ -497,7 +497,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
             while (it.hasNext()) {
                 it.next();
                 mInstalledModules.append_child("key").text().set(it.key().toUtf8().constData());
-                QStringList entry = it.value();
+                QStringList const entry = it.value();
                 mInstalledModules.append_child("filepath").text().set(entry.at(0).toUtf8().constData());
                 if (entry.at(0).endsWith(qsl("mpackage"), Qt::CaseInsensitive) || entry.at(0).endsWith(qsl("zip"), Qt::CaseInsensitive)) {
                     mInstalledModules.append_child("zipSync").text().set(entry.at(1).toUtf8().constData());
@@ -878,13 +878,13 @@ void XMLexport::writeTrigger(TTrigger* pT, pugi::xml_node xmlParent)
             auto regexCodeList = trigger.append_child("regexCodeList");
             // Revert the first 16 ANSI colour codes back to the wrong values
             // that are still used in the save files
-            QStringList unfixedAnsiColourPatternList = remapAnsiToColorNumber(pT->mPatterns, pT->mPatternKinds);
+            QStringList const unfixedAnsiColourPatternList = remapAnsiToColorNumber(pT->mPatterns, pT->mPatternKinds);
             for (int i = 0; i < unfixedAnsiColourPatternList.size(); ++i) {
                 regexCodeList.append_child("string").text().set(unfixedAnsiColourPatternList.at(i).toUtf8().constData());
             }
 
             auto regexCodePropertyList = trigger.append_child("regexCodePropertyList");
-            for (int i : qAsConst(pT->mPatternKinds)) {
+            for (int const i : qAsConst(pT->mPatternKinds)) {
                 regexCodePropertyList.append_child("integer").text().set(QString::number(i).toUtf8().constData());
             }
         }
@@ -1192,13 +1192,13 @@ QStringList XMLexport::remapAnsiToColorNumber(const QStringList & patternList, c
 {
 
     QStringList results;
-    QRegularExpression regex = QRegularExpression(qsl("^ANSI_COLORS_F{(\\d+|IGNORE|DEFAULT)}_B{(\\d+|IGNORE|DEFAULT)}$"));
+    QRegularExpression const regex = QRegularExpression(qsl("^ANSI_COLORS_F{(\\d+|IGNORE|DEFAULT)}_B{(\\d+|IGNORE|DEFAULT)}$"));
     QStringListIterator itPattern(patternList);
     QListIterator<int> itType(typeList);
     while (itPattern.hasNext() && itType.hasNext()) {
         if (itType.next() == REGEX_COLOR_PATTERN) {
             if (!itPattern.next().isEmpty()) {
-                QRegularExpressionMatch match = regex.match(itPattern.peekPrevious());
+                QRegularExpressionMatch const match = regex.match(itPattern.peekPrevious());
                 // Although we define two '('...')' capture groups the count/size is
                 // 3 (0 is the whole string)!
                 if (match.hasMatch() && match.capturedTexts().size() == 3) {

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -470,7 +470,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("blankLineBehaviour") = QMetaEnum::fromType<Host::BlankLineBehaviour>().valueToKey(
             static_cast<int>(pHost->mBlankLineBehaviour));
     host.append_attribute("NetworkPacketTimeout") = pHost->mTelnet.getPostingTimeout();
-    if (int const mode = static_cast<int>(pHost->getControlCharacterMode()); mode) {
+    if (const int mode = static_cast<int>(pHost->getControlCharacterMode()); mode) {
         // Don't bother to include the attribute if ignoreIterator is the default (zero)
         // value - and as ignoreIterator is an ASCII digit ignoreIterator only needs
         // QString::toLatin1() encoding:
@@ -884,7 +884,7 @@ void XMLexport::writeTrigger(TTrigger* pT, pugi::xml_node xmlParent)
             }
 
             auto regexCodePropertyList = trigger.append_child("regexCodePropertyList");
-            for (int const i : qAsConst(pT->mPatternKinds)) {
+            for (const int i : qAsConst(pT->mPatternKinds)) {
                 regexCodePropertyList.append_child("integer").text().set(QString::number(i).toUtf8().constData());
             }
         }

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -497,7 +497,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
             while (it.hasNext()) {
                 it.next();
                 mInstalledModules.append_child("key").text().set(it.key().toUtf8().constData());
-                QStringList const entry = it.value();
+                const QStringList entry = it.value();
                 mInstalledModules.append_child("filepath").text().set(entry.at(0).toUtf8().constData());
                 if (entry.at(0).endsWith(qsl("mpackage"), Qt::CaseInsensitive) || entry.at(0).endsWith(qsl("zip"), Qt::CaseInsensitive)) {
                     mInstalledModules.append_child("zipSync").text().set(entry.at(1).toUtf8().constData());
@@ -878,7 +878,7 @@ void XMLexport::writeTrigger(TTrigger* pT, pugi::xml_node xmlParent)
             auto regexCodeList = trigger.append_child("regexCodeList");
             // Revert the first 16 ANSI colour codes back to the wrong values
             // that are still used in the save files
-            QStringList const unfixedAnsiColourPatternList = remapAnsiToColorNumber(pT->mPatterns, pT->mPatternKinds);
+            const QStringList unfixedAnsiColourPatternList = remapAnsiToColorNumber(pT->mPatterns, pT->mPatternKinds);
             for (int i = 0; i < unfixedAnsiColourPatternList.size(); ++i) {
                 regexCodeList.append_child("string").text().set(unfixedAnsiColourPatternList.at(i).toUtf8().constData());
             }

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -971,7 +971,7 @@ void XMLimport::readHost(Host* pHost)
                 while (it.hasNext()) {
                     it.next();
                     QStringList moduleList;
-                    QStringList const entryList = it.value();
+                    const QStringList entryList = it.value();
                     moduleList << entryList.at(0);
                     moduleList << entryList.at(1);
                     pHost->mInstalledModules[it.key()] = moduleList;

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -148,7 +148,7 @@ std::pair<bool, QString> XMLimport::importPackage(QFile* pfile, QString packName
                     versionString = attributes().value(qsl("version")).toString();
                     if (!versionString.isEmpty()) {
                         bool isOk = false;
-                        float const versionNumber = versionString.toFloat(&isOk);
+                        const float versionNumber = versionString.toFloat(&isOk);
                         if (isOk) {
                             mVersionMajor = qFloor(versionNumber);
                             mVersionMinor = qRound(1000.0 * versionNumber) - (1000 * mVersionMajor);

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -148,7 +148,7 @@ std::pair<bool, QString> XMLimport::importPackage(QFile* pfile, QString packName
                     versionString = attributes().value(qsl("version")).toString();
                     if (!versionString.isEmpty()) {
                         bool isOk = false;
-                        float versionNumber = versionString.toFloat(&isOk);
+                        float const versionNumber = versionString.toFloat(&isOk);
                         if (isOk) {
                             mVersionMajor = qFloor(versionNumber);
                             mVersionMinor = qRound(1000.0 * versionNumber) - (1000 * mVersionMajor);
@@ -163,7 +163,7 @@ std::pair<bool, QString> XMLimport::importPackage(QFile* pfile, QString packName
                     /*||(mVersionMajor==1&&mVersionMinor)*/) {
                     // Minor check is not currently relevant, just abort on 2.000f or more
 
-                    QString moanMsg = tr("[ ALERT ] - Sorry, the file being read:\n"
+                    QString const moanMsg = tr("[ ALERT ] - Sorry, the file being read:\n"
                                          "\"%1\"\n"
                                          "reports it has a version (%2) it must have come from a later Mudlet version,\n"
                                          "and this one cannot read it, you need a newer Mudlet!")
@@ -270,7 +270,7 @@ void XMLimport::readVariable(TVar* pParent)
     int keyType = 0;
     int valueType;
 
-    QString what = name().toString();
+    QString const what = name().toString();
     while (!atEnd()) {
         readNext();
         if (isEndElement()) {
@@ -318,7 +318,7 @@ void XMLimport::readHiddenVariables()
 
         if (isStartElement()) {
             if (name() == qsl("name")) {
-                QString var = readElementText();
+                QString const var = readElementText();
                 vu->addHidden(var);
                 continue;
             }
@@ -373,14 +373,14 @@ void XMLimport::readMap()
     }
 
     mpHost->mpMap->reportStringToProgressDialog(tr("Assigning rooms to their areas..."));
-    int roomTotal = tempAreaRoomsHash.count();
+    int const roomTotal = tempAreaRoomsHash.count();
     int currentRoomCount = 0;
 
     QListIterator<int> itAreaWithRooms(tempAreaRoomsHash.uniqueKeys());
     while (itAreaWithRooms.hasNext()) {
-        int areaId = itAreaWithRooms.next();
+        int const areaId = itAreaWithRooms.next();
         auto values = tempAreaRoomsHash.values(areaId);
-        QSet<int> areaRoomsSet{values.begin(), values.end()};
+        QSet<int> const areaRoomsSet{values.begin(), values.end()};
 
         if (!mpHost->mpMap->mpRoomDB->areas.contains(areaId)) {
             // It is known for map files to have rooms with area Ids that are
@@ -407,8 +407,8 @@ void XMLimport::readEnvColors()
 
 void XMLimport::readEnvColor()
 {
-    int id = attributes().value(qsl("id")).toString().toInt();
-    int color = attributes().value(qsl("color")).toString().toInt();
+    int const id = attributes().value(qsl("id")).toString().toInt();
+    int const color = attributes().value(qsl("color")).toString().toInt();
 
     mpHost->mpMap->mEnvColors[id] = color;
 }
@@ -429,8 +429,8 @@ void XMLimport::readAreas()
 void XMLimport::readArea()
 {
     if (attributes().hasAttribute(qsl("id"))) {
-        int id = attributes().value(qsl("id")).toString().toInt();
-        QString name = attributes().value(qsl("name")).toString();
+        int const id = attributes().value(qsl("id")).toString().toInt();
+        QString const name = attributes().value(qsl("name")).toString();
 
         mpHost->mpMap->mpRoomDB->addArea(id, name);
     }
@@ -499,13 +499,13 @@ void XMLimport::readRoom(QMultiHash<int, int>& areamRoomMultiHash, unsigned int*
                       // entranceMultiHash
         } else if (Q_LIKELY(name() == qsl("exit"))) {
             QString dir = attributes().value(qsl("direction")).toString();
-            int e = attributes().value(qsl("target")).toString().toInt();
+            int const e = attributes().value(qsl("target")).toString().toInt();
             // If there is a "hidden" exit mark it as a locked door, otherwise
             // if there is a "door" mark it as an open/closed/locked door
             // depending on the value (I.R.E. MUD maps always uses "1" for "door"
             // and/or "hidden" - though the latter does not always appear with
             // former):
-            int door = (attributes().hasAttribute(qsl("hidden")) && attributes().value(qsl("hidden")).toString().toInt() == 1)
+            int const door = (attributes().hasAttribute(qsl("hidden")) && attributes().value(qsl("hidden")).toString().toInt() == 1)
                     ? 3
                     : (attributes().hasAttribute(qsl("door")) && attributes().value(qsl("door")).toString().toInt() >= 0 && attributes().value(qsl("door")).toString().toInt() <= 3)
                       ? attributes().value(qsl("door")).toString().toInt()
@@ -659,7 +659,7 @@ void XMLimport::readHelpPackage()
             break;
         } else if (isStartElement()) {
             if (name() == qsl("helpURL")) {
-                QString contents = readElementText();
+                QString const contents = readElementText();
                 mpHost->moduleHelp[mPackageName].insert("helpURL", contents);
             }
         }
@@ -761,8 +761,8 @@ void XMLimport::readHost(Host* pHost)
     pHost->mEnableMSP = attributes().value(qsl("mEnableMSP")) == YES;
     pHost->mMapStrongHighlight = attributes().value(qsl("mMapStrongHighlight")) == YES;
     pHost->mEnableSpellCheck = attributes().value(qsl("mEnableSpellCheck")) == YES;
-    bool enableUserDictionary = attributes().value(qsl("mEnableUserDictionary")) == YES;
-    bool useSharedDictionary = attributes().value(qsl("mUseSharedDictionary")) == YES;
+    bool const enableUserDictionary = attributes().value(qsl("mEnableUserDictionary")) == YES;
+    bool const useSharedDictionary = attributes().value(qsl("mUseSharedDictionary")) == YES;
     pHost->setUserDictionaryOptions(enableUserDictionary, useSharedDictionary);
     pHost->mAcceptServerGUI = attributes().value(qsl("mAcceptServerGUI")) == YES;
     pHost->mAcceptServerMedia = attributes().value(qsl("mAcceptServerMedia")) == YES;
@@ -879,7 +879,7 @@ void XMLimport::readHost(Host* pHost)
     pHost->mShowRoomID = attributes().value(qsl("mShowRoomIDs")) == YES;
     pHost->mShowPanel = attributes().value(qsl("mShowPanel")) == YES;
     pHost->mHaveMapperScript = attributes().value(qsl("mHaveMapperScript")) == YES;
-    QStringView ignore(attributes().value(qsl("mDoubleClickIgnore")));
+    QStringView const ignore(attributes().value(qsl("mDoubleClickIgnore")));
     for (auto character : ignore) {
         pHost->mDoubleClickIgnore.insert(character);
     }
@@ -902,7 +902,7 @@ void XMLimport::readHost(Host* pHost)
     pHost->mSslIgnoreSelfSigned = attributes().value(qsl("mSslIgnoreSelfSigned")) == YES;
     pHost->mSslIgnoreAll = attributes().value(qsl("mSslIgnoreAll")) == YES;
     pHost->mAskTlsAvailable = attributes().value(qsl("mAskTlsAvailable")) == YES;
-    bool compactInputLine = attributes().value(QLatin1String("CompactInputLine")) == YES;
+    bool const compactInputLine = attributes().value(QLatin1String("CompactInputLine")) == YES;
     pHost->setCompactInputLine(compactInputLine);
     if (mudlet::self()->mpCurrentActiveHost == pHost) {
         mudlet::self()->dactionInputLine->setChecked(compactInputLine);
@@ -971,7 +971,7 @@ void XMLimport::readHost(Host* pHost)
                 while (it.hasNext()) {
                     it.next();
                     QStringList moduleList;
-                    QStringList entryList = it.value();
+                    QStringList const entryList = it.value();
                     moduleList << entryList.at(0);
                     moduleList << entryList.at(1);
                     pHost->mInstalledModules[it.key()] = moduleList;
@@ -1196,7 +1196,7 @@ int XMLimport::readTrigger(TTrigger* pParent)
     pT->mColorTrigger = attributes().value(qsl("isColorTrigger")) == YES;
 
     // Is this a "TriggerGroup" or a "Trigger"
-    QString what = name().toString();
+    QString const what = name().toString();
     while (!atEnd()) {
         readNext();
 
@@ -1206,7 +1206,7 @@ int XMLimport::readTrigger(TTrigger* pParent)
             if (name() == qsl("name")) {
                 pT->setName(readElementText());
             } else if (name() == qsl("script")) {
-                QString tempScript = readScriptElement();
+                QString const tempScript = readScriptElement();
                 if (!pT->setScript(tempScript)) {
                     qDebug().nospace() << "XMLimport::readTrigger(...): ERROR: can not compile trigger's lua code for: " << pT->getName();
                 }
@@ -1307,7 +1307,7 @@ int XMLimport::readTimer(TTimer* pParent)
         pT->mModuleMember = true;
     }
 
-    QString what = name().toString();
+    QString const what = name().toString();
     while (!atEnd()) {
         readNext();
         if (isEndElement()) {
@@ -1318,7 +1318,7 @@ int XMLimport::readTimer(TTimer* pParent)
             } else if (name() == qsl("packageName")) {
                 pT->mPackageName = readElementText();
             } else if (name() == qsl("script")) {
-                QString tempScript = readScriptElement();
+                QString const tempScript = readScriptElement();
                 if (!pT->setScript(tempScript)) {
                     qDebug().nospace() << "XMLimport::readTimer(...): ERROR: can not compile timer's lua code for: " << pT->getName();
                 }
@@ -1374,7 +1374,7 @@ int XMLimport::readAlias(TAlias* pParent)
         pT->mModuleMember = true;
     }
 
-    QString what = name().toString();
+    QString const what = name().toString();
     while (!atEnd()) {
         readNext();
 
@@ -1386,7 +1386,7 @@ int XMLimport::readAlias(TAlias* pParent)
             } else if (name() == qsl("packageName")) {
                 pT->mPackageName = readElementText();
             } else if (name() == qsl("script")) {
-                QString tempScript = readScriptElement();
+                QString const tempScript = readScriptElement();
                 if (!pT->setScript(tempScript)) {
                     qDebug().nospace() << "XMLimport::readAlias(...): ERROR: can not compile alias's lua code for: " << pT->getName();
                 }
@@ -1441,7 +1441,7 @@ int XMLimport::readAction(TAction* pParent)
         pT->mModuleMember = true;
     }
 
-    QString what = name().toString();
+    QString const what = name().toString();
     while (!atEnd()) {
         readNext();
         if (isEndElement()) {
@@ -1452,7 +1452,7 @@ int XMLimport::readAction(TAction* pParent)
             } else if (name() == qsl("packageName")) {
                 pT->mPackageName = readElementText();
             } else if (name() == qsl("script")) {
-                QString tempScript = readScriptElement();
+                QString const tempScript = readScriptElement();
                 if (!pT->setScript(tempScript)) {
                     qDebug().nospace() << "XMLimport::readAction(...): ERROR: can not compile action's lua code for: " << pT->getName();
                 }
@@ -1531,7 +1531,7 @@ int XMLimport::readScript(TScript* pParent)
         script->mModuleMember = true;
     }
 
-    QString what = name().toString();
+    QString const what = name().toString();
     while (!atEnd()) {
         readNext();
         if (isEndElement()) {
@@ -1542,7 +1542,7 @@ int XMLimport::readScript(TScript* pParent)
             } else if (name() == qsl("packageName")) {
                 script->mPackageName = readElementText();
             } else if (name() == qsl("script")) {
-                QString tempScript = readScriptElement();
+                QString const tempScript = readScriptElement();
                 if (!script->setScript(tempScript)) {
                     qDebug().nospace().noquote() << "XMLimport::readScript(...) ERROR - can not compile script's lua code for \"" << script->getName() << "\"; reason: " << script->getError() << ".";
                 }
@@ -1592,7 +1592,7 @@ int XMLimport::readKey(TKey* pParent)
         pT->mModuleMember = true;
     }
 
-    QString what = name().toString();
+    QString const what = name().toString();
     while (!atEnd()) {
         readNext();
 
@@ -1604,7 +1604,7 @@ int XMLimport::readKey(TKey* pParent)
             } else if (name() == qsl("packageName")) {
                 pT->mPackageName = readElementText();
             } else if (name() == qsl("script")) {
-                QString tempScript = readScriptElement();
+                QString const tempScript = readScriptElement();
                 if (!pT->setScript(tempScript)) {
                     qDebug().nospace() << "XMLimport::readKey(...): ERROR: can not compile key's lua code for: " << pT->getName();
                 }
@@ -1687,9 +1687,9 @@ void XMLimport::readIntegerList(QList<int>& list, const QString& parentName, con
             break;
         } else if (isStartElement()) {
             if (name() == qsl("integer")) {
-                QString numberText = readElementText();
+                QString const numberText = readElementText();
                 bool ok = false;
-                int num = numberText.toInt(&ok, 10);
+                int const num = numberText.toInt(&ok, 10);
                 if (Q_LIKELY(!numberText.isEmpty() && ok)) {
                     switch (num) {
                     case REGEX_SUBSTRING:
@@ -1786,12 +1786,12 @@ void XMLimport::remapColorsToAnsiNumber(QStringList & patternList, const QList<i
     // it to capture a '-' sign as part of the color numbers as we use -2 for
     // ignored which was/is/will not handled by code before Mudlet 3.17.x (and
     // we might have more  negative numbers in the future!)
-    QRegularExpression regex = QRegularExpression(qsl("FG(-?\\d+)BG(-?\\d+)"));
+    QRegularExpression const regex = QRegularExpression(qsl("FG(-?\\d+)BG(-?\\d+)"));
     QMutableStringListIterator itPattern(patternList);
     QListIterator<int> itType(typeList);
     while (itPattern.hasNext() && itType.hasNext()) {
         if (itType.next() == REGEX_COLOR_PATTERN) {
-            QRegularExpressionMatch match = regex.match(itPattern.next());
+            QRegularExpressionMatch const match = regex.match(itPattern.next());
             // Although we define two '('...')' capture groups the count/size is
             // 3 (0 is the whole string)!
             if (match.capturedTexts().size() == 3) {
@@ -1883,7 +1883,7 @@ void XMLimport::readStopWatchMap()
             break;
         } else if (isStartElement()) {
             if (name() == qsl("stopwatch")) {
-                int watchId = attributes().value(qsl("id")).toInt();
+                int const watchId = attributes().value(qsl("id")).toInt();
                 auto pStopWatch = new stopWatch();
                 pStopWatch->setName(attributes().value(qsl("name")).toString());
                 pStopWatch->mIsPersistent = true;

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -761,8 +761,8 @@ void XMLimport::readHost(Host* pHost)
     pHost->mEnableMSP = attributes().value(qsl("mEnableMSP")) == YES;
     pHost->mMapStrongHighlight = attributes().value(qsl("mMapStrongHighlight")) == YES;
     pHost->mEnableSpellCheck = attributes().value(qsl("mEnableSpellCheck")) == YES;
-    bool const enableUserDictionary = attributes().value(qsl("mEnableUserDictionary")) == YES;
-    bool const useSharedDictionary = attributes().value(qsl("mUseSharedDictionary")) == YES;
+    const bool enableUserDictionary = attributes().value(qsl("mEnableUserDictionary")) == YES;
+    const bool useSharedDictionary = attributes().value(qsl("mUseSharedDictionary")) == YES;
     pHost->setUserDictionaryOptions(enableUserDictionary, useSharedDictionary);
     pHost->mAcceptServerGUI = attributes().value(qsl("mAcceptServerGUI")) == YES;
     pHost->mAcceptServerMedia = attributes().value(qsl("mAcceptServerMedia")) == YES;
@@ -902,7 +902,7 @@ void XMLimport::readHost(Host* pHost)
     pHost->mSslIgnoreSelfSigned = attributes().value(qsl("mSslIgnoreSelfSigned")) == YES;
     pHost->mSslIgnoreAll = attributes().value(qsl("mSslIgnoreAll")) == YES;
     pHost->mAskTlsAvailable = attributes().value(qsl("mAskTlsAvailable")) == YES;
-    bool const compactInputLine = attributes().value(QLatin1String("CompactInputLine")) == YES;
+    const bool compactInputLine = attributes().value(QLatin1String("CompactInputLine")) == YES;
     pHost->setCompactInputLine(compactInputLine);
     if (mudlet::self()->mpCurrentActiveHost == pHost) {
         mudlet::self()->dactionInputLine->setChecked(compactInputLine);

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -163,7 +163,7 @@ std::pair<bool, QString> XMLimport::importPackage(QFile* pfile, QString packName
                     /*||(mVersionMajor==1&&mVersionMinor)*/) {
                     // Minor check is not currently relevant, just abort on 2.000f or more
 
-                    QString const moanMsg = tr("[ ALERT ] - Sorry, the file being read:\n"
+                    const QString moanMsg = tr("[ ALERT ] - Sorry, the file being read:\n"
                                          "\"%1\"\n"
                                          "reports it has a version (%2) it must have come from a later Mudlet version,\n"
                                          "and this one cannot read it, you need a newer Mudlet!")
@@ -270,7 +270,7 @@ void XMLimport::readVariable(TVar* pParent)
     int keyType = 0;
     int valueType;
 
-    QString const what = name().toString();
+    const QString what = name().toString();
     while (!atEnd()) {
         readNext();
         if (isEndElement()) {
@@ -318,7 +318,7 @@ void XMLimport::readHiddenVariables()
 
         if (isStartElement()) {
             if (name() == qsl("name")) {
-                QString const var = readElementText();
+                const QString var = readElementText();
                 vu->addHidden(var);
                 continue;
             }
@@ -430,7 +430,7 @@ void XMLimport::readArea()
 {
     if (attributes().hasAttribute(qsl("id"))) {
         int const id = attributes().value(qsl("id")).toString().toInt();
-        QString const name = attributes().value(qsl("name")).toString();
+        const QString name = attributes().value(qsl("name")).toString();
 
         mpHost->mpMap->mpRoomDB->addArea(id, name);
     }
@@ -659,7 +659,7 @@ void XMLimport::readHelpPackage()
             break;
         } else if (isStartElement()) {
             if (name() == qsl("helpURL")) {
-                QString const contents = readElementText();
+                const QString contents = readElementText();
                 mpHost->moduleHelp[mPackageName].insert("helpURL", contents);
             }
         }
@@ -1196,7 +1196,7 @@ int XMLimport::readTrigger(TTrigger* pParent)
     pT->mColorTrigger = attributes().value(qsl("isColorTrigger")) == YES;
 
     // Is this a "TriggerGroup" or a "Trigger"
-    QString const what = name().toString();
+    const QString what = name().toString();
     while (!atEnd()) {
         readNext();
 
@@ -1206,7 +1206,7 @@ int XMLimport::readTrigger(TTrigger* pParent)
             if (name() == qsl("name")) {
                 pT->setName(readElementText());
             } else if (name() == qsl("script")) {
-                QString const tempScript = readScriptElement();
+                const QString tempScript = readScriptElement();
                 if (!pT->setScript(tempScript)) {
                     qDebug().nospace() << "XMLimport::readTrigger(...): ERROR: can not compile trigger's lua code for: " << pT->getName();
                 }
@@ -1307,7 +1307,7 @@ int XMLimport::readTimer(TTimer* pParent)
         pT->mModuleMember = true;
     }
 
-    QString const what = name().toString();
+    const QString what = name().toString();
     while (!atEnd()) {
         readNext();
         if (isEndElement()) {
@@ -1318,7 +1318,7 @@ int XMLimport::readTimer(TTimer* pParent)
             } else if (name() == qsl("packageName")) {
                 pT->mPackageName = readElementText();
             } else if (name() == qsl("script")) {
-                QString const tempScript = readScriptElement();
+                const QString tempScript = readScriptElement();
                 if (!pT->setScript(tempScript)) {
                     qDebug().nospace() << "XMLimport::readTimer(...): ERROR: can not compile timer's lua code for: " << pT->getName();
                 }
@@ -1374,7 +1374,7 @@ int XMLimport::readAlias(TAlias* pParent)
         pT->mModuleMember = true;
     }
 
-    QString const what = name().toString();
+    const QString what = name().toString();
     while (!atEnd()) {
         readNext();
 
@@ -1386,7 +1386,7 @@ int XMLimport::readAlias(TAlias* pParent)
             } else if (name() == qsl("packageName")) {
                 pT->mPackageName = readElementText();
             } else if (name() == qsl("script")) {
-                QString const tempScript = readScriptElement();
+                const QString tempScript = readScriptElement();
                 if (!pT->setScript(tempScript)) {
                     qDebug().nospace() << "XMLimport::readAlias(...): ERROR: can not compile alias's lua code for: " << pT->getName();
                 }
@@ -1441,7 +1441,7 @@ int XMLimport::readAction(TAction* pParent)
         pT->mModuleMember = true;
     }
 
-    QString const what = name().toString();
+    const QString what = name().toString();
     while (!atEnd()) {
         readNext();
         if (isEndElement()) {
@@ -1452,7 +1452,7 @@ int XMLimport::readAction(TAction* pParent)
             } else if (name() == qsl("packageName")) {
                 pT->mPackageName = readElementText();
             } else if (name() == qsl("script")) {
-                QString const tempScript = readScriptElement();
+                const QString tempScript = readScriptElement();
                 if (!pT->setScript(tempScript)) {
                     qDebug().nospace() << "XMLimport::readAction(...): ERROR: can not compile action's lua code for: " << pT->getName();
                 }
@@ -1531,7 +1531,7 @@ int XMLimport::readScript(TScript* pParent)
         script->mModuleMember = true;
     }
 
-    QString const what = name().toString();
+    const QString what = name().toString();
     while (!atEnd()) {
         readNext();
         if (isEndElement()) {
@@ -1542,7 +1542,7 @@ int XMLimport::readScript(TScript* pParent)
             } else if (name() == qsl("packageName")) {
                 script->mPackageName = readElementText();
             } else if (name() == qsl("script")) {
-                QString const tempScript = readScriptElement();
+                const QString tempScript = readScriptElement();
                 if (!script->setScript(tempScript)) {
                     qDebug().nospace().noquote() << "XMLimport::readScript(...) ERROR - can not compile script's lua code for \"" << script->getName() << "\"; reason: " << script->getError() << ".";
                 }
@@ -1592,7 +1592,7 @@ int XMLimport::readKey(TKey* pParent)
         pT->mModuleMember = true;
     }
 
-    QString const what = name().toString();
+    const QString what = name().toString();
     while (!atEnd()) {
         readNext();
 
@@ -1604,7 +1604,7 @@ int XMLimport::readKey(TKey* pParent)
             } else if (name() == qsl("packageName")) {
                 pT->mPackageName = readElementText();
             } else if (name() == qsl("script")) {
-                QString const tempScript = readScriptElement();
+                const QString tempScript = readScriptElement();
                 if (!pT->setScript(tempScript)) {
                     qDebug().nospace() << "XMLimport::readKey(...): ERROR: can not compile key's lua code for: " << pT->getName();
                 }
@@ -1687,7 +1687,7 @@ void XMLimport::readIntegerList(QList<int>& list, const QString& parentName, con
             break;
         } else if (isStartElement()) {
             if (name() == qsl("integer")) {
-                QString const numberText = readElementText();
+                const QString numberText = readElementText();
                 bool ok = false;
                 int const num = numberText.toInt(&ok, 10);
                 if (Q_LIKELY(!numberText.isEmpty() && ok)) {
@@ -1712,7 +1712,7 @@ void XMLimport::readIntegerList(QList<int>& list, const QString& parentName, con
                     default:
                         mpHost->postMessage(qsl("[ ERROR ] - \"%1\" as a number when reading the 'regexCodePropertyList' element of the 'Trigger' or 'TriggerGroup' element \"%2\" cannot be understood by this version of Mudlet, is it from a later version? Converting it to a SUBSTRING type so the data can be shown but it will probably not work as expected.").arg(numberText, parentName));
                         list << REGEX_SUBSTRING; //Set it to the default type
-                    }                        
+                    }
 
                 } else {
                     qWarning(R"(XMLimport::readIntegerList(...) ERROR: unable to convert: "%s" to a number when reading the 'regexCodePropertyList' element of the 'Trigger' or 'TriggerGroup' element "%s"!)",

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -373,12 +373,12 @@ void XMLimport::readMap()
     }
 
     mpHost->mpMap->reportStringToProgressDialog(tr("Assigning rooms to their areas..."));
-    int const roomTotal = tempAreaRoomsHash.count();
+    const int roomTotal = tempAreaRoomsHash.count();
     int currentRoomCount = 0;
 
     QListIterator<int> itAreaWithRooms(tempAreaRoomsHash.uniqueKeys());
     while (itAreaWithRooms.hasNext()) {
-        int const areaId = itAreaWithRooms.next();
+        const int areaId = itAreaWithRooms.next();
         auto values = tempAreaRoomsHash.values(areaId);
         QSet<int> const areaRoomsSet{values.begin(), values.end()};
 
@@ -407,8 +407,8 @@ void XMLimport::readEnvColors()
 
 void XMLimport::readEnvColor()
 {
-    int const id = attributes().value(qsl("id")).toString().toInt();
-    int const color = attributes().value(qsl("color")).toString().toInt();
+    const int id = attributes().value(qsl("id")).toString().toInt();
+    const int color = attributes().value(qsl("color")).toString().toInt();
 
     mpHost->mpMap->mEnvColors[id] = color;
 }
@@ -429,7 +429,7 @@ void XMLimport::readAreas()
 void XMLimport::readArea()
 {
     if (attributes().hasAttribute(qsl("id"))) {
-        int const id = attributes().value(qsl("id")).toString().toInt();
+        const int id = attributes().value(qsl("id")).toString().toInt();
         const QString name = attributes().value(qsl("name")).toString();
 
         mpHost->mpMap->mpRoomDB->addArea(id, name);
@@ -499,13 +499,13 @@ void XMLimport::readRoom(QMultiHash<int, int>& areamRoomMultiHash, unsigned int*
                       // entranceMultiHash
         } else if (Q_LIKELY(name() == qsl("exit"))) {
             QString dir = attributes().value(qsl("direction")).toString();
-            int const e = attributes().value(qsl("target")).toString().toInt();
+            const int e = attributes().value(qsl("target")).toString().toInt();
             // If there is a "hidden" exit mark it as a locked door, otherwise
             // if there is a "door" mark it as an open/closed/locked door
             // depending on the value (I.R.E. MUD maps always uses "1" for "door"
             // and/or "hidden" - though the latter does not always appear with
             // former):
-            int const door = (attributes().hasAttribute(qsl("hidden")) && attributes().value(qsl("hidden")).toString().toInt() == 1)
+            const int door = (attributes().hasAttribute(qsl("hidden")) && attributes().value(qsl("hidden")).toString().toInt() == 1)
                     ? 3
                     : (attributes().hasAttribute(qsl("door")) && attributes().value(qsl("door")).toString().toInt() >= 0 && attributes().value(qsl("door")).toString().toInt() <= 3)
                       ? attributes().value(qsl("door")).toString().toInt()
@@ -1689,7 +1689,7 @@ void XMLimport::readIntegerList(QList<int>& list, const QString& parentName, con
             if (name() == qsl("integer")) {
                 const QString numberText = readElementText();
                 bool ok = false;
-                int const num = numberText.toInt(&ok, 10);
+                const int num = numberText.toInt(&ok, 10);
                 if (Q_LIKELY(!numberText.isEmpty() && ok)) {
                     switch (num) {
                     case REGEX_SUBSTRING:
@@ -1883,7 +1883,7 @@ void XMLimport::readStopWatchMap()
             break;
         } else if (isStartElement()) {
             if (name() == qsl("stopwatch")) {
-                int const watchId = attributes().value(qsl("id")).toInt();
+                const int watchId = attributes().value(qsl("id")).toInt();
                 auto pStopWatch = new stopWatch();
                 pStopWatch->setName(attributes().value(qsl("name")).toString());
                 pStopWatch->mIsPersistent = true;

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -216,7 +216,7 @@ void Discord::setEndTimeStamp(Host* pHost, int64_t epochTimeStamp)
 
 void Discord::setParty(Host* pHost, int partySize)
 {
-    int validPartySize = qMax(0, partySize);
+    int const validPartySize = qMax(0, partySize);
     if (validPartySize) {
         // Is more than zero:
         if (mPartyMax.value(pHost) < validPartySize) {
@@ -238,8 +238,8 @@ void Discord::setParty(Host* pHost, int partySize)
 
 void Discord::setParty(Host* pHost, int partySize, int partyMax)
 {
-    int validPartySize = qMax(0, partySize);
-    int validPartyMax = qMax(0, partyMax);
+    int const validPartySize = qMax(0, partySize);
+    int const validPartyMax = qMax(0, partyMax);
 
     if (validPartyMax) {
         // We have a party max size that is a positive number - so use the
@@ -328,7 +328,7 @@ void Discord::UpdatePresence()
 #if defined(DEBUG_DISCORD)
         qDebug().nospace().noquote() << "Discord::UpdatePresence() INFO - no current active Host instance, sending update using built-in Mudlet ApplicationID:\n" << tempPresence;
 #endif
-        DiscordRichPresence convertedPresence(tempPresence.convert());
+        DiscordRichPresence const convertedPresence(tempPresence.convert());
         Discord_UpdatePresence(&convertedPresence);
 
         return;
@@ -457,7 +457,7 @@ void Discord::UpdatePresence()
     qDebug().nospace().noquote() << "Discord::UpdatePresence() INFO - sending update:\n" << *pDiscordPresence;
 #endif
     // Convert our stored presence into the format that the RPC library wants:
-    DiscordRichPresence convertedPresence(pDiscordPresence->convert());
+    DiscordRichPresence const convertedPresence(pDiscordPresence->convert());
     Discord_UpdatePresence(&convertedPresence);
 }
 
@@ -539,7 +539,7 @@ QString Discord::deduceGameName(const QString& address)
 // first is true.
 QPair<bool, QString> Discord::gameIntegrationSupported(const QString& address)
 {
-    QString deducedName = deduceGameName(address);
+    QString const deducedName = deduceGameName(address);
 
     // Handle using localhost as an off-line testing case
     if (deducedName == QLatin1String("localhost")) {
@@ -558,7 +558,7 @@ bool Discord::libraryLoaded()
 // quint64, or qulonglong)
 bool Discord::setApplicationID(Host* pHost, const QString& text)
 {
-    QString oldID = mHostApplicationIDs.value(pHost);
+    QString const oldID = mHostApplicationIDs.value(pHost);
     if (oldID == text) {
         // No change so do nothing
         return true;

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -539,7 +539,7 @@ QString Discord::deduceGameName(const QString& address)
 // first is true.
 QPair<bool, QString> Discord::gameIntegrationSupported(const QString& address)
 {
-    QString const deducedName = deduceGameName(address);
+    const QString deducedName = deduceGameName(address);
 
     // Handle using localhost as an off-line testing case
     if (deducedName == QLatin1String("localhost")) {
@@ -558,7 +558,7 @@ bool Discord::libraryLoaded()
 // quint64, or qulonglong)
 bool Discord::setApplicationID(Host* pHost, const QString& text)
 {
-    QString const oldID = mHostApplicationIDs.value(pHost);
+    const QString oldID = mHostApplicationIDs.value(pHost);
     if (oldID == text) {
         // No change so do nothing
         return true;

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -216,7 +216,7 @@ void Discord::setEndTimeStamp(Host* pHost, int64_t epochTimeStamp)
 
 void Discord::setParty(Host* pHost, int partySize)
 {
-    int const validPartySize = qMax(0, partySize);
+    const int validPartySize = qMax(0, partySize);
     if (validPartySize) {
         // Is more than zero:
         if (mPartyMax.value(pHost) < validPartySize) {
@@ -238,8 +238,8 @@ void Discord::setParty(Host* pHost, int partySize)
 
 void Discord::setParty(Host* pHost, int partySize, int partyMax)
 {
-    int const validPartySize = qMax(0, partySize);
-    int const validPartyMax = qMax(0, partyMax);
+    const int validPartySize = qMax(0, partySize);
+    const int validPartyMax = qMax(0, partyMax);
 
     if (validPartyMax) {
         // We have a party max size that is a positive number - so use the

--- a/src/discord.h
+++ b/src/discord.h
@@ -136,7 +136,7 @@ private:
 // Note "inline" is REQUIRED:
 inline QDebug& operator<<(QDebug& debug, const localDiscordPresence& ldp)
 {
-    QDebugStateSaver saver(debug);
+    QDebugStateSaver const saver(debug);
     Q_UNUSED(saver);
 
     QString result = qsl("localDiscordPresence(\n"

--- a/src/dlgColorTrigger.cpp
+++ b/src/dlgColorTrigger.cpp
@@ -242,7 +242,7 @@ void dlgColorTrigger::slot_setRBGButtonFocus()
 void dlgColorTrigger::slot_grayColorChanged(int sliderValue)
 {
     mGrayAnsiColorNumber = 232 + sliderValue;
-    int const value = (sliderValue - 232) * 10 + 8;
+    const int value = (sliderValue - 232) * 10 + 8;
 
     mGrayAnsiColor = QColor(value, value, value);
     label_grayValue->setText(qsl("[%1]").arg(QString::number(mGrayAnsiColorNumber)));

--- a/src/dlgColorTrigger.cpp
+++ b/src/dlgColorTrigger.cpp
@@ -242,7 +242,7 @@ void dlgColorTrigger::slot_setRBGButtonFocus()
 void dlgColorTrigger::slot_grayColorChanged(int sliderValue)
 {
     mGrayAnsiColorNumber = 232 + sliderValue;
-    int value = (sliderValue - 232) * 10 + 8;
+    int const value = (sliderValue - 232) * 10 + 8;
 
     mGrayAnsiColor = QColor(value, value, value);
     label_grayValue->setText(qsl("[%1]").arg(QString::number(mGrayAnsiColorNumber)));

--- a/src/dlgComposer.cpp
+++ b/src/dlgComposer.cpp
@@ -30,7 +30,7 @@ dlgComposer::dlgComposer(Host* pH)
 : mpHost(pH)
 {
     setupUi(this);
-    QFont font = QFont(qsl("Bitstream Vera Sans Mono"), 10, QFont::Normal);
+    QFont const font = QFont(qsl("Bitstream Vera Sans Mono"), 10, QFont::Normal);
     edit->setFont(font);
     connect(saveButton, &QAbstractButton::clicked, this, &dlgComposer::slot_save);
     connect(cancelButton, &QAbstractButton::clicked, this, &dlgComposer::slot_cancel);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -719,7 +719,7 @@ void dlgConnectionProfiles::slot_deleteProfile()
 QString dlgConnectionProfiles::readProfileData(const QString& profile, const QString& item) const
 {
     QFile file(mudlet::getMudletPath(mudlet::profileDataItemPath, profile, item));
-    bool const success = file.open(QIODevice::ReadOnly);
+    const bool success = file.open(QIODevice::ReadOnly);
     QString ret;
     if (success) {
         QDataStream ifs(&file);
@@ -1254,7 +1254,7 @@ void dlgConnectionProfiles::slot_setCustomIcon()
         return;
     }
 
-    bool const success = mudlet::self()->setProfileIcon(profileName, imageLocation).first;
+    const bool success = mudlet::self()->setProfileIcon(profileName, imageLocation).first;
     if (!success) {
         return;
     }
@@ -1282,7 +1282,7 @@ void dlgConnectionProfiles::slot_resetCustomIcon()
 {
     auto profileName = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
 
-    bool const success = mudlet::self()->resetProfileIcon(profileName).first;
+    const bool success = mudlet::self()->resetProfileIcon(profileName).first;
     if (!success) {
         return;
     }

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -878,7 +878,7 @@ void dlgConnectionProfiles::slot_itemClicked(QListWidgetItem* pItem)
 
     QDir dir(mudlet::getMudletPath(mudlet::profileXmlFilesPath, profile_name));
     dir.setSorting(QDir::Time);
-    QStringList const entries = dir.entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
+    const QStringList entries = dir.entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
 
     for (const auto& entry : entries) {
         QRegularExpression const rx(qsl("(\\d+)\\-(\\d+)\\-(\\d+)#(\\d+)\\-(\\d+)\\-(\\d+).xml"));

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -179,8 +179,8 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
         // change it anyhow:
         abort->setIcon(QIcon::fromTheme(qsl("dialog-close"), QIcon(qsl(":/icons/dialog-close.png"))));
 
-        QIcon icon_new(QIcon::fromTheme(qsl("document-new"), QIcon(qsl(":/icons/document-new.png"))));
-        QIcon icon_connect(QIcon::fromTheme(qsl("dialog-ok-apply"), QIcon(qsl(":/icons/preferences-web-browser-cache.png"))));
+        QIcon const icon_new(QIcon::fromTheme(qsl("document-new"), QIcon(qsl(":/icons/document-new.png"))));
+        QIcon const icon_connect(QIcon::fromTheme(qsl("dialog-ok-apply"), QIcon(qsl(":/icons/preferences-web-browser-cache.png"))));
 
         offline_button->setIcon(QIcon(qsl(":/icons/mudlet_editor.png")));
         connect_button->setIcon(icon_connect);
@@ -198,7 +198,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
         // Remove the marker:
         cursor.removeSelectedText();
         // Insert the current icon image into the same place:
-        QImage image_new(QPixmap(icon_new.pixmap(new_profile_button->iconSize())).toImage());
+        QImage const image_new(QPixmap(icon_new.pixmap(new_profile_button->iconSize())).toImage());
         cursor.insertImage(image_new);
         cursor.clearSelection();
 
@@ -207,7 +207,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
                    "dlgConnectionProfiles::dlgConnectionProfiles(...)",
                    "CONNECT_PROFILE_ICON text marker not found in welcome_message text for when icons are shown on dialogue buttons");
         cursor.removeSelectedText();
-        QImage image_connect(QPixmap(icon_connect.pixmap(connect_button->iconSize())).toImage());
+        QImage const image_connect(QPixmap(icon_connect.pixmap(connect_button->iconSize())).toImage());
         cursor.insertImage(image_connect);
         cursor.clearSelection();
     } else {
@@ -319,7 +319,7 @@ void dlgConnectionProfiles::slot_updateDescription()
     QListWidgetItem* pItem = profiles_tree_widget->currentItem();
 
     if (pItem) {
-        QString description = mud_description_textedit->toPlainText();
+        QString const description = mud_description_textedit->toPlainText();
         writeProfileData(pItem->data(csmNameRole).toString(), qsl("description"), description);
 
         // don't display custom profile descriptions as a tooltip, as passwords could be stored in there
@@ -452,7 +452,7 @@ void dlgConnectionProfiles::slot_updateDiscordOptIn(int state)
 
 void dlgConnectionProfiles::slot_updatePort(const QString& ignoreBlank)
 {
-    QString port = port_entry->text().trimmed();
+    QString const port = port_entry->text().trimmed();
 
     if (ignoreBlank.isEmpty()) {
         validPort = false;
@@ -496,18 +496,18 @@ void dlgConnectionProfiles::slot_updateName(const QString& newName)
 void dlgConnectionProfiles::slot_saveName()
 {
     QListWidgetItem* pItem = profiles_tree_widget->currentItem();
-    QString newProfileName = profile_name_entry->text().trimmed();
-    QString newProfileHost = host_name_entry->text().trimmed();
-    QString newProfilePort = port_entry->text().trimmed();
-    int newProfileSslTsl = port_ssl_tsl->isChecked() * 2;
+    QString const newProfileName = profile_name_entry->text().trimmed();
+    QString const newProfileHost = host_name_entry->text().trimmed();
+    QString const newProfilePort = port_entry->text().trimmed();
+    int const newProfileSslTsl = port_ssl_tsl->isChecked() * 2;
 
     validateProfile();
     if (!validName || newProfileName.isEmpty() || !pItem) {
         return;
     }
 
-    QString currentProfileEditName = pItem->data(csmNameRole).toString();
-    int row = mProfileList.indexOf(currentProfileEditName);
+    QString const currentProfileEditName = pItem->data(csmNameRole).toString();
+    int const row = mProfileList.indexOf(currentProfileEditName);
     if ((row >= 0) && (row < mProfileList.size())) {
         mProfileList[row] = newProfileName;
     } else {
@@ -525,8 +525,8 @@ void dlgConnectionProfiles::slot_saveName()
 
     setItemName(pItem, newProfileName);
 
-    QDir currentPath(mudlet::getMudletPath(mudlet::profileHomePath, currentProfileEditName));
-    QDir dir;
+    QDir const currentPath(mudlet::getMudletPath(mudlet::profileHomePath, currentProfileEditName));
+    QDir const dir;
 
     if (currentPath.exists()) {
         // CHECKME: previous code specified a path ending in a '/'
@@ -591,7 +591,7 @@ void dlgConnectionProfiles::slot_addProfile()
     informationalArea->show();
     tabWidget_connectionInfo->show();
 
-    QString newname = tr("new profile name");
+    QString const newname = tr("new profile name");
 
     auto pItem = new QListWidgetItem();
     if (!pItem) {
@@ -628,7 +628,7 @@ void dlgConnectionProfiles::slot_addProfile()
 // enables the deletion button once the correct text (profile name) is entered
 void dlgConnectionProfiles::slot_deleteProfileCheck(const QString& text)
 {
-    QString profile = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
+    QString const profile = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
     if (profile != text) {
         delete_button->setEnabled(false);
     } else {
@@ -640,7 +640,7 @@ void dlgConnectionProfiles::slot_deleteProfileCheck(const QString& text)
 // actually performs the deletion once the correct text has been entered
 void dlgConnectionProfiles::slot_reallyDeleteProfile()
 {
-    QString profile = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
+    QString const profile = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
     reallyDeleteProfile(profile);
 }
 
@@ -669,14 +669,14 @@ void dlgConnectionProfiles::slot_deleteProfile()
         return;
     }
 
-    QString profile = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
+    QString const profile = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
     const QStringList& onlyShownPredefinedProfiles{mudlet::self()->mOnlyShownPredefinedProfiles};
     if (!onlyShownPredefinedProfiles.isEmpty() && onlyShownPredefinedProfiles.contains(profile)) {
         // Do NOT allow deletion of the prioritised predefined MUD:
         return;
     }
 
-    QDir profileDirContents(mudlet::getMudletPath(mudlet::profileXmlFilesPath, profile));
+    QDir const profileDirContents(mudlet::getMudletPath(mudlet::profileXmlFilesPath, profile));
     if (!profileDirContents.exists() || profileDirContents.isEmpty()) {
         // shortcut - don't show profile deletion confirmation if there is no data to delete
         reallyDeleteProfile(profile);
@@ -719,7 +719,7 @@ void dlgConnectionProfiles::slot_deleteProfile()
 QString dlgConnectionProfiles::readProfileData(const QString& profile, const QString& item) const
 {
     QFile file(mudlet::getMudletPath(mudlet::profileDataItemPath, profile, item));
-    bool success = file.open(QIODevice::ReadOnly);
+    bool const success = file.open(QIODevice::ReadOnly);
     QString ret;
     if (success) {
         QDataStream ifs(&file);
@@ -878,19 +878,19 @@ void dlgConnectionProfiles::slot_itemClicked(QListWidgetItem* pItem)
 
     QDir dir(mudlet::getMudletPath(mudlet::profileXmlFilesPath, profile_name));
     dir.setSorting(QDir::Time);
-    QStringList entries = dir.entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
+    QStringList const entries = dir.entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
 
     for (const auto& entry : entries) {
-        QRegularExpression rx(qsl("(\\d+)\\-(\\d+)\\-(\\d+)#(\\d+)\\-(\\d+)\\-(\\d+).xml"));
-        QRegularExpressionMatch match = rx.match(entry);
+        QRegularExpression const rx(qsl("(\\d+)\\-(\\d+)\\-(\\d+)#(\\d+)\\-(\\d+)\\-(\\d+).xml"));
+        QRegularExpressionMatch const match = rx.match(entry);
 
         if (match.capturedStart() != -1) {
             QString day;
-            QString month = match.captured(2);
+            QString const month = match.captured(2);
             QString year;
-            QString hour = match.captured(4);
-            QString minute = match.captured(5);
-            QString second = match.captured(6);
+            QString const hour = match.captured(4);
+            QString const minute = match.captured(5);
+            QString const second = match.captured(6);
             if (match.captured(1).toInt() > 31 && match.captured(3).toInt() >= 1 && match.captured(3).toInt() <= 31) {
                 // I have been experimenting with code that puts the year first
                 // which is actually quite useful - this accommodates such cases
@@ -908,7 +908,7 @@ void dlgConnectionProfiles::slot_itemClicked(QListWidgetItem* pItem)
             datetime.setDate(QDate(year.toInt(), month.toInt(), day.toInt()));
             profile_history->addItem(mudlet::self()->getUserLocale().toString(datetime, mDateTimeFormat), QVariant(entry));
         } else if (entry == QLatin1String("autosave.xml")) {
-            QFileInfo fileInfo(dir, entry);
+            QFileInfo const fileInfo(dir, entry);
             auto lastModified = fileInfo.lastModified();
             profile_history->addItem(QIcon::fromTheme(qsl("document-save"), QIcon(qsl(":/icons/document-save.png"))),
                                      mudlet::self()->getUserLocale().toString(lastModified, mDateTimeFormat),
@@ -1028,7 +1028,7 @@ void dlgConnectionProfiles::fillout_form()
         }
 
 #if defined(QT_DEBUG)
-        QString mudServer = qsl("Mudlet self-test");
+        QString const mudServer = qsl("Mudlet self-test");
         if (!deletedDefaultMuds.contains(mudServer) && !mProfileList.contains(mudServer)) {
             mProfileList.append(mudServer);
             pItem = new QListWidgetItem();
@@ -1068,7 +1068,7 @@ void dlgConnectionProfiles::fillout_form()
         const auto fileinfo = QFileInfo(mudlet::getMudletPath(mudlet::profileXmlFilesPath, profileName));
         if (fileinfo.exists()) {
             firstMudletLaunch = false;
-            QDateTime profile_lastRead = fileinfo.lastModified();
+            QDateTime const profile_lastRead = fileinfo.lastModified();
             // Since Qt 5.x null QTimes and QDateTimes are invalid - and might not
             // work as expected - so test for validity of the test_date value as well
             if ((!test_date.isValid()) || profile_lastRead > test_date) {
@@ -1205,7 +1205,7 @@ std::optional<QColor> getCustomColor(const QString& profileName)
         }
 
         QTextStream in(&file);
-        QString colorString = in.readLine();
+        QString const colorString = in.readLine();
         QColor color(colorString);
         if (color.isValid()) {
             return {color};
@@ -1224,7 +1224,7 @@ void dlgConnectionProfiles::generateCustomProfile(const QString& profileName) co
 
 void dlgConnectionProfiles::slot_profileContextMenu(QPoint pos)
 {
-    QPoint globalPos = profiles_tree_widget->mapToGlobal(pos);
+    QPoint const globalPos = profiles_tree_widget->mapToGlobal(pos);
     auto profileName = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
 
     QMenu menu;
@@ -1248,13 +1248,13 @@ void dlgConnectionProfiles::slot_setCustomIcon()
 {
     auto profileName = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
 
-    QString imageLocation = QFileDialog::getOpenFileName(
+    QString const imageLocation = QFileDialog::getOpenFileName(
             this, tr("Select custom image for profile (should be 120x30)"), QStandardPaths::writableLocation(QStandardPaths::HomeLocation), tr("Images (%1)").arg(qsl("*.png *.gif *.jpg")));
     if (imageLocation.isEmpty()) {
         return;
     }
 
-    bool success = mudlet::self()->setProfileIcon(profileName, imageLocation).first;
+    bool const success = mudlet::self()->setProfileIcon(profileName, imageLocation).first;
     if (!success) {
         return;
     }
@@ -1282,7 +1282,7 @@ void dlgConnectionProfiles::slot_resetCustomIcon()
 {
     auto profileName = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
 
-    bool success = mudlet::self()->resetProfileIcon(profileName).first;
+    bool const success = mudlet::self()->resetProfileIcon(profileName).first;
     if (!success) {
         return;
     }
@@ -1332,7 +1332,7 @@ void dlgConnectionProfiles::slot_copyProfile()
     }
 
     // copy the folder on-disk
-    QDir dir(mudlet::getMudletPath(mudlet::profileHomePath, oldname));
+    QDir const dir(mudlet::getMudletPath(mudlet::profileHomePath, oldname));
     if (!dir.exists()) {
         mCopyingProfile = false;
         return;
@@ -1374,14 +1374,14 @@ void dlgConnectionProfiles::slot_copyOnlySettingsOfProfile()
         return;
     }
 
-    QDir newProfileDir(mudlet::getMudletPath(mudlet::profileHomePath, profile_name));
+    QDir const newProfileDir(mudlet::getMudletPath(mudlet::profileHomePath, profile_name));
     newProfileDir.mkpath(newProfileDir.path());
     if (!newProfileDir.exists()) {
         return;
     }
 
     // copy relevant profile files
-    for (QString file : {"url", "port", "password", "login", "description"}) {
+    for (QString const file : {"url", "port", "password", "login", "description"}) {
         auto filePath = qsl("%1/%2").arg(mudlet::getMudletPath(mudlet::profileHomePath, oldname), file);
         auto newFilePath = qsl("%1/%2").arg(mudlet::getMudletPath(mudlet::profileHomePath, profile_name), file);
         QFile::copy(filePath, newFilePath);
@@ -1443,8 +1443,8 @@ bool dlgConnectionProfiles::copyProfileWidget(QString& profile_name, QString& ol
 
 void dlgConnectionProfiles::copyProfileSettingsOnly(const QString& oldname, const QString& newname)
 {
-    QDir oldProfiledir(mudlet::getMudletPath(mudlet::profileXmlFilesPath, oldname));
-    QDir newProfiledir(mudlet::getMudletPath(mudlet::profileXmlFilesPath, newname));
+    QDir const oldProfiledir(mudlet::getMudletPath(mudlet::profileXmlFilesPath, oldname));
+    QDir const newProfiledir(mudlet::getMudletPath(mudlet::profileXmlFilesPath, newname));
     newProfiledir.mkpath(newProfiledir.absolutePath());
     QStringList entries = oldProfiledir.entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
     if (entries.empty()) {
@@ -1462,7 +1462,7 @@ void dlgConnectionProfiles::copyProfileSettingsOnly(const QString& oldname, cons
 bool dlgConnectionProfiles::extractSettingsFromProfile(pugi::xml_document& newProfile, const QString& copySettingsFrom)
 {
     pugi::xml_document oldProfile;
-    pugi::xml_parse_result result = oldProfile.load_file(copySettingsFrom.toUtf8().constData());
+    pugi::xml_parse_result const result = oldProfile.load_file(copySettingsFrom.toUtf8().constData());
     if (!result) {
         qWarning() << "dlgConnectionProfiles::copyProfileSettingsOnly() ERROR: couldn't parse" << copySettingsFrom;
         qWarning() << "Parse error: " << result.description() << ", character pos= " << result.offset;
@@ -1485,7 +1485,7 @@ bool dlgConnectionProfiles::extractSettingsFromProfile(pugi::xml_document& newPr
 
     // remove installed packages/modules
     const auto hostPackageResults = oldProfile.select_nodes("/MudletPackage/HostPackage");
-    pugi::xml_node hostPackage = hostPackageResults.first().node();
+    pugi::xml_node const hostPackage = hostPackageResults.first().node();
     auto host = hostPackage.child("Host");
     host.remove_child("mInstalledPackages");
     host.remove_child("mInstalledModules");
@@ -1524,7 +1524,7 @@ void dlgConnectionProfiles::slot_load()
 
 void dlgConnectionProfiles::loadProfile(bool alsoConnect)
 {
-    QString profile_name = profile_name_entry->text().trimmed();
+    QString const profile_name = profile_name_entry->text().trimmed();
 
     if (profile_name.isEmpty()) {
         return;
@@ -1550,7 +1550,7 @@ void dlgConnectionProfiles::loadProfile(bool alsoConnect)
         return;
     }
 
-    QString folder(mudlet::getMudletPath(mudlet::profileXmlFilesPath, profile_name));
+    QString const folder(mudlet::getMudletPath(mudlet::profileXmlFilesPath, profile_name));
     QDir dir(folder);
     dir.setSorting(QDir::Time);
     QStringList entries = dir.entryList(QDir::Files, QDir::Time);
@@ -1676,7 +1676,7 @@ bool dlgConnectionProfiles::validateProfile()
             valid = false;
         }
 
-        QString port = port_entry->text().trimmed();
+        QString const port = port_entry->text().trimmed();
         if (!port.isEmpty() && (port.indexOf(QRegularExpression(qsl("^\\d+$")), 0) == -1)) {
             QString val = port;
             val.chop(1);
@@ -1689,7 +1689,7 @@ bool dlgConnectionProfiles::validateProfile()
         }
 
         bool ok;
-        int num = port.trimmed().toInt(&ok);
+        int const num = port.trimmed().toInt(&ok);
         if (!port.isEmpty() && (num > 65536 && ok)) {
             notificationAreaIconLabelError->show();
             notificationAreaMessageBox->setText(qsl("%1\n%2\n\n").arg(notificationAreaMessageBox->text(), tr("Port number must be above zero and below 65535.")));
@@ -1723,7 +1723,7 @@ bool dlgConnectionProfiles::validateProfile()
 #endif
 
         QUrl check;
-        QString url = host_name_entry->text().trimmed();
+        QString const url = host_name_entry->text().trimmed();
         check.setHost(url);
 
         if (url.isEmpty()) {
@@ -1805,26 +1805,26 @@ bool dlgConnectionProfiles::validateProfile()
 // credit: http://www.qtcentre.org/archive/index.php/t-23469.html
 bool dlgConnectionProfiles::copyFolder(const QString& sourceFolder, const QString& destFolder)
 {
-    QDir sourceDir(sourceFolder);
+    QDir const sourceDir(sourceFolder);
     if (!sourceDir.exists()) {
         return false;
     }
 
-    QDir destDir(destFolder);
+    QDir const destDir(destFolder);
     if (!destDir.exists()) {
         destDir.mkdir(destFolder);
     }
     QStringList files = sourceDir.entryList(QDir::Files);
     for (int i = 0; i < files.count(); i++) {
-        QString srcName = sourceFolder + QDir::separator() + files[i];
-        QString destName = destFolder + QDir::separator() + files[i];
+        QString const srcName = sourceFolder + QDir::separator() + files[i];
+        QString const destName = destFolder + QDir::separator() + files[i];
         QFile::copy(srcName, destName);
     }
     files.clear();
     files = sourceDir.entryList(QDir::AllDirs | QDir::NoDotAndDotDot);
     for (int i = 0; i < files.count(); i++) {
-        QString srcName = sourceFolder + QDir::separator() + files[i];
-        QString destName = destFolder + QDir::separator() + files[i];
+        QString const srcName = sourceFolder + QDir::separator() + files[i];
+        QString const destName = destFolder + QDir::separator() + files[i];
         copyFolder(srcName, destName);
     }
     return true;
@@ -1896,7 +1896,7 @@ void dlgConnectionProfiles::setupMudProfile(QListWidgetItem* pItem, const QStrin
 
     profiles_tree_widget->addItem(pItem);
     if (!hasCustomIcon(mudServer)) {
-        QPixmap pixmap(iconFileName);
+        QPixmap const pixmap(iconFileName);
         if (pixmap.isNull()) {
             qWarning() << mudServer << "doesn't have a valid icon";
             return;
@@ -1918,26 +1918,26 @@ QIcon dlgConnectionProfiles::customIcon(const QString& text, const std::optional
 {
     QPixmap background(120, 30);
 
-    QColor color = backgroundColor.value_or(mCustomIconColors.at(static_cast<int>((qHash(text) * 8131) % mCustomIconColors.count())));
+    QColor const color = backgroundColor.value_or(mCustomIconColors.at(static_cast<int>((qHash(text) * 8131) % mCustomIconColors.count())));
     background.fill(color);
 
     // Set to one larger than wanted so that do loop can contain the decrementor
     int fontSize = 30;
     QFont font(qsl("Bitstream Vera Sans Mono"), fontSize, QFont::Normal);
     // For an icon of size 120x30 allow 89x29 for the text:
-    QRect textRectangle(0, 0, 89, 29);
+    QRect const textRectangle(0, 0, 89, 29);
     QRect testRect;
     // Really long names will be drawn very small (font size 6) with the ends clipped off:
     do {
         font.setPointSize(--fontSize);
-        QFontMetrics metrics(font);
+        QFontMetrics const metrics(font);
         testRect = metrics.boundingRect(textRectangle, Qt::AlignCenter | Qt::TextWordWrap, text);
     } while (fontSize > 6 && !textRectangle.contains(testRect));
 
     { // Enclosed in braces to limit lifespan of QPainter:
         QPainter painter(&background);
         painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
-        QPixmap pixmap(qsl(":/icons/mudlet_main_32px.png"));
+        QPixmap const pixmap(qsl(":/icons/mudlet_main_32px.png"));
         painter.drawPixmap(QRect(5, 5, 20, 20), pixmap);
         if (color.lightness() > 127) {
             painter.setPen(Qt::black);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -525,8 +525,8 @@ void dlgConnectionProfiles::slot_saveName()
 
     setItemName(pItem, newProfileName);
 
-    QDir const currentPath(mudlet::getMudletPath(mudlet::profileHomePath, currentProfileEditName));
-    QDir const dir;
+    const QDir currentPath(mudlet::getMudletPath(mudlet::profileHomePath, currentProfileEditName));
+    const QDir dir;
 
     if (currentPath.exists()) {
         // CHECKME: previous code specified a path ending in a '/'
@@ -676,7 +676,7 @@ void dlgConnectionProfiles::slot_deleteProfile()
         return;
     }
 
-    QDir const profileDirContents(mudlet::getMudletPath(mudlet::profileXmlFilesPath, profile));
+    const QDir profileDirContents(mudlet::getMudletPath(mudlet::profileXmlFilesPath, profile));
     if (!profileDirContents.exists() || profileDirContents.isEmpty()) {
         // shortcut - don't show profile deletion confirmation if there is no data to delete
         reallyDeleteProfile(profile);
@@ -1332,7 +1332,7 @@ void dlgConnectionProfiles::slot_copyProfile()
     }
 
     // copy the folder on-disk
-    QDir const dir(mudlet::getMudletPath(mudlet::profileHomePath, oldname));
+    const QDir dir(mudlet::getMudletPath(mudlet::profileHomePath, oldname));
     if (!dir.exists()) {
         mCopyingProfile = false;
         return;
@@ -1374,7 +1374,7 @@ void dlgConnectionProfiles::slot_copyOnlySettingsOfProfile()
         return;
     }
 
-    QDir const newProfileDir(mudlet::getMudletPath(mudlet::profileHomePath, profile_name));
+    const QDir newProfileDir(mudlet::getMudletPath(mudlet::profileHomePath, profile_name));
     newProfileDir.mkpath(newProfileDir.path());
     if (!newProfileDir.exists()) {
         return;
@@ -1443,8 +1443,8 @@ bool dlgConnectionProfiles::copyProfileWidget(QString& profile_name, QString& ol
 
 void dlgConnectionProfiles::copyProfileSettingsOnly(const QString& oldname, const QString& newname)
 {
-    QDir const oldProfiledir(mudlet::getMudletPath(mudlet::profileXmlFilesPath, oldname));
-    QDir const newProfiledir(mudlet::getMudletPath(mudlet::profileXmlFilesPath, newname));
+    const QDir oldProfiledir(mudlet::getMudletPath(mudlet::profileXmlFilesPath, oldname));
+    const QDir newProfiledir(mudlet::getMudletPath(mudlet::profileXmlFilesPath, newname));
     newProfiledir.mkpath(newProfiledir.absolutePath());
     QStringList entries = oldProfiledir.entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
     if (entries.empty()) {
@@ -1805,12 +1805,12 @@ bool dlgConnectionProfiles::validateProfile()
 // credit: http://www.qtcentre.org/archive/index.php/t-23469.html
 bool dlgConnectionProfiles::copyFolder(const QString& sourceFolder, const QString& destFolder)
 {
-    QDir const sourceDir(sourceFolder);
+    const QDir sourceDir(sourceFolder);
     if (!sourceDir.exists()) {
         return false;
     }
 
-    QDir const destDir(destFolder);
+    const QDir destDir(destFolder);
     if (!destDir.exists()) {
         destDir.mkdir(destFolder);
     }

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1224,7 +1224,7 @@ void dlgConnectionProfiles::generateCustomProfile(const QString& profileName) co
 
 void dlgConnectionProfiles::slot_profileContextMenu(QPoint pos)
 {
-    QPoint const globalPos = profiles_tree_widget->mapToGlobal(pos);
+    const QPoint globalPos = profiles_tree_widget->mapToGlobal(pos);
     auto profileName = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
 
     QMenu menu;

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -908,7 +908,7 @@ void dlgConnectionProfiles::slot_itemClicked(QListWidgetItem* pItem)
             datetime.setDate(QDate(year.toInt(), month.toInt(), day.toInt()));
             profile_history->addItem(mudlet::self()->getUserLocale().toString(datetime, mDateTimeFormat), QVariant(entry));
         } else if (entry == QLatin1String("autosave.xml")) {
-            QFileInfo const fileInfo(dir, entry);
+            const QFileInfo fileInfo(dir, entry);
             auto lastModified = fileInfo.lastModified();
             profile_history->addItem(QIcon::fromTheme(qsl("document-save"), QIcon(qsl(":/icons/document-save.png"))),
                                      mudlet::self()->getUserLocale().toString(lastModified, mDateTimeFormat),

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -179,8 +179,8 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
         // change it anyhow:
         abort->setIcon(QIcon::fromTheme(qsl("dialog-close"), QIcon(qsl(":/icons/dialog-close.png"))));
 
-        QIcon const icon_new(QIcon::fromTheme(qsl("document-new"), QIcon(qsl(":/icons/document-new.png"))));
-        QIcon const icon_connect(QIcon::fromTheme(qsl("dialog-ok-apply"), QIcon(qsl(":/icons/preferences-web-browser-cache.png"))));
+        const QIcon icon_new(QIcon::fromTheme(qsl("document-new"), QIcon(qsl(":/icons/document-new.png"))));
+        const QIcon icon_connect(QIcon::fromTheme(qsl("dialog-ok-apply"), QIcon(qsl(":/icons/preferences-web-browser-cache.png"))));
 
         offline_button->setIcon(QIcon(qsl(":/icons/mudlet_editor.png")));
         connect_button->setIcon(icon_connect);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -319,7 +319,7 @@ void dlgConnectionProfiles::slot_updateDescription()
     QListWidgetItem* pItem = profiles_tree_widget->currentItem();
 
     if (pItem) {
-        QString const description = mud_description_textedit->toPlainText();
+        const QString description = mud_description_textedit->toPlainText();
         writeProfileData(pItem->data(csmNameRole).toString(), qsl("description"), description);
 
         // don't display custom profile descriptions as a tooltip, as passwords could be stored in there
@@ -452,7 +452,7 @@ void dlgConnectionProfiles::slot_updateDiscordOptIn(int state)
 
 void dlgConnectionProfiles::slot_updatePort(const QString& ignoreBlank)
 {
-    QString const port = port_entry->text().trimmed();
+    const QString port = port_entry->text().trimmed();
 
     if (ignoreBlank.isEmpty()) {
         validPort = false;
@@ -496,9 +496,9 @@ void dlgConnectionProfiles::slot_updateName(const QString& newName)
 void dlgConnectionProfiles::slot_saveName()
 {
     QListWidgetItem* pItem = profiles_tree_widget->currentItem();
-    QString const newProfileName = profile_name_entry->text().trimmed();
-    QString const newProfileHost = host_name_entry->text().trimmed();
-    QString const newProfilePort = port_entry->text().trimmed();
+    const QString newProfileName = profile_name_entry->text().trimmed();
+    const QString newProfileHost = host_name_entry->text().trimmed();
+    const QString newProfilePort = port_entry->text().trimmed();
     int const newProfileSslTsl = port_ssl_tsl->isChecked() * 2;
 
     validateProfile();
@@ -506,7 +506,7 @@ void dlgConnectionProfiles::slot_saveName()
         return;
     }
 
-    QString const currentProfileEditName = pItem->data(csmNameRole).toString();
+    const QString currentProfileEditName = pItem->data(csmNameRole).toString();
     int const row = mProfileList.indexOf(currentProfileEditName);
     if ((row >= 0) && (row < mProfileList.size())) {
         mProfileList[row] = newProfileName;
@@ -591,7 +591,7 @@ void dlgConnectionProfiles::slot_addProfile()
     informationalArea->show();
     tabWidget_connectionInfo->show();
 
-    QString const newname = tr("new profile name");
+    const QString newname = tr("new profile name");
 
     auto pItem = new QListWidgetItem();
     if (!pItem) {
@@ -628,7 +628,7 @@ void dlgConnectionProfiles::slot_addProfile()
 // enables the deletion button once the correct text (profile name) is entered
 void dlgConnectionProfiles::slot_deleteProfileCheck(const QString& text)
 {
-    QString const profile = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
+    const QString profile = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
     if (profile != text) {
         delete_button->setEnabled(false);
     } else {
@@ -640,7 +640,7 @@ void dlgConnectionProfiles::slot_deleteProfileCheck(const QString& text)
 // actually performs the deletion once the correct text has been entered
 void dlgConnectionProfiles::slot_reallyDeleteProfile()
 {
-    QString const profile = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
+    const QString profile = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
     reallyDeleteProfile(profile);
 }
 
@@ -669,7 +669,7 @@ void dlgConnectionProfiles::slot_deleteProfile()
         return;
     }
 
-    QString const profile = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
+    const QString profile = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
     const QStringList& onlyShownPredefinedProfiles{mudlet::self()->mOnlyShownPredefinedProfiles};
     if (!onlyShownPredefinedProfiles.isEmpty() && onlyShownPredefinedProfiles.contains(profile)) {
         // Do NOT allow deletion of the prioritised predefined MUD:
@@ -886,11 +886,11 @@ void dlgConnectionProfiles::slot_itemClicked(QListWidgetItem* pItem)
 
         if (match.capturedStart() != -1) {
             QString day;
-            QString const month = match.captured(2);
+            const QString month = match.captured(2);
             QString year;
-            QString const hour = match.captured(4);
-            QString const minute = match.captured(5);
-            QString const second = match.captured(6);
+            const QString hour = match.captured(4);
+            const QString minute = match.captured(5);
+            const QString second = match.captured(6);
             if (match.captured(1).toInt() > 31 && match.captured(3).toInt() >= 1 && match.captured(3).toInt() <= 31) {
                 // I have been experimenting with code that puts the year first
                 // which is actually quite useful - this accommodates such cases
@@ -1028,7 +1028,7 @@ void dlgConnectionProfiles::fillout_form()
         }
 
 #if defined(QT_DEBUG)
-        QString const mudServer = qsl("Mudlet self-test");
+        const QString mudServer = qsl("Mudlet self-test");
         if (!deletedDefaultMuds.contains(mudServer) && !mProfileList.contains(mudServer)) {
             mProfileList.append(mudServer);
             pItem = new QListWidgetItem();
@@ -1205,7 +1205,7 @@ std::optional<QColor> getCustomColor(const QString& profileName)
         }
 
         QTextStream in(&file);
-        QString const colorString = in.readLine();
+        const QString colorString = in.readLine();
         QColor color(colorString);
         if (color.isValid()) {
             return {color};
@@ -1248,7 +1248,7 @@ void dlgConnectionProfiles::slot_setCustomIcon()
 {
     auto profileName = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
 
-    QString const imageLocation = QFileDialog::getOpenFileName(
+    const QString imageLocation = QFileDialog::getOpenFileName(
             this, tr("Select custom image for profile (should be 120x30)"), QStandardPaths::writableLocation(QStandardPaths::HomeLocation), tr("Images (%1)").arg(qsl("*.png *.gif *.jpg")));
     if (imageLocation.isEmpty()) {
         return;
@@ -1381,7 +1381,7 @@ void dlgConnectionProfiles::slot_copyOnlySettingsOfProfile()
     }
 
     // copy relevant profile files
-    for (QString const file : {"url", "port", "password", "login", "description"}) {
+    for (const QString file : {"url", "port", "password", "login", "description"}) {
         auto filePath = qsl("%1/%2").arg(mudlet::getMudletPath(mudlet::profileHomePath, oldname), file);
         auto newFilePath = qsl("%1/%2").arg(mudlet::getMudletPath(mudlet::profileHomePath, profile_name), file);
         QFile::copy(filePath, newFilePath);
@@ -1524,7 +1524,7 @@ void dlgConnectionProfiles::slot_load()
 
 void dlgConnectionProfiles::loadProfile(bool alsoConnect)
 {
-    QString const profile_name = profile_name_entry->text().trimmed();
+    const QString profile_name = profile_name_entry->text().trimmed();
 
     if (profile_name.isEmpty()) {
         return;
@@ -1550,7 +1550,7 @@ void dlgConnectionProfiles::loadProfile(bool alsoConnect)
         return;
     }
 
-    QString const folder(mudlet::getMudletPath(mudlet::profileXmlFilesPath, profile_name));
+    const QString folder(mudlet::getMudletPath(mudlet::profileXmlFilesPath, profile_name));
     QDir dir(folder);
     dir.setSorting(QDir::Time);
     QStringList entries = dir.entryList(QDir::Files, QDir::Time);
@@ -1569,7 +1569,7 @@ void dlgConnectionProfiles::loadProfile(bool alsoConnect)
             //: %1 is the path and file name (i.e. the location) of the problem fil
             pHost->postMessage(tr("[ ERROR ] - Something went wrong loading your Mudlet profile and it could not be loaded.\n"
                 "Try loading an older version in 'Connect - Options - Profile history' or double-check that %1 looks correct.").arg(file.fileName()));
-        
+
             qDebug().nospace().noquote() << "dlgConnectionProfiles::loadProfile(" << alsoConnect << ") ERROR - loading \"" << file.fileName() << "\" failed, reason: \"" << message << "\".";
         } else {
             pHost->mLoadedOk = true;
@@ -1676,7 +1676,7 @@ bool dlgConnectionProfiles::validateProfile()
             valid = false;
         }
 
-        QString const port = port_entry->text().trimmed();
+        const QString port = port_entry->text().trimmed();
         if (!port.isEmpty() && (port.indexOf(QRegularExpression(qsl("^\\d+$")), 0) == -1)) {
             QString val = port;
             val.chop(1);
@@ -1723,7 +1723,7 @@ bool dlgConnectionProfiles::validateProfile()
 #endif
 
         QUrl check;
-        QString const url = host_name_entry->text().trimmed();
+        const QString url = host_name_entry->text().trimmed();
         check.setHost(url);
 
         if (url.isEmpty()) {
@@ -1816,15 +1816,15 @@ bool dlgConnectionProfiles::copyFolder(const QString& sourceFolder, const QStrin
     }
     QStringList files = sourceDir.entryList(QDir::Files);
     for (int i = 0; i < files.count(); i++) {
-        QString const srcName = sourceFolder + QDir::separator() + files[i];
-        QString const destName = destFolder + QDir::separator() + files[i];
+        const QString srcName = sourceFolder + QDir::separator() + files[i];
+        const QString destName = destFolder + QDir::separator() + files[i];
         QFile::copy(srcName, destName);
     }
     files.clear();
     files = sourceDir.entryList(QDir::AllDirs | QDir::NoDotAndDotDot);
     for (int i = 0; i < files.count(); i++) {
-        QString const srcName = sourceFolder + QDir::separator() + files[i];
-        QString const destName = destFolder + QDir::separator() + files[i];
+        const QString srcName = sourceFolder + QDir::separator() + files[i];
+        const QString destName = destFolder + QDir::separator() + files[i];
         copyFolder(srcName, destName);
     }
     return true;

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -499,7 +499,7 @@ void dlgConnectionProfiles::slot_saveName()
     const QString newProfileName = profile_name_entry->text().trimmed();
     const QString newProfileHost = host_name_entry->text().trimmed();
     const QString newProfilePort = port_entry->text().trimmed();
-    int const newProfileSslTsl = port_ssl_tsl->isChecked() * 2;
+    const int newProfileSslTsl = port_ssl_tsl->isChecked() * 2;
 
     validateProfile();
     if (!validName || newProfileName.isEmpty() || !pItem) {
@@ -507,7 +507,7 @@ void dlgConnectionProfiles::slot_saveName()
     }
 
     const QString currentProfileEditName = pItem->data(csmNameRole).toString();
-    int const row = mProfileList.indexOf(currentProfileEditName);
+    const int row = mProfileList.indexOf(currentProfileEditName);
     if ((row >= 0) && (row < mProfileList.size())) {
         mProfileList[row] = newProfileName;
     } else {
@@ -1689,7 +1689,7 @@ bool dlgConnectionProfiles::validateProfile()
         }
 
         bool ok;
-        int const num = port.trimmed().toInt(&ok);
+        const int num = port.trimmed().toInt(&ok);
         if (!port.isEmpty() && (num > 65536 && ok)) {
             notificationAreaIconLabelError->show();
             notificationAreaMessageBox->setText(qsl("%1\n%2\n\n").arg(notificationAreaMessageBox->text(), tr("Port number must be above zero and below 65535.")));

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -151,7 +151,7 @@ QPair<bool, QString> dlgIRC::sendMsg(const QString& target, const QString& messa
 
     // inform the command parser of the target for this message.
     // parses the message and then reverts the target to avoid confusing our UI.
-    QString lastParserTarget = commandParser->target();
+    QString const lastParserTarget = commandParser->target();
     commandParser->setTarget(msgTarget);
     IrcCommand* command = commandParser->parse(message);
     commandParser->setTarget(lastParserTarget);
@@ -160,7 +160,7 @@ QPair<bool, QString> dlgIRC::sendMsg(const QString& target, const QString& messa
         return QPair<bool, QString>(false, qsl("message could not be parsed"));
     }
 
-    bool isCustomCommand = processCustomCommand(command);
+    bool const isCustomCommand = processCustomCommand(command);
     if (isCustomCommand) {
         return QPair<bool, QString>(true, qsl("command processed by client"));
     }
@@ -191,7 +191,7 @@ QPair<bool, QString> dlgIRC::sendMsg(const QString& target, const QString& messa
 
 void dlgIRC::ircRestart(bool reloadConfigs)
 {
-    QString msg = tr("Restarting IRC Client");
+    QString const msg = tr("Restarting IRC Client");
     ircBrowser->append(IrcMessageFormatter::formatMessage("! %1.").arg(msg));
 
     // issue a quit message to the network if we're connected.
@@ -200,7 +200,7 @@ void dlgIRC::ircRestart(bool reloadConfigs)
     }
 
     // remove the old buffers.
-    for (QString chName : qAsConst(mChannels)) {
+    for (QString const chName : qAsConst(mChannels)) {
         if (chName == serverBuffer->name()) {
             continue; // skip the server-buffer.
         }
@@ -304,7 +304,7 @@ bool dlgIRC::processCustomCommand(IrcCommand* cmd)
     if (cmdName == "CLEAR") {
         auto * buffer = bufferList->currentIndex().data(Irc::BufferRole).value<IrcBuffer*>();
         if (cmd->parameters().count() > 1) {
-            QString bufferName = cmd->parameters().at(1);
+            QString const bufferName = cmd->parameters().at(1);
             //QString cBufferName = buffer->title();
             if (!bufferName.isEmpty()) {
                 buffer = bufferModel->find(bufferName);
@@ -368,12 +368,12 @@ bool dlgIRC::processCustomCommand(IrcCommand* cmd)
             }
         }
         if (limit <= 0) {
-            QString error = tr("[Error] MSGLIMIT requires <limit> to be a whole number greater than zero!");
+            QString const error = tr("[Error] MSGLIMIT requires <limit> to be a whole number greater than zero!");
             ircBrowser->append(IrcMessageFormatter::formatMessage(error, qsl("indianred")));
             return true;
         }
         if (cmd->parameters().count() > 2) {
-            QString bufferName = cmd->parameters().at(2);
+            QString const bufferName = cmd->parameters().at(2);
             if (!bufferName.isEmpty()) {
                 IrcBuffer* buffer = bufferModel->find(bufferName);
                 if (buffer) {
@@ -430,7 +430,7 @@ void dlgIRC::slot_onTextEdited()
 
 void dlgIRC::slot_onTextEntered()
 {
-    QString input = lineEdit->text();
+    QString const input = lineEdit->text();
 
     // add this line to our history list.
     if (!input.isEmpty()) {
@@ -449,7 +449,7 @@ void dlgIRC::slot_onTextEntered()
     IrcCommand* command = commandParser->parse(input);
     if (command) {
         // handle custom commands
-        bool isCustomCommand = processCustomCommand(command);
+        bool const isCustomCommand = processCustomCommand(command);
         if (isCustomCommand) {
             lineEdit->clear();
             return;
@@ -479,7 +479,7 @@ void dlgIRC::slot_onTextEntered()
         lineEdit->clear();
     } else if (input.length() > 1) {
         QString error;
-        QString command = lineEdit->text().mid(1).split(" ", Qt::SkipEmptyParts).value(0).toUpper();
+        QString const command = lineEdit->text().mid(1).split(" ", Qt::SkipEmptyParts).value(0).toUpper();
         if (commandParser->commands().contains(command)) {
             error = tr("[ERROR] Syntax: %1").arg(commandParser->syntax(command).replace(qsl("<"), qsl("&lt;")).replace(qsl(">"), qsl("&gt;")));
         } else {
@@ -528,7 +528,7 @@ void dlgIRC::slot_onBufferAdded(IrcBuffer* buffer)
     userModel->setSortMethod(Irc::SortByTitle);
     userModels.insert(buffer, userModel);
     // activate the new buffer
-    int idx = bufferModel->buffers().indexOf(buffer);
+    int const idx = bufferModel->buffers().indexOf(buffer);
     if (idx != -1) {
         bufferList->setCurrentIndex(bufferModel->index(idx));
     }
@@ -565,7 +565,7 @@ void dlgIRC::slot_onUserActivated(const QModelIndex& index)
         }
         IrcBuffer* buffer = bufferModel->add(user->name());
         // activate the new query
-        int idx = bufferModel->buffers().indexOf(buffer);
+        int const idx = bufferModel->buffers().indexOf(buffer);
         if (idx != -1) {
             bufferList->setCurrentIndex(bufferModel->index(idx));
         }
@@ -598,14 +598,14 @@ void dlgIRC::slot_receiveMessage(IrcMessage* message)
     }
     QTextDocument* document = bufferTexts.value(buffer);
     if (document) {
-        QString html = IrcMessageFormatter::formatMessage(message);
+        QString const html = IrcMessageFormatter::formatMessage(message);
         if (!html.isEmpty()) {
             // send a plain-text formatted copy of the message to Lua, as long as it isn't our own.
             if (!message->isOwn()) {
-                QString textToLua = IrcMessageFormatter::formatMessage(message, true);
+                QString const textToLua = IrcMessageFormatter::formatMessage(message, true);
                 if (!textToLua.isEmpty()) {
-                    QString from = message->nick();
-                    QString to = getMessageTarget(message, buffer->title());
+                    QString const from = message->nick();
+                    QString const to = getMessageTarget(message, buffer->title());
                     mpHost->postIrcMessage(from, to, textToLua);
                 }
             }
@@ -628,7 +628,7 @@ void dlgIRC::slot_onAnchorClicked(const QUrl& link)
 void dlgIRC::slot_nickNameRequired(const QString& reserved, QString* alt)
 {
     Q_UNUSED(alt)
-    QString newNick = qsl("%1_%2").arg(reserved, QString::number(rand() % 10000));
+    QString const newNick = qsl("%1_%2").arg(reserved, QString::number(rand() % 10000));
     ircBrowser->append(IrcMessageFormatter::formatMessage(tr("! The Nickname %1 is reserved. Automatically changing Nickname to: %2").arg(reserved, newNick)));
     connection->setNickName(newNick);
 }
@@ -652,26 +652,26 @@ void dlgIRC::slot_joinedChannel(IrcJoinMessage* message)
         mReadyForSending = true;
     }
 
-    QString chan = message->channel();
+    QString const chan = message->channel();
     if (!mChannels.contains(chan)) {
         mChannels << chan;
     }
 
     if (message->isOwn()) {
-        QString luaText = IrcMessageFormatter::formatMessage(static_cast<IrcMessage*>(message), true);
+        QString const luaText = IrcMessageFormatter::formatMessage(static_cast<IrcMessage*>(message), true);
         mpHost->postIrcMessage(message->nick(), message->channel(), luaText);
     }
 }
 
 void dlgIRC::slot_partedChannel(IrcPartMessage* message)
 {
-    QString chan = message->channel();
+    QString const chan = message->channel();
     if (mChannels.contains(chan)) {
         mChannels.removeAll(chan);
     }
 
     if (message->isOwn()) {
-        QString luaText = IrcMessageFormatter::formatMessage(static_cast<IrcMessage*>(message), true);
+        QString const luaText = IrcMessageFormatter::formatMessage(static_cast<IrcMessage*>(message), true);
         mpHost->postIrcMessage(message->nick(), message->channel(), luaText);
     }
 }
@@ -727,7 +727,7 @@ QString dlgIRC::readIrcHostName(Host* pH)
 
 int dlgIRC::readIrcHostPort(Host* pH)
 {
-    QString portStr = pH->readProfileData(dlgIRC::HostPortCfgItem);
+    QString const portStr = pH->readProfileData(dlgIRC::HostPortCfgItem);
     bool ok;
     int port = portStr.toInt(&ok);
     if (portStr.isEmpty() || !ok) {
@@ -740,7 +740,7 @@ int dlgIRC::readIrcHostPort(Host* pH)
 
 bool dlgIRC::readIrcHostSecure(Host* pH)
 {
-    QString secureStr = pH->readProfileData(dlgIRC::HostSecureCfgItem);
+    QString const secureStr = pH->readProfileData(dlgIRC::HostSecureCfgItem);
     return secureStr.contains(QLatin1String("true"), Qt::CaseInsensitive);
 }
 
@@ -767,7 +767,7 @@ QString dlgIRC::readIrcPassword(Host* pH)
 QString dlgIRC::readAppDefaultIrcNick()
 {
     QFile file(mudlet::getMudletPath(mudlet::mainDataItemPath, qsl("irc_nick")));
-    bool opened = file.open(QIODevice::ReadOnly);
+    bool const opened = file.open(QIODevice::ReadOnly);
     QString rstr;
     if (opened) {
         QDataStream ifs(&file);
@@ -783,7 +783,7 @@ QString dlgIRC::readAppDefaultIrcNick()
 void dlgIRC::writeAppDefaultIrcNick(const QString& nick)
 {
     QSaveFile file(mudlet::getMudletPath(mudlet::mainDataItemPath, qsl("irc_nick")));
-    bool opened = file.open(QIODevice::WriteOnly);
+    bool const opened = file.open(QIODevice::WriteOnly);
     if (opened) {
         QDataStream ofs(&file);
         if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
@@ -799,7 +799,7 @@ void dlgIRC::writeAppDefaultIrcNick(const QString& nick)
 QStringList dlgIRC::readIrcChannels(Host* pH)
 {
     QStringList channels;
-    QString channelstr = pH->readProfileData(dlgIRC::ChannelsCfgItem);
+    QString const channelstr = pH->readProfileData(dlgIRC::ChannelsCfgItem);
     if (channelstr.isEmpty()) {
         channels << dlgIRC::DefaultChannels;
     } else {

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -151,7 +151,7 @@ QPair<bool, QString> dlgIRC::sendMsg(const QString& target, const QString& messa
 
     // inform the command parser of the target for this message.
     // parses the message and then reverts the target to avoid confusing our UI.
-    QString const lastParserTarget = commandParser->target();
+    const QString lastParserTarget = commandParser->target();
     commandParser->setTarget(msgTarget);
     IrcCommand* command = commandParser->parse(message);
     commandParser->setTarget(lastParserTarget);
@@ -191,7 +191,7 @@ QPair<bool, QString> dlgIRC::sendMsg(const QString& target, const QString& messa
 
 void dlgIRC::ircRestart(bool reloadConfigs)
 {
-    QString const msg = tr("Restarting IRC Client");
+    const QString msg = tr("Restarting IRC Client");
     ircBrowser->append(IrcMessageFormatter::formatMessage("! %1.").arg(msg));
 
     // issue a quit message to the network if we're connected.
@@ -200,7 +200,7 @@ void dlgIRC::ircRestart(bool reloadConfigs)
     }
 
     // remove the old buffers.
-    for (QString const chName : qAsConst(mChannels)) {
+    for (const QString chName : qAsConst(mChannels)) {
         if (chName == serverBuffer->name()) {
             continue; // skip the server-buffer.
         }
@@ -304,7 +304,7 @@ bool dlgIRC::processCustomCommand(IrcCommand* cmd)
     if (cmdName == "CLEAR") {
         auto * buffer = bufferList->currentIndex().data(Irc::BufferRole).value<IrcBuffer*>();
         if (cmd->parameters().count() > 1) {
-            QString const bufferName = cmd->parameters().at(1);
+            const QString bufferName = cmd->parameters().at(1);
             //QString cBufferName = buffer->title();
             if (!bufferName.isEmpty()) {
                 buffer = bufferModel->find(bufferName);
@@ -368,12 +368,12 @@ bool dlgIRC::processCustomCommand(IrcCommand* cmd)
             }
         }
         if (limit <= 0) {
-            QString const error = tr("[Error] MSGLIMIT requires <limit> to be a whole number greater than zero!");
+            const QString error = tr("[Error] MSGLIMIT requires <limit> to be a whole number greater than zero!");
             ircBrowser->append(IrcMessageFormatter::formatMessage(error, qsl("indianred")));
             return true;
         }
         if (cmd->parameters().count() > 2) {
-            QString const bufferName = cmd->parameters().at(2);
+            const QString bufferName = cmd->parameters().at(2);
             if (!bufferName.isEmpty()) {
                 IrcBuffer* buffer = bufferModel->find(bufferName);
                 if (buffer) {
@@ -430,7 +430,7 @@ void dlgIRC::slot_onTextEdited()
 
 void dlgIRC::slot_onTextEntered()
 {
-    QString const input = lineEdit->text();
+    const QString input = lineEdit->text();
 
     // add this line to our history list.
     if (!input.isEmpty()) {
@@ -479,7 +479,7 @@ void dlgIRC::slot_onTextEntered()
         lineEdit->clear();
     } else if (input.length() > 1) {
         QString error;
-        QString const command = lineEdit->text().mid(1).split(" ", Qt::SkipEmptyParts).value(0).toUpper();
+        const QString command = lineEdit->text().mid(1).split(" ", Qt::SkipEmptyParts).value(0).toUpper();
         if (commandParser->commands().contains(command)) {
             error = tr("[ERROR] Syntax: %1").arg(commandParser->syntax(command).replace(qsl("<"), qsl("&lt;")).replace(qsl(">"), qsl("&gt;")));
         } else {
@@ -598,14 +598,14 @@ void dlgIRC::slot_receiveMessage(IrcMessage* message)
     }
     QTextDocument* document = bufferTexts.value(buffer);
     if (document) {
-        QString const html = IrcMessageFormatter::formatMessage(message);
+        const QString html = IrcMessageFormatter::formatMessage(message);
         if (!html.isEmpty()) {
             // send a plain-text formatted copy of the message to Lua, as long as it isn't our own.
             if (!message->isOwn()) {
-                QString const textToLua = IrcMessageFormatter::formatMessage(message, true);
+                const QString textToLua = IrcMessageFormatter::formatMessage(message, true);
                 if (!textToLua.isEmpty()) {
-                    QString const from = message->nick();
-                    QString const to = getMessageTarget(message, buffer->title());
+                    const QString from = message->nick();
+                    const QString to = getMessageTarget(message, buffer->title());
                     mpHost->postIrcMessage(from, to, textToLua);
                 }
             }
@@ -628,7 +628,7 @@ void dlgIRC::slot_onAnchorClicked(const QUrl& link)
 void dlgIRC::slot_nickNameRequired(const QString& reserved, QString* alt)
 {
     Q_UNUSED(alt)
-    QString const newNick = qsl("%1_%2").arg(reserved, QString::number(rand() % 10000));
+    const QString newNick = qsl("%1_%2").arg(reserved, QString::number(rand() % 10000));
     ircBrowser->append(IrcMessageFormatter::formatMessage(tr("! The Nickname %1 is reserved. Automatically changing Nickname to: %2").arg(reserved, newNick)));
     connection->setNickName(newNick);
 }
@@ -652,26 +652,26 @@ void dlgIRC::slot_joinedChannel(IrcJoinMessage* message)
         mReadyForSending = true;
     }
 
-    QString const chan = message->channel();
+    const QString chan = message->channel();
     if (!mChannels.contains(chan)) {
         mChannels << chan;
     }
 
     if (message->isOwn()) {
-        QString const luaText = IrcMessageFormatter::formatMessage(static_cast<IrcMessage*>(message), true);
+        const QString luaText = IrcMessageFormatter::formatMessage(static_cast<IrcMessage*>(message), true);
         mpHost->postIrcMessage(message->nick(), message->channel(), luaText);
     }
 }
 
 void dlgIRC::slot_partedChannel(IrcPartMessage* message)
 {
-    QString const chan = message->channel();
+    const QString chan = message->channel();
     if (mChannels.contains(chan)) {
         mChannels.removeAll(chan);
     }
 
     if (message->isOwn()) {
-        QString const luaText = IrcMessageFormatter::formatMessage(static_cast<IrcMessage*>(message), true);
+        const QString luaText = IrcMessageFormatter::formatMessage(static_cast<IrcMessage*>(message), true);
         mpHost->postIrcMessage(message->nick(), message->channel(), luaText);
     }
 }
@@ -727,7 +727,7 @@ QString dlgIRC::readIrcHostName(Host* pH)
 
 int dlgIRC::readIrcHostPort(Host* pH)
 {
-    QString const portStr = pH->readProfileData(dlgIRC::HostPortCfgItem);
+    const QString portStr = pH->readProfileData(dlgIRC::HostPortCfgItem);
     bool ok;
     int port = portStr.toInt(&ok);
     if (portStr.isEmpty() || !ok) {
@@ -740,7 +740,7 @@ int dlgIRC::readIrcHostPort(Host* pH)
 
 bool dlgIRC::readIrcHostSecure(Host* pH)
 {
-    QString const secureStr = pH->readProfileData(dlgIRC::HostSecureCfgItem);
+    const QString secureStr = pH->readProfileData(dlgIRC::HostSecureCfgItem);
     return secureStr.contains(QLatin1String("true"), Qt::CaseInsensitive);
 }
 
@@ -799,7 +799,7 @@ void dlgIRC::writeAppDefaultIrcNick(const QString& nick)
 QStringList dlgIRC::readIrcChannels(Host* pH)
 {
     QStringList channels;
-    QString const channelstr = pH->readProfileData(dlgIRC::ChannelsCfgItem);
+    const QString channelstr = pH->readProfileData(dlgIRC::ChannelsCfgItem);
     if (channelstr.isEmpty()) {
         channels << dlgIRC::DefaultChannels;
     } else {

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -160,7 +160,7 @@ QPair<bool, QString> dlgIRC::sendMsg(const QString& target, const QString& messa
         return QPair<bool, QString>(false, qsl("message could not be parsed"));
     }
 
-    bool const isCustomCommand = processCustomCommand(command);
+    const bool isCustomCommand = processCustomCommand(command);
     if (isCustomCommand) {
         return QPair<bool, QString>(true, qsl("command processed by client"));
     }
@@ -449,7 +449,7 @@ void dlgIRC::slot_onTextEntered()
     IrcCommand* command = commandParser->parse(input);
     if (command) {
         // handle custom commands
-        bool const isCustomCommand = processCustomCommand(command);
+        const bool isCustomCommand = processCustomCommand(command);
         if (isCustomCommand) {
             lineEdit->clear();
             return;
@@ -767,7 +767,7 @@ QString dlgIRC::readIrcPassword(Host* pH)
 QString dlgIRC::readAppDefaultIrcNick()
 {
     QFile file(mudlet::getMudletPath(mudlet::mainDataItemPath, qsl("irc_nick")));
-    bool const opened = file.open(QIODevice::ReadOnly);
+    const bool opened = file.open(QIODevice::ReadOnly);
     QString rstr;
     if (opened) {
         QDataStream ifs(&file);
@@ -783,7 +783,7 @@ QString dlgIRC::readAppDefaultIrcNick()
 void dlgIRC::writeAppDefaultIrcNick(const QString& nick)
 {
     QSaveFile file(mudlet::getMudletPath(mudlet::mainDataItemPath, qsl("irc_nick")));
-    bool const opened = file.open(QIODevice::WriteOnly);
+    const bool opened = file.open(QIODevice::WriteOnly);
     if (opened) {
         QDataStream ofs(&file);
         if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -528,7 +528,7 @@ void dlgIRC::slot_onBufferAdded(IrcBuffer* buffer)
     userModel->setSortMethod(Irc::SortByTitle);
     userModels.insert(buffer, userModel);
     // activate the new buffer
-    int const idx = bufferModel->buffers().indexOf(buffer);
+    const int idx = bufferModel->buffers().indexOf(buffer);
     if (idx != -1) {
         bufferList->setCurrentIndex(bufferModel->index(idx));
     }
@@ -565,7 +565,7 @@ void dlgIRC::slot_onUserActivated(const QModelIndex& index)
         }
         IrcBuffer* buffer = bufferModel->add(user->name());
         // activate the new query
-        int const idx = bufferModel->buffers().indexOf(buffer);
+        const int idx = bufferModel->buffers().indexOf(buffer);
         if (idx != -1) {
             bufferList->setCurrentIndex(bufferModel->index(idx));
         }

--- a/src/dlgMapLabel.cpp
+++ b/src/dlgMapLabel.cpp
@@ -180,7 +180,7 @@ void dlgMapLabel::slot_updateControls()
 
 void dlgMapLabel::slot_updateControlsVisibility()
 {
-    bool isText = isTextLabel();
+    bool const isText = isTextLabel();
     label_image->setVisible(!isText);
     lineEdit_image->setVisible(!isText);
     checkBox_stretchImage->setVisible(!isText);

--- a/src/dlgMapLabel.cpp
+++ b/src/dlgMapLabel.cpp
@@ -180,7 +180,7 @@ void dlgMapLabel::slot_updateControls()
 
 void dlgMapLabel::slot_updateControlsVisibility()
 {
-    bool const isText = isTextLabel();
+    const bool isText = isTextLabel();
     label_image->setVisible(!isText);
     lineEdit_image->setVisible(!isText);
     checkBox_stretchImage->setVisible(!isText);

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -289,7 +289,7 @@ void dlgMapper::slot_toggle3DView(const bool is3DMode)
 
 void dlgMapper::slot_roomSize(int size)
 {
-    float const floatSize = static_cast<float>(size / 10.0);
+    const float floatSize = static_cast<float>(size / 10.0);
     mp2dMap->setRoomSize(floatSize);
     mp2dMap->update();
 }

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -61,7 +61,7 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
     QMap<QString, QString> areaNames;
     while (it.hasNext()) {
         it.next();
-        QString const name = it.value();
+        const QString name = it.value();
         areaNames.insert(name.toLower(), name);
     }
     //areaNames.sort();
@@ -144,7 +144,7 @@ void dlgMapper::updateAreaComboBox()
         return;
     }
 
-    QString const oldValue = comboBox_showArea->currentText(); // Remember where we were
+    const QString oldValue = comboBox_showArea->currentText(); // Remember where we were
     QMapIterator<int, QString> itAreaNamesA(mpMap->mpRoomDB->getAreaNamesMap());
     //insert sort them alphabetically (case INsensitive)
     QMap<QString, QString> areaNames;
@@ -344,7 +344,7 @@ void dlgMapper::resetAreaComboBoxToPlayerRoomArea()
         int const playerRoomArea = pR->getArea();
         TArea* pA = mpMap->mpRoomDB->getArea(playerRoomArea);
         if (pA) {
-            QString const areaName = mpMap->mpRoomDB->getAreaNamesMap().value(playerRoomArea);
+            const QString areaName = mpMap->mpRoomDB->getAreaNamesMap().value(playerRoomArea);
             if (!areaName.isEmpty()) {
                 comboBox_showArea->setCurrentText(areaName);
             } else {

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -341,7 +341,7 @@ void dlgMapper::resetAreaComboBoxToPlayerRoomArea()
 
     TRoom* pR = mpMap->mpRoomDB->getRoom(mpMap->mRoomIdHash.value(mpMap->mProfileName));
     if (pR) {
-        int const playerRoomArea = pR->getArea();
+        const int playerRoomArea = pR->getArea();
         TArea* pA = mpMap->mpRoomDB->getArea(playerRoomArea);
         if (pA) {
             const QString areaName = mpMap->mpRoomDB->getAreaNamesMap().value(playerRoomArea);

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -61,7 +61,7 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
     QMap<QString, QString> areaNames;
     while (it.hasNext()) {
         it.next();
-        QString name = it.value();
+        QString const name = it.value();
         areaNames.insert(name.toLower(), name);
     }
     //areaNames.sort();
@@ -144,7 +144,7 @@ void dlgMapper::updateAreaComboBox()
         return;
     }
 
-    QString oldValue = comboBox_showArea->currentText(); // Remember where we were
+    QString const oldValue = comboBox_showArea->currentText(); // Remember where we were
     QMapIterator<int, QString> itAreaNamesA(mpMap->mpRoomDB->getAreaNamesMap());
     //insert sort them alphabetically (case INsensitive)
     QMap<QString, QString> areaNames;
@@ -289,7 +289,7 @@ void dlgMapper::slot_toggle3DView(const bool is3DMode)
 
 void dlgMapper::slot_roomSize(int size)
 {
-    float floatSize = static_cast<float>(size / 10.0);
+    float const floatSize = static_cast<float>(size / 10.0);
     mp2dMap->setRoomSize(floatSize);
     mp2dMap->update();
 }
@@ -341,10 +341,10 @@ void dlgMapper::resetAreaComboBoxToPlayerRoomArea()
 
     TRoom* pR = mpMap->mpRoomDB->getRoom(mpMap->mRoomIdHash.value(mpMap->mProfileName));
     if (pR) {
-        int playerRoomArea = pR->getArea();
+        int const playerRoomArea = pR->getArea();
         TArea* pA = mpMap->mpRoomDB->getArea(playerRoomArea);
         if (pA) {
-            QString areaName = mpMap->mpRoomDB->getAreaNamesMap().value(playerRoomArea);
+            QString const areaName = mpMap->mpRoomDB->getAreaNamesMap().value(playerRoomArea);
             if (!areaName.isEmpty()) {
                 comboBox_showArea->setCurrentText(areaName);
             } else {

--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -73,7 +73,7 @@ void dlgModuleManager::layoutModules()
     QMap<int, QStringList> mOrder;
     while (it.hasNext()) {
         it.next();
-        int priority = mpHost->mModulePriorities[it.key()];
+        int const priority = mpHost->mModulePriorities[it.key()];
         if (mOrder.contains(priority)) {
             mOrder[priority].append(it.key());
         } else {
@@ -86,7 +86,7 @@ void dlgModuleManager::layoutModules()
         QStringList pModules = it2.value();
         pModules.sort();
         for (int i = 0; i < pModules.size(); i++) {
-            int row = moduleTable->rowCount();
+            int const row = moduleTable->rowCount();
             moduleTable->insertRow(row);
             auto masterModule = new QTableWidgetItem();
             auto itemEntry = new QTableWidgetItem();
@@ -108,7 +108,7 @@ void dlgModuleManager::layoutModules()
             // checkbox more central in the column
             masterModule->setTextAlignment(Qt::AlignCenter);
 
-            QString moduleName = pModules[i];
+            QString const moduleName = pModules[i];
             itemEntry->setText(moduleName);
             itemEntry->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
             itemLocation->setText(moduleInfo[0]);
@@ -130,7 +130,7 @@ void dlgModuleManager::slot_installModule()
         return;
     }
 
-    QString fileName = QFileDialog::getOpenFileName(this, tr("Load Mudlet Module"), QDir::currentPath());
+    QString const fileName = QFileDialog::getOpenFileName(this, tr("Load Mudlet Module"), QDir::currentPath());
     if (fileName.isEmpty()) {
         return;
     }
@@ -155,7 +155,7 @@ void dlgModuleManager::slot_uninstallModule()
         return;
     }
 
-    int cRow = moduleTable->currentRow();
+    int const cRow = moduleTable->currentRow();
     QTableWidgetItem* pI = moduleTable->item(cRow, 0);
     if (pI) {
         mpHost->uninstallPackage(pI->text(), 1);
@@ -172,7 +172,7 @@ void dlgModuleManager::slot_moduleClicked(QTableWidgetItem* pItem)
         return;
     }
 
-    int i = pItem->row();
+    int const i = pItem->row();
 
     QTableWidgetItem* entry = moduleTable->item(i, 0);
     QTableWidgetItem* checkStatus = moduleTable->item(i, 2);
@@ -201,7 +201,7 @@ void dlgModuleManager::slot_moduleChanged(QTableWidgetItem* pItem)
         return;
     }
 
-    int i = pItem->row();
+    int const i = pItem->row();
 
     QStringList moduleStringList;
     QTableWidgetItem* entry = moduleTable->item(i, 0);
@@ -225,7 +225,7 @@ void dlgModuleManager::slot_helpModule()
     if (!mpHost) {
         return;
     }
-    int cRow = moduleTable->currentRow();
+    int const cRow = moduleTable->currentRow();
     QTableWidgetItem* pI = moduleTable->item(cRow, 0);
     if (!pI) {
         return;
@@ -234,12 +234,12 @@ void dlgModuleManager::slot_helpModule()
         if (!mudlet::self()->openWebPage(mpHost->moduleHelp.value(pI->text()).value(QLatin1String("helpURL")))) {
             //failed first open, try for a module related path
             QTableWidgetItem* item = moduleTable->item(cRow, 3);
-            QString itemPath = item->text();
+            QString const itemPath = item->text();
             QStringList path = itemPath.split(QDir::separator());
             path.pop_back();
             path.append(QDir::separator());
             path.append(mpHost->moduleHelp.value(pI->text()).value(QLatin1String("helpURL")));
-            QString path2 = path.join(QString());
+            QString const path2 = path.join(QString());
             if (!mudlet::self()->openWebPage(path2)) {
                 helpButton->setDisabled(true);
             }

--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -73,7 +73,7 @@ void dlgModuleManager::layoutModules()
     QMap<int, QStringList> mOrder;
     while (it.hasNext()) {
         it.next();
-        int const priority = mpHost->mModulePriorities[it.key()];
+        const int priority = mpHost->mModulePriorities[it.key()];
         if (mOrder.contains(priority)) {
             mOrder[priority].append(it.key());
         } else {
@@ -86,7 +86,7 @@ void dlgModuleManager::layoutModules()
         QStringList pModules = it2.value();
         pModules.sort();
         for (int i = 0; i < pModules.size(); i++) {
-            int const row = moduleTable->rowCount();
+            const int row = moduleTable->rowCount();
             moduleTable->insertRow(row);
             auto masterModule = new QTableWidgetItem();
             auto itemEntry = new QTableWidgetItem();
@@ -155,7 +155,7 @@ void dlgModuleManager::slot_uninstallModule()
         return;
     }
 
-    int const cRow = moduleTable->currentRow();
+    const int cRow = moduleTable->currentRow();
     QTableWidgetItem* pI = moduleTable->item(cRow, 0);
     if (pI) {
         mpHost->uninstallPackage(pI->text(), 1);
@@ -172,7 +172,7 @@ void dlgModuleManager::slot_moduleClicked(QTableWidgetItem* pItem)
         return;
     }
 
-    int const i = pItem->row();
+    const int i = pItem->row();
 
     QTableWidgetItem* entry = moduleTable->item(i, 0);
     QTableWidgetItem* checkStatus = moduleTable->item(i, 2);
@@ -201,7 +201,7 @@ void dlgModuleManager::slot_moduleChanged(QTableWidgetItem* pItem)
         return;
     }
 
-    int const i = pItem->row();
+    const int i = pItem->row();
 
     QStringList moduleStringList;
     QTableWidgetItem* entry = moduleTable->item(i, 0);
@@ -225,7 +225,7 @@ void dlgModuleManager::slot_helpModule()
     if (!mpHost) {
         return;
     }
-    int const cRow = moduleTable->currentRow();
+    const int cRow = moduleTable->currentRow();
     QTableWidgetItem* pI = moduleTable->item(cRow, 0);
     if (!pI) {
         return;

--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -108,7 +108,7 @@ void dlgModuleManager::layoutModules()
             // checkbox more central in the column
             masterModule->setTextAlignment(Qt::AlignCenter);
 
-            QString const moduleName = pModules[i];
+            const QString moduleName = pModules[i];
             itemEntry->setText(moduleName);
             itemEntry->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
             itemLocation->setText(moduleInfo[0]);
@@ -130,7 +130,7 @@ void dlgModuleManager::slot_installModule()
         return;
     }
 
-    QString const fileName = QFileDialog::getOpenFileName(this, tr("Load Mudlet Module"), QDir::currentPath());
+    const QString fileName = QFileDialog::getOpenFileName(this, tr("Load Mudlet Module"), QDir::currentPath());
     if (fileName.isEmpty()) {
         return;
     }
@@ -234,12 +234,12 @@ void dlgModuleManager::slot_helpModule()
         if (!mudlet::self()->openWebPage(mpHost->moduleHelp.value(pI->text()).value(QLatin1String("helpURL")))) {
             //failed first open, try for a module related path
             QTableWidgetItem* item = moduleTable->item(cRow, 3);
-            QString const itemPath = item->text();
+            const QString itemPath = item->text();
             QStringList path = itemPath.split(QDir::separator());
             path.pop_back();
             path.append(QDir::separator());
             path.append(mpHost->moduleHelp.value(pI->text()).value(QLatin1String("helpURL")));
-            QString const path2 = path.join(QString());
+            const QString path2 = path.join(QString());
             if (!mudlet::self()->openWebPage(path2)) {
                 helpButton->setDisabled(true);
             }

--- a/src/dlgNotepad.cpp
+++ b/src/dlgNotepad.cpp
@@ -61,8 +61,8 @@ dlgNotepad::~dlgNotepad()
 
 void dlgNotepad::save()
 {
-    QString const directoryFile = mudlet::getMudletPath(mudlet::profileHomePath, mpHost->getName());
-    QString const fileName = mudlet::getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), utf8EncodedNotesFileName);
+    const QString directoryFile = mudlet::getMudletPath(mudlet::profileHomePath, mpHost->getName());
+    const QString fileName = mudlet::getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), utf8EncodedNotesFileName);
     QDir const dirFile;
     if (!dirFile.exists(directoryFile)) {
         dirFile.mkpath(directoryFile);

--- a/src/dlgNotepad.cpp
+++ b/src/dlgNotepad.cpp
@@ -63,7 +63,7 @@ void dlgNotepad::save()
 {
     const QString directoryFile = mudlet::getMudletPath(mudlet::profileHomePath, mpHost->getName());
     const QString fileName = mudlet::getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), utf8EncodedNotesFileName);
-    QDir const dirFile;
+    const QDir dirFile;
     if (!dirFile.exists(directoryFile)) {
         dirFile.mkpath(directoryFile);
     }

--- a/src/dlgNotepad.cpp
+++ b/src/dlgNotepad.cpp
@@ -61,9 +61,9 @@ dlgNotepad::~dlgNotepad()
 
 void dlgNotepad::save()
 {
-    QString directoryFile = mudlet::getMudletPath(mudlet::profileHomePath, mpHost->getName());
-    QString fileName = mudlet::getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), utf8EncodedNotesFileName);
-    QDir dirFile;
+    QString const directoryFile = mudlet::getMudletPath(mudlet::profileHomePath, mpHost->getName());
+    QString const fileName = mudlet::getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), utf8EncodedNotesFileName);
+    QDir const dirFile;
     if (!dirFile.exists(directoryFile)) {
         dirFile.mkpath(directoryFile);
     }

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -286,7 +286,7 @@ void dlgPackageExporter::slot_packageChanged(int index)
     } else {
         ui->Icon->hide();
     }
-    QIcon const myIcon(mPackageIconPath);
+    const QIcon myIcon(mPackageIconPath);
     ui->Icon->clear();
     ui->Icon->setPixmap(myIcon.pixmap(ui->Icon->size()));
     ui->lineEdit_title->setText(packageInfo.value(qsl("title")));
@@ -351,7 +351,7 @@ void dlgPackageExporter::slot_importIcon()
         return;
     }
     mPackageIconPath = fileName;
-    QIcon const myIcon(mPackageIconPath);
+    const QIcon myIcon(mPackageIconPath);
     ui->Icon->clear();
     ui->Icon->setPixmap(myIcon.pixmap(ui->Icon->size()));
     ui->Icon->show();

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -304,7 +304,7 @@ void dlgPackageExporter::slot_packageChanged(int index)
 
     //get files and folders from package
     ui->listWidget_addedFiles->clear();
-    QFileInfo const info(qsl("%1/%2/").arg(packagePath, packageName));
+    const QFileInfo info(qsl("%1/%2/").arg(packagePath, packageName));
     if (!info.exists()) {
         return;
     }
@@ -312,7 +312,7 @@ void dlgPackageExporter::slot_packageChanged(int index)
     QStringList ignore;
     ignore << QLatin1String("config.lua") << qsl("%1.xml").arg(packageName);
     while (it.hasNext()) {
-        QFileInfo const f(it.next());
+        const QFileInfo f(it.next());
         if (ignore.contains(f.fileName(), Qt::CaseInsensitive)) {
             continue;
         }
@@ -396,7 +396,7 @@ bool dlgPackageExporter::eventFilter(QObject* obj, QEvent* evt)
             }
             for (int i = mDescriptionImages.size() - 1; i >= 0; i--) {
                 QString fname = mDescriptionImages.at(i);
-                QFileInfo const info(fname);
+                const QFileInfo info(fname);
                 fname = QUrl::toPercentEncoding(fname).constData();
                 plainText.replace(qsl("$%1").arg(info.fileName()), fname);
             }
@@ -419,7 +419,7 @@ bool dlgPackageExporter::eventFilter(QObject* obj, QEvent* evt)
             QDropEvent* dropEvent = static_cast<QDropEvent*>(evt);
             for (const auto& url : dropEvent->mimeData()->urls()) {
                 const QString fname = url.toLocalFile();
-                QFileInfo const info(fname);
+                const QFileInfo info(fname);
                 if (info.exists()) {
                     ui->listWidget_addedFiles->addItem(fname);
                 }
@@ -447,7 +447,7 @@ void dlgPackageExporter::copy_directory(const QString& fromDir, const QString& t
     }
     targetDir.mkdir(toDir);
     while (it.hasNext()) {
-        QFileInfo const f(it.next());
+        const QFileInfo f(it.next());
         if (f.fileName() == QLatin1String(".") || f.fileName() == QLatin1String("..") || f.isSymLink()) {
             continue;
         }
@@ -520,7 +520,7 @@ void dlgPackageExporter::slot_exportPackage()
     // start copying assets in the background
     auto assetsFuture = QtConcurrent::run(dlgPackageExporter::copyAssetsToTmp, assetPaths, tempPath);
 
-    QFileInfo const iconFile = copyIconToTmp(tempPath);
+    const QFileInfo iconFile = copyIconToTmp(tempPath);
 
     mXmlPathFileName = qsl("%1/%2.xml").arg(stagingDirName, mPackageName);
     writeConfigFile(stagingDirName, iconFile, plainDescription);
@@ -601,7 +601,7 @@ QString dlgPackageExporter::copyNewImagesToTmp(const QString& tempPath) const
     QString plainDescription = mPlainDescription;
     for (int i = mDescriptionImages.size() - 1; i >= 0; i--) {
         const QString fname = mDescriptionImages.at(i);
-        QFileInfo const info(fname);
+        const QFileInfo info(fname);
         if (plainDescription.contains(qsl("$%1").arg(info.fileName()))) {
             newImagesList.append(fname);
         }
@@ -615,7 +615,7 @@ QString dlgPackageExporter::copyNewImagesToTmp(const QString& tempPath) const
             descriptionImageDir.mkpath(descriptionImagesDirName);
         }
         for (int i = newImagesList.size() - 1; i >= 0; i--) {
-            QFileInfo const imageFile(newImagesList.at(i));
+            const QFileInfo imageFile(newImagesList.at(i));
             if (imageFile.exists()) {
                 QString imageDir = descriptionImagesDirName;
                 imageDir.append(imageFile.fileName());
@@ -644,7 +644,7 @@ void dlgPackageExporter::cleanupUnusedImages(const QString& tempPath, const QStr
     // iterate through all images in folder, if our list doesn't contain it - remove
     QDirIterator allImagesCopied(qsl("%1.mudlet/description_images").arg(tempPath), QDir::Files);
     while (allImagesCopied.hasNext()) {
-        QFileInfo const copiedImage(allImagesCopied.next());
+        const QFileInfo copiedImage(allImagesCopied.next());
         if (!imagesInUse.contains(copiedImage.baseName())) {
             if (!QFile(copiedImage.absoluteFilePath()).remove()) {
                 qDebug() << "couldn't remove unused image" << copiedImage.fileName();
@@ -836,7 +836,7 @@ void dlgPackageExporter::writeConfigFile(const QString& stagingDirName, const QF
 
 QFileInfo dlgPackageExporter::copyIconToTmp(const QString& tempPath) const
 {
-    QFileInfo const iconFile(mPackageIconPath);
+    const QFileInfo iconFile(mPackageIconPath);
     if (iconFile.exists()) {
         QString iconDirName = qsl("%1.mudlet/Icon/").arg(tempPath);
         const QDir iconDir = QDir(iconDirName);
@@ -852,7 +852,7 @@ QFileInfo dlgPackageExporter::copyIconToTmp(const QString& tempPath) const
 std::pair<bool, QString> dlgPackageExporter::copyAssetsToTmp(const QStringList& assetPaths, const QString& tempPath)
 {
     for (const auto& assetPath : assetPaths) {
-        QFileInfo const asset(assetPath);
+        const QFileInfo asset(assetPath);
         QString filePath = tempPath;
         filePath.append(asset.fileName());
         if (!asset.exists()) {
@@ -924,7 +924,7 @@ std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDi
             continue;
         }
 
-        QFileInfo const stagingFileInfo(stagingFile.fileInfo());
+        const QFileInfo stagingFileInfo(stagingFile.fileInfo());
         if (!stagingFileInfo.isReadable()) {
             qWarning() << "dlgPackageExporter::slot_exportPackage() skipping file: " << stagingFile.fileName() << "it is NOT readable!";
             continue;
@@ -1540,7 +1540,7 @@ void dlgPackageExporterDescription::insertFromMimeData(const QMimeData* source)
                        << "svg";
         for (const auto& url : source->urls()) {
             const QString fname = url.toLocalFile();
-            QFileInfo const info(fname);
+            const QFileInfo info(fname);
             if (info.exists() && accepted_types.contains(info.suffix().trimmed(), Qt::CaseInsensitive)) {
                 if (!my_parent->mDescriptionImages.contains(fname)) {
                     my_parent->mDescriptionImages.append(fname);
@@ -1555,7 +1555,7 @@ void dlgPackageExporterDescription::insertFromMimeData(const QMimeData* source)
             QString plainText = my_parent->mPlainDescription;
             for (int i = my_parent->mDescriptionImages.size() - 1; i >= 0; i--) {
                 QString fname = my_parent->mDescriptionImages.at(i);
-                QFileInfo const info(fname);
+                const QFileInfo info(fname);
                 fname = QUrl::toPercentEncoding(fname).constData();
                 plainText.replace(qsl("$%1").arg(info.fileName()), fname);
             }

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -610,7 +610,7 @@ QString dlgPackageExporter::copyNewImagesToTmp(const QString& tempPath) const
     if (!newImagesList.isEmpty()) {
         //Create description image dir
         const QString descriptionImagesDirName = qsl("%1.mudlet/description_images/").arg(tempPath);
-        QDir const descriptionImageDir = QDir(descriptionImagesDirName);
+        const QDir descriptionImageDir = QDir(descriptionImagesDirName);
         if (!descriptionImageDir.exists()) {
             descriptionImageDir.mkpath(descriptionImagesDirName);
         }
@@ -839,7 +839,7 @@ QFileInfo dlgPackageExporter::copyIconToTmp(const QString& tempPath) const
     QFileInfo const iconFile(mPackageIconPath);
     if (iconFile.exists()) {
         QString iconDirName = qsl("%1.mudlet/Icon/").arg(tempPath);
-        QDir const iconDir = QDir(iconDirName);
+        const QDir iconDir = QDir(iconDirName);
         if (!iconDir.exists()) {
             iconDir.mkpath(iconDirName);
         }

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -1430,7 +1430,7 @@ void dlgPackageExporter::listTimers()
     }
 }
 
-void dlgPackageExporter::displayResultMessage(const QString& html, bool const isSuccessMessage)
+void dlgPackageExporter::displayResultMessage(const QString& html, const bool isSuccessMessage)
 {
     if (!isSuccessMessage) {
         // Big RED error message

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -215,7 +215,7 @@ void dlgPackageExporter::slot_removeDependency()
 
 void dlgPackageExporter::slot_packageChanged(int index)
 {
-    QString const packageName = ui->packageList->currentText();
+    const QString packageName = ui->packageList->currentText();
     uncheckAllChildren();
     if (index != 0) {
         ui->lineEdit_packageName->setText(packageName);
@@ -274,12 +274,12 @@ void dlgPackageExporter::slot_packageChanged(int index)
         }
     }
 
-    QString const packagePath{mudlet::getMudletPath(mudlet::profileHomePath, mpHost->getName())};
+    const QString packagePath{mudlet::getMudletPath(mudlet::profileHomePath, mpHost->getName())};
     //fill package metadata
     mPackageIconPath.clear();
     QMap<QString, QString> const packageInfo = mpHost->mPackageInfo.value(packageName);
     ui->lineEdit_author->setText(packageInfo.value(qsl("author")));
-    QString const icon{packageInfo.value(qsl("icon"))};
+    const QString icon{packageInfo.value(qsl("icon"))};
     if (!icon.isEmpty()) {
         mPackageIconPath = qsl("%1/%2/.mudlet/Icon/%3").arg(packagePath, packageName, icon);
         ui->Icon->show();
@@ -294,7 +294,7 @@ void dlgPackageExporter::slot_packageChanged(int index)
     QString description{mPlainDescription};
     description.replace(QLatin1String("$packagePath"), qsl("%1/%2").arg(packagePath, packageName));
     ui->textEdit_description->setMarkdown(description);
-    QString const version = packageInfo.value(qsl("version"));
+    const QString version = packageInfo.value(qsl("version"));
     ui->lineEdit_version->setText(version);
     QStringList const dependencies = packageInfo.value(qsl("dependencies")).split(QLatin1Char(','));
     ui->comboBox_dependencies->clear();
@@ -346,7 +346,7 @@ void dlgPackageExporter::checkToEnableExportButton()
 
 void dlgPackageExporter::slot_importIcon()
 {
-    QString const fileName = QFileDialog::getOpenFileName(this, tr("Open Icon"), QDir::currentPath(), tr("Image Files (*.png *.jpg *.jpeg *.bmp *.tif *.ico *.icns)"));
+    const QString fileName = QFileDialog::getOpenFileName(this, tr("Open Icon"), QDir::currentPath(), tr("Image Files (*.png *.jpg *.jpeg *.bmp *.tif *.ico *.icns)"));
     if (fileName.isEmpty()) {
         return;
     }
@@ -386,10 +386,10 @@ bool dlgPackageExporter::eventFilter(QObject* obj, QEvent* evt)
             //during package creation it uses the profile folder. But once the package is created it will use
             //profile folder/packagename
             QString plainText{mPlainDescription};
-            QString const profilePath{mudlet::getMudletPath(mudlet::profileHomePath, mpHost->getName())};
+            const QString profilePath{mudlet::getMudletPath(mudlet::profileHomePath, mpHost->getName())};
             //$packagePath will be replaced by the resource path if an existing package is selected
             if (ui->packageList->currentIndex() != 0) {
-                QString const packageName = ui->packageList->currentText();
+                const QString packageName = ui->packageList->currentText();
                 plainText.replace(QLatin1String("$packagePath"), qsl("%1/%2").arg(profilePath, packageName));
             } else {
                 plainText.replace(QLatin1String("$packagePath"), profilePath);
@@ -418,7 +418,7 @@ bool dlgPackageExporter::eventFilter(QObject* obj, QEvent* evt)
         if (evt->type() == QEvent::Drop) {
             QDropEvent* dropEvent = static_cast<QDropEvent*>(evt);
             for (const auto& url : dropEvent->mimeData()->urls()) {
-                QString const fname = url.toLocalFile();
+                const QString fname = url.toLocalFile();
                 QFileInfo const info(fname);
                 if (info.exists()) {
                     ui->listWidget_addedFiles->addItem(fname);
@@ -487,7 +487,7 @@ void dlgPackageExporter::slot_exportPackage()
     // To avoid confusion if the user looks in that part of their file-system we
     // will append a "/mudlet" suffix so they can see that we are interested in
     // those files:
-    QString const stagingDirName = qsl("%1/mudlet/%2").arg(QStandardPaths::writableLocation(QStandardPaths::TempLocation), mPackageName);
+    const QString stagingDirName = qsl("%1/mudlet/%2").arg(QStandardPaths::writableLocation(QStandardPaths::TempLocation), mPackageName);
     QDir packageDir = QDir(stagingDirName);
     if (!packageDir.exists()) {
         packageDir.mkpath(stagingDirName);
@@ -496,7 +496,7 @@ void dlgPackageExporter::slot_exportPackage()
         packageDir.mkpath(stagingDirName);
     }
 
-    QString const tempPath = qsl("%1/").arg(stagingDirName);
+    const QString tempPath = qsl("%1/").arg(stagingDirName);
 
     mExportingPackage = true;
     QApplication::setOverrideCursor(Qt::BusyCursor);
@@ -600,7 +600,7 @@ QString dlgPackageExporter::copyNewImagesToTmp(const QString& tempPath) const
     //don't change the original plain description here as it may still be needed, for example if creating another package
     QString plainDescription = mPlainDescription;
     for (int i = mDescriptionImages.size() - 1; i >= 0; i--) {
-        QString const fname = mDescriptionImages.at(i);
+        const QString fname = mDescriptionImages.at(i);
         QFileInfo const info(fname);
         if (plainDescription.contains(qsl("$%1").arg(info.fileName()))) {
             newImagesList.append(fname);
@@ -609,7 +609,7 @@ QString dlgPackageExporter::copyNewImagesToTmp(const QString& tempPath) const
 
     if (!newImagesList.isEmpty()) {
         //Create description image dir
-        QString const descriptionImagesDirName = qsl("%1.mudlet/description_images/").arg(tempPath);
+        const QString descriptionImagesDirName = qsl("%1.mudlet/description_images/").arg(tempPath);
         QDir const descriptionImageDir = QDir(descriptionImagesDirName);
         if (!descriptionImageDir.exists()) {
             descriptionImageDir.mkpath(descriptionImagesDirName);
@@ -622,7 +622,7 @@ QString dlgPackageExporter::copyNewImagesToTmp(const QString& tempPath) const
                 QFile::copy(imageFile.absoluteFilePath(), imageDir);
             }
             //replaces spaces with %20 in image file name to create a compatible url
-            QString const imageName = QUrl::toPercentEncoding(imageFile.fileName()).constData();
+            const QString imageName = QUrl::toPercentEncoding(imageFile.fileName()).constData();
             //replace temporary path with the path that is now inside the package
             plainDescription.replace(qsl("$%1").arg(imageFile.fileName()), qsl("$packagePath/.mudlet/description_images/%1").arg(imageName));
         }
@@ -819,7 +819,7 @@ void dlgPackageExporter::writeConfigFile(const QString& stagingDirName, const QF
     mPackageConfig.append(qsl("created = \"%1\"\n").arg(iso8601timestamp.toString(Qt::ISODate)));
     mPackageComment.append(qsl("    created: %1\n").arg(iso8601timestamp.toString(Qt::ISODate)));
 
-    QString const luaConfig = qsl("%1/config.lua").arg(stagingDirName);
+    const QString luaConfig = qsl("%1/config.lua").arg(stagingDirName);
     QSaveFile configFile(luaConfig);
     if (configFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
         QTextStream out(&configFile);
@@ -886,7 +886,7 @@ std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDi
     if (!archive) {
         zip_error_t zipError;
         zip_error_init_with_code(&zipError, ze);
-        QString const errMsg = tr("Failed to open package file. Error is: \"%1\".",
+        const QString errMsg = tr("Failed to open package file. Error is: \"%1\".",
                             // Intentional comment to separate arguments
                             "This zipError message is shown when the libzip library code is unable to open the file that was to be the end result of the export process. As this may be an existing "
                             "file anywhere "
@@ -916,7 +916,7 @@ std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDi
     // Value is fullName in file-system:
     QMap<QString, QString> fileEntries;
     while (stagingFile.hasNext() && isOk) {
-        QString const itEntry = stagingFile.next();
+        const QString itEntry = stagingFile.next();
         Q_UNUSED(itEntry);
         // Dot and DotDot entries are no use to us so skip them
         if (!(stagingFile.fileName().compare(qsl(".")) && stagingFile.fileName().compare(qsl("..")))) {
@@ -955,11 +955,11 @@ std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDi
 
     QStringListIterator itDirectoryName(directoryEntries);
     while (itDirectoryName.hasNext() && isOk) {
-        QString const directoryName = itDirectoryName.next();
+        const QString directoryName = itDirectoryName.next();
         // zip_dir_add(...) returns the index of the
         // added directory item in the archive or -1 on error:
         if (zip_dir_add(archive, directoryName.toStdString().c_str(), ZIP_FL_ENC_UTF_8) == -1) {
-            QString const errorMsg = tr("Failed to add directory \"%1\" to package. Error is: \"%2\".").arg(directoryName, zip_strerror(archive));
+            const QString errorMsg = tr("Failed to add directory \"%1\" to package. Error is: \"%2\".").arg(directoryName, zip_strerror(archive));
             zip_discard(archive);
             return {false, errorMsg};
         }
@@ -1028,13 +1028,13 @@ std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDi
         ze = zip_close(archive);
         if (ze) {
             // libzip's C interface around the error message isn't trivial - so copy it over into Qt land where things are simpler
-            QString const zipError{zip_strerror(archive)};
+            const QString zipError{zip_strerror(archive)};
             if (zipError == qsl("Operation cancelled")) {
                 zip_discard(archive);
                 return {false, tr("Export cancelled.")};
             }
 
-            QString const errorMsg = tr("Failed to zip up the package. Error is: \"%1\".",
+            const QString errorMsg = tr("Failed to zip up the package. Error is: \"%1\".",
                                   // Intentional comment to separate arguments
                                   "This error message is displayed at the final stage of exporting a package when all the sourced files are finally put into the archive. Unfortunately this may be "
                                   "the point at which something breaks because a problem was not spotted/detected in the process earlier...")
@@ -1089,7 +1089,7 @@ void dlgPackageExporter::slot_addFiles()
 
 void dlgPackageExporter::slot_openPackageLocation()
 {
-    QString const profileName(mpHost->getName());
+    const QString profileName(mpHost->getName());
 
     mPackagePath = QFileDialog::getExistingDirectory(
             nullptr, tr("Where do you want to save the package?"), mudlet::getMudletPath(mudlet::profileHomePath, profileName), QFileDialog::DontUseNativeDialog | QFileDialog::ShowDirsOnly);
@@ -1142,7 +1142,7 @@ void dlgPackageExporter::checkChildren(QTreeWidgetItem* item) const
     if (!mCheckChildren) {
         return;
     }
-    QString const packageName = ui->packageList->currentText();
+    const QString packageName = ui->packageList->currentText();
     auto checkState = item->checkState(0);
     // Don't check top folder if it has the same name as the package
     if (item->text(0) == packageName && item->data(0, Qt::UserRole) == isTopFolder) {
@@ -1539,13 +1539,13 @@ void dlgPackageExporterDescription::insertFromMimeData(const QMimeData* source)
                        << "bmp"
                        << "svg";
         for (const auto& url : source->urls()) {
-            QString const fname = url.toLocalFile();
+            const QString fname = url.toLocalFile();
             QFileInfo const info(fname);
             if (info.exists() && accepted_types.contains(info.suffix().trimmed(), Qt::CaseInsensitive)) {
                 if (!my_parent->mDescriptionImages.contains(fname)) {
                     my_parent->mDescriptionImages.append(fname);
                 }
-                QString const imgSrc = qsl("![Image]($%1)").arg(info.fileName());
+                const QString imgSrc = qsl("![Image]($%1)").arg(info.fileName());
                 myCursor.insertText(imgSrc);
             }
         }

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -812,7 +812,7 @@ void dlgPackageExporter::writeConfigFile(const QString& stagingDirName, const QF
     appendToDetails(qsl("version"), ui->lineEdit_version->text());
     appendToDetails(qsl("dependencies"), dependencies.join(","));
     QDateTime iso8601timestamp = QDateTime::currentDateTime();
-    int const offset = iso8601timestamp.offsetFromUtc();
+    const int offset = iso8601timestamp.offsetFromUtc();
     iso8601timestamp.setOffsetFromUtc(offset);
     QDateTime iso8601time(QDateTime::currentDateTime());
     iso8601time.setTimeSpec(Qt::OffsetFromUTC);
@@ -1460,7 +1460,7 @@ void dlgPackageExporter::slot_recountItems(QTreeWidgetItem *item)
     if (!debounce) {
         debounce = true;
         QTimer::singleShot(0, this, [this]() {
-            int const itemsToExport = countCheckedItems();
+            const int itemsToExport = countCheckedItems();
             if (itemsToExport) {
                 mpSelectionText->setTitle(tr("Select what to export (%n item(s))",
                                              // Intentional comment to separate arguments
@@ -1524,7 +1524,7 @@ void dlgPackageExporterDescription::insertFromMimeData(const QMimeData* source)
     dlgPackageExporter* my_parent = static_cast<dlgPackageExporter*>(topLevelWidget());
     if (source->hasUrls()) {
         QTextCursor myCursor = textCursor();
-        int const oldPos = myCursor.position();
+        const int oldPos = myCursor.position();
         // Allows to insert image at cursor position if using copy/paste
         if (hasFocus()) {
             myCursor.setPosition(oldPos);

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -296,7 +296,7 @@ void dlgPackageExporter::slot_packageChanged(int index)
     ui->textEdit_description->setMarkdown(description);
     const QString version = packageInfo.value(qsl("version"));
     ui->lineEdit_version->setText(version);
-    QStringList const dependencies = packageInfo.value(qsl("dependencies")).split(QLatin1Char(','));
+    const QStringList dependencies = packageInfo.value(qsl("dependencies")).split(QLatin1Char(','));
     ui->comboBox_dependencies->clear();
     if (!dependencies.at(0).isEmpty()) {
         ui->comboBox_dependencies->addItems(dependencies);

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -215,7 +215,7 @@ void dlgPackageExporter::slot_removeDependency()
 
 void dlgPackageExporter::slot_packageChanged(int index)
 {
-    QString packageName = ui->packageList->currentText();
+    QString const packageName = ui->packageList->currentText();
     uncheckAllChildren();
     if (index != 0) {
         ui->lineEdit_packageName->setText(packageName);
@@ -274,19 +274,19 @@ void dlgPackageExporter::slot_packageChanged(int index)
         }
     }
 
-    QString packagePath{mudlet::getMudletPath(mudlet::profileHomePath, mpHost->getName())};
+    QString const packagePath{mudlet::getMudletPath(mudlet::profileHomePath, mpHost->getName())};
     //fill package metadata
     mPackageIconPath.clear();
-    QMap<QString, QString> packageInfo = mpHost->mPackageInfo.value(packageName);
+    QMap<QString, QString> const packageInfo = mpHost->mPackageInfo.value(packageName);
     ui->lineEdit_author->setText(packageInfo.value(qsl("author")));
-    QString icon{packageInfo.value(qsl("icon"))};
+    QString const icon{packageInfo.value(qsl("icon"))};
     if (!icon.isEmpty()) {
         mPackageIconPath = qsl("%1/%2/.mudlet/Icon/%3").arg(packagePath, packageName, icon);
         ui->Icon->show();
     } else {
         ui->Icon->hide();
     }
-    QIcon myIcon(mPackageIconPath);
+    QIcon const myIcon(mPackageIconPath);
     ui->Icon->clear();
     ui->Icon->setPixmap(myIcon.pixmap(ui->Icon->size()));
     ui->lineEdit_title->setText(packageInfo.value(qsl("title")));
@@ -294,9 +294,9 @@ void dlgPackageExporter::slot_packageChanged(int index)
     QString description{mPlainDescription};
     description.replace(QLatin1String("$packagePath"), qsl("%1/%2").arg(packagePath, packageName));
     ui->textEdit_description->setMarkdown(description);
-    QString version = packageInfo.value(qsl("version"));
+    QString const version = packageInfo.value(qsl("version"));
     ui->lineEdit_version->setText(version);
-    QStringList dependencies = packageInfo.value(qsl("dependencies")).split(QLatin1Char(','));
+    QStringList const dependencies = packageInfo.value(qsl("dependencies")).split(QLatin1Char(','));
     ui->comboBox_dependencies->clear();
     if (!dependencies.at(0).isEmpty()) {
         ui->comboBox_dependencies->addItems(dependencies);
@@ -304,7 +304,7 @@ void dlgPackageExporter::slot_packageChanged(int index)
 
     //get files and folders from package
     ui->listWidget_addedFiles->clear();
-    QFileInfo info(qsl("%1/%2/").arg(packagePath, packageName));
+    QFileInfo const info(qsl("%1/%2/").arg(packagePath, packageName));
     if (!info.exists()) {
         return;
     }
@@ -312,7 +312,7 @@ void dlgPackageExporter::slot_packageChanged(int index)
     QStringList ignore;
     ignore << QLatin1String("config.lua") << qsl("%1.xml").arg(packageName);
     while (it.hasNext()) {
-        QFileInfo f(it.next());
+        QFileInfo const f(it.next());
         if (ignore.contains(f.fileName(), Qt::CaseInsensitive)) {
             continue;
         }
@@ -346,12 +346,12 @@ void dlgPackageExporter::checkToEnableExportButton()
 
 void dlgPackageExporter::slot_importIcon()
 {
-    QString fileName = QFileDialog::getOpenFileName(this, tr("Open Icon"), QDir::currentPath(), tr("Image Files (*.png *.jpg *.jpeg *.bmp *.tif *.ico *.icns)"));
+    QString const fileName = QFileDialog::getOpenFileName(this, tr("Open Icon"), QDir::currentPath(), tr("Image Files (*.png *.jpg *.jpeg *.bmp *.tif *.ico *.icns)"));
     if (fileName.isEmpty()) {
         return;
     }
     mPackageIconPath = fileName;
-    QIcon myIcon(mPackageIconPath);
+    QIcon const myIcon(mPackageIconPath);
     ui->Icon->clear();
     ui->Icon->setPixmap(myIcon.pixmap(ui->Icon->size()));
     ui->Icon->show();
@@ -386,17 +386,17 @@ bool dlgPackageExporter::eventFilter(QObject* obj, QEvent* evt)
             //during package creation it uses the profile folder. But once the package is created it will use
             //profile folder/packagename
             QString plainText{mPlainDescription};
-            QString profilePath{mudlet::getMudletPath(mudlet::profileHomePath, mpHost->getName())};
+            QString const profilePath{mudlet::getMudletPath(mudlet::profileHomePath, mpHost->getName())};
             //$packagePath will be replaced by the resource path if an existing package is selected
             if (ui->packageList->currentIndex() != 0) {
-                QString packageName = ui->packageList->currentText();
+                QString const packageName = ui->packageList->currentText();
                 plainText.replace(QLatin1String("$packagePath"), qsl("%1/%2").arg(profilePath, packageName));
             } else {
                 plainText.replace(QLatin1String("$packagePath"), profilePath);
             }
             for (int i = mDescriptionImages.size() - 1; i >= 0; i--) {
                 QString fname = mDescriptionImages.at(i);
-                QFileInfo info(fname);
+                QFileInfo const info(fname);
                 fname = QUrl::toPercentEncoding(fname).constData();
                 plainText.replace(qsl("$%1").arg(info.fileName()), fname);
             }
@@ -418,8 +418,8 @@ bool dlgPackageExporter::eventFilter(QObject* obj, QEvent* evt)
         if (evt->type() == QEvent::Drop) {
             QDropEvent* dropEvent = static_cast<QDropEvent*>(evt);
             for (const auto& url : dropEvent->mimeData()->urls()) {
-                QString fname = url.toLocalFile();
-                QFileInfo info(fname);
+                QString const fname = url.toLocalFile();
+                QFileInfo const info(fname);
                 if (info.exists()) {
                     ui->listWidget_addedFiles->addItem(fname);
                 }
@@ -447,7 +447,7 @@ void dlgPackageExporter::copy_directory(const QString& fromDir, const QString& t
     }
     targetDir.mkdir(toDir);
     while (it.hasNext()) {
-        QFileInfo f(it.next());
+        QFileInfo const f(it.next());
         if (f.fileName() == QLatin1String(".") || f.fileName() == QLatin1String("..") || f.isSymLink()) {
             continue;
         }
@@ -487,7 +487,7 @@ void dlgPackageExporter::slot_exportPackage()
     // To avoid confusion if the user looks in that part of their file-system we
     // will append a "/mudlet" suffix so they can see that we are interested in
     // those files:
-    QString stagingDirName = qsl("%1/mudlet/%2").arg(QStandardPaths::writableLocation(QStandardPaths::TempLocation), mPackageName);
+    QString const stagingDirName = qsl("%1/mudlet/%2").arg(QStandardPaths::writableLocation(QStandardPaths::TempLocation), mPackageName);
     QDir packageDir = QDir(stagingDirName);
     if (!packageDir.exists()) {
         packageDir.mkpath(stagingDirName);
@@ -496,7 +496,7 @@ void dlgPackageExporter::slot_exportPackage()
         packageDir.mkpath(stagingDirName);
     }
 
-    QString tempPath = qsl("%1/").arg(stagingDirName);
+    QString const tempPath = qsl("%1/").arg(stagingDirName);
 
     mExportingPackage = true;
     QApplication::setOverrideCursor(Qt::BusyCursor);
@@ -520,7 +520,7 @@ void dlgPackageExporter::slot_exportPackage()
     // start copying assets in the background
     auto assetsFuture = QtConcurrent::run(dlgPackageExporter::copyAssetsToTmp, assetPaths, tempPath);
 
-    QFileInfo iconFile = copyIconToTmp(tempPath);
+    QFileInfo const iconFile = copyIconToTmp(tempPath);
 
     mXmlPathFileName = qsl("%1/%2.xml").arg(stagingDirName, mPackageName);
     writeConfigFile(stagingDirName, iconFile, plainDescription);
@@ -600,8 +600,8 @@ QString dlgPackageExporter::copyNewImagesToTmp(const QString& tempPath) const
     //don't change the original plain description here as it may still be needed, for example if creating another package
     QString plainDescription = mPlainDescription;
     for (int i = mDescriptionImages.size() - 1; i >= 0; i--) {
-        QString fname = mDescriptionImages.at(i);
-        QFileInfo info(fname);
+        QString const fname = mDescriptionImages.at(i);
+        QFileInfo const info(fname);
         if (plainDescription.contains(qsl("$%1").arg(info.fileName()))) {
             newImagesList.append(fname);
         }
@@ -609,20 +609,20 @@ QString dlgPackageExporter::copyNewImagesToTmp(const QString& tempPath) const
 
     if (!newImagesList.isEmpty()) {
         //Create description image dir
-        QString descriptionImagesDirName = qsl("%1.mudlet/description_images/").arg(tempPath);
-        QDir descriptionImageDir = QDir(descriptionImagesDirName);
+        QString const descriptionImagesDirName = qsl("%1.mudlet/description_images/").arg(tempPath);
+        QDir const descriptionImageDir = QDir(descriptionImagesDirName);
         if (!descriptionImageDir.exists()) {
             descriptionImageDir.mkpath(descriptionImagesDirName);
         }
         for (int i = newImagesList.size() - 1; i >= 0; i--) {
-            QFileInfo imageFile(newImagesList.at(i));
+            QFileInfo const imageFile(newImagesList.at(i));
             if (imageFile.exists()) {
                 QString imageDir = descriptionImagesDirName;
                 imageDir.append(imageFile.fileName());
                 QFile::copy(imageFile.absoluteFilePath(), imageDir);
             }
             //replaces spaces with %20 in image file name to create a compatible url
-            QString imageName = QUrl::toPercentEncoding(imageFile.fileName()).constData();
+            QString const imageName = QUrl::toPercentEncoding(imageFile.fileName()).constData();
             //replace temporary path with the path that is now inside the package
             plainDescription.replace(qsl("$%1").arg(imageFile.fileName()), qsl("$packagePath/.mudlet/description_images/%1").arg(imageName));
         }
@@ -633,7 +633,7 @@ QString dlgPackageExporter::copyNewImagesToTmp(const QString& tempPath) const
 // purge images from tmp which are no longer used by the description
 void dlgPackageExporter::cleanupUnusedImages(const QString& tempPath, const QString& plainDescription)
 {
-    static QRegularExpression imagesInUsePattern(R"(\$packagePath\/\.mudlet\/description_images\/(.+?)\.)");
+    static QRegularExpression const imagesInUsePattern(R"(\$packagePath\/\.mudlet\/description_images\/(.+?)\.)");
     QStringList imagesInUse;
     QRegularExpressionMatchIterator i = imagesInUsePattern.globalMatch(plainDescription);
     while (i.hasNext()) {
@@ -644,7 +644,7 @@ void dlgPackageExporter::cleanupUnusedImages(const QString& tempPath, const QStr
     // iterate through all images in folder, if our list doesn't contain it - remove
     QDirIterator allImagesCopied(qsl("%1.mudlet/description_images").arg(tempPath), QDir::Files);
     while (allImagesCopied.hasNext()) {
-        QFileInfo copiedImage(allImagesCopied.next());
+        QFileInfo const copiedImage(allImagesCopied.next());
         if (!imagesInUse.contains(copiedImage.baseName())) {
             if (!QFile(copiedImage.absoluteFilePath()).remove()) {
                 qDebug() << "couldn't remove unused image" << copiedImage.fileName();
@@ -812,14 +812,14 @@ void dlgPackageExporter::writeConfigFile(const QString& stagingDirName, const QF
     appendToDetails(qsl("version"), ui->lineEdit_version->text());
     appendToDetails(qsl("dependencies"), dependencies.join(","));
     QDateTime iso8601timestamp = QDateTime::currentDateTime();
-    int offset = iso8601timestamp.offsetFromUtc();
+    int const offset = iso8601timestamp.offsetFromUtc();
     iso8601timestamp.setOffsetFromUtc(offset);
     QDateTime iso8601time(QDateTime::currentDateTime());
     iso8601time.setTimeSpec(Qt::OffsetFromUTC);
     mPackageConfig.append(qsl("created = \"%1\"\n").arg(iso8601timestamp.toString(Qt::ISODate)));
     mPackageComment.append(qsl("    created: %1\n").arg(iso8601timestamp.toString(Qt::ISODate)));
 
-    QString luaConfig = qsl("%1/config.lua").arg(stagingDirName);
+    QString const luaConfig = qsl("%1/config.lua").arg(stagingDirName);
     QSaveFile configFile(luaConfig);
     if (configFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
         QTextStream out(&configFile);
@@ -836,10 +836,10 @@ void dlgPackageExporter::writeConfigFile(const QString& stagingDirName, const QF
 
 QFileInfo dlgPackageExporter::copyIconToTmp(const QString& tempPath) const
 {
-    QFileInfo iconFile(mPackageIconPath);
+    QFileInfo const iconFile(mPackageIconPath);
     if (iconFile.exists()) {
         QString iconDirName = qsl("%1.mudlet/Icon/").arg(tempPath);
-        QDir iconDir = QDir(iconDirName);
+        QDir const iconDir = QDir(iconDirName);
         if (!iconDir.exists()) {
             iconDir.mkpath(iconDirName);
         }
@@ -852,7 +852,7 @@ QFileInfo dlgPackageExporter::copyIconToTmp(const QString& tempPath) const
 std::pair<bool, QString> dlgPackageExporter::copyAssetsToTmp(const QStringList& assetPaths, const QString& tempPath)
 {
     for (const auto& assetPath : assetPaths) {
-        QFileInfo asset(assetPath);
+        QFileInfo const asset(assetPath);
         QString filePath = tempPath;
         filePath.append(asset.fileName());
         if (!asset.exists()) {
@@ -886,7 +886,7 @@ std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDi
     if (!archive) {
         zip_error_t zipError;
         zip_error_init_with_code(&zipError, ze);
-        QString errMsg = tr("Failed to open package file. Error is: \"%1\".",
+        QString const errMsg = tr("Failed to open package file. Error is: \"%1\".",
                             // Intentional comment to separate arguments
                             "This zipError message is shown when the libzip library code is unable to open the file that was to be the end result of the export process. As this may be an existing "
                             "file anywhere "
@@ -916,7 +916,7 @@ std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDi
     // Value is fullName in file-system:
     QMap<QString, QString> fileEntries;
     while (stagingFile.hasNext() && isOk) {
-        QString itEntry = stagingFile.next();
+        QString const itEntry = stagingFile.next();
         Q_UNUSED(itEntry);
         // Dot and DotDot entries are no use to us so skip them
         if (!(stagingFile.fileName().compare(qsl(".")) && stagingFile.fileName().compare(qsl("..")))) {
@@ -924,7 +924,7 @@ std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDi
             continue;
         }
 
-        QFileInfo stagingFileInfo(stagingFile.fileInfo());
+        QFileInfo const stagingFileInfo(stagingFile.fileInfo());
         if (!stagingFileInfo.isReadable()) {
             qWarning() << "dlgPackageExporter::slot_exportPackage() skipping file: " << stagingFile.fileName() << "it is NOT readable!";
             continue;
@@ -955,11 +955,11 @@ std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDi
 
     QStringListIterator itDirectoryName(directoryEntries);
     while (itDirectoryName.hasNext() && isOk) {
-        QString directoryName = itDirectoryName.next();
+        QString const directoryName = itDirectoryName.next();
         // zip_dir_add(...) returns the index of the
         // added directory item in the archive or -1 on error:
         if (zip_dir_add(archive, directoryName.toStdString().c_str(), ZIP_FL_ENC_UTF_8) == -1) {
-            QString errorMsg = tr("Failed to add directory \"%1\" to package. Error is: \"%2\".").arg(directoryName, zip_strerror(archive));
+            QString const errorMsg = tr("Failed to add directory \"%1\" to package. Error is: \"%2\".").arg(directoryName, zip_strerror(archive));
             zip_discard(archive);
             return {false, errorMsg};
         }
@@ -1028,13 +1028,13 @@ std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDi
         ze = zip_close(archive);
         if (ze) {
             // libzip's C interface around the error message isn't trivial - so copy it over into Qt land where things are simpler
-            QString zipError{zip_strerror(archive)};
+            QString const zipError{zip_strerror(archive)};
             if (zipError == qsl("Operation cancelled")) {
                 zip_discard(archive);
                 return {false, tr("Export cancelled.")};
             }
 
-            QString errorMsg = tr("Failed to zip up the package. Error is: \"%1\".",
+            QString const errorMsg = tr("Failed to zip up the package. Error is: \"%1\".",
                                   // Intentional comment to separate arguments
                                   "This error message is displayed at the final stage of exporting a package when all the sourced files are finally put into the archive. Unfortunately this may be "
                                   "the point at which something breaks because a problem was not spotted/detected in the process earlier...")
@@ -1089,7 +1089,7 @@ void dlgPackageExporter::slot_addFiles()
 
 void dlgPackageExporter::slot_openPackageLocation()
 {
-    QString profileName(mpHost->getName());
+    QString const profileName(mpHost->getName());
 
     mPackagePath = QFileDialog::getExistingDirectory(
             nullptr, tr("Where do you want to save the package?"), mudlet::getMudletPath(mudlet::profileHomePath, profileName), QFileDialog::DontUseNativeDialog | QFileDialog::ShowDirsOnly);
@@ -1142,7 +1142,7 @@ void dlgPackageExporter::checkChildren(QTreeWidgetItem* item) const
     if (!mCheckChildren) {
         return;
     }
-    QString packageName = ui->packageList->currentText();
+    QString const packageName = ui->packageList->currentText();
     auto checkState = item->checkState(0);
     // Don't check top folder if it has the same name as the package
     if (item->text(0) == packageName && item->data(0, Qt::UserRole) == isTopFolder) {
@@ -1460,7 +1460,7 @@ void dlgPackageExporter::slot_recountItems(QTreeWidgetItem *item)
     if (!debounce) {
         debounce = true;
         QTimer::singleShot(0, this, [this]() {
-            int itemsToExport = countCheckedItems();
+            int const itemsToExport = countCheckedItems();
             if (itemsToExport) {
                 mpSelectionText->setTitle(tr("Select what to export (%n item(s))",
                                              // Intentional comment to separate arguments
@@ -1524,7 +1524,7 @@ void dlgPackageExporterDescription::insertFromMimeData(const QMimeData* source)
     dlgPackageExporter* my_parent = static_cast<dlgPackageExporter*>(topLevelWidget());
     if (source->hasUrls()) {
         QTextCursor myCursor = textCursor();
-        int oldPos = myCursor.position();
+        int const oldPos = myCursor.position();
         // Allows to insert image at cursor position if using copy/paste
         if (hasFocus()) {
             myCursor.setPosition(oldPos);
@@ -1539,13 +1539,13 @@ void dlgPackageExporterDescription::insertFromMimeData(const QMimeData* source)
                        << "bmp"
                        << "svg";
         for (const auto& url : source->urls()) {
-            QString fname = url.toLocalFile();
-            QFileInfo info(fname);
+            QString const fname = url.toLocalFile();
+            QFileInfo const info(fname);
             if (info.exists() && accepted_types.contains(info.suffix().trimmed(), Qt::CaseInsensitive)) {
                 if (!my_parent->mDescriptionImages.contains(fname)) {
                     my_parent->mDescriptionImages.append(fname);
                 }
-                QString imgSrc = qsl("![Image]($%1)").arg(info.fileName());
+                QString const imgSrc = qsl("![Image]($%1)").arg(info.fileName());
                 myCursor.insertText(imgSrc);
             }
         }
@@ -1555,7 +1555,7 @@ void dlgPackageExporterDescription::insertFromMimeData(const QMimeData* source)
             QString plainText = my_parent->mPlainDescription;
             for (int i = my_parent->mDescriptionImages.size() - 1; i >= 0; i--) {
                 QString fname = my_parent->mDescriptionImages.at(i);
-                QFileInfo info(fname);
+                QFileInfo const info(fname);
                 fname = QUrl::toPercentEncoding(fname).constData();
                 plainText.replace(qsl("$%1").arg(info.fileName()), fname);
             }

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -97,7 +97,7 @@ void dlgPackageManager::resetPackageTable()
 
 void dlgPackageManager::slot_installPackage()
 {
-    QString fileName = QFileDialog::getOpenFileName(this, tr("Import Mudlet Package"), QDir::currentPath());
+    QString const fileName = QFileDialog::getOpenFileName(this, tr("Import Mudlet Package"), QDir::currentPath());
     if (fileName.isEmpty()) {
         return;
     }
@@ -113,10 +113,10 @@ void dlgPackageManager::slot_installPackage()
 
 void dlgPackageManager::slot_removePackages()
 {
-    QModelIndexList selection = packageTable->selectionModel()->selectedRows();
+    QModelIndexList const selection = packageTable->selectionModel()->selectedRows();
     QStringList removePackages;
     for (int i = 0; i < selection.count(); i++) {
-        QModelIndex index = selection.at(i);
+        QModelIndex const index = selection.at(i);
         auto package = packageTable->item(index.row(), 0);
         removePackages << package->text();
     }
@@ -140,7 +140,7 @@ void dlgPackageManager::slot_itemClicked(QTableWidgetItem* pItem)
     for (int i = additionalDetails->rowCount() - 1; i >= 0; --i) {
         additionalDetails->removeRow(i);
     }
-    QString packageName = packageTable->item(pItem->row(), 0)->text();
+    QString const packageName = packageTable->item(pItem->row(), 0)->text();
     auto packageInfo{mpHost->mPackageInfo.value(packageName)};
     if (packageInfo.isEmpty()) {
         packageDescription->clear();
@@ -158,7 +158,7 @@ void dlgPackageManager::slot_itemClicked(QTableWidgetItem* pItem)
         packageDescription->hide();
     } else {
         packageDescription->show();
-        QString packageDir = mudlet::self()->getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), packageName);
+        QString const packageDir = mudlet::self()->getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), packageName);
         description.replace(QLatin1String("$packagePath"), packageDir);
         packageDescription->setMarkdown(description);
     }
@@ -168,7 +168,7 @@ void dlgPackageManager::slot_itemClicked(QTableWidgetItem* pItem)
     details << qsl("author") << qsl("version") << qsl("created") << qsl("dependencies");
     int counter = 0;
     for (int i = 0; i < details.size(); i++) {
-        QString valueText{packageInfo.take(details.at(i))};
+        QString const valueText{packageInfo.take(details.at(i))};
         if (valueText.isEmpty()) {
             continue;
         }
@@ -198,7 +198,7 @@ void dlgPackageManager::slot_itemClicked(QTableWidgetItem* pItem)
         additionalDetails->show();
         detailsLabel->show();
     }
-    int maxHeight = additionalDetails->rowCount() * additionalDetails->rowHeight(0);
+    int const maxHeight = additionalDetails->rowCount() * additionalDetails->rowHeight(0);
     additionalDetails->setMaximumHeight(maxHeight);
     additionalDetails->verticalScrollBar()->hide();
     packageTable->scrollToItem(pItem);
@@ -228,8 +228,8 @@ void dlgPackageManager::fillAdditionalDetails(const QMap<QString, QString>& pack
 
 void dlgPackageManager::slot_toggleRemoveButton()
 {
-    QModelIndexList selection = packageTable->selectionModel()->selectedRows();
-    int selectionCount = selection.count();
+    QModelIndexList const selection = packageTable->selectionModel()->selectedRows();
+    int const selectionCount = selection.count();
     removeButton->setEnabled(selectionCount);
     if (selectionCount) {
         removeButton->setText(tr("Remove %n package(s)",

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -198,7 +198,7 @@ void dlgPackageManager::slot_itemClicked(QTableWidgetItem* pItem)
         additionalDetails->show();
         detailsLabel->show();
     }
-    int const maxHeight = additionalDetails->rowCount() * additionalDetails->rowHeight(0);
+    const int maxHeight = additionalDetails->rowCount() * additionalDetails->rowHeight(0);
     additionalDetails->setMaximumHeight(maxHeight);
     additionalDetails->verticalScrollBar()->hide();
     packageTable->scrollToItem(pItem);
@@ -229,7 +229,7 @@ void dlgPackageManager::fillAdditionalDetails(const QMap<QString, QString>& pack
 void dlgPackageManager::slot_toggleRemoveButton()
 {
     QModelIndexList const selection = packageTable->selectionModel()->selectedRows();
-    int const selectionCount = selection.count();
+    const int selectionCount = selection.count();
     removeButton->setEnabled(selectionCount);
     if (selectionCount) {
         removeButton->setText(tr("Remove %n package(s)",

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -97,7 +97,7 @@ void dlgPackageManager::resetPackageTable()
 
 void dlgPackageManager::slot_installPackage()
 {
-    QString const fileName = QFileDialog::getOpenFileName(this, tr("Import Mudlet Package"), QDir::currentPath());
+    const QString fileName = QFileDialog::getOpenFileName(this, tr("Import Mudlet Package"), QDir::currentPath());
     if (fileName.isEmpty()) {
         return;
     }
@@ -140,7 +140,7 @@ void dlgPackageManager::slot_itemClicked(QTableWidgetItem* pItem)
     for (int i = additionalDetails->rowCount() - 1; i >= 0; --i) {
         additionalDetails->removeRow(i);
     }
-    QString const packageName = packageTable->item(pItem->row(), 0)->text();
+    const QString packageName = packageTable->item(pItem->row(), 0)->text();
     auto packageInfo{mpHost->mPackageInfo.value(packageName)};
     if (packageInfo.isEmpty()) {
         packageDescription->clear();
@@ -158,7 +158,7 @@ void dlgPackageManager::slot_itemClicked(QTableWidgetItem* pItem)
         packageDescription->hide();
     } else {
         packageDescription->show();
-        QString const packageDir = mudlet::self()->getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), packageName);
+        const QString packageDir = mudlet::self()->getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), packageName);
         description.replace(QLatin1String("$packagePath"), packageDir);
         packageDescription->setMarkdown(description);
     }
@@ -168,7 +168,7 @@ void dlgPackageManager::slot_itemClicked(QTableWidgetItem* pItem)
     details << qsl("author") << qsl("version") << qsl("created") << qsl("dependencies");
     int counter = 0;
     for (int i = 0; i < details.size(); i++) {
-        QString const valueText{packageInfo.take(details.at(i))};
+        const QString valueText{packageInfo.take(details.at(i))};
         if (valueText.isEmpty()) {
             continue;
         }

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -687,7 +687,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         checkBox_spellCheck->setText(tr("System dictionaries:", "On *nix systems where we find the system ones we use them."));
     }
 
-    QDir const dir(path);
+    const QDir dir(path);
     QStringList entries = dir.entryList(QDir::Files, QDir::Time);
     // QRegularExpression rex(qsl(R"(\.dic$)"));
     // Use the affix file as that may eliminate supplimental dictionaries:
@@ -2439,7 +2439,7 @@ void dlgProfilePreferences::slot_saveMap()
 QString dlgProfilePreferences::mapSaveLoadDirectory(Host* pHost)
 {
     const QString mapsPath = mudlet::getMudletPath(mudlet::profileMapsPath, pHost->getName());
-    QDir const mapsDir = QDir(mapsPath);
+    const QDir mapsDir = QDir(mapsPath);
     return mapsDir.exists() ? mapsPath : mudlet::getMudletPath(mudlet::profileHomePath, pHost->getName());
 }
 
@@ -2493,7 +2493,7 @@ void dlgProfilePreferences::slot_copyMap()
             // update, or rather REPLACE TMap::mRoomIdHash
 
             // Check for the destination directory for the other profiles
-            QDir const toProfileDir;
+            const QDir toProfileDir;
             const QString toProfileDirPathString = mudlet::getMudletPath(mudlet::profileMapsPath, toProfileName);
             if (!toProfileDir.exists(toProfileDirPathString)) {
                 if (!toProfileDir.mkpath(toProfileDirPathString)) {
@@ -3315,7 +3315,7 @@ void dlgProfilePreferences::slot_tabChanged(int tabIndex)
         return;
     }
 
-    QDir const dir;
+    const QDir dir;
     const QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
     if (!dir.mkpath(cacheDir)) {
         qWarning() << "Couldn't create cache directory for edbee themes: " << cacheDir;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -844,7 +844,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     mIsLoggingTimestamps->setChecked(pHost->mIsLoggingTimestamps);
     mIsToLogInHtml->setChecked(pHost->mIsNextLogFileInHtmlFormat);
 
-    bool const isLogFileNameEntryShown = pHost->mLogFileNameFormat.isEmpty();
+    const bool isLogFileNameEntryShown = pHost->mLogFileNameFormat.isEmpty();
     const QString logExtension = pHost->mIsNextLogFileInHtmlFormat ? ".html" : ".txt";
     label_logFileNameExtension->setVisible(isLogFileNameEntryShown);
     lineEdit_logFileName->setVisible(isLogFileNameEntryShown);
@@ -2295,7 +2295,7 @@ void dlgProfilePreferences::loadMap(const QString& fileName)
 
     // Ensure the setting is already made as the TConsole::loadMap(...) uses
     // the set value:
-    bool const showAuditErrors = mudlet::self()->showMapAuditErrors();
+    const bool showAuditErrors = mudlet::self()->showMapAuditErrors();
     mudlet::self()->setShowMapAuditErrors(checkBox_reportMapIssuesOnScreen->isChecked());
 
     bool success = false;
@@ -2414,7 +2414,7 @@ void dlgProfilePreferences::slot_saveMap()
         // show up when saving big maps
 
         // Ensure the setting is already made as the saveMap(...) uses the set value
-        bool const showAuditErrors = mudlet::self()->showMapAuditErrors();
+        const bool showAuditErrors = mudlet::self()->showMapAuditErrors();
         mudlet::self()->setShowMapAuditErrors(checkBox_reportMapIssuesOnScreen->isChecked());
 
         bool success = false;
@@ -2527,7 +2527,7 @@ void dlgProfilePreferences::slot_copyMap()
 
     // Ensure the setting is already made as the value could be used in the
     // code following after
-    bool const savedOldAuditErrorsToConsoleEnabledSetting = mudlet::self()->showMapAuditErrors();
+    const bool savedOldAuditErrorsToConsoleEnabledSetting = mudlet::self()->showMapAuditErrors();
     mudlet::self()->setShowMapAuditErrors(checkBox_reportMapIssuesOnScreen->isChecked());
 
     // We now KNOW there are places where the destination profiles will/have
@@ -2745,7 +2745,7 @@ void dlgProfilePreferences::slot_logFileNameFormatChange(const int index)
         return;
     }
 
-    bool const isShown = comboBox_logFileNameFormat->currentData().toString().isEmpty();
+    const bool isShown = comboBox_logFileNameFormat->currentData().toString().isEmpty();
     lineEdit_logFileName->setVisible(isShown);
     label_logFileName->setVisible(isShown);
     label_logFileNameExtension->setVisible(isShown);
@@ -2798,7 +2798,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         if (pHost->mpMap) {
             // Need to save the original value in case we change it in the line
             // following this one:
-            bool const defaultAreaWasNotShown = pHost->mpMap->getDefaultAreaShown();
+            const bool defaultAreaWasNotShown = pHost->mpMap->getDefaultAreaShown();
             pHost->mpMap->setDefaultAreaShown(checkBox_showDefaultArea->isChecked());
             if (pHost->mpMap->mpMapper) {
                 pHost->mpMap->mpMapper->mp2dMap->mMapperUseAntiAlias = mMapperUseAntiAlias->isChecked();
@@ -2861,14 +2861,14 @@ void dlgProfilePreferences::slot_saveAndClose()
         const QString oldIrcPass = dlgIRC::readIrcPassword(pHost);
         const QString oldIrcHost = dlgIRC::readIrcHostName(pHost);
         const QString oldIrcPort = QString::number(dlgIRC::readIrcHostPort(pHost));
-        bool const oldIrcSecure = dlgIRC::readIrcHostSecure(pHost);
+        const bool oldIrcSecure = dlgIRC::readIrcHostSecure(pHost);
         const QString oldIrcChannels = dlgIRC::readIrcChannels(pHost).join(" ");
 
         QString newIrcNick = ircNick->text();
         const QString newIrcPass = ircPassword->text();
         QString newIrcHost = ircHostName->text();
         QString newIrcPort = ircHostPort->text();
-        bool const newIrcSecure = ircHostSecure->isChecked();
+        const bool newIrcSecure = ircHostSecure->isChecked();
         QString newIrcChannels = ircChannels->text();
         QStringList newChanList;
         int nIrcPort = dlgIRC::DefaultHostPort;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -677,7 +677,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     // prevents us using it to find any system ones
     const QString& currentDictionary = pHost->getSpellDic();
     // This will also set mudlet::mUsingMudletDictionaries as appropriate:
-    QString const path = mudlet::getMudletPath(mudlet::hunspellDictionaryPath, currentDictionary);
+    const QString path = mudlet::getMudletPath(mudlet::hunspellDictionaryPath, currentDictionary);
 
     // Tweak the label for the provided spelling dictionaries depending on where
     // they come from:
@@ -845,7 +845,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     mIsToLogInHtml->setChecked(pHost->mIsNextLogFileInHtmlFormat);
 
     bool const isLogFileNameEntryShown = pHost->mLogFileNameFormat.isEmpty();
-    QString const logExtension = pHost->mIsNextLogFileInHtmlFormat ? ".html" : ".txt";
+    const QString logExtension = pHost->mIsNextLogFileInHtmlFormat ? ".html" : ".txt";
     label_logFileNameExtension->setVisible(isLogFileNameEntryShown);
     lineEdit_logFileName->setVisible(isLogFileNameEntryShown);
     label_logFileName->setVisible(isLogFileNameEntryShown);
@@ -900,7 +900,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     mpMenu->clear();
     for (unsigned int i = 0, total = profileList.size(); i < total; ++i) {
-        QString const s = profileList.at(i);
+        const QString s = profileList.at(i);
         if (s.isEmpty() || !s.compare(pHost->getName())) {
             // Do not include THIS profile in the list - it will
             // automatically get saved - as the file to copy to the other
@@ -1080,7 +1080,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
                 QList<QSslError> const sslErrors = pHost->mTelnet.getSslErrors();
 
                 for (int a = 0; a < sslErrors.count(); a++) {
-                    QString const thisError = qsl("<li>%1</li>").arg(sslErrors.at(a).errorString());
+                    const QString thisError = qsl("<li>%1</li>").arg(sslErrors.at(a).errorString());
                     notificationAreaMessageBox->setText(qsl("%1\n%2").arg(notificationAreaMessageBox->text(), thisError));
 
                     if (sslErrors.at(a).error() == QSslError::SelfSignedCertificate) {
@@ -2202,7 +2202,7 @@ void dlgProfilePreferences::fillOutMapHistory()
         return;
     }
 
-    QString const profile_name = pHost->getName();
+    const QString profile_name = pHost->getName();
     auto const locale = mudlet::self()->getUserLocale();
     int longestMapHistoryLength = 0;
     QIcon const icon_autoSave{QIcon::fromTheme(qsl("document-save"), QIcon(qsl(":/icons/document-save.png")))};
@@ -2231,11 +2231,11 @@ void dlgProfilePreferences::fillOutMapHistory()
         if (match.capturedStart() != -1) {
             // A recognised date-time stamp file name of any Mudlet map file type:
             QString day;
-            QString const month = match.captured(2);
+            const QString month = match.captured(2);
             QString year;
-            QString const hour = match.captured(4);
-            QString const minute = match.captured(5);
-            QString const second = match.captured(6);
+            const QString hour = match.captured(4);
+            const QString minute = match.captured(5);
+            const QString second = match.captured(6);
             if (match.captured(1).toInt() > 31 && match.captured(3).toInt() >= 1 && match.captured(3).toInt() <= 31) {
                 year = match.captured(1);
                 day = match.captured(3);
@@ -2243,9 +2243,9 @@ void dlgProfilePreferences::fillOutMapHistory()
                 day = match.captured(1);
                 year = match.captured(3);
             }
-            QString const extension = match.captured(7);
+            const QString extension = match.captured(7);
             QDateTime const datetime(QDate(year.toInt(), month.toInt(), day.toInt()), QTime(hour.toInt(), minute.toInt(), second.toInt()));
-            QString const itemText = locale.toString(datetime, dateTimeFormat);
+            const QString itemText = locale.toString(datetime, dateTimeFormat);
             longestMapHistoryLength = qMax(longestMapHistoryLength, itemText.size());
             if (!extension.compare(QLatin1String("xml"), Qt::CaseInsensitive)) {
                 comboBox_mapHistory->addItem(icon_xmlFile, itemText, QVariant(mapPathFileName));
@@ -2261,7 +2261,7 @@ void dlgProfilePreferences::fillOutMapHistory()
             // The auto-saved file:
             QFileInfo const fileInfo(mapSaveDir, entry);
             auto lastModified = fileInfo.lastModified();
-            QString const itemText = locale.toString(lastModified, dateTimeFormat);
+            const QString itemText = locale.toString(lastModified, dateTimeFormat);
             longestMapHistoryLength = qMax(longestMapHistoryLength, itemText.size());
             comboBox_mapHistory->addItem(icon_autoSave, itemText, QVariant(mapPathFileName));
         } else {
@@ -2438,7 +2438,7 @@ void dlgProfilePreferences::slot_saveMap()
 
 QString dlgProfilePreferences::mapSaveLoadDirectory(Host* pHost)
 {
-    QString const mapsPath = mudlet::getMudletPath(mudlet::profileMapsPath, pHost->getName());
+    const QString mapsPath = mudlet::getMudletPath(mudlet::profileMapsPath, pHost->getName());
     QDir const mapsDir = QDir(mapsPath);
     return mapsDir.exists() ? mapsPath : mudlet::getMudletPath(mudlet::profileHomePath, pHost->getName());
 }
@@ -2486,7 +2486,7 @@ void dlgProfilePreferences::slot_copyMap()
     while (itAction.hasNext()) {
         QAction* _action = itAction.next();
         if (_action->isChecked()) {
-            QString const toProfileName = _action->text();
+            const QString toProfileName = _action->text();
             toProfilesRoomIdMap.insert(toProfileName, 0);
             // 0 is used as sentinel value that we don't have a valid Id yet
             // for the given Host - the contents of this map will be used to
@@ -2494,10 +2494,10 @@ void dlgProfilePreferences::slot_copyMap()
 
             // Check for the destination directory for the other profiles
             QDir const toProfileDir;
-            QString const toProfileDirPathString = mudlet::getMudletPath(mudlet::profileMapsPath, toProfileName);
+            const QString toProfileDirPathString = mudlet::getMudletPath(mudlet::profileMapsPath, toProfileName);
             if (!toProfileDir.exists(toProfileDirPathString)) {
                 if (!toProfileDir.mkpath(toProfileDirPathString)) {
-                    QString const errMsg = tr("[ ERROR ] - Unable to use or create directory to store map for other profile \"%1\".\n"
+                    const QString errMsg = tr("[ ERROR ] - Unable to use or create directory to store map for other profile \"%1\".\n"
                                         "Please check that you have permissions/access to:\n"
                                         "\"%2\"\n"
                                         "and there is enough space. The copying operation has failed.")
@@ -2610,7 +2610,7 @@ void dlgProfilePreferences::slot_copyMap()
     // we just saved!
     QString thisProfileLatestMapPathFileName;
     QFile thisProfileLatestMapFile;
-    QString const sourceMapFolder(mudlet::getMudletPath(mudlet::profileMapsPath, pHost->getName()));
+    const QString sourceMapFolder(mudlet::getMudletPath(mudlet::profileMapsPath, pHost->getName()));
     QStringList const mProfileList = QDir(sourceMapFolder).entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
     for (unsigned int i = 0, total = mProfileList.size(); i < total; ++i) {
         thisProfileLatestMapPathFileName = mProfileList.at(i);
@@ -2633,7 +2633,7 @@ void dlgProfilePreferences::slot_copyMap()
     itOtherProfile.toFront();
     while (itOtherProfile.hasNext()) {
         itOtherProfile.next();
-        QString const otherHostName = itOtherProfile.key();
+        const QString otherHostName = itOtherProfile.key();
         // Copy over into the profiles map folder, so it is loaded first when map is open - this covers the offline case
         label_mapFileActionResult->setText(tr("Copying over map to %1 - please wait...").arg(otherHostName));
         qApp->processEvents(); // Copied from "Loading map - please wait..." case
@@ -2692,7 +2692,7 @@ void dlgProfilePreferences::slot_setLogDir()
      * dialog while the directory selector is open...!
      */
     // Seems to return "." when Cancel is hit:
-    QString const currentLogDir = QFileDialog::getExistingDirectory(
+    const QString currentLogDir = QFileDialog::getExistingDirectory(
             this, tr("Where should Mudlet save log files?"), (mLogDirPath.isEmpty() ? lineEdit_logFileFolder->placeholderText() : mLogDirPath), QFileDialog::DontUseNativeDialog);
 
     if (!currentLogDir.isEmpty() && currentLogDir != nullptr) {
@@ -2849,7 +2849,7 @@ void dlgProfilePreferences::slot_saveAndClose()
             console->changeColors();
         }
 
-        QString const lIgnore = doubleclick_ignore_lineedit->text();
+        const QString lIgnore = doubleclick_ignore_lineedit->text();
         pHost->mDoubleClickIgnore.clear();
         for (auto character : lIgnore) {
             pHost->mDoubleClickIgnore.insert(character);
@@ -2857,15 +2857,15 @@ void dlgProfilePreferences::slot_saveAndClose()
 
         pHost->mpMap->mSaveVersion = comboBox_mapFileSaveFormatVersion->currentData().toInt();
 
-        QString const oldIrcNick = dlgIRC::readIrcNickName(pHost);
-        QString const oldIrcPass = dlgIRC::readIrcPassword(pHost);
-        QString const oldIrcHost = dlgIRC::readIrcHostName(pHost);
-        QString const oldIrcPort = QString::number(dlgIRC::readIrcHostPort(pHost));
+        const QString oldIrcNick = dlgIRC::readIrcNickName(pHost);
+        const QString oldIrcPass = dlgIRC::readIrcPassword(pHost);
+        const QString oldIrcHost = dlgIRC::readIrcHostName(pHost);
+        const QString oldIrcPort = QString::number(dlgIRC::readIrcHostPort(pHost));
         bool const oldIrcSecure = dlgIRC::readIrcHostSecure(pHost);
-        QString const oldIrcChannels = dlgIRC::readIrcChannels(pHost).join(" ");
+        const QString oldIrcChannels = dlgIRC::readIrcChannels(pHost).join(" ");
 
         QString newIrcNick = ircNick->text();
-        QString const newIrcPass = ircPassword->text();
+        const QString newIrcPass = ircPassword->text();
         QString newIrcHost = ircHostName->text();
         QString newIrcPort = ircHostPort->text();
         bool const newIrcSecure = ircHostSecure->isChecked();
@@ -2895,7 +2895,7 @@ void dlgProfilePreferences::slot_saveAndClose()
 
         if (!newIrcChannels.isEmpty()) {
             QStringList const tL = newIrcChannels.split(" ", Qt::SkipEmptyParts);
-            for (QString const s : tL) {
+            for (const QString s : tL) {
                 if (s.startsWith("#") || s.startsWith("&") || s.startsWith("+")) {
                     newChanList << s;
                 }
@@ -3316,14 +3316,14 @@ void dlgProfilePreferences::slot_tabChanged(int tabIndex)
     }
 
     QDir const dir;
-    QString const cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    const QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
     if (!dir.mkpath(cacheDir)) {
         qWarning() << "Couldn't create cache directory for edbee themes: " << cacheDir;
         return;
     }
 
     QSettings settings("mudlet", "Mudlet");
-    QString const themesURL = settings.value("colorSublimeThemesURL", qsl("https://github.com/Colorsublime/Colorsublime-Themes/archive/master.zip")).toString();
+    const QString themesURL = settings.value("colorSublimeThemesURL", qsl("https://github.com/Colorsublime/Colorsublime-Themes/archive/master.zip")).toString();
     // a default update period is 24h
     // it would be nice to use C++14's numeric separator but Qt Creator still
     // does not like them for its Clang code model analyser (and the built in
@@ -3426,8 +3426,8 @@ void dlgProfilePreferences::populateThemesList()
     if (themesFile.open(QIODevice::ReadOnly)) {
         unsortedThemes = QJsonDocument::fromJson(themesFile.readAll()).array();
         for (auto theme : qAsConst(unsortedThemes)) {
-            QString const themeText = theme.toObject()["Title"].toString();
-            QString const themeFileName = theme.toObject()["FileName"].toString();
+            const QString themeText = theme.toObject()["Title"].toString();
+            const QString themeFileName = theme.toObject()["FileName"].toString();
 
             if (!themeText.isEmpty() && !themeFileName.isEmpty()) {
                 sortedThemes << std::make_pair(themeText, themeFileName);
@@ -3618,7 +3618,7 @@ void dlgProfilePreferences::generateMapGlyphDisplay()
     QHashIterator<QString, QSet<int>> itUsedSymbol(roomSymbolsHash);
     while (itUsedSymbol.hasNext()) {
         itUsedSymbol.next();
-        QString const symbol = itUsedSymbol.key();
+        const QString symbol = itUsedSymbol.key();
         QList<int> roomsWithSymbol = itUsedSymbol.value().values();
         if (roomsWithSymbol.count() > 1) {
             std::sort(roomsWithSymbol.begin(), roomsWithSymbol.end());
@@ -3762,7 +3762,7 @@ void dlgProfilePreferences::generateDiscordTooltips()
     }
 
     auto setToolTip = [=](QWidget* widget, const QString& highlight) {
-        QString const tooltip = qsl(R"(
+        const QString tooltip = qsl(R"(
   <style type="text/css">
     .tg  {border-collapse:collapse;border-spacing:0;}
     .tg td{font-size:12px;padding:10px 5px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;border-color:black;}

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2259,7 +2259,7 @@ void dlgProfilePreferences::fillOutMapHistory()
             }
         } else if (!entry.compare(QLatin1String("autosave.dat"), Qt::CaseInsensitive)) {
             // The auto-saved file:
-            QFileInfo const fileInfo(mapSaveDir, entry);
+            const QFileInfo fileInfo(mapSaveDir, entry);
             auto lastModified = fileInfo.lastModified();
             const QString itemText = locale.toString(lastModified, dateTimeFormat);
             longestMapHistoryLength = qMax(longestMapHistoryLength, itemText.size());

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -635,7 +635,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     search_engine_combobox->addItems(QStringList(mpHost->mSearchEngineData.keys()));
 
     // set to saved value or default to Google
-    int const savedText = search_engine_combobox->findText(mpHost->getSearchEngine().first);
+    const int savedText = search_engine_combobox->findText(mpHost->getSearchEngine().first);
     search_engine_combobox->setCurrentIndex(savedText == -1 ? 1 : savedText);
 
     mFORCE_MXP_NEGOTIATION_OFF->setChecked(pHost->mFORCE_MXP_NEGOTIATION_OFF);
@@ -953,7 +953,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
                     comboBox_mapFileSaveFormatVersion->addItem(tr("%1 {Downgraded, for sharing with older version users, NOT recommended}").arg(i), QVariant(i));
                 }
             }
-            int const _indexForCurrentSaveFormat = comboBox_mapFileSaveFormatVersion->findData(pHost->mpMap->mSaveVersion, Qt::UserRole);
+            const int _indexForCurrentSaveFormat = comboBox_mapFileSaveFormatVersion->findData(pHost->mpMap->mSaveVersion, Qt::UserRole);
             if (_indexForCurrentSaveFormat >= 0) {
                 comboBox_mapFileSaveFormatVersion->setCurrentIndex(_indexForCurrentSaveFormat);
             }
@@ -967,7 +967,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         mpDoubleSpinBox_mapSymbolFontFudge->setSingleStep(0.01);
         auto * pmapViewLayout = qobject_cast<QGridLayout*>(groupBox_mapViewOptions->layout());
         if (pmapViewLayout) {
-            int const existingRows = pmapViewLayout->rowCount();
+            const int existingRows = pmapViewLayout->rowCount();
             pmapViewLayout->addWidget(pLabel_mapSymbolFontFudge, existingRows, 0);
             pmapViewLayout->addWidget(mpDoubleSpinBox_mapSymbolFontFudge, existingRows, 1);
         } else {
@@ -1032,7 +1032,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         // first) value
         comboBox_encoding->setCurrentIndex(0);
     } else {
-        int const currentIndex = comboBox_encoding->findData(pHost->mTelnet.getEncoding());
+        const int currentIndex = comboBox_encoding->findData(pHost->mTelnet.getEncoding());
         if (currentIndex >=0) {
             comboBox_encoding->setCurrentIndex(currentIndex);
         } else {
@@ -2594,7 +2594,7 @@ void dlgProfilePreferences::slot_copyMap()
                            // show up when saving big maps
 
     // Temporarily use whatever version is currently set
-    int const oldSaveVersionFormat = pHost->mpMap->mSaveVersion;
+    const int oldSaveVersionFormat = pHost->mpMap->mSaveVersion;
     pHost->mpMap->mSaveVersion = comboBox_mapFileSaveFormatVersion->currentData().toInt();
 
     if (!pHost->mpConsole->saveMap(QString())) {
@@ -2946,8 +2946,8 @@ void dlgProfilePreferences::slot_saveAndClose()
         slot_setDisplayFont();
 
         if (console) {
-            int const x = console->width();
-            int const y = console->height();
+            const int x = console->width();
+            const int y = console->height();
             QSize const s = QSize(x, y);
             QResizeEvent event(s, s);
             QApplication::sendEvent(console, &event);
@@ -3328,7 +3328,7 @@ void dlgProfilePreferences::slot_tabChanged(int tabIndex)
     // it would be nice to use C++14's numeric separator but Qt Creator still
     // does not like them for its Clang code model analyser (and the built in
     // one is even less receptive to): 86'400'000
-    int const themesUpdatePeriod = settings.value("themesUpdatePeriod", 86400000).toInt();
+    const int themesUpdatePeriod = settings.value("themesUpdatePeriod", 86400000).toInt();
     // save the defaults in settings so the field is visible for editing in config file if needed
     settings.setValue("colorSublimeThemesURL", themesURL);
     settings.setValue("themesUpdatePeriod", themesUpdatePeriod);
@@ -3886,7 +3886,7 @@ void dlgProfilePreferences::slot_setMapSymbolFont(const QFont & font)
         return;
     }
 
-    int const pointSize = pHost->mpMap->mMapSymbolFont.pointSize();
+    const int pointSize = pHost->mpMap->mMapSymbolFont.pointSize();
     if (pHost->mpMap->mMapSymbolFont != font) {
         pHost->mpMap->mMapSymbolFont = font;
         pHost->mpMap->mMapSymbolFont.setPointSize(pointSize);

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -635,7 +635,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     search_engine_combobox->addItems(QStringList(mpHost->mSearchEngineData.keys()));
 
     // set to saved value or default to Google
-    int savedText = search_engine_combobox->findText(mpHost->getSearchEngine().first);
+    int const savedText = search_engine_combobox->findText(mpHost->getSearchEngine().first);
     search_engine_combobox->setCurrentIndex(savedText == -1 ? 1 : savedText);
 
     mFORCE_MXP_NEGOTIATION_OFF->setChecked(pHost->mFORCE_MXP_NEGOTIATION_OFF);
@@ -677,7 +677,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     // prevents us using it to find any system ones
     const QString& currentDictionary = pHost->getSpellDic();
     // This will also set mudlet::mUsingMudletDictionaries as appropriate:
-    QString path = mudlet::getMudletPath(mudlet::hunspellDictionaryPath, currentDictionary);
+    QString const path = mudlet::getMudletPath(mudlet::hunspellDictionaryPath, currentDictionary);
 
     // Tweak the label for the provided spelling dictionaries depending on where
     // they come from:
@@ -687,11 +687,11 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         checkBox_spellCheck->setText(tr("System dictionaries:", "On *nix systems where we find the system ones we use them."));
     }
 
-    QDir dir(path);
+    QDir const dir(path);
     QStringList entries = dir.entryList(QDir::Files, QDir::Time);
     // QRegularExpression rex(qsl(R"(\.dic$)"));
     // Use the affix file as that may eliminate supplimental dictionaries:
-    QRegularExpression rex(qsl(R"(\.aff$)"));
+    QRegularExpression const rex(qsl(R"(\.aff$)"));
     entries = entries.filter(rex);
     // Don't emit signals - like (void) QListWidget::currentItemChanged(QListWidgetItem *current, QListWidgetItem *previous)
     // while populating the widget, it reduces noise about:
@@ -804,7 +804,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     USE_UNIX_EOL->setChecked(pHost->mUSE_UNIX_EOL);
 
     if (mudlet::self()->mDiscord.libraryLoaded()) {
-        Host::DiscordOptionFlags discordFlags = pHost->mDiscordAccessFlags;
+        Host::DiscordOptionFlags const discordFlags = pHost->mDiscordAccessFlags;
         groupBox_discordPrivacy->show();
         checkBox_discordLuaAPI->setChecked(discordFlags & Host::DiscordLuaAccessEnabled);
 
@@ -844,8 +844,8 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     mIsLoggingTimestamps->setChecked(pHost->mIsLoggingTimestamps);
     mIsToLogInHtml->setChecked(pHost->mIsNextLogFileInHtmlFormat);
 
-    bool isLogFileNameEntryShown = pHost->mLogFileNameFormat.isEmpty();
-    QString logExtension = pHost->mIsNextLogFileInHtmlFormat ? ".html" : ".txt";
+    bool const isLogFileNameEntryShown = pHost->mLogFileNameFormat.isEmpty();
+    QString const logExtension = pHost->mIsNextLogFileInHtmlFormat ? ".html" : ".txt";
     label_logFileNameExtension->setVisible(isLogFileNameEntryShown);
     lineEdit_logFileName->setVisible(isLogFileNameEntryShown);
     label_logFileName->setVisible(isLogFileNameEntryShown);
@@ -891,7 +891,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     // load profiles into mappers "copy map to profile" combobox
     // this feature should work seamlessly both for online and offline profiles
-    QStringList profileList = QDir(mudlet::getMudletPath(mudlet::profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Time); // sort by profile "hotness"
+    QStringList const profileList = QDir(mudlet::getMudletPath(mudlet::profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Time); // sort by profile "hotness"
     pushButton_chooseProfiles->setEnabled(false);
     pushButton_copyMap->setEnabled(false);
     if (!mpMenu) {
@@ -900,7 +900,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     mpMenu->clear();
     for (unsigned int i = 0, total = profileList.size(); i < total; ++i) {
-        QString s = profileList.at(i);
+        QString const s = profileList.at(i);
         if (s.isEmpty() || !s.compare(pHost->getName())) {
             // Do not include THIS profile in the list - it will
             // automatically get saved - as the file to copy to the other
@@ -953,7 +953,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
                     comboBox_mapFileSaveFormatVersion->addItem(tr("%1 {Downgraded, for sharing with older version users, NOT recommended}").arg(i), QVariant(i));
                 }
             }
-            int _indexForCurrentSaveFormat = comboBox_mapFileSaveFormatVersion->findData(pHost->mpMap->mSaveVersion, Qt::UserRole);
+            int const _indexForCurrentSaveFormat = comboBox_mapFileSaveFormatVersion->findData(pHost->mpMap->mSaveVersion, Qt::UserRole);
             if (_indexForCurrentSaveFormat >= 0) {
                 comboBox_mapFileSaveFormatVersion->setCurrentIndex(_indexForCurrentSaveFormat);
             }
@@ -967,7 +967,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         mpDoubleSpinBox_mapSymbolFontFudge->setSingleStep(0.01);
         auto * pmapViewLayout = qobject_cast<QGridLayout*>(groupBox_mapViewOptions->layout());
         if (pmapViewLayout) {
-            int existingRows = pmapViewLayout->rowCount();
+            int const existingRows = pmapViewLayout->rowCount();
             pmapViewLayout->addWidget(pLabel_mapSymbolFontFudge, existingRows, 0);
             pmapViewLayout->addWidget(mpDoubleSpinBox_mapSymbolFontFudge, existingRows, 1);
         } else {
@@ -1032,7 +1032,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         // first) value
         comboBox_encoding->setCurrentIndex(0);
     } else {
-        int currentIndex = comboBox_encoding->findData(pHost->mTelnet.getEncoding());
+        int const currentIndex = comboBox_encoding->findData(pHost->mTelnet.getEncoding());
         if (currentIndex >=0) {
             comboBox_encoding->setCurrentIndex(currentIndex);
         } else {
@@ -1057,7 +1057,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
 #if !defined(QT_NO_SSL)
     if (QSslSocket::supportsSsl() && pHost->mSslTsl) {
-        QSslCertificate cert = pHost->mTelnet.getPeerCertificate();
+        QSslCertificate const cert = pHost->mTelnet.getPeerCertificate();
         if (cert.isNull()) {
             groupBox_ssl_certificate->hide();
         } else {
@@ -1077,10 +1077,10 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
                 notificationAreaMessageBox->show();
                 //notificationAreaMessageBox->setText(pHost->mTelnet.errorString());
 
-                QList<QSslError> sslErrors = pHost->mTelnet.getSslErrors();
+                QList<QSslError> const sslErrors = pHost->mTelnet.getSslErrors();
 
                 for (int a = 0; a < sslErrors.count(); a++) {
-                    QString thisError = qsl("<li>%1</li>").arg(sslErrors.at(a).errorString());
+                    QString const thisError = qsl("<li>%1</li>").arg(sslErrors.at(a).errorString());
                     notificationAreaMessageBox->setText(qsl("%1\n%2").arg(notificationAreaMessageBox->text(), thisError));
 
                     if (sslErrors.at(a).error() == QSslError::SelfSignedCertificate) {
@@ -2202,12 +2202,12 @@ void dlgProfilePreferences::fillOutMapHistory()
         return;
     }
 
-    QString profile_name = pHost->getName();
+    QString const profile_name = pHost->getName();
     auto const locale = mudlet::self()->getUserLocale();
     int longestMapHistoryLength = 0;
-    QIcon icon_autoSave{QIcon::fromTheme(qsl("document-save"), QIcon(qsl(":/icons/document-save.png")))};
-    QIcon icon_xmlFile{QIcon::fromTheme(qsl("application-xml"), QIcon(qsl(":/icons/application-xml.png")))};
-    QIcon icon_jsonFile{QIcon::fromTheme(qsl("application-json"), QIcon(qsl(":/icons/application-json.png")))};
+    QIcon const icon_autoSave{QIcon::fromTheme(qsl("document-save"), QIcon(qsl(":/icons/document-save.png")))};
+    QIcon const icon_xmlFile{QIcon::fromTheme(qsl("application-xml"), QIcon(qsl(":/icons/application-xml.png")))};
+    QIcon const icon_jsonFile{QIcon::fromTheme(qsl("application-json"), QIcon(qsl(":/icons/application-json.png")))};
     QString dateTimeFormat = mudlet::self()->getUserLocale().dateTimeFormat();
     if (dateTimeFormat.contains(QLatin1Char('t'))) {
         // There is a timezone identifier in there - which (apart from perhaps
@@ -2224,18 +2224,18 @@ void dlgProfilePreferences::fillOutMapHistory()
     const QRegularExpression mapSaveRegularExpression{qsl("(\\d+)\\-(\\d+)\\-(\\d+)#(\\d+)\\-(\\d+)\\-(\\d+)(?:map)?\\.(dat|xml|json)"), QRegularExpression::CaseInsensitiveOption};
     QDir mapSaveDir(mudlet::getMudletPath(mudlet::profileMapsPath, profile_name).append(QLatin1Char('/')));
     mapSaveDir.setSorting(QDir::Time);
-    QStringList mapSaveEntries = mapSaveDir.entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
+    QStringList const mapSaveEntries = mapSaveDir.entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
     for (const auto& entry : mapSaveEntries) {
-        QRegularExpressionMatch match = mapSaveRegularExpression.match(entry);
+        QRegularExpressionMatch const match = mapSaveRegularExpression.match(entry);
         const QString mapPathFileName = mapSaveDir.absoluteFilePath(entry);
         if (match.capturedStart() != -1) {
             // A recognised date-time stamp file name of any Mudlet map file type:
             QString day;
-            QString month = match.captured(2);
+            QString const month = match.captured(2);
             QString year;
-            QString hour = match.captured(4);
-            QString minute = match.captured(5);
-            QString second = match.captured(6);
+            QString const hour = match.captured(4);
+            QString const minute = match.captured(5);
+            QString const second = match.captured(6);
             if (match.captured(1).toInt() > 31 && match.captured(3).toInt() >= 1 && match.captured(3).toInt() <= 31) {
                 year = match.captured(1);
                 day = match.captured(3);
@@ -2243,9 +2243,9 @@ void dlgProfilePreferences::fillOutMapHistory()
                 day = match.captured(1);
                 year = match.captured(3);
             }
-            QString extension = match.captured(7);
-            QDateTime datetime(QDate(year.toInt(), month.toInt(), day.toInt()), QTime(hour.toInt(), minute.toInt(), second.toInt()));
-            QString itemText = locale.toString(datetime, dateTimeFormat);
+            QString const extension = match.captured(7);
+            QDateTime const datetime(QDate(year.toInt(), month.toInt(), day.toInt()), QTime(hour.toInt(), minute.toInt(), second.toInt()));
+            QString const itemText = locale.toString(datetime, dateTimeFormat);
             longestMapHistoryLength = qMax(longestMapHistoryLength, itemText.size());
             if (!extension.compare(QLatin1String("xml"), Qt::CaseInsensitive)) {
                 comboBox_mapHistory->addItem(icon_xmlFile, itemText, QVariant(mapPathFileName));
@@ -2259,9 +2259,9 @@ void dlgProfilePreferences::fillOutMapHistory()
             }
         } else if (!entry.compare(QLatin1String("autosave.dat"), Qt::CaseInsensitive)) {
             // The auto-saved file:
-            QFileInfo fileInfo(mapSaveDir, entry);
+            QFileInfo const fileInfo(mapSaveDir, entry);
             auto lastModified = fileInfo.lastModified();
-            QString itemText = locale.toString(lastModified, dateTimeFormat);
+            QString const itemText = locale.toString(lastModified, dateTimeFormat);
             longestMapHistoryLength = qMax(longestMapHistoryLength, itemText.size());
             comboBox_mapHistory->addItem(icon_autoSave, itemText, QVariant(mapPathFileName));
         } else {
@@ -2295,7 +2295,7 @@ void dlgProfilePreferences::loadMap(const QString& fileName)
 
     // Ensure the setting is already made as the TConsole::loadMap(...) uses
     // the set value:
-    bool showAuditErrors = mudlet::self()->showMapAuditErrors();
+    bool const showAuditErrors = mudlet::self()->showMapAuditErrors();
     mudlet::self()->setShowMapAuditErrors(checkBox_reportMapIssuesOnScreen->isChecked());
 
     bool success = false;
@@ -2414,7 +2414,7 @@ void dlgProfilePreferences::slot_saveMap()
         // show up when saving big maps
 
         // Ensure the setting is already made as the saveMap(...) uses the set value
-        bool showAuditErrors = mudlet::self()->showMapAuditErrors();
+        bool const showAuditErrors = mudlet::self()->showMapAuditErrors();
         mudlet::self()->setShowMapAuditErrors(checkBox_reportMapIssuesOnScreen->isChecked());
 
         bool success = false;
@@ -2438,8 +2438,8 @@ void dlgProfilePreferences::slot_saveMap()
 
 QString dlgProfilePreferences::mapSaveLoadDirectory(Host* pHost)
 {
-    QString mapsPath = mudlet::getMudletPath(mudlet::profileMapsPath, pHost->getName());
-    QDir mapsDir = QDir(mapsPath);
+    QString const mapsPath = mudlet::getMudletPath(mudlet::profileMapsPath, pHost->getName());
+    QDir const mapsDir = QDir(mapsPath);
     return mapsDir.exists() ? mapsPath : mudlet::getMudletPath(mudlet::profileHomePath, pHost->getName());
 }
 
@@ -2486,18 +2486,18 @@ void dlgProfilePreferences::slot_copyMap()
     while (itAction.hasNext()) {
         QAction* _action = itAction.next();
         if (_action->isChecked()) {
-            QString toProfileName = _action->text();
+            QString const toProfileName = _action->text();
             toProfilesRoomIdMap.insert(toProfileName, 0);
             // 0 is used as sentinel value that we don't have a valid Id yet
             // for the given Host - the contents of this map will be used to
             // update, or rather REPLACE TMap::mRoomIdHash
 
             // Check for the destination directory for the other profiles
-            QDir toProfileDir;
-            QString toProfileDirPathString = mudlet::getMudletPath(mudlet::profileMapsPath, toProfileName);
+            QDir const toProfileDir;
+            QString const toProfileDirPathString = mudlet::getMudletPath(mudlet::profileMapsPath, toProfileName);
             if (!toProfileDir.exists(toProfileDirPathString)) {
                 if (!toProfileDir.mkpath(toProfileDirPathString)) {
-                    QString errMsg = tr("[ ERROR ] - Unable to use or create directory to store map for other profile \"%1\".\n"
+                    QString const errMsg = tr("[ ERROR ] - Unable to use or create directory to store map for other profile \"%1\".\n"
                                         "Please check that you have permissions/access to:\n"
                                         "\"%2\"\n"
                                         "and there is enough space. The copying operation has failed.")
@@ -2527,7 +2527,7 @@ void dlgProfilePreferences::slot_copyMap()
 
     // Ensure the setting is already made as the value could be used in the
     // code following after
-    bool savedOldAuditErrorsToConsoleEnabledSetting = mudlet::self()->showMapAuditErrors();
+    bool const savedOldAuditErrorsToConsoleEnabledSetting = mudlet::self()->showMapAuditErrors();
     mudlet::self()->setShowMapAuditErrors(checkBox_reportMapIssuesOnScreen->isChecked());
 
     // We now KNOW there are places where the destination profiles will/have
@@ -2594,7 +2594,7 @@ void dlgProfilePreferences::slot_copyMap()
                            // show up when saving big maps
 
     // Temporarily use whatever version is currently set
-    int oldSaveVersionFormat = pHost->mpMap->mSaveVersion;
+    int const oldSaveVersionFormat = pHost->mpMap->mSaveVersion;
     pHost->mpMap->mSaveVersion = comboBox_mapFileSaveFormatVersion->currentData().toInt();
 
     if (!pHost->mpConsole->saveMap(QString())) {
@@ -2610,8 +2610,8 @@ void dlgProfilePreferences::slot_copyMap()
     // we just saved!
     QString thisProfileLatestMapPathFileName;
     QFile thisProfileLatestMapFile;
-    QString sourceMapFolder(mudlet::getMudletPath(mudlet::profileMapsPath, pHost->getName()));
-    QStringList mProfileList = QDir(sourceMapFolder).entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
+    QString const sourceMapFolder(mudlet::getMudletPath(mudlet::profileMapsPath, pHost->getName()));
+    QStringList const mProfileList = QDir(sourceMapFolder).entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
     for (unsigned int i = 0, total = mProfileList.size(); i < total; ++i) {
         thisProfileLatestMapPathFileName = mProfileList.at(i);
         if (thisProfileLatestMapPathFileName.isEmpty()) {
@@ -2633,7 +2633,7 @@ void dlgProfilePreferences::slot_copyMap()
     itOtherProfile.toFront();
     while (itOtherProfile.hasNext()) {
         itOtherProfile.next();
-        QString otherHostName = itOtherProfile.key();
+        QString const otherHostName = itOtherProfile.key();
         // Copy over into the profiles map folder, so it is loaded first when map is open - this covers the offline case
         label_mapFileActionResult->setText(tr("Copying over map to %1 - please wait...").arg(otherHostName));
         qApp->processEvents(); // Copied from "Loading map - please wait..." case
@@ -2692,7 +2692,7 @@ void dlgProfilePreferences::slot_setLogDir()
      * dialog while the directory selector is open...!
      */
     // Seems to return "." when Cancel is hit:
-    QString currentLogDir = QFileDialog::getExistingDirectory(
+    QString const currentLogDir = QFileDialog::getExistingDirectory(
             this, tr("Where should Mudlet save log files?"), (mLogDirPath.isEmpty() ? lineEdit_logFileFolder->placeholderText() : mLogDirPath), QFileDialog::DontUseNativeDialog);
 
     if (!currentLogDir.isEmpty() && currentLogDir != nullptr) {
@@ -2745,7 +2745,7 @@ void dlgProfilePreferences::slot_logFileNameFormatChange(const int index)
         return;
     }
 
-    bool isShown = comboBox_logFileNameFormat->currentData().toString().isEmpty();
+    bool const isShown = comboBox_logFileNameFormat->currentData().toString().isEmpty();
     lineEdit_logFileName->setVisible(isShown);
     label_logFileName->setVisible(isShown);
     label_logFileNameExtension->setVisible(isShown);
@@ -2798,7 +2798,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         if (pHost->mpMap) {
             // Need to save the original value in case we change it in the line
             // following this one:
-            bool defaultAreaWasNotShown = pHost->mpMap->getDefaultAreaShown();
+            bool const defaultAreaWasNotShown = pHost->mpMap->getDefaultAreaShown();
             pHost->mpMap->setDefaultAreaShown(checkBox_showDefaultArea->isChecked());
             if (pHost->mpMap->mpMapper) {
                 pHost->mpMap->mpMapper->mp2dMap->mMapperUseAntiAlias = mMapperUseAntiAlias->isChecked();
@@ -2819,7 +2819,7 @@ void dlgProfilePreferences::slot_saveAndClose()
                 pHost->mpMap->mpMapper->update();
             }
         }
-        QMargins newBorders{leftBorderWidth->value(), topBorderHeight->value(), rightBorderWidth->value(), bottomBorderHeight->value()};
+        QMargins const newBorders{leftBorderWidth->value(), topBorderHeight->value(), rightBorderWidth->value(), bottomBorderHeight->value()};
         pHost->setBorders(newBorders);
         pHost->commandLineMinimumHeight = commandLineMinimumHeight->value();
         pHost->mFORCE_MXP_NEGOTIATION_OFF = mFORCE_MXP_NEGOTIATION_OFF->isChecked();
@@ -2849,7 +2849,7 @@ void dlgProfilePreferences::slot_saveAndClose()
             console->changeColors();
         }
 
-        QString lIgnore = doubleclick_ignore_lineedit->text();
+        QString const lIgnore = doubleclick_ignore_lineedit->text();
         pHost->mDoubleClickIgnore.clear();
         for (auto character : lIgnore) {
             pHost->mDoubleClickIgnore.insert(character);
@@ -2857,18 +2857,18 @@ void dlgProfilePreferences::slot_saveAndClose()
 
         pHost->mpMap->mSaveVersion = comboBox_mapFileSaveFormatVersion->currentData().toInt();
 
-        QString oldIrcNick = dlgIRC::readIrcNickName(pHost);
-        QString oldIrcPass = dlgIRC::readIrcPassword(pHost);
-        QString oldIrcHost = dlgIRC::readIrcHostName(pHost);
-        QString oldIrcPort = QString::number(dlgIRC::readIrcHostPort(pHost));
-        bool oldIrcSecure = dlgIRC::readIrcHostSecure(pHost);
-        QString oldIrcChannels = dlgIRC::readIrcChannels(pHost).join(" ");
+        QString const oldIrcNick = dlgIRC::readIrcNickName(pHost);
+        QString const oldIrcPass = dlgIRC::readIrcPassword(pHost);
+        QString const oldIrcHost = dlgIRC::readIrcHostName(pHost);
+        QString const oldIrcPort = QString::number(dlgIRC::readIrcHostPort(pHost));
+        bool const oldIrcSecure = dlgIRC::readIrcHostSecure(pHost);
+        QString const oldIrcChannels = dlgIRC::readIrcChannels(pHost).join(" ");
 
         QString newIrcNick = ircNick->text();
-        QString newIrcPass = ircPassword->text();
+        QString const newIrcPass = ircPassword->text();
         QString newIrcHost = ircHostName->text();
         QString newIrcPort = ircHostPort->text();
-        bool newIrcSecure = ircHostSecure->isChecked();
+        bool const newIrcSecure = ircHostSecure->isChecked();
         QString newIrcChannels = ircChannels->text();
         QStringList newChanList;
         int nIrcPort = dlgIRC::DefaultHostPort;
@@ -2894,8 +2894,8 @@ void dlgProfilePreferences::slot_saveAndClose()
         }
 
         if (!newIrcChannels.isEmpty()) {
-            QStringList tL = newIrcChannels.split(" ", Qt::SkipEmptyParts);
-            for (QString s : tL) {
+            QStringList const tL = newIrcChannels.split(" ", Qt::SkipEmptyParts);
+            for (QString const s : tL) {
                 if (s.startsWith("#") || s.startsWith("&") || s.startsWith("+")) {
                     newChanList << s;
                 }
@@ -2946,9 +2946,9 @@ void dlgProfilePreferences::slot_saveAndClose()
         slot_setDisplayFont();
 
         if (console) {
-            int x = console->width();
-            int y = console->height();
-            QSize s = QSize(x, y);
+            int const x = console->width();
+            int const y = console->height();
+            QSize const s = QSize(x, y);
             QResizeEvent event(s, s);
             QApplication::sendEvent(console, &event);
         }
@@ -3156,7 +3156,7 @@ void dlgProfilePreferences::populateScriptsList()
     // a items of item name ("My first alias"), item type ("alias"), and item ID
     std::vector<std::tuple<QString, QString, int>> items;
 
-    std::list<TTrigger*> triggers = pHost->getTriggerUnit()->getTriggerRootNodeList();
+    std::list<TTrigger*> const triggers = pHost->getTriggerUnit()->getTriggerRootNodeList();
     for (auto trigger : triggers) {
         if (!trigger->getScript().isEmpty() && !trigger->isTemporary()) {
             items.push_back({trigger->getName(), qsl("trigger"), trigger->getID()});
@@ -3164,7 +3164,7 @@ void dlgProfilePreferences::populateScriptsList()
         addTriggersToPreview(trigger, items);
     }
 
-    std::list<TAlias*> aliases = pHost->getAliasUnit()->getAliasRootNodeList();
+    std::list<TAlias*> const aliases = pHost->getAliasUnit()->getAliasRootNodeList();
     for (auto alias : aliases) {
         if (!alias->getScript().isEmpty() && !alias->isTemporary()) {
             items.push_back({alias->getName(), qsl("alias"), alias->getID()});
@@ -3172,7 +3172,7 @@ void dlgProfilePreferences::populateScriptsList()
         addAliasesToPreview(alias, items);
     }
 
-    std::list<TScript*> scripts = pHost->getScriptUnit()->getScriptRootNodeList();
+    std::list<TScript*> const scripts = pHost->getScriptUnit()->getScriptRootNodeList();
     for (auto script : scripts) {
         if (!script->getScript().isEmpty()) {
             items.push_back({script->getName(), qsl("script"), script->getID()});
@@ -3180,7 +3180,7 @@ void dlgProfilePreferences::populateScriptsList()
         addScriptsToPreview(script, items);
     }
 
-    std::list<TTimer*> timers = pHost->getTimerUnit()->getTimerRootNodeList();
+    std::list<TTimer*> const timers = pHost->getTimerUnit()->getTimerRootNodeList();
     for (auto timer : timers) {
         if (!timer->getScript().isEmpty() && !timer->isTemporary()) {
             items.push_back({timer->getName(), qsl("timer"), timer->getID()});
@@ -3188,7 +3188,7 @@ void dlgProfilePreferences::populateScriptsList()
         addTimersToPreview(timer, items);
     }
 
-    std::list<TKey*> keys = pHost->getKeyUnit()->getKeyRootNodeList();
+    std::list<TKey*> const keys = pHost->getKeyUnit()->getKeyRootNodeList();
     for (auto key : keys) {
         if (!key->getScript().isEmpty() && !key->isTemporary()) {
             items.push_back({key->getName(), qsl("key"), key->getID()});
@@ -3196,7 +3196,7 @@ void dlgProfilePreferences::populateScriptsList()
         addKeysToPreview(key, items);
     }
 
-    std::list<TAction*> actions = pHost->getActionUnit()->getActionRootNodeList();
+    std::list<TAction*> const actions = pHost->getActionUnit()->getActionRootNodeList();
     for (auto action : actions) {
         if (!action->getScript().isEmpty()) {
             items.push_back({action->getName(), qsl("button"), action->getID()});
@@ -3315,20 +3315,20 @@ void dlgProfilePreferences::slot_tabChanged(int tabIndex)
         return;
     }
 
-    QDir dir;
-    QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    QDir const dir;
+    QString const cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
     if (!dir.mkpath(cacheDir)) {
         qWarning() << "Couldn't create cache directory for edbee themes: " << cacheDir;
         return;
     }
 
     QSettings settings("mudlet", "Mudlet");
-    QString themesURL = settings.value("colorSublimeThemesURL", qsl("https://github.com/Colorsublime/Colorsublime-Themes/archive/master.zip")).toString();
+    QString const themesURL = settings.value("colorSublimeThemesURL", qsl("https://github.com/Colorsublime/Colorsublime-Themes/archive/master.zip")).toString();
     // a default update period is 24h
     // it would be nice to use C++14's numeric separator but Qt Creator still
     // does not like them for its Clang code model analyser (and the built in
     // one is even less receptive to): 86'400'000
-    int themesUpdatePeriod = settings.value("themesUpdatePeriod", 86400000).toInt();
+    int const themesUpdatePeriod = settings.value("themesUpdatePeriod", 86400000).toInt();
     // save the defaults in settings so the field is visible for editing in config file if needed
     settings.setValue("colorSublimeThemesURL", themesURL);
     settings.setValue("themesUpdatePeriod", themesUpdatePeriod);
@@ -3349,7 +3349,7 @@ void dlgProfilePreferences::slot_tabChanged(int tabIndex)
     manager->setCache(diskCache);
 
 
-    QUrl url(themesURL);
+    QUrl const url(themesURL);
     QNetworkRequest request(url);
     request.setRawHeader(QByteArray("User-Agent"), QByteArray(qsl("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, APP_BUILD).toUtf8().constData()));
     // github uses redirects
@@ -3382,7 +3382,7 @@ void dlgProfilePreferences::slot_tabChanged(int tabIndex)
                             return;
                         }
 
-                        QByteArray downloadedArchive = reply->readAll();
+                        QByteArray const downloadedArchive = reply->readAll();
 
                         tempThemesArchive = new QTemporaryFile();
                         if (!tempThemesArchive->open()) {
@@ -3391,7 +3391,7 @@ void dlgProfilePreferences::slot_tabChanged(int tabIndex)
                         tempThemesArchive->write(downloadedArchive);
                         tempThemesArchive->close();
 
-                        QTemporaryDir temporaryDir;
+                        QTemporaryDir const temporaryDir;
                         if (!temporaryDir.isValid()) {
                             return;
                         }
@@ -3426,8 +3426,8 @@ void dlgProfilePreferences::populateThemesList()
     if (themesFile.open(QIODevice::ReadOnly)) {
         unsortedThemes = QJsonDocument::fromJson(themesFile.readAll()).array();
         for (auto theme : qAsConst(unsortedThemes)) {
-            QString themeText = theme.toObject()["Title"].toString();
-            QString themeFileName = theme.toObject()["FileName"].toString();
+            QString const themeText = theme.toObject()["Title"].toString();
+            QString const themeFileName = theme.toObject()["FileName"].toString();
 
             if (!themeText.isEmpty() && !themeFileName.isEmpty()) {
                 sortedThemes << std::make_pair(themeText, themeFileName);
@@ -3593,8 +3593,8 @@ void dlgProfilePreferences::slot_handleHostDeletion(Host* pHost)
 
 void dlgProfilePreferences::generateMapGlyphDisplay()
 {
-    QHash<QString, QSet<int>> roomSymbolsHash(mpHost->mpMap->roomSymbolsHash());
-    QPointer<QTableWidget> pTableWidget = mpDialogMapGlyphUsage->findChild<QTableWidget*>(QLatin1String("tableWidget"));
+    QHash<QString, QSet<int>> const roomSymbolsHash(mpHost->mpMap->roomSymbolsHash());
+    QPointer<QTableWidget> const pTableWidget = mpDialogMapGlyphUsage->findChild<QTableWidget*>(QLatin1String("tableWidget"));
     if (!pTableWidget) {
         return;
     }
@@ -3618,7 +3618,7 @@ void dlgProfilePreferences::generateMapGlyphDisplay()
     QHashIterator<QString, QSet<int>> itUsedSymbol(roomSymbolsHash);
     while (itUsedSymbol.hasNext()) {
         itUsedSymbol.next();
-        QString symbol = itUsedSymbol.key();
+        QString const symbol = itUsedSymbol.key();
         QList<int> roomsWithSymbol = itUsedSymbol.value().values();
         if (roomsWithSymbol.count() > 1) {
             std::sort(roomsWithSymbol.begin(), roomsWithSymbol.end());
@@ -3633,13 +3633,13 @@ void dlgProfilePreferences::generateMapGlyphDisplay()
         pSymbolAnyFont->setToolTip(utils::richText(tr("The room symbol will appear like this if symbols (glyphs) from any font can be used.")));
         pSymbolAnyFont->setFont(anyFont);
 
-        QFontMetrics SymbolInFontMetrics(selectedFont);
-        QFontMetrics SymbolAnyFontMetrics(anyFont);
+        QFontMetrics const SymbolInFontMetrics(selectedFont);
+        QFontMetrics const SymbolAnyFontMetrics(anyFont);
 
         // pCodePoints is the sequence of UTF-32 codepoints in the symbol and
         // this ought to be what is needed to check that a font or set of fonts
         // can render the codepoints:
-        QVector<quint32> pCodePoints = symbol.toUcs4();
+        QVector<quint32> const pCodePoints = symbol.toUcs4();
         // These can be used to flag symbols that cannot be reproduced
         bool isSingleFontUsable = true;
         bool isAllFontUsable = true;
@@ -3762,7 +3762,7 @@ void dlgProfilePreferences::generateDiscordTooltips()
     }
 
     auto setToolTip = [=](QWidget* widget, const QString& highlight) {
-        QString tooltip = qsl(R"(
+        QString const tooltip = qsl(R"(
   <style type="text/css">
     .tg  {border-collapse:collapse;border-spacing:0;}
     .tg td{font-size:12px;padding:10px 5px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;border-color:black;}
@@ -3886,7 +3886,7 @@ void dlgProfilePreferences::slot_setMapSymbolFont(const QFont & font)
         return;
     }
 
-    int pointSize = pHost->mpMap->mMapSymbolFont.pointSize();
+    int const pointSize = pHost->mpMap->mMapSymbolFont.pointSize();
     if (pHost->mpMap->mMapSymbolFont != font) {
         pHost->mpMap->mMapSymbolFont = font;
         pHost->mpMap->mMapSymbolFont.setPointSize(pointSize);
@@ -3975,7 +3975,7 @@ void dlgProfilePreferences::setButtonColor(QPushButton* button, const QColor& co
             return;
         }
 
-        QColor disabledColor = QColor::fromHsl(color.hslHue(), color.hslSaturation()/4, color.lightness(), color.alpha());
+        QColor const disabledColor = QColor::fromHsl(color.hslHue(), color.hslSaturation()/4, color.lightness(), color.alpha());
         if (button == pushButton_playerRoomPrimaryColor || button == pushButton_playerRoomSecondaryColor) {
 
             // These two buttons show a color that may have transparency; so,

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2205,9 +2205,9 @@ void dlgProfilePreferences::fillOutMapHistory()
     const QString profile_name = pHost->getName();
     auto const locale = mudlet::self()->getUserLocale();
     int longestMapHistoryLength = 0;
-    QIcon const icon_autoSave{QIcon::fromTheme(qsl("document-save"), QIcon(qsl(":/icons/document-save.png")))};
-    QIcon const icon_xmlFile{QIcon::fromTheme(qsl("application-xml"), QIcon(qsl(":/icons/application-xml.png")))};
-    QIcon const icon_jsonFile{QIcon::fromTheme(qsl("application-json"), QIcon(qsl(":/icons/application-json.png")))};
+    const QIcon icon_autoSave{QIcon::fromTheme(qsl("document-save"), QIcon(qsl(":/icons/document-save.png")))};
+    const QIcon icon_xmlFile{QIcon::fromTheme(qsl("application-xml"), QIcon(qsl(":/icons/application-xml.png")))};
+    const QIcon icon_jsonFile{QIcon::fromTheme(qsl("application-json"), QIcon(qsl(":/icons/application-json.png")))};
     QString dateTimeFormat = mudlet::self()->getUserLocale().dateTimeFormat();
     if (dateTimeFormat.contains(QLatin1Char('t'))) {
         // There is a timezone identifier in there - which (apart from perhaps

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -891,7 +891,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     // load profiles into mappers "copy map to profile" combobox
     // this feature should work seamlessly both for online and offline profiles
-    QStringList const profileList = QDir(mudlet::getMudletPath(mudlet::profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Time); // sort by profile "hotness"
+    const QStringList profileList = QDir(mudlet::getMudletPath(mudlet::profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Time); // sort by profile "hotness"
     pushButton_chooseProfiles->setEnabled(false);
     pushButton_copyMap->setEnabled(false);
     if (!mpMenu) {
@@ -2224,7 +2224,7 @@ void dlgProfilePreferences::fillOutMapHistory()
     const QRegularExpression mapSaveRegularExpression{qsl("(\\d+)\\-(\\d+)\\-(\\d+)#(\\d+)\\-(\\d+)\\-(\\d+)(?:map)?\\.(dat|xml|json)"), QRegularExpression::CaseInsensitiveOption};
     QDir mapSaveDir(mudlet::getMudletPath(mudlet::profileMapsPath, profile_name).append(QLatin1Char('/')));
     mapSaveDir.setSorting(QDir::Time);
-    QStringList const mapSaveEntries = mapSaveDir.entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
+    const QStringList mapSaveEntries = mapSaveDir.entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
     for (const auto& entry : mapSaveEntries) {
         QRegularExpressionMatch const match = mapSaveRegularExpression.match(entry);
         const QString mapPathFileName = mapSaveDir.absoluteFilePath(entry);
@@ -2611,7 +2611,7 @@ void dlgProfilePreferences::slot_copyMap()
     QString thisProfileLatestMapPathFileName;
     QFile thisProfileLatestMapFile;
     const QString sourceMapFolder(mudlet::getMudletPath(mudlet::profileMapsPath, pHost->getName()));
-    QStringList const mProfileList = QDir(sourceMapFolder).entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
+    const QStringList mProfileList = QDir(sourceMapFolder).entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
     for (unsigned int i = 0, total = mProfileList.size(); i < total; ++i) {
         thisProfileLatestMapPathFileName = mProfileList.at(i);
         if (thisProfileLatestMapPathFileName.isEmpty()) {
@@ -2894,7 +2894,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         }
 
         if (!newIrcChannels.isEmpty()) {
-            QStringList const tL = newIrcChannels.split(" ", Qt::SkipEmptyParts);
+            const QStringList tL = newIrcChannels.split(" ", Qt::SkipEmptyParts);
             for (const QString s : tL) {
                 if (s.startsWith("#") || s.startsWith("&") || s.startsWith("+")) {
                     newChanList << s;

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -124,8 +124,8 @@ QWidget* RoomIdLineEditDelegate::createEditor(QWidget* parent, const QStyleOptio
             if (exitToRoom) {
                 // Valid exit roomID in place:
                 const int exitAreaID = exitToRoom->getArea();
-                bool const outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
-                bool const exitRoomLocked = exitToRoom->isLocked;
+                const bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
+                const bool exitRoomLocked = exitToRoom->isLocked;
                 mpDlgRoomExits->setActionOnExit(mpEditor, exitRoomLocked
                                                 ? mpDlgRoomExits->mpAction_exitRoomLocked
                                                 : outOfAreaExit
@@ -203,8 +203,8 @@ void RoomIdLineEditDelegate::slot_specialRoomExitIdEdited(const QString& text) c
     if (pExitToRoom) {
         // A valid exit roomID number:
         const int exitAreaID = pExitToRoom->getArea();
-        bool const outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
-        bool const exitRoomLocked = pExitToRoom->isLocked;
+        const bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
+        const bool exitRoomLocked = pExitToRoom->isLocked;
         QString exitAreaName;
         if (outOfAreaExit) {
             exitAreaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(exitAreaID);
@@ -954,8 +954,8 @@ void dlgRoomExits::setIconAndToolTipsOnSpecialExit(QTreeWidgetItem* pSpecialExit
     if (pExitToRoom) {
         // A valid exit roomID number:
         const int exitAreaID = pExitToRoom->getArea();
-        bool const outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
-        bool const exitRoomLocked = pExitToRoom->isLocked;
+        const bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
+        const bool exitRoomLocked = pExitToRoom->isLocked;
         QString exitAreaName;
         if (outOfAreaExit) {
             exitAreaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(exitAreaID);
@@ -1110,8 +1110,8 @@ void dlgRoomExits::normalExitEdited(const QString& roomExitIdText, QLineEdit* pE
     TRoom* exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(roomExitIdText.toInt());
     if (exitToRoom) {
         const int exitAreaID = exitToRoom->getArea();
-        bool const outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
-        bool const exitRoomLocked = exitToRoom->isLocked;
+        const bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
+        const bool exitRoomLocked = exitToRoom->isLocked;
         QString exitAreaName;
         if (outOfAreaExit) {
             exitAreaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(exitAreaID);
@@ -1458,8 +1458,8 @@ void dlgRoomExits::initExit(int direction,
         exitLineEdit->setText(QString::number(exitId)); //Put in the value
         exitLineEdit->setEnabled(true);                 //Enable it for editing
         const int exitAreaID = pExitR->getArea();
-        bool const outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
-        bool const exitRoomLocked = pExitR->isLocked;
+        const bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
+        const bool exitRoomLocked = pExitR->isLocked;
         QString exitAreaName;
         if (outOfAreaExit) {
             exitAreaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(exitAreaID);

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -123,7 +123,7 @@ QWidget* RoomIdLineEditDelegate::createEditor(QWidget* parent, const QStyleOptio
             TRoom* exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
             if (exitToRoom) {
                 // Valid exit roomID in place:
-                int const exitAreaID = exitToRoom->getArea();
+                const int exitAreaID = exitToRoom->getArea();
                 bool const outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
                 bool const exitRoomLocked = exitToRoom->isLocked;
                 mpDlgRoomExits->setActionOnExit(mpEditor, exitRoomLocked
@@ -202,7 +202,7 @@ void RoomIdLineEditDelegate::slot_specialRoomExitIdEdited(const QString& text) c
     QString roomIdToolTipText;
     if (pExitToRoom) {
         // A valid exit roomID number:
-        int const exitAreaID = pExitToRoom->getArea();
+        const int exitAreaID = pExitToRoom->getArea();
         bool const outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
         bool const exitRoomLocked = pExitToRoom->isLocked;
         QString exitAreaName;
@@ -481,8 +481,8 @@ void dlgRoomExits::save()
 
     for (int i = 0; i < specialExits->topLevelItemCount(); ++i) {
         QTreeWidgetItem* pI = specialExits->topLevelItem(i);
-        int const value = pI->text(ExitsTreeWidget::colIndex_exitRoomId).toInt();
-        int const weight = pI->text(ExitsTreeWidget::colIndex_exitWeight).toInt();
+        const int value = pI->text(ExitsTreeWidget::colIndex_exitRoomId).toInt();
+        const int weight = pI->text(ExitsTreeWidget::colIndex_exitWeight).toInt();
         int door = 0;
         bool locked = false;
         if (pI->checkState(ExitsTreeWidget::colIndex_doorLocked) == Qt::Checked) {
@@ -953,7 +953,7 @@ void dlgRoomExits::setIconAndToolTipsOnSpecialExit(QTreeWidgetItem* pSpecialExit
     TRoom* pExitToRoom = mpHost->mpMap->mpRoomDB->getRoom(pSpecialExit->text(ExitsTreeWidget::colIndex_exitRoomId).toInt());
     if (pExitToRoom) {
         // A valid exit roomID number:
-        int const exitAreaID = pExitToRoom->getArea();
+        const int exitAreaID = pExitToRoom->getArea();
         bool const outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
         bool const exitRoomLocked = pExitToRoom->isLocked;
         QString exitAreaName;
@@ -1109,7 +1109,7 @@ void dlgRoomExits::normalExitEdited(const QString& roomExitIdText, QLineEdit* pE
 {
     TRoom* exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(roomExitIdText.toInt());
     if (exitToRoom) {
-        int const exitAreaID = exitToRoom->getArea();
+        const int exitAreaID = exitToRoom->getArea();
         bool const outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
         bool const exitRoomLocked = exitToRoom->isLocked;
         QString exitAreaName;
@@ -1457,7 +1457,7 @@ void dlgRoomExits::initExit(int direction,
     if (exitId > 0 && pExitR) {                         //Does this exit point anywhere
         exitLineEdit->setText(QString::number(exitId)); //Put in the value
         exitLineEdit->setEnabled(true);                 //Enable it for editing
-        int const exitAreaID = pExitR->getArea();
+        const int exitAreaID = pExitR->getArea();
         bool const outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
         bool const exitRoomLocked = pExitR->isLocked;
         QString exitAreaName;
@@ -1568,7 +1568,7 @@ void dlgRoomExits::init()
     QMapIterator<QString, int> it(pR->getSpecialExits());
     while (it.hasNext()) {
         it.next();
-        int const id_to = it.value();
+        const int id_to = it.value();
         const QString dir = it.key();
         auto pSpecialExit = new TExit();
         // It should be impossible for this not to be valid:
@@ -1617,7 +1617,7 @@ void dlgRoomExits::init()
         pI->setToolTip(ExitsTreeWidget::colIndex_doorClosed, utils::richText(tr("Orange (Closed) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).")));
         pI->setToolTip(ExitsTreeWidget::colIndex_doorLocked, utils::richText(tr("Red (Locked) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).")));
         {
-            int const specialDoor = pR->getDoor(dir);
+            const int specialDoor = pR->getDoor(dir);
             switch (specialDoor) {
             case 0:
                 pI->setCheckState(ExitsTreeWidget::colIndex_doorNone, Qt::Checked);
@@ -1962,7 +1962,7 @@ void dlgRoomExits::slot_checkModified()
     // At the same time existing special exits which now have a empty/zero
     // value in the ExitsTreeWidget::colIndex_exitRoomId field will be deleted if "save"ed...
     if (!isModified) {
-        int const originalCount = originalSpecialExits.count();
+        const int originalCount = originalSpecialExits.count();
         int currentCount = 0;
         for (int i = 0; i < specialExits->topLevelItemCount(); i++) {
             QTreeWidgetItem* pI = specialExits->topLevelItem(i);

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -494,7 +494,7 @@ void dlgRoomExits::save()
         } else if (pI->checkState(ExitsTreeWidget::colIndex_doorNone) == Qt::Checked) {
             door = 0;
         }
-        QString const key = pI->text(ExitsTreeWidget::colIndex_command);
+        const QString key = pI->text(ExitsTreeWidget::colIndex_command);
         if (key != mSpecialExitCommandPlaceholder
             && value != 0 && mpHost->mpMap->mpRoomDB->getRoom(value) != nullptr) {
             originalExitCmds.remove(key);
@@ -1569,7 +1569,7 @@ void dlgRoomExits::init()
     while (it.hasNext()) {
         it.next();
         int const id_to = it.value();
-        QString const dir = it.key();
+        const QString dir = it.key();
         auto pSpecialExit = new TExit();
         // It should be impossible for this not to be valid:
         Q_ASSERT_X(pSpecialExit, "dlgRoomExits::init(...)", "failed to generate a new TExit");
@@ -1997,7 +1997,7 @@ void dlgRoomExits::slot_checkModified()
                         || pI->text(ExitsTreeWidget::colIndex_exitRoomId).toInt() <= 0) {
                         continue; // Ignore new or to be deleted entries
                     }
-                    QString const currentCmd = pI->text(ExitsTreeWidget::colIndex_command);
+                    const QString currentCmd = pI->text(ExitsTreeWidget::colIndex_command);
                     TExit currentExit;
                     currentExit.destination = pI->text(ExitsTreeWidget::colIndex_exitRoomId).toInt();
                     currentExit.hasNoRoute = pI->checkState(ExitsTreeWidget::colIndex_lockExit) == Qt::Checked;

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -123,9 +123,9 @@ QWidget* RoomIdLineEditDelegate::createEditor(QWidget* parent, const QStyleOptio
             TRoom* exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
             if (exitToRoom) {
                 // Valid exit roomID in place:
-                int exitAreaID = exitToRoom->getArea();
-                bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
-                bool exitRoomLocked = exitToRoom->isLocked;
+                int const exitAreaID = exitToRoom->getArea();
+                bool const outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
+                bool const exitRoomLocked = exitToRoom->isLocked;
                 mpDlgRoomExits->setActionOnExit(mpEditor, exitRoomLocked
                                                 ? mpDlgRoomExits->mpAction_exitRoomLocked
                                                 : outOfAreaExit
@@ -202,9 +202,9 @@ void RoomIdLineEditDelegate::slot_specialRoomExitIdEdited(const QString& text) c
     QString roomIdToolTipText;
     if (pExitToRoom) {
         // A valid exit roomID number:
-        int exitAreaID = pExitToRoom->getArea();
-        bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
-        bool exitRoomLocked = pExitToRoom->isLocked;
+        int const exitAreaID = pExitToRoom->getArea();
+        bool const outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
+        bool const exitRoomLocked = pExitToRoom->isLocked;
         QString exitAreaName;
         if (outOfAreaExit) {
             exitAreaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(exitAreaID);
@@ -481,8 +481,8 @@ void dlgRoomExits::save()
 
     for (int i = 0; i < specialExits->topLevelItemCount(); ++i) {
         QTreeWidgetItem* pI = specialExits->topLevelItem(i);
-        int value = pI->text(ExitsTreeWidget::colIndex_exitRoomId).toInt();
-        int weight = pI->text(ExitsTreeWidget::colIndex_exitWeight).toInt();
+        int const value = pI->text(ExitsTreeWidget::colIndex_exitRoomId).toInt();
+        int const weight = pI->text(ExitsTreeWidget::colIndex_exitWeight).toInt();
         int door = 0;
         bool locked = false;
         if (pI->checkState(ExitsTreeWidget::colIndex_doorLocked) == Qt::Checked) {
@@ -494,7 +494,7 @@ void dlgRoomExits::save()
         } else if (pI->checkState(ExitsTreeWidget::colIndex_doorNone) == Qt::Checked) {
             door = 0;
         }
-        QString key = pI->text(ExitsTreeWidget::colIndex_command);
+        QString const key = pI->text(ExitsTreeWidget::colIndex_command);
         if (key != mSpecialExitCommandPlaceholder
             && value != 0 && mpHost->mpMap->mpRoomDB->getRoom(value) != nullptr) {
             originalExitCmds.remove(key);
@@ -953,9 +953,9 @@ void dlgRoomExits::setIconAndToolTipsOnSpecialExit(QTreeWidgetItem* pSpecialExit
     TRoom* pExitToRoom = mpHost->mpMap->mpRoomDB->getRoom(pSpecialExit->text(ExitsTreeWidget::colIndex_exitRoomId).toInt());
     if (pExitToRoom) {
         // A valid exit roomID number:
-        int exitAreaID = pExitToRoom->getArea();
-        bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
-        bool exitRoomLocked = pExitToRoom->isLocked;
+        int const exitAreaID = pExitToRoom->getArea();
+        bool const outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
+        bool const exitRoomLocked = pExitToRoom->isLocked;
         QString exitAreaName;
         if (outOfAreaExit) {
             exitAreaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(exitAreaID);
@@ -1109,9 +1109,9 @@ void dlgRoomExits::normalExitEdited(const QString& roomExitIdText, QLineEdit* pE
 {
     TRoom* exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(roomExitIdText.toInt());
     if (exitToRoom) {
-        int exitAreaID = exitToRoom->getArea();
-        bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
-        bool exitRoomLocked = exitToRoom->isLocked;
+        int const exitAreaID = exitToRoom->getArea();
+        bool const outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
+        bool const exitRoomLocked = exitToRoom->isLocked;
         QString exitAreaName;
         if (outOfAreaExit) {
             exitAreaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(exitAreaID);
@@ -1457,9 +1457,9 @@ void dlgRoomExits::initExit(int direction,
     if (exitId > 0 && pExitR) {                         //Does this exit point anywhere
         exitLineEdit->setText(QString::number(exitId)); //Put in the value
         exitLineEdit->setEnabled(true);                 //Enable it for editing
-        int exitAreaID = pExitR->getArea();
-        bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
-        bool exitRoomLocked = pExitR->isLocked;
+        int const exitAreaID = pExitR->getArea();
+        bool const outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
+        bool const exitRoomLocked = pExitR->isLocked;
         QString exitAreaName;
         if (outOfAreaExit) {
             exitAreaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(exitAreaID);
@@ -1568,8 +1568,8 @@ void dlgRoomExits::init()
     QMapIterator<QString, int> it(pR->getSpecialExits());
     while (it.hasNext()) {
         it.next();
-        int id_to = it.value();
-        QString dir = it.key();
+        int const id_to = it.value();
+        QString const dir = it.key();
         auto pSpecialExit = new TExit();
         // It should be impossible for this not to be valid:
         Q_ASSERT_X(pSpecialExit, "dlgRoomExits::init(...)", "failed to generate a new TExit");
@@ -1617,7 +1617,7 @@ void dlgRoomExits::init()
         pI->setToolTip(ExitsTreeWidget::colIndex_doorClosed, utils::richText(tr("Orange (Closed) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).")));
         pI->setToolTip(ExitsTreeWidget::colIndex_doorLocked, utils::richText(tr("Red (Locked) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).")));
         {
-            int specialDoor = pR->getDoor(dir);
+            int const specialDoor = pR->getDoor(dir);
             switch (specialDoor) {
             case 0:
                 pI->setCheckState(ExitsTreeWidget::colIndex_doorNone, Qt::Checked);
@@ -1962,7 +1962,7 @@ void dlgRoomExits::slot_checkModified()
     // At the same time existing special exits which now have a empty/zero
     // value in the ExitsTreeWidget::colIndex_exitRoomId field will be deleted if "save"ed...
     if (!isModified) {
-        int originalCount = originalSpecialExits.count();
+        int const originalCount = originalSpecialExits.count();
         int currentCount = 0;
         for (int i = 0; i < specialExits->topLevelItemCount(); i++) {
             QTreeWidgetItem* pI = specialExits->topLevelItem(i);
@@ -1997,7 +1997,7 @@ void dlgRoomExits::slot_checkModified()
                         || pI->text(ExitsTreeWidget::colIndex_exitRoomId).toInt() <= 0) {
                         continue; // Ignore new or to be deleted entries
                     }
-                    QString currentCmd = pI->text(ExitsTreeWidget::colIndex_command);
+                    QString const currentCmd = pI->text(ExitsTreeWidget::colIndex_command);
                     TExit currentExit;
                     currentExit.destination = pI->text(ExitsTreeWidget::colIndex_exitRoomId).toInt();
                     currentExit.hasNoRoute = pI->checkState(ExitsTreeWidget::colIndex_lockExit) == Qt::Checked;

--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -147,7 +147,7 @@ void dlgRoomProperties::init(
 
 void dlgRoomProperties::initLockInstructions()
 {
-    QString const instructions = tr("Lock room(s), so it/they will never be used for speedwalking",
+    const QString instructions = tr("Lock room(s), so it/they will never be used for speedwalking",
                            // Intentional comment to separate arguments!
                            "This text will be shown at a checkbox, where you can set/unset a number of room's lock.",
                            mpRooms.size());
@@ -309,7 +309,7 @@ void dlgRoomProperties::accept()
     //   to the other room data here) - They need no further review at this time.
 
     // Find symbol to return back
-    QString const newSymbol = getNewSymbol();
+    const QString newSymbol = getNewSymbol();
     bool changeSymbol = true;
     QColor const newSymbolColor = selectedSymbolColor;
     bool changeSymbolColor = true;
@@ -374,7 +374,7 @@ int dlgRoomProperties::getNewWeight()
     if (mpWeights.size() <= 1) {
         return spinBox_weight->value();
     }
-    QString const newWeightText = comboBox_weight->currentText();
+    const QString newWeightText = comboBox_weight->currentText();
     if (newWeightText == multipleValuesPlaceholder) {
         return -1; // User did not want to select any weight, so we will do no change
     }

--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -423,7 +423,7 @@ QFont dlgRoomProperties::getFontForPreview(QString symbolString)
         for (int i = 0; i < codePoints.size(); ++i) {
             isUsable.append(mapSymbolFontMetrics.inFontUcs4(codePoints.at(i)));
         }
-        bool const needToFallback = isUsable.contains(false);
+        const bool needToFallback = isUsable.contains(false);
         if (needToFallback) {
             symbolString = QString(QChar::ReplacementCharacter);
             font.setStyleStrategy(static_cast<QFont::StyleStrategy>(mpHost->mpMap->mMapSymbolFont.styleStrategy() & ~(QFont::NoFontMerging)));

--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -320,7 +320,7 @@ void dlgRoomProperties::accept()
     }
 
     // Find weight to return back
-    int const newWeight = getNewWeight();
+    const int newWeight = getNewWeight();
     bool changeWeight = true;
     if (newWeight <= -1) {
         // We don't want to change then

--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -556,7 +556,7 @@ void dlgRoomProperties::slot_openRoomColorSelector()
         auto pI = new QListWidgetItem(listWidget);
         QPixmap pix = QPixmap(50, 50);
         pix.fill(c);
-        QIcon const mi(pix);
+        const QIcon mi(pix);
         pI->setIcon(mi);
         pI->setText(QString::number(it.key()));
         listWidget->addItem(pI);

--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -147,7 +147,7 @@ void dlgRoomProperties::init(
 
 void dlgRoomProperties::initLockInstructions()
 {
-    QString instructions = tr("Lock room(s), so it/they will never be used for speedwalking",
+    QString const instructions = tr("Lock room(s), so it/they will never be used for speedwalking",
                            // Intentional comment to separate arguments!
                            "This text will be shown at a checkbox, where you can set/unset a number of room's lock.",
                            mpRooms.size());
@@ -309,9 +309,9 @@ void dlgRoomProperties::accept()
     //   to the other room data here) - They need no further review at this time.
 
     // Find symbol to return back
-    QString newSymbol = getNewSymbol();
+    QString const newSymbol = getNewSymbol();
     bool changeSymbol = true;
-    QColor newSymbolColor = selectedSymbolColor;
+    QColor const newSymbolColor = selectedSymbolColor;
     bool changeSymbolColor = true;
     if (newSymbol == multipleValuesPlaceholder) {
         // We don't want to change then
@@ -320,7 +320,7 @@ void dlgRoomProperties::accept()
     }
 
     // Find weight to return back
-    int newWeight = getNewWeight();
+    int const newWeight = getNewWeight();
     bool changeWeight = true;
     if (newWeight <= -1) {
         // We don't want to change then
@@ -328,7 +328,7 @@ void dlgRoomProperties::accept()
     }
 
     // Find lock status to return back
-    Qt::CheckState newCheckState = checkBox_locked->checkState();
+    Qt::CheckState const newCheckState = checkBox_locked->checkState();
     bool changeLockStatus = true;
     bool newLockStatus;
     if (newCheckState == Qt::PartiallyChecked) {
@@ -360,8 +360,8 @@ QString dlgRoomProperties::getNewSymbol()
     }
     QString newSymbolText = comboBox_roomSymbol->currentText();
     // Parse the initial text before the curly braces containing count
-    QRegularExpression countStripper(qsl("^(.*) {.*}$"));
-    QRegularExpressionMatch match = countStripper.match(newSymbolText);
+    QRegularExpression const countStripper(qsl("^(.*) {.*}$"));
+    QRegularExpressionMatch const match = countStripper.match(newSymbolText);
     if (match.hasMatch() && match.lastCapturedIndex() > 0) {
         return match.captured(1);
     }
@@ -374,13 +374,13 @@ int dlgRoomProperties::getNewWeight()
     if (mpWeights.size() <= 1) {
         return spinBox_weight->value();
     }
-    QString newWeightText = comboBox_weight->currentText();
+    QString const newWeightText = comboBox_weight->currentText();
     if (newWeightText == multipleValuesPlaceholder) {
         return -1; // User did not want to select any weight, so we will do no change
     }
     // Parse an initial number out of what was selected or typed
-    QRegularExpression countStripper(qsl("^\\s*(\\d+)"));
-    QRegularExpressionMatch match = countStripper.match(newWeightText);
+    QRegularExpression const countStripper(qsl("^\\s*(\\d+)"));
+    QRegularExpressionMatch const match = countStripper.match(newWeightText);
     if (match.hasMatch() && match.lastCapturedIndex() > 0) {
         return match.captured(1).toInt();
     }
@@ -417,13 +417,13 @@ QFont dlgRoomProperties::getFontForPreview(QString symbolString)
     auto font = mpHost->mpMap->mMapSymbolFont;
     font.setPointSize(font.pointSize() * 0.9);
     if (!symbolString.isEmpty()) {
-        QFontMetrics mapSymbolFontMetrics = QFontMetrics(font);
-        QVector<quint32> codePoints = symbolString.toUcs4();
+        QFontMetrics const mapSymbolFontMetrics = QFontMetrics(font);
+        QVector<quint32> const codePoints = symbolString.toUcs4();
         QVector<bool> isUsable;
         for (int i = 0; i < codePoints.size(); ++i) {
             isUsable.append(mapSymbolFontMetrics.inFontUcs4(codePoints.at(i)));
         }
-        bool needToFallback = isUsable.contains(false);
+        bool const needToFallback = isUsable.contains(false);
         if (needToFallback) {
             symbolString = QString(QChar::ReplacementCharacter);
             font.setStyleStrategy(static_cast<QFont::StyleStrategy>(mpHost->mpMap->mMapSymbolFont.styleStrategy() & ~(QFont::NoFontMerging)));
@@ -556,7 +556,7 @@ void dlgRoomProperties::slot_openRoomColorSelector()
         auto pI = new QListWidgetItem(listWidget);
         QPixmap pix = QPixmap(50, 50);
         pix.fill(c);
-        QIcon mi(pix);
+        QIcon const mi(pix);
         pI->setIcon(mi);
         pI->setText(QString::number(it.key()));
         listWidget->addItem(pI);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -779,35 +779,35 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     QPixmap pixMap_subString(256, 256);
     pixMap_subString.fill(Qt::black);
-    QIcon const icon_subString(pixMap_subString);
+    const QIcon icon_subString(pixMap_subString);
 
     QPixmap pixMap_perl_regex(256, 256);
     pixMap_perl_regex.fill(Qt::blue);
-    QIcon const icon_perl_regex(pixMap_perl_regex);
+    const QIcon icon_perl_regex(pixMap_perl_regex);
 
     QPixmap pixMap_begin_of_line_substring(256, 256);
     pixMap_begin_of_line_substring.fill(Qt::red);
-    QIcon const icon_begin_of_line_substring(pixMap_begin_of_line_substring);
+    const QIcon icon_begin_of_line_substring(pixMap_begin_of_line_substring);
 
     QPixmap pixMap_exact_match(256, 256);
     pixMap_exact_match.fill(Qt::green);
-    QIcon const icon_exact_match(pixMap_exact_match);
+    const QIcon icon_exact_match(pixMap_exact_match);
 
     QPixmap pixMap_lua_function(256, 256);
     pixMap_lua_function.fill(Qt::cyan);
-    QIcon const icon_lua_function(pixMap_lua_function);
+    const QIcon icon_lua_function(pixMap_lua_function);
 
     QPixmap pixMap_line_spacer(256, 256);
     pixMap_line_spacer.fill(Qt::magenta);
-    QIcon const icon_line_spacer(pixMap_line_spacer);
+    const QIcon icon_line_spacer(pixMap_line_spacer);
 
     QPixmap pixMap_color_trigger(256, 256);
     pixMap_color_trigger.fill(Qt::lightGray);
-    QIcon const icon_color_trigger(pixMap_color_trigger);
+    const QIcon icon_color_trigger(pixMap_color_trigger);
 
     QPixmap pixMap_prompt(256, 256);
     pixMap_prompt.fill(Qt::yellow);
-    QIcon const icon_prompt(pixMap_prompt);
+    const QIcon icon_prompt(pixMap_prompt);
 
     QStringList patternList;
     patternList << tr("substring")

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -271,7 +271,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     //QScopedPointer<edbee::StringTextAutoCompleteProvider> provider(new edbee::StringTextAutoCompleteProvider);
 
     // Add lua functions and reserved lua terms to an AutoComplete provider
-    for (QString const key : mudlet::smLuaFunctionNames.keys()) {
+    for (const QString key : mudlet::smLuaFunctionNames.keys()) {
         provider->add(key, 3, mudlet::smLuaFunctionNames.value(key).toString());
     }
 
@@ -1433,8 +1433,8 @@ void dlgTriggerEditor::searchVariables(const QString& text)
 
             QTreeWidgetItem* pItem;
             QTreeWidgetItem* parent = nullptr;
-            QString const name = varDecendent->getName();
-            QString const value = varDecendent->getValue();
+            const QString name = varDecendent->getName();
+            const QString value = varDecendent->getValue();
             QStringList const idStringList = vu->shortVarName(varDecendent);
             QString idString;
             // Take the first element - to comply with lua requirement it
@@ -1446,7 +1446,7 @@ void dlgTriggerEditor::searchVariables(const QString& text)
                 idString = midStrings.takeFirst();
                 QStringListIterator itSubString(midStrings);
                 while (itSubString.hasNext()) {
-                    QString const intermediate = itSubString.next();
+                    const QString intermediate = itSubString.next();
                     bool isOk = false;
                     int const numberValue = intermediate.toInt(&isOk);
                     if (isOk && QString::number(numberValue) == intermediate) {
@@ -1501,7 +1501,7 @@ void dlgTriggerEditor::searchKeys(const QString& text)
     for (auto key : nodes) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString const name = key->getName();
+        const QString name = key->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -1573,7 +1573,7 @@ void dlgTriggerEditor::searchTimers(const QString& text)
     for (auto timer : nodes) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString const name = timer->getName();
+        const QString name = timer->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -1645,7 +1645,7 @@ void dlgTriggerEditor::searchActions(const QString& text)
     for (auto action : nodes) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString const name = action->getName();
+        const QString name = action->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -1767,7 +1767,7 @@ void dlgTriggerEditor::searchScripts(const QString& text)
     for (auto script : nodes) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString const name = script->getName();
+        const QString name = script->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -1851,7 +1851,7 @@ void dlgTriggerEditor::searchAliases(const QString& text)
     for (auto alias : nodes) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString const name = alias->getName();
+        const QString name = alias->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -1938,7 +1938,7 @@ void dlgTriggerEditor::searchTriggers(const QString& text)
     for (auto trigger : nodes) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString const name = trigger->getName();
+        const QString name = trigger->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -2040,7 +2040,7 @@ void dlgTriggerEditor::recursiveSearchTriggers(TTrigger* pTriggerParent, const Q
     for (auto trigger : *childrenList) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString const name = trigger->getName();
+        const QString name = trigger->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -2146,7 +2146,7 @@ void dlgTriggerEditor::recursiveSearchAlias(TAlias* pTriggerParent, const QStrin
     for (auto alias : *childrenList) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString const name = alias->getName();
+        const QString name = alias->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -2235,7 +2235,7 @@ void dlgTriggerEditor::recursiveSearchScripts(TScript* pTriggerParent, const QSt
     for (auto script : *childrenList) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString const name = script->getName();
+        const QString name = script->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -2321,7 +2321,7 @@ void dlgTriggerEditor::recursiveSearchActions(TAction* pTriggerParent, const QSt
     for (auto action : *childrenList) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString const name = action->getName();
+        const QString name = action->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -2445,7 +2445,7 @@ void dlgTriggerEditor::recursiveSearchTimers(TTimer* pTriggerParent, const QStri
     for (auto timer : *childrenList) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString const name = timer->getName();
+        const QString name = timer->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -2519,7 +2519,7 @@ void dlgTriggerEditor::recursiveSearchKeys(TKey* pTriggerParent, const QString& 
     for (auto key : *childrenList) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString const name = key->getName();
+        const QString name = key->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -3694,7 +3694,7 @@ void dlgTriggerEditor::addTrigger(bool isFolder)
     }
     QStringList const patterns;
     QList<int> const patternKinds;
-    QString const script = "";
+    const QString script = "";
     QStringList nameL;
     nameL << name;
 
@@ -3797,9 +3797,9 @@ void dlgTriggerEditor::addTimer(bool isFolder)
     } else {
         name = tr("New timer");
     }
-    QString const command = "";
+    const QString command = "";
     QTime const time;
-    QString const script = "";
+    const QString script = "";
     QStringList nameL;
     nameL << name;
 
@@ -3958,7 +3958,7 @@ void dlgTriggerEditor::addKey(bool isFolder)
     } else {
         name = tr("New key");
     }
-    QString const script = "";
+    const QString script = "";
     QStringList nameL;
     nameL << name;
 
@@ -4046,9 +4046,9 @@ void dlgTriggerEditor::addAlias(bool isFolder)
     } else {
         name = tr("New alias");
     }
-    QString const regex = "";
-    QString const command = "";
-    QString const script = "";
+    const QString regex = "";
+    const QString command = "";
+    const QString script = "";
     QStringList nameL;
     nameL << name;
 
@@ -4141,9 +4141,9 @@ void dlgTriggerEditor::addAction(bool isFolder)
     } else {
         name = tr("New button");
     }
-    QString const cmdButtonUp = "";
-    QString const cmdButtonDown = "";
-    QString const script = "";
+    const QString cmdButtonUp = "";
+    const QString cmdButtonDown = "";
+    const QString script = "";
     QStringList nameL;
     nameL << name;
 
@@ -4231,7 +4231,7 @@ void dlgTriggerEditor::addScript(bool isFolder)
     } else {
         name = tr("New script");
     }
-    QString const script;
+    const QString script;
     QStringList nameL;
     nameL << name;
 
@@ -4415,8 +4415,8 @@ void dlgTriggerEditor::saveTrigger()
     }
 
     mpTriggersMainArea->trimName();
-    QString const name = mpTriggersMainArea->lineEdit_trigger_name->text();
-    QString const command = mpTriggersMainArea->lineEdit_trigger_command->text();
+    const QString name = mpTriggersMainArea->lineEdit_trigger_name->text();
+    const QString command = mpTriggersMainArea->lineEdit_trigger_command->text();
     bool const isMultiline = mpTriggersMainArea->groupBox_multiLineTrigger->isChecked();
     QStringList patterns;
     QList<int> patternKinds;
@@ -4457,12 +4457,12 @@ void dlgTriggerEditor::saveTrigger()
         patterns << pattern;
     }
 
-    QString const script = mpSourceEditorEdbeeDocument->text();
+    const QString script = mpSourceEditorEdbeeDocument->text();
 
     int const triggerID = pItem->data(0, Qt::UserRole).toInt();
     TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(triggerID);
     if (pT) {
-        QString const old_name = pT->getName();
+        const QString old_name = pT->getName();
         pT->setName(name);
         pT->setCommand(command);
         pT->setRegexCodeList(patterns, patternKinds);
@@ -4594,15 +4594,15 @@ void dlgTriggerEditor::saveTimer()
     }
 
     mpTimersMainArea->trimName();
-    QString const name = mpTimersMainArea->lineEdit_timer_name->text();
-    QString const script = mpSourceEditorEdbeeDocument->text();
+    const QString name = mpTimersMainArea->lineEdit_timer_name->text();
+    const QString script = mpSourceEditorEdbeeDocument->text();
 
 
     int const timerID = pItem->data(0, Qt::UserRole).toInt();
     TTimer* pT = mpHost->getTimerUnit()->getTimer(timerID);
     if (pT) {
         pT->setName(name);
-        QString const command = mpTimersMainArea->lineEdit_timer_command->text();
+        const QString command = mpTimersMainArea->lineEdit_timer_command->text();
         int const hours = mpTimersMainArea->timeEdit_timer_hours->time().hour();
         int const minutes = mpTimersMainArea->timeEdit_timer_minutes->time().minute();
         int const secs = mpTimersMainArea->timeEdit_timer_seconds->time().second();
@@ -4710,11 +4710,11 @@ void dlgTriggerEditor::saveAlias()
 
     mpAliasMainArea->trimName();
     QString name = mpAliasMainArea->lineEdit_alias_name->text();
-    QString const regex = mpAliasMainArea->lineEdit_alias_pattern->text();
+    const QString regex = mpAliasMainArea->lineEdit_alias_pattern->text();
     if (!regex.isEmpty() && ((name.isEmpty()) || (name == tr("New alias")))) {
         name = regex;
     }
-    QString const substitution = mpAliasMainArea->lineEdit_alias_command->text();
+    const QString substitution = mpAliasMainArea->lineEdit_alias_command->text();
     //check if sub will trigger regex, ignore if there's nothing in regex - could be an alias group
     QRegularExpression const rx(regex);
     QRegularExpressionMatch const match = rx.match(substitution);
@@ -4731,13 +4731,13 @@ void dlgTriggerEditor::saveAlias()
         return;
     }
 
-    QString const script = mpSourceEditorEdbeeDocument->text();
+    const QString script = mpSourceEditorEdbeeDocument->text();
 
 
     int const triggerID = pItem->data(0, Qt::UserRole).toInt();
     TAlias* pT = mpHost->getAliasUnit()->getAlias(triggerID);
     if (pT) {
-        QString const old_name = pT->getName();
+        const QString old_name = pT->getName();
         pT->setName(name);
         pT->setCommand(substitution);
         pT->setRegexCode(regex); // This could generate an error state if regex does not compile
@@ -4843,11 +4843,11 @@ void dlgTriggerEditor::saveAction()
     }
 
     mpActionsMainArea->trimName();
-    QString const name = mpActionsMainArea->lineEdit_action_name->text();
-    QString const icon = mpActionsMainArea->lineEdit_action_icon->text();
-    QString const commandDown = mpActionsMainArea->lineEdit_action_button_command_down->text();
-    QString const commandUp = mpActionsMainArea->lineEdit_action_button_command_up->text();
-    QString const script = mpSourceEditorEdbeeDocument->text();
+    const QString name = mpActionsMainArea->lineEdit_action_name->text();
+    const QString icon = mpActionsMainArea->lineEdit_action_icon->text();
+    const QString commandDown = mpActionsMainArea->lineEdit_action_button_command_down->text();
+    const QString commandUp = mpActionsMainArea->lineEdit_action_button_command_up->text();
+    const QString script = mpSourceEditorEdbeeDocument->text();
     // currentIndex() can return -1 if no setting was previously made - need to fixup:
     int const rotation = qMax(0, mpActionsMainArea->comboBox_action_button_rotation->currentIndex());
     int const columns = mpActionsMainArea->spinBox_action_bar_columns->text().toInt();
@@ -5005,7 +5005,7 @@ void dlgTriggerEditor::writeScript(int id)
         return;
     }
 
-    QString const scriptCode = pT->getScript();
+    const QString scriptCode = pT->getScript();
     mpSourceEditorEdbeeDocument->setText(scriptCode);
 }
 
@@ -5019,8 +5019,8 @@ void dlgTriggerEditor::saveScript()
     QString old_name;
 
     mpScriptsMainArea->trimName();
-    QString const name = mpScriptsMainArea->lineEdit_script_name->text();
-    QString const script = mpSourceEditorEdbeeDocument->text();
+    const QString name = mpScriptsMainArea->lineEdit_script_name->text();
+    const QString script = mpSourceEditorEdbeeDocument->text();
     mpScriptsMainAreaEditHandlerItem = nullptr;
     QList<QListWidgetItem*> itemList;
     for (int i = 0; i < mpScriptsMainArea->listWidget_script_registered_event_handlers->count(); i++) {
@@ -5201,7 +5201,7 @@ void dlgTriggerEditor::saveVar()
     if (!variable) {
         return;
     }
-    QString const newName = mpVarsMainArea->lineEdit_var_name->text();
+    const QString newName = mpVarsMainArea->lineEdit_var_name->text();
     QString newValue = mpSourceEditorEdbeeDocument->text();
     if (newName.isEmpty()) {
         slot_variableSelected(pItem);
@@ -5387,8 +5387,8 @@ void dlgTriggerEditor::saveKey()
     if (name.isEmpty() || name == tr("New key")) {
         name = mpKeysMainArea->lineEdit_key_binding->text();
     }
-    QString const command = mpKeysMainArea->lineEdit_key_command->text();
-    QString const script = mpSourceEditorEdbeeDocument->text();
+    const QString command = mpKeysMainArea->lineEdit_key_command->text();
+    const QString script = mpSourceEditorEdbeeDocument->text();
 
 
     int const triggerID = pItem->data(0, Qt::UserRole).toInt();
@@ -5724,7 +5724,7 @@ void dlgTriggerEditor::slot_triggerSelected(QTreeWidgetItem* pItem)
         }
         // Scroll to the last used pattern:
         mpScrollArea->ensureWidgetVisible(mTriggerPatternEdit.at(qBound(0, patternList.size(), 49)));
-        QString const command = pT->getCommand();
+        const QString command = pT->getCommand();
         mpTriggersMainArea->lineEdit_trigger_name->setText(pItem->text(0));
         mpTriggersMainArea->lineEdit_trigger_command->setText(command);
         mpTriggersMainArea->groupBox_multiLineTrigger->setChecked(pT->isMultiline());
@@ -5793,9 +5793,9 @@ void dlgTriggerEditor::slot_aliasSelected(QTreeWidgetItem* pItem)
     int const ID = pItem->data(0, Qt::UserRole).toInt();
     TAlias* pT = mpHost->getAliasUnit()->getAlias(ID);
     if (pT) {
-        QString const pattern = pT->getRegexCode();
-        QString const command = pT->getCommand();
-        QString const name = pT->getName();
+        const QString pattern = pT->getRegexCode();
+        const QString command = pT->getCommand();
+        const QString name = pT->getName();
 
         mpAliasMainArea->lineEdit_alias_pattern->setText(pattern);
         mpAliasMainArea->lineEdit_alias_command->setText(command);
@@ -5842,12 +5842,12 @@ void dlgTriggerEditor::slot_keySelected(QTreeWidgetItem* pItem)
     int const ID = pItem->data(0, Qt::UserRole).toInt();
     TKey* pT = mpHost->getKeyUnit()->getKey(ID);
     if (pT) {
-        QString const command = pT->getCommand();
-        QString const name = pT->getName();
+        const QString command = pT->getCommand();
+        const QString name = pT->getName();
         mpKeysMainArea->lineEdit_key_command->clear();
         mpKeysMainArea->lineEdit_key_command->setText(command);
         mpKeysMainArea->lineEdit_key_name->setText(name);
-        QString const keyName = mpHost->getKeyUnit()->getKeyName(pT->getKeyCode(), pT->getKeyModifiers());
+        const QString keyName = mpHost->getKeyUnit()->getKeyName(pT->getKeyCode(), pT->getKeyModifiers());
         mpKeysMainArea->lineEdit_key_binding->setText(keyName);
 
         clearDocument(mpSourceEditorEdbee, pT->getScript());
@@ -6327,7 +6327,7 @@ void dlgTriggerEditor::slot_scriptsSelected(QTreeWidgetItem* pItem)
     int const ID = pItem->data(0, Qt::UserRole).toInt();
     TScript* pT = mpHost->getScriptUnit()->getScript(ID);
     if (pT) {
-        QString const name = pT->getName();
+        const QString name = pT->getName();
         QStringList eventHandlerList = pT->getEventHandlerList();
         for (int i = 0; i < eventHandlerList.size(); i++) {
             auto pItem = new QListWidgetItem(mpScriptsMainArea->listWidget_script_registered_event_handlers);
@@ -6335,7 +6335,7 @@ void dlgTriggerEditor::slot_scriptsSelected(QTreeWidgetItem* pItem)
             mpScriptsMainArea->listWidget_script_registered_event_handlers->addItem(pItem);
         }
         mpScriptsMainArea->lineEdit_script_name->clear();
-        QString const script = pT->getScript();
+        const QString script = pT->getScript();
         clearDocument(mpSourceEditorEdbee, script);
 
         mpScriptsMainArea->lineEdit_script_name->setText(name);
@@ -6381,8 +6381,8 @@ void dlgTriggerEditor::slot_timerSelected(QTreeWidgetItem* pItem)
     int const ID = pItem->data(0, Qt::UserRole).toInt();
     TTimer* pT = mpHost->getTimerUnit()->getTimer(ID);
     if (pT) {
-        QString const command = pT->getCommand();
-        QString const name = pT->getName();
+        const QString command = pT->getCommand();
+        const QString name = pT->getName();
         mpTimersMainArea->lineEdit_timer_command->setText(command);
         mpTimersMainArea->lineEdit_timer_name->setText(name);
         QTime const time = pT->getTime();
@@ -6462,7 +6462,7 @@ void dlgTriggerEditor::populateKeys()
             continue;
         }
 
-        QString const s = key->getName();
+        const QString s = key->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(mpKeyBaseItem, sList);
@@ -6541,7 +6541,7 @@ void dlgTriggerEditor::populateActions()
             continue;
         }
 
-        QString const s = action->getName();
+        const QString s = action->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(mpActionBaseItem, sList);
@@ -6624,7 +6624,7 @@ void dlgTriggerEditor::populateAliases()
             continue;
         }
 
-        QString const s = alias->getName();
+        const QString s = alias->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(mpAliasBaseItem, sList);
@@ -6699,7 +6699,7 @@ void dlgTriggerEditor::populateScripts()
 {
     std::list<TScript*> const baseNodeList_scripts = mpHost->getScriptUnit()->getScriptRootNodeList();
     for (auto script : baseNodeList_scripts) {
-        QString const s = script->getName();
+        const QString s = script->getName();
 
         QStringList sList;
         sList << s;
@@ -6757,7 +6757,7 @@ void dlgTriggerEditor::populateTimers()
         if (timer->isTemporary()) {
             continue;
         }
-        QString const s = timer->getName();
+        const QString s = timer->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(mpTimerBaseItem, sList);
@@ -6847,7 +6847,7 @@ void dlgTriggerEditor::populateTriggers()
         if (trigger->isTemporary()) {
             continue;
         }
-        QString const s = trigger->getName();
+        const QString s = trigger->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(mpTriggerBaseItem, sList);
@@ -6953,7 +6953,7 @@ void dlgTriggerEditor::expand_child_triggers(TTrigger* pTriggerParent, QTreeWidg
 {
     std::list<TTrigger*>* childrenList = pTriggerParent->getChildrenList();
     for (auto trigger : *childrenList) {
-        QString const s = trigger->getName();
+        const QString s = trigger->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(pWidgetItemParent, sList);
@@ -7037,7 +7037,7 @@ void dlgTriggerEditor::expand_child_key(TKey* pTriggerParent, QTreeWidgetItem* p
 {
     std::list<TKey*>* childrenList = pTriggerParent->getChildrenList();
     for (auto key : *childrenList) {
-        QString const s = key->getName();
+        const QString s = key->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(pWidgetItemParent, sList);
@@ -7104,7 +7104,7 @@ void dlgTriggerEditor::expand_child_scripts(TScript* pTriggerParent, QTreeWidget
 {
     std::list<TScript*>* childrenList = pTriggerParent->getChildrenList();
     for (auto script : *childrenList) {
-        QString const s = script->getName();
+        const QString s = script->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(pWidgetItemParent, sList);
@@ -7162,7 +7162,7 @@ void dlgTriggerEditor::expand_child_alias(TAlias* pTriggerParent, QTreeWidgetIte
 {
     std::list<TAlias*>* childrenList = pTriggerParent->getChildrenList();
     for (auto alias : *childrenList) {
-        QString const s = alias->getName();
+        const QString s = alias->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(pWidgetItemParent, sList);
@@ -7228,7 +7228,7 @@ void dlgTriggerEditor::expand_child_action(TAction* pTriggerParent, QTreeWidgetI
 {
     std::list<TAction*>* childrenList = pTriggerParent->getChildrenList();
     for (auto action : *childrenList) {
-        QString const s = action->getName();
+        const QString s = action->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(pWidgetItemParent, sList);
@@ -7288,7 +7288,7 @@ void dlgTriggerEditor::expand_child_timers(TTimer* pTimerParent, QTreeWidgetItem
 {
     std::list<TTimer*>* childrenList = pTimerParent->getChildrenList();
     for (auto timer : *childrenList) {
-        QString const s = timer->getName();
+        const QString s = timer->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(pWidgetItemParent, sList);
@@ -8157,7 +8157,7 @@ void dlgTriggerEditor::slot_scriptMainAreaEditHandler(QListWidgetItem*)
     }
     mIsScriptsMainAreaEditHandler = true;
     mpScriptsMainAreaEditHandlerItem = pItem;
-    QString const regex = pItem->text();
+    const QString regex = pItem->text();
     if (regex.isEmpty()) {
         mIsScriptsMainAreaEditHandler = false;
         return;
@@ -9046,7 +9046,7 @@ void dlgTriggerEditor::slot_import()
         qWarning().nospace().noquote() << "dlgTriggerEditor::slot_import() WARNING - switch(EditorViewType) not expected to be called for \"EditorViewType::cmUnknownView!\"";
     }
 
-    QString const fileName = QFileDialog::getOpenFileName(this, tr("Import Mudlet Package"), QDir::currentPath());
+    const QString fileName = QFileDialog::getOpenFileName(this, tr("Import Mudlet Package"), QDir::currentPath());
     if (fileName.isEmpty()) {
         return;
     }
@@ -9264,8 +9264,8 @@ void dlgTriggerEditor::key_grab_callback(const Qt::Key key, const Qt::KeyboardMo
     if (!pKeyUnit) {
         return;
     }
-    QString const keyName = pKeyUnit->getKeyName(key, modifier);
-    QString const name = keyName;
+    const QString keyName = pKeyUnit->getKeyName(key, modifier);
+    const QString name = keyName;
     mpKeysMainArea->lineEdit_key_binding->setText(name);
     QTreeWidgetItem* pItem = treeWidget_keys->currentItem();
     if (pItem) {
@@ -9344,7 +9344,7 @@ void dlgTriggerEditor::slot_soundTrigger()
 {
     // Use the existing path/filename if it is not empty, otherwise start in
     // profile home directory:
-    QString const fileName = QFileDialog::getOpenFileName(this,
+    const QString fileName = QFileDialog::getOpenFileName(this,
                                                     tr("Choose sound file"),
                                                     mpTriggersMainArea->lineEdit_soundFile->text().isEmpty()
                                                     ? mudlet::getMudletPath(mudlet::profileHomePath, mpHost->getName())
@@ -9822,8 +9822,8 @@ void dlgTriggerEditor::slot_toggleGroupBoxColorizeTrigger(const bool state)
 
     if (state) {
         // Enabled so make buttons have full colour:
-        QString const fgColor = mpTriggersMainArea->pushButtonFgColor->property(cButtonBaseColor).toString();
-        QString const bgColor = mpTriggersMainArea->pushButtonBgColor->property(cButtonBaseColor).toString();
+        const QString fgColor = mpTriggersMainArea->pushButtonFgColor->property(cButtonBaseColor).toString();
+        const QString bgColor = mpTriggersMainArea->pushButtonBgColor->property(cButtonBaseColor).toString();
         mpTriggersMainArea->pushButtonFgColor->setStyleSheet(generateButtonStyleSheet(fgColor, true));
         mpTriggersMainArea->pushButtonBgColor->setStyleSheet(generateButtonStyleSheet(bgColor, true));
         mpTriggersMainArea->pushButtonFgColor->setText(fgColor == QLatin1String("transparent") ? tr("keep", "Keep the existing colour on matches to highlight. Use shortest word possible so it fits on the button") : QString());

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -271,7 +271,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     //QScopedPointer<edbee::StringTextAutoCompleteProvider> provider(new edbee::StringTextAutoCompleteProvider);
 
     // Add lua functions and reserved lua terms to an AutoComplete provider
-    for (QString key : mudlet::smLuaFunctionNames.keys()) {
+    for (QString const key : mudlet::smLuaFunctionNames.keys()) {
         provider->add(key, 3, mudlet::smLuaFunctionNames.value(key).toString());
     }
 
@@ -779,35 +779,35 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     QPixmap pixMap_subString(256, 256);
     pixMap_subString.fill(Qt::black);
-    QIcon icon_subString(pixMap_subString);
+    QIcon const icon_subString(pixMap_subString);
 
     QPixmap pixMap_perl_regex(256, 256);
     pixMap_perl_regex.fill(Qt::blue);
-    QIcon icon_perl_regex(pixMap_perl_regex);
+    QIcon const icon_perl_regex(pixMap_perl_regex);
 
     QPixmap pixMap_begin_of_line_substring(256, 256);
     pixMap_begin_of_line_substring.fill(Qt::red);
-    QIcon icon_begin_of_line_substring(pixMap_begin_of_line_substring);
+    QIcon const icon_begin_of_line_substring(pixMap_begin_of_line_substring);
 
     QPixmap pixMap_exact_match(256, 256);
     pixMap_exact_match.fill(Qt::green);
-    QIcon icon_exact_match(pixMap_exact_match);
+    QIcon const icon_exact_match(pixMap_exact_match);
 
     QPixmap pixMap_lua_function(256, 256);
     pixMap_lua_function.fill(Qt::cyan);
-    QIcon icon_lua_function(pixMap_lua_function);
+    QIcon const icon_lua_function(pixMap_lua_function);
 
     QPixmap pixMap_line_spacer(256, 256);
     pixMap_line_spacer.fill(Qt::magenta);
-    QIcon icon_line_spacer(pixMap_line_spacer);
+    QIcon const icon_line_spacer(pixMap_line_spacer);
 
     QPixmap pixMap_color_trigger(256, 256);
     pixMap_color_trigger.fill(Qt::lightGray);
-    QIcon icon_color_trigger(pixMap_color_trigger);
+    QIcon const icon_color_trigger(pixMap_color_trigger);
 
     QPixmap pixMap_prompt(256, 256);
     pixMap_prompt.fill(Qt::yellow);
-    QIcon icon_prompt(pixMap_prompt);
+    QIcon const icon_prompt(pixMap_prompt);
 
     QStringList patternList;
     patternList << tr("substring")
@@ -850,7 +850,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     }
     // force the minimum size of the scroll area for the trigger items to be one
     // and a half trigger item widgets:
-    int triggerWidgetItemMinHeight = qRound(mTriggerPatternEdit.at(0)->minimumSizeHint().height() * 1.5);
+    int const triggerWidgetItemMinHeight = qRound(mTriggerPatternEdit.at(0)->minimumSizeHint().height() * 1.5);
     mpScrollArea->setMinimumHeight(triggerWidgetItemMinHeight);
 
     widget_searchTerm->updateGeometry();
@@ -910,7 +910,7 @@ void dlgTriggerEditor::slot_setToolBarIconSize(const int s)
         toolBar2->setToolButtonStyle(Qt::ToolButtonIconOnly);
     }
 
-    QSize newSize(s * 8, s * 8);
+    QSize const newSize(s * 8, s * 8);
     toolBar->setIconSize(newSize);
     toolBar2->setIconSize(newSize);
 }
@@ -921,7 +921,7 @@ void dlgTriggerEditor::slot_setTreeWidgetIconSize(const int s)
         return;
     }
 
-    QSize newSize(s * 8, s * 8);
+    QSize const newSize(s * 8, s * 8);
     treeWidget_triggers->setIconSize(newSize);
     treeWidget_aliases->setIconSize(newSize);
     treeWidget_timers->setIconSize(newSize);
@@ -945,11 +945,11 @@ void dlgTriggerEditor::readSettings()
        For compatibility with older settings, if no config is loaded
        from the config directory "mudlet", application "Mudlet", we try to load from the config
        directory "Mudlet", application "Mudlet 1.0". */
-    QSettings settings_new("mudlet", "Mudlet");
-    QSettings settings((settings_new.contains("pos") ? "mudlet" : "Mudlet"), (settings_new.contains("pos") ? "Mudlet" : "Mudlet 1.0"));
+    QSettings const settings_new("mudlet", "Mudlet");
+    QSettings const settings((settings_new.contains("pos") ? "mudlet" : "Mudlet"), (settings_new.contains("pos") ? "Mudlet" : "Mudlet 1.0"));
 
-    QPoint pos = settings.value("script_editor_pos", QPoint(10, 10)).toPoint();
-    QSize size = settings.value("script_editor_size", QSize(600, 400)).toSize();
+    QPoint const pos = settings.value("script_editor_pos", QPoint(10, 10)).toPoint();
+    QSize const size = settings.value("script_editor_size", QSize(600, 400)).toSize();
     resize(size);
     move(pos);
 
@@ -1004,7 +1004,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
 
         // This was inside the loop but it is a constant value for the duration
         // of this method!
-        int idSearch = pItem->data(0, IdRole).toInt();
+        int const idSearch = pItem->data(0, IdRole).toInt();
 
         for (auto treeWidgetItem : qAsConst(foundItemsList)) {
 
@@ -1057,7 +1057,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
     case EditorViewType::cmAliasView: {
         foundItemsList = treeWidget_aliases->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString| Qt::MatchRecursive, 0);
 
-        int idSearch = pItem->data(0, IdRole).toInt();
+        int const idSearch = pItem->data(0, IdRole).toInt();
 
         for (auto treeWidgetItem : qAsConst(foundItemsList)) {
 
@@ -1105,7 +1105,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
     case EditorViewType::cmScriptView: {
         foundItemsList = treeWidget_scripts->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString| Qt::MatchRecursive, 0);
 
-        int idSearch = pItem->data(0, IdRole).toInt();
+        int const idSearch = pItem->data(0, IdRole).toInt();
 
         for (auto treeWidgetItem : qAsConst(foundItemsList)) {
 
@@ -1156,7 +1156,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
     case EditorViewType::cmActionView: {
         foundItemsList = treeWidget_actions->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString| Qt::MatchRecursive, 0);
 
-        int idSearch = pItem->data(0, IdRole).toInt();
+        int const idSearch = pItem->data(0, IdRole).toInt();
 
         for (auto treeWidgetitem : qAsConst(foundItemsList)) {
 
@@ -1220,7 +1220,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
     case EditorViewType::cmTimerView: {
         foundItemsList = treeWidget_timers->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString| Qt::MatchRecursive, 0);
 
-        int idSearch = pItem->data(0, IdRole).toInt();
+        int const idSearch = pItem->data(0, IdRole).toInt();
 
         for (auto treeWidgetItem : qAsConst(foundItemsList)) {
 
@@ -1264,8 +1264,8 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
         foundItemsList = treeWidget_keys->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString| Qt::MatchRecursive, 0);
 
         for (auto treeWidgetItem : qAsConst(foundItemsList)) {
-            int idTree = treeWidgetItem->data(0, IdRole).toInt();
-            int idSearch = pItem->data(0, IdRole).toInt();
+            int const idTree = treeWidgetItem->data(0, IdRole).toInt();
+            int const idSearch = pItem->data(0, IdRole).toInt();
             if (idTree == idSearch) {
                 slot_showKeys();
                 slot_keySelected(treeWidgetItem);
@@ -1315,7 +1315,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
     case EditorViewType::cmVarsView: {
         LuaInterface* lI = mpHost->getLuaInterface();
         VarUnit* vu = lI->getVarUnit();
-        QStringList varShort = pItem->data(0, IdRole).toStringList();
+        QStringList const varShort = pItem->data(0, IdRole).toStringList();
         QList<QTreeWidgetItem*> list;
         recurseVariablesDown(mpVarBaseItem, list);
         QListIterator<QTreeWidgetItem*> it(list);
@@ -1433,9 +1433,9 @@ void dlgTriggerEditor::searchVariables(const QString& text)
 
             QTreeWidgetItem* pItem;
             QTreeWidgetItem* parent = nullptr;
-            QString name = varDecendent->getName();
-            QString value = varDecendent->getValue();
-            QStringList idStringList = vu->shortVarName(varDecendent);
+            QString const name = varDecendent->getName();
+            QString const value = varDecendent->getValue();
+            QStringList const idStringList = vu->shortVarName(varDecendent);
             QString idString;
             // Take the first element - to comply with lua requirement it
             // must begin with not a digit and not contain any spaces so is
@@ -1446,9 +1446,9 @@ void dlgTriggerEditor::searchVariables(const QString& text)
                 idString = midStrings.takeFirst();
                 QStringListIterator itSubString(midStrings);
                 while (itSubString.hasNext()) {
-                    QString intermediate = itSubString.next();
+                    QString const intermediate = itSubString.next();
                     bool isOk = false;
-                    int numberValue = intermediate.toInt(&isOk);
+                    int const numberValue = intermediate.toInt(&isOk);
                     if (isOk && QString::number(numberValue) == intermediate) {
                         // This seems to be an integer
                         idString.append(qsl("[%1]").arg(intermediate));
@@ -1497,11 +1497,11 @@ void dlgTriggerEditor::searchVariables(const QString& text)
 
 void dlgTriggerEditor::searchKeys(const QString& text)
 {
-    std::list<TKey*> nodes = mpHost->getKeyUnit()->getKeyRootNodeList();
+    std::list<TKey*> const nodes = mpHost->getKeyUnit()->getKeyRootNodeList();
     for (auto key : nodes) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString name = key->getName();
+        QString const name = key->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -1532,8 +1532,8 @@ void dlgTriggerEditor::searchKeys(const QString& text)
         }
 
         // Script content
-        QStringList textList = key->getScript().split("\n");
-        int total = textList.count();
+        QStringList const textList = key->getScript().split("\n");
+        int const total = textList.count();
         for (int index = 0; index < total; ++index) {
             // CHECK: This may NOT be an optimisation...!
             if (textList.at(index).isEmpty() || !textList.at(index).contains(text, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) {
@@ -1569,11 +1569,11 @@ void dlgTriggerEditor::searchKeys(const QString& text)
 
 void dlgTriggerEditor::searchTimers(const QString& text)
 {
-    std::list<TTimer*> nodes = mpHost->getTimerUnit()->getTimerRootNodeList();
+    std::list<TTimer*> const nodes = mpHost->getTimerUnit()->getTimerRootNodeList();
     for (auto timer : nodes) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString name = timer->getName();
+        QString const name = timer->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -1604,8 +1604,8 @@ void dlgTriggerEditor::searchTimers(const QString& text)
         }
 
         // Script content
-        QStringList textList = timer->getScript().split("\n");
-        int total = textList.count();
+        QStringList const textList = timer->getScript().split("\n");
+        int const total = textList.count();
         for (int index = 0; index < total; ++index) {
             // CHECK: This may NOT be an optimisation...!
             if (textList.at(index).isEmpty() || !textList.at(index).contains(text, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) {
@@ -1641,11 +1641,11 @@ void dlgTriggerEditor::searchTimers(const QString& text)
 
 void dlgTriggerEditor::searchActions(const QString& text)
 {
-    std::list<TAction*> nodes = mpHost->getActionUnit()->getActionRootNodeList();
+    std::list<TAction*> const nodes = mpHost->getActionUnit()->getActionRootNodeList();
     for (auto action : nodes) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString name = action->getName();
+        QString const name = action->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -1763,11 +1763,11 @@ void dlgTriggerEditor::searchActions(const QString& text)
 
 void dlgTriggerEditor::searchScripts(const QString& text)
 {
-    std::list<TScript*> nodes = mpHost->getScriptUnit()->getScriptRootNodeList();
+    std::list<TScript*> const nodes = mpHost->getScriptUnit()->getScriptRootNodeList();
     for (auto script : nodes) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString name = script->getName();
+        QString const name = script->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -1847,11 +1847,11 @@ void dlgTriggerEditor::searchScripts(const QString& text)
 
 void dlgTriggerEditor::searchAliases(const QString& text)
 {
-    std::list<TAlias*> nodes = mpHost->getAliasUnit()->getAliasRootNodeList();
+    std::list<TAlias*> const nodes = mpHost->getAliasUnit()->getAliasRootNodeList();
     for (auto alias : nodes) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString name = alias->getName();
+        QString const name = alias->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -1897,8 +1897,8 @@ void dlgTriggerEditor::searchAliases(const QString& text)
         }
 
         // Script content - now put last
-        QStringList textList = alias->getScript().split("\n");
-        int total = textList.count();
+        QStringList const textList = alias->getScript().split("\n");
+        int const total = textList.count();
         for (int index = 0; index < total; ++index) {
             // CHECK: This may NOT be an optimisation...!
             if (textList.at(index).isEmpty() || !textList.at(index).contains(text, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) {
@@ -1934,11 +1934,11 @@ void dlgTriggerEditor::searchAliases(const QString& text)
 
 void dlgTriggerEditor::searchTriggers(const QString& text)
 {
-    std::list<TTrigger*> nodes = mpHost->getTriggerUnit()->getTriggerRootNodeList();
+    std::list<TTrigger*> const nodes = mpHost->getTriggerUnit()->getTriggerRootNodeList();
     for (auto trigger : nodes) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString name = trigger->getName();
+        QString const name = trigger->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -2040,7 +2040,7 @@ void dlgTriggerEditor::recursiveSearchTriggers(TTrigger* pTriggerParent, const Q
     for (auto trigger : *childrenList) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString name = trigger->getName();
+        QString const name = trigger->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -2146,7 +2146,7 @@ void dlgTriggerEditor::recursiveSearchAlias(TAlias* pTriggerParent, const QStrin
     for (auto alias : *childrenList) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString name = alias->getName();
+        QString const name = alias->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -2192,8 +2192,8 @@ void dlgTriggerEditor::recursiveSearchAlias(TAlias* pTriggerParent, const QStrin
         }
 
         // Script content - now put last
-        QStringList textList = alias->getScript().split("\n");
-        int total = textList.count();
+        QStringList const textList = alias->getScript().split("\n");
+        int const total = textList.count();
         for (int index = 0; index < total; ++index) {
             // CHECK: This may NOT be an optimisation...!
             if (textList.at(index).isEmpty() || !textList.at(index).contains(text, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) {
@@ -2235,7 +2235,7 @@ void dlgTriggerEditor::recursiveSearchScripts(TScript* pTriggerParent, const QSt
     for (auto script : *childrenList) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString name = script->getName();
+        QString const name = script->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -2321,7 +2321,7 @@ void dlgTriggerEditor::recursiveSearchActions(TAction* pTriggerParent, const QSt
     for (auto action : *childrenList) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString name = action->getName();
+        QString const name = action->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -2445,7 +2445,7 @@ void dlgTriggerEditor::recursiveSearchTimers(TTimer* pTriggerParent, const QStri
     for (auto timer : *childrenList) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString name = timer->getName();
+        QString const name = timer->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -2476,8 +2476,8 @@ void dlgTriggerEditor::recursiveSearchTimers(TTimer* pTriggerParent, const QStri
         }
 
         // Script content
-        QStringList textList = timer->getScript().split("\n");
-        int total = textList.count();
+        QStringList const textList = timer->getScript().split("\n");
+        int const total = textList.count();
         for (int index = 0; index < total; ++index) {
             // CHECK: This may NOT be an optimisation...!
             if (textList.at(index).isEmpty() || !textList.at(index).contains(text, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) {
@@ -2519,7 +2519,7 @@ void dlgTriggerEditor::recursiveSearchKeys(TKey* pTriggerParent, const QString& 
     for (auto key : *childrenList) {
         QTreeWidgetItem* pItem;
         QTreeWidgetItem* parent = nullptr;
-        QString name = key->getName();
+        QString const name = key->getName();
         int startPos = 0;
 
         if ((startPos = name.indexOf(text, 0, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) != -1) {
@@ -2550,8 +2550,8 @@ void dlgTriggerEditor::recursiveSearchKeys(TKey* pTriggerParent, const QString& 
         }
 
         // Script content
-        QStringList textList = key->getScript().split("\n");
-        int total = textList.count();
+        QStringList const textList = key->getScript().split("\n");
+        int const total = textList.count();
         for (int index = 0; index < total; ++index) {
             // CHECK: This may NOT be an optimisation...!
             if (textList.at(index).isEmpty() || !textList.at(index).contains(text, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) {
@@ -3057,7 +3057,7 @@ void dlgTriggerEditor::children_icon_timer(QTreeWidgetItem* pWidgetItemParent)
 
         QIcon icon;
         QString itemDescription;
-        bool itemActive = (pT->isActive() || pT->shouldBeActive());
+        bool const itemActive = (pT->isActive() || pT->shouldBeActive());
 
         if (pItem->childCount() > 0) {
             children_icon_timer(pItem);
@@ -3401,7 +3401,7 @@ void dlgTriggerEditor::activeToggle_action()
         }
     }
 
-    bool itemActive = pT->isActive();
+    bool const itemActive = pT->isActive();
     if (pT->isFolder()) {
         itemDescription = (itemActive ? descActiveFolder : descInactiveFolder);
         if (!pT->ancestorsActive()) {
@@ -3482,7 +3482,7 @@ void dlgTriggerEditor::children_icon_action(QTreeWidgetItem* pWidgetItemParent)
 
         QIcon icon;
         QString itemDescription;
-        bool itemActive = pT->isActive();
+        bool const itemActive = pT->isActive();
         if (pItem->childCount() > 0) {
             children_icon_action(pItem);
         }
@@ -3692,9 +3692,9 @@ void dlgTriggerEditor::addTrigger(bool isFolder)
     } else {
         name = tr("New trigger");
     }
-    QStringList patterns;
-    QList<int> patternKinds;
-    QString script = "";
+    QStringList const patterns;
+    QList<int> const patternKinds;
+    QString const script = "";
     QStringList nameL;
     nameL << name;
 
@@ -3703,7 +3703,7 @@ void dlgTriggerEditor::addTrigger(bool isFolder)
     TTrigger* pT = nullptr;
 
     if (pParent) {
-        int parentID = pParent->data(0, Qt::UserRole).toInt();
+        int const parentID = pParent->data(0, Qt::UserRole).toInt();
 
         TTrigger* pParentTrigger = mpHost->getTriggerUnit()->getTrigger(parentID);
         if (pParentTrigger) {
@@ -3750,7 +3750,7 @@ void dlgTriggerEditor::addTrigger(bool isFolder)
     pT->mStayOpen = 0;
     pT->setConditionLineDelta(0);
     pT->registerTrigger();
-    int childID = pT->getID();
+    int const childID = pT->getID();
     pNewItem->setData(0, Qt::UserRole, childID);
     QIcon icon;
     QString itemDescription;
@@ -3797,9 +3797,9 @@ void dlgTriggerEditor::addTimer(bool isFolder)
     } else {
         name = tr("New timer");
     }
-    QString command = "";
-    QTime time;
-    QString script = "";
+    QString const command = "";
+    QTime const time;
+    QString const script = "";
     QStringList nameL;
     nameL << name;
 
@@ -3808,7 +3808,7 @@ void dlgTriggerEditor::addTimer(bool isFolder)
     TTimer* pT = nullptr;
 
     if (pParent) {
-        int parentID = pParent->data(0, Qt::UserRole).toInt();
+        int const parentID = pParent->data(0, Qt::UserRole).toInt();
 
         TTimer* pParentTrigger = mpHost->getTimerUnit()->getTimer(parentID);
         if (pParentTrigger) {
@@ -3851,7 +3851,7 @@ void dlgTriggerEditor::addTimer(bool isFolder)
     pT->setIsFolder(isFolder);
     pT->setIsActive(false);
     mpHost->getTimerUnit()->registerTimer(pT);
-    int childID = pT->getID();
+    int const childID = pT->getID();
     pNewItem->setData(0, Qt::UserRole, childID);
     QIcon icon;
 
@@ -3958,7 +3958,7 @@ void dlgTriggerEditor::addKey(bool isFolder)
     } else {
         name = tr("New key");
     }
-    QString script = "";
+    QString const script = "";
     QStringList nameL;
     nameL << name;
 
@@ -3967,7 +3967,7 @@ void dlgTriggerEditor::addKey(bool isFolder)
     TKey* pT = nullptr;
 
     if (pParent) {
-        int parentID = pParent->data(0, Qt::UserRole).toInt();
+        int const parentID = pParent->data(0, Qt::UserRole).toInt();
 
         TKey* pParentTrigger = mpHost->getKeyUnit()->getKey(parentID);
         if (pParentTrigger) {
@@ -4011,7 +4011,7 @@ void dlgTriggerEditor::addKey(bool isFolder)
     pT->setIsFolder(isFolder);
     pT->setIsActive(false);
     pT->registerKey();
-    int childID = pT->getID();
+    int const childID = pT->getID();
     pNewItem->setData(0, Qt::UserRole, childID);
     QIcon icon;
     QString itemDescription;
@@ -4046,9 +4046,9 @@ void dlgTriggerEditor::addAlias(bool isFolder)
     } else {
         name = tr("New alias");
     }
-    QString regex = "";
-    QString command = "";
-    QString script = "";
+    QString const regex = "";
+    QString const command = "";
+    QString const script = "";
     QStringList nameL;
     nameL << name;
 
@@ -4057,7 +4057,7 @@ void dlgTriggerEditor::addAlias(bool isFolder)
     TAlias* pT = nullptr;
 
     if (pParent) {
-        int parentID = pParent->data(0, Qt::UserRole).toInt();
+        int const parentID = pParent->data(0, Qt::UserRole).toInt();
 
         TAlias* pParentTrigger = mpHost->getAliasUnit()->getAlias(parentID);
         if (pParentTrigger) {
@@ -4102,7 +4102,7 @@ void dlgTriggerEditor::addAlias(bool isFolder)
     pT->setIsFolder(isFolder);
     pT->setIsActive(false);
     pT->registerAlias();
-    int childID = pT->getID();
+    int const childID = pT->getID();
     pNewItem->setData(0, Qt::UserRole, childID);
     QIcon icon;
     QString itemDescription;
@@ -4141,9 +4141,9 @@ void dlgTriggerEditor::addAction(bool isFolder)
     } else {
         name = tr("New button");
     }
-    QString cmdButtonUp = "";
-    QString cmdButtonDown = "";
-    QString script = "";
+    QString const cmdButtonUp = "";
+    QString const cmdButtonDown = "";
+    QString const script = "";
     QStringList nameL;
     nameL << name;
 
@@ -4152,7 +4152,7 @@ void dlgTriggerEditor::addAction(bool isFolder)
     QPointer<TAction> pT = nullptr;
 
     if (pParent) {
-        int parentID = pParent->data(0, Qt::UserRole).toInt();
+        int const parentID = pParent->data(0, Qt::UserRole).toInt();
 
         TAction* pParentAction = mpHost->getActionUnit()->getAction(parentID);
         if (pParentAction) {
@@ -4189,7 +4189,7 @@ void dlgTriggerEditor::addAction(bool isFolder)
     pT->setIsFolder(isFolder);
     pT->setIsActive(false);
     pT->registerAction();
-    int childID = pT->getID();
+    int const childID = pT->getID();
     pNewItem->setData(0, Qt::UserRole, childID);
     QIcon icon;
     QString itemDescription;
@@ -4231,7 +4231,7 @@ void dlgTriggerEditor::addScript(bool isFolder)
     } else {
         name = tr("New script");
     }
-    QString script;
+    QString const script;
     QStringList nameL;
     nameL << name;
 
@@ -4240,7 +4240,7 @@ void dlgTriggerEditor::addScript(bool isFolder)
     TScript* pT = nullptr;
 
     if (pParent) {
-        int parentID = pParent->data(0, Qt::UserRole).toInt();
+        int const parentID = pParent->data(0, Qt::UserRole).toInt();
 
         TScript* pParentTrigger = mpHost->getScriptUnit()->getScript(parentID);
         if (pParentTrigger) {
@@ -4283,7 +4283,7 @@ void dlgTriggerEditor::addScript(bool isFolder)
     pT->setIsFolder(isFolder);
     pT->setIsActive(false);
     pT->registerScript();
-    int childID = pT->getID();
+    int const childID = pT->getID();
     pNewItem->setData(0, Qt::UserRole, childID);
     QIcon icon;
     QString itemDescription;
@@ -4415,14 +4415,14 @@ void dlgTriggerEditor::saveTrigger()
     }
 
     mpTriggersMainArea->trimName();
-    QString name = mpTriggersMainArea->lineEdit_trigger_name->text();
-    QString command = mpTriggersMainArea->lineEdit_trigger_command->text();
-    bool isMultiline = mpTriggersMainArea->groupBox_multiLineTrigger->isChecked();
+    QString const name = mpTriggersMainArea->lineEdit_trigger_name->text();
+    QString const command = mpTriggersMainArea->lineEdit_trigger_command->text();
+    bool const isMultiline = mpTriggersMainArea->groupBox_multiLineTrigger->isChecked();
     QStringList patterns;
     QList<int> patternKinds;
     for (int i = 0; i < 50; i++) {
         QString pattern = mTriggerPatternEdit.at(i)->lineEdit_pattern->text();
-        int patternType = mTriggerPatternEdit.at(i)->comboBox_patternType->currentIndex();
+        int const patternType = mTriggerPatternEdit.at(i)->comboBox_patternType->currentIndex();
         if (pattern.isEmpty() && patternType != REGEX_PROMPT && patternType != REGEX_LINE_SPACER) {
             continue;
         }
@@ -4457,12 +4457,12 @@ void dlgTriggerEditor::saveTrigger()
         patterns << pattern;
     }
 
-    QString script = mpSourceEditorEdbeeDocument->text();
+    QString const script = mpSourceEditorEdbeeDocument->text();
 
-    int triggerID = pItem->data(0, Qt::UserRole).toInt();
+    int const triggerID = pItem->data(0, Qt::UserRole).toInt();
     TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(triggerID);
     if (pT) {
-        QString old_name = pT->getName();
+        QString const old_name = pT->getName();
         pT->setName(name);
         pT->setCommand(command);
         pT->setRegexCodeList(patterns, patternKinds);
@@ -4594,20 +4594,20 @@ void dlgTriggerEditor::saveTimer()
     }
 
     mpTimersMainArea->trimName();
-    QString name = mpTimersMainArea->lineEdit_timer_name->text();
-    QString script = mpSourceEditorEdbeeDocument->text();
+    QString const name = mpTimersMainArea->lineEdit_timer_name->text();
+    QString const script = mpSourceEditorEdbeeDocument->text();
 
 
-    int timerID = pItem->data(0, Qt::UserRole).toInt();
+    int const timerID = pItem->data(0, Qt::UserRole).toInt();
     TTimer* pT = mpHost->getTimerUnit()->getTimer(timerID);
     if (pT) {
         pT->setName(name);
-        QString command = mpTimersMainArea->lineEdit_timer_command->text();
-        int hours = mpTimersMainArea->timeEdit_timer_hours->time().hour();
-        int minutes = mpTimersMainArea->timeEdit_timer_minutes->time().minute();
-        int secs = mpTimersMainArea->timeEdit_timer_seconds->time().second();
-        int msecs = mpTimersMainArea->timeEdit_timer_msecs->time().msec();
-        QTime time(hours, minutes, secs, msecs);
+        QString const command = mpTimersMainArea->lineEdit_timer_command->text();
+        int const hours = mpTimersMainArea->timeEdit_timer_hours->time().hour();
+        int const minutes = mpTimersMainArea->timeEdit_timer_minutes->time().minute();
+        int const secs = mpTimersMainArea->timeEdit_timer_seconds->time().second();
+        int const msecs = mpTimersMainArea->timeEdit_timer_msecs->time().msec();
+        QTime const time(hours, minutes, secs, msecs);
         pT->setTime(time);
         pT->setCommand(command);
         pT->setName(name);
@@ -4710,14 +4710,14 @@ void dlgTriggerEditor::saveAlias()
 
     mpAliasMainArea->trimName();
     QString name = mpAliasMainArea->lineEdit_alias_name->text();
-    QString regex = mpAliasMainArea->lineEdit_alias_pattern->text();
+    QString const regex = mpAliasMainArea->lineEdit_alias_pattern->text();
     if (!regex.isEmpty() && ((name.isEmpty()) || (name == tr("New alias")))) {
         name = regex;
     }
-    QString substitution = mpAliasMainArea->lineEdit_alias_command->text();
+    QString const substitution = mpAliasMainArea->lineEdit_alias_command->text();
     //check if sub will trigger regex, ignore if there's nothing in regex - could be an alias group
-    QRegularExpression rx(regex);
-    QRegularExpressionMatch match = rx.match(substitution);
+    QRegularExpression const rx(regex);
+    QRegularExpressionMatch const match = rx.match(substitution);
 
     QString itemDescription;
     if (!regex.isEmpty() && match.capturedStart() != -1) {
@@ -4731,13 +4731,13 @@ void dlgTriggerEditor::saveAlias()
         return;
     }
 
-    QString script = mpSourceEditorEdbeeDocument->text();
+    QString const script = mpSourceEditorEdbeeDocument->text();
 
 
-    int triggerID = pItem->data(0, Qt::UserRole).toInt();
+    int const triggerID = pItem->data(0, Qt::UserRole).toInt();
     TAlias* pT = mpHost->getAliasUnit()->getAlias(triggerID);
     if (pT) {
-        QString old_name = pT->getName();
+        QString const old_name = pT->getName();
         pT->setName(name);
         pT->setCommand(substitution);
         pT->setRegexCode(regex); // This could generate an error state if regex does not compile
@@ -4843,15 +4843,15 @@ void dlgTriggerEditor::saveAction()
     }
 
     mpActionsMainArea->trimName();
-    QString name = mpActionsMainArea->lineEdit_action_name->text();
-    QString icon = mpActionsMainArea->lineEdit_action_icon->text();
-    QString commandDown = mpActionsMainArea->lineEdit_action_button_command_down->text();
-    QString commandUp = mpActionsMainArea->lineEdit_action_button_command_up->text();
-    QString script = mpSourceEditorEdbeeDocument->text();
+    QString const name = mpActionsMainArea->lineEdit_action_name->text();
+    QString const icon = mpActionsMainArea->lineEdit_action_icon->text();
+    QString const commandDown = mpActionsMainArea->lineEdit_action_button_command_down->text();
+    QString const commandUp = mpActionsMainArea->lineEdit_action_button_command_up->text();
+    QString const script = mpSourceEditorEdbeeDocument->text();
     // currentIndex() can return -1 if no setting was previously made - need to fixup:
-    int rotation = qMax(0, mpActionsMainArea->comboBox_action_button_rotation->currentIndex());
-    int columns = mpActionsMainArea->spinBox_action_bar_columns->text().toInt();
-    bool isChecked = mpActionsMainArea->checkBox_action_button_isPushDown->isChecked();
+    int const rotation = qMax(0, mpActionsMainArea->comboBox_action_button_rotation->currentIndex());
+    int const columns = mpActionsMainArea->spinBox_action_bar_columns->text().toInt();
+    bool const isChecked = mpActionsMainArea->checkBox_action_button_isPushDown->isChecked();
     // bottom location is no longer supported i.e. location = 1 = 0 = location top
     // currentIndex() can return -1 if no setting was previously made - need to fixup:
     int location = qMax(0, mpActionsMainArea->comboBox_action_bar_location->currentIndex());
@@ -4860,12 +4860,12 @@ void dlgTriggerEditor::saveAction()
     }
 
     // currentIndex() can return -1 if no setting was previously made - need to fixup:
-    int orientation = qMax(0, mpActionsMainArea->comboBox_action_bar_orientation->currentIndex());
+    int const orientation = qMax(0, mpActionsMainArea->comboBox_action_bar_orientation->currentIndex());
 
     // This is an unnecessary level of indentation but has been retained to
     // reduce the noise in a git commit/diff caused by the removal of a
     // redundant "if( pITem )" - can be removed next time the file is modified
-    int actionID = pItem->data(0, Qt::UserRole).toInt();
+    int const actionID = pItem->data(0, Qt::UserRole).toInt();
     TAction* pA = mpHost->getActionUnit()->getAction(actionID);
     if (pA) {
         // Check if data has been changed before it gets updated.
@@ -4893,7 +4893,7 @@ void dlgTriggerEditor::saveAction()
 
         QIcon icon;
         QString itemDescription;
-        bool itemActive = pA->isActive();
+        bool const itemActive = pA->isActive();
         if (pA->isFolder()) {
             itemDescription = (itemActive ? descActiveFolder : descInactiveFolder);
             if (!pA->mPackageName.isEmpty()) {
@@ -4995,7 +4995,7 @@ void dlgTriggerEditor::writeScript(int id)
     if (mCurrentView == EditorViewType::cmUnknownView || mCurrentView != EditorViewType::cmScriptView) {
         return;
     }
-    int scriptID = pItem->data(0, Qt::UserRole).toInt();
+    int const scriptID = pItem->data(0, Qt::UserRole).toInt();
     if (scriptID != id) {
         return;
     }
@@ -5005,7 +5005,7 @@ void dlgTriggerEditor::writeScript(int id)
         return;
     }
 
-    QString scriptCode = pT->getScript();
+    QString const scriptCode = pT->getScript();
     mpSourceEditorEdbeeDocument->setText(scriptCode);
 }
 
@@ -5019,8 +5019,8 @@ void dlgTriggerEditor::saveScript()
     QString old_name;
 
     mpScriptsMainArea->trimName();
-    QString name = mpScriptsMainArea->lineEdit_script_name->text();
-    QString script = mpSourceEditorEdbeeDocument->text();
+    QString const name = mpScriptsMainArea->lineEdit_script_name->text();
+    QString const script = mpSourceEditorEdbeeDocument->text();
     mpScriptsMainAreaEditHandlerItem = nullptr;
     QList<QListWidgetItem*> itemList;
     for (int i = 0; i < mpScriptsMainArea->listWidget_script_registered_event_handlers->count(); i++) {
@@ -5036,7 +5036,7 @@ void dlgTriggerEditor::saveScript()
     }
 
 
-    int scriptID = pItem->data(0, Qt::UserRole).toInt();
+    int const scriptID = pItem->data(0, Qt::UserRole).toInt();
     TScript* pT = mpHost->getScriptUnit()->getScript(scriptID);
     if (!pT) {
         return;
@@ -5051,7 +5051,7 @@ void dlgTriggerEditor::saveScript()
     mpHost->getTriggerUnit()->doCleanup();
     QIcon icon;
     QString itemDescription;
-    bool itemActive = pT->isActive();
+    bool const itemActive = pT->isActive();
     if (pT->isFolder()) {
         itemDescription = (itemActive ? descActiveFolder : descInactiveFolder);
         if (!pT->mPackageName.isEmpty()) {
@@ -5148,8 +5148,8 @@ int dlgTriggerEditor::canRecast(QTreeWidgetItem* pItem, int newNameType, int new
     if (!var) {
         return 2;
     }
-    int currentNameType = var->getKeyType();
-    int currentValueType = var->getValueType();
+    int const currentNameType = var->getKeyType();
+    int const currentValueType = var->getValueType();
     //most anything is ok to do.  We just want to enforce these rules:
     //you cannot change the type of a table that has children
     //rule removed to see if anything bad happens:
@@ -5201,7 +5201,7 @@ void dlgTriggerEditor::saveVar()
     if (!variable) {
         return;
     }
-    QString newName = mpVarsMainArea->lineEdit_var_name->text();
+    QString const newName = mpVarsMainArea->lineEdit_var_name->text();
     QString newValue = mpSourceEditorEdbeeDocument->text();
     if (newName.isEmpty()) {
         slot_variableSelected(pItem);
@@ -5214,7 +5214,7 @@ void dlgTriggerEditor::saveVar()
         uiNameType = LUA_TNONE;
     }
     //check variable recasting
-    int varRecast = canRecast(pItem, uiNameType, uiValueType);
+    int const varRecast = canRecast(pItem, uiNameType, uiValueType);
     if ((uiNameType == -1) || (variable && uiNameType != variable->getKeyType())) {
         if (QString(newName).toInt()) {
             uiNameType = LUA_TNUMBER;
@@ -5387,11 +5387,11 @@ void dlgTriggerEditor::saveKey()
     if (name.isEmpty() || name == tr("New key")) {
         name = mpKeysMainArea->lineEdit_key_binding->text();
     }
-    QString command = mpKeysMainArea->lineEdit_key_command->text();
-    QString script = mpSourceEditorEdbeeDocument->text();
+    QString const command = mpKeysMainArea->lineEdit_key_command->text();
+    QString const script = mpSourceEditorEdbeeDocument->text();
 
 
-    int triggerID = pItem->data(0, Qt::UserRole).toInt();
+    int const triggerID = pItem->data(0, Qt::UserRole).toInt();
     TKey* pT = mpHost->getKeyUnit()->getKey(triggerID);
     if (pT) {
         pItem->setText(0, name);
@@ -5401,7 +5401,7 @@ void dlgTriggerEditor::saveKey()
 
         QIcon icon;
         QString itemDescription;
-        bool itemActive = pT->isActive();
+        bool const itemActive = pT->isActive();
         if (pT->isFolder()) {
             itemDescription = (itemActive ? descActiveFolder : descInactiveFolder);
             if (!pT->mPackageName.isEmpty()) {
@@ -5521,7 +5521,7 @@ void dlgTriggerEditor::slot_setupPatternControls(int type)
         return;
     }
 
-    int row = pBox->itemData(0).toInt();
+    int const row = pBox->itemData(0).toInt();
     if (row < 0 || row >= 50) {
         return;
     }
@@ -5626,11 +5626,11 @@ void dlgTriggerEditor::slot_triggerSelected(QTreeWidgetItem* pItem)
     mpTriggersMainArea->pushButtonBgColor->setProperty(cButtonBaseColor, QVariant());
     mpTriggersMainArea->spinBox_lineMargin->setValue(1);
 
-    int ID = pItem->data(0, Qt::UserRole).toInt();
+    int const ID = pItem->data(0, Qt::UserRole).toInt();
     TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(ID);
     if (pT) {
-        QStringList patternList = pT->getPatternsList();
-        QList<int> propertyList = pT->getRegexCodePropertyList();
+        QStringList const patternList = pT->getPatternsList();
+        QList<int> const propertyList = pT->getRegexCodePropertyList();
 
         if (patternList.size() != propertyList.size()) {
             return;
@@ -5645,7 +5645,7 @@ void dlgTriggerEditor::slot_triggerSelected(QTreeWidgetItem* pItem)
             }
             // Use operator[] so we have write access to the array/list member:
             dlgTriggerPatternEdit* pPatternItem = mTriggerPatternEdit[i];
-            int pType = propertyList.at(i);
+            int const pType = propertyList.at(i);
             if (!pType) {
                 // If the control is for the default (0) case nudge the setting
                 // up and down so that it copies the colour icon for the
@@ -5724,7 +5724,7 @@ void dlgTriggerEditor::slot_triggerSelected(QTreeWidgetItem* pItem)
         }
         // Scroll to the last used pattern:
         mpScrollArea->ensureWidgetVisible(mTriggerPatternEdit.at(qBound(0, patternList.size(), 49)));
-        QString command = pT->getCommand();
+        QString const command = pT->getCommand();
         mpTriggersMainArea->lineEdit_trigger_name->setText(pItem->text(0));
         mpTriggersMainArea->lineEdit_trigger_command->setText(command);
         mpTriggersMainArea->groupBox_multiLineTrigger->setChecked(pT->isMultiline());
@@ -5741,10 +5741,10 @@ void dlgTriggerEditor::slot_triggerSelected(QTreeWidgetItem* pItem)
         mpTriggersMainArea->toolButton_clearSoundFile->setEnabled(!mpTriggersMainArea->lineEdit_soundFile->text().isEmpty());
         mpTriggersMainArea->groupBox_triggerColorizer->setChecked(pT->isColorizerTrigger());
 
-        QColor fgColor(pT->getFgColor());
-        QColor bgColor(pT->getBgColor());
-        bool transparentFg = fgColor == QColorConstants::Transparent;
-        bool transparentBg = bgColor == QColorConstants::Transparent;
+        QColor const fgColor(pT->getFgColor());
+        QColor const bgColor(pT->getBgColor());
+        bool const transparentFg = fgColor == QColorConstants::Transparent;
+        bool const transparentBg = bgColor == QColorConstants::Transparent;
         mpTriggersMainArea->pushButtonFgColor->setStyleSheet(generateButtonStyleSheet(fgColor, pT->isColorizerTrigger()));
         mpTriggersMainArea->pushButtonFgColor->setProperty(cButtonBaseColor, transparentFg ? qsl("transparent") : fgColor.name());
         mpTriggersMainArea->pushButtonFgColor->setText(transparentFg ? tr("keep",
@@ -5790,12 +5790,12 @@ void dlgTriggerEditor::slot_aliasSelected(QTreeWidgetItem* pItem)
     clearDocument(mpSourceEditorEdbee); // Alias Select
 
     mpAliasMainArea->lineEdit_alias_name->setText(pItem->text(0));
-    int ID = pItem->data(0, Qt::UserRole).toInt();
+    int const ID = pItem->data(0, Qt::UserRole).toInt();
     TAlias* pT = mpHost->getAliasUnit()->getAlias(ID);
     if (pT) {
-        QString pattern = pT->getRegexCode();
-        QString command = pT->getCommand();
-        QString name = pT->getName();
+        QString const pattern = pT->getRegexCode();
+        QString const command = pT->getCommand();
+        QString const name = pT->getName();
 
         mpAliasMainArea->lineEdit_alias_pattern->setText(pattern);
         mpAliasMainArea->lineEdit_alias_command->setText(command);
@@ -5839,15 +5839,15 @@ void dlgTriggerEditor::slot_keySelected(QTreeWidgetItem* pItem)
     clearDocument(mpSourceEditorEdbee); // Key Select
 
     mpKeysMainArea->lineEdit_key_binding->setText(pItem->text(0));
-    int ID = pItem->data(0, Qt::UserRole).toInt();
+    int const ID = pItem->data(0, Qt::UserRole).toInt();
     TKey* pT = mpHost->getKeyUnit()->getKey(ID);
     if (pT) {
-        QString command = pT->getCommand();
-        QString name = pT->getName();
+        QString const command = pT->getCommand();
+        QString const name = pT->getName();
         mpKeysMainArea->lineEdit_key_command->clear();
         mpKeysMainArea->lineEdit_key_command->setText(command);
         mpKeysMainArea->lineEdit_key_name->setText(name);
-        QString keyName = mpHost->getKeyUnit()->getKeyName(pT->getKeyCode(), pT->getKeyModifiers());
+        QString const keyName = mpHost->getKeyUnit()->getKeyName(pT->getKeyCode(), pT->getKeyModifiers());
         mpKeysMainArea->lineEdit_key_binding->setText(keyName);
 
         clearDocument(mpSourceEditorEdbee, pT->getScript());
@@ -5903,8 +5903,8 @@ void dlgTriggerEditor::slot_variableChanged(QTreeWidgetItem* pItem)
     if (!pItem || mChangingVar) {
         return;
     }
-    int column = 0;
-    int state = pItem->checkState(column);
+    int const column = 0;
+    int const state = pItem->checkState(column);
     LuaInterface* lI = mpHost->getLuaInterface();
     VarUnit* vu = lI->getVarUnit();
     TVar* var = vu->getWVar(pItem);
@@ -5973,8 +5973,8 @@ void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
     }
 
     mChangingVar = true;
-    int column = treeWidget_variables->currentColumn();
-    int state = pItem->checkState(column);
+    int const column = treeWidget_variables->currentColumn();
+    int const state = pItem->checkState(column);
     LuaInterface* lI = mpHost->getLuaInterface();
     VarUnit* vu = lI->getVarUnit();
     TVar* var = vu->getWVar(pItem); // This does NOT modify pItem or what it points at
@@ -6048,8 +6048,8 @@ void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
         return;
     }
 
-    int varType = var->getValueType();
-    int keyType = var->getKeyType();
+    int const varType = var->getValueType();
+    int const keyType = var->getKeyType();
     QIcon icon;
 
     switch (keyType) {
@@ -6189,7 +6189,7 @@ void dlgTriggerEditor::slot_actionSelected(QTreeWidgetItem* pItem)
     mpCurrentActionItem = pItem; //remember what has been clicked to save it
     // ID will be 0 for the root of the treewidget and it is not appropriate
     // to show any right hand side details - pT will also be nullptr!
-    int ID = pItem->data(0, Qt::UserRole).toInt();
+    int const ID = pItem->data(0, Qt::UserRole).toInt();
     TAction* pT = mpHost->getActionUnit()->getAction(ID);
     if (pT) {
         mpActionsMainArea->lineEdit_action_name->setText(pT->getName());
@@ -6324,10 +6324,10 @@ void dlgTriggerEditor::slot_scriptsSelected(QTreeWidgetItem* pItem)
     mpScriptsMainArea->lineEdit_script_name->clear();
     mpScriptsMainArea->listWidget_script_registered_event_handlers->clear();
     mpScriptsMainArea->lineEdit_script_name->setText(pItem->text(0));
-    int ID = pItem->data(0, Qt::UserRole).toInt();
+    int const ID = pItem->data(0, Qt::UserRole).toInt();
     TScript* pT = mpHost->getScriptUnit()->getScript(ID);
     if (pT) {
-        QString name = pT->getName();
+        QString const name = pT->getName();
         QStringList eventHandlerList = pT->getEventHandlerList();
         for (int i = 0; i < eventHandlerList.size(); i++) {
             auto pItem = new QListWidgetItem(mpScriptsMainArea->listWidget_script_registered_event_handlers);
@@ -6335,7 +6335,7 @@ void dlgTriggerEditor::slot_scriptsSelected(QTreeWidgetItem* pItem)
             mpScriptsMainArea->listWidget_script_registered_event_handlers->addItem(pItem);
         }
         mpScriptsMainArea->lineEdit_script_name->clear();
-        QString script = pT->getScript();
+        QString const script = pT->getScript();
         clearDocument(mpSourceEditorEdbee, script);
 
         mpScriptsMainArea->lineEdit_script_name->setText(name);
@@ -6378,14 +6378,14 @@ void dlgTriggerEditor::slot_timerSelected(QTreeWidgetItem* pItem)
     mpTimersMainArea->timeEdit_timer_msecs->setTime(QTime(0, 0, 0, 0));
     mpTimersMainArea->lineEdit_timer_name->setText(pItem->text(0));
 
-    int ID = pItem->data(0, Qt::UserRole).toInt();
+    int const ID = pItem->data(0, Qt::UserRole).toInt();
     TTimer* pT = mpHost->getTimerUnit()->getTimer(ID);
     if (pT) {
-        QString command = pT->getCommand();
-        QString name = pT->getName();
+        QString const command = pT->getCommand();
+        QString const name = pT->getName();
         mpTimersMainArea->lineEdit_timer_command->setText(command);
         mpTimersMainArea->lineEdit_timer_name->setText(name);
-        QTime time = pT->getTime();
+        QTime const time = pT->getTime();
         mpTimersMainArea->timeEdit_timer_hours->setTime(QTime(time.hour(), 0, 0, 0));
         mpTimersMainArea->timeEdit_timer_minutes->setTime(QTime(0, time.minute(), 0, 0));
         mpTimersMainArea->timeEdit_timer_seconds->setTime(QTime(0, 0, time.second(), 0));
@@ -6456,13 +6456,13 @@ void dlgTriggerEditor::fillout_form()
 
 void dlgTriggerEditor::populateKeys()
 {
-    std::list<TKey*> baseNodeList_key = mpHost->getKeyUnit()->getKeyRootNodeList();
+    std::list<TKey*> const baseNodeList_key = mpHost->getKeyUnit()->getKeyRootNodeList();
     for (auto key : baseNodeList_key) {
         if (key->isTemporary()) {
             continue;
         }
 
-        QString s = key->getName();
+        QString const s = key->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(mpKeyBaseItem, sList);
@@ -6470,7 +6470,7 @@ void dlgTriggerEditor::populateKeys()
         mpKeyBaseItem->addChild(pItem);
         QIcon icon;
         QString itemDescription;
-        bool itemActive = key->isActive();
+        bool const itemActive = key->isActive();
         if (key->hasChildren()) {
             expand_child_key(key, pItem);
         }
@@ -6535,13 +6535,13 @@ void dlgTriggerEditor::populateKeys()
 }
 void dlgTriggerEditor::populateActions()
 {
-    std::list<TAction*> baseNodeList_action = mpHost->getActionUnit()->getActionRootNodeList();
+    std::list<TAction*> const baseNodeList_action = mpHost->getActionUnit()->getActionRootNodeList();
     for (auto action : baseNodeList_action) {
         if (action->isTemporary()) {
             continue;
         }
 
-        QString s = action->getName();
+        QString const s = action->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(mpActionBaseItem, sList);
@@ -6554,7 +6554,7 @@ void dlgTriggerEditor::populateActions()
         }
         if (action->state()) {
             clearEditorNotification();
-            bool itemActive = action->isActive();
+            bool const itemActive = action->isActive();
             if (action->isFolder()) {
                 itemDescription = (itemActive ? descActiveFolder : descInactiveFolder);
                 if (!action->mPackageName.isEmpty()) {
@@ -6618,13 +6618,13 @@ void dlgTriggerEditor::populateActions()
 }
 void dlgTriggerEditor::populateAliases()
 {
-    std::list<TAlias*> baseNodeList_alias = mpHost->getAliasUnit()->getAliasRootNodeList();
+    std::list<TAlias*> const baseNodeList_alias = mpHost->getAliasUnit()->getAliasRootNodeList();
     for (auto alias : baseNodeList_alias) {
         if (alias->isTemporary()) {
             continue;
         }
 
-        QString s = alias->getName();
+        QString const s = alias->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(mpAliasBaseItem, sList);
@@ -6632,7 +6632,7 @@ void dlgTriggerEditor::populateAliases()
         mpAliasBaseItem->addChild(pItem);
         QIcon icon;
         QString itemDescription;
-        bool itemActive = alias->isActive();
+        bool const itemActive = alias->isActive();
         if (alias->hasChildren()) {
             expand_child_alias(alias, pItem);
         }
@@ -6697,9 +6697,9 @@ void dlgTriggerEditor::populateAliases()
 }
 void dlgTriggerEditor::populateScripts()
 {
-    std::list<TScript*> baseNodeList_scripts = mpHost->getScriptUnit()->getScriptRootNodeList();
+    std::list<TScript*> const baseNodeList_scripts = mpHost->getScriptUnit()->getScriptRootNodeList();
     for (auto script : baseNodeList_scripts) {
-        QString s = script->getName();
+        QString const s = script->getName();
 
         QStringList sList;
         sList << s;
@@ -6708,7 +6708,7 @@ void dlgTriggerEditor::populateScripts()
         mpScriptsBaseItem->addChild(pItem);
         QIcon icon;
         QString itemDescription;
-        bool itemActive = script->isActive();
+        bool const itemActive = script->isActive();
         if (script->hasChildren()) {
             expand_child_scripts(script, pItem);
         }
@@ -6752,12 +6752,12 @@ void dlgTriggerEditor::populateScripts()
 }
 void dlgTriggerEditor::populateTimers()
 {
-    std::list<TTimer *> baseNodeList_timers = mpHost->getTimerUnit()->getTimerRootNodeList();
+    std::list<TTimer *> const baseNodeList_timers = mpHost->getTimerUnit()->getTimerRootNodeList();
     for (auto timer : baseNodeList_timers) {
         if (timer->isTemporary()) {
             continue;
         }
-        QString s = timer->getName();
+        QString const s = timer->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(mpTimerBaseItem, sList);
@@ -6765,7 +6765,7 @@ void dlgTriggerEditor::populateTimers()
         mpTimerBaseItem->addChild(pItem);
         QIcon icon;
         QString itemDescription;
-        bool itemActive = timer->isActive();
+        bool const itemActive = timer->isActive();
         if (timer->hasChildren()) {
             expand_child_timers(timer, pItem);
         }
@@ -6842,12 +6842,12 @@ void dlgTriggerEditor::populateTimers()
 }
 void dlgTriggerEditor::populateTriggers()
 {
-    std::list<TTrigger *> baseNodeList = mpHost->getTriggerUnit()->getTriggerRootNodeList();
+    std::list<TTrigger *> const baseNodeList = mpHost->getTriggerUnit()->getTriggerRootNodeList();
     for (auto trigger : baseNodeList) {
         if (trigger->isTemporary()) {
             continue;
         }
-        QString s = trigger->getName();
+        QString const s = trigger->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(mpTriggerBaseItem, sList);
@@ -6855,7 +6855,7 @@ void dlgTriggerEditor::populateTriggers()
         mpTriggerBaseItem->addChild(pItem);
         QIcon icon;
         QString itemDescription;
-        bool itemActive = trigger->isActive();
+        bool const itemActive = trigger->isActive();
         if (trigger->hasChildren()) {
             expand_child_triggers(trigger, pItem);
         }
@@ -6953,7 +6953,7 @@ void dlgTriggerEditor::expand_child_triggers(TTrigger* pTriggerParent, QTreeWidg
 {
     std::list<TTrigger*>* childrenList = pTriggerParent->getChildrenList();
     for (auto trigger : *childrenList) {
-        QString s = trigger->getName();
+        QString const s = trigger->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(pWidgetItemParent, sList);
@@ -7037,7 +7037,7 @@ void dlgTriggerEditor::expand_child_key(TKey* pTriggerParent, QTreeWidgetItem* p
 {
     std::list<TKey*>* childrenList = pTriggerParent->getChildrenList();
     for (auto key : *childrenList) {
-        QString s = key->getName();
+        QString const s = key->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(pWidgetItemParent, sList);
@@ -7104,7 +7104,7 @@ void dlgTriggerEditor::expand_child_scripts(TScript* pTriggerParent, QTreeWidget
 {
     std::list<TScript*>* childrenList = pTriggerParent->getChildrenList();
     for (auto script : *childrenList) {
-        QString s = script->getName();
+        QString const s = script->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(pWidgetItemParent, sList);
@@ -7162,7 +7162,7 @@ void dlgTriggerEditor::expand_child_alias(TAlias* pTriggerParent, QTreeWidgetIte
 {
     std::list<TAlias*>* childrenList = pTriggerParent->getChildrenList();
     for (auto alias : *childrenList) {
-        QString s = alias->getName();
+        QString const s = alias->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(pWidgetItemParent, sList);
@@ -7228,7 +7228,7 @@ void dlgTriggerEditor::expand_child_action(TAction* pTriggerParent, QTreeWidgetI
 {
     std::list<TAction*>* childrenList = pTriggerParent->getChildrenList();
     for (auto action : *childrenList) {
-        QString s = action->getName();
+        QString const s = action->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(pWidgetItemParent, sList);
@@ -7288,7 +7288,7 @@ void dlgTriggerEditor::expand_child_timers(TTimer* pTimerParent, QTreeWidgetItem
 {
     std::list<TTimer*>* childrenList = pTimerParent->getChildrenList();
     for (auto timer : *childrenList) {
-        QString s = timer->getName();
+        QString const s = timer->getName();
         QStringList sList;
         sList << s;
         auto pItem = new QTreeWidgetItem(pWidgetItemParent, sList);
@@ -8157,7 +8157,7 @@ void dlgTriggerEditor::slot_scriptMainAreaEditHandler(QListWidgetItem*)
     }
     mIsScriptsMainAreaEditHandler = true;
     mpScriptsMainAreaEditHandlerItem = pItem;
-    QString regex = pItem->text();
+    QString const regex = pItem->text();
     if (regex.isEmpty()) {
         mIsScriptsMainAreaEditHandler = false;
         return;
@@ -8480,7 +8480,7 @@ void dlgTriggerEditor::exportTrigger(const QString& fileName)
     TTrigger* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_triggers->currentItem();
     if (pItem) {
-        int triggerID = pItem->data(0, Qt::UserRole).toInt();
+        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getTriggerUnit()->getTrigger(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8504,7 +8504,7 @@ void dlgTriggerEditor::exportTimer(const QString& fileName)
     TTimer* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_timers->currentItem();
     if (pItem) {
-        int triggerID = pItem->data(0, Qt::UserRole).toInt();
+        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getTimerUnit()->getTimer(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8528,7 +8528,7 @@ void dlgTriggerEditor::exportAlias(const QString& fileName)
     TAlias* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_aliases->currentItem();
     if (pItem) {
-        int triggerID = pItem->data(0, Qt::UserRole).toInt();
+        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getAliasUnit()->getAlias(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8552,7 +8552,7 @@ void dlgTriggerEditor::exportAction(const QString& fileName)
     TAction* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_actions->currentItem();
     if (pItem) {
-        int triggerID = pItem->data(0, Qt::UserRole).toInt();
+        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getActionUnit()->getAction(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8576,7 +8576,7 @@ void dlgTriggerEditor::exportScript(const QString& fileName)
     TScript* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_scripts->currentItem();
     if (pItem) {
-        int triggerID = pItem->data(0, Qt::UserRole).toInt();
+        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getScriptUnit()->getScript(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8600,7 +8600,7 @@ void dlgTriggerEditor::exportKey(const QString& fileName)
     TKey* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_keys->currentItem();
     if (pItem) {
-        int triggerID = pItem->data(0, Qt::UserRole).toInt();
+        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getKeyUnit()->getKey(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8625,7 +8625,7 @@ void dlgTriggerEditor::exportTriggerToClipboard()
     TTrigger* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_triggers->currentItem();
     if (pItem) {
-        int triggerID = pItem->data(0, Qt::UserRole).toInt();
+        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getTriggerUnit()->getTrigger(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8648,7 +8648,7 @@ void dlgTriggerEditor::exportTimerToClipboard()
     TTimer* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_timers->currentItem();
     if (pItem) {
-        int triggerID = pItem->data(0, Qt::UserRole).toInt();
+        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getTimerUnit()->getTimer(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8671,7 +8671,7 @@ void dlgTriggerEditor::exportAliasToClipboard()
     TAlias* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_aliases->currentItem();
     if (pItem) {
-        int triggerID = pItem->data(0, Qt::UserRole).toInt();
+        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getAliasUnit()->getAlias(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8694,7 +8694,7 @@ void dlgTriggerEditor::exportActionToClipboard()
     TAction* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_actions->currentItem();
     if (pItem) {
-        int triggerID = pItem->data(0, Qt::UserRole).toInt();
+        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getActionUnit()->getAction(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8717,7 +8717,7 @@ void dlgTriggerEditor::exportScriptToClipboard()
     TScript* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_scripts->currentItem();
     if (pItem) {
-        int triggerID = pItem->data(0, Qt::UserRole).toInt();
+        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getScriptUnit()->getScript(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8740,7 +8740,7 @@ void dlgTriggerEditor::exportKeyToClipboard()
     TKey* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_keys->currentItem();
     if (pItem) {
-        int triggerID = pItem->data(0, Qt::UserRole).toInt();
+        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getKeyUnit()->getKey(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8893,7 +8893,7 @@ void dlgTriggerEditor::slot_pasteXml()
         auto parentRow = parent.row();
         auto parentId = parent.data(Qt::UserRole).toInt();
 
-        int siblingRow = treeWidget_triggers->currentIndex().row() + 1;
+        int const siblingRow = treeWidget_triggers->currentIndex().row() + 1;
         mpHost->getTriggerUnit()->reParentTrigger(importedItemID, 0, parentId, parentRow, siblingRow);
         break;
     }
@@ -8902,7 +8902,7 @@ void dlgTriggerEditor::slot_pasteXml()
         auto parentRow = parent.row();
         auto parentId = parent.data(Qt::UserRole).toInt();
 
-        int siblingRow = treeWidget_timers->currentIndex().row() + 1;
+        int const siblingRow = treeWidget_timers->currentIndex().row() + 1;
         mpHost->getTimerUnit()->reParentTimer(importedItemID, 0, parentId, parentRow, siblingRow);
         break;
     }
@@ -8911,7 +8911,7 @@ void dlgTriggerEditor::slot_pasteXml()
         auto parentRow = parent.row();
         auto parentId = parent.data(Qt::UserRole).toInt();
 
-        int siblingRow = treeWidget_aliases->currentIndex().row() + 1;
+        int const siblingRow = treeWidget_aliases->currentIndex().row() + 1;
         mpHost->getAliasUnit()->reParentAlias(importedItemID, 0, parentId, parentRow, siblingRow);
         break;
     }
@@ -8920,7 +8920,7 @@ void dlgTriggerEditor::slot_pasteXml()
         auto parentRow = parent.row();
         auto parentId = parent.data(Qt::UserRole).toInt();
 
-        int siblingRow = treeWidget_scripts->currentIndex().row() + 1;
+        int const siblingRow = treeWidget_scripts->currentIndex().row() + 1;
         mpHost->getScriptUnit()->reParentScript(importedItemID, 0, parentId, parentRow, siblingRow);
         break;
     }
@@ -8929,7 +8929,7 @@ void dlgTriggerEditor::slot_pasteXml()
         auto parentRow = parent.row();
         auto parentId = parent.data(Qt::UserRole).toInt();
 
-        int siblingRow = treeWidget_actions->currentIndex().row() + 1;
+        int const siblingRow = treeWidget_actions->currentIndex().row() + 1;
         mpHost->getActionUnit()->reParentAction(importedItemID, 0, parentId, parentRow, siblingRow);
         break;
     }
@@ -8938,7 +8938,7 @@ void dlgTriggerEditor::slot_pasteXml()
         auto parentRow = parent.row();
         auto parentId = parent.data(Qt::UserRole).toInt();
 
-        int siblingRow = treeWidget_keys->currentIndex().row() + 1;
+        int const siblingRow = treeWidget_keys->currentIndex().row() + 1;
         mpHost->getKeyUnit()->reParentKey(importedItemID, 0, parentId, parentRow, siblingRow);
         break;
     }
@@ -9046,7 +9046,7 @@ void dlgTriggerEditor::slot_import()
         qWarning().nospace().noquote() << "dlgTriggerEditor::slot_import() WARNING - switch(EditorViewType) not expected to be called for \"EditorViewType::cmUnknownView!\"";
     }
 
-    QString fileName = QFileDialog::getOpenFileName(this, tr("Import Mudlet Package"), QDir::currentPath());
+    QString const fileName = QFileDialog::getOpenFileName(this, tr("Import Mudlet Package"), QDir::currentPath());
     if (fileName.isEmpty()) {
         return;
     }
@@ -9264,12 +9264,12 @@ void dlgTriggerEditor::key_grab_callback(const Qt::Key key, const Qt::KeyboardMo
     if (!pKeyUnit) {
         return;
     }
-    QString keyName = pKeyUnit->getKeyName(key, modifier);
-    QString name = keyName;
+    QString const keyName = pKeyUnit->getKeyName(key, modifier);
+    QString const name = keyName;
     mpKeysMainArea->lineEdit_key_binding->setText(name);
     QTreeWidgetItem* pItem = treeWidget_keys->currentItem();
     if (pItem) {
-        int triggerID = pItem->data(0, Qt::UserRole).toInt();
+        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
         TKey* pT = mpHost->getKeyUnit()->getKey(triggerID);
         if (pT) {
             pT->setKeyCode(key);
@@ -9313,7 +9313,7 @@ void dlgTriggerEditor::slot_colorizeTriggerSetFgColor()
                                         this,
                                         tr("Select foreground color to apply to matches"));
     color = color.isValid() ? color : QColorConstants::Transparent;
-    bool keepColor = color == QColorConstants::Transparent;
+    bool const keepColor = color == QColorConstants::Transparent;
     mpTriggersMainArea->pushButtonFgColor->setStyleSheet(generateButtonStyleSheet(color));
     mpTriggersMainArea->pushButtonFgColor->setText(keepColor ? tr("keep", "Keep the existing colour on matches to highlight. Use shortest word possible so it fits on the button") : QString());
     mpTriggersMainArea->pushButtonFgColor->setProperty(cButtonBaseColor, keepColor ? qsl("transparent") : color.name());
@@ -9334,7 +9334,7 @@ void dlgTriggerEditor::slot_colorizeTriggerSetBgColor()
                                         this,
                                         tr("Select background color to apply to matches"));
     color = color.isValid() ? color : QColorConstants::Transparent;
-    bool keepColor = color == QColorConstants::Transparent;
+    bool const keepColor = color == QColorConstants::Transparent;
     mpTriggersMainArea->pushButtonBgColor->setStyleSheet(generateButtonStyleSheet(color));
     mpTriggersMainArea->pushButtonBgColor->setText(keepColor ? tr("keep", "Keep the existing colour on matches to highlight. Use shortest word possible so it fits on the button") : QString());
     mpTriggersMainArea->pushButtonBgColor->setProperty(cButtonBaseColor, keepColor ? qsl("transparent") : color.name());
@@ -9344,7 +9344,7 @@ void dlgTriggerEditor::slot_soundTrigger()
 {
     // Use the existing path/filename if it is not empty, otherwise start in
     // profile home directory:
-    QString fileName = QFileDialog::getOpenFileName(this,
+    QString const fileName = QFileDialog::getOpenFileName(this,
                                                     tr("Choose sound file"),
                                                     mpTriggersMainArea->lineEdit_soundFile->text().isEmpty()
                                                     ? mudlet::getMudletPath(mudlet::profileHomePath, mpHost->getName())
@@ -9377,7 +9377,7 @@ void dlgTriggerEditor::slot_colorTriggerFg()
     if (!pItem) {
         return;
     }
-    int triggerID = pItem->data(0, Qt::UserRole).toInt();
+    int const triggerID = pItem->data(0, Qt::UserRole).toInt();
     TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(triggerID);
     if (!pT) {
         return;
@@ -9409,7 +9409,7 @@ void dlgTriggerEditor::slot_colorTriggerFg()
     pD->setWindowModality(Qt::ApplicationModal);
     pD->exec();
 
-    QColor color = pT->mColorTriggerFgColor;
+    QColor const color = pT->mColorTriggerFgColor;
     // The above will be an invalid colour if the colour has been reset/ignored
     // The dialogue should have changed pT->mColorTriggerFgAnsi
     QString styleSheet;
@@ -9441,7 +9441,7 @@ void dlgTriggerEditor::slot_colorTriggerBg()
     if (!pItem) {
         return;
     }
-    int triggerID = pItem->data(0, Qt::UserRole).toInt();
+    int const triggerID = pItem->data(0, Qt::UserRole).toInt();
     TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(triggerID);
     if (!pT) {
         return;
@@ -9473,7 +9473,7 @@ void dlgTriggerEditor::slot_colorTriggerBg()
     pD->setWindowModality(Qt::ApplicationModal);
     pD->exec();
 
-    QColor color = pT->mColorTriggerBgColor;
+    QColor const color = pT->mColorTriggerBgColor;
     // The above will be an invalid colour if the colour has been reset/ignored
     QString styleSheet;
     if (color.isValid()) {
@@ -9500,7 +9500,7 @@ void dlgTriggerEditor::slot_updateStatusBar(const QString& statusText)
 {
     // edbee adds the scope and last command which is rather technical debugging information,
     // so strip it away by removing the first pipe and everything after it
-    QRegularExpressionMatch match = simplifyEdbeeStatusBarRegex->match(statusText, 0, QRegularExpression::PartialPreferFirstMatch);
+    QRegularExpressionMatch const match = simplifyEdbeeStatusBarRegex->match(statusText, 0, QRegularExpression::PartialPreferFirstMatch);
     QString stripped;
     if (match.hasPartialMatch() || match.hasMatch()) {
         stripped = match.captured(1);
@@ -9718,7 +9718,7 @@ QString dlgTriggerEditor::generateButtonStyleSheet(const QColor& color, const bo
                          color.name());
         }
 
-        QColor disabledColor = QColor::fromHsl(color.hslHue(), color.hslSaturation()/4, color.lightness());
+        QColor const disabledColor = QColor::fromHsl(color.hslHue(), color.hslSaturation()/4, color.lightness());
         return mudlet::self()->mTEXT_ON_BG_STYLESHEET
                 .arg(QLatin1String("darkGray"), disabledColor.name());
     } else {
@@ -9822,8 +9822,8 @@ void dlgTriggerEditor::slot_toggleGroupBoxColorizeTrigger(const bool state)
 
     if (state) {
         // Enabled so make buttons have full colour:
-        QString fgColor = mpTriggersMainArea->pushButtonFgColor->property(cButtonBaseColor).toString();
-        QString bgColor = mpTriggersMainArea->pushButtonBgColor->property(cButtonBaseColor).toString();
+        QString const fgColor = mpTriggersMainArea->pushButtonFgColor->property(cButtonBaseColor).toString();
+        QString const bgColor = mpTriggersMainArea->pushButtonBgColor->property(cButtonBaseColor).toString();
         mpTriggersMainArea->pushButtonFgColor->setStyleSheet(generateButtonStyleSheet(fgColor, true));
         mpTriggersMainArea->pushButtonBgColor->setStyleSheet(generateButtonStyleSheet(bgColor, true));
         mpTriggersMainArea->pushButtonFgColor->setText(fgColor == QLatin1String("transparent") ? tr("keep", "Keep the existing colour on matches to highlight. Use shortest word possible so it fits on the button") : QString());

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -948,7 +948,7 @@ void dlgTriggerEditor::readSettings()
     QSettings const settings_new("mudlet", "Mudlet");
     QSettings const settings((settings_new.contains("pos") ? "mudlet" : "Mudlet"), (settings_new.contains("pos") ? "Mudlet" : "Mudlet 1.0"));
 
-    QPoint const pos = settings.value("script_editor_pos", QPoint(10, 10)).toPoint();
+    const QPoint pos = settings.value("script_editor_pos", QPoint(10, 10)).toPoint();
     QSize const size = settings.value("script_editor_size", QSize(600, 400)).toSize();
     resize(size);
     move(pos);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -3057,7 +3057,7 @@ void dlgTriggerEditor::children_icon_timer(QTreeWidgetItem* pWidgetItemParent)
 
         QIcon icon;
         QString itemDescription;
-        bool const itemActive = (pT->isActive() || pT->shouldBeActive());
+        const bool itemActive = (pT->isActive() || pT->shouldBeActive());
 
         if (pItem->childCount() > 0) {
             children_icon_timer(pItem);
@@ -3401,7 +3401,7 @@ void dlgTriggerEditor::activeToggle_action()
         }
     }
 
-    bool const itemActive = pT->isActive();
+    const bool itemActive = pT->isActive();
     if (pT->isFolder()) {
         itemDescription = (itemActive ? descActiveFolder : descInactiveFolder);
         if (!pT->ancestorsActive()) {
@@ -3482,7 +3482,7 @@ void dlgTriggerEditor::children_icon_action(QTreeWidgetItem* pWidgetItemParent)
 
         QIcon icon;
         QString itemDescription;
-        bool const itemActive = pT->isActive();
+        const bool itemActive = pT->isActive();
         if (pItem->childCount() > 0) {
             children_icon_action(pItem);
         }
@@ -4417,7 +4417,7 @@ void dlgTriggerEditor::saveTrigger()
     mpTriggersMainArea->trimName();
     const QString name = mpTriggersMainArea->lineEdit_trigger_name->text();
     const QString command = mpTriggersMainArea->lineEdit_trigger_command->text();
-    bool const isMultiline = mpTriggersMainArea->groupBox_multiLineTrigger->isChecked();
+    const bool isMultiline = mpTriggersMainArea->groupBox_multiLineTrigger->isChecked();
     QStringList patterns;
     QList<int> patternKinds;
     for (int i = 0; i < 50; i++) {
@@ -4851,7 +4851,7 @@ void dlgTriggerEditor::saveAction()
     // currentIndex() can return -1 if no setting was previously made - need to fixup:
     const int rotation = qMax(0, mpActionsMainArea->comboBox_action_button_rotation->currentIndex());
     const int columns = mpActionsMainArea->spinBox_action_bar_columns->text().toInt();
-    bool const isChecked = mpActionsMainArea->checkBox_action_button_isPushDown->isChecked();
+    const bool isChecked = mpActionsMainArea->checkBox_action_button_isPushDown->isChecked();
     // bottom location is no longer supported i.e. location = 1 = 0 = location top
     // currentIndex() can return -1 if no setting was previously made - need to fixup:
     int location = qMax(0, mpActionsMainArea->comboBox_action_bar_location->currentIndex());
@@ -4893,7 +4893,7 @@ void dlgTriggerEditor::saveAction()
 
         QIcon icon;
         QString itemDescription;
-        bool const itemActive = pA->isActive();
+        const bool itemActive = pA->isActive();
         if (pA->isFolder()) {
             itemDescription = (itemActive ? descActiveFolder : descInactiveFolder);
             if (!pA->mPackageName.isEmpty()) {
@@ -5051,7 +5051,7 @@ void dlgTriggerEditor::saveScript()
     mpHost->getTriggerUnit()->doCleanup();
     QIcon icon;
     QString itemDescription;
-    bool const itemActive = pT->isActive();
+    const bool itemActive = pT->isActive();
     if (pT->isFolder()) {
         itemDescription = (itemActive ? descActiveFolder : descInactiveFolder);
         if (!pT->mPackageName.isEmpty()) {
@@ -5401,7 +5401,7 @@ void dlgTriggerEditor::saveKey()
 
         QIcon icon;
         QString itemDescription;
-        bool const itemActive = pT->isActive();
+        const bool itemActive = pT->isActive();
         if (pT->isFolder()) {
             itemDescription = (itemActive ? descActiveFolder : descInactiveFolder);
             if (!pT->mPackageName.isEmpty()) {
@@ -5743,8 +5743,8 @@ void dlgTriggerEditor::slot_triggerSelected(QTreeWidgetItem* pItem)
 
         QColor const fgColor(pT->getFgColor());
         QColor const bgColor(pT->getBgColor());
-        bool const transparentFg = fgColor == QColorConstants::Transparent;
-        bool const transparentBg = bgColor == QColorConstants::Transparent;
+        const bool transparentFg = fgColor == QColorConstants::Transparent;
+        const bool transparentBg = bgColor == QColorConstants::Transparent;
         mpTriggersMainArea->pushButtonFgColor->setStyleSheet(generateButtonStyleSheet(fgColor, pT->isColorizerTrigger()));
         mpTriggersMainArea->pushButtonFgColor->setProperty(cButtonBaseColor, transparentFg ? qsl("transparent") : fgColor.name());
         mpTriggersMainArea->pushButtonFgColor->setText(transparentFg ? tr("keep",
@@ -6470,7 +6470,7 @@ void dlgTriggerEditor::populateKeys()
         mpKeyBaseItem->addChild(pItem);
         QIcon icon;
         QString itemDescription;
-        bool const itemActive = key->isActive();
+        const bool itemActive = key->isActive();
         if (key->hasChildren()) {
             expand_child_key(key, pItem);
         }
@@ -6554,7 +6554,7 @@ void dlgTriggerEditor::populateActions()
         }
         if (action->state()) {
             clearEditorNotification();
-            bool const itemActive = action->isActive();
+            const bool itemActive = action->isActive();
             if (action->isFolder()) {
                 itemDescription = (itemActive ? descActiveFolder : descInactiveFolder);
                 if (!action->mPackageName.isEmpty()) {
@@ -6632,7 +6632,7 @@ void dlgTriggerEditor::populateAliases()
         mpAliasBaseItem->addChild(pItem);
         QIcon icon;
         QString itemDescription;
-        bool const itemActive = alias->isActive();
+        const bool itemActive = alias->isActive();
         if (alias->hasChildren()) {
             expand_child_alias(alias, pItem);
         }
@@ -6708,7 +6708,7 @@ void dlgTriggerEditor::populateScripts()
         mpScriptsBaseItem->addChild(pItem);
         QIcon icon;
         QString itemDescription;
-        bool const itemActive = script->isActive();
+        const bool itemActive = script->isActive();
         if (script->hasChildren()) {
             expand_child_scripts(script, pItem);
         }
@@ -6765,7 +6765,7 @@ void dlgTriggerEditor::populateTimers()
         mpTimerBaseItem->addChild(pItem);
         QIcon icon;
         QString itemDescription;
-        bool const itemActive = timer->isActive();
+        const bool itemActive = timer->isActive();
         if (timer->hasChildren()) {
             expand_child_timers(timer, pItem);
         }
@@ -6855,7 +6855,7 @@ void dlgTriggerEditor::populateTriggers()
         mpTriggerBaseItem->addChild(pItem);
         QIcon icon;
         QString itemDescription;
-        bool const itemActive = trigger->isActive();
+        const bool itemActive = trigger->isActive();
         if (trigger->hasChildren()) {
             expand_child_triggers(trigger, pItem);
         }
@@ -9313,7 +9313,7 @@ void dlgTriggerEditor::slot_colorizeTriggerSetFgColor()
                                         this,
                                         tr("Select foreground color to apply to matches"));
     color = color.isValid() ? color : QColorConstants::Transparent;
-    bool const keepColor = color == QColorConstants::Transparent;
+    const bool keepColor = color == QColorConstants::Transparent;
     mpTriggersMainArea->pushButtonFgColor->setStyleSheet(generateButtonStyleSheet(color));
     mpTriggersMainArea->pushButtonFgColor->setText(keepColor ? tr("keep", "Keep the existing colour on matches to highlight. Use shortest word possible so it fits on the button") : QString());
     mpTriggersMainArea->pushButtonFgColor->setProperty(cButtonBaseColor, keepColor ? qsl("transparent") : color.name());
@@ -9334,7 +9334,7 @@ void dlgTriggerEditor::slot_colorizeTriggerSetBgColor()
                                         this,
                                         tr("Select background color to apply to matches"));
     color = color.isValid() ? color : QColorConstants::Transparent;
-    bool const keepColor = color == QColorConstants::Transparent;
+    const bool keepColor = color == QColorConstants::Transparent;
     mpTriggersMainArea->pushButtonBgColor->setStyleSheet(generateButtonStyleSheet(color));
     mpTriggersMainArea->pushButtonBgColor->setText(keepColor ? tr("keep", "Keep the existing colour on matches to highlight. Use shortest word possible so it fits on the button") : QString());
     mpTriggersMainArea->pushButtonBgColor->setProperty(cButtonBaseColor, keepColor ? qsl("transparent") : color.name());

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1315,7 +1315,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
     case EditorViewType::cmVarsView: {
         LuaInterface* lI = mpHost->getLuaInterface();
         VarUnit* vu = lI->getVarUnit();
-        QStringList const varShort = pItem->data(0, IdRole).toStringList();
+        const QStringList varShort = pItem->data(0, IdRole).toStringList();
         QList<QTreeWidgetItem*> list;
         recurseVariablesDown(mpVarBaseItem, list);
         QListIterator<QTreeWidgetItem*> it(list);
@@ -1435,7 +1435,7 @@ void dlgTriggerEditor::searchVariables(const QString& text)
             QTreeWidgetItem* parent = nullptr;
             const QString name = varDecendent->getName();
             const QString value = varDecendent->getValue();
-            QStringList const idStringList = vu->shortVarName(varDecendent);
+            const QStringList idStringList = vu->shortVarName(varDecendent);
             QString idString;
             // Take the first element - to comply with lua requirement it
             // must begin with not a digit and not contain any spaces so is
@@ -1532,7 +1532,7 @@ void dlgTriggerEditor::searchKeys(const QString& text)
         }
 
         // Script content
-        QStringList const textList = key->getScript().split("\n");
+        const QStringList textList = key->getScript().split("\n");
         const int total = textList.count();
         for (int index = 0; index < total; ++index) {
             // CHECK: This may NOT be an optimisation...!
@@ -1604,7 +1604,7 @@ void dlgTriggerEditor::searchTimers(const QString& text)
         }
 
         // Script content
-        QStringList const textList = timer->getScript().split("\n");
+        const QStringList textList = timer->getScript().split("\n");
         const int total = textList.count();
         for (int index = 0; index < total; ++index) {
             // CHECK: This may NOT be an optimisation...!
@@ -1897,7 +1897,7 @@ void dlgTriggerEditor::searchAliases(const QString& text)
         }
 
         // Script content - now put last
-        QStringList const textList = alias->getScript().split("\n");
+        const QStringList textList = alias->getScript().split("\n");
         const int total = textList.count();
         for (int index = 0; index < total; ++index) {
             // CHECK: This may NOT be an optimisation...!
@@ -2192,7 +2192,7 @@ void dlgTriggerEditor::recursiveSearchAlias(TAlias* pTriggerParent, const QStrin
         }
 
         // Script content - now put last
-        QStringList const textList = alias->getScript().split("\n");
+        const QStringList textList = alias->getScript().split("\n");
         const int total = textList.count();
         for (int index = 0; index < total; ++index) {
             // CHECK: This may NOT be an optimisation...!
@@ -2476,7 +2476,7 @@ void dlgTriggerEditor::recursiveSearchTimers(TTimer* pTriggerParent, const QStri
         }
 
         // Script content
-        QStringList const textList = timer->getScript().split("\n");
+        const QStringList textList = timer->getScript().split("\n");
         const int total = textList.count();
         for (int index = 0; index < total; ++index) {
             // CHECK: This may NOT be an optimisation...!
@@ -2550,7 +2550,7 @@ void dlgTriggerEditor::recursiveSearchKeys(TKey* pTriggerParent, const QString& 
         }
 
         // Script content
-        QStringList const textList = key->getScript().split("\n");
+        const QStringList textList = key->getScript().split("\n");
         const int total = textList.count();
         for (int index = 0; index < total; ++index) {
             // CHECK: This may NOT be an optimisation...!
@@ -3692,7 +3692,7 @@ void dlgTriggerEditor::addTrigger(bool isFolder)
     } else {
         name = tr("New trigger");
     }
-    QStringList const patterns;
+    const QStringList patterns;
     QList<int> const patternKinds;
     const QString script = "";
     QStringList nameL;
@@ -5629,7 +5629,7 @@ void dlgTriggerEditor::slot_triggerSelected(QTreeWidgetItem* pItem)
     const int ID = pItem->data(0, Qt::UserRole).toInt();
     TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(ID);
     if (pT) {
-        QStringList const patternList = pT->getPatternsList();
+        const QStringList patternList = pT->getPatternsList();
         QList<int> const propertyList = pT->getRegexCodePropertyList();
 
         if (patternList.size() != propertyList.size()) {

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -850,7 +850,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     }
     // force the minimum size of the scroll area for the trigger items to be one
     // and a half trigger item widgets:
-    int const triggerWidgetItemMinHeight = qRound(mTriggerPatternEdit.at(0)->minimumSizeHint().height() * 1.5);
+    const int triggerWidgetItemMinHeight = qRound(mTriggerPatternEdit.at(0)->minimumSizeHint().height() * 1.5);
     mpScrollArea->setMinimumHeight(triggerWidgetItemMinHeight);
 
     widget_searchTerm->updateGeometry();
@@ -1004,7 +1004,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
 
         // This was inside the loop but it is a constant value for the duration
         // of this method!
-        int const idSearch = pItem->data(0, IdRole).toInt();
+        const int idSearch = pItem->data(0, IdRole).toInt();
 
         for (auto treeWidgetItem : qAsConst(foundItemsList)) {
 
@@ -1057,7 +1057,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
     case EditorViewType::cmAliasView: {
         foundItemsList = treeWidget_aliases->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString| Qt::MatchRecursive, 0);
 
-        int const idSearch = pItem->data(0, IdRole).toInt();
+        const int idSearch = pItem->data(0, IdRole).toInt();
 
         for (auto treeWidgetItem : qAsConst(foundItemsList)) {
 
@@ -1105,7 +1105,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
     case EditorViewType::cmScriptView: {
         foundItemsList = treeWidget_scripts->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString| Qt::MatchRecursive, 0);
 
-        int const idSearch = pItem->data(0, IdRole).toInt();
+        const int idSearch = pItem->data(0, IdRole).toInt();
 
         for (auto treeWidgetItem : qAsConst(foundItemsList)) {
 
@@ -1156,7 +1156,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
     case EditorViewType::cmActionView: {
         foundItemsList = treeWidget_actions->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString| Qt::MatchRecursive, 0);
 
-        int const idSearch = pItem->data(0, IdRole).toInt();
+        const int idSearch = pItem->data(0, IdRole).toInt();
 
         for (auto treeWidgetitem : qAsConst(foundItemsList)) {
 
@@ -1220,7 +1220,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
     case EditorViewType::cmTimerView: {
         foundItemsList = treeWidget_timers->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString| Qt::MatchRecursive, 0);
 
-        int const idSearch = pItem->data(0, IdRole).toInt();
+        const int idSearch = pItem->data(0, IdRole).toInt();
 
         for (auto treeWidgetItem : qAsConst(foundItemsList)) {
 
@@ -1264,8 +1264,8 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
         foundItemsList = treeWidget_keys->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString| Qt::MatchRecursive, 0);
 
         for (auto treeWidgetItem : qAsConst(foundItemsList)) {
-            int const idTree = treeWidgetItem->data(0, IdRole).toInt();
-            int const idSearch = pItem->data(0, IdRole).toInt();
+            const int idTree = treeWidgetItem->data(0, IdRole).toInt();
+            const int idSearch = pItem->data(0, IdRole).toInt();
             if (idTree == idSearch) {
                 slot_showKeys();
                 slot_keySelected(treeWidgetItem);
@@ -1448,7 +1448,7 @@ void dlgTriggerEditor::searchVariables(const QString& text)
                 while (itSubString.hasNext()) {
                     const QString intermediate = itSubString.next();
                     bool isOk = false;
-                    int const numberValue = intermediate.toInt(&isOk);
+                    const int numberValue = intermediate.toInt(&isOk);
                     if (isOk && QString::number(numberValue) == intermediate) {
                         // This seems to be an integer
                         idString.append(qsl("[%1]").arg(intermediate));
@@ -1533,7 +1533,7 @@ void dlgTriggerEditor::searchKeys(const QString& text)
 
         // Script content
         QStringList const textList = key->getScript().split("\n");
-        int const total = textList.count();
+        const int total = textList.count();
         for (int index = 0; index < total; ++index) {
             // CHECK: This may NOT be an optimisation...!
             if (textList.at(index).isEmpty() || !textList.at(index).contains(text, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) {
@@ -1605,7 +1605,7 @@ void dlgTriggerEditor::searchTimers(const QString& text)
 
         // Script content
         QStringList const textList = timer->getScript().split("\n");
-        int const total = textList.count();
+        const int total = textList.count();
         for (int index = 0; index < total; ++index) {
             // CHECK: This may NOT be an optimisation...!
             if (textList.at(index).isEmpty() || !textList.at(index).contains(text, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) {
@@ -1898,7 +1898,7 @@ void dlgTriggerEditor::searchAliases(const QString& text)
 
         // Script content - now put last
         QStringList const textList = alias->getScript().split("\n");
-        int const total = textList.count();
+        const int total = textList.count();
         for (int index = 0; index < total; ++index) {
             // CHECK: This may NOT be an optimisation...!
             if (textList.at(index).isEmpty() || !textList.at(index).contains(text, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) {
@@ -2193,7 +2193,7 @@ void dlgTriggerEditor::recursiveSearchAlias(TAlias* pTriggerParent, const QStrin
 
         // Script content - now put last
         QStringList const textList = alias->getScript().split("\n");
-        int const total = textList.count();
+        const int total = textList.count();
         for (int index = 0; index < total; ++index) {
             // CHECK: This may NOT be an optimisation...!
             if (textList.at(index).isEmpty() || !textList.at(index).contains(text, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) {
@@ -2477,7 +2477,7 @@ void dlgTriggerEditor::recursiveSearchTimers(TTimer* pTriggerParent, const QStri
 
         // Script content
         QStringList const textList = timer->getScript().split("\n");
-        int const total = textList.count();
+        const int total = textList.count();
         for (int index = 0; index < total; ++index) {
             // CHECK: This may NOT be an optimisation...!
             if (textList.at(index).isEmpty() || !textList.at(index).contains(text, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) {
@@ -2551,7 +2551,7 @@ void dlgTriggerEditor::recursiveSearchKeys(TKey* pTriggerParent, const QString& 
 
         // Script content
         QStringList const textList = key->getScript().split("\n");
-        int const total = textList.count();
+        const int total = textList.count();
         for (int index = 0; index < total; ++index) {
             // CHECK: This may NOT be an optimisation...!
             if (textList.at(index).isEmpty() || !textList.at(index).contains(text, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive))) {
@@ -3703,7 +3703,7 @@ void dlgTriggerEditor::addTrigger(bool isFolder)
     TTrigger* pT = nullptr;
 
     if (pParent) {
-        int const parentID = pParent->data(0, Qt::UserRole).toInt();
+        const int parentID = pParent->data(0, Qt::UserRole).toInt();
 
         TTrigger* pParentTrigger = mpHost->getTriggerUnit()->getTrigger(parentID);
         if (pParentTrigger) {
@@ -3750,7 +3750,7 @@ void dlgTriggerEditor::addTrigger(bool isFolder)
     pT->mStayOpen = 0;
     pT->setConditionLineDelta(0);
     pT->registerTrigger();
-    int const childID = pT->getID();
+    const int childID = pT->getID();
     pNewItem->setData(0, Qt::UserRole, childID);
     QIcon icon;
     QString itemDescription;
@@ -3808,7 +3808,7 @@ void dlgTriggerEditor::addTimer(bool isFolder)
     TTimer* pT = nullptr;
 
     if (pParent) {
-        int const parentID = pParent->data(0, Qt::UserRole).toInt();
+        const int parentID = pParent->data(0, Qt::UserRole).toInt();
 
         TTimer* pParentTrigger = mpHost->getTimerUnit()->getTimer(parentID);
         if (pParentTrigger) {
@@ -3851,7 +3851,7 @@ void dlgTriggerEditor::addTimer(bool isFolder)
     pT->setIsFolder(isFolder);
     pT->setIsActive(false);
     mpHost->getTimerUnit()->registerTimer(pT);
-    int const childID = pT->getID();
+    const int childID = pT->getID();
     pNewItem->setData(0, Qt::UserRole, childID);
     QIcon icon;
 
@@ -3967,7 +3967,7 @@ void dlgTriggerEditor::addKey(bool isFolder)
     TKey* pT = nullptr;
 
     if (pParent) {
-        int const parentID = pParent->data(0, Qt::UserRole).toInt();
+        const int parentID = pParent->data(0, Qt::UserRole).toInt();
 
         TKey* pParentTrigger = mpHost->getKeyUnit()->getKey(parentID);
         if (pParentTrigger) {
@@ -4011,7 +4011,7 @@ void dlgTriggerEditor::addKey(bool isFolder)
     pT->setIsFolder(isFolder);
     pT->setIsActive(false);
     pT->registerKey();
-    int const childID = pT->getID();
+    const int childID = pT->getID();
     pNewItem->setData(0, Qt::UserRole, childID);
     QIcon icon;
     QString itemDescription;
@@ -4057,7 +4057,7 @@ void dlgTriggerEditor::addAlias(bool isFolder)
     TAlias* pT = nullptr;
 
     if (pParent) {
-        int const parentID = pParent->data(0, Qt::UserRole).toInt();
+        const int parentID = pParent->data(0, Qt::UserRole).toInt();
 
         TAlias* pParentTrigger = mpHost->getAliasUnit()->getAlias(parentID);
         if (pParentTrigger) {
@@ -4102,7 +4102,7 @@ void dlgTriggerEditor::addAlias(bool isFolder)
     pT->setIsFolder(isFolder);
     pT->setIsActive(false);
     pT->registerAlias();
-    int const childID = pT->getID();
+    const int childID = pT->getID();
     pNewItem->setData(0, Qt::UserRole, childID);
     QIcon icon;
     QString itemDescription;
@@ -4152,7 +4152,7 @@ void dlgTriggerEditor::addAction(bool isFolder)
     QPointer<TAction> pT = nullptr;
 
     if (pParent) {
-        int const parentID = pParent->data(0, Qt::UserRole).toInt();
+        const int parentID = pParent->data(0, Qt::UserRole).toInt();
 
         TAction* pParentAction = mpHost->getActionUnit()->getAction(parentID);
         if (pParentAction) {
@@ -4189,7 +4189,7 @@ void dlgTriggerEditor::addAction(bool isFolder)
     pT->setIsFolder(isFolder);
     pT->setIsActive(false);
     pT->registerAction();
-    int const childID = pT->getID();
+    const int childID = pT->getID();
     pNewItem->setData(0, Qt::UserRole, childID);
     QIcon icon;
     QString itemDescription;
@@ -4240,7 +4240,7 @@ void dlgTriggerEditor::addScript(bool isFolder)
     TScript* pT = nullptr;
 
     if (pParent) {
-        int const parentID = pParent->data(0, Qt::UserRole).toInt();
+        const int parentID = pParent->data(0, Qt::UserRole).toInt();
 
         TScript* pParentTrigger = mpHost->getScriptUnit()->getScript(parentID);
         if (pParentTrigger) {
@@ -4283,7 +4283,7 @@ void dlgTriggerEditor::addScript(bool isFolder)
     pT->setIsFolder(isFolder);
     pT->setIsActive(false);
     pT->registerScript();
-    int const childID = pT->getID();
+    const int childID = pT->getID();
     pNewItem->setData(0, Qt::UserRole, childID);
     QIcon icon;
     QString itemDescription;
@@ -4422,7 +4422,7 @@ void dlgTriggerEditor::saveTrigger()
     QList<int> patternKinds;
     for (int i = 0; i < 50; i++) {
         QString pattern = mTriggerPatternEdit.at(i)->lineEdit_pattern->text();
-        int const patternType = mTriggerPatternEdit.at(i)->comboBox_patternType->currentIndex();
+        const int patternType = mTriggerPatternEdit.at(i)->comboBox_patternType->currentIndex();
         if (pattern.isEmpty() && patternType != REGEX_PROMPT && patternType != REGEX_LINE_SPACER) {
             continue;
         }
@@ -4459,7 +4459,7 @@ void dlgTriggerEditor::saveTrigger()
 
     const QString script = mpSourceEditorEdbeeDocument->text();
 
-    int const triggerID = pItem->data(0, Qt::UserRole).toInt();
+    const int triggerID = pItem->data(0, Qt::UserRole).toInt();
     TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(triggerID);
     if (pT) {
         const QString old_name = pT->getName();
@@ -4598,15 +4598,15 @@ void dlgTriggerEditor::saveTimer()
     const QString script = mpSourceEditorEdbeeDocument->text();
 
 
-    int const timerID = pItem->data(0, Qt::UserRole).toInt();
+    const int timerID = pItem->data(0, Qt::UserRole).toInt();
     TTimer* pT = mpHost->getTimerUnit()->getTimer(timerID);
     if (pT) {
         pT->setName(name);
         const QString command = mpTimersMainArea->lineEdit_timer_command->text();
-        int const hours = mpTimersMainArea->timeEdit_timer_hours->time().hour();
-        int const minutes = mpTimersMainArea->timeEdit_timer_minutes->time().minute();
-        int const secs = mpTimersMainArea->timeEdit_timer_seconds->time().second();
-        int const msecs = mpTimersMainArea->timeEdit_timer_msecs->time().msec();
+        const int hours = mpTimersMainArea->timeEdit_timer_hours->time().hour();
+        const int minutes = mpTimersMainArea->timeEdit_timer_minutes->time().minute();
+        const int secs = mpTimersMainArea->timeEdit_timer_seconds->time().second();
+        const int msecs = mpTimersMainArea->timeEdit_timer_msecs->time().msec();
         QTime const time(hours, minutes, secs, msecs);
         pT->setTime(time);
         pT->setCommand(command);
@@ -4734,7 +4734,7 @@ void dlgTriggerEditor::saveAlias()
     const QString script = mpSourceEditorEdbeeDocument->text();
 
 
-    int const triggerID = pItem->data(0, Qt::UserRole).toInt();
+    const int triggerID = pItem->data(0, Qt::UserRole).toInt();
     TAlias* pT = mpHost->getAliasUnit()->getAlias(triggerID);
     if (pT) {
         const QString old_name = pT->getName();
@@ -4849,8 +4849,8 @@ void dlgTriggerEditor::saveAction()
     const QString commandUp = mpActionsMainArea->lineEdit_action_button_command_up->text();
     const QString script = mpSourceEditorEdbeeDocument->text();
     // currentIndex() can return -1 if no setting was previously made - need to fixup:
-    int const rotation = qMax(0, mpActionsMainArea->comboBox_action_button_rotation->currentIndex());
-    int const columns = mpActionsMainArea->spinBox_action_bar_columns->text().toInt();
+    const int rotation = qMax(0, mpActionsMainArea->comboBox_action_button_rotation->currentIndex());
+    const int columns = mpActionsMainArea->spinBox_action_bar_columns->text().toInt();
     bool const isChecked = mpActionsMainArea->checkBox_action_button_isPushDown->isChecked();
     // bottom location is no longer supported i.e. location = 1 = 0 = location top
     // currentIndex() can return -1 if no setting was previously made - need to fixup:
@@ -4860,12 +4860,12 @@ void dlgTriggerEditor::saveAction()
     }
 
     // currentIndex() can return -1 if no setting was previously made - need to fixup:
-    int const orientation = qMax(0, mpActionsMainArea->comboBox_action_bar_orientation->currentIndex());
+    const int orientation = qMax(0, mpActionsMainArea->comboBox_action_bar_orientation->currentIndex());
 
     // This is an unnecessary level of indentation but has been retained to
     // reduce the noise in a git commit/diff caused by the removal of a
     // redundant "if( pITem )" - can be removed next time the file is modified
-    int const actionID = pItem->data(0, Qt::UserRole).toInt();
+    const int actionID = pItem->data(0, Qt::UserRole).toInt();
     TAction* pA = mpHost->getActionUnit()->getAction(actionID);
     if (pA) {
         // Check if data has been changed before it gets updated.
@@ -4995,7 +4995,7 @@ void dlgTriggerEditor::writeScript(int id)
     if (mCurrentView == EditorViewType::cmUnknownView || mCurrentView != EditorViewType::cmScriptView) {
         return;
     }
-    int const scriptID = pItem->data(0, Qt::UserRole).toInt();
+    const int scriptID = pItem->data(0, Qt::UserRole).toInt();
     if (scriptID != id) {
         return;
     }
@@ -5036,7 +5036,7 @@ void dlgTriggerEditor::saveScript()
     }
 
 
-    int const scriptID = pItem->data(0, Qt::UserRole).toInt();
+    const int scriptID = pItem->data(0, Qt::UserRole).toInt();
     TScript* pT = mpHost->getScriptUnit()->getScript(scriptID);
     if (!pT) {
         return;
@@ -5148,8 +5148,8 @@ int dlgTriggerEditor::canRecast(QTreeWidgetItem* pItem, int newNameType, int new
     if (!var) {
         return 2;
     }
-    int const currentNameType = var->getKeyType();
-    int const currentValueType = var->getValueType();
+    const int currentNameType = var->getKeyType();
+    const int currentValueType = var->getValueType();
     //most anything is ok to do.  We just want to enforce these rules:
     //you cannot change the type of a table that has children
     //rule removed to see if anything bad happens:
@@ -5214,7 +5214,7 @@ void dlgTriggerEditor::saveVar()
         uiNameType = LUA_TNONE;
     }
     //check variable recasting
-    int const varRecast = canRecast(pItem, uiNameType, uiValueType);
+    const int varRecast = canRecast(pItem, uiNameType, uiValueType);
     if ((uiNameType == -1) || (variable && uiNameType != variable->getKeyType())) {
         if (QString(newName).toInt()) {
             uiNameType = LUA_TNUMBER;
@@ -5391,7 +5391,7 @@ void dlgTriggerEditor::saveKey()
     const QString script = mpSourceEditorEdbeeDocument->text();
 
 
-    int const triggerID = pItem->data(0, Qt::UserRole).toInt();
+    const int triggerID = pItem->data(0, Qt::UserRole).toInt();
     TKey* pT = mpHost->getKeyUnit()->getKey(triggerID);
     if (pT) {
         pItem->setText(0, name);
@@ -5521,7 +5521,7 @@ void dlgTriggerEditor::slot_setupPatternControls(int type)
         return;
     }
 
-    int const row = pBox->itemData(0).toInt();
+    const int row = pBox->itemData(0).toInt();
     if (row < 0 || row >= 50) {
         return;
     }
@@ -5626,7 +5626,7 @@ void dlgTriggerEditor::slot_triggerSelected(QTreeWidgetItem* pItem)
     mpTriggersMainArea->pushButtonBgColor->setProperty(cButtonBaseColor, QVariant());
     mpTriggersMainArea->spinBox_lineMargin->setValue(1);
 
-    int const ID = pItem->data(0, Qt::UserRole).toInt();
+    const int ID = pItem->data(0, Qt::UserRole).toInt();
     TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(ID);
     if (pT) {
         QStringList const patternList = pT->getPatternsList();
@@ -5645,7 +5645,7 @@ void dlgTriggerEditor::slot_triggerSelected(QTreeWidgetItem* pItem)
             }
             // Use operator[] so we have write access to the array/list member:
             dlgTriggerPatternEdit* pPatternItem = mTriggerPatternEdit[i];
-            int const pType = propertyList.at(i);
+            const int pType = propertyList.at(i);
             if (!pType) {
                 // If the control is for the default (0) case nudge the setting
                 // up and down so that it copies the colour icon for the
@@ -5790,7 +5790,7 @@ void dlgTriggerEditor::slot_aliasSelected(QTreeWidgetItem* pItem)
     clearDocument(mpSourceEditorEdbee); // Alias Select
 
     mpAliasMainArea->lineEdit_alias_name->setText(pItem->text(0));
-    int const ID = pItem->data(0, Qt::UserRole).toInt();
+    const int ID = pItem->data(0, Qt::UserRole).toInt();
     TAlias* pT = mpHost->getAliasUnit()->getAlias(ID);
     if (pT) {
         const QString pattern = pT->getRegexCode();
@@ -5839,7 +5839,7 @@ void dlgTriggerEditor::slot_keySelected(QTreeWidgetItem* pItem)
     clearDocument(mpSourceEditorEdbee); // Key Select
 
     mpKeysMainArea->lineEdit_key_binding->setText(pItem->text(0));
-    int const ID = pItem->data(0, Qt::UserRole).toInt();
+    const int ID = pItem->data(0, Qt::UserRole).toInt();
     TKey* pT = mpHost->getKeyUnit()->getKey(ID);
     if (pT) {
         const QString command = pT->getCommand();
@@ -5903,8 +5903,8 @@ void dlgTriggerEditor::slot_variableChanged(QTreeWidgetItem* pItem)
     if (!pItem || mChangingVar) {
         return;
     }
-    int const column = 0;
-    int const state = pItem->checkState(column);
+    const int column = 0;
+    const int state = pItem->checkState(column);
     LuaInterface* lI = mpHost->getLuaInterface();
     VarUnit* vu = lI->getVarUnit();
     TVar* var = vu->getWVar(pItem);
@@ -5973,8 +5973,8 @@ void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
     }
 
     mChangingVar = true;
-    int const column = treeWidget_variables->currentColumn();
-    int const state = pItem->checkState(column);
+    const int column = treeWidget_variables->currentColumn();
+    const int state = pItem->checkState(column);
     LuaInterface* lI = mpHost->getLuaInterface();
     VarUnit* vu = lI->getVarUnit();
     TVar* var = vu->getWVar(pItem); // This does NOT modify pItem or what it points at
@@ -6048,8 +6048,8 @@ void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
         return;
     }
 
-    int const varType = var->getValueType();
-    int const keyType = var->getKeyType();
+    const int varType = var->getValueType();
+    const int keyType = var->getKeyType();
     QIcon icon;
 
     switch (keyType) {
@@ -6189,7 +6189,7 @@ void dlgTriggerEditor::slot_actionSelected(QTreeWidgetItem* pItem)
     mpCurrentActionItem = pItem; //remember what has been clicked to save it
     // ID will be 0 for the root of the treewidget and it is not appropriate
     // to show any right hand side details - pT will also be nullptr!
-    int const ID = pItem->data(0, Qt::UserRole).toInt();
+    const int ID = pItem->data(0, Qt::UserRole).toInt();
     TAction* pT = mpHost->getActionUnit()->getAction(ID);
     if (pT) {
         mpActionsMainArea->lineEdit_action_name->setText(pT->getName());
@@ -6324,7 +6324,7 @@ void dlgTriggerEditor::slot_scriptsSelected(QTreeWidgetItem* pItem)
     mpScriptsMainArea->lineEdit_script_name->clear();
     mpScriptsMainArea->listWidget_script_registered_event_handlers->clear();
     mpScriptsMainArea->lineEdit_script_name->setText(pItem->text(0));
-    int const ID = pItem->data(0, Qt::UserRole).toInt();
+    const int ID = pItem->data(0, Qt::UserRole).toInt();
     TScript* pT = mpHost->getScriptUnit()->getScript(ID);
     if (pT) {
         const QString name = pT->getName();
@@ -6378,7 +6378,7 @@ void dlgTriggerEditor::slot_timerSelected(QTreeWidgetItem* pItem)
     mpTimersMainArea->timeEdit_timer_msecs->setTime(QTime(0, 0, 0, 0));
     mpTimersMainArea->lineEdit_timer_name->setText(pItem->text(0));
 
-    int const ID = pItem->data(0, Qt::UserRole).toInt();
+    const int ID = pItem->data(0, Qt::UserRole).toInt();
     TTimer* pT = mpHost->getTimerUnit()->getTimer(ID);
     if (pT) {
         const QString command = pT->getCommand();
@@ -8480,7 +8480,7 @@ void dlgTriggerEditor::exportTrigger(const QString& fileName)
     TTrigger* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_triggers->currentItem();
     if (pItem) {
-        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
+        const int triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getTriggerUnit()->getTrigger(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8504,7 +8504,7 @@ void dlgTriggerEditor::exportTimer(const QString& fileName)
     TTimer* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_timers->currentItem();
     if (pItem) {
-        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
+        const int triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getTimerUnit()->getTimer(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8528,7 +8528,7 @@ void dlgTriggerEditor::exportAlias(const QString& fileName)
     TAlias* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_aliases->currentItem();
     if (pItem) {
-        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
+        const int triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getAliasUnit()->getAlias(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8552,7 +8552,7 @@ void dlgTriggerEditor::exportAction(const QString& fileName)
     TAction* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_actions->currentItem();
     if (pItem) {
-        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
+        const int triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getActionUnit()->getAction(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8576,7 +8576,7 @@ void dlgTriggerEditor::exportScript(const QString& fileName)
     TScript* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_scripts->currentItem();
     if (pItem) {
-        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
+        const int triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getScriptUnit()->getScript(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8600,7 +8600,7 @@ void dlgTriggerEditor::exportKey(const QString& fileName)
     TKey* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_keys->currentItem();
     if (pItem) {
-        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
+        const int triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getKeyUnit()->getKey(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8625,7 +8625,7 @@ void dlgTriggerEditor::exportTriggerToClipboard()
     TTrigger* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_triggers->currentItem();
     if (pItem) {
-        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
+        const int triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getTriggerUnit()->getTrigger(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8648,7 +8648,7 @@ void dlgTriggerEditor::exportTimerToClipboard()
     TTimer* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_timers->currentItem();
     if (pItem) {
-        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
+        const int triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getTimerUnit()->getTimer(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8671,7 +8671,7 @@ void dlgTriggerEditor::exportAliasToClipboard()
     TAlias* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_aliases->currentItem();
     if (pItem) {
-        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
+        const int triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getAliasUnit()->getAlias(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8694,7 +8694,7 @@ void dlgTriggerEditor::exportActionToClipboard()
     TAction* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_actions->currentItem();
     if (pItem) {
-        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
+        const int triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getActionUnit()->getAction(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8717,7 +8717,7 @@ void dlgTriggerEditor::exportScriptToClipboard()
     TScript* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_scripts->currentItem();
     if (pItem) {
-        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
+        const int triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getScriptUnit()->getScript(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8740,7 +8740,7 @@ void dlgTriggerEditor::exportKeyToClipboard()
     TKey* pT = nullptr;
     QTreeWidgetItem* pItem = treeWidget_keys->currentItem();
     if (pItem) {
-        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
+        const int triggerID = pItem->data(0, Qt::UserRole).toInt();
         pT = mpHost->getKeyUnit()->getKey(triggerID);
         if (pT) {
             name = pT->getName();
@@ -8893,7 +8893,7 @@ void dlgTriggerEditor::slot_pasteXml()
         auto parentRow = parent.row();
         auto parentId = parent.data(Qt::UserRole).toInt();
 
-        int const siblingRow = treeWidget_triggers->currentIndex().row() + 1;
+        const int siblingRow = treeWidget_triggers->currentIndex().row() + 1;
         mpHost->getTriggerUnit()->reParentTrigger(importedItemID, 0, parentId, parentRow, siblingRow);
         break;
     }
@@ -8902,7 +8902,7 @@ void dlgTriggerEditor::slot_pasteXml()
         auto parentRow = parent.row();
         auto parentId = parent.data(Qt::UserRole).toInt();
 
-        int const siblingRow = treeWidget_timers->currentIndex().row() + 1;
+        const int siblingRow = treeWidget_timers->currentIndex().row() + 1;
         mpHost->getTimerUnit()->reParentTimer(importedItemID, 0, parentId, parentRow, siblingRow);
         break;
     }
@@ -8911,7 +8911,7 @@ void dlgTriggerEditor::slot_pasteXml()
         auto parentRow = parent.row();
         auto parentId = parent.data(Qt::UserRole).toInt();
 
-        int const siblingRow = treeWidget_aliases->currentIndex().row() + 1;
+        const int siblingRow = treeWidget_aliases->currentIndex().row() + 1;
         mpHost->getAliasUnit()->reParentAlias(importedItemID, 0, parentId, parentRow, siblingRow);
         break;
     }
@@ -8920,7 +8920,7 @@ void dlgTriggerEditor::slot_pasteXml()
         auto parentRow = parent.row();
         auto parentId = parent.data(Qt::UserRole).toInt();
 
-        int const siblingRow = treeWidget_scripts->currentIndex().row() + 1;
+        const int siblingRow = treeWidget_scripts->currentIndex().row() + 1;
         mpHost->getScriptUnit()->reParentScript(importedItemID, 0, parentId, parentRow, siblingRow);
         break;
     }
@@ -8929,7 +8929,7 @@ void dlgTriggerEditor::slot_pasteXml()
         auto parentRow = parent.row();
         auto parentId = parent.data(Qt::UserRole).toInt();
 
-        int const siblingRow = treeWidget_actions->currentIndex().row() + 1;
+        const int siblingRow = treeWidget_actions->currentIndex().row() + 1;
         mpHost->getActionUnit()->reParentAction(importedItemID, 0, parentId, parentRow, siblingRow);
         break;
     }
@@ -8938,7 +8938,7 @@ void dlgTriggerEditor::slot_pasteXml()
         auto parentRow = parent.row();
         auto parentId = parent.data(Qt::UserRole).toInt();
 
-        int const siblingRow = treeWidget_keys->currentIndex().row() + 1;
+        const int siblingRow = treeWidget_keys->currentIndex().row() + 1;
         mpHost->getKeyUnit()->reParentKey(importedItemID, 0, parentId, parentRow, siblingRow);
         break;
     }
@@ -9269,7 +9269,7 @@ void dlgTriggerEditor::key_grab_callback(const Qt::Key key, const Qt::KeyboardMo
     mpKeysMainArea->lineEdit_key_binding->setText(name);
     QTreeWidgetItem* pItem = treeWidget_keys->currentItem();
     if (pItem) {
-        int const triggerID = pItem->data(0, Qt::UserRole).toInt();
+        const int triggerID = pItem->data(0, Qt::UserRole).toInt();
         TKey* pT = mpHost->getKeyUnit()->getKey(triggerID);
         if (pT) {
             pT->setKeyCode(key);
@@ -9377,7 +9377,7 @@ void dlgTriggerEditor::slot_colorTriggerFg()
     if (!pItem) {
         return;
     }
-    int const triggerID = pItem->data(0, Qt::UserRole).toInt();
+    const int triggerID = pItem->data(0, Qt::UserRole).toInt();
     TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(triggerID);
     if (!pT) {
         return;
@@ -9441,7 +9441,7 @@ void dlgTriggerEditor::slot_colorTriggerBg()
     if (!pItem) {
         return;
     }
-    int const triggerID = pItem->data(0, Qt::UserRole).toInt();
+    const int triggerID = pItem->data(0, Qt::UserRole).toInt();
     TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(triggerID);
     if (!pT) {
         return;

--- a/src/exitstreewidget.cpp
+++ b/src/exitstreewidget.cpp
@@ -42,7 +42,7 @@ void ExitsTreeWidget::keyPressEvent(QKeyEvent* event)
         closePersistentEditor(currentItem(), colIndex_command);
     }
     if (event->key() == Qt::Key_Delete && hasFocus()) {
-        QList<QTreeWidgetItem*> selection = selectedItems();
+        QList<QTreeWidgetItem*> const selection = selectedItems();
         for (auto pItem : selection) {
             takeTopLevelItem(indexOfTopLevelItem(pItem));
         }

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -463,7 +463,7 @@ void GLWidget::paintGL()
             exitList.push_back(pR->getNorthwest());
             exitList.push_back(pR->getUp());
             exitList.push_back(pR->getDown());
-            int const e = pR->z;
+            const int e = pR->z;
             const int ef = abs(e % 26);
             glMaterialfv(GL_FRONT, GL_AMBIENT_AND_DIFFUSE, planeColor[ef]);
             glMateriali(GL_FRONT, GL_SHININESS, 1);
@@ -486,7 +486,7 @@ void GLWidget::paintGL()
                               planeColor[ef][2],
                               planeColor[ef][3]);*/
                 }
-                for (int const k : exitList) {
+                for (const int k : exitList) {
                     bool areaExit = false;
                     if (k == -1) {
                         continue;
@@ -897,7 +897,7 @@ void GLWidget::paintGL()
                     }
                 }
             } else {
-                for (int const k : exitList) {
+                for (const int k : exitList) {
                     bool areaExit = false;
                     if (k == -1) {
                         continue;
@@ -1330,7 +1330,7 @@ void GLWidget::paintGL()
         QSetIterator<int> itRoom(pArea->getAreaRooms());
         while (itRoom.hasNext()) {
             glDisable(GL_LIGHT1);
-            int const currentRoomId = itRoom.next();
+            const int currentRoomId = itRoom.next();
             TRoom* pR = mpMap->mpRoomDB->getRoom(currentRoomId);
             if (!pR) {
                 continue;
@@ -1353,7 +1353,7 @@ void GLWidget::paintGL()
                 }
             }
 
-            int const e = pR->z;
+            const int e = pR->z;
             const int ef = abs(e % 26);
             glMaterialfv(GL_FRONT, GL_AMBIENT_AND_DIFFUSE, planeColor[ef]);
             glMateriali(GL_FRONT, GL_SHININESS, 36); //gut:96
@@ -2060,8 +2060,8 @@ void GLWidget::mousePressEvent(QMouseEvent* event)
 #else
         auto eventPos = event->position().toPoint();
 #endif
-        int const x = eventPos.x();
-        int const y = height() - eventPos.y(); // the opengl origin is at bottom left
+        const int x = eventPos.x();
+        const int y = height() - eventPos.y(); // the opengl origin is at bottom left
         GLuint buff[16] = {0};
         GLint hits;
         GLint view[4];
@@ -2169,8 +2169,8 @@ void GLWidget::mouseReleaseEvent(QMouseEvent* event)
 
 void GLWidget::wheelEvent(QWheelEvent* e)
 {
-    int const xDelta = qRound(e->angleDelta().x() / (8.0 * 15.0));
-    int const yDelta = qRound(e->angleDelta().y() / (8.0 * 15.0));
+    const int xDelta = qRound(e->angleDelta().x() / (8.0 * 15.0));
+    const int yDelta = qRound(e->angleDelta().y() / (8.0 * 15.0));
     bool used = false;
     if (yDelta) {
         if (abs(mScale) < 0.3) {

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -223,7 +223,7 @@ void GLWidget::slot_setCameraPositionZ(int angle)
 
 void GLWidget::initializeGL()
 {
-    QColor color(QColorConstants::Black);
+    QColor const color(QColorConstants::Black);
     glClearColor(color.redF(), color.greenF(), color.blueF(), color.alphaF());
     xRot = 1;
     yRot = 5;
@@ -463,7 +463,7 @@ void GLWidget::paintGL()
             exitList.push_back(pR->getNorthwest());
             exitList.push_back(pR->getUp());
             exitList.push_back(pR->getDown());
-            int e = pR->z;
+            int const e = pR->z;
             const int ef = abs(e % 26);
             glMaterialfv(GL_FRONT, GL_AMBIENT_AND_DIFFUSE, planeColor[ef]);
             glMateriali(GL_FRONT, GL_SHININESS, 1);
@@ -486,7 +486,7 @@ void GLWidget::paintGL()
                               planeColor[ef][2],
                               planeColor[ef][3]);*/
                 }
-                for (int k : exitList) {
+                for (int const k : exitList) {
                     bool areaExit = false;
                     if (k == -1) {
                         continue;
@@ -503,8 +503,8 @@ void GLWidget::paintGL()
                     auto ex = static_cast<float>(pExit->x);
                     auto ey = static_cast<float>(pExit->y);
                     auto ez = static_cast<float>(pExit->z);
-                    QVector3D p1(ex, ey, ez);
-                    QVector3D p2(rx, ry, rz);
+                    QVector3D const p1(ex, ey, ez);
+                    QVector3D const p2(rx, ry, rz);
                     glLoadIdentity();
                     gluLookAt(px * 0.1 + xRot, py * 0.1 + yRot, pz * 0.1 + zRot, px * 0.1, py * 0.1, pz * 0.1, 0.0, 1.0, 0.0);
                     glScalef(0.1, 0.1, 0.1);
@@ -781,7 +781,7 @@ void GLWidget::paintGL()
                             if (!mpMap->mCustomEnvColors.contains(env)) {
                                 if (16 < env && env < 232)
                                 {
-                                    quint8 base = env - 16;
+                                    quint8 const base = env - 16;
                                     quint8 r = base / 36;
                                     quint8 g = (base - (r * 36)) / 6;
                                     quint8 b = (base - (r * 36)) - (g * 6);
@@ -795,7 +795,7 @@ void GLWidget::paintGL()
                                     mc3[2] = b / 255.0;
                                     mc3[3] = 0.2;
                                 } else if (231 < env && env < 256) {
-                                    quint8 k = ((env - 232) * 10) + 8;
+                                    quint8 const k = ((env - 232) * 10) + 8;
                                     glColor4ub(k, k, k, 200);
                                     mc3[0] = k / 255.0;
                                     mc3[1] = k / 255.0;
@@ -804,7 +804,7 @@ void GLWidget::paintGL()
                                 }
                                 break;
                             }
-                            QColor& _c = mpMap->mCustomEnvColors[env];
+                            QColor const& _c = mpMap->mCustomEnvColors[env];
                             glColor4ub(_c.red(), _c.green(), _c.blue(), 25);
                             mc3[0] = _c.redF();
                             mc3[1] = _c.greenF();
@@ -897,7 +897,7 @@ void GLWidget::paintGL()
                     }
                 }
             } else {
-                for (int k : exitList) {
+                for (int const k : exitList) {
                     bool areaExit = false;
                     if (k == -1) {
                         continue;
@@ -915,8 +915,8 @@ void GLWidget::paintGL()
                     auto ex = static_cast<float>(pExit->x);
                     auto ey = static_cast<float>(pExit->y);
                     auto ez = static_cast<float>(pExit->z);
-                    QVector3D p1(ex, ey, ez);
-                    QVector3D p2(rx, ry, rz);
+                    QVector3D const p1(ex, ey, ez);
+                    QVector3D const p2(rx, ry, rz);
                     glLoadIdentity();
                     gluLookAt(px * 0.1 + xRot, py * 0.1 + yRot, pz * 0.1 + zRot, px * 0.1, py * 0.1, pz * 0.1, 0.0, 1.0, 0.0);
                     glScalef(0.1, 0.1, 0.1);
@@ -1191,7 +1191,7 @@ void GLWidget::paintGL()
                             if (!mpMap->mCustomEnvColors.contains(env)) {
                                 if (16 < env && env < 232)
                                 {
-                                    quint8 base = env - 16;
+                                    quint8 const base = env - 16;
                                     quint8 r = base / 36;
                                     quint8 g = (base - (r * 36)) / 6;
                                     quint8 b = (base - (r * 36)) - (g * 6);
@@ -1205,7 +1205,7 @@ void GLWidget::paintGL()
                                     mc3[2] = b / 255.0;
                                     mc3[3] = 0.2;
                                 } else if (231 < env && env < 256) {
-                                    quint8 k = ((env - 232) * 10) + 8;
+                                    quint8 const k = ((env - 232) * 10) + 8;
                                     glColor4ub(k, k, k, 200);
                                     mc3[0] = k / 255.0;
                                     mc3[1] = k / 255.0;
@@ -1214,7 +1214,7 @@ void GLWidget::paintGL()
                                 }
                                 break;
                             }
-                            QColor& _c = mpMap->mCustomEnvColors[env];
+                            QColor const& _c = mpMap->mCustomEnvColors[env];
                             glColor4ub(_c.red(), _c.green(), _c.blue(), 255);
                             mc3[0] = _c.redF();
                             mc3[1] = _c.greenF();
@@ -1330,7 +1330,7 @@ void GLWidget::paintGL()
         QSetIterator<int> itRoom(pArea->getAreaRooms());
         while (itRoom.hasNext()) {
             glDisable(GL_LIGHT1);
-            int currentRoomId = itRoom.next();
+            int const currentRoomId = itRoom.next();
             TRoom* pR = mpMap->mpRoomDB->getRoom(currentRoomId);
             if (!pR) {
                 continue;
@@ -1353,7 +1353,7 @@ void GLWidget::paintGL()
                 }
             }
 
-            int e = pR->z;
+            int const e = pR->z;
             const int ef = abs(e % 26);
             glMaterialfv(GL_FRONT, GL_AMBIENT_AND_DIFFUSE, planeColor[ef]);
             glMateriali(GL_FRONT, GL_SHININESS, 36); //gut:96
@@ -1585,7 +1585,7 @@ void GLWidget::paintGL()
                     if (!mpMap->mCustomEnvColors.contains(env)) {
                         if (16 < env && env < 232)
                         {
-                            quint8 base = env - 16;
+                            quint8 const base = env - 16;
                             quint8 r = base / 36;
                             quint8 g = (base - (r * 36)) / 6;
                             quint8 b = (base - (r * 36)) - (g * 6);
@@ -1599,7 +1599,7 @@ void GLWidget::paintGL()
                             mc3[2] = b / 255.0;
                             mc3[3] = 0.2;
                         } else if (231 < env && env < 256) {
-                            quint8 k = ((env - 232) * 10) + 8;
+                            quint8 const k = ((env - 232) * 10) + 8;
                             glColor4ub(k, k, k, 200);
                             mc3[0] = k / 255.0;
                             mc3[1] = k / 255.0;
@@ -1608,7 +1608,7 @@ void GLWidget::paintGL()
                         }
                         break;
                     }
-                    QColor& _c = mpMap->mCustomEnvColors[env];
+                    QColor const& _c = mpMap->mCustomEnvColors[env];
                     glColor4ub(_c.red(), _c.green(), _c.blue(), 255);
                     mc3[0] = _c.redF();
                     mc3[1] = _c.greenF();
@@ -1888,7 +1888,7 @@ void GLWidget::paintGL()
                 if (!mpMap->mCustomEnvColors.contains(env)) {
                     if (16 < env && env < 232)
                     {
-                        quint8 base = env - 16;
+                        quint8 const base = env - 16;
                         quint8 r = base / 36;
                         quint8 g = (base - (r * 36)) / 6;
                         quint8 b = (base - (r * 36)) - (g * 6);
@@ -1902,7 +1902,7 @@ void GLWidget::paintGL()
                         mc3[2] = b / 255.0;
                         mc3[3] = 0.2;
                     } else if (231 < env && env < 256) {
-                        quint8 k = ((env - 232) * 10) + 8;
+                        quint8 const k = ((env - 232) * 10) + 8;
                         glColor4ub(k, k, k, 200);
                         mc3[0] = k / 255.0;
                         mc3[1] = k / 255.0;
@@ -1911,7 +1911,7 @@ void GLWidget::paintGL()
                     }
                     break;
                 }
-                QColor& _c = mpMap->mCustomEnvColors[env];
+                QColor const& _c = mpMap->mCustomEnvColors[env];
                 glColor4ub(_c.red(), _c.green(), _c.blue(), 255);
                 mc3[0] = _c.redF();
                 mc3[1] = _c.greenF();
@@ -2060,8 +2060,8 @@ void GLWidget::mousePressEvent(QMouseEvent* event)
 #else
         auto eventPos = event->position().toPoint();
 #endif
-        int x = eventPos.x();
-        int y = height() - eventPos.y(); // the opengl origin is at bottom left
+        int const x = eventPos.x();
+        int const y = height() - eventPos.y(); // the opengl origin is at bottom left
         GLuint buff[16] = {0};
         GLint hits;
         GLint view[4];
@@ -2169,8 +2169,8 @@ void GLWidget::mouseReleaseEvent(QMouseEvent* event)
 
 void GLWidget::wheelEvent(QWheelEvent* e)
 {
-    int xDelta = qRound(e->angleDelta().x() / (8.0 * 15.0));
-    int yDelta = qRound(e->angleDelta().y() / (8.0 * 15.0));
+    int const xDelta = qRound(e->angleDelta().x() / (8.0 * 15.0));
+    int const yDelta = qRound(e->angleDelta().y() / (8.0 * 15.0));
     bool used = false;
     if (yDelta) {
         if (abs(mScale) < 0.3) {

--- a/src/ircmessageformatter.cpp
+++ b/src/ircmessageformatter.cpp
@@ -175,7 +175,7 @@ QString IrcMessageFormatter::formatKickMessage(IrcKickMessage* message, bool isF
 QString IrcMessageFormatter::formatModeMessage(IrcModeMessage* message, bool isForLua)
 {
     Q_UNUSED(isForLua)
-    QString args = message->arguments().join(" ");
+    QString const args = message->arguments().join(" ");
     if (message->isReply()) {
         return QObject::tr("! %1 mode is %2 %3").arg(message->target(), message->mode(), args);
     } else {
@@ -207,7 +207,7 @@ QString IrcMessageFormatter::formatNamesMessage(IrcNamesMessage* message, bool i
     if (isForLua) {
         // lua actually needs the names for parsing, since getting a names
         // list from the UI userModel alone would be limiting to the IRC commands.
-        QString nameList = message->names().join(" ");
+        QString const nameList = message->names().join(" ");
         return QObject::tr("! %1 has %2 users: %3").arg(message->channel(), count, nameList);
     } else {
         return QObject::tr("! %1 has %2 users").arg(message->channel(), count);
@@ -256,7 +256,7 @@ QString IrcMessageFormatter::formatNoticeMessage(IrcNoticeMessage* message, bool
         // lua only needs the message text.
         return IrcTextFormat().toPlainText(message->content());
     } else {
-        QString content = IrcTextFormat().toHtml(message->content());
+        QString const content = IrcTextFormat().toHtml(message->content());
         return QObject::tr("&lt;%1%2&gt; [%3] %4").arg(message->nick(), pfx, message->target(), content);
     }
 }
@@ -340,8 +340,8 @@ QString IrcMessageFormatter::formatPartMessage(IrcPartMessage* message, bool isF
 QString IrcMessageFormatter::formatPongMessage(IrcPongMessage* message, bool isForLua)
 {
     Q_UNUSED(isForLua)
-    quint64 msec = message->timeStamp().toMSecsSinceEpoch();
-    quint64 dms = (QDateTime::currentMSecsSinceEpoch() - msec);
+    quint64 const msec = message->timeStamp().toMSecsSinceEpoch();
+    quint64 const dms = (QDateTime::currentMSecsSinceEpoch() - msec);
     return QObject::tr("! %1 replied in %2 seconds").arg(message->nick()).arg(dms / 1000.0, 4, 'f', 3, QLatin1Char('0'));
 }
 
@@ -465,15 +465,15 @@ QString IrcMessageFormatter::formatSeconds(int secs)
 QString IrcMessageFormatter::formatDuration(int secs)
 {
     QStringList idle;
-    if (int days = secs / 86400) {
+    if (int const days = secs / 86400) {
         idle += QObject::tr("%1 days").arg(days);
     }
     secs %= 86400;
-    if (int hours = secs / 3600) {
+    if (int const hours = secs / 3600) {
         idle += QObject::tr("%1 hours").arg(hours);
     }
     secs %= 3600;
-    if (int mins = secs / 60) {
+    if (int const mins = secs / 60) {
         idle += QObject::tr("%1 mins").arg(mins);
     }
     idle += QObject::tr("%1 secs").arg(secs % 60);

--- a/src/ircmessageformatter.cpp
+++ b/src/ircmessageformatter.cpp
@@ -175,7 +175,7 @@ QString IrcMessageFormatter::formatKickMessage(IrcKickMessage* message, bool isF
 QString IrcMessageFormatter::formatModeMessage(IrcModeMessage* message, bool isForLua)
 {
     Q_UNUSED(isForLua)
-    QString const args = message->arguments().join(" ");
+    const QString args = message->arguments().join(" ");
     if (message->isReply()) {
         return QObject::tr("! %1 mode is %2 %3").arg(message->target(), message->mode(), args);
     } else {
@@ -207,7 +207,7 @@ QString IrcMessageFormatter::formatNamesMessage(IrcNamesMessage* message, bool i
     if (isForLua) {
         // lua actually needs the names for parsing, since getting a names
         // list from the UI userModel alone would be limiting to the IRC commands.
-        QString const nameList = message->names().join(" ");
+        const QString nameList = message->names().join(" ");
         return QObject::tr("! %1 has %2 users: %3").arg(message->channel(), count, nameList);
     } else {
         return QObject::tr("! %1 has %2 users").arg(message->channel(), count);
@@ -256,7 +256,7 @@ QString IrcMessageFormatter::formatNoticeMessage(IrcNoticeMessage* message, bool
         // lua only needs the message text.
         return IrcTextFormat().toPlainText(message->content());
     } else {
-        QString const content = IrcTextFormat().toHtml(message->content());
+        const QString content = IrcTextFormat().toHtml(message->content());
         return QObject::tr("&lt;%1%2&gt; [%3] %4").arg(message->nick(), pfx, message->target(), content);
     }
 }

--- a/src/ircmessageformatter.cpp
+++ b/src/ircmessageformatter.cpp
@@ -465,15 +465,15 @@ QString IrcMessageFormatter::formatSeconds(int secs)
 QString IrcMessageFormatter::formatDuration(int secs)
 {
     QStringList idle;
-    if (int const days = secs / 86400) {
+    if (const int days = secs / 86400) {
         idle += QObject::tr("%1 days").arg(days);
     }
     secs %= 86400;
-    if (int const hours = secs / 3600) {
+    if (const int hours = secs / 3600) {
         idle += QObject::tr("%1 hours").arg(hours);
     }
     secs %= 3600;
-    if (int const mins = secs / 60) {
+    if (const int mins = secs / 60) {
         idle += QObject::tr("%1 mins").arg(mins);
     }
     idle += QObject::tr("%1 secs").arg(secs % 60);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,7 +126,7 @@ void removeOldNoteColorEmojiFonts()
 
 QTranslator* loadTranslationsForCommandLine()
 {
-    QSettings settings_new(QLatin1String("mudlet"), QLatin1String("Mudlet"));
+    QSettings const settings_new(QLatin1String("mudlet"), QLatin1String("Mudlet"));
     auto pSettings = new QSettings((settings_new.contains(QLatin1String("pos")) ? QLatin1String("mudlet") : QLatin1String("Mudlet")),
                                    (settings_new.contains(QLatin1String("pos")) ? QLatin1String("Mudlet") : QLatin1String("Mudlet 1.0")));
     auto interfaceLanguage = pSettings->value(QLatin1String("interfaceLanguage")).toString();
@@ -141,7 +141,7 @@ QTranslator* loadTranslationsForCommandLine()
     // If we allow the translations to be outside of the resource file inside
     // the application executable then this will have to be revised to handle
     // it:
-    bool isOk = pMudletTranslator->load(userLocale, qsl("mudlet"), QString("_"), qsl(":/lang"), qsl(".qm"));
+    bool const isOk = pMudletTranslator->load(userLocale, qsl("mudlet"), QString("_"), qsl(":/lang"), qsl(".qm"));
     if (!isOk) {
         return nullptr;
     }
@@ -243,27 +243,27 @@ int main(int argc, char* argv[])
     // other than that a non-null fourth argument maybe responsible for
     // making the option take a value that follows it - as such they do not
     // need to be passed to the translation system.
-    QCommandLineOption profileToOpen(QStringList() << qsl("p") << qsl("profile"), qsl("Profile to open automatically"), qsl("profile"));
+    QCommandLineOption const profileToOpen(QStringList() << qsl("p") << qsl("profile"), qsl("Profile to open automatically"), qsl("profile"));
     parser.addOption(profileToOpen);
 
-    QCommandLineOption showHelp(QStringList() << qsl("h") << qsl("help"), qsl("Display help and exit"));
+    QCommandLineOption const showHelp(QStringList() << qsl("h") << qsl("help"), qsl("Display help and exit"));
     parser.addOption(showHelp);
 
-    QCommandLineOption showVersion(QStringList() << qsl("v") << qsl("version"), qsl("Display version and exit"));
+    QCommandLineOption const showVersion(QStringList() << qsl("v") << qsl("version"), qsl("Display version and exit"));
     parser.addOption(showVersion);
 
-    QCommandLineOption beQuiet(QStringList() << qsl("q") << qsl("quiet"), qsl("Don't show the splash screen when starting"));
+    QCommandLineOption const beQuiet(QStringList() << qsl("q") << qsl("quiet"), qsl("Don't show the splash screen when starting"));
     parser.addOption(beQuiet);
 
-    QCommandLineOption mirrorToStdout(QStringList() << qsl("m") << qsl("mirror"), qsl("Mirror output of all consoles to STDOUT"));
+    QCommandLineOption const mirrorToStdout(QStringList() << qsl("m") << qsl("mirror"), qsl("Mirror output of all consoles to STDOUT"));
     parser.addOption(mirrorToStdout);
 
-    QCommandLineOption onlyPredefinedProfileToShow(QStringList() << qsl("o") << qsl("only"),
+    QCommandLineOption const onlyPredefinedProfileToShow(QStringList() << qsl("o") << qsl("only"),
                                                    qsl("Set Mudlet to only show this predefined MUD profile and hide all other predefined ones."),
                                                    qsl("predefined_game"));
     parser.addOption(onlyPredefinedProfileToShow);
 
-    bool parsedCommandLineOk = parser.parse(app->arguments());
+    bool const parsedCommandLineOk = parser.parse(app->arguments());
 
     const QString appendLF{qsl("%1\n")};
     const QString append2LF{qsl("%1\n\n")};
@@ -371,20 +371,20 @@ int main(int argc, char* argv[])
         commandLineTranslator.clear();
     }
 
-    QStringList cliProfiles = parser.values(profileToOpen);
-    QStringList onlyProfiles = parser.values(onlyPredefinedProfileToShow);
+    QStringList const cliProfiles = parser.values(profileToOpen);
+    QStringList const onlyProfiles = parser.values(onlyPredefinedProfileToShow);
 
-    bool show_splash = !(parser.isSet(beQuiet)); // Not --quiet.
+    bool const show_splash = !(parser.isSet(beQuiet)); // Not --quiet.
     QImage splashImage = mudlet::getSplashScreen();
 
     if (show_splash) {
         QPainter painter(&splashImage);
         unsigned fontSize = 16;
-        QString sourceVersionText = QString(QCoreApplication::translate("main", "Version: %1").arg(APP_VERSION APP_BUILD));
+        QString const sourceVersionText = QString(QCoreApplication::translate("main", "Version: %1").arg(APP_VERSION APP_BUILD));
 
         bool isWithinSpace = false;
         while (!isWithinSpace) {
-            QFont font("Bitstream Vera Serif", fontSize, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
+            QFont const font("Bitstream Vera Serif", fontSize, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
             QTextLayout versionTextLayout(sourceVersionText, font, painter.device());
             versionTextLayout.beginLayout();
             // Start work in this text item
@@ -396,11 +396,11 @@ int main(int argc, char* argv[])
             //Splashscreen bitmap is (now) 320x360 - hopefully entire line will all fit into 280
             versionTextline.setPosition(QPointF(0, 0));
             // Only pretend, so we can see how much space it will take
-            QTextLine dummy = versionTextLayout.createLine();
+            QTextLine const dummy = versionTextLayout.createLine();
             if (!dummy.isValid()) {
                 // No second line so have got all text in first so can do it
                 isWithinSpace = true;
-                qreal versionTextWidth = versionTextline.naturalTextWidth();
+                qreal const versionTextWidth = versionTextline.naturalTextWidth();
                 // This is the ACTUAL width of the created text
                 versionTextline.setPosition(QPointF((320 - versionTextWidth) / 2.0, 270));
                 // And now we can place it centred horizontally
@@ -418,20 +418,20 @@ int main(int argc, char* argv[])
 
         // Repeat for other text, but we know it will fit at given size
         // PLACEMARKER: Date-stamp needing annual update
-        QString sourceCopyrightText = qsl("©️ Mudlet makers 2008-2023");
-        QFont font(qsl("Bitstream Vera Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
+        QString const sourceCopyrightText = qsl("©️ Mudlet makers 2008-2023");
+        QFont const font(qsl("Bitstream Vera Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
         QTextLayout copyrightTextLayout(sourceCopyrightText, font, painter.device());
         copyrightTextLayout.beginLayout();
         QTextLine copyrightTextline = copyrightTextLayout.createLine();
         copyrightTextline.setLineWidth(280);
         copyrightTextline.setPosition(QPointF(1, 1));
-        qreal copyrightTextWidth = copyrightTextline.naturalTextWidth();
+        qreal const copyrightTextWidth = copyrightTextline.naturalTextWidth();
         copyrightTextline.setPosition(QPointF((320 - copyrightTextWidth) / 2.0, 340));
         copyrightTextLayout.endLayout();
         painter.setPen(QColor(112, 16, 0, 255)); // #701000
         copyrightTextLayout.draw(&painter, QPointF(0, 0));
     }
-    QPixmap pixmap = QPixmap::fromImage(splashImage);
+    QPixmap const pixmap = QPixmap::fromImage(splashImage);
 #if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
     // Specifying the screen here seems to help to put the splash screen on the
     // same monitor that the main application window will be put upon on first
@@ -446,8 +446,8 @@ int main(int argc, char* argv[])
     }
     app->processEvents();
 
-    QString homeDirectory = mudlet::getMudletPath(mudlet::mainPath);
-    QDir dir;
+    QString const homeDirectory = mudlet::getMudletPath(mudlet::mainPath);
+    QDir const dir;
     bool first_launch = false;
     if (!dir.exists(homeDirectory)) {
         dir.mkpath(homeDirectory);
@@ -455,11 +455,11 @@ int main(int argc, char* argv[])
     }
 
 #if defined(INCLUDE_FONTS)
-    QString bitstreamVeraFontDirectory(qsl("%1/ttf-bitstream-vera-1.10").arg(mudlet::getMudletPath(mudlet::mainFontsPath)));
+    QString const bitstreamVeraFontDirectory(qsl("%1/ttf-bitstream-vera-1.10").arg(mudlet::getMudletPath(mudlet::mainFontsPath)));
     if (!dir.exists(bitstreamVeraFontDirectory)) {
         dir.mkpath(bitstreamVeraFontDirectory);
     }
-    QString ubuntuFontDirectory(qsl("%1/ubuntu-font-family-0.83").arg(mudlet::getMudletPath(mudlet::mainFontsPath)));
+    QString const ubuntuFontDirectory(qsl("%1/ubuntu-font-family-0.83").arg(mudlet::getMudletPath(mudlet::mainFontsPath)));
     if (!dir.exists(ubuntuFontDirectory)) {
         dir.mkpath(ubuntuFontDirectory);
     }
@@ -468,7 +468,7 @@ int main(int argc, char* argv[])
     removeOldNoteColorEmojiFonts();
     // PLACEMARKER: current Noto Color Emoji font directory specification:
     // Release: "Unicode 15.0"
-    QString notoFontDirectory{qsl("%1/noto-color-emoji-2022-09-16-v2.038").arg(mudlet::getMudletPath(mudlet::mainFontsPath))};
+    QString const notoFontDirectory{qsl("%1/noto-color-emoji-2022-09-16-v2.038").arg(mudlet::getMudletPath(mudlet::mainFontsPath))};
     if (!dir.exists(notoFontDirectory)) {
         dir.mkpath(notoFontDirectory);
     }
@@ -529,7 +529,7 @@ int main(int argc, char* argv[])
 #endif // defined(Q_OS_LINUX)
 #endif // defined(INCLUDE_FONTS)
 
-    QString homeLink = qsl("%1/mudlet-data").arg(QDir::homePath());
+    QString const homeLink = qsl("%1/mudlet-data").arg(QDir::homePath());
 #if defined(Q_OS_WIN32)
     /*
      * From Qt Documentation for:
@@ -555,7 +555,7 @@ int main(int argc, char* argv[])
         }
     }
 #else
-    QFile linkFile(homeLink);
+    QFile const linkFile(homeLink);
     if (!linkFile.exists() && first_launch) {
         QFile::link(homeDirectory, homeLink);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,7 +141,7 @@ QTranslator* loadTranslationsForCommandLine()
     // If we allow the translations to be outside of the resource file inside
     // the application executable then this will have to be revised to handle
     // it:
-    bool const isOk = pMudletTranslator->load(userLocale, qsl("mudlet"), QString("_"), qsl(":/lang"), qsl(".qm"));
+    const bool isOk = pMudletTranslator->load(userLocale, qsl("mudlet"), QString("_"), qsl(":/lang"), qsl(".qm"));
     if (!isOk) {
         return nullptr;
     }
@@ -263,7 +263,7 @@ int main(int argc, char* argv[])
                                                    qsl("predefined_game"));
     parser.addOption(onlyPredefinedProfileToShow);
 
-    bool const parsedCommandLineOk = parser.parse(app->arguments());
+    const bool parsedCommandLineOk = parser.parse(app->arguments());
 
     const QString appendLF{qsl("%1\n")};
     const QString append2LF{qsl("%1\n\n")};
@@ -374,7 +374,7 @@ int main(int argc, char* argv[])
     QStringList const cliProfiles = parser.values(profileToOpen);
     QStringList const onlyProfiles = parser.values(onlyPredefinedProfileToShow);
 
-    bool const show_splash = !(parser.isSet(beQuiet)); // Not --quiet.
+    const bool show_splash = !(parser.isSet(beQuiet)); // Not --quiet.
     QImage splashImage = mudlet::getSplashScreen();
 
     if (show_splash) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -447,7 +447,7 @@ int main(int argc, char* argv[])
     app->processEvents();
 
     const QString homeDirectory = mudlet::getMudletPath(mudlet::mainPath);
-    QDir const dir;
+    const QDir dir;
     bool first_launch = false;
     if (!dir.exists(homeDirectory)) {
         dir.mkpath(homeDirectory);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -371,8 +371,8 @@ int main(int argc, char* argv[])
         commandLineTranslator.clear();
     }
 
-    QStringList const cliProfiles = parser.values(profileToOpen);
-    QStringList const onlyProfiles = parser.values(onlyPredefinedProfileToShow);
+    const QStringList cliProfiles = parser.values(profileToOpen);
+    const QStringList onlyProfiles = parser.values(onlyPredefinedProfileToShow);
 
     const bool show_splash = !(parser.isSet(beQuiet)); // Not --quiet.
     QImage splashImage = mudlet::getSplashScreen();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -380,7 +380,7 @@ int main(int argc, char* argv[])
     if (show_splash) {
         QPainter painter(&splashImage);
         unsigned fontSize = 16;
-        QString const sourceVersionText = QString(QCoreApplication::translate("main", "Version: %1").arg(APP_VERSION APP_BUILD));
+        const QString sourceVersionText = QString(QCoreApplication::translate("main", "Version: %1").arg(APP_VERSION APP_BUILD));
 
         bool isWithinSpace = false;
         while (!isWithinSpace) {
@@ -418,7 +418,7 @@ int main(int argc, char* argv[])
 
         // Repeat for other text, but we know it will fit at given size
         // PLACEMARKER: Date-stamp needing annual update
-        QString const sourceCopyrightText = qsl("©️ Mudlet makers 2008-2023");
+        const QString sourceCopyrightText = qsl("©️ Mudlet makers 2008-2023");
         QFont const font(qsl("Bitstream Vera Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
         QTextLayout copyrightTextLayout(sourceCopyrightText, font, painter.device());
         copyrightTextLayout.beginLayout();
@@ -446,7 +446,7 @@ int main(int argc, char* argv[])
     }
     app->processEvents();
 
-    QString const homeDirectory = mudlet::getMudletPath(mudlet::mainPath);
+    const QString homeDirectory = mudlet::getMudletPath(mudlet::mainPath);
     QDir const dir;
     bool first_launch = false;
     if (!dir.exists(homeDirectory)) {
@@ -455,11 +455,11 @@ int main(int argc, char* argv[])
     }
 
 #if defined(INCLUDE_FONTS)
-    QString const bitstreamVeraFontDirectory(qsl("%1/ttf-bitstream-vera-1.10").arg(mudlet::getMudletPath(mudlet::mainFontsPath)));
+    const QString bitstreamVeraFontDirectory(qsl("%1/ttf-bitstream-vera-1.10").arg(mudlet::getMudletPath(mudlet::mainFontsPath)));
     if (!dir.exists(bitstreamVeraFontDirectory)) {
         dir.mkpath(bitstreamVeraFontDirectory);
     }
-    QString const ubuntuFontDirectory(qsl("%1/ubuntu-font-family-0.83").arg(mudlet::getMudletPath(mudlet::mainFontsPath)));
+    const QString ubuntuFontDirectory(qsl("%1/ubuntu-font-family-0.83").arg(mudlet::getMudletPath(mudlet::mainFontsPath)));
     if (!dir.exists(ubuntuFontDirectory)) {
         dir.mkpath(ubuntuFontDirectory);
     }
@@ -468,7 +468,7 @@ int main(int argc, char* argv[])
     removeOldNoteColorEmojiFonts();
     // PLACEMARKER: current Noto Color Emoji font directory specification:
     // Release: "Unicode 15.0"
-    QString const notoFontDirectory{qsl("%1/noto-color-emoji-2022-09-16-v2.038").arg(mudlet::getMudletPath(mudlet::mainFontsPath))};
+    const QString notoFontDirectory{qsl("%1/noto-color-emoji-2022-09-16-v2.038").arg(mudlet::getMudletPath(mudlet::mainFontsPath))};
     if (!dir.exists(notoFontDirectory)) {
         dir.mkpath(notoFontDirectory);
     }
@@ -529,7 +529,7 @@ int main(int argc, char* argv[])
 #endif // defined(Q_OS_LINUX)
 #endif // defined(INCLUDE_FONTS)
 
-    QString const homeLink = qsl("%1/mudlet-data").arg(QDir::homePath());
+    const QString homeLink = qsl("%1/mudlet-data").arg(QDir::homePath());
 #if defined(Q_OS_WIN32)
     /*
      * From Qt Documentation for:

--- a/src/mapInfoContributorManager.cpp
+++ b/src/mapInfoContributorManager.cpp
@@ -90,7 +90,7 @@ MapInfoProperties MapInfoContributorManager::shortInfo(int roomID, int selection
     QString infoText;
     TRoom* room = mpHost->mpMap->mpRoomDB->getRoom(roomID);
     if (room) {
-        QString areaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(areaId);
+        QString const areaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(areaId);
         static const QRegularExpression trailingPunctuation(qsl("[.,/]+$"));
         auto roomName = QString(room->name);
         if (mpHost->mMapViewOnly) {
@@ -113,7 +113,7 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
     TRoom* room = mpHost->mpMap->mpRoomDB->getRoom(roomID);
     if (room) {
         TArea* area = mpHost->mpMap->mpRoomDB->getArea(areaId);
-        QString areaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(areaId);
+        QString const areaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(areaId);
         if (area) {
             infoText = qsl("%1\n").arg(
                            tr("Area:%1%2 ID:%1%3 x:%1%4%1<‑>%1%5 y:%1%6%1<‑>%1%7 z:%1%8%1<‑>%1%9",

--- a/src/mapInfoContributorManager.cpp
+++ b/src/mapInfoContributorManager.cpp
@@ -90,7 +90,7 @@ MapInfoProperties MapInfoContributorManager::shortInfo(int roomID, int selection
     QString infoText;
     TRoom* room = mpHost->mpMap->mpRoomDB->getRoom(roomID);
     if (room) {
-        QString const areaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(areaId);
+        const QString areaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(areaId);
         static const QRegularExpression trailingPunctuation(qsl("[.,/]+$"));
         auto roomName = QString(room->name);
         if (mpHost->mMapViewOnly) {
@@ -113,7 +113,7 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
     TRoom* room = mpHost->mpMap->mpRoomDB->getRoom(roomID);
     if (room) {
         TArea* area = mpHost->mpMap->mpRoomDB->getArea(areaId);
-        QString const areaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(areaId);
+        const QString areaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(areaId);
         if (area) {
             infoText = qsl("%1\n").arg(
                            tr("Area:%1%2 ID:%1%3 x:%1%4%1<‑>%1%5 y:%1%6%1<‑>%1%7 z:%1%8%1<‑>%1%9",

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4195,8 +4195,8 @@ Hunhandle* mudlet::prepareSharedDictionary()
     }
 
     // Need to check that the files exist first:
-    QString const dictionaryPath(getMudletPath(mudlet::mainDataItemPath, qsl("mudlet.dic")));
-    QString const affixPath(getMudletPath(mudlet::mainDataItemPath, qsl("mudlet.aff")));
+    QString dictionaryPath(getMudletPath(mudlet::mainDataItemPath, qsl("mudlet.dic")));
+    QString affixPath(getMudletPath(mudlet::mainDataItemPath, qsl("mudlet.aff")));
     int oldWordCount = 0;
     QStringList wordList;
     QHash<QString, unsigned int> graphemeCounts;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -405,7 +405,7 @@ mudlet::mudlet()
 #if defined(INCLUDE_UPDATER)
     if (scmIsPublicTestVersion) {
         mpActionReportIssue = new QAction(tr("Report issue"), this);
-        QStringList const issueReportIcons {"face-uncertain.png", "face-surprise.png", "face-smile.png", "face-sad.png", "face-plain.png"};
+        const QStringList issueReportIcons {"face-uncertain.png", "face-surprise.png", "face-smile.png", "face-sad.png", "face-plain.png"};
         auto randomIcon = QRandomGenerator::global()->bounded(issueReportIcons.size());
         mpActionReportIssue->setIcon(QIcon(qsl(":/icons/%1").arg(issueReportIcons.at(randomIcon))));
         mpActionReportIssue->setToolTip(utils::richText(tr("The public test build gets newer features to you quicker, and you help us find issues in them quicker. Spotted something odd? Let us know asap!")));
@@ -2802,7 +2802,7 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
     //Load rest of modules after scripts
     while (it2.hasNext()) {
         it2.next();
-        QStringList const modules = it2.value();
+        const QStringList modules = it2.value();
         mudlet::installModulesList(pHost, modules);
     }
 
@@ -3690,7 +3690,7 @@ bool mudlet::migratePasswordsToSecureStorage()
     }
     mStorePasswordsSecurely = true;
 
-    QStringList const profiles = QDir(mudlet::getMudletPath(mudlet::profilesPath))
+    const QStringList profiles = QDir(mudlet::getMudletPath(mudlet::profilesPath))
                                    .entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
 
     for (const auto& profile : profiles) {
@@ -3749,7 +3749,7 @@ bool mudlet::migratePasswordsToProfileStorage()
     }
     mStorePasswordsSecurely = false;
 
-    QStringList const profiles = QDir(mudlet::getMudletPath(mudlet::profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+    const QStringList profiles = QDir(mudlet::getMudletPath(mudlet::profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
 
     for (const auto& profile : profiles) {
         auto* job = new QKeychain::ReadPasswordJob(qsl("Mudlet profile"));

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1825,7 +1825,7 @@ void mudlet::readEarlySettings(const QSettings& settings)
 
 void mudlet::readLateSettings(const QSettings& settings)
 {
-    QPoint const pos = settings.value(qsl("pos"), QPoint(0, 0)).toPoint();
+    const QPoint pos = settings.value(qsl("pos"), QPoint(0, 0)).toPoint();
     QSize const size = settings.value(qsl("size"), QSize(750, 550)).toSize();
     // A sensible default has already been set up according to whether we are on
     // a netbook or not before this gets called so only change if there is a

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4132,9 +4132,9 @@ Hunhandle* mudlet::prepareProfileDictionary(const QString& hostName, QSet<QStrin
 {
     // Need to check that the files exist first:
     // full dictionary path+filename
-    QString const dictionaryPath(getMudletPath(mudlet::profileDataItemPath, hostName, qsl("profile.dic")));
+    QString dictionaryPath(getMudletPath(mudlet::profileDataItemPath, hostName, qsl("profile.dic")));
     // full affix path+filename
-    QString const affixPath(getMudletPath(mudlet::profileDataItemPath, hostName, qsl("profile.aff")));
+    QString affixPath(getMudletPath(mudlet::profileDataItemPath, hostName, qsl("profile.aff")));
 
     int oldWordCount = 0;
     QStringList wordList;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1121,7 +1121,7 @@ void mudlet::scanForQtTranslations(const QString& path)
         itTranslation.next();
         const QString languageCode = itTranslation.key();
         std::unique_ptr<QTranslator> pQtTranslator = std::make_unique<QTranslator>();
-        QString const translationFileName(qsl("qt_%1.qm").arg(languageCode));
+        const QString translationFileName(qsl("qt_%1.qm").arg(languageCode));
         if (pQtTranslator->load(translationFileName, path)) {
             // qDebug().noquote().nospace() << "    found a Qt translation for locale code: \"" << languageCode << "\"";
             /*
@@ -1162,7 +1162,7 @@ void mudlet::loadTranslators(const QString& languageCode)
 
     translation const currentTranslation = mTranslationsMap.value(languageCode);
     QPointer<QTranslator> const pQtTranslator = new QTranslator;
-    QString const qtTranslatorFileName = currentTranslation.getQtTranslationFileName();
+    const QString qtTranslatorFileName = currentTranslation.getQtTranslationFileName();
     if (!qtTranslatorFileName.isEmpty()) {
         // Need to use load(fileName (e.g. {qt_xx_YY.qm"}, pathName) form - Qt
         // mangles the former to find the actual best one to use, but we
@@ -1177,7 +1177,7 @@ void mudlet::loadTranslators(const QString& languageCode)
     }
 
     QPointer<QTranslator> const pMudletTranslator = new QTranslator;
-    QString const mudletTranslatorFileName = currentTranslation.getMudletTranslationFileName();
+    const QString mudletTranslatorFileName = currentTranslation.getMudletTranslationFileName();
     if (!mudletTranslatorFileName.isEmpty()) {
         bool const isOk = pMudletTranslator->load(mudletTranslatorFileName, mPathNameMudletTranslations);
         if (isOk && !pMudletTranslator->isEmpty()) {
@@ -1259,7 +1259,7 @@ void mudlet::slot_closeCurrentProfile()
 
 void mudlet::slot_closeProfileRequested(int tab)
 {
-    QString const name = mpTabBar->tabData(tab).toString();
+    const QString name = mpTabBar->tabData(tab).toString();
     closeHost(name);
 }
 
@@ -1370,7 +1370,7 @@ void mudlet::reshowRequiredMainConsoles()
 // Moved as much as possible to activateProfile()...
 void mudlet::slot_tabChanged(int tabID)
 {
-    QString const hostName = mpTabBar->tabData(tabID).toString();
+    const QString hostName = mpTabBar->tabData(tabID).toString();
     activateProfile(mHostManager.getHost(hostName));
 }
 
@@ -1386,7 +1386,7 @@ void mudlet::addConsoleForNewHost(Host* pH)
     pH->mpConsole = pConsole;
     pConsole->setWindowTitle(pH->getName());
     pConsole->setObjectName(pH->getName());
-    QString const tabName = pH->getName();
+    const QString tabName = pH->getName();
     int const newTabID = mpTabBar->addTab(tabName);
     /*
      * There is a sneaky feature on some OSes (I found it on FreeBSD but
@@ -1471,7 +1471,7 @@ void mudlet::slot_timerFires()
     }
 
     // Pull the Host name and TTimer::id from the properties:
-    QString const hostName(pQT->property(TTimer::scmProperty_HostName).toString());
+    const QString hostName(pQT->property(TTimer::scmProperty_HostName).toString());
     if (Q_UNLIKELY(hostName.isEmpty())) {
         qWarning().nospace().noquote() << "mudlet::slot_timerFires() INFO - Host name is empty - so TTimer has probably been deleted.";
         pQT->deleteLater();
@@ -1586,7 +1586,7 @@ bool mudlet::saveWindowLayout()
         return false;
     }
 
-    QString const layoutFilePath = getMudletPath(mainDataItemPath, qsl("windowLayout.dat"));
+    const QString layoutFilePath = getMudletPath(mainDataItemPath, qsl("windowLayout.dat"));
 
     QSaveFile layoutFile(layoutFilePath);
     if (layoutFile.open(QIODevice::WriteOnly)) {
@@ -1617,7 +1617,7 @@ bool mudlet::loadWindowLayout()
     }
     qDebug() << "mudlet::loadWindowLayout() - loading layout.";
 
-    QString const layoutFilePath = getMudletPath(mainDataItemPath, qsl("windowLayout.dat"));
+    const QString layoutFilePath = getMudletPath(mainDataItemPath, qsl("windowLayout.dat"));
 
     QFile layoutFile(layoutFilePath);
     if (layoutFile.exists()) {
@@ -2437,7 +2437,7 @@ void mudlet::updateDiscordNamedIcon()
         return;
     }
 
-    QString const gameName = pHost->getDiscordGameName();
+    const QString gameName = pHost->getDiscordGameName();
 
     bool const hasCustom = !pHost->getDiscordInviteURL().isEmpty();
 
@@ -2476,7 +2476,7 @@ void mudlet::slot_replay()
         return;
     }
 
-    QString const fileName = QFileDialog::getOpenFileName(this, tr("Select Replay"),
+    const QString fileName = QFileDialog::getOpenFileName(this, tr("Select Replay"),
                                                     getMudletPath(profileReplayAndLogFilesPath, pHost->getName()),
                                                     tr("*.dat"));
     if (fileName.isEmpty()) {
@@ -2550,7 +2550,7 @@ void mudlet::startAutoLogin(const QStringList& cliProfiles)
     }
 
     for (auto& hostName : hostList) {
-        QString const val = readProfileData(hostName, qsl("autologin"));
+        const QString val = readProfileData(hostName, qsl("autologin"));
         if (val.toInt() == Qt::Checked) {
             doAutoLogin(hostName);
             openedProfile = true;
@@ -2683,7 +2683,7 @@ void mudlet::doAutoLogin(const QString& profile_name)
     LuaInterface* lI = pHost->getLuaInterface();
     lI->getVars(true);
 
-    QString const folder = getMudletPath(profileXmlFilesPath, profile_name);
+    const QString folder = getMudletPath(profileXmlFilesPath, profile_name);
     QDir dir(folder);
     dir.setSorting(QDir::Time);
     QStringList entries = dir.entryList(QDir::Files, QDir::Time);
@@ -2706,7 +2706,7 @@ void mudlet::doAutoLogin(const QString& profile_name)
         if (auto [success, message] = importer.importPackage(&file); !success) {
             pHost->postMessage(tr("[ ERROR ] - Something went wrong loading your Mudlet profile and it could not be loaded.\n"
                 "Try loading an older version in 'Connect - Options - Profile history' or double-check that %1 looks correct.").arg(file.fileName()));
-        
+
             qDebug().nospace().noquote() << "mudlet::doAutoLogin(\"" << profile_name << "\") ERROR - loading \"" << file.fileName() << "\" failed, reason: \"" << message << "\".";
         } else {
             pHost->mLoadedOk = true;
@@ -2723,7 +2723,7 @@ void mudlet::doAutoLogin(const QString& profile_name)
     pHost->setLogin(readProfileData(profile_name, qsl("login")));
     pHost->setPass(readProfileData(profile_name, qsl("password")));
 
-    QString const val = readProfileData(profile_name, qsl("autoreconnect"));
+    const QString val = readProfileData(profile_name, qsl("autoreconnect"));
     if (!val.isEmpty() && val.toInt() == Qt::Checked) {
         pHost->setAutoReconnect(true);
     } else {
@@ -2832,7 +2832,7 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
     if (connect) {
         pHost->mTelnet.connectIt(pHost->getUrl(), pHost->getPort());
     } else {
-        QString const infoMsg = tr("[  OK  ]  - Profile \"%1\" loaded in offline mode.").arg(profile);
+        const QString infoMsg = tr("[  OK  ]  - Profile \"%1\" loaded in offline mode.").arg(profile);
         pHost->postMessage(infoMsg);
     }
 }
@@ -2913,7 +2913,7 @@ void mudlet::slot_compactInputLine(const bool state)
         mpCurrentActiveHost->setCompactInputLine(state);
         // Make sure players don't get confused when accidentally hiding buttons.
         if (QKeySequence* shortcut = mpShortcutsManager->getSequence(qsl("Compact input line")); state && !mpCurrentActiveHost->mTutorialForCompactLineAlreadyShown && shortcut && !shortcut->isEmpty()) {
-            QString const infoMsg = tr("[ INFO ]  - Compact input line set. Press %1 to show bottom-right buttons again.",
+            const QString infoMsg = tr("[ INFO ]  - Compact input line set. Press %1 to show bottom-right buttons again.",
                                  "Here %1 will be replaced with the keyboard shortcut, default is ALT+L.").arg(shortcut->toString());
             mpCurrentActiveHost->postMessage(infoMsg);
             mpCurrentActiveHost->mTutorialForCompactLineAlreadyShown = true;
@@ -3127,8 +3127,8 @@ bool mudlet::unzip(const QString& archivePath, const QString& destination, const
     // Value is: absolute path needed when extracting files
     for (zip_int64_t i = 0, total = zip_get_num_entries(archive, 0); i < total; ++i) {
         if (!zip_stat_index(archive, static_cast<zip_uint64_t>(i), 0, &zs)) {
-            QString const entryInArchive(zs.name);
-            QString const pathInArchive(entryInArchive.section(qsl("/"), 0, -2));
+            const QString entryInArchive(zs.name);
+            const QString pathInArchive(entryInArchive.section(qsl("/"), 0, -2));
             // TODO: We are supposed to validate the fields (except the
             // "valid" one itself) in zs before using them:
             // i.e. check that zs.name is valid ( zs.valid & ZIP_STAT_NAME )
@@ -3148,7 +3148,7 @@ bool mudlet::unzip(const QString& archivePath, const QString& destination, const
     QMapIterator<QString, QString> itPath(directoriesNeededMap);
     while (itPath.hasNext()) {
         itPath.next();
-        QString const folderToCreate = qsl("%1%2").arg(destination, itPath.value());
+        const QString folderToCreate = qsl("%1%2").arg(destination, itPath.value());
         if (!tmpDir.exists(folderToCreate)) {
             if (!tmpDir.mkpath(folderToCreate)) {
                 zip_close(archive);
@@ -3162,7 +3162,7 @@ bool mudlet::unzip(const QString& archivePath, const QString& destination, const
     for (zip_int64_t i = 0, total = zip_get_num_entries(archive, 0); i < total; ++i) {
         // No need to check return value as we've already done it first time
         zip_stat_index(archive, static_cast<zip_uint64_t>(i), 0, &zs);
-        QString const entryInArchive(zs.name);
+        const QString entryInArchive(zs.name);
         if (!entryInArchive.endsWith(QLatin1Char('/'))) {
             // TODO: check that zs.size is valid ( zs.valid & ZIP_STAT_SIZE )
             zf = zip_fopen_index(archive, static_cast<zip_uint64_t>(i), 0);
@@ -3249,7 +3249,7 @@ bool mudlet::loadEdbeeTheme(const QString& themeName, const QString& themeFile)
     // getMudletPath(...) needs the themeFile to determine if it is the
     // "default" which is stored in the resource file and not downloaded into
     // the cache:
-    QString const themeLocation(getMudletPath(editorWidgetThemePathFile, themeFile));
+    const QString themeLocation(getMudletPath(editorWidgetThemePathFile, themeFile));
     auto result = themeManager->readThemeFile(themeLocation, themeName);
     if (result == nullptr) {
         qWarning() << themeManager->lastErrorMessage();
@@ -3940,7 +3940,7 @@ bool mudlet::scanDictionaryFile(const QString& dictionaryPath, int& oldWC, QHash
             int endPos = graphemeFinder.toNextBoundary();
             do {
                 if (endPos > 0) {
-                    QString const grapheme(dictionaryLine.mid(startPos, endPos - startPos));
+                    const QString grapheme(dictionaryLine.mid(startPos, endPos - startPos));
                     if (gc.contains(grapheme)) {
                         ++gc[grapheme];
                     } else {
@@ -4108,7 +4108,7 @@ int mudlet::scanWordList(QStringList& wl, QHash<QString, unsigned int>& gc)
         int endPos = graphemeFinder.toNextBoundary();
         do {
             if (endPos > 0) {
-                QString const grapheme(wl.at(index).mid(startPos, endPos - startPos));
+                const QString grapheme(wl.at(index).mid(startPos, endPos - startPos));
                 if (gc.contains(grapheme)) {
                     ++gc[grapheme];
                 } else {
@@ -4238,8 +4238,8 @@ Hunhandle* mudlet::prepareSharedDictionary()
 bool mudlet::saveDictionary(const QString& pathFileBaseName, QSet<QString>& wordSet)
 {
     // First update the line count in the list of words
-    QString const dictionaryPath(qsl("%1.dic").arg(pathFileBaseName));
-    QString const affixPath(qsl("%1.aff").arg(pathFileBaseName));
+    const QString dictionaryPath(qsl("%1.dic").arg(pathFileBaseName));
+    const QString affixPath(qsl("%1.aff").arg(pathFileBaseName));
     QHash<QString, unsigned int> graphemeCounts;
 
     // The file will have previously been created - for it to be missing now is
@@ -4561,7 +4561,7 @@ void mudlet::slot_tabMoved(const int oldPos, const int newPos)
 void mudlet::refreshTabBar()
 {
     for (const auto& pHost : mHostManager) {
-        QString const hostName = pHost->getName();
+        const QString hostName = pHost->getName();
         if (smDebugMode) {
             mpTabBar->applyPrefixToDisplayedText(hostName, TDebug::getTag(pHost.data()));
         } else {
@@ -4629,7 +4629,7 @@ bool mudlet::desktopInDarkMode()
     QProcess process;
     process.start(qsl("gsettings"), QStringList() << qsl("get") << qsl("org.gnome.desktop.interface") << qsl("gtk-theme"));
     process.waitForFinished();
-    QString const output = QString::fromUtf8(process.readAllStandardOutput());
+    const QString output = QString::fromUtf8(process.readAllStandardOutput());
     return output.contains(qsl("-dark"), Qt::CaseInsensitive);
 #endif
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1168,7 +1168,7 @@ void mudlet::loadTranslators(const QString& languageCode)
         // mangles the former to find the actual best one to use, but we
         // shouldn't include the path in the first element as it seems to mess
         // up the process of locating the file:
-        bool const isOk = pQtTranslator->load(qtTranslatorFileName, mPathNameQtTranslations);
+        const bool isOk = pQtTranslator->load(qtTranslatorFileName, mPathNameQtTranslations);
         if (isOk && !pQtTranslator->isEmpty()) {
             // qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - installing Qt libraries' translation from a path and file name specified as: \"" << mPathNameQtTranslations << "/"<< qtTranslatorFileName << "\"...";
             qApp->installTranslator(pQtTranslator);
@@ -1179,7 +1179,7 @@ void mudlet::loadTranslators(const QString& languageCode)
     QPointer<QTranslator> const pMudletTranslator = new QTranslator;
     const QString mudletTranslatorFileName = currentTranslation.getMudletTranslationFileName();
     if (!mudletTranslatorFileName.isEmpty()) {
-        bool const isOk = pMudletTranslator->load(mudletTranslatorFileName, mPathNameMudletTranslations);
+        const bool isOk = pMudletTranslator->load(mudletTranslatorFileName, mPathNameMudletTranslations);
         if (isOk && !pMudletTranslator->isEmpty()) {
 //            qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - installing Mudlet translation from: \"" << mPathNameMudletTranslations << "/"
 //                                         << mudletTranslatorFileName << "\"...";
@@ -1632,7 +1632,7 @@ bool mudlet::loadWindowLayout()
             ifs >> layoutData;
             layoutFile.close();
 
-            bool const rv = restoreState(layoutData);
+            const bool rv = restoreState(layoutData);
 
             commitLayoutUpdates(true);
             mIsLoadingLayout = false;
@@ -2439,7 +2439,7 @@ void mudlet::updateDiscordNamedIcon()
 
     const QString gameName = pHost->getDiscordGameName();
 
-    bool const hasCustom = !pHost->getDiscordInviteURL().isEmpty();
+    const bool hasCustom = !pHost->getDiscordInviteURL().isEmpty();
 
     mpActionDiscord->setIconText(gameName.isEmpty() ? qsl("Discord") : QFontMetrics(mpActionDiscord->font()).elidedText(gameName, Qt::ElideRight, 90));
 
@@ -4664,7 +4664,7 @@ void mudlet::onlyShowProfiles(const QStringList& predefinedProfiles)
     if (bool layEasterEgg = (now.time().second() < 30); layEasterEgg) {
         // Only do it in the first half of any minute:
 #else
-    if (bool const layEasterEgg = (now.date().month() == 4
+    if (const bool layEasterEgg = (now.date().month() == 4
                         && now.date().day() == 1); layEasterEgg) {
 #endif // ! DEBUG_EASTER_EGGS
         // clang-format on

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -181,7 +181,7 @@ mudlet::mudlet()
     menuAbout->setToolTipsVisible(true);
 
     setAttribute(Qt::WA_DeleteOnClose);
-    QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    QSizePolicy const sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setWindowTitle(scmVersion);
     if (scmIsReleaseVersion) {
         setWindowIcon(QIcon(qsl(":/icons/mudlet.png")));
@@ -212,7 +212,7 @@ mudlet::mudlet()
     layoutTopLevel->setContentsMargins(0, 0, 0, 0);
     layoutTopLevel->addWidget(mpTabBar);
     mpWidget_profileContainer = new QWidget(frame);
-    QPalette mainPalette;
+    QPalette const mainPalette;
     mpWidget_profileContainer->setPalette(mainPalette);
     mpWidget_profileContainer->setContentsMargins(0, 0, 0, 0);
     mpWidget_profileContainer->setSizePolicy(sizePolicy);
@@ -405,7 +405,7 @@ mudlet::mudlet()
 #if defined(INCLUDE_UPDATER)
     if (scmIsPublicTestVersion) {
         mpActionReportIssue = new QAction(tr("Report issue"), this);
-        QStringList issueReportIcons {"face-uncertain.png", "face-surprise.png", "face-smile.png", "face-sad.png", "face-plain.png"};
+        QStringList const issueReportIcons {"face-uncertain.png", "face-surprise.png", "face-smile.png", "face-sad.png", "face-plain.png"};
         auto randomIcon = QRandomGenerator::global()->bounded(issueReportIcons.size());
         mpActionReportIssue->setIcon(QIcon(qsl(":/icons/%1").arg(issueReportIcons.at(randomIcon))));
         mpActionReportIssue->setToolTip(utils::richText(tr("The public test build gets newer features to you quicker, and you help us find issues in them quicker. Spotted something odd? Let us know asap!")));
@@ -435,7 +435,7 @@ mudlet::mudlet()
         connect(actionFullScreeniew, &QAction::triggered, this, &mudlet::slot_toggleFullScreenView);
     }
 
-    QFont mainFont = QFont(qsl("Bitstream Vera Sans Mono"), 8, QFont::Normal);
+    QFont const mainFont = QFont(qsl("Bitstream Vera Sans Mono"), 8, QFont::Normal);
     mpWidget_profileContainer->setFont(mainFont);
     mpWidget_profileContainer->show();
 
@@ -635,7 +635,7 @@ QSettings* mudlet::getQSettings()
         For compatibility with older settings, if no config is loaded
         from the config directory "mudlet", application "Mudlet", we try to load from the config
         directory "Mudlet", application "Mudlet 1.0". */
-    QSettings settings_new("mudlet", "Mudlet");
+    QSettings const settings_new("mudlet", "Mudlet");
     return new QSettings((settings_new.contains("pos") ? "mudlet" : "Mudlet"), (settings_new.contains("pos") ? "Mudlet" : "Mudlet 1.0"));
 }
 
@@ -1028,8 +1028,8 @@ void mudlet::scanForMudletTranslations(const QString& path)
     if (path == qsl(":/lang")) {
         QFile file(qsl(":/translation-stats.json"));
         if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-            QByteArray saveData = file.readAll();
-            QJsonDocument loadDoc(QJsonDocument::fromJson(saveData));
+            QByteArray const saveData = file.readAll();
+            QJsonDocument const loadDoc(QJsonDocument::fromJson(saveData));
             translationStats = loadDoc.object();
             file.close();
         } else {
@@ -1121,7 +1121,7 @@ void mudlet::scanForQtTranslations(const QString& path)
         itTranslation.next();
         const QString languageCode = itTranslation.key();
         std::unique_ptr<QTranslator> pQtTranslator = std::make_unique<QTranslator>();
-        QString translationFileName(qsl("qt_%1.qm").arg(languageCode));
+        QString const translationFileName(qsl("qt_%1.qm").arg(languageCode));
         if (pQtTranslator->load(translationFileName, path)) {
             // qDebug().noquote().nospace() << "    found a Qt translation for locale code: \"" << languageCode << "\"";
             /*
@@ -1151,7 +1151,7 @@ void mudlet::loadTranslators(const QString& languageCode)
         QMutableListIterator<QPointer<QTranslator>> itTranslator(mTranslatorsLoadedList);
         itTranslator.toBack();
         while (itTranslator.hasPrevious()) {
-            QPointer<QTranslator> pTranslator = itTranslator.previous();
+            QPointer<QTranslator> const pTranslator = itTranslator.previous();
             if (pTranslator) {
                 qApp->removeTranslator(pTranslator);
                 itTranslator.remove();
@@ -1160,15 +1160,15 @@ void mudlet::loadTranslators(const QString& languageCode)
         }
     }
 
-    translation currentTranslation = mTranslationsMap.value(languageCode);
-    QPointer<QTranslator> pQtTranslator = new QTranslator;
-    QString qtTranslatorFileName = currentTranslation.getQtTranslationFileName();
+    translation const currentTranslation = mTranslationsMap.value(languageCode);
+    QPointer<QTranslator> const pQtTranslator = new QTranslator;
+    QString const qtTranslatorFileName = currentTranslation.getQtTranslationFileName();
     if (!qtTranslatorFileName.isEmpty()) {
         // Need to use load(fileName (e.g. {qt_xx_YY.qm"}, pathName) form - Qt
         // mangles the former to find the actual best one to use, but we
         // shouldn't include the path in the first element as it seems to mess
         // up the process of locating the file:
-        bool isOk = pQtTranslator->load(qtTranslatorFileName, mPathNameQtTranslations);
+        bool const isOk = pQtTranslator->load(qtTranslatorFileName, mPathNameQtTranslations);
         if (isOk && !pQtTranslator->isEmpty()) {
             // qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - installing Qt libraries' translation from a path and file name specified as: \"" << mPathNameQtTranslations << "/"<< qtTranslatorFileName << "\"...";
             qApp->installTranslator(pQtTranslator);
@@ -1176,10 +1176,10 @@ void mudlet::loadTranslators(const QString& languageCode)
         }
     }
 
-    QPointer<QTranslator> pMudletTranslator = new QTranslator;
-    QString mudletTranslatorFileName = currentTranslation.getMudletTranslationFileName();
+    QPointer<QTranslator> const pMudletTranslator = new QTranslator;
+    QString const mudletTranslatorFileName = currentTranslation.getMudletTranslationFileName();
     if (!mudletTranslatorFileName.isEmpty()) {
-        bool isOk = pMudletTranslator->load(mudletTranslatorFileName, mPathNameMudletTranslations);
+        bool const isOk = pMudletTranslator->load(mudletTranslatorFileName, mPathNameMudletTranslations);
         if (isOk && !pMudletTranslator->isEmpty()) {
 //            qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - installing Mudlet translation from: \"" << mPathNameMudletTranslations << "/"
 //                                         << mudletTranslatorFileName << "\"...";
@@ -1209,7 +1209,7 @@ bool mudlet::openWebPage(const QString& path)
     if (path.isEmpty() || path.isNull()) {
         return false;
     }
-    QUrl url(path, QUrl::TolerantMode);
+    QUrl const url(path, QUrl::TolerantMode);
     if (!url.isValid()) {
         return false;
     }
@@ -1259,7 +1259,7 @@ void mudlet::slot_closeCurrentProfile()
 
 void mudlet::slot_closeProfileRequested(int tab)
 {
-    QString name = mpTabBar->tabData(tab).toString();
+    QString const name = mpTabBar->tabData(tab).toString();
     closeHost(name);
 }
 
@@ -1270,7 +1270,7 @@ void mudlet::closeHost(const QString& name)
         return;
     }
 
-    std::list<QPointer<TToolBar>> hostToolBarMap = pH->getActionUnit()->getToolBarList();
+    std::list<QPointer<TToolBar>> const hostToolBarMap = pH->getActionUnit()->getToolBarList();
     QMap<QString, TDockWidget*>& dockWindowMap = pH->mpConsole->mDockWidgetMap;
     QMap<QString, TConsole*>& hostConsoleMap = pH->mpConsole->mSubConsoleMap;
 
@@ -1370,7 +1370,7 @@ void mudlet::reshowRequiredMainConsoles()
 // Moved as much as possible to activateProfile()...
 void mudlet::slot_tabChanged(int tabID)
 {
-    QString hostName = mpTabBar->tabData(tabID).toString();
+    QString const hostName = mpTabBar->tabData(tabID).toString();
     activateProfile(mHostManager.getHost(hostName));
 }
 
@@ -1386,8 +1386,8 @@ void mudlet::addConsoleForNewHost(Host* pH)
     pH->mpConsole = pConsole;
     pConsole->setWindowTitle(pH->getName());
     pConsole->setObjectName(pH->getName());
-    QString tabName = pH->getName();
-    int newTabID = mpTabBar->addTab(tabName);
+    QString const tabName = pH->getName();
+    int const newTabID = mpTabBar->addTab(tabName);
     /*
      * There is a sneaky feature on some OSes (I found it on FreeBSD but
      * it is notable switched OFF by default on MacOs) where Qt adds an
@@ -1448,9 +1448,9 @@ void mudlet::addConsoleForNewHost(Host* pH)
     // Setting mpCurrentActiveHost to pH is now done by the following
     slot_tabChanged(newTabID);
 
-    int x = pH->mpConsole->width();
-    int y = pH->mpConsole->height();
-    QSize s = QSize(x, y);
+    int const x = pH->mpConsole->width();
+    int const y = pH->mpConsole->height();
+    QSize const s = QSize(x, y);
     QResizeEvent event(s, s);
     updateDiscordNamedIcon();
     QApplication::sendEvent(pH->mpConsole, &event);
@@ -1471,7 +1471,7 @@ void mudlet::slot_timerFires()
     }
 
     // Pull the Host name and TTimer::id from the properties:
-    QString hostName(pQT->property(TTimer::scmProperty_HostName).toString());
+    QString const hostName(pQT->property(TTimer::scmProperty_HostName).toString());
     if (Q_UNLIKELY(hostName.isEmpty())) {
         qWarning().nospace().noquote() << "mudlet::slot_timerFires() INFO - Host name is empty - so TTimer has probably been deleted.";
         pQT->deleteLater();
@@ -1480,7 +1480,7 @@ void mudlet::slot_timerFires()
 
     Host* pHost = mHostManager.getHost(hostName);
     Q_ASSERT_X(pHost, "mudlet::slot_timerFires()", "Unable to deduce Host pointer from data in QTimer");
-    int id = pQT->property(TTimer::scmProperty_TTimerId).toInt();
+    int const id = pQT->property(TTimer::scmProperty_TTimerId).toInt();
     if (Q_UNLIKELY(!id)) {
         qWarning().nospace().noquote() << "mudlet::slot_timerFires() INFO - TTimer ID is zero - so TTimer has probably been deleted.";
         pQT->deleteLater();
@@ -1586,14 +1586,14 @@ bool mudlet::saveWindowLayout()
         return false;
     }
 
-    QString layoutFilePath = getMudletPath(mainDataItemPath, qsl("windowLayout.dat"));
+    QString const layoutFilePath = getMudletPath(mainDataItemPath, qsl("windowLayout.dat"));
 
     QSaveFile layoutFile(layoutFilePath);
     if (layoutFile.open(QIODevice::WriteOnly)) {
         // revert update markers to ready objects for saving.
         commitLayoutUpdates();
 
-        QByteArray layoutData = saveState();
+        QByteArray const layoutData = saveState();
         QDataStream ofs(&layoutFile);
         if (scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
             ofs.setVersion(scmQDataStreamFormat_5_12);
@@ -1617,7 +1617,7 @@ bool mudlet::loadWindowLayout()
     }
     qDebug() << "mudlet::loadWindowLayout() - loading layout.";
 
-    QString layoutFilePath = getMudletPath(mainDataItemPath, qsl("windowLayout.dat"));
+    QString const layoutFilePath = getMudletPath(mainDataItemPath, qsl("windowLayout.dat"));
 
     QFile layoutFile(layoutFilePath);
     if (layoutFile.exists()) {
@@ -1632,7 +1632,7 @@ bool mudlet::loadWindowLayout()
             ifs >> layoutData;
             layoutFile.close();
 
-            bool rv = restoreState(layoutData);
+            bool const rv = restoreState(layoutData);
 
             commitLayoutUpdates(true);
             mIsLoadingLayout = false;
@@ -1667,7 +1667,7 @@ void mudlet::hideEvent(QHideEvent* event)
 
 std::optional<QSize> mudlet::getImageSize(const QString& imageLocation)
 {
-    QImage image(imageLocation);
+    QImage const image(imageLocation);
 
     if (image.isNull()) {
         return {};
@@ -1799,7 +1799,7 @@ void mudlet::readEarlySettings(const QSettings& settings)
         mEnableFullScreenMode = settings.value(qsl("enableFullScreenMode"), QVariant(false)).toBool();
     } else {
         // We do not have a QSettings value stored so check for the sentinel file:
-        QFile file_use_smallscreen(getMudletPath(mainDataItemPath, qsl("mudlet_option_use_smallscreen")));
+        QFile const file_use_smallscreen(getMudletPath(mainDataItemPath, qsl("mudlet_option_use_smallscreen")));
         mEnableFullScreenMode = file_use_smallscreen.exists();
     }
 
@@ -1825,8 +1825,8 @@ void mudlet::readEarlySettings(const QSettings& settings)
 
 void mudlet::readLateSettings(const QSettings& settings)
 {
-    QPoint pos = settings.value(qsl("pos"), QPoint(0, 0)).toPoint();
-    QSize size = settings.value(qsl("size"), QSize(750, 550)).toSize();
+    QPoint const pos = settings.value(qsl("pos"), QPoint(0, 0)).toPoint();
+    QSize const size = settings.value(qsl("size"), QSize(750, 550)).toSize();
     // A sensible default has already been set up according to whether we are on
     // a netbook or not before this gets called so only change if there is a
     // setting stored:
@@ -2437,9 +2437,9 @@ void mudlet::updateDiscordNamedIcon()
         return;
     }
 
-    QString gameName = pHost->getDiscordGameName();
+    QString const gameName = pHost->getDiscordGameName();
 
-    bool hasCustom = !pHost->getDiscordInviteURL().isEmpty();
+    bool const hasCustom = !pHost->getDiscordInviteURL().isEmpty();
 
     mpActionDiscord->setIconText(gameName.isEmpty() ? qsl("Discord") : QFontMetrics(mpActionDiscord->font()).elidedText(gameName, Qt::ElideRight, 90));
 
@@ -2476,7 +2476,7 @@ void mudlet::slot_replay()
         return;
     }
 
-    QString fileName = QFileDialog::getOpenFileName(this, tr("Select Replay"),
+    QString const fileName = QFileDialog::getOpenFileName(this, tr("Select Replay"),
                                                     getMudletPath(profileReplayAndLogFilesPath, pHost->getName()),
                                                     tr("*.dat"));
     if (fileName.isEmpty()) {
@@ -2550,7 +2550,7 @@ void mudlet::startAutoLogin(const QStringList& cliProfiles)
     }
 
     for (auto& hostName : hostList) {
-        QString val = readProfileData(hostName, qsl("autologin"));
+        QString const val = readProfileData(hostName, qsl("autologin"));
         if (val.toInt() == Qt::Checked) {
             doAutoLogin(hostName);
             openedProfile = true;
@@ -2625,7 +2625,7 @@ int64_t mudlet::getPhysicalMemoryTotal()
     // return static_cast<int64_t>(sysconf(_SC_PHYS_PAGES)) * static_cast<int64_t>(sysconf(_SC_PAGE_SIZE));
     struct sysinfo memInfo;
     sysinfo(&memInfo);
-    int64_t total = memInfo.totalram;
+    int64_t const total = memInfo.totalram;
     return total * static_cast<int64_t>(memInfo.mem_unit);
 #else
     return -1;
@@ -2683,7 +2683,7 @@ void mudlet::doAutoLogin(const QString& profile_name)
     LuaInterface* lI = pHost->getLuaInterface();
     lI->getVars(true);
 
-    QString folder = getMudletPath(profileXmlFilesPath, profile_name);
+    QString const folder = getMudletPath(profileXmlFilesPath, profile_name);
     QDir dir(folder);
     dir.setSorting(QDir::Time);
     QStringList entries = dir.entryList(QDir::Files, QDir::Time);
@@ -2723,7 +2723,7 @@ void mudlet::doAutoLogin(const QString& profile_name)
     pHost->setLogin(readProfileData(profile_name, qsl("login")));
     pHost->setPass(readProfileData(profile_name, qsl("password")));
 
-    QString val = readProfileData(profile_name, qsl("autoreconnect"));
+    QString const val = readProfileData(profile_name, qsl("autoreconnect"));
     if (!val.isEmpty() && val.toInt() == Qt::Checked) {
         pHost->setAutoReconnect(true);
     } else {
@@ -2802,7 +2802,7 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
     //Load rest of modules after scripts
     while (it2.hasNext()) {
         it2.next();
-        QStringList modules = it2.value();
+        QStringList const modules = it2.value();
         mudlet::installModulesList(pHost, modules);
     }
 
@@ -2832,7 +2832,7 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
     if (connect) {
         pHost->mTelnet.connectIt(pHost->getUrl(), pHost->getPort());
     } else {
-        QString infoMsg = tr("[  OK  ]  - Profile \"%1\" loaded in offline mode.").arg(profile);
+        QString const infoMsg = tr("[  OK  ]  - Profile \"%1\" loaded in offline mode.").arg(profile);
         pHost->postMessage(infoMsg);
     }
 }
@@ -2913,7 +2913,7 @@ void mudlet::slot_compactInputLine(const bool state)
         mpCurrentActiveHost->setCompactInputLine(state);
         // Make sure players don't get confused when accidentally hiding buttons.
         if (QKeySequence* shortcut = mpShortcutsManager->getSequence(qsl("Compact input line")); state && !mpCurrentActiveHost->mTutorialForCompactLineAlreadyShown && shortcut && !shortcut->isEmpty()) {
-            QString infoMsg = tr("[ INFO ]  - Compact input line set. Press %1 to show bottom-right buttons again.",
+            QString const infoMsg = tr("[ INFO ]  - Compact input line set. Press %1 to show bottom-right buttons again.",
                                  "Here %1 will be replaced with the keyboard shortcut, default is ALT+L.").arg(shortcut->toString());
             mpCurrentActiveHost->postMessage(infoMsg);
             mpCurrentActiveHost->mTutorialForCompactLineAlreadyShown = true;
@@ -2938,7 +2938,7 @@ mudlet::~mudlet()
         QMutableListIterator<QPointer<QTranslator>> itTranslator(mTranslatorsLoadedList);
         itTranslator.toBack();
         while (itTranslator.hasPrevious()) {
-            QPointer<QTranslator> pTranslator = itTranslator.previous();
+            QPointer<QTranslator> const pTranslator = itTranslator.previous();
             if (pTranslator) {
                 qApp->removeTranslator(pTranslator);
                 itTranslator.remove();
@@ -3127,8 +3127,8 @@ bool mudlet::unzip(const QString& archivePath, const QString& destination, const
     // Value is: absolute path needed when extracting files
     for (zip_int64_t i = 0, total = zip_get_num_entries(archive, 0); i < total; ++i) {
         if (!zip_stat_index(archive, static_cast<zip_uint64_t>(i), 0, &zs)) {
-            QString entryInArchive(zs.name);
-            QString pathInArchive(entryInArchive.section(qsl("/"), 0, -2));
+            QString const entryInArchive(zs.name);
+            QString const pathInArchive(entryInArchive.section(qsl("/"), 0, -2));
             // TODO: We are supposed to validate the fields (except the
             // "valid" one itself) in zs before using them:
             // i.e. check that zs.name is valid ( zs.valid & ZIP_STAT_NAME )
@@ -3148,7 +3148,7 @@ bool mudlet::unzip(const QString& archivePath, const QString& destination, const
     QMapIterator<QString, QString> itPath(directoriesNeededMap);
     while (itPath.hasNext()) {
         itPath.next();
-        QString folderToCreate = qsl("%1%2").arg(destination, itPath.value());
+        QString const folderToCreate = qsl("%1%2").arg(destination, itPath.value());
         if (!tmpDir.exists(folderToCreate)) {
             if (!tmpDir.mkpath(folderToCreate)) {
                 zip_close(archive);
@@ -3162,7 +3162,7 @@ bool mudlet::unzip(const QString& archivePath, const QString& destination, const
     for (zip_int64_t i = 0, total = zip_get_num_entries(archive, 0); i < total; ++i) {
         // No need to check return value as we've already done it first time
         zip_stat_index(archive, static_cast<zip_uint64_t>(i), 0, &zs);
-        QString entryInArchive(zs.name);
+        QString const entryInArchive(zs.name);
         if (!entryInArchive.endsWith(QLatin1Char('/'))) {
             // TODO: check that zs.size is valid ( zs.valid & ZIP_STAT_SIZE )
             zf = zip_fopen_index(archive, static_cast<zip_uint64_t>(i), 0);
@@ -3180,9 +3180,9 @@ bool mudlet::unzip(const QString& archivePath, const QString& destination, const
             }
 
             bytesRead = 0;
-            zip_uint64_t bytesExpected = zs.size;
+            zip_uint64_t const bytesExpected = zs.size;
             while (bytesRead < bytesExpected && fd.error() == QFileDevice::NoError) {
-                zip_int64_t len = zip_fread(zf, buf, sizeof(buf));
+                zip_int64_t const len = zip_fread(zf, buf, sizeof(buf));
                 if (len < 0) {
                     fd.close();
                     zip_fclose(zf);
@@ -3229,7 +3229,7 @@ bool mudlet::loadLuaFunctionList()
         return false;
     }
 
-    QJsonObject json_obj = json_doc.object();
+    QJsonObject const json_obj = json_doc.object();
 
     if (json_obj.isEmpty()) {
         return false;
@@ -3249,7 +3249,7 @@ bool mudlet::loadEdbeeTheme(const QString& themeName, const QString& themeFile)
     // getMudletPath(...) needs the themeFile to determine if it is the
     // "default" which is stored in the resource file and not downloaded into
     // the cache:
-    QString themeLocation(getMudletPath(editorWidgetThemePathFile, themeFile));
+    QString const themeLocation(getMudletPath(editorWidgetThemePathFile, themeFile));
     auto result = themeManager->readThemeFile(themeLocation, themeName);
     if (result == nullptr) {
         qWarning() << themeManager->lastErrorMessage();
@@ -3643,7 +3643,7 @@ void mudlet::slot_newDataOnHost(const QString& hostName, const bool isLowerPrior
 
 QStringList mudlet::getAvailableFonts()
 {
-    QFontDatabase database;
+    QFontDatabase const database;
 
     return database.families(QFontDatabase::Any);
 }
@@ -3667,7 +3667,7 @@ void mudlet::setEnableFullScreenMode(const bool state)
         QSaveFile file(filePath);
         if (state) {
             file.open(QIODevice::WriteOnly | QIODevice::Text);
-            QTextStream out(&file);
+            QTextStream const out(&file);
             Q_UNUSED(out);
             if (!file.commit()) {
                 qDebug() << "mudlet::setEnableFullScreenMode: error saving fullscreen state: " << file.errorString();
@@ -3690,7 +3690,7 @@ bool mudlet::migratePasswordsToSecureStorage()
     }
     mStorePasswordsSecurely = true;
 
-    QStringList profiles = QDir(mudlet::getMudletPath(mudlet::profilesPath))
+    QStringList const profiles = QDir(mudlet::getMudletPath(mudlet::profilesPath))
                                    .entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
 
     for (const auto& profile : profiles) {
@@ -3749,7 +3749,7 @@ bool mudlet::migratePasswordsToProfileStorage()
     }
     mStorePasswordsSecurely = false;
 
-    QStringList profiles = QDir(mudlet::getMudletPath(mudlet::profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+    QStringList const profiles = QDir(mudlet::getMudletPath(mudlet::profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
 
     for (const auto& profile : profiles) {
         auto* job = new QKeychain::ReadPasswordJob(qsl("Mudlet profile"));
@@ -3940,7 +3940,7 @@ bool mudlet::scanDictionaryFile(const QString& dictionaryPath, int& oldWC, QHash
             int endPos = graphemeFinder.toNextBoundary();
             do {
                 if (endPos > 0) {
-                    QString grapheme(dictionaryLine.mid(startPos, endPos - startPos));
+                    QString const grapheme(dictionaryLine.mid(startPos, endPos - startPos));
                     if (gc.contains(grapheme)) {
                         ++gc[grapheme];
                     } else {
@@ -3970,7 +3970,7 @@ bool mudlet::scanDictionaryFile(const QString& dictionaryPath, int& oldWC, QHash
         QCollator sorter;
         sorter.setCaseSensitivity(Qt::CaseSensitive);
         std::sort(wl.begin(), wl.end(), sorter);
-        int dupCount = wl.removeDuplicates();
+        int const dupCount = wl.removeDuplicates();
         if (dupCount) {
             qDebug().nospace().noquote() << "  Removed " << dupCount << " duplicates.";
         }
@@ -4029,7 +4029,7 @@ int mudlet::getDictionaryWordCount(const QString &dictionaryPath)
     // Read the header line containing the word count:
     ds.readLineInto(&dictionaryLine);
     bool isOk = false;
-    int oldWordCount = dictionaryLine.toInt(&isOk);
+    int const oldWordCount = dictionaryLine.toInt(&isOk);
     dict.close();
     if (isOk) {
         return oldWordCount;
@@ -4091,7 +4091,7 @@ bool mudlet::overwriteAffixFile(const QString& affixPath, const QHash<QString, u
 // Returns the count of words in the first argument:
 int mudlet::scanWordList(QStringList& wl, QHash<QString, unsigned int>& gc)
 {
-    int wordCount = wl.count();
+    int const wordCount = wl.count();
     if (wordCount > 1) {
         // This will use the system default locale - it might be better to use
         // the Mudlet one...
@@ -4108,7 +4108,7 @@ int mudlet::scanWordList(QStringList& wl, QHash<QString, unsigned int>& gc)
         int endPos = graphemeFinder.toNextBoundary();
         do {
             if (endPos > 0) {
-                QString grapheme(wl.at(index).mid(startPos, endPos - startPos));
+                QString const grapheme(wl.at(index).mid(startPos, endPos - startPos));
                 if (gc.contains(grapheme)) {
                     ++gc[grapheme];
                 } else {
@@ -4132,9 +4132,9 @@ Hunhandle* mudlet::prepareProfileDictionary(const QString& hostName, QSet<QStrin
 {
     // Need to check that the files exist first:
     // full dictionary path+filename
-    QString dictionaryPath(getMudletPath(mudlet::profileDataItemPath, hostName, qsl("profile.dic")));
+    QString const dictionaryPath(getMudletPath(mudlet::profileDataItemPath, hostName, qsl("profile.dic")));
     // full affix path+filename
-    QString affixPath(getMudletPath(mudlet::profileDataItemPath, hostName, qsl("profile.aff")));
+    QString const affixPath(getMudletPath(mudlet::profileDataItemPath, hostName, qsl("profile.aff")));
 
     int oldWordCount = 0;
     QStringList wordList;
@@ -4149,7 +4149,7 @@ Hunhandle* mudlet::prepareProfileDictionary(const QString& hostName, QSet<QStrin
     }
 
     // We have read, sorted (and deduplicated if it was) the wordlist
-    int wordCount = wordList.count();
+    int const wordCount = wordList.count();
     if (wordCount > oldWordCount) {
         qDebug().nospace().noquote() << "  Considered an extra " << wordCount - oldWordCount << " words.";
     } else if (wordCount < oldWordCount) {
@@ -4195,8 +4195,8 @@ Hunhandle* mudlet::prepareSharedDictionary()
     }
 
     // Need to check that the files exist first:
-    QString dictionaryPath(getMudletPath(mudlet::mainDataItemPath, qsl("mudlet.dic")));
-    QString affixPath(getMudletPath(mudlet::mainDataItemPath, qsl("mudlet.aff")));
+    QString const dictionaryPath(getMudletPath(mudlet::mainDataItemPath, qsl("mudlet.dic")));
+    QString const affixPath(getMudletPath(mudlet::mainDataItemPath, qsl("mudlet.aff")));
     int oldWordCount = 0;
     QStringList wordList;
     QHash<QString, unsigned int> graphemeCounts;
@@ -4210,7 +4210,7 @@ Hunhandle* mudlet::prepareSharedDictionary()
     }
 
     // We have read, sorted (and deduplicated if it was) the wordlist
-    int wordCount = wordList.count();
+    int const wordCount = wordList.count();
     if (wordCount > oldWordCount) {
         qDebug().nospace().noquote() << "  Considered an extra " << wordCount - oldWordCount << " words.";
     } else if (wordCount < oldWordCount) {
@@ -4238,13 +4238,13 @@ Hunhandle* mudlet::prepareSharedDictionary()
 bool mudlet::saveDictionary(const QString& pathFileBaseName, QSet<QString>& wordSet)
 {
     // First update the line count in the list of words
-    QString dictionaryPath(qsl("%1.dic").arg(pathFileBaseName));
-    QString affixPath(qsl("%1.aff").arg(pathFileBaseName));
+    QString const dictionaryPath(qsl("%1.dic").arg(pathFileBaseName));
+    QString const affixPath(qsl("%1.aff").arg(pathFileBaseName));
     QHash<QString, unsigned int> graphemeCounts;
 
     // The file will have previously been created - for it to be missing now is
     // not expected - thought it shouldn't really be fatal...
-    int oldWordCount = getDictionaryWordCount(dictionaryPath);
+    int const oldWordCount = getDictionaryWordCount(dictionaryPath);
     if (oldWordCount == -1) {
         return false;
     }
@@ -4252,7 +4252,7 @@ bool mudlet::saveDictionary(const QString& pathFileBaseName, QSet<QString>& word
     QStringList wordList{wordSet.begin(), wordSet.end()};
 
     // This also sorts wordList as a wanted side-effect:
-    int wordCount = scanWordList(wordList, graphemeCounts);
+    int const wordCount = scanWordList(wordList, graphemeCounts);
     // We have sorted and scanned the wordlist
     if (wordCount > oldWordCount) {
         qDebug().nospace().noquote() << "  Saved an extra " << wordCount - oldWordCount << " words in dictionary.";
@@ -4394,7 +4394,7 @@ void mudlet::setNetworkRequestDefaults(const QUrl& url, QNetworkRequest& request
     request.setRawHeader(QByteArray("User-Agent"), QByteArray(qsl("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, APP_BUILD).toUtf8().constData()));
 #if !defined(QT_NO_SSL)
     if (url.scheme() == qsl("https")) {
-        QSslConfiguration config(QSslConfiguration::defaultConfiguration());
+        QSslConfiguration const config(QSslConfiguration::defaultConfiguration());
         request.setSslConfiguration(config);
     }
 #endif
@@ -4425,7 +4425,7 @@ void mudlet::activateProfile(Host* pHost)
     }
 
     const QString newActiveHostName{pHost->getName()};
-    int newActiveTabIndex = hostNameToTabMap.value(newActiveHostName, -1);
+    int const newActiveTabIndex = hostNameToTabMap.value(newActiveHostName, -1);
 
     if (mpCurrentActiveHost && mpCurrentActiveHost->mpConsole) {
         // Tell the old profile that it is losing focus:
@@ -4480,9 +4480,9 @@ void mudlet::activateProfile(Host* pHost)
     mpCurrentActiveHost->raiseEvent(focusGainedEvent);
 
     // Tell the new profile's main window that it might be resize via a Qt event:
-    int x = mpCurrentActiveHost->mpConsole->width();
-    int y = mpCurrentActiveHost->mpConsole->height();
-    QSize s = QSize(x, y);
+    int const x = mpCurrentActiveHost->mpConsole->width();
+    int const y = mpCurrentActiveHost->mpConsole->height();
+    QSize const s = QSize(x, y);
     QResizeEvent event(s, s);
     QApplication::sendEvent(mpCurrentActiveHost->mpConsole, &event);
 
@@ -4534,7 +4534,7 @@ void mudlet::setupTrayIcon()
 void mudlet::slot_tabMoved(const int oldPos, const int newPos)
 {
     const QStringList& tabNamesInOrder = mpTabBar->tabNames();
-    int itemsCount = mpSplitter_profileContainer->count();
+    int const itemsCount = mpSplitter_profileContainer->count();
     Q_ASSERT_X(itemsCount == tabNamesInOrder.count(), "mudlet::slot_tabMoved(...)", "mismatch in count of tabs and TMainConsoles");
     QMap<QString, QWidget*> widgetMap;
     // Gather the QWidget pointers for each TMainConsole and store them
@@ -4561,7 +4561,7 @@ void mudlet::slot_tabMoved(const int oldPos, const int newPos)
 void mudlet::refreshTabBar()
 {
     for (const auto& pHost : mHostManager) {
-        QString hostName = pHost->getName();
+        QString const hostName = pHost->getName();
         if (smDebugMode) {
             mpTabBar->applyPrefixToDisplayedText(hostName, TDebug::getTag(pHost.data()));
         } else {
@@ -4629,7 +4629,7 @@ bool mudlet::desktopInDarkMode()
     QProcess process;
     process.start(qsl("gsettings"), QStringList() << qsl("get") << qsl("org.gnome.desktop.interface") << qsl("gtk-theme"));
     process.waitForFinished();
-    QString output = QString::fromUtf8(process.readAllStandardOutput());
+    QString const output = QString::fromUtf8(process.readAllStandardOutput());
     return output.contains(qsl("-dark"), Qt::CaseInsensitive);
 #endif
 
@@ -4664,7 +4664,7 @@ void mudlet::onlyShowProfiles(const QStringList& predefinedProfiles)
     if (bool layEasterEgg = (now.time().second() < 30); layEasterEgg) {
         // Only do it in the first half of any minute:
 #else
-    if (bool layEasterEgg = (now.date().month() == 4
+    if (bool const layEasterEgg = (now.date().month() == 4
                         && now.date().day() == 1); layEasterEgg) {
 #endif // ! DEBUG_EASTER_EGGS
         // clang-format on
@@ -4675,7 +4675,7 @@ void mudlet::onlyShowProfiles(const QStringList& predefinedProfiles)
             return QImage(eggFileName);
         } else {
             // For the zeroth case just rotate the picture 180 degrees:
-            QImage original(mudlet::scmIsReleaseVersion
+            QImage const original(mudlet::scmIsReleaseVersion
                                     ? qsl(":/splash/Mudlet_splashscreen_main.png")
                                     : mudlet::scmIsPublicTestVersion ? qsl(":/splash/Mudlet_splashscreen_ptb.png")
                                                                      : qsl(":/splash/Mudlet_splashscreen_development.png"));

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1387,7 +1387,7 @@ void mudlet::addConsoleForNewHost(Host* pH)
     pConsole->setWindowTitle(pH->getName());
     pConsole->setObjectName(pH->getName());
     const QString tabName = pH->getName();
-    int const newTabID = mpTabBar->addTab(tabName);
+    const int newTabID = mpTabBar->addTab(tabName);
     /*
      * There is a sneaky feature on some OSes (I found it on FreeBSD but
      * it is notable switched OFF by default on MacOs) where Qt adds an
@@ -1448,8 +1448,8 @@ void mudlet::addConsoleForNewHost(Host* pH)
     // Setting mpCurrentActiveHost to pH is now done by the following
     slot_tabChanged(newTabID);
 
-    int const x = pH->mpConsole->width();
-    int const y = pH->mpConsole->height();
+    const int x = pH->mpConsole->width();
+    const int y = pH->mpConsole->height();
     QSize const s = QSize(x, y);
     QResizeEvent event(s, s);
     updateDiscordNamedIcon();
@@ -1480,7 +1480,7 @@ void mudlet::slot_timerFires()
 
     Host* pHost = mHostManager.getHost(hostName);
     Q_ASSERT_X(pHost, "mudlet::slot_timerFires()", "Unable to deduce Host pointer from data in QTimer");
-    int const id = pQT->property(TTimer::scmProperty_TTimerId).toInt();
+    const int id = pQT->property(TTimer::scmProperty_TTimerId).toInt();
     if (Q_UNLIKELY(!id)) {
         qWarning().nospace().noquote() << "mudlet::slot_timerFires() INFO - TTimer ID is zero - so TTimer has probably been deleted.";
         pQT->deleteLater();
@@ -3970,7 +3970,7 @@ bool mudlet::scanDictionaryFile(const QString& dictionaryPath, int& oldWC, QHash
         QCollator sorter;
         sorter.setCaseSensitivity(Qt::CaseSensitive);
         std::sort(wl.begin(), wl.end(), sorter);
-        int const dupCount = wl.removeDuplicates();
+        const int dupCount = wl.removeDuplicates();
         if (dupCount) {
             qDebug().nospace().noquote() << "  Removed " << dupCount << " duplicates.";
         }
@@ -4029,7 +4029,7 @@ int mudlet::getDictionaryWordCount(const QString &dictionaryPath)
     // Read the header line containing the word count:
     ds.readLineInto(&dictionaryLine);
     bool isOk = false;
-    int const oldWordCount = dictionaryLine.toInt(&isOk);
+    const int oldWordCount = dictionaryLine.toInt(&isOk);
     dict.close();
     if (isOk) {
         return oldWordCount;
@@ -4091,7 +4091,7 @@ bool mudlet::overwriteAffixFile(const QString& affixPath, const QHash<QString, u
 // Returns the count of words in the first argument:
 int mudlet::scanWordList(QStringList& wl, QHash<QString, unsigned int>& gc)
 {
-    int const wordCount = wl.count();
+    const int wordCount = wl.count();
     if (wordCount > 1) {
         // This will use the system default locale - it might be better to use
         // the Mudlet one...
@@ -4149,7 +4149,7 @@ Hunhandle* mudlet::prepareProfileDictionary(const QString& hostName, QSet<QStrin
     }
 
     // We have read, sorted (and deduplicated if it was) the wordlist
-    int const wordCount = wordList.count();
+    const int wordCount = wordList.count();
     if (wordCount > oldWordCount) {
         qDebug().nospace().noquote() << "  Considered an extra " << wordCount - oldWordCount << " words.";
     } else if (wordCount < oldWordCount) {
@@ -4210,7 +4210,7 @@ Hunhandle* mudlet::prepareSharedDictionary()
     }
 
     // We have read, sorted (and deduplicated if it was) the wordlist
-    int const wordCount = wordList.count();
+    const int wordCount = wordList.count();
     if (wordCount > oldWordCount) {
         qDebug().nospace().noquote() << "  Considered an extra " << wordCount - oldWordCount << " words.";
     } else if (wordCount < oldWordCount) {
@@ -4244,7 +4244,7 @@ bool mudlet::saveDictionary(const QString& pathFileBaseName, QSet<QString>& word
 
     // The file will have previously been created - for it to be missing now is
     // not expected - thought it shouldn't really be fatal...
-    int const oldWordCount = getDictionaryWordCount(dictionaryPath);
+    const int oldWordCount = getDictionaryWordCount(dictionaryPath);
     if (oldWordCount == -1) {
         return false;
     }
@@ -4252,7 +4252,7 @@ bool mudlet::saveDictionary(const QString& pathFileBaseName, QSet<QString>& word
     QStringList wordList{wordSet.begin(), wordSet.end()};
 
     // This also sorts wordList as a wanted side-effect:
-    int const wordCount = scanWordList(wordList, graphemeCounts);
+    const int wordCount = scanWordList(wordList, graphemeCounts);
     // We have sorted and scanned the wordlist
     if (wordCount > oldWordCount) {
         qDebug().nospace().noquote() << "  Saved an extra " << wordCount - oldWordCount << " words in dictionary.";
@@ -4425,7 +4425,7 @@ void mudlet::activateProfile(Host* pHost)
     }
 
     const QString newActiveHostName{pHost->getName()};
-    int const newActiveTabIndex = hostNameToTabMap.value(newActiveHostName, -1);
+    const int newActiveTabIndex = hostNameToTabMap.value(newActiveHostName, -1);
 
     if (mpCurrentActiveHost && mpCurrentActiveHost->mpConsole) {
         // Tell the old profile that it is losing focus:
@@ -4480,8 +4480,8 @@ void mudlet::activateProfile(Host* pHost)
     mpCurrentActiveHost->raiseEvent(focusGainedEvent);
 
     // Tell the new profile's main window that it might be resize via a Qt event:
-    int const x = mpCurrentActiveHost->mpConsole->width();
-    int const y = mpCurrentActiveHost->mpConsole->height();
+    const int x = mpCurrentActiveHost->mpConsole->width();
+    const int y = mpCurrentActiveHost->mpConsole->height();
     QSize const s = QSize(x, y);
     QResizeEvent event(s, s);
     QApplication::sendEvent(mpCurrentActiveHost->mpConsole, &event);
@@ -4534,7 +4534,7 @@ void mudlet::setupTrayIcon()
 void mudlet::slot_tabMoved(const int oldPos, const int newPos)
 {
     const QStringList& tabNamesInOrder = mpTabBar->tabNames();
-    int const itemsCount = mpSplitter_profileContainer->count();
+    const int itemsCount = mpSplitter_profileContainer->count();
     Q_ASSERT_X(itemsCount == tabNamesInOrder.count(), "mudlet::slot_tabMoved(...)", "mismatch in count of tabs and TMainConsoles");
     QMap<QString, QWidget*> widgetMap;
     // Gather the QWidget pointers for each TMainConsole and store them


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Mark read-only variables as const - that is, not intended to change after they've been declared
#### Motivation for adding to Mudlet
So we don't change them by accident later on, and also to clearly state intentions for the variables
#### Other info (issues closed, discussion etc)
This is also recommended by the [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es25-declare-an-object-const-or-constexpr-unless-you-want-to-modify-its-value-later-on)