### PR TITLE
Fix: typo in previous commit omitted a space

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1905,7 +1905,7 @@ bool Host::removeDir(const QString& dirName, const QString& originalPath)
     bool result = true;
     const QDir dir(dirName);
     if (dir.exists(dirName)) {
-        for (QFileInfo  const&info : dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden | QDir::AllDirs | QDir::Files, QDir::DirsFirst)) {
+        for (QFileInfo const& info : dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden | QDir::AllDirs | QDir::Files, QDir::DirsFirst)) {
             // prevent recursion outside of the original branch
             if (info.isDir() && info.absoluteFilePath().startsWith(originalPath)) {
                 result = removeDir(info.absoluteFilePath(), originalPath);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a space that is not functionally required (apparently) but which is required for human readability.

#### Motivation for adding to Mudlet
Clean a mistake I made last time

#### Other info (issues closed, discussion etc)
Caused by my #7179.