### PR TITLE
Improve: clear split TConsole when disabling scrolling

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -307,14 +307,7 @@ bool TCommandLine::event(QEvent* event)
         case Qt::Key_Return: // This is the main one (not the keypad)
             if ((ke->modifiers() & allModifiers) == Qt::ControlModifier) {
                 // If Ctrl-Return is pressed - scroll to the bottom of text:
-                mpConsole->mLowerPane->mCursorY = mpConsole->buffer.size();
-                mpConsole->mLowerPane->hide();
-                mpConsole->buffer.mCursorY = mpConsole->buffer.size();
-                mpConsole->mUpperPane->mCursorY = mpConsole->buffer.size();
-                mpConsole->mUpperPane->mCursorX = 0;
-                mpConsole->mUpperPane->mIsTailMode = true;
-                mpConsole->mUpperPane->updateScreenView();
-                mpConsole->mUpperPane->forceUpdate();
+                mpConsole->clearSplit();
                 ke->accept();
                 return true;
 

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1719,10 +1719,13 @@ void TConsole::setHorizontalScrollBar(bool isEnabled)
     }
 }
 
-void TConsole::setScrolling(bool enabled)
+void TConsole::setScrolling(const bool state)
 {
     if (mType & (UserWindow | SubConsole)) {
-        mScrollingEnabled = enabled;
+        mScrollingEnabled = state;
+        if (!state) {
+            clearSplit();
+        }
     }
 }
 
@@ -2406,4 +2409,16 @@ void TConsole::handleLinesOverflowEvent(const int lineCount)
     sysWindowOverflow.mArgumentList.append(QString::number(-linesSpare));
     sysWindowOverflow.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
     mpHost->raiseEvent(sysWindowOverflow);
+}
+
+void TConsole::clearSplit()
+{
+    mLowerPane->mCursorY = buffer.size();
+    mLowerPane->hide();
+    buffer.mCursorY = buffer.size();
+    mUpperPane->mCursorY = buffer.size();
+    mUpperPane->mCursorX = 0;
+    mUpperPane->mIsTailMode = true;
+    mUpperPane->updateScreenView();
+    mUpperPane->forceUpdate();
 }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1728,7 +1728,7 @@ void TConsole::setScrolling(const bool state)
 {
     if (mType & (UserWindow | SubConsole)) {
         mScrollingEnabled = state;
-        if (!state) {
+        if (!mScrollingEnabled) {
             clearSplit();
         }
     }

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -160,7 +160,7 @@ public:
     void setCommandFgColor(int, int, int, int);
     void setScrollBarVisible(bool);
     void setHorizontalScrollBar(bool);
-    void setScrolling(bool enabled);
+    void setScrolling(const bool state);
     void setCmdVisible(bool);
     void changeColors();
     void scrollDown(int lines);
@@ -212,6 +212,7 @@ public:
     // (QStringList) TBuffer::lineBuffer) exceeds the number of rows in a
     // non-scrolling window:
     void handleLinesOverflowEvent(const int lineCount);
+    void clearSplit();
 
 
     QPointer<Host> mpHost;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1485,14 +1485,7 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
 
 
     if (event->button() == Qt::MiddleButton) {
-        mpConsole->mLowerPane->mCursorY = mpConsole->buffer.size(); //
-        mpConsole->mLowerPane->hide();
-        mpBuffer->mCursorY = mpBuffer->size();
-        mpConsole->mUpperPane->mCursorY = mpConsole->buffer.size(); //
-        mpConsole->mUpperPane->mCursorX = 0;
-        mpConsole->mUpperPane->mIsTailMode = true;
-        mpConsole->mUpperPane->updateScreenView();
-        mpConsole->mUpperPane->forceUpdate();
+        mpConsole->clearSplit();
         event->accept();
         return;
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
As I identified the code required was already used in two separate places I refactored it out to a new method `(void) TConsole::clearSplit()` so it could be used in a new, third place as well.

#### Motivation for adding to Mudlet
As I mentioned in https://github.com/Mudlet/Mudlet/pull/6848#issuecomment-1569192566 disabling scrolling when the `TConsole` had already been scrolled (and had thus been split) locked the split in place and if the window was cleared only the upper pane had all it's content removed. This addition - as well as refactoring the code that clears the split from two existing places - adds it to the code that disables scrolling so when that happens any existing split is cleared.

#### Other info (issues closed, discussion etc)
DRY!