### PR TITLE
Fix: newly-created profiles in PTBs not being saveable

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1559,6 +1559,7 @@ void dlgConnectionProfiles::loadProfile(bool alsoConnect)
     pHost->hideMudletsVariables();
     if (entries.isEmpty()) {
         firstTimeLoad = true;
+        pHost->mLoadedOk = true;
     } else {
         QFile file(qsl("%1%2").arg(folder, profile_history->itemData(profile_history->currentIndex()).toString()));
         file.open(QFile::ReadOnly | QFile::Text);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2690,6 +2690,7 @@ void mudlet::doAutoLogin(const QString& profile_name)
     bool preInstallPackages = false;
     if (entries.isEmpty()) {
         preInstallPackages = true;
+        pHost->mLoadedOk = true;
 
         const auto it = TGameDetails::findGame(profile_name);
         if (it != TGameDetails::scmDefaultGames.end()) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Newly-created profiles weren't being flagged as having loaded okay - and because the default is "no" until it's OK, they weren't save-able.
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/6856
#### Other info (issues closed, discussion etc)
`preInstallPackages` and `firstTimeLoad` are actually referring to the same thing in two different places... should at least be the same variable names!