### PR TITLE
Improve: show script loading errors

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -767,7 +767,7 @@ void Host::resetProfile_phase2()
     getAliasUnit()->compileAll();
     getActionUnit()->compileAll();
     getKeyUnit()->compileAll();
-    getScriptUnit()->compileAll();
+    getScriptUnit()->compileAll(true);
 
     mResetProfile = false;
 

--- a/src/ScriptUnit.cpp
+++ b/src/ScriptUnit.cpp
@@ -204,11 +204,11 @@ int ScriptUnit::getNewID()
     return ++mMaxID;
 }
 
-void ScriptUnit::compileAll()
+void ScriptUnit::compileAll(bool saveLoadingError)
 {
     for (auto script : mScriptRootNodeList) {
         if (script->isActive()) {
-            script->compileAll();
+            script->compileAll(saveLoadingError);
         }
     }
 }

--- a/src/ScriptUnit.h
+++ b/src/ScriptUnit.h
@@ -57,7 +57,7 @@ public:
     }
 
     TScript* getScript(int id);
-    void compileAll();
+    void compileAll(bool saveLoadingError = false);
     bool registerScript(TScript* pT);
     void unregisterScript(TScript* pT);
     void reParentScript(int childID, int oldParentID, int newParentID, int parentPosition = -1, int childPosition = -1);

--- a/src/TScript.cpp
+++ b/src/TScript.cpp
@@ -174,7 +174,9 @@ std::optional<QString> TScript::getLoadingError()
 // error: The error message to set as the loading error.
 void TScript::setLoadingError(const QString& error)
 {
-    mLoadingError = error;
+    if (!error.isEmpty()) {
+        mLoadingError = error;
+    }
 }
 
 // Clears the loading error message for this script.

--- a/src/TScript.cpp
+++ b/src/TScript.cpp
@@ -84,14 +84,14 @@ void TScript::setEventHandlerList(QStringList handlerList)
 }
 
 
-void TScript::compileAll()
+void TScript::compileAll(bool saveLoadingError)
 {
     if (mpHost->mResetProfile) {
         mNeedsToBeCompiled = true;
     }
-    compile();
+    compile(saveLoadingError);
     for (auto script : *mpMyChildrenList) {
-        script->compileAll();
+        script->compileAll(saveLoadingError);
     }
 }
 
@@ -103,10 +103,10 @@ void TScript::callEventHandler(const TEvent& pEvent)
     }
 }
 
-void TScript::compile()
+void TScript::compile(bool saveLoadingError)
 {
     if (mNeedsToBeCompiled) {
-        if (!compileScript()) {
+        if (!compileScript(saveLoadingError)) {
             if (mudlet::smDebugMode) {
                 TDebug(Qt::white, Qt::red) << "ERROR: Lua compile error. compiling script of script:" << mName << "\n" >> mpHost;
             }
@@ -114,7 +114,7 @@ void TScript::compile()
         }
     }
     for (auto script : *mpMyChildrenList) {
-        script->compile();
+        script->compile(saveLoadingError);
     }
 }
 
@@ -128,7 +128,7 @@ bool TScript::setScript(const QString& script)
     return mOK_code;
 }
 
-bool TScript::compileScript()
+bool TScript::compileScript(bool saveLoadingError)
 {
     QString error;
     if (mpHost->mLuaInterpreter.compile(mScript, error, QString("Script: ") + getName())) {
@@ -141,6 +141,9 @@ bool TScript::compileScript()
     } else {
         mOK_code = false;
         setError(error);
+        if (saveLoadingError) {
+            setLoadingError(error);
+        }
         return false;
     }
 }
@@ -153,4 +156,31 @@ void TScript::execute()
         }
     }
     mpHost->mLuaInterpreter.call(mFuncName, mName);
+}
+
+// Gets the Lua error message for this script if one occurred during profile load
+// Returns:
+// - The loading error message if there was one
+// - An empty optional if no loading error occurred
+std::optional<QString> TScript::getLoadingError()
+{
+    return mLoadingError;
+}
+
+// Sets the loading error message for this script.
+// Used when an error occurs loading the script during profile load.
+// The loading error can later be retrieved using getLoadingError().
+//
+// error: The error message to set as the loading error.
+void TScript::setLoadingError(const QString& error)
+{
+    mLoadingError = error;
+}
+
+// Clears the loading error message for this script.
+// Used to clear a loading error once it has been handled.
+// After calling this, getLoadingError() will return an empty optional.
+void TScript::clearLoadingError()
+{
+    mLoadingError.reset();
 }

--- a/src/TScript.h
+++ b/src/TScript.h
@@ -27,6 +27,7 @@
 #include "pre_guard.h"
 #include <QPointer>
 #include <QStringList>
+#include <optional>
 #include "post_guard.h"
 
 class Host;

--- a/src/TScript.h
+++ b/src/TScript.h
@@ -45,9 +45,9 @@ public:
 
     QString getName() { return mName; }
     void setName(const QString& name) { mName = name; }
-    void compile();
-    void compileAll();
-    bool compileScript();
+    void compile(bool saveLoadingError = false);
+    void compileAll(bool saveLoadingError = false);
+    bool compileScript(bool saveLoadingError = false);
     void execute();
     QString getScript() { return mScript; }
     bool setScript(const QString& script);
@@ -55,6 +55,9 @@ public:
     void callEventHandler(const TEvent&);
     void setEventHandlerList(QStringList handlerList);
     QStringList getEventHandlerList() { return mEventHandlerList; }
+    std::optional<QString> getLoadingError();
+    void setLoadingError(const QString& error);
+    void clearLoadingError();
     bool exportItem;
     bool mModuleMasterFolder;
 
@@ -67,6 +70,7 @@ private:
     bool mNeedsToBeCompiled;
     QStringList mEventHandlerList;
     bool mModuleMember;
+    std::optional<QString> mLoadingError;
 };
 
 #endif // MUDLET_TSCRIPT_H

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -10094,16 +10094,16 @@ void dlgTriggerEditor::changeEvent(QEvent* e)
 {
     if (e->type() == QEvent::ActivationChange && this->isActiveWindow()) {
         if (mCurrentView == EditorViewType::cmScriptView) {
-            QTreeWidgetItem* pItem = treeWidget_scripts->currentItem();
-            if (!pItem) {
+            auto scriptTreeWidgetItem = treeWidget_scripts->currentItem();
+            if (!scriptTreeWidgetItem) {
                 return;
             }
 
-            TScript* pT = mpHost->getScriptUnit()->getScript(pItem->data(0, Qt::UserRole).toInt());
-            if (!pT) {
+            TScript* script = mpHost->getScriptUnit()->getScript(scriptTreeWidgetItem->data(0, Qt::UserRole).toInt());
+            if (!script) {
                 return;
             }
-            if (auto error = pT->getLoadingError(); error) {
+            if (auto error = script->getLoadingError(); error) {
                 showWarning(tr("While loading the profile, this script had an error that has since been fixed, "
                                "possibly by another script. The error was:%2%3")
                                     .arg(qsl("<br>"), error.value()));

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -5143,8 +5143,6 @@ void dlgTriggerEditor::saveScript()
 void dlgTriggerEditor::clearEditorNotification() const
 {
     mpSystemMessageArea->hide();
-    qDebug() << "Clear editor notification called.";
-
 }
 
 int dlgTriggerEditor::canRecast(QTreeWidgetItem* pItem, int newNameType, int newValueType)

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -7463,6 +7463,7 @@ void dlgTriggerEditor::enterEvent(TEnterEvent* event)
 void dlgTriggerEditor::focusInEvent(QFocusEvent* pE)
 {
     Q_UNUSED(pE)
+    qDebug() << "focusInEvent fired!!";
     if (mNeedUpdateData) {
         saveOpenChanges();
         treeWidget_triggers->clear();
@@ -10084,6 +10085,29 @@ void dlgTriggerEditor::hideSystemMessageArea()
         TScript* pT = mpHost->getScriptUnit()->getScript(pItem->data(0, Qt::UserRole).toInt());
         if (pT && pT->getLoadingError()) {
             pT->clearLoadingError();
+        }
+    }
+}
+
+// In case the profile was reset while the editor was out of focus, checks for any script loading errors and displays them
+void dlgTriggerEditor::changeEvent(QEvent* e)
+{
+    if (e->type() == QEvent::ActivationChange && this->isActiveWindow()) {
+        if (mCurrentView == EditorViewType::cmScriptView) {
+            QTreeWidgetItem* pItem = treeWidget_scripts->currentItem();
+            if (!pItem) {
+                return;
+            }
+
+            TScript* pT = mpHost->getScriptUnit()->getScript(pItem->data(0, Qt::UserRole).toInt());
+            if (!pT) {
+                return;
+            }
+            if (auto error = pT->getLoadingError(); error) {
+                showWarning(tr("While loading the profile, this script had an error that has since been fixed, "
+                               "possibly by another script. The error was:%2%3")
+                                    .arg(qsl("<br>"), error.value()));
+            }
         }
     }
 }

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -224,6 +224,7 @@ public:
     void setSearchOptions(const SearchOptions);
     void setEditorShowBidi(const bool);
     void showCurrentTriggerItem();
+    void hideSystemMessageArea();
 
 public slots:
     void slot_toggleHiddenVariables(bool);

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -180,6 +180,7 @@ public:
     bool eventFilter(QObject*, QEvent* event) override;
     bool event(QEvent* event) override;
     void resizeEvent(QResizeEvent *event) override;
+    void changeEvent(QEvent* e) override;
     void fillout_form();
     void showError(const QString&);
     void showWarning(const QString&);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2706,7 +2706,7 @@ void mudlet::doAutoLogin(const QString& profile_name)
         if (auto [success, message] = importer.importPackage(&file); !success) {
             pHost->postMessage(tr("[ ERROR ] - Something went wrong loading your Mudlet profile and it could not be loaded.\n"
                 "Try loading an older version in 'Connect - Options - Profile history' or double-check that %1 looks correct.").arg(file.fileName()));
-        
+
             qDebug().nospace().noquote() << "mudlet::doAutoLogin(\"" << profile_name << "\") ERROR - loading \"" << file.fileName() << "\" failed, reason: \"" << message << "\".";
         } else {
             pHost->mLoadedOk = true;
@@ -2768,6 +2768,7 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
     pHost->mIsProfileLoadingSequence = true;
     // The Host instance gets its TMainConsole here:
     addConsoleForNewHost(pHost);
+    // enable script compilation (which is off by default)
     pHost->mBlockScriptCompile = false;
     // This uses the external LuaGlobal.lua file to load all the other external
     // lua files, including the condenseMapLoad() function needed by the
@@ -2796,7 +2797,7 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
     // This will build all the scripts in the collection of script items (but
     // not triggers/aliases/etc) - presumably so that the event handlers
     // are ready for use.
-    pHost->getScriptUnit()->compileAll();
+    pHost->getScriptUnit()->compileAll(true);
     pHost->updateAnsi16ColorsInTable();
 
     //Load rest of modules after scripts


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Added the ability to detect script loading errors, store them on the script, and display them to the user in the script editor.

![Screenshot 2023-05-27 9 08 55 AM](https://github.com/Mudlet/Mudlet/assets/110988/7722654b-d7d2-436b-a47b-24d413d8398a)


#### Motivation for adding to Mudlet
This allows users to be notified if there were any issues loading their scripts on profile load or after a profile reset. Without this, errors would show just once as soon as a script was clicked on - and go away as soon as the mouse was released. Displaying the errors in the UI allows for the coder to find such errors easier - and hopefully know what to do with them, since they are a common source of confusion in our #help channel.

#### Other info (issues closed, discussion etc)
Please try the PR out in practice first before reviewing! Here's an example to get started with:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE MudletPackage>
<MudletPackage version="1.001">
	<ScriptPackage>
		<ScriptGroup isActive="yes" isFolder="yes">
			<name>Referencing yet undeclared values test</name>
			<packageName></packageName>
			<script></script>
			<eventHandlerList />
			<Script isActive="yes" isFolder="no">
				<name>referencing undeclared value</name>
				<packageName></packageName>
				<script>a[1] = true</script>
				<eventHandlerList />
			</Script>
			<Script isActive="yes" isFolder="no">
				<name>declaring said value</name>
				<packageName></packageName>
				<script>a = {}</script>
				<eventHandlerList />
			</Script>
		</ScriptGroup>
	</ScriptPackage>
</MudletPackage>
```
