### PR TITLE
Fix a crash when double-clicking on a word to select it

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1109,14 +1109,14 @@ void TTextEdit::expandSelectionToWords()
     if (yind >= 0 && yind < static_cast<int>(mpBuffer->lineBuffer.size())) {
         for (; xind >= 0; --xind) {
             // Ensure xind is within the valid range for the current line
-            if not (xind < static_cast<int>(mpBuffer->lineBuffer.at(yind).size())) {
+            if (xind < static_cast<int>(mpBuffer->lineBuffer.at(yind).size())) {
+                const QChar currentChar = mpBuffer->lineBuffer.at(yind).at(xind);
+                if (currentChar == QChar::Space
+                    || mpHost->mDoubleClickIgnore.contains(currentChar)) {
+                    break;
+                }
+            } else {
                 break; // xind is out of bounds, break the loop
-            }
-            
-            const QChar currentChar = mpBuffer->lineBuffer.at(yind).at(xind);
-            if (currentChar == QChar::Space
-                || mpHost->mDoubleClickIgnore.contains(currentChar)) {
-                break;
             }
         }
     }

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1109,14 +1109,14 @@ void TTextEdit::expandSelectionToWords()
     if (yind >= 0 && yind < static_cast<int>(mpBuffer->lineBuffer.size())) {
         for (; xind >= 0; --xind) {
             // Ensure xind is within the valid range for the current line
-            if (xind < static_cast<int>(mpBuffer->lineBuffer.at(yind).size())) {
-                const QChar currentChar = mpBuffer->lineBuffer.at(yind).at(xind);
-                if (currentChar == QChar::Space
-                    || mpHost->mDoubleClickIgnore.contains(currentChar)) {
-                    break;
-                }
-            } else {
+            if not (xind < static_cast<int>(mpBuffer->lineBuffer.at(yind).size())) {
                 break; // xind is out of bounds, break the loop
+            }
+            
+            const QChar currentChar = mpBuffer->lineBuffer.at(yind).at(xind);
+            if (currentChar == QChar::Space
+                || mpHost->mDoubleClickIgnore.contains(currentChar)) {
+                break;
             }
         }
     }

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1104,10 +1104,20 @@ void TTextEdit::expandSelectionToWords()
 {
     int yind = mPA.y();
     int xind = mPA.x();
-    for (; xind >= 0; --xind) {
-        if (mpBuffer->lineBuffer.at(yind).at(xind) == QChar::Space
-            || mpHost->mDoubleClickIgnore.contains(mpBuffer->lineBuffer.at(yind).at(xind))) {
-            break;
+
+    // Check if yind is within the valid range of lineBuffer
+    if (yind >= 0 && yind < static_cast<int>(mpBuffer->lineBuffer.size())) {
+        for (; xind >= 0; --xind) {
+            // Ensure xind is within the valid range for the current line
+            if (xind < static_cast<int>(mpBuffer->lineBuffer.at(yind).size())) {
+                const QChar currentChar = mpBuffer->lineBuffer.at(yind).at(xind);
+                if (currentChar == QChar::Space
+                    || mpHost->mDoubleClickIgnore.contains(currentChar)) {
+                    break;
+                }
+            } else {
+                break; // xind is out of bounds, break the loop
+            }
         }
     }
     mDragStart.setX(xind + 1);
@@ -1115,15 +1125,23 @@ void TTextEdit::expandSelectionToWords()
 
     yind = mPB.y();
     xind = mPB.x();
-    for (; xind < static_cast<int>(mpBuffer->lineBuffer.at(yind).size()); ++xind) {
-        if (mpBuffer->lineBuffer.at(yind).at(xind) == QChar::Space
-            || mpHost->mDoubleClickIgnore.contains(mpBuffer->lineBuffer.at(yind).at(xind))) {
-            break;
+
+    // Repeat the check for yind and xind for the second part
+    if (yind >= 0 && yind < static_cast<int>(mpBuffer->lineBuffer.size())) {
+        for (; xind < static_cast<int>(mpBuffer->lineBuffer.at(yind).size()); ++xind) {
+            const QChar currentChar = mpBuffer->lineBuffer.at(yind).at(xind);
+            if (currentChar == QChar::Space
+                || mpHost->mDoubleClickIgnore.contains(currentChar)) {
+                break;
+            }
+        } else {
+            break; // xind is out of bounds, break the loop
         }
     }
     mDragSelectionEnd.setX(xind - 1);
     mPB.setX(xind - 1);
 }
+
 
 void TTextEdit::expandSelectionToLine(int y)
 {

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1134,13 +1134,12 @@ void TTextEdit::expandSelectionToWords()
                 || mpHost->mDoubleClickIgnore.contains(currentChar)) {
                 break;
             }
-        } else {
-            break; // xind is out of bounds, break the loop
         }
     }
     mDragSelectionEnd.setX(xind - 1);
     mPB.setX(xind - 1);
 }
+
 
 
 void TTextEdit::expandSelectionToLine(int y)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix a crash as shown by the stacktrace https://pastebin.com/GHbzFZNs
#### Motivation for adding to Mudlet
Bugfix
#### Other info (issues closed, discussion etc)
Fix written with the help of chatgpt, here is the conversation for anyone else who'd like to copy this: https://chat.openai.com/share/cf97d3d8-e419-4878-9a2b-87409195340a