### PR TITLE
Infrastructure: fixes to allow CMake Qt6 builds

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4204,7 +4204,7 @@ void T2DMap::slot_setArea()
                         }
                     }
                 }
-                auto &targetAreaName = mpMap->mpRoomDB->getAreaNamesMap().value(newAreaId);
+                const auto &targetAreaName = mpMap->mpRoomDB->getAreaNamesMap().value(newAreaId);
                 mpMap->mpMapper->comboBox_showArea->setCurrentText(targetAreaName);
 #if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
                 switchArea(targetAreaName);

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2169,7 +2169,13 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
         return;
     }
     bool firstChar = (lineBuffer.back().isEmpty());
-    int length = std::min(text.size(), MAX_CHARACTERS_PER_ECHO);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    const int length = std::min(text.size(), MAX_CHARACTERS_PER_ECHO);
+#else
+    // Qt 6 changed the return type of QLIST<T>::size() to qsizetype which is
+    // not directly comparable to a const int& without a cast:
+    const int length = std::min(static_cast<int>(text.size()), MAX_CHARACTERS_PER_ECHO);
+#endif
     if (sub_end >= length) {
         sub_end = text.size() - 1;
     }
@@ -2270,7 +2276,11 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
         return;
     }
     bool firstChar = (lineBuffer.back().isEmpty());
-    int length = std::min(text.size(), MAX_CHARACTERS_PER_ECHO);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    const int length = std::min(text.size(), MAX_CHARACTERS_PER_ECHO);
+#else
+    const int length = std::min(static_cast<int>(text.size()), MAX_CHARACTERS_PER_ECHO);
+#endif
     if (sub_end >= length) {
         sub_end = text.size() - 1;
     }
@@ -2367,7 +2377,11 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
         return;
     }
     bool firstChar = (lineBuffer.back().isEmpty());
-    int length = std::min(text.size(), MAX_CHARACTERS_PER_ECHO);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    const int length = std::min(text.size(), MAX_CHARACTERS_PER_ECHO);
+#else
+    const int length = std::min(static_cast<int>(text.size()), MAX_CHARACTERS_PER_ECHO);
+#endif
     int lineEndPos = sub_end;
     if (lineEndPos >= length) {
         lineEndPos = text.size() - 1;

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -297,8 +297,14 @@ void TMedia::setMediaPlayersMuted(const TMediaData::MediaProtocol mediaProtocol,
     QListIterator<TMediaPlayer> itTMediaPlayer(mTMediaPlayerList);
 
     while (itTMediaPlayer.hasNext()) {
-        TMediaPlayer const pPlayer = itTMediaPlayer.next();
-        pPlayer.getMediaPlayer()->setMuted(state);
+        const TMediaPlayer player = itTMediaPlayer.next();
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+        player.getMediaPlayer()->setMuted(state);
+#else
+        if (player.getMediaPlayer()->audioOutput()) {
+            player.getMediaPlayer()->audioOutput()->setMuted(state);
+        }
+#endif
     }
 }
 

--- a/src/TMxpElementRegistry.h
+++ b/src/TMxpElementRegistry.h
@@ -22,6 +22,7 @@
 
 #include "MxpTag.h"
 #include "pre_guard.h"
+#include <QHash>
 #include <QMap>
 #include <QStringList>
 #include <QList>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
* In `src/T2DMap.cpp` Qt6 objects to assigning an rvalue to a non-`const` lvalue.
* In three places in `src/TBuffer.cpp` because Qt6 has changed the type of the return value of `QList<T>::size()` (including the `QList<QChar>` that is a `QString`) from `int` to `qsizetype` and that is not directly comparable in a `std::min(<T>, <T>)` to a `const int&` it needs a `static_cast<T>`. Also the value so generated happens to be unmodified afterwards so should also be declared `const` in both the Qt 5 and 6 cases.
* In `src/TMedia.cpp` in Qt6 the outputs from a `QMediaPlayer` have been moved to a separate `QAudioOutput` class and that has to be accessed in order to mute the output - but the `(QAudioOutput*) QMediaPlayer::audioOutput()` value can be a `nullptr`.
* In `src/TMxpElementRegistry.h` for Qt6 it is necessary to include the `<QHash>` header file which, presumably, must have been include implicitly in Qt5.

#### Motivation for adding to Mudlet
I discovered these whilst investigating @mpconley 's query: https://github.com/Mudlet/Mudlet/pull/6654#issuecomment-1774110129

#### Other info (issues closed, discussion etc)
This enabled me to build with CMake in Qt Creator with both Qt 5 and 6 type builds with some local setup/settings as I mentioned in that other PR's comments.
