### PR TITLE
Improvement: Custom MXP elements now support default values for arguments

### DIFF
--- a/src/TMxpCustomElementTagHandler.cpp
+++ b/src/TMxpCustomElementTagHandler.cpp
@@ -121,6 +121,10 @@ QString TMxpCustomElementTagHandler::mapAttributes(const TMxpElement& element, c
             return tag->getAttribute(attrIndex).getName();
         }
 
+        // If an attribute was not given, use its default value - if defined:
+        if (element.defaultValues.contains(attrName.toLower())) {
+            return element.defaultValues.value(attrName.toLower());
+        }
         return text;
     };
 
@@ -151,6 +155,9 @@ const QMap<QString, QString>& TMxpCustomElementTagHandler::parseFlagAttributes(c
             values[attrName] = tag->getAttributeValue(attrName);
         } else if (tag->getAttributesCount() > i) {
             values[attrName] = tag->getAttribute(i).getName();
+        } else if (el.defaultValues.contains(attrName)) {
+            // if we have no explicit value for the attribute, but a default, use that one.
+            values[attrName] = el.defaultValues.value(attrName);
         }
     }
     return values;

--- a/src/TMxpElementDefinitionHandler.cpp
+++ b/src/TMxpElementDefinitionHandler.cpp
@@ -46,7 +46,21 @@ TMxpTagHandlerResult TMxpElementDefinitionHandler::handleStartTag(TMxpContext& c
     }
 
     if (tag->hasAttribute("ATT")) {
-        element.attrs = tag->getAttributeValue("ATT").toLower().split(' ', Qt::SkipEmptyParts);
+        // Split attribute list into list of attributes and loop over each definiten
+        element.attrs = tag->getAttributeValue("ATT").split(' ', Qt::SkipEmptyParts);
+
+        for (int i = 0, numattr = element.attrs.size(); i < numattr; i++) {
+            QString attr = element.attrs.at(i);
+            // Find an argument after a = (if any), like in ATT="NAME=someone"
+            QString arg = attr.section("=", 1);
+
+            // The attribute name is the first part before any = . We have them all lowercase internally
+            element.attrs[i] = attr = attr.section("=", 0, 0).toLower();
+            if (!arg.isEmpty()) {
+                // If a default argument was specified, store it.
+                element.defaultValues[attr] = arg;
+            }
+        }
     }
 
     if (tag->hasAttribute("TAG")) {

--- a/src/TMxpElementRegistry.h
+++ b/src/TMxpElementRegistry.h
@@ -35,6 +35,8 @@ struct TMxpElement
     QStringList attrs;
     QString tag;
     QString flags;
+    // if a custom element definition specified a default for an attribute, it's in defaultValues[attribute]
+    QHash<QString, QString> defaultValues;
     bool open;
     bool empty;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,7 +82,7 @@ add_test(NAME TMxpEntityTagHandlerTest COMMAND TMxpEntityTagHandlerTest)
 add_executable(TMxpVersionTagTest TMxpVersionTagTest.cpp ../src/TMxpVersionTagHandler.cpp ../src/TMxpTagParser.cpp ../src/TMxpNodeBuilder.cpp ../src/MxpTag.cpp ../src/TStringUtils.cpp ../src/TMxpTagHandler.cpp)
 add_test(NAME TMxpVersionTagTest COMMAND TMxpVersionTagTest)
 
-add_executable(TMxpCustomElementTagHandlerTest TMxpCustomElementTagHandlerTest.cpp TMxpStubClient.cpp ${MXP_SOURCE} ../src/TMxpSendTagHandler.cpp ../src/TMxpTagParser.cpp ../src/TMxpNodeBuilder.cpp )
+add_executable(TMxpCustomElementTagHandlerTest TMxpCustomElementTagHandlerTest.cpp ${MXP_SOURCE} ../src/TMxpSendTagHandler.cpp ../src/TMxpTagParser.cpp ../src/TMxpNodeBuilder.cpp )
 add_test(NAME TMxpCustomElementTagHandlerTest COMMAND TMxpCustomElementTagHandlerTest)
 
 add_executable(TLuaInterfaceTest TLuaInterfaceTest.cpp ../src/LuaInterface.cpp ../src/TVar.cpp ../src/VarUnit.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,6 +82,9 @@ add_test(NAME TMxpEntityTagHandlerTest COMMAND TMxpEntityTagHandlerTest)
 add_executable(TMxpVersionTagTest TMxpVersionTagTest.cpp ../src/TMxpVersionTagHandler.cpp ../src/TMxpTagParser.cpp ../src/TMxpNodeBuilder.cpp ../src/MxpTag.cpp ../src/TStringUtils.cpp ../src/TMxpTagHandler.cpp)
 add_test(NAME TMxpVersionTagTest COMMAND TMxpVersionTagTest)
 
+add_executable(TMxpCustomElementTagHandlerTest TMxpCustomElementTagHandlerTest.cpp TMxpStubClient.cpp ${MXP_SOURCE} ../src/TMxpSendTagHandler.cpp ../src/TMxpTagParser.cpp ../src/TMxpNodeBuilder.cpp )
+add_test(NAME TMxpCustomElementTagHandlerTest COMMAND TMxpCustomElementTagHandlerTest)
+
 add_executable(TLuaInterfaceTest TLuaInterfaceTest.cpp ../src/LuaInterface.cpp ../src/TVar.cpp ../src/VarUnit.cpp)
 add_test(NAME TLuaInterfaceTest COMMAND TLuaInterfaceTest)
 

--- a/test/TMxpCustomElementTagHandlerTest.cpp
+++ b/test/TMxpCustomElementTagHandlerTest.cpp
@@ -1,0 +1,288 @@
+/***************************************************************************
+ *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2023 by Michael Weller - michael.weller@t-online.de     *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QTest>
+#include <TMxpSendTagHandler.h>
+#include <TMxpElementDefinitionHandler.h>
+#include <TMxpCustomElementTagHandler.h>
+#include <TMxpFormattingTagsHandler.h>
+#include <TMxpColorTagHandler.h>
+#include <TMxpTagParser.h>
+#include <TMxpTagProcessor.h>
+
+#include "TMxpStubClient.h"
+
+/*
+ * One can certainly argue if this should be in a separate module, but
+ * I want to include only the handlers needed by this file into the module
+ * for a sensible link time and executable size
+ */
+
+class TMxpStubHandlerContext : public TMxpStubContext {
+    TMxpSendTagHandler sendTagHandler;
+    TMxpFormattingTagsHandler formattingTagsHandler;
+    TMxpColorTagHandler colorTagHandler;
+
+public:
+    virtual TMxpTagHandlerResult handleTag(TMxpContext& ctx, TMxpClient& client, MxpTag* tag)
+    {
+        TMxpTagHandler *tagHandler;
+
+        if (sendTagHandler.supports(ctx, client, tag)) {
+            tagHandler = &sendTagHandler;
+        } else if (formattingTagsHandler.supports(ctx, client, tag)) {
+            tagHandler = &formattingTagsHandler;
+        } else if (colorTagHandler.supports(ctx, client, tag)) {
+            tagHandler = &colorTagHandler;
+        } else {
+            qDebug() << QString("unhandled Tag: [%1%2]").arg(tag->isEndTag() ? "/" : "").arg(tag->getName());
+            return MXP_TAG_HANDLED;
+        }
+        qDebug() << QString("handleTag([%1%2])").arg(tag->isEndTag() ? "/" : "").arg(tag->getName());
+        return tag->isStartTag() ? tagHandler->handleStartTag(ctx, client, tag->asStartTag()) : tagHandler->handleEndTag(ctx, client, tag->asEndTag());
+    }
+};
+
+class TMxpCustomElementTagHandlerTest : public QObject {
+Q_OBJECT
+
+private:
+
+private slots:
+    QSharedPointer<MxpNode> parseNode(const QString& tagText) const
+    {
+        auto nodes = TMxpTagParser::parseToMxpNodeList(tagText);
+        return nodes.size() > 0 ? nodes.first() : nullptr;
+    }
+
+    void testCustomItemCmd() {
+        // Complex Example: Aldebaran defines a profile with definitions like this:
+        // <!EL ITI '<SEND "examine &ID;|drop &ID;" HINT="&CMDH;examine|drop">' ATT='ID'>
+        // Then uses <ITI inv##N>a rock</ITI> for brevity all over the mud (here plain ITem in Inventory)
+        // Note the use of positional parameter ID (first arg)
+        // Mudlet, up to version 4.10, made the hints ALL UPPER in this context
+
+        TMxpStubHandlerContext ctx;
+        TMxpStubClient stub;
+        TMxpTagParser parser;
+
+        ctx.getEntityResolver().registerEntity("&CMDH;", "");
+
+        auto defTag = parseNode("<!EL ITI '<SEND \"examine &ID;|drop &ID;\" HINT=\"&CMDH;examine|drop\">' ATT='ID'>)");
+        auto startTag = parseNode("<ITI inv##10>");
+        auto endTag = parseNode("</ITI>");
+
+        TMxpElementDefinitionHandler definitionHandler;
+        definitionHandler.handleTag(ctx, stub, defTag->asStartTag());
+
+        TMxpCustomElementTagHandler customElementTagHandler;
+        TMxpTagHandler& tagHandler = customElementTagHandler;
+
+        tagHandler.handleTag(ctx, stub, startTag->asStartTag());
+        tagHandler.handleContent("a rock");
+        tagHandler.handleTag(ctx, stub, endTag->asEndTag());
+
+        QCOMPARE(stub.mHrefs.size(), 2);
+        QCOMPARE(stub.mHrefs[0], "send([[examine inv##10]])");
+        QCOMPARE(stub.mHrefs[1], "send([[drop inv##10]])");
+
+        QCOMPARE(stub.mHints.size(), 2);
+        QCOMPARE(stub.mHints[0], "EXAMINE");
+        QCOMPARE(stub.mHints[1], "DROP");
+    }
+
+    void testCustomElementDynamicEntity() {
+        // Complex Example: Aldebaran has a global custom element MAP used in maps printed for
+        // the player to click onto it and then follow the map.
+        // However, it uses the id of the map currently looked at in an entity redefined for
+        // each map you look at.
+        // <!EL ITI '<SEND "examine &ID;|drop &ID;" HINT="&CMDH;examine|drop">' ATT='ID'>
+        // Then uses <ITI inv##N>a rock</ITI> for brevity all over the mud (here plain ITem in Inventory)
+        // Note the use of positional parameter ID (first arg)
+        // Mudlet, up to version 4.10, made the hints ALL UPPER in this context
+
+        TMxpStubHandlerContext ctx;
+        TMxpStubClient stub;
+        TMxpTagParser parser;
+
+        ctx.getEntityResolver().registerEntity("&MID;", "map of the newbie jungle");
+
+        auto defTag = parseNode("<!EL MAP '<SEND \"follow &MID; to &ID;\" HINT=\"go here\">' ATT='ID'>");
+
+        TMxpElementDefinitionHandler definitionHandler;
+        definitionHandler.handleTag(ctx, stub, defTag->asStartTag());
+
+        auto startTag = parseNode("<MAP P8x7>");
+        auto endTag = parseNode("</MAP>");
+
+        TMxpCustomElementTagHandler customElementTagHandler;
+        TMxpTagHandler& tagHandler = customElementTagHandler;
+
+        tagHandler.handleTag(ctx, stub, startTag->asStartTag());
+        tagHandler.handleContent("*");
+        tagHandler.handleTag(ctx, stub, endTag->asEndTag());
+
+        QCOMPARE(stub.mHrefs.size(), 1);
+        QCOMPARE(stub.mHrefs[0], "send([[follow map of the newbie jungle to P8x7]])");
+
+        QCOMPARE(stub.mHints.size(), 1);
+        QCOMPARE(stub.mHints[0], "GO HERE");
+
+        // Now player looks at another map and gets an MXP button to go to another place.
+        // Note the MAP element is NOT redefined, only the entity.
+        ctx.getEntityResolver().registerEntity("&MID;", "map of the south forest");
+        startTag = parseNode("<MAP P42>");
+        endTag = parseNode("</MAP>");
+
+        tagHandler.handleTag(ctx, stub, startTag->asStartTag());
+        tagHandler.handleContent("*");
+        tagHandler.handleTag(ctx, stub, endTag->asEndTag());
+
+        QCOMPARE(stub.mHrefs.size(), 1);
+        QCOMPARE(stub.mHrefs[0], "send([[follow map of the south forest to P42]])");
+
+        QCOMPARE(stub.mHints.size(), 1);
+        QCOMPARE(stub.mHints[0], "GO HERE");
+    }
+
+    void testCustomElementDefaultAttributes() {
+        // This example literally taken from the MXP definition at https://www.zuggsoft.com/zmud/mxp.htm#ELEMENT
+        //
+        // <!ELEMENT boldtext '<COLOR &col;><B>' ATT='col=red'>
+        //
+        // Then you could use it on the MUD like this:
+        //
+        // <boldtext>This is bold red</boldtext>
+        // <boldtext col=blue>This is bold blue text</boldtext>
+        // <boldtext blue>This is also bold blue text</boldtext>
+
+        TMxpStubHandlerContext ctx;
+        TMxpStubClient stub;
+        TMxpTagParser parser;
+
+        auto defTag = parseNode("<!ELEMENT boldtext '<COLOR &col;><B>' ATT='col=red'>");
+
+        TMxpElementDefinitionHandler definitionHandler;
+        definitionHandler.handleTag(ctx, stub, defTag->asStartTag());
+
+        auto startTag = parseNode("<boldtext>");
+        auto endTag = parseNode("</boldtext>");
+
+        TMxpCustomElementTagHandler customElementTagHandler;
+        TMxpTagHandler& tagHandler = customElementTagHandler;
+
+        tagHandler.handleTag(ctx, stub, startTag->asStartTag());
+        tagHandler.handleContent("This is bold red");
+        // is it?
+        // QCOMPARE(stub.isBold(), true); // This test cannot be used b4 the MXPFormatting Tags PR is merged
+        QCOMPARE(stub.fgColor, "red");
+        tagHandler.handleTag(ctx, stub, endTag->asEndTag());
+
+        // back to defaults:
+        // QCOMPARE(stub.isBold(), false);
+        QCOMPARE(stub.fgColor, "");
+
+        startTag = parseNode("<boldtext COL=blue>)");
+        tagHandler.handleTag(ctx, stub, startTag->asStartTag());
+        tagHandler.handleContent("This is bold blue text");
+        // is it?
+        // QCOMPARE(stub.isBold(), true);
+        QCOMPARE(stub.fgColor, "blue");
+        tagHandler.handleTag(ctx, stub, endTag->asEndTag());
+
+        // back to defaults:
+        // QCOMPARE(stub.isBold(), false);
+        QCOMPARE(stub.fgColor, "");
+
+        startTag = parseNode("<boldtext blue>)");
+        tagHandler.handleTag(ctx, stub, startTag->asStartTag());
+        tagHandler.handleContent("This is also bold blue text");
+        // is it?
+
+        // QCOMPARE(stub.isBold(), true);
+        // QCOMPARE(stub.fgColor, "blue");
+        tagHandler.handleTag(ctx, stub, endTag->asEndTag());
+
+        // back to defaults:
+        // QCOMPARE(stub.isBold(), false);
+        QCOMPARE(stub.fgColor, "");
+    }
+
+    void testCustomElementPlayer() {
+        // Real life example from Aldebaran: (there are more sensible ones with EXPIRE which Mudlet does not yet support)
+        //
+        // <!EL WH '<SEND "whisper &NAME; |finger &NAME; |tell &NAME; " HINT="whisper &NAME;|finger &NAME;|tell &NAME;" PROMPT>' ATT='NAME=someone'>
+        // 
+        // Used like <WH playerid>Player</WH> says: Hello!
+        // However, if player is invisible, playerid is empty, like <WH >Someone</WH> says: Hello!
+        //
+        // Upper and lower case are mixed in the entity name to make this a more severe test case
+
+        TMxpStubHandlerContext ctx;
+        TMxpStubClient stub;
+        TMxpTagParser parser;
+
+        auto defTag = parseNode("<!EL WH '<SEND \"whisper &Name; |finger &NAme; |tell &namE; \" HINT=\"whisper &name;|finger &NAME;|tell &NAME;\" PROMPT>' ATT='NAme=someone'>");
+
+        TMxpElementDefinitionHandler definitionHandler;
+        definitionHandler.handleTag(ctx, stub, defTag->asStartTag());
+
+        auto startTag = parseNode("<WH playerid>");
+        auto endTag = parseNode("</WH>");
+
+        TMxpCustomElementTagHandler customElementTagHandler;
+        TMxpTagHandler& tagHandler = customElementTagHandler;
+
+        tagHandler.handleTag(ctx, stub, startTag->asStartTag());
+        tagHandler.handleContent("Player");
+        tagHandler.handleTag(ctx, stub, endTag->asEndTag());
+
+        QCOMPARE(stub.mHrefs.size(), 3);
+        QCOMPARE(stub.mHrefs[0], "printCmdLine([[whisper playerid ]])");
+        QCOMPARE(stub.mHrefs[1], "printCmdLine([[finger playerid ]])");
+        QCOMPARE(stub.mHrefs[2], "printCmdLine([[tell playerid ]])");
+
+        QCOMPARE(stub.mHints.size(), 3);
+        QCOMPARE(stub.mHints[0], "WHISPER playerid");
+        QCOMPARE(stub.mHints[1], "FINGER playerid");
+        QCOMPARE(stub.mHints[2], "TELL playerid");
+
+        // Now w/o a NAME parameter given:
+        startTag = parseNode("<WH>");
+        tagHandler.handleTag(ctx, stub, startTag->asStartTag());
+        tagHandler.handleContent("Invisible SuperAdmin");
+        tagHandler.handleTag(ctx, stub, endTag->asEndTag());
+
+        QCOMPARE(stub.mHrefs.size(), 3);
+        QCOMPARE(stub.mHrefs[0], "printCmdLine([[whisper someone ]])");
+        QCOMPARE(stub.mHrefs[1], "printCmdLine([[finger someone ]])");
+        QCOMPARE(stub.mHrefs[2], "printCmdLine([[tell someone ]])");
+
+        QCOMPARE(stub.mHints.size(), 3);
+        QCOMPARE(stub.mHints[0], "WHISPER someone");
+        QCOMPARE(stub.mHints[1], "FINGER someone");
+        QCOMPARE(stub.mHints[2], "TELL someone");
+    }
+};
+
+#include "TMxpCustomElementTagHandlerTest.moc"
+QTEST_MAIN(TMxpCustomElementTagHandlerTest)
+


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Custom Element Definition and Handler are changed to handle default values by ATT="EntityName=DefaultValue" as specified in the MXP protocol definition.
#### Motivation for adding to Mudlet
Improve MXP compliance.
#### Other info (issues closed, discussion etc)
To see this issue (in addition to reviewing the test code coming with this PR):

connect to aldebaran-mud.de port 2000
login as guest
y     (confirm you want to login as a guest)

Now do:
who

Notice the mouse-over hint on your (or another players) name in the who output.

Right click and try some commands. Admittedly guest has no finger info, and the game does not allow you to tell to yourself (and you have to wait for a few minutes for your mana to build up for tell), so you can't really do much.

Alternatively, you can just login with another guest character (but mudlet needs a second game profile for this) and "look". The issue is the same with the short description of the other guest character. But here you can also select "whisper" from the menu, which will work nicely.

BTW, all commands are just copied in the input line, even for "finger guest" you have to hit enter. This is by design / limitation of the MXP SEND command (you cannot choose 'PROMPT' per menu entry, only globally).

With the current mudlet version this does not work. This is due to the definition:
&lt;!EL PL '&lt;SEND "tell &amp;NAME; |finger &amp;NAME; " HINT="tell &amp;NAME;|finger &amp;NAME;" PROMPT>' ATT='NAME=someone'>

Mudlet misinterpretes 'NAME=someone' as the whole name of the entity, not just NAME. 

The effect of the default value 'someone' is not easy to demonstrate, except when you can find an invisible wizard and convince him to to interact with you. However, you can do:

say ^&lt;PL player_id>Test1&lt;/PL>

and

say ^&lt;PL>Test2&lt;/PL>

and see/use the menus created by/in Mudlet for the echo of Test1 and Test2. You'll see how it refers to player_id or someone.

Note that Mudlet should actually not evaluate the PL tag in the say command, as it is a secure MXP tag and the session is in open mode at this time. However, Mudlet does not honor this security measure as of now, which is another, unrelated, issue. 