### PR TITLE
Improve: Update error message in db:create()

### DIFF
--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -441,7 +441,7 @@ function db:create(db_name, sheets, force)
     db.__env = luasql.sqlite3()
   end
 
-  assert(db_name == db:safe_name(db_name), "Santized name does not match argument.  Check you are using the correct database.")
+  assert(db_name == db:safe_name(db_name), "Database name contains illegal characters.  Only alphanumeric characters are valid.  Database not created or loaded.")
 
   db_name = db:safe_name(db_name)
 


### PR DESCRIPTION
Change error message when safe_name check fails.

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Error message in db:create()

#### Motivation for adding to Mudlet
More user friendly and descriptive.

#### Other info (issues closed, discussion etc)
#7069