### PR TITLE
Infra: Additional deploy script fixes for Windows PTB build process

### DIFF
--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -322,11 +322,16 @@ else
     cd - || exit 1
     echo "$Changelog"
     
+    VersionString="${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}"
+    VersionString="${VersionString,,}"
+    
     echo "=== Creating release in Dblsqd ==="
-    dblsqd release -a mudlet -c public-test-build -m "$Changelog" "${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT,,}"
+    echo "dblsqd release -a mudlet -c public-test-build -m \"$Changelog\" \"${VersionString}\""
+    dblsqd release -a mudlet -c public-test-build -m "$Changelog" "${VersionString}"
 
     echo "=== Registering release with Dblsqd ==="
-    dblsqd push -a mudlet -c public-test-build -r "${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT,,}" -s mudlet --type 'standalone' --attach "win:${DBLSQDTYPE}" "${DEPLOY_URL}"
+    echo "dblsqd push -a mudlet -c public-test-build -r \"${VersionString}\" -s mudlet --type 'standalone' --attach win:\"${DBLSQDTYPE}\" \"${DEPLOY_URL}\""
+    dblsqd push -a mudlet -c public-test-build -r "${VersionString}" -s mudlet --type 'standalone' --attach win:"${DBLSQDTYPE}" "${DEPLOY_URL}"
 
   fi
 fi

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -290,14 +290,14 @@ else
 
     SHA256SUM=$(shasum -a 256 "$setupExePath" | awk '{print $1}')
 
-    # file_cat=3 asuming Windows is the 3rd item in WP-Download-Manager category
+    # file_cat=0 asuming Windows is the 0th item in WP-Download-Manager category
     curl -X POST 'https://www.mudlet.org/wp-content/plugins/wp-downloadmanager/download-add.php' \
     -H "x-wp-download-token: $X_WP_DOWNLOAD_TOKEN" \
     -F "file_type=2" \
     -F "file_remote=$DEPLOY_URL" \
     -F "file_name=Mudlet-${VERSION} (windows-$BUILD_BITNESS)" \
     -F "file_des=sha256: $SHA256SUM" \
-    -F "file_cat=3" \
+    -F "file_cat=0" \
     -F "file_permission=-1" \
     -F "output=json" \
     -F "do=Add File"

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -323,7 +323,7 @@ else
     echo "$Changelog"
     
     echo "=== Creating release in Dblsqd ==="
-    dblsqd release -a mudlet -c public-test-build -m \""$Changelog\"" \""${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT,,}\""
+    dblsqd release -a mudlet -c public-test-build -m "$Changelog" "${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT,,}"
 
     echo "=== Registering release with Dblsqd ==="
     dblsqd push -a mudlet -c public-test-build -r "${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT,,}" -s mudlet --type 'standalone' --attach "win:${DBLSQDTYPE}" "${DEPLOY_URL}"

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -318,7 +318,7 @@ else
     
     echo "=== Generating a changelog ==="
     cd "$GITHUB_WORKSPACE/CI" || exit 1
-    Changelog=$(lua "${GITHUB_WORKSPACE}/CI/generate-changelog.lua" --mode ptb --releasefile "$DownloadedFeed")
+    Changelog=$(lua5.1 "${GITHUB_WORKSPACE}/CI/generate-changelog.lua" --mode ptb --releasefile "$DownloadedFeed")
     cd - || exit 1
     echo "$Changelog"
     

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -203,7 +203,7 @@ ROCKCOMMAND="${MINGW_INTERNAL_BASE_DIR}/bin/luarocks --lua-version 5.1"
 echo ""
 echo "  Checking, and installing if needed, the luarocks used by Mudlet..."
 echo ""
-WANTED_ROCKS=("luafilesystem" "lua-yajl" "luautf8" "lua-zip" "lrexlib-pcre" "luasql-sqlite3")
+WANTED_ROCKS=("luafilesystem" "lua-yajl" "luautf8" "lua-zip" "lrexlib-pcre" "luasql-sqlite3" "argparse")
 
 success="true"
 for ROCK in "${WANTED_ROCKS[@]}"; do

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -203,7 +203,7 @@ ROCKCOMMAND="${MINGW_INTERNAL_BASE_DIR}/bin/luarocks --lua-version 5.1"
 echo ""
 echo "  Checking, and installing if needed, the luarocks used by Mudlet..."
 echo ""
-WANTED_ROCKS=("luafilesystem" "lua-yajl" "luautf8" "lua-zip" "lrexlib-pcre" "luasql-sqlite3" "argparse")
+WANTED_ROCKS=("luafilesystem" "lua-yajl" "luautf8" "lua-zip" "lrexlib-pcre" "luasql-sqlite3" "argparse" "lunajson")
 
 success="true"
 for ROCK in "${WANTED_ROCKS[@]}"; do


### PR DESCRIPTION
The Changelog creation was attempting to use Lua 5.4 and hence did not locate the installed version 5.1 argparse luarock. Changed the lua call to lua5.1 to explicitly invoke the lua5.1 interpreter. Additionally added the required lunajson rock for Changelog creation.

The dblsql call was failing possibly due to the version string not being properly lowercased, so trying again with it all lowercase instead of just the commit sha. 

Also noticed that I had set the file_cat to 3 but it should have been 0 for Windows according to the appveyor script.