### PR TITLE
Fix: Escape quote for MSDP JSON

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -13981,6 +13981,7 @@ void TLuaInterpreter::msdp2Lua(const char* src)
             script.append('\\');
             break;
         case '\"':
+            script.append('\\');
             script.append('\"');
             break;
         default:


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Parsing of the quote (") character results in a JSON error for the [MSDP](https://tintin.mudhalla.net/protocols/msdp/) protocol. This update escapes the quote character during the transformation of the MSDP string so that it could be parsed as JSON.

The author of this fix does not use MSDP and will need assistance verifying it.

#### Motivation for adding to Mudlet
Resolving issues.

#### Other info (issues closed, discussion etc)
Author: Tamarindo@StickMUD
Release Note: Fixed an issue where quotes in text passed to MSDP would generate a JSON error in Mudlet.
Closes issues #5290 #6893 