### PR TITLE
Infrastructure: install mudlet.desktop on Linux platforms

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -636,6 +636,11 @@ if(UNIX AND NOT APPLE)
     DESTINATION "share/mudlet/lua"
     PATTERN ".git" EXCLUDE PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ
                                        WORLD_READ)
+   install(
+    FILES "../mudlet.desktop"
+    DESTINATION "share/applications" PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ
+      WORLD_READ)
+
   install(
     TARGETS mudlet
     RUNTIME


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Install mudlet.desktop into a standard system location.
#### Motivation for adding to Mudlet
Maybe this'll make the system shortcut up when using flatpak to install Mudlet.
#### Other info (issues closed, discussion etc)
I tried doing this as part of https://github.com/Mudlet/Mudlet/pull/6494, but for some reason my changes to the cmake files aren't being picked up, which is concerning. Trying this again as a separate PR that I'll merge back to the flatpak branch.