### PR TITLE
Improve: add separate tooltips to insertPopup() and echoPopup() functions

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -238,9 +238,9 @@ int TBuffer::getLastLineNumber()
     }
 }
 
-void TBuffer::addLink(bool trigMode, const QString& text, QStringList& command, QStringList& hint, TChar format, QVector<int> luaReference)
+void TBuffer::addLink(bool trigMode, const QString& text, QStringList& command, QStringList& hint, QStringList& tooltip, TChar format, QVector<int> luaReference)
 {
-    const int id = mLinkStore.addLinks(command, hint, mpHost, luaReference);
+    const int id = mLinkStore.addLinks(command, hint, tooltip, mpHost, luaReference);
 
     if (!trigMode) {
         append(text, 0, text.length(), format.mFgColor, format.mBgColor, format.mFlags, id);
@@ -2366,7 +2366,7 @@ TBuffer TBuffer::copy(QPoint& P1, QPoint& P2)
     for (const int total = P2.x(); x < total; ++x) {
         const int linkId = buffer.at(y).at(x).linkIndex();
         if (linkId && (linkId != oldLinkId)) {
-            id = slice.mLinkStore.addLinks(mLinkStore.getLinksConst(linkId), mLinkStore.getHintsConst(linkId), mpHost);
+            id = slice.mLinkStore.addLinks(mLinkStore.getLinksConst(linkId), mLinkStore.getHintsConst(linkId), mLinkStore.getTooltipsConst(linkId), mpHost);
             oldLinkId = linkId;
         }
 
@@ -2441,7 +2441,7 @@ void TBuffer::appendBuffer(const TBuffer& chunk)
     for (int cx = 0, total = static_cast<int>(chunk.buffer.at(0).size()); cx < total; ++cx) {
         const int linkId = chunk.buffer.at(0).at(cx).linkIndex();
         if (linkId && (oldLinkId != linkId)) {
-            id = mLinkStore.addLinks(chunk.mLinkStore.getLinksConst(linkId), chunk.mLinkStore.getHintsConst(linkId), mpHost);
+            id = mLinkStore.addLinks(chunk.mLinkStore.getLinksConst(linkId), chunk.mLinkStore.getHintsConst(linkId), chunk.mLinkStore.getTooltipsConst(linkId), mpHost);
             oldLinkId = linkId;
         }
         if (!linkId) {
@@ -2935,7 +2935,7 @@ bool TBuffer::deleteLines(int from, int to)
     }
 }
 
-bool TBuffer::applyLink(const QPoint& P_begin, const QPoint& P_end, const QStringList& linkFunction, const QStringList& linkHint, QVector<int> luaReference)
+bool TBuffer::applyLink(const QPoint& P_begin, const QPoint& P_end, const QStringList& linkFunction, const QStringList& linkHint, const QStringList& linkTooltip, QVector<int> luaReference)
 {
     const int x1 = P_begin.x();
     const int x2 = P_end.x();
@@ -2967,16 +2967,15 @@ bool TBuffer::applyLink(const QPoint& P_begin, const QPoint& P_end, const QStrin
                         return true;
                     }
                 }
-                if (linkID == 0) {
-                    linkID = mLinkStore.addLinks(linkFunction, linkHint, mpHost, luaReference);
+                if (!linkID) {
+                    linkID = mLinkStore.addLinks(linkFunction, linkHint, linkTooltip, mpHost, luaReference);
                 }
                 buffer.at(y).at(x++).mLinkIndex = linkID;
             }
         }
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 // Replaces (bool)TBuffer::applyXxxx(QPoint& P_begin, QPoint& P_end, bool state)

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -161,7 +161,7 @@ public:
     int wrapLine(int startLine, int screenWidth, int indentSize, TChar& format);
     void log(int, int);
     int skipSpacesAtBeginOfLine(const int row, const int column);
-    void addLink(bool, const QString& text, QStringList& command, QStringList& hint, TChar format, QVector<int> luaReference = QVector<int>());
+    void addLink(bool, const QString& text, QStringList& command, QStringList& hint, QStringList& tooltip, TChar format, QVector<int> luaReference = QVector<int>());
     QString bufferToHtml(const bool showTimeStamp = false, const int row = -1, const int endColumn = -1, const int startColumn = 0,  int spacePadding = 0);
     int size() { return static_cast<int>(buffer.size()); }
     bool isEmpty() const { return buffer.size() == 0; }
@@ -174,7 +174,7 @@ public:
     bool deleteLine(int);
     bool deleteLines(int from, int to);
     bool applyAttribute(const QPoint& P_begin, const QPoint& P_end, const TChar::AttributeFlags attributes, const bool state);
-    bool applyLink(const QPoint& P_begin, const QPoint& P_end, const QStringList& linkFunction, const QStringList& linkHist, QVector<int> luaReference = QVector<int>());
+    bool applyLink(const QPoint& P_begin, const QPoint& P_end, const QStringList& linkFunction, const QStringList& linkHint, const QStringList& linkTooltip, QVector<int> luaReference = QVector<int>());
     bool applyFgColor(const QPoint&, const QPoint&, const QColor&);
     bool applyBgColor(const QPoint&, const QPoint&, const QColor&);
     void appendBuffer(const TBuffer& chunk);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1156,7 +1156,7 @@ void TConsole::reset()
     mFormatCurrent.setAllDisplayAttributes(TChar::None);
 }
 
-void TConsole::insertLink(const QString& text, QStringList& func, QStringList& hint, QPoint P, bool customFormat, QVector<int> luaReference)
+void TConsole::insertLink(const QString& text, QStringList& func, QStringList& hint, QStringList& tooltip, QPoint P, bool customFormat, QVector<int> luaReference)
 {
     const int x = P.x();
     const int y = P.y();
@@ -1173,7 +1173,7 @@ void TConsole::insertLink(const QString& text, QStringList& func, QStringList& h
             buffer.insertInLine(P, text, standardLinkFormat);
         }
 
-        buffer.applyLink(P, P2, func, hint, luaReference);
+        buffer.applyLink(P, P2, func, hint, tooltip, luaReference);
 
         if (y < mEngineCursor) {
             mUpperPane->needUpdate(mUserCursor.y(), mUserCursor.y() + 1);
@@ -1183,9 +1183,9 @@ void TConsole::insertLink(const QString& text, QStringList& func, QStringList& h
     } else {
         if ((buffer.buffer.empty() && buffer.buffer[0].empty()) || mUserCursor == buffer.getEndPos()) {
             if (customFormat) {
-                buffer.addLink(mTriggerEngineMode, text, func, hint, mFormatCurrent, luaReference);
+                buffer.addLink(mTriggerEngineMode, text, func, hint, tooltip, mFormatCurrent, luaReference);
             } else {
-                buffer.addLink(mTriggerEngineMode, text, func, hint, standardLinkFormat, luaReference);
+                buffer.addLink(mTriggerEngineMode, text, func, hint, tooltip, standardLinkFormat, luaReference);
             }
 
             mUpperPane->showNewLines();
@@ -1198,7 +1198,7 @@ void TConsole::insertLink(const QString& text, QStringList& func, QStringList& h
                 buffer.insertInLine(mUserCursor, text, standardLinkFormat);
             }
 
-            buffer.applyLink(P, P2, func, hint, luaReference);
+            buffer.applyLink(P, P2, func, hint, tooltip, luaReference);
             if (text.indexOf("\n") != -1) {
                 const int y_tmp = mUserCursor.y();
                 const int down = buffer.wrapLine(mUserCursor.y(), mpHost->mScreenWidth, mpHost->mWrapIndentCount, mFormatCurrent);
@@ -1297,9 +1297,9 @@ void TConsole::insertText(const QString& msg)
     insertText(msg, mUserCursor);
 }
 
-void TConsole::insertLink(const QString& text, QStringList& func, QStringList& hint, bool customFormat, QVector<int> luaReference)
+void TConsole::insertLink(const QString& text, QStringList& func, QStringList& hint, QStringList& tooltip, bool customFormat, QVector<int> luaReference)
 {
-    insertLink(text, func, hint, mUserCursor, customFormat, luaReference);
+    insertLink(text, func, hint, tooltip, mUserCursor, customFormat, luaReference);
 }
 
 void TConsole::insertHTML(const QString& text)
@@ -1647,9 +1647,9 @@ std::tuple<bool, QString, int, int> TConsole::getSelection()
     return {true, text, start, length};
 }
 
-void TConsole::setLink(const QStringList& linkFunction, const QStringList& linkHint, const QVector<int> linkReference)
+void TConsole::setLink(const QStringList& linkFunction, const QStringList& linkHint, const QStringList& linkTooltip, const QVector<int> linkReference)
 {
-    buffer.applyLink(P_begin, P_end, linkFunction, linkHint, linkReference);
+    buffer.applyLink(P_begin, P_end, linkFunction, linkHint, linkTooltip, linkReference);
     mUpperPane->forceUpdate();
     mLowerPane->forceUpdate();
 }
@@ -1769,13 +1769,13 @@ void TConsole::printCommand(QString& msg)
     }
 }
 
-void TConsole::echoLink(const QString& text, QStringList& func, QStringList& hint, bool customFormat, QVector<int> luaReference)
+void TConsole::echoLink(const QString& text, QStringList& func, QStringList& hint, QStringList& tooltip, bool customFormat, QVector<int> luaReference)
 {
     if (customFormat) {
-        buffer.addLink(mTriggerEngineMode, text, func, hint, mFormatCurrent, luaReference);
+        buffer.addLink(mTriggerEngineMode, text, func, hint, tooltip, mFormatCurrent, luaReference);
     } else {
         const TChar f = TChar(Qt::blue, (mType == MainConsole ? mpHost->mBgColor : mBgColor), TChar::Underline);
-        buffer.addLink(mTriggerEngineMode, text, func, hint, f, luaReference);
+        buffer.addLink(mTriggerEngineMode, text, func, hint, tooltip, f, luaReference);
     }
     mUpperPane->showNewLines();
     mLowerPane->showNewLines();

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -109,9 +109,9 @@ public:
     void insertHTML(const QString&);
     void insertText(const QString&);
     void insertText(const QString&, QPoint);
-    void insertLink(const QString&, QStringList&, QStringList&, QPoint, bool customFormat = false, QVector<int> luaReference = QVector<int>());
-    void insertLink(const QString&, QStringList&, QStringList&, bool customFormat = false, QVector<int> luaReference = QVector<int>());
-    void echoLink(const QString& text, QStringList& func, QStringList& hint, bool customFormat = false, QVector<int> luaReference = QVector<int>());
+    void insertLink(const QString&, QStringList&, QStringList&, QStringList&, QPoint, bool customFormat = false, QVector<int> luaReference = QVector<int>());
+    void insertLink(const QString&, QStringList&, QStringList&, QStringList&, bool customFormat = false, QVector<int> luaReference = QVector<int>());
+    void echoLink(const QString& text, QStringList& func, QStringList& hint, QStringList& tooltip, bool customFormat = false, QVector<int> luaReference = QVector<int>());
     void copy();
     void cut();
     void paste();
@@ -181,7 +181,7 @@ public:
     bool setFont(const QString& font);
     bool setConsoleBackgroundImage(const QString&, int);
     bool resetConsoleBackgroundImage();
-    void setLink(const QStringList& linkFunction, const QStringList& linkHint, const QVector<int> linkReference = QVector<int>());
+    void setLink(const QStringList& linkFunction, const QStringList& linkHint, const QStringList& linkTooltip, const QVector<int> linkReference = QVector<int>());
     // Cannot be called setAttributes as that would mask an inherited method
     void setDisplayAttributes(const TChar::AttributeFlags, const bool);
     void showEvent(QShowEvent* event) override;

--- a/src/TLinkStore.cpp
+++ b/src/TLinkStore.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
- *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2022-2023 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -19,11 +19,11 @@
  ***************************************************************************/
 
 #include "TLinkStore.h"
-#if not defined(LinkStore_Test)
+#if !defined(LinkStore_Test)
 #include "Host.h"
 #endif
 
-int TLinkStore::addLinks(const QStringList& links, const QStringList& hints, Host* pH, const QVector<int>& luaReference)
+int TLinkStore::addLinks(const QStringList& links, const QStringList& hints, const QStringList& tooltips, Host* pH, const QVector<int>& luaReference)
 {
     if (++mLinkID > mMaxLinks) {
         mLinkID = 1;
@@ -34,6 +34,7 @@ int TLinkStore::addLinks(const QStringList& links, const QStringList& hints, Hos
 
     mLinkStore[mLinkID] = links;
     mHintStore[mLinkID] = hints;
+    mTooltipStore[mLinkID] = tooltips;
     mReferenceStore[mLinkID] = luaReference;
 
     return mLinkID;
@@ -47,49 +48,9 @@ void TLinkStore::freeReference(Host* pH, const QVector<int>& oldReference)
 
     for (int i = 0, total = oldReference.size(); i < total; ++i) {
         if (oldReference.value(i, 0)) {
-            #if not defined(LinkStore_Test)
+#if !defined(LinkStore_Test)
             pH->mLuaInterpreter.freeLuaRegistryIndex(oldReference.at(i));
-            #endif
+#endif
         }
     }
-}
-
-QStringList TLinkStore::getCurrentLinks() const
-{
-    return mLinkStore.value(mLinkID);
-}
-
-void TLinkStore::setCurrentLinks(const QStringList& links)
-{
-    mLinkStore[mLinkID] = links;
-}
-
-QStringList& TLinkStore::getLinks(int id)
-{
-    return mLinkStore[id];
-}
-
-QStringList& TLinkStore::getHints(int id)
-{
-    return mHintStore[id];
-}
-
-QVector<int> TLinkStore::getReference(int id) const
-{
-    return mReferenceStore.value(id);
-}
-
-QStringList TLinkStore::getLinksConst(int id) const
-{
-    return mLinkStore.value(id);
-}
-
-QStringList TLinkStore::getHintsConst(int id) const
-{
-    return mHintStore.value(id);
-}
-
-int TLinkStore::getCurrentLinkID() const
-{
-    return mLinkID;
 }

--- a/src/TLinkStore.h
+++ b/src/TLinkStore.h
@@ -3,7 +3,7 @@
 
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
- *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2022-2023 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -40,18 +40,20 @@ public:
     : mMaxLinks(maxLinks)
     {}
 
-    int addLinks(const QStringList& links, const QStringList& hints, Host* pH = nullptr, const QVector<int>& luaReference = QVector<int>());
+    int addLinks(const QStringList& links, const QStringList& hints, const QStringList& tooltips, Host* pH = nullptr, const QVector<int>& luaReference = QVector<int>());
 
-    QStringList& getLinks(int id);
-    QStringList& getHints(int id);
-    QStringList getLinksConst(int id) const;
-    QStringList getHintsConst(int id) const;
-    QVector<int> getReference(int id) const;
+    QStringList& getLinks(int id) { return mLinkStore[id]; }
+    QStringList& getHints(int id) { return mHintStore[id]; }
+    QStringList& getTooltips(int id)  { return mTooltipStore[id]; }
+    QStringList getLinksConst(int id) const { return mLinkStore.value(id); }
+    QStringList getHintsConst(int id) const { return mHintStore.value(id); }
+    QStringList getTooltipsConst(int id) const { return mTooltipStore.value(id); }
+    QVector<int> getReference(int id) const { return mReferenceStore.value(id); }
 
-    int getCurrentLinkID() const;
+    int getCurrentLinkID() const { return mLinkID; }
 
-    QStringList getCurrentLinks() const;
-    void setCurrentLinks(const QStringList& links);
+    QStringList getCurrentLinks() const { return mLinkStore.value(mLinkID); }
+    void setCurrentLinks(const QStringList& links) { mLinkStore[mLinkID] = links; }
 
 private:
     void freeReference(Host* pH, const QVector<int>& luaReference);
@@ -62,6 +64,7 @@ private:
 
     QMap<int, QStringList> mLinkStore;
     QMap<int, QStringList> mHintStore;
+    QMap<int, QStringList> mTooltipStore;
     QMap<int, QVector<int>> mReferenceStore;
 };
 

--- a/src/TMxpMudlet.cpp
+++ b/src/TMxpMudlet.cpp
@@ -65,7 +65,8 @@ void TMxpMudlet::popColor(QList<QColor>& stack)
 
 int TMxpMudlet::setLink(const QStringList& links, const QStringList& hints)
 {
-    return getLinkStore().addLinks(links, hints, mpHost);
+    // We do not support tooltips separately from hints in the MXP protocol:
+    return getLinkStore().addLinks(links, hints, hints, mpHost);
 }
 
 bool TMxpMudlet::getLink(int id, QStringList** links, QStringList** hints)

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -122,7 +122,12 @@ public:
     // to be related to the file monitoring feature in the *nix tail command.
     // See, e.g.: https://en.wikipedia.org/wiki/Tail_(Unix)#File_monitoring
     bool mIsTailMode;
-    QMap<QString, std::pair<QString, int>> mPopupCommands;
+    // The content to use for the current popup (link)
+    // Key: is an index stored when the popup is created - this has been
+    // changed from the previous "text to show for each popup" to avoid
+    // problems with duplicate texts:
+    // Value: is the lua code as a string (first) or the lua function reference number (second)
+    QMap<int, std::pair<QString, int>> mPopupCommands;
     // How many lines the screen scrolled since it was last rendered.
     int mScrollVector;
     QRegion mSelectedRegion;

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -1550,7 +1550,7 @@ win32 {
 }
 
 # This is a list of files that we want to show up in the Qt Creator IDE that are
-# not otherwise used by the project:
+# not otherwise used by the main project:
 OTHER_FILES += \
     ../.appveyor.yml \
     ../.crowdin.yml \
@@ -1614,6 +1614,19 @@ OTHER_FILES += \
     ../docker/docker-compose.override.linux.yml \
     ../docker/docker-compose.yml \
     ../docker/Dockerfile \
+    ../test/CMakeLists.txt \
+    ../test/GUIConsoleTests.mpackage \
+    ../test/TEntityHandlerTest.cpp \
+    ../test/TEntityResolverTest.cpp \
+    ../test/TLinkStoreTest.cpp \
+    ../test/TLuaInterfaceTest.cpp \
+    ../test/TMxpCustomElementTagHandlerTest.cpp \
+    ../test/TMxpEntityTagHandlerTest.cpp \
+    ../test/TMxpFormattingTagsTest.cpp \
+    ../test/TMxpSendTagHandlerTest.cpp \
+    ../test/TMxpStubClient.h \
+    ../test/TMxpTagParserTest.cpp \
+    ../test/TMxpVersionTagTest.cpp \
     mac-deploy.sh \
     mudlet-lua/genDoc.sh \
     mudlet-lua/lua/ldoc.css

--- a/test/TLinkStoreTest.cpp
+++ b/test/TLinkStoreTest.cpp
@@ -24,7 +24,7 @@ private slots:
         hints.append("Get &href;");
         hints.append("Look at &href;");
 
-        int id = store.addLinks(links, hints);
+        int id = store.addLinks(links, hints, hints);
 
         QStringList links2 = store.getLinks(id);
         QCOMPARE(links2, links);
@@ -41,19 +41,19 @@ private slots:
 
         QStringList links;
 
-        store.addLinks(links, links);
+        store.addLinks(links, links, links);
         QCOMPARE(store.getCurrentLinkID(), 1);
 
-        store.addLinks(links, links);
+        store.addLinks(links, links, links);
         QCOMPARE(store.getCurrentLinkID(), 2);
 
-        store.addLinks(links, links);
+        store.addLinks(links, links, links);
         QCOMPARE(store.getCurrentLinkID(), 3);
 
-        store.addLinks(links, links);
+        store.addLinks(links, links, links);
         QCOMPARE(store.getCurrentLinkID(), 1);
 
-        store.addLinks(links, links);
+        store.addLinks(links, links, links);
         QCOMPARE(store.getCurrentLinkID(), 2);
     }
 
@@ -64,9 +64,9 @@ private slots:
         QStringList links;
         links.append("GET &href;");
 
-        store.addLinks(links, links);
-        store.addLinks(links, links);
-        store.addLinks(links, links);
+        store.addLinks(links, links, links);
+        store.addLinks(links, links, links);
+        store.addLinks(links, links, links);
 
         QCOMPARE(store.getCurrentLinkID(), 3);
         QCOMPARE(store.getLinks(3), links);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
For these two functions the previous hint text was use both for the entries in the right-click (context) menu AND the tool-tip that is shown when the pointer is hovered over the link text. This means that it is not possible to use fancy rich-text for the tool tip content as it would also show in the context menu items - this PR improves on that.

If the command (string or function form) and the hint entries are empty strings `""` then a context menu entry is not made for that one but it can still have a tooltip - which is a means to introduce content for the tool-tip independent of any particular item. Furthermore if the command (string or function form) is an empty string (so there is nothing to do) but there **is** a hint then that hint text is entered into the context menu as a disabled (inactive) item - which might be useful in some situations.

#### Motivation for adding to Mudlet
The corresponding `insertLink(...)` and `echoLink(...)` functions only use the "hint" text for the hover tool- tip and that can be written using Qt's Rich-Text (in the same manner as "Labels" can) to be quite fancy.

#### Other info (issues closed, discussion etc)
Previously when the popup (context, right click, menu) is generated and displayed a temporary `QMap` is created to hold the commands or functions that all the `QAction`s will need to call if activated. It did use the "hint" or context menu text for each item as the key - however this would not handle duplicate texts. I have switched to storing the entry number of the items in the tables supplied (starting at `1` not `0`) as the key for that table instead and store the same value as the `Qt::UserRole` data item for each `QAction` - this will now work should the same text be used for more than one "hint".