### PR TITLE
Add: clearMapSelection() function

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -5206,3 +5206,14 @@ void T2DMap::setPlayerRoomStyle(const int type)
         mPlayerRoomColorGradentStops[4] = QGradientStop(0.95, QColor(255, 0, 0, 150));
     } // End of switch ()
 }
+
+void T2DMap::clearSelection()
+{
+    if (!mMultiSelection && !mMultiSelectionSet.isEmpty()) {
+        mMultiSelectionSet.clear();
+        mMultiSelectionHighlightRoomId = 0;
+        mMultiSelectionListWidget.hide();
+        mMultiSelectionListWidget.clear();
+        update();
+    }
+}

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -89,6 +89,8 @@ public:
     // This is NOT used as a slot in newer versions
     void switchArea(const QString& newAreaName);
 #endif
+    void clearSelection();
+
 
 
     // default 2D zoom level

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15733,6 +15733,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getSaveCommandHistory", TLuaInterpreter::getSaveCommandHistory);
     lua_register(pGlobalLua, "enableScrolling", TLuaInterpreter::enableScrolling);
     lua_register(pGlobalLua, "disableScrolling", TLuaInterpreter::disableScrolling);
+    lua_register(pGlobalLua, "clearMapSelection", TLuaInterpreter::clearMapSelection);
     // PLACEMARKER: End of main Lua interpreter functions registration
     // check new functions against https://www.linguistic-antipatterns.com when creating them
 
@@ -16760,6 +16761,25 @@ int TLuaInterpreter::getMapSelection(lua_State* L)
 
     }
 
+    return 1;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearMapSelection
+int TLuaInterpreter::clearMapSelection(lua_State* L)
+{
+    Host* pHost = &getHostFromLua(L);
+    if (!pHost || !pHost->mpMap || !pHost->mpMap->mpMapper || !pHost->mpMap->mpMapper->mp2dMap) {
+        return warnArgumentValue(L, __func__, "no map present or loaded");
+    }
+    if (pHost->mpMap->mpMapper->mp2dMap->mMultiSelection) {
+        return warnArgumentValue(L, __func__, "rooms are being selected right now and cannot be stopped at this point");
+    }
+    if (pHost->mpMap->mpMapper->mp2dMap->mMultiSelectionSet.isEmpty()) {
+        lua_pushboolean(L, false);
+    } else {
+        pHost->mpMap->mpMapper->mp2dMap->clearSelection();
+        lua_pushboolean(L, true);
+    }
     return 1;
 }
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -653,6 +653,7 @@ public:
     static int getConfig(lua_State*);
     static int getSaveCommandHistory(lua_State*);
     static int setSaveCommandHistory(lua_State*);
+    static int clearMapSelection(lua_State*);
     // PLACEMARKER: End of Lua functions declarations
     // check new functions against https://www.linguistic-antipatterns.com when creating them
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This will close #6892 as it provides a function `clearMapSelection()` that will clear and remove the selection of rooms (with the display of them in a widget in the left of the 2D mapper widget). For functional reasons (that it would be difficult to make work) it will fail and return a `nil` plus and error message should the user be dragging the box to make a selection at the time it is called. Otherwise it will return `true` or `false` depending on whether a selection was cleared or not respectively.

#### Motivation for adding to Mudlet
Requested by Discord user Zooka#5558 (at the time of writing) in the Discord **#help** channel at 2023/06/15 00:53: https://www.discord.com/channels/283581582550237184/283582068334526464/1118689800564781176
#### Other info (issues closed, discussion etc)
When the code was put in place to pass the details of the selected rooms back to the Lua sub-system via the `getMapSelection()` function it was anticipated by me that that method might be extended to provide details about other things that could be selected by the user in the 2D map. However, up to now, this has not happened, but it might affect whether providing this true or false return value is still feasible if it does.
