### PR TITLE
Infrastructure: add PATH and BUILD_COMMIT export to register script for Windows PTB

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -109,5 +109,7 @@ jobs:
       env:
         ARCH: ${{env.ARCH}}
         VERSION_STRING: ${{env.VERSION_STRING}}
+        BUILD_COMMIT: ${{env.BUILD_COMMIT}}
+        PATH: ${{env.PATH}}
       run: $GITHUB_WORKSPACE/CI/register-windows-release.sh
 

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -346,6 +346,8 @@ fi
   echo "PUBLIC_TEST_BUILD=${PublicTestBuild}"
   echo "ARCH=${ARCH}"
   echo "VERSION_STRING=${VersionString}"
+  echo "BUILD_COMMIT=${BUILD_COMMIT}"
+  echo "PATH=${PATH}"
 } >> "$GITHUB_ENV"
 
 echo ""

--- a/CI/register-windows-release.sh
+++ b/CI/register-windows-release.sh
@@ -18,6 +18,15 @@
 #   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
 ###########################################################################
 
+# This script reads the JSON feed for a given GitHub artifact with the given
+# BUILD_COMMIT and registers it with dblsqd. It will attempt this for up to
+# an hour, every minute until success.
+# GHA Env vars needed:
+#    ARCH - For registering wither 32 or 64 bit build with dblsqd
+#    BUILD_COMMIT - For listing the json feed
+#    PATH - For path of dblsqd
+#    VERSION_STRING - The version of Mudlet being released
+
 # Version: 1.0.0    Initial Release
 
 # Exit codes:

--- a/CI/register-windows-release.sh
+++ b/CI/register-windows-release.sh
@@ -27,6 +27,7 @@
 
 echo "=== Downloading JSON feed ==="
 json_url="https://make.mudlet.org/snapshots/json.php?commitid=${BUILD_COMMIT}"
+echo "$json_url"
 
 # Timeout in seconds before we give up
 timeout_period=$((60 * 60))


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

The register script requires some additional environment vars to be sent along from the deploy script, namely BUILD_COMMIT which is used to grab the url info from json.php with commitid=${BUILD_COMMIT}, as well as PATH to find the dblsqd executable.
#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
