### PR TITLE
Fix: update Windows CI build of libzip

### DIFF
--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -335,9 +335,9 @@ function InstallZlib() {
 
 function InstallLibzip() {
   $Env:Path = $NoShPath
-  DownloadFile "https://libzip.org/download/libzip-1.7.3.tar.gz" "libzip.tar.gz"
+  DownloadFile "https://libzip.org/download/libzip-1.10.1.tar.gz" "libzip.tar.gz"
   ExtractTar "$workingBaseDir\libzip.tar.gz" "$workingBaseDir\libzip"
-  Set-Location "$workingBaseDir\libzip\libzip-1.7.3"
+  Set-Location "$workingBaseDir\libzip\libzip-1.10.1"
   if (!(Test-Path -Path "build" -PathType Container)) {
     Step "Creating libzip build path"
     New-Item build -ItemType Directory >> "$logFile" 2>&1

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -335,7 +335,7 @@ function InstallZlib() {
 
 function InstallLibzip() {
   $Env:Path = $NoShPath
-  DownloadFile "https://libzip.org/download/libzip-1.10.1.tar.gz" "libzip.tar.gz"
+  DownloadFile "https://github.com/nih-at/libzip/releases/download/v1.10.1/libzip-1.10.1.tar.gz" "libzip-1.10.1.tar.gz"
   ExtractTar "$workingBaseDir\libzip.tar.gz" "$workingBaseDir\libzip"
   Set-Location "$workingBaseDir\libzip\libzip-1.10.1"
   if (!(Test-Path -Path "build" -PathType Container)) {

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -335,7 +335,7 @@ function InstallZlib() {
 
 function InstallLibzip() {
   $Env:Path = $NoShPath
-  DownloadFile "https://github.com/nih-at/libzip/releases/download/v1.10.1/libzip-1.10.1.tar.gz" "libzip-1.10.1.tar.gz"
+  DownloadFile "https://github.com/nih-at/libzip/releases/download/v1.10.1/libzip-1.10.1.tar.gz" "libzip.tar.gz"
   ExtractTar "$workingBaseDir\libzip.tar.gz" "$workingBaseDir\libzip"
   Set-Location "$workingBaseDir\libzip\libzip-1.10.1"
   if (!(Test-Path -Path "build" -PathType Container)) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR updates the version used for Windows CI builds from *1.7.3* to **1.10.1** to see if that solves the problem.

#### Motivation for adding to Mudlet
For a week or so these have been failing - supposedly because of a certification problem when trying to download the source files to build `libzip` however it seems that upstream have release a new version - which according to https://libzip.org/packages/ has already made it's way into MSYS2.

#### Other info (issues closed, discussion etc)