### PR TITLE
Infrastructure: Fix artifact name regression after previous release-queue PR 7265

### DIFF
--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -285,7 +285,7 @@ else
     RELEASE_TAG="release"
   fi
 
-  uploadFilename="${installerExePath}"
+  uploadFilename="Mudlet-$VERSION$MUDLET_VERSION_BUILD-$BUILD_COMMIT-windows-$BUILD_BITNESS.exe"
   moveToUploadDir "$uploadFilename" 1
   
   echo "=== Installing NodeJS ==="


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

A merge error reverted the uploadFilename to include the packge dir path in the file name, this PR fixes that by removing the path.

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
