### PR TITLE
Improve: Media New Finish Parameter & Fix Fadein & Stop w/ FadeAway 

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5939,7 +5939,7 @@ int TLuaInterpreter::playMusicFileAsOrderedArguments(lua_State* L)
                 return lua_error(L);
             }
 
-            mediaData.setMediaEnd(intValue);
+            mediaData.setMediaFinish(intValue);
             break;
         }
     }
@@ -5991,7 +5991,7 @@ int TLuaInterpreter::playMusicFileAsTableArgument(lua_State* L)
             } else if (key == QLatin1String("tag") && !value.isEmpty()) {
                 mediaData.setMediaTag(value);
             }
-        } else if (key == QLatin1String("volume") || key == QLatin1String("fadein") || key == QLatin1String("fadeout") || key == QLatin1String("start") || key == QLatin1String("end") || key == QLatin1String("loops")) {
+        } else if (key == QLatin1String("volume") || key == QLatin1String("fadein") || key == QLatin1String("fadeout") || key == QLatin1String("start") || key == QLatin1String("finish") || key == QLatin1String("loops")) {
             int value = getVerifiedInt(L,
                                        __func__,
                                        -1,
@@ -5999,7 +5999,7 @@ int TLuaInterpreter::playMusicFileAsTableArgument(lua_State* L)
                                        : key == QLatin1String("fadein")  ? "value for fadein"
                                        : key == QLatin1String("fadeout") ? "value for fadeout"
                                        : key == QLatin1String("start")   ? "value for start"
-                                       : key == QLatin1String("end")     ? "value for end"
+                                       : key == QLatin1String("finish")  ? "value for finish"
                                                                          : "value for loops");
 
             if (key == QLatin1String("volume")) {
@@ -6034,13 +6034,13 @@ int TLuaInterpreter::playMusicFileAsTableArgument(lua_State* L)
                 }
 
                 mediaData.setMediaStart(value);
-            } else if (key == QLatin1String("end")) {
+            } else if (key == QLatin1String("finish")) {
                 if (value < 0) {
-                    lua_pushfstring(L, "playMusicFile: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "end", value);
+                    lua_pushfstring(L, "playMusicFile: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "finish", value);
                     return lua_error(L);
                 }
 
-                mediaData.setMediaEnd(value);
+                mediaData.setMediaFinish(value);
             } else if (key == QLatin1String("loops")) {
                 if (value < TMediaData::MediaLoopsRepeat || value == 0) {
                     value = TMediaData::MediaLoopsDefault;
@@ -6093,7 +6093,7 @@ int TLuaInterpreter::playSoundFileAsOrderedArguments(lua_State* L)
     QString stringValue;
     int intValue = 0;
 
-    // name[,volume][,fadein][,fadeout][,start][,loops][,key][,tag][,priority][,url][,end]
+    // name[,volume][,fadein][,fadeout][,start][,loops][,key][,tag][,priority][,url][,finish]
     for (int i = 1; i <= numArgs; i++) {
         if (lua_isnil(L, i)) {
             continue;
@@ -6188,14 +6188,14 @@ int TLuaInterpreter::playSoundFileAsOrderedArguments(lua_State* L)
             mediaData.setMediaUrl(stringValue);
             break;
         case 11:
-            intValue = getVerifiedInt(L, __func__, i, "end");
+            intValue = getVerifiedInt(L, __func__, i, "finish");
 
             if (intValue < 0) {
-                lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %s)", "end", intValue);
+                lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %s)", "finish", intValue);
                 return lua_error(L);
             }
 
-            mediaData.setMediaEnd(intValue);
+            mediaData.setMediaFinish(intValue);
             break;
         }
     }
@@ -6248,7 +6248,7 @@ int TLuaInterpreter::playSoundFileAsTableArgument(lua_State* L)
             } else if (key == QLatin1String("tag") && !value.isEmpty()) {
                 mediaData.setMediaTag(value);
             }
-        } else if (key == QLatin1String("volume") || key == QLatin1String("fadein") || key == QLatin1String("fadeout") || key == QLatin1String("start") || key == QLatin1String("end") || key == QLatin1String("loops")
+        } else if (key == QLatin1String("volume") || key == QLatin1String("fadein") || key == QLatin1String("fadeout") || key == QLatin1String("start") || key == QLatin1String("finish") || key == QLatin1String("loops")
                    || key == QLatin1String("priority")) {
             int value = getVerifiedInt(L,
                                        __func__,
@@ -6257,7 +6257,7 @@ int TLuaInterpreter::playSoundFileAsTableArgument(lua_State* L)
                                        : key == QLatin1String("fadein")  ? "value for fadein"
                                        : key == QLatin1String("fadeout") ? "value for fadeout"
                                        : key == QLatin1String("start")   ? "value for start"
-                                       : key == QLatin1String("end")     ? "value for end"
+                                       : key == QLatin1String("finish")  ? "value for finish"
                                        : key == QLatin1String("loops")   ? "value for loops"
                                                                          : "value for priority");
 
@@ -6293,13 +6293,13 @@ int TLuaInterpreter::playSoundFileAsTableArgument(lua_State* L)
                 }
 
                 mediaData.setMediaStart(value);
-            } else if (key == QLatin1String("end")) {
+            } else if (key == QLatin1String("finish")) {
                 if (value < 0) {
-                    lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "end", value);
+                    lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "finish", value);
                     return lua_error(L);
                 }
 
-                mediaData.setMediaEnd(value);
+                mediaData.setMediaFinish(value);
             } else if (key == QLatin1String("loops")) {
                 if (value < TMediaData::MediaLoopsRepeat || value == 0) {
                     value = TMediaData::MediaLoopsDefault;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5844,7 +5844,7 @@ int TLuaInterpreter::playMusicFileAsOrderedArguments(lua_State* L)
     int intValue = 0;
     bool boolValue = 0;
 
-    // name[,volume][,fadein][,fadeout][,start][,loops][,key][,tag][,continue][,url][,end]
+    // name[,volume][,fadein][,fadeout][,start][,loops][,key][,tag][,continue][,url][,finish]
     for (int i = 1; i <= numArgs; i++) {
         if (lua_isnil(L, i)) {
             continue;
@@ -5932,10 +5932,10 @@ int TLuaInterpreter::playMusicFileAsOrderedArguments(lua_State* L)
             mediaData.setMediaUrl(stringValue);
             break;
         case 11:
-            intValue = getVerifiedInt(L, __func__, i, "end");
+            intValue = getVerifiedInt(L, __func__, i, "finish");
 
             if (intValue < 0) {
-                lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "end", intValue);
+                lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "finish", intValue);
                 return lua_error(L);
             }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5844,7 +5844,7 @@ int TLuaInterpreter::playMusicFileAsOrderedArguments(lua_State* L)
     int intValue = 0;
     bool boolValue = 0;
 
-    // name[,volume][,fadein][,fadeout][,start][,loops][,key][,tag][,continue][,url])
+    // name[,volume][,fadein][,fadeout][,start][,loops][,key][,tag][,continue][,url][,end]
     for (int i = 1; i <= numArgs; i++) {
         if (lua_isnil(L, i)) {
             continue;
@@ -5931,6 +5931,16 @@ int TLuaInterpreter::playMusicFileAsOrderedArguments(lua_State* L)
             stringValue = getVerifiedString(L, __func__, i, "url");
             mediaData.setMediaUrl(stringValue);
             break;
+        case 11:
+            intValue = getVerifiedInt(L, __func__, i, "end");
+
+            if (intValue < 0) {
+                lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "end", intValue);
+                return lua_error(L);
+            }
+
+            mediaData.setMediaEnd(intValue);
+            break;
         }
     }
 
@@ -5981,7 +5991,7 @@ int TLuaInterpreter::playMusicFileAsTableArgument(lua_State* L)
             } else if (key == QLatin1String("tag") && !value.isEmpty()) {
                 mediaData.setMediaTag(value);
             }
-        } else if (key == QLatin1String("volume") || key == QLatin1String("fadein") || key == QLatin1String("fadeout") || key == QLatin1String("start") || key == QLatin1String("loops")) {
+        } else if (key == QLatin1String("volume") || key == QLatin1String("fadein") || key == QLatin1String("fadeout") || key == QLatin1String("start") || key == QLatin1String("end") || key == QLatin1String("loops")) {
             int value = getVerifiedInt(L,
                                        __func__,
                                        -1,
@@ -5989,6 +5999,7 @@ int TLuaInterpreter::playMusicFileAsTableArgument(lua_State* L)
                                        : key == QLatin1String("fadein")  ? "value for fadein"
                                        : key == QLatin1String("fadeout") ? "value for fadeout"
                                        : key == QLatin1String("start")   ? "value for start"
+                                       : key == QLatin1String("end")     ? "value for end"
                                                                          : "value for loops");
 
             if (key == QLatin1String("volume")) {
@@ -6023,6 +6034,13 @@ int TLuaInterpreter::playMusicFileAsTableArgument(lua_State* L)
                 }
 
                 mediaData.setMediaStart(value);
+            } else if (key == QLatin1String("end")) {
+                if (value < 0) {
+                    lua_pushfstring(L, "playMusicFile: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "end", value);
+                    return lua_error(L);
+                }
+
+                mediaData.setMediaEnd(value);
             } else if (key == QLatin1String("loops")) {
                 if (value < TMediaData::MediaLoopsRepeat || value == 0) {
                     value = TMediaData::MediaLoopsDefault;
@@ -6075,7 +6093,7 @@ int TLuaInterpreter::playSoundFileAsOrderedArguments(lua_State* L)
     QString stringValue;
     int intValue = 0;
 
-    // name[,volume][,fadein][,fadeout][,start][,loops][,key][,tag][,priority][,url])
+    // name[,volume][,fadein][,fadeout][,start][,loops][,key][,tag][,priority][,url][,end]
     for (int i = 1; i <= numArgs; i++) {
         if (lua_isnil(L, i)) {
             continue;
@@ -6169,6 +6187,16 @@ int TLuaInterpreter::playSoundFileAsOrderedArguments(lua_State* L)
             stringValue = getVerifiedString(L, __func__, i, "url");
             mediaData.setMediaUrl(stringValue);
             break;
+        case 11:
+            intValue = getVerifiedInt(L, __func__, i, "end");
+
+            if (intValue < 0) {
+                lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %s)", "end", intValue);
+                return lua_error(L);
+            }
+
+            mediaData.setMediaEnd(intValue);
+            break;
         }
     }
 
@@ -6220,7 +6248,7 @@ int TLuaInterpreter::playSoundFileAsTableArgument(lua_State* L)
             } else if (key == QLatin1String("tag") && !value.isEmpty()) {
                 mediaData.setMediaTag(value);
             }
-        } else if (key == QLatin1String("volume") || key == QLatin1String("fadein") || key == QLatin1String("fadeout") || key == QLatin1String("start") || key == QLatin1String("loops")
+        } else if (key == QLatin1String("volume") || key == QLatin1String("fadein") || key == QLatin1String("fadeout") || key == QLatin1String("start") || key == QLatin1String("end") || key == QLatin1String("loops")
                    || key == QLatin1String("priority")) {
             int value = getVerifiedInt(L,
                                        __func__,
@@ -6229,6 +6257,7 @@ int TLuaInterpreter::playSoundFileAsTableArgument(lua_State* L)
                                        : key == QLatin1String("fadein")  ? "value for fadein"
                                        : key == QLatin1String("fadeout") ? "value for fadeout"
                                        : key == QLatin1String("start")   ? "value for start"
+                                       : key == QLatin1String("end")     ? "value for end"
                                        : key == QLatin1String("loops")   ? "value for loops"
                                                                          : "value for priority");
 
@@ -6264,6 +6293,13 @@ int TLuaInterpreter::playSoundFileAsTableArgument(lua_State* L)
                 }
 
                 mediaData.setMediaStart(value);
+            } else if (key == QLatin1String("end")) {
+                if (value < 0) {
+                    lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "end", value);
+                    return lua_error(L);
+                }
+
+                mediaData.setMediaEnd(value);
             } else if (key == QLatin1String("loops")) {
                 if (value < TMediaData::MediaLoopsRepeat || value == 0) {
                     value = TMediaData::MediaLoopsDefault;
@@ -6320,8 +6356,10 @@ int TLuaInterpreter::stopMusicAsOrderedArguments(lua_State* L)
     TMediaData mediaData{};
     const int numArgs = lua_gettop(L);
     QString stringValue;
+    bool boolValue;
+    int intValue;
 
-    // values as ordered args: name[,key][,tag])
+    // values as ordered args: name[,key][,tag][,fadeaway][,fadeout]
     for (int i = 1; i <= numArgs; i++) {
         if (lua_isnil(L, i)) {
             continue;
@@ -6346,6 +6384,20 @@ int TLuaInterpreter::stopMusicAsOrderedArguments(lua_State* L)
         case 3:
             stringValue = getVerifiedString(L, __func__, i, "tag");
             mediaData.setMediaTag(stringValue);
+            break;
+        case 4:
+            boolValue = getVerifiedBool(L, __func__, i, "fadeaway");
+            mediaData.setMediaFadeAway(boolValue);
+            break;
+        case 5:
+            intValue = getVerifiedInt(L, __func__, i, "fadeout");
+
+            if (intValue < 0) {
+                lua_pushfstring(L, "stopMusic: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "fadeout", intValue);
+                return lua_error(L);
+            }
+
+            mediaData.setMediaFadeOut(intValue);
             break;
         }
     }
@@ -6386,6 +6438,18 @@ int TLuaInterpreter::stopMusicAsTableArgument(lua_State* L)
             } else if (key == QLatin1String("tag") && !value.isEmpty()) {
                 mediaData.setMediaTag(value);
             }
+        } else if (key == QLatin1String("fadeaway")) {
+            const bool value = getVerifiedBool(L, __func__, -1, "value for fadeaway must be boolean");
+            mediaData.setMediaFadeAway(value);
+        } else if (key == QLatin1String("fadeout")) {
+            int value = getVerifiedInt(L, __func__, -1, "value for fadeout");
+
+            if (value < 0) {
+                lua_pushfstring(L, "stopMusic: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "fadeout", value);
+                return lua_error(L);
+            }
+
+            mediaData.setMediaFadeOut(value);
         }
 
         // removes value, but keeps key for next iteration
@@ -6430,6 +6494,7 @@ int TLuaInterpreter::stopSoundsAsOrderedArguments(lua_State* L)
     TMediaData mediaData{};
     const int numArgs = lua_gettop(L);
     QString stringValue;
+    bool boolValue;
     int intValue = 0;
 
     // values as ordered args: name[,key][,tag][,priority])
@@ -6468,6 +6533,20 @@ int TLuaInterpreter::stopSoundsAsOrderedArguments(lua_State* L)
             }
 
             mediaData.setMediaPriority(intValue);
+            break;
+        case 5:
+            boolValue = getVerifiedBool(L, __func__, i, "fadeaway");
+            mediaData.setMediaFadeAway(boolValue);
+            break;
+        case 6:
+            intValue = getVerifiedInt(L, __func__, i, "fadeout");
+
+            if (intValue < 0) {
+                lua_pushfstring(L, "stopSounds: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "fadeout", intValue);
+                return lua_error(L);
+            }
+
+            mediaData.setMediaFadeOut(intValue);
             break;
         }
     }
@@ -6520,6 +6599,18 @@ int TLuaInterpreter::stopSoundsAsTableArgument(lua_State* L)
 
                 mediaData.setMediaPriority(value);
             }
+        } else if (key == QLatin1String("fadeaway")) {
+            const bool value = getVerifiedBool(L, __func__, -1, "value for fadeaway must be boolean");
+            mediaData.setMediaFadeAway(value);
+        } else if (key == QLatin1String("fadeout")) {
+            int value = getVerifiedInt(L, __func__, -1, "value for fadeout");
+
+            if (value < 0) {
+                lua_pushfstring(L, "stopSounds: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "fadeout", value);
+                return lua_error(L);
+            }
+
+            mediaData.setMediaFadeOut(value);
         }
 
         // removes value, but keeps key for next iteration

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -206,9 +206,9 @@ void TMedia::stopMedia(TMediaData& mediaData)
                 const int finishPosition = pPlayer.getMediaData().getMediaFinish();
                 const int duration = pPlayer.getMediaPlayer()->duration();
                 const int currentPosition = pPlayer.getMediaPlayer()->position();
-                const int fadeOut = pPlayer.getMediaData().getMediaFadeOut();
+                const int fadeOut = pPlayer.getMediaData().getMediaFadeOut() ? pPlayer.getMediaData().getMediaFadeOut() : mediaData.getMediaFadeOut();
                 const int remainingDuration = (finishPosition != TMediaData::MediaFinishNotSet ? finishPosition : duration) - currentPosition;
-                const int endDuration = fadeOut != TMediaData::MediaFadeNotSet ? fadeOut : std::min(remainingDuration, 5000);
+                const int endDuration = fadeOut != TMediaData::MediaFadeNotSet ? std::min(remainingDuration, fadeOut) : std::min(remainingDuration, 5000);
                 const int endPosition = currentPosition + endDuration;
                 TMediaPlayer pUpdatePlayer = pPlayer;
                 TMediaData updateMediaData = pUpdatePlayer.getMediaData();
@@ -755,10 +755,6 @@ void TMedia::connectMediaPlayer(TMediaPlayer& player)
         const int relativeFadeOutPosition = fadeOutUsed ? relativeDuration - fadeOutDuration : TMediaData::MediaFadeNotSet;
         bool actionTaken = false;
 
-        qWarning() << "***********" << player.getMediaData().getMediaEnd() <<  "***********";
-
-        qWarning() << "progress = " << progress << "volume = " << volume << " duration = " << duration << " fadeInDuration = " << fadeInDuration << " fadeOutDuration = " << fadeOutDuration << " startPosition = " << startPosition << " finishPosition = " << finishPosition << " endPosition = " << endPosition << " fadeInUsed = " << fadeInUsed << " fadeOutUsed = " << fadeOutUsed << " endUsed = " << endUsed << " finishUsed = " << finishUsed << " relativeDuration = " << relativeDuration << " relativeFadeInPosition = " << relativeFadeInPosition << " relativeFadeOutPosition = " << relativeFadeOutPosition;
-
         if (progress > relativeDuration && (endUsed || finishUsed)) {
             player.getMediaPlayer()->stop();
         } else {
@@ -767,11 +763,9 @@ void TMedia::connectMediaPlayer(TMediaPlayer& player)
                     double const fadeInVolume = static_cast<double>(volume * (progress - startPosition)) / static_cast<double>((relativeFadeInPosition - startPosition) * 1.0);
 
                     player.setVolume(qRound(fadeInVolume));
-                    qWarning() << "progress = " << "new volume = " << qRound(fadeInVolume);
                     actionTaken = true;
                 } else if (progress == relativeFadeInPosition) {
                     player.setVolume(volume);
-                    qWarning() << "progress = " << "new volume = " << volume;
                     actionTaken = true;
                 }
             }
@@ -781,14 +775,12 @@ void TMedia::connectMediaPlayer(TMediaPlayer& player)
                     double const fadeOutVolume = static_cast<double>(volume * (relativeDuration - progress)) / static_cast<double>(fadeOutDuration * 1.0);
 
                     player.setVolume(qRound(fadeOutVolume));
-                    qWarning() << "progress = " << "new volume = " << qRound(fadeOutVolume);
                     actionTaken = true;
                 }
             }
 
             if (!actionTaken && ((fadeInUsed && progress > relativeFadeInPosition) || (fadeOutUsed && progress < relativeFadeOutPosition))) {
                 player.setVolume(volume); // Added to support multiple continue = true calls of same music
-                qWarning() << "progress = " << "new volume = " << volume;
             }
         }
     });

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -118,6 +118,7 @@ private:
     void downloadFile(TMediaData& mediaData);
     QString setupMediaAbsolutePathFileName(TMediaData& mediaData);
     QList<TMediaPlayer> getMediaPlayerList(TMediaData& mediaData);
+    void connectMediaPlayer(TMediaPlayer& player);
     void updateMediaPlayerList(TMediaPlayer& player);
     TMediaPlayer getMediaPlayer(TMediaData& mediaData);
     TMediaPlayer matchMediaPlayer(TMediaData& mediaData, const QString& absolutePathFileName);
@@ -133,7 +134,7 @@ private:
     static int parseJSONByMediaFadeIn(QJsonObject& json);
     static int parseJSONByMediaFadeOut(QJsonObject& json);
     static int parseJSONByMediaStart(QJsonObject& json);
-    static int parseJSONByMediaEnd(QJsonObject& json);
+    static int parseJSONByMediaFinish(QJsonObject& json);
     static int parseJSONByMediaPriority(QJsonObject& json);
     static int parseJSONByMediaLoops(QJsonObject& json);
     static TMediaData::MediaContinue parseJSONByMediaContinue(QJsonObject& json);

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -133,12 +133,14 @@ private:
     static int parseJSONByMediaFadeIn(QJsonObject& json);
     static int parseJSONByMediaFadeOut(QJsonObject& json);
     static int parseJSONByMediaStart(QJsonObject& json);
+    static int parseJSONByMediaEnd(QJsonObject& json);
     static int parseJSONByMediaPriority(QJsonObject& json);
     static int parseJSONByMediaLoops(QJsonObject& json);
     static TMediaData::MediaContinue parseJSONByMediaContinue(QJsonObject& json);
     static QString parseJSONByMediaTag(QJsonObject& json);
     static QString parseJSONByMediaUrl(QJsonObject& json);
     static QString parseJSONByMediaKey(QJsonObject& json);
+    static TMediaData::MediaFadeAway parseJSONByMediaFadeAway(QJsonObject& json);
 
     void parseJSONForMediaDefault(QJsonObject& json);
     void parseJSONForMediaLoad(QJsonObject& json);

--- a/src/TMediaData.h
+++ b/src/TMediaData.h
@@ -142,17 +142,6 @@ public:
             mMediaStart = mediaStart;
         }
     }
-    int getMediaEnd() const { return mMediaEnd; }
-    void setMediaEnd(int mediaEnd)
-    {
-        if (mediaEnd < TMediaData::MediaEndNotSet) {
-            mMediaEnd = TMediaData::MediaEndNotSet;
-        } else {
-            mMediaEnd = mediaEnd;
-        }
-    }
-    bool getMediaFadeAway() const { return mMediaFadeAway; }
-    void setMediaFadeAway(bool mediaFadeAway) { mMediaFadeAway = mediaFadeAway; }
     int getMediaFinish() const { return mMediaFinish; }
     void setMediaFinish(int mediaFinish)
     {
@@ -160,6 +149,17 @@ public:
             mMediaFinish = TMediaData::MediaFinishNotSet;
         } else {
             mMediaFinish = mediaFinish;
+        }
+    }
+    bool getMediaFadeAway() const { return mMediaFadeAway; }
+    void setMediaFadeAway(bool mediaFadeAway) { mMediaFadeAway = mediaFadeAway; }
+    int getMediaEnd() const { return mMediaEnd; }
+    void setMediaEnd(int mediaEnd)
+    {
+        if (mediaEnd < TMediaData::MediaEndNotSet) {
+            mMediaEnd = TMediaData::MediaEndNotSet;
+        } else {
+            mMediaEnd = mediaEnd;
         }
     }
     QString getMediaAbsolutePathFileName() const { return mMediaAbsolutePathFileName; }
@@ -173,12 +173,12 @@ private:
     int mMediaFadeIn = MediaFadeNotSet;
     int mMediaFadeOut = MediaFadeNotSet;
     int mMediaStart = MediaStartDefault;
-    int mMediaEnd = MediaEndNotSet;
+    int mMediaFinish = MediaFinishNotSet;
     int mMediaLoops = MediaLoopsDefault;
     int mMediaPriority = MediaPriorityNotSet;
     bool mMediaContinue = MediaContinueDefault;
     bool mMediaFadeAway = MediaFadeAwayDefault;
-    int mMediaFinish = MediaFinishNotSet;
+    int mMediaEnd = MediaEndNotSet;
     QString mMediaTag;
     QString mMediaUrl;
     QString mMediaKey;

--- a/src/TMediaData.h
+++ b/src/TMediaData.h
@@ -64,8 +64,14 @@ public:
         MediaContinueRestart = false,
         MediaContinueDefault = true};
 
+    enum MediaFadeAway {
+        MediaFadeAwayEnabled = true,
+        MediaFadeAwayDefault = false};
+
     static const int MediaFadeNotSet = 0;
     static const int MediaStartDefault = 0;
+    static const int MediaEndNotSet = 0;
+    static const int MediaFinishNotSet = 0;
 
     int getMediaProtocol() const { return mMediaProtocol; }
     void setMediaProtocol(int mediaProtocol) { mMediaProtocol = mediaProtocol; }
@@ -136,6 +142,26 @@ public:
             mMediaStart = mediaStart;
         }
     }
+    int getMediaEnd() const { return mMediaEnd; }
+    void setMediaEnd(int mediaEnd)
+    {
+        if (mediaEnd < TMediaData::MediaEndNotSet) {
+            mMediaEnd = TMediaData::MediaEndNotSet;
+        } else {
+            mMediaEnd = mediaEnd;
+        }
+    }
+    bool getMediaFadeAway() const { return mMediaFadeAway; }
+    void setMediaFadeAway(bool mediaFadeAway) { mMediaFadeAway = mediaFadeAway; }
+    int getMediaFinish() const { return mMediaFinish; }
+    void setMediaFinish(int mediaFinish)
+    {
+        if (mediaFinish < TMediaData::MediaFinishNotSet) {
+            mMediaFinish = TMediaData::MediaFinishNotSet;
+        } else {
+            mMediaFinish = mediaFinish;
+        }
+    }
     QString getMediaAbsolutePathFileName() const { return mMediaAbsolutePathFileName; }
     void setMediaAbsolutePathFileName(QString mediaAbsolutePathFileName) { mMediaAbsolutePathFileName = mediaAbsolutePathFileName; }
 
@@ -147,9 +173,12 @@ private:
     int mMediaFadeIn = MediaFadeNotSet;
     int mMediaFadeOut = MediaFadeNotSet;
     int mMediaStart = MediaStartDefault;
+    int mMediaEnd = MediaEndNotSet;
     int mMediaLoops = MediaLoopsDefault;
     int mMediaPriority = MediaPriorityNotSet;
     bool mMediaContinue = MediaContinueDefault;
+    bool mMediaFadeAway = MediaFadeAwayDefault;
+    int mMediaFinish = MediaFinishNotSet;
     QString mMediaTag;
     QString mMediaUrl;
     QString mMediaKey;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
These outcomes are expected:

- Add a `finish` parameter to [playSoundFile()](https://wiki.mudlet.org/w/Manual:Miscellaneous_Functions#playSoundFile) and [playMusicFile()](https://wiki.mudlet.org/w/Manual:Miscellaneous_Functions#playMusicFile) so media will stop on its own at a given position. Enable `fadeout` to adjust accordingly if `finish` is used.
- Fix the handling of the `fadein` parameter for [playSoundFile()](https://wiki.mudlet.org/w/Manual:Miscellaneous_Functions#playSoundFile) and [playMusicFile()](https://wiki.mudlet.org/w/Manual:Miscellaneous_Functions#playMusicFile) to adjust when the `start` parameter is used
- Add two parameters to [stopSounds()](https://wiki.mudlet.org/w/Manual:Miscellaneous_Functions#stopSounds) and [stopMusic()](https://wiki.mudlet.org/w/Manual:Miscellaneous_Functions#stopMusic), when either parameter or both parameters are used a *fadeaway* effect begins stopping media in a similar way to `fadeout`, however it decreases volume immediately from the current media position for playing media:
    - `fadeaway` this value defaults to false, enabled when true.
        - If there was a `fadeout` previously defined in [playSoundFile()](https://wiki.mudlet.org/w/Manual:Miscellaneous_Functions#playSoundFile) or [playMusicFile()](https://wiki.mudlet.org/w/Manual:Miscellaneous_Functions#playMusicFile) this value will default to the lesser of the time remaining on the track or number of milliseconds defined in `fadeout`
        -  If there was no `fadeout` previously defined in [playSoundFile()](https://wiki.mudlet.org/w/Manual:Miscellaneous_Functions#playSoundFile) or [playMusicFile()](https://wiki.mudlet.org/w/Manual:Miscellaneous_Functions#playMusicFile) this value will default to the lesser of the time remaining on the track or 5000 milliseconds
    - `fadeout` this value in milliseconds will be used when there is no fadeout defined already from [playSoundFile()](https://wiki.mudlet.org/w/Manual:Miscellaneous_Functions#playSoundFile) or [playMusicFile()](https://wiki.mudlet.org/w/Manual:Miscellaneous_Functions#playMusicFile).
        - The lesser of time remaining on the track or the value defined here for `fadeout` will be used

#### Motivation for adding to Mudlet
Issues requested

#### Other info (issues closed, discussion etc)
Completes enhancement for #7018 and resolves #7016 

*Testing*

Start music at 30 seconds in, fade in over 10 seconds
```lua
lua playMusicFile({name = "spacemusic.mp3", url = "https://www.iamtalon.me/", start = 30000, fadein = 10000})
```
Start music at 20 seconds in, fade in over 10 seconds, finish at 50 seconds into the track, fadeout 10 seconds before the finish
```lua
lua playMusicFile({name = "spacemusic.mp3", start = 20000, fadein = 10000, finish = 50000, fadeout = 10000})
```
Play the music, then trigger the *fadeaway* effect which will fadeout the track for 5 seconds prior to stopping it.
```lua
lua playMusicFile({name = "spacemusic.mp3"})
lua stopMusic({fadeaway = true})
```
Play the music, then trigger the *fadeaway* effect which will fadeout the track for 20 seconds prior to stopping it.
```lua
lua playMusicFile({name = "spacemusic.mp3", fadeout = 20000})
lua stopMusic({fadeaway = true})
```
Play the music, then trigger the *fadeaway* effect which will fadeout the track for 25 seconds prior to stopping it.
```lua
lua playMusicFile({name = "spacemusic.mp3"})
lua stopMusic({fadeaway = true, fadeout = 25000})
```