### PR TITLE
Improve: add named captures to Aliases

### DIFF
--- a/src/TAlias.h
+++ b/src/TAlias.h
@@ -38,6 +38,8 @@ class Host;
 
 #define MAX_CAPTURE_GROUPS 33
 
+using NameGroupMatches = QVector<QPair<QString, QString>>;
+
 class TAlias : public Tree<TAlias>
 {
     Q_DECLARE_TR_FUNCTIONS(TAlias) // Needed so we can use tr() even though TAlias is NOT derived from QObject
@@ -78,6 +80,7 @@ public:
     QString mFuncName;
     bool exportItem = true;
     bool mRegisteredAnonymousLuaFunction = false;
+    QVector<NameGroupMatches> nameCaptures;
 
 private:
     bool mNeedsToBeCompiled = true;

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -360,18 +360,18 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
         }
     }
 
-    int namecount; //NOLINT(cppcoreguidelines-init-variables)
-    int name_entry_size; //NOLINT(cppcoreguidelines-init-variables)
-    char* tabptr; //NOLINT(cppcoreguidelines-init-variables)
+    int namecount = 0;
+    int name_entry_size = 0;
+    char* tabptr = nullptr;
 
     pcre_fullinfo(re.data(), nullptr, PCRE_INFO_NAMECOUNT, &namecount);
 
     if (namecount > 0) {
         // Based on snippet https://github.com/vmg/pcre/blob/master/pcredemo.c#L216
-        // Retrieves char table end entry size and extracts name of group  and captures from
+        // Retrieves char table end entry size and extracts name of group and captures from
         pcre_fullinfo(re.data(), nullptr, PCRE_INFO_NAMETABLE, &tabptr);
         pcre_fullinfo(re.data(), nullptr, PCRE_INFO_NAMEENTRYSIZE, &name_entry_size);
-        for (i = 0; i < namecount; i++) {
+        for (i = 0; i < namecount; ++i) {
             const int n = (tabptr[0] << 8) | tabptr[1];
             auto name = QString::fromUtf8(&tabptr[2]).trimmed(); //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)
             auto* substring_start = haystackC + ovector[2*n]; //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This has been done by carefully comparing the matching code from the PCRE trigger item. Some variables have been renamed so they match up better.

#### Motivation for adding to Mudlet
This has been a long-standing but unlisted wish-list item but someone actually raised an issue for it! :grinning:

Fortunately much of the needed code was already in place, just the bit that injected the named group results into the Lua sub-system was missing (the call to `TLuaInterpreter::setCaptureNameGroups(nameGroups, namePositions)`)!

#### Other info (issues closed, discussion etc)
It does actually make writing aliases a bit easier because it is easier to construct an alias using `matches.target` say rather than `matches[4]` if `?<target>` has been inserted at the start of the relevant capture group. It also makes extending/modifying an alias easier as there is no need to juggle indexes in the Lua script that uses, say, `matches.target` compared to one that uses `matches[4]`.

This should close #7171.