### PR TITLE
Fix: don't send GMCP auth if we don't have character/password filled out

### DIFF
--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -49,10 +49,13 @@ void GMCPAuthenticator::sendCredentials()
     auto character = mpHost->getLogin();
     auto password = mpHost->getPass();
     QJsonObject credentials;
-    if (!character.isEmpty() && !password.isEmpty()) {
-        credentials["account"] = character;
-        credentials["password"] = password;
+    if (character.isEmpty() && password.isEmpty()) {
+        return;
     }
+
+    credentials["account"] = character;
+    credentials["password"] = password;
+
     QJsonDocument doc(credentials);
     QString gmcpMessage = doc.toJson(QJsonDocument::Compact);
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Don't send GMCP auth if we don't have character/password filled out
#### Motivation for adding to Mudlet
IRE games will disconnect if the GMCP auth is sent in with blank details - this is part of spec, but it was something we added after the initial drafts
#### Other info (issues closed, discussion etc)
Temporary measure to enable connecting to IRE games