### PR TITLE
Improve: Change AdjustableContainer default look and feel

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -1063,12 +1063,11 @@ function Adjustable.Container:new(cons,container)
 
     me.adjLabelstyle = me.adjLabelstyle or [[
     background-color: rgba(0,0,0,100%);
-    border: 4px double green;
-    border-radius: 4px;]]
+    border: 2px groove white;]]
     me.menuStyleMode = "light"
     me.buttonstyle= me.buttonstyle or [[
-    QLabel{ border-radius: 7px; background-color: rgba(255,30,30,100%);}
-    QLabel::hover{ background-color: rgba(255,0,0,50%);}
+    QLabel{ border-color: rgba(255,255,255,100%); background-color: rgba(0,0,0,100%); }
+    QLabel::hover{ background-color: rgba(160,160,160,50%); }
     ]]
 
     me:createContainers()
@@ -1106,7 +1105,7 @@ function Adjustable.Container:new(cons,container)
     me.minimizeLabel:setClickCallback("Adjustable.Container.onClickMin", me)
     me.attLabel:setOnEnter("Adjustable.Container.onEnterAtt", me)
     me.goInside = true
-    me.titleTxtColor = me.titleTxtColor or "green"
+    me.titleTxtColor = me.titleTxtColor or "grey"
     me.titleText = me.titleText or me.name.." - Adjustable Container"
     me:setTitle()
     me.lockStyle = me.lockStyle or "standard"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Change AdjustableContainer default look and feel from green to grey to fit more in with the default look and feel of Mudlet overall.

Before;
![image](https://github.com/Mudlet/Mudlet/assets/136661366/5d5ab6b4-1826-4f42-bc00-089344a43237)

After;
![image](https://github.com/Mudlet/Mudlet/assets/136661366/05922ad0-42d2-4b72-92e9-7d068f961cc9)

#### Motivation for adding to Mudlet
To make the default look and feel more consistent.

To change back to the green look and feel of older versions use the following stylesheets for `adjLabelstyle` and `buttonstyle`, also change the `titleTxtColor` to `green`.  e.g.

```
Adjustable.Container:new ({ 
    adjLabelstyle = [[background-color: rgba(0,0,0,100%); 
      border: 4px double green;
      border-radius: 4px;]],
    buttonstyle = [[
    QLabel{ border-radius: 7px; background-color: rgba(255,30,30,100%);}
    QLabel::hover{ background-color: rgba(255,0,0,50%);}
    ]],
    titleTxtColor = "green"
})
```