### PR TITLE
improve: link to reference to wikipedia in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 ## About
 
-Mudlet is a quality [MUD](https://en.wikipedia.org/wiki/MUD) client, designed to take mudding to a new level.
+Mudlet is a quality [MUD](https://en.wikipedia.org/wiki/Multi-user_dungeon) client, designed to take mudding to a new level.
 
 It’s a modern breed of a client on the gaming scene – with an intuitive user interface, a specially designed scripting framework, and a very fast text display. That, along with cross-platform capability and an open-source development model result in a very likable game client.
 


### PR DESCRIPTION
changed the link of MUD to Multi-user dungeon wiki page.

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
As there was a little typo to the link of MUD, modified that to refer to https://en.wikipedia.org/wiki/Multi-user_dungeon

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
