### PR TITLE
Fix: Remove version from terminal type

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2521,15 +2521,15 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
 
                     switch (mCycleCountMTTS) {
                         case 0: {
-                            const QString clientNameAndVersion = qsl("%1-%2").arg(getNewEnvironClientName(), getNewEnvironClientVersion());
-                            cmd += clientNameAndVersion.toStdString(); // Example: MUDLET-4/17/2-DEV
+                            const QString clientName = getNewEnvironClientName();
+                            cmd += clientName.toStdString();
 
                             if (mpHost->mEnableMTTS) { // If we don't MTTS, remainder of the cases do not execute.
                                 mCycleCountMTTS++;
                                 qDebug() << "MTTS enabled";
-                                qDebug() << "WE send TERMINAL_TYPE (MTTS) terminal type is" << clientNameAndVersion;
+                                qDebug() << "WE send TERMINAL_TYPE (MTTS) terminal type is" << clientName;
                             } else {
-                                qDebug() << "WE send TERMINAL_TYPE is" << clientNameAndVersion;
+                                qDebug() << "WE send TERMINAL_TYPE is" << clientName;
                             }
 
                             break;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
To simplify and increase standardization, this pull request updates the display of the initial return of Telnet's TTYPE Option enabling Mudlet to respond with `MUDLET` on the first call to TTYPE.

Prior versions of Mudlet reported TTYPE as `Mudlet 4.17.2`. During our enhancements for MTTS and NEW-ENVIRON, it was noted by @SlySven that per [RFC 1010](https://tools.ietf.org/html/rfc1010) and this more [modern reference](https://www.iana.org/assignments/terminal-type-names/terminal-type-names.xhtml#terminal-type-names-1), TTYPE should be uppercase, and otherwise only contain digits, `-`, and `/`. This results in `MUDLET-4/17/2`. While meeting the RFC, there was at least one game, Avalon.de, noted in #4066, that has breaking changes associated with this format update.

Research shows other game clients are not sharing the client _version_ via TTYPE (i.e., `CMUD`, `TINTIN++`, `mushclient`, `Beip`, `XTERM`). If a game is interested in the version, this may be obtained from negotiating NEW-ENVIRON via the `CLIENT_VERSION` variable.

It is a good time to standardize given the additions of MTTS and NEW-ENVIRON coming soon for the release. If games need to make updates, let's keep it simple and present `MUDLET` as the TTYPE, which is RFC compliant, and similar to the other clients, and enable those interested in the version to negotiate NEW-ENVIRON and go get it.

#### Motivation for adding to Mudlet
Standardization, simplifying.

#### Other info (issues closed, discussion etc)
Author: Tamarindo@StickMUD