### PR TITLE
improve error messages by making code start on first line

### DIFF
--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -120,10 +120,10 @@ bool TAction::setScript(const QString& script)
 
 bool TAction::compileScript()
 {
-    mFuncName = QString("Action") + QString::number(mID);
-    const QString code = QString("function %1() %2\nend").arg(mFuncName, mScript);
+    mFuncName = qsl("Action%1").arg(QString::number(mID));
+    const QString code = qsl("function %1() %2\nend").arg(mFuncName, mScript);
     QString error;
-    if (mpHost->mLuaInterpreter.compile(code, error, QString("Button: ") + getName())) {
+    if (mpHost->mLuaInterpreter.compile(code, error, qsl("Button: %1").arg(getName()))) {
         mNeedsToBeCompiled = false;
         mOK_code = true;
         return true;

--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -121,7 +121,7 @@ bool TAction::setScript(const QString& script)
 bool TAction::compileScript()
 {
     mFuncName = QString("Action") + QString::number(mID);
-    const QString code = QString("function ") + mFuncName + QString("()\n") + mScript + QString("\nend\n");
+    const QString code = QString("function %1() %2\nend").arg(mFuncName, mScript);
     QString error;
     if (mpHost->mLuaInterpreter.compile(code, error, QString("Button: ") + getName())) {
         mNeedsToBeCompiled = false;

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -165,8 +165,8 @@ bool TKey::setScript(const QString& script)
 
 bool TKey::compileScript()
 {
-    mFuncName = QString("Key") + QString::number(mID);
-    const QString code = QString("function %1() %2\nend").arg(mFuncName, mScript);
+    mFuncName = qsl("Key%1").arg(QString::number(mID));
+    const QString code = qsl("function %1() %2\nend").arg(mFuncName, mScript);
     QString error;
     if (mpHost->mLuaInterpreter.compile(code, error, QString("Key: ") + getName())) {
         mNeedsToBeCompiled = false;

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -166,7 +166,7 @@ bool TKey::setScript(const QString& script)
 bool TKey::compileScript()
 {
     mFuncName = QString("Key") + QString::number(mID);
-    const QString code = QString("function ") + mFuncName + QString("()\n") + mScript + QString("\nend\n");
+    const QString code = QString("function %1() %2\nend").arg(mFuncName, mScript);
     QString error;
     if (mpHost->mLuaInterpreter.compile(code, error, QString("Key: ") + getName())) {
         mNeedsToBeCompiled = false;

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -168,7 +168,7 @@ bool TKey::compileScript()
     mFuncName = qsl("Key%1").arg(QString::number(mID));
     const QString code = qsl("function %1() %2\nend").arg(mFuncName, mScript);
     QString error;
-    if (mpHost->mLuaInterpreter.compile(code, error, QString("Key: ") + getName())) {
+    if (mpHost->mLuaInterpreter.compile(code, error, qsl("Key: %1").arg(getName()))) {
         mNeedsToBeCompiled = false;
         mOK_code = true;
         return true;

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -192,10 +192,10 @@ bool TTimer::setScript(const QString& script)
 
 bool TTimer::compileScript()
 {
-    mFuncName = QString("Timer") + QString::number(mID);
-    const QString code = QString("function %1() %2\nend").arg(mFuncName, mScript);
+    mFuncName = qsl("Timer%1").arg(QString::number(mID));
+    const QString code = qsl("function %1() %2\nend").arg(mFuncName, mScript);
     QString error;
-    if (mpHost->mLuaInterpreter.compile(code, error, "Timer: " + getName())) {
+    if (mpHost->mLuaInterpreter.compile(code, error, "Timer: %1".arg(getName()))) {
         mNeedsToBeCompiled = false;
         mOK_code = true;
         return true;

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -193,7 +193,7 @@ bool TTimer::setScript(const QString& script)
 bool TTimer::compileScript()
 {
     mFuncName = QString("Timer") + QString::number(mID);
-    const QString code = QString("function ") + mFuncName + QString("()\n") + mScript + QString("\nend\n");
+    const QString code = QString("function %1() %2\nend").arg(mFuncName, mScript);
     QString error;
     if (mpHost->mLuaInterpreter.compile(code, error, "Timer: " + getName())) {
         mNeedsToBeCompiled = false;

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -195,7 +195,7 @@ bool TTimer::compileScript()
     mFuncName = qsl("Timer%1").arg(QString::number(mID));
     const QString code = qsl("function %1() %2\nend").arg(mFuncName, mScript);
     QString error;
-    if (mpHost->mLuaInterpreter.compile(code, error, "Timer: %1".arg(getName()))) {
+    if (mpHost->mLuaInterpreter.compile(code, error, qsl("Timer: %1").arg(getName()))) {
         mNeedsToBeCompiled = false;
         mOK_code = true;
         return true;

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -240,7 +240,7 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds)
             std::stringstream func;
             func << "trigger" << mID << "condition" << i;
             funcName = func.str();
-            const QString code = qsl("function %1()\n%2\nend\n").arg(funcName.c_str(), patterns[i]);
+            const QString code = qsl("function %1() %2\nend").arg(funcName.c_str(), patterns[i]);
             QString error;
             if (!mpLua->compile(code, error, QString::fromStdString(funcName))) {
                 setError(qsl("<b><font color='blue'>%1</font></b>")
@@ -1324,7 +1324,7 @@ bool TTrigger::setScript(const QString& script)
 bool TTrigger::compileScript()
 {
     mFuncName = qsl("Trigger%1").arg(QString::number(mID));
-    const QString code = qsl("function %1()\n%2\nend\n").arg(mFuncName, mScript);
+    const QString code = qsl("function %1() %2\nend").arg(mFuncName, mScript);
     QString error;
     if (mpLua->compile(code, error, qsl("Trigger: %1").arg(getName()))) {
         mNeedsToBeCompiled = false;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Behind the scenes there are things like `code = qsl("function Alias%1() %2\nend").arg(id, code)` which handles the code of an alias and embeds it into a function.  Timers, triggers, and keybinds all have similar, but with the `function X()` on a line alone.  When they get compiled, the first line of an alias code box is also the first line of the resulting function, so an error on the first line of the edit box code is also the first line of the post-embed code.  But for the other type of items, the first line of edit box is second line of post-embed code.  When compiling, the system is looking at the post-embed code, so it gives errors with line numbers that make sense with aliases but are confusing with the others.

This edit should make them all similar to aliases.

#### Motivation for adding to Mudlet
fix #1460 
#### Other info (issues closed, discussion etc)
Error messages say things like "near X" instead of citing column numbers, so I don't think there are any negative consequences for first line being on same line after `function X()`.  It's how aliases are handled already.