### PR TITLE
Improve: report custom exits data when using debug operator

### DIFF
--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -221,7 +221,7 @@ inline QDebug operator<<(QDebug debug, const TRoom* room)
     debug.nospace() << ", name=" << room->name;
     debug.nospace() << ", area=" << room->getArea();
     debug.nospace() << ", pos=" << room->x << "," << room->y << "," << room->z;
-    
+
     debug.nospace() << ", exits:";
     if (room->getNorth() != -1) {
         debug.nospace() << ", north=" << room->getNorth();
@@ -270,25 +270,28 @@ inline QDebug operator<<(QDebug debug, const TRoom* room)
     }
 
     QMap<QString, QList<QPointF>> customLines = room->customLines;
+    QMap<QString, QColor> customLinesColor = room->customLinesColor;
+    QMap<QString, bool> customLinesArrow = room->customLinesArrow;
+    QMap<QString, Qt::PenStyle> customLinesStyle = room->customLinesStyle;
     if (!customLines.isEmpty()) {
         debug.nospace() << ", customLines=(";
-        for (QMap<QString, QList<QPointF>>::const_iterator it = customLines.begin(); it != customLines.end(); ++it) {
-            debug.nospace() << it.key() << ": " << it.value() << ", ";
+        for (const auto& [key, value] : customLines) {
+            debug.nospace() << key << ": " << value << " (color: " << customLinesColor.value(key).name() << ", arrow: " << (customLinesArrow.value(key) ? "yes" : "no")
+                            << ", style: " << static_cast<int>(customLinesStyle.value(key)) << "), ";
         }
         debug.nospace() << ")";
     }
-    
-    
+
     int weight = room->getWeight();
     if (weight != -1) {
-        debug.nospace() << ", weight=" << weight; 
+        debug.nospace() << ", weight=" << weight;
     }
-    
+
     QString symbol = room->mSymbol;
     if (!symbol.isEmpty()) {
         debug.nospace() << ", symbol=" << symbol;
     }
-    
+
     auto exitWeights = room->getExitWeights();
     if (!exitWeights.isEmpty()) {
         debug.nospace() << ", exitWeights=(";

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -194,7 +194,7 @@ private:
     int south = -1;
     int southwest = -1;
     int west = -1;
-    int northwest =-1;
+    int northwest = -1;
     int up = -1;
     int down = -1;
     int in = -1;
@@ -274,13 +274,14 @@ inline QDebug operator<<(QDebug debug, const TRoom* room)
     QMap<QString, bool> customLinesArrow = room->customLinesArrow;
     QMap<QString, Qt::PenStyle> customLinesStyle = room->customLinesStyle;
     if (!customLines.isEmpty()) {
-        debug.nospace() << ", customLines=(";
-        for (const auto& [key, value] : customLines) {
-            debug.nospace() << key << ": " << value << " (color: " << customLinesColor.value(key).name() << ", arrow: " << (customLinesArrow.value(key) ? "yes" : "no")
-                            << ", style: " << static_cast<int>(customLinesStyle.value(key)) << "), ";
+        debug.nospace() << ", customlines=(";
+        for (auto it = customLines.constBegin(); it != customLines.constEnd(); ++it) {
+            debug.nospace() << it.key().toLower() << ": " << it.value() << " (color: " << customLinesColor.value(it.key()).name().toLower()
+                            << ", arrow: " << (customLinesArrow.value(it.key()) ? "yes" : "no") << ", style: " << static_cast<int>(customLinesStyle.value(it.key())) << "), ";
         }
         debug.nospace() << ")";
     }
+
 
     int weight = room->getWeight();
     if (weight != -1) {

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -276,7 +276,7 @@ inline QDebug operator<<(QDebug debug, const TRoom* room)
     if (!customLines.isEmpty()) {
         debug.nospace() << ", customlines=(";
         for (auto it = customLines.constBegin(); it != customLines.constEnd(); ++it) {
-            debug.nospace() << it.key().toLower() << ": " << it.value() << " (color: " << customLinesColor.value(it.key()).name().toLower()
+            debug.nospace() << it.key() << ": " << it.value() << " (color: " << customLinesColor.value(it.key()).name().toLower()
                             << ", arrow: " << (customLinesArrow.value(it.key()) ? "yes" : "no") << ", style: " << static_cast<int>(customLinesStyle.value(it.key())) << "), ";
         }
         debug.nospace() << ")";


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Report custom exits data when using debug operator

Example:
```
local areaid = addAreaName("my first area")
local newroomid = createRoomID()
addRoom(newroomid)
setRoomArea(newroomid, "my first area")
setRoomCoordinates(newroomid, 0, 0, 0)

local otherroomid = createRoomID()
addRoom(otherroomid)
setRoomArea(otherroomid, "my first area")
setRoomCoordinates(otherroomid, 0, 5, 0)

addSpecialExit(newroomid, otherroomid, "climb Rope")
addCustomLine(newroomid, {{4.5, 5.5, 3}, {4.5, 9.5, 3}, {6.0, 9.5, 3}}, "climb Rope", "dash dot dot line", {128, 128, 0}, false)

centerview(newroomid)
```
Output when doing `qDebug() << room;`
TRoom(4), name="", area=2, pos=0,0,0, exits:, specialExits=("climb Rope".5, ), customlines=("climb rope": QList(QPointF(4.5,5.5), QPointF(4.5,9.5), QPointF(6,9.5)) (color: "#808000", arrow: no, style: 5), ), weight=1


#### Motivation for adding to Mudlet
https://github.com/Mudlet/Mudlet/pull/7184#discussion_r1622634254
#### Other info (issues closed, discussion etc)
