### PR TITLE
Improve: Hold ctrl while dragging to install as module

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1980,7 +1980,30 @@ void TConsole::setProfileName(const QString& newName)
 void TConsole::dragEnterEvent(QDragEnterEvent* e)
 {
     if (e->mimeData()->hasUrls() || e->mimeData()->hasText()) {
-        e->acceptProposedAction();
+        // Use ctrl key to decide if action is link or copy
+        // CopyAction corresponds to installing dropped file as a package
+        // LinkAction corresponds to installing dropped file as a module
+        Qt::KeyboardModifiers modifiers = e->keyboardModifiers();
+        if (modifiers & Qt::ControlModifier) {
+            e->setDropAction(Qt::LinkAction);
+        } else {
+            e->setDropAction(Qt::CopyAction);
+        }
+        e->accept();
+    }
+}
+void TConsole::dragMoveEvent(QDragMoveEvent* e) {
+    if (e->mimeData()->hasUrls() || e->mimeData()->hasText()) {
+        // Use ctrl key to decide if action is link or copy
+        // CopyAction corresponds to installing dropped file as a package
+        // LinkAction corresponds to installing dropped file as a module
+        Qt::KeyboardModifiers modifiers = e->keyboardModifiers();
+        if (modifiers & Qt::ControlModifier) {
+            e->setDropAction(Qt::LinkAction);
+        } else {
+            e->setDropAction(Qt::CopyAction);
+        }
+        e->accept();
     }
 }
 

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -318,6 +318,7 @@ public slots:
 
 protected:
     void dragEnterEvent(QDragEnterEvent*) override;
+    void dragMoveEvent(QDragMoveEvent*) override;
     void dropEvent(QDropEvent*) override;
     void mouseReleaseEvent(QMouseEvent*) override;
     void mousePressEvent(QMouseEvent*) override;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2563,11 +2563,16 @@ int TLuaInterpreter::scrollingActive(lua_State* L)
     return 1;
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#holdingCtrl
-int TLuaInterpreter::holdingCtrl(lua_State* L)
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#holdingModifiers
+int TLuaInterpreter::holdingModifiers(lua_State* L)
 {
-    bool ctrlHeld = QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier);
-    lua_pushboolean(L, ctrlHeld);
+    Qt::KeyboardModifiers keyModifiers;
+    keyModifiers = static_cast<Qt::KeyboardModifiers>(
+        getVerifiedInt(L, __func__, 1, "key modifier", true)
+    );
+    Qt::KeyboardModifiers modifiersHeld = QGuiApplication::queryKeyboardModifiers();
+    qDebug() << "held: " << modifiersHeld << " - Searching: " << keyModifiers;
+    lua_pushboolean(L, modifiersHeld == keyModifiers);
     return 1;
 }
 
@@ -15759,7 +15764,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "disableScrolling", TLuaInterpreter::disableScrolling);
     lua_register(pGlobalLua, "clearMapSelection", TLuaInterpreter::clearMapSelection);
     lua_register(pGlobalLua, "scrollingActive", TLuaInterpreter::scrollingActive);
-    lua_register(pGlobalLua, "holdingCtrl", TLuaInterpreter::holdingCtrl);
+    lua_register(pGlobalLua, "holdingModifiers", TLuaInterpreter::holdingModifiers);
     // PLACEMARKER: End of main Lua interpreter functions registration
     // check new functions against https://www.linguistic-antipatterns.com when creating them
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2571,7 +2571,6 @@ int TLuaInterpreter::holdingModifiers(lua_State* L)
         getVerifiedInt(L, __func__, 1, "key modifier", true)
     );
     Qt::KeyboardModifiers modifiersHeld = QGuiApplication::queryKeyboardModifiers();
-    qDebug() << "held: " << modifiersHeld << " - Searching: " << keyModifiers;
     lua_pushboolean(L, modifiersHeld == keyModifiers);
     return 1;
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2563,6 +2563,14 @@ int TLuaInterpreter::scrollingActive(lua_State* L)
     return 1;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#holdingCtrl
+int TLuaInterpreter::holdingCtrl(lua_State* L)
+{
+    bool ctrlHeld = QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier);
+    lua_pushboolean(L, ctrlHeld);
+    return 1;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableCommandLine
 // This (and the next) function originally only worked on TConsole instances
 // to show/hide a command line at the bottom (and the first would create the
@@ -15751,6 +15759,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "disableScrolling", TLuaInterpreter::disableScrolling);
     lua_register(pGlobalLua, "clearMapSelection", TLuaInterpreter::clearMapSelection);
     lua_register(pGlobalLua, "scrollingActive", TLuaInterpreter::scrollingActive);
+    lua_register(pGlobalLua, "holdingCtrl", TLuaInterpreter::holdingCtrl);
     // PLACEMARKER: End of main Lua interpreter functions registration
     // check new functions against https://www.linguistic-antipatterns.com when creating them
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -655,6 +655,7 @@ public:
     static int getSaveCommandHistory(lua_State*);
     static int setSaveCommandHistory(lua_State*);
     static int clearMapSelection(lua_State*);
+    static int holdingCtrl(lua_State*);
     // PLACEMARKER: End of Lua functions declarations
     // check new functions against https://www.linguistic-antipatterns.com when creating them
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -655,7 +655,7 @@ public:
     static int getSaveCommandHistory(lua_State*);
     static int setSaveCommandHistory(lua_State*);
     static int clearMapSelection(lua_State*);
-    static int holdingCtrl(lua_State*);
+    static int holdingModifiers(lua_State*);
     // PLACEMARKER: End of Lua functions declarations
     // check new functions against https://www.linguistic-antipatterns.com when creating them
 

--- a/src/lua-function-list.json
+++ b/src/lua-function-list.json
@@ -269,6 +269,7 @@
     "highlightRoom": "highlightRoom( roomID, color1Red, color1Green, color1Blue, color2Red, color2Green, color2Blue, highlightRadius, color1Alpha, color2Alpha)",
     "hinsertLink": "hinsertLink([windowName], text, command, hint, true)",
     "hinsertPopup": "hinsertPopup([windowName], text, {commands}, {hints}, [useCurrentFormatElseDefault])",
+    "holdingCtrl": "holdingCtrl()",
     "hreplace": "hreplace([window, ]text)",
     "hreplaceLine": "hreplaceLine ([window], text)",
     "insertLink": "insertLink([windowName], text, command, hint, [useCurrentLinkFormat])",

--- a/src/lua-function-list.json
+++ b/src/lua-function-list.json
@@ -269,7 +269,7 @@
     "highlightRoom": "highlightRoom( roomID, color1Red, color1Green, color1Blue, color2Red, color2Green, color2Blue, highlightRadius, color1Alpha, color2Alpha)",
     "hinsertLink": "hinsertLink([windowName], text, command, hint, true)",
     "hinsertPopup": "hinsertPopup([windowName], text, {commands}, {hints}, [useCurrentFormatElseDefault])",
-    "holdingCtrl": "holdingCtrl()",
+    "holdingModifiers": "holdingModifiers(modifier)",
     "hreplace": "hreplace([window, ]text)",
     "hreplaceLine": "hreplaceLine ([window], text)",
     "insertLink": "insertLink([windowName], text, command, hint, [useCurrentLinkFormat])",

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -1175,7 +1175,7 @@ function packageDrop(event, fileName, suffix)
   if not table.contains(acceptableSuffix, suffix) then
     return
   end
-  if holdingCtrl() then
+  if holdingModifiers(mudlet.keymodifier.Control) then
     verboseModuleInstall(fileName)
   else
     verbosePackageInstall(fileName)

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -1107,6 +1107,26 @@ function verbosePackageInstall(fileName)
   end
 end
 
+function verboseModuleInstall(fileName)
+  local ok, err = installModule(fileName)
+  local moduleName = fileName
+  -- That is all for installing, now to announce the result to the user:
+  mudlet.Locale = mudlet.Locale or loadTranslations("Mudlet")
+  if ok then
+    local successText = mudlet.Locale.moduleInstallSuccess.message
+    successText = string.format(successText, moduleName)
+    local okPrefix = mudlet.Locale.prefixOk.message
+    decho('<0,160,0>' .. okPrefix .. '<190,100,50>' .. successText .. '\n')
+    -- Light Green and Orange-ish; see cTelnet::postMessage for color comparison
+  else
+    local failureText = mudlet.Locale.moduleInstallFail.message
+    failureText = string.format(failureText, moduleName, err)
+    local warnPrefix = mudlet.Locale.prefixWarn.message
+    decho('<0,150,190>' .. warnPrefix .. '<190,150,0>' .. failureText .. '\n')
+    -- Cyan and Orange; see cTelnet::postMessage for color comparison
+  end
+end
+
 local oldInstallPackage = installPackage
 
 -- Override of original installPackage to allow installs from URL
@@ -1155,7 +1175,11 @@ function packageDrop(event, fileName, suffix)
   if not table.contains(acceptableSuffix, suffix) then
     return
   end
-  verbosePackageInstall(fileName)
+  if holdingCtrl() then
+    verboseModuleInstall(fileName)
+  else
+    verbosePackageInstall(fileName)
+  end
 end
 registerAnonymousEventHandler("sysDropEvent", "packageDrop")
 

--- a/translations/lua/mudlet-lua.json
+++ b/translations/lua/mudlet-lua.json
@@ -75,6 +75,14 @@
     "message":"Installing '%s' failed: %s",
     "description":"Failure message after drag&drop of package file onto Mudlet - %s is the file name"
   },
+  "Mudlet.moduleInstallSuccess": {
+    "message":"Module '%s' installed successfully.",
+    "description":"Success message after drag&drop of module file onto Mudlet - %s is the file name"
+  },
+  "Mudlet.moduleInstallFail": {
+    "message":"Installing '%s' failed: %s",
+    "description":"Failure message after drag&drop of module file onto Mudlet - %s is the file name"
+  },
   "Mudlet.packageDownloading": {
     "message":"Downloading package from %s.",
     "description": "Download package from Url for installation - %s is source url"


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
- Added new Lua function holdingCtrl()
- Updated Other.lua to install as module if holdingCtrl()
- Created a matching VerboseModuleInstall() function to let the user know their module has been installed
#### Motivation for adding to Mudlet
https://github.com/Mudlet/Mudlet/issues/3617
#### Other info (issues closed, discussion etc)

https://github.com/Mudlet/Mudlet/assets/147658676/f0621ec6-2a42-43d4-aa28-eb6a9f951fe9

/claim #3617