### PR TITLE
Fix: don't send GMCP auth if either character or password is not filled in

### DIFF
--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -49,7 +49,7 @@ void GMCPAuthenticator::sendCredentials()
     auto character = mpHost->getLogin();
     auto password = mpHost->getPass();
     QJsonObject credentials;
-    if (character.isEmpty() && password.isEmpty()) {
+    if (character.isEmpty() || password.isEmpty()) {
         return;
     }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Don't send GMCP auth if either character or password is not filled in. Previous PR would still send the data in if _either_ character or password was filled in, which isn't correct.
#### Motivation for adding to Mudlet
Bugfix 2.
#### Other info (issues closed, discussion etc)
