### PR TITLE
Infrastructure: don't error on missing history file for 'main' command line

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1474,10 +1474,12 @@ void TCommandLine::restoreHistory()
     }
     // else no such file - which will be the case for the first time the
     // command line is created - so it might not be an error:
-    qDebug() << "TCommandLine::restoreHistory() ALERT - unable to open command history for the command line called: "
-             << mCommandLineName << " of type: " << mType
-             << " because the file: " << mBackingFileName
-             << " does not exist in the profile's home directory, unless this is a new command line then this is an unexpected error.";
+    if (mCommandLineName != qsl("main")) {
+        qDebug() << "TCommandLine::restoreHistory() ALERT - unable to open command history for the command line called: "
+                << mCommandLineName << " of type: " << mType
+                << " because the file: " << mBackingFileName
+                << " does not exist in the profile's home directory, unless this is a new command line then this is an unexpected error.";
+    }
 }
 
 void TCommandLine::slot_saveHistory()


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Launching Mudlet for the first time now says this:

> TCommandLine::restoreHistory() ALERT - unable to open command history for the command line called:  "main"  of type:  QFlags(0x1)  because the file:  "command_history_main"  does not exist in the profile's home directory, unless this is a new command line then this is an unexpected error.

([see logs](https://github.com/Mudlet/Mudlet/actions/runs/5135883127/jobs/9241884508?pr=6772#step:32:52))

Remove this error just for the 'main' command line.
#### Motivation for adding to Mudlet
It will always happen on first launch for the main input line - so it's not really helping anything.
#### Other info (issues closed, discussion etc)
