### PR TITLE
Infrastructure: Revert bump jurplel/install-qt-action from 3 to 4

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -59,7 +59,7 @@ jobs:
         fetch-depth: 0
 
     - name: (Windows) Install Qt
-      uses: jurplel/install-qt-action@v4
+      uses: jurplel/install-qt-action@v3
       if: runner.os == 'Windows'
       with:
         version: ${{matrix.qt}}
@@ -68,7 +68,7 @@ jobs:
         cache: true
 
     - name: (Linux/macOS) Install Qt
-      uses: jurplel/install-qt-action@v4
+      uses: jurplel/install-qt-action@v3
       if: runner.os == 'Linux' || runner.os == 'macOS'
       with:
         version: ${{matrix.qt}}

--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -37,7 +37,7 @@ jobs:
         repository: ${{github.event.pull_request.head.repo.full_name}}
 
     - name: (Windows) Install Qt
-      uses: jurplel/install-qt-action@v4
+      uses: jurplel/install-qt-action@v3
       if: runner.os == 'Windows'
       with:
         version: ${{matrix.qt}}
@@ -46,7 +46,7 @@ jobs:
         cache: true
 
     - name: (Linux/macOS) Install Qt
-      uses: jurplel/install-qt-action@v4
+      uses: jurplel/install-qt-action@v3
       if: runner.os == 'Linux' || runner.os == 'macOS'
       with:
         version: ${{matrix.qt}}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
         submodules: true
 
     - name: (Windows) Install Qt
-      uses: jurplel/install-qt-action@v4
+      uses: jurplel/install-qt-action@v3
       if: runner.os == 'Windows'
       with:
         version: ${{matrix.qt}}
@@ -57,7 +57,7 @@ jobs:
         cache: true
 
     - name: (Linux/macOS) Install Qt
-      uses: jurplel/install-qt-action@v4
+      uses: jurplel/install-qt-action@v3
       if: runner.os == 'Linux' || runner.os == 'macOS'
       with:
         version: ${{matrix.qt}}


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
This reverts commit bb8365bab23ccbc1804e12a77ad8670074e0b3df. Version 4 of the action doesn't actually exist - perhaps it was created but deleted. Dependabot didn't catch this and still left a PR open that I merged.
#### Motivation for adding to Mudlet
Fix builds to work again.
#### Other info (issues closed, discussion etc)
