### PR TITLE
Infrastructure: Stop Linux PTB being empty

### DIFF
--- a/mudlet.desktop
+++ b/mudlet.desktop
@@ -6,6 +6,6 @@ Comment=Play online text-based games (MUDs)
 Exec=mudlet %f
 Terminal=false
 Type=Application
-MimeType=application/zip
+MimeType=application/zip;
 Icon=mudlet
 Categories=Game;AdventureGame;RolePlaying;ActionGame;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Make MimeType a list by adding a semicolon after, just like Categories have as well

#### Motivation for adding to Mudlet
Fix #7084 maybe

#### Other info (issues closed, discussion etc)
In Linux compilation logs on Github Actions, one error message moaned about MimeType not being a list.