### PR TITLE
Infrastructure: Revert release queue commits and add support for direct SCP from deploy script

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -110,10 +110,10 @@ jobs:
 
     - name: Register Release
       shell: msys2 {0}
-      if: env.RELEASE_TAG == 'release' || env.RELEASE_TAG == 'public-test-build'
+      if: env.PUBLIC_TEST_BUILD == 'true'
       env:
         ARCH: ${{env.ARCH}}
         VERSION_STRING: ${{env.VERSION_STRING}}
         BUILD_COMMIT: ${{env.BUILD_COMMIT}}
-      run: $GITHUB_WORKSPACE/CI/register-windows-release.sh ${{ env.RELEASE_TAG }}
-
+        PATH: ${{env.PATH}}
+      run: $GITHUB_WORKSPACE/CI/register-windows-release.sh

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -83,6 +83,8 @@ jobs:
         DBLSQD_USER: ${{secrets.DBLSQD_USER}}
         DBLSQD_PASS: ${{secrets.DBLSQD_PASS}}
         DEPLOY_KEY_PASS: ${{secrets.DEPLOY_KEY_PASS}}
+        DEPLOY_SSH_KEY: ${{secrets.DEPLOY_SSH_KEY}}
+        DEPLOY_PATH: ${{secrets.DEPLOY_PATH}}
         WIN_SIGNING_PASS: ${{secrets.WIN_SIGNING_PASS}}
         GITHUB_REPO_NAME: ${{ github.repository }}
         GITHUB_REPO_TAG: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
@@ -115,5 +117,4 @@ jobs:
         ARCH: ${{env.ARCH}}
         VERSION_STRING: ${{env.VERSION_STRING}}
         BUILD_COMMIT: ${{env.BUILD_COMMIT}}
-        PATH: ${{env.PATH}}
       run: $GITHUB_WORKSPACE/CI/register-windows-release.sh

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -285,7 +285,7 @@ else
     RELEASE_TAG="release"
   fi
 
-  uploadFilename="Mudlet-$VERSION$MUDLET_VERSION_BUILD-$BUILD_COMMIT-windows-$BUILD_BITNESS.exe"
+  uploadFilename="${installerExePath}"
   moveToUploadDir "$uploadFilename" 1
   
   echo "=== Installing NodeJS ==="

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -279,15 +279,32 @@ else
 
   if [[ "$PublicTestBuild" == "true" ]]; then
     echo "=== Uploading public test build to make.mudlet.org ==="
-    RELEASE_TAG="public-test-build"
+
+    uploadFilename="Mudlet-$VERSION$MUDLET_VERSION_BUILD-$BUILD_COMMIT-windows-$BUILD_BITNESS.exe"
+
+    # Installer named $uploadFilename should exist in $PACKAGE_DIR now, we're ok to proceed
+    moveToUploadDir "$uploadFilename" 1
   else
-    echo "=== Uploading release build to make.mudlet.org ==="
-    RELEASE_TAG="release"
+
+    echo "=== Uploading installer to https://www.mudlet.org/wp-content/files/?C=M;O=D ==="
+    scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$installerExePath" "mudmachine@mudlet.org:${DEPLOY_PATH}"
+    DEPLOY_URL="https://www.mudlet.org/wp-content/files/Mudlet-${VERSION}-windows-$BUILD_BITNESS-installer.exe"
+
+    SHA256SUM=$(shasum -a 256 "$installerExePath" | awk '{print $1}')
+
+    # file_cat=0 assuming Windows is the 0th item in WP-Download-Manager category
+    curl -X POST 'https://www.mudlet.org/wp-content/plugins/wp-downloadmanager/download-add.php' \
+    -H "x-wp-download-token: $X_WP_DOWNLOAD_TOKEN" \
+    -F "file_type=2" \
+    -F "file_remote=$DEPLOY_URL" \
+    -F "file_name=Mudlet-${VERSION} (windows-$BUILD_BITNESS)" \
+    -F "file_des=sha256: $SHA256SUM" \
+    -F "file_cat=0" \
+    -F "file_permission=-1" \
+    -F "output=json" \
+    -F "do=Add File"
   fi
 
-  uploadFilename="${installerExePath}"
-  moveToUploadDir "$uploadFilename" 1
-  
   echo "=== Installing NodeJS ==="
   choco install nodejs --version="22.1.0" -y -r -n
   PATH="/c/Program Files/nodejs/:/c/npm/prefix/:${PATH}"
@@ -297,38 +314,39 @@ else
   npm install -g dblsqd-cli
   dblsqd login -e "https://api.dblsqd.com/v1/jsonrpc" -u "$DBLSQD_USER" -p "$DBLSQD_PASS"
 
-  echo "=== Downloading release feed ==="
-  DownloadedFeed=$(mktemp)
-  curl "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/${RELEASE_TAG}/win/${ARCH}" -o "$DownloadedFeed"
-    
-  echo "=== Generating a changelog ==="
-  cd "$GITHUB_WORKSPACE/CI" || exit 1
-  Changelog=$(lua5.1 "${GITHUB_WORKSPACE}/CI/generate-changelog.lua" --mode release --releasefile "$DownloadedFeed")
-  cd - || exit 1
-  echo "$Changelog"
-    
-  echo "=== Creating release in Dblsqd ==="
-  VersionString="${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT,,}"
-  export VersionString
+  if [[ "$PublicTestBuild" == "true" ]]; then
+    echo "=== Downloading release feed ==="
+    DownloadedFeed=$(mktemp)
+    curl "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/win/${ARCH}" -o "$DownloadedFeed"
 
-  # This may fail as a build from another architecture may have already registered a release with dblsqd,
-  # if so, that is OK...
-  echo "=== Creating release in Dblsqd ==="
-  echo "dblsqd release -a mudlet -c ${RELEASE_TAG} -m \"$Changelog\" \"${VersionString}\""
-  dblsqd release -a mudlet -c "${RELEASE_TAG}" -m "$Changelog" "${VersionString}" || true
+    echo "=== Generating a changelog ==="
+    cd "$GITHUB_WORKSPACE/CI" || exit 1
+    Changelog=$(lua5.1 "${GITHUB_WORKSPACE}/CI/generate-changelog.lua" --mode ptb --releasefile "$DownloadedFeed")
+    cd - || exit 1
+    echo "$Changelog"
 
+    echo "=== Creating release in Dblsqd ==="
+    VersionString="${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT,,}"
+    export VersionString
+
+    # This may fail as a build from another architecture may have already registered a release with dblsqd,
+    # if so, that is OK...
+    echo "dblsqd release -a mudlet -c public-test-build -m \"$Changelog\" \"${VersionString}\""
+    dblsqd release -a mudlet -c public-test-build -m "$Changelog" "${VersionString}" || true
+  fi
 fi
 
 if [[ -n "$GITHUB_PULL_REQUEST_NUMBER" ]]; then
   prId=" ,#$GITHUB_PULL_REQUEST_NUMBER"
 fi
 
-# Make these available to GHA and the register script
+# Make PublicTestBuild available GHA to check if we need to run the register step
 {
-  echo "RELEASE_TAG=${RELEASE_TAG}"
+  echo "PUBLIC_TEST_BUILD=${PublicTestBuild}"
   echo "ARCH=${ARCH}"
   echo "VERSION_STRING=${VersionString}"
   echo "BUILD_COMMIT=${BUILD_COMMIT}"
+  echo "PATH=${PATH}"
 } >> "$GITHUB_ENV"
 
 echo ""

--- a/CI/register-windows-release.sh
+++ b/CI/register-windows-release.sh
@@ -18,33 +18,21 @@
 #   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
 ###########################################################################
 
-# Version: 1.1.0    Modified to work with release and public-test-build
-#          1.0.0    Initial Release
-
 # This script reads the JSON feed for a given GitHub artifact with the given
 # BUILD_COMMIT and registers it with dblsqd. It will attempt this for up to
 # an hour, every minute until success.
 # GHA Env vars needed:
 #    ARCH - For registering wither 32 or 64 bit build with dblsqd
 #    BUILD_COMMIT - For listing the json feed
+#    PATH - For path of dblsqd
 #    VERSION_STRING - The version of Mudlet being released
+
+# Version: 1.0.0    Initial Release
 
 # Exit codes:
 # 0 - Everything is fine. 8-)
 # 1 - Timeout exceeded, failure
 # 2 - ARCH not properly set
-# 3 - No release tag argument provided
-# 4 - Invalid release tag provided
-
-if [ $# -lt 1 ]; then
-  echo "No release tag provided"
-  exit 3
-fi
-RELEASE_TAG=$1
-if [ "$RELEASE_TAG" != "release" ] && [ "$RELEASE_TAG" != 'public-test-build' ]; then
-  echo "Invalid release tag $RELEASE_TAG provided"
-  exit 4
-fi
 
 echo "=== Downloading JSON feed ==="
 json_url="https://make.mudlet.org/snapshots/json.php?commitid=${BUILD_COMMIT}"
@@ -118,10 +106,10 @@ while true; do
     sleep $retry_interval
 done
 
+
 echo "=== Registering release with Dblsqd ==="
-echo "dblsqd push -a mudlet -c ${RELEASE_TAG} -r \"${VERSION_STRING}\" -s mudlet --type 'standalone' --attach win:${ARCH} \"${matching_url}\""
+echo "dblsqd push -a mudlet -c public-test-build -r \"${VERSION_STRING}\" -s mudlet --type 'standalone' --attach win:${ARCH} \"${matching_url}\""
 
 PATH="/c/Program Files/nodejs/:/c/npm/prefix/:${PATH}"
 export PATH
-dblsqd push -a mudlet -c "${RELEASE_TAG}" -r "${VERSION_STRING}" -s mudlet --type 'standalone' --attach win:"${ARCH}" "${matching_url}"
-
+dblsqd push -a mudlet -c public-test-build -r "${VERSION_STRING}" -s mudlet --type 'standalone' --attach win:"${ARCH}" "${matching_url}"


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

This reverts commits 5b2d510 and 1bf0066 which routed a release build through the gha queue process. This is not needed as we can scp using an ssh key instead.

SSH Key needs to be set as a GitHub secret along with the deploy path, see yaml env below:

DEPLOY_SSH_KEY: ${{secrets.DEPLOY_SSH_KEY}}
DEPLOY_PATH: ${{secrets.DEPLOY_PATH}}

#### Motivation for adding to Mudlet

Support automating release deployments

#### Other info (issues closed, discussion etc)
