### PR TITLE
Fix: Remove checks for size and just show the window

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
@@ -50,9 +50,7 @@ end
 
 --Override show to keep the dimensions of the UserWindow
 function Geyser.UserWindow:show()
-  local w,h = self.get_width(),self.get_height()
   self.Parent.show(self)
-  self:resize(w,h)
 end
 
 --- Your UserWindow will be docked at position (pos):


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove checks for size and just show the window.

#### Motivation for adding to Mudlet
fixes #7248 

#### Other info (issues closed, discussion etc)
For some reason Linux returns incorrect user window sizes.  Removing the resize call after .show(self) seems to fix the problem (at least on Linux).

@patrickvinas @jmckisson can you please confirm this build works correctly on windows?
