### PR TITLE
Infrastructure: replace std::make_tuple uses

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -807,7 +807,7 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
 
     if (mIsProfileLoadingSequence) {
         //If we're inside of profile loading sequence modules might not be loaded yet, thus we can accidetnally clear their contents
-        return std::make_tuple(false, filename_xml, qsl("profile loading is in progress"));
+        return {false, filename_xml, qsl("profile loading is in progress")};
     }
 
     const QDir dir_xml;
@@ -816,7 +816,7 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
     }
 
     if (currentlySavingProfile()) {
-        return std::make_tuple(false, QString(), qsl("a save is already in progress"));
+        return {false, QString(), qsl("a save is already in progress")};
     }
 
     if (saveFolder.isEmpty() && saveName.isEmpty()) {
@@ -847,7 +847,7 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
         mWritingHostAndModules = false;
     });
     watcher->setFuture(mModuleFuture);
-    return std::make_tuple(true, filename_xml, QString());
+    return {true, filename_xml, QString()};
 }
 
 // exports without the host settings for some reason
@@ -857,13 +857,13 @@ std::tuple<bool, QString, QString> Host::saveProfileAs(const QString& file)
     qApp->processEvents();
 
     if (currentlySavingProfile()) {
-        return std::make_tuple(false, QString(), qsl("a save is already in progress"));
+        return {false, QString(), qsl("a save is already in progress")};
     }
 
     auto writer = new XMLexport(this);
     writers.insert(qsl("profile"), writer);
     writer->exportProfile(file);
-    return std::make_tuple(true, file, QString());
+    return {true, file, QString()};
 }
 
 void Host::xmlSaved(const QString& xmlName)
@@ -3866,7 +3866,7 @@ bool Host::setBackgroundColor(const QString& name, int r, int g, int b, int alph
         } else {
             styleSheet.append(newColor);
         }
-        
+
         pL->setStyleSheet(styleSheet);
         return true;
     }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1633,18 +1633,18 @@ bool TConsole::selectSection(int from, int to)
 std::tuple<bool, QString, int, int> TConsole::getSelection()
 {
     if (mUserCursor.y() >= static_cast<int>(buffer.buffer.size())) {
-        return std::make_tuple(false, qsl("the selection is no longer valid"), 0, 0);
+        return {false, qsl("the selection is no longer valid"), 0, 0};
     }
 
     const auto start = P_begin.x();
     const auto length = P_end.x() - P_begin.x();
     const auto line = buffer.line(mUserCursor.y());
     if (line.size() < start) {
-        return std::make_tuple(false, qsl("the selection is no longer valid"), 0, 0);
+        return {false, qsl("the selection is no longer valid"), 0, 0};
     }
 
     const auto text = line.mid(start, length);
-    return std::make_tuple(true, text, start, length);
+    return {true, text, start, length};
 }
 
 void TConsole::setLink(const QStringList& linkFunction, const QStringList& linkHint, const QVector<int> linkReference)

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2158,7 +2158,7 @@ int TLuaInterpreter::resetStopWatch(lua_State* L)
 std::tuple<bool, int> TLuaInterpreter::getWatchId(lua_State* L, Host& h)
 {
     if (lua_type(L, 1) == LUA_TNUMBER) {
-        return std::make_tuple(true, static_cast<int>(lua_tointeger(L, 1)));
+        return {true, static_cast<int>(lua_tointeger(L, 1))};
     }
 
     const QString name{lua_tostring(L, 1)};
@@ -2171,10 +2171,10 @@ std::tuple<bool, int> TLuaInterpreter::getWatchId(lua_State* L, Host& h)
         } else {
             lua_pushfstring(L, "stopwatch with name '%s' not found", name.toUtf8().constData());
         }
-        return std::make_tuple(false, 0);
+        return {false, 0};
     }
 
-    return std::make_tuple(true, watchId);
+    return {true, watchId};
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#adjustStopWatch

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -754,7 +754,7 @@ int TTextEdit::getGraphemeWidth(uint unicode) const
                                              << qsl("%1").arg(unicode, 4, 16, QLatin1Char('0')).toUtf8().constData() << ".";
             }
             if (Q_UNLIKELY(newCodePointToWarnAbout)) {
-                mProblemCodepoints.insert(unicode, std::make_tuple(1, "Unprintable"));
+                mProblemCodepoints.insert(unicode, std::tuple{1, "Unprintable"});
             } else {
                 auto [count, reason] = mProblemCodepoints.value(unicode);
                 mProblemCodepoints.insert(unicode, std::tuple{++count, reason});


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Replace std::make_tuple uses with the brace {} initialisers
#### Motivation for adding to Mudlet
Keep a good, consistent codestyle for others to copy from when contributing to Mudlet
#### Other info (issues closed, discussion etc)
No longer necessary now that we are on C++17
