### PR TITLE
Infra: Repair name of Linux PTB version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ execute_process(
 # If a CI/CB build system provides an alternative Git SHA1 to identify the build
 # use that instead - reporting which is being used:
 if(DEFINED ENV{BUILD_COMMIT} AND NOT $ENV{BUILD_COMMIT} STREQUAL "")
-    set(GIT_SHA1 string(TOLOWER $ENV{BUILD_COMMIT}))
+    string(TOLOWER $ENV{BUILD_COMMIT} GIT_SHA1)
     message(STATUS "Git SHA1 set from environemnt: ${GIT_SHA1}")
 else()
     message(STATUS "Git SHA1 used: ${GIT_SHA1}")


### PR DESCRIPTION
#### Brief overview of PR changes/additions
I made an error in #7160 as I thought that something that looked like a function call returned a value that could be assigned to something with a `set(...)` but CMake doesn't work like that, instead one has to provide a variable to recieve the value as the last argument to a `string(...)` function. :roll_eyes:

#### Motivation for adding to Mudlet
Fix an error that causes cruft to appear, at least, in the version number on the first tab of the "About Mudlet" dialogue.

#### Other info (issues closed, discussion etc)
This should close #7220.