### PR TITLE
Fix: Cannot delete an MXP entity which is not all lower case

### DIFF
--- a/src/TEntityResolver.cpp
+++ b/src/TEntityResolver.cpp
@@ -52,7 +52,7 @@ bool TEntityResolver::registerEntity(const QString& entity, const QString& str)
 }
 
 bool TEntityResolver::unregisterEntity(const QString & entity){
-    return mEntititesMap.remove(entity) > 0;
+    return mEntititesMap.remove(entity.toLower()) > 0;
 }
 
 QString TEntityResolver::resolveCode(const QString& entityValue)

--- a/test/TMxpEntityTagHandlerTest.cpp
+++ b/test/TMxpEntityTagHandlerTest.cpp
@@ -155,6 +155,12 @@ private slots:
 
         processor.handleNode(processor, stub, parseNode("<!EN entity delete>").get());
         QCOMPARE(processor.getEntityResolver().getResolution("&entity;"), "&entity;");
+
+        processor.getEntityResolver().registerEntity("&myEntity;", "v2");
+        QCOMPARE(processor.getEntityResolver().getResolution("&myEntity;"), "v2");
+
+        processor.handleNode(processor, stub, parseNode("<!EN myEntity delete>").get());
+        QCOMPARE(processor.getEntityResolver().getResolution("&myEntity;"), "&myEntity;");
     }
 
     void testEmpty() {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
If a mud creates an MXP entity that is no all lowercase, it cannot be deleted.
This is because entity names are managed as all lowercase internally... Except for &lt;!EN ... DELETE> which will fail to find the entity definition if the name is not all lowercase.
The PR also extends TMxpEntityTagHandlerTest.cpp to check for this issue.
#### Motivation for adding to Mudlet
Improve MXP compliance by fixing this issue.
#### Other info (issues closed, discussion etc)
I have no real life example for this issue, AFAIK most games don't delete entities, they just redefine them when needed.
Actually, <B>note</B> that the MXP protocol specifies entities as case sensitive: &lt;CITE>Also note that as in XML, entities are case sensitive, so &amp;Start; is different than &amp;start;&lt;/CITE>.

Mudlet breaks this requirement. However, entity names are converted to lower case all over the place in the code. It will be quite painful to remove this in all places. I also fear that some muds may already rely on this incompliant behaviour of Mudlet, so it might be better to leave this as it is. IMHO, a sensible mud developer/coder should really not use entities which just differ by case. 
