### PR TITLE
Fix: Replace QMediaPlaylist for move to Qt 6

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -136,6 +136,7 @@ set(mudlet_SRCS
     TMap.cpp
     TMapLabel.cpp
     TMedia.cpp
+    TMediaPlaylist.cpp
     TMxpElementDefinitionHandler.cpp
     TMxpElementRegistry.cpp
     TMxpFormattingTagsHandler.cpp
@@ -303,6 +304,7 @@ set(mudlet_HDRS
     TMapLabel.h
     TMatchState.h
     TMedia.h
+    TMediaPlaylist.h
     TMxpBRTagHandler.h
     TMxpClient.h
     TMxpColorTagHandler.h

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -28,9 +28,6 @@
 #include <QFileInfo>
 #include <QJsonDocument>
 #include <QJsonObject>
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-#include <QMediaPlaylist>
-#endif
 #include <QNetworkDiskCache>
 #include <QRandomGenerator>
 #include <QStandardPaths>

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -834,6 +834,33 @@ QList<TMediaPlayer> TMedia::getMediaPlayerList(TMediaData& mediaData)
 
 void TMedia::connectMediaPlayer(TMediaPlayer& player)
 {
+    disconnect(player.getMediaPlayer(), &QMediaPlayer::mediaStatusChanged, nullptr, nullptr);
+    connect(player.getMediaPlayer(), &QMediaPlayer::mediaStatusChanged, this, [=](QMediaPlayer::MediaStatus mediaStatus) {
+        if (mediaStatus == QMediaPlayer::EndOfMedia) {
+            if (player.playlist() && !player.playlist()->isEmpty()) {
+                QUrl nextMedia = player.playlist()->next();
+
+                if (!nextMedia.isEmpty()) {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+                    player.getMediaPlayer()->setMedia(nextMedia);
+#else
+                    player.getMediaPlayer()->setSource(nextMedia);
+#endif
+                    player.getMediaPlayer()->play();
+                } else if (player.playlist()->playbackMode() == TMediaPlaylist::Loop) {
+                    // Start from the beginning if the playlist is set to loop
+                    player.playlist()->setCurrentIndex(0);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+                    player.getMediaPlayer()->setMedia(player.playlist()->currentMedia());
+#else
+                    player.getMediaPlayer()->setSourceplayer.playlist()->currentMedia());
+#endif
+                    player.getMediaPlayer()->play();
+                }
+            }
+        }
+    });
+
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     disconnect(player.getMediaPlayer(), &QMediaPlayer::stateChanged, nullptr, nullptr);
     connect(player.getMediaPlayer(), &QMediaPlayer::stateChanged, this,
@@ -1113,7 +1140,6 @@ void TMedia::matchMediaKeyAndStopMediaVariants(TMediaData& mediaData, const QStr
 
 void TMedia::play(TMediaData& mediaData)
 {
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     if (mediaData.getMediaProtocol() == TMediaData::MediaProtocolMSP && !mpHost->mEnableMSP) {
         return;
     }
@@ -1149,11 +1175,21 @@ void TMedia::play(TMediaData& mediaData)
         return;
     }
 
-    auto playlist = !sameMusicIsPlaying ? new QMediaPlaylist : (pPlayer.getMediaPlayer()->playlist() != nullptr ? pPlayer.getMediaPlayer()->playlist() : new QMediaPlaylist);
+    //auto playlist = !sameMusicIsPlaying ? new QMediaPlaylist : (pPlayer.getMediaPlayer()->playlist() != nullptr ? pPlayer.getMediaPlayer()->playlist() : new QMediaPlaylist);
+    //auto playlist = !sameMusicIsPlaying ? new TMediaPlaylist : (pPlayer.playlist() != nullptr ? pPlayer.playlist() : new TMediaPlaylist);
+
+    TMediaPlaylist* playlist = pPlayer.playlist();
+
+    if (!sameMusicIsPlaying) {
+        playlist->clear();
+        playlist->setPlaybackMode(TMediaPlaylist::Sequential);
+    }
+
     QString absolutePathFileName;
 
     if (mediaData.getMediaLoops() == TMediaData::MediaLoopsDefault) { // Play once
-        playlist->setPlaybackMode(QMediaPlaylist::Sequential);
+        //playlist->setPlaybackMode(QMediaPlaylist::Sequential);
+        playlist->setPlaybackMode(TMediaPlaylist::Sequential);
 
         if (sameMusicIsPlaying) {
             if (mediaData.getMediaContinue() == TMediaData::MediaContinueRestart) {
@@ -1186,10 +1222,15 @@ void TMedia::play(TMediaData& mediaData)
         }
 
         const QUrl mediaSource = QUrl::fromLocalFile(absolutePathFileName);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
         pPlayer.getMediaPlayer()->setMedia(mediaSource);
+#else
+        pPlayer.getMediaPlayer()->setSource(mediaSource);
+#endif
     } else {
         if (mediaData.getMediaLoops() == TMediaData::MediaLoopsRepeat) { // Repeat indefinitely
-            playlist->setPlaybackMode(QMediaPlaylist::Loop);
+            //playlist->setPlaybackMode(QMediaPlaylist::Loop);
+            playlist->setPlaybackMode(TMediaPlaylist::Loop);
 
             if (sameMusicIsPlaying) {
                 if (mediaData.getMediaContinue() == TMediaData::MediaContinueRestart) {
@@ -1219,7 +1260,8 @@ void TMedia::play(TMediaData& mediaData)
 
             playlist->addMedia(QUrl::fromLocalFile(absolutePathFileName));
         } else {
-            playlist->setPlaybackMode(QMediaPlaylist::Sequential);
+            //playlist->setPlaybackMode(QMediaPlaylist::Sequential);
+            playlist->setPlaybackMode(TMediaPlaylist::Sequential);
 
             if (sameMusicIsPlaying) {
                 if (mediaData.getMediaContinue() == TMediaData::MediaContinueRestart) {
@@ -1262,38 +1304,55 @@ void TMedia::play(TMediaData& mediaData)
             return;
         }
 
-        playlist->setCurrentIndex(1);
-        pPlayer.getMediaPlayer()->setPlaylist(playlist);
+        //playlist->setCurrentIndex(1);
+        //pPlayer.getMediaPlayer()->setPlaylist(playlist);
+        playlist->setCurrentIndex(0);
+        pPlayer.setPlaylist(playlist);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+        pPlayer.getMediaPlayer()->setMedia(playlist->currentMedia());
+#else
+        pPlayer.getMediaPlayer()->setSource(playlist->currentMedia());
+#endif
     }
 
     // Set volume, start and play media
-    pPlayer.getMediaPlayer()->setVolume(mediaData.getMediaFadeIn() != TMediaData::MediaFadeNotSet ? 1 : mediaData.getMediaVolume());
+    pPlayer.setVolume(mediaData.getMediaFadeIn() != TMediaData::MediaFadeNotSet ? 1 : mediaData.getMediaVolume());
     pPlayer.getMediaPlayer()->setPosition(mediaData.getMediaStart());
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     if (mediaData.getMediaFadeIn() != TMediaData::MediaFadeNotSet || mediaData.getMediaFadeOut() != TMediaData::MediaFadeNotSet) {
         pPlayer.getMediaPlayer()->setNotifyInterval(50); // Smoother volume changes with the tighter interval (default = 1000).
     }
+#endif
 
     // Set whether or not we should be muted
     switch (mediaData.getMediaProtocol()) {
         case TMediaData::MediaProtocolAPI:
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
             pPlayer.getMediaPlayer()->setMuted(mudlet::self()->muteAPI());
+#else
+            pPlayer.getMediaPlayer()->audioOutput()->setMuted(mudlet::self()->muteAPI());
+#endif
             break;
         case TMediaData::MediaProtocolGMCP:
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
             pPlayer.getMediaPlayer()->setMuted(mudlet::self()->muteMCMP());
+#else
+            pPlayer.getMediaPlayer()->audioOutput()->setMuted(mudlet::self()->muteMCMP());
+#endif
             break;
         case TMediaData::MediaProtocolMSP:
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
             pPlayer.getMediaPlayer()->setMuted(mudlet::self()->muteMSP());
+#else
+            pPlayer.getMediaPlayer()->audioOutput()->setMuted(mudlet::self()->muteMSP());
+#endif
             break;
     }
 
     pPlayer.getMediaPlayer()->play();
 
     updateMediaPlayerList(pPlayer);
-#else
-    Q_UNUSED(mediaData)
-#warning QMediaPlaylist was removed in Qt6 - it has not been reimplemented yet!
-#endif
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Scripting#type:_sound

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -853,7 +853,7 @@ void TMedia::connectMediaPlayer(TMediaPlayer& player)
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
                     player.getMediaPlayer()->setMedia(player.playlist()->currentMedia());
 #else
-                    player.getMediaPlayer()->setSourceplayer.playlist()->currentMedia());
+                    player.getMediaPlayer()->setSource(player.playlist()->currentMedia());
 #endif
                     player.getMediaPlayer()->play();
                 }
@@ -1175,9 +1175,6 @@ void TMedia::play(TMediaData& mediaData)
         return;
     }
 
-    //auto playlist = !sameMusicIsPlaying ? new QMediaPlaylist : (pPlayer.getMediaPlayer()->playlist() != nullptr ? pPlayer.getMediaPlayer()->playlist() : new QMediaPlaylist);
-    //auto playlist = !sameMusicIsPlaying ? new TMediaPlaylist : (pPlayer.playlist() != nullptr ? pPlayer.playlist() : new TMediaPlaylist);
-
     TMediaPlaylist* playlist = pPlayer.playlist();
 
     if (!sameMusicIsPlaying) {
@@ -1188,7 +1185,6 @@ void TMedia::play(TMediaData& mediaData)
     QString absolutePathFileName;
 
     if (mediaData.getMediaLoops() == TMediaData::MediaLoopsDefault) { // Play once
-        //playlist->setPlaybackMode(QMediaPlaylist::Sequential);
         playlist->setPlaybackMode(TMediaPlaylist::Sequential);
 
         if (sameMusicIsPlaying) {
@@ -1229,7 +1225,6 @@ void TMedia::play(TMediaData& mediaData)
 #endif
     } else {
         if (mediaData.getMediaLoops() == TMediaData::MediaLoopsRepeat) { // Repeat indefinitely
-            //playlist->setPlaybackMode(QMediaPlaylist::Loop);
             playlist->setPlaybackMode(TMediaPlaylist::Loop);
 
             if (sameMusicIsPlaying) {
@@ -1260,7 +1255,6 @@ void TMedia::play(TMediaData& mediaData)
 
             playlist->addMedia(QUrl::fromLocalFile(absolutePathFileName));
         } else {
-            //playlist->setPlaybackMode(QMediaPlaylist::Sequential);
             playlist->setPlaybackMode(TMediaPlaylist::Sequential);
 
             if (sameMusicIsPlaying) {
@@ -1304,8 +1298,6 @@ void TMedia::play(TMediaData& mediaData)
             return;
         }
 
-        //playlist->setCurrentIndex(1);
-        //pPlayer.getMediaPlayer()->setPlaylist(playlist);
         playlist->setCurrentIndex(0);
         pPlayer.setPlaylist(playlist);
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -28,6 +28,7 @@
 #include "TEvent.h"
 #include "mudlet.h"
 #include "TMediaData.h"
+#include "TMediaPlaylist.h"
 
 #include "pre_guard.h"
 #include <QAudioOutput>
@@ -50,6 +51,7 @@ public:
     TMediaPlayer(Host* pHost, TMediaData& mediaData)
     : mpHost(pHost)
     , mMediaData(mediaData)
+    , mPlaylist(new TMediaPlaylist())
     , mMediaPlayer(new QMediaPlayer(pHost))
     , initialized(true)
     {
@@ -77,11 +79,21 @@ public:
         return mMediaPlayer->audioOutput()->setVolume(volume / 100.0f);
 #endif
     }
+    TMediaPlaylist* playlist() const {
+        return mPlaylist;
+    }
+    void setPlaylist(TMediaPlaylist* playlist) {
+        if (mPlaylist != playlist) {
+            delete mPlaylist;
+            mPlaylist = playlist;
+        }
+    }
 
 private:
     QPointer<Host> mpHost;
     TMediaData mMediaData;
     QMediaPlayer* mMediaPlayer = nullptr;
+    TMediaPlaylist* mPlaylist;
     bool initialized = false;
 };
 

--- a/src/TMediaPlaylist.cpp
+++ b/src/TMediaPlaylist.cpp
@@ -1,0 +1,125 @@
+/***************************************************************************
+ *   Copyright (C) 2024 by Mike Conley - mike.conley@stickmud.com          *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "TMediaPlaylist.h"
+
+#include "pre_guard.h"
+#include <QRandomGenerator>
+#include "post_guard.h"
+
+TMediaPlaylist::TMediaPlaylist()
+    : mCurrentIndex(0), mPlaybackMode(Sequential) {}
+
+TMediaPlaylist::~TMediaPlaylist() {}
+
+void TMediaPlaylist::addMedia(const QUrl &url) {
+    mMediaList.append(url);
+}
+
+void TMediaPlaylist::removeMedia(int startIndex, int endIndex) {
+    if (endIndex >= startIndex && startIndex >= 0 && endIndex < mMediaList.size()) {
+        for (int i = endIndex; i >= startIndex; --i) {
+            mMediaList.removeAt(i);
+        }
+    }
+}
+
+void TMediaPlaylist::clear() {
+    mMediaList.clear();
+}
+
+int TMediaPlaylist::mediaCount() const {
+    return mMediaList.count();
+}
+
+bool TMediaPlaylist::isEmpty() const {
+    return mMediaList.isEmpty();
+}
+
+void TMediaPlaylist::setPlaybackMode(PlaybackMode mode) {
+    mPlaybackMode = mode;
+}
+
+TMediaPlaylist::PlaybackMode TMediaPlaylist::playbackMode() const {
+    return mPlaybackMode;
+}
+
+QUrl TMediaPlaylist::currentMedia() const {
+    if (!mMediaList.isEmpty() && mCurrentIndex >= 0 && mCurrentIndex < mMediaList.size()) {
+        return mMediaList.at(mCurrentIndex);
+    }
+    return QUrl();
+}
+
+bool TMediaPlaylist::setCurrentIndex(int index) {
+    if (index >= 0 && index < mMediaList.size()) {
+        mCurrentIndex = index;
+        return true;
+    }
+    return false;
+}
+
+int TMediaPlaylist::currentIndex() const {
+    return mCurrentIndex;
+}
+
+int TMediaPlaylist::nextIndex() const {
+    if (mPlaybackMode == Loop && (mCurrentIndex + 1 == mMediaList.size())) {
+        return 0;
+    } else if (mPlaybackMode == Random) {
+        return QRandomGenerator::global()->bounded(mMediaList.size());
+    } else if (mCurrentIndex + 1 < mMediaList.size()) {
+        return mCurrentIndex + 1;
+    }
+    return -1; // No valid next index if out of range
+}
+
+QUrl TMediaPlaylist::next() {
+    if (mMediaList.isEmpty()) {
+        return QUrl();
+    }
+
+    if (mPlaybackMode == Loop && (mCurrentIndex + 1 == mMediaList.size())) {
+        mCurrentIndex = 0;
+    } else if (mPlaybackMode == Random) {
+        mCurrentIndex = QRandomGenerator::global()->bounded(mMediaList.size());
+    } else {
+        mCurrentIndex++;
+    }
+
+    if (mCurrentIndex < mMediaList.size()) {
+        return mMediaList.at(mCurrentIndex);
+    }
+
+    return QUrl();
+}
+
+QUrl TMediaPlaylist::previous() {
+    if (mPlaybackMode == Loop && mCurrentIndex == 0) {
+        mCurrentIndex = mMediaList.size() - 1;
+    } else {
+        mCurrentIndex--;
+    }
+
+    if (mCurrentIndex >= 0) {
+        return mMediaList.at(mCurrentIndex);
+    }
+
+    return QUrl();
+}

--- a/src/TMediaPlaylist.h
+++ b/src/TMediaPlaylist.h
@@ -1,0 +1,61 @@
+#ifndef TMEDIAPLAYLIST_H
+#define TMEDIAPLAYLIST_H
+
+/***************************************************************************
+ *   Copyright (C) 2024 by Mike Conley - mike.conley@stickmud.com          *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "pre_guard.h"
+#include <QList>
+#include <QUrl>
+#include "post_guard.h"
+
+class TMediaPlaylist
+{
+public:
+    enum PlaybackMode {
+        Sequential,
+        Loop,
+        Random
+    };
+
+    TMediaPlaylist();
+    ~TMediaPlaylist();
+
+    void addMedia(const QUrl &url);
+    void removeMedia(int startIndex, int endIndex);
+    void clear();
+    int mediaCount() const;
+    bool isEmpty() const;
+    void setPlaybackMode(PlaybackMode mode);
+    PlaybackMode playbackMode() const;
+
+    QUrl currentMedia() const;
+    bool setCurrentIndex(int index);
+    int currentIndex() const;
+    int nextIndex() const;
+    QUrl next();
+    QUrl previous();
+
+private:
+    QList<QUrl> mMediaList;
+    int mCurrentIndex;
+    PlaybackMode mPlaybackMode;
+};
+
+#endif // TMEDIAPLAYLIST_H

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -669,6 +669,7 @@ SOURCES += \
     TMap.cpp \
     TMapLabel.cpp \
     TMedia.cpp \
+    TMediaPlaylist.cpp \
     TMxpBRTagHandler.cpp \
     TMxpElementDefinitionHandler.cpp \
     TMxpElementRegistry.cpp \
@@ -797,6 +798,7 @@ HEADERS += \
     TMatchState.h \
     TMedia.h \
     TMediaData.h \
+    TMediaPlaylist.h \
     TMxpBRTagHandler.h \
     TMxpClient.h \
     TMxpColorTagHandler.h \


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

To move to Qt 6, Mudlet must eliminate a dependency on QMediaPlaylist. A revised implementation is included.

#### Motivation for adding to Mudlet

The update to Qt6 removed QMediaPlaylist support

#### Other info (issues closed, discussion etc)

Author: Tamarindo@StickMUD

API call for testing:
```lua
lua playMusicFile({name = "167124__patricia-mcmillen__rugby-club-in-spain.mp3", volume = 100, fadein = 20000, fadeout = 53000, loops = 2, continue = true})
```