### PR TITLE
Fix: Local variable stored in non-local memory for instanceCoordinator

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -398,15 +398,15 @@ int main(int argc, char* argv[])
     // 1. This current process will start as normal.
     // 2. The package will be queued for install until a profile is selected.
 
-    MudletInstanceCoordinator instanceCoordinator("MudletInstanceCoordinator");
-    const bool firstInstanceOfMudlet = instanceCoordinator.tryToStart();
+    std::unique_ptr<MudletInstanceCoordinator> instanceCoordinator = std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator");
+    const bool firstInstanceOfMudlet = instanceCoordinator->tryToStart();
 
     const QStringList positionalArguments = parser.positionalArguments();
     if (!positionalArguments.isEmpty()) {
         const QString absPath = QDir(positionalArguments.first()).absolutePath();
-        instanceCoordinator.queuePackage(absPath);
+        instanceCoordinator->queuePackage(absPath);
         if (!firstInstanceOfMudlet) {
-            const bool successful = instanceCoordinator.installPackagesRemotely();
+            const bool successful = instanceCoordinator->installPackagesRemotely();
             if (successful) {
                 return 0;
             } else {
@@ -625,7 +625,7 @@ int main(int argc, char* argv[])
 #endif
 
     // Pass ownership of MudletInstanceCoordinator to mudlet.
-    mudlet::self()->registerInstanceCoordinator(&instanceCoordinator);
+    mudlet::self()->takeOwnershipOfInstanceCoordinator(std::move(instanceCoordinator));
 
     // Handle "QEvent::FileOpen" events.
     FileOpenHandler fileOpenHandler;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -85,6 +85,7 @@
 #include <QToolTip>
 #include <QVariantHash>
 #include <QRandomGenerator>
+#include <memory>
 #include <zip.h>
 #include <QStyle>
 #if defined(Q_OS_WIN32)
@@ -4747,14 +4748,14 @@ void mudlet::activateProfile(Host* pHost)
     mInstanceCoordinator->installPackagesToHost(mpCurrentActiveHost);
 }
 
-void mudlet::registerInstanceCoordinator(MudletInstanceCoordinator* instanceCoordinator)
+void mudlet::takeOwnershipOfInstanceCoordinator(std::unique_ptr<MudletInstanceCoordinator> instanceCoordinator)
 {
-    mInstanceCoordinator = instanceCoordinator;
+    mInstanceCoordinator = std::move(instanceCoordinator);
 }
 
 MudletInstanceCoordinator* mudlet::getInstanceCoordinator()
 {
-    return mInstanceCoordinator;
+    return mInstanceCoordinator.get();
 }
 void mudlet::setGlobalStyleSheet(const QString& styleSheet)
 {

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -34,6 +34,7 @@
 #include "ShortcutsManager.h"
 #include "TMediaData.h"
 #include "utils.h"
+#include <memory>
 
 #if defined(INCLUDE_UPDATER)
 #include "updater.h"
@@ -307,7 +308,7 @@ public:
 
 
     void activateProfile(Host*);
-    void registerInstanceCoordinator(MudletInstanceCoordinator*);
+    void takeOwnershipOfInstanceCoordinator(std::unique_ptr<MudletInstanceCoordinator>);
     MudletInstanceCoordinator* getInstanceCoordinator();
     void addConsoleForNewHost(Host*);
     QPair<bool, bool> addWordToSet(const QString&);
@@ -478,7 +479,7 @@ public:
     QSystemTrayIcon mTrayIcon;
     bool mUsingMudletDictionaries = false;
     bool mWindowMinimized = false;
-    MudletInstanceCoordinator* mInstanceCoordinator;
+    std::unique_ptr<MudletInstanceCoordinator> mInstanceCoordinator;
     // How many graphemes do we need before we run the spell checker on a "word" in the command line:
     int mMinLengthForSpellCheck = 3;
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
- Replaced `Mudlet::registerInstanceCoordinator` with `Mudlet::takeOwnershipOfInstanceCoordinator`.
- Used unique_ptr and std::move() to transfer ownership rather than passing a raw pointer of `MudletInstanceCoordinator`.

#### Motivation for adding to Mudlet
CodeQL warning
![image](https://github.com/Mudlet/Mudlet/assets/147658676/3344899f-d24c-4cd7-8cf7-dfac8d180d53)
https://github.com/Mudlet/Mudlet/pull/7065#issuecomment-1907554354
#### Other info (issues closed, discussion etc)
