### PR TITLE
Add: Map mouse click event (sysMapWindowMousePressEvent)

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3190,11 +3190,11 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
         }
 
     }
-
-    TEvent sysMapMouseClickEvent{};
-    sysMapMouseClickEvent.mArgumentList.append(QLatin1String("sysMapMouseClickEvent"));
-    sysMapMouseClickEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-    mpHost->raiseEvent(sysMapMouseClickEvent);    
+    
+    TEvent sysMapWindowMousePressEvent{};
+    sysMapWindowMousePressEvent.mArgumentList.append(QLatin1String("sysMapWindowMousePressEvent"));
+    sysMapWindowMousePressEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    mpHost->raiseEvent(sysMapWindowMousePressEvent);  
     
     updateSelectionWidget();
     update();

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3191,6 +3191,11 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
 
     }
 
+    TEvent sysMapMouseClickEvent{};
+    sysMapMouseClickEvent.mArgumentList.append(QLatin1String("sysMapMouseClickEvent"));
+    sysMapMouseClickEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    mpHost->raiseEvent(sysMapMouseClickEvent);    
+    
     updateSelectionWidget();
     update();
 }


### PR DESCRIPTION
Add sysMapWindowMousePressEvent to know when a user clicked the map window.

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

sysWindowMousePressEvent only works on the main window.  This adds mouse press events
to the mapper window.

#### Motivation for adding to Mudlet

To know _when_ a user has clicked the window, e.g. when a room is selected.

#### Other info (issues closed, discussion etc)

Haven't added double clicks or release events.  I couldn't think of a use case.  This is
also only the 2D mapper. 
