### PR TITLE
Fix incorrect allocation error handling in a few files

### DIFF
--- a/src/TEncodingTable.cpp
+++ b/src/TEncodingTable.cpp
@@ -43,7 +43,7 @@ QList<QByteArray> TEncodingTable::getEncodingNames() const
                 if (encoding == "CP437") {
                     // Okay to insert our replacement TTextCodex_XXXX into the
                     // system we must instantiate them once:
-                    auto* pTTextCodec_437 = new TTextCodec_437();
+                    auto* pTTextCodec_437 = new (std::nothrow) TTextCodec_437();
                     // Now that it has been instantiated, the system knows about
                     // it - indeed it takes possession of it and we must NOT
                     // delete it ourselves!
@@ -51,17 +51,17 @@ QList<QByteArray> TEncodingTable::getEncodingNames() const
                         itEncoding.insert(pTTextCodec_437->name());
                     }
                 } else if (encoding == "CP667") {
-                    auto* pTTextCodec_667 = new TTextCodec_667();
+                    auto* pTTextCodec_667 = new (std::nothrow) TTextCodec_667();
                     if (pTTextCodec_667) {
                         itEncoding.insert(pTTextCodec_667->name());
                     }
                 } else if (encoding == "CP737") {
-                    auto* pTTextCodec_737 = new TTextCodec_737();
+                    auto* pTTextCodec_737 = new (std::nothrow) TTextCodec_737();
                     if (pTTextCodec_737) {
                         itEncoding.insert(pTTextCodec_737->name());
                     }
                 } else if (encoding == "CP869") {
-                    auto* pTTextCodec_869 = new TTextCodec_869();
+                    auto* pTTextCodec_869 = new (std::nothrow) TTextCodec_869();
                     if (pTTextCodec_869) {
                         itEncoding.insert(pTTextCodec_869->name());
                     }

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -1216,7 +1216,7 @@ TColorTable* TTrigger::createColorPattern(int ansiFg, int ansiBg)
         return nullptr;
     }
 
-    auto pCT = new TColorTable;
+    auto pCT = new (std::nothrow) TColorTable;
     if (!pCT) {
         return nullptr;
     }

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -615,7 +615,7 @@ void dlgConnectionProfiles::slot_addProfile()
 
     const QString newname = tr("new profile name");
 
-    auto pItem = new QListWidgetItem();
+    auto pItem = new (std::nothrow) QListWidgetItem();
     if (!pItem) {
         return;
     }
@@ -1445,7 +1445,7 @@ bool dlgConnectionProfiles::copyProfileWidget(QString& profile_name, QString& ol
         profile_name = profile_name2;
     }
 
-    pItem = new QListWidgetItem();
+    pItem = new (std::nothrow) QListWidgetItem();
     if (!pItem) {
         return false;
     }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1498,7 +1498,7 @@ void mudlet::addConsoleForNewHost(Host* pH)
     if (pH->mpConsole) {
         return;
     }
-    auto pConsole = new TMainConsole(pH);
+    auto pConsole = new (std::nothrow) TMainConsole(pH);
     if (!pConsole) {
         return;
     }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
To avoid a potential crash, improve the code's handling of allocation failures by returning a null check instead of throwing an exception.
#### Motivation for adding to Mudlet
Cleaner code with fewer potential issues
#### Other info (issues closed, discussion etc)
This document explains what was going on really well: [Incorrect allocation-error handling · Code scanning alert #138 · Mudlet_Mudlet.pdf](https://github.com/Mudlet/Mudlet/files/14232200/Incorrect.allocation-error.handling.Code.scanning.alert.138.Mudlet_Mudlet.pdf)
