### PR TITLE
Infrastructure: refactor and simplify profile closing

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -477,9 +477,11 @@ Host::~Host()
     }
     mErrorLogStream.flush();
     mErrorLogFile.close();
-    // We are in the destructor - so it is not a good idea for anything we call
-    // to refer to our members, given that we want the name of the profile in
-    // the following pass it in as a value so we don't need to access the member
+    // Since this is a destructor, it's risky to rely on member variables within the destructor itself.
+    // To avoid this, we can pass the profile name as an argument instead of accessing it
+    // directly as a member variable. This ensures the destructor doesn't depend on the 
+    // object's state being valid.
+
     TDebug::removeHost(this, mHostName);
 }
 
@@ -511,12 +513,12 @@ bool Host::requestClose()
     // the close() method called here to return a true if the event was
     // accepted:
     if (!mpConsole->close()) {
-        // Nope the user doesn't want this to close - and it won't have set it's
+        // Nope the user doesn't want this to close - and it won't have set its
         // mEnableClose flag:
         return false;
     }
 
-    // The above will have initiated a save of the profile (and it's map) if it
+    // The above will have initiated a save of the profile (and its map) if it
     // got a true returned from the TMainConsole::close() call.
 
     // Get rid of any dialogs we might have open:
@@ -530,7 +532,7 @@ bool Host::requestClose()
 void Host::closeChildren()
 {
     mIsClosingDown = true;
-    std::list<QPointer<TToolBar>> const hostToolBarMap = getActionUnit()->getToolBarList();
+    const auto hostToolBarMap = getActionUnit()->getToolBarList();
     // disconnect before removing objects from memory as sysDisconnectionEvent needs that stuff.
     if (mSslTsl) {
         mTelnet.abortConnection();
@@ -943,7 +945,7 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
         // This is likely to be the save as the profile is closed
         qDebug().noquote().nospace() << "Host::saveProfile(...) INFO - called with no saveFolder or saveName arguments for profile '"
                                      << mHostName
-                                     << "' so assuming it is a end of session save and the TCommandLines' histories need saving...";
+                                     << "' so assuming it is an end of session save and the TCommandLines' histories need saving...";
         emit signal_saveCommandLinesHistory();
     }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -941,9 +941,9 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
 
     if (saveFolder.isEmpty() && saveName.isEmpty()) {
         // This is likely to be the save as the profile is closed
-        qDebug().noquote().nospace() << "Host::saveProfile(...) INFO - called with no saveFolder or saveName arguments for "
+        qDebug().noquote().nospace() << "Host::saveProfile(...) INFO - called with no saveFolder or saveName arguments for profile '"
                                      << mHostName
-                                     << " so assuming it is a end of session save and the TCommandLines' histories need saving...";
+                                     << "' so assuming it is a end of session save and the TCommandLines' histories need saving...";
         emit signal_saveCommandLinesHistory();
     }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -546,9 +546,11 @@ void Host::closeChildren()
 
     stopAllTriggers();
 
-    mpEditorDialog->setAttribute(Qt::WA_DeleteOnClose);
-    mpEditorDialog->close();
-    mpEditorDialog = nullptr;
+    if (mpEditorDialog) {
+        mpEditorDialog->setAttribute(Qt::WA_DeleteOnClose);
+        mpEditorDialog->close();
+        mpEditorDialog = nullptr;
+    }
 
     for (const QString& consoleName : mpConsole->mSubConsoleMap.keys()) {
         // Only user-windows will be in this map:

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -493,7 +493,7 @@ void Host::forceClose()
     }
 
     mForcedClose = true;
-    postMessage(tr("[ ALERT ] - this profile is being forced to save and close."));
+    postMessage(tr("[ ALERT ] - This profile will now save and close."));
     // Ensure the above is displayed before proceeding...
     qApp->processEvents();
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -495,14 +495,8 @@ void Host::forceClose()
     // Ensure the above is displayed before proceeding...
     qApp->processEvents();
 
-    // Because we have set the mForcedClose flag above this WILL succeed - but
-    // whilst debugging lets confirm this - it does the profile and map saving:
-    bool closeResult = mpConsole->close();
-
-    // Get rid of any dialogs we might have open:
-    closeChildren();
-
-    Q_ASSERT_X(closeResult, "Host::forceClose()", "TMainConsole::forceClose() call did not succeed!");
+    // Because we have set the mForcedClose flag above a requestClose()
+    // afterwards WILL succeed
 }
 
 // Returns true if we are closing down
@@ -535,7 +529,7 @@ bool Host::requestClose()
 
 void Host::closeChildren()
 {
-    closingDown();
+    mIsClosingDown = true;
     std::list<QPointer<TToolBar>> const hostToolBarMap = getActionUnit()->getToolBarList();
     // disconnect before removing objects from memory as sysDisconnectionEvent needs that stuff.
     if (mSslTsl) {

--- a/src/Host.h
+++ b/src/Host.h
@@ -913,7 +913,7 @@ private:
     // Whether to display each item's ID number in the editor:
     bool mShowIDsInEditor = false;
 
-    // Set when the mudlet singleton demands that we close - used to force a
+    // Set when the mudlet singleton demands that we close - used to force an
     // attempt to save the profile and map - without asking:
     bool mForcedClose = false;
 };

--- a/src/Host.h
+++ b/src/Host.h
@@ -212,8 +212,13 @@ public:
     bool            getLargeAreaExitArrows() const { return mLargeAreaExitArrows; }
     void            setLargeAreaExitArrows(const bool);
 
-    void closingDown();
-    bool isClosingDown();
+    void            closingDown() { mIsClosingDown = true; }
+    bool            isClosingDown() const { return mIsClosingDown; }
+    bool            requestClose();
+    void            forceClose();
+    bool            isClosingForced() const { return mForcedClose; }
+
+
     unsigned int assemblePath();
     bool checkForMappingScript();
     bool checkForCustomSpeedwalk();
@@ -355,7 +360,6 @@ public:
     void setCompactInputLine(const bool state);
     bool getCompactInputLine() const { return mCompactInputLine; }
     QPointer<TConsole> findConsole(QString name);
-    void close();
 
     QPair<bool, QStringList> getLines(const QString& windowName, const int lineFrom, const int lineTo);
     std::pair<bool, QString> openWindow(const QString& name, bool loadLayout, bool autoDock, const QString& area);
@@ -474,7 +478,6 @@ public:
     QString mProxyUsername;
     QString mProxyPassword;
 
-    bool mIsGoingDown;
     // Used to force the test compilation of the scripts for TActions ("Buttons")
     // that are pushdown buttons that run when they are "pushed down" during
     // loading even though the buttons start out with themselves NOT being
@@ -746,6 +749,7 @@ private:
     void autoSaveMap();
     QString sanitizePackageName(const QString packageName) const;
     TCommandLine* activeCommandLine();
+    void closeChildren();
 
 
     QFont mDisplayFont;
@@ -769,7 +773,7 @@ private:
     int mHostID;
     QString mHostName;
     QString mDiscordGameName; // Discord self-reported game name
-    bool mIsClosingDown;
+    bool mIsClosingDown = false;
 
     QString mLine;
     QString mLogin;
@@ -910,6 +914,10 @@ private:
 
     // Whether to display each item's ID number in the editor:
     bool mShowIDsInEditor = false;
+
+    // Set when the mudlet singleton demands that we close - used to force a
+    // attempt to save the profile and map - without asking:
+    bool mForcedClose = false;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(Host::DiscordOptionFlags)

--- a/src/Host.h
+++ b/src/Host.h
@@ -212,12 +212,10 @@ public:
     bool            getLargeAreaExitArrows() const { return mLargeAreaExitArrows; }
     void            setLargeAreaExitArrows(const bool);
 
-    void            closingDown() { mIsClosingDown = true; }
-    bool            isClosingDown() const { return mIsClosingDown; }
-    bool            requestClose();
     void            forceClose();
+    bool            isClosingDown() const { return mIsClosingDown; }
     bool            isClosingForced() const { return mForcedClose; }
-
+    bool            requestClose();
 
     unsigned int assemblePath();
     bool checkForMappingScript();

--- a/src/HostManager.cpp
+++ b/src/HostManager.cpp
@@ -25,16 +25,18 @@
 #include "dlgMapper.h"
 #include "mudlet.h"
 
-bool HostManager::deleteHost(const QString& hostname)
+void HostManager::deleteHost(const QString& hostname)
 {
-    // make sure this is really a new host
+    // make sure this is really an existing host
     if (!mHostPool.contains(hostname)) {
         qDebug() << "HostManager::deleteHost(" << hostname.toUtf8().constData() << ") ERROR: not a member of host pool... aborting!";
-        return false;
-    } else {
-        const int ret = mHostPool.remove(hostname);
-        return ret;
+        return;
     }
+
+    // As this pulls the QSharedPointer that hostname identifies out of the pool
+    // the Host goes out of scope when execution leaves this method and thus
+    // gets destroyed:
+    mHostPool.remove(hostname);
 }
 
 bool HostManager::addHost(const QString& hostname, const QString& port, const QString& login, const QString& pass)

--- a/src/HostManager.h
+++ b/src/HostManager.h
@@ -52,12 +52,12 @@ class HostManager
 
 
 public:
-    HostManager() = default; /* : mpActiveHost() - Not needed */
+    HostManager() = default;
 
     Host* getHost(const QString& hostname);
     bool addHost(const QString& name, const QString& port, const QString& login, const QString& pass);
     int getHostCount();
-    bool deleteHost(const QString&);
+    void deleteHost(const QString&);
     void postIrcMessage(const QString&, const QString&, const QString&);
     void postInterHostEvent(const Host*, const TEvent&, const bool = false);
     void changeAllHostColour(const Host*);

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2750,8 +2750,13 @@ inline int TBuffer::wrap(int startLine)
     return insertedLines > 0 ? insertedLines : 0;
 }
 
+// This only works on the Main Console for a profile
 void TBuffer::log(int fromLine, int toLine)
 {
+    if (mpHost.isNull()) {
+        return;
+    }
+
     TBuffer* pB = &mpHost->mpConsole->buffer;
     if (pB != this || !mpHost->mpConsole->mLogToLogFile) {
         return;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -286,7 +286,6 @@ public:
     bool mIsPromptLine = false;
     QToolButton* logButton = nullptr;
     QToolButton* timeStampButton = nullptr;
-    bool mUserAgreedToCloseConsole = false;
     QLineEdit* mpBufferSearchBox = nullptr;
     QAction* mpAction_searchCaseSensitive = nullptr;
     QToolButton* mpBufferSearchUp = nullptr;

--- a/src/TDebug.cpp
+++ b/src/TDebug.cpp
@@ -163,7 +163,7 @@ void TDebug::changeHostName(const Host* pHost, const QString& newName)
     }
 }
 
-/* static */ void TDebug::addHost(Host* pHost)
+/* static */ void TDebug::addHost(Host* pHost, const QString hostName)
 {
     if (!initialised) {
         smAvailableIdentifiers << qsl("[A] ") << qsl("[B] ") << qsl("[C] ") << qsl("[D] ") << qsl("[E] ")
@@ -179,12 +179,6 @@ void TDebug::changeHostName(const Host* pHost, const QString& newName)
         return;
     }
 
-    QString hostName = pHost->getName();
-    // Take a deep-copy to prevent RVO of the Host::getName() method from
-    // stopping deleting the 'Host::mHostName` when the profile is destroyed
-    // - so this copy can persist independently of the original when the latter
-    // goes away:
-    hostName.detach();
     QPair<QString, QString> newIdentifier;
     if (TDebug::smAvailableIdentifiers.isEmpty()) {
         // Run out of identifiers - use fall-back one:
@@ -209,7 +203,7 @@ void TDebug::changeHostName(const Host* pHost, const QString& newName)
     }
 }
 
-/* static */ void TDebug::removeHost(Host* pHost)
+/* static */ void TDebug::removeHost(Host* pHost, const QString hostName)
 {
     auto identifier = TDebug::smIdentifierMap.take(pHost);
     // Check for the use of non-profile specific tags:
@@ -218,7 +212,7 @@ void TDebug::changeHostName(const Host* pHost, const QString& newName)
         smAvailableIdentifiers.enqueue(identifier.second);
     }
     TDebug localMessage(Qt::darkGray, Qt::white);
-    localMessage << qsl("Profile '%1' ended.\n").arg(pHost->getName()) >> nullptr;
+    localMessage << qsl("Profile '%1' ended.\n").arg(hostName) >> nullptr;
     TDebug tableMessage(Qt::white, Qt::black);
     tableMessage << TDebug::displayNewTable() >> nullptr;
 }
@@ -273,7 +267,7 @@ void TDebug::changeHostName(const Host* pHost, const QString& newName)
             // for it - this will also cause a pair of new TDebug messages to
             // be created and processed prior to the call to this method being
             // completed:
-            addHost(pHost);
+            addHost(pHost, pHost->getName());
         }
         // By now smIdentifierMap WILL contain something for pHost - but use an
         // the "fault" mark (a bang/exclaimation point) if something is really

--- a/src/TDebug.h
+++ b/src/TDebug.h
@@ -86,8 +86,8 @@ public:
     explicit TDebug(const QColor&, const QColor&);
     ~TDebug() = default;
 
-    static void addHost(Host*);
-    static void removeHost(Host*);
+    static void addHost(Host*, const QString); // Might need to NOLINT this to prevent a warning about not using a reference
+    static void removeHost(Host*, const QString); // Might need to NOLINT this to prevent a warning about not using a reference
     static void changeHostName(const Host*, const QString&);
     static void flushMessageQueue();
     static QString getTag(Host*);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1320,7 +1320,7 @@ int TLuaInterpreter::setModulePriority(lua_State* L)
 int TLuaInterpreter::closeMudlet(lua_State* L)
 {
     Q_UNUSED(L)
-    mudlet::self()->forceClose();
+    mudlet::self()->armForceClose();
     return 0;
 }
 

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -1532,3 +1532,113 @@ void TMainConsole::showStatistics()
 
     mpHost->mpConsole->raise();
 }
+
+void TMainConsole::closeEvent(QCloseEvent* event)
+{
+    qDebug().nospace().noquote() << "TMainConsole::closeEvent(...) INFO - received by \"" << mpHost->getName() << "\".";
+    TEvent conCloseEvent{};
+    conCloseEvent.mArgumentList.append(qsl("sysExitEvent"));
+    conCloseEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    mpHost->raiseEvent(conCloseEvent);
+
+    if (mpHost->mFORCE_SAVE_ON_EXIT || mpHost->isClosingForced()) {
+        mudlet::self()->saveWindowLayout();
+        mpHost->modulesToWrite.clear();
+        // We are not checking the status result from here!
+        mpHost->saveProfile();
+
+        if (mpHost->mpMap && mpHost->mpMap->mpRoomDB) {
+            // There is a map loaded - but it *could* have no rooms at all!
+            const QDir dir_map;
+            const QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
+            const QString filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString("yyyy-MM-dd#HH-mm-ss"));
+            if (!dir_map.exists(directory_map)) {
+                dir_map.mkpath(directory_map);
+            }
+            QSaveFile file(filename_map);
+            if (file.open(QIODevice::WriteOnly)) {
+                QDataStream out(&file);
+                if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+                    out.setVersion(mudlet::scmQDataStreamFormat_5_12);
+                }
+                // FIXME: https://github.com/Mudlet/Mudlet/issues/6316 - unchecked return value - we are not handling a failure to save the map!
+                mpHost->mpMap->serialize(out);
+                if (!file.commit()) {
+                    qWarning() << "TMainConsole::closeEvent(...) WARNING - error saving map: " << file.errorString();
+                }
+            }
+        }
+        mpHost->waitForProfileSave();
+        event->accept();
+        return;
+    }
+
+    if (!mEnableClose) {
+    ASK:
+        const int choice = QMessageBox::question(this, tr("Save profile?"), tr("Do you want to save the profile %1?").arg(mProfileName), QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+        if (choice == QMessageBox::Cancel) {
+            event->ignore();
+            return;
+        }
+
+        if (choice == QMessageBox::Yes) {
+            mudlet::self()->saveWindowLayout();
+
+            mpHost->modulesToWrite.clear();
+            auto [ok, filename, error] = mpHost->saveProfile();
+
+            if (!ok) {
+                QMessageBox::critical(this,
+                                      tr("Could not save profile"),
+                                      tr("Sorry, could not save your profile as \"%1\" - got the following error: \"%2\".")
+                                              .arg(filename, error),
+                                      QMessageBox::Retry);
+                goto ASK;
+            }
+
+            if (mpHost->mpMap && mpHost->mpMap->mpRoomDB) {
+                // There is a map loaded - but it *could* have no rooms at all!
+                const QDir dir_map;
+                const QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
+                const QString filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
+                if (!dir_map.exists(directory_map)) {
+                    dir_map.mkpath(directory_map);
+                }
+
+                QSaveFile file(filename_map);
+                if (file.open(QIODevice::WriteOnly)) {
+                    QDataStream out(&file);
+                    if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+                        out.setVersion(mudlet::scmQDataStreamFormat_5_12);
+                    }
+                    // FIXME: https://github.com/Mudlet/Mudlet/issues/6316 - unchecked return value - we are not handling a failure to save the map!
+                    mpHost->mpMap->serialize(out);
+                    if (!file.commit()) {
+                        qDebug() << "TConsole::closeEvent: error saving map: " << file.errorString();
+                    }
+                }
+            }
+
+            mpHost->waitForProfileSave();
+            mEnableClose = true;
+            event->accept();
+            return;
+        }
+
+        if (choice == QMessageBox::No) {
+            mudlet::self()->saveWindowLayout();
+            mEnableClose = true;
+            event->accept();
+            return;
+        }
+
+        if (!mudlet::self()->isGoingDown()) {
+            QMessageBox::warning(this, "Aborting exit", "Session exit aborted on user request.");
+            event->ignore();
+            return;
+        }
+
+        mEnableClose = true;
+        event->accept();
+    }
+}

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -48,6 +48,7 @@ public:
 
     void resizeEvent(QResizeEvent* event) override;
     void resetMainConsole();
+    void closeEvent(QCloseEvent*) override;
     TConsole* createMiniConsole(const QString& windowname, const QString& name, int x, int y, int width, int height);
     TScrollBox* createScrollBox(const QString& windowname, const QString& name, int x, int y, int width, int height);
     bool raiseWindow(const QString& name);
@@ -137,7 +138,7 @@ signals:
 private:
     // Was public in Host class but made private there and cloned to here
     // (for main TConsole) to prevent it being changed without going through the
-    // process to load in the the changed dictionary:
+    // process to load in the changed dictionary:
     QString mSpellDic;
 
     // Cloned from Host
@@ -161,6 +162,7 @@ private:
     // for the ".aff" file - this member is for the per profile option only as
     // the shared one is held by the mudlet singleton class:
     QSet<QString> mWordSet_profile;
+    bool mEnableClose = false;
 };
 
 #endif // MUDLET_TMAINCONSOLE_H

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -508,7 +508,7 @@ void cTelnet::slot_socketDisconnected()
     mNeedDecompression = false;
     reset();
 
-    if (!mpHost->mIsGoingDown) {
+    if (!mpHost->isClosingDown()) {
         postMessage(spacer);
 
 #if !defined(QT_NO_SSL)

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -133,6 +133,13 @@ dlgPackageExporter::dlgPackageExporter(QWidget *parent, Host* pHost)
 
     //: Title of the window. The %1 will be replaced by the current profile's name
     setWindowTitle(tr("Package Exporter - %1").arg(mpHost->getName()));
+
+    // Ensure this dialog goes away if the Host (profile) is closed while we are
+    // open - as this is parented to the mudlet instance rather than the Host
+    // of the profile it would otherwise be left around if only the profile was
+    // being closed:
+    connect(mpHost, &QObject::destroyed, this, &dlgPackageExporter::slot_cancelExport);
+    connect(mpHost, &QObject::destroyed, this, &dlgPackageExporter::close);
 }
 
 dlgPackageExporter::~dlgPackageExporter()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4864,7 +4864,7 @@ void mudlet::onlyShowProfiles(const QStringList& predefinedProfiles)
 // The Lua interpreter cannot call mudlet::forceClose() directly as the latter
 // will destroy the former before a direct call has completed which has bad
 // effects (like the Lua API resetProfile() once did). Instead arrange for it
-// to be done by a "zero" timer:
+// to be done on the next Qt event loop iteration:
 void mudlet::armForceClose()
 {
     QTimer::singleShot(0, this, [this]() {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4860,3 +4860,14 @@ void mudlet::onlyShowProfiles(const QStringList& predefinedProfiles)
     return QImage(qsl(":/splash/Mudlet_splashscreen_main.png"));
 #endif // INCLUDE_VARIABLE_SPLASH_SCREEN
 }
+
+// The Lua interpreter cannot call mudlet::forceClose() directly as the latter
+// will destroy the former before a direct call has completed which has bad
+// effects (like the Lua API resetProfile() once did). Instead arrange for it
+// to be done by a "zero" timer:
+void mudlet::armForceClose()
+{
+    QTimer::singleShot(0, this, [this]() {
+        forceClose();
+    });
+}

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1383,87 +1383,31 @@ void mudlet::slot_closeCurrentProfile()
 void mudlet::slot_closeProfileRequested(int tab)
 {
     const QString name = mpTabBar->tabData(tab).toString();
-    closeHost(name);
-}
-
-void mudlet::closeHost(const QString& name)
-{
     Host* pH = mHostManager.getHost(name);
     if (!pH) {
         return;
     }
 
-    std::list<QPointer<TToolBar>> const hostToolBarMap = pH->getActionUnit()->getToolBarList();
-    QMap<QString, TDockWidget*>& dockWindowMap = pH->mpConsole->mDockWidgetMap;
-    QMap<QString, TConsole*>& hostConsoleMap = pH->mpConsole->mSubConsoleMap;
-
-    if (!pH->mpConsole->close()) {
+    if (!pH->requestClose()) {
         return;
     }
 
-    pH->mpConsole->mUserAgreedToCloseConsole = true;
-    pH->closingDown();
+    closeHost(name);
+}
 
-    // disconnect before removing objects from memory as sysDisconnectionEvent needs that stuff.
-    if (pH->mSslTsl) {
-        pH->mTelnet.abortConnection();
-    } else {
-        pH->mTelnet.disconnectIt();
-    }
-
-    pH->stopAllTriggers();
-    pH->mpEditorDialog->setAttribute(Qt::WA_DeleteOnClose);
-    pH->mpEditorDialog->close();
-    pH->mpEditorDialog = nullptr;
-
-    for (auto consoleName : hostConsoleMap.keys()) {
-        if (dockWindowMap.contains(consoleName)) {
-            dockWindowMap[consoleName]->setAttribute(Qt::WA_DeleteOnClose);
-            dockWindowMap[consoleName]->close();
-            removeDockWidget(dockWindowMap[consoleName]);
-            dockWindowMap.remove(consoleName);
-        }
-
-        hostConsoleMap[consoleName]->close();
-        hostConsoleMap.remove(consoleName);
-    }
-
-    if (pH->mpNotePad) {
-        pH->mpNotePad->save();
-        pH->mpNotePad->setAttribute(Qt::WA_DeleteOnClose);
-        pH->mpNotePad->close();
-        pH->mpNotePad = nullptr;
-    }
-
-    for (TToolBar* pTB : hostToolBarMap) {
-        if (pTB) {
-            pTB->setAttribute(Qt::WA_DeleteOnClose);
-            pTB->deleteLater();
-        }
-    }
-
-    // close IRC client window if it is open.
-    if (pH->mpDlgIRC) {
-        pH->mpDlgIRC->setAttribute(Qt::WA_DeleteOnClose);
-        pH->mpDlgIRC->deleteLater();
-    }
-
+// This removes the Host (profile) from this class's QMainWindow and related
+// structures:
+void mudlet::closeHost(const QString& name)
+{
+    Host* pH = mHostManager.getHost(name);
     migrateDebugConsole(pH);
 
-    pH->mpConsole->close();
-
     mpTabBar->removeTab(name);
-    // PLACEMARKER: Host destruction (1) - from close button on tab bar
-    // Unfortunately the spaghetti nature of the code means that the profile
-    // is also (maybe) saved (or not) in the TConsole::close() call prior to
-    // here but because that is optional we cannot only force a "save"
-    // operation in the profile preferences dialog for the Host specific
-    // details BEFORE the save (so any changes make it into the save) -
-    // instead we just have to accept that any profile changes will not be
-    // saved if the preferences dialog is not closed before the profile is...
+    // PLACEMARKER: Host destruction (1) - from all sources
     int hostCount = mHostManager.getHostCount();
     emit signal_hostDestroyed(pH, --hostCount);
-    mHostManager.deleteHost(pH->getName());
+    // This is what kills the Host instance:
+    mHostManager.deleteHost(name);
     emit signal_adjustAccessibleNames();
     updateMultiViewControls();
 }
@@ -1803,34 +1747,53 @@ Host* mudlet::getActiveHost()
 {
     if (mpCurrentActiveHost && mpCurrentActiveHost->mpConsole) {
         return mpCurrentActiveHost;
-    } else {
-        return nullptr;
     }
+
+    return nullptr;
 }
 
+// Received when the OS/DE/WM tells Mudlet to close (or we force the close
+// ourselves):
 void mudlet::closeEvent(QCloseEvent* event)
 {
-    QVector<QString> closingHosts;
+    qDebug() << "mudlet::closeEvent(...) INFO - called!";
 
+    QStringList hostsToDestroy;
+    bool abortClose = false;
+    // Due to the way that Hosts are stored we cannot do a closeHost(hostName)
+    // within the following loop as it fatally messes with what mHostManager
+    // contains - this is STL iterator stuff! Slysven 2024/04
     for (auto pHost : mHostManager) {
-        const auto console = pHost->mpConsole;
-        if (!console) {
+        if (pHost->requestClose()) {
+            // If we get here then the user has agreed to close it and the
+            // profile has been saved - if required - or both have happened
+            // automatically - and the main console has been told to close:
+
+            hostsToDestroy.append(pHost->getName());
             continue;
         }
-        if (!console->close()) {
-            // close out any profiles that we have agreed to close so far
-            for (const auto& hostName : qAsConst(closingHosts)) {
-                closeHost(hostName);
-            }
 
-            event->ignore();
-            return;
-        } else {
-            console->mUserAgreedToCloseConsole = true;
-            closingHosts.append(pHost->getName());
-        }
+        // This profile is not to be closed or the user has cancelled the close,
+        // in either case the application close cannot proceed - so give up,
+        // but we cannot just ignore() the event and return as there may be
+        // previously closed profiles to clean up:
+        abortClose = true;
+        // Stop the iteration
+        break;
     }
 
+    // Clean up the profiles that are being closed
+    for (auto const& hostName : hostsToDestroy) {
+        closeHost(hostName);
+    }
+
+    // Now we bail out if the close is cancelled:
+    if (abortClose) {
+        event->ignore();
+        return;
+    }
+
+    // Since we are here the close is to be completed:
     writeSettings();
 
     goingDown();
@@ -1839,18 +1802,8 @@ void mudlet::closeEvent(QCloseEvent* event)
         smpDebugArea->close();
     }
 
-    for (auto pHost : mHostManager) {
-        pHost->close();
-    }
-
     // hide main Mudlet window once we're sure the 'do you want to save the profile?' won't come up
     hide();
-
-    for (auto pHost : mHostManager) {
-        if (pHost->currentlySavingProfile()) {
-            pHost->waitForProfileSave();
-        }
-    }
 
     // pass the event on so dblsqd can perform an update
     // if automatic updates have been disabled
@@ -1860,50 +1813,10 @@ void mudlet::closeEvent(QCloseEvent* event)
 void mudlet::forceClose()
 {
     for (auto pHost : mHostManager) {
-        auto console = pHost->mpConsole;
-        if (!console) {
-            continue;
-        }
-        pHost->saveProfile();
-        console->mUserAgreedToCloseConsole = true;
-
-        if (pHost->mSslTsl) {
-            pHost->mTelnet.abortConnection();
-        } else {
-            pHost->mTelnet.disconnectIt();
-        }
-
-        // close script-editor
-        if (pHost->mpEditorDialog) {
-            pHost->mpEditorDialog->setAttribute(Qt::WA_DeleteOnClose);
-            pHost->mpEditorDialog->close();
-        }
-
-        if (pHost->mpNotePad) {
-            pHost->mpNotePad->save();
-            pHost->mpNotePad->setAttribute(Qt::WA_DeleteOnClose);
-            pHost->mpNotePad->close();
-            pHost->mpNotePad = nullptr;
-        }
-
-        if (pHost->mpDlgIRC) {
-            pHost->mpDlgIRC->close();
-        }
-
-        console->close();
+        pHost->forceClose();
     }
 
-    // hide main Mudlet window once we're sure the 'do you want to save the profile?' won't come up
-    hide();
-
-    for (auto pHost : mHostManager) {
-        if (pHost->currentlySavingProfile()) {
-            pHost->waitForProfileSave();
-        }
-    }
-
-    writeSettings();
-
+    // This will fire the closeEvent(...)
     close();
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1762,7 +1762,7 @@ void mudlet::closeEvent(QCloseEvent* event)
     bool abortClose = false;
     // Due to the way that Hosts are stored we cannot do a closeHost(hostName)
     // within the following loop as it fatally messes with what mHostManager
-    // contains - this is STL iterator stuff! Slysven 2024/04
+    // contains - this is STL iterator stuff!
     for (auto pHost : mHostManager) {
         if (pHost->requestClose()) {
             // If we get here then the user has agreed to close it and the

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -323,6 +323,7 @@ public:
     void doAutoLogin(const QString&);
     void enableToolbarButtons();
     void forceClose();
+    void armForceClose();
     Host* getActiveHost();
     QStringList getAvailableFonts();
     QList<QString> getAvailableTranslationCodes() const { return mTranslationsMap.keys(); }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
An attempt to improve the process of closing multiple profiles, including handling the case where a closure of the whole Mudlet application is cancelled part way through by the end-user selecting the "Cancel" option when asked if they want to save a profile or not.

#### Motivation for adding to Mudlet
When multi-playing carrying out the above action (cancelling part way through) can leave widgets and dialogues for profiles open even though the underlying `Host` instance has gone away. This can easily lead to fatal segmentation faults when those widgets or dialogues try to reference something that is no longer present. Additionally the code prior to this PR had multiple execution paths when "closing" a profile leading to some of them not doing all the things they needed to - hence the issues just listed. This PR tries to rationalise the execution path and reduce the amount of duplication so that it is easier to follow and amend in the future.

#### Other info (issues closed, discussion etc)
A `closeEvent(QEvent*)` for the `TMainConsole` class has been created to override the `TConsole` one as it is the only console that has to be concerned with saving the profile.

The way the code was structured meant that the destruction of `TDockWidget`s would sometimes hit a
`"TConsole::closeEvent(QCloseEvent*) INFO - closing a UserWindow but the TDockWidget pointer was not found to be removed...";` message - this was because the relevant `TDockWidget` had already been removed from the `(QMap<QString, TDockWidget*>) TMainConsole::mDockWidgetMap` before the `TConsole::closeEvent(...)` was executed.

The `(bool) Host::mIsGoingDown` flag was unnecessary and seemed to duplicate the `(bool) Host::mIsClosingDown` one - OTOH I did need a new `(bool) Host::mForcedClose` flag to signal that the main application was being forcibly closed and that everything should be saved whether the user had set the "auto-save on exit option" or not. The `(bool) TConsole::mUserAgreedToCloseConsole` flag has been renamed and moved to be `(bool) TMainConsole::mEnableClose` instead.

The actions to close down widgets and dialogues associated with a profile have been moved to the new `(void) Host::closeChildren` method which is called by ~~both the `(void) Host::forceClose()` method - which cannot be aborted and~~ the `(bool) Host::requestClose()` which can be aborted, and returns `false` if that *has* happened. ***Edit: the forceClose() method now just sets a flag which forces the requestClose() to not ask questions and just save things...*** 

The `HostManager::deleteHost(const QString&)` return value was never used so I changed it to be a `void` method. Note that this is the method that is actually responsible for destroying the `Host` instance for each profile.

The `(static void) TDebug::removeHost(Host*)` method needs the name of the profile that is "going away" but because it is called from the `Host` destructor I ran into a copy of seg. faults from:
* calling `Host::getName()` from there
* calling `TBuffer::log(...)` indirectly from there because that dereferences `Host::mpConsole` to check if the `TBuffer` is the one for the main console and there wasn't a valid `Host` at that point.

The process of iterating through all the open profiles to close them down in `(void) mudlet::closeEvent(QCloseEvent*)` is more tricky than it seems because the `for (auto pHost : mHostManager)` loop blows up if `mHostManager` is modified in anyway during the iteration. Instead I found I had to note down the profiles that have been closed and only destroy them after the "Do you wanna save this profile?" loop has been gone through for as many as get closed.

Because the package exporter widget is parented to the widget that is effectively the `QMainWindow` for the mudlet instance rather than the `TMainConsole` for it's profile, it was not getting closed/destroyed should it have been open when the profile it was associated with get closed but the Mudlet application stay running. As the `Host` class is NOT derived from a `QWidget` the dialogue could not be made a child of it; instead I've arranged for the `QObject::destroyed` signal of the `Host` to cancel and close it instead.