### PR TITLE
Fix: require utf8 like any other lua packages (#7235)

### DIFF
--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -32,6 +32,9 @@ end
 if package.loaded["lfs"] then
   lfs = require "lfs"
 end
+if package.loaded["utf8"] then
+  utf8 = require "utf8"
+end
 
 -- TODO this is required by DB.lua, so we might load it all at one place
 --if package.loaded["luasql.sqlite3"] then require "luasql.sqlite3" end


### PR DESCRIPTION
This fixes a lua start-up issue on my fresh mudlet development install:

/home/adrian/local/share/mudlet/lua/LuaGlobal.lua
  ([string "-- Mudlet Lua packages loader..."]:179:
  /home/adrian/local/share/mudlet/lua/StringUtils.lua:143:
  attempt to index global
  'utf8' (a nil value))

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
