### PR TITLE
Improve: lowercase triggers and scripts in tooltips

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -324,9 +324,9 @@ mudlet::mudlet()
     mpActionMuteMedia->setObjectName(qsl("muteMedia"));
     mpActionMuteMedia->setCheckable(true);
 
-    mpActionMuteAPI = new QAction(tr("Mute sounds from Mudlet (Triggers, Scripts, etc.)"), this);
+    mpActionMuteAPI = new QAction(tr("Mute sounds from Mudlet (triggers, scripts, etc.)"), this);
     mpActionMuteAPI->setIcon(QIcon(qsl(":/icons/mute.png")));
-    mpActionMuteAPI->setIconText(tr("Mute sounds from Mudlet (Triggers, Scripts, etc.)"));
+    mpActionMuteAPI->setIconText(tr("Mute sounds from Mudlet (triggers, scripts, etc.)"));
     mpActionMuteAPI->setObjectName(qsl("muteAPI"));
     mpActionMuteAPI->setCheckable(true);
 
@@ -3030,7 +3030,7 @@ void mudlet::toggleMute(bool state, QAction* toolbarAction, QAction* menuAction,
 
 void mudlet::slot_muteAPI(const bool state)
 {
-    toggleMute(state, mpActionMuteAPI, dactionMuteAPI, true, tr("Unmute sounds from Mudlet (Triggers, Scripts, etc.)"), tr("Mute sounds from Mudlet (Triggers, Scripts, etc.)"));
+    toggleMute(state, mpActionMuteAPI, dactionMuteAPI, true, tr("Unmute sounds from Mudlet (Triggers, Scripts, etc.)"), tr("Mute sounds from Mudlet (triggers, scripts, etc.)"));
 }
 
 void mudlet::slot_muteGame(const bool state)

--- a/src/ui/main_window.ui
+++ b/src/ui/main_window.ui
@@ -352,7 +352,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Mute sounds from Mudlet (Triggers, Scripts, etc.)</string>
+    <string>Mute sounds from Mudlet (triggers, scripts, etc.)</string>
    </property>
    <property name="toolTip">
     <string>&lt;p&gt;Mutes media played by the Lua API and scripts.&lt;/p&gt;</string>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Lowercase triggers and scripts in tooltips
#### Motivation for adding to Mudlet
They aren't referring to any one thing in particular, so they should be lowercase
#### Other info (issues closed, discussion etc)
