### PR TITLE
fix: attributeFlags: fix "bold is bright"

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -879,7 +879,7 @@ COMMIT_LINE:
         }
 
         const TChar::AttributeFlags attributeFlags =
-                ( ((mBold || mpHost->mMxpClient.bold()) ? TChar::Bold : TChar::None)
+                ( (mpHost && mpHost->mBoldIsBright ? TChar::None : (mBold || mpHost->mMxpClient.bold()) ? TChar::Bold : TChar::None)
                 | (mFaint ? TChar::Faint : TChar::None)
                 | ((mItalics || mpHost->mMxpClient.italic()) ? TChar::Italic : TChar::None)
                 | (mOverline ? TChar::Overline : TChar::None)


### PR DESCRIPTION
Under "bold is bright", the bolding should never happen.

Else, the user not only sees "bright" colors when a color has the bold attribute, but they also see it bolded.

IOW, `\e[0;1;31m` should show:
- a "bright red", and not a "bolded bright red", under "bold is bright"
- a "dark red, but bolded", if "bold is bright" is unticked.

#### Brief overview of PR changes/additions

Fix bold is bright showing bolded bright colors insteat of just bright

#### Motivation for adding to Mudlet

Fix a problem many seem to be having

#### Other info (issues closed, discussion etc)
