### PR TITLE
Infra: correct some inconsistencies in embedded Build version in resources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,23 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+# Check to see if the source has been modified from that in the commit:
+execute_process(
+    COMMAND ${GIT_EXECUTABLE} status --porcelain -uno
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE SOURCE_DIRTY_OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Report the Git SHA1 found - and if the source does not match it (has been modified):
+if(SOURCE_DIRTY_OUTPUT STREQUAL "")
+    set(SOURCE_DIRTY FALSE)
+    message(STATUS "Git SHA1: ${GIT_SHA1}")
+else()
+    set(SOURCE_DIRTY TRUE)
+    message(STATUS "Git SHA1: ${GIT_SHA1} (MODIFIED)")
+endif()
+
 # APP_BUILD should only be empty/null in official "release" builds, developers
 # may like to set the MUDLET_VERSION_BUILD environment variable to their user
 # and branch names to make it easier to tell different builds apart!
@@ -106,13 +123,20 @@ execute_process(
 # values are also assigned to the "VERSION" and "BUILD" variables in the native
 # qmake project file, which is NOW called: ./src/mudlet.pro
 set(APP_VERSION 4.17.2)
-if(DEFINED ENV{MUDLET_VERSION_BUILD} AND NOT $ENV{MUDLET_VERSION_BUILD}
-                                         STREQUAL "")
-  file(WRITE ${CMAKE_SOURCE_DIR}/src/app-build.txt "$ENV{MUDLET_VERSION_BUILD}")
-  set(APP_BUILD $ENV{MUDLET_VERSION_BUILD})
+if(DEFINED ENV{MUDLET_VERSION_BUILD} AND NOT $ENV{MUDLET_VERSION_BUILD} STREQUAL "")
+    if(SOURCE_DIRTY)
+        file(WRITE ${CMAKE_SOURCE_DIR}/src/app-build.txt "$ENV{MUDLET_VERSION_BUILD}-${GIT_SHA1}-MODIFIED")
+    else()
+        file(WRITE ${CMAKE_SOURCE_DIR}/src/app-build.txt "$ENV{MUDLET_VERSION_BUILD}-${GIT_SHA1}")
+    endif()
+    set(APP_BUILD $ENV{MUDLET_VERSION_BUILD})
 else()
-  file(WRITE ${CMAKE_SOURCE_DIR}/src/app-build.txt "-dev")
-  set(APP_BUILD "-dev")
+    if(SOURCE_DIRTY)
+        file(WRITE ${CMAKE_SOURCE_DIR}/src/app-build.txt "-dev-${GIT_SHA1}-MODIFIED")
+    else()
+        file(WRITE ${CMAKE_SOURCE_DIR}/src/app-build.txt "-dev-${GIT_SHA1}")
+    endif()
+    set(APP_BUILD "-dev")
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -443,7 +443,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
         }
     }
 
-    if (mudlet::self()->publicTestVersion) {
+    if (mudlet::self()->cmPublicTestVersion) {
         thankForUsingPTB();
     }
 

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1826,7 +1826,9 @@ void TConsole::echo(const QString& msg)
 
 void TConsole::copy()
 {
-    mpHost->mpConsole->mClipboard = buffer.copy(P_begin, P_end);
+    if (!(P_begin.isNull() && P_end.isNull())) {
+        mpHost->mpConsole->mClipboard = buffer.copy(P_begin, P_end);
+    }
 }
 
 void TConsole::cut()

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1826,9 +1826,7 @@ void TConsole::echo(const QString& msg)
 
 void TConsole::copy()
 {
-    if (!(P_begin.isNull() && P_end.isNull())) {
-        mpHost->mpConsole->mClipboard = buffer.copy(P_begin, P_end);
-    }
+    mpHost->mpConsole->mClipboard = buffer.copy(P_begin, P_end);
 }
 
 void TConsole::cut()

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -12164,10 +12164,10 @@ int TLuaInterpreter::getCustomEnvColorTable(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMudletVersion
 int TLuaInterpreter::getMudletVersion(lua_State* L)
 {
+    // This variable can't be const as we append to it in some cases:
     QByteArray version = QByteArray(APP_VERSION).trimmed();
-    QByteArray const build = mudlet::self()->mAppBuild.trimmed().toLocal8Bit();
-
-    QList<QByteArray> const versionData = version.split('.');
+    const QByteArray build = mudlet::self()->cmAppBuild.toUtf8();
+    const QList<QByteArray> versionData = version.split('.');
     if (versionData.size() != 3) {
         qWarning() << "TLuaInterpreter::getMudletVersion(): ERROR: Version data not correctly set on compilation,\n"
                    << "   is the VERSION value in the project file present?";
@@ -12245,7 +12245,7 @@ int TLuaInterpreter::getMudletVersion(lua_State* L)
         lua_pushinteger(L, revision);
         lua_settable(L, -3);
         lua_pushstring(L, "build");
-        lua_pushstring(L, mudlet::self()->mAppBuild.trimmed().toUtf8().constData());
+        lua_pushstring(L, build);
         lua_settable(L, -3);
     } else {
         lua_pushstring(L,

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -260,7 +260,7 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
             logStream << "  <meta http-equiv='content-type' content='text/html; charset=utf-8'>";
             // put the charset as early as possible as the parser MUST restart when it
             // switches away from the ASCII default
-            logStream << "  <meta name='generator' content='" << tr("Mudlet MUD Client version: %1%2").arg(APP_VERSION, mudlet::self()->mAppBuild) << "'>\n";
+            logStream << "  <meta name='generator' content='" << tr("Mudlet MUD Client version: %1%2").arg(APP_VERSION, mudlet::self()->cmAppBuild) << "'>\n";
             // Nice to identify what made the file!
             logStream << "  <title>" << tr("Mudlet, log from %1 profile").arg(mProfileName) << "</title>\n";
             // Web-page title

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1956,7 +1956,7 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
     }
 
     if (otherProfileVersion > mDefaultVersion) {
-        if (mudlet::self()->releaseVersion || mudlet::self()->publicTestVersion) {
+        if (mudlet::self()->cmReleaseVersion || mudlet::self()->cmPublicTestVersion) {
             // This is a release/public test version - should not support any map file versions higher that it was built for
             if (fileVersion) {
                 *fileVersion = otherProfileVersion;

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -651,7 +651,7 @@ void TMedia::downloadFile(TMediaData& mediaData)
         return;
     } else {
         QNetworkRequest request = QNetworkRequest(fileUrl);
-        request.setRawHeader(QByteArray("User-Agent"), QByteArray(qsl("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, mudlet::self()->mAppBuild).toUtf8().constData()));
+        request.setRawHeader(QByteArray("User-Agent"), qsl("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, mudlet::self()->cmAppBuild).toUtf8());
         request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
 #if !defined(QT_NO_SSL)
         if (fileUrl.scheme() == qsl("https")) {

--- a/src/TMxpMudlet.cpp
+++ b/src/TMxpMudlet.cpp
@@ -26,7 +26,7 @@
 
 QString TMxpMudlet::getVersion()
 {
-    return mudlet::self()->scmVersion;
+    return mudlet::self()->cmVersion;
 }
 
 void TMxpMudlet::sendToServer(QString& str)

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1580,7 +1580,7 @@ void TTextEdit::slot_copySelectionToClipboardHTML()
     // switches away from the ASCII default
     text.append("  <meta name='generator' content='Mudlet MUD Client version: ");
     text.append(APP_VERSION);
-    text.append(mudlet::self()->mAppBuild);
+    text.append(mudlet::self()->cmAppBuild);
     text.append("'>\n");
     // Nice to identify what made the file!
     text.append("  <title>");

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -813,7 +813,7 @@ pugi::xml_node XMLexport::writeXmlHeader()
     mExportDoc.append_child(pugi::node_doctype).set_value("MudletPackage");
 
     auto mudletPackage = mExportDoc.append_child("MudletPackage");
-    mudletPackage.append_attribute("version") = mudlet::self()->scmMudletXmlDefaultVersion.toUtf8().constData();
+    mudletPackage.append_attribute("version") = mudlet::scmMudletXmlDefaultVersion.toUtf8().constData();
 
     return mudletPackage;
 }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -75,10 +75,7 @@ cTelnet::cTelnet(Host* pH, const QString& profileName)
     // than that in the initialisation list so that it is processed as a change
     // to set up the initial encoder
     encodingChanged("UTF-8");
-    termType = qsl("Mudlet " APP_VERSION);
-    if (mudlet::self()->mAppBuild.trimmed().length()) {
-        termType.append(mudlet::self()->mAppBuild);
-    }
+    termType = qsl("Mudlet %1%2").arg(APP_VERSION, mudlet::self()->cmAppBuild);
 
     command = "";
     // The raw string literals are QByteArrays now not QStrings:
@@ -1018,13 +1015,9 @@ QString cTelnet::getNewEnvironClientName()
 
 QString cTelnet::getNewEnvironClientVersion()
 {
-    QString clientVersion = APP_VERSION;
+    QString clientVersion = qsl(APP_VERSION "%1").arg(mudlet::self()->cmAppBuild);
     static const auto allInvalidCharacters = QRegularExpression(qsl("[^A-Z,0-9,-,\\/]"));
     static const auto multipleHyphens = QRegularExpression(qsl("-{2,}"));
-
-    if (auto build = mudlet::self()->mAppBuild; build.trimmed().length()) {
-        clientVersion.append(build);
-    }
 
     /*
     * The valid characters for termType are more restricted than being ASCII
@@ -1741,8 +1734,8 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             output += TN_IAC;
             output += TN_SB;
             output += OPT_ATCP;
-            // mudlet::self()->mAppBuild could, conceivably contain a non ASCII character:
-            std::string atcpOptions = std::string("hello Mudlet ") + std::string(APP_VERSION) + mudlet::self()->mAppBuild.toUtf8().constData() + "\ncomposer 1\nchar_vitals 1\nroom_brief 1\nroom_exits 1\nmap_display 1\n";
+            // mudlet::self()->getAppBuild() could, conceivable, contain non ASCII characters:
+            std::string atcpOptions = std::string("hello Mudlet ") + std::string(APP_VERSION) + mudlet::self()->cmAppBuild.toUtf8().constData() + "\ncomposer 1\nchar_vitals 1\nroom_brief 1\nroom_exits 1\nmap_display 1\n";
             output += encodeAndCookBytes(atcpOptions);
             output += TN_IAC;
             output += TN_SE;
@@ -1765,8 +1758,8 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             output = TN_IAC;
             output += TN_SB;
             output += OPT_GMCP;
-            // mudlet::self()->mAppBuild could, conceivably contain a non-ASCII character:
-            output += encodeAndCookBytes(std::string(R"(Core.Hello { "client": "Mudlet", "version": ")") + APP_VERSION + mudlet::self()->mAppBuild.toUtf8().constData() + std::string(R"("})"));
+            // mudlet::self()->getAppBuild() could, conceivable, contain non ASCII characters:
+            output += encodeAndCookBytes(std::string(R"(Core.Hello { "client": "Mudlet", "version": ")") + APP_VERSION + mudlet::self()->cmAppBuild.toUtf8().constData() + std::string(R"("})"));
             output += TN_IAC;
             output += TN_SE;
             socketOutRaw(output);
@@ -2350,8 +2343,8 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 output += TN_IAC;
                 output += TN_SB;
                 output += OPT_ATCP;
-                // mudlet::self()->mAppBuild *could* be a non-ASCII UTF-8 string:
-                std::string atcpOptions = std::string("hello Mudlet ") + std::string(APP_VERSION) + mudlet::self()->mAppBuild.toUtf8().constData() + "\ncomposer 1\nchar_vitals 1\nroom_brief 1\nroom_exits 1\nmap_display 1\n";
+                // mudlet::self()->getAppBuild() could, conceivable, contain non ASCII characters:
+                std::string atcpOptions = std::string("hello Mudlet ") + std::string(APP_VERSION) + mudlet::self()->cmAppBuild.toUtf8().constData() + "\ncomposer 1\nchar_vitals 1\nroom_brief 1\nroom_exits 1\nmap_display 1\n";
                 output += encodeAndCookBytes(atcpOptions);
                 output += TN_IAC;
                 output += TN_SE;

--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -40,13 +40,13 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent)
 {
     setupUi(this);
 
-    QImage splashImage = mudlet::getSplashScreen(mudlet::self()->releaseVersion, mudlet::self()->publicTestVersion);
+    QImage splashImage = mudlet::getSplashScreen(mudlet::self()->cmReleaseVersion, mudlet::self()->cmPublicTestVersion);
 
     { // Brace code using painter to ensure it is freed at right time...
         QPainter painter(&splashImage);
 
         unsigned fontSize = 16;
-        QString sourceVersionText = QString("Version: " + qsl(APP_VERSION) + mudlet::self()->mAppBuild);
+        const QString sourceVersionText = qsl("Version: %1%2").arg(qsl(APP_VERSION), mudlet::self()->cmAppBuild);
 
         bool isWithinSpace = false;
         while (!isWithinSpace) {
@@ -1100,7 +1100,7 @@ QString dlgAboutDialog::createBuildInfo() const
                "</table>")
             .arg(tr("Technical information:"), // %1
                  tr("Version"), // %2
-                 mudlet::self()->scmVersion, // %3
+                 mudlet::self()->cmVersion, // %3
                  tr("OS"), // %4
                  QSysInfo::prettyProductName(), // %5
                  tr("CPU"), // %6

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -38,7 +38,7 @@
 
 dlgIRC::dlgIRC(Host* pHost)
 : mpHost(pHost)
-, mRealName(mudlet::self()->scmVersion)
+, mRealName(mudlet::self()->cmVersion)
 {
     setupUi(this);
     setWindowIcon(QIcon(qsl(":/icons/mudlet_irc.png")));

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -168,7 +168,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
     }
 
 #if defined(INCLUDE_UPDATER)
-    if (mudlet::self()->developmentVersion) {
+    if (mudlet::self()->cmDevelopmentVersion) {
         // tick the box and make it be "un-untickable" as automatic updates are
         // disabled in dev builds
         checkbox_noAutomaticUpdates->setChecked(true);
@@ -3106,7 +3106,7 @@ void dlgProfilePreferences::slot_saveAndClose()
     }
 
 #if defined(INCLUDE_UPDATER)
-    if (mudlet::self()->releaseVersion || mudlet::self()->publicTestVersion) {
+    if (mudlet::self()->cmReleaseVersion || mudlet::self()->cmPublicTestVersion) {
         pMudlet->pUpdater->setAutomaticUpdates(!checkbox_noAutomaticUpdates->isChecked());
     }
 #endif
@@ -3409,7 +3409,7 @@ void dlgProfilePreferences::slot_tabChanged(int tabIndex)
 
     QUrl const url(themesURL);
     QNetworkRequest request(url);
-    request.setRawHeader(QByteArray("User-Agent"), QByteArray(qsl("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, mudlet::self()->mAppBuild).toUtf8().constData()));
+    request.setRawHeader(QByteArray("User-Agent"), qsl("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, mudlet::self()->cmAppBuild).toUtf8());
     // github uses redirects
     request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     // load from cache if possible

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -230,10 +230,11 @@ int main(int argc, char* argv[])
     QFile gitShaFile(":/app-build.txt");
     gitShaFile.open(QIODevice::ReadOnly | QIODevice::Text);
     QString appBuild = QString::fromUtf8(gitShaFile.readAll());
+    appBuild = appBuild.trimmed();
+    gitShaFile.close();
 
     const bool releaseVersion = appBuild.isEmpty();
-    const bool publicTestVersion = appBuild.startsWith("-ptb");
-    const bool developmentVersion = !releaseVersion && !publicTestVersion;
+    const bool publicTestVersion = appBuild.startsWith(qsl("-ptb"));
 
     if (publicTestVersion) {
         app->setApplicationName(qsl("Mudlet Public Test Build"));
@@ -243,7 +244,7 @@ int main(int argc, char* argv[])
     if (releaseVersion) {
         app->setApplicationVersion(APP_VERSION);
     } else {
-        app->setApplicationVersion(QString(APP_VERSION) + appBuild);
+        app->setApplicationVersion(qsl(APP_VERSION).append(appBuild));
     }
 
     QPointer<QTranslator> commandLineTranslator(loadTranslationsForCommandLine());
@@ -409,9 +410,8 @@ int main(int argc, char* argv[])
             const bool successful = instanceCoordinator->installPackagesRemotely();
             if (successful) {
                 return 0;
-            } else {
-                return 1;
             }
+            return 1;
         }
     }
 
@@ -433,7 +433,7 @@ int main(int argc, char* argv[])
     if (showSplash) {
         QPainter painter(&splashImage);
         unsigned fontSize = 16;
-        const QString sourceVersionText = QString(QCoreApplication::translate("main", "Version: %1").arg(APP_VERSION + appBuild));
+        const QString sourceVersionText = QString(QCoreApplication::translate("main", "Version: %1%2").arg(APP_VERSION, appBuild));
 
         bool isWithinSpace = false;
         while (!isWithinSpace) {
@@ -614,7 +614,7 @@ int main(int argc, char* argv[])
     }
 #endif
 
-    mudlet::start();
+    mudlet::start(appBuild);
 
 #if defined(Q_OS_WIN)
     // Associate mudlet with .mpackage files

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -130,7 +130,7 @@ mudlet::mudlet(QString appBuild)
 : QMainWindow()
 , cmReleaseVersion(appBuild.isEmpty())
 , cmPublicTestVersion(appBuild.startsWith(qsl("-ptb")))
-, cmDevelopmentVersion(!(cmReleaseVersion||cmPublicTestVersion))
+, cmDevelopmentVersion(!(cmReleaseVersion || cmPublicTestVersion))
 , cmVersion(qsl("Mudlet " APP_VERSION "%1").arg(appBuild))
 , cmAppBuild(appBuild)
 {

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -129,7 +129,7 @@ class mudlet : public QMainWindow, public Ui::main_window
 
 public:
     Q_DISABLE_COPY(mudlet)
-    mudlet(QString appBuild);
+    explicit mudlet(QString appBuild);
     ~mudlet() override;
 
     enum Appearance {

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -129,7 +129,7 @@ class mudlet : public QMainWindow, public Ui::main_window
 
 public:
     Q_DISABLE_COPY(mudlet)
-    mudlet();
+    mudlet(QString appBuild);
     ~mudlet() override;
 
     enum Appearance {
@@ -237,20 +237,20 @@ public:
     static bool loadLuaFunctionList();
     static std::string replaceString(std::string subject, const std::string& search, const std::string& replace);
     static mudlet* self();
-    static void setNetworkRequestDefaults(const QUrl& url, QNetworkRequest& request);
     // This method allows better debugging when mudlet::self() is called inappropriately.
-    static void start();
+    static void start(const QString& appBuild);
     static bool unzip(const QString& archivePath, const QString& destination, const QDir& tmpDir);
     static QImage getSplashScreen(bool releaseVersion, bool testVersion);
 
 
-    QString mAppBuild;
     // final, official release
-    bool releaseVersion;
+    const bool cmReleaseVersion = false;
     // unofficial "nightly" build - still a type of a release
-    bool publicTestVersion;
+    const bool cmPublicTestVersion = false;
     // used by developers in everyday coding:
-    bool developmentVersion;
+    const bool cmDevelopmentVersion = false;
+    const QString cmVersion;
+    const QString cmAppBuild;
     // "scmMudletXmlDefaultVersion" number represents a major (integer part) and minor
     // (1000ths, range 0 to 999) that is used as a "version" attribute number when
     // writing the <MudletPackage ...> element of all (but maps if I ever get around
@@ -292,7 +292,6 @@ public:
     // translations done high enough will get a gold star to hide the last few percent
     // as well as encourage translators to maintain it
     static const int scmTranslationGoldStar = 95;
-    QString scmVersion;
     // These have to be "inline" to satisfy the ODR (One Definition Rule):
     inline static bool smDebugMode = false;
     inline static bool smFirstLaunch = false;
@@ -408,6 +407,8 @@ public:
     bool muteMSP() const { return mMuteMSP; }
     bool mediaMuted() const { return mMuteAPI && mMuteMCMP && mMuteMSP; }
     bool mediaUnmuted() const { return !mMuteAPI && !mMuteMCMP && !mMuteMSP; }
+    void setNetworkRequestDefaults(const QUrl& url, QNetworkRequest& request);
+
 
     Appearance mAppearance = Appearance::systemSetting;
     // 1 (of 2) needed to work around a (Windows/MacOs specific QStyleFactory)
@@ -606,7 +607,8 @@ private:
     void reshowRequiredMainConsoles();
     void toggleMuteForProtocol(bool state, QAction* toolbarAction, QAction* menuAction, TMediaData::MediaProtocol protocol, const QString& unmuteText, const QString& muteText);
 
-    inline static QPointer<mudlet> smpSelf = nullptr;
+
+    inline static QPointer<mudlet> smpSelf;
 
 
     bool mDarkMode = false;

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -160,7 +160,7 @@ void Updater::setupOnWindows()
 {
     // Setup to automatically download the new release when an update is available
     connect(feed, &dblsqd::Feed::ready, feed, [=]() {
-        if (mudlet::self()->developmentVersion) {
+        if (mudlet::self()->cmDevelopmentVersion) {
             return;
         }
 
@@ -225,7 +225,7 @@ void Updater::setupOnLinux()
     connect(feed, &dblsqd::Feed::ready, this, [=]() {
         // don't update development builds to prevent auto-update from overwriting your
         // compiled binary while in development
-        if (mudlet::self()->developmentVersion) {
+        if (mudlet::self()->cmDevelopmentVersion) {
             return;
         }
 
@@ -418,7 +418,7 @@ bool Updater::shouldShowChangelog()
     return false;
 #endif
 
-    if (mudlet::self()->developmentVersion || !updateAutomatically()) {
+    if (mudlet::self(*)->cmDevelopmentVersion || !updateAutomatically()) {
         return false;
     }
 

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -418,7 +418,7 @@ bool Updater::shouldShowChangelog()
     return false;
 #endif
 
-    if (mudlet::self(*)->cmDevelopmentVersion || !updateAutomatically()) {
+    if (mudlet::self()->cmDevelopmentVersion || !updateAutomatically()) {
         return false;
     }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Change a CMake project file so that the Git SHA1 is always included in the "Application Build" value that gets stored in the app_build.txt file. The qmake project file did do that, but if a value was in the `MUDLET_VERSION_BUILD` environmental variable it was not being included in the "Version" text shown within Mudlet with that build system.

Also changes the mix of `BUILD_TEST` and `BUILD` in the qmake project file back so that they are all `BUILD`.

Also apply/change some prefixes to indicate class membership and const-ness - some of which have been changed

Now closes the `app-build.txt` file after it has been read from the embedded resources. Also trim off the trailing white-space (end of line) from the text read from that. Also, now only read the file once, and pass the detail into the `mudlet` class constructor, which has been revised so that some key `bool` and `QString` values have been moved back into the class as `const` members. This avoids some awkward to do `static const` variable initialisation which could not trim white space from the text.

#### Motivation for adding to Mudlet
I had found that setting a `MUDLET_VERSION_BUILD` environmental variable in my builds was no longer showing up in the displayed version information for qmake type builds.

Furthermore due to a previous incomplete renaming of the Mudlet `BUILD` qmake variable to `BUILD_TEST` the Application icon was not being correctly set on Windows builds.


The naming of some of the `mudlet` class members no longer matched up to the prefixing {`c` = `const`, `s` = `static`, `m` = member`} that has been used. This PR tries to sort out that, especially as some have been changed by this PR.


#### Other info (issues closed, discussion etc)
Apply some prefixes to indicate class membership and const-ness - some of which have been changed:
* `(bool) mudlet::releaseVersion` ==> `(const bool) mudlet::cmReleaseVersion`
* `(bool) mudlet::publicTestVersion` ==> `(const bool) mudlet::cmPublicTestVersion`
* `(bool) mudlet::developmentVersion` ==> `(const bool) mudlet::cmDevelopmentVersion`
* `(QString) mudlet::scmVersion` ==> `(const QString) mudlet::cmVersion`
* `(QString) mudlet::mAppBuild` ==> `(const QString) mudlet::cmAppBuild`
* `(static void) mudlet::setNetworkRequestDefaults(const QUrl&, QNetworkRequest&)` ==> `(void) mudlet::setNetworkRequestDefaults(const QUrl&, QNetworkRequest&)`
