### PR TITLE
Infrastructure: remove original Mingw from CI process

### DIFF
--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -195,22 +195,6 @@ function InstallCmake() {
   }
 }
 
-function InstallMingwGet() {
-  DownloadFile "https://osdn.net/frs/redir.php?m=rwthaachen&f=mingw%2F68260%2Fmingw-get-0.6.3-mingw32-pre-20170905-1-bin.zip" "mingw-get.zip"
-  if (!(Test-Path -Path "C:\MinGW" -PathType Container)) {
-    Step "Creating MinGW path"
-    New-Item -Path "C:\MinGW" -ItemType "directory" >> "$logFile" 2>&1
-  }
-  ExtractZip "mingw-get.zip" "C:\MinGW"
-}
-
-function InstallMsys() {
-  Step "Updating mingw-get info"
-  exec "mingw-get" @("update")
-  Step "Installing mingw32-autotools"
-  exec "mingw-get" @("install", "mingw32-autotools")
-}
-
 function InstallBoost([string] $outputLocation = "C:\Libraries\") {
   DownloadFile "https://sourceforge.net/projects/boost/files/boost/1.83.0/boost_1_83_0.tar.gz/download" "boost.tar.gz" $true
   if (!(Test-Path -Path "C:\Libraries\" -PathType Container)) {
@@ -476,14 +460,6 @@ function CheckAndInstall7z(){
 
 function CheckAndInstallCmake(){
     CheckAndInstall "cmake" "$CMakePath\cmake.exe" { InstallCmake }
-}
-
-function CheckAndInstallMingwGet(){
-    CheckAndInstall "mingw-get" "C:\MinGW\bin\mingw-get.exe" { InstallMingwGet }
-}
-
-function CheckAndInstallMsys(){
-    CheckAndInstall "MSYS and autotools" "C:\MinGW\bin\autoconf" { InstallMsys }
 }
 
 function CheckAndInstallBoost(){

--- a/CI/appveyor.install.ps1
+++ b/CI/appveyor.install.ps1
@@ -15,8 +15,6 @@ $Env:PATH = "$CMakePath;C:\MinGW\bin;C:\MinGW\msys\1.0\bin;C:\Program Files\7-Zi
 CheckAndInstall7z
 CheckAndInstallCcache
 CheckAndInstallCmake
-CheckAndInstallMingwGet
-CheckAndInstallMsys
 CheckAndInstallBoost
 CheckAndInstallQt
 CheckAndInstallPython


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Eliminates the installation of the original Mingw from our CI process. Apart from anything else it is already installed in the AppVeyor build we do and Mingw-w64 seems to be a more up to date and reliable setup.

#### Motivation for adding to Mudlet
I don't think we need it.

#### Other info (issues closed, discussion etc)