### PR TITLE
Add: means to compose raw data for Lua Telnet testing and new protocols

### DIFF
--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -285,6 +285,7 @@ public:
     static int sendTelnetChannel102(lua_State*);
     static int isPrompt(lua_State*);
     static int feedTriggers(lua_State*);
+    static int feedTelnet(lua_State*);
     static int Wait(lua_State*);
     static int expandAlias(lua_State*);
     static int sendRaw(lua_State*);
@@ -713,7 +714,6 @@ public slots:
     void slot_deleteSender(int, QProcess::ExitStatus);
 
 private:
-    bool callReference(lua_State*, QString name, int parameters);
     static bool getVerifiedBool(lua_State*, const char* functionName, const int pos, const char* publicName, const bool isOptional = false);
     static QString getVerifiedString(lua_State*, const char* functionName, const int pos, const char* publicName, const bool isOptional = false);
     static int getVerifiedInt(lua_State*, const char* functionName, const int pos, const char* publicName, const bool isOptional = false);
@@ -723,30 +723,15 @@ private:
     static void errorArgumentType(lua_State*, const char* functionName, const int pos, const char* publicName, const char* publicType, const bool isOptional = false);
     static int warnArgumentValue(lua_State*, const char* functionName, const QString& message, const bool useFalseInsteadofNil = false);
     static int warnArgumentValue(lua_State*, const char* functionName, const char* message, const bool useFalseInsteadofNil = false);
-    void logError(std::string& e, const QString&, const QString& function);
-    void logEventError(const QString& event, const QString& error);
     static int setLabelCallback(lua_State*, const QString& funcName);
     static int movieFunc(lua_State*, const QString& funcName);
-    std::pair<bool, QString> validLuaCode(const QString &code);
-    std::pair<bool, QString> validateLuaCodeParam(int index);
-    QByteArray encodeBytes(const char*);
-    void setMatches(lua_State*);
     static std::pair<bool, QString> discordApiEnabled(lua_State*, bool writeAccess = false);
-    void setupLanguageData();
-    QString readScriptFile(const QString& path) const;
     static void setRequestDefaults(const QUrl& url, QNetworkRequest& request);
     static int performHttpRequest(lua_State*, const char* functionName, const int pos, QNetworkAccessManager::Operation operation, const QString& verb);
-    void handleHttpOK(QNetworkReply*);
     static void raiseDownloadProgressEvent(lua_State*, QString, qint64, qint64);
-#if defined(Q_OS_WIN32)
-    void loadUtf8Filenames();
-#endif
-    void insertColorTableEntry(lua_State*, const QColor&, const QString&);
     // The last argument is only needed if the third one is true:
     static void generateElapsedTimeTable(lua_State*, const QStringList&, const bool, const qint64 elapsedTimeMilliSeconds = 0);
     static std::tuple<bool, int> getWatchId(lua_State*, Host&);
-    bool loadLuaModule(QQueue<QString>& resultMsgQueue, const QString& requirement, const QString& failureConsequence = QString(), const QString& description = QString(), const QString& luaModuleId = QString());
-    void insertNativeSeparatorsFunction(lua_State*);
     static void pushMapLabelPropertiesToLua(lua_State*, const TMapLabel& label);
     static std::pair<int, TAction*> getTActionFromIdOrName(lua_State*, const int, const char*);
     static int loadMediaFileAsOrderedArguments(lua_State*);
@@ -762,11 +747,33 @@ private:
     static void parseCommandOrFunction(lua_State*, const char*, int&, QString&, int&);
     static void parseCommandsOrFunctionsTable(lua_State*, const char*, int&, QStringList&, QVector<int>&);
     static void parseHintsTable(lua_State*, const char*, int&, QStringList&);
+    static QByteArray parseTelnetCodes(const QByteArray&);
+
+    bool callReference(lua_State*, QString name, int parameters);
+    void logError(std::string& e, const QString&, const QString& function);
+    void logEventError(const QString& event, const QString& error);
+    std::pair<bool, QString> validLuaCode(const QString &code);
+    std::pair<bool, QString> validateLuaCodeParam(int index);
+    QByteArray encodeBytes(const char*);
+    void setMatches(lua_State*);
+    void setupLanguageData();
+    QString readScriptFile(const QString& path) const;
+    void handleHttpOK(QNetworkReply*);
+#if defined(Q_OS_WIN32)
+    void loadUtf8Filenames();
+#endif
+
+    void insertColorTableEntry(lua_State*, const QColor&, const QString&);
     struct lua_state_deleter {
         void operator()(lua_State* ptr) const noexcept {
             lua_close(ptr);
         }
     };
+
+
+    bool loadLuaModule(QQueue<QString>& resultMsgQueue, const QString& requirement, const QString& failureConsequence = QString(), const QString& description = QString(), const QString& luaModuleId = QString());
+    void insertNativeSeparatorsFunction(lua_State*);
+
 
     const int LUA_FUNCTION_MAX_ARGS = 50;
     std::list<std::string> mCaptureGroupList;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2938,7 +2938,7 @@ void cTelnet::slot_socketReadyToBeRead()
     processSocketData(in_buffer, amount);
 }
 
-void cTelnet::processSocketData(char* in_buffer, int amount)
+void cTelnet::processSocketData(char* in_buffer, int amount, const bool loopbackTesting)
 {
     // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (3 of 7) - investigate switching from using `char[]` to `std::array<char>`
     char out_buffer[BUFFER_SIZE + 10];
@@ -2962,7 +2962,7 @@ void cTelnet::processSocketData(char* in_buffer, int amount)
         }
         // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (4 of 7) - investigate switching from using `char[]` to `std::array<char>`
         buffer[static_cast<size_t>(datalen)] = '\0';
-        if (mpHost->mpConsole->mRecordReplay) {
+        if (!loopbackTesting && mpHost->mpConsole->mRecordReplay) {
             ++mRecordingChunkCount;
             // QElapsedTimer::elapsed() returns a qint64, it replaces a
             // previous QTime::elapsed() which returns a int (effectively a

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -211,6 +211,7 @@ public:
     std::tuple<QString, int, bool> getConnectionInfo() const;
     void setPostingTimeout(const int);
     int getPostingTimeout() const { return mTimeOut; }
+    void loopbackTest(QByteArray& data) { processSocketData(data.data(), data.size(), true); }
 
 
     QMap<int, bool> supportedTelnetOptions;
@@ -253,7 +254,9 @@ signals:
 private:
     cTelnet() = default;
 
-    void processSocketData(char *data, int size);
+    // loopbackTesting is for internal testing whilst OFF-LINE using the
+    // feedTelnet(...) Lua function.
+    void processSocketData(char *data, int size, const bool loopbackTesting = false);
     void initStreamDecompressor();
     int decompressBuffer(char*& in_buffer, int& length, char* out_buffer);
     void reset();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR modifies the Lua API function `sendSocket(...)` and adds a new function `feedTelnet(...)` so that there are means to create and issue data containing the ASCII NULL byte value, and also adds a means to insert other bytes that are useful when creating tests/protocol handlers for Telnet sub-options.

#### Motivation for adding to Mudlet
The current implementation of `sendSocket(...)` and `feedTriggers(...)` are not able to insert ASCII NULL characters into their data as it immediately terminates the C-string that contains it. Furthermore the latter does not insert its data into the "processing" early enough to enable testing of the Telnet protocol/sub-option handling.

#### Other info (issues closed, discussion etc)
I discovered the need for something like this when I was reviewing #7058 and found that, even with the `\###` way (where ### is a three digit number between `000` and `255`) of including unprintable characters it was not possible to embed the `000` value as it gets converted into the ASCII NULL character that terminates a "C" type string. Whilst constructing a way to get around that - by using "tags" enclosed in `<`...`>` to represent particular byte value I realised it would be useful to include tags for all the ASCII control characters and also the Telnet control codes (with a `T_`) prefix and also some ones (with a `O_` the letter O prefix) representing some common or potentially useful Telnet sub-options - some of which Mudlet supports already as well as some that might be done in the future. The latter is important because without this capability it would not be possible to generate required data streams in an add-on Lua package to send to a MUD Game Server.

So that the table of tags used can be identified in the future calling `feedTelnet("")` i.e. with an empty string, will obviously not generate anything to send to the internal Mudlet telnet protocol handler, but will prompt a simple version number stored in that function to be returned as a second argument to the Lua caller.

This PR also adds a return value to `sendSocket(...)` which will return true or false depending on whether it was actually possible to send the data "up the socket" - which we had been determining but not returning in the past. Also worth noting is that - to prevent confusing the internal Telnet processing - `feedTelnet(...)` will refuse to send the generated data into there unless the socket that would be also producing data to go in is in an unconnected state - i.e. that the profile is loaded but not connecting or connected to the Game Server.