### PR TITLE
Add Korean as a selectable language for Mudlet

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1213,6 +1213,8 @@ void mudlet::scanForMudletTranslations(const QString& path)
                 currentTranslation.mNativeName = qsl("Suomeksi");
             } else if (!languageCode.compare(QLatin1String("ar_SA"), Qt::CaseInsensitive)) {
                 currentTranslation.mNativeName = qsl("العربية");
+            } else if (!languageCode.compare(QLatin1String("ko_KR"), Qt::CaseInsensitive)) {
+                currentTranslation.mNativeName = qsl("한국어");
             } else {
                 currentTranslation.mNativeName = languageCode;
             }

--- a/translations/translated/qm.qrc
+++ b/translations/translated/qm.qrc
@@ -17,5 +17,6 @@
         <file>mudlet_tr_TR.qm</file>
         <file>mudlet_fi_FI.qm</file>
         <file>mudlet_ar_SA.qm</file>
+        <file>mudlet_ko_KR.qm</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add Korean as a selectable language for Mudlet
#### Motivation for adding to Mudlet
We now have a translator who's translating it :D
#### Other info (issues closed, discussion etc)
List of Korean games: https://mud.toox.co.kr/bbs/board.php?bo_table=board_3