### PR TITLE
Fix: Wordwrap for MiniConsole and echo

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2255,7 +2255,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
 
 // Wraps text to max line length of mWrapAt
 // Applies indentation of mWrapIndent to wrapped lines
-QString TBuffer::wrapText(const QString& text)
+QString TBuffer::wrapText(const QString& text) const
 {
     if ( mWrapAt <= mWrapIndent ) {
         qWarning() << "mWrapAt (" << mWrapAt << ") is too small to accommodate mWrapIndent (" << mWrapIndent << ")";
@@ -2268,7 +2268,7 @@ QString TBuffer::wrapText(const QString& text)
     int wordsInCurrentLine = 0;
 
     for ( int i = 0; i < text.size(); i++ ) {
-        bool at_newline = text.at(i) == '\n';
+        bool const at_newline = text.at(i) == '\n';
         if ( at_newline ){
             currentLine += currentWord;
             wrappedText += '\n' + currentLine;
@@ -2280,7 +2280,7 @@ QString TBuffer::wrapText(const QString& text)
 
         currentWord += text.at(i);
 
-        bool atWordBreak = wordBreaks.indexOf(text.at(i)) > -1;
+        bool const atWordBreak = wordBreaks.indexOf(text.at(i)) > -1;
         if ( atWordBreak ) {
             // Reached break in word
             // Add current word to the line and reset for next word
@@ -2289,15 +2289,15 @@ QString TBuffer::wrapText(const QString& text)
             wordsInCurrentLine++;
         }
 
-        int lineLengthWithWord = currentLine.size() + currentWord.size();
-        bool needNewLine = lineLengthWithWord >= mWrapAt;
+        int const lineLengthWithWord = currentLine.size() + currentWord.size();
+        bool const needNewLine = lineLengthWithWord >= mWrapAt;
 
         if ( needNewLine ) {
             // Current word would cause an overflow, so wrap the text.
             if ( wordsInCurrentLine == 0 ) {
                 // If a word is too long to fit on a line,
                 // the word will be split between lines
-                int splitIndex = mWrapAt - currentLine.size();
+                int const splitIndex = mWrapAt - currentLine.size();
                 currentLine += currentWord.left(splitIndex);
                 currentWord = currentWord.mid(splitIndex);
             }

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2269,44 +2269,44 @@ QString TBuffer::wrapText(const QString& text) const
     const QString indentText = QChar::LineFeed + QString(" ").repeated(mWrapIndent);
 
     for (qsizetype curLineStart = 0; curLineStart < text.size(); curLineStart++) {
-        // 1. Find where the next line break is.
-        //    The end of the input text also counts as a line break.
+        // Find where the next line break is.
+        // The end of the input text also counts as a line break.
         qsizetype nextLineBreak = text.indexOf(QChar::LineFeed, curLineStart);
         if (nextLineBreak == -1) {
             nextLineBreak = text.size();
         }
 
-        // 2. Find where the wrap window ends
-        qsizetype wrapWindowEnd = curLineStart + mWrapAt - curIndent;
+        // Find where the wrap window ends
+        const qsizetype wrapWindowEnd = curLineStart + mWrapAt - curIndent;
 
-        // 3. If linebreak happens within wrap window:
-        //    Clear indentation, write the line, and skip the rest of the steps
-        if (nextLineBreak >= 0 && nextLineBreak < wrapWindowEnd) {
+        // If linebreak happens within wrap window:
+        // Clear indentation, write the line, and skip the rest of the steps
+        if (nextLineBreak < wrapWindowEnd) {
             curIndent = 0;
-            qsizetype lineWidth = nextLineBreak - curLineStart + 1;
+            const qsizetype lineWidth = nextLineBreak - curLineStart + 1;
             wrappedText += text.midRef(curLineStart, lineWidth);
             curLineStart = nextLineBreak;
             continue;
         }
 
-        // 4. Find a good place to break up this line
+        // Find a good place to break up this line
         lineFinder.setPosition(wrapWindowEnd + 1);
         lineFinder.toPreviousBoundary();
         qsizetype safeLineEnd = lineFinder.position();
 
-        // 5. If a single word is too long to fit in the wrap window,
-        //    write as much of it as possible
+        // If a single word is too long to fit in the wrap window:
+        // Write as much of it as possible
         if (safeLineEnd <= curLineStart) {
             safeLineEnd = wrapWindowEnd;
         }
 
-        // 6. Move start point forward, set indention level
-        qsizetype lineWidth = safeLineEnd - curLineStart;
+        // Move start point forward, set indention level
+        const qsizetype lineWidth = safeLineEnd - curLineStart;
         wrappedText += text.midRef(curLineStart, lineWidth);
         curIndent = mWrapIndent;
         curLineStart = safeLineEnd - 1;
 
-        // 7. Apply indentation, unless we've reached the end of the text
+        // Apply indentation, unless we've reached the end of the text
         if (curLineStart < text.size()) {
             wrappedText += indentText;
         }

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2268,7 +2268,7 @@ QString TBuffer::wrapText(const QString& text) const
     int wordsInCurrentLine = 0;
 
     for (int i = 0; i < text.size(); i++) {
-        bool const at_newline = text.at(i) == '\n';
+        const bool at_newline = text.at(i) == '\n';
         if (at_newline) {
             currentLine += currentWord;
             wrappedText += '\n' + currentLine;
@@ -2280,7 +2280,7 @@ QString TBuffer::wrapText(const QString& text) const
 
         currentWord += text.at(i);
 
-        bool const atWordBreak = wordBreaks.indexOf(text.at(i)) > -1;
+        const bool atWordBreak = wordBreaks.indexOf(text.at(i)) > -1;
         if (atWordBreak) {
             // Reached break in word
             // Add current word to the line and reset for next word
@@ -2289,15 +2289,15 @@ QString TBuffer::wrapText(const QString& text) const
             wordsInCurrentLine++;
         }
 
-        int const lineLengthWithWord = currentLine.size() + currentWord.size();
-        bool const needNewLine = lineLengthWithWord >= mWrapAt;
+        const int lineLengthWithWord = currentLine.size() + currentWord.size();
+        const bool needNewLine = lineLengthWithWord >= mWrapAt;
 
         if (needNewLine) {
             // Current word would cause an overflow, so wrap the text.
             if (wordsInCurrentLine == 0) {
                 // If a word is too long to fit on a line,
                 // the word will be split between lines
-                int const splitIndex = mWrapAt - currentLine.size();
+                const int splitIndex = mWrapAt - currentLine.size();
                 currentLine += currentWord.left(splitIndex);
                 currentWord = currentWord.mid(splitIndex);
             }

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2267,7 +2267,7 @@ QString TBuffer::wrapText(const QString& text) const
     QString currentLine;
     int wordsInCurrentLine = 0;
 
-    for (int i = 0; i < text.size(); i++) {
+    for (qsizetype i = 0; i < text.size(); i++) {
         const bool at_newline = (text.at(i) == QChar::LineFeed);
         if (at_newline) {
             currentLine += currentWord;
@@ -2289,7 +2289,7 @@ QString TBuffer::wrapText(const QString& text) const
             wordsInCurrentLine++;
         }
 
-        const int lineLengthWithWord = currentLine.size() + currentWord.size();
+        const qsizetype lineLengthWithWord = currentLine.size() + currentWord.size();
         const bool needNewLine = (lineLengthWithWord >= mWrapAt);
 
         if (needNewLine) {
@@ -2297,7 +2297,7 @@ QString TBuffer::wrapText(const QString& text) const
             if (wordsInCurrentLine == 0) {
                 // If a word is too long to fit on a line,
                 // the word will be split between lines
-                const int splitIndex = mWrapAt - currentLine.size();
+                const qsizetype splitIndex = mWrapAt - currentLine.size();
                 currentLine += currentWord.left(splitIndex);
                 currentWord = currentWord.mid(splitIndex);
             }

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2255,9 +2255,9 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
 
 // Wraps text to max line length of mWrapAt
 // Applies indentation of mWrapIndent to wrapped lines
-QString TBuffer::wrapText(const QString& text){
-
-    if ( mWrapAt <= mWrapIndent ){
+QString TBuffer::wrapText(const QString& text)
+{
+    if ( mWrapAt <= mWrapIndent ) {
         qWarning() << "mWrapAt (" << mWrapAt << ") is too small to accommodate mWrapIndent (" << mWrapIndent << ")";
     }
 
@@ -2267,7 +2267,7 @@ QString TBuffer::wrapText(const QString& text){
     QString currentLine;
     int wordsInCurrentLine = 0;
 
-    for ( int i = 0; i < text.size(); i++ ){
+    for ( int i = 0; i < text.size(); i++ ) {
         bool at_newline = text.at(i) == '\n';
         if ( at_newline ){
             currentLine += currentWord;
@@ -2292,9 +2292,9 @@ QString TBuffer::wrapText(const QString& text){
         int lineLengthWithWord = currentLine.size() + currentWord.size();
         bool needNewLine = lineLengthWithWord >= mWrapAt;
 
-        if ( needNewLine ){
+        if ( needNewLine ) {
             // Current word would cause an overflow, so wrap the text.
-            if ( wordsInCurrentLine == 0 ){
+            if ( wordsInCurrentLine == 0 ) {
                 // If a word is too long to fit on a line,
                 // the word will be split between lines
                 int splitIndex = mWrapAt - currentLine.size();

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2268,8 +2268,8 @@ QString TBuffer::wrapText(const QString& text) const
     int wordsInCurrentLine = 0;
 
     for (qsizetype i = 0; i < text.size(); i++) {
-        const bool at_newline = (text.at(i) == QChar::LineFeed);
-        if (at_newline) {
+        const bool atNewline = (text.at(i) == QChar::LineFeed);
+        if (atNewline) {
             currentLine += currentWord;
             wrappedText += QChar::LineFeed % currentLine;
             currentLine.clear();

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2280,7 +2280,7 @@ QString TBuffer::wrapText(const QString& text) const
 
         currentWord += text.at(i);
 
-        const bool atWordBreak = wordBreaks.indexOf(text.at(i)) > -1;
+        const bool atWordBreak = (wordBreaks.indexOf(text.at(i)) > -1);
         if (atWordBreak) {
             // Reached break in word
             // Add current word to the line and reset for next word
@@ -2290,7 +2290,7 @@ QString TBuffer::wrapText(const QString& text) const
         }
 
         const int lineLengthWithWord = currentLine.size() + currentWord.size();
-        const bool needNewLine = lineLengthWithWord >= mWrapAt;
+        const bool needNewLine = (lineLengthWithWord >= mWrapAt);
 
         if (needNewLine) {
             // Current word would cause an overflow, so wrap the text.

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2268,10 +2268,10 @@ QString TBuffer::wrapText(const QString& text) const
     int wordsInCurrentLine = 0;
 
     for (int i = 0; i < text.size(); i++) {
-        const bool at_newline = text.at(i) == '\n';
+        const bool at_newline = (text.at(i) == QChar::LineFeed);
         if (at_newline) {
             currentLine += currentWord;
-            wrappedText += '\n' + currentLine;
+            wrappedText += QChar::LineFeed % currentLine;
             currentLine.clear();
             currentWord.clear();
             wordsInCurrentLine = 0;
@@ -2301,13 +2301,13 @@ QString TBuffer::wrapText(const QString& text) const
                 currentLine += currentWord.left(splitIndex);
                 currentWord = currentWord.mid(splitIndex);
             }
-            wrappedText += '\n' + currentLine;
+            wrappedText += QChar::LineFeed % currentLine;
             currentLine = QString(' ').repeated(mWrapIndent);
             wordsInCurrentLine = 0;
         }
     }
     currentLine += currentWord;
-    wrappedText += '\n' + currentLine;
+    wrappedText += QChar::LineFeed % currentLine;
     return wrappedText;
 }
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2291,8 +2291,9 @@ QString TBuffer::wrapText(const QString& text) const
 
         const qsizetype lineLengthWithWord = currentLine.size() + currentWord.size();
         const bool needNewLine = (lineLengthWithWord >= mWrapAt);
+        const bool atFinalCharacter = (i == text.size()-1);
 
-        if (needNewLine) {
+        if (needNewLine || atFinalCharacter) {
             // Current word would cause an overflow, so wrap the text.
             if (!wordsInCurrentLine) {
                 // If a word is too long to fit on a line,
@@ -2306,8 +2307,6 @@ QString TBuffer::wrapText(const QString& text) const
             wordsInCurrentLine = 0;
         }
     }
-    currentLine += currentWord;
-    wrappedText += QChar::LineFeed % currentLine;
     return wrappedText;
 }
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2257,7 +2257,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
 // Applies indentation of mWrapIndent to wrapped lines
 QString TBuffer::wrapText(const QString& text){
 
-    if( mWrapAt <= mWrapIndent ){
+    if ( mWrapAt <= mWrapIndent ){
         qWarning() << "mWrapAt (" << mWrapAt << ") is too small to accommodate mWrapIndent (" << mWrapIndent << ")";
     }
 
@@ -2267,9 +2267,9 @@ QString TBuffer::wrapText(const QString& text){
     QString currentLine;
     int wordsInCurrentLine = 0;
 
-    for( int i = 0; i < text.size(); i++ ){
+    for ( int i = 0; i < text.size(); i++ ){
         bool at_newline = text.at(i) == '\n';
-        if(at_newline){
+        if ( at_newline ){
             currentLine += currentWord;
             wrappedText += '\n' + currentLine;
             currentLine.clear();
@@ -2281,7 +2281,7 @@ QString TBuffer::wrapText(const QString& text){
         currentWord += text.at(i);
 
         bool atWordBreak = wordBreaks.indexOf(text.at(i)) > -1;
-        if( atWordBreak ) {
+        if ( atWordBreak ) {
             // Reached break in word
             // Add current word to the line and reset for next word
             currentLine += currentWord;
@@ -2292,9 +2292,9 @@ QString TBuffer::wrapText(const QString& text){
         int lineLengthWithWord = currentLine.size() + currentWord.size();
         bool needNewLine = lineLengthWithWord >= mWrapAt;
 
-        if( needNewLine ){
+        if ( needNewLine ){
             // Current word would cause an overflow, so wrap the text.
-            if( wordsInCurrentLine == 0 ){
+            if ( wordsInCurrentLine == 0 ){
                 // If a word is too long to fit on a line,
                 // the word will be split between lines
                 int splitIndex = mWrapAt - currentLine.size();

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2257,7 +2257,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
 // Applies indentation of mWrapIndent to wrapped lines
 QString TBuffer::wrapText(const QString& text){
 
-    if(mWrapAt <= mWrapIndent){
+    if( mWrapAt <= mWrapIndent ){
         qWarning() << "mWrapAt (" << mWrapAt << ") is too small to accommodate mWrapIndent (" << mWrapIndent << ")";
     }
 
@@ -2267,7 +2267,7 @@ QString TBuffer::wrapText(const QString& text){
     QString currentLine;
     int wordsInCurrentLine = 0;
 
-    for(int i=0; i<text.size(); i++){
+    for( int i = 0; i < text.size(); i++ ){
         bool at_newline = text.at(i) == '\n';
         if(at_newline){
             currentLine += currentWord;
@@ -2281,7 +2281,7 @@ QString TBuffer::wrapText(const QString& text){
         currentWord += text.at(i);
 
         bool atWordBreak = wordBreaks.indexOf(text.at(i)) > -1;
-        if(atWordBreak) {
+        if( atWordBreak ) {
             // Reached break in word
             // Add current word to the line and reset for next word
             currentLine += currentWord;
@@ -2292,9 +2292,9 @@ QString TBuffer::wrapText(const QString& text){
         int lineLengthWithWord = currentLine.size() + currentWord.size();
         bool needNewLine = lineLengthWithWord >= mWrapAt;
 
-        if(needNewLine){
+        if( needNewLine ){
             // Current word would cause an overflow, so wrap the text.
-            if(wordsInCurrentLine == 0 ){
+            if( wordsInCurrentLine == 0 ){
                 // If a word is too long to fit on a line,
                 // the word will be split between lines
                 int splitIndex = mWrapAt - currentLine.size();

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2294,7 +2294,7 @@ QString TBuffer::wrapText(const QString& text) const
 
         if (needNewLine) {
             // Current word would cause an overflow, so wrap the text.
-            if (wordsInCurrentLine == 0) {
+            if (!wordsInCurrentLine) {
                 // If a word is too long to fit on a line,
                 // the word will be split between lines
                 const qsizetype splitIndex = mWrapAt - currentLine.size();

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2257,7 +2257,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
 // Applies indentation of mWrapIndent to wrapped lines
 QString TBuffer::wrapText(const QString& text) const
 {
-    if ( mWrapAt <= mWrapIndent ) {
+    if (mWrapAt <= mWrapIndent) {
         qWarning() << "mWrapAt (" << mWrapAt << ") is too small to accommodate mWrapIndent (" << mWrapIndent << ")";
     }
 
@@ -2267,9 +2267,9 @@ QString TBuffer::wrapText(const QString& text) const
     QString currentLine;
     int wordsInCurrentLine = 0;
 
-    for ( int i = 0; i < text.size(); i++ ) {
+    for (int i = 0; i < text.size(); i++) {
         bool const at_newline = text.at(i) == '\n';
-        if ( at_newline ){
+        if (at_newline) {
             currentLine += currentWord;
             wrappedText += '\n' + currentLine;
             currentLine.clear();
@@ -2281,7 +2281,7 @@ QString TBuffer::wrapText(const QString& text) const
         currentWord += text.at(i);
 
         bool const atWordBreak = wordBreaks.indexOf(text.at(i)) > -1;
-        if ( atWordBreak ) {
+        if (atWordBreak) {
             // Reached break in word
             // Add current word to the line and reset for next word
             currentLine += currentWord;
@@ -2292,9 +2292,9 @@ QString TBuffer::wrapText(const QString& text) const
         int const lineLengthWithWord = currentLine.size() + currentWord.size();
         bool const needNewLine = lineLengthWithWord >= mWrapAt;
 
-        if ( needNewLine ) {
+        if (needNewLine) {
             // Current word would cause an overflow, so wrap the text.
-            if ( wordsInCurrentLine == 0 ) {
+            if (wordsInCurrentLine == 0) {
                 // If a word is too long to fit on a line,
                 // the word will be split between lines
                 int const splitIndex = mWrapAt - currentLine.size();

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -253,7 +253,7 @@ public:
     bool insertInLine(QPoint& cursor, const QString& what, const TChar& format);
     void expandLine(int y, int count, TChar&);
     int wrapLine(int startLine, int screenWidth, int indentSize, TChar& format);
-    QString wrapText(const QString& text);
+    QString wrapText(const QString& text) const;
     void log(int, int);
     int skipSpacesAtBeginOfLine(const int row, const int column);
     void addLink(bool, const QString& text, QStringList& command, QStringList& hint, TChar format, QVector<int> luaReference = QVector<int>());

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -253,6 +253,7 @@ public:
     bool insertInLine(QPoint& cursor, const QString& what, const TChar& format);
     void expandLine(int y, int count, TChar&);
     int wrapLine(int startLine, int screenWidth, int indentSize, TChar& format);
+    QString wrapText(const QString& text);
     void log(int, int);
     int skipSpacesAtBeginOfLine(const int row, const int column);
     void addLink(bool, const QString& text, QStringList& command, QStringList& hint, TChar format, QVector<int> luaReference = QVector<int>());

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1792,7 +1792,8 @@ void TConsole::print(const char* txt)
 // echoUserWindow(const QString& msg) was a redundant wrapper around this method:
 void TConsole::print(const QString& msg)
 {
-    buffer.append(msg, 0, msg.size(), mFormatCurrent.foreground(), mFormatCurrent.background(), mFormatCurrent.allDisplayAttributes());
+    const QString wrappedText = buffer.wrapText(msg);
+    buffer.append(wrappedText, 0, wrappedText.size(), mFormatCurrent.foreground(), mFormatCurrent.background(), mFormatCurrent.allDisplayAttributes());
     mUpperPane->showNewLines();
     mLowerPane->showNewLines();
 
@@ -1805,7 +1806,8 @@ void TConsole::print(const QString& msg)
 // same as this method it was just that the arguments were in a different order
 void TConsole::print(const QString& msg, const QColor fgColor, const QColor bgColor)
 {
-    buffer.append(msg, 0, msg.size(), fgColor, bgColor);
+    const QString wrappedText = buffer.wrapText(msg);
+    buffer.append(wrappedText, 0, wrappedText.size(), fgColor, bgColor);
     mUpperPane->showNewLines();
     mLowerPane->showNewLines();
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
* Added a `TBuffer::wrapText`. It takes a QString, and returns a wrapped and indented version of that QString.
* Modified both `TConsole::print` functions to wrap the message before calling `TBuffer::append`.

#### Motivation for adding to Mudlet
MiniConsole output was not being intented. The following script did not work as expected:
```lua
Geyser.MiniConsole:new({name = "indent-test"})
setWindowWrapIndent("indent-test", 10)
echo("indent-test", "This is the song that doesn't end, yes it goes on and on my friend, some people started singing it not knowing what it was, and they'll continue singing it forever just because this is the song that doesn't end...")
```
/claim #5936
fixes https://github.com/Mudlet/Mudlet/issues/5936
#### Other info (issues closed, discussion etc)
Fixed for MiniConsole:
![image](https://github.com/Mudlet/Mudlet/assets/147658676/38841017-1243-4fed-aa86-91cc5dd70e50)

Fixed for echo:
![image](https://github.com/Mudlet/Mudlet/assets/147658676/93b5ed64-b45d-44da-a0d5-7c282a323fec)
