### PR TITLE
Fix: Accept JSON int for Client.GUI.version

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2056,8 +2056,11 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
 
             auto versionJSON = json.value(qsl("version"));
 
-            if (versionJSON != QJsonValue::Undefined && !versionJSON.toString().isEmpty()) {
+            if (versionJSON != QJsonValue::Undefined && versionJSON.isString() && !versionJSON.toString().isEmpty()) {
                 version = versionJSON.toString();
+            } else if (versionJSON != QJsonValue::Undefined && versionJSON.toInt()) {
+                version = qsl("%1").arg(versionJSON.toInt());
+                qWarning() << "version" << version;
             } else {
                 return;
             }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2060,7 +2060,6 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
                 version = versionJSON.toString();
             } else if (versionJSON != QJsonValue::Undefined && versionJSON.toInt()) {
                 version = qsl("%1").arg(versionJSON.toInt());
-                qWarning() << "version" << version;
             } else {
                 return;
             }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Enable games to send an integer value for the `version` associated with the JSON for `Client.GUI`.
#### Motivation for adding to Mudlet
Resolve #7042 
#### Other info (issues closed, discussion etc)
Closes #7042

**Testing**
Same result for both of these. This is version being sent as int JSON.
<img width="1363" alt="Screenshot 2023-12-26 at 4 34 08 PM" src="https://github.com/Mudlet/Mudlet/assets/3058178/b85ad821-74a6-490c-85a7-878329e99b3b">
This is version being sent as string JSON.
<img width="1377" alt="Screenshot 2023-12-26 at 4 38 31 PM" src="https://github.com/Mudlet/Mudlet/assets/3058178/f6ea3b4f-4f03-43e1-9895-56312ff161ce">
