### PR TITLE
Add compare function for comparing tables (and other things)

### DIFF
--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -562,6 +562,10 @@ function _comp(a, b)
   return true
 end
 
+--- exposes _comp as compare as it's a global, has been for years, and is also
+--- extremely useful. But documenting it as _comp is inconsistent with the rest
+--- of the API
+compare = _comp
 
 
 --- <b><u>TODO</u></b> phpTable(...) - abuse to: http://richard.warburton.it


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
This makes the `_comp` function available as `compare` which is a much more API and documentation friendly name.

#### Motivation for adding to Mudlet
 I believe it was not originally intended to be exposed, hence the `_` at the front of the name, but it's been a global and used by those in the know for a while, and is honestly the best way to compare two values of unknown type, especially if you want to compare two tables by their values rather than their memory reference.
This keeps coming up on Discord, finally happened enough times close enough to each other to spur me to immediate action.

#### Other info (issues closed, discussion etc)

```
REPLet:> compare({}, 2)
---- OUTPUT ----
false

REPLet:> compare({}, {})
---- OUTPUT ----
true

REPLet:> compare(2,2)
---- OUTPUT ----
true
```