### PR TITLE
Fix: Solve the case when two error messages are present

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2683,10 +2683,9 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
     }
 
     if (reply->error() != QNetworkReply::NoError && reply->error() != QNetworkReply::OperationCanceledError) {
-            // Don't report on any errors here as we've already done so in slot_downloadError(...) previously.
-            cleanup();
-            return;
-        }
+        // Don't report on any errors here as we've already done so in slot_downloadError(...) previously.
+        cleanup();
+        return;
         // else was QNetworkReply::OperationCanceledError and we already handle
         // THAT in slot_downloadCancel()
     }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2654,7 +2654,7 @@ void TMap::slot_downloadError(QNetworkReply::NetworkError error)
 
     if (error != QNetworkReply::OperationCanceledError) {
         // No point in reporting Cancel as that is handled elsewhere
-        const QString errMsg = tr("[ ERROR ] - Map download encountered an error:\n%1.").arg(mpNetworkReply->errorString());
+        const QString errMsg = tr("[ ERROR ] - Map download encountered an error:\n%1").arg(mpNetworkReply->errorString());
         postMessage(errMsg);
     }
 }
@@ -2685,8 +2685,7 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
     if (reply->error() != QNetworkReply::NoError) {
         if (reply->error() != QNetworkReply::OperationCanceledError) {
             // Don't post an error for the cancel case - it has already been done
-            const QString alertMsg = tr("[ ALERT ] - Map download failed, error reported was:\n%1.").arg(reply->errorString());
-            postMessage(alertMsg);
+            // Don't report on the map not downloading properly, because we already reported before. Just do the cleanup.
             cleanup();
             return;
         }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2683,7 +2683,7 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
     }
 
     if (reply->error() != QNetworkReply::NoError && reply->error() != QNetworkReply::OperationCanceledError) {
-            // Don't post an error for the cancel case - it has already been done
+            // Don't report on any errors here as we've already done so in slot_downloadError(...) previously.
             cleanup();
             return;
         }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2682,10 +2682,8 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
         qWarning() << "TMap::slot_replyFinished( QNetworkReply * ) ERROR - received argument was not the expected stored pointer.";
     }
 
-    if (reply->error() != QNetworkReply::NoError) {
-        if (reply->error() != QNetworkReply::OperationCanceledError) {
+    if (reply->error() != QNetworkReply::NoError && reply->error() != QNetworkReply::OperationCanceledError) {
             // Don't post an error for the cancel case - it has already been done
-            // Don't report on the map not downloading properly, because we already reported before. Just do the cleanup.
             cleanup();
             return;
         }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Solves #2720. Two error messages were printed for not downloading the map, now just one is printed.
#### Motivation for adding to Mudlet
The original issue was deemed to cause confusion for users.
#### Other info (issues closed, discussion etc)
/claim #2720
fixes #2720