### PR TITLE
Fix: improve symbols on map pan buttons

### DIFF
--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -84,12 +84,12 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
 
     widget_panel->setVisible(mpHost->mShowPanel);
     connect(checkBox_roundRooms, &QAbstractButton::clicked, this, &dlgMapper::slot_toggleRoundRooms);
-    connect(pushButton_shiftZup, &QAbstractButton::clicked, mp2dMap, &T2DMap::slot_shiftZup);
-    connect(pushButton_shiftZdown, &QAbstractButton::clicked, mp2dMap, &T2DMap::slot_shiftZdown);
-    connect(pushButton_shiftLeft, &QAbstractButton::clicked, mp2dMap, &T2DMap::slot_shiftLeft);
-    connect(pushButton_shiftRight, &QAbstractButton::clicked, mp2dMap, &T2DMap::slot_shiftRight);
-    connect(pushButton_shiftUp, &QAbstractButton::clicked, mp2dMap, &T2DMap::slot_shiftUp);
-    connect(pushButton_shiftDown, &QAbstractButton::clicked, mp2dMap, &T2DMap::slot_shiftDown);
+    connect(toolButton_shiftZup, &QAbstractButton::clicked, mp2dMap, &T2DMap::slot_shiftZup);
+    connect(toolButton_shiftZdown, &QAbstractButton::clicked, mp2dMap, &T2DMap::slot_shiftZdown);
+    connect(toolButton_shiftLeft, &QAbstractButton::clicked, mp2dMap, &T2DMap::slot_shiftLeft);
+    connect(toolButton_shiftRight, &QAbstractButton::clicked, mp2dMap, &T2DMap::slot_shiftRight);
+    connect(toolButton_shiftUp, &QAbstractButton::clicked, mp2dMap, &T2DMap::slot_shiftUp);
+    connect(toolButton_shiftDown, &QAbstractButton::clicked, mp2dMap, &T2DMap::slot_shiftDown);
     connect(spinBox_exitSize, qOverload<int>(&QSpinBox::valueChanged), this, &dlgMapper::slot_exitSize);
     connect(spinBox_roomSize, qOverload<int>(&QSpinBox::valueChanged), this, &dlgMapper::slot_roomSize);
     connect(toolButton_togglePanel, &QAbstractButton::clicked, this, &dlgMapper::slot_togglePanel);
@@ -250,12 +250,12 @@ void dlgMapper::slot_toggle3DView(const bool is3DMode)
         connect(pushButton_increaseBottom, &QAbstractButton::clicked, glWidget, &GLWidget::slot_showMoreLowerLevels);
         connect(pushButton_reduceTop, &QAbstractButton::clicked, glWidget, &GLWidget::slot_showLessUpperLevels);
         connect(pushButton_reduceBottom, &QAbstractButton::clicked, glWidget, &GLWidget::slot_showLessLowerLevels);
-        connect(pushButton_shiftZup, &QAbstractButton::clicked, glWidget, &GLWidget::slot_shiftZup);
-        connect(pushButton_shiftZdown, &QAbstractButton::clicked, glWidget, &GLWidget::slot_shiftZdown);
-        connect(pushButton_shiftLeft, &QAbstractButton::clicked, glWidget, &GLWidget::slot_shiftLeft);
-        connect(pushButton_shiftRight, &QAbstractButton::clicked, glWidget, &GLWidget::slot_shiftRight);
-        connect(pushButton_shiftUp, &QAbstractButton::clicked, glWidget, &GLWidget::slot_shiftUp);
-        connect(pushButton_shiftDown, &QAbstractButton::clicked, glWidget, &GLWidget::slot_shiftDown);
+        connect(toolButton_shiftZup, &QAbstractButton::clicked, glWidget, &GLWidget::slot_shiftZup);
+        connect(toolButton_shiftZdown, &QAbstractButton::clicked, glWidget, &GLWidget::slot_shiftZdown);
+        connect(toolButton_shiftLeft, &QAbstractButton::clicked, glWidget, &GLWidget::slot_shiftLeft);
+        connect(toolButton_shiftRight, &QAbstractButton::clicked, glWidget, &GLWidget::slot_shiftRight);
+        connect(toolButton_shiftUp, &QAbstractButton::clicked, glWidget, &GLWidget::slot_shiftUp);
+        connect(toolButton_shiftDown, &QAbstractButton::clicked, glWidget, &GLWidget::slot_shiftDown);
         connect(pushButton_defaultView, &QAbstractButton::clicked, glWidget, &GLWidget::slot_defaultView);
         connect(pushButton_sideView, &QAbstractButton::clicked, glWidget, &GLWidget::slot_sideView);
         connect(pushButton_topView, &QAbstractButton::clicked, glWidget, &GLWidget::slot_topView);

--- a/src/ui/mapper.ui
+++ b/src/ui/mapper.ui
@@ -167,47 +167,7 @@
              <number>0</number>
             </property>
             <item>
-             <widget class="QPushButton" name="pushButton_shiftLeft">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>20</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>30</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="baseSize">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <weight>50</weight>
-                <bold>false</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string notr="true">⯇</string>
-              </property>
-              <property name="autoRepeat">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="pushButton_shiftUp">
+             <widget class="QToolButton" name="toolButton_shiftLeft">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -233,15 +193,18 @@
                </size>
               </property>
               <property name="text">
-               <string notr="true">⯆</string>
+               <string />
               </property>
               <property name="autoRepeat">
                <bool>true</bool>
               </property>
+              <property name="arrowType">
+               <enum>Qt::LeftArrow</enum>
+              </property>
              </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="pushButton_shiftDown">
+             <widget class="QToolButton" name="toolButton_shiftUp">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -267,15 +230,55 @@
                </size>
               </property>
               <property name="text">
-               <string notr="true">⯅</string>
+               <string />
               </property>
               <property name="autoRepeat">
                <bool>true</bool>
               </property>
+              <property name="arrowType">
+               <enum>Qt::DownArrow</enum>
+              </property>
              </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="pushButton_shiftRight">
+             <widget class="QToolButton" name="toolButton_shiftDown">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>20</width>
+                <height>20</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>30</width>
+                <height>20</height>
+               </size>
+              </property>
+              <property name="baseSize">
+               <size>
+                <width>0</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string />
+              </property>
+              <property name="autoRepeat">
+               <bool>true</bool>
+              </property>
+              <property name="arrowType">
+               <enum>Qt::UpArrow</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QToolButton" name="toolButton_shiftRight">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -301,15 +304,18 @@
                </size>
               </property>
               <property name="text">
-               <string notr="true">⯈</string>
+               <string />
               </property>
               <property name="autoRepeat">
                <bool>true</bool>
               </property>
+              <property name="arrowType">
+               <enum>Qt::RightArrow</enum>
+              </property>
              </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="pushButton_shiftZup">
+             <widget class="QToolButton" name="toolButton_shiftZup">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                 <horstretch>25</horstretch>
@@ -336,7 +342,6 @@
               </property>
               <property name="font">
                <font>
-                <weight>75</weight>
                 <bold>true</bold>
                </font>
               </property>
@@ -346,7 +351,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="pushButton_shiftZdown">
+             <widget class="QToolButton" name="toolButton_shiftZdown">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -373,7 +378,6 @@
               </property>
               <property name="font">
                <font>
-                <weight>75</weight>
                 <bold>true</bold>
                </font>
               </property>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR converts all 6 of the pan control buttons into `QToolButton`s which have the feature that Qt can itself generate triangular "Arrow" icons for - which *might* avoid the "emojification" that was taking place in the current release code for some OS/Font combinations. The two Z direction buttons do not have such arrows and retain their original "+" or "-" text.

#### Motivation for adding to Mudlet
On some MacOS users machines the map pan buttons are not included in the font that is being used to render the mapper controls. One user has suggested that we try some arrow symbols instead and I tried that already in PR #6981. However those did seem a bit thin and I have an alternative that I wish to test here.

#### Other info (issues closed, discussion etc)
This may close #5454.

Only one of this and #6981 should be needed (and count towards my Hacktoberfest total this year! :grinning:)

