### PR TITLE
Fix: update area dropdown when new area is created via API

### DIFF
--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -288,6 +288,11 @@ int TLuaInterpreter::addAreaName(lua_State* L)
 
     // Note that adding an area name implicitly creates an underlying TArea instance
     lua_pushnumber(L, host.mpMap->mpRoomDB->addArea(name));
+
+    if (host.mpMap->mpMapper) {
+        host.mpMap->mpMapper->updateAreaComboBox();
+    }
+
     host.mpMap->setUnsaved(__func__);
     host.mpMap->update();
 
@@ -1111,7 +1116,6 @@ int TLuaInterpreter::deleteArea(lua_State* L)
     }
 
     if (result) {
-        // Update mapper Area names widget, using method designed for it...!
         if (host.mpMap->mpMapper) {
             host.mpMap->mpMapper->updateAreaComboBox();
         }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Update area dropdown when new area is created via API
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/7245
#### Other info (issues closed, discussion etc)
