### PR TITLE
Improve: save and restore multi-view mode between Mudlet application runs

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1900,6 +1900,16 @@ void mudlet::readLateSettings(const QSettings& settings)
     mCopyAsImageTimeout = settings.value(qsl("copyAsImageTimeout"), mCopyAsImageTimeout).toInt();
 
     mMinLengthForSpellCheck = settings.value("minLengthForSpellCheck", 3).toInt();
+
+    // Make a local version of the value so that we can update the real one
+    // by calling the slot method that does that and ALSO carry out the
+    // other things needed for it:
+    bool multiView = false;
+    if (settings.contains(qsl("enableMultiViewMode"))) {
+        // We have a setting stored for this
+        multiView = settings.value(qsl("enableMultiViewMode"), QVariant(false)).toBool();
+    }
+    slot_multiView(multiView);
 }
 
 void mudlet::setToolBarIconSize(const int s)
@@ -2037,6 +2047,7 @@ void mudlet::writeSettings()
     settings.setValue("appearance", mAppearance);
 
     settings.setValue("minLengthForSpellCheck", mMinLengthForSpellCheck);
+    settings.setValue(qsl("enableMultiViewMode"), mMultiView);
 }
 
 void mudlet::slot_showConnectionDialog()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Although the situation as described in the related issue seems to be the opposite to how the OP reported it, it is true that the multi-view mode is NOT saved between Mudlet runs. This PR fixes that so that the multi-view mode **is** now saved between runs so that if it is set when Mudlet closes it will then be applied in a future run once a second profile is opened.

#### Motivation for adding to Mudlet
Improvement in Mudlet operation

#### Other info (issues closed, discussion etc)
This will, I think, close #6917.
