### PR TITLE
Fix: Error if db does not match safe name, allow numbers in db names

### DIFF
--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -381,7 +381,7 @@ end
 --   "mydatabase", and "../../../../etc/passwd" becomes "etcpasswd". This prevents any possible
 --   security issues with database names.
 function db:safe_name(name)
-  name = name:gsub("[^%ad]", "")
+  name = name:gsub("[^%a%d]", "")
   name = name:lower()
   return name
 end
@@ -440,6 +440,8 @@ function db:create(db_name, sheets, force)
   if not db.__env or db.__env == 'SQLite3 environment (closed)' then
     db.__env = luasql.sqlite3()
   end
+
+  assert(db_name == db:safe_name(db_name), "Santized name does not match argument.  Check you are using the correct database.")
 
   db_name = db:safe_name(db_name)
 

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -3,7 +3,7 @@ describe("Tests DB.lua functions", function()
   describe("Tests that DB creation and deletion works", function()
     describe("Test the functionality of db:create", function()
       it("Should create a db", function()
-        mydb = db:create("peoplet_testingonly", {
+        mydb = db:create("peoplettestingonly", {
           friends={"name", "city", "notes"},
           enemies={
             name="",
@@ -26,7 +26,7 @@ describe("Tests DB.lua functions", function()
     end)
 
     it("Should recreate a DB", function()
-      mydb = db:create("peoplet_testingonly", {
+      mydb = db:create("peoplettestingonly", {
         friends={"name", "city", "notes"},
         enemies={
           name="",
@@ -46,7 +46,7 @@ describe("Tests DB.lua functions", function()
     end)
 
     it("Should create and add a row", function()
-      mydb = db:create("peoplet_testingonly", {
+      mydb = db:create("peoplettestingonly", {
         friends={"name", "city", "notes"},
         enemies={
           name="",
@@ -75,7 +75,7 @@ describe("Tests DB.lua functions", function()
 
   describe("Tests basic db:create() and db:add()", function()
     before_each(function()
-      mydb = db:create("peoplet_testingonly", {
+      mydb = db:create("peoplettestingonly", {
         friends={"name", "city", "notes"},
         enemies={
           name="",
@@ -137,7 +137,7 @@ describe("Tests DB.lua functions", function()
 
   describe("Tests db:fetch()'s sorting functionality", function()
     before_each(function()
-      mydb = db:create("dslpnp_datat_testingonly", {
+      mydb = db:create("dslpnpdatattestingonly", {
         people = {
           name = "",
           race = "",
@@ -183,7 +183,7 @@ describe("Tests DB.lua functions", function()
 
   describe("Tests db:create() ability to add a new row to an existing database", function()
     before_each(function()
-      mydb = db:create("mydbt_testingonly", {
+      mydb = db:create("mydbttestingonly", {
         sheet = {
           row1 = "",
           row2 = 0,
@@ -241,7 +241,7 @@ describe("Tests DB.lua functions", function()
         _violations = "REPLACE"
       }
 
-      mydb = db:create("mydbt_testingonly", { sheet = newschema })
+      mydb = db:create("mydbttestingonly", { sheet = newschema })
       assert.are.same(db.__schema.mydbttestingonly.sheet.columns, newschema)
       local newrow = db:fetch(mydb.sheet)[1]
       assert.are.same("some data", newrow.row1)
@@ -253,7 +253,7 @@ describe("Tests DB.lua functions", function()
   function()
 
     before_each(function()
-      mydb = db:create("mydbt_testingonly",
+      mydb = db:create("mydbttestingonly",
         {
           sheet = {
             name = "", id = 0,
@@ -341,7 +341,7 @@ describe("Tests DB.lua functions", function()
   function()
 
     before_each(function()
-      mydb = db:create("mydbt_testingonly",
+      mydb = db:create("mydbttestingonly",
         {
           sheet = {
             name = "", id = 0, blubb = "",
@@ -362,7 +362,7 @@ describe("Tests DB.lua functions", function()
 
     it("should successfully delete columns in an empty table.",
     function()
-      mydb = db:create("mydbt_testingonly", { sheet = { name = "", id = 0 }})
+      mydb = db:create("mydbttestingonly", { sheet = { name = "", id = 0 }})
       local test = { name = "foo", id = 500 }
       db:add(mydb.sheet, test)
       local res = db:fetch(mydb.sheet)
@@ -375,7 +375,7 @@ describe("Tests DB.lua functions", function()
     function()
       local test = { name = "foo", id = 500, blubb = "bar" }
       db:add(mydb.sheet, test)
-      mydb = db:create("mydbt_testingonly", { sheet = { name = "", id = 0 }}, true)
+      mydb = db:create("mydbttestingonly", { sheet = { name = "", id = 0 }}, true)
       local res = db:fetch(mydb.sheet)
       test.blubb = nil -- we expect the blubb gets deleted
       assert.are.equal(1, #res)
@@ -387,14 +387,14 @@ describe("Tests DB.lua functions", function()
     function()
       local test = { name = "foo", id = 500, blubb = "bar" }
       db:add(mydb.sheet, test)
-      assert.has_error(function() db:create("mydbt_testingonly", { sheet = { name = "", id = 0 }}) end)
+      assert.has_error(function() db:create("mydbttestingonly", { sheet = { name = "", id = 0 }}) end)
     end)
 
     it("should successfully delete empty columns in a non empty table",
     function()
       local test = { name = "foo", id = 500, blubb = db:Null() }
       db:add(mydb.sheet, test)
-      mydb = db:create("mydbt_testingonly", { sheet = { name = "", id = 0 }}, true)
+      mydb = db:create("mydbttestingonly", { sheet = { name = "", id = 0 }}, true)
       local res = db:fetch(mydb.sheet)
       test.blubb = nil -- we expect the blubb gets deleted
       assert.are.equal(1, #res)
@@ -408,7 +408,7 @@ describe("Tests DB.lua functions", function()
   function()
 
     before_each(function()
-      mydb = db:create("mydbt_testingonly",
+      mydb = db:create("mydbttestingonly",
         {
           sheet = {
             name = "", id = 0, city = "",
@@ -609,7 +609,7 @@ describe("Tests DB.lua functions", function()
   function()
 
     before_each(function()
-      mydb = db:create("mydbt_testingonly",
+      mydb = db:create("mydbttestingonly",
         {
           sheet = {
             name = "", count = 0,
@@ -911,7 +911,7 @@ describe("Tests DB.lua functions", function()
   describe("Tests, if NULL handling works as intended",
   function()
     before_each(function()
-      mydb = db:create("mydbt_nulltesting",
+      mydb = db:create("mydbtnulltesting",
         {
           sheet = {
             name = "",
@@ -980,7 +980,7 @@ describe("Tests DB.lua functions", function()
 
     it("should be able to create a table with default NULL",
     function()
-      mydb = db:create("mydbt_nulltesting",
+      mydb = db:create("mydbtnulltesting",
       {
         sheet = {
           name = "",
@@ -1004,7 +1004,7 @@ describe("Tests DB.lua functions", function()
 
     it("should be able to add a column with default NULL to a table",
     function()
-      mydb = db:create("mydbt_nulltesting",
+      mydb = db:create("mydbtnulltesting",
       {
         sheet = {
           name = "",
@@ -1013,7 +1013,7 @@ describe("Tests DB.lua functions", function()
         }
       })
 
-      mydb = db:create("mydbt_nulltesting",
+      mydb = db:create("mydbtnulltesting",
       {
         sheet = {
           name = "",

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -211,7 +211,7 @@ describe("Tests DB.lua functions", function()
         _violations = "REPLACE"
       }
 
-      mydb = db:create("mydbt_testingonly", { sheet = newschema })
+      mydb = db:create("mydbttestingonly", { sheet = newschema })
       assert.are.same(db.__schema.mydbttestingonly.sheet.columns, newschema)
     end)
 
@@ -225,7 +225,7 @@ describe("Tests DB.lua functions", function()
         _violations = "REPLACE"
       }
 
-      mydb = db:create("mydbt_testingonly", { sheet = newschema })
+      mydb = db:create("mydbttestingonly", { sheet = newschema })
       assert.are.same(db.__schema.mydbttestingonly.sheet.columns, newschema)
     end)
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- display error if create(db_name) doesn't match exactly what user entered
- fix regex to allow numbers in DB filenames

#### Other info (issues closed, discussion etc)
Fixes #7009