### PR TITLE
Fix map.renameArea function calls.

### DIFF
--- a/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
+++ b/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
@@ -5150,7 +5150,6 @@ function map.renameArea(name, exact)
   if not (map.currentroom or getRoomArea(map.currentRoom)) then
     map.echo("Don't know what area are we in at the moment, to rename it.")
   else
-    setAreaName(getRoomArea(map.currentRoom), name)
     map.echo(
       string.format(
         "Renamed %s to %s (%d).",
@@ -5159,6 +5158,7 @@ function map.renameArea(name, exact)
         getRoomArea(map.currentRoom)
       )
     )
+    setAreaName(getRoomArea(map.currentRoom), name)			
     centerview(map.currentRoom)
   end
 end


### PR DESCRIPTION
Calling setAreaName() before the echo resulted in the wrong area name being sent to the user.  Call setAreaName() after instead.

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Using 'area rename' command would show
`> area rename New Area Name`
`(mapper): Renamed New Area Name to New Area Name (5).`

now displays correctly
`(mapper): Renamed Old Area Name to New Area Name (5).`

#### Motivation for adding to Mudlet
Improve user experience.

#### Other info (issues closed, discussion etc)
Fix will apply to IRE mapping script as well.