### PR TITLE
Fix: generic_mapper Window Shown config not updating

### DIFF
--- a/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
+++ b/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
@@ -1518,7 +1518,7 @@ function map.setConfigs(key, val, sub_key)
     if tonumber(val) then val = tonumber(val) end
     if not toggle then
         if key == "map_window" then
-            if map.configs.map_window[sub_key] then
+            if map.configs.map_window[sub_key] ~= nil then
                 map.configs.map_window[sub_key] = val
                 map.echo(string.format("Map config %s set to: %s", sub_key, tostring(val)))
             else


### PR DESCRIPTION
#### Brief overview of PR changes/additions
When the value of a map_window sub_key is false, current behavior will echo Unknown map config to the window and not change the value. This change will check to see if the sub_key is nil instead, so that if the value is the boolean false the value can be updated properly.

#### Motivation for adding to Mudlet
I was working on a GUI, and trying to set the value explicitly, and it was reporting Unknown map config.

#### Other info (issues closed, discussion etc)
After determining this on my own, found that an issue had been opened and come to the same conclusion, and this should close #6319.