### PR TITLE
Improve: simplify dlgIRC::sendMsg(...)

### DIFF
--- a/src/TLuaInterpreterNetworking.cpp
+++ b/src/TLuaInterpreterNetworking.cpp
@@ -399,8 +399,7 @@ int TLuaInterpreter::sendIrc(lua_State* L)
         return warnArgumentValue(L, __func__, "not ready to send just yet");
     }
 
-    QPair<bool, QString> const result = pHost->mpDlgIRC->sendMsg(target, msg);
-
+    const auto result = pHost->mpDlgIRC->sendMsg(target, msg);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
     }

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -138,10 +138,12 @@ void dlgIRC::startClient()
     mIrcStarted = true;
 }
 
+// Only the Lua sub-system call to this method even looks at the return values
+// and even then it only uses the second one if the first is false:
 QPair<bool, QString> dlgIRC::sendMsg(const QString& target, const QString& message)
 {
     if (message.isEmpty()) {
-        return QPair<bool, QString>(true, qsl("message processed by client"));
+        return {true, QString()};
     }
 
     QString msgTarget = target;
@@ -157,12 +159,12 @@ QPair<bool, QString> dlgIRC::sendMsg(const QString& target, const QString& messa
     commandParser->setTarget(lastParserTarget);
 
     if (!command) {
-        return QPair<bool, QString>(false, qsl("message could not be parsed"));
+        return {false, qsl("message could not be parsed")};
     }
 
     const bool isCustomCommand = processCustomCommand(command);
     if (isCustomCommand) {
-        return QPair<bool, QString>(true, qsl("command processed by client"));
+        return {true, QString()};
     }
 
     // update ping-started time if this command was a ping
@@ -176,7 +178,7 @@ QPair<bool, QString> dlgIRC::sendMsg(const QString& target, const QString& messa
     if (command->type() == IrcCommand::Quit) {
         setAttribute(Qt::WA_DeleteOnClose);
         close();
-        return QPair<bool, QString>(true, qsl("closing client"));
+        return {true, QString()};
     }
 
     // echo own messages (servers do not send our own messages back)
@@ -186,7 +188,7 @@ QPair<bool, QString> dlgIRC::sendMsg(const QString& target, const QString& messa
         delete msg;
     }
 
-    return QPair<bool, QString>(true, qsl("sent to server"));
+    return {true, QString()};
 }
 
 void dlgIRC::ircRestart(bool reloadConfigs)
@@ -355,6 +357,7 @@ bool dlgIRC::processCustomCommand(IrcCommand* cmd)
             msgText = QString(cmd->parameters().mid(2).join(" "));
         }
 
+        // This could return a false + error message but we seem to be ignoring that:
         sendMsg(target, msgText);
         return true;
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Removes some unused "success" strings from the specified method. Also makes use of `auto` in one place instead of explicitly (and redundantly with latter C++ standards) specifying variables assigned to that method's return value.

#### Motivation for adding to Mudlet
It was returning values that we don't use and the remainder could be written more succinctly.

#### Other info (issues closed, discussion etc)
I found this whilst reviewing similar code in the MMCP (permanent) draft branch/PR #7155.