### PR TITLE
Fix: ensure all TConsole instances have a name

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3034,11 +3034,8 @@ std::pair<bool, QString> Host::openWindow(const QString& name, bool loadLayout, 
         mpConsole->mDockWidgetMap.insert(name, dockwidget);
         // It wasn't obvious but the parent passed to the TConsole constructor
         // is sliced down to a QWidget and is NOT a TDockWidget pointer:
-        console = new TConsole(this, TConsole::UserWindow, dockwidget->widget());
+        console = new TConsole(this, name, TConsole::UserWindow, dockwidget->widget());
         console->setObjectName(qsl("dockWindowConsole_%1_%2").arg(hostName, name));
-        // Without this the TConsole instance inside the TDockWidget will be
-        // left being called the default value of "main":
-        console->mConsoleName = name;
         console->setContentsMargins(0, 0, 0, 0);
         dockwidget->setTConsole(console);
         console->layerCommandLine->hide();

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -62,6 +62,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
 , mpHost(pH)
 , buffer(pH, this)
 , emergencyStop(new QToolButton)
+, mConsoleName(name)
 , mpBaseVFrame(new QWidget(this))
 , mpTopToolBar(new QWidget(mpBaseVFrame))
 , mpBaseHFrame(new QWidget(mpBaseVFrame))

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -56,8 +56,8 @@
 const QString TConsole::cmLuaLineVariable("line");
 
 // A high-performance text widget with split screen ability for scrolling back
-// Contains two TTextEdits, each backed by a TBuffer
-TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
+// Contains two TTextEdits, and is backed by a TBuffer
+TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidget* parent)
 : QWidget(parent)
 , mpHost(pH)
 , buffer(pH, this)

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -99,8 +99,8 @@ public:
     Q_DECLARE_FLAGS(SearchOptions, SearchOption)
 
     Q_DISABLE_COPY(TConsole)
-    explicit TConsole(Host*, ConsoleType type = UnknownType, QWidget* parent = nullptr);
-    ~TConsole();
+    explicit TConsole(Host*, const QString&, const ConsoleType type = UnknownType, QWidget* parent = nullptr);
+    ~TConsole() override;
 
     void reset();
     void resizeConsole();

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -51,7 +51,7 @@
 
 
 TMainConsole::TMainConsole(Host* pH, QWidget* parent)
-: TConsole(pH, TConsole::MainConsole, parent)
+: TConsole(pH, qsl("main"), TConsole::MainConsole, parent)
 , mClipboard(pH)
 {
     // During first use where mIsDebugConsole IS true mudlet::self() is null
@@ -428,16 +428,15 @@ QString TMainConsole::getCurrentLine(std::string& buf)
 TConsole* TMainConsole::createBuffer(const QString& name)
 {
     if (!mSubConsoleMap.contains(name)) {
-        auto pC = new TConsole(mpHost, Buffer);
+        auto pC = new TConsole(mpHost, name, Buffer);
         mSubConsoleMap[name] = pC;
-        pC->mConsoleName = name;
         pC->setContentsMargins(0, 0, 0, 0);
         pC->hide();
         pC->layerCommandLine->hide();
         return pC;
-    } else {
-        return nullptr;
     }
+
+    return nullptr;
 }
 
 void TMainConsole::resetMainConsole()
@@ -489,18 +488,17 @@ TConsole* TMainConsole::createMiniConsole(const QString& windowname, const QStri
     auto pS = mScrollBoxMap.value(windowname);
     if (!pC) {
         if (pS) {
-            pC = new TConsole(mpHost, SubConsole, pS->widget());
+            pC = new TConsole(mpHost, name, SubConsole, pS->widget());
         } else if (pW) {
-            pC = new TConsole(mpHost, SubConsole, pW->widget());
+            pC = new TConsole(mpHost, name, SubConsole, pW->widget());
         } else {
-            pC = new TConsole(mpHost, SubConsole, mpMainFrame);
+            pC = new TConsole(mpHost, name, SubConsole, mpMainFrame);
         }
         if (!pC) {
             return nullptr;
         }
         mSubConsoleMap[name] = pC;
         pC->setObjectName(name);
-        pC->mConsoleName = name;
         const auto& hostCommandLine = mpHost->mpConsole->mpCommandLine;
         pC->setFocusProxy(hostCommandLine);
         pC->mUpperPane->setFocusProxy(hostCommandLine);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -310,7 +310,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     connect(mpSourceEditorEdbee->textEditorComponent(), &QWidget::customContextMenuRequested, this, &dlgTriggerEditor::slot_editorContextMenu);
 
     // option areas
-    mpErrorConsole = new TConsole(mpHost, TConsole::ErrorConsole, this);
+    mpErrorConsole = new TConsole(mpHost, qsl("errors_%1").arg(hostName), TConsole::ErrorConsole, this);
     mpErrorConsole->setWrapAt(100);
     mpErrorConsole->mUpperPane->slot_toggleTimeStamps(true);
     mpErrorConsole->mLowerPane->slot_toggleTimeStamps(true);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2691,7 +2691,7 @@ void mudlet::attachDebugArea(const QString& hostname)
 
     smpDebugArea = new QMainWindow(nullptr);
     const auto pHost = mHostManager.getHost(hostname);
-    smpDebugConsole = new TConsole(pHost, TConsole::CentralDebugConsole);
+    smpDebugConsole = new TConsole(pHost, qsl("centralDebug"), TConsole::CentralDebugConsole);
     smpDebugConsole->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     smpDebugConsole->setWrapAt(100);
     smpDebugArea->setCentralWidget(smpDebugConsole);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This is a more comprehensive fix that also obsoletes #6926 which should be closed to defer to this one. 

#### Motivation for adding to Mudlet
As noted in that Pull-request it seems that #6232  - (commit 3c7593ab) removed a default value for `(QString) TConsole::mConsoleName` which was `main` - as such this meant that the `TMainConsole` was left with that member being a null `QString` which broke some parts of Mudlet that were looking for it to contain `main`.

#### Other info (issues closed, discussion etc)
I guess this was not spotted sooner because much of our code (especially the Lua API) assumes that an unnamed `TConsole` identifier is actually meant to be the `TMainConsole` instance for a profile...

This bug does not have an associated issue raised for it - so there isn't a linked one to close.