### PR TITLE
Fix: Resolve raw telnet Client.GUI error

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1963,6 +1963,7 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
 
         QString version;
         QString url;
+        bool rawTelnet = false;
 
         auto document = QJsonDocument::fromJson(data.toUtf8());
 
@@ -1982,6 +1983,8 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
             if (url.isEmpty()) {
                 return;
             }
+
+            rawTelnet = true;
         } else {
             // This is JSON
             auto json = document.object();
@@ -2046,6 +2049,10 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
             connect(mpProgressDialog, &QProgressDialog::canceled, mpPackageDownloadReply, &QNetworkReply::abort);
             mpProgressDialog->setAttribute(Qt::WA_DeleteOnClose);
             mpProgressDialog->show();
+        }
+
+        if (rawTelnet) {
+            return; // Do not add to the GMCP table
         }
     } else if (transcodedMsg.startsWith(QLatin1String("Client.Map"), Qt::CaseInsensitive)) {
         mpHost->setMmpMapLocation(data);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Resolves an error that appears in the log for games that use the non-JSON way to load Client.GUI from a server. The approach taken is to skip setting a value in the GMCP table in this case where raw telnet is used and then we avoid the error.

#### Motivation for adding to Mudlet
Issue registered in Mudlet

#### Other info (issues closed, discussion etc)

Closes #6739 

**Testing**
Create an account on Clessidra and when the GUI loads there will be no error message in the log vs. the current production release of Mudlet (4.17.2).