### PR TITLE
Fix "Show errors" crashing Mudlet

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5946,7 +5946,7 @@ std::pair<int, QString> TLuaInterpreter::createPermScript(const QString& name, c
 
     const int id = pS->getID();
     pS->setIsActive(false);
-    mpHost->mpEditorDialog->mNeedUpdateData = true;
+    updateEditorDialogIfNeeded();
     return {id, QString()};
 }
 
@@ -6014,7 +6014,7 @@ std::pair<int, QString> TLuaInterpreter::startPermTimer(const QString& name, con
     }
 
     pT->setIsActive(false);
-    mpHost->mpEditorDialog->mNeedUpdateData = true;
+    updateEditorDialogIfNeeded();
     return {pT->getID(), QString()};
 }
 
@@ -6063,7 +6063,7 @@ std::pair<int, QString> TLuaInterpreter::startPermAlias(const QString& name, con
     pT->registerAlias();
     pT->setScript(function);
     pT->setName(name);
-    mpHost->mpEditorDialog->mNeedUpdateData = true;
+    updateEditorDialogIfNeeded();
     return {pT->getID(), QString()};
 }
 
@@ -6108,7 +6108,7 @@ std::pair<int, QString> TLuaInterpreter::startPermKey(QString& name, QString& pa
     // CHECK: The lua code in function could fail to compile - but there is no feedback here to the caller.
     pT->setScript(function);
     pT->setName(name);
-    mpHost->mpEditorDialog->mNeedUpdateData = true;
+    updateEditorDialogIfNeeded();
     return {pT->getID(), QString()};
 }
 
@@ -6290,7 +6290,7 @@ std::pair<int, QString> TLuaInterpreter::startPermRegexTrigger(const QString& na
     pT->registerTrigger();
     pT->setScript(function);
     pT->setName(name);
-    mpHost->mpEditorDialog->mNeedUpdateData = true;
+    updateEditorDialogIfNeeded();
     return std::pair(pT->getID(), QString());
 }
 
@@ -6318,7 +6318,7 @@ std::pair<int, QString> TLuaInterpreter::startPermBeginOfLineStringTrigger(const
     pT->registerTrigger();
     pT->setScript(function);
     pT->setName(name);
-    mpHost->mpEditorDialog->mNeedUpdateData = true;
+    updateEditorDialogIfNeeded();
     return std::pair(pT->getID(), QString());
 }
 
@@ -6346,7 +6346,7 @@ std::pair<int, QString> TLuaInterpreter::startPermSubstringTrigger(const QString
     pT->registerTrigger();
     pT->setScript(function);
     pT->setName(name);
-    mpHost->mpEditorDialog->mNeedUpdateData = true;
+    updateEditorDialogIfNeeded();
     return {pT->getID(), QString()};
 }
 
@@ -6373,7 +6373,7 @@ std::pair<int, QString> TLuaInterpreter::startPermPromptTrigger(const QString& n
     pT->registerTrigger();
     pT->setScript(function);
     pT->setName(name);
-    mpHost->mpEditorDialog->mNeedUpdateData = true;
+    updateEditorDialogIfNeeded();
     return {pT->getID(), QString()};
 }
 
@@ -7442,4 +7442,11 @@ int TLuaInterpreter::setSaveCommandHistory(lua_State* L)
     pCommandline->mSaveCommands = saveCommands;
     lua_pushboolean(L, true);
     return 1;
+}
+
+void TLuaInterpreter::updateEditorDialogIfNeeded()
+{
+    if (mpHost->mpEditorDialog) {
+        mpHost->mpEditorDialog->mNeedUpdateData = true;
+    }
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5946,7 +5946,7 @@ std::pair<int, QString> TLuaInterpreter::createPermScript(const QString& name, c
 
     const int id = pS->getID();
     pS->setIsActive(false);
-    updateEditorDialogIfNeeded();
+    updateEditor();
     return {id, QString()};
 }
 
@@ -6016,7 +6016,7 @@ std::pair<int, QString> TLuaInterpreter::startPermTimer(const QString& name, con
     }
 
     pT->setIsActive(false);
-    updateEditorDialogIfNeeded();
+    updateEditor();
     return {pT->getID(), QString()};
 }
 
@@ -6065,7 +6065,7 @@ std::pair<int, QString> TLuaInterpreter::startPermAlias(const QString& name, con
     pT->registerAlias();
     pT->setScript(function);
     pT->setName(name);
-    updateEditorDialogIfNeeded();
+    updateEditor();
     return {pT->getID(), QString()};
 }
 
@@ -6110,7 +6110,7 @@ std::pair<int, QString> TLuaInterpreter::startPermKey(QString& name, QString& pa
     // CHECK: The lua code in function could fail to compile - but there is no feedback here to the caller.
     pT->setScript(function);
     pT->setName(name);
-    updateEditorDialogIfNeeded();
+    updateEditor();
     return {pT->getID(), QString()};
 }
 
@@ -6292,7 +6292,7 @@ std::pair<int, QString> TLuaInterpreter::startPermRegexTrigger(const QString& na
     pT->registerTrigger();
     pT->setScript(function);
     pT->setName(name);
-    updateEditorDialogIfNeeded();
+    updateEditor();
     return std::pair(pT->getID(), QString());
 }
 
@@ -6320,7 +6320,7 @@ std::pair<int, QString> TLuaInterpreter::startPermBeginOfLineStringTrigger(const
     pT->registerTrigger();
     pT->setScript(function);
     pT->setName(name);
-    updateEditorDialogIfNeeded();
+    updateEditor();
     return std::pair(pT->getID(), QString());
 }
 
@@ -6348,7 +6348,7 @@ std::pair<int, QString> TLuaInterpreter::startPermSubstringTrigger(const QString
     pT->registerTrigger();
     pT->setScript(function);
     pT->setName(name);
-    updateEditorDialogIfNeeded();
+    updateEditor();
     return {pT->getID(), QString()};
 }
 
@@ -6375,7 +6375,7 @@ std::pair<int, QString> TLuaInterpreter::startPermPromptTrigger(const QString& n
     pT->registerTrigger();
     pT->setScript(function);
     pT->setName(name);
-    updateEditorDialogIfNeeded();
+    updateEditor();
     return {pT->getID(), QString()};
 }
 
@@ -7446,7 +7446,7 @@ int TLuaInterpreter::setSaveCommandHistory(lua_State* L)
     return 1;
 }
 
-void TLuaInterpreter::updateEditorDialogIfNeeded()
+void TLuaInterpreter::updateEditor()
 {
     if (mpHost->mpEditorDialog) {
         mpHost->mpEditorDialog->mNeedUpdateData = true;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5976,7 +5976,9 @@ std::pair<int, QString> TLuaInterpreter::setScriptCode(const QString& name, cons
         pS->setScript(oldCode);
         return {-1, qsl("unable to compile \"%1\" for the script \"%2\" at position %3, reason: %4").arg(luaCode, name, QString::number(pos + 1), errMsg)};
     }
-    mpHost->mpEditorDialog->writeScript(id);
+    if (mpHost->mpEditorDialog) {
+        mpHost->mpEditorDialog->writeScript(id);
+    }
     return {id, QString()};
 }
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -778,6 +778,7 @@ private:
             lua_close(ptr);
         }
     };
+    void updateEditorDialogIfNeeded();
 
 
     bool loadLuaModule(QQueue<QString>& resultMsgQueue, const QString& requirement, const QString& failureConsequence = QString(), const QString& description = QString(), const QString& luaModuleId = QString());

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -778,7 +778,7 @@ private:
             lua_close(ptr);
         }
     };
-    void updateEditorDialogIfNeeded();
+    void updateEditor();
 
 
     bool loadLuaModule(QQueue<QString>& resultMsgQueue, const QString& requirement, const QString& failureConsequence = QString(), const QString& description = QString(), const QString& luaModuleId = QString());

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -534,6 +534,11 @@ mudlet::mudlet()
         if (!host) {
             return;
         }
+        host->mpEditorDialog = createMudletEditor();
+        if (!host->mpEditorDialog) {
+            return;
+        }
+
         host->mpEditorDialog->showCurrentTriggerItem();
         host->mpEditorDialog->raise();
         host->mpEditorDialog->showNormal();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix "Show errors" button crashing Mudlet, along with issues in running permScript* and other script-related functions without having opened the Mudlet editor first.
#### Motivation for adding to Mudlet
Bugfix
#### Other info (issues closed, discussion etc)
Originally reported in https://discord.com/channels/283581582550237184/427919962561052673/1243552479099224074, introduced by https://github.com/Mudlet/Mudlet/pull/7215.