### PR TITLE
Infrastructure: Fixes for Windows PTB uploading

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -112,6 +112,7 @@ jobs:
       shell: pwsh
       
     - name: Register Release
+      shell: msys2 {0}
       if: env.PUBLIC_TEST_BUILD == 'true'
       run: $GITHUB_WORKSPACE/CI/register-windows-release.sh
 

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -121,6 +121,7 @@ cd "$PACKAGE_DIR" || exit 1
 rm ./*.cpp ./*.o
 
 # Helper function to move a packaged mudlet to the upload directory and set up an artifact upload
+# We require the files to be uploaded to exist in $PACKAGE_DIR
 moveToUploadDir() {
   local uploadFilename=$1
   local unzip=$2
@@ -254,12 +255,11 @@ else
   rm -rf "${PACKAGE_DIR:?}/*"
 
   echo "=== Copying installer over ==="
-  mv "$GITHUB_WORKSPACE/squirreloutput/Setup.exe" "$PACKAGE_DIR"
-
-  setupExePath="$PACKAGE_DIR/Setup.exe"
+  installerExePath="${PACKAGE_DIR}/Mudlet-$VERSION$MUDLET_VERSION_BUILD-$BUILD_COMMIT-windows-$BUILD_BITNESS.exe"
+  mv "$GITHUB_WORKSPACE/squirreloutput/Setup.exe" "${installerExePath}"
 
   # Check if the setup executable exists
-  if [[ ! -f "$setupExePath" ]]; then
+  if [[ ! -f "$installerExePath" ]]; then
     echo "=== ERROR: Squirrel failed to generate the installer! Build aborted. Squirrel log is:"
 
     # Check if the SquirrelSetup.log exists and display its content
@@ -276,14 +276,13 @@ else
 
     exit 5
   fi
-  
-  installerExePath="Mudlet-$VERSION$MUDLET_VERSION_BUILD-$BUILD_COMMIT-windows-$BUILD_BITNESS.exe"
-  mv "${setupExePath}" "${installerExePath}"
 
   if [[ "$PublicTestBuild" == "true" ]]; then
     echo "=== Uploading public test build to make.mudlet.org ==="
     
-    uploadFilename="${installerExePath}"
+    uploadFilename="Mudlet-$VERSION$MUDLET_VERSION_BUILD-$BUILD_COMMIT-windows-$BUILD_BITNESS.exe"
+    
+    # Installer named $uploadFilename should exist in $PACKAGE_DIR now, we're ok to proceed
     moveToUploadDir "$uploadFilename" 1
   else
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

The recent addition of register-windows-release.sh was being run in a powershell environment instead of the desired msys2 shell.
The produced Setup.exe is now properly renamed and moved to the package directory required by the moveToUploadDir() function in deploy-mudlet-for-windows.sh, and referenced with preceding $PACKAGE_DIR/ path.

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
