### PR TITLE
Infra: update mirror URL for file hosted by osdn

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Don't:
 * translate the Mudlet API: functions, events, error messages or constants (e.g. `main` console)
 * use numbers in the API - English words are preferred instead
 * try to assemble a sentence on the fly - English grammar does not translate into other languages. Present the full sentence to translators instead
-* assume English-centric plural forms, other languages do not necessarily have the simple add an "s"/"es" for more/less then the singular case.
+* assume English-centric plural forms, other languages do not necessarily have the simple add an "s"/"es" for more/less than the singular case.
 * assume universal quote and number punctuation formats. There are languages that use « and » instead of " for "quoting" words or phrases. Qt can provide Locale specific displays of numbers/dates/times.
 
 # Tooltip tips:

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -196,7 +196,7 @@ function InstallCmake() {
 }
 
 function InstallMingwGet() {
-  DownloadFile "https://osdn.net/frs/redir.php?m=rwthaachen&f=mingw%2F68260%2Fmingw-get-0.6.3-mingw32-pre-20170905-1-bin.zip" "mingw-get.zip"
+  DownloadFile "https://osdn.net/frs/redir.php?m=ipconnect&f=mingw%2F68260%2Fmingw-get-0.6.3-mingw32-pre-20170905-1-bin.zip" "mingw-get.zip"
   if (!(Test-Path -Path "C:\MinGW" -PathType Container)) {
     Step "Creating MinGW path"
     New-Item -Path "C:\MinGW" -ItemType "directory" >> "$logFile" 2>&1

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -535,7 +535,7 @@ QString Discord::deduceGameName(const QString& address)
 }
 
 // Returns true in First if this is a MUD we know about (and have an Icon for in
-// on the Mudlet Discord erver!) and the deduced name in Second - if the
+// on the Mudlet Discord server!) and the deduced name in Second - if the
 // first is true.
 QPair<bool, QString> Discord::gameIntegrationSupported(const QString& address)
 {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Change the URL of file mentioned at https://osdn.net/projects/mingw/downloads/68260/mingw-get-0.6.3-mingw32-pre-20170905-1-bin.zip/

#### Motivation for adding to Mudlet
Builds were failing, but not every time, like https://ci.appveyor.com/project/Mudlet/mudlet/builds/49542655
Last lines were
```
==== compiling and installing mingw-get ====
---- Downloading ----
Exception calling "DownloadFile" with "2" argument(s): "The underlying connection was closed: Could not establish 
trust relationship for the SSL/TLS secure channel."
```
I looked in the script files and found URL associated with mingw-get and downloaded it myself a few times.  It uses a 302 Location redirect going to 2 different URLs, sometimes working and others with an expired certificate.
Then I found the link above which is similar URL but different `m=`.  Looks like `m` is for mirror, and the old one is name of a German university that maybe is no longer mirroring for them or something.

#### Other info (issues closed, discussion etc)
Discussion started with https://discord.com/channels/283581582550237184/283582439002210305/1225440152621551698