### PR TITLE
Infrastructure: reposition const before type specifier

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -606,7 +606,7 @@ void Host::reloadModules()
         if (otherHost == this || !otherHost->mpConsole) {
             continue;
         }
-        QMap<QString, int> const& modulePri = otherHost->mModulePriorities;
+        const QMap<QString, int>& modulePri = otherHost->mModulePriorities;
         QMap<int, QStringList> moduleOrder;
 
         auto modulePrioritiesIt = modulePri.constBegin();
@@ -967,7 +967,7 @@ void Host::thankForUsingPTB()
 
 void Host::setMediaLocationGMCP(const QString& mediaUrl)
 {
-    QUrl const url = QUrl(mediaUrl);
+    const QUrl url = QUrl(mediaUrl);
 
     if (!url.isValid()) {
         return;
@@ -983,7 +983,7 @@ QString Host::getMediaLocationGMCP() const
 
 void Host::setMediaLocationMSP(const QString& mediaUrl)
 {
-    QUrl const url = QUrl(mediaUrl);
+    const QUrl url = QUrl(mediaUrl);
 
     if (!url.isValid()) {
         return;
@@ -1799,7 +1799,7 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, int modul
         }
         QStringList _filterList;
         _filterList << qsl("*.xml") << qsl("*.trigger");
-        QFileInfoList const entries = _dir.entryInfoList(_filterList, QDir::Files);
+        const QFileInfoList entries = _dir.entryInfoList(_filterList, QDir::Files);
         for (auto& entry : entries) {
             file2.setFileName(entry.absoluteFilePath());
             file2.open(QFile::ReadOnly | QFile::Text);
@@ -3931,7 +3931,7 @@ bool Host::setBackgroundImage(const QString& name, QString& imgPath, int mode)
 
     auto pL = mpConsole->mLabelMap.value(name);
     if (pL) {
-        QPixmap const bgPixmap(imgPath);
+        const QPixmap bgPixmap(imgPath);
         pL->setPixmap(bgPixmap);
         return true;
     }
@@ -4050,7 +4050,7 @@ void Host::createMapper(const bool loadDefaultMap)
     if (loadDefaultMap && pMap->mpRoomDB->isEmpty()) {
         qDebug() << "Host::create_mapper() - restore map case 3.";
         pMap->pushErrorMessagesToFile(tr("Pre-Map loading(3) report"), true);
-        QDateTime const now(QDateTime::currentDateTime());
+        const QDateTime now(QDateTime::currentDateTime());
         if (pMap->restore(QString())) {
             pMap->audit();
             pMap->mpMapper->mp2dMap->init();
@@ -4323,7 +4323,7 @@ void Host::setBorders(QMargins borders)
     }
     auto x = mpConsole->width();
     auto y = mpConsole->height();
-    QSize const s = QSize(x, y);
+    const QSize s = QSize(x, y);
     QResizeEvent event(s, s);
     QApplication::sendEvent(mpConsole, &event);
     mpConsole->raiseMudletSysWindowResizeEvent(x, y);

--- a/src/Host.h
+++ b/src/Host.h
@@ -125,7 +125,7 @@ private:
 #ifndef QT_NO_DEBUG_STREAM
 inline QDebug& operator<<(QDebug& debug, const stopWatch& stopwatch)
 {
-    QDebugStateSaver const saver(debug);
+    const QDebugStateSaver saver(debug);
     Q_UNUSED(saver);
     debug.nospace() << qsl("stopwatch(mIsRunning: %1 mInitialised: %2 mIsPersistent: %3 mEffectiveStartDateTime: %4 mElapsedTime: %5)")
                        .arg((stopwatch.running() ? QLatin1String("true") : QLatin1String("false")),

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -101,7 +101,7 @@ T2DMap::T2DMap(QWidget* parent)
     mMultiSelectionListWidget.setItemsExpandable(false);
     mMultiSelectionListWidget.setSelectionMode(QAbstractItemView::MultiSelection); // Was ExtendedSelection
     mMultiSelectionListWidget.setRootIsDecorated(false);
-    QSizePolicy const multiSelectionSizePolicy(QSizePolicy::Maximum, QSizePolicy::Expanding);
+    const QSizePolicy multiSelectionSizePolicy(QSizePolicy::Maximum, QSizePolicy::Expanding);
     mMultiSelectionListWidget.setSizePolicy(multiSelectionSizePolicy);
     mMultiSelectionListWidget.setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
     mMultiSelectionListWidget.setFrameShape(QFrame::NoFrame);
@@ -319,7 +319,7 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
                     TRoom* closestCenterRoom = nullptr;
                     while (itpRoom.hasNext()) {
                         TRoom* room = itpRoom.next();
-                        QVector2D const meanToRoom(static_cast<float>(room->x) - mean_x, static_cast<float>(room->y) - mean_y);
+                        const QVector2D meanToRoom(static_cast<float>(room->x) - mean_x, static_cast<float>(room->y) - mean_y);
                         if (closestSquareDistance < -0.5) {
                             // Test for first time around loop - for initialisation
                             // Don't use an equality to zero test, we are using
@@ -382,7 +382,7 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
                 TRoom* closestCenterRoom = nullptr;
                 while (itpRoom.hasNext()) {
                     TRoom* room = itpRoom.next();
-                    QVector2D const meanToRoom(static_cast<float>(room->x) - mean_x, static_cast<float>(room->y) - mean_y);
+                    const QVector2D meanToRoom(static_cast<float>(room->x) - mean_x, static_cast<float>(room->y) - mean_y);
                     if (closestSquareDistance < -0.5) {
                         // Test for first time around loop - for initialisation
                         // Don't use an equality to zero test, we are using
@@ -455,8 +455,8 @@ void T2DMap::addSymbolToPixmapCache(const QString key, const QString text, const
     symbolPainter.setFont(mpMap->mMapSymbolFont);
     symbolPainter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing | QPainter::SmoothPixmapTransform, true);
 
-    QFontMetrics const mapSymbolFontMetrics = symbolPainter.fontMetrics();
-    QVector<quint32> const codePoints = symbolString.toUcs4();
+    const QFontMetrics mapSymbolFontMetrics = symbolPainter.fontMetrics();
+    const QVector<quint32> codePoints = symbolString.toUcs4();
     QVector<bool> isUsable;
     for (int i = 0; i < codePoints.size(); ++i) {
         isUsable.append(mapSymbolFontMetrics.inFontUcs4(codePoints.at(i)));
@@ -473,7 +473,7 @@ void T2DMap::addSymbolToPixmapCache(const QString key, const QString text, const
         fontForThisSymbol.setStyleStrategy(static_cast<QFont::StyleStrategy>(mpMap->mMapSymbolFont.styleStrategy() & ~(QFont::NoFontMerging)));
     }
 
-    qreal const fudgeFactor = symbolRectangle.toRect().width() * mpMap->mMapSymbolFontFudgeFactor;
+    const qreal fudgeFactor = symbolRectangle.toRect().width() * mpMap->mMapSymbolFontFudgeFactor;
     QRectF testRectangle(0, 0, fudgeFactor, fudgeFactor);
     testRectangle.moveCenter(pixmap->rect().center());
     QRectF boundaryRect;
@@ -525,7 +525,7 @@ bool T2DMap::sizeFontToFitTextInRect( QFont & font, const QRectF & boundaryRect,
     }
 
     qreal fontSize = qMax(minFontSize, font.pointSizeF());  // protect against too-small initial value
-    QRectF const testRect(boundaryRect.width() * (100 - percentageMargin) / 200.0,
+    const QRectF testRect(boundaryRect.width() * (100 - percentageMargin) / 200.0,
                     boundaryRect.height() * (100 - percentageMargin) / 200.0,
                     boundaryRect.width() * (100 - percentageMargin) / 100.0,
                     boundaryRect.height() * (100 - percentageMargin) / 100.);
@@ -716,7 +716,7 @@ inline void T2DMap::drawRoom(QPainter& painter,
 
     if (mBubbleMode) {
         const float roomRadius = 0.5 * rSize * mRoomWidth;
-        QPointF const roomCenter = QPointF(rx, ry);
+        const QPointF roomCenter = QPointF(rx, ry);
         if (!isRoomSelected) {
             // CHECK: The use of a gradient fill to a white center on round
             // rooms might look nice in some situations but not in all:
@@ -744,14 +744,14 @@ inline void T2DMap::drawRoom(QPainter& painter,
             // in this method that handles clicking on the out of area exit so
             // that a speed walk is done to the room in the OTHER area:
             const float roomRadius = 0.4 * mRoomWidth;
-            QPointF const roomCenter = QPointF(rx, ry);
+            const QPointF roomCenter = QPointF(rx, ry);
             QRadialGradient gradient(roomCenter, roomRadius);
             gradient.setColorAt(0.95, QColor(255, 0, 0, 150));
             gradient.setColorAt(0.80, QColor(150, 100, 100, 150));
             gradient.setColorAt(0.799, QColor(150, 100, 100, 100));
             gradient.setColorAt(0.7, QColor(255, 0, 0, 200));
             gradient.setColorAt(0, Qt::white);
-            QPen const transparentPen(Qt::transparent);
+            const QPen transparentPen(Qt::transparent);
             QPainterPath diameterPath;
             painter.setBrush(gradient);
             painter.setPen(transparentPen);
@@ -816,11 +816,11 @@ inline void T2DMap::drawRoom(QPainter& painter,
     // Do we need to draw the custom (user specified) highlight
     if (pRoom->highlight) {
         const float roomRadius = (pRoom->highlightRadius * mRoomWidth) / 2.0;
-        QPointF const roomCenter = QPointF(rx, ry);
+        const QPointF roomCenter = QPointF(rx, ry);
         QRadialGradient gradient(roomCenter, roomRadius);
         gradient.setColorAt(0.85, pRoom->highlightColor);
         gradient.setColorAt(0, pRoom->highlightColor2);
-        QPen const transparentPen(Qt::transparent);
+        const QPen transparentPen(Qt::transparent);
         QPainterPath diameterPath;
         painter.setBrush(gradient);
         painter.setPen(transparentPen);
@@ -1105,8 +1105,8 @@ inline void T2DMap::drawRoom(QPainter& painter,
         QMapIterator<int, QPointF> it(areaExitsMap);
         while (it.hasNext()) {
             it.next();
-            QPointF const roomCenter = it.value();
-            QRectF const dr = QRectF(roomCenter.x(), roomCenter.y(), mRoomWidth * rSize, mRoomHeight * rSize);
+            const QPointF roomCenter = it.value();
+            const QRectF dr = QRectF(roomCenter.x(), roomCenter.y(), mRoomWidth * rSize, mRoomHeight * rSize);
 
             // clang-format off
             if ((mPick
@@ -1131,7 +1131,7 @@ inline void T2DMap::drawRoom(QPainter& painter,
                 gradient.setColorAt(0.799, QColor(150, 100, 100, 100));
                 gradient.setColorAt(0.7, QColor(255, 0, 0, 200));
                 gradient.setColorAt(0, Qt::white);
-                QPen const transparentPen(Qt::transparent);
+                const QPen transparentPen(Qt::transparent);
                 QPainterPath myPath;
                 painter.setBrush(gradient);
                 painter.setPen(transparentPen);
@@ -1333,7 +1333,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
 
         mapNameFont.setStyleStrategy(QFont::StyleStrategy(QFont::PreferNoShaping|QFont::PreferAntialias|QFont::PreferOutline));
 
-        double const sizeAdjust = 0;
+        const double sizeAdjust = 0;
         mapNameFont.setPointSizeF(static_cast<qreal>(mRoomWidth) * rSize * pow(1.1, sizeAdjust) / 2.0);
         showRoomNames = (mapNameFont.pointSizeF() > 3.0);
     }
@@ -1441,14 +1441,14 @@ void T2DMap::paintEvent(QPaintEvent* e)
     if (isPlayerRoomVisible) {
         drawRoom(painter, roomVNumFont, mapNameFont, pen, pPlayerRoom, pDrawnArea->gridMode, isFontBigEnoughToShowRoomVnum, showRoomNames, playerRoomId, static_cast<float>(playerRoomOnWidgetCoordinates.x()), static_cast<float>(playerRoomOnWidgetCoordinates.y()), areaExitsMap);
         painter.save();
-        QPen const transparentPen(Qt::transparent);
+        const QPen transparentPen(Qt::transparent);
         QPainterPath myPath;
-        double const roomRadius = (mpMap->mPlayerRoomOuterDiameterPercentage / 200.0) * static_cast<double>(mRoomWidth);
+        const double roomRadius = (mpMap->mPlayerRoomOuterDiameterPercentage / 200.0) * static_cast<double>(mRoomWidth);
         QRadialGradient gradient(playerRoomOnWidgetCoordinates, roomRadius);
         if (mpHost->mMapStrongHighlight) {
             // Never set, no means to except via XMLImport, as dlgMapper class's
             // slot_toggleStrongHighlight is not wired up to anything
-            QRectF const dr = QRectF(playerRoomOnWidgetCoordinates.x() - (static_cast<double>(mRoomWidth) * rSize) / 2.0,
+            const QRectF dr = QRectF(playerRoomOnWidgetCoordinates.x() - (static_cast<double>(mRoomWidth) * rSize) / 2.0,
                                playerRoomOnWidgetCoordinates.y() - (static_cast<double>(mRoomHeight) * rSize) / 2.0,
                                static_cast<double>(mRoomWidth) * rSize, static_cast<double>(mRoomHeight) * rSize);
             painter.fillRect(dr, QColor(255, 0, 0, 150));
@@ -1526,11 +1526,11 @@ void T2DMap::paintEvent(QPaintEvent* e)
         if (pR_multiSelectionHighlight) {
             const float r_mSx = pR_multiSelectionHighlight->x * mRoomWidth + mRX;
             const float r_mSy = pR_multiSelectionHighlight->y * -1 * mRoomHeight + mRY;
-            QPen const savePen = painter.pen();
-            QBrush const saveBrush = painter.brush();
+            const QPen savePen = painter.pen();
+            const QBrush saveBrush = painter.brush();
             const float roomRadius = mRoomWidth * 1.2;
             const float roomDiagonal = mRoomWidth * 1.2;
-            QPointF const roomCenter = QPointF(r_mSx, r_mSy);
+            const QPointF roomCenter = QPointF(r_mSx, r_mSy);
 
             QPen yellowPen(QColor(255, 255, 50, 192)); // Quarter opaque yellow pen
             yellowPen.setWidth(mRoomWidth * 0.1);
@@ -1588,11 +1588,11 @@ void T2DMap::paintEvent(QPaintEvent* e)
     if (!mHelpMsg.isEmpty()) {
         painter.setPen(QColor(255, 155, 50));
         QFont _f = painter.font();
-        QFont const _f2 = _f;
+        const QFont _f2 = _f;
         _f.setPointSize(12); // 20 was a little large
         _f.setBold(true);
         painter.setFont(_f);
-        QRect const _r = QRect(0, 0, widgetWidth, widgetHeight);
+        const QRect _r = QRect(0, 0, widgetWidth, widgetHeight);
         painter.drawText(_r, Qt::AlignHCenter | Qt::AlignBottom | Qt::TextWordWrap, mHelpMsg);
         // Now draw text centered at bottom, so it does not clash with info window
         painter.setFont(_f2);
@@ -1937,7 +1937,7 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
 
                 const float ex = room->x * mRoomWidth + mRX;
                 const float ey = room->y * mRoomHeight * -1 + mRY;
-                QPointF const origin = QPointF(ex, ey);
+                const QPointF origin = QPointF(ex, ey);
                 // The following sets a point offset from the room center
                 // that depends on the exit direction that the custom line
                 // heads to from the room center - it forms a fixed segment
@@ -2006,17 +2006,17 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                     if (room->customLinesArrow.value(itk.key())) {
                         QLineF l0 = QLineF(polyLinePoints.last(), polyLinePoints.at(polyLinePoints.size() - 2));
                         l0.setLength(exitWidth * 5.0);
-                        QPointF const _p1 = l0.p1();
-                        QPointF const _p2 = l0.p2();
-                        QLineF const l1 = QLineF(l0);
-                        qreal const w1 = l1.angle() - 90.0;
+                        const QPointF _p1 = l0.p1();
+                        const QPointF _p2 = l0.p2();
+                        const QLineF l1 = QLineF(l0);
+                        const qreal w1 = l1.angle() - 90.0;
                         QLineF l2;
                         l2.setP1(_p2);
                         l2.setAngle(w1);
                         l2.setLength(exitWidth * 2.0);
-                        QPointF const _p3 = l2.p2();
+                        const QPointF _p3 = l2.p2();
                         l2.setAngle(l2.angle() + 180.0);
-                        QPointF const _p4 = l2.p2();
+                        const QPointF _p4 = l2.p2();
                         QPolygonF _poly;
                         _poly.append(_p1);
                         _poly.append(_p3);
@@ -2033,9 +2033,9 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                     }
 
                     if (_id == mCustomLineSelectedRoom && itk.key() == mCustomLineSelectedExit) {
-                        QPen const _savedPen = painter.pen();
+                        const QPen _savedPen = painter.pen();
                         QPen _pen;
-                        QBrush const _brush = painter.brush();
+                        const QBrush _brush = painter.brush();
                         painter.setBrush(Qt::NoBrush);
                         // The first two points in the polyLinePoints are
                         // fixed for all exit directions and do not get
@@ -2068,8 +2068,8 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
             if (direction >= DIR_NORTH && direction <= DIR_SOUTHWEST) {
                 // Stubs on non-XY plane exits are handled differently and we
                 // do not support special exit stubs (yet?)
-                QVector3D const uDirection = mpMap->scmUnitVectors.value(direction);
-                QLineF const stubLine(rx, ry, rx + uDirection.x() * 0.5 * mRoomWidth, ry + uDirection.y() * 0.5 * mRoomHeight);
+                const QVector3D uDirection = mpMap->scmUnitVectors.value(direction);
+                const QLineF stubLine(rx, ry, rx + uDirection.x() * 0.5 * mRoomWidth, ry + uDirection.y() * 0.5 * mRoomHeight);
                 const QString doorKey{TRoom::dirCodeToShortString(direction)};
                 // Draw the door lines before we draw the stub or the filled
                 // circle on the end - so that the latter overlays the doors
@@ -2084,7 +2084,7 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 // And turn off drawing the border (outline):
                 painter.setPen(Qt::NoPen);
                 QPainterPath stubMarkingCirclePath;
-                QRectF const surroundingRectF(stubLine.p2().x() - 0.1 * mRoomWidth, stubLine.p2().y() - 0.1 * mRoomHeight, 0.2 * mRoomWidth, 0.2 * mRoomHeight);
+                const QRectF surroundingRectF(stubLine.p2().x() - 0.1 * mRoomWidth, stubLine.p2().y() - 0.1 * mRoomHeight, 0.2 * mRoomWidth, 0.2 * mRoomHeight);
                 stubMarkingCirclePath.arcTo(surroundingRectF, 0.0, 360.0);
                 // So this should draw a solid filled circle whose diameter
                 // is fixed and not dependent on the exit line thickness:
@@ -2111,8 +2111,8 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
             const float ey = pE->y * mRoomHeight * -1 + mRY;
             const int ez = pE->z;
 
-            QVector3D const p1(ex, ey, ez);
-            QVector3D const p2(rx, ry, rz);
+            const QVector3D p1(ex, ey, ez);
+            const QVector3D p2(rx, ry, rz);
             // This was a QLine (so used integer coordinates), but lets
             // try with a QLineF as we are using floating point numbers:
             QLineF line;
@@ -2120,7 +2120,7 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 // Non-area exit:
                 if (!oneWayExits.contains(rID)) {
                     // Two way exit
-                    QLineF const l0 = QLineF(p2.toPointF(), p1.toPointF());
+                    const QLineF l0 = QLineF(p2.toPointF(), p1.toPointF());
                     painter.save();
                     QPen exitPen = painter.pen();
                     // We need the line not to extend past the actual end point:
@@ -2132,8 +2132,8 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                     QLineF l0 = QLineF(p2.toPointF(), p1.toPointF());
                     QLineF k0 = l0;
                     k0.setLength((l0.length() - exitWidth * 5.0) / 2.0);
-                    qreal const dx = k0.dx();
-                    qreal const dy = k0.dy();
+                    const qreal dx = k0.dx();
+                    const qreal dy = k0.dy();
                     painter.save();
                     QPen arrowPen = painter.pen();
                     QPen oneWayLinePen = painter.pen();
@@ -2145,17 +2145,17 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                     painter.drawLine(l0);
 
                     l0.setLength(exitWidth * 5.0);
-                    QPointF const _p1 = l0.p2();
-                    QPointF const _p2 = l0.p1();
-                    QLineF const l1 = QLineF(l0);
-                    qreal const w1 = l1.angle() - 90.0;
+                    const QPointF _p1 = l0.p2();
+                    const QPointF _p2 = l0.p1();
+                    const QLineF l1 = QLineF(l0);
+                    const qreal w1 = l1.angle() - 90.0;
                     QLineF l2;
                     l2.setP1(_p2);
                     l2.setAngle(w1);
                     l2.setLength(exitWidth * 2.0);
-                    QPointF const _p3 = l2.p2();
+                    const QPointF _p3 = l2.p2();
                     l2.setAngle(l2.angle() + 180.0);
-                    QPointF const _p4 = l2.p2();
+                    const QPointF _p4 = l2.p2();
                     QPolygonF poly;
                     poly.append(_p1);
                     poly.append(_p3);
@@ -2226,10 +2226,10 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 } else {
                     l0.setLength(exitWidth * 5.0);
                 }
-                QPointF const p1 = l0.p1();
-                QPointF const p2 = l0.p2();
-                QLineF const l1 = QLineF(l0);
-                qreal const w1 = l1.angle() - 90.0;
+                const QPointF p1 = l0.p1();
+                const QPointF p2 = l0.p2();
+                const QLineF l1 = QLineF(l0);
+                const qreal w1 = l1.angle() - 90.0;
                 QLineF l2;
                 l2.setP1(p2);
                 l2.setAngle(w1);
@@ -2238,9 +2238,9 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 } else {
                     l2.setLength(exitWidth * 2.0);
                 }
-                QPointF const p3 = l2.p2();
+                const QPointF p3 = l2.p2();
                 l2.setAngle(l2.angle() + 180.0);
-                QPointF const p4 = l2.p2();
+                const QPointF p4 = l2.p2();
                 QPolygonF polygon;
                 polygon.append(p1);
                 polygon.append(p3);
@@ -2309,11 +2309,11 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
         // have been drawn otherwise later drawn rooms will overwrite the
         // mark, especially on areas in gridmode.
         if (customLineDestinationTarget > 0 && customLineDestinationTarget == _id) {
-            QPen const savePen = painter.pen();
-            QBrush const saveBrush = painter.brush();
+            const QPen savePen = painter.pen();
+            const QBrush saveBrush = painter.brush();
             const float roomRadius = mRoomWidth * 1.2;
             const float roomDiagonal = mRoomWidth * 1.2;
-            QPointF const roomCenter = QPointF(rx, ry);
+            const QPointF roomCenter = QPointF(rx, ry);
 
             QPen yellowPen(QColor(255, 255, 50, 192)); // Quarter opaque yellow pen
             yellowPen.setWidth(mRoomWidth * 0.1);
@@ -2503,7 +2503,7 @@ void T2DMap::updateMapLabel(QRectF labelRectangle, int labelId, TArea* pArea)
     if (mpDlgMapLabel->isTextLabel()) {
         labelPainter.drawText(drawRectangle, Qt::AlignHCenter | Qt::AlignCenter, label.text, nullptr);
     } else {
-        QPixmap const imagePixmap = QPixmap(imagePath).scaled(drawRectangle.size(), mpDlgMapLabel->stretchImage() ? Qt::IgnoreAspectRatio : Qt::KeepAspectRatio);
+        const QPixmap imagePixmap = QPixmap(imagePath).scaled(drawRectangle.size(), mpDlgMapLabel->stretchImage() ? Qt::IgnoreAspectRatio : Qt::KeepAspectRatio);
         auto point = mpDlgMapLabel->stretchImage() ? QPoint(0, 0) : pixmap.rect().center() - imagePixmap.rect().center();
         labelPainter.drawPixmap(point, imagePixmap);
     }
@@ -2549,7 +2549,7 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
         mHelpMsg.clear();
         if (mSizeLabel) {
             mSizeLabel = false;
-            QRectF const labelRect = mMultiRect;
+            const QRectF labelRect = mMultiRect;
             createLabel(labelRect);
         }
         mMultiRect = QRect(0, 0, 0, 0);
@@ -3163,7 +3163,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                     const int mx = event->pos().x();
                     const int my = event->pos().y();
                     const QPoint click = QPoint(mx, my);
-                    QRectF const br = QRect(labelX, labelY, mapLabel.clickSize.width(), mapLabel.clickSize.height());
+                    const QRectF br = QRect(labelX, labelY, mapLabel.clickSize.width(), mapLabel.clickSize.height());
                     if (br.contains(click)) {
                         mapLabel.highlight = !mapLabel.highlight;
                         mLabelHighlighted = mapLabel.highlight;
@@ -3963,7 +3963,7 @@ void T2DMap::slot_spread()
             itCustomLine.next();
             QList<QPointF> customLinePoints = itCustomLine.value();
             for (auto& customLinePoint : customLinePoints) {
-                QPointF const movingPoint = customLinePoint;
+                const QPointF movingPoint = customLinePoint;
                 customLinePoint.setX(static_cast<float>((movingPoint.x() - dx) * spread + dx));
                 customLinePoint.setY(static_cast<float>((movingPoint.y() - dx) * spread + dy));
             }
@@ -4024,7 +4024,7 @@ void T2DMap::slot_shrink()
             itCustomLine.next();
             QList<QPointF> customLinePoints = itCustomLine.value();
             for (auto& customLinePoint : customLinePoints) {
-                QPointF const movingPoint = customLinePoint;
+                const QPointF movingPoint = customLinePoint;
                 customLinePoint.setX(static_cast<float>((movingPoint.x() - dx) / spread + dx));
                 customLinePoint.setY(static_cast<float>((movingPoint.y() - dx) / spread + dy));
             }
@@ -4242,12 +4242,12 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
     }
     if (mpMap->m2DPanMode) {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-        QPointF const panNewPosition = event->localPos();
+        const QPointF panNewPosition = event->localPos();
 #else
         QPointF panNewPosition = event->position();
 #endif
         mShiftMode = true;
-        QPointF const movement = mpMap->m2DPanStart - panNewPosition;
+        const QPointF movement = mpMap->m2DPanStart - panNewPosition;
         mMapCenterX += movement.x() / mRoomWidth;
         mMapCenterY += movement.y() / mRoomHeight;
         mpMap->m2DPanStart = panNewPosition;
@@ -4260,9 +4260,9 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
         if (room) {
             if (room->customLines.contains(mCustomLineSelectedExit)) {
                 if (room->customLines[mCustomLineSelectedExit].size() > mCustomLineSelectedPoint) {
-                    qreal const mx = static_cast<qreal>(event->pos().x()) / static_cast<qreal>(mRoomWidth) + mMapCenterX - static_cast<qreal>(xspan / 2.0f);
-                    qreal const my = static_cast<qreal>(yspan / 2.0f) - static_cast<qreal>(event->pos().y()) / static_cast<qreal>(mRoomHeight) - mMapCenterY;
-                    QPointF const pc = QPointF(mx, my);
+                    const qreal mx = static_cast<qreal>(event->pos().x()) / static_cast<qreal>(mRoomWidth) + mMapCenterX - static_cast<qreal>(xspan / 2.0f);
+                    const qreal my = static_cast<qreal>(yspan / 2.0f) - static_cast<qreal>(event->pos().y()) / static_cast<qreal>(mRoomHeight) - mMapCenterY;
+                    const QPointF pc = QPointF(mx, my);
                     room->customLines[mCustomLineSelectedExit][mCustomLineSelectedPoint] = pc;
                     room->calcRoomDimensions();
                     repaint();
@@ -4453,7 +4453,7 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
                     itk.next();
                     QList<QPointF> _pL = itk.value();
                     for (auto& point : _pL) {
-                        QPointF const op = point;
+                        const QPointF op = point;
                         point.setX(static_cast<float>(op.x() + dx));
                         point.setY(static_cast<float>(op.y() + dy));
                     }
@@ -4506,7 +4506,7 @@ bool T2DMap::getCenterSelection()
                 continue;
             }
 
-            QVector3D const meanToRoom(static_cast<float>(room->x) - mean_x, static_cast<float>(room->y) - mean_y, static_cast<float>(room->z) - mean_z);
+            const QVector3D meanToRoom(static_cast<float>(room->x) - mean_x, static_cast<float>(room->y) - mean_y, static_cast<float>(room->z) - mean_z);
             if (closestSquareDistance < -0.5) {
                 // Don't use an equality to zero test, we are using floats so
                 // need to allow for a little bit of fuzzzyness!
@@ -4537,7 +4537,7 @@ void T2DMap::wheelEvent(QWheelEvent* e)
     // However the event "pos()" depends on the widget it came from so we have
     // to use "globalPos()" instead and see how it lies in relation to the child
     // widget:
-    QRect const selectionListWidgetGlobalRect = QRect(mapToGlobal(mMultiSelectionListWidget.frameRect().topLeft()), mapToGlobal(mMultiSelectionListWidget.frameRect().bottomRight()));
+    const QRect selectionListWidgetGlobalRect = QRect(mapToGlobal(mMultiSelectionListWidget.frameRect().topLeft()), mapToGlobal(mMultiSelectionListWidget.frameRect().bottomRight()));
     if (mMultiSelectionListWidget.isVisible() && selectionListWidgetGlobalRect.contains(e->globalPosition().toPoint())) {
         e->accept();
         return;
@@ -4555,7 +4555,7 @@ void T2DMap::wheelEvent(QWheelEvent* e)
     const int yDelta = qRound(delta.y() * (e->modifiers() & Qt::ControlModifier ? 5.0 : 1.0) / (8.0 * 15.0));
     if (yDelta) {
         mPick = false;
-        qreal const oldZoom = xyzoom;
+        const qreal oldZoom = xyzoom;
         xyzoom = qMax(csmMinXYZoom, xyzoom * pow(1.07, yDelta));
         mpMap->mpRoomDB->getArea(mAreaID)->set2DMapZoom(xyzoom);
 
@@ -5148,7 +5148,7 @@ void T2DMap::setPlayerRoomStyle(const int type)
     // Indicate the LARGEST size we will need
     mPlayerRoomColorGradentStops.reserve(5);
 
-    double const factor = mpMap->mPlayerRoomInnerDiameterPercentage / 100.0;
+    const double factor = mpMap->mPlayerRoomInnerDiameterPercentage / 100.0;
     const bool solid = (mpMap->mPlayerRoomInnerDiameterPercentage == 0);
     switch (type) {
     case 1: // Simple(?) shaded red ring:

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -625,14 +625,14 @@ void TArea::writeJsonArea(QJsonArray& array) const
         // Must add on any remainder otherwise the total will be wrong:
         mpMap->incrementJsonProgressDialog(true, true, currentRoomCount % 10);
     }
-    QJsonValue const roomsValue{roomsArray};
+    const QJsonValue roomsValue{roomsArray};
     areaObj.insert(QLatin1String("rooms"), roomsValue);
 
     // Process the labels after the rooms so that the first area shows something
     // quickly (from the rooms) even if it has a number of labels to do.
 
     writeJsonLabels(areaObj);
-    QJsonValue const areaValue{areaObj};
+    const QJsonValue areaValue{areaObj};
     array.append(areaValue);
 }
 
@@ -678,7 +678,7 @@ void TArea::writeJsonUserData(QJsonObject& obj) const
     QMapIterator<QString, QString> itDataItem(mUserData);
     while (itDataItem.hasNext()) {
         itDataItem.next();
-        QJsonValue const userDataValue{itDataItem.value()};
+        const QJsonValue userDataValue{itDataItem.value()};
         userDataObj.insert(itDataItem.key(), userDataValue);
     }
     const QJsonValue userDatasValue{userDataObj};
@@ -719,7 +719,7 @@ void TArea::writeJsonLabels(QJsonObject& obj) const
             }
         }
     }
-    QJsonValue const labelsValue{labelArray};
+    const QJsonValue labelsValue{labelArray};
     obj.insert(QLatin1String("labels"), labelsValue);
 }
 
@@ -755,7 +755,7 @@ void TArea::writeJsonLabel(QJsonArray& array, const int id, const TMapLabel* pLa
     //: Default text if a label is created in mapper with no text
     if (!(pLabel->text.isEmpty() || !pLabel->text.compare(tr("no text")))) {
         // Don't include the text if it is am image:
-        QJsonValue const textValue{pLabel->text};
+        const QJsonValue textValue{pLabel->text};
         labelObj.insert(QLatin1String("text"), textValue);
     }
 
@@ -778,11 +778,11 @@ void TArea::writeJsonLabel(QJsonArray& array, const int id, const TMapLabel* pLa
         QJsonObject backgroundColorObj;
         TMap::writeJsonColor(foregroundColorObj, pLabel->fgColor);
         TMap::writeJsonColor(backgroundColorObj, pLabel->bgColor);
-        QJsonValue const foregroundColorValue{foregroundColorObj};
-        QJsonValue const backgroundColorValue{backgroundColorObj};
+        const QJsonValue foregroundColorValue{foregroundColorObj};
+        const QJsonValue backgroundColorValue{backgroundColorObj};
         colorsArray.append(foregroundColorValue);
         colorsArray.append(backgroundColorValue);
-        QJsonValue const colorsValue{colorsArray};
+        const QJsonValue colorsValue{colorsArray};
         labelObj.insert(QLatin1String("colors"), colorsValue);
     }
 
@@ -824,7 +824,7 @@ void TArea::readJsonLabel(const QJsonObject& labelObj)
         // assembled the operator== is too picky for our purposes as even the
         // way the colour was put together (color spec type) can make them NOT
         // seem to be the same when we'd think they were...
-        QJsonArray const colorsArray = labelObj.value(QLatin1String("colors")).toArray();
+        const QJsonArray colorsArray = labelObj.value(QLatin1String("colors")).toArray();
         label.fgColor = TMap::readJsonColor(colorsArray.at(0).toObject());
         label.bgColor = TMap::readJsonColor(colorsArray.at(1).toObject());
     } else {
@@ -832,7 +832,7 @@ void TArea::readJsonLabel(const QJsonObject& labelObj)
         label.bgColor = defaultLabelBackground;
     }
 
-    QJsonArray const imageArray = labelObj.value(QLatin1String("image")).toArray();
+    const QJsonArray imageArray = labelObj.value(QLatin1String("image")).toArray();
     QList<QByteArray> pixmapData;
     for (int i = 0, total = imageArray.size(); i < total; ++i) {
         pixmapData.append(imageArray.at(i).toString().toLatin1());
@@ -871,7 +871,7 @@ QSizeF TArea::readJsonSize(const QJsonObject& obj, const QString& title) const
         return size;
     }
 
-    QJsonArray const valueArray = obj.value(title).toArray();
+    const QJsonArray valueArray = obj.value(title).toArray();
     if (valueArray.at(0).isDouble()) {
         size.setWidth(valueArray.at(0).toDouble());
     }
@@ -898,7 +898,7 @@ QVector3D TArea::readJson3DCoordinates(const QJsonObject& obj, const QString& ti
         return position;
     }
 
-    QJsonArray const valueArray = obj.value(title).toArray();
+    const QJsonArray valueArray = obj.value(title).toArray();
     if (valueArray.at(0).isDouble()) {
         position.setX(valueArray.at(0).toDouble());
     }
@@ -943,7 +943,7 @@ QList<QByteArray> TArea::convertImageToBase64Data(const QPixmap& pixmap) const
 
 QPixmap TArea::convertBase64DataToImage(const QList<QByteArray>& pixmapArray) const
 {
-    QByteArray const decodedImageArray = QByteArray::fromBase64(pixmapArray.join());
+    const QByteArray decodedImageArray = QByteArray::fromBase64(pixmapArray.join());
     QPixmap pixmap;
     pixmap.loadFromData(decodedImageArray);
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -387,7 +387,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
     }
 
     // Check this each packet
-    QByteArray const usedEncoding = mpHost->mTelnet.getEncoding();
+    const QByteArray usedEncoding = mpHost->mTelnet.getEncoding();
     if (mEncoding != usedEncoding) {
         encodingChanged(usedEncoding);
         // Will have to dump any stored bytes as they will be in the old
@@ -573,7 +573,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                     // Needed for mud.durismud.com see forum message topic:
                     // https://forums.mudlet.org/viewtopic.php?f=9&t=22887
                     const int dataLength = spanEnd - spanStart;
-                    QByteArray const temp = QByteArray::fromRawData(localBuffer.substr(localBufferPosition, dataLength).c_str(), dataLength);
+                    const QByteArray temp = QByteArray::fromRawData(localBuffer.substr(localBufferPosition, dataLength).c_str(), dataLength);
                     bool isOk = false;
                     const int spacesNeeded = temp.toInt(&isOk);
                     if (isOk && spacesNeeded > 0) {
@@ -616,7 +616,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                      *   scrollback buffer - which is again a NWIH for us...!
                      */
                     const int dataLength = spanEnd - spanStart;
-                    QByteArray const temp = QByteArray::fromRawData(localBuffer.substr(localBufferPosition, dataLength).c_str(), dataLength);
+                    const QByteArray temp = QByteArray::fromRawData(localBuffer.substr(localBufferPosition, dataLength).c_str(), dataLength);
                     bool isOk = false;
                     const int argValue = temp.toInt(&isOk);
                     if (isOk) {

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -414,7 +414,7 @@ private:
 // Note "inline" is REQUIRED:
 inline QDebug& operator<<(QDebug& debug, const TChar::AttributeFlags& attributes)
 {
-    QDebugStateSaver const saver(debug);
+    const QDebugStateSaver saver(debug);
     QString result = QLatin1String("TChar::AttributeFlags(");
     QStringList presentAttributes;
     if (attributes & TChar::Bold) {

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -64,7 +64,7 @@ TCommandLine::TCommandLine(Host* pHost, const QString& name, CommandLineType typ
     setPalette(mRegularPalette);
     //style subCommandLines by stylesheet
     if (mType != MainCommandLine) {
-        QColor const c = mpHost->mCommandLineBgColor;
+        const QColor c = mpHost->mCommandLineBgColor;
         const QString styleSheet{qsl("QPlainTextEdit{background-color: rgb(%1, %2, %3);}").arg(c.red()).arg(c.green()).arg(c.blue())};
         setStyleSheet(styleSheet);
     }
@@ -623,7 +623,7 @@ void TCommandLine::adjustHeight()
         mpConsole->layerCommandLine->setMaximumHeight(_height);
         const int x = mpConsole->width();
         const int y = mpConsole->height();
-        QSize const s = QSize(x, y);
+        const QSize s = QSize(x, y);
         QResizeEvent event(s, s);
         QApplication::sendEvent(mpConsole, &event);
     }
@@ -1032,8 +1032,8 @@ void TCommandLine::handleTabCompletion(bool direction)
             return;
         }
         QString lastWord;
-        QRegularExpression const reg = QRegularExpression(qsl(R"(\b(\w+)$)"), QRegularExpression::UseUnicodePropertiesOption);
-        QRegularExpressionMatch const match = reg.match(mTabCompletionTyped);
+        const QRegularExpression reg = QRegularExpression(qsl(R"(\b(\w+)$)"), QRegularExpression::UseUnicodePropertiesOption);
+        const QRegularExpressionMatch match = reg.match(mTabCompletionTyped);
         const int typePosition = match.capturedStart();
         if (reg.captureCount() >= 1) {
             lastWord = match.captured(1);
@@ -1267,7 +1267,7 @@ void TCommandLine::recheckWholeLine()
     }
 
     // Save the current position
-    QTextCursor const oldCursor = textCursor();
+    const QTextCursor oldCursor = textCursor();
 
     QTextCursor c = textCursor();
     // Move Cursor AND selection anchor to start:

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -97,11 +97,11 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     setAttribute(Qt::WA_DeleteOnClose);
     setAttribute(Qt::WA_OpaquePaintEvent); //was disabled
 
-    QSizePolicy const sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    QSizePolicy const sizePolicy3(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    QSizePolicy const sizePolicy2(QSizePolicy::Expanding, QSizePolicy::Fixed);
-    QSizePolicy const sizePolicy4(QSizePolicy::Fixed, QSizePolicy::Expanding);
-    QSizePolicy const sizePolicy5(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    const QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    const QSizePolicy sizePolicy3(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    const QSizePolicy sizePolicy2(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    const QSizePolicy sizePolicy4(QSizePolicy::Fixed, QSizePolicy::Expanding);
+    const QSizePolicy sizePolicy5(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
     mpMainFrame->setContentsMargins(0, 0, 0, 0);
 
@@ -566,7 +566,7 @@ Host* TConsole::getHost()
 
 void TConsole::resizeConsole()
 {
-    QSize const size = QSize(width(), height());
+    const QSize size = QSize(width(), height());
     QResizeEvent event(size, size);
     QApplication::sendEvent(this, &event);
 }
@@ -700,7 +700,7 @@ void TConsole::refresh()
     mpMainDisplay->move(mBorders.left(), mBorders.top());
     x = width();
     y = height();
-    QSize const s = QSize(x, y);
+    const QSize s = QSize(x, y);
     QResizeEvent event(s, s);
     QApplication::sendEvent(this, &event);
 }
@@ -1359,7 +1359,7 @@ std::list<int> TConsole::getFgColor()
     auto line = buffer.buffer.at(y);
     const int len = static_cast<int>(line.size());
     if (len - 1 >= x) {
-        QColor const color(line.at(x).foreground());
+        const QColor color(line.at(x).foreground());
         result.push_back(color.red());
         result.push_back(color.green());
         result.push_back(color.blue());
@@ -1386,7 +1386,7 @@ std::list<int> TConsole::getBgColor()
     auto line = buffer.buffer.at(y);
     const int len = static_cast<int>(line.size());
     if (len - 1 >= x) {
-        QColor const color(line.at(x).background());
+        const QColor color(line.at(x).background());
         result.push_back(color.red());
         result.push_back(color.green());
         result.push_back(color.blue());
@@ -1462,7 +1462,7 @@ bool TConsole::resetConsoleBackgroundImage()
 
 void TConsole::setCmdVisible(bool isVisible)
 {
-    QSizePolicy const sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    const QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     // create MiniConsole commandline if it's not existing
     if (!mpCommandLine) {
         if (!isVisible) {
@@ -1958,7 +1958,7 @@ QSize TConsole::getMainWindowSize() const
     if (isHidden()) {
         return mOldSize;
     }
-    QSize const consoleSize = size();
+    const QSize consoleSize = size();
     const int toolbarWidth = mpLeftToolBar->width() + mpRightToolBar->width();
     const int toolbarHeight = mpTopToolBar->height();
     const int commandLineHeight = mpCommandLine->height();
@@ -2031,7 +2031,7 @@ void TConsole::dropEvent(QDropEvent* e)
         }
     }
     if (e->mimeData()->hasText()) {
-        if (QUrl const url(e->mimeData()->text()); url.isValid()) {
+        if (const QUrl url(e->mimeData()->text()); url.isValid()) {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
             const QPoint pos = e->pos();
 #else

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -345,7 +345,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS(TConsole::ConsoleType)
 inline QDebug& operator<<(QDebug& debug, const TConsole::ConsoleType& type)
 {
     QString text;
-    QDebugStateSaver const saver(debug);
+    const QDebugStateSaver saver(debug);
     switch (type) {
     case TConsole::UnknownType:           text = qsl("Unknown"); break;
     case TConsole::CentralDebugConsole:   text = qsl("Central Debug Console"); break;

--- a/src/TEasyButtonBar.cpp
+++ b/src/TEasyButtonBar.cpp
@@ -49,7 +49,7 @@ TEasyButtonBar::TEasyButtonBar(TAction* pA, QString name, QWidget* pW)
         setContentsMargins(0, 0, 0, 0);
         mpLayout->setContentsMargins(0, 0, 0, 0);
         mpLayout->setSpacing(0);
-        QSizePolicy const sizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+        const QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
         mpWidget->setSizePolicy(sizePolicy);
     } else {
         mpWidget->setMinimumHeight(mpTAction->mSizeY);
@@ -76,7 +76,7 @@ void TEasyButtonBar::addButton(TFlipButton* pB)
         }
     } else {
         qDebug() << "setting up custom sizes";
-        QSize const size = QSize(pB->mpTAction->mSizeX, pB->mpTAction->mSizeY);
+        const QSize size = QSize(pB->mpTAction->mSizeX, pB->mpTAction->mSizeY);
         pB->setMaximumSize(size);
         pB->setMinimumSize(size);
         pB->setParent(mpWidget);
@@ -136,7 +136,7 @@ void TEasyButtonBar::finalize()
     }
     auto fillerWidget = new QWidget;
 
-    QSizePolicy const sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    const QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     fillerWidget->setSizePolicy(sizePolicy);
     int columns = mpTAction->getButtonColumns();
     if (columns <= 0) {
@@ -200,7 +200,7 @@ void TEasyButtonBar::clear()
         mpWidget->setLayout(mpLayout);
         mpLayout->setContentsMargins(0, 0, 0, 0);
         mpLayout->setSpacing(0);
-        QSizePolicy const sizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+        const QSizePolicy sizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
         mpWidget->setSizePolicy(sizePolicy);
 
         mpWidget->setContentsMargins(0, 0, 0, 0);

--- a/src/TEncodingTable.cpp
+++ b/src/TEncodingTable.cpp
@@ -36,7 +36,7 @@ QList<QByteArray> TEncodingTable::getEncodingNames() const
 
         QMutableByteArrayListIterator itEncoding(results);
         while (itEncoding.hasNext()) {
-            QByteArray const encoding{itEncoding.next()};
+            const QByteArray encoding{itEncoding.next()};
             QTextCodec* pEncoding = QTextCodec::codecForName(encoding);
             if (!pEncoding) {
                 // We do not have that encoder available after all

--- a/src/TEvent.h
+++ b/src/TEvent.h
@@ -47,7 +47,7 @@ public:
 // Note "inline" is REQUIRED:
 inline QDebug& operator<<(QDebug& debug, const TEvent& event)
 {
-    QDebugStateSaver const saver(debug);
+    const QDebugStateSaver saver(debug);
     const int argCount = event.mArgumentList.count();
     const int typeCount = event.mArgumentTypeList.count();
     int i = 0;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1133,13 +1133,13 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
                         luaL_typename(L, 1));
         return lua_error(L);
     }
-    QByteArray const data{lua_tostring(L, 1)};
+    const QByteArray data{lua_tostring(L, 1)};
     bool dataIsUtf8Encoded = true;
     if (lua_gettop(L) > 1) {
         dataIsUtf8Encoded = getVerifiedBool(L, __func__, 2, "Utf8Encoded", true);
     }
 
-    QByteArray const currentEncoding = host.mTelnet.getEncoding();
+    const QByteArray currentEncoding = host.mTelnet.getEncoding();
     if (dataIsUtf8Encoded) {
         // We can convert the data from a QByteArray to a QString:
         if (currentEncoding == "UTF-8") {
@@ -2466,7 +2466,7 @@ int TLuaInterpreter::setMergeTables(lua_State* L)
 int TLuaInterpreter::getMudletVersion(lua_State* L)
 {
     QByteArray version = QByteArray(APP_VERSION).trimmed();
-    QByteArray const build = mudlet::self()->mAppBuild.trimmed().toLocal8Bit();
+    const QByteArray build = mudlet::self()->mAppBuild.trimmed().toLocal8Bit();
 
     QList<QByteArray> const versionData = version.split('.');
     if (versionData.size() != 3) {
@@ -2578,13 +2578,13 @@ int TLuaInterpreter::getTime(lua_State* L)
             format = getVerifiedString(L, __func__, 2, "custom time format");
         }
     }
-    QDateTime const time = QDateTime::currentDateTime();
+    const QDateTime time = QDateTime::currentDateTime();
     if (return_string) {
         tm = time.toString(format);
         lua_pushstring(L, tm.toUtf8().constData());
     } else {
-        QDate const dt = time.date();
-        QTime const tm = time.time();
+        const QDate dt = time.date();
+        const QTime tm = time.time();
         lua_createtable(L, 0, 4);
         lua_pushstring(L, "hour");
         lua_pushinteger(L, tm.hour());
@@ -3015,7 +3015,7 @@ int TLuaInterpreter::setServerEncoding(lua_State* L)
         lua_pushfstring(L, "setServerEncoding: bad argument #1 type (newEncoding as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QByteArray const newEncoding = lua_tostring(L, 1);
+    const QByteArray newEncoding = lua_tostring(L, 1);
     QPair<bool, QString> const results = host.mTelnet.setEncoding(newEncoding);
 
     if (!results.first) {
@@ -3597,13 +3597,13 @@ void TLuaInterpreter::parseJSON(QString& key, const QString& string_data, const 
     }
     // auto-detect IRE composer
     if (tokenList.size() == 3 && tokenList.at(0).toLower() == "ire" && tokenList.at(1).toLower() == "composer" && tokenList.at(2).toLower() == "edit") {
-        QRegularExpression const rx(qsl(R"lit(\{ ?"title": ?"(.*)", ?"text": ?"(.*)" ?\})lit"));
-        QRegularExpressionMatch const match = rx.match(string_data);
+        const QRegularExpression rx(qsl(R"lit(\{ ?"title": ?"(.*)", ?"text": ?"(.*)" ?\})lit"));
+        const QRegularExpressionMatch match = rx.match(string_data);
 
         if (match.capturedStart() != -1) {
             const QString title = match.captured(1);
             QString initialText = match.captured(2);
-            QRegularExpression const codeRegex(qsl(R"lit(\\n|\\t|\\"|\\\\|\\u[0-9a-cA-C][0-9a-fA-F]{3}|\\u[dD][0-7][0-9a-fA-F]{2}|\\u[efEF][0-9a-fA-F]{3}|\\u[dD][89abAB][0-9a-fA-F]{2}\\u[dD][c-fC-F][0-9a-fA-F]{2})lit"));
+            const QRegularExpression codeRegex(qsl(R"lit(\\n|\\t|\\"|\\\\|\\u[0-9a-cA-C][0-9a-fA-F]{3}|\\u[dD][0-7][0-9a-fA-F]{2}|\\u[efEF][0-9a-fA-F]{3}|\\u[dD][89abAB][0-9a-fA-F]{2}\\u[dD][c-fC-F][0-9a-fA-F]{2})lit"));
             // We are about to search for 8 escape code strings within the initial text that the game gave us, patterns are:
             // \n  \t  \"  \\ - new line, tab, quote, backslash
             // Then there are three patterns for \uXXXX where XXXX is a 4-digit hexadecimal value
@@ -3730,7 +3730,7 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
 void TLuaInterpreter::msdp2Lua(const char* src)
 {
     Host& host = getHostFromLua(pGlobalLua);
-    QByteArray const transcodedSrc = host.mTelnet.decodeBytes(src);
+    const QByteArray transcodedSrc = host.mTelnet.decodeBytes(src);
     QStringList varList;
     QByteArray lastVar;
     const int textLength = transcodedSrc.length();
@@ -4609,7 +4609,7 @@ int TLuaInterpreter::performHttpRequest(lua_State *L, const char* functionName, 
     }
 
     const QString urlString = getVerifiedString(L, functionName, pos + 2, "remote url");
-    QUrl const url = QUrl::fromUserInput(urlString);
+    const QUrl url = QUrl::fromUserInput(urlString);
 
     if (!url.isValid()) {
         return warnArgumentValue(L, __func__, qsl("url is invalid, reason: %1.").arg(url.errorString()));
@@ -4691,7 +4691,7 @@ int TLuaInterpreter::unzipAsync(lua_State *L)
     const QString zipLocation = getVerifiedString(L, __func__, 1, "zip location");
     QString extractLocation = getVerifiedString(L, __func__, 2, "extract location");
 
-    QTemporaryDir const temporaryDir;
+    const QTemporaryDir temporaryDir;
     if (!temporaryDir.isValid()) {
         return warnArgumentValue(L, __func__, "couldn't create temporary directory to extract the zip into");
     }
@@ -5982,7 +5982,7 @@ std::pair<int, QString> TLuaInterpreter::setScriptCode(const QString& name, cons
 // No documentation available in wiki - internal function
 std::pair<int, QString> TLuaInterpreter::startPermTimer(const QString& name, const QString& parent, double timeout, const QString& function)
 {
-    QTime const time = QTime(0, 0, 0, 0).addMSecs(qRound(timeout * 1000));
+    const QTime time = QTime(0, 0, 0, 0).addMSecs(qRound(timeout * 1000));
     TTimer* pT;
     if (parent.isEmpty()) {
         pT = new TTimer(qsl("newPermTimerWithoutAnId"), time, mpHost);
@@ -6020,7 +6020,7 @@ std::pair<int, QString> TLuaInterpreter::startPermTimer(const QString& name, con
 // No documentation available in wiki - internal function
 QPair<int, QString> TLuaInterpreter::startTempTimer(double timeout, const QString& function, const bool repeating)
 {
-    QTime const time = QTime(0,0,0,0).addMSecs(qRound(timeout * 1000));
+    const QTime time = QTime(0,0,0,0).addMSecs(qRound(timeout * 1000));
     auto* pT = new TTimer(qsl("newTempTimerWithoutAnId"), time, mpHost, repeating);
     pT->setTime(time);
     pT->setIsFolder(false);
@@ -6850,7 +6850,7 @@ void TLuaInterpreter::createHttpHeadersTable(lua_State* L, QNetworkReply* reply)
 
     // Parse headers, add them as key-value pairs to the empty table
     const QList<QByteArray> headerList = reply->rawHeaderList();
-    for (QByteArray const header : headerList) {
+    for (const QByteArray header : headerList) {
         // Push header key onto stack
         lua_pushstring(L, header.constData());
         // Push header value onto stack
@@ -6881,8 +6881,8 @@ void TLuaInterpreter::createCookiesTable(lua_State* L, QNetworkReply* reply)
     // Parse cookies, add them as key-value pairs to the empty table
     const Host& host = getHostFromLua(L);
     QNetworkCookieJar* cookieJar = host.mLuaInterpreter.mpFileDownloader->cookieJar();
-    QList<QNetworkCookie> const cookies = cookieJar->cookiesForUrl(reply->url());
-    for (QNetworkCookie const cookie : cookies) {
+    const QList<QNetworkCookie> cookies = cookieJar->cookiesForUrl(reply->url());
+    for (const QNetworkCookie cookie : cookies) {
         // Push cookie name onto stack
         lua_pushstring(L, cookie.name().constData());
         // Push cookie value onto stack

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -3452,7 +3452,7 @@ int TLuaInterpreter::setMapUserData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMapZoom
 int TLuaInterpreter::setMapZoom(lua_State* L)
 {
-    qreal const zoom = getVerifiedDouble(L, __func__, 1, "zoom");
+    const qreal zoom = getVerifiedDouble(L, __func__, 1, "zoom");
     int areaID = 0;
     if (lua_gettop(L) > 1) {
         areaID = getVerifiedInt(L, __func__, 2, "area id", true);

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -194,7 +194,7 @@ int TLuaInterpreter::adjustStopWatch(lua_State* L)
         return 2;
     }
 
-    double const adjustment = getVerifiedDouble(L, __func__, 2, "modification in seconds");
+    const double adjustment = getVerifiedDouble(L, __func__, 2, "modification in seconds");
     const bool result = host.adjustStopWatch(watchId, qRound(adjustment * 1000.0));
     // This is only likely to fail when a numeric first argument was given:
     if (!result) {
@@ -1226,7 +1226,7 @@ int TLuaInterpreter::permTimer(lua_State* L)
 {
     const QString name = getVerifiedString(L, __func__, 1, "timer name");
     const QString parent = getVerifiedString(L, __func__, 2, "timer parent name");
-    double const time = getVerifiedDouble(L, __func__, 3, "time in seconds");
+    const double time = getVerifiedDouble(L, __func__, 3, "time in seconds");
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
     if (auto [validationResult, validationMessage] = pLuaInterpreter->validateLuaCodeParam(4); !validationResult) {
@@ -1656,7 +1656,7 @@ int TLuaInterpreter::setTriggerStayOpen(lua_State* L)
     if (lua_gettop(L) > 1) {
         windowName = WINDOW_NAME(L, s++);
     }
-    double const b = getVerifiedDouble(L, __func__, s, "number of lines");
+    const double b = getVerifiedDouble(L, __func__, s, "number of lines");
     Host& host = getHostFromLua(L);
     host.getTriggerUnit()->setTriggerStayOpen(windowName, static_cast<int>(b));
     return 0;
@@ -2464,7 +2464,7 @@ int TLuaInterpreter::tempRegexTrigger(lua_State* L)
 int TLuaInterpreter::tempTimer(lua_State* L)
 {
     bool repeating{};
-    double const time = getVerifiedDouble(L, __func__, 1, "time in seconds {maybe decimal}");
+    const double time = getVerifiedDouble(L, __func__, 1, "time in seconds {maybe decimal}");
     const int n = lua_gettop(L);
 
     Host& host = getHostFromLua(L);

--- a/src/TLuaInterpreterNetworking.cpp
+++ b/src/TLuaInterpreterNetworking.cpp
@@ -131,7 +131,7 @@ int TLuaInterpreter::downloadFile(lua_State* L)
     Host& host = getHostFromLua(L);
     const QString localFile = getVerifiedString(L, __func__, 1, "local filename");
     const QString urlString = getVerifiedString(L, __func__, 2, "remote url");
-    QUrl const url = QUrl::fromUserInput(urlString);
+    const QUrl url = QUrl::fromUserInput(urlString);
     if (!url.isValid()) {
         return warnArgumentValue(L, __func__, qsl("url is invalid, reason: %1").arg(url.errorString()));
     }
@@ -300,7 +300,7 @@ int TLuaInterpreter::sendATCP(lua_State* L)
         lua_pushfstring(L, "sendATCP: bad argument #1 type (message as string expected, got %1!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    std::string const msg = host.mTelnet.encodeAndCookBytes(lua_tostring(L, 1));
+    const std::string msg = host.mTelnet.encodeAndCookBytes(lua_tostring(L, 1));
 
     std::string what;
     if (lua_gettop(L) > 1) {
@@ -344,7 +344,7 @@ int TLuaInterpreter::sendGMCP(lua_State* L)
         lua_pushfstring(L, "sendGMCP: bad argument #1 type (message as string expected, got %1!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    std::string const msg = host.mTelnet.encodeAndCookBytes(lua_tostring(L, 1));
+    const std::string msg = host.mTelnet.encodeAndCookBytes(lua_tostring(L, 1));
 
     std::string what;
     if (lua_gettop(L) > 1) {
@@ -426,7 +426,7 @@ int TLuaInterpreter::sendMSDP(lua_State* L)
         }
     }
 
-    std::string const variable = host.mTelnet.encodeAndCookBytes(lua_tostring(L, 1));
+    const std::string variable = host.mTelnet.encodeAndCookBytes(lua_tostring(L, 1));
 
     std::string output;
     output += TN_IAC;
@@ -456,7 +456,7 @@ int TLuaInterpreter::sendTelnetChannel102(lua_State* L)
                         luaL_typename(L, 1));
         return lua_error(L);
     }
-    std::string const msg = lua_tostring(L, 1);
+    const std::string msg = lua_tostring(L, 1);
     if (msg.length() != 2) {
         return warnArgumentValue(L, __func__, qsl(
             "invalid message of length %1 supplied, it should be two bytes (may use lua \\### for each byte where ### is a number between 1 and 254)")
@@ -547,7 +547,7 @@ int TLuaInterpreter::setIrcServer(lua_State* L)
     int secure = false;
     int port = 6667;
     QString password;
-    std::string const addr = getVerifiedString(L, __func__, 1, "hostname").toStdString();
+    const std::string addr = getVerifiedString(L, __func__, 1, "hostname").toStdString();
     if (addr.empty()) {
         return warnArgumentValue(L, __func__, "hostname must not be empty");
     }
@@ -595,7 +595,7 @@ int TLuaInterpreter::getHTTP(lua_State* L)
 {
     auto& host = getHostFromLua(L);
     const QString urlString = getVerifiedString(L, __func__, 1, "remote url");
-    QUrl const url = QUrl::fromUserInput(urlString);
+    const QUrl url = QUrl::fromUserInput(urlString);
     if (!url.isValid()) {
         return warnArgumentValue(L, __func__, qsl("url is invalid, reason: %1").arg(url.errorString()));
     }
@@ -654,7 +654,7 @@ int TLuaInterpreter::deleteHTTP(lua_State *L)
 {
     auto& host = getHostFromLua(L);
     const QString urlString = getVerifiedString(L, __func__, 1, "remote url");
-    QUrl const url = QUrl::fromUserInput(urlString);
+    const QUrl url = QUrl::fromUserInput(urlString);
     if (!url.isValid()) {
         return warnArgumentValue(L, __func__, qsl("url is invalid, reason: %1").arg(url.errorString()));
     }

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -1101,7 +1101,7 @@ int TLuaInterpreter::getProfileTabNumber(lua_State* L)
 int TLuaInterpreter::getMainWindowSize(lua_State* L)
 {
     const Host& host = getHostFromLua(L);
-    QSize const mainWindowSize = host.mpConsole->getMainWindowSize();
+    const QSize mainWindowSize = host.mpConsole->getMainWindowSize();
 
     lua_pushnumber(L, mainWindowSize.width());
     lua_pushnumber(L, mainWindowSize.height());
@@ -1213,7 +1213,7 @@ int TLuaInterpreter::getTextFormat(lua_State* L)
     lua_pushboolean(L, format & TChar::Underline);
     lua_settable(L, -3);
 
-    QColor const foreground(result.second.foreground());
+    const QColor foreground(result.second.foreground());
     lua_pushstring(L, "foreground");
     lua_newtable(L);
     lua_pushnumber(L, 1);
@@ -1229,7 +1229,7 @@ int TLuaInterpreter::getTextFormat(lua_State* L)
     lua_settable(L, -3);
     lua_settable(L, -3);
 
-    QColor const background(result.second.background());
+    const QColor background(result.second.background());
     lua_pushstring(L, "background");
     lua_newtable(L);
     lua_pushnumber(L, 1);
@@ -1254,7 +1254,7 @@ int TLuaInterpreter::getUserWindowSize(lua_State* L)
     const QString windowName {WINDOW_NAME(L, 1)};
 
     const Host& host = getHostFromLua(L);
-    QSize const userWindowSize = host.mpConsole->getUserWindowSize(windowName);
+    const QSize userWindowSize = host.mpConsole->getUserWindowSize(windowName);
     lua_pushnumber(L, userWindowSize.width());
     lua_pushnumber(L, userWindowSize.height());
 
@@ -1661,8 +1661,8 @@ int TLuaInterpreter::moveCursorEnd(lua_State* L)
 int TLuaInterpreter::moveWindow(lua_State* L)
 {
     const QString text = getVerifiedString(L, __func__, 1, "name");
-    double const x1 = getVerifiedDouble(L, __func__, 2, "x");
-    double const y1 = getVerifiedDouble(L, __func__, 3, "y");
+    const double x1 = getVerifiedDouble(L, __func__, 2, "x");
+    const double y1 = getVerifiedDouble(L, __func__, 3, "y");
     Host& host = getHostFromLua(L);
     host.moveWindow(text, static_cast<int>(x1), static_cast<int>(y1));
     return 0;
@@ -1837,8 +1837,8 @@ int TLuaInterpreter::resetFormat(lua_State* L)
 int TLuaInterpreter::resizeWindow(lua_State* L)
 {
     const QString text = getVerifiedString(L, __func__, 1, "windowName");
-    double const x1 = getVerifiedDouble(L, __func__, 2, "width");
-    double const y1 = getVerifiedDouble(L, __func__, 3, "height");
+    const double x1 = getVerifiedDouble(L, __func__, 2, "width");
+    const double y1 = getVerifiedDouble(L, __func__, 3, "height");
     Host& host = getHostFromLua(L);
     host.resizeWindow(text, static_cast<int>(x1), static_cast<int>(y1));
     return 0;
@@ -3202,7 +3202,7 @@ int TLuaInterpreter::pasteWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableScrolling
 int TLuaInterpreter::enableScrolling(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     if (windowName.compare(qsl("main"), Qt::CaseSensitive) == 0) {
         lua_pushnil(L);
         lua_pushfstring(L, "scrolling cannot be enabled/disabled for the 'main' window", windowName.toUtf8().constData());
@@ -3218,7 +3218,7 @@ int TLuaInterpreter::enableScrolling(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableScrolling
 int TLuaInterpreter::disableScrolling(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     if (windowName.compare(qsl("main"), Qt::CaseSensitive) == 0) {
         lua_pushnil(L);
         lua_pushfstring(L, "scrolling cannot be enabled/disabled for the 'main' window", windowName.toUtf8().constData());
@@ -3234,7 +3234,7 @@ int TLuaInterpreter::disableScrolling(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#scrollingActive
 int TLuaInterpreter::scrollingActive(lua_State* L)
 {
-    QString const windowName {WINDOW_NAME(L, 1)};
+    const QString windowName {WINDOW_NAME(L, 1)};
     if (windowName.compare(qsl("main"), Qt::CaseSensitive) == 0) {
         // Handle the main console case:
         lua_pushboolean(L, true);

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -158,7 +158,7 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
 {
     const auto loggingPath = mudlet::getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), qsl("autolog"));
     QFile file(loggingPath);
-    QDateTime const logDateTime = QDateTime::currentDateTime();
+    const QDateTime logDateTime = QDateTime::currentDateTime();
     if (!mLogToLogFile) {
         file.open(QIODevice::WriteOnly | QIODevice::Text);
         QTextStream out(&file);
@@ -657,11 +657,11 @@ std::pair<bool, QString> TMainConsole::setLabelCustomCursor(const QString& name,
 
     auto pL = mLabelMap.value(name);
     if (pL) {
-        QPixmap const cursor_pixmap = QPixmap(pixMapLocation);
+        const QPixmap cursor_pixmap = QPixmap(pixMapLocation);
         if (cursor_pixmap.isNull()) {
             return {false, qsl("couldn't find custom cursor, is the location \"%1\" correct?").arg(pixMapLocation)};
         }
-        QCursor const custom_cursor = QCursor(cursor_pixmap, hotX, hotY);
+        const QCursor custom_cursor = QCursor(cursor_pixmap, hotX, hotY);
         pL->setCursor(custom_cursor);
         return {true, QString()};
     }
@@ -696,7 +696,7 @@ std::pair<bool, QString> TMainConsole::createMapper(const QString& windowname, i
         mpHost->mpMap->mpMapper = mpMapper;
         qDebug() << "TConsole::createMapper() - restore map case 2.";
         mpHost->mpMap->pushErrorMessagesToFile(tr("Pre-Map loading(2) report"), true);
-        QDateTime const now(QDateTime::currentDateTime());
+        const QDateTime now(QDateTime::currentDateTime());
 
         if (mpHost->mpMap->restore(QString())) {
             mpHost->mpMap->audit();
@@ -765,7 +765,7 @@ bool TMainConsole::setBackgroundImage(const QString& name, const QString& path)
 {
     auto pL = mLabelMap.value(name);
     if (pL) {
-        QPixmap const bgPixmap(path);
+        const QPixmap bgPixmap(path);
         pL->setPixmap(bgPixmap);
         return true;
     } else {
@@ -926,7 +926,7 @@ QSize TMainConsole::getUserWindowSize(const QString& windowname) const
 {
     auto pW = mDockWidgetMap.value(windowname);
     if (pW){
-        QSize const windowSize = pW->widget()->size();
+        const QSize windowSize = pW->widget()->size();
         QSize userWindowSize(windowSize.width(), windowSize.height());
         return userWindowSize;
     }
@@ -1165,7 +1165,7 @@ void TMainConsole::printOnDisplay(std::string& incomingSocketData, const bool is
         mpHost->mLuaInterpreter.signalMXPEvent(event.name, event.attrs, event.actions);
     }
 
-    double const processT = mProcessingTimer.elapsed() / 1000.0;
+    const double processT = mProcessingTimer.elapsed() / 1000.0;
     if (mpHost->mTelnet.mGA_Driver) {
         /*:
         The first argument 'N' represents the 'N'etwork latency; the second 'S' the
@@ -1279,7 +1279,7 @@ bool TMainConsole::loadMap(const QString& location)
 
     qDebug() << "TMainConsole::loadMap() - restore map case 1.";
     pHost->mpMap->pushErrorMessagesToFile(tr("Pre-Map loading(1) report"), true);
-    QDateTime const now(QDateTime::currentDateTime());
+    const QDateTime now(QDateTime::currentDateTime());
 
     bool result = false;
     if (pHost->mpMap->restore(location)) {
@@ -1343,7 +1343,7 @@ bool TMainConsole::importMap(const QString& location, QString* errMsg)
     // been logged...
     qDebug() << "TMainConsole::importingMap() - importing map case 1.";
     pHost->mpMap->pushErrorMessagesToFile(tr("Pre-Map importing(1) report"), true);
-    QDateTime const now(QDateTime::currentDateTime());
+    const QDateTime now(QDateTime::currentDateTime());
 
     bool result = false;
 

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -219,7 +219,7 @@ QString TMap::connectExitStubByDirection(const int fromRoomId, const int dirType
     }
 
     const int reverseDir = scmReverseDirections.value(dirType);
-    QVector3D const unitVector = scmUnitVectors.value(dirType);
+    const QVector3D unitVector = scmUnitVectors.value(dirType);
     // QVector3D is composed of floating point values so we need to round them
     // if we want to assign them to integral variables without compiler warnings!
     const int ux = qRound(unitVector.x());
@@ -1344,7 +1344,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
             qint8 oldCharacterCode = 0;
             if (pR->mSymbol.length()) {
                 // There is something for a symbol
-                QChar const firstChar = pR->mSymbol.at(0);
+                const QChar firstChar = pR->mSymbol.at(0);
                 if (pR->mSymbol.length() == 1 && firstChar.row() == 0 && firstChar.cell() > 32) {
                     // It is something that can be represented by the past unsigned short
                     oldCharacterCode = firstChar.toLatin1();
@@ -1768,7 +1768,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
                     ifs >> pA->mUserData;
                 } else if (mVersion >= 17) {
                     ifs >> pA->mUserData;
-                    qreal const fallback_map2DZoom = pA->mUserData.take(QLatin1String("system.fallback_map2DZoom")).toDouble();
+                    const qreal fallback_map2DZoom = pA->mUserData.take(QLatin1String("system.fallback_map2DZoom")).toDouble();
                     pA->mLast2DMapZoom = (fallback_map2DZoom >= T2DMap::csmMinXYZoom) ? fallback_map2DZoom : T2DMap::csmDefaultXYZoom;
                 }
                 if (mVersion >= 21) {
@@ -2179,14 +2179,14 @@ int TMap::createMapLabel(int area, const QString& text, float x, float y, float 
     label.noScaling = noScaling;
     label.temporary = temporary;
 
-    QRectF const lr = QRectF(0, 0, 1000, 1000);
+    const QRectF lr = QRectF(0, 0, 1000, 1000);
     QPixmap pix(lr.size().toSize());
     pix.fill(Qt::transparent);
     QPainter lp(&pix);
     lp.fillRect(lr, label.bgColor);
     QPen lpen;
     lpen.setColor(label.fgColor);
-    QFont const font(fontName.has_value() ? fontName.value() : QString(), fontSize);
+    const QFont font(fontName.has_value() ? fontName.value() : QString(), fontSize);
     lp.setRenderHint(QPainter::TextAntialiasing, true);
     lp.setPen(lpen);
     lp.setFont(font);
@@ -2195,7 +2195,7 @@ int TMap::createMapLabel(int area, const QString& text, float x, float y, float 
 
     label.size = br.normalized().size();
     label.pix = pix.copy(br.normalized().topLeft().x(), br.normalized().topLeft().y(), br.normalized().width(), br.normalized().height());
-    QSizeF const s = QSizeF(label.size.width() / zoom, label.size.height() / zoom);
+    const QSizeF s = QSizeF(label.size.width() / zoom, label.size.height() / zoom);
     label.size = s;
     label.clickSize = s;
 
@@ -2229,8 +2229,8 @@ int TMap::createMapImageLabel(int area, QString imagePath, float x, float y, flo
     label.noScaling = false;
     label.temporary = temporary;
 
-    QRectF const drawRect = QRectF(0, 0, static_cast<qreal>(width * zoom), static_cast<qreal>(height * zoom));
-    QPixmap const imagePixmap = QPixmap(imagePath);
+    const QRectF drawRect = QRectF(0, 0, static_cast<qreal>(width * zoom), static_cast<qreal>(height * zoom));
+    const QPixmap imagePixmap = QPixmap(imagePath);
     QPixmap pix = QPixmap(drawRect.size().toSize());
     pix.fill(Qt::transparent);
     QPainter lp(&pix);
@@ -3012,7 +3012,7 @@ std::pair<bool, QString> TMap::writeJsonMapFile(const QString& dest)
     }
     // Convert the array of all the mCustomEnvColors into a QJsonValue so we
     // can add it to the map object:
-    QJsonValue const mCustomEnvColorsValue{customEnvColorArray};
+    const QJsonValue mCustomEnvColorsValue{customEnvColorArray};
     mapObj.insert(QLatin1String("customEnvColors"), mCustomEnvColorsValue);
 
     mapObj.insert(QLatin1String("mapSymbolFontDetails"), mMapSymbolFont.toString());
@@ -3024,11 +3024,11 @@ std::pair<bool, QString> TMap::writeJsonMapFile(const QString& dest)
     QJsonObject playerRoomInnerColorObj;
     writeJsonColor(playerRoomOuterColorObj, mPlayerRoomOuterColor);
     writeJsonColor(playerRoomInnerColorObj, mPlayerRoomInnerColor);
-    QJsonValue const playerRoomOuterColorValue{playerRoomOuterColorObj};
-    QJsonValue const playerRoomInnerColorValue{playerRoomInnerColorObj};
+    const QJsonValue playerRoomOuterColorValue{playerRoomOuterColorObj};
+    const QJsonValue playerRoomInnerColorValue{playerRoomInnerColorObj};
     playerRoomColorsArray.append(playerRoomOuterColorValue);
     playerRoomColorsArray.append(playerRoomInnerColorValue);
-    QJsonValue const playerRoomColorsValue{playerRoomColorsArray};
+    const QJsonValue playerRoomColorsValue{playerRoomColorsArray};
     mapObj.insert(QLatin1String("playerRoomColors"), playerRoomColorsValue);
     mapObj.insert(QLatin1String("playerRoomStyle"), static_cast<double>(mPlayerRoomStyle));
     mapObj.insert(QLatin1String("playerRoomOuterDiameterPercentage"), static_cast<double>(mPlayerRoomOuterDiameterPercentage));
@@ -3074,10 +3074,10 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
                     : qsl("could not open file \"%1\"").arg(source))};
     }
 
-    QByteArray const mapData = file.readAll();
+    const QByteArray mapData = file.readAll();
     file.close();
     QJsonParseError jsonErr;
-    QJsonDocument const doc(QJsonDocument::fromJson(mapData, &jsonErr));
+    const QJsonDocument doc(QJsonDocument::fromJson(mapData, &jsonErr));
     if (jsonErr.error != QJsonParseError::NoError) {
         return {false, (translatableTexts
                     ? tr("could not parse file, reason: \"%1\" at offset %2")
@@ -3165,7 +3165,7 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
     QColor playerRoomInnerColor;
 
     if (mapObj.contains(QLatin1String("playerRoomColors")) && mapObj.value(QLatin1String("playerRoomColors")).isArray()) {
-        QJsonArray const playerRoomColorArray = mapObj.value(QLatin1String("playerRoomColors")).toArray();
+        const QJsonArray playerRoomColorArray = mapObj.value(QLatin1String("playerRoomColors")).toArray();
         if (playerRoomColorArray.size() == 2 && playerRoomColorArray.at(0).isObject() && playerRoomColorArray.at(1).isObject()) {
             playerRoomOuterColor = readJsonColor(playerRoomColorArray.at(0).toObject());
             playerRoomInnerColor = readJsonColor(playerRoomColorArray.at(1).toObject());
@@ -3322,10 +3322,10 @@ void TMap::writeJsonColor(QJsonObject& obj, const QColor& color)
     colorRGBAArray.append(static_cast<double>(color.blue()));
     if (color.alpha() < 255) {
         colorRGBAArray.append(static_cast<double>(color.alpha()));
-        QJsonValue const colorRGBAValue{colorRGBAArray};
+        const QJsonValue colorRGBAValue{colorRGBAArray};
         obj.insert(QLatin1String("color32RGBA"), colorRGBAValue);
     } else {
-        QJsonValue const colorRGBAValue{colorRGBAArray};
+        const QJsonValue colorRGBAValue{colorRGBAArray};
         obj.insert(QLatin1String("color24RGB"), colorRGBAValue);
     }
 }

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -86,7 +86,7 @@ void TMedia::playMedia(TMediaData& mediaData)
         }
 
         const QString absolutePathFileName = TMedia::setupMediaAbsolutePathFileName(mediaData);
-        QFile const mediaFile(absolutePathFileName);
+        const QFile mediaFile(absolutePathFileName);
 
         if (!mediaFile.exists()) {
             if (fileRelative) {
@@ -441,7 +441,7 @@ void TMedia::transitionNonRelativeFile(TMediaData& mediaData)
         qWarning() << qsl("TMedia::playMedia() WARNING - attempt made to create a directory failed: %1").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()));
     } else {
         const QString mediaFilePath = qsl("%1/%2").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()), mediaData.getMediaFileName().section('/', -1));
-        QFile const mediaFile(mediaFilePath);
+        const QFile mediaFile(mediaFilePath);
 
         if (!mediaFile.exists() && !QFile::copy(mediaData.getMediaFileName(), mediaFilePath)) {
             qWarning() << qsl("TMedia::playMedia() WARNING - attempt made to copy file %1 to a directory %2 failed.").arg(mediaData.getMediaFileName(), mediaFilePath);
@@ -761,7 +761,7 @@ void TMedia::downloadFile(TMediaData& mediaData)
         request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
 #if !defined(QT_NO_SSL)
         if (fileUrl.scheme() == qsl("https")) {
-            QSslConfiguration const config(QSslConfiguration::defaultConfiguration());
+            const QSslConfiguration config(QSslConfiguration::defaultConfiguration());
             request.setSslConfiguration(config);
         }
 #endif
@@ -866,7 +866,7 @@ void TMedia::connectMediaPlayer(TMediaPlayer& player)
         } else {
             if (fadeInUsed) {
                 if (progress < relativeFadeInPosition) {
-                    double const fadeInVolume = static_cast<double>(volume * (progress - startPosition)) / static_cast<double>((relativeFadeInPosition - startPosition) * 1.0);
+                    const double fadeInVolume = static_cast<double>(volume * (progress - startPosition)) / static_cast<double>((relativeFadeInPosition - startPosition) * 1.0);
 
                     player.setVolume(qRound(fadeInVolume));
                     actionTaken = true;
@@ -878,7 +878,7 @@ void TMedia::connectMediaPlayer(TMediaPlayer& player)
 
             if (!actionTaken && fadeOutUsed && progress > 0) {
                 if (progress > relativeFadeOutPosition) {
-                    double const fadeOutVolume = static_cast<double>(volume * (relativeDuration - progress)) / static_cast<double>(fadeOutDuration * 1.0);
+                    const double fadeOutVolume = static_cast<double>(volume * (relativeDuration - progress)) / static_cast<double>(fadeOutDuration * 1.0);
 
                     player.setVolume(qRound(fadeOutVolume));
                     actionTaken = true;
@@ -1009,9 +1009,9 @@ void TMedia::handlePlayerPlaybackStateChanged(QMediaPlayerPlaybackState playback
         TEvent mediaFinished{};
         mediaFinished.mArgumentList.append("sysMediaFinished");
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-        QUrl const mediaUrl = pPlayer.getMediaPlayer()->media().request().url();
+        const QUrl mediaUrl = pPlayer.getMediaPlayer()->media().request().url();
 #else
-        QUrl mediaUrl = pPlayer.getMediaPlayer()->source();
+        const QUrl mediaUrl = pPlayer.getMediaPlayer()->source();
 #endif
         mediaFinished.mArgumentList.append(mediaUrl.fileName());
         mediaFinished.mArgumentList.append(mediaUrl.path());
@@ -1185,7 +1185,7 @@ void TMedia::play(TMediaData& mediaData)
             TMedia::matchMediaKeyAndStopMediaVariants(mediaData, absolutePathFileName); // If mediaKey matches, check for uniqueness.
         }
 
-        QUrl const mediaSource = QUrl::fromLocalFile(absolutePathFileName);
+        const QUrl mediaSource = QUrl::fromLocalFile(absolutePathFileName);
         pPlayer.getMediaPlayer()->setMedia(mediaSource);
     } else {
         if (mediaData.getMediaLoops() == TMediaData::MediaLoopsRepeat) { // Repeat indefinitely
@@ -1556,7 +1556,7 @@ void TMedia::parseJSONForMediaLoad(QJsonObject& json)
 
     const QString absolutePathFileName = TMedia::setupMediaAbsolutePathFileName(mediaData);
 
-    QFile const mediaFile(absolutePathFileName);
+    const QFile mediaFile(absolutePathFileName);
 
     if (!mediaFile.exists()) {
         TMedia::downloadFile(mediaData);

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -663,8 +663,8 @@ void TRoom::calcRoomDimensions()
             continue;
         }
         for (auto pointInLine : pointsInLine) {
-            qreal const pointX = pointInLine.x();
-            qreal const pointY = pointInLine.y();
+            const qreal pointX = pointInLine.x();
+            const qreal pointY = pointInLine.y();
             if (pointX < min_x) {
                 min_x = pointX;
             }
@@ -1693,7 +1693,7 @@ void TRoom::writeJsonRoom(QJsonArray& obj) const
     roomObj.insert(QLatin1String("id"), static_cast<double>(id));
 
     if (!name.isEmpty()) {
-        QJsonValue const nameValue{name};
+        const QJsonValue nameValue{name};
         roomObj.insert(QLatin1String("name"), nameValue);
     }
 
@@ -2143,16 +2143,16 @@ void TRoom::readJsonCustomExitLine(const QJsonObject& exitObj, const QString& di
         return;
     }
 
-    QJsonArray const customLinePointsArray = customLineObj.value(QLatin1String("coordinates")).toArray();
+    const QJsonArray customLinePointsArray = customLineObj.value(QLatin1String("coordinates")).toArray();
     if (customLinePointsArray.isEmpty()) {
         return;
     }
 
     QList<QPointF> points;
     for (int i = 0, total = customLinePointsArray.count(); i < total; ++i) {
-        QJsonArray const customLinePointCoordinateArray = customLinePointsArray.at(i).toArray();
+        const QJsonArray customLinePointCoordinateArray = customLinePointsArray.at(i).toArray();
         if (customLinePointCoordinateArray.size() == 2 && customLinePointCoordinateArray.at(0).isDouble() && customLinePointCoordinateArray.at(1).isDouble()) {
-            QPointF const point{customLinePointCoordinateArray.at(0).toDouble(), customLinePointCoordinateArray.at(1).toDouble()};
+            const QPointF point{customLinePointCoordinateArray.at(0).toDouble(), customLinePointCoordinateArray.at(1).toDouble()};
 
             // We might wish to consider if there is a z in the future to
             // accommodate 3D custom lines...!
@@ -2314,7 +2314,7 @@ void TRoom::writeJsonHighlight(QJsonObject& obj) const
     }
 
     highlightObj.insert(QLatin1String("radius"), static_cast<double>(highlightRadius));
-    QJsonValue const highlightValue{highlightObj};
+    const QJsonValue highlightValue{highlightObj};
     obj.insert(QLatin1String("highlight"), highlightValue);
 }
 
@@ -2358,7 +2358,7 @@ void TRoom::readJsonSymbol(const QJsonObject& roomObj)
         mSymbol = symbolObj.value(QLatin1String("text")).toString();
     }
 
-    QColor const color = TMap::readJsonColor(symbolObj);
+    const QColor color = TMap::readJsonColor(symbolObj);
     if (color.isValid()) {
         mSymbolColor = color;
     }

--- a/src/TToolBar.cpp
+++ b/src/TToolBar.cpp
@@ -114,7 +114,7 @@ void TToolBar::addButton(TFlipButton* pB)
         pB->setMaximumSize(size);
         pB->setMinimumSize(size);
     } else {
-        QSize const size = QSize(pB->mpTAction->mSizeX, pB->mpTAction->mSizeY);
+        const QSize size = QSize(pB->mpTAction->mSizeX, pB->mpTAction->mSizeY);
         pB->setMaximumSize(size);
         pB->setMinimumSize(size);
         pB->setParent(mpWidget);
@@ -169,7 +169,7 @@ void TToolBar::finalize()
         return;
     }
     auto fillerWidget = new QWidget;
-    QSizePolicy const sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    const QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     fillerWidget->setSizePolicy(sizePolicy);
     int columns = mpTAction->getButtonColumns();
     if (columns <= 0) {
@@ -224,7 +224,7 @@ void TToolBar::clear()
         mpLayout = new QGridLayout(mpWidget);
         mpLayout->setContentsMargins(0, 0, 0, 0);
         mpLayout->setSpacing(0);
-        QSizePolicy const sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+        const QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
         mpWidget->setSizePolicy(sizePolicy);
     } else {
         mpLayout = nullptr;

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -453,7 +453,7 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
             auto iti = posList.begin();
             for (int position = 1; iti != posList.end(); ++iti, ++its, position++) {
                 const int begin = *iti;
-                std::string const& s = *its;
+                const std::string& s = *its;
                 const int length = QString::fromStdString(s).size();
                 if (total > 1) {
                     // skip complete match in Perl /g option type of triggers
@@ -543,7 +543,7 @@ void TTrigger::processBeginOfLine(const QString& needle, int patternNumber, int 
         auto its = captureList.begin();
         for (auto iti = posList.begin(); iti != posList.end(); ++iti, ++its) {
             const int begin = *iti;
-            std::string const& s = *its;
+            const std::string& s = *its;
             const int length = QString::fromStdString(s).size();
             pC->selectSection(begin, length);
             if (mBgColor != QColorConstants::Transparent) {
@@ -681,7 +681,7 @@ void TTrigger::processSubstringMatch(const QString& haystack, const QString& nee
         auto its = captureList.begin();
         for (auto iti = posList.begin(); iti != posList.end(); ++iti, ++its) {
             const int begin = *iti;
-            std::string const& s = *its;
+            const std::string& s = *its;
             const int length = QString::fromStdString(s).size();
             pC->selectSection(begin, length);
             if (mBgColor != QColorConstants::Transparent) {
@@ -801,7 +801,7 @@ void TTrigger::processColorPattern(int patternNumber, std::list<std::string>& ca
         for (auto iti = posList.begin(); iti != posList.end(); ++iti, ++its) {
             const int begin = *iti;
             //                qDebug() << "TTrigger::match_color_pattern(" << line << "," << patternNumber << ") INFO - match found: " << (*its).c_str() << " size is:" << (*its).size();
-            std::string const& s = *its;
+            const std::string& s = *its;
             const int length = QString::fromStdString(s).size();
             pC->selectSection(begin, length);
             if (mBgColor != QColorConstants::Transparent) {
@@ -944,7 +944,7 @@ void TTrigger::processExactMatch(const QString& line, int patternNumber, int pos
         auto its = captureList.begin();
         for (auto iti = posList.begin(); iti != posList.end(); ++iti, ++its) {
             const int begin = *iti;
-            std::string const& s = *its;
+            const std::string& s = *its;
             const int length = QString::fromStdString(s).size();
             pC->selectSection(begin, length);
             if (mBgColor != QColorConstants::Transparent) {
@@ -1207,8 +1207,8 @@ TColorTable* TTrigger::createColorPattern(int ansiFg, int ansiBg)
      * 16 dark white          ->  7
      */
 
-    QColor const fgColor = mpHost->getAnsiColor(ansiFg, false);
-    QColor const bgColor = mpHost->getAnsiColor(ansiBg, true);
+    const QColor fgColor = mpHost->getAnsiColor(ansiFg, false);
+    const QColor bgColor = mpHost->getAnsiColor(ansiBg, true);
 
     // If BOTH ansiFg AND ansiBg are scmIgnored then the color pattern is
     // totally unset
@@ -1468,9 +1468,9 @@ void TTrigger::decodeColorPatternText(const QString& patternText, int& fgColorCo
 {
     // The numbers used for the text have changed - see table in:
     // TColorTable* TTrigger::createColorPattern(int ansiFg, int ansiBg)
-    QRegularExpression const regex = QRegularExpression(qsl("^ANSI_COLORS_F{(\\d+|DEFAULT|IGNORE)}_B{(\\d+|DEFAULT|IGNORE)}$"));
+    const QRegularExpression regex = QRegularExpression(qsl("^ANSI_COLORS_F{(\\d+|DEFAULT|IGNORE)}_B{(\\d+|DEFAULT|IGNORE)}$"));
     // Was QRegularExpression regex = QRegularExpression(qsl(R"(FG(\d+)BG(\d+))"));
-    QRegularExpressionMatch const match = regex.match(patternText);
+    const QRegularExpressionMatch match = regex.match(patternText);
     // scmDefault is the new code for "default" colour (as 0 is a valid ANSI color number!)
     // scmIgnored is the new code for "reset" i.e. NOT set color trigger (i.e. don't
     // bother with checking this part of the colour)

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -1198,13 +1198,13 @@ QStringList XMLexport::remapAnsiToColorNumber(const QStringList & patternList, c
 {
 
     QStringList results;
-    QRegularExpression const regex = QRegularExpression(qsl("^ANSI_COLORS_F{(\\d+|IGNORE|DEFAULT)}_B{(\\d+|IGNORE|DEFAULT)}$"));
+    const QRegularExpression regex = QRegularExpression(qsl("^ANSI_COLORS_F{(\\d+|IGNORE|DEFAULT)}_B{(\\d+|IGNORE|DEFAULT)}$"));
     QStringListIterator itPattern(patternList);
     QListIterator<int> itType(typeList);
     while (itPattern.hasNext() && itType.hasNext()) {
         if (itType.next() == REGEX_COLOR_PATTERN) {
             if (!itPattern.next().isEmpty()) {
-                QRegularExpressionMatch const match = regex.match(itPattern.peekPrevious());
+                const QRegularExpressionMatch match = regex.match(itPattern.peekPrevious());
                 // Although we define two '('...')' capture groups the count/size is
                 // 3 (0 is the whole string)!
                 if (match.hasMatch() && match.capturedTexts().size() == 3) {

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -917,7 +917,7 @@ void XMLimport::readHost(Host* pHost)
         pHost->mLineSize = 10.0; // Same value as is in Host class initializer list
     }
 
-    QStringView const ignore(attributes().value(qsl("mDoubleClickIgnore")));
+    const QStringView ignore(attributes().value(qsl("mDoubleClickIgnore")));
 
     for (auto character : ignore) {
         pHost->mDoubleClickIgnore.insert(character);
@@ -1831,12 +1831,12 @@ void XMLimport::remapColorsToAnsiNumber(QStringList & patternList, const QList<i
     // it to capture a '-' sign as part of the color numbers as we use -2 for
     // ignored which was/is/will not handled by code before Mudlet 3.17.x (and
     // we might have more  negative numbers in the future!)
-    QRegularExpression const regex = QRegularExpression(qsl("FG(-?\\d+)BG(-?\\d+)"));
+    const QRegularExpression regex = QRegularExpression(qsl("FG(-?\\d+)BG(-?\\d+)"));
     QMutableStringListIterator itPattern(patternList);
     QListIterator<int> itType(typeList);
     while (itPattern.hasNext() && itType.hasNext()) {
         if (itType.next() == REGEX_COLOR_PATTERN) {
-            QRegularExpressionMatch const match = regex.match(itPattern.next());
+            const QRegularExpressionMatch match = regex.match(itPattern.next());
             // Although we define two '('...')' capture groups the count/size is
             // 3 (0 is the whole string)!
             if (match.capturedTexts().size() == 3) {

--- a/src/discord.h
+++ b/src/discord.h
@@ -136,7 +136,7 @@ private:
 // Note "inline" is REQUIRED:
 inline QDebug& operator<<(QDebug& debug, const localDiscordPresence& ldp)
 {
-    QDebugStateSaver const saver(debug);
+    const QDebugStateSaver saver(debug);
     Q_UNUSED(saver);
 
     QString result = qsl("localDiscordPresence(\n"

--- a/src/dlgComposer.cpp
+++ b/src/dlgComposer.cpp
@@ -30,7 +30,7 @@ dlgComposer::dlgComposer(Host* pH)
 : mpHost(pH)
 {
     setupUi(this);
-    QFont const font = QFont(qsl("Bitstream Vera Sans Mono"), 10, QFont::Normal);
+    const QFont font = QFont(qsl("Bitstream Vera Sans Mono"), 10, QFont::Normal);
     edit->setFont(font);
     connect(saveButton, &QAbstractButton::clicked, this, &dlgComposer::slot_save);
     connect(cancelButton, &QAbstractButton::clicked, this, &dlgComposer::slot_cancel);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -198,7 +198,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
         // Remove the marker:
         cursor.removeSelectedText();
         // Insert the current icon image into the same place:
-        QImage const image_new(QPixmap(icon_new.pixmap(new_profile_button->iconSize())).toImage());
+        const QImage image_new(QPixmap(icon_new.pixmap(new_profile_button->iconSize())).toImage());
         cursor.insertImage(image_new);
         cursor.clearSelection();
 
@@ -207,7 +207,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
                    "dlgConnectionProfiles::dlgConnectionProfiles(...)",
                    "CONNECT_PROFILE_ICON text marker not found in welcome_message text for when icons are shown on dialogue buttons");
         cursor.removeSelectedText();
-        QImage const image_connect(QPixmap(icon_connect.pixmap(connect_button->iconSize())).toImage());
+        const QImage image_connect(QPixmap(icon_connect.pixmap(connect_button->iconSize())).toImage());
         cursor.insertImage(image_connect);
         cursor.clearSelection();
     } else {
@@ -903,8 +903,8 @@ void dlgConnectionProfiles::slot_itemClicked(QListWidgetItem* pItem)
     const QStringList entries = dir.entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
 
     for (const auto& entry : entries) {
-        QRegularExpression const rx(qsl("(\\d+)\\-(\\d+)\\-(\\d+)#(\\d+)\\-(\\d+)\\-(\\d+).xml"));
-        QRegularExpressionMatch const match = rx.match(entry);
+        const QRegularExpression rx(qsl("(\\d+)\\-(\\d+)\\-(\\d+)#(\\d+)\\-(\\d+)\\-(\\d+).xml"));
+        const QRegularExpressionMatch match = rx.match(entry);
 
         if (match.capturedStart() != -1) {
             QString day;
@@ -1090,7 +1090,7 @@ void dlgConnectionProfiles::fillout_form()
         const auto fileinfo = QFileInfo(mudlet::getMudletPath(mudlet::profileXmlFilesPath, profileName));
         if (fileinfo.exists()) {
             firstMudletLaunch = false;
-            QDateTime const profile_lastRead = fileinfo.lastModified();
+            const QDateTime profile_lastRead = fileinfo.lastModified();
             // Since Qt 5.x null QTimes and QDateTimes are invalid - and might not
             // work as expected - so test for validity of the test_date value as well
             if ((!test_date.isValid()) || profile_lastRead > test_date) {
@@ -1922,7 +1922,7 @@ void dlgConnectionProfiles::setupMudProfile(QListWidgetItem* pItem, const QStrin
 
     profiles_tree_widget->addItem(pItem);
     if (!hasCustomIcon(mudServer)) {
-        QPixmap const pixmap(iconFileName);
+        const QPixmap pixmap(iconFileName);
         if (pixmap.isNull()) {
             qWarning() << mudServer << "doesn't have a valid icon";
             return;
@@ -1944,26 +1944,26 @@ QIcon dlgConnectionProfiles::customIcon(const QString& text, const std::optional
 {
     QPixmap background(120, 30);
 
-    QColor const color = backgroundColor.value_or(mCustomIconColors.at(static_cast<int>((qHash(text) * 8131) % mCustomIconColors.count())));
+    const QColor color = backgroundColor.value_or(mCustomIconColors.at(static_cast<int>((qHash(text) * 8131) % mCustomIconColors.count())));
     background.fill(color);
 
     // Set to one larger than wanted so that do loop can contain the decrementor
     int fontSize = 30;
     QFont font(qsl("Bitstream Vera Sans Mono"), fontSize, QFont::Normal);
     // For an icon of size 120x30 allow 89x29 for the text:
-    QRect const textRectangle(0, 0, 89, 29);
+    const QRect textRectangle(0, 0, 89, 29);
     QRect testRect;
     // Really long names will be drawn very small (font size 6) with the ends clipped off:
     do {
         font.setPointSize(--fontSize);
-        QFontMetrics const metrics(font);
+        const QFontMetrics metrics(font);
         testRect = metrics.boundingRect(textRectangle, Qt::AlignCenter | Qt::TextWordWrap, text);
     } while (fontSize > 6 && !textRectangle.contains(testRect));
 
     { // Enclosed in braces to limit lifespan of QPainter:
         QPainter painter(&background);
         painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
-        QPixmap const pixmap(qsl(":/icons/mudlet_main_32px.png"));
+        const QPixmap pixmap(qsl(":/icons/mudlet_main_32px.png"));
         painter.drawPixmap(QRect(5, 5, 20, 20), pixmap);
         if (color.lightness() > 127) {
             painter.setPen(Qt::black);

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -636,7 +636,7 @@ QString dlgPackageExporter::copyNewImagesToTmp(const QString& tempPath) const
 // purge images from tmp which are no longer used by the description
 void dlgPackageExporter::cleanupUnusedImages(const QString& tempPath, const QString& plainDescription)
 {
-    static QRegularExpression const imagesInUsePattern(R"(\$packagePath\/\.mudlet\/description_images\/(.+?)\.)");
+    static const QRegularExpression imagesInUsePattern(R"(\$packagePath\/\.mudlet\/description_images\/(.+?)\.)");
     QStringList imagesInUse;
     QRegularExpressionMatchIterator i = imagesInUsePattern.globalMatch(plainDescription);
     while (i.hasNext()) {

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -113,10 +113,10 @@ void dlgPackageManager::slot_installPackage()
 
 void dlgPackageManager::slot_removePackages()
 {
-    QModelIndexList const selection = packageTable->selectionModel()->selectedRows();
+    const QModelIndexList selection = packageTable->selectionModel()->selectedRows();
     QStringList removePackages;
     for (int i = 0; i < selection.count(); i++) {
-        QModelIndex const index = selection.at(i);
+        const QModelIndex index = selection.at(i);
         auto package = packageTable->item(index.row(), 0);
         removePackages << package->text();
     }
@@ -228,7 +228,7 @@ void dlgPackageManager::fillAdditionalDetails(const QMap<QString, QString>& pack
 
 void dlgPackageManager::slot_toggleRemoveButton()
 {
-    QModelIndexList const selection = packageTable->selectionModel()->selectedRows();
+    const QModelIndexList selection = packageTable->selectionModel()->selectedRows();
     const int selectionCount = selection.count();
     removeButton->setEnabled(selectionCount);
     if (selectionCount) {

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -694,7 +694,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     QStringList entries = dir.entryList(QDir::Files, QDir::Time);
     // QRegularExpression rex(qsl(R"(\.dic$)"));
     // Use the affix file as that may eliminate supplimental dictionaries:
-    QRegularExpression const rex(qsl(R"(\.aff$)"));
+    const QRegularExpression rex(qsl(R"(\.aff$)"));
     entries = entries.filter(rex);
     // Don't emit signals - like (void) QListWidget::currentItemChanged(QListWidgetItem *current, QListWidgetItem *previous)
     // while populating the widget, it reduces noise about:
@@ -1081,7 +1081,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
 #if !defined(QT_NO_SSL)
     if (QSslSocket::supportsSsl() && pHost->mSslTsl) {
-        QSslCertificate const cert = pHost->mTelnet.getPeerCertificate();
+        const QSslCertificate cert = pHost->mTelnet.getPeerCertificate();
         if (cert.isNull()) {
             groupBox_ssl_certificate->hide();
         } else {
@@ -2270,7 +2270,7 @@ void dlgProfilePreferences::fillOutMapHistory()
     mapSaveDir.setSorting(QDir::Time);
     const QStringList mapSaveEntries = mapSaveDir.entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
     for (const auto& entry : mapSaveEntries) {
-        QRegularExpressionMatch const match = mapSaveRegularExpression.match(entry);
+        const QRegularExpressionMatch match = mapSaveRegularExpression.match(entry);
         const QString mapPathFileName = mapSaveDir.absoluteFilePath(entry);
         if (match.capturedStart() != -1) {
             // A recognised date-time stamp file name of any Mudlet map file type:
@@ -2288,7 +2288,7 @@ void dlgProfilePreferences::fillOutMapHistory()
                 year = match.captured(3);
             }
             const QString extension = match.captured(7);
-            QDateTime const datetime(QDate(year.toInt(), month.toInt(), day.toInt()), QTime(hour.toInt(), minute.toInt(), second.toInt()));
+            const QDateTime datetime(QDate(year.toInt(), month.toInt(), day.toInt()), QTime(hour.toInt(), minute.toInt(), second.toInt()));
             const QString itemText = locale.toString(datetime, dateTimeFormat);
             longestMapHistoryLength = qMax(longestMapHistoryLength, itemText.size());
             if (!extension.compare(QLatin1String("xml"), Qt::CaseInsensitive)) {
@@ -2873,7 +2873,7 @@ void dlgProfilePreferences::slot_saveAndClose()
                 pHost->mpMap->mpMapper->update();
             }
         }
-        QMargins const newBorders{leftBorderWidth->value(), topBorderHeight->value(), rightBorderWidth->value(), bottomBorderHeight->value()};
+        const QMargins newBorders{leftBorderWidth->value(), topBorderHeight->value(), rightBorderWidth->value(), bottomBorderHeight->value()};
         pHost->setBorders(newBorders);
         pHost->commandLineMinimumHeight = commandLineMinimumHeight->value();
         pHost->mFORCE_MXP_NEGOTIATION_OFF = mFORCE_MXP_NEGOTIATION_OFF->isChecked();
@@ -3003,7 +3003,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         if (console) {
             const int x = console->width();
             const int y = console->height();
-            QSize const s = QSize(x, y);
+            const QSize s = QSize(x, y);
             QResizeEvent event(s, s);
             QApplication::sendEvent(console, &event);
         }
@@ -3407,7 +3407,7 @@ void dlgProfilePreferences::slot_tabChanged(int tabIndex)
     manager->setCache(diskCache);
 
 
-    QUrl const url(themesURL);
+    const QUrl url(themesURL);
     QNetworkRequest request(url);
     request.setRawHeader(QByteArray("User-Agent"), QByteArray(qsl("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, mudlet::self()->mAppBuild).toUtf8().constData()));
     // github uses redirects
@@ -3440,7 +3440,7 @@ void dlgProfilePreferences::slot_tabChanged(int tabIndex)
                             return;
                         }
 
-                        QByteArray const downloadedArchive = reply->readAll();
+                        const QByteArray downloadedArchive = reply->readAll();
 
                         tempThemesArchive = new QTemporaryFile();
                         if (!tempThemesArchive->open()) {
@@ -3449,7 +3449,7 @@ void dlgProfilePreferences::slot_tabChanged(int tabIndex)
                         tempThemesArchive->write(downloadedArchive);
                         tempThemesArchive->close();
 
-                        QTemporaryDir const temporaryDir;
+                        const QTemporaryDir temporaryDir;
                         if (!temporaryDir.isValid()) {
                             return;
                         }
@@ -3691,13 +3691,13 @@ void dlgProfilePreferences::generateMapGlyphDisplay()
         pSymbolAnyFont->setToolTip(utils::richText(tr("The room symbol will appear like this if symbols (glyphs) from any font can be used.")));
         pSymbolAnyFont->setFont(anyFont);
 
-        QFontMetrics const SymbolInFontMetrics(selectedFont);
-        QFontMetrics const SymbolAnyFontMetrics(anyFont);
+        const QFontMetrics SymbolInFontMetrics(selectedFont);
+        const QFontMetrics SymbolAnyFontMetrics(anyFont);
 
         // pCodePoints is the sequence of UTF-32 codepoints in the symbol and
         // this ought to be what is needed to check that a font or set of fonts
         // can render the codepoints:
-        QVector<quint32> const pCodePoints = symbol.toUcs4();
+        const QVector<quint32> pCodePoints = symbol.toUcs4();
         // These can be used to flag symbols that cannot be reproduced
         bool isSingleFontUsable = true;
         bool isAllFontUsable = true;
@@ -4040,7 +4040,7 @@ void dlgProfilePreferences::setButtonColor(QPushButton* button, const QColor& co
             return;
         }
 
-        QColor const disabledColor = QColor::fromHsl(color.hslHue(), color.hslSaturation()/4, color.lightness(), color.alpha());
+        const QColor disabledColor = QColor::fromHsl(color.hslHue(), color.hslSaturation()/4, color.lightness(), color.alpha());
         if (button == pushButton_playerRoomPrimaryColor || button == pushButton_playerRoomSecondaryColor) {
 
             // These two buttons show a color that may have transparency; so,

--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -313,7 +313,7 @@ void dlgRoomProperties::accept()
     // Find symbol to return back
     const QString newSymbol = getNewSymbol();
     bool changeSymbol = true;
-    QColor const newSymbolColor = selectedSymbolColor;
+    const QColor newSymbolColor = selectedSymbolColor;
     bool changeSymbolColor = true;
     if (newSymbol == multipleValuesPlaceholder) {
         // We don't want to change then
@@ -362,8 +362,8 @@ QString dlgRoomProperties::getNewSymbol()
     }
     QString newSymbolText = comboBox_roomSymbol->currentText();
     // Parse the initial text before the curly braces containing count
-    QRegularExpression const countStripper(qsl("^(.*) {.*}$"));
-    QRegularExpressionMatch const match = countStripper.match(newSymbolText);
+    const QRegularExpression countStripper(qsl("^(.*) {.*}$"));
+    const QRegularExpressionMatch match = countStripper.match(newSymbolText);
     if (match.hasMatch() && match.lastCapturedIndex() > 0) {
         return match.captured(1);
     }
@@ -381,8 +381,8 @@ int dlgRoomProperties::getNewWeight()
         return -1; // User did not want to select any weight, so we will do no change
     }
     // Parse an initial number out of what was selected or typed
-    QRegularExpression const countStripper(qsl("^\\s*(\\d+)"));
-    QRegularExpressionMatch const match = countStripper.match(newWeightText);
+    const QRegularExpression countStripper(qsl("^\\s*(\\d+)"));
+    const QRegularExpressionMatch match = countStripper.match(newWeightText);
     if (match.hasMatch() && match.lastCapturedIndex() > 0) {
         return match.captured(1).toInt();
     }
@@ -419,8 +419,8 @@ QFont dlgRoomProperties::getFontForPreview(QString symbolString)
     auto font = mpHost->mpMap->mMapSymbolFont;
     font.setPointSize(font.pointSize() * 0.9);
     if (!symbolString.isEmpty()) {
-        QFontMetrics const mapSymbolFontMetrics = QFontMetrics(font);
-        QVector<quint32> const codePoints = symbolString.toUcs4();
+        const QFontMetrics mapSymbolFontMetrics = QFontMetrics(font);
+        const QVector<quint32> codePoints = symbolString.toUcs4();
         QVector<bool> isUsable;
         for (int i = 0; i < codePoints.size(); ++i) {
             isUsable.append(mapSymbolFontMetrics.inFontUcs4(codePoints.at(i)));

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -935,7 +935,7 @@ void dlgTriggerEditor::slot_setToolBarIconSize(const int s)
         toolBar2->setToolButtonStyle(Qt::ToolButtonIconOnly);
     }
 
-    QSize const newSize(s * 8, s * 8);
+    const QSize newSize(s * 8, s * 8);
     toolBar->setIconSize(newSize);
     toolBar2->setIconSize(newSize);
 }
@@ -946,7 +946,7 @@ void dlgTriggerEditor::slot_setTreeWidgetIconSize(const int s)
         return;
     }
 
-    QSize const newSize(s * 8, s * 8);
+    const QSize newSize(s * 8, s * 8);
     treeWidget_triggers->setIconSize(newSize);
     treeWidget_aliases->setIconSize(newSize);
     treeWidget_timers->setIconSize(newSize);
@@ -970,11 +970,11 @@ void dlgTriggerEditor::readSettings()
        For compatibility with older settings, if no config is loaded
        from the config directory "mudlet", application "Mudlet", we try to load from the config
        directory "Mudlet", application "Mudlet 1.0". */
-    QSettings const settings_new("mudlet", "Mudlet");
-    QSettings const settings((settings_new.contains("pos") ? "mudlet" : "Mudlet"), (settings_new.contains("pos") ? "Mudlet" : "Mudlet 1.0"));
+    const QSettings settings_new("mudlet", "Mudlet");
+    const QSettings settings((settings_new.contains("pos") ? "mudlet" : "Mudlet"), (settings_new.contains("pos") ? "Mudlet" : "Mudlet 1.0"));
 
     const QPoint pos = settings.value("script_editor_pos", QPoint(10, 10)).toPoint();
-    QSize const size = settings.value("script_editor_size", QSize(600, 400)).toSize();
+    const QSize size = settings.value("script_editor_size", QSize(600, 400)).toSize();
     resize(size);
     move(pos);
 
@@ -3830,7 +3830,7 @@ void dlgTriggerEditor::addTimer(bool isFolder)
         name = tr("New timer");
     }
     const QString command = "";
-    QTime const time;
+    const QTime time;
     const QString script = "";
     QStringList nameL;
     nameL << name;
@@ -4645,7 +4645,7 @@ void dlgTriggerEditor::saveTimer()
         const int minutes = mpTimersMainArea->timeEdit_timer_minutes->time().minute();
         const int secs = mpTimersMainArea->timeEdit_timer_seconds->time().second();
         const int msecs = mpTimersMainArea->timeEdit_timer_msecs->time().msec();
-        QTime const time(hours, minutes, secs, msecs);
+        const QTime time(hours, minutes, secs, msecs);
         pT->setTime(time);
         pT->setCommand(command);
         pT->setName(name);
@@ -4757,8 +4757,8 @@ void dlgTriggerEditor::saveAlias()
     }
     const QString substitution = mpAliasMainArea->lineEdit_alias_command->text();
     //check if sub will trigger regex, ignore if there's nothing in regex - could be an alias group
-    QRegularExpression const rx(regex);
-    QRegularExpressionMatch const match = rx.match(substitution);
+    const QRegularExpression rx(regex);
+    const QRegularExpressionMatch match = rx.match(substitution);
 
     QString itemDescription;
     if (!regex.isEmpty() && match.capturedStart() != -1) {
@@ -5809,8 +5809,8 @@ void dlgTriggerEditor::slot_triggerSelected(QTreeWidgetItem* pItem)
         mpTriggersMainArea->toolButton_clearSoundFile->setEnabled(!mpTriggersMainArea->lineEdit_soundFile->text().isEmpty());
         mpTriggersMainArea->groupBox_triggerColorizer->setChecked(pT->isColorizerTrigger());
 
-        QColor const fgColor(pT->getFgColor());
-        QColor const bgColor(pT->getBgColor());
+        const QColor fgColor(pT->getFgColor());
+        const QColor bgColor(pT->getBgColor());
         const bool transparentFg = fgColor == QColorConstants::Transparent;
         const bool transparentBg = bgColor == QColorConstants::Transparent;
         mpTriggersMainArea->pushButtonFgColor->setStyleSheet(generateButtonStyleSheet(fgColor, pT->isColorizerTrigger()));
@@ -6464,7 +6464,7 @@ void dlgTriggerEditor::slot_timerSelected(QTreeWidgetItem* pItem)
         mpTimersMainArea->lineEdit_timer_command->setText(command);
         mpTimersMainArea->lineEdit_timer_name->setText(name);
         mpTimersMainArea->label_idNumber->setText(QString::number(ID));
-        QTime const time = pT->getTime();
+        const QTime time = pT->getTime();
         mpTimersMainArea->timeEdit_timer_hours->setTime(QTime(time.hour(), 0, 0, 0));
         mpTimersMainArea->timeEdit_timer_minutes->setTime(QTime(0, time.minute(), 0, 0));
         mpTimersMainArea->timeEdit_timer_seconds->setTime(QTime(0, 0, time.second(), 0));
@@ -9518,7 +9518,7 @@ void dlgTriggerEditor::slot_colorTriggerFg()
     pD->setWindowModality(Qt::ApplicationModal);
     pD->exec();
 
-    QColor const color = pT->mColorTriggerFgColor;
+    const QColor color = pT->mColorTriggerFgColor;
     // The above will be an invalid colour if the colour has been reset/ignored
     // The dialogue should have changed pT->mColorTriggerFgAnsi
     QString styleSheet;
@@ -9581,7 +9581,7 @@ void dlgTriggerEditor::slot_colorTriggerBg()
     pD->setWindowModality(Qt::ApplicationModal);
     pD->exec();
 
-    QColor const color = pT->mColorTriggerBgColor;
+    const QColor color = pT->mColorTriggerBgColor;
     // The above will be an invalid colour if the colour has been reset/ignored
     QString styleSheet;
     if (color.isValid()) {
@@ -9825,7 +9825,7 @@ QString dlgTriggerEditor::generateButtonStyleSheet(const QColor& color, const bo
                          color.name());
         }
 
-        QColor const disabledColor = QColor::fromHsl(color.hslHue(), color.hslSaturation()/4, color.lightness());
+        const QColor disabledColor = QColor::fromHsl(color.hslHue(), color.hslSaturation()/4, color.lightness());
         return mudlet::self()->mTEXT_ON_BG_STYLESHEET
                 .arg(QLatin1String("darkGray"), disabledColor.name());
     } else {

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -223,7 +223,7 @@ void GLWidget::slot_setCameraPositionZ(int angle)
 
 void GLWidget::initializeGL()
 {
-    QColor const color(QColorConstants::Black);
+    const QColor color(QColorConstants::Black);
     glClearColor(color.redF(), color.greenF(), color.blueF(), color.alphaF());
     xRot = 1;
     yRot = 5;
@@ -503,8 +503,8 @@ void GLWidget::paintGL()
                     auto ex = static_cast<float>(pExit->x);
                     auto ey = static_cast<float>(pExit->y);
                     auto ez = static_cast<float>(pExit->z);
-                    QVector3D const p1(ex, ey, ez);
-                    QVector3D const p2(rx, ry, rz);
+                    const QVector3D p1(ex, ey, ez);
+                    const QVector3D p2(rx, ry, rz);
                     glLoadIdentity();
                     gluLookAt(px * 0.1 + xRot, py * 0.1 + yRot, pz * 0.1 + zRot, px * 0.1, py * 0.1, pz * 0.1, 0.0, 1.0, 0.0);
                     glScalef(0.1, 0.1, 0.1);
@@ -804,7 +804,7 @@ void GLWidget::paintGL()
                                 }
                                 break;
                             }
-                            QColor const& _c = mpMap->mCustomEnvColors[env];
+                            const QColor& _c = mpMap->mCustomEnvColors[env];
                             glColor4ub(_c.red(), _c.green(), _c.blue(), 25);
                             mc3[0] = _c.redF();
                             mc3[1] = _c.greenF();
@@ -915,8 +915,8 @@ void GLWidget::paintGL()
                     auto ex = static_cast<float>(pExit->x);
                     auto ey = static_cast<float>(pExit->y);
                     auto ez = static_cast<float>(pExit->z);
-                    QVector3D const p1(ex, ey, ez);
-                    QVector3D const p2(rx, ry, rz);
+                    const QVector3D p1(ex, ey, ez);
+                    const QVector3D p2(rx, ry, rz);
                     glLoadIdentity();
                     gluLookAt(px * 0.1 + xRot, py * 0.1 + yRot, pz * 0.1 + zRot, px * 0.1, py * 0.1, pz * 0.1, 0.0, 1.0, 0.0);
                     glScalef(0.1, 0.1, 0.1);
@@ -1214,7 +1214,7 @@ void GLWidget::paintGL()
                                 }
                                 break;
                             }
-                            QColor const& _c = mpMap->mCustomEnvColors[env];
+                            const QColor& _c = mpMap->mCustomEnvColors[env];
                             glColor4ub(_c.red(), _c.green(), _c.blue(), 255);
                             mc3[0] = _c.redF();
                             mc3[1] = _c.greenF();
@@ -1608,7 +1608,7 @@ void GLWidget::paintGL()
                         }
                         break;
                     }
-                    QColor const& _c = mpMap->mCustomEnvColors[env];
+                    const QColor& _c = mpMap->mCustomEnvColors[env];
                     glColor4ub(_c.red(), _c.green(), _c.blue(), 255);
                     mc3[0] = _c.redF();
                     mc3[1] = _c.greenF();
@@ -1911,7 +1911,7 @@ void GLWidget::paintGL()
                     }
                     break;
                 }
-                QColor const& _c = mpMap->mCustomEnvColors[env];
+                const QColor& _c = mpMap->mCustomEnvColors[env];
                 glColor4ub(_c.red(), _c.green(), _c.blue(), 255);
                 mc3[0] = _c.redF();
                 mc3[1] = _c.greenF();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -129,7 +129,7 @@ void removeOldNoteColorEmojiFonts()
 
 QTranslator* loadTranslationsForCommandLine()
 {
-    QSettings const settings_new(QLatin1String("mudlet"), QLatin1String("Mudlet"));
+    const QSettings settings_new(QLatin1String("mudlet"), QLatin1String("Mudlet"));
     auto pSettings = new QSettings((settings_new.contains(QLatin1String("pos")) ? QLatin1String("mudlet") : QLatin1String("Mudlet")),
                                    (settings_new.contains(QLatin1String("pos")) ? QLatin1String("Mudlet") : QLatin1String("Mudlet 1.0")));
     auto interfaceLanguage = pSettings->value(QLatin1String("interfaceLanguage")).toString();
@@ -436,7 +436,7 @@ int main(int argc, char* argv[])
 
         bool isWithinSpace = false;
         while (!isWithinSpace) {
-            QFont const font("Bitstream Vera Serif", fontSize, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
+            const QFont font("Bitstream Vera Serif", fontSize, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
             QTextLayout versionTextLayout(sourceVersionText, font, painter.device());
             versionTextLayout.beginLayout();
             // Start work in this text item
@@ -448,11 +448,11 @@ int main(int argc, char* argv[])
             //Splashscreen bitmap is (now) 320x360 - hopefully entire line will all fit into 280
             versionTextline.setPosition(QPointF(0, 0));
             // Only pretend, so we can see how much space it will take
-            QTextLine const dummy = versionTextLayout.createLine();
+            const QTextLine dummy = versionTextLayout.createLine();
             if (!dummy.isValid()) {
                 // No second line so have got all text in first so can do it
                 isWithinSpace = true;
-                qreal const versionTextWidth = versionTextline.naturalTextWidth();
+                const qreal versionTextWidth = versionTextline.naturalTextWidth();
                 // This is the ACTUAL width of the created text
                 versionTextline.setPosition(QPointF((320 - versionTextWidth) / 2.0, 270));
                 // And now we can place it centred horizontally
@@ -471,19 +471,19 @@ int main(int argc, char* argv[])
         // Repeat for other text, but we know it will fit at given size
         // PLACEMARKER: Date-stamp needing annual update
         const QString sourceCopyrightText = qsl("©️ Mudlet makers 2008-2023");
-        QFont const font(qsl("Bitstream Vera Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
+        const QFont font(qsl("Bitstream Vera Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
         QTextLayout copyrightTextLayout(sourceCopyrightText, font, painter.device());
         copyrightTextLayout.beginLayout();
         QTextLine copyrightTextline = copyrightTextLayout.createLine();
         copyrightTextline.setLineWidth(280);
         copyrightTextline.setPosition(QPointF(1, 1));
-        qreal const copyrightTextWidth = copyrightTextline.naturalTextWidth();
+        const qreal copyrightTextWidth = copyrightTextline.naturalTextWidth();
         copyrightTextline.setPosition(QPointF((320 - copyrightTextWidth) / 2.0, 340));
         copyrightTextLayout.endLayout();
         painter.setPen(QColor(112, 16, 0, 255)); // #701000
         copyrightTextLayout.draw(&painter, QPointF(0, 0));
     }
-    QPixmap const pixmap = QPixmap::fromImage(splashImage);
+    const QPixmap pixmap = QPixmap::fromImage(splashImage);
 #if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
     // Specifying the screen here seems to help to put the splash screen on the
     // same monitor that the main application window will be put upon on first
@@ -607,7 +607,7 @@ int main(int argc, char* argv[])
         }
     }
 #else
-    QFile const linkFile(homeLink);
+    const QFile linkFile(homeLink);
     if (!linkFile.exists() && first_launch) {
         QFile::link(homeDirectory, homeLink);
     }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -193,7 +193,7 @@ mudlet::mudlet()
     menuAbout->setToolTipsVisible(true);
 
     setAttribute(Qt::WA_DeleteOnClose);
-    QSizePolicy const sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    const QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setWindowTitle(scmVersion);
     if (releaseVersion) {
         setWindowIcon(QIcon(qsl(":/icons/mudlet.png")));
@@ -224,7 +224,7 @@ mudlet::mudlet()
     layoutTopLevel->setContentsMargins(0, 0, 0, 0);
     layoutTopLevel->addWidget(mpTabBar);
     mpWidget_profileContainer = new QWidget(frame);
-    QPalette const mainPalette;
+    const QPalette mainPalette;
     mpWidget_profileContainer->setPalette(mainPalette);
     mpWidget_profileContainer->setContentsMargins(0, 0, 0, 0);
     mpWidget_profileContainer->setSizePolicy(sizePolicy);
@@ -483,7 +483,7 @@ mudlet::mudlet()
         connect(actionFullScreeniew, &QAction::triggered, this, &mudlet::slot_toggleFullScreenView);
     }
 
-    QFont const mainFont = QFont(qsl("Bitstream Vera Sans Mono"), 8, QFont::Normal);
+    const QFont mainFont = QFont(qsl("Bitstream Vera Sans Mono"), 8, QFont::Normal);
     mpWidget_profileContainer->setFont(mainFont);
     mpWidget_profileContainer->show();
 
@@ -705,7 +705,7 @@ QSettings* mudlet::getQSettings()
         For compatibility with older settings, if no config is loaded
         from the config directory "mudlet", application "Mudlet", we try to load from the config
         directory "Mudlet", application "Mudlet 1.0". */
-    QSettings const settings_new("mudlet", "Mudlet");
+    const QSettings settings_new("mudlet", "Mudlet");
     return new QSettings((settings_new.contains("pos") ? "mudlet" : "Mudlet"), (settings_new.contains("pos") ? "Mudlet" : "Mudlet 1.0"));
 }
 
@@ -1149,8 +1149,8 @@ void mudlet::scanForMudletTranslations(const QString& path)
     if (path == qsl(":/lang")) {
         QFile file(qsl(":/translation-stats.json"));
         if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-            QByteArray const saveData = file.readAll();
-            QJsonDocument const loadDoc(QJsonDocument::fromJson(saveData));
+            const QByteArray saveData = file.readAll();
+            const QJsonDocument loadDoc(QJsonDocument::fromJson(saveData));
             translationStats = loadDoc.object();
             file.close();
         } else {
@@ -1332,7 +1332,7 @@ bool mudlet::openWebPage(const QString& path)
     if (path.isEmpty() || path.isNull()) {
         return false;
     }
-    QUrl const url(path, QUrl::TolerantMode);
+    const QUrl url(path, QUrl::TolerantMode);
     if (!url.isValid()) {
         return false;
     }
@@ -1573,7 +1573,7 @@ void mudlet::addConsoleForNewHost(Host* pH)
 
     const int x = pH->mpConsole->width();
     const int y = pH->mpConsole->height();
-    QSize const s = QSize(x, y);
+    const QSize s = QSize(x, y);
     QResizeEvent event(s, s);
     updateDiscordNamedIcon();
     QApplication::sendEvent(pH->mpConsole, &event);
@@ -1716,7 +1716,7 @@ bool mudlet::saveWindowLayout()
         // revert update markers to ready objects for saving.
         commitLayoutUpdates();
 
-        QByteArray const layoutData = saveState();
+        const QByteArray layoutData = saveState();
         QDataStream ofs(&layoutFile);
         if (scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
             ofs.setVersion(scmQDataStreamFormat_5_12);
@@ -1790,7 +1790,7 @@ void mudlet::hideEvent(QHideEvent* event)
 
 std::optional<QSize> mudlet::getImageSize(const QString& imageLocation)
 {
-    QImage const image(imageLocation);
+    const QImage image(imageLocation);
 
     if (image.isNull()) {
         return {};
@@ -1922,7 +1922,7 @@ void mudlet::readEarlySettings(const QSettings& settings)
         mEnableFullScreenMode = settings.value(qsl("enableFullScreenMode"), QVariant(false)).toBool();
     } else {
         // We do not have a QSettings value stored so check for the sentinel file:
-        QFile const file_use_smallscreen(getMudletPath(mainDataItemPath, qsl("mudlet_option_use_smallscreen")));
+        const QFile file_use_smallscreen(getMudletPath(mainDataItemPath, qsl("mudlet_option_use_smallscreen")));
         mEnableFullScreenMode = file_use_smallscreen.exists();
     }
 
@@ -1949,7 +1949,7 @@ void mudlet::readEarlySettings(const QSettings& settings)
 void mudlet::readLateSettings(const QSettings& settings)
 {
     const QPoint pos = settings.value(qsl("pos"), QPoint(0, 0)).toPoint();
-    QSize const size = settings.value(qsl("size"), QSize(750, 550)).toSize();
+    const QSize size = settings.value(qsl("size"), QSize(750, 550)).toSize();
     // A sensible default has already been set up according to whether we are on
     // a netbook or not before this gets called so only change if there is a
     // setting stored:
@@ -3470,7 +3470,7 @@ bool mudlet::loadLuaFunctionList()
         return false;
     }
 
-    QJsonObject const json_obj = json_doc.object();
+    const QJsonObject json_obj = json_doc.object();
 
     if (json_obj.isEmpty()) {
         return false;
@@ -3884,7 +3884,7 @@ void mudlet::slot_newDataOnHost(const QString& hostName, const bool isLowerPrior
 
 QStringList mudlet::getAvailableFonts()
 {
-    QFontDatabase const database;
+    const QFontDatabase database;
 
     return database.families(QFontDatabase::Any);
 }
@@ -3908,7 +3908,7 @@ void mudlet::setEnableFullScreenMode(const bool state)
         QSaveFile file(filePath);
         if (state) {
             file.open(QIODevice::WriteOnly | QIODevice::Text);
-            QTextStream const out(&file);
+            const QTextStream out(&file);
             Q_UNUSED(out);
             if (!file.commit()) {
                 qDebug() << "mudlet::setEnableFullScreenMode: error saving fullscreen state: " << file.errorString();
@@ -4635,7 +4635,7 @@ void mudlet::setNetworkRequestDefaults(const QUrl& url, QNetworkRequest& request
     request.setRawHeader(QByteArray("User-Agent"), QByteArray(qsl("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, mudlet::self()->mAppBuild).toUtf8().constData()));
 #if !defined(QT_NO_SSL)
     if (url.scheme() == qsl("https")) {
-        QSslConfiguration const config(QSslConfiguration::defaultConfiguration());
+        const QSslConfiguration config(QSslConfiguration::defaultConfiguration());
         request.setSslConfiguration(config);
     }
 #endif
@@ -4723,7 +4723,7 @@ void mudlet::activateProfile(Host* pHost)
     // Tell the new profile's main window that it might be resize via a Qt event:
     const int x = mpCurrentActiveHost->mpConsole->width();
     const int y = mpCurrentActiveHost->mpConsole->height();
-    QSize const s = QSize(x, y);
+    const QSize s = QSize(x, y);
     QResizeEvent event(s, s);
     QApplication::sendEvent(mpCurrentActiveHost->mpConsole, &event);
 
@@ -4931,7 +4931,7 @@ void mudlet::onlyShowProfiles(const QStringList& predefinedProfiles)
             return QImage(eggFileName);
         } else {
             // For the zeroth case just rotate the picture 180 degrees:
-            QImage const original(releaseVersion
+            const QImage original(releaseVersion
                                     ? qsl(":/splash/Mudlet_splashscreen_main.png")
                                     : testVersion ? qsl(":/splash/Mudlet_splashscreen_ptb.png")
                                                                      : qsl(":/splash/Mudlet_splashscreen_development.png"));


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR tries to put all `const`s before the type (class).

#### Motivation for adding to Mudlet
There is a mix of positioning of `const`s where it is used to indicate that a variable is not to be modified by program code, we tend to put it before the type but a prior PR (which looks to have been done with an automated tool) has resulted in a mix of cases some with the const adjacent to the variable. This lack of consistency can be confusing.

#### Other info (issues closed, discussion etc)
It looks like this came about in #6843.

This will upset the Danger detector because of the number of files modified but it should be fairly straightforward to review.