### PR TITLE
Fix: Crash & MSP Downloads

### DIFF
--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -59,6 +59,7 @@ void TMedia::playMedia(TMediaData& mediaData)
     mediaData.setMediaFileName(mediaData.getMediaFileName().replace(QLatin1Char('\\'), QLatin1Char('/')));
 
     if (mediaData.getMediaProtocol() == TMediaData::MediaProtocolMSP && mediaData.getMediaFileName() == qsl("Off")) {
+        TMedia::processUrl(mediaData);
         return;
     }
 
@@ -778,15 +779,14 @@ TMediaPlayer TMedia::getMediaPlayer(TMediaData& mediaData)
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     disconnect(pPlayer.getMediaPlayer(), &QMediaPlayer::stateChanged, nullptr, nullptr);
     connect(pPlayer.getMediaPlayer(), &QMediaPlayer::stateChanged, this,
-            [&](QMediaPlayerPlaybackState playbackState) { handlePlayerPlaybackStateChanged(playbackState, pPlayer); });
+            [=](QMediaPlayerPlaybackState playbackState) { handlePlayerPlaybackStateChanged(playbackState, pPlayer); });
 #else
     disconnect(pPlayer.getMediaPlayer(), &QMediaPlayer::playbackStateChanged, nullptr, nullptr);
     connect(pPlayer.getMediaPlayer(), &QMediaPlayer::playbackStateChanged, this,
-            [&](QMediaPlayerPlaybackState playbackState) { handlePlayerPlaybackStateChanged(playbackState, pPlayer); });
+            [=](QMediaPlayerPlaybackState playbackState) { handlePlayerPlaybackStateChanged(playbackState, pPlayer); });
 #endif
     disconnect(pPlayer.getMediaPlayer(), &QMediaPlayer::positionChanged, nullptr, nullptr);
-
-    connect(pPlayer.getMediaPlayer(), &QMediaPlayer::positionChanged, this, [&](qint64 progress) {
+    connect(pPlayer.getMediaPlayer(), &QMediaPlayer::positionChanged, this, [=](qint64 progress) {
         const int volume = pPlayer.getMediaData().getMediaVolume();
         const int fadeInPosition = pPlayer.getMediaData().getMediaFadeIn();
         const int fadeOutPosition = pPlayer.getMediaData().getMediaFadeOut();

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -70,7 +70,7 @@ public:
         return mMediaPlayer->playbackState();
 #endif
     }
-    void setVolume(int volume) {
+    void setVolume(int volume) const {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
         return mMediaPlayer->setVolume(volume);
 #else


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Mudlet was not downloading sounds nested in a subdirectory from the Internet and playing them with Mud Sound Protocol (MSP). Also, a segfault was entered into the development stream with https://github.com/Mudlet/Mudlet/pull/6654, which this resolves.
#### Motivation for adding to Mudlet
Issue https://github.com/Mudlet/Mudlet/issues/6790
Issue https://github.com/Mudlet/Mudlet/issues/6851
#### Other info (issues closed, discussion etc)
Resolved an issue where Mudlet was not downloading sounds from the Internet and playing them with Mud Sound Protocol (MSP).

**Steps to reproduce the issue from #6790:**

- Logon to aldebaran-mud.de 2000 as the guest character.
- Create a [sound trigger](https://wiki.mudlet.org/w/Manual:Supported_Protocols#MSP_for_Lua) for MSP.
- Issue these commands: yes;;s;;e;;e;;e;;s;;strike gong.

If you are on the PTB, your Mudlet client may crash. If you are on 4.17.2, you'll just likely not hear the sound as intended, although it will have downloaded. And if you are using this PR, hopefully everything works great!
