### PR TITLE
Infrastructure: remove CCACHE_IGNOREOPTIONS which never worked

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,9 +15,6 @@ environment:
     CCACHE_DIR: "%APPVEYOR_BUILD_FOLDER%\\.ccache"
     # our appveyor cache size is 1G
     CCACHE_MAXSIZE: 1G
-    # APP_BUILD embeds the git sha which changes on every commit, throwing the cache off
-    # ignore it for snapshots but not for PTBs or releases
-    CCACHE_IGNOREOPTIONS: "-DAPP_BUILD=-testing*"
   signing_password:
     secure: JJDxNdreMgNn/IOcY+UVmlaqgDT4a7vcxsY3nfcgWY4=
   DEPLOY_KEY_PASS:

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -49,8 +49,6 @@ jobs:
     env:
       BOOST_ROOT: ${{github.workspace}}/3rdparty/boost
       BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.83.0/boost_1_83_0.tar.bz2/download
-      # APP_BUILD embeds the git sha which changes on every commit, throwing the cache off - ignore it
-      CCACHE_IGNOREOPTIONS: "-DAPP_BUILD=*"
 
     steps:
     - name: Checkout Mudlet source code

--- a/.github/workflows/performance-analysis.yml
+++ b/.github/workflows/performance-analysis.yml
@@ -20,12 +20,6 @@ jobs:
             compiler: gcc_64
             os: [ self-hosted, pi4 ]
 
-
-    env:
-      # APP_BUILD embeds the git sha which changes on every commit, throwing the cache off - ignore it
-      CCACHE_IGNOREOPTIONS: "-DAPP_BUILD=*"
-
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove the `CCACHE_IGNOREOPTIONS` variable from our configuration, which never had an effect on caching anyway. It was https://github.com/Mudlet/Mudlet/pull/6822 instead that sped caching up.
#### Motivation for adding to Mudlet
Keeping things clean and tidy aids in development velocity.
#### Other info (issues closed, discussion etc)
