### PR TITLE
Add overflow event for non scrolling consoles

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Check https://www.linguistic-antipatterns.com when naming anything to help ensur
 * use braces {} around all statements (ie, `if`'s and so on), even if they are one line
 * use `qsl()` to wrap Qt strings, this ensures they're created at compile time
 * at the same time, don't use a blank `qsl("")` - use `QString()` in that case ([source](http://blog.qt.io/blog/2014/06/13/qt-weekly-13-qstringliteral/))
-
+* escape dynamic label information with .toHtmlEscaped() to ensure safe display ([example](https://github.com/Mudlet/Mudlet/pull/6807/files)).
 
 # Internationalization do's and don'ts
 

--- a/.github/workflows/performance-analysis.yml
+++ b/.github/workflows/performance-analysis.yml
@@ -40,7 +40,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install build-essential git liblua5.1-dev zlib1g-dev libhunspell-dev libpcre3-dev \
           libzip-dev libboost-graph-dev libyajl-dev libpulse-dev lua-rex-pcre lua-filesystem lua-zip \
-          lua-sql-sqlite3 qtmultimedia5-dev qttools5-dev luarocks ccache libpugixml-dev cmake -y
+          lua-sql-sqlite3 qtmultimedia5-dev qttools5-dev luarocks ccache libpugixml-dev cmake ninja-build -y
 
         sudo luarocks install luautf8
         sudo luarocks install lua-yajl YAJL_LIBDIR=`find /usr -name "libyajl.so" -printf '%h\n'` YAJL_INCDIR=/usr/include
@@ -56,15 +56,17 @@ jobs:
 
     - name: Build Mudlet
       run : |
-        WITH_UPDATER=NO WITH_3DMAPPER=NO qmake ./src/mudlet.pro
-        make -j $(expr `nproc` - 1)
+        WITH_UPDATER=NO WITH_3DMAPPER=NO cmake -DCMAKE_BUILD_TYPE=Release -S${{github.workspace}} -B${{github.workspace}}/build -G Ninja
+        cd ${{github.workspace}}/build
+        ninja -j $(expr `nproc` - 1)
+        tree
 
     - name: Check ccache stats post build
       if: runner.os == 'Linux' || runner.os == 'macOS'
       run: ccache --show-stats
 
     - name: Copy mudlet executable in place for executing display benchmark
-      run: cp ${{github.workspace}}/mudlet ${{github.workspace}}/src
+      run: cp ${{github.workspace}}/build/src/mudlet ${{github.workspace}}/src
       shell: bash
 
     - name: Remove Mudlet config directory

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@
   <a href="https://www.codefactor.io/repository/github/mudlet/mudlet">
     <img src="https://www.codefactor.io/repository/github/mudlet/mudlet/badge" alt="CodeFactor" />
   </a>
+  <a href="https://console.algora.io/org/Mudlet/bounties?status=open">
+    <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fconsole.algora.io%2Fapi%2Fshields%2FMudlet%2Fbounties%3Fstatus%3Dopen"/>
+  </a>
 </p>
 
 <p align="center">

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -765,7 +765,7 @@ COMMIT_LINE:
             timeBuffer.push_back(QString());
             promptBuffer << false;
             if (static_cast<int>(buffer.size()) > mLinesLimit) {
-                // Whilst we also include a call to TConsole::raiseLinesOverflowEventIfRequired(...)
+                // Whilst we also include a call to TConsole::handleLinesOverflowEvent(...)
                 // in all other methods where the following is used (because
                 // both need to monitor the number of lines of text in the
                 // buffer) the event that the former may be required to
@@ -2171,7 +2171,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
     // - that the content has not exceeded the number of lines that can be
     // shown in the upper pane and to raise an event if it has
     if (!mpConsole.isNull()) {
-        mpConsole->raiseLinesOverflowEventIfRequired(lineBuffer.size());
+        mpConsole->handleLinesOverflowEvent(lineBuffer.size());
     }
 }
 
@@ -2264,7 +2264,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
     // Check - for "non-scrollable" TConsoles that the content has not exceeded
     // the number of lines that can be shown and raise an event if it has:
     if (!mpConsole.isNull()) {
-        mpConsole->raiseLinesOverflowEventIfRequired(lineBuffer.size());
+        mpConsole->handleLinesOverflowEvent(lineBuffer.size());
     }
 }
 
@@ -2313,7 +2313,7 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
     // Check - for "non-scrollable" TConsoles that the content has not exceeded
     // the number of lines that can be shown and raise an event if it has:
     if (!mpConsole.isNull()) {
-        mpConsole->raiseLinesOverflowEventIfRequired(lineBuffer.size());
+        mpConsole->handleLinesOverflowEvent(lineBuffer.size());
     }
 }
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -765,7 +765,7 @@ COMMIT_LINE:
             timeBuffer.push_back(QString());
             promptBuffer << false;
             if (static_cast<int>(buffer.size()) > mLinesLimit) {
-                // Whilst we also include a call to TConsole::checkNumberOfLines(...)
+                // Whilst we also include a call to TConsole::raiseLinesOverflowEventIfRequired(...)
                 // in all other methods where the following is used (because
                 // both need to monitor the number of lines of text in the
                 // buffer) the event that the former may be required to
@@ -2171,7 +2171,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
     // - that the content has not exceeded the number of lines that can be
     // shown in the upper pane and to raise an event if it has
     if (!mpConsole.isNull()) {
-        mpConsole->checkNumberOfLines(lineBuffer.size());
+        mpConsole->raiseLinesOverflowEventIfRequired(lineBuffer.size());
     }
 }
 
@@ -2264,7 +2264,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
     // Check - for "non-scrollable" TConsoles that the content has not exceeded
     // the number of lines that can be shown and raise an event if it has:
     if (!mpConsole.isNull()) {
-        mpConsole->checkNumberOfLines(lineBuffer.size());
+        mpConsole->raiseLinesOverflowEventIfRequired(lineBuffer.size());
     }
 }
 
@@ -2313,7 +2313,7 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
     // Check - for "non-scrollable" TConsoles that the content has not exceeded
     // the number of lines that can be shown and raise an event if it has:
     if (!mpConsole.isNull()) {
-        mpConsole->checkNumberOfLines(lineBuffer.size());
+        mpConsole->raiseLinesOverflowEventIfRequired(lineBuffer.size());
     }
 }
 

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2349,7 +2349,7 @@ void TConsole::slot_clearSearchResults()
     mLowerPane->forceUpdate();
 }
 
-void TConsole::checkNumberOfLines(const int lineCount)
+void TConsole::raiseLinesOverflowEventIfRequired(const int lineCount)
 {
     if (mType & ~(UserWindow | SubConsole)) {
         // It isn't a type that we need to worry about the number of lines of

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2349,7 +2349,7 @@ void TConsole::slot_clearSearchResults()
     mLowerPane->forceUpdate();
 }
 
-void TConsole::raiseLinesOverflowEventIfRequired(const int lineCount)
+void TConsole::handleLinesOverflowEvent(const int lineCount)
 {
     if (mType & ~(UserWindow | SubConsole)) {
         // It isn't a type that we need to worry about the number of lines of

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2348,3 +2348,33 @@ void TConsole::slot_clearSearchResults()
     mUpperPane->forceUpdate();
     mLowerPane->forceUpdate();
 }
+
+void TConsole::checkNumberOfLines(const int lineCount)
+{
+    if (mType & ~(UserWindow | SubConsole)) {
+        // It isn't a type that we need to worry about the number of lines of
+        // text in it:
+        return;
+    }
+
+    if (mScrollingEnabled) {
+        // It is capable of scrolling so a "text overflow" is not a concern:
+        return;
+    }
+
+    const int linesSpare = mUpperPane->getRowCount() - lineCount;
+    if (linesSpare >= 0) {
+        // There IS space for all the lines
+        return;
+    }
+
+    // Else we do have an overflow situation so let's raise an event for it:
+    TEvent sysWindowOverflow {};
+    sysWindowOverflow.mArgumentList.append(QLatin1String("sysWindowOverflowEvent"));
+    sysWindowOverflow.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    sysWindowOverflow.mArgumentList.append(mConsoleName);
+    sysWindowOverflow.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    sysWindowOverflow.mArgumentList.append(QString::number(-linesSpare));
+    sysWindowOverflow.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    mpHost->raiseEvent(sysWindowOverflow);
+}

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -208,6 +208,10 @@ public:
     void setSearchOptions(const SearchOptions);
     void setProxyForFocus(TCommandLine*);
     void raiseMudletSysWindowResizeEvent(const int overallWidth, const int overallHeight);
+    // Raises an event if the number of lines (in the
+    // (QStringList) TBuffer::lineBuffer) exceeds the number of rows in a
+    // non-scrolling window:
+    void checkNumberOfLines(const int lineCount);
 
 
     QPointer<Host> mpHost;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -211,7 +211,7 @@ public:
     // Raises an event if the number of lines (in the
     // (QStringList) TBuffer::lineBuffer) exceeds the number of rows in a
     // non-scrolling window:
-    void checkNumberOfLines(const int lineCount);
+    void raiseLinesOverflowEventIfRequired(const int lineCount);
 
 
     QPointer<Host> mpHost;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -211,7 +211,7 @@ public:
     // Raises an event if the number of lines (in the
     // (QStringList) TBuffer::lineBuffer) exceeds the number of rows in a
     // non-scrolling window:
-    void raiseLinesOverflowEventIfRequired(const int lineCount);
+    void handleLinesOverflowEvent(const int lineCount);
 
 
     QPointer<Host> mpHost;

--- a/src/TMxpSendTagHandler.cpp
+++ b/src/TMxpSendTagHandler.cpp
@@ -33,6 +33,12 @@ TMxpTagHandlerResult TMxpSendTagHandler::handleStartTag(TMxpContext& ctx, TMxpCl
         mIsHrefInContent = true;
     }
 
+    // Entities in href and hint may contain | separators, so interpolate them first:
+    href = ctx.getEntityResolver().interpolate(href);
+    if (!hint.isEmpty()) {
+        hint = ctx.getEntityResolver().interpolate(hint);
+    }
+
     QStringList hrefs = href.split('|');
     QStringList hints = hint.isEmpty() ? hrefs : hint.split('|');
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
When a non-scrolling `TConsole` has text added to it that exceeds the number of lines it can show this raises a `sysWindowOverflowEvent` with the name of the console and the number of lines that have "scrolled off the top" i.e. that have been hidden because there is not enough space for them all. This can be used to manage the size of the text kept in that window so that it is always fully visible.

#### Motivation for adding to Mudlet
This was prompted by the second part of my comment:
https://github.com/Mudlet/Mudlet/pull/6848#pullrequestreview-1425398702

#### Other issues
As I was looking at code that examines the number of lines of text in the buffer I spotted that there were a couple of cases where the size of the buffer or the size of a line in that buffer was being taken and then being compared to be `<1` when really an `isEmpty()` test is a clearer indication of intent - and where assignment to a temporary `(int) length` variable could be made more streamlined.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>