### PR TITLE
Add: automatically update map on all changes via API

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -811,16 +811,6 @@ int TLuaInterpreter::loadReplay(lua_State* L)
     }
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#updateMap
-int TLuaInterpreter::updateMap(lua_State* L)
-{
-    const Host& host = getHostFromLua(L);
-    if (host.mpMap) {
-        host.mpMap->update();
-    }
-    return 0;
-}
-
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#cut
 int TLuaInterpreter::cut(lua_State* L)
 {

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -1042,7 +1042,6 @@ int TLuaInterpreter::createMapper(lua_State* L)
         return warnArgumentValue(L, __func__, message);
     }
 
-    host.mpMap->update();
     lua_pushboolean(L, true);
     return 1;
 }
@@ -2459,7 +2458,6 @@ int TLuaInterpreter::loadMap(lua_State* L)
         isOk = host.mpConsole->loadMap(location);
     }
     lua_pushboolean(L, isOk);
-    host.mpMap->update();
     return 1;
 }
 
@@ -3419,7 +3417,6 @@ int TLuaInterpreter::setGridMode(lua_State* L)
         host.mpMap->update();
     }
     host.mpMap->setUnsaved(__func__);
-    host.mpMap->update();
     lua_pushboolean(L, true);
     return 1;
 }
@@ -3624,7 +3621,6 @@ int TLuaInterpreter::setRoomIDbyHash(lua_State* L)
     }
     host.mpMap->mpRoomDB->hashToRoomID[hash] = id;
     host.mpMap->mpRoomDB->roomIDToHash[id] = hash;
-    host.mpMap->update();
     return 0;
 }
 
@@ -3708,7 +3704,6 @@ int TLuaInterpreter::unHighlightRoom(lua_State* L)
     } else {
         lua_pushboolean(L, false);
     }
-    host.mpMap->update();
     return 1;
 }
 

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -699,17 +699,17 @@ int TLuaInterpreter::clearAreaUserDataItem(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearMapSelection
 int TLuaInterpreter::clearMapSelection(lua_State* L)
 {
-    Host* pHost = &getHostFromLua(L);
-    if (!pHost || !pHost->mpMap || !pHost->mpMap->mpMapper || !pHost->mpMap->mpMapper->mp2dMap) {
+    const Host& host = getHostFromLua(L);
+    if (!host.mpMap || !host.mpMap->mpMapper || !host.mpMap->mpMapper->mp2dMap) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
-    if (pHost->mpMap->mpMapper->mp2dMap->mMultiSelection) {
+    if (host.mpMap->mpMapper->mp2dMap->mMultiSelection) {
         return warnArgumentValue(L, __func__, "rooms are being selected right now and cannot be stopped at this point");
     }
-    if (pHost->mpMap->mpMapper->mp2dMap->mMultiSelectionSet.isEmpty()) {
+    if (host.mpMap->mpMapper->mp2dMap->mMultiSelectionSet.isEmpty()) {
         lua_pushboolean(L, false);
     } else {
-        pHost->mpMap->mpMapper->mp2dMap->clearSelection();
+        host.mpMap->mpMapper->mp2dMap->clearSelection();
         lua_pushboolean(L, true);
     }
     host.mpMap->update();

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -817,8 +817,7 @@ int TLuaInterpreter::clearSpecialExits(lua_State* L)
     host.mpMap->update();
     return 0;
 }
-
-
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#closeMapWidget
 int TLuaInterpreter::closeMapWidget(lua_State* L)
 {
     Host& host = getHostFromLua(L);
@@ -1125,7 +1124,7 @@ int TLuaInterpreter::deleteArea(lua_State* L)
     return 1;
 }
 
-
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#deleteMap
 int TLuaInterpreter::deleteMap(lua_State* L)
 {
     const Host& host = getHostFromLua(L);

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -3407,20 +3407,30 @@ bool TMap::incrementJsonProgressDialog(const bool isExportNotImport, const bool 
 
 void TMap::update()
 {
-#if defined(INCLUDE_3DMAPPER)
-    if (mpM) {
-        mpM->update();
+    static bool debounce;
+    if (debounce) {
+        qDebug() << "TMap::update() - debounce";
+        return;
     }
-#endif
-    if (mpMapper) {
-        mpMapper->checkBox_showRoomNames->setVisible(getRoomNamesPresent());
-        mpMapper->checkBox_showRoomNames->setChecked(getRoomNamesShown());
 
-        if (mpMapper->mp2dMap) {
-            mpMapper->mp2dMap->mNewMoveAction = true;
-            mpMapper->mp2dMap->update();
+    debounce = true;
+    QTimer::singleShot(0, this, [this]() {
+        qDebug() << "TMap::update() - debounce done";
+#if defined(INCLUDE_3DMAPPER)
+        if (mpM) {
+            mpM->update();
         }
-    }
+#endif
+        if (mpMapper) {
+            mpMapper->checkBox_showRoomNames->setVisible(getRoomNamesPresent());
+            mpMapper->checkBox_showRoomNames->setChecked(getRoomNamesShown());
+
+            if (mpMapper->mp2dMap) {
+                mpMapper->mp2dMap->mNewMoveAction = true;
+                mpMapper->mp2dMap->update();
+            }
+        }
+    });
 }
 
 QColor TMap::getColor(int id)

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -3405,32 +3405,35 @@ bool TMap::incrementJsonProgressDialog(const bool isExportNotImport, const bool 
     return mpProgressDialog->wasCanceled();
 }
 
+/**
+ * Update the the 2D and 3D map visually.
+ *
+ * It ensures debouncing internally to ensure that bulk calls are efficient.
+ */
 void TMap::update()
 {
     static bool debounce;
-    if (debounce) {
-        qDebug() << "TMap::update() - debounce";
-        return;
-    }
+    if (!debounce) {
+        debounce = true;
+        QTimer::singleShot(0, this, [this]() {
+            debounce = false;
 
-    debounce = true;
-    QTimer::singleShot(0, this, [this]() {
-        qDebug() << "TMap::update() - debounce done";
 #if defined(INCLUDE_3DMAPPER)
-        if (mpM) {
-            mpM->update();
-        }
-#endif
-        if (mpMapper) {
-            mpMapper->checkBox_showRoomNames->setVisible(getRoomNamesPresent());
-            mpMapper->checkBox_showRoomNames->setChecked(getRoomNamesShown());
-
-            if (mpMapper->mp2dMap) {
-                mpMapper->mp2dMap->mNewMoveAction = true;
-                mpMapper->mp2dMap->update();
+            if (mpM) {
+                mpM->update();
             }
-        }
-    });
+#endif
+            if (mpMapper) {
+                mpMapper->checkBox_showRoomNames->setVisible(getRoomNamesPresent());
+                mpMapper->checkBox_showRoomNames->setChecked(getRoomNamesShown());
+
+                if (mpMapper->mp2dMap) {
+                    mpMapper->mp2dMap->mNewMoveAction = true;
+                    mpMapper->mp2dMap->update();
+                }
+            }
+        });
+    }
 }
 
 QColor TMap::getColor(int id)

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -1464,6 +1464,8 @@ void dlgPackageExporter::slot_recountItems(QTreeWidgetItem *item)
     if (!debounce) {
         debounce = true;
         QTimer::singleShot(0, this, [this]() {
+            debounce = false;
+            
             const int itemsToExport = countCheckedItems();
             if (itemsToExport) {
                 //: This is the text shown at the top of a groupbox when there is %n (one or more) items to export in the Package exporter dialogue; the initial (and when there is no items selected) is a separate text.
@@ -1472,7 +1474,6 @@ void dlgPackageExporter::slot_recountItems(QTreeWidgetItem *item)
                 //: This is the text shown at the top of a groupbox initially and when there is NO items to export in the Package exporter dialogue.
                 mpSelectionText->setTitle(tr("Select what to export"));
             }
-            debounce = false;
         });
     }
 }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Automatically update map on all map changes via API while not losing performance.
#### Motivation for adding to Mudlet
Better user experience.
#### Other info (issues closed, discussion etc)
Alleviates the need for calling https://wiki.mudlet.org/w/Manual:Mapper_Functions#updateMap and fixes the inconsistency where some functions were updating the map automatically and others haven't.