### PR TITLE
Infra: remove double SHA1 from CI builds

### DIFF
--- a/CI/appveyor.after_success.ps1
+++ b/CI/appveyor.after_success.ps1
@@ -19,16 +19,10 @@ Remove-Item * -include *.cpp, *.o
 
 $Script:PublicTestBuild = if ($Env:MUDLET_VERSION_BUILD) { $Env:MUDLET_VERSION_BUILD.StartsWith('-ptb') } else { $FALSE }
 
-if (Test-Path Env:APPVEYOR_PULL_REQUEST_NUMBER) {
-  $Script:Commit = git rev-parse --short $Env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT
-} else {
-  $Script:Commit = git rev-parse --short HEAD
-}
-
 if ("$Env:APPVEYOR_REPO_TAG" -eq "false" -and -Not $Script:PublicTestBuild) {
   Write-Output "=== Creating a snapshot build ==="
   Rename-Item -Path "$Env:APPVEYOR_BUILD_FOLDER\src\release\mudlet.exe" -NewName "Mudlet.exe"
-  cmd /c 7z a Mudlet-%VERSION%%MUDLET_VERSION_BUILD%-windows.zip "%APPVEYOR_BUILD_FOLDER%\src\release\*"
+  cmd /c 7z a Mudlet-%VERSION%%MUDLET_VERSION_BUILD%%BUILD_COMMIT%-windows.zip "%APPVEYOR_BUILD_FOLDER%\src\release\*"
 
   Set-Variable -Name "uri" -Value "https://make.mudlet.org/snapshots/Mudlet-$env:VERSION$env:MUDLET_VERSION_BUILD-$env:BUILD_COMMIT-windows.zip";
   Set-Variable -Name "inFile" -Value "Mudlet-$env:VERSION$env:MUDLET_VERSION_BUILD-$env:BUILD_COMMIT-windows.zip";
@@ -51,7 +45,7 @@ if ("$Env:APPVEYOR_REPO_TAG" -eq "false" -and -Not $Script:PublicTestBuild) {
     # Squirrel takes Start menu name from the binary
     Rename-Item -Path "$Env:APPVEYOR_BUILD_FOLDER\src\release\mudlet.exe" -NewName "Mudlet PTB.exe"
     # ensure sha part always starts with a character due to https://github.com/Squirrel/Squirrel.Windows/issues/1394
-    $Script:VersionAndSha = "$Env:VERSION-ptb$Script:Commit"
+    $Script:VersionAndSha = "$Env:VERSION-ptb-$Env:BUILD_COMMIT"
   } else {
     Write-Output "=== Creating a release build ==="
     Rename-Item -Path "$Env:APPVEYOR_BUILD_FOLDER\src\release\mudlet.exe" -NewName "Mudlet.exe"

--- a/CI/appveyor.after_success.ps1
+++ b/CI/appveyor.after_success.ps1
@@ -30,8 +30,8 @@ if ("$Env:APPVEYOR_REPO_TAG" -eq "false" -and -Not $Script:PublicTestBuild) {
   Rename-Item -Path "$Env:APPVEYOR_BUILD_FOLDER\src\release\mudlet.exe" -NewName "Mudlet.exe"
   cmd /c 7z a Mudlet-%VERSION%%MUDLET_VERSION_BUILD%-windows.zip "%APPVEYOR_BUILD_FOLDER%\src\release\*"
 
-  Set-Variable -Name "uri" -Value "https://make.mudlet.org/snapshots/Mudlet-$env:VERSION$env:MUDLET_VERSION_BUILD-windows.zip";
-  Set-Variable -Name "inFile" -Value "Mudlet-$env:VERSION$env:MUDLET_VERSION_BUILD-windows.zip";
+  Set-Variable -Name "uri" -Value "https://make.mudlet.org/snapshots/Mudlet-$env:VERSION$env:MUDLET_VERSION_BUILD-$env:BUILD_COMMIT-windows.zip";
+  Set-Variable -Name "inFile" -Value "Mudlet-$env:VERSION$env:MUDLET_VERSION_BUILD-$env:BUILD_COMMIT-windows.zip";
   Set-Variable -Name "outFile" -Value "upload-location.txt";
   Write-Output "=== Uploading the snapshot build ==="
   Invoke-RestMethod -Uri $uri -Method PUT -InFile $inFile -OutFile $outFile;
@@ -125,7 +125,7 @@ if ("$Env:APPVEYOR_REPO_TAG" -eq "false" -and -Not $Script:PublicTestBuild) {
 
   if ($Script:PublicTestBuild) {
     Write-Output "=== Uploading public test build to make.mudlet.org ==="
-    Set-Variable -Name "uri" -Value "https://make.mudlet.org/snapshots/Mudlet-$env:VERSION$env:MUDLET_VERSION_BUILD-windows.exe";
+    Set-Variable -Name "uri" -Value "https://make.mudlet.org/snapshots/Mudlet-$env:VERSION$env:MUDLET_VERSION_BUILD-$env:BUILD_COMMIT-windows.exe";
     Set-Variable -Name "inFile" -Value "${Env:APPVEYOR_BUILD_FOLDER}\src\release\Setup.exe";
     Set-Variable -Name "outFile" -Value "upload-location.txt";
     Invoke-RestMethod -Uri $uri -Method PUT -InFile $inFile -OutFile $outFile;
@@ -195,10 +195,10 @@ if ("$Env:APPVEYOR_REPO_TAG" -eq "false" -and -Not $Script:PublicTestBuild) {
     Pop-Location
     Write-Output $Script:Changelog
     Write-Output "=== Creating release in Dblsqd ==="
-    dblsqd release -a mudlet -c public-test-build -m $Script:Changelog "${Env:VERSION}${Env:MUDLET_VERSION_BUILD}".ToLower()
+    dblsqd release -a mudlet -c public-test-build -m $Script:Changelog "${Env:VERSION}${Env:MUDLET_VERSION_BUILD}-${Env:BUILD_COMMIT}".ToLower()
 
     Write-Output "=== Registering release with Dblsqd ==="
-    dblsqd push -a mudlet -c public-test-build -r "${Env:VERSION}${Env:MUDLET_VERSION_BUILD}".ToLower() -s mudlet --type "standalone" --attach win:x86 "${DEPLOY_URL}"
+    dblsqd push -a mudlet -c public-test-build -r "${Env:VERSION}${Env:MUDLET_VERSION_BUILD}-${Env:BUILD_COMMIT}".ToLower() -s mudlet --type "standalone" --attach win:x86 "${DEPLOY_URL}"
   }
   #  else {
   #   Write-Output "=== Registering release with Dblsqd ==="
@@ -213,7 +213,13 @@ if (Test-Path Env:APPVEYOR_PULL_REQUEST_NUMBER) {
 echo ""
 echo "******************************************************"
 echo ""
-echo "Finished building Mudlet $Env:VERSION$Env:MUDLET_VERSION_BUILD"
+if ("$Env:MUDLET_VERSION_BUILD" -eq "") {
+  # A release build
+  echo "Finished building Mudlet $Env:VERSION$Env:MUDLET_VERSION_BUILD"
+} else {
+  # Not a release build so include the Git SHA1 in the message
+  echo "Finished building Mudlet $Env:VERSION$Env:MUDLET_VERSION_BUILD-$Env:BUILD_COMMIT"
+}
 if (Test-Path variable:DEPLOY_URL) {
     echo "Deployed the output to $DEPLOY_URL"
 }

--- a/CI/appveyor.after_success.ps1
+++ b/CI/appveyor.after_success.ps1
@@ -22,7 +22,7 @@ $Script:PublicTestBuild = if ($Env:MUDLET_VERSION_BUILD) { $Env:MUDLET_VERSION_B
 if ("$Env:APPVEYOR_REPO_TAG" -eq "false" -and -Not $Script:PublicTestBuild) {
   Write-Output "=== Creating a snapshot build ==="
   Rename-Item -Path "$Env:APPVEYOR_BUILD_FOLDER\src\release\mudlet.exe" -NewName "Mudlet.exe"
-  cmd /c 7z a Mudlet-%VERSION%%MUDLET_VERSION_BUILD%%BUILD_COMMIT%-windows.zip "%APPVEYOR_BUILD_FOLDER%\src\release\*"
+  cmd /c 7z a Mudlet-%VERSION%%MUDLET_VERSION_BUILD%-%BUILD_COMMIT%-windows.zip "%APPVEYOR_BUILD_FOLDER%\src\release\*"
 
   Set-Variable -Name "uri" -Value "https://make.mudlet.org/snapshots/Mudlet-$env:VERSION$env:MUDLET_VERSION_BUILD-$env:BUILD_COMMIT-windows.zip";
   Set-Variable -Name "inFile" -Value "Mudlet-$env:VERSION$env:MUDLET_VERSION_BUILD-$env:BUILD_COMMIT-windows.zip";

--- a/CI/appveyor.after_success.ps1
+++ b/CI/appveyor.after_success.ps1
@@ -209,7 +209,7 @@ echo "******************************************************"
 echo ""
 if ("$Env:MUDLET_VERSION_BUILD" -eq "") {
   # A release build
-  echo "Finished building Mudlet $Env:VERSION$Env:MUDLET_VERSION_BUILD"
+  echo "Finished building Mudlet $Env:VERSION"
 } else {
   # Not a release build so include the Git SHA1 in the message
   echo "Finished building Mudlet $Env:VERSION$Env:MUDLET_VERSION_BUILD-$Env:BUILD_COMMIT"

--- a/CI/appveyor.set-build-info.ps1
+++ b/CI/appveyor.set-build-info.ps1
@@ -12,7 +12,7 @@ if ($Env:APPVEYOR_REPO_TAG -eq "false") {
       # branch creating a new commit - as such we need to refer to the
       # grandparent (with the "~2" suffix) of the resulting commit to get the
       # SHA1 we want:
-      $Env:BUILD_COMMIT = git rev-parse --short $Env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT~2
+      $Env:BUILD_COMMIT = git rev-parse --short $Env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT
       $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD-PR$Env:APPVEYOR_PULL_REQUEST_NUMBER"
   } else {
     $Env:BUILD_COMMIT = git rev-parse --short HEAD

--- a/CI/appveyor.set-build-info.ps1
+++ b/CI/appveyor.set-build-info.ps1
@@ -36,7 +36,7 @@ $Env:VERSION = $VersionRegex.Match($VersionLine).Groups[1].Value
 
 if ($Env:MUDLET_VERSION_BUILD -eq "") {
   # A release build maybe?
-  Write-Output "BUILDING MUDLET $Env:VERSION
+  Write-Output "BUILDING MUDLET $Env:VERSION"
 } else {
   # Otherwise we should report the Git SHA1 which is no longer in MUDLET_VERSION_BUILD:
   Write-Output "BUILDING MUDLET $Env:VERSION$Env:MUDLET_VERSION_BUILD-$Env:BUILD_COMMIT"

--- a/CI/appveyor.set-build-info.ps1
+++ b/CI/appveyor.set-build-info.ps1
@@ -8,17 +8,11 @@ if ($Env:APPVEYOR_REPO_TAG -eq "false") {
     $Env:MUDLET_VERSION_BUILD = "-testing"
   }
   if (Test-Path Env:APPVEYOR_PULL_REQUEST_NUMBER) {
-      $Script:Commit = git rev-parse --short $Env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT
-      $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD-PR$Env:APPVEYOR_PULL_REQUEST_NUMBER-$Commit"
+      $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD-PR$Env:APPVEYOR_PULL_REQUEST_NUMBER"
   } else {
-    $Script:Commit = git rev-parse --short HEAD
-
     if ($Env:MUDLET_VERSION_BUILD -eq "-ptb") {
       $Script:Date = Get-Date -Format "yyyy-MM-dd"
-      $Script:Short_Commit = $Script:Commit.Substring(0, 5)
-      $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD-$Date-$Short_Commit"
-    } else {
-      $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD-$Commit"
+      $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD-$Date"
     }
   }
 }

--- a/CI/appveyor.set-build-info.ps1
+++ b/CI/appveyor.set-build-info.ps1
@@ -8,8 +8,11 @@ if ($Env:APPVEYOR_REPO_TAG -eq "false") {
     $Env:MUDLET_VERSION_BUILD = "-testing"
   }
   if (Test-Path Env:APPVEYOR_PULL_REQUEST_NUMBER) {
+      $Env:BUILD_COMMIT = git rev-parse --short $Env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT
       $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD-PR$Env:APPVEYOR_PULL_REQUEST_NUMBER"
   } else {
+    $Env:BUILD_COMMIT = git rev-parse --short HEAD
+
     if ($Env:MUDLET_VERSION_BUILD -eq "-ptb") {
       $Script:Date = Get-Date -Format "yyyy-MM-dd"
       $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD-$Date"
@@ -19,9 +22,16 @@ if ($Env:APPVEYOR_REPO_TAG -eq "false") {
 
 # not all systems we deal with allow uppercase ascii characters
 $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD".ToLower()
+$Env:BUILD_COMMIT = "$Env:BUILD_COMMIT".ToLower()
 
 $VersionLine = Select-String -Pattern "Version =" $Env:APPVEYOR_BUILD_FOLDER/src/mudlet.pro
 $VersionRegex = [regex]'= {1}(.+)$'
 $Env:VERSION = $VersionRegex.Match($VersionLine).Groups[1].Value
 
-Write-Output "BUILDING MUDLET $Env:VERSION$Env:MUDLET_VERSION_BUILD"
+if ($Env:MUDLET_VERSION_BUILD -eq "") {
+  # A release build maybe?
+  Write-Output "BUILDING MUDLET $Env:VERSION$Env:MUDLET_VERSION_BUILD"
+} else {
+  # Otherwise we should report the Git SHA1 which is no longer in MUDLET_VERSION_BUILD:
+  Write-Output "BUILDING MUDLET $Env:VERSION$Env:MUDLET_VERSION_BUILD-$Env:BUILD_COMMIT"
+}

--- a/CI/appveyor.set-build-info.ps1
+++ b/CI/appveyor.set-build-info.ps1
@@ -8,10 +8,11 @@ if ($Env:APPVEYOR_REPO_TAG -eq "false") {
     $Env:MUDLET_VERSION_BUILD = "-testing"
   }
   if (Test-Path Env:APPVEYOR_PULL_REQUEST_NUMBER) {
-      # APPVEYOR_PULL_REQUEST_HEAD_COMMIT is the development branch commit that
-      # a Pull-Request is merged onto - as such we do not want this for
-      # labelling a PR - instead we want APPVEYOR_REPO_COMMIT
-      $Env:BUILD_COMMIT = git rev-parse --short $Env:APPVEYOR_REPO_COMMIT
+      # AppVeyor builds of PRs merge the PR head onto the current development
+      # branch creating a new commit - as such we need to refer to the
+      # grandparent (with the "~2" suffix) of the resulting commit to get the
+      # SHA1 we want:
+      $Env:BUILD_COMMIT = git rev-parse --short $Env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT~2
       $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD-PR$Env:APPVEYOR_PULL_REQUEST_NUMBER"
   } else {
     $Env:BUILD_COMMIT = git rev-parse --short HEAD

--- a/CI/appveyor.set-build-info.ps1
+++ b/CI/appveyor.set-build-info.ps1
@@ -8,7 +8,10 @@ if ($Env:APPVEYOR_REPO_TAG -eq "false") {
     $Env:MUDLET_VERSION_BUILD = "-testing"
   }
   if (Test-Path Env:APPVEYOR_PULL_REQUEST_NUMBER) {
-      $Env:BUILD_COMMIT = git rev-parse --short $Env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT
+      # APPVEYOR_PULL_REQUEST_HEAD_COMMIT is the development branch commit that
+      # a Pull-Request is merged onto - as such we do not want this for
+      # labelling a PR - instead we want APPVEYOR_REPO_COMMIT
+      $Env:BUILD_COMMIT = git rev-parse --short $Env:APPVEYOR_REPO_COMMIT
       $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD-PR$Env:APPVEYOR_PULL_REQUEST_NUMBER"
   } else {
     $Env:BUILD_COMMIT = git rev-parse --short HEAD

--- a/CI/appveyor.set-build-info.ps1
+++ b/CI/appveyor.set-build-info.ps1
@@ -10,8 +10,10 @@ if ($Env:APPVEYOR_REPO_TAG -eq "false") {
   if (Test-Path Env:APPVEYOR_PULL_REQUEST_NUMBER) {
       # AppVeyor builds of PRs merge the PR head onto the current development
       # branch creating a new commit - as such we need to refer to the
-      # grandparent (with the "~2" suffix) of the resulting commit to get the
-      # SHA1 we want:
+      # commit Git SHA1 supplied to us rather than trying to back track to the
+      # ancestor in the "working" tree (though it does mean the code state is
+      # not accurately described as it only reports PR's head without reference
+      # to the state of the development at the time of the build:
       $Env:BUILD_COMMIT = git rev-parse --short $Env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT
       $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD-PR$Env:APPVEYOR_PULL_REQUEST_NUMBER"
   } else {
@@ -34,7 +36,7 @@ $Env:VERSION = $VersionRegex.Match($VersionLine).Groups[1].Value
 
 if ($Env:MUDLET_VERSION_BUILD -eq "") {
   # A release build maybe?
-  Write-Output "BUILDING MUDLET $Env:VERSION$Env:MUDLET_VERSION_BUILD"
+  Write-Output "BUILDING MUDLET $Env:VERSION
 } else {
   # Otherwise we should report the Git SHA1 which is no longer in MUDLET_VERSION_BUILD:
   Write-Output "BUILDING MUDLET $Env:VERSION$Env:MUDLET_VERSION_BUILD-$Env:BUILD_COMMIT"

--- a/CI/travis.after_success.sh
+++ b/CI/travis.after_success.sh
@@ -17,7 +17,13 @@ fi
 echo ""
 echo "******************************************************"
 echo ""
-echo "Finished building Mudlet ${VERSION}${MUDLET_VERSION_BUILD}"
+if [ -z ${MUDLET_VERSION_BUILD} ]; then
+  # A release build
+  echo "Finished building Mudlet ${VERSION}${MUDLET_VERSION_BUILD}"
+else
+  # Not a release build so include the Git SHA1 in the message
+  echo "Finished building Mudlet ${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}"
+end
 if [ ! -z "${DEPLOY_URL}" ]; then
   echo "Deployed the output to ${DEPLOY_URL}"
 fi

--- a/CI/travis.after_success.sh
+++ b/CI/travis.after_success.sh
@@ -19,9 +19,9 @@ echo "******************************************************"
 echo ""
 if [ -z ${MUDLET_VERSION_BUILD} ]; then
   # A release build
-  echo "Finished building Mudlet ${VERSION}${MUDLET_VERSION_BUILD}"
+  echo "Finished building Mudlet ${VERSION}"
 else
-  # Not a release build so include the Git SHA1 in the message
+  # Not a release build so include the details including the Git SHA1 in the message
   echo "Finished building Mudlet ${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}"
 fi
 if [ ! -z "${DEPLOY_URL}" ]; then

--- a/CI/travis.after_success.sh
+++ b/CI/travis.after_success.sh
@@ -23,7 +23,7 @@ if [ -z ${MUDLET_VERSION_BUILD} ]; then
 else
   # Not a release build so include the Git SHA1 in the message
   echo "Finished building Mudlet ${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}"
-end
+fi
 if [ ! -z "${DEPLOY_URL}" ]; then
   echo "Deployed the output to ${DEPLOY_URL}"
 fi

--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -38,7 +38,7 @@ then
 #    exit
 #  fi
 
-  # get commit date now before we check out and change into another git repository
+  # We refer to $BUILD_COMMIT in the environment to get the commit data now
   COMMIT_DATE=$(git show -s --format="%cs" | tr -d '-')
   YESTERDAY_DATE=$(date -d "yesterday" '+%F' | tr -d '-')
 
@@ -53,20 +53,20 @@ then
 
   if ! [[ "$GITHUB_REF" =~ ^"refs/tags/" ]] && [ "${public_test_build}" != "true" ]; then
     echo "== Creating a snapshot build =="
-    ./make-installer.sh "${VERSION}${MUDLET_VERSION_BUILD}"
+    ./make-installer.sh "${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}"
     cd "${BUILD_DIR}/../installers/generic-linux"
 
-    chmod +x "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}.AppImage"
-    tar -cvf "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-linux-x64.AppImage.tar" "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}.AppImage"
+    chmod +x "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}.AppImage"
+    tar -cvf "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-linux-x64.AppImage.tar" "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}.AppImage"
 
 
     echo "=== ... later, via Github ==="
     # Move the finished file into a folder of its own, because we ask Github to upload contents of a folder
     mkdir "upload/"
-    mv "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-linux-x64.AppImage.tar" "upload/"
+    mv "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-linux-x64.AppImage.tar" "upload/"
     {
       echo "FOLDER_TO_UPLOAD=$(pwd)/upload"
-      echo "UPLOAD_FILENAME=Mudlet-$VERSION$MUDLET_VERSION_BUILD-linux-x64"
+      echo "UPLOAD_FILENAME=Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-linux-x64"
     } >> "$GITHUB_ENV"
     DEPLOY_URL="Github artifact, see https://github.com/$GITHUB_REPOSITORY/runs/$GITHUB_RUN_ID"
 
@@ -84,7 +84,7 @@ then
     fi
 
     if [ "${public_test_build}" == "true" ]; then
-      ./make-installer.sh -pr "${VERSION}${MUDLET_VERSION_BUILD}"
+      ./make-installer.sh -pr "${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}"
     else
       ./make-installer.sh -r "${VERSION}"
     fi
@@ -96,7 +96,7 @@ then
     fi
 
     if [ "${public_test_build}" == "true" ]; then
-      tar -cvf "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-linux-x64.AppImage.tar" "Mudlet PTB.AppImage"
+      tar -cvf "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-linux-x64.AppImage.tar" "Mudlet PTB.AppImage"
     else
       tar -cvf "Mudlet-${VERSION}-linux-x64.AppImage.tar" "Mudlet.AppImage"
     fi
@@ -104,10 +104,10 @@ then
     if [ "${public_test_build}" == "true" ]; then
       echo "=== Setting up for Github upload ==="
       mkdir "upload/"
-      mv "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-linux-x64.AppImage.tar" "upload/"
+      mv "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-linux-x64.AppImage.tar" "upload/"
       {
         echo "FOLDER_TO_UPLOAD=$(pwd)/upload"
-        echo "UPLOAD_FILENAME=Mudlet-$VERSION$MUDLET_VERSION_BUILD-linux-x64"
+        echo "UPLOAD_FILENAME=Mudlet-$VERSION$MUDLET_VERSION_BUILD-${BUILD_COMMIT}-linux-x64"
       } >> "$GITHUB_ENV"
       DEPLOY_URL="Github artifact, see https://github.com/$GITHUB_REPOSITORY/runs/$GITHUB_RUN_ID"
     else
@@ -145,7 +145,7 @@ then
       changelog=$(lua "${SOURCE_DIR}/CI/generate-changelog.lua" --mode ptb --releasefile "${downloadedfeed}")
 
       echo "=== Creating release in Dblsqd ==="
-      dblsqd release -a mudlet -c public-test-build -m "${changelog}" "${VERSION}${MUDLET_VERSION_BUILD}" || true
+      dblsqd release -a mudlet -c public-test-build -m "${changelog}" "${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}" || true
 
       # release registration and uploading will be manual for the time being
     else

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -63,7 +63,7 @@ if [ "${DEPLOY}" = "deploy" ]; then
 
   if ! [[ "$GITHUB_REF" =~ ^"refs/tags/" ]] && [ "${public_test_build}" != "true" ]; then
     echo "== Creating a snapshot build =="
-    appBaseName="Mudlet-${VERSION}${MUDLET_VERSION_BUILD}"
+    appBaseName="Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}"
     if [ -n "${GITHUB_REPOSITORY}" ]; then
       mv "${BUILD_DIR}/src/mudlet.app" "${BUILD_DIR}/${appBaseName}.app"
     else
@@ -107,7 +107,7 @@ if [ "${DEPLOY}" = "deploy" ]; then
     fi
 
     if [ "${public_test_build}" == "true" ]; then
-      ./make-installer.sh -pr "${VERSION}${MUDLET_VERSION_BUILD}" "$app"
+      ./make-installer.sh -pr "${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}" "$app"
     else
       ./make-installer.sh -r "${VERSION}" "$app"
     fi
@@ -121,7 +121,7 @@ if [ "${DEPLOY}" = "deploy" ]; then
     fi
 
     if [ "${public_test_build}" == "true" ]; then
-      mv "${HOME}/Desktop/Mudlet PTB.dmg" "${HOME}/Desktop/Mudlet-${VERSION}${MUDLET_VERSION_BUILD}.dmg"
+      mv "${HOME}/Desktop/Mudlet PTB.dmg" "${HOME}/Desktop/Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}.dmg"
     else
       mv "${HOME}/Desktop/Mudlet.dmg" "${HOME}/Desktop/Mudlet-${VERSION}.dmg"
     fi
@@ -129,10 +129,10 @@ if [ "${DEPLOY}" = "deploy" ]; then
     if [ "${public_test_build}" == "true" ]; then
       echo "=== Setting up for Github upload ==="
       mkdir "upload/"
-      mv "${HOME}/Desktop/Mudlet-${VERSION}${MUDLET_VERSION_BUILD}.dmg" "upload/"
+      mv "${HOME}/Desktop/Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}.dmg" "upload/"
       {
         echo "FOLDER_TO_UPLOAD=$(pwd)/upload"
-        echo "UPLOAD_FILENAME=Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-macos"
+        echo "UPLOAD_FILENAME=Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-macos"
       } >> "$GITHUB_ENV"
       DEPLOY_URL="Github artifact, see https://github.com/$GITHUB_REPOSITORY/runs/$GITHUB_RUN_ID"
     else
@@ -169,7 +169,7 @@ if [ "${DEPLOY}" = "deploy" ]; then
       changelog=$(lua "${SOURCE_DIR}/CI/generate-changelog.lua" --mode ptb --releasefile "${downloadedfeed}")
 
       echo "=== Creating release in Dblsqd ==="
-      dblsqd release -a mudlet -c public-test-build -m "${changelog}" "${VERSION}${MUDLET_VERSION_BUILD}" || true
+      dblsqd release -a mudlet -c public-test-build -m "${changelog}" "${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}" || true
 
       # release registration and uploading will be manual for the time being
     else

--- a/CI/travis.set-build-info.sh
+++ b/CI/travis.set-build-info.sh
@@ -10,8 +10,8 @@ if [ -z "${TRAVIS_TAG}" ] && ! [[ "$GITHUB_REF" =~ ^"refs/tags/" ]]; then
   fi
 
   if [ -n "$TRAVIS_PULL_REQUEST" ]; then # building for a PR
+    BUILD_COMMIT=$(git rev-parse --short "${TRAVIS_PULL_REQUEST_SHA}")
     MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD}-PR${TRAVIS_PULL_REQUEST}"
-    BUILD_COMMIT=$(git rev-parse --short HEAD)
     PR_NUMBER=${TRAVIS_PULL_REQUEST}
     export PR_NUMBER
   elif [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then

--- a/CI/travis.set-build-info.sh
+++ b/CI/travis.set-build-info.sh
@@ -10,25 +10,19 @@ if [ -z "${TRAVIS_TAG}" ] && ! [[ "$GITHUB_REF" =~ ^"refs/tags/" ]]; then
   fi
 
   if [ -n "$TRAVIS_PULL_REQUEST" ]; then # building for a PR
-    BUILD_COMMIT=$(git rev-parse --short "${TRAVIS_PULL_REQUEST_SHA}")
-    MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD}-PR${TRAVIS_PULL_REQUEST}-${BUILD_COMMIT}"
+    MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD}-PR${TRAVIS_PULL_REQUEST}"
     PR_NUMBER=${TRAVIS_PULL_REQUEST}
     export PR_NUMBER
   elif [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
-    BUILD_COMMIT=$(git rev-parse --short "${GITHUB_SHA}^2")
     PR_NUMBER=$(echo "$GITHUB_REF" | sed 's/refs\///' |sed 's/pull\///' | sed 's/\/merge//')
-    MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD}-PR${PR_NUMBER}-${BUILD_COMMIT}"
+    MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD}-PR${PR_NUMBER}"
     echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_ENV"
   else
     BUILD_COMMIT=$(git rev-parse --short HEAD)
 
     if [ "${MUDLET_VERSION_BUILD}" = "-ptb" ]; then
       DATE=$(date +'%Y-%m-%d')
-      # add a short commit to version for changelog generation know what was last released
-      SHORT_COMMIT=$(echo "${BUILD_COMMIT}" | cut -c1-5)
-      MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD}-${DATE}-${SHORT_COMMIT}"
-    else
-      MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}"
+      MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD}-${DATE}"
     fi
   fi
 fi

--- a/CI/travis.set-build-info.sh
+++ b/CI/travis.set-build-info.sh
@@ -15,6 +15,9 @@ if [ -z "${TRAVIS_TAG}" ] && ! [[ "$GITHUB_REF" =~ ^"refs/tags/" ]]; then
     PR_NUMBER=${TRAVIS_PULL_REQUEST}
     export PR_NUMBER
   elif [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+    # GITHUB_SHA identifies the commitish that results from merging the PR's
+    # state onto the development branch and the ^2 to that returns the HEAD
+    # of the PR before that happened.
     BUILD_COMMIT=$(git rev-parse --short "${GITHUB_SHA}^2")
     PR_NUMBER=$(echo "$GITHUB_REF" | sed 's/refs\///' |sed 's/pull\///' | sed 's/\/merge//')
     MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD}-PR${PR_NUMBER}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,10 +104,21 @@ message(STATUS "Git SHA1: ${GIT_SHA1}")
 # dlgAboutDialog.cpp and TLuaInterpreter.cpp.  It will not necessarily cause
 # those files to be automatically rebuilt so you may need to 'touch' those files
 # if the variables are changed and you are not doing a full, clean, rebuild! Use
-# APP_VERSION, APP_BUILD and APP_TARGET defines in the source code if needed.
+# APP_VERSION and APP_TARGET defines in the source code if needed.
+#
+# APP_BUILD is going away (it is not currently used in the source code now as
+# Mudlet instead reads it from the resource file) however until the CI/CB system
+# is cleaned up to not use it in any way in the
+# /CI/(travis|appveyor).validate_deployment.(sh|ps1) scripts we probably have to
+# leave it in place:
+#
 # IMPORTANT: To insure consistency please ensure the SAME of the first two
 # values are also assigned to the "VERSION" and "BUILD" variables in the native
 # qmake project file, which is NOW called: ./src/mudlet.pro
+# NOTE: the CI/CB build process examines the following line to determine the
+# underlying version of the Mudlet build for all our current CI/CB processes
+# even a Windows one that currently runs using qmake - so don't mess with it
+# unless you are a Core Developer adjusting the overall versioning:
 set(APP_VERSION 4.17.2)
 # We now make APP_BUILD a CACHE variable so it can be propagated to the ./src/
 # sub-directory build.
@@ -117,11 +128,16 @@ if(DEFINED ENV{MUDLET_VERSION_BUILD} AND NOT $ENV{MUDLET_VERSION_BUILD}
   message(STATUS "Value written to app-build.txt file: $ENV{MUDLET_VERSION_BUILD}-${GIT_SHA1}")
   set(APP_BUILD $ENV{MUDLET_VERSION_BUILD} CACHE STRING "This variable is automatically set during the CMake run and should not be manually altered!" FORCE)
 else()
-  file(WRITE ${CMAKE_SOURCE_DIR}/src/app-build.txt "-dev-${GIT_SHA1}")
-  message(STATUS "Value written to app-build.txt file: -dev-${GIT_SHA1}")
-  set(APP_BUILD "-dev" CACHE STRING "This variable is automatically set during the CMake run and should not be manually altered!" FORCE)
+#  file(WRITE ${CMAKE_SOURCE_DIR}/src/app-build.txt "-dev-${GIT_SHA1}")
+#  message(STATUS "Value written to app-build.txt file: -dev-${GIT_SHA1}")
+#  set(APP_BUILD "-dev" CACHE STRING "This variable is automatically set during the CMake run and should not be manually altered!" FORCE)
+  # Core dev team setting things up for a release should comment out the above
+  # three lines and uncomment these below - note that the app-build.txt must not
+  # contain anything (other than whitespace) for a RELEASE build:
+  file(WRITE ${CMAKE_SOURCE_DIR}/src/app-build.txt " ")
+  message(STATUS "Value written to app-build.txt file: {nothing}")
+  set(APP_BUILD "" CACHE STRING "This variable is automatically set during the CMake run and should not be manually altered!" FORCE)
 endif()
-
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,14 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-# Report it:
-message(STATUS "Git SHA1: ${GIT_SHA1}")
+# If a CI/CB build system provides an alternative Git SHA1 to identify the build
+# use that instead - reporting which is being used:
+if(DEFINED ENV{BUILD_COMMIT} AND NOT $ENV{BUILD_COMMIT} STREQUAL "")
+    set(GIT_SHA1 string(TOLOWER $ENV{BUILD_COMMIT}))
+    message(STATUS "Git SHA1 set from environemnt: ${GIT_SHA1}")
+else()
+    message(STATUS "Git SHA1 used: ${GIT_SHA1}")
+endif()
 
 # APP_BUILD should only be empty/null in official "release" builds, developers
 # may like to set the MUDLET_VERSION_BUILD environment variable to their user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,15 +128,15 @@ if(DEFINED ENV{MUDLET_VERSION_BUILD} AND NOT $ENV{MUDLET_VERSION_BUILD}
   message(STATUS "Value written to app-build.txt file: $ENV{MUDLET_VERSION_BUILD}-${GIT_SHA1}")
   set(APP_BUILD $ENV{MUDLET_VERSION_BUILD} CACHE STRING "This variable is automatically set during the CMake run and should not be manually altered!" FORCE)
 else()
-#  file(WRITE ${CMAKE_SOURCE_DIR}/src/app-build.txt "-dev-${GIT_SHA1}")
-#  message(STATUS "Value written to app-build.txt file: -dev-${GIT_SHA1}")
-#  set(APP_BUILD "-dev" CACHE STRING "This variable is automatically set during the CMake run and should not be manually altered!" FORCE)
+  file(WRITE ${CMAKE_SOURCE_DIR}/src/app-build.txt "-dev-${GIT_SHA1}")
+  message(STATUS "Value written to app-build.txt file: -dev-${GIT_SHA1}")
+  set(APP_BUILD "-dev" CACHE STRING "This variable is automatically set during the CMake run and should not be manually altered!" FORCE)
   # Core dev team setting things up for a release should comment out the above
   # three lines and uncomment these below - note that the app-build.txt must not
   # contain anything (other than whitespace) for a RELEASE build:
-  file(WRITE ${CMAKE_SOURCE_DIR}/src/app-build.txt " ")
-  message(STATUS "Value written to app-build.txt file: {nothing}")
-  set(APP_BUILD "" CACHE STRING "This variable is automatically set during the CMake run and should not be manually altered!" FORCE)
+  # file(WRITE ${CMAKE_SOURCE_DIR}/src/app-build.txt " ")
+  # message(STATUS "Value written to app-build.txt file: {nothing}")
+  # set(APP_BUILD "" CACHE STRING "This variable is automatically set during the CMake run and should not be manually altered!" FORCE)
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,7 +43,9 @@ if(WIN32)
     list(APPEND mudlet_RCCS icons/mudlet_ptb.ico)
   elseif((APP_BUILD matches "-dev.+") or (APP_BUILD matches "-test.+"))
     # The above test may not be correct as it won't pick up builds where
-    # MUDLET_VERSION_BUILD has been set in the environment:
+    # MUDLET_VERSION_BUILD has been set in the environment - OTOH for
+    # "Packagers" they will likely want the original icon anyhow for their
+    # modified for their system packages of Mudlet:
     list(APPEND mudlet_RCCS icons/mudlet_dev.ico)
   else()
     list(APPEND mudlet_RCCS icons/mudlet.ico)

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -118,7 +118,7 @@ GIT_GRANDPARENTB_SHA1 = $$system($$GIT_EXECUTABLE rev-parse --quiet --short HEAD
 
 APPVEYOR_REPO_NAME_TEST = $$(APPVEYOR_REPO_NAME)
 APPVEYOR_PR_HEAD_COMMIT = $$(APPVEYOR_PULL_REQUEST_HEAD_COMMIT)
-APPVEYOR_PR_HEAD_COMMIT = lower( APPVEYOR_PR_HEAD_COMMIT )
+APPVEYOR_PR_HEAD_COMMIT = $$lower($$APPVEYOR_PR_HEAD_COMMIT)
 !isEmpty( APPVEYOR_REPO_NAME_TEST ):!isEmpty( APPVEYOR_PR_HEAD_COMMIT ):equals(APPVEYOR_REPO_NAME_TEST, "Mudlet/Mudlet" ) {
   # Building a PR in the AppVeyor environment of Mudlet's own repository
   !build_pass:message("Adjusting Git SHA1 for Mudlet's own Windows build on AppVeyor, to provided commit...")

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -119,15 +119,23 @@ isEmpty( BUILD ) {
 # "-dev" for the development build
 # "-ptb" for the public test build
 # "" for the release build
-   BUILD = "-dev-"$${GIT_SHA1}
+# A core dev team member setting things up for a release should comment out the
+# following line - as the app-build.txt file must not contain anything (other
+# than whitespace) for a RELEASE build:
+#   BUILD = "-dev-"$${GIT_SHA1}
 } else {
    BUILD = $${BUILD}-$${GIT_SHA1}
 }
 
-!build_pass:message("Value written to app-build.txt file: " $${BUILD})
-
-# This does append a line-feed to the file which might be problematic!
+# This does append a line-feed to the file which would be problematic if it
+# wasn't trimmed off when read:
 write_file( app-build.txt, BUILD )
+
+isEmpty( BUILD ) {
+    !build_pass:message("Value written to app-build.txt file: {nothing}")
+} else {
+    !build_pass:message("Value written to app-build.txt file: " $${BUILD})
+}
 
 # As the above also modifies the splash screen image (so developers get reminded
 # what they are working with!) Packagers (e.g. for Linux distributions) will
@@ -141,7 +149,12 @@ isEmpty( WITH_VS_SCREEN_TEST ) | !equals(WITH_VS_SCREEN_TEST, "NO" ) {
 # Changing BUILD and VERSION values affects: ctelnet.cpp, main.cpp, mudlet.cpp
 # dlgAboutDialog.cpp and TLuaInterpreter.cpp.  It does NOT cause those files to
 # be automatically rebuilt so you will need to 'touch' them...!
-# Use APP_VERSION, APP_BUILD and APP_TARGET defines in the source code if needed.
+# Use APP_VERSION and APP_TARGET defines in the source code if needed.
+# APP_BUILD is going away (it is not currently used in the source code now as
+# Mudlet instead reads it from the resource file) however until the CI/CB system
+# is cleaned up to not use it in any way in the
+# /CI/(travis|appveyor).validate_deployment.(sh|ps1) scripts we probably have to
+# leave it in place:
 DEFINES += APP_VERSION=\\\"$${VERSION}\\\"
 DEFINES += APP_BUILD=\\\"$${BUILD}\\\"
 

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -122,7 +122,7 @@ isEmpty( BUILD ) {
 # A core dev team member setting things up for a release should comment out the
 # following line - as the app-build.txt file must not contain anything (other
 # than whitespace) for a RELEASE build:
-#   BUILD = "-dev-"$${GIT_SHA1}
+   BUILD = "-dev-"$${GIT_SHA1}
 } else {
    BUILD = $${BUILD}-$${GIT_SHA1}
 }

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -103,10 +103,10 @@ GIT_EXECUTABLE = git
 # want the grandparent (the ~2) as it gets merged on top of the current
 # development branch (the ~1) for builds there:
 GIT_SHA1 = $$system($$GIT_EXECUTABLE rev-parse --short HEAD)
-GIT_PARENTA_SHA1 = $$system($$GIT_EXECUTABLE rev-parse --short HEAD~1)
-GIT_PARENTB_SHA1 = $$system($$GIT_EXECUTABLE rev-parse --short HEAD^1)
-GIT_GRANDPARENTA_SHA1 = $$system($$GIT_EXECUTABLE rev-parse --short HEAD~2)
-GIT_GRANDPARENTB_SHA1 = $$system($$GIT_EXECUTABLE rev-parse --short HEAD^2)
+GIT_PARENTA_SHA1 = $$system($$GIT_EXECUTABLE rev-parse --quiet --short HEAD~1)
+GIT_PARENTB_SHA1 = $$system($$GIT_EXECUTABLE rev-parse --quiet --short HEAD^1)
+GIT_GRANDPARENTA_SHA1 = $$system($$GIT_EXECUTABLE rev-parse --quiet --short HEAD~2)
+GIT_GRANDPARENTB_SHA1 = $$system($$GIT_EXECUTABLE rev-parse --quiet --short HEAD^2)
 !build_pass{
 # Report the above, for debugging purposes:
   message("Git HEAD SHA1: " $${GIT_SHA1})
@@ -116,15 +116,13 @@ GIT_GRANDPARENTB_SHA1 = $$system($$GIT_EXECUTABLE rev-parse --short HEAD^2)
   message("Git HEAD^2 SHA1: " $${GIT_GRANDPARENTB_SHA1})
 }
 
-APPVEYOR_TEST = $$(APPVEYOR)
-APPVEYOR_TEST = upper( APPVEYOR_TEST )
 APPVEYOR_REPO_NAME_TEST = $$(APPVEYOR_REPO_NAME)
-!isEmpty( APPVEYOR_TEST ): !isEmpty( APPVEYOR_REPO_NAME_TEST ):equals(APPVEYOR_TEST, "TRUE" ):equals(APPVEYOR_REPO_NAME_TEST, "Mudlet/Mudlet" ) {
-  # Building in the AppVeyor environment of Mudlet's own repository, note
-  # that APPVEYOR is "true" on the Ubuntu (linux) platform (that we are not
-  # using), but "True" on Windows (and other platforms they provide)
-  !build_pass:message("Adjusting Git SHA1 for Mudlet's own Windows build on AppVeyor, to grandparent commit...")
-  GIT_SHA1 = $${GIT_GRANDPARENTB_SHA1}
+APPVEYOR_PR_HEAD_COMMIT = $$(APPVEYOR_PULL_REQUEST_HEAD_COMMIT)
+APPVEYOR_PR_HEAD_COMMIT = lower( APPVEYOR_PR_HEAD_COMMIT )
+!isEmpty( APPVEYOR_REPO_NAME_TEST ):!isEmpty( APPVEYOR_PR_HEAD_COMMIT ):equals(APPVEYOR_REPO_NAME_TEST, "Mudlet/Mudlet" ) {
+  # Building a PR in the AppVeyor environment of Mudlet's own repository
+  !build_pass:message("Adjusting Git SHA1 for Mudlet's own Windows build on AppVeyor, to provided commit...")
+  GIT_SHA1 = $${APPVEYOR_PR_HEAD_COMMIT}
 }
 
 ########################## Version and Build setting ###########################

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -118,6 +118,7 @@ APPVEYOR_PR_HEAD_COMMIT = $$lower($$APPVEYOR_PR_HEAD_COMMIT)
 !build_pass{
 # Report the above, for debugging purposes:
   message("Git SHA1 used: " $${GIT_SHA1})
+}
 
 ########################## Version and Build setting ###########################
 # Set the current Mudlet Version, unfortunately the Qt documentation suggests

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -103,23 +103,28 @@ GIT_EXECUTABLE = git
 # want the grandparent (the ~2) as it gets merged on top of the current
 # development branch (the ~1) for builds there:
 GIT_SHA1 = $$system($$GIT_EXECUTABLE rev-parse --short HEAD)
-GIT_PARENT_SHA1 = $$system($$GIT_EXECUTABLE rev-parse --short HEAD~1)
-GIT_GRANDPARENT_SHA1 = $$system($$GIT_EXECUTABLE rev-parse --short HEAD~2)
+GIT_PARENTA_SHA1 = $$system($$GIT_EXECUTABLE rev-parse --short HEAD~1)
+GIT_PARENTB_SHA1 = $$system($$GIT_EXECUTABLE rev-parse --short HEAD^1)
+GIT_GRANDPARENTA_SHA1 = $$system($$GIT_EXECUTABLE rev-parse --short HEAD~2)
+GIT_GRANDPARENTB_SHA1 = $$system($$GIT_EXECUTABLE rev-parse --short HEAD^2)
 !build_pass{
 # Report the above, for debugging purposes:
   message("Git HEAD SHA1: " $${GIT_SHA1})
-  message("Git HEAD~1 SHA1: " $${GIT_PARENT_SHA1})
-  message("Git HEAD~2 SHA1: " $${GIT_GRANDPARENT_SHA1})
+  message("Git HEAD~1 SHA1: " $${GIT_PARENTA_SHA1})
+  message("Git HEAD^1 SHA1: " $${GIT_PARENTB_SHA1})
+  message("Git HEAD~2 SHA1: " $${GIT_GRANDPARENTA_SHA1})
+  message("Git HEAD^2 SHA1: " $${GIT_GRANDPARENTB_SHA1})
 }
 
-APPVEYOR_TEST = upper($$(APPVEYOR))
+APPVEYOR_TEST = $$(APPVEYOR)
+APPVEYOR_TEST = upper( APPVEYOR_TEST )
 APPVEYOR_REPO_NAME_TEST = $$(APPVEYOR_REPO_NAME)
 !isEmpty( APPVEYOR_TEST ): !isEmpty( APPVEYOR_REPO_NAME_TEST ):equals(APPVEYOR_TEST, "TRUE" ):equals(APPVEYOR_REPO_NAME_TEST, "Mudlet/Mudlet" ) {
   # Building in the AppVeyor environment of Mudlet's own repository, note
   # that APPVEYOR is "true" on the Ubuntu (linux) platform (that we are not
   # using), but "True" on Windows (and other platforms they provide)
   !build_pass:message("Adjusting Git SHA1 for Mudlet's own Windows build on AppVeyor, to grandparent commit...")
-  GIT_SHA1 = $${GIT_GRANDPARENT_SHA1}
+  GIT_SHA1 = $${GIT_GRANDPARENTB_SHA1}
 }
 
 ########################## Version and Build setting ###########################


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR attempts to fix things by no longer appending the Git SHA1 to the "MUDLET_VERSION_BUILD" environmental variable in the CI/CB script files.

#### Motivation for adding to Mudlet
It was breaking the PTB builds because their version identification was malformed with two copies of the development branch git SHA1 for PTB (and presumably) Release builds. Testing and PR builds had the HEAD SHA1 for the current branch applied first followed by that of the development branch commit that the branch was rebased onto. Given the values concerned the first one (which is now generated internally by the QMake/CMake build process) seems to be the one that we want to keep around. This is so that it can be embedded in a "resource" file rather than passed to each object file that gets compiled. 

#### Other info (issues closed, discussion etc)
Note: there is some cruft in the `CI/travis.set-build-info.sh` file relating to builds on the Travis platform - but seen they abandoned supporting FOSS projects a few years back there is no need for that baggage however, to keep things simple I have updated that fragment even though it is ripe for excision from there.

Hopefully this will close #7158 and #7159.