### PR TITLE
Improvement: MXP Send menus can have a custom mouse over tooltip

### DIFF
--- a/src/TMxpSendTagHandler.cpp
+++ b/src/TMxpSendTagHandler.cpp
@@ -42,7 +42,8 @@ TMxpTagHandlerResult TMxpSendTagHandler::handleStartTag(TMxpContext& ctx, TMxpCl
     QStringList hrefs = href.split('|');
     QStringList hints = hint.isEmpty() ? hrefs : hint.split('|');
 
-    while (hints.size() > hrefs.size()) {
+    // remove excess hints, but allow for a custom tooltip
+    while (hints.size() > hrefs.size() + 1) {
         hints.removeFirst();
     }
 

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1229,10 +1229,12 @@ void TTextEdit::updateTextCursor(const QMouseEvent* event, int lineIndex, int tC
             if (mpBuffer->buffer.at(lineIndex).at(tCharIndex).linkIndex() && !isOutOfbounds) {
                 setCursor(Qt::PointingHandCursor);
                 QStringList tooltip = mpBuffer->mLinkStore.getHints(mpBuffer->buffer.at(lineIndex).at(tCharIndex).linkIndex());
+                QStringList commands = mpBuffer->mLinkStore.getLinks(mpBuffer->buffer.at(lineIndex).at(tCharIndex).linkIndex());
+                // If a special tooltip hint was given, use that one.
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-                QToolTip::showText(event->globalPos(), tooltip.join(QChar::LineFeed));
+                QToolTip::showText(event->globalPos(), tooltip.size() > commands.size() ? tooltip[0] : tooltip.join(QChar::LineFeed));
 #else
-                QToolTip::showText(event->globalPosition().toPoint(), tooltip.join(QChar::LineFeed));
+                QToolTip::showText(event->globalPosition().toPoint(), tooltip.size() > commands.size() ? tooltip[0] : tooltip.join(QChar::LineFeed));
 #endif
             } else {
                 setCursor(Qt::IBeamCursor);
@@ -1865,13 +1867,16 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
                     QStringList hint = mpBuffer->mLinkStore.getHints(mpBuffer->buffer.at(y).at(x).linkIndex());
                     QVector<int> luaReference = mpBuffer->mLinkStore.getReference(mpBuffer->buffer.at(y).at(x).linkIndex());
                     if (command.size() > 1) {
+                        // skip a special tooltip hint, if one was given
+                        int hint_offset = hint.size() > command.size() ? 1 : 0;
+
                         auto popup = new QMenu(this);
                         popup->setAttribute(Qt::WA_DeleteOnClose);
                         for (int i = 0, total = command.size(); i < total; ++i) {
                             QAction* pA;
-                            if (i < hint.size()) {
-                                pA = popup->addAction(hint[i]);
-                                mPopupCommands[hint[i]] = {command[i], luaReference.value(i, 0)};
+                            if (i + hint_offset < hint.size()) {
+                                pA = popup->addAction(hint[i + hint_offset]);
+                                mPopupCommands[hint[i + hint_offset]] = {command[i], luaReference.value(i, 0)};
                             } else {
                                 pA = popup->addAction(command[i]);
                                 mPopupCommands[command[i]] = {command[i], luaReference.value(i, 0)};


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
A game can now specify a custom mouse over tooltip for a SEND element menu
#### Motivation for adding to Mudlet
Improve MXP compliance
#### Other info (issues closed, discussion etc)
This MXP feature is described in [https://www.zuggsoft.com/zmud/mxp.htm#Links](url) under `<SEND>` menus: _If the Hint text contains one additional string, it is used as the mouse-over text_
It changes Mudlets display of the menu tooltip of `<SEND "bow|jump|smile" HINT="bow to all people (right-click for more options)|bow to all people|jump up and down|smile at people around you">menu</SEND>` from
![mudlet_b4_patch](https://github.com/Mudlet/Mudlet/assets/72653851/5fbc565b-128b-4ff8-92ea-741483ef3588)
 to 
![mudlet_after_patch](https://github.com/Mudlet/Mudlet/assets/72653851/140c8020-f37a-4ab8-9d77-03872cf3b155)
.