### PR TITLE
Fix: enableTrigger() does not work always on groups

### DIFF
--- a/src/Tree.h
+++ b/src/Tree.h
@@ -68,7 +68,13 @@ public:
     void setModuleName(const QString& n) { mModuleName = n; }
     QString getModuleName() const { return mModuleName; }
     bool isFolder() { return mFolder; }
-    void setIsFolder(bool b) { mFolder = b; }
+    void setIsFolder(bool b) {
+        mFolder = b;
+        // Allow the folder to be enabled
+        if (b) {
+            mOK_init = true;
+        }
+    }
 
     T* mpParent;
     std::list<T*>* mpMyChildrenList;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Updated Tree.h so mOK_init is set to true whenever something becomes a folder.

#### Motivation for adding to Mudlet
/claim #5875

This script would not enable the "mygroup" trigger:
```lua
if exists('mygroup', 'trigger') == 0 then
    permGroup('mygroup', 'trigger')
end
if exists('mytr', 'trigger') == 0 then
    permPromptTrigger('mytr', 'mygroup', '')
end
enableTrigger('mytr')
disableTrigger('mygroup')
debugc("isActive('mygroup', 'trigger')=" .. isActive('mygroup', 'trigger'))
enableTrigger('mygroup')
debugc("isActive('mygroup', 'trigger')=" .. isActive('mygroup', 'trigger'))
```
#### Other info (issues closed, discussion etc)

The script did not function as expected because:
- enableTrigger() does not enable the trigger if mOK_init (in Tree.h) is false.
- mOK_init was being set to false for "mygroup" upon initial creation.
- Mudlet would only update mOK_init to true for a trigger folder upon restart or interaction with the trigger via the UI.

In the above lua script, "mygroup" will now have mOK_init set to true when "mytr" is added as a child. The error view shows the expected values:
```
[DEBUG:] isActive('mygroup', 'trigger')=0
[DEBUG:] isActive('mygroup', 'trigger')=1
```
Is this an acceptable fix?