### PR TITLE
Fix map rooms command not matching with optional area name.

### DIFF
--- a/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
+++ b/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
@@ -466,7 +466,7 @@ end</script>
 			<Alias isActive="yes" isFolder="no">
 				<name>Map Rooms Alias</name>
 				<script>-- map rooms &lt;area&gt; - shows the list of rooms in an area
-map.echoRoomList(matches[2])</script>
+map.echoRoomList(matches[2] or getRoomArea(map.currentRoom))</script>
 				<command></command>
 				<packageName></packageName>
 				<regex>^map rooms(?: (.+))?$</regex>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
'map rooms' wasn't finding the current area when missing optional 'area name' argument.

#### Motivation for adding to Mudlet
Missed during porting of IRE script.

#### Other info (issues closed, discussion etc)
