### PR TITLE
Fix: correct on screen information for MacOS

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1022,7 +1022,11 @@ void TConsole::scrollUp(int lines)
     if (lowerAppears) {
         QTimer::singleShot(0, this, [this]() {  mUpperPane->scrollUp(mLowerPane->getRowCount()); });
         if (!mpHost->mTutorialForSplitscreenScrollbackAlreadyShown) {
-            const QString infoMsg = tr("[ INFO ]  - Split-screen scrollback activated. Press CTRL-ENTER to cancel.");
+#if defined(Q_OS_MACOS)
+            const QString infoMsg = tr("[ INFO ]  - Split-screen scrollback activated. Press <⌘>+<ENTER> to cancel.");
+#else
+            const QString infoMsg = tr("[ INFO ]  - Split-screen scrollback activated. Press <CTRL>+<ENTER> to cancel.");
+#endif
             mpHost->postMessage(infoMsg);
             mpHost->mTutorialForSplitscreenScrollbackAlreadyShown = true;
         }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5468,7 +5468,7 @@ void TLuaInterpreter::initLuaGlobals()
     // AppInstaller on Linux would like the C search path to also be set to
     // a ./lib sub-directory of the current binary directory:
     additionalCPaths << qsl("%1/lib/?.so").arg(appPath);
-#elif defined(Q_OS_MAC)
+#elif defined(Q_OS_MACOS)
     // macOS app bundle would like the search path to also be set to the current
     // binary directory for both modules and binary libraries:
     additionalCPaths << qsl("%1/?.so").arg(appPath);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -92,7 +92,7 @@
 #include <QSettings>
 #endif
 
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
 // wrap in namespace since `Collection` defined in these headers will clash with Boost
 namespace coreMacOS {
 #include <CoreFoundation/CoreFoundation.h>
@@ -4801,7 +4801,7 @@ bool mudlet::desktopInDarkMode()
 #if defined(Q_OS_WIN32)
     QSettings settings(R"(HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize)", QSettings::NativeFormat);
     return settings.value("AppsUseLightTheme", 1).toInt() == 0;
-#elif defined(Q_OS_MAC)
+#elif defined(Q_OS_MACOS)
     bool isDark = false;
     CFStringRef uiStyleKey = CFSTR("AppleInterfaceStyle");
     CFStringRef uiStyle = nullptr;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add a different message for when the split-screen is first activated for the MacOS case.

#### Motivation for adding to Mudlet
The message that appears when the main console is scrolled up for the first time is incorrect as it refers to pressing the "Control" key - however on Mac computers the key is the "⌘" or "Command" one.

#### Other info (issues closed, discussion etc)
Whilst adding in a MacOS specific piece of code to fix this I noticed that in some places the Qt defined `Q_OS_MACOS` symbol was not being used instead `Q_OS_MAC` was being used - the Qt 5.15 documentation notes however that this is a:
> Deprecated synonym for `Q_OS_DARWIN`. Do not use.

so I have also changed all three of those to the correct one instead,