### PR TITLE
Fix: crash on moving rooms

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3648,7 +3648,11 @@ void T2DMap::slot_movePosition()
 
     auto dialog = new QDialog(this);
     auto gridLayout = new QGridLayout;
-    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    // Do NOT try to set the Qt::WA_DeleteOnClose attribute on the dialogue,
+    // because we want to read the details from the QLineEdits on it after the
+    // user has clicked "OK" on the dialog - and setting that flag will cause
+    // it (and those QLineEdits) to be destroyed by the time the QDialog:exec()
+    // call returns which is before we've got those details!
     dialog->setLayout(gridLayout);
     dialog->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
     dialog->setContentsMargins(0, 0, 0, 0);
@@ -3718,6 +3722,7 @@ void T2DMap::slot_movePosition()
             room->z += dz;
         }
     }
+    dialog->deleteLater();
     repaint();
     mpMap->setUnsaved(__func__);
 }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
In fact this ought to be happening in other cases as well when using the "Move to position" 2D Mapper context menu option. It is a result of setting the `Qt::WA_DeleteOnClose` attribute on the `QDialog` used to get the user's input and using `QDialog::exect()` in order to "run" the dialog. As a result it deletes itself when the user clicks the "Okay" button but Mudlet has been trying (and crashing when it cannot) to read the text contents of the `QLineEdit`s that the user has typed their input into after that point!

The fix is to NOT set that attribute. To ensure that the dialog is cleared from memory after use (as #6531 was trying to do) we must ensure that the dialog is destroyed AFTER the details have been gathered - or even if they are not because "Cancel" has been clicked instead and the safest method to do that is to call `QObject::deleteLater()` on it when we have finished with it - then it gets scheduled for destruction and the underlying Qt code does that when "control returns to the main event loop" - importantly it is safe to call that more than once on the same object which is not always the case for the core C++ `delete X` operation).

#### Motivation for adding to Mudlet
As the title and related issue suggests, to stop a fatal seg. fault when one or more rooms are moved in the 2D mapper with the "Move to position" context menu action is used.

#### Other info (issues closed, discussion etc)
This should close #6932. As a check I have reviewed all the other places where `QDialog::exec()` is used and I have determined to my satisfaction that there are no other cases in our code where this could also happen. Further investigation shows that the bug was introduced by #6531 inserted into the code base by @Kebap in February this year (so will affect **4.17.x** releases up until this fix goes in).

