### PR TITLE
Fix: opening profile automatically or from command line misses details

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -408,6 +408,24 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
                     {"Google",     "https://www.google.com/search?q="}
     });
 
+    // These details are filled in by the dlgConnectionProfile class when that
+    // is used to select a profile however when the profile is auto-loaded or
+    // selected from a command line argument that does not happen and they need
+    // to be populated ASAP from the stored details in the profile's settings.
+    mUrl = readProfileData(qsl("url"));
+    const QString host_port = readProfileData(qsl("port"));
+    if (bool isOk = false; !host_port.isEmpty() && host_port.toInt(&isOk) && isOk) {
+        mPort = host_port.toInt();
+    }
+    mLogin = readProfileData(qsl("login"));
+
+    const QString val = readProfileData(qsl("autoreconnect"));
+    setAutoReconnect(!val.isEmpty() && val.toInt() == Qt::Checked);
+
+    // This settings also need to be configured, note that the only time not to
+    // save the setting is on profile loading:
+    mTelnet.setEncoding(readProfileData(qsl("encoding")).toUtf8(), false);
+
     auto optin = readProfileData(qsl("discordserveroptin"));
     if (!optin.isEmpty()) {
         mDiscordDisableServerSide = optin.toInt() == Qt::Unchecked ? true : false;

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -514,10 +514,10 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
             }
         }
 
-        host.append_child("url").text().set(pHost->mUrl.toUtf8().constData());
+        host.append_child("url").text().set(pHost->getUrl().toUtf8().constData());
         host.append_child("serverPackageName").text().set(pHost->mServerGUI_Package_name.toUtf8().constData());
         host.append_child("serverPackageVersion").text().set(pHost->mServerGUI_Package_version.toUtf8().constData());
-        host.append_child("port").text().set(QString::number(pHost->mPort).toUtf8().constData());
+        host.append_child("port").text().set(QString::number(pHost->getPort()).toUtf8().constData());
         auto borders = pHost->borders();
         host.append_child("borderTopHeight").text().set(QString::number(borders.top()).toUtf8().constData());
         host.append_child("borderBottomHeight").text().set(QString::number(borders.bottom()).toUtf8().constData());

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2767,20 +2767,6 @@ void mudlet::doAutoLogin(const QString& profile_name)
         }
     }
 
-    pHost->setLogin(readProfileData(profile_name, qsl("login")));
-    pHost->setPass(readProfileData(profile_name, qsl("password")));
-
-    const QString val = readProfileData(profile_name, qsl("autoreconnect"));
-    if (!val.isEmpty() && val.toInt() == Qt::Checked) {
-        pHost->setAutoReconnect(true);
-    } else {
-        pHost->setAutoReconnect(false);
-    }
-
-    // This settings also need to be configured, note that the only time not to
-    // save the setting is on profile loading:
-    pHost->mTelnet.setEncoding(readProfileData(profile_name, qsl("encoding")).toUtf8(), false);
-
     if (preInstallPackages) {
         mudlet::self()->setupPreInstallPackages(pHost->getUrl().toLower());
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
It was happening after #6709 because that stopped reading the Game Server URL and port number from the Game Save data (as it should be read from the per profile data stored in the profile's base directory and NOT, except for special cases, the game save). However the details were being read and stored in the `Host` instance in "normal" main case by the "Connect Profile" dialogue but in the auto-load and for the command-line argument cases that dialogue is not used and the details were not being read so the URL was an empty string and the port was set to the default `23`.

#### Motivation for adding to Mudlet
To close the issue raised.

#### Other info (issues closed, discussion etc)
This should close #6753.
