### PR TITLE
Fix: Building on MacOS without the updater

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -562,8 +562,10 @@ if(WIN32)
 endif()
 
 if(APPLE)
+  target_link_libraries(mudlet "-framework AppKit")
+
   if(USE_UPDATER)
-    target_link_libraries(mudlet cocoa-qt-glue "-framework AppKit")
+    target_link_libraries(mudlet cocoa-qt-glue)
   endif(USE_UPDATER)
 
   set_target_properties(mudlet PROPERTIES


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Include `target_link_libraries(mudlet "-framework AppKit")` on darwin when USE_UPDATER is false.

This is required because AppKit is not only used for the updater, but also for accessibility features, like in https://github.com/Mudlet/Mudlet/blob/3bd76f24c81226338290e3295ff4833083b8bfd3/src/AnnouncerMac.mm

When building with USE_UPDATER=false, everything compiles, but results in a linking error.

#### Motivation for adding to Mudlet

Mudlet is already packaged in nixpkgs on linux, and I am fixing the build on MacOS as well.
Nix builds packages somewhat isolated from the environment, and all dependencies have to be specified to be included.
We also build the program without the updater so the user can keep using the package built by nix, which is read-only and reproducible.
This revealed that AppKit is missing when building without the updater, as the entire compilation/build works just fine until the very last step, where we get a linking error because we do not have AppKit.

#### Other info (issues closed, discussion etc)

Built on MacOS Sonoma 14.0 on arm64, builds successfully with the patch applied here: https://github.com/NixOS/nixpkgs/pull/281657
