### PR TITLE
Fix: invalid grey QColor generated for grey-scale part of color triggers

### DIFF
--- a/src/dlgColorTrigger.cpp
+++ b/src/dlgColorTrigger.cpp
@@ -240,7 +240,7 @@ void dlgColorTrigger::slot_setRBGButtonFocus()
 void dlgColorTrigger::slot_grayColorChanged(int sliderValue)
 {
     mGrayAnsiColorNumber = 232 + sliderValue;
-    const int value = (sliderValue - 232) * 10 + 8;
+    const int value = sliderValue * 10 + 8;
 
     mGrayAnsiColor = QColor(value, value, value);
     label_grayValue->setText(qsl("[%1]").arg(QString::number(mGrayAnsiColorNumber)));


### PR DESCRIPTION
#### Motivation for adding to Mudlet
There is supposed to be a label that demonstrates the grey value selected when the "More colors" button is clicked for a color trigger item and the 24 position slider is adjusted. This color is also supposed to be replaced in the foreground or background colour set for the color trigger and is recorded as part of the details for a color trigger.

#### Brief overview of PR changes/additions
However, a defect in #5328 seems to have been based on the "slider-value" being passed to `(void) dlgColorTrigger::slot_grayColorChanged(int)` being in the range 232 to 255 rather than the 0 to 23 that it is. The result is that the QColor generated from that grey scale part of the ANSI 256 color range is wrong (invalid). This at least means that the grey color chosen does not show up in the editor - it also may mean that such color triggers may be defective and not work as expected.

#### Other info (issues closed, discussion etc)
The previous PR that introduced this bug is over 2 years old - I guess it was not something that rates more than a **low** priority - but it is a one-liner to fix! :grinning: