### PR TITLE
Fix: crash using cut

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1119,10 +1119,8 @@ void TConsole::scrollUp(int lines)
 
 void TConsole::deselect()
 {
-    P_begin.setX(0);
-    P_begin.setY(0);
-    P_end.setX(0);
-    P_end.setY(0);
+    P_begin = QPoint();
+    P_end = QPoint();
 }
 
 void TConsole::showEvent(QShowEvent* event)
@@ -1182,7 +1180,7 @@ void TConsole::insertLink(const QString& text, QStringList& func, QStringList& h
         return;
 
     } else {
-        if ((buffer.buffer.empty() && buffer.buffer[0].empty()) || mUserCursor == buffer.getEndPos()) {
+        if ((buffer.buffer.empty()) || mUserCursor == buffer.getEndPos()) {
             if (customFormat) {
                 buffer.addLink(mTriggerEngineMode, text, func, hint, mFormatCurrent, luaReference);
             } else {
@@ -1231,7 +1229,7 @@ void TConsole::insertText(const QString& text, QPoint P)
         }
 
     } else {
-        if ((buffer.buffer.empty() && buffer.buffer[0].empty()) || mUserCursor == buffer.getEndPos()) {
+        if ((buffer.buffer.empty()) || mUserCursor == buffer.getEndPos()) {
             buffer.append(text, 0, text.size(), mFormatCurrent);
             mUpperPane->showNewLines();
             mLowerPane->showNewLines();
@@ -1557,10 +1555,8 @@ bool TConsole::moveCursor(int x, int y)
 
 int TConsole::select(const QString& text, int numOfMatch)
 {
-    if (mUserCursor.y() < 0) {
-        return -1;
-    }
-    if (mUserCursor.y() >= buffer.size()) {
+    if (mUserCursor.y() < 0 || mUserCursor.y() >= buffer.size()) {
+        deselect();
         return -1;
     }
 
@@ -1579,19 +1575,18 @@ int TConsole::select(const QString& text, int numOfMatch)
         begin = li.indexOf(text, begin + 1);
 
         if (begin == -1) {
-            P_begin.setX(0);
-            P_begin.setY(0);
-            P_end.setX(0);
-            P_end.setY(0);
+            deselect();
             return -1;
         }
     }
+    if (begin < 0) {
+        deselect();
+        return -1;
+    }
 
     const int end = begin + text.size();
-    P_begin.setX(begin);
-    P_begin.setY(mUserCursor.y());
-    P_end.setX(end);
-    P_end.setY(mUserCursor.y());
+    P_begin = QPoint(begin, mUserCursor.y());
+    P_end = QPoint(end, mUserCursor.y());
 
     if (mudlet::smDebugMode) {
         TDebug(Qt::darkRed, Qt::black) << "P_begin(" << P_begin.x() << "/" << P_begin.y() << "), P_end(" << P_end.x() << "/" << P_end.y()
@@ -1616,10 +1611,8 @@ bool TConsole::selectSection(int from, int to)
     if (from > s || from + to > s) {
         return false;
     }
-    P_begin.setX(from);
-    P_begin.setY(mUserCursor.y());
-    P_end.setX(from + to);
-    P_end.setY(mUserCursor.y());
+    P_begin = QPoint(from, mUserCursor.y());
+    P_end = QPoint(from + to, mUserCursor.y());
 
     if (mudlet::smDebugMode) {
         TDebug(Qt::darkMagenta, Qt::black) << "P_begin(" << P_begin.x() << "/" << P_begin.y() << "), P_end(" << P_end.x() << "/" << P_end.y() << ") selectedText:\n\""


### PR DESCRIPTION
Actually it was being cause by a failure to reset `(QPoint) TConsole::P_begin` and `(QPoint) TConsole::P_end` - which are used to record the selection in the event that the `TBuffer` was empty or for some other reason the selection was not found when called from `selectString(...)` which uses `(int) TConsole::select(const QString, int)`.

There was also a Hindenbug lying in `TConsole::insertLink(...)` and `TConsole::insertText(...)` where if `buffer.buffer.empty()` was `true`, execution would then proceed to evaluate `buffer.buffer[0].empty()` which is undefined behaviour because there would not **be** a `buffer.buffer[0]`!

This should close #4634 - which I have reproduced in the current `development` branch code with the following function:
```lua
function testCut()

clearWindow()
feedTriggers("This is a test line.\n")
selectString(line, 1)
cut()

tempTimer(3, "feedTriggers(\"This is a second test line.\n\")")

tempTimer(6, "selectString(line, 1) cut()")

end
```

After the first time this is called, repeats will crash Mudlet when the 6 second delayed `selectString(line, 1) cut()` is called. One thing to note is that this code actually fails to follow the Wiki guidance for **[`selectString(...)`](https://wiki.mudlet.org/w/Manual:Lua_Functions#selectString)** which says "Note: To prevent working on random text if your selection didn't actually select anything, check the -1 return code before doing changes"!

/claim #4634