### PR TITLE
Improve: Add optional argument to only flash containers when visible.

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -286,10 +286,15 @@ end
 
 --- Flashes a white box over the dimensions of this container.
 -- This is very useful to see where a container actually is if you've
--- forgotten its details.
+-- forgotten its details or as an alert function to notify the user.
 -- @param time Time in seconds to flash for, default is 1.0s.
-function Geyser.Container:flash (time)
+-- @param[opt=true] onHidden Optional, use as an alert function and don't flash hidden containers.
+function Geyser.Container:flash (time, onHidden)
   local time = time or 1.0
+  local onHidden = onHidden ~= false
+  
+  if not onHidden then return end
+  
   local x, y, width, height = self.get_x(), self.get_y(), self.get_width(), self.get_height()
   local name = self.name .. "_dimensions_flash"
   createLabel(self.windowname ,name, x, y, width, height, 1)


### PR DESCRIPTION
Extends usage to be able to use the function as an alert/notification function.

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Add optional boolean argument which defaults to true to maintain backward compatibility.
True = flash a container, hidden or visible
False = only flash if visible

#### Motivation for adding to Mudlet

Gives the scripter a way to add alerts/notifications to their GUI.

#### Other info (issues closed, discussion etc)
Closes #6973.