### PR TITLE
Improvement: MXP SEND menus can be extended with MXP entities

### DIFF
--- a/src/TMxpSendTagHandler.cpp
+++ b/src/TMxpSendTagHandler.cpp
@@ -33,6 +33,12 @@ TMxpTagHandlerResult TMxpSendTagHandler::handleStartTag(TMxpContext& ctx, TMxpCl
         mIsHrefInContent = true;
     }
 
+    // Entities in href and hint may contain | separators, so interpolate them first:
+    href = ctx.getEntityResolver().interpolate(href);
+    if (!hint.isEmpty()) {
+        hint = ctx.getEntityResolver().interpolate(hint);
+    }
+
     QStringList hrefs = href.split('|');
     QStringList hints = hint.isEmpty() ? hrefs : hint.split('|');
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
MXP entities in send tags are interpolated before HREF and HINT lists are split into part
#### Motivation for adding to Mudlet
Enhance MXP compatibility with other clients (like mushclient and cmud) and MXP using muds.
#### Other info (issues closed, discussion etc)
To see the issue / change in action:

connect to aldebaran-mud.de port 2000
login as guest
y     (confirm you want to login as a guest)

Notice the mouse-over hint on the ... elipsis in the default prompt.
Right click and try some commands.

Now do:
alias bh ^BE HAPPY^bounce hap

Try entering 'bh' if you like. Do the mouse over again (in one of the prompts printed after the alias cmd), right click
and try the "BE HAPPY" command from the menu.
