### PR TITLE
Fix: remove bogus double read of profile's game save data

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2749,7 +2749,6 @@ void mudlet::doAutoLogin(const QString& profile_name)
         file.open(QFile::ReadOnly | QFile::Text);
         XMLimport importer(pHost);
         qDebug() << "[LOADING PROFILE]:" << file.fileName();
-        importer.importPackage(&file);
         if (auto [success, message] = importer.importPackage(&file); !success) {
             pHost->postMessage(tr("[ ERROR ] - Something went wrong loading your Mudlet profile and it could not be loaded.\n"
                 "Try loading an older version in 'Connect - Options - Profile history' or double-check that %1 looks correct.").arg(file.fileName()));


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This looks to be an error introduced in #6791 where a single line that did an unchecked load of the profile's game save was to be replaced with a checking version that reports any problems - but the original unchecked one didn't get removed.

#### Motivation for adding to Mudlet
I spotted that I was getting "premature end of file" errors in reading the profile data (from the second, error reporting call to `importer.importPackage(&file)`) and then noted that it was repeating the action on the previous line. This struck me as a defect as there is no reason to read the file twice!
