### PR TITLE
Fix: Remove Geyser.ScrollBox:setStyleSheet(...) from LDocs

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserScrollBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserScrollBox.lua
@@ -30,7 +30,8 @@ end
 -- Save a reference to our parent constructor
 Geyser.ScrollBox.parent = Geyser.Window
 
---- Sets the style sheet of the scrollbox
+-- Sets the style sheet of the scrollbox.
+-- @todo Not currently implemented.
 -- @param css The style sheet string
 -- function Geyser.ScrollBox:setStyleSheet(css)
 --     css = css or self.stylesheet


### PR DESCRIPTION
Remove Geyser.ScrollBox:setStyleSheet(...) from LDocs as it is not currently implemented.

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Minor LDocs change.

#### Motivation for adding to Mudlet

#6959

#### Other info (issues closed, discussion etc)
