### PR TITLE
Infrastructure: update en us plural

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -429,7 +429,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 
     if (mudlet::self()->smFirstLaunch) {
         QTimer::singleShot(0, this, [this]() {
-            mpConsole->mpCommandLine->setPlaceholderText(tr("Text to send to the game"));
+            mpConsole->mpCommandLine->setPlaceholderText(Host::tr("Text to send to the game"));
         });
     }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2379,8 +2379,9 @@ void cTelnet::postMessage(QString msg)
             QString prefix = body.at(0).left(prefixLength).toUpper();
             QString firstLineTail = body.at(0).mid(prefixLength);
             body.removeFirst();
-            //: Keep the capitalisation, the translated text at 7 letters max so it aligns nicely
-            if (prefix.contains(tr("ERROR")) || prefix.contains(QLatin1String("ERROR"))) {
+            if ( //: Keep the capitalisation, the translated text at 7 letters max so it aligns nicely
+                 prefix.contains(tr("ERROR")) || prefix.contains(QLatin1String("ERROR"))) {
+
                 mpHost->mpConsole->print(prefix, Qt::red, mpHost->mBgColor);                                  // Bright Red
                 mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(255, 255, 50), mpHost->mBgColor); // Bright Yellow
                 for (int _i = 0; _i < body.size(); ++_i) {
@@ -2392,8 +2393,9 @@ void cTelnet::postMessage(QString msg)
                 if (!body.empty()) {
                     mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(255, 255, 50), mpHost->mBgColor); // Bright Yellow
                 }
-            //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
-            } else if (prefix.contains(tr("LUA")) || prefix.contains(QLatin1String("LUA"))) {
+            } else if ( //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
+                        prefix.contains(tr("LUA")) || prefix.contains(QLatin1String("LUA"))) {
+
                 mpHost->mpConsole->print(prefix, QColor(80, 160, 255), mpHost->mBgColor);                    // Light blue
                 mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(50, 200, 50), mpHost->mBgColor); // Light green
                 for (int _i = 0; _i < body.size(); ++_i) {
@@ -2404,8 +2406,9 @@ void cTelnet::postMessage(QString msg)
                 if (!body.empty()) {
                     mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(200, 50, 50), mpHost->mBgColor); // Red
                 }
-            //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
-            } else if (prefix.contains(tr("WARN")) || prefix.contains(QLatin1String("WARN"))) {
+            } else if ( //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
+                        prefix.contains(tr("WARN")) || prefix.contains(QLatin1String("WARN"))) {
+
                 mpHost->mpConsole->print(prefix, QColor(0, 150, 190), mpHost->mBgColor);                     // Cyan
                 mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(190, 150, 0), mpHost->mBgColor); // Orange
                 for (int _i = 0; _i < body.size(); ++_i) {
@@ -2416,8 +2419,9 @@ void cTelnet::postMessage(QString msg)
                 if (!body.empty()) {
                     mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(190, 150, 0), mpHost->mBgColor);
                 }
-            //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
-            } else if (prefix.contains(tr("ALERT")) || prefix.contains(QLatin1String("ALERT"))) {
+            } else if ( //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
+                        prefix.contains(tr("ALERT")) || prefix.contains(QLatin1String("ALERT"))) {
+
                 mpHost->mpConsole->print(prefix, QColor(190, 100, 50), mpHost->mBgColor);                     // Orange-ish
                 mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(190, 190, 50), mpHost->mBgColor); // Yellow
                 for (int _i = 0; _i < body.size(); ++_i) {
@@ -2428,8 +2432,9 @@ void cTelnet::postMessage(QString msg)
                 if (!body.empty()) {
                     mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(190, 190, 50), mpHost->mBgColor); // Yellow
                 }
-            //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
-            } else if (prefix.contains(tr("INFO")) || prefix.contains(QLatin1String("INFO"))) {
+            } else if ( //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
+                        prefix.contains(tr("INFO")) || prefix.contains(QLatin1String("INFO"))) {
+
                 mpHost->mpConsole->print(prefix, QColor(0, 150, 190), mpHost->mBgColor);                   // Cyan
                 mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(0, 160, 0), mpHost->mBgColor); // Light Green
                 for (int _i = 0; _i < body.size(); ++_i) {
@@ -2440,8 +2445,9 @@ void cTelnet::postMessage(QString msg)
                 if (!body.empty()) {
                     mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(0, 160, 0), mpHost->mBgColor); // Light Green
                 }
-            //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
-            } else if (prefix.contains(tr("OK")) || prefix.contains(QLatin1String("OK"))) {
+            } else if ( //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
+                        prefix.contains(tr("OK")) || prefix.contains(QLatin1String("OK"))) {
+
                 mpHost->mpConsole->print(prefix, QColor(0, 160, 0), mpHost->mBgColor);                        // Light Green
                 mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(190, 100, 50), mpHost->mBgColor); // Orange-ish
                 for (int _i = 0; _i < body.size(); ++_i) {

--- a/translations/translated/mudlet_en_US.ts
+++ b/translations/translated/mudlet_en_US.ts
@@ -15,18 +15,10 @@
 <context>
     <name>MapInfoContributorManager</name>
     <message numerus="yes">
-        <source>Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1center of %n selected rooms</source>
-        <comment>This text uses non-breaking spaces (as &apos;%1&apos;s, as Qt Creator cannot handle them literally in raw strings) and a non-breaking hyphen which are used to prevent the line being split at some places it might otherwise be; when translating please consider at which points the text may be divided to fit onto more than one line. This text is for when TWO or MORE rooms are selected; %1 is the room number for which %2-%4 are the x,y and z coordinates of the room nearest the middle of the selection. This room has the yellow cross-hairs. %n is the count of rooms selected and will ALWAYS be greater than 1 in this situation. It is provided so that non-English translations can select required plural forms as needed.</comment>
-        <translation type="vanished">
-            <numerusform>{unused} Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1center of %n selected rooms</numerusform>
-            <numerusform>Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1center of %n selected rooms</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
         <location filename="../../src/mapInfoContributorManager.cpp" line="218"/>
         <source>Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1center of %n selected rooms</source>
         <extracomment>This text uses non-breaking spaces (as &apos;%1&apos;s, as Qt Creator cannot handle them literally in raw strings) and a non-breaking hyphen which are used to prevent the line being split at some places it might otherwise be; when translating please consider at which points the text may be divided to fit onto more than one line. This text is for when TWO or MORE rooms are selected; %1 is the room number for which %2-%4 are the x,y and z coordinates of the room nearest the middle of the selection. This room has the yellow cross-hairs. %n is the count of rooms selected and will ALWAYS be greater than 1 in this situation. It is provided so that non-English translations can select required plural forms as needed.</extracomment>
-        <translation type="unfinished">
+        <translation>
             <numerusform>{unused} Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1center of %n selected rooms</numerusform>
             <numerusform>Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1center of %n selected rooms</numerusform>
         </translation>
@@ -103,18 +95,10 @@ be in these areas...</numerusform>
 <context>
     <name>dlgPackageExporter</name>
     <message numerus="yes">
-        <source>Select what to export (%n item(s))</source>
-        <comment>This is the text shown at the top of a groupbox when there is %n (one or more) items to export in the Package exporter dialogue; the initial (and when there is no items selected) is a separate text.</comment>
-        <translation type="vanished">
-            <numerusform>Select what to export (%n item)</numerusform>
-            <numerusform>Select what to export (%n items)</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
         <location filename="../../src/dlgPackageExporter.cpp" line="1465"/>
         <source>Select what to export (%n item(s))</source>
         <extracomment>This is the text shown at the top of a groupbox when there is %n (one or more) items to export in the Package exporter dialogue; the initial (and when there is no items selected) is a separate text.</extracomment>
-        <translation type="unfinished">
+        <translation>
             <numerusform>Select what to export (%n item)</numerusform>
             <numerusform>Select what to export (%n items)</numerusform>
         </translation>
@@ -123,18 +107,10 @@ be in these areas...</numerusform>
 <context>
     <name>dlgPackageManager</name>
     <message numerus="yes">
-        <source>Remove %n package(s)</source>
-        <comment>Message on button in package manager to remove one or more (%n is the count of) selected package(s).</comment>
-        <translation type="vanished">
-            <numerusform>Remove %n package</numerusform>
-            <numerusform>Remove %n packages</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
         <location filename="../../src/dlgPackageManager.cpp" line="236"/>
         <source>Remove %n package(s)</source>
         <extracomment>Message on button in package manager to remove one or more (%n is the count of) selected package(s).</extracomment>
-        <translation type="unfinished">
+        <translation>
             <numerusform>Remove %n package</numerusform>
             <numerusform>Remove %n packages</numerusform>
         </translation>
@@ -143,27 +119,11 @@ be in these areas...</numerusform>
 <context>
     <name>dlgProfilePreferences</name>
     <message numerus="yes">
-        <source>copy to %n destination(s)</source>
-        <comment>text on button to put the map from this profile into the other profiles to receive the map from this profile, %n is the number of other profiles that have already been selected to receive it and will be zero or more. The button will also be disabled (greyed out) in the zero case but the text will still be visible.</comment>
-        <translation type="vanished">
-            <numerusform>copy to %n destination</numerusform>
-            <numerusform>copy to %n destinations</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n selected - change destinations...</source>
-        <comment>text on button to select other profiles to receive the map from this profile, %n is the number of other profiles that have already been selected to receive it and will always be 1 or more</comment>
-        <translation type="vanished">
-            <numerusform>%n selected - change destination...</numerusform>
-            <numerusform>%n selected - change destinations...</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
         <location filename="../../src/dlgProfilePreferences.cpp" line="161"/>
         <location filename="../../src/dlgProfilePreferences.cpp" line="3134"/>
         <source>copy to %n destination(s)</source>
         <extracomment>text on button to put the map from this profile into the other profiles to receive the map from this profile, %n is the number of other profiles that have already been selected to receive it and will be zero or more. The button will also be disabled (greyed out) in the zero case but the text will still be visible.</extracomment>
-        <translation type="unfinished">
+        <translation>
             <numerusform>copy to %n destination</numerusform>
             <numerusform>copy to %n destinations</numerusform>
         </translation>
@@ -172,7 +132,7 @@ be in these areas...</numerusform>
         <location filename="../../src/dlgProfilePreferences.cpp" line="3141"/>
         <source>%n selected - change destinations...</source>
         <extracomment>text on button to select other profiles to receive the map from this profile, %n is the number of other profiles that have already been selected to receive it and will always be 1 or more</extracomment>
-        <translation type="unfinished">
+        <translation>
             <numerusform>%n selected - change destination...</numerusform>
             <numerusform>%n selected - change destinations...</numerusform>
         </translation>
@@ -244,36 +204,11 @@ be in these areas...</numerusform>
 <context>
     <name>mudlet</name>
     <message numerus="yes">
-        <source>&lt;p&gt;About Mudlet&lt;/p&gt;&lt;p&gt;&lt;i&gt;%n update(s) is/are now available!&lt;/i&gt;&lt;p&gt;</source>
-        <comment>This is the tooltip text for the &apos;About&apos; Mudlet main toolbar button when it has been changed by adding a menu which now contains the original &apos;About Mudlet&apos; action and a new one to access the manual update process</comment>
-        <translation type="vanished">
-            <numerusform>&lt;p&gt;About Mudlet&lt;/p&gt;&lt;p&gt;&lt;i&gt;An update is now available!&lt;/i&gt;&lt;p&gt;</numerusform>
-            <numerusform>&lt;p&gt;About Mudlet&lt;/p&gt;&lt;p&gt;&lt;i&gt;%n updates are now available!&lt;/i&gt;&lt;p&gt;</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>Review %n update(s)...</source>
-        <comment>Review update(s) menu item, %n is the count of how many updates are available</comment>
-        <translatorcomment>Could do with the insertion of &quot;the&quot; as a second word!</translatorcomment>
-        <translation type="vanished">
-            <numerusform>Review the update...</numerusform>
-            <numerusform>Review the %n updates...</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>Review the update(s) available...</source>
-        <comment>Tool-tip for review update(s) menu item, given that the count of how many updates are available is already shown in the menu, the %n parameter that is that number need not be used here</comment>
-        <translation type="vanished">
-            <numerusform>Review the update available...</numerusform>
-            <numerusform>Review the updates available...</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
         <location filename="../../src/mudlet.cpp" line="3572"/>
         <source>&lt;p&gt;About Mudlet&lt;/p&gt;&lt;p&gt;&lt;i&gt;%n update(s) is/are now available!&lt;/i&gt;&lt;p&gt;</source>
         <extracomment>This is the tooltip text for the &apos;About&apos; Mudlet main toolbar button when it has been changed by adding a menu which now contains the original &apos;About Mudlet&apos; action and a new one to access the manual update process</extracomment>
-        <translation type="unfinished">
-            <numerusform>&lt;p&gt;About Mudlet&lt;/p&gt;&lt;p&gt;&lt;i&gt;An update is now available!&lt;/i&gt;&lt;p&gt;</numerusform>
+        <translation>
+            <numerusform>&lt;p&gt;About Mudlet&lt;/p&gt;&lt;p&gt;&lt;i&gt;%1 update is now available!&lt;/i&gt;&lt;p&gt;</numerusform>
             <numerusform>&lt;p&gt;About Mudlet&lt;/p&gt;&lt;p&gt;&lt;i&gt;%n updates are now available!&lt;/i&gt;&lt;p&gt;</numerusform>
         </translation>
     </message>
@@ -281,8 +216,8 @@ be in these areas...</numerusform>
         <location filename="../../src/mudlet.cpp" line="3590"/>
         <source>Review %n update(s)...</source>
         <extracomment>Review update(s) menu item, %n is the count of how many updates are available</extracomment>
-        <translation type="unfinished">
-            <numerusform>Review the update...</numerusform>
+        <translation>
+            <numerusform>Review the %1 update...</numerusform>
             <numerusform>Review the %n updates...</numerusform>
         </translation>
     </message>
@@ -290,7 +225,7 @@ be in these areas...</numerusform>
         <location filename="../../src/mudlet.cpp" line="3593"/>
         <source>Review the update(s) available...</source>
         <extracomment>Tool-tip for review update(s) menu item, given that the count of how many updates are available is already shown in the menu, the %n parameter that is that number need not be used here</extracomment>
-        <translation type="unfinished">
+        <translation>
             <numerusform>Review the update available...</numerusform>
             <numerusform>Review the updates available...</numerusform>
         </translation>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fix and correct a code structuring error as well as updating en-US numerus translations.

#### Motivation for adding to Mudlet
Whilst running `lupdate` to update `translations/translated/mudlet_en_US.ts` it reported that some translation metadata could not be parsed for the `[ XXXX ] - ` messages that `cTelnet::postMessage(...)` processes.

![Screenshot_20230612_121709](https://github.com/Mudlet/Mudlet/assets/6163092/b0eba936-4c87-4a33-89dc-c3e814011e23)

Looking more closely I could see that `else if` was being used but the external comments were not in the correct location with the result that they would not be correctly parsed by the `lupdate` tool.
![Screenshot_20230612_121903](https://github.com/Mudlet/Mudlet/assets/6163092/ff99e4a3-b0d3-4e15-b723-4df0b42d64e9)

This PR fixes them.

There was also a string marked for translation inside a lambda function in the `Host` class that, because it was inside a lambda, was not able to report the class it was in and thus was missing from the strings that `lupdate` handled, by adding a class prefix this is now sorted out.

#### Other info (issues closed, discussion etc)
See comment below - we need to revise the code that auto-generated the Mudlet repository PR that this PR works on so that it has a different name each time it activates!