### PR TITLE
Infrastructure: fix codeql 3rd party dependency filtering

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -168,6 +168,10 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{ matrix.language }}"
+        upload: false
+        output: sarif-results
 
     - name: Filter out 3rdparty dependencies
       uses: advanced-security/filter-sarif@v1


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix codeql 3rd party dependency filtering
#### Motivation for adding to Mudlet
Fix CodeQL action, which has [been broken](https://github.com/Mudlet/Mudlet/actions/workflows/codeql-analysis.yml) for a month or so
#### Other info (issues closed, discussion etc)
Default behaviour of the action was changed to upload results right away - this we couldn't filter them