### PR TITLE
Add: getConfig & setConfig option for HTML logging

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7253,6 +7253,10 @@ int TLuaInterpreter::setConfig(lua_State * L)
         host.mBoldIsBright = getVerifiedBool(L, __func__, 2, "value");
         return success();
     }
+    if (key == qsl("logInHTML")) {
+        host.mIsNextLogFileInHtmlFormat = getVerifiedBool(L, __func__, 2, "value");
+        return success();
+    }
     return warnArgumentValue(L, __func__, qsl("'%1' isn't a valid configuration option").arg(key));
 }
 
@@ -7361,7 +7365,8 @@ int TLuaInterpreter::getConfig(lua_State *L)
                 lua_pushstring(L, "asis");
             }
         } },
-        { qsl("boldIsBright"), [&](){ lua_pushboolean(L, host.mBoldIsBright); } } //, <- not needed until another one is added
+        { qsl("boldIsBright"), [&](){ lua_pushboolean(L, host.mBoldIsBright); } },
+        { qsl("logInHTML"), [&](){ lua_pushboolean(L, host.mIsNextLogFileInHtmlFormat); } } //, <- not needed until another one is added
     };
 
     auto it = configMap.find(key);

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -1250,6 +1250,7 @@ function getConfig(...)
       "fixUnnecessaryLinebreaks",
       "forceNewEnvironNegotiationOff",
       "inputLineStrictUnixEndings",
+      "logInHTML",
       "mapExitSize", 
       "mapperPanelVisible",
       "mapRoomSize",


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds "logInHTML" option to `getConfig(...)` and `setConfig(...)`

#### Motivation for adding to Mudlet
As requested by the Discord user **gravitas6674** in the message https://canary.discord.com/channels/283581582550237184/283582439002210305/1242741636459663360 in our Mudlet-Development channel on 2024/05/22 at 07:31.

#### Other info (issues closed, discussion etc)
Closes #7231.