### PR TITLE
Infrastructure: switch from custom to standard action for cache saving

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -240,11 +240,12 @@ jobs:
          echo "WITH_FONTS=no" >> $GITHUB_ENV
 
     - name: (Linux/macOS) restore ccache
-      uses: pat-s/always-upload-cache@v3.0.11
+      uses: actions/cache@v4
       with:
         path: ${{runner.workspace}}/ccache
         key: ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.qt}}-${{ github.sha }}
         restore-keys: ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.qt}}
+        save-always: true
       if: matrix.os != 'windows-latest'
 
     - name: (Linux) Set build info


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Switch from custom to standard action for always saving cache
#### Motivation for adding to Mudlet
Actions provided by Github should be better supported.
#### Other info (issues closed, discussion etc)
We had to use a 3rd party action for saving cache since the standard one didn't support this behaviour previously.