### PR TITLE
Fix: make Mudlet binary map saves with Qt6 compatible with Qt5 builds

### DIFF
--- a/src/TArea.h
+++ b/src/TArea.h
@@ -43,7 +43,7 @@ class TArea
 
     friend bool TMap::serialize(QDataStream&, int);
     friend bool TMap::restore(QString, bool);
-    friend bool TMap::retrieveMapFileStats(QString, QString*, int*, int*, int*, int*);
+    friend bool TMap::retrieveMapFileStats(QString, QString*, int*, int*, qsizetype*, qsizetype*);
 
 public:
     TArea(TMap*, TRoomDB*);

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -128,7 +128,7 @@ public:
     bool gotoRoom(int, int);
     bool serialize(QDataStream&, int saveVersion = 0);
     bool restore(QString location, bool downloadIfNotFound = true);
-    bool retrieveMapFileStats(QString, QString*, int*, int*, int*, int*);
+    bool retrieveMapFileStats(QString, QString*, int*, int*, qsizetype*, qsizetype*);
     void initGraph();
     QString connectExitStubByDirection(const int fromRoomId, const int dirType);
     QString connectExitStubByToId(const int fromRoomId, const int toRoomId);
@@ -179,7 +179,7 @@ public:
 
     std::pair<bool, QString> writeJsonMapFile(const QString&);
     std::pair<bool, QString> readJsonMapFile(const QString&, const bool translatableTexts = false, const bool allowUserCancellation = true);
-    int getCurrentProgressRoomCount() const { return mProgressDialogRoomsCount; }
+    qsizetype getCurrentProgressRoomCount() const { return mProgressDialogRoomsCount; }
     bool incrementJsonProgressDialog(const bool isExportNotImport, const bool isRoomNotLabel, const int increment = 1);
     QString getDefaultAreaName() const { return mDefaultAreaName; }
     QString getUnnamedAreaName() const { return mUnnamedAreaName; }
@@ -374,12 +374,12 @@ private:
     QProgressDialog* mpProgressDialog = nullptr;
     // Using during updates of text in progress dialog partially from other
     // classes:
-    int mProgressDialogAreasTotal = 0;
-    int mProgressDialogAreasCount = 0;
-    int mProgressDialogRoomsTotal = 0;
-    int mProgressDialogRoomsCount = 0;
-    int mProgressDialogLabelsTotal = 0;
-    int mProgressDialogLabelsCount = 0;
+    qsizetype mProgressDialogAreasTotal = 0;
+    qsizetype mProgressDialogAreasCount = 0;
+    qsizetype mProgressDialogRoomsTotal = 0;
+    qsizetype mProgressDialogRoomsCount = 0;
+    qsizetype mProgressDialogLabelsTotal = 0;
+    qsizetype mProgressDialogLabelsCount = 0;
 
     // Used to flag whether the map auto-save needs to be done after the next interval:
     bool mUnsavedMap = false;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2571,8 +2571,8 @@ void dlgProfilePreferences::slot_copyMap()
 
         // Most of these we'll just get for debugging!
         QString otherProfileFileUsed;
-        int otherProfileRoomCount;
-        int otherProfileAreaCount;
+        qsizetype otherProfileRoomCount;
+        qsizetype otherProfileAreaCount;
         int otherProfileVersion;
         int otherProfileCurrentRoomId; // What we are looking for!
         if (pHost->mpMap->retrieveMapFileStats(itOtherProfile.key(),


### PR DESCRIPTION
#### Brief overview of PR changes/additions
`static_cast<qint32>(...)` all Qt container `size()`/`count()`s when writing them to a binary map file.

#### Motivation for adding to Mudlet
The return type from a Qt "container" type (well in fact ALL classes) `size()`/`count()` operation is now defined as `qsizetype` which just happens to effectively be a `int64_t` (`qint64`, 8 bytes) unfortunately in the past - for Qt5 it was an `int`, which for all the platforms we compile Mudlet on corresponds to an `int32_t` (`qint32`, 4 bytes). The differences in size means that writing them to a `QDataStream` produces incompatible files. The simplest fix, given that we are not expecting *any* value so produced to overflow the prior `int32_t` type is to explicitly `static_cast` the values in all cases.

#### Other info (issues closed, discussion etc)
This will close #7003