### PR TITLE
[Infrastructure]: Enable TLS 1.3 for powershell dependency downloads

### DIFF
--- a/CI/appveyor.install.ps1
+++ b/CI/appveyor.install.ps1
@@ -3,7 +3,7 @@ $global:ErrorActionPreference = "Stop"
 
 # activate higher TLS version. Seems PS only uses 1.0 by default
 # credit: https://stackoverflow.com/questions/41618766/powershell-invoke-webrequest-fails-with-ssl-tls-secure-channel/48030563#48030563
-[Net.ServicePointManager]::SecurityProtocol = [System.Security.Authentication.SslProtocols] "tls, tls11, tls12"
+[Net.ServicePointManager]::SecurityProtocol = [System.Security.Authentication.SslProtocols] "tls, tls11, tls12, tls13"
 
 . .\appveyor.functions.ps1
 

--- a/CI/appveyor.install.ps1
+++ b/CI/appveyor.install.ps1
@@ -5,6 +5,8 @@ $global:ErrorActionPreference = "Stop"
 # credit: https://stackoverflow.com/questions/41618766/powershell-invoke-webrequest-fails-with-ssl-tls-secure-channel/48030563#48030563
 [Net.ServicePointManager]::SecurityProtocol = [System.Security.Authentication.SslProtocols] "tls, tls11, tls12, tls13"
 
+iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
 . .\appveyor.functions.ps1
 
 SetQtBaseDir "$logFile"

--- a/CI/appveyor.install.ps1
+++ b/CI/appveyor.install.ps1
@@ -5,7 +5,7 @@ $global:ErrorActionPreference = "Stop"
 # credit: https://stackoverflow.com/questions/41618766/powershell-invoke-webrequest-fails-with-ssl-tls-secure-channel/48030563#48030563
 [Net.ServicePointManager]::SecurityProtocol = [System.Security.Authentication.SslProtocols] "tls, tls11, tls12, tls13"
 
-iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+$blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 . .\appveyor.functions.ps1
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Enables TSL 1.3 for powershell to download files using Invoe-WebRequest

#### Motivation for adding to Mudlet
Should fix download issues for libzip.

#### Other info (issues closed, discussion etc)
