### PR TITLE
Infrastructure: fix PTB updates for mac/linux

### DIFF
--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Retrieve binaries available on make.mudlet.org
       run: |
-        LATEST_FEED=$(tempfile) || exit 1
+        LATEST_FEED=$(mktemp /tmp/latest_feed.XXXXXX) || exit 1
         curl --silent --output $LATEST_FEED "https://make.mudlet.org/snapshots/json.php?commitid=$PTB_COMMIT"
 
         if [ "$(cat "$LATEST_FEED" | jq --raw-output '.status')" != "ok" ]; then

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -48,10 +48,8 @@ jobs:
         echo "Linux PTB link: $LINUX_PTB_URL"
         echo "macOS PTB link: $MACOS_PTB_URL"
 
-        {
-          echo "LINUX_PTB_URL=$LINUX_PTB_URL"
-          echo "MACOS_PTB_URL=$MACOS_PTB_URL"
-        } >> "$GITHUB_ENV"
+        echo "LINUX_PTB_URL=$LINUX_PTB_URL" >> $GITHUB_ENV
+        echo "MACOS_PTB_URL=$MACOS_PTB_URL" >> $GITHUB_ENV
 
     - name: Setup dblsqd client
       run: |


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
PTB updates for mac/linux don't seem to be registered anymore due to an [odd error](https://github.com/Mudlet/Mudlet/actions/runs/9411024816/job/25923640567):

```
Error: Unable to process file command 'env' successfully.
Error: Invalid format 'https://make.mudlet.org/snapshots/1b7b76/Mudlet-4.17.2-testing-834d7d01-linux-x64.AppImage.tar'
```

Changed syntax used to set the variable, maybe this will work better?
#### Motivation for adding to Mudlet
Mac/Linux PTBs weren't seeing new updates
#### Other info (issues closed, discussion etc)
