### PR TITLE
Infrastructure: Update 7z to a later version

### DIFF
--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -177,9 +177,9 @@ function CheckAndInstall([string] $dependencyName, [string] $signalFile, [script
 # installation functions
 function InstallSevenZ() {
   if($64Bit){
-    $downloadUrl = "https://www.7-zip.org/a/7z1900-x64.exe"
+    $downloadUrl = "https://www.7-zip.org/a/7z2301-x64.exe"
   } else {
-    $downloadUrl = "https://www.7-zip.org/a/7z1900.exe"
+    $downloadUrl = "https://www.7-zip.org/a/7z2301.exe"
   }
   DownloadFile "$downloadUrl" "7z-installer.exe"
   Step "installing 7z"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- 7zip version used during compilation setup was 1900, is now 2301

#### Motivation for adding to Mudlet
- Hint from @SlySven those can be updated

#### Other info (issues closed, discussion etc)
- you can see all the improvements that have happened between 19.00 and 23.01 here:
https://www.7-zip.org/history.txt
