### PR TITLE
Infrastructure: additional fixes to dblsqd registration for windows 

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -110,4 +110,8 @@ jobs:
         $uri = "https://make.mudlet.org/snapshots/gha_queue.php?artifact_name=$($env:UPLOAD_FILENAME)&unzip=$($env:PARAM_UNZIP)"
         Invoke-WebRequest -Uri $uri -Method Post
       shell: pwsh
+      
+    - name: Register Release
+      if: env.PUBLIC_TEST_BUILD == 'true'
+      run: $GITHUB_WORKSPACE/CI/register-windows-release.sh
 

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -323,10 +323,16 @@ else
     echo "$Changelog"
     
     echo "=== Creating release in Dblsqd ==="
-    dblsqd release -a mudlet -c public-test-build -m "$Changelog" "${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT,,}"
+    VersionString="${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}"
+    VersionString="${VersionString,,}"
+
+    echo "=== Creating release in Dblsqd ==="
+    echo "dblsqd release -a mudlet -c public-test-build -m \"$Changelog\" \"${VersionString}\""
+    dblsqd release -a mudlet -c public-test-build -m "$Changelog" "${VersionString}"
 
     echo "=== Registering release with Dblsqd ==="
-    dblsqd push -a mudlet -c public-test-build -r "${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT,,}" -s mudlet --type 'standalone' --attach "win:${DBLSQDTYPE}" "${DEPLOY_URL}"
+    echo "dblsqd push -a mudlet -c public-test-build -r \"${VersionString}\" -s mudlet --type 'standalone' --attach win:\"${DBLSQDTYPE}\" \"${DEPLOY_URL}\""
+    dblsqd push -a mudlet -c public-test-build -r "${VersionString}" -s mudlet --type 'standalone' --attach win:"${DBLSQDTYPE}" "${DEPLOY_URL}"
 
   fi
 fi

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -48,6 +48,7 @@ else
   echo "of those two types."
   exit 2
 fi
+export DBLSQDTYPE
 
 cd "$GITHUB_WORKSPACE" || exit 1
 
@@ -306,6 +307,7 @@ else
   echo "=== Installing NodeJS ==="
   choco install nodejs --version="22.1.0"
   PATH="/c/Program Files/nodejs/:/c/npm/prefix/:${PATH}"
+  export PATH
   
   echo "=== Installing dblsqd-cli ==="
   npm install -g dblsqd-cli
@@ -323,23 +325,23 @@ else
     echo "$Changelog"
     
     echo "=== Creating release in Dblsqd ==="
-    VersionString="${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}"
-    VersionString="${VersionString,,}"
+    VersionString="${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT,,}"
+    export VersionString
 
+    # This may fail as a build from another architecture may have already registered a release with dblsqd,
+    # if so, that is OK...
     echo "=== Creating release in Dblsqd ==="
     echo "dblsqd release -a mudlet -c public-test-build -m \"$Changelog\" \"${VersionString}\""
-    dblsqd release -a mudlet -c public-test-build -m "$Changelog" "${VersionString}"
-
-    echo "=== Registering release with Dblsqd ==="
-    echo "dblsqd push -a mudlet -c public-test-build -r \"${VersionString}\" -s mudlet --type 'standalone' --attach win:\"${DBLSQDTYPE}\" \"${DEPLOY_URL}\""
-    dblsqd push -a mudlet -c public-test-build -r "${VersionString}" -s mudlet --type 'standalone' --attach win:"${DBLSQDTYPE}" "${DEPLOY_URL}"
-
+    dblsqd release -a mudlet -c public-test-build -m "$Changelog" "${VersionString}" || true
   fi
 fi
 
 if [[ -n "$GITHUB_PULL_REQUEST_NUMBER" ]]; then
   prId=" ,#$GITHUB_PULL_REQUEST_NUMBER"
 fi
+
+# Make PublicTestBuild available GHA to check if we need to run the register step
+echo "PUBLIC_TEST_BUILD=${PublicTestBuild}" >> "$GITHUB_ENV"
 
 echo ""
 echo "******************************************************"

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -290,14 +290,14 @@ else
 
     SHA256SUM=$(shasum -a 256 "$setupExePath" | awk '{print $1}')
 
-    # file_cat=3 asuming Windows is the 3rd item in WP-Download-Manager category
+    # file_cat=0 asuming Windows is the 0th item in WP-Download-Manager category
     curl -X POST 'https://www.mudlet.org/wp-content/plugins/wp-downloadmanager/download-add.php' \
     -H "x-wp-download-token: $X_WP_DOWNLOAD_TOKEN" \
     -F "file_type=2" \
     -F "file_remote=$DEPLOY_URL" \
     -F "file_name=Mudlet-${VERSION} (windows-$BUILD_BITNESS)" \
     -F "file_des=sha256: $SHA256SUM" \
-    -F "file_cat=3" \
+    -F "file_cat=0" \
     -F "file_permission=-1" \
     -F "output=json" \
     -F "do=Add File"

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -37,18 +37,17 @@ if [ "${MSYSTEM}" = "MSYS" ]; then
 elif [ "${MSYSTEM}" = "MINGW32" ]; then
   export BUILD_BITNESS="32"
   export BUILDCOMPONENT="i686"
-  export DBLSQDTYPE="x86"
+  export ARCH="x86"
 elif [ "${MSYSTEM}" = "MINGW64" ]; then
   export BUILD_BITNESS="64"
   export BUILDCOMPONENT="x86_64"
-  export DBLSQDTYPE="x86_64"
+  export ARCH="x86_64"
 else
   echo "This script is not set up to handle systems of type ${MSYSTEM}, only MINGW32 or"
   echo "MINGW64 are currently supported. Please rerun this in a bash terminal of one"
   echo "of those two types."
   exit 2
 fi
-export DBLSQDTYPE
 
 cd "$GITHUB_WORKSPACE" || exit 1
 
@@ -319,7 +318,7 @@ else
   if [[ "$PublicTestBuild" == "true" ]]; then
     echo "=== Downloading release feed ==="
     DownloadedFeed=$(mktemp)
-    curl "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/win/${DBLSQDTYPE}" -o "$DownloadedFeed"
+    curl "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/win/${ARCH}" -o "$DownloadedFeed"
     
     echo "=== Generating a changelog ==="
     cd "$GITHUB_WORKSPACE/CI" || exit 1

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -316,7 +316,7 @@ else
   if [[ "$PublicTestBuild" == "true" ]]; then
     echo "=== Downloading release feed ==="
     DownloadedFeed=$(mktemp)
-    curl "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/win/x86" -o "$DownloadedFeed"
+    curl "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/win/${DBLSQDTYPE}" -o "$DownloadedFeed"
     
     echo "=== Generating a changelog ==="
     cd "$GITHUB_WORKSPACE/CI" || exit 1

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -277,21 +277,24 @@ else
 
     exit 5
   fi
+  
+  installerExePath="Mudlet-$VERSION$MUDLET_VERSION_BUILD-$BUILD_COMMIT-windows-$BUILD_BITNESS.exe"
+  mv "${setupExePath}" "${installerExePath}"
 
   if [[ "$PublicTestBuild" == "true" ]]; then
     echo "=== Uploading public test build to make.mudlet.org ==="
     
-    uploadFilename="Mudlet-$VERSION$MUDLET_VERSION_BUILD-$BUILD_COMMIT-windows-$BUILD_BITNESS.exe"
+    uploadFilename="${installerExePath}"
     moveToUploadDir "$uploadFilename" 1
   else
 
     echo "=== Uploading installer to https://www.mudlet.org/wp-content/files/?C=M;O=D ==="
-    scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$setupExePath" "mudmachine@mudlet.org:${DEPLOY_PATH}"
+    scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$installerExePath" "mudmachine@mudlet.org:${DEPLOY_PATH}"
     DEPLOY_URL="https://www.mudlet.org/wp-content/files/Mudlet-${VERSION}-windows-$BUILD_BITNESS-installer.exe"
 
-    SHA256SUM=$(shasum -a 256 "$setupExePath" | awk '{print $1}')
+    SHA256SUM=$(shasum -a 256 "$installerExePath" | awk '{print $1}')
 
-    # file_cat=0 asuming Windows is the 0th item in WP-Download-Manager category
+    # file_cat=0 assuming Windows is the 0th item in WP-Download-Manager category
     curl -X POST 'https://www.mudlet.org/wp-content/plugins/wp-downloadmanager/download-add.php' \
     -H "x-wp-download-token: $X_WP_DOWNLOAD_TOKEN" \
     -F "file_type=2" \

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -318,7 +318,7 @@ else
     
     echo "=== Generating a changelog ==="
     cd "$GITHUB_WORKSPACE/CI" || exit 1
-    Changelog=$(lua "${GITHUB_WORKSPACE}/CI/generate-changelog.lua" --mode ptb --releasefile "$DownloadedFeed")
+    Changelog=$(lua5.1 "${GITHUB_WORKSPACE}/CI/generate-changelog.lua" --mode ptb --releasefile "$DownloadedFeed")
     cd - || exit 1
     echo "$Changelog"
     

--- a/CI/register-windows-release.sh
+++ b/CI/register-windows-release.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+###########################################################################
+#   Copyright (C) 2024-2024  by John McKisson - john.mckisson@gmail.com   #
+#                                                                         #
+#   This program is free software; you can redistribute it and/or modify  #
+#   it under the terms of the GNU General Public License as published by  #
+#   the Free Software Foundation; either version 2 of the License, or     #
+#   (at your option) any later version.                                   #
+#                                                                         #
+#   This program is distributed in the hope that it will be useful,       #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+#   GNU General Public License for more details.                          #
+#                                                                         #
+#   You should have received a copy of the GNU General Public License     #
+#   along with this program; if not, write to the                         #
+#   Free Software Foundation, Inc.,                                       #
+#   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
+###########################################################################
+
+# Version: 1.0.0    Initial Release
+
+# Exit codes:
+# 0 - Everything is fine. 8-)
+# 1 - Timeout exceeded, failure
+# 2 - DBLSQDTYPE not properly set
+
+echo "=== Downloading JSON feed ==="
+json_url="https://make.mudlet.org/snapshots/json.php?commitid=${BUILD_COMMIT}"
+
+# Timeout in seconds before we give up
+timeout_period=$((60 * 60))
+# Time interval between retries in seconds
+retry_interval=60
+# Start time
+start_time=$(date +%s)
+
+
+# Return Codes:
+# 0 - Success!
+# 1 - curl failure
+# 2 - json parse failure
+# 3 - no matching URL found
+FetchAndCheckURL() {
+    json_data=$(curl -s "$json_url")
+
+    # Check if curl succeeded
+    if [ $? -ne 0 ]; then
+      echo "Failed to download JSON feed."
+      return 1
+    fi
+
+    # Determine the search pattern based on DBLSQDTYPE environment variable
+    if [ "$DBLSQDTYPE" == "x86" ]; then
+      search_pattern="windows-32"
+    elif [ "$DBLSQDTYPE" == "x86_64" ]; then
+      search_pattern="windows-64"
+    else
+      echo "DBLSQDTYPE environment variable is not set to x86 or x86_64."
+      exit 2
+    fi
+
+    # Use jq to filter the JSON data
+    matching_url=$(echo "$json_data" | jq -r --arg search_pattern "$search_pattern" '.data[] | select(.platform == "windows" and (.url | test($search_pattern))) | .url')
+
+    # Check if jq succeeded
+    if [ $? -ne 0 ]; then
+      echo "Failed to parse JSON data."
+      return 2
+    fi
+
+    # Check if the URL was found
+    if [ -z "$matching_url" ]; then
+      echo "No matching URL found."
+      return 3
+    fi
+    
+    echo "Matching URL:"
+    echo "$matching_url"
+    
+    return 0
+}
+
+# Loop until timeout or success
+while true; do
+    FetchAndCheckURL
+    if [ $? -eq 0 ]; then
+        echo "=== Found URL, proceeding with registration ==="
+        break
+    fi
+    
+    # Check if timeout period has been reached
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ $elapsed_time -ge $timeout_period ]; then
+        echo "=== Timeout period reached. Exiting ==="
+        exit 1
+    fi
+
+    echo "=== Retrying in ${retry_interval} seconds ==="
+    sleep $retry_interval
+done
+
+
+echo "=== Registering release with Dblsqd ==="
+echo "dblsqd push -a mudlet -c public-test-build -r \"${VersionString}\" -s mudlet --type 'standalone' --attach win:\"${DBLSQDTYPE}\" \"${matching_url}\""
+dblsqd push -a mudlet -c public-test-build -r "${VersionString}" -s mudlet --type 'standalone' --attach win:"${DBLSQDTYPE}" "${matching_url}"

--- a/CI/register-windows-release.sh
+++ b/CI/register-windows-release.sh
@@ -23,7 +23,7 @@
 # Exit codes:
 # 0 - Everything is fine. 8-)
 # 1 - Timeout exceeded, failure
-# 2 - DBLSQDTYPE not properly set
+# 2 - ARCH not properly set
 
 echo "=== Downloading JSON feed ==="
 json_url="https://make.mudlet.org/snapshots/json.php?commitid=${BUILD_COMMIT}"
@@ -50,13 +50,13 @@ FetchAndCheckURL() {
       return 1
     fi
 
-    # Determine the search pattern based on DBLSQDTYPE environment variable
-    if [ "$DBLSQDTYPE" == "x86" ]; then
+    # Determine the search pattern based on ARCH environment variable
+    if [ "$ARCH" == "x86" ]; then
       search_pattern="windows-32"
-    elif [ "$DBLSQDTYPE" == "x86_64" ]; then
+    elif [ "$ARCH" == "x86_64" ]; then
       search_pattern="windows-64"
     else
-      echo "DBLSQDTYPE environment variable is not set to x86 or x86_64."
+      echo "ARCH environment variable is not set to x86 or x86_64."
       exit 2
     fi
 
@@ -103,5 +103,5 @@ done
 
 
 echo "=== Registering release with Dblsqd ==="
-echo "dblsqd push -a mudlet -c public-test-build -r \"${VersionString}\" -s mudlet --type 'standalone' --attach win:${DBLSQDTYPE} \"${matching_url}\""
-dblsqd push -a mudlet -c public-test-build -r "${VersionString}" -s mudlet --type 'standalone' --attach win:"${DBLSQDTYPE}" "${matching_url}"
+echo "dblsqd push -a mudlet -c public-test-build -r \"${VersionString}\" -s mudlet --type 'standalone' --attach win:${ARCH} \"${matching_url}\""
+dblsqd push -a mudlet -c public-test-build -r "${VersionString}" -s mudlet --type 'standalone' --attach win:"${ARCH}" "${matching_url}"

--- a/CI/register-windows-release.sh
+++ b/CI/register-windows-release.sh
@@ -45,7 +45,7 @@ FetchAndCheckURL() {
     json_data=$(curl -s "$json_url")
 
     # Check if curl succeeded
-    if [ $? -ne 0 ]; then
+    if ! curl -s "$json_url" -o /dev/null; then
       echo "Failed to download JSON feed."
       return 1
     fi
@@ -63,12 +63,6 @@ FetchAndCheckURL() {
     # Use jq to filter the JSON data
     matching_url=$(echo "$json_data" | jq -r --arg search_pattern "$search_pattern" '.data[] | select(.platform == "windows" and (.url | test($search_pattern))) | .url')
 
-    # Check if jq succeeded
-    if [ $? -ne 0 ]; then
-      echo "Failed to parse JSON data."
-      return 2
-    fi
-
     # Check if the URL was found
     if [ -z "$matching_url" ]; then
       echo "No matching URL found."
@@ -83,8 +77,7 @@ FetchAndCheckURL() {
 
 # Loop until timeout or success
 while true; do
-    FetchAndCheckURL
-    if [ $? -eq 0 ]; then
+    if FetchAndCheckURL; then
         echo "=== Found URL, proceeding with registration ==="
         break
     fi

--- a/CI/register-windows-release.sh
+++ b/CI/register-windows-release.sh
@@ -103,5 +103,5 @@ done
 
 
 echo "=== Registering release with Dblsqd ==="
-echo "dblsqd push -a mudlet -c public-test-build -r \"${VersionString}\" -s mudlet --type 'standalone' --attach win:\"${DBLSQDTYPE}\" \"${matching_url}\""
+echo "dblsqd push -a mudlet -c public-test-build -r \"${VersionString}\" -s mudlet --type 'standalone' --attach win:${DBLSQDTYPE} \"${matching_url}\""
 dblsqd push -a mudlet -c public-test-build -r "${VersionString}" -s mudlet --type 'standalone' --attach win:"${DBLSQDTYPE}" "${matching_url}"

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -47,6 +47,7 @@
 # 2 - Unsupported MSYS2/MINGGW shell type
 # 5 - Invalid command line argument
 # 6 - One or more Luarocks could not be installed
+# 7 - One of more packages failed to install
 
 
 if [ "${MSYSTEM}" = "MINGW64" ]; then
@@ -91,27 +92,63 @@ echo "    to go and have a cup of tea (other beverages are available) in the mea
 echo ""
 
 if [ "${MSYSTEM}" = "MINGW64" ]; then
-/usr/bin/pacman -Su --needed --noconfirm \
-    "mingw-w64-${BUILDCOMPONENT}-qt6-base" \
-    "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia" \
-    "mingw-w64-${BUILDCOMPONENT}-qt6-svg" \
-    "mingw-w64-${BUILDCOMPONENT}-qt6-speech" \
-    "mingw-w64-${BUILDCOMPONENT}-qt6-imageformats" \
-    "mingw-w64-${BUILDCOMPONENT}-qt6-tools" \
-    "mingw-w64-${BUILDCOMPONENT}-qt6-5compat" \
-    "mingw-w64-${BUILDCOMPONENT}-qtkeychain-qt6"
+  echo "=== Installing Qt6 Packages ==="
+  pacman_attempts=1
+  while true; do
+    /usr/bin/pacman -Su --needed --noconfirm \
+      "mingw-w64-${BUILDCOMPONENT}-qt6-base" \
+      "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia" \
+      "mingw-w64-${BUILDCOMPONENT}-qt6-svg" \
+      "mingw-w64-${BUILDCOMPONENT}-qt6-speech" \
+      "mingw-w64-${BUILDCOMPONENT}-qt6-imageformats" \
+      "mingw-w64-${BUILDCOMPONENT}-qt6-tools" \
+      "mingw-w64-${BUILDCOMPONENT}-qt6-5compat" \
+      "mingw-w64-${BUILDCOMPONENT}-qtkeychain-qt6"
+        
+    if [ $? -eq 0 ]; then
+      break
+    fi
+    
+    pacman_attempts=$((pacman_attempts +1))
+    if [ $pacman_attempts -eq 10 ]; then
+      exit 7
+    fi
+    
+    echo "=== Some packages failed to install, waiting and trying again ==="
+    sleep 10
+  done
+  
 else
-/usr/bin/pacman -Su --needed --noconfirm \
-    "mingw-w64-${BUILDCOMPONENT}-qt5-base" \
-    "mingw-w64-${BUILDCOMPONENT}-qt5-multimedia" \
-    "mingw-w64-${BUILDCOMPONENT}-qt5-svg" \
-    "mingw-w64-${BUILDCOMPONENT}-qt5-speech" \
-    "mingw-w64-${BUILDCOMPONENT}-qt5-imageformats" \
-    "mingw-w64-${BUILDCOMPONENT}-qt5-winextras" \
-    "mingw-w64-${BUILDCOMPONENT}-qt5-tools"
+
+  echo "=== Installing Qt5 Packages ==="
+  pacman_attempts=1
+  while true; do
+    /usr/bin/pacman -Su --needed --noconfirm \
+      "mingw-w64-${BUILDCOMPONENT}-qt5-base" \
+      "mingw-w64-${BUILDCOMPONENT}-qt5-multimedia" \
+      "mingw-w64-${BUILDCOMPONENT}-qt5-svg" \
+      "mingw-w64-${BUILDCOMPONENT}-qt5-speech" \
+      "mingw-w64-${BUILDCOMPONENT}-qt5-imageformats" \
+      "mingw-w64-${BUILDCOMPONENT}-qt5-winextras" \
+      "mingw-w64-${BUILDCOMPONENT}-qt5-tools"
+    
+    if [ $? -eq 0 ]; then
+      break
+    fi
+    
+    pacman_attempts=$((pacman_attempts +1))
+    if [ $pacman_attempts -eq 10 ]; then
+      exit 7
+    fi
+    
+    echo "=== Some packages failed to install, waiting and trying again ==="
+    sleep 10
+  done
 fi
 
-/usr/bin/pacman -Su --needed --noconfirm \
+pacman_attempts=1
+while true; do
+  /usr/bin/pacman -Su --needed --noconfirm \
     git \
     man \
     rsync \
@@ -130,6 +167,19 @@ fi
     "mingw-w64-${BUILDCOMPONENT}-yajl" \
     "mingw-w64-${BUILDCOMPONENT}-lua-luarocks" \
     "mingw-w64-${BUILDCOMPONENT}-jq"
+    
+  if [ $? -eq 0 ]; then
+    break
+  fi
+    
+  pacman_attempts=$((pacman_attempts +1))
+  if [ $pacman_attempts -eq 10 ]; then
+    exit 7
+  fi
+    
+  echo "=== Some packages failed to install, waiting and trying again ==="
+  sleep 10
+done
 
 echo ""
 echo "    Completed"

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -95,7 +95,7 @@ if [ "${MSYSTEM}" = "MINGW64" ]; then
   echo "=== Installing Qt6 Packages ==="
   pacman_attempts=1
   while true; do
-    /usr/bin/pacman -Su --needed --noconfirm \
+    if /usr/bin/pacman -Su --needed --noconfirm \
       "mingw-w64-${BUILDCOMPONENT}-qt6-base" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-svg" \
@@ -103,10 +103,8 @@ if [ "${MSYSTEM}" = "MINGW64" ]; then
       "mingw-w64-${BUILDCOMPONENT}-qt6-imageformats" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-tools" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-5compat" \
-      "mingw-w64-${BUILDCOMPONENT}-qtkeychain-qt6"
-        
-    if [ $? -eq 0 ]; then
-      break
+      "mingw-w64-${BUILDCOMPONENT}-qtkeychain-qt6"; then 
+        break
     fi
     
     pacman_attempts=$((pacman_attempts +1))
@@ -123,17 +121,15 @@ else
   echo "=== Installing Qt5 Packages ==="
   pacman_attempts=1
   while true; do
-    /usr/bin/pacman -Su --needed --noconfirm \
+    if /usr/bin/pacman -Su --needed --noconfirm \
       "mingw-w64-${BUILDCOMPONENT}-qt5-base" \
       "mingw-w64-${BUILDCOMPONENT}-qt5-multimedia" \
       "mingw-w64-${BUILDCOMPONENT}-qt5-svg" \
       "mingw-w64-${BUILDCOMPONENT}-qt5-speech" \
       "mingw-w64-${BUILDCOMPONENT}-qt5-imageformats" \
       "mingw-w64-${BUILDCOMPONENT}-qt5-winextras" \
-      "mingw-w64-${BUILDCOMPONENT}-qt5-tools"
-    
-    if [ $? -eq 0 ]; then
-      break
+      "mingw-w64-${BUILDCOMPONENT}-qt5-tools"; then
+        break
     fi
     
     pacman_attempts=$((pacman_attempts +1))
@@ -148,7 +144,7 @@ fi
 
 pacman_attempts=1
 while true; do
-  /usr/bin/pacman -Su --needed --noconfirm \
+  if /usr/bin/pacman -Su --needed --noconfirm \
     git \
     man \
     rsync \
@@ -166,10 +162,8 @@ while true; do
     "mingw-w64-${BUILDCOMPONENT}-boost" \
     "mingw-w64-${BUILDCOMPONENT}-yajl" \
     "mingw-w64-${BUILDCOMPONENT}-lua-luarocks" \
-    "mingw-w64-${BUILDCOMPONENT}-jq"
-    
-  if [ $? -eq 0 ]; then
-    break
+    "mingw-w64-${BUILDCOMPONENT}-jq"; then
+      break
   fi
     
   pacman_attempts=$((pacman_attempts +1))
@@ -186,7 +180,7 @@ echo "    Completed"
 echo ""
 
 
-if [ $(grep -c "/.luarocks-${MSYSTEM}" ${MINGW_INTERNAL_BASE_DIR}/etc/luarocks/config-5.1.lua) -eq 0 ]; then
+if [ "$(grep -c "/.luarocks-${MSYSTEM}" ${MINGW_INTERNAL_BASE_DIR}/etc/luarocks/config-5.1.lua)" -eq 0 ]; then
   # The luarocks config file has not been tweaked to put the compiled rocks in
   # a location that is different for each different MSYS2 environment
   echo "  Tweaking location for constructed Luarocks so 32 and 64 bits ones do"
@@ -223,7 +217,7 @@ echo ""
 # but which cannot make any missing intermediate directories if the
 # luafilesystem module for Lua 5.4 is not present, see:
 # https://github.com/msys2/MINGW-packages/pull/12002
-if [ $(luarocks --lua-version 5.4 list | grep -c "luafilesystem") -eq 0 ]; then
+if [ "$(luarocks --lua-version 5.4 list | grep -c "luafilesystem")" -eq 0 ]; then
   # Need to install the 5.4 luafilesystem rock
   echo "  Improving the luarocks operation by installing the 5.4 luafilesystem rock."
   neededPath=$(${MINGW_INTERNAL_BASE_DIR}/bin/luarocks --lua-version 5.4 install luafilesystem 2>&1 | grep "failed making directory" | cut -c 32-)
@@ -258,12 +252,12 @@ WANTED_ROCKS=("luafilesystem" "lua-yajl" "luautf8" "lua-zip" "lrexlib-pcre" "lua
 
 success="true"
 for ROCK in "${WANTED_ROCKS[@]}"; do
-  if [ $(luarocks --lua-version 5.1 list | grep -c "${ROCK}") -eq 0 ]; then
+  if [ "$(luarocks --lua-version 5.1 list | grep -c "${ROCK}")" -eq 0 ]; then
     # This rock is not present
     echo "    ${ROCK}..."
     echo ""
     ${ROCKCOMMAND} install "${ROCK}"
-	if [ $(luarocks --lua-version 5.1 list | grep -c "${ROCK}") -eq 0 ]; then
+	if [ "$(luarocks --lua-version 5.1 list | grep -c "${ROCK}")" -eq 0 ]; then
 	    echo "    ${ROCK} didn't get installed - try rerunning this script..."
 		success="false"
 	else

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -203,7 +203,7 @@ ROCKCOMMAND="${MINGW_INTERNAL_BASE_DIR}/bin/luarocks --lua-version 5.1"
 echo ""
 echo "  Checking, and installing if needed, the luarocks used by Mudlet..."
 echo ""
-WANTED_ROCKS=("luafilesystem" "lua-yajl" "luautf8" "lua-zip" "lrexlib-pcre" "luasql-sqlite3" "argparse")
+WANTED_ROCKS=("luafilesystem" "lua-yajl" "luautf8" "lua-zip" "lrexlib-pcre" "luasql-sqlite3" "argparse" "lunajson")
 
 success="true"
 for ROCK in "${WANTED_ROCKS[@]}"; do

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -128,7 +128,8 @@ fi
     "mingw-w64-${BUILDCOMPONENT}-zlib" \
     "mingw-w64-${BUILDCOMPONENT}-boost" \
     "mingw-w64-${BUILDCOMPONENT}-yajl" \
-    "mingw-w64-${BUILDCOMPONENT}-lua-luarocks" 
+    "mingw-w64-${BUILDCOMPONENT}-lua-luarocks" \
+    "mingw-w64-${BUILDCOMPONENT}-jq"
 
 echo ""
 echo "    Completed"

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -107,10 +107,10 @@ if [ "${MSYSTEM}" = "MINGW64" ]; then
         break
     fi
     
-    pacman_attempts=$((pacman_attempts +1))
     if [ $pacman_attempts -eq 10 ]; then
       exit 7
     fi
+    pacman_attempts=$((pacman_attempts +1))
     
     echo "=== Some packages failed to install, waiting and trying again ==="
     sleep 10
@@ -132,10 +132,10 @@ else
         break
     fi
     
-    pacman_attempts=$((pacman_attempts +1))
     if [ $pacman_attempts -eq 10 ]; then
       exit 7
     fi
+    pacman_attempts=$((pacman_attempts +1))
     
     echo "=== Some packages failed to install, waiting and trying again ==="
     sleep 10
@@ -166,10 +166,10 @@ while true; do
       break
   fi
     
-  pacman_attempts=$((pacman_attempts +1))
   if [ $pacman_attempts -eq 10 ]; then
     exit 7
   fi
+  pacman_attempts=$((pacman_attempts +1))
     
   echo "=== Some packages failed to install, waiting and trying again ==="
   sleep 10


### PR DESCRIPTION
The Changelog creation was attempting to use Lua 5.4 and hence did not locate the installed version 5.1 argparse luarock. Changed the lua call to lua5.1 to explicitly invoke the lua5.1 interpreter. Additionally added the required lunajson rock for Changelog creation.

The dblsql call was failing possibly due to the version string not being properly lowercased, so trying again with it all lowercase instead of just the commit sha. 

Also noticed that I had set the file_cat to 3 but it should have been 0 for Windows according to the appveyor script.