### PR TITLE
Fix: a wrong function name and a bogus error return value in setScript(...)

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -8200,13 +8200,11 @@ int TLuaInterpreter::setScript(lua_State* L)
     }
 
     auto [id, message] = pLuaInterpreter->setScriptCode(name, luaCode, --pos);
-    lua_pushnumber(L, id);
     if (id == -1) {
-        lua_pushfstring(L, "permScript: cannot set script (%s)", message.toUtf8().constData());
+        lua_pushfstring(L, "setScript: cannot set script (%s)", message.toUtf8().constData());
         return lua_error(L);
     }
     lua_pushnumber(L, id);
-
     return 1;
 }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
An error in #3515 meant that `-1` and `false` would be returned should the new lua code not compile instead `-1` and an `"error message"`.

The code was revised in #4536 as part of wider changes that made failure to compile the lua script/code for all code setting functions throw a lua error (aborting execution of the caller) with, what should be an error message instead of a sentinel value (`-1`) and a message. However with the prior error the error message will likely just be "-1"!

In correcting the above I also discovered that the wanted error message was: `"permScript: cannot set script (`\<error message>`)"` for this function when it should begin with `setScript` and not `permScript`!

#### Motivation for adding to Mudlet
Fixing something that looks broken.

#### Other info (issues closed, discussion etc)
I found this and want it fixed for #6742 .