### PR TITLE
Infrastructure: extend range of SGR codes captured

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -103,6 +103,40 @@ TChar::TChar(const TChar& copy)
 {
 }
 
+quint8 TChar::alternateFont() const
+{
+    // As this is the most likely case check it first:
+    if (!(mFlags & AltFontMask)) {
+        return 0;
+    }
+
+    if (mFlags & AltFont9) {
+        return 9;
+    }
+    if (mFlags & AltFont8) {
+        return 8;
+    }
+    if (mFlags & AltFont7) {
+        return 7;
+    }
+    if (mFlags & AltFont6) {
+        return 6;
+    }
+    if (mFlags & AltFont5) {
+        return 5;
+    }
+    if (mFlags & AltFont4) {
+        return 4;
+    }
+    if (mFlags & AltFont3) {
+        return 3;
+    }
+    if (mFlags & AltFont2) {
+        return 2;
+    }
+    return 1;
+}
+
 const QString timeStampFormat = qsl("hh:mm:ss.zzz ");
 const QString blankTimeStamp  = qsl("------------ ");
 
@@ -547,7 +581,10 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                                 | (mOverline ? TChar::Overline : TChar::None)
                                 | (mReverse ? TChar::Reverse : TChar::None)
                                 | (mStrikeOut || mpHost->mMxpClient.strikeOut() ? TChar::StrikeOut : TChar::None)
-                                | (mUnderline || mpHost->mMxpClient.underline() ? TChar::Underline : TChar::None);
+                                | (mUnderline || mpHost->mMxpClient.underline() ? TChar::Underline : TChar::None)
+                                | (mFastBlink ? TChar::FastBlink : (mBlink ? TChar::Blink :TChar::None))
+                                | (TChar::alternateFontFlag(mAltFont))
+                                | (mConcealed ? TChar::Concealed : TChar::None);
 
                         // Note: we are using the background color for the
                         // foreground color as well so that we are transparent:
@@ -698,7 +735,10 @@ COMMIT_LINE:
                             | (mOverline ? TChar::Overline : TChar::None)
                             | (mReverse ? TChar::Reverse : TChar::None)
                             | (mStrikeOut || mpHost->mMxpClient.strikeOut() ? TChar::StrikeOut : TChar::None)
-                            | (mUnderline || mpHost->mMxpClient.underline() ? TChar::Underline : TChar::None);
+                            | (mUnderline || mpHost->mMxpClient.underline() ? TChar::Underline : TChar::None)
+                            | (mFastBlink ? TChar::FastBlink : (mBlink ? TChar::Blink :TChar::None))
+                            | (TChar::alternateFontFlag(mAltFont))
+                            | (mConcealed ? TChar::Concealed : TChar::None);
 
                     // Note: we are using the background color for the
                     // foreground color as well so that we are transparent:
@@ -841,7 +881,10 @@ COMMIT_LINE:
                 | (mOverline ? TChar::Overline : TChar::None)
                 | (mReverse ? TChar::Reverse : TChar::None)
                 | (mStrikeOut || mpHost->mMxpClient.strikeOut() ? TChar::StrikeOut : TChar::None)
-                | (mUnderline || mpHost->mMxpClient.underline() ? TChar::Underline : TChar::None);
+                | (mUnderline || mpHost->mMxpClient.underline() ? TChar::Underline : TChar::None)
+                | (mFastBlink ? TChar::FastBlink : (mBlink ? TChar::Blink :TChar::None))
+                | (TChar::alternateFontFlag(mAltFont))
+                | (mConcealed ? TChar::Concealed : TChar::None);
 
         TChar c((!mIsDefaultColor && mBold) ? mForeGroundColorLight : mForeGroundColor, mBackGroundColor, attributeFlags);
 
@@ -1484,6 +1527,10 @@ void TBuffer::decodeSGR(const QString& sequence)
                     mReverse = false;
                     mStrikeOut = false;
                     mUnderline = false;
+                    mBlink = false;
+                    mFastBlink = false;
+                    mConcealed = false;
+                    mAltFont = 0;
                     break;
                 case 1:
                     mBold = true;
@@ -1513,28 +1560,54 @@ void TBuffer::decodeSGR(const QString& sequence)
                     // sub-string separated part:
                     mUnderline = true;
                     break;
-                 case 5:
-                     if (mItalics) {
-                         mItalicBeforeBlink = true;
-                     }
-                     mItalics = true;
-                     break; //slow-blinking, represented as italics instead
-                 case 6:
-                     if (mItalics) {
-                         mItalicBeforeBlink = true;
-                     }
-                     mItalics = true;
-                     break; //fast blinking, represented as italics instead
+                case 5:
+                    mBlink = true;
+                    mFastBlink = false;
+                    break; //slow-blinking, display as italics instead for the moment
+                case 6:
+                    mBlink = false;
+                    mFastBlink = true;
+                    break; //fast blinking, display as italics instead for the moment
                 case 7:
                     mReverse = true;
                     break;
-                // case 8: // Concealed characters (set foreground to be the same as background?)
-                //    break;
+                case 8: // Concealed characters (set foreground to be the same as background?)
+                    mConcealed = true;
+                    break;
                 case 9:
                     mStrikeOut = true;
                     break;
-                // case 10:
-                //    break; //default font
+                case 10: //default font
+                    mAltFont = 0;
+                    break;
+                case 11: // 11 to 19 are alternate fonts, what and where those
+                         // are set is not so well specified
+                    mAltFont = 1;
+                    break;
+                case 12:
+                    mAltFont = 2;
+                    break;
+                case 13:
+                    mAltFont = 3;
+                    break;
+                case 14:
+                    mAltFont = 4;
+                    break;
+                case 15:
+                    mAltFont = 5;
+                    break;
+                case 16:
+                    mAltFont = 6;
+                    break;
+                case 17:
+                    mAltFont = 7;
+                    break;
+                case 18:
+                    mAltFont = 8;
+                    break;
+                case 19:
+                    mAltFont = 9;
+                    break;
                 // case 21: // Double underline according to specs
                 //    break;
                 case 22:
@@ -1546,17 +1619,16 @@ void TBuffer::decodeSGR(const QString& sequence)
                 case 24:
                     mUnderline = false;
                     break;
-                 case 25:
-                     if (!mItalicBeforeBlink) {
-                         mItalics = false;
-                     }
-                     mItalicBeforeBlink = false;
+                case 25:
+                    mBlink = false;
+                    mFastBlink = false;
                     break; // blink off
                 case 27:
                     mReverse = false;
                     break;
-                // case 28: // Revealed characters (undoes the effect of "8")
-                //    break;
+                case 28: // Revealed characters (undoes the effect of "8")
+                    mConcealed = false;
+                    break;
                 case 29:
                     mStrikeOut = false;
                     break;

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -440,12 +440,6 @@ inline QDebug& operator<<(QDebug& debug, const TChar::AttributeFlags& attributes
     if (attributes & TChar::FastBlink) {
         presentAttributes << QLatin1String("FastBlink (0x80)");
     }
-    if (attributes & TChar::Found) {
-        presentAttributes << QLatin1String("Found (0x100000)");
-    }
-    if (attributes & TChar::Echo) {
-        presentAttributes << QLatin1String("Echo (0x200000)");
-    }
     if (attributes & TChar::AltFont1) {
         presentAttributes << QLatin1String("AltFont1 (0x100)");
     }
@@ -462,16 +456,25 @@ inline QDebug& operator<<(QDebug& debug, const TChar::AttributeFlags& attributes
         presentAttributes << QLatin1String("AltFont5 (0x1000)");
     }
     if (attributes & TChar::AltFont6) {
-        presentAttributes << QLatin1String("AltFont1 (0x2000)");
+        presentAttributes << QLatin1String("AltFont6 (0x2000)");
     }
     if (attributes & TChar::AltFont7) {
-        presentAttributes << QLatin1String("AltFont1 (0x4000)");
+        presentAttributes << QLatin1String("AltFont7 (0x4000)");
     }
     if (attributes & TChar::AltFont8) {
-        presentAttributes << QLatin1String("AltFont1 (0x8000)");
+        presentAttributes << QLatin1String("AltFont8 (0x8000)");
     }
     if (attributes & TChar::AltFont9) {
-        presentAttributes << QLatin1String("AltFont1 (0x10000)");
+        presentAttributes << QLatin1String("AltFont9 (0x10000)");
+    }
+    if (attributes & TChar::Concealed) {
+        presentAttributes << QLatin1String("AltFont9 (0x20000)");
+    }
+    if (attributes & TChar::Found) {
+        presentAttributes << QLatin1String("Found (0x100000)");
+    }
+    if (attributes & TChar::Echo) {
+        presentAttributes << QLatin1String("Echo (0x200000)");
     }
     if (presentAttributes.isEmpty()) {
         result.append(QLatin1String("None (0x0))"));

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -61,28 +61,57 @@ public:
     enum AttributeFlag {
         None = 0x0,
         // Replaces TCHAR_BOLD 2
-        Bold = 0x1,
+        Bold = 0x1,                   // 0000 0000 0000 0000 0000 0000 0000 0001
         // Replaces TCHAR_ITALICS 1
-        Italic = 0x2,
+        Italic = 0x2,                 // 0000 0000 0000 0000 0000 0000 0000 0010
         // Replaces TCHAR_UNDERLINE 4
-        Underline = 0x4,
-        // New, TCHAR_OVERLINE had not been previous done, is
+        Underline = 0x4,              // 0000 0000 0000 0000 0000 0000 0000 0100
         // ANSI CSI SGR Overline (53 on, 55 off)
-        Overline = 0x8,
+        Overline = 0x8,               // 0000 0000 0000 0000 0000 0000 0000 1000
         // Replaces TCHAR_STRIKEOUT 32
-        StrikeOut = 0x10,
+        StrikeOut = 0x10,             // 0000 0000 0000 0000 0000 0000 0001 0000
         // NOT a replacement for TCHAR_INVERSE, that is now covered by the
         // separate isSelected bool but they must be EX-ORed at the point of
         // painting the Character
-        Reverse = 0x20,
-        // The attributes that are currently user settable and what should be
-        // consider in HTML generation:
-        TestMask = 0x3f,
+        Reverse = 0x20,               // 0000 0000 0000 0000 0000 0000 0010 0000
+        // Flashing less than 150 times a minute:
+        Blink = 0x40,                 // 0000 0000 0000 0000 0000 0000 0100 0000
+        // Flashing at least 150 times a minute:
+        FastBlink = 0x80,             // 0000 0000 0000 0000 0000 0000 1000 0000
+        // Alternate fonts 1 to 9 from SGR 11 m to SGR 19 m; we flag each one
+        // separately so that trigger processing can select them individually
+        // which could not be done should they be rolled up into just 4 bits.
+        // As one can only be active at a time only the highest one should be
+        // used if/when we can actually paint different fonts in a TConsole at
+        // the same time; currently there is no MUD standard to specify what the
+        // alternatives are:
+        AltFont1 = 0x00100,           // 0000 0000 0000 0000 0000 0001 0000 0000
+        AltFont2 = 0x00200,           // 0000 0000 0000 0000 0000 0010 0000 0000
+        AltFont3 = 0x00400,           // 0000 0000 0000 0000 0000 0100 0000 0000
+        AltFont4 = 0x00800,           // 0000 0000 0000 0000 0000 1000 0000 0000
+        AltFont5 = 0x01000,           // 0000 0000 0000 0000 0001 0000 0000 0000
+        AltFont6 = 0x02000,           // 0000 0000 0000 0000 0010 0000 0000 0000
+        AltFont7 = 0x04000,           // 0000 0000 0000 0000 0100 0000 0000 0000
+        AltFont8 = 0x08000,           // 0000 0000 0000 0000 1000 0000 0000 0000
+        AltFont9 = 0x10000,           // 0000 0000 0000 0001 0000 0000 0000 0000
+        // From SGR 8 m; however there is no MUD standard protocol to control
+        // when we should show concealed text.
+        Concealed = 0x20000,          // 0000 0000 0000 0010 0000 0000 0000 0000
+        // Mask for "is flashing" at any rate - will return a logical true
+        // should either of the above be set - should both be set then FastBlink
+        // should take preference over Blink:
+        BlinkMask = 0xC0,             // 0000 0000 0000 0000 0000 0000 1100 0000
+        // Mask for "any alternate font" - only the most significant one should
+        // be used if more than one is set:
+        AltFontMask = 0x1ff00,        // 0000 0000 0000 0001 1111 1111 0000 0000
+        TestMask = 0x3ffff,           // 0000 0000 0000 0011 1111 1111 1111 1111
+        // The remainder are internal use ones that do not related to SGR codes
+        // that have been parsed from the incoming text.
         // Has been found in a search operation (currently Main Console only)
         // and has been given a highlight to indicate that:
-        Found = 0x40,
+        Found = 0x100000,             // 0000 0000 0001 0000 0000 0000 0000 0000
         // Replaces TCHAR_ECHO 16
-        Echo = 0x100
+        Echo = 0x200000               // 0000 0000 0010 0000 0000 0000 0000 0000
     };
     Q_DECLARE_FLAGS(AttributeFlags, AttributeFlag)
 
@@ -105,8 +134,9 @@ public:
         mFgColor = newForeGroundColor;
         mBgColor = newBackGroundColor;
     }
-    // Only considers the following flags: Bold, Italic, Overline, Reverse,
-    // Strikeout, Underline, does not consider Echo:
+    // Only considers the following flags: AltFont#, Bold, Conceal,
+    // FastBlink/Blink, Italic, Overline, Reverse, Strikeout, Underline,
+    // - does not consider Echo or Found:
     void setAllDisplayAttributes(const AttributeFlags newDisplayAttributes) { mFlags = (mFlags & ~TestMask) | (newDisplayAttributes & TestMask); }
     void setForeground(const QColor& newColor) { mFgColor = newColor; }
     void setBackground(const QColor& newColor) { mBgColor = newColor; }
@@ -129,6 +159,71 @@ public:
     bool isStruckOut() const { return mFlags & StrikeOut; }
     bool isReversed() const { return mFlags & Reverse; }
     bool isFound() const { return mFlags & Found; }
+    // Special case - if fast blink is set then do NOT say that blink is set to
+    // preserve priority of the former over the latter:
+    bool isBlinking() const { return (mFlags & FastBlink) ? false : (mFlags & Blink); }
+    bool isFastBlinking() const { return mFlags & FastBlink; }
+    quint8 alternateFont() const;
+    static TChar::AttributeFlag alternateFontFlag(const quint8 altFontNumber) {
+        switch (altFontNumber) {
+        case 1: return AltFont1;
+        case 2: return AltFont2;
+        case 3: return AltFont3;
+        case 4: return AltFont4;
+        case 5: return AltFont5;
+        case 6: return AltFont6;
+        case 7: return AltFont7;
+        case 8: return AltFont8;
+        case 9: return AltFont9;
+        default:
+            Q_ASSERT_X(altFontNumber < 10, "alternateFontFlag", "value out of range 0 to 9");
+            return None;
+        }
+    }
+    static QString attributeType(const AttributeFlag flag) {
+        switch (flag) {
+        case None:
+            return qsl("None");
+        case Bold:
+            return qsl("Bold");
+        case Italic:
+            return qsl("Italic");
+        case Underline:
+            return qsl("Underline");
+        case Overline:
+            return qsl("Overline");
+        case StrikeOut:
+            return qsl("StrikeOut");
+        case Reverse:
+            return qsl("Reverse");
+        case Blink:
+            return qsl("Blink");
+        case FastBlink:
+            return qsl("FastBlink");
+        case AltFont1:
+            return qsl("AltFont1");
+        case AltFont2:
+            return qsl("AltFont2");
+        case AltFont3:
+            return qsl("AltFont3");
+        case AltFont4:
+            return qsl("AltFont4");
+        case AltFont5:
+            return qsl("AltFont5");
+        case AltFont6:
+            return qsl("AltFont6");
+        case AltFont7:
+            return qsl("AltFont7");
+        case AltFont8:
+            return qsl("AltFont8");
+        case AltFont9:
+            return qsl("AltFont9");
+        case Concealed:
+            return qsl("Concealed");
+        default:
+            return qsl("Unknown");
+        }
+    }
 
 private:
     QColor mFgColor;
@@ -137,7 +232,6 @@ private:
     // Kept as a separate flag because it must often be handled separately
     bool mIsSelected = false;
     int mLinkIndex = 0;
-
 };
 Q_DECLARE_OPERATORS_FOR_FLAGS(TChar::AttributeFlags)
 
@@ -287,7 +381,12 @@ private:
     bool mReverse = false;
     bool mStrikeOut = false;
     bool mUnderline = false;
-    bool mItalicBeforeBlink = false;
+    // If BOTH of these ever get set than only mFastBlink is to be considered
+    // set - when setting one ensure the other is reset:
+    bool mBlink = false;
+    bool mFastBlink = false;
+    bool mConcealed = false;
+    quint8 mAltFont = 0;
 
     QString mMudLine;
     std::deque<TChar> mMudBuffer;
@@ -335,12 +434,51 @@ inline QDebug& operator<<(QDebug& debug, const TChar::AttributeFlags& attributes
     if (attributes & TChar::Reverse) {
         presentAttributes << QLatin1String("Reverse (0x20)");
     }
-    if (attributes & TChar::Echo) {
-        presentAttributes << QLatin1String("Echo (0x100)");
+    if (attributes & TChar::Blink) {
+        presentAttributes << QLatin1String("Blink (0x40)");
     }
-    result.append(presentAttributes.join(QLatin1String(", ")));
-    result.append(QLatin1String(")"));
-    debug.nospace() << result;
+    if (attributes & TChar::FastBlink) {
+        presentAttributes << QLatin1String("FastBlink (0x80)");
+    }
+    if (attributes & TChar::Found) {
+        presentAttributes << QLatin1String("Found (0x100000)");
+    }
+    if (attributes & TChar::Echo) {
+        presentAttributes << QLatin1String("Echo (0x200000)");
+    }
+    if (attributes & TChar::AltFont1) {
+        presentAttributes << QLatin1String("AltFont1 (0x100)");
+    }
+    if (attributes & TChar::AltFont2) {
+        presentAttributes << QLatin1String("AltFont2 (0x200)");
+    }
+    if (attributes & TChar::AltFont3) {
+        presentAttributes << QLatin1String("AltFont3 (0x400)");
+    }
+    if (attributes & TChar::AltFont4) {
+        presentAttributes << QLatin1String("AltFont4 (0x800)");
+    }
+    if (attributes & TChar::AltFont5) {
+        presentAttributes << QLatin1String("AltFont5 (0x1000)");
+    }
+    if (attributes & TChar::AltFont6) {
+        presentAttributes << QLatin1String("AltFont1 (0x2000)");
+    }
+    if (attributes & TChar::AltFont7) {
+        presentAttributes << QLatin1String("AltFont1 (0x4000)");
+    }
+    if (attributes & TChar::AltFont8) {
+        presentAttributes << QLatin1String("AltFont1 (0x8000)");
+    }
+    if (attributes & TChar::AltFont9) {
+        presentAttributes << QLatin1String("AltFont1 (0x10000)");
+    }
+    if (presentAttributes.isEmpty()) {
+        result.append(QLatin1String("None (0x0))"));
+    } else {
+        result.append(presentAttributes.join(QLatin1String(", ")).append(QLatin1String(")")));
+    }
+    debug.nospace().noquote() << result;
     return debug;
 }
 #endif // QT_NO_DEBUG_STREAM

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -703,10 +703,16 @@ void TTextEdit::drawGraphemeForeground(QPainter& painter, const QColor& fgColor,
 {
     TChar::AttributeFlags attributes = charStyle.allDisplayAttributes();
     const bool isBold = attributes & TChar::Bold;
-    const bool isItalics = attributes & TChar::Italic;
+    // At present we cannot display flashing text - and we just make it italic
+    // (we ought to eventually add knobs for them so they can be shown in a user
+    // preferred style - which might be static for some users) - anyhow Mudlet
+    // will still detect the difference between the options:
+    const bool isItalics = attributes & (TChar::Italic | TChar::Blink | TChar::FastBlink);
     const bool isOverline = attributes & TChar::Overline;
     const bool isStrikeOut = attributes & TChar::StrikeOut;
     const bool isUnderline = attributes & TChar::Underline;
+    // const bool isConcealed = attributes & TChar::Concealed;
+    // const int altFontIndex = charStyle.alternateFont();
     if ((painter.font().bold() != isBold)
             || (painter.font().italic() != isItalics)
             || (painter.font().overline() != isOverline)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This is an initial step that I can isolate into a PR for submission independently so as to keep the "chunk" size smaller and easier to digest for reviewing. It detects and records some more SGR codes than we currently do, specifically:
* 5 - slow, less than 150 times a minute, blinking
* 6 - fast, at least 150 times a minute, blinking
* 8 - concealed ON
* 10 - default font
* 11 - alternate font 1
* 12 - alternate font 2
* 13 - alternate font 3
* 14 - alternate font 4
* 15 - alternate font 5
* 16 - alternate font 6
* 17 - alternate font 7
* 18 - alternate font 8
* 19 - alternate font 9
* 25 - blink OFF
* 28 - concealed OFF

#### Motivation for adding to Mudlet
I already have some prototype code that provides support for painting in different fonts but it needs a little more work to complete and I will submit it in a following PR that will need this one to have been merged first.

#### Other info (issues closed, discussion etc)
We already handle the two types of blinking by hard-coding them to italics, this PR replicates that but at the point where the text is painted rather then when the SGR parameters are parsed.