### PR TITLE
Improve: Mark undesired spaces around regex with a middle dot

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,6 +85,7 @@ set(mudlet_SRCS
     exitstreewidget.cpp
     FontManager.cpp
     GifTracker.cpp
+    TrailingWhitespaceMarker.cpp
     Host.cpp
     HostManager.cpp
     ircmessageformatter.cpp
@@ -239,6 +240,7 @@ set(mudlet_HDRS
     exitstreewidget.h
     FontManager.h
     GifTracker.h
+    TrailingWhitespaceMarker.h
     Host.h
     HostManager.h
     ircmessageformatter.h

--- a/src/TrailingWhitespaceMarker.cpp
+++ b/src/TrailingWhitespaceMarker.cpp
@@ -22,7 +22,7 @@
 #include <QDebug>
 void unmarkQString(QString* text) {
     QChar middleDot(0x00B7);
-    text->replace(middleDot,' ');
+    text->replace(middleDot, ' ');
 }
 void markQString(QString* text) {
     QChar middleDot(0x00B7);
@@ -35,11 +35,10 @@ void markQString(QString* text) {
 
     // Mark leading spaces before ^ with a middle dot
     if (trimmedText.at(0) == '^') {
-        for(int i=0;i<text->length();i++){
-            if(text->at(i) == ' '){
-                text->replace(i,1,middleDot);
-            }
-            else {
+        for (int i = 0; i < text->length(); i++){
+            if (text->at(i) == ' '){
+                text->replace(i, 1, middleDot);
+            } else {
                 break;
             }
         }
@@ -47,11 +46,10 @@ void markQString(QString* text) {
 
     // Mark trailing spaces after $ with a middle dot
     if (trimmedText.at(trimmedText.length()-1) == '$') {
-        for(int i=text->length()-1;i>-1;i--){
-            if(text->at(i) == ' '){
-                text->replace(i,1,middleDot);
-            }
-            else {
+        for (int i = text->length() - 1; i > -1; i--){
+            if (text->at(i) == ' '){
+                text->replace(i, 1, middleDot);
+            } else {
                 break;
             }
         }

--- a/src/TrailingWhitespaceMarker.cpp
+++ b/src/TrailingWhitespaceMarker.cpp
@@ -1,0 +1,91 @@
+/***************************************************************************
+ *   Copyright (C) 2023-2023 by Adam Robinson - seldon1951@hotmail.com     *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QString>
+#include <QLineEdit>
+#include <QDebug>
+void unmarkQString(QString* text) {
+    QChar middleDot(0x00B7);
+    text->replace(middleDot,' ');
+}
+void markQString(QString* text) {
+    QChar middleDot(0x00B7);
+
+    // Trim text, check first and last character for ^ or $
+    QString trimmedText = text->trimmed();
+    if (trimmedText.length() == 0) {
+        return;
+    }
+
+    // Mark leading spaces before ^ with a middle dot
+    if (trimmedText.at(0) == '^') {
+        for(int i=0;i<text->length();i++){
+            if(text->at(i) == ' '){
+                text->replace(i,1,middleDot);
+            }
+            else {
+                break;
+            }
+        }
+    }
+
+    // Mark trailing spaces after $ with a middle dot
+    if (trimmedText.at(trimmedText.length()-1) == '$') {
+        for(int i=text->length()-1;i>-1;i--){
+            if(text->at(i) == ' '){
+                text->replace(i,1,middleDot);
+            }
+            else {
+                break;
+            }
+        }
+    }
+
+}
+
+void markQLineEdit(QLineEdit* lineEdit) {
+
+    QString text = lineEdit->text();
+
+    unmarkQString(&text);
+    markQString(&text);
+
+    lineEdit->blockSignals(true);
+    int cursorPos = lineEdit->cursorPosition();
+    lineEdit->setText(text);
+    lineEdit->setCursorPosition(cursorPos);
+
+
+    lineEdit->blockSignals(false);
+}
+
+void unmarkQLineEdit(QLineEdit* lineEdit) {
+
+    QString text = lineEdit->text();
+
+    unmarkQString(&text);
+
+    lineEdit->blockSignals(true);
+    int cursorPos = lineEdit->cursorPosition();
+    lineEdit->setText(text);
+    lineEdit->setCursorPosition(cursorPos);
+
+
+    lineEdit->blockSignals(false);
+}

--- a/src/TrailingWhitespaceMarker.h
+++ b/src/TrailingWhitespaceMarker.h
@@ -1,10 +1,5 @@
-#ifndef MUDLET_DLGALIASESMAINAREA_H
-#define MUDLET_DLGALIASESMAINAREA_H
-
 /***************************************************************************
- *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2023-2023 by Adam Robinson - seldon1951@hotmail.com     *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -21,29 +16,14 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
+#ifndef MUDLET_TRAILINGWHITESPACEMARKER_H
+#define MUDLET_TRAILINGWHITESPACEMARKER_H
 
-#include "TrailingWhitespaceMarker.h"
+#include <QString>
+#include <QLineEdit>
 
-#include "pre_guard.h"
-#include "ui_aliases_main_area.h"
-#include "post_guard.h"
-
-
-class dlgAliasMainArea : public QWidget, public Ui::aliases_main_area
-{
-    Q_OBJECT
-
-public:
-    Q_DISABLE_COPY(dlgAliasMainArea)
-    explicit dlgAliasMainArea(QWidget*);
-
-    // public function allow to trim even when QLineEdit::editingFinished()
-    // is not raised. Example: When the user saves without leaving the LineEdit
-    void trimName();
-
-private slots:
-    void slot_editingNameFinished();
-    void slot_changedPattern();
-};
-
-#endif // MUDLET_DLGALIASESMAINAREA_H
+void markQString(QString* input);
+void unmarkQString(QString* input);
+void markQLineEdit(QLineEdit* lineEdit);
+void unmarkQLineEdit(QLineEdit* lineEdit);
+#endif // MUDLET_TRAILINGWHITESPACEMARKER_H

--- a/src/dlgAliasMainArea.cpp
+++ b/src/dlgAliasMainArea.cpp
@@ -20,6 +20,7 @@
 
 
 #include "dlgAliasMainArea.h"
+#include "TrailingWhitespaceMarker.h"
 #include "mudlet.h"
 
 dlgAliasMainArea::dlgAliasMainArea(QWidget* pParentWidget)
@@ -29,6 +30,7 @@ dlgAliasMainArea::dlgAliasMainArea(QWidget* pParentWidget)
     setupUi(this);
 
     connect(lineEdit_alias_name, &QLineEdit::editingFinished, this, &dlgAliasMainArea::slot_editingNameFinished);
+    connect(lineEdit_alias_pattern, &QLineEdit::textChanged, this, &dlgAliasMainArea::slot_changedPattern);
 
     if (mudlet::self()->smFirstLaunch) {
         //: This text is shown as placeholder in the pattern box when no real pattern was entered, yet.
@@ -44,4 +46,8 @@ void dlgAliasMainArea::trimName()
 void dlgAliasMainArea::slot_editingNameFinished()
 {
     trimName();
+}
+void dlgAliasMainArea::slot_changedPattern()
+{
+    markQLineEdit(lineEdit_alias_pattern);
 }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -853,7 +853,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
         connect(pBox, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgTriggerEditor::slot_setupPatternControls);
         connect(pItem->pushButton_fgColor, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_colorTriggerFg);
         connect(pItem->pushButton_bgColor, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_colorTriggerBg);
-        connect(pItem->lineEdit_pattern,&QLineEdit::textChanged,this,&dlgTriggerEditor::slot_changedPattern);
+        connect(pItem->lineEdit_pattern,&QLineEdit::textChanged, this, &dlgTriggerEditor::slot_changedPattern);
         HpatternList->layout()->addWidget(pItem);
         mTriggerPatternEdit.push_back(pItem);
         pItem->mRow = i;

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -853,7 +853,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
         connect(pBox, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgTriggerEditor::slot_setupPatternControls);
         connect(pItem->pushButton_fgColor, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_colorTriggerFg);
         connect(pItem->pushButton_bgColor, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_colorTriggerBg);
-        connect(pItem->lineEdit_pattern,&QLineEdit::textChanged, this, &dlgTriggerEditor::slot_changedPattern);
+        connect(pItem->lineEdit_pattern, &QLineEdit::textChanged, this, &dlgTriggerEditor::slot_changedPattern);
         HpatternList->layout()->addWidget(pItem);
         mTriggerPatternEdit.push_back(pItem);
         pItem->mRow = i;

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -300,6 +300,7 @@ private slots:
     void slot_toggleSearchCaseSensitivity(bool);
     void slot_toggleSearchIncludeVariables(bool);
     void slot_toggleGroupBoxColorizeTrigger(const bool);
+    void slot_changedPattern();
     void slot_clearSearchResults();
     void slot_clearSoundFile();
     void slot_editorContextMenu();
@@ -468,6 +469,8 @@ private:
         {tr("Statistics"), tr("Ctrl+9")},
         {tr("Debug"),      tr("Ctrl+0")}
     };
+
+    std::unordered_map<QLineEdit*,bool> lineEditShouldMarkSpaces;
 
     QToolBar* toolBar = nullptr;
     QToolBar* toolBar2 = nullptr;

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -470,7 +470,7 @@ private:
         {tr("Debug"),      tr("Ctrl+0")}
     };
 
-    std::unordered_map<QLineEdit*,bool> lineEditShouldMarkSpaces;
+    std::unordered_map<QLineEdit*, bool> lineEditShouldMarkSpaces;
 
     QToolBar* toolBar = nullptr;
     QToolBar* toolBar2 = nullptr;

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -573,6 +573,7 @@ SOURCES += \
     exitstreewidget.cpp \
     FontManager.cpp \
     GifTracker.cpp \
+    TrailingWhitespaceMarker.cpp \
     Host.cpp \
     HostManager.cpp \
     ircmessageformatter.cpp \
@@ -689,6 +690,7 @@ HEADERS += \
     EAction.h \
     exitstreewidget.h \
     GifTracker.h \
+    TrailingWhitespaceMarker.h \
     Host.h \
     HostManager.h \
     ircmessageformatter.h \


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
- Created TrailingWhitespaceMarker with functions to mark and unmark QStrings and QLineEdits
- Enabled for alias regex
- Enabled for trigger regex, but only when perl regex is selected in the dropdown
#### Motivation for adding to Mudlet
Pasting in regex that contains trailing spaces will not function as intended. It is difficult for users to spot this, since spaces are invisible. https://github.com/Mudlet/Mudlet/issues/4525
#### Other info (issues closed, discussion etc)
Demo:

https://github.com/Mudlet/Mudlet/assets/147658676/cc6b771f-0488-48a9-b063-9c5e0b9a8828

/claim #4525

Is this solution acceptable?