### PR TITLE
Fix: use different symbols on map pan buttons

### DIFF
--- a/src/ui/mapper.ui
+++ b/src/ui/mapper.ui
@@ -199,7 +199,7 @@
                </font>
               </property>
               <property name="text">
-               <string notr="true">⯇</string>
+               <string notr="true">←</string>
               </property>
               <property name="autoRepeat">
                <bool>true</bool>
@@ -233,7 +233,7 @@
                </size>
               </property>
               <property name="text">
-               <string notr="true">⯆</string>
+               <string notr="true">↓</string>
               </property>
               <property name="autoRepeat">
                <bool>true</bool>
@@ -267,7 +267,7 @@
                </size>
               </property>
               <property name="text">
-               <string notr="true">⯅</string>
+               <string notr="true">↑</string>
               </property>
               <property name="autoRepeat">
                <bool>true</bool>
@@ -301,7 +301,7 @@
                </size>
               </property>
               <property name="text">
-               <string notr="true">⯈</string>
+               <string notr="true">→</string>
               </property>
               <property name="autoRepeat">
                <bool>true</bool>


### PR DESCRIPTION
#### Motivation for adding to Mudlet
On some MacOS users machines the map pan buttons are not included in the font that is being used to render the mapper controls. One user has suggested that we try some arrow symbols instead.

#### Brief overview of PR changes/additions
This PR changes them as follows:
* from '⯅' U+2BC5 {BLACK MEDIUM UP-POINTING TRIANGLE CENTRED} to '↑' U+2191 {UPWARDS ARROW}
* from '⯆' U+2BC6 {BLACK MEDIUM DOWN-POINTING TRIANGLE CENTRED} to '↓' U+2193 {DOWNWARDS ARROW}
* from '⯇' U+2BC7 {BLACK MEDIUM LEFT-POINTING TRIANGLE CENTRED} to '←' U+2190 {LEFTWARDS ARROW}
* from '⯈' U+2BC8 {BLACK MEDIUM RIGHT-POINTING TRIANGLE CENTRED} to '→' U+2192 {RIGHTWARDS ARROW}

#### Other info (issues closed, discussion etc)
Another set was proposed by a different person but on my Windows machine the left and right triangles got "emojified" which is what we are trying to avoid. Ideally the chosen glyphs should not change like that for any of our three main supported OSes.

This may close #5454.