### PR TITLE
Infrastructure: Editorial fixes to a few Lua API error messages

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2598,7 +2598,7 @@ int TLuaInterpreter::setExitStub(lua_State* L)
     }
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
-        lua_pushstring(L, "setExitStub: RoomId doesn't exist");
+        lua_pushstring(L, "setExitStub: roomId doesn't exist");
         return lua_error(L);
     }
     if (dir > 12 || dir < 1) {
@@ -2787,7 +2787,7 @@ int TLuaInterpreter::getModulePriority(lua_State* L)
         lua_pushnumber(L, priority);
         return 1;
     } else {
-        lua_pushstring(L, "getModulePriority: Module doesn't exist");
+        lua_pushstring(L, "getModulePriority: module doesn't exist");
         return lua_error(L);
     }
     return 0;
@@ -4172,12 +4172,12 @@ int TLuaInterpreter::startLogging(lua_State* L)
         if (host.mpConsole->mLogToLogFile) {
             host.mpConsole->logButton->setChecked(true);
             // Sets the button as checked but clicked() & pressed() signals are NOT generated
-            lua_pushfstring(L, "Main console output has started to be logged to file: %s.", host.mpConsole->mLogFileName.toUtf8().constData());
+            lua_pushfstring(L, "Main console output has started to be logged to file: %s", host.mpConsole->mLogFileName.toUtf8().constData());
             lua_pushstring(L, host.mpConsole->mLogFileName.toUtf8().constData());
             lua_pushnumber(L, 1);
         } else {
             host.mpConsole->logButton->setChecked(false);
-            lua_pushfstring(L, "Main console output has stopped being logged to file: %s.", savedLogFileName.toUtf8().constData());
+            lua_pushfstring(L, "Main console output has stopped being logged to file: %s", savedLogFileName.toUtf8().constData());
             lua_pushstring(L, host.mpConsole->mLogFileName.toUtf8().constData());
             lua_pushnumber(L, 0);
         }
@@ -4185,7 +4185,7 @@ int TLuaInterpreter::startLogging(lua_State* L)
     } else {
         lua_pushnil(L);
         if (host.mpConsole->mLogToLogFile) {
-            lua_pushfstring(L, "Main console output is already being logged to file: %s.", host.mpConsole->mLogFileName.toUtf8().constData());
+            lua_pushfstring(L, "Main console output is already being logged to file: %s", host.mpConsole->mLogFileName.toUtf8().constData());
             lua_pushstring(L, host.mpConsole->mLogFileName.toUtf8().constData());
             lua_pushnumber(L, -1);
         } else {
@@ -17719,7 +17719,7 @@ int TLuaInterpreter::removeCommandLineMenuEvent(lua_State * L)
 
     if (commandline->contextMenuItems.remove(menuLabel) == 0) {
         lua_pushboolean(L, false);
-        lua_pushfstring(L, "removeCommandLineMenuEvent: Cannot remove '%s', menu item does not exist.", menuLabel.toUtf8().constData());
+        lua_pushfstring(L, "removeCommandLineMenuEvent: cannot remove '%s', menu item does not exist", menuLabel.toUtf8().constData());
         return 2;
     }
     lua_pushboolean(L, true);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Editorial fixes to a few Lua API error messages: lowercase after the function name `:` and no period at the end of the message.
#### Motivation for adding to Mudlet
Consistency and professionalism
#### Other info (issues closed, discussion etc)
