### PR TITLE
Infrastructure: run macOS tests anyway even if PTB generation was skipped

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -355,7 +355,7 @@ jobs:
         if [ -d "${{runner.workspace}}/b/ninja/${{env.UPLOAD_FILENAME}}.app" ]; then
           cp -r ${{runner.workspace}}/b/ninja/${{env.UPLOAD_FILENAME}}.app ~/Desktop/Mudlet.app
         else
-          cp -r ${{runner.workspace}}/b/ninja/build/Mudlet.app ~/Desktop
+          cp -r ${{runner.workspace}}/b/ninja/src/mudlet.app ~/Desktop/Mudlet.app
         fi
         cd ~/Desktop
         sudo codesign --remove-signature Mudlet.app

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -344,11 +344,6 @@ jobs:
       run: cp ${{runner.workspace}}/b/ninja/src/mudlet ${{github.workspace}}/src
       shell: bash
 
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      with:
-        limit-access-to-actor: true
-
     - name: (macOS) Prep binary for running tests
       if: matrix.run_tests == 'true' && runner.os == 'macOS'
       run: |

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -305,7 +305,7 @@ jobs:
         RUNNER_OS: ${{runner.os}}
         DEPLOY: ${{matrix.deploy}}
 
-    - name: add ssh-agent for tag deployment
+    - name: add ssh-agent for release uploads
       if: (runner.os == 'Linux' || runner.os == 'macOS') && matrix.deploy == 'deploy' && startsWith(github.ref, 'refs/tags/Mudlet-')
       uses: webfactory/ssh-agent@v0.8.0
       with:
@@ -341,16 +341,24 @@ jobs:
     # we need to be in the right place for LuaGlobals.lua to load
     - name: (Linux) Prep binary for running tests
       if: matrix.run_tests == 'true' && runner.os =='Linux'
-      # macOS binary is in ${{runner.workspace}}/b/ninja/${{env.UPLOAD_FILENAME}}/Contents/MacOS
       run: cp ${{runner.workspace}}/b/ninja/src/mudlet ${{github.workspace}}/src
       shell: bash
+
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
 
     - name: (macOS) Prep binary for running tests
       if: matrix.run_tests == 'true' && runner.os == 'macOS'
       run: |
-        cp -r ${{runner.workspace}}/b/ninja/${{env.UPLOAD_FILENAME}}.app ~/Desktop
+        if [ -d "${{runner.workspace}}/b/ninja/${{env.UPLOAD_FILENAME}}.app" ]; then
+          cp -r ${{runner.workspace}}/b/ninja/${{env.UPLOAD_FILENAME}}.app ~/Desktop/Mudlet.app
+        else
+          cp -r ${{runner.workspace}}/b/ninja/build/Mudlet.app ~/Desktop
+        fi
         cd ~/Desktop
-        sudo codesign --remove-signature ${{env.UPLOAD_FILENAME}}.app
+        sudo codesign --remove-signature Mudlet.app
       shell: bash
 
     - name: (Linux) Run Lua tests
@@ -368,7 +376,7 @@ jobs:
       if: matrix.run_tests == 'true' && runner.os == 'macOS'
       timeout-minutes: 5
       shell: bash
-      run: ~/Desktop/${{env.UPLOAD_FILENAME}}.app/Contents/MacOS/mudlet --profile "Mudlet self-test" --mirror
+      run: ~/Desktop/Mudlet.app/Contents/MacOS/mudlet --profile "Mudlet self-test" --mirror
       env:
         AUTORUN_BUSTED_TESTS: 'true'
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -34,8 +34,6 @@ if [[ "${MUDLET_VERSION_BUILD}" == -ptb* ]]; then
   public_test_build="true"
 fi
 
-public_test_build="true" # temp ptb build testing
-
 # we deploy only certain builds
 if [ "${DEPLOY}" = "deploy" ]; then
 
@@ -95,8 +93,6 @@ if [ "${DEPLOY}" = "deploy" ]; then
         echo "== No new commits, aborting public test build generation =="
         exit 0
       fi
-
-      exit 0 # temp exit
 
       echo "== Creating a public test build =="
       if [ -n "${GITHUB_REPOSITORY}" ]; then

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -34,6 +34,8 @@ if [[ "${MUDLET_VERSION_BUILD}" == -ptb* ]]; then
   public_test_build="true"
 fi
 
+public_test_build="true" # temp ptb build testing
+
 # we deploy only certain builds
 if [ "${DEPLOY}" = "deploy" ]; then
 
@@ -93,6 +95,8 @@ if [ "${DEPLOY}" = "deploy" ]; then
         echo "== No new commits, aborting public test build generation =="
         exit 0
       fi
+
+      exit 0 # temp exit
 
       echo "== Creating a public test build =="
       if [ -n "${GITHUB_REPOSITORY}" ]; then


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Run macOS tests anyway even if PTB generation was skipped
#### Motivation for adding to Mudlet
Build should be passing when no PTB needs to be made, not failing
#### Other info (issues closed, discussion etc)
Closes https://github.com/Mudlet/Mudlet/issues/7279. Confirmed working successfully in https://github.com/Mudlet/Mudlet/actions/runs/9630709529/job/26561583984