### PR TITLE
Fix LDoc comment causing automated ldoc action to fail

### DIFF
--- a/src/mudlet-lua/README.md
+++ b/src/mudlet-lua/README.md
@@ -9,7 +9,7 @@ Project structure:
             LuaGlobal.lua     loader for all Lua code used by Mudlet
 
         tests/                unit tests for mudlet-lua 
-        mudlet-lua-doc/       generated documentation (depreciated)
+        mudlet-lua-doc/       generated documentation
 
         CONTRIBS
         genDoc.sh             script for generation documentation

--- a/src/mudlet-lua/TODO
+++ b/src/mudlet-lua/TODO
@@ -1,4 +1,4 @@
-need to sort out single GIT repozitory for all mudlet code
+need to sort out single GIT repository for all mudlet code
 	(well it's not so bad now ... there is one for lua and one for rest)
 
 

--- a/src/mudlet-lua/lua/geyser/Geyser.lua
+++ b/src/mudlet-lua/lua/geyser/Geyser.lua
@@ -1,10 +1,10 @@
---------------------------------------
---                                  --
--- The Geyser Layout Manager by guy --
---                                  --
---------------------------------------
---
+--- The Geyser Layout Manager for Mudlet.
+-- <br/>See also: <a href="https://wiki.mudlet.org/w/Manual:Geyser">Mudlet Manual</a>
+-- @author guy
+-- @module Geyser
+
 -- Load code in following order:
+-- <pre>
 --    Geyser.lua
 --    GeyserGeyser.lua
 --    GeyserUtil.lua
@@ -18,12 +18,10 @@
 --    GeyserMapper.lua
 --    GeyserReposition.lua
 --    GeyserTests.lua
-
-
+-- </pre>
 
 -- UNCOMMENT EVERYTHING BELOW THIS LINE FOR VERSIONS PRIOR TO 1.1.0
 --myoldresizer = myoldresizer or handleWindowResizeEvent
 --function handleWindowResizeEvent()
 --	raiseEvent("sysWindowResizeEvent")
 --end
-

--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -1,20 +1,15 @@
---Adjustable Container
---Just use it like a normal Geyser Container with some extras like:
---moveable, adjustable size, attach to borders, minimizeable, save/load...
---right click on top border for menu
---Inspired heavily by Adjustable Label (by Jor'Mox ) and EMCO (by demonnic )
---by Edru 2020
+--- Just like a normal container, only adjustable.
+-- Just use it like a normal Geyser Container with some extras like:
+-- moveable, adjustable size, attach to borders, minimizeable, save/load.
+-- Right click on top border for menu.<br/>
+-- Inspired heavily by Adjustable Label (by Jor'Mox) and EMCO (by demonnic)
+-- <br/>See: <a href="https://wiki.mudlet.org/w/Manual:Geyser#Adjustable.Container">Mudlet Manual</a>
+-- @author guy
+-- @author Edru
+-- @module Adjustable.Container
 
 Adjustable = Adjustable or {}
 
---------------------------------------
---                                  --
--- The Geyser Layout Manager by guy --
--- Adjustable Container by Edru     --
---                                  --
---------------------------------------
--- Adjustable Container
--- @module AdjustableContainer
 Adjustable.Container = Adjustable.Container or Geyser.Container:new({name = "AdjustableContainerClass"})
 
 local adjustInfo = {}

--- a/src/mudlet-lua/lua/geyser/GeyserButton.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserButton.lua
@@ -1,7 +1,8 @@
 --- Represents a clickable button. Can be a single clickable action or a two state button
 -- which alternates between the two states when clicked.
--- @class table
--- @name Geyser.Button
+-- @author guy
+-- @author demonnic
+-- @module Geyser.Button
 -- @field twoState If true, the button will be treated as a two state button, with 'up' and 'down' states.
 -- @field state 'up' or 'down' depending on button state for two state buttons. Will always be 'up' if a single state button.
 -- @field tooltip The text to show when the button is hovered over. For two state buttons will be used for the 'up' tooltip

--- a/src/mudlet-lua/lua/geyser/GeyserButton.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserButton.lua
@@ -1,23 +1,24 @@
 --- Represents a clickable button. Can be a single clickable action or a two state button
 -- which alternates between the two states when clicked.
--- @author guy
+-- <br/>See also: <a href="https://wiki.mudlet.org/w/Manual:Geyser#Geyser.Button">Mudlet Manual</a>
 -- @author demonnic
 -- @module Geyser.Button
--- @field twoState If true, the button will be treated as a two state button, with 'up' and 'down' states.
--- @field state 'up' or 'down' depending on button state for two state buttons. Will always be 'up' if a single state button.
--- @field tooltip The text to show when the button is hovered over. For two state buttons will be used for the 'up' tooltip
--- @field downTooltip The text to show when the button is hovered over while in the 'down' state.
--- @field toolTipDuration The amount of time for the tooltip to show. Used for both 'up' and 'down' states.
--- @field clickCommand The command to send when the button is clicked. For two state buttons, used when clicking in the 'up' state. Will be skipped if clickFunction is defined.
--- @field clickFunction Optional function to run when button clicked. For two state buttons, used when clicking in the 'up' state. If defined takes precedence over clickCommand.
--- @field downCommand The command to send when the two state button is clicked while in the 'down' state.
--- @field downFunction The function to run when the two state button is clicked while in the 'down' state.
--- @field downColor The color to make the button while it is in the 'down' state. Superceded by downStyle
--- @field downStyle The stylesheet to use for the button while it is in the 'down' state. Supercedes downColor
--- @field color The color to make the button. If a two state button, will be used for the 'up' state. Superceded by style
--- @field style The stylesheet to use for the button. If a two state button, will be used for the 'up' state. Supercedes color
+
+--- A clickable button.
+-- @field name The name of the button.
+-- @field height The height of the button in pixels.
+-- @field width The height of the button in pixels.
+-- @field color The color to make the button. If a two state button, will be used for the 'up' state. Superceded by 'style' which is valid and optional stylesheet to use for the button. If a two state button, will be used for the 'up' state.
+-- @field downColor The color to make the button while it is in the 'down' state. Superceded by 'downStyle' which is valid and optional stylesheet to use for the button while it is in the 'down' state.
 -- @field msg The text to put on the button. If a two state button, will be used for the 'up' state.
 -- @field downMsg The text to put on the button in the 'down' state.
+-- @field tooltip The text to show when the button is hovered over. For two state buttons will be used for the 'up' tooltip
+-- @field downTooltip The text to show when the button is hovered over while in the 'down' state.
+-- @field downCommand The command to send when the two state button is clicked while in the 'down' state. 'downFunction' is also valid and optional function to run when the two state button is clicked while in the 'down' state.
+-- @field clickCommand The command to send when the button is clicked. For two state buttons, used when clicking in the 'up' state. Will be skipped if 'clickFunction' is defined.  'clickFunction' is also valid and optional function to run when button clicked. For two state buttons, used when clicking in the 'up' state. If defined takes precedence over clickCommand.
+-- @field twoState If true, the button will be treated as a two state button, with 'up' and 'down' states.
+-- @field state 'up' or 'down' depending on button state for two state buttons. Will always be 'up' if a single state button.
+-- @field toolTipDuration The amount of time for the tooltip to show. Used for both 'up' and 'down' states.
 Geyser.Button = {
   name            = "GeyserButtonClass",
   height          = 50,

--- a/src/mudlet-lua/lua/geyser/GeyserColor.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserColor.lua
@@ -1,8 +1,6 @@
---------------------------------------
---                                  --
--- The Geyser Layout Manager by guy --
---                                  --
---------------------------------------
+--- Geyser color functions.
+-- @author guy
+-- @module Geyser.Color
 
 Geyser.Color = {}
 

--- a/src/mudlet-lua/lua/geyser/GeyserCommandLine.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserCommandLine.lua
@@ -1,13 +1,10 @@
---------------------------------------
--- --
--- The Geyser Layout Manager by guy --
---  CommandLine support by Edru     --
--- --
---------------------------------------
+--- Represents a (sub)commandLine primitive.
+-- <br/>See also: <a href="https://wiki.mudlet.org/w/Manual:Geyser#Geyser.CommandLine">Mudlet Manual</a>
+-- @author guy
+-- @author Edru
+-- @module Geyser.CommandLine
 
---- Represents a (sub)commandLine primitive
--- @class table
--- @name Geyser.CommandLine
+--- Represents a (sub)commandLine primitive.
 Geyser.CommandLine = Geyser.Window:new({
   name = "CommandLineClass"
 })
@@ -46,19 +43,18 @@ function Geyser.CommandLine:getText()
 end
 
 --- Sets the style sheet of the command-line
--- @param css The style sheet string
+-- @param css the style sheet string
 function Geyser.CommandLine:setStyleSheet(css)
   css = css or self.stylesheet
   setCmdLineStyleSheet(self.name, css)
   self.stylesheet = css
 end
 
---- Sets an action to be used when text is send in this commandline. When this
+--- Sets an action to be used when text is sent in this commandline. When this
 -- function is called by the event system, text the commandline sends will be 
--- appended as the final argument (see @{sysCmdLineEvent}) and also in Geyser.Label
--- the setClickCallback events
--- @param func The function to use.
--- @param ... Parameters to pass to the function.
+-- appended as the final argument.
+-- @param func the function to use
+-- @param ... parameters to pass to the function
 function Geyser.CommandLine:setAction(func, ...)
   setCmdLineAction(self.name, func, ...)
   self.actionFunc = func

--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -1,14 +1,9 @@
---------------------------------------
---                                  --
--- The Geyser Layout Manager by guy --
---                                  --
---------------------------------------
-
 --- Represents a generic container with positional information.
 -- Has no notion of contents and is used to contain other windows
 -- and impose some sense of order.
--- @class table
--- @name Geyser.Container
+-- <br/>See also: <a href="https://wiki.mudlet.org/w/Manual:Geyser#Geyser.Container">Mudlet Manual</a>
+-- @author guy
+-- @module Geyser.Container
 -- @field parent The parent class of this window
 -- @field type The type of this window, usually lowercase of the classname and
 --             can be used in checks for certain types. For a Container
@@ -45,11 +40,8 @@
 --                 based on the character constraint. Default is 8.
 -- @field h_policy This sets if this widget should be stretched/shrunk horizontally or not
 -- @field v_policy This sets if this widget should be stretched/shrunk vertically or not
--- @field v_stretch_factor This sets by how much more then window will be stretched horizontally in comparison to
---                 other windows
--- @field v_stretch_factor This sets by how much more then window will be stretched vertically in comparison to
---                 other windows
-
+-- @field v_stretch_factor This sets by how much more then window will be stretched horizontally in comparison to other windows
+-- @field v_stretch_factor This sets by how much more then window will be stretched vertically in comparison to other windows
 Geyser.Container = {
   name = "ContainerClass",
   x = "10px",
@@ -319,6 +311,7 @@ setmetatable(Geyser.Container, Geyser)
 -- @param cons Any Lua table that contains appropriate constraint entries.
 --             Include any parameter such as name or fontSize in cons
 --             that are to be used for the new window.
+-- @param container The parent container.
 function Geyser.Container:new(cons, container)
   -- create new table for the container and copy over constraints
   local me = Geyser.copyTable(cons)

--- a/src/mudlet-lua/lua/geyser/GeyserGauge.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGauge.lua
@@ -1,12 +1,9 @@
---------------------------------------
---                                  --
--- The Geyser Layout Manager by guy --
---                                  --
---------------------------------------
+--- Represents a gauge that can be either vertical or horizontal.
+-- <br/>See also: <a href="https://wiki.mudlet.org/w/Manual:Geyser#Geyser.Gauge">Mudlet Manual</a>
+-- @author guy
+-- @module Geyser.Gauge
 
 --- Represents a gauge that can be either vertical or horizontal.
--- @class table
--- @name Geyser.Gauge
 -- @field value Percentage value of how "full" the gauge is.
 -- @field strict If true, will cap the value of the gauge at 100, preventing
 --               it from overflowing the edge. Defaults to false to maintain
@@ -148,7 +145,9 @@ function Geyser.Gauge:setFgColor(color)
 end
 
 --- Sets the text on the gauge, overwrites inherited echo function.
--- @param text The text to set.
+-- @param message the text to set
+-- @param color the color of the text
+-- @param format the text format
 function Geyser.Gauge:echo(message, color, format)
   self.text:echo(message, color, format)
   self.format = self.text.format
@@ -209,7 +208,7 @@ function Geyser.Gauge:new (cons, container)
   setmetatable(me, self)
   self.__index = self
   me.windowname = me.windowname or me.container.windowname or "main"
-  -----------------------------------------------------------
+
   -- Now create the Gauge using primitives and tastey classes
 
   -- Set up the constraints for the front label, the label that changes size to

--- a/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
@@ -1,12 +1,6 @@
---------------------------------------
---                                  --
--- The Geyser Layout Manager by guy --
---                                  --
---------------------------------------
-
---==================================================
--- Create the Geyser Root Container
---==================================================
+--- Geyser namespace.
+-- @author guy
+-- @module Geyser.Geyser
 
 --- Create the Geyser namespace.
 -- Geyser is considered to be a "container window" for the purposes
@@ -57,7 +51,8 @@ end
 
 --- Add a window to the list that this container manages.
 -- this is the basis for the 2 add functions
--- @param window The window to add this container
+-- @param window the window to add this container
+-- @param cons table of Geyser window options such as name, width, and height
 function Geyser:base_add (window, cons)
   cons = cons or window -- 'cons' is optional
 
@@ -84,8 +79,7 @@ end
 --- Add a window to the list that this container manages.
 -- The window will be shown after added to the container
 -- @param window The window to add this container
--- @param cons
--- @param passOn manages the inheritance of this add function
+-- @param cons table of Geyser window options such as name, width, and height
 function Geyser:add (window, cons)
   self:base_add(window, cons)
   window:show()
@@ -96,8 +90,8 @@ end
 -- container is hidden already
 -- used by Adjustable.Container and changeContainer but can be used by any container using the new2 constructor
 -- @param window The window to add this container
--- @param cons
--- @param passOn manages the inheritance of this add function. If set to true this add function will be inherited by all children.
+-- @param cons table of Geyser window options such as name, width, and height
+-- @param passAdd2 manages the inheritance of this add function. If set to true this add function will be inherited by all children.
 -- @param exclude manages types which have to be excluded from overwriting their add function as they have their own
 function Geyser:add2 (window, cons, passAdd2, exclude)
   cons = cons or window -- 'cons' is optional
@@ -158,7 +152,8 @@ end
 
 --- Removes a window from the parent it is in and puts it in a new one
 -- This is only used internally.
--- @param window The new parents windowname
+-- @param self
+-- @param windowname The new parents windowname
 local function setMyWindow(self, windowname)
   windowname = windowname or "main"
   local name
@@ -184,7 +179,8 @@ end
 
 --- Removes all containers windows from the parent they are in and puts them in a new one
 -- This is only used internally
--- @param window The new parents windowname
+-- @param self
+-- @param windowname The new parents windowname
 local function setContainerWindow(self, windowname)
   self.windowname = windowname
   --Iterate through windows has a given order and prevents problems with z-coordinate

--- a/src/mudlet-lua/lua/geyser/GeyserHBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserHBox.lua
@@ -1,10 +1,9 @@
---------------------------------------
---                                  --
--- The Geyser Layout Manager by guy --
---                                  --
---        HBox by Beliar            --
---                                  --
---------------------------------------
+--- A horizontal box container.
+-- <br/>See also: <a href="https://wiki.mudlet.org/w/Manual:Geyser#HBox.2FVBox">Mudlet Manual</a>
+-- @author guy
+-- @author Beliar
+-- @module Geyser.HBox
+
 Geyser.HBox = Geyser.Container:new({
   name = "HBoxClass"
 })

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -1,14 +1,9 @@
--- Label class to use CSS and images
-
---------------------------------------
---                                  --
--- The Geyser Layout Manager by guy --
---                                  --
---------------------------------------
+--- Label class to use CSS and images.
+-- <br/>See also: <a href="https://wiki.mudlet.org/w/Manual:Geyser#Geyser.Label">Mudlet Manual</a>
+-- @author guy
+-- @module Geyser.Label
 
 --- Represents a label like we all know and love.
--- @class table
--- @name Geyser.Label
 -- @field fillBg 1 if the background is to be filled, 0 for no background.
 Geyser.Label = Geyser.Window:new({
   name = "LabelClass",
@@ -171,8 +166,8 @@ function Geyser.Label:autoAdjustSize()
 end
 
 ---Enable autoAdjustSize
--- @param set width to false if just autoAdjust height
--- @param set height to false if just autoAdjust width
+-- @param width set width to false if just autoAdjust height
+-- @param height set height to false if just autoAdjust width
 function Geyser.Label:enableAutoAdjustSize(width, height)
   self.autoHeight = true
   self.autoWidth = true
@@ -194,7 +189,7 @@ function Geyser.Label:disableAutoAdjustSize()
 end
 
 ---setMovie allows to set a gif animation on a label
--- @param filename the path to the gif file
+-- @param fileName the path to the gif file
 function Geyser.Label:setMovie(fileName)
   result, error = setMovie(self.name, fileName)
   self:autoAdjustSize()
@@ -448,7 +443,7 @@ end
 
 --- Set a predefined mouse cursor shape for this label
 -- @param cursorShape the predefined cursorshape as a string
--- see: https://wiki.mudlet.org/w/CursorShapes
+-- See: <a href="https://wiki.mudlet.org/w/CursorShapes">https://wiki.mudlet.org/w/CursorShapes</a>
 function Geyser.Label:setCursor(cursorShape)
   setLabelCursor(self.name, cursorShape)
   -- Get cursorShape as string
@@ -461,9 +456,11 @@ function Geyser.Label:setCursor(cursorShape)
   self.cursorShape = cursorShape
 end
 
---- Set a custom mouse cursor shape for this label
+--- Set a custom mouse cursor shape for this label.
+-- See: <a href=https://doc.qt.io/qt-5/qcursor.html#shape>https://doc.qt.io/qt-5/qcursor.html#shape</a>
 -- @param customCursor location of your custom cursor. It's suggested to use a png with size of 32x32 which is supported on all platforms
--- see https://doc.qt.io/qt-5/qcursor.html#shape
+-- @param hotX the X position of the cursor hotspot
+-- @param hotY the Y position of the cursor hotspot
 function Geyser.Label:setCustomCursor(customCursor, hotX, hotY)
   hotX = hotX or -1
   hotY = hotY or -1
@@ -499,7 +496,7 @@ function closeAllLevels(label)
 end
 
 --- Closes all nested labels under the given label, including any
---- nested children those children might possess
+-- nested children those children might possess
 -- @param label The name of the label to use
 function closeNestChildren(label)
   local nLabels = label.nestedLabels
@@ -522,7 +519,7 @@ function closeNestChildren(label)
 end
 
 --- Internal function.  This is a callback from a nested
---- labels scrollbar.
+-- labels scrollbar.
 -- @param label The name of the scrollbar
 function doNestScroll(label)
   local scrollDir = 0
@@ -554,7 +551,7 @@ function doNestScroll(label)
 end
 
 --- Displays the nested elements within label, and orients them
---- appropriately
+-- appropriately
 -- @param label The name of the label to use
 function Geyser.Label:displayNest()
   local maxDim = {}
@@ -965,7 +962,8 @@ function Geyser.Label:addScrollbars(parent, layout)
   return { backward, forward }
 end
 
----@param cons table of Geyser window options such as name, width, and height
+--- Add a child to this label.
+-- @param cons table of Geyser window options such as name, width, and height
 -- @param cons.name a unique name for the label
 -- @param cons.height height of the label - specify it as the defaults are huge
 -- @param cons.width width of the label - specify it as the defaults are huge
@@ -975,6 +973,7 @@ end
 -- @param[opt='white'] cons.fgColor optional foreground colour - colour to use for text on the label
 -- @param[opt='black'] cons.bgColor optional background colour - colour of the whole label
 -- @param[opt=1] cons.fillBg 1 if the background is to be filled, 0 for no background
+-- @param container the container to add as a child
 function Geyser.Label:addChild(cons, container)
   cons = cons or {}
   cons.type = cons.type or "nestedLabel"
@@ -1149,9 +1148,9 @@ function Geyser.Label:onRightClick(event)
   end
 end
 
---- finds and returns a right click menu item
--- @param name Name of the menu item. If the menu item has a parent name needs to be given as "Parent.MenuItemName"
--- @param only used internally the right click menu [optional]
+--- Finds and returns a right click menu item.
+-- @param name name of the menu item. If the menu item has a parent name needs to be given as "Parent.MenuItemName"
+-- @param parent only used internally the right click menu [optional]
 -- @param findParent only used internally to return a Parent [optional]
 function Geyser.Label:findMenuElement(name, parent, findParent)
   if not name then
@@ -1360,9 +1359,10 @@ end
 -- @field angleDeltaY A number corresponding with the horizontal wheel motion. For most devices, this number is in increments of 120
 -- @table mouseWheelEvent
 
---- Returns a table in the format of getTextFormat which describes the default formatting created by any stylesheets
+--- Returns a table in the format of getTextFormat which describes the default formatting created by any stylesheets.
 -- which are applied to the label.
--- @see https://wiki.mudlet.org/w/Manual:Lua_Functions#getLabelFormat and https://wiki.mudlet.org/w/Manual:Lua_Functions#getTextFormat
+-- See: <a href="https://wiki.mudlet.org/w/Manual:Lua_Functions#getLabelFormat">https://wiki.mudlet.org/w/Manual:Lua_Functions#getLabelFormat</a>
+-- See: <a href="https://wiki.mudlet.org/w/Manual:Lua_Functions#getTextFormat">https://wiki.mudlet.org/w/Manual:Lua_Functions#getLabelFormat</a>
 function Geyser.Label:getFormat()
   return getLabelFormat(self.name)
 end

--- a/src/mudlet-lua/lua/geyser/GeyserMapper.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMapper.lua
@@ -1,13 +1,10 @@
---------------------------------------
--- --
--- The Geyser Layout Manager by guy --
--- createMapper support by Vadi --
--- --
---------------------------------------
+--- Represents a mapper primitive.
+-- <br/>See also: <a href="https://wiki.mudlet.org/w/Manual:Geyser#Geyser.Mapper">Mudlet Manual</a>
+-- @author guy
+-- @author Vadi
+-- @module Geyser.Mapper
 
---- Represents a mapper primitive
--- @class table
--- @name Geyser.Mapper
+--- Represents a mapper primitive.
 -- @field wrapAt Where line wrapping occurs. Default is 300 characters.
 Geyser.Mapper = Geyser.Window:new({
   name = "MapperClass"
@@ -107,7 +104,7 @@ function Geyser.Mapper:new (cons, container)
   if me.embedded == nil and not me.dockPosition then
      me.embedded = true 
   end
-  -----------------------------------------------------------
+
   -- Now create the Mapper using primitives
   if me.dockPosition and me.dockPosition:lower() == "floating" then
     me.dockPosition = "f"

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -1,12 +1,9 @@
---------------------------------------
---                                  --
--- The Geyser Layout Manager by guy --
---                                  --
---------------------------------------
+--- Represents a miniconsole primitive.
+-- <br/>See also: <a href="https://wiki.mudlet.org/w/Manual:Geyser#Geyser.MiniConsole">Mudlet Manual</a>
+-- @author guy
+-- @module Geyser.MiniConsole
 
---- Represents a miniconsole primitive
--- @class table
--- @name Geyser.MiniConsole
+--- Represents a miniconsole primitive.
 -- @field wrapAt Where line wrapping occurs. Default is 300 characters.
 Geyser.MiniConsole = Geyser.Window:new({
   name = "MiniConsoleClass",
@@ -147,10 +144,9 @@ function Geyser.MiniConsole:disableCommandLine()
   disableCommandLine(self.name)
 end
 
---- Sets an action to be used when text is send in this commandline. When this
+--- Sets an action to be used when text is sent in this commandline. When this
 -- function is called by the event system, text the commandline sends will be
--- appended as the final argument (see @{sysCmdLineEvent}) and also in Geyser.Label
--- the setClickCallback events
+-- appended as the final argument.
 -- @param func The function to use.
 -- @param ... Parameters to pass to the function.
 function Geyser.MiniConsole:setCmdAction(func, ...)
@@ -577,7 +573,7 @@ function Geyser.MiniConsole:new (cons, container)
   -- Set the metatable.
   setmetatable(me, self)
   self.__index = self
-  -----------------------------------------------------------
+
   -- Now create the MiniConsole using primitives
   if not string.find(me.name, ".+Class$") then
     me.windowname = me.windowname or me.container.windowname or "main"

--- a/src/mudlet-lua/lua/geyser/GeyserReposition.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserReposition.lua
@@ -1,11 +1,14 @@
---------------------------------------
---                                  --
--- The Geyser Layout Manager by guy --
---                                  --
---------------------------------------
+--- Responds to sysWindowResizeEvent and causes all windows managed
+-- by Geyser to update their sizes and positions.
+-- @author guy
+-- @module GeyserReposition
 
 --- Responds to sysWindowResizeEvent and causes all windows managed
 -- by Geyser to update their sizes and positions.
+-- @param event a sysWindowResizeEvent or sysUserWindowResizeEvent event
+-- @param w the new width
+-- @param h the new height
+-- @param arg additional arguments
 function GeyserReposition(event, w, h, arg)
   for _, window in pairs(Geyser.windowList) do
     if event == "sysUserWindowResizeEvent" and window.type == "userwindow" and arg.."Container" == window.name then

--- a/src/mudlet-lua/lua/geyser/GeyserScrollBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserScrollBox.lua
@@ -1,13 +1,11 @@
---------------------------------------
--- --
--- The Geyser Layout Manager by guy --
---  ScrollBox support by Edru     --
--- --
---------------------------------------
+--- Represents a ScrollBox primitive.
+-- <br/>See also: <a href="https://wiki.mudlet.org/w/Manual:Geyser#Add_a_scrollable_box">Mudlet Manual</a>
+
+-- @author guy
+-- @author Edru
+-- @module Geyser.ScrollBox
 
 --- Represents a ScrollBox primitive
--- @class table
--- @name Geyser.ScrollBox
 Geyser.ScrollBox = Geyser.Window:new({
     name = "ScrollBoxClass"
 })

--- a/src/mudlet-lua/lua/geyser/GeyserSetConstraints.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserSetConstraints.lua
@@ -1,9 +1,6 @@
---------------------------------------
---                                  --
--- The Geyser Layout Manager by guy --
---                                  --
---------------------------------------
-
+--- Setting window contraints.
+-- @author guy
+-- @module Geyser.SetConstraints
 
 function Geyser.calc_constraints (window, cons, container)
   oldlocale = os.setlocale(nil, "numeric")

--- a/src/mudlet-lua/lua/geyser/GeyserStyleSheet.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserStyleSheet.lua
@@ -1,7 +1,11 @@
---- Represents a stylesheet used for styling Labels
--- Based primarily off the work of Vadi on CSSMan (https://forums.mudlet.org/viewtopic.php?f=6&t=3502)
+--- Represents a stylesheet used for styling labels.
+-- Based primarily off the work of Vadi on CSSMan <a href="https://forums.mudlet.org/viewtopic.php?f=6&t=3502">CSSMan</a>.
 -- This version extends it with recursive inheritance of properties, storing the target of the stylesheet (QLabel, QPlainTextEdit, etc), and parsing string stylesheets for them.
+-- <br/>See also: <a href="https://wiki.mudlet.org/w/Manual:Geyser#Geyser.StyleSheet">Mudlet Manual</a>
+-- @author guy
+-- @author Vadi
 -- @module Geyser.StyleSheet
+
 Geyser.StyleSheet = {}
 Geyser.StyleSheet.__index = Geyser.StyleSheet
 
@@ -149,7 +153,7 @@ function Geyser.StyleSheet:setParent(parent)
 end
 
 --- Allows you to set a target for this stylesheet to effect, such as "QPlainTextEdit" etc.
--- @param The target to apply this stylesheet to. if not provided will clear the target.
+-- @param target the target to apply this stylesheet to. if not provided will clear the target
 function Geyser.StyleSheet:setTarget(target)
   if target == nil then
     self.target = nil

--- a/src/mudlet-lua/lua/geyser/GeyserTests.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserTests.lua
@@ -1,10 +1,6 @@
---------------------------------------
---                                  --
--- The Geyser Layout Manager by guy --
---                                  --
---------------------------------------
-
--- TESTS FOR GEYSER --
+--- Tests for Geyser.
+-- @author guy
+-- @module Geyser.Tests
 
 --- Test labels.  Creates 101 Labels of varying hue and transparency.
 function Geyser.testLabels()
@@ -145,7 +141,6 @@ function Geyser.demo1()
 
   geyserDemoContainer:add(label1) -- you know the drill
 
-  ----------------------------------------
   -- 4. Add another miniconsole below the gauge that extends
   -- to the bottom of the screen and wraps at 40 characters and
   -- another clickable label.
@@ -170,13 +165,11 @@ function Geyser.demo1()
   geyserDemoContainer:add(label2) -- same here
 
 
-  ----------------------------------------
   -- 5. hide all windows just created
 
   geyserDemoContainer:hide()
 
 
-  ----------------------------------------
   -- 6. now show them again
 
   geyserDemoContainer:show()

--- a/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
@@ -1,15 +1,12 @@
---------------------------------------
---                                  --
--- The Geyser Layout Manager by guy --
--- UserWindow support by Edru       --
---                                  --
---------------------------------------
+--- Represents a UserWindow Class.
+-- <br/>See also: <a href="https://wiki.mudlet.org/w/Manual:Geyser#Geyser.UserWindow">Mudlet Manual</a>
+-- @author guy
+-- @author Edru
+-- @module Geyser.UserWindow
 
 --- Represents a UserWindow Class
---Support of UserWindows in Geyser
---UserWindows use also all the functions of MiniConsole as they contain one
--- @class table
--- @name Geyser.UserWindow
+-- Support of UserWindows in Geyser
+-- UserWindows use also all the functions of MiniConsole as they contain one
 Geyser.UserWindow = Geyser.MiniConsole:new({
   name = "UserWindowClass",
   color = "black"})

--- a/src/mudlet-lua/lua/geyser/GeyserUtil.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserUtil.lua
@@ -1,8 +1,6 @@
---------------------------------------
---                                  --
--- The Geyser Layout Manager by guy --
---                                  --
---------------------------------------
+--- Assorted Geyser utilities.
+-- @author guy
+-- @module Geyser.Util
 
 --- Generate a window name unique to this session.
 function Geyser.nameGen (type)

--- a/src/mudlet-lua/lua/geyser/GeyserVBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserVBox.lua
@@ -1,10 +1,9 @@
---------------------------------------
---                                  --
--- The Geyser Layout Manager by guy --
---                                  --
---        VBox by Beliar            --
---                                  --
---------------------------------------
+--- A vertical box container.
+-- <br/>See also: <a href="https://wiki.mudlet.org/w/Manual:Geyser#HBox.2FVBox">Mudlet Manual</a>
+-- @author guy
+-- @author Beliar
+-- @module Geyser.VBox
+
 Geyser.VBox = Geyser.Container:new({
   name = "VBoxClass"
 })

--- a/src/mudlet-lua/lua/geyser/GeyserWindow.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserWindow.lua
@@ -1,15 +1,12 @@
---------------------------------------
---                                  --
--- The Geyser Layout Manager by guy --
---                                  --
---------------------------------------
+--- Represents an abstract window class designed to be subclassed for windows
+-- that are built on Mudlet primitives, like labels.
+-- @author guy
+-- @module Geyser.Window
 
 local cparse = Geyser.Color.parse
 
 --- Represents an abstract window class designed to be subclassed for windows
 -- that are built on Mudlet primitives, like labels.
--- @class table
--- @name Geyser.Window
 -- @field message The message last *echo()'d to this window. Default is “”.
 -- @field bgColor Text background color, default "white"
 -- @field fgColor Text foreground color, default "black"
@@ -110,8 +107,8 @@ end
 -- @param bold The bolded status. 1 is bold, 0 is normal.
 -- @param underline The underlined status. 1 is underlined, 0 is normal.
 -- @param italics The italicized status. 1 is italicized, 0 is normal.
-function Geyser.Window:setTextFormat(r1, g1, b1, r1, g2, b2, bold, underline, italics)
-  setTextFormat(self.name, r1, g1, b1, r1, g2, b2, bold, underline, italics)
+function Geyser.Window:setTextFormat(r1, g1, b1, r2, g2, b2, bold, underline, italics)
+  setTextFormat(self.name, r1, g1, b1, r2, g2, b2, bold, underline, italics)
 end
 
 --- Sets bolded text.

--- a/src/mudlet-lua/luadoc-guide.txt
+++ b/src/mudlet-lua/luadoc-guide.txt
@@ -1,3 +1,8 @@
+Lua documentation is now generated with LDoc (https://github.com/lunarmodules/ldoc)
+Manual: https://lunarmodules.github.io/ldoc/manual/manual.md.html
+
+Below is kept for historical purposes and may be removed in future versions.
+--
 This file should give you basic guidelines for documenting mudlet-lua code 
 with LuaDoc. (Keep in mind that we did few extensions to LuaDoc,
 so this is not generic LuaDoc guide. All Mudlet LuaDoc extensions are 
@@ -31,7 +36,7 @@ Thank you!
 --- @param a is used for ... param description.
 --- @param b LuaDoc will generate basic doc for all omitted parameters.
 ---
---- @return truu/false (to keep if brief)
+--- @return true/false (to keep if brief)
 ---
 --- @usage Description of example.
 ---   <pre>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The automated action of building the LDocs hasn't been working for some months due to an errant LDoc comment. See
https://github.com/Mudlet/Mudlet/actions/runs/6268731308/job/17024132323 for failure log.  This PR fixes that and some improvements to the code documentation.

- Fix all warnings
- Add a few new comments
- Add links to Mudlet Manual where appropriate
- Change some tags to LDoc style

#### Motivation for adding to Mudlet
Comment introduced in #6801 broke the automated build.

#### Other info (issues closed, discussion etc)
As above did some extra work on tidying up the docs.  Still more to do like some missing parameter and return comments, but this will fix the automated action at least.
