### PR TITLE
fix: Rename MainConsole to "main" again

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1430,6 +1430,7 @@ void mudlet::addConsoleForNewHost(Host* pH)
         return;
     }
     pH->mpConsole = pConsole;
+    pConsole->mConsoleName = qsl("main");
     pConsole->setWindowTitle(pH->getName());
     pConsole->setObjectName(pH->getName());
     const QString tabName = pH->getName();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
MainConsole was not named "main" anymore
#### Motivation for adding to Mudlet
some events depend on it: sysWindowMousePressEvent for example but also others
#### Other info (issues closed, discussion etc)
Probably related to the change in TConsole.h in https://github.com/Mudlet/Mudlet/commit/3c7593abed604d2e6df9c1b06734a2e6ecdd5511# but I agree with the change there, we should name the MainConsole directly after creation as we do for Mini(Sub)Consoles and Userwindows.