### PR TITLE
Fix: Tooltip hints for MXP hints no longer forced to uppercase

### DIFF
--- a/src/TMxpCustomElementTagHandler.cpp
+++ b/src/TMxpCustomElementTagHandler.cpp
@@ -90,13 +90,8 @@ MxpStartTag TMxpCustomElementTagHandler::resolveElementDefinition(const TMxpElem
     auto mapping = [customTag, element](const MxpTagAttribute& attr) {
         if (!attr.hasValue()) {
             return MxpTagAttribute(mapAttributes(element, attr.getName(), customTag));
-        } else {
-            if (attr.isNamed("hint")) { // not needed according to the spec, but kept to avoid changes for the user interface
-                return MxpTagAttribute(attr.getName(), mapAttributes(element, attr.getValue().toUpper(), customTag));
-            } else {
-                return MxpTagAttribute(attr.getName(), mapAttributes(element, attr.getValue(), customTag));
-            }
         }
+        return MxpTagAttribute(attr.getName(), mapAttributes(element, attr.getValue(), customTag));
     };
 
     return definitionTag->transform(mapping);

--- a/test/TMxpCustomElementTagHandlerTest.cpp
+++ b/test/TMxpCustomElementTagHandlerTest.cpp
@@ -105,8 +105,8 @@ private slots:
         QCOMPARE(stub.mHrefs[1], "send([[drop inv##10]])");
 
         QCOMPARE(stub.mHints.size(), 2);
-        QCOMPARE(stub.mHints[0], "EXAMINE");
-        QCOMPARE(stub.mHints[1], "DROP");
+        QCOMPARE(stub.mHints[0], "examine");
+        QCOMPARE(stub.mHints[1], "drop");
     }
 
     void testCustomElementDynamicEntity() {
@@ -144,7 +144,7 @@ private slots:
         QCOMPARE(stub.mHrefs[0], "send([[follow map of the newbie jungle to P8x7]])");
 
         QCOMPARE(stub.mHints.size(), 1);
-        QCOMPARE(stub.mHints[0], "GO HERE");
+        QCOMPARE(stub.mHints[0], "go here");
 
         // Now player looks at another map and gets an MXP button to go to another place.
         // Note the MAP element is NOT redefined, only the entity.
@@ -160,7 +160,7 @@ private slots:
         QCOMPARE(stub.mHrefs[0], "send([[follow map of the south forest to P42]])");
 
         QCOMPARE(stub.mHints.size(), 1);
-        QCOMPARE(stub.mHints[0], "GO HERE");
+        QCOMPARE(stub.mHints[0], "go here");
     }
 
     void testCustomElementDefaultAttributes() {
@@ -260,9 +260,9 @@ private slots:
         QCOMPARE(stub.mHrefs[2], "printCmdLine([[tell playerid ]])");
 
         QCOMPARE(stub.mHints.size(), 3);
-        QCOMPARE(stub.mHints[0], "WHISPER playerid");
-        QCOMPARE(stub.mHints[1], "FINGER playerid");
-        QCOMPARE(stub.mHints[2], "TELL playerid");
+        QCOMPARE(stub.mHints[0], "whisper playerid");
+        QCOMPARE(stub.mHints[1], "finger playerid");
+        QCOMPARE(stub.mHints[2], "tell playerid");
 
         // Now w/o a NAME parameter given:
         startTag = parseNode("<WH>");
@@ -276,9 +276,9 @@ private slots:
         QCOMPARE(stub.mHrefs[2], "printCmdLine([[tell someone ]])");
 
         QCOMPARE(stub.mHints.size(), 3);
-        QCOMPARE(stub.mHints[0], "WHISPER someone");
-        QCOMPARE(stub.mHints[1], "FINGER someone");
-        QCOMPARE(stub.mHints[2], "TELL someone");
+        QCOMPARE(stub.mHints[0], "whisper someone");
+        QCOMPARE(stub.mHints[1], "finger someone");
+        QCOMPARE(stub.mHints[2], "tell someone");
     }
 };
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
In some, but not all, occasions the tooltip hints of MXP hints were forced to all upper case by Mudlet 
#### Motivation for adding to Mudlet
Improvement of MXP compatibility, more uniform menu appearance.
#### Other info (issues closed, discussion etc)
Mudlet forced HINT attributes used in custom elements to upper case, but only there. Note that entities were interpolated afterwards, hence not forced to uppercase. I think the behaviour is inconsistent and not 'logically' comprehensible for a user.
Afaik, if the mud specifies a HINT text it should be display as such. If the game wants it to show up in UPPERCASE the game should just say so.
**However,** in difference to my other MXP patches, it will change the look of the GUI for games that somehow depend on it.
So.. it can be argued.

It does change the non uniform display of hints like those two from the unfixed version: 
![send_b4](https://github.com/Mudlet/Mudlet/assets/72653851/71507e6e-6ae7-437b-87bc-d0ddbaf00eea) and 
![sendprompt_b4](https://github.com/Mudlet/Mudlet/assets/72653851/1dfd75be-9ba8-4dac-83d6-0883cb3c8bf5)
to 
![send_after](https://github.com/Mudlet/Mudlet/assets/72653851/2fc2e4f3-c21c-411a-bc92-d6325077fccb)
![sendprompt_after](https://github.com/Mudlet/Mudlet/assets/72653851/fb2e5c0b-8574-4a72-8366-f733a6bd8bd0)

Also, it used to deal with HINTs only prior to entity resolution, so without the fix it looked like 
![mixedmenu_b4](https://github.com/Mudlet/Mudlet/assets/72653851/3f824de0-7245-4ead-8b4f-f25c561d603e)
rather than 
![mixedmenu_after](https://github.com/Mudlet/Mudlet/assets/72653851/97e23ee2-6c50-4c49-9be7-561402ef1573)

And the only difference between these two menus (both from the unfixed version) 
![send_plain](https://github.com/Mudlet/Mudlet/assets/72653851/5acf8ea3-6134-4b4d-93b1-6ac6ded77944)
![send_custom_element](https://github.com/Mudlet/Mudlet/assets/72653851/cfb47c73-0118-4f7d-acf8-cef2f43bc896)
is that the first uses a plain `<send>` while the second uses a custom element.

Again, you can see this in action by connecting to aldebaran-mud.de 2000 , login as guest (y to confirm) and with 'set mxp test 4'.