### PR TITLE
Fix crash in setProfileStylesheet() if called before profile open

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -472,7 +472,7 @@ Host::~Host()
     mErrorLogFile.close();
     // Since this is a destructor, it's risky to rely on member variables within the destructor itself.
     // To avoid this, we can pass the profile name as an argument instead of accessing it
-    // directly as a member variable. This ensures the destructor doesn't depend on the 
+    // directly as a member variable. This ensures the destructor doesn't depend on the
     // object's state being valid.
 
     TDebug::removeHost(this, mHostName);
@@ -3894,7 +3894,9 @@ bool Host::setProfileStyleSheet(const QString& styleSheet)
 
     mProfileStyleSheet = styleSheet;
     mpConsole->setStyleSheet(styleSheet);
-    mpEditorDialog->setStyleSheet(styleSheet);
+    if (mpEditorDialog) {
+        mpEditorDialog->setStyleSheet(styleSheet);
+    }
 
     if (mpDlgProfilePreferences) {
         mpDlgProfilePreferences->setStyleSheet(styleSheet);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix crash in setProfileStylesheet() if called before profile open
#### Motivation for adding to Mudlet
Bugfix
#### Other info (issues closed, discussion etc)
Editor window is not always available now