### PR TITLE
Infrastucture: fix osx compilation with Qt 6

### DIFF
--- a/CI/travis.osx.install.sh
+++ b/CI/travis.osx.install.sh
@@ -58,4 +58,4 @@ gem update cocoapods
 # we want to expand the subshell only once (it's only temporary anyways)
 # shellcheck disable=2139
 alias luarocks-5.1="luarocks --lua-dir='$(brew --prefix lua@5.1)'"
-luarocks-5.1 --local install lua-yajl
+LIBRARY_PATH=/opt/homebrew/Cellar/yajl/2.1.0/lib C_INCLUDE_PATH=/opt/homebrew/Cellar/yajl/2.1.0/include luarocks-5.1 --local install lua-yajl

--- a/CI/travis.osx.install.sh
+++ b/CI/travis.osx.install.sh
@@ -38,9 +38,7 @@ for i in $BREWS; do
   for RETRIES in $(seq 1 3); do
     echo " "
     echo "Installing ${i}"
-    #Added the -w (whole-word) option so that the grep will NOT match for pcre2
-    #when we are considering pcre:
-    brew list | grep -w -q $i || brew install $i
+    brew install "$i"
     STATUS="$?"
     if [ "${STATUS}" -eq 0 ]; then
       break

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,8 @@ cmake_minimum_required(VERSION 3.3)
 if(APPLE)
   # needed for fetching Sparkle
   cmake_minimum_required(VERSION 3.18)
-  # minimum supported version by Apple
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE STRING "")
+  # minimum supported version by Qt6 for our Qt5/Qt6 build compatibility
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "")
 endif()
 
 if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/vcpkg/scripts/buildsystems/vcpkg.cmake)

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2284,7 +2284,7 @@ QString TBuffer::wrapText(const QString& text) const
         if (nextLineBreak < wrapWindowEnd) {
             curIndent = 0;
             const qsizetype lineWidth = nextLineBreak - curLineStart + 1;
-            wrappedText += text.midRef(curLineStart, lineWidth);
+            wrappedText += text.mid(curLineStart, lineWidth);
             curLineStart = nextLineBreak;
             continue;
         }
@@ -2302,7 +2302,7 @@ QString TBuffer::wrapText(const QString& text) const
 
         // Move start point forward, set indention level
         const qsizetype lineWidth = safeLineEnd - curLineStart;
-        wrappedText += text.midRef(curLineStart, lineWidth);
+        wrappedText += text.mid(curLineStart, lineWidth);
         curIndent = mWrapIndent;
         curLineStart = safeLineEnd - 1;
 
@@ -2313,6 +2313,7 @@ QString TBuffer::wrapText(const QString& text) const
     }
     return wrappedText;
 }
+
 
 void TBuffer::append(const QString& text, int sub_start, int sub_end, const QColor& fgColor, const QColor& bgColor, TChar::AttributeFlags flags, int linkID)
 {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
These changes will enable Mudlet to build with Qt 6 on macOS. When pulling, do `git pull --recurse-submodules` to ensure the submodule update comes through.
#### Motivation for adding to Mudlet
Road towards Qt 6.
#### Other info (issues closed, discussion etc)
