### PR TITLE
Add: scrollingState() function to Lua API

### DIFF
--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -161,6 +161,7 @@ public:
     void setScrollBarVisible(bool);
     void setHorizontalScrollBar(bool);
     void setScrolling(const bool state);
+    bool getScrolling() const { return mScrollingEnabled; }
     void setCmdVisible(bool);
     void changeColors();
     void scrollDown(int lines);
@@ -302,7 +303,6 @@ public:
     int mBgImageMode = 0;
     QString mBgImagePath;
     bool mHScrollBarEnabled = false;
-    bool mScrollingEnabled = true;
     ControlCharacterMode mControlCharacter = ControlCharacterMode::AsIs;
 
 
@@ -335,6 +335,7 @@ private:
     SearchOptions mSearchOptions = SearchOptionNone;
     QAction* mpAction_searchOptions = nullptr;
     QIcon mIcon_searchOptions;
+    bool mScrollingEnabled = true;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(TConsole::ConsoleType)

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2548,6 +2548,21 @@ int TLuaInterpreter::disableScrolling(lua_State* L)
     return 1;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#scrollingState
+int TLuaInterpreter::scrollingState(lua_State* L)
+{
+    QString const windowName {WINDOW_NAME(L, 1)};
+    if (windowName.compare(qsl("main"), Qt::CaseSensitive) == 0) {
+        // Handle the main console case:
+        lua_pushboolean(L, true);
+        return 1;
+    }
+
+    auto console = CONSOLE(L, windowName);
+    lua_pushboolean(L, console->getScrolling());
+    return 1;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableCommandLine
 // This (and the next) function originally only worked on TConsole instances
 // to show/hide a command line at the bottom (and the first would create the
@@ -15733,6 +15748,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getSaveCommandHistory", TLuaInterpreter::getSaveCommandHistory);
     lua_register(pGlobalLua, "enableScrolling", TLuaInterpreter::enableScrolling);
     lua_register(pGlobalLua, "disableScrolling", TLuaInterpreter::disableScrolling);
+    lua_register(pGlobalLua, "scrollingState", TLuaInterpreter::scrollingState);
     // PLACEMARKER: End of main Lua interpreter functions registration
     // check new functions against https://www.linguistic-antipatterns.com when creating them
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2548,8 +2548,8 @@ int TLuaInterpreter::disableScrolling(lua_State* L)
     return 1;
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#scrollingState
-int TLuaInterpreter::scrollingState(lua_State* L)
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#scrollingActive
+int TLuaInterpreter::scrollingActive(lua_State* L)
 {
     QString const windowName {WINDOW_NAME(L, 1)};
     if (windowName.compare(qsl("main"), Qt::CaseSensitive) == 0) {
@@ -15748,7 +15748,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getSaveCommandHistory", TLuaInterpreter::getSaveCommandHistory);
     lua_register(pGlobalLua, "enableScrolling", TLuaInterpreter::enableScrolling);
     lua_register(pGlobalLua, "disableScrolling", TLuaInterpreter::disableScrolling);
-    lua_register(pGlobalLua, "scrollingState", TLuaInterpreter::scrollingState);
+    lua_register(pGlobalLua, "scrollingActive", TLuaInterpreter::scrollingActive);
     // PLACEMARKER: End of main Lua interpreter functions registration
     // check new functions against https://www.linguistic-antipatterns.com when creating them
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -471,6 +471,7 @@ public:
     static int enableHorizontalScrollBar(lua_State*);
     static int enableScrolling(lua_State*);
     static int disableScrolling(lua_State*);
+    static int scrollingState(lua_State*);
     static int enableCommandLine(lua_State*);
     static int disableCommandLine(lua_State*);
     static int enableClickthrough(lua_State*);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -471,7 +471,7 @@ public:
     static int enableHorizontalScrollBar(lua_State*);
     static int enableScrolling(lua_State*);
     static int disableScrolling(lua_State*);
-    static int scrollingState(lua_State*);
+    static int scrollingActive(lua_State*);
     static int enableCommandLine(lua_State*);
     static int disableCommandLine(lua_State*);
     static int enableClickthrough(lua_State*);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The absence of a "getter" was noted by me in: https://github.com/Mudlet/Mudlet/pull/6875#issuecomment-1572542949

#### Motivation for adding to Mudlet
This provides that function.

#### Other info (issues closed, discussion etc)
Note that this PR also makes the `(bool) TConsole::mScrollingEnabled` flag private so that it cannot be manipulated by other classes except via the accessor functions (including the one added herein) so that the additional functionality in the setter (that clears any existing "split" - and sets the `(bool) TTextEdit::mIsTailMode` flag for the upper pane in the console) cannot be bypassed by those classes trying to modify the flag directory.
