### PR TITLE
Infrastructure: Export vars to GHA to be made available in PTB registration script

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -113,5 +113,8 @@ jobs:
       
     - name: Register Release
       if: env.PUBLIC_TEST_BUILD == 'true'
+      env:
+        ARCH: ${{env.ARCH}}
+        VERSION_STRING: ${{env.VERSION_STRING}}
       run: $GITHUB_WORKSPACE/CI/register-windows-release.sh
 

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -343,7 +343,11 @@ if [[ -n "$GITHUB_PULL_REQUEST_NUMBER" ]]; then
 fi
 
 # Make PublicTestBuild available GHA to check if we need to run the register step
-echo "PUBLIC_TEST_BUILD=${PublicTestBuild}" >> "$GITHUB_ENV"
+{
+  echo "PUBLIC_TEST_BUILD=${PublicTestBuild}"
+  echo "ARCH=${ARCH}"
+  echo "VERSION_STRING=${VersionString}"
+} >> "$GITHUB_ENV"
 
 echo ""
 echo "******************************************************"

--- a/CI/register-windows-release.sh
+++ b/CI/register-windows-release.sh
@@ -96,5 +96,5 @@ done
 
 
 echo "=== Registering release with Dblsqd ==="
-echo "dblsqd push -a mudlet -c public-test-build -r \"${VersionString}\" -s mudlet --type 'standalone' --attach win:${ARCH} \"${matching_url}\""
-dblsqd push -a mudlet -c public-test-build -r "${VersionString}" -s mudlet --type 'standalone' --attach win:"${ARCH}" "${matching_url}"
+echo "dblsqd push -a mudlet -c public-test-build -r \"${VERSION_STRING}\" -s mudlet --type 'standalone' --attach win:${ARCH} \"${matching_url}\""
+dblsqd push -a mudlet -c public-test-build -r "${VERSION_STRING}" -s mudlet --type 'standalone' --attach win:"${ARCH}" "${matching_url}"


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Simply exporting a var in a bash script doesn't seem to make it available to further steps in the build yml, this explicitly exports the needed variables in the register script to GITHUB_ENV where they can be picked up properly.

#### Motivation for adding to Mudlet
Further fixes to dblsqd windows build registration
#### Other info (issues closed, discussion etc)
