### PR TITLE
Fix: revert bold/bright colour changes

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015-2020, 2022-2024 by Stephen Lyons                   *
+ *   Copyright (C) 2015-2020, 2022-2023 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *   Copyright (C) 2018 by Huadong Qi - novload@outlook.com                *
@@ -705,17 +705,6 @@ public:
     Q_ENUM(CaretShortcut)
     // shortcut to switch between the input line and the main window
     CaretShortcut mCaretShortcut = CaretShortcut::None;
-
-    // Support a long-standing hack among all clients for using the <SGR>1m
-    // Bold) code to select a set of brighter 8 colors (the second eight) from
-    // the 256 colors for "16 color" mode of operation - alongside the basic
-    // <SGR>30m (Black) to <SGR>37m (White) set of codes. Using the "AIXTERM"
-    // codes (<SGR>90m to <SGR>97m) codes or the <SGR>38::5:Nm ones are later
-    // (better) ways of accessing that second set of 8 but some Servers only
-    // know the first for 16 color operation. The prior behaviour for Mudlet
-    // would be almost equivalent to this option being true but it limits the
-    // ability to have completely separate bold (and faint) font weightings:
-    bool mBoldIsBright = true;
 
 signals:
     // Tells TTextEdit instances for this profile how to draw the ambiguous

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -890,7 +890,10 @@ COMMIT_LINE:
                 | (TChar::alternateFontFlag(mAltFont))
                 | (mConcealed ? TChar::Concealed : TChar::None));
 
-        TChar c(mForeGroundColor, mBackGroundColor, attributeFlags);
+        TChar c((mpHost && mpHost->mBoldIsBright && mMayShift8ColorSet && mBold) ? mForeGroundColorLight
+                                                                                     : mForeGroundColor,
+                mBackGroundColor,
+                attributeFlags);
 
         if (mpHost->mMxpClient.isInLinkMode()) {
             c.mLinkIndex = mLinkStore.getCurrentLinkID();
@@ -917,12 +920,13 @@ COMMIT_LINE:
     }
 }
 
-void TBuffer::decodeSGR38(QColor& color, const QStringList& parameters, const bool isColonSeparated)
+void TBuffer::decodeSGR38(const QStringList& parameters, bool isColonSeparated)
 {
 #if defined(DEBUG_SGR_PROCESSING)
-    qDebug() << "    TBuffer::decodeSGR38(QColor&, " << parameters << "," << isColonSeparated <<") INFO - called";
+    qDebug() << "    TBuffer::decodeSGR38(" << parameters << "," << isColonSeparated <<") INFO - called";
 #endif
     if (parameters.at(1) == QLatin1String("5")) {
+
         int tag = 0;
         if (parameters.count() > 2) {
             bool isOk = false;
@@ -949,22 +953,22 @@ void TBuffer::decodeSGR38(QColor& color, const QStringList& parameters, const bo
 
         if (tag >=0 && tag < 16) {
             switch (tag) {
-            case 0:     color = mBlack;          break;
-            case 1:     color = mRed;            break;
-            case 2:     color = mGreen;          break;
-            case 3:     color = mYellow;         break;
-            case 4:     color = mBlue;           break;
-            case 5:     color = mMagenta;        break;
-            case 6:     color = mCyan;           break;
-            case 7:     color = mWhite;          break;
-            case 8:     color = mLightBlack;     break;
-            case 9:     color = mLightRed;       break;
-            case 10:    color = mLightGreen;     break;
-            case 11:    color = mLightYellow;    break;
-            case 12:    color = mLightBlue;      break;
-            case 13:    color = mLightMagenta;   break;
-            case 14:    color = mLightCyan;      break;
-            case 15:    color = mLightWhite;     break;
+            case 0:     mForeGroundColor = mBlack;          break;
+            case 1:     mForeGroundColor = mRed;            break;
+            case 2:     mForeGroundColor = mGreen;          break;
+            case 3:     mForeGroundColor = mYellow;         break;
+            case 4:     mForeGroundColor = mBlue;           break;
+            case 5:     mForeGroundColor = mMagenta;        break;
+            case 6:     mForeGroundColor = mCyan;           break;
+            case 7:     mForeGroundColor = mWhite;          break;
+            case 8:     mForeGroundColor = mLightBlack;     break;
+            case 9:     mForeGroundColor = mLightRed;       break;
+            case 10:    mForeGroundColor = mLightGreen;     break;
+            case 11:    mForeGroundColor = mLightYellow;    break;
+            case 12:    mForeGroundColor = mLightBlue;      break;
+            case 13:    mForeGroundColor = mLightMagenta;   break;
+            case 14:    mForeGroundColor = mLightCyan;      break;
+            case 15:    mForeGroundColor = mLightWhite;     break;
             }
 
         } else if (tag >=15 && tag < 232) {
@@ -978,13 +982,13 @@ void TBuffer::decodeSGR38(QColor& color, const QStringList& parameters, const bo
             // To match the common terminal palettes, the values are
             // scaled as follows:
             // 0: 0, 1: 95, 2:135, 3:175, 4:215, 5:255
-            color = QColor(r == 0 ? 0 : (r - 1) * 40 + 95,
-                           g == 0 ? 0 : (g - 1) * 40 + 95,
-                           b == 0 ? 0 : (b - 1) * 40 + 95);
+            mForeGroundColor = QColor(r == 0 ? 0 : (r - 1) * 40 + 95,
+                                      g == 0 ? 0 : (g - 1) * 40 + 95,
+                                      b == 0 ? 0 : (b - 1) * 40 + 95);
 
         } else if (tag >=232 && tag < 256) {
             const int value = (tag - 232) * 10 + 8;
-            color = QColor(value, value, value);
+            mForeGroundColor = QColor(value, value, value);
         }
         // else ignore it altogether
 
@@ -993,23 +997,23 @@ void TBuffer::decodeSGR38(QColor& color, const QStringList& parameters, const bo
         if (parameters.count() >= 6) {
             // Have enough for all three colour
             // components
-            color = QColor(qBound(0, parameters.at(3).toInt(), 255), qBound(0, parameters.at(4).toInt(), 255), qBound(0, parameters.at(5).toInt(), 255));
+            mForeGroundColor = QColor(qBound(0, parameters.at(3).toInt(), 255), qBound(0, parameters.at(4).toInt(), 255), qBound(0, parameters.at(5).toInt(), 255));
         } else if (parameters.count() >= 5) {
             // Have enough for two colour
             // components, but blue component is
             // zero
-            color = QColor(qBound(0, parameters.at(3).toInt(), 255), qBound(0, parameters.at(4).toInt(), 255), 0);
+            mForeGroundColor = QColor(qBound(0, parameters.at(3).toInt(), 255), qBound(0, parameters.at(4).toInt(), 255), 0);
         } else if (parameters.count() >= 4) {
             // Have enough for one colour component,
             // but green and blue components are
             // zero
-            color = QColor(qBound(0, parameters.at(3).toInt(), 255), 0, 0);
+            mForeGroundColor = QColor(qBound(0, parameters.at(3).toInt(), 255), 0, 0);
         } else  {
             // No codes left for any colour
             // components so colour must be black,
             // as all of red, green and blue
             // components are zero
-            color = Qt::black;
+            mForeGroundColor = Qt::black;
         }
 
         if (parameters.count() >= 3 && !parameters.at(2).isEmpty()) {
@@ -1050,13 +1054,14 @@ void TBuffer::decodeSGR38(QColor& color, const QStringList& parameters, const bo
     }
 }
 
-void TBuffer::decodeSGR48(QColor& color, const QStringList& parameters, const bool isColonSeparated)
+void TBuffer::decodeSGR48(const QStringList& parameters, bool isColonSeparated)
 {
 #if defined(DEBUG_SGR_PROCESSING)
-    qDebug() << "    TBuffer::decodeSGR48(QColor&, " << parameters << "," << isColonSeparated <<") INFO - called";
+    qDebug() << "    TBuffer::decodeSGR48(" << parameters << "," << isColonSeparated <<") INFO - called";
 #endif
 
     if (parameters.at(1) == QLatin1String("5")) {
+
         int tag = 0;
         if (parameters.count() > 2) {
             bool isOk = false;
@@ -1083,22 +1088,22 @@ void TBuffer::decodeSGR48(QColor& color, const QStringList& parameters, const bo
 
         if (tag >=0 && tag < 16) {
             switch (tag) {
-            case 0:     color = mBlack;          break;
-            case 1:     color = mRed;            break;
-            case 2:     color = mGreen;          break;
-            case 3:     color = mYellow;         break;
-            case 4:     color = mBlue;           break;
-            case 5:     color = mMagenta;        break;
-            case 6:     color = mCyan;           break;
-            case 7:     color = mWhite;          break;
-            case 8:     color = mLightBlack;     break;
-            case 9:     color = mLightRed;       break;
-            case 10:    color = mLightGreen;     break;
-            case 11:    color = mLightYellow;    break;
-            case 12:    color = mLightBlue;      break;
-            case 13:    color = mLightMagenta;   break;
-            case 14:    color = mLightCyan;      break;
-            case 15:    color = mLightWhite;     break;
+            case 0:     mBackGroundColor = mBlack;          break;
+            case 1:     mBackGroundColor = mRed;            break;
+            case 2:     mBackGroundColor = mGreen;          break;
+            case 3:     mBackGroundColor = mYellow;         break;
+            case 4:     mBackGroundColor = mBlue;           break;
+            case 5:     mBackGroundColor = mMagenta;        break;
+            case 6:     mBackGroundColor = mCyan;           break;
+            case 7:     mBackGroundColor = mWhite;          break;
+            case 8:     mBackGroundColor = mLightBlack;     break;
+            case 9:     mBackGroundColor = mLightRed;       break;
+            case 10:    mBackGroundColor = mLightGreen;     break;
+            case 11:    mBackGroundColor = mLightYellow;    break;
+            case 12:    mBackGroundColor = mLightBlue;      break;
+            case 13:    mBackGroundColor = mLightMagenta;   break;
+            case 14:    mBackGroundColor = mLightCyan;      break;
+            case 15:    mBackGroundColor = mLightWhite;     break;
             }
 
         } else if (tag >= 16 && tag < 232) {
@@ -1112,13 +1117,13 @@ void TBuffer::decodeSGR48(QColor& color, const QStringList& parameters, const bo
             // To match the common terminal palettes, the values are
             // scaled as follows:
             // 0: 0, 1: 95, 2:135, 3:175, 4:215, 5:255
-            color = QColor(r == 0 ? 0 : (r - 1) * 40 + 95,
-                           g == 0 ? 0 : (g - 1) * 40 + 95,
-                           b == 0 ? 0 : (b - 1) * 40 + 95);
+            mBackGroundColor = QColor(r == 0 ? 0 : (r - 1) * 40 + 95,
+                                      g == 0 ? 0 : (g - 1) * 40 + 95,
+                                      b == 0 ? 0 : (b - 1) * 40 + 95);
 
         } else if (tag >= 232 && tag < 256) {
             const int value = (tag - 232) * 10 + 8;
-            color = QColor(value, value, value);
+            mBackGroundColor = QColor(value, value, value);
         }
         // else ignore it altogether
 
@@ -1127,26 +1132,26 @@ void TBuffer::decodeSGR48(QColor& color, const QStringList& parameters, const bo
         if (parameters.count() >= 6) {
             // Have enough for all three colour
             // components
-            color = QColor(qBound(0, parameters.at(3).toInt(), 255), qBound(0, parameters.at(4).toInt(), 255), qBound(0, parameters.at(5).toInt(), 255));
+            mBackGroundColor = QColor(qBound(0, parameters.at(3).toInt(), 255), qBound(0, parameters.at(4).toInt(), 255), qBound(0, parameters.at(5).toInt(), 255));
 
         } else if (parameters.count() >= 5) {
             // Have enough for two colour
             // components, but blue component is
             // zero
-            color = QColor(qBound(0, parameters.at(3).toInt(), 255), qBound(0, parameters.at(4).toInt(), 255), 0);
+            mBackGroundColor = QColor(qBound(0, parameters.at(3).toInt(), 255), qBound(0, parameters.at(4).toInt(), 255), 0);
 
         } else if (parameters.count() >= 4) {
             // Have enough for one colour component,
             // but green and blue components are
             // zero
-            color = QColor(qBound(0, parameters.at(3).toInt(), 255), 0, 0);
+            mBackGroundColor = QColor(qBound(0, parameters.at(3).toInt(), 255), 0, 0);
 
         } else  {
             // No codes left for any colour
             // components so colour must be black,
             // as all of red, green and blue
             // components are zero
-            color = Qt::black;
+            mBackGroundColor = Qt::black;
         }
 
         if (parameters.count() >= 3 && !parameters.at(2).isEmpty()) {
@@ -1196,15 +1201,6 @@ void TBuffer::decodeSGR(const QString& sequence)
     }
 
     const bool haveColorSpaceId = pHost->getHaveColorSpaceId();
-    const bool boldIsBright = pHost->mBoldIsBright;
-    QColor foregroundColor = mForeGroundColor;
-    QColor lightForegroundColor = foregroundColor;
-    QColor backgroundColor = mBackGroundColor;
-    QColor lightBackgroundColor = backgroundColor;
-    std::optional<bool> hasBold;
-    std::optional<bool> hasFaint;
-    std::optional<bool> has8ColorFg;
-    std::optional<bool> has8ColorBg;
 
     const QStringList parameterStrings = sequence.split(QChar(';'));
     for (int paraIndex = 0, total = parameterStrings.count(); paraIndex < total; ++paraIndex) {
@@ -1217,8 +1213,7 @@ void TBuffer::decodeSGR(const QString& sequence)
             const QStringList parameterElements(allParameterElements.split(QChar(':')));
             if (parameterElements.at(0) == QLatin1String("38")) {
                 if (parameterElements.count() >= 2) {
-                    decodeSGR38(foregroundColor, parameterElements, true);
-                    lightForegroundColor = foregroundColor;
+                    decodeSGR38(parameterElements, true);
 
                 } else {
                     // We only have a single element in this parameterString,
@@ -1250,8 +1245,7 @@ void TBuffer::decodeSGR(const QString& sequence)
                             // We have the parameter needed
                             madeElements << parameterStrings.at(paraIndex + 2);
                         }
-                        decodeSGR38(foregroundColor, madeElements, false);
-                        lightForegroundColor = foregroundColor;
+                        decodeSGR38(madeElements, false);
                         // Move the index to consume the used values
                         paraIndex += 2;
                         break;
@@ -1301,8 +1295,7 @@ void TBuffer::decodeSGR(const QString& sequence)
                             }
                         }
 
-                        decodeSGR38(foregroundColor, madeElements, false);
-                        lightForegroundColor = foregroundColor;
+                        decodeSGR38(madeElements, false);
                         // Move the index to consume the used values
                         paraIndex += (haveColorSpaceId ? 5 : 4);
                         break;
@@ -1317,8 +1310,7 @@ void TBuffer::decodeSGR(const QString& sequence)
             // End of if (parameterElements.at(0) == QLatin1String("38"))
             } else if (parameterElements.at(0) == QLatin1String("48")) {
                 if (parameterElements.count() >= 2) {
-                    decodeSGR48(backgroundColor, parameterElements, true);
-                    lightBackgroundColor = backgroundColor;
+                    decodeSGR48(parameterElements, true);
 
                 } else {
                     // We only have a single element in this parameterString,
@@ -1351,8 +1343,7 @@ void TBuffer::decodeSGR(const QString& sequence)
                             madeElements << parameterStrings.at(paraIndex + 2);
                         }
                         // Move the index to consume the used values
-                        decodeSGR48(backgroundColor, madeElements, false);
-                        lightBackgroundColor = backgroundColor;
+                        decodeSGR48(madeElements, false);
                         paraIndex += 2;
                         break;
                     case 4: // Not handled but we still should skip its arguments
@@ -1402,8 +1393,7 @@ void TBuffer::decodeSGR(const QString& sequence)
                         }
 
                         // Move the index to consume the used values
-                        decodeSGR48(backgroundColor, madeElements, false);
-                        lightBackgroundColor = backgroundColor;
+                        decodeSGR48(madeElements, false);
                         paraIndex += (haveColorSpaceId ? 5 : 4);
                         break;
                     case 1: // This uses no extra arguments and, as it means
@@ -1485,10 +1475,9 @@ void TBuffer::decodeSGR(const QString& sequence)
             if (isOk) {
                 switch (tag) {
                 case 0:
-                    foregroundColor = pHost->mFgColor;
-                    lightForegroundColor = foregroundColor;
-                    backgroundColor = pHost->mBgColor;
-                    lightBackgroundColor = backgroundColor;
+                    mForeGroundColor = pHost->mFgColor;
+                    mBackGroundColor = pHost->mBgColor;
+                    mMayShift8ColorSet = false;
                     mBold = false;
                     mFaint = false;
                     mItalics = false;
@@ -1500,22 +1489,12 @@ void TBuffer::decodeSGR(const QString& sequence)
                     mFastBlink = false;
                     mConcealed = false;
                     mAltFont = 0;
-                    hasBold = false;
-                    hasFaint = false;
-                    has8ColorFg = false;
-                    has8ColorBg = false;
                     break;
                 case 1:
-                    // While we note this we will not apply it to the
-                    // TBuffer::mBold flag straight away as we may instead need
-                    // it to shift colors from the first 8 ANSI colors set to
-                    // the second for either the fore- or back-ground colors:
-                    hasBold = true;
+                    mBold = true;
                     break;
                 case 2:
-                    // Likewise for this one as the bold one - but only so we
-                    // don't use it if the bold is used to shift a color:
-                    hasFaint = true;
+                    mFaint = true;
                     break;
                 case 3:
                     // There is a proposal by the "VTE" terminal
@@ -1588,8 +1567,8 @@ void TBuffer::decodeSGR(const QString& sequence)
                 // case 21: // Double underline according to specs
                 //    break;
                 case 22: // "Neither Bold nor Dim" (Faint)
-                    hasBold = false;
-                    hasFaint = false;
+                    mBold = false;
+                    mFaint = false;
                     break;
                 case 23:
                     mItalics = false;
@@ -1611,51 +1590,50 @@ void TBuffer::decodeSGR(const QString& sequence)
                     mStrikeOut = false;
                     break;
                 case 30:
-                    foregroundColor = mBlack;
-                    lightForegroundColor = mLightBlack;
-                    // This has priority over Background color
-                    has8ColorFg = true;
+                    mForeGroundColor = mBlack;
+                    mForeGroundColorLight = mLightBlack;
+                    mMayShift8ColorSet = true;
                     break;
                 case 31:
-                    foregroundColor = mRed;
-                    lightForegroundColor = mLightRed;
-                    has8ColorFg = true;
+                    mForeGroundColor = mRed;
+                    mForeGroundColorLight = mLightRed;
+                    mMayShift8ColorSet = true;
                     break;
                 case 32:
-                    foregroundColor = mGreen;
-                    lightForegroundColor = mLightGreen;
-                    has8ColorFg = true;
+                    mForeGroundColor = mGreen;
+                    mForeGroundColorLight = mLightGreen;
+                    mMayShift8ColorSet = true;
                     break;
                 case 33:
-                    foregroundColor = mYellow;
-                    lightForegroundColor = mLightYellow;
-                    has8ColorFg = true;
+                    mForeGroundColor = mYellow;
+                    mForeGroundColorLight = mLightYellow;
+                    mMayShift8ColorSet = true;
                     break;
                 case 34:
-                    foregroundColor = mBlue;
-                    lightForegroundColor = mLightBlue;
-                    has8ColorFg = true;
+                    mForeGroundColor = mBlue;
+                    mForeGroundColorLight = mLightBlue;
+                    mMayShift8ColorSet = true;
                     break;
                 case 35:
-                    foregroundColor = mMagenta;
-                    lightForegroundColor = mLightMagenta;
-                    has8ColorFg = true;
+                    mForeGroundColor = mMagenta;
+                    mForeGroundColorLight = mLightMagenta;
+                    mMayShift8ColorSet = true;
                     break;
                 case 36:
-                    foregroundColor = mCyan;
-                    lightForegroundColor = mLightCyan;
-                    has8ColorFg = true;
+                    mForeGroundColor = mCyan;
+                    mForeGroundColorLight = mLightCyan;
+                    mMayShift8ColorSet = true;
                     break;
                 case 37:
-                    foregroundColor = mWhite;
-                    lightForegroundColor = mLightWhite;
-                    has8ColorFg = true;
+                    mForeGroundColor = mWhite;
+                    mForeGroundColorLight = mLightWhite;
+                    mMayShift8ColorSet = true;
                     break;
                 case 38: {
                     // We are not now using the basic 8 colors so we won't
                     // attempt to use the Bold attribute to shift those to the
                     // next 8 out of the first 16:
-                    has8ColorFg = false;
+                    mMayShift8ColorSet = false;
                     // We only have single elements so we will need to steal the
                     // needed number from the remainder:
                     if (paraIndex + 1 >= total) {
@@ -1684,8 +1662,7 @@ void TBuffer::decodeSGR(const QString& sequence)
                             madeElements << parameterStrings.at(paraIndex + 2);
                         }
                         // Move the index to consume the used values
-                        decodeSGR38(foregroundColor, madeElements, false);
-                        lightForegroundColor = foregroundColor;
+                        decodeSGR38(madeElements, false);
                         paraIndex += 2;
                         break;
                     case 4: // Not handled but we still should skip its arguments
@@ -1737,8 +1714,7 @@ void TBuffer::decodeSGR(const QString& sequence)
                         // Move the index to consume the used values LESS
                         // the one that the for loop will handle - even if it
                         // goes past end
-                        decodeSGR38(foregroundColor, madeElements, false);
-                        lightForegroundColor = foregroundColor;
+                        decodeSGR38(madeElements, false);
                         paraIndex += (haveColorSpaceId ? 5 : 4);
                         break;
                     case 1: // This uses no extra arguments and, as it means
@@ -1750,59 +1726,34 @@ void TBuffer::decodeSGR(const QString& sequence)
                 }
                     break;
                 case 39: //default foreground color
-                    foregroundColor = pHost->mFgColor;
-                    lightForegroundColor = foregroundColor;
-                    has8ColorFg = false;
+                    mForeGroundColor = pHost->mFgColor;
+                    mMayShift8ColorSet = false;
                     break;
                 case 40:
-                    // We have an 8-color setting for the background color
-                    // however it will only be considered to be a 16-color
-                    // one if the foreground is NOT also set within this
-                    // SGR sequence:
-                    has8ColorBg = true;
-                    backgroundColor = mBlack;
-                    lightBackgroundColor = mLightBlack;
+                    mBackGroundColor = mBlack;
                     break;
                 case 41:
-                    has8ColorBg = true;
-                    backgroundColor = mRed;
-                    lightBackgroundColor = mLightRed;
+                    mBackGroundColor = mRed;
                     break;
                 case 42:
-                    has8ColorBg = true;
-                    backgroundColor = mGreen;
-                    lightBackgroundColor = mLightGreen;
+                    mBackGroundColor = mGreen;
                     break;
                 case 43:
-                    has8ColorBg = true;
-                    backgroundColor = mYellow;
-                    lightBackgroundColor = mLightGreen;
+                    mBackGroundColor = mYellow;
                     break;
                 case 44:
-                    has8ColorBg = true;
-                    backgroundColor = mBlue;
-                    lightBackgroundColor = mLightBlue;
+                    mBackGroundColor = mBlue;
                     break;
                 case 45:
-                    has8ColorBg = true;
-                    backgroundColor = mMagenta;
-                    lightBackgroundColor = mLightMagenta;
+                    mBackGroundColor = mMagenta;
                     break;
                 case 46:
-                    has8ColorBg = true;
-                    backgroundColor = mCyan;
-                    lightBackgroundColor = mLightCyan;
+                    mBackGroundColor = mCyan;
                     break;
                 case 47:
-                    has8ColorBg = true;
-                    backgroundColor = mWhite;
-                    lightBackgroundColor = mLightWhite;
+                    mBackGroundColor = mWhite;
                     break;
                 case 48: {
-                    // We are not now using the basic 8 colors so we won't
-                    // attempt to use the Bold attribute to shift those to the
-                    // next 8 out of the first 16:
-                    has8ColorBg = false;
                     // We only have single elements so we will need to steal the
                     // needed number from the remainder:
                     if (paraIndex + 1 >= total) {
@@ -1831,8 +1782,7 @@ void TBuffer::decodeSGR(const QString& sequence)
                             madeElements << parameterStrings.at(paraIndex + 2);
                         }
                         // Move the index to consume the used values
-                        decodeSGR48(backgroundColor, madeElements, false);
-                        lightBackgroundColor = backgroundColor;
+                        decodeSGR48(madeElements, false);
                         paraIndex += 2;
                         break;
                     case 4: // Not handled but we still should skip its arguments
@@ -1882,8 +1832,7 @@ void TBuffer::decodeSGR(const QString& sequence)
                         }
 
                         // Move the index to consume the used values
-                        decodeSGR48(backgroundColor, madeElements, false);
-                        lightBackgroundColor = backgroundColor;
+                        decodeSGR48(madeElements, false);
                         paraIndex += (haveColorSpaceId ? 5 : 4);
                         break;
                     case 1: // This uses no extra arguments and, as it means
@@ -1896,7 +1845,6 @@ void TBuffer::decodeSGR(const QString& sequence)
                     break;
                 case 49: // default background color
                     mBackGroundColor = pHost->mBgColor;
-                    has8ColorBg = false;
                     break;
                 // case 51: // Framed
                 //    break;
@@ -1924,144 +1872,66 @@ void TBuffer::decodeSGR(const QString& sequence)
                 // case 65: // cancels the effects of 60 to 64
                 //    break;
                 case 90:
-                    foregroundColor = mLightBlack;
-                    lightForegroundColor = foregroundColor;
-                    has8ColorFg = false;
+                    mForeGroundColor = mLightBlack;
+                    mMayShift8ColorSet = false;
                     break;
                 case 91:
-                    foregroundColor = mLightRed;
-                    lightForegroundColor = foregroundColor;
-                    has8ColorFg = false;
+                    mForeGroundColor = mLightRed;
+                    mMayShift8ColorSet = false;
                     break;
                 case 92:
-                    foregroundColor = mLightGreen;
-                    lightForegroundColor = foregroundColor;
-                    has8ColorFg = false;
+                    mForeGroundColor = mLightGreen;
+                    mMayShift8ColorSet = false;
                     break;
                 case 93:
-                    foregroundColor = mLightYellow;
-                    lightForegroundColor = foregroundColor;
-                    has8ColorFg = false;
+                    mForeGroundColor = mLightYellow;
+                    mMayShift8ColorSet = false;
                     break;
                 case 94:
-                    foregroundColor = mLightBlue;
-                    lightForegroundColor = foregroundColor;
-                    has8ColorFg = false;
+                    mForeGroundColor = mLightBlue;
+                    mMayShift8ColorSet = false;
                     break;
                 case 95:
-                    foregroundColor = mLightMagenta;
-                    lightForegroundColor = foregroundColor;
-                    has8ColorFg = false;
+                    mForeGroundColor = mLightMagenta;
+                    mMayShift8ColorSet = false;
                     break;
                 case 96:
-                    foregroundColor = mLightCyan;
-                    lightForegroundColor = foregroundColor;
-                    has8ColorFg = false;
+                    mForeGroundColor = mLightCyan;
+                    mMayShift8ColorSet = false;
                     break;
                 case 97:
-                    foregroundColor = mLightWhite;
-                    lightForegroundColor = foregroundColor;
-                    has8ColorFg = false;
+                    mForeGroundColor = mLightWhite;
+                    mMayShift8ColorSet = false;
                     break;
                 case 100:
-                    backgroundColor = mLightBlack;
-                    lightBackgroundColor = backgroundColor;
-                    has8ColorBg = false;
+                    mBackGroundColor = mLightBlack;
                     break;
                 case 101:
-                    backgroundColor = mLightRed;
-                    lightBackgroundColor = backgroundColor;
-                    has8ColorBg = false;
+                    mBackGroundColor = mLightRed;
                     break;
                 case 102:
-                    backgroundColor = mLightGreen;
-                    lightBackgroundColor = backgroundColor;
-                    has8ColorBg = false;
+                    mBackGroundColor = mLightGreen;
                     break;
                 case 103:
-                    backgroundColor = mLightYellow;
-                    lightBackgroundColor = backgroundColor;
-                    has8ColorBg = false;
+                    mBackGroundColor = mLightYellow;
                     break;
                 case 104:
-                    backgroundColor = mLightBlue;
-                    lightBackgroundColor = backgroundColor;
-                    has8ColorBg = false;
+                    mBackGroundColor = mLightBlue;
                     break;
                 case 105:
-                    backgroundColor = mLightMagenta;
-                    lightBackgroundColor = backgroundColor;
-                    has8ColorBg = false;
+                    mBackGroundColor = mLightMagenta;
                     break;
                 case 106:
-                    backgroundColor = mLightCyan;
-                    lightBackgroundColor = backgroundColor;
-                    has8ColorBg = false;
+                    mBackGroundColor = mLightCyan;
                     break;
                 case 107:
-                    backgroundColor = mLightWhite;
-                    lightBackgroundColor = backgroundColor;
-                    has8ColorBg = false;
+                    mBackGroundColor = mLightWhite;
                     break;
                 default:
                     qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - Unhandled single SGR code sequence CSI " << tag << " m received, Mudlet will ignore it.";
                 }
             }
         }
-    }
-
-    if (boldIsBright) {
-        if (!(  (has8ColorFg.has_value() && has8ColorFg.value())
-             || (has8ColorBg.has_value() && has8ColorBg.value()))) {
-
-            // We have not got an 8-color mode setting so we can trust that the
-            // bold (and faint) settings refers to font presentation rather then
-            // 16 color mode setting:
-            if (hasBold.has_value()) {
-                mBold = hasBold.value();
-            }
-            if (hasFaint.has_value()) {
-                mFaint = hasFaint.value();
-            }
-            // Now set the color changes we've detected (if any) during the
-            // parsing of this SGR sequence:
-            mForeGroundColor = foregroundColor;
-            mBackGroundColor = backgroundColor;
-        } else {
-            // Either an 8 color foreground or background color or both have
-            // been set
-            if (hasBold.has_value() && hasBold.value()) {
-                // AND the bold setting has been given
-                if (has8ColorFg.has_value() && has8ColorFg.value()) {
-                    // As an 8-color foreground color has been given so switch
-                    // the foreground color to the second 8 in a 16 color set:
-                    mForeGroundColor = lightForegroundColor;
-                    mBackGroundColor = backgroundColor;
-                } else {
-                    if (has8ColorBg.has_value() && has8ColorBg.value()) {
-                        // As an 8-color foreground color has not been given but
-                        // an 8-color background has, so switch the background
-                        // color to the second 8 in a 16 color set:
-                        mBackGroundColor = lightBackgroundColor;
-                    } else {
-                        mBackGroundColor = backgroundColor;
-                    }
-                    mForeGroundColor = foregroundColor;
-                }
-            } else {
-                mForeGroundColor = foregroundColor;
-                mBackGroundColor = backgroundColor;
-            }
-        }
-    } else {
-        if (hasBold.has_value()) {
-            mBold = hasBold.value();
-        }
-        if (hasFaint.has_value()) {
-            mFaint = hasFaint.value();
-        }
-        mForeGroundColor = foregroundColor;
-        mBackGroundColor = backgroundColor;
     }
 }
 

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -379,8 +379,8 @@ private:
     bool processBig5Sequence(const std::string&, bool, size_t, size_t&, bool&);
     bool processEUC_KRSequence(const std::string&, bool, size_t, size_t&, bool&);
     void decodeSGR(const QString&);
-    void decodeSGR38(QColor&, const QStringList&, const bool isColonSeparated = true);
-    void decodeSGR48(QColor&, const QStringList&, const bool isColonSeparated = true);
+    void decodeSGR38(const QStringList&, bool isColonSeparated = true);
+    void decodeSGR48(const QStringList&, bool isColonSeparated = true);
     void decodeOSC(const QString&);
     void resetColors();
 
@@ -415,6 +415,7 @@ private:
     QColor mLightWhite;
     QColor mWhite;
     QColor mForeGroundColor;
+    QColor mForeGroundColorLight;
     QColor mBackGroundColor;
 
     QPointer<Host> mpHost;
@@ -432,6 +433,12 @@ private:
     bool mFastBlink = false;
     bool mConcealed = false;
     quint8 mAltFont = 0;
+    // If enabled by a per profile setting (Host::mBoldIsBright == true) this
+    // will cause the first 8 ANSI colors (set by direct <SGR>30m to <SGR>37m)
+    // to be converted to second 8 ANSI colors (equivalent to <SGR>90m to
+    // <SGR>97m) if the Bold attribute (<SGR>1m) is ALSO active -  was called
+    // mIsDefaultColor but used in an inverted sense:
+    bool mMayShift8ColorSet = false;
 
     QString mMudLine;
     std::deque<TChar> mMudBuffer;

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015, 2017-2018, 2020, 2022-2024 by Stephen Lyons       *
+ *   Copyright (C) 2015, 2017-2018, 2020, 2022-2023 by Stephen Lyons       *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -31,7 +31,6 @@
 #include <QChar>
 #include <QColor>
 #include <QDebug>
-#include <QFont>
 #include <QMap>
 #include <QQueue>
 #include <QPoint>
@@ -63,16 +62,6 @@ public:
         None = 0x0,
         // Replaces TCHAR_BOLD 2
         Bold = 0x1,                   // 0000 0000 0000 0000 0000 0000 0000 0001
-        Faint = 0x40000,              // 0000 0000 0000 0100 0000 0000 0000 0000
-        /*
-         * The above pair of values for our text attribute flags can be
-         * combined to produced four different QFont::weight values - note
-         * however that the numeric values assigned to the enum have changed
-         * between Qt 5 & 6:
-         * Note that both values with the Bold flag should be greater than the
-         * QFont::Medium (Qt5: 57, Qt6: 500) value so BOTH will produce a
-         * QFont::bold() value of true, whereas the other two will not.
-         */
         // Replaces TCHAR_ITALICS 1
         Italic = 0x2,                 // 0000 0000 0000 0000 0000 0000 0000 0010
         // Replaces TCHAR_UNDERLINE 4
@@ -115,7 +104,7 @@ public:
         // Mask for "any alternate font" - only the most significant one should
         // be used if more than one is set:
         AltFontMask = 0x1ff00,        // 0000 0000 0000 0001 1111 1111 0000 0000
-        TestMask = 0x7ffff,           // 0000 0000 0000 0111 1111 1111 1111 1111
+        TestMask = 0x3ffff,           // 0000 0000 0000 0011 1111 1111 1111 1111
         // The remainder are internal use ones that do not related to SGR codes
         // that have been parsed from the incoming text.
         // Has been found in a search operation (currently Main Console only)
@@ -164,7 +153,6 @@ public:
     bool isSelected() const { return mIsSelected; }
     int linkIndex () const { return mLinkIndex; }
     bool isBold() const { return mFlags & Bold; }
-    bool isFaint() const { return mFlags & Faint; }
     bool isItalic() const { return mFlags & Italic; }
     bool isUnderlined() const { return mFlags & Underline; }
     bool isOverlined() const { return mFlags & Overline; }
@@ -261,45 +249,6 @@ class TBuffer
 
 public:
     explicit TBuffer(Host* pH, TConsole* pConsole = nullptr);
-
-    /*
-     * From the Qt5 documentation:
-     * "Qt uses a weighting scale from 0 to 99 similar to, but not the same
-     * as, the scales used in Windows or CSS. A weight of 0 will be thin,
-     * whilst 99 will be extremely black."
-     * From the Qt6 documentation:
-     * "Qt uses a weighting scale from 1 to 1000 compatible with OpenType. A
-     * weight of 1 will be thin, whilst 1000 will be extremely black."
-     * In summary:
-     *                 enum QFont::Weight  Qt5  Qt6
-     *                 QFont::Thin           0  100
-     * Faint           QFont::ExtraLight    12  200
-     *                 QFont::Light         25  300
-     * Normal          QFont::Normal        50  400
-     *                 QFont::Medium        57  500
-     * Faint + Bold    QFont::DemiBold      63  600
-     *                 QFont::Bold          75  700
-     * Bold            QFont::ExtraBold     81  800
-     *                 QFont::Black         87  900
-     *
-     * Used in TTextEdit::drawGraphemeForeground(...) and
-     * dlgProfilePreferences::updateFontSampleDisplays(const QFont& newFont)
-     * and (for Qt 6.x or later) TBuffer::bufferToHtml(...):
-     */
-    static const QFont::Weight csmFontWeight_faint = QFont::ExtraLight;
-    static const QFont::Weight csmFontWeight_normal = QFont::Normal;
-    static const QFont::Weight csmFontWeight_boldAndFaint = QFont::DemiBold;
-    static const QFont::Weight csmFontWeight_bold = QFont::ExtraBold;
-#if QT_VERSION < QT_VERSION_CHECK(6 , 0, 0)
-    // Used in TBuffer::bufferToHtml(...) for Qt5 ONLY - the above and below
-    // values need to be kept in sync if changes are made - the Qt5 values below
-    // have to be the numeric equivalent to the enum values for the Qt6 ones:
-    static const int csmCssFontWeight_faint = 200;
-    static const int csmCssFontWeight_normal = 400;
-    static const int csmCssFontWeight_boldAndFaint = 600;
-    static const int csmCssFontWeight_bold = 800;
-#endif
-
     QPoint insert(QPoint&, const QString& text, int, int, int, int, int, int, bool bold, bool italics, bool underline, bool strikeout);
     bool insertInLine(QPoint& cursor, const QString& what, const TChar& format);
     void expandLine(int y, int count, TChar&);
@@ -396,6 +345,7 @@ private:
     // Second stage in decoding OSC sequences - set true when we see the ASCII
     // ESC character followed by the ']' one:
     bool mGotOSC = false;
+    bool mIsDefaultColor = true;
 
 
     QColor mBlack;
@@ -414,6 +364,12 @@ private:
     QColor mMagenta;
     QColor mLightWhite;
     QColor mWhite;
+    // These three replace three sets of three integers that were used to hold
+    // colour components during the parsing of SGR sequences, they were called:
+    // fgColor{R|G|B}, fgColorLight{R|G|B} and bgColor{R|G|B} apart from
+    // anything else, the first and last sets had the same names as arguments
+    // to several of the methods which meant the latter shadowed and masked
+    // them off!
     QColor mForeGroundColor;
     QColor mForeGroundColorLight;
     QColor mBackGroundColor;
@@ -421,7 +377,6 @@ private:
     QPointer<Host> mpHost;
 
     bool mBold = false;
-    bool mFaint = false;
     bool mItalics = false;
     bool mOverline = false;
     bool mReverse = false;
@@ -433,12 +388,6 @@ private:
     bool mFastBlink = false;
     bool mConcealed = false;
     quint8 mAltFont = 0;
-    // If enabled by a per profile setting (Host::mBoldIsBright == true) this
-    // will cause the first 8 ANSI colors (set by direct <SGR>30m to <SGR>37m)
-    // to be converted to second 8 ANSI colors (equivalent to <SGR>90m to
-    // <SGR>97m) if the Bold attribute (<SGR>1m) is ALSO active -  was called
-    // mIsDefaultColor but used in an inverted sense:
-    bool mMayShift8ColorSet = false;
 
     QString mMudLine;
     std::deque<TChar> mMudBuffer;
@@ -470,9 +419,6 @@ inline QDebug& operator<<(QDebug& debug, const TChar::AttributeFlags& attributes
     QStringList presentAttributes;
     if (attributes & TChar::Bold) {
         presentAttributes << QLatin1String("Bold (0x01)");
-    }
-    if (attributes & TChar::Faint) {
-        presentAttributes << QLatin1String("Faint (0x40000)");
     }
     if (attributes & TChar::Italic) {
         presentAttributes << QLatin1String("Italic (0x02)");

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2024 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2013-2023 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       *
  *   Copyright (C) 2016 by Eric Wallace - eewallace@gmail.com              *
  *   Copyright (C) 2016 by Chris Leacy - cleacy1972@gmail.com              *
@@ -5075,7 +5075,6 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "loadRawFile", TLuaInterpreter::loadReplay);
     lua_register(pGlobalLua, "loadReplay", TLuaInterpreter::loadReplay);
     lua_register(pGlobalLua, "setBold", TLuaInterpreter::setBold);
-    lua_register(pGlobalLua, "setFaint", TLuaInterpreter::setFaint);
     lua_register(pGlobalLua, "setItalics", TLuaInterpreter::setItalics);
     lua_register(pGlobalLua, "setOverline", TLuaInterpreter::setOverline);
     lua_register(pGlobalLua, "setReverse", TLuaInterpreter::setReverse);
@@ -7251,10 +7250,6 @@ int TLuaInterpreter::setConfig(lua_State * L)
         }
         return success();
     }
-    if (key == qsl("boldIsBright")) {
-        host.mBoldIsBright = getVerifiedBool(L, __func__, 2, "value");
-        return success();
-    }
     if (key == qsl("logInHTML")) {
         host.mIsNextLogFileInHtmlFormat = getVerifiedBool(L, __func__, 2, "value");
         return success();
@@ -7367,7 +7362,6 @@ int TLuaInterpreter::getConfig(lua_State *L)
                 lua_pushstring(L, "asis");
             }
         } },
-        { qsl("boldIsBright"), [&](){ lua_pushboolean(L, host.mBoldIsBright); } },
         { qsl("logInHTML"), [&](){ lua_pushboolean(L, host.mIsNextLogFileInHtmlFormat); } } //, <- not needed until another one is added
     };
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -3,7 +3,7 @@
 
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2016, 2018-2024 by Stephen Lyons                   *
+ *   Copyright (C) 2013-2016, 2018-2023 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016-2018 by Ian Adkins - ieadkins@gmail.com            *
@@ -431,7 +431,6 @@ public:
     static int hideToolBar(lua_State*);
     static int loadReplay(lua_State*);
     static int setBold(lua_State*);
-    static int setFaint(lua_State*);
     static int setItalics(lua_State*);
     static int setReverse(lua_State*);
     static int setOverline(lua_State*);

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2024 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2013-2022 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       *
  *   Copyright (C) 2016 by Eric Wallace - eewallace@gmail.com              *
  *   Copyright (C) 2016 by Chris Leacy - cleacy1972@gmail.com              *
@@ -1188,36 +1188,29 @@ int TLuaInterpreter::getTextFormat(lua_State* L)
 
     lua_newtable(L);
 
+    TChar::AttributeFlags const format = result.second.allDisplayAttributes();
     lua_pushstring(L, "bold");
-    lua_pushboolean(L, result.second.isBold());
-    lua_settable(L, -3);
-
-    lua_pushstring(L, "blink");
-    lua_pushnumber(L, result.second.isFastBlinking() ? 2 : (result.second.isBlinking() ? 1 : 0));
-    lua_settable(L, -3);
-
-    lua_pushstring(L, "faint");
-    lua_pushboolean(L, result.second.isFaint());
+    lua_pushboolean(L, format & TChar::Bold);
     lua_settable(L, -3);
 
     lua_pushstring(L, "italic");
-    lua_pushboolean(L, result.second.isItalic());
+    lua_pushboolean(L, format & TChar::Italic);
     lua_settable(L, -3);
 
     lua_pushstring(L, "overline");
-    lua_pushboolean(L, result.second.isOverlined());
+    lua_pushboolean(L, format & TChar::Overline);
     lua_settable(L, -3);
 
     lua_pushstring(L, "reverse");
-    lua_pushboolean(L, result.second.isReversed());
+    lua_pushboolean(L, format & TChar::Reverse);
     lua_settable(L, -3);
 
     lua_pushstring(L, "strikeout");
-    lua_pushboolean(L, result.second.isStruckOut());
+    lua_pushboolean(L, format & TChar::StrikeOut);
     lua_settable(L, -3);
 
     lua_pushstring(L, "underline");
-    lua_pushboolean(L, result.second.isUnderlined());
+    lua_pushboolean(L, format & TChar::Underline);
     lua_settable(L, -3);
 
     const QColor foreground(result.second.foreground());
@@ -2272,21 +2265,6 @@ int TLuaInterpreter::setBorderTop(lua_State* L)
     return 0;
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBold
-int TLuaInterpreter::setFaint(lua_State* L)
-{
-    QString windowName;
-    int s = 1;
-    if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
-        windowName = WINDOW_NAME(L, s++);
-    }
-    const bool isAttributeEnabled = getVerifiedBool(L, __func__, s, "enable faint attribute");
-    auto console = CONSOLE(L, windowName);
-    console->setDisplayAttributes(TChar::Faint, isAttributeEnabled);
-    lua_pushboolean(L, true);
-    return 1;
-}
-
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setFgColor
 int TLuaInterpreter::setFgColor(lua_State* L)
 {
@@ -2787,61 +2765,93 @@ int TLuaInterpreter::setTextFormat(lua_State* L)
     colorComponents[5] = qRound(qBound(0.0, getVerifiedDouble(L, __func__, 7, "blue foreground color component"), 255.0));
 
     int s = 7;
+    bool bold;
+    if (lua_isboolean(L, ++s)) {
+        bold = lua_toboolean(L, s);
+    } else if (lua_isnumber(L, s)) {
+        bold = !qFuzzyCompare(1.0, 1.0 + lua_tonumber(L, s));
+    } else {
+        lua_pushfstring(L, "setTextFormat: bad argument #%d type (bold format as boolean or number {true/non-zero to enable} expected, got %s!)",
+                        s, luaL_typename(L, s));
+        return lua_error(L);
+    }
 
-    auto formatFlag = [&] (const char* name) {
+    bool underline;
+    if (lua_isboolean(L, ++s)) {
+        underline = lua_toboolean(L, s);
+    } else if (lua_isnumber(L, s)) {
+        underline = !qFuzzyCompare(1.0, 1.0 + lua_tonumber(L, s));
+    } else {
+        lua_pushfstring(L, "setTextFormat: bad argument #%d type (underline format as boolean or number {true/non-zero to enable} expected, got %s!)",
+                        s, luaL_typename(L, s));
+        return lua_error(L);
+    }
+
+    bool italics;
+    if (lua_isboolean(L, ++s)) {
+        italics = lua_toboolean(L, s);
+    } else if (lua_isnumber(L, s)) {
+        italics = !qFuzzyCompare(1.0, 1.0 + lua_tonumber(L, s));
+    } else {
+        lua_pushfstring(L, "setTextFormat: bad argument #%d type (italic format as boolean or number {true/non-zero to enable} expected, got %s!)",
+                        s, luaL_typename(L, s));
+        return lua_error(L);
+    }
+
+    bool strikeout = false;
+    if (s < n) {
+        // s has not been incremented yet so this means we still have another argument!
+
         if (lua_isboolean(L, ++s)) {
-            // Surprisingly, the return type from lua_toboolean(...) is actually
-            // numeric:
-            return static_cast<bool>(lua_toboolean(L, s));
+            strikeout = lua_toboolean(L, s);
+        } else if (lua_isnumber(L, s)) {
+            strikeout = !qFuzzyCompare(1.0, 1.0 + lua_tonumber(L, s));
+        } else {
+            lua_pushfstring(L, "setTextFormat: bad argument #%d type (strikeout format as boolean or number {true/non-zero to enable} is optional, got %s!)",
+                            s, luaL_typename(L, s));
+            return lua_error(L);
         }
-        if (lua_isnumber(L, s)) {
-            return !qFuzzyCompare(1.0, 1.0 + lua_tonumber(L, s));
-        }
-        lua_pushfstring(L, "setTextFormat: bad argument #%d type (%s format as boolean or number {true/non-zero to enable} expected, got %s!)",
-                        s, name, luaL_typename(L, s));
-        lua_error(L);
-        Q_UNREACHABLE();
-    };
+    }
 
-    auto optionalFormatFlag = [&] (const char* name) {
-        if (++s > n) {
-            // We do the pre-increment here so that it always gets done, even
-            // though we are past the end of the arguments so that we can still
-            // track where we are if debugging:
-            return false;
+    bool overline = false;
+    if (s < n) {
+        // s has not been incremented yet so this means we still have another argument!
+        if (lua_isboolean(L, ++s)) {
+            overline = lua_toboolean(L, s);
+        } else if (lua_isnumber(L, s)) {
+            overline = !qFuzzyCompare(1.0, 1.0 + lua_tonumber(L, s));
+        } else {
+            lua_pushfstring(L, "setTextFormat: bad argument #%d type (overline format as boolean or number {true/non-zero to enable} is optional, got %s!)",
+                            s, luaL_typename(L, s));
+            return lua_error(L);
         }
-        if (lua_isboolean(L, s)) {
-            return static_cast<bool>(lua_toboolean(L, s));
-        }
-        if (lua_isnumber(L, s)) {
-            return !qFuzzyCompare(1.0, 1.0 + lua_tonumber(L, s));
-        }
-        lua_pushfstring(L, "setTextFormat: bad argument #%d type (%s format as boolean or number {true/non-zero to enable} is optional, got %s!)",
-                        s, name, luaL_typename(L, s));
-        lua_error(L);
-        Q_UNREACHABLE();
-    };
+    }
 
-    bool bold = formatFlag("bold"); // Arg: 8
-    bool underline = formatFlag("underline"); // Arg: 9
-    bool italics = formatFlag("italic"); // Arg: 10
-    bool strikeout = optionalFormatFlag("strikeout"); // Arg: 11
-    bool overline = optionalFormatFlag("overline"); // Arg: 12
-    bool reverse = optionalFormatFlag("reverse"); // Arg: 13
-    bool faint = optionalFormatFlag("faint"); // Arg: 14
+    bool reverse = false;
+    if (s < n) {
+        // s has not been incremented yet so this means we still have another argument!
+        if (lua_isboolean(L, ++s)) {
+            reverse = lua_toboolean(L, s);
+        } else if (lua_isnumber(L, s)) {
+            reverse = !qFuzzyCompare(1.0, 1.0 + lua_tonumber(L, s));
+        } else {
+            lua_pushfstring(L, "setTextFormat: bad argument #%d type (reverse format as boolean or number {true/non-zero to enable} is optional, got %s!)",
+                            s, luaL_typename(L, s));
+            return lua_error(L);
+        }
+    }
 
     TChar::AttributeFlags const flags = (bold ? TChar::Bold : TChar::None)
-                                        | (faint ? TChar::Faint : TChar::None)
-                                        | (italics ? TChar::Italic : TChar::None)
-                                        | (overline ? TChar::Overline : TChar::None)
-                                        | (reverse ? TChar::Reverse : TChar::None)
-                                        | (strikeout ? TChar::StrikeOut : TChar::None)
-                                        | (underline ? TChar::Underline : TChar::None);
+            | (italics ? TChar::Italic : TChar::None)
+            | (overline ? TChar::Overline : TChar::None)
+            | (reverse ? TChar::Reverse : TChar::None)
+            | (strikeout ? TChar::StrikeOut : TChar::None)
+            | (underline ? TChar::Underline : TChar::None);
 
     if (!host.mpConsole->setTextFormat(windowName,
-                                       QColor(colorComponents.at(3), colorComponents.at(4), colorComponents.at(5)),
-                                       QColor(colorComponents.at(0), colorComponents.at(1), colorComponents.at(2)),
-                                       flags)) {
+                                      QColor(colorComponents.at(3), colorComponents.at(4), colorComponents.at(5)),
+                                      QColor(colorComponents.at(0), colorComponents.at(1), colorComponents.at(2)),
+                                      flags)) {
         return warnArgumentValue(L, __func__, qsl("window '%1' does not exist").arg(windowName), true);
     }
 

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2016, 2018-2022, 2023 by Stephen Lyons             *
+ *   Copyright (C) 2014-2016, 2018-2022 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *                                                                         *

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2016, 2018-2024 by Stephen Lyons                   *
+ *   Copyright (C) 2014-2016, 2018-2023 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
  *   Copyright (C) 2017 by Chris Reid - WackyWormer@hotmail.com            *
@@ -701,11 +701,8 @@ int TTextEdit::drawGraphemeBackground(QPainter& painter, QVector<QColor>& fgColo
 
 void TTextEdit::drawGraphemeForeground(QPainter& painter, const QColor& fgColor, const QRect& textRect, const QString& grapheme, TChar& charStyle) const
 {
-    const TChar::AttributeFlags attributes = charStyle.allDisplayAttributes();
+    TChar::AttributeFlags attributes = charStyle.allDisplayAttributes();
     const bool isBold = attributes & TChar::Bold;
-    const bool isFaint = attributes & TChar::Faint;
-    const QFont::Weight fontWeight = (isBold ? (isFaint ? TBuffer::csmFontWeight_boldAndFaint : TBuffer::csmFontWeight_bold)
-                                             : (isFaint ? TBuffer::csmFontWeight_faint : TBuffer::csmFontWeight_normal));
     // At present we cannot display flashing text - and we just make it italic
     // (we ought to eventually add knobs for them so they can be shown in a user
     // preferred style - which might be static for some users) - anyhow Mudlet
@@ -716,14 +713,14 @@ void TTextEdit::drawGraphemeForeground(QPainter& painter, const QColor& fgColor,
     const bool isUnderline = attributes & TChar::Underline;
     // const bool isConcealed = attributes & TChar::Concealed;
     // const int altFontIndex = charStyle.alternateFont();
-    if ((painter.font().weight() != fontWeight)
+    if ((painter.font().bold() != isBold)
             || (painter.font().italic() != isItalics)
             || (painter.font().overline() != isOverline)
             || (painter.font().strikeOut() != isStrikeOut)
             || (painter.font().underline() != isUnderline)) {
 
         QFont font = painter.font();
-        font.setWeight(fontWeight);
+        font.setBold(isBold);
         font.setItalic(isItalics);
         font.setOverline(isOverline);
         font.setStrikeOut(isStrikeOut);

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -2,7 +2,7 @@
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
- *   Copyright (C) 2017-2024 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2017-2023 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -486,8 +486,6 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     if (pHost->getLargeAreaExitArrows()) {
         host.append_attribute("Large2DMapAreaExitArrows") = "yes";
     }
-
-    host.append_attribute("BoldIsBright") = pHost->mBoldIsBright ? "yes" : "no";
 
     { // Blocked so that indentation reflects that of the XML file
         host.append_child("name").text().set(pHost->mHostName.toUtf8().constData());

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016-2024 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2016-2023 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -989,13 +989,6 @@ void XMLimport::readHost(Host* pHost)
     } else {
         // The default (and for map/profile files from before 4.15.0):
         pHost->setLargeAreaExitArrows(false);
-    }
-
-    if (attributes().hasAttribute(qsl("BoldIsBright"))) {
-        pHost->mBoldIsBright = (attributes().value(qsl("BoldIsBright")) == YES);
-    } else {
-        // The default, backwards compatible, option is true, though false would be "better":
-        pHost->mBoldIsBright = true;
     }
 
     if (attributes().value(qsl("mShowInfo")) == qsl("no")) {

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014, 2016-2018, 2020-2024 by Stephen Lyons             *
+ *   Copyright (C) 2014, 2016-2018, 2020-2023 by Stephen Lyons             *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *                                                                         *
@@ -794,6 +794,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         // has a font size larger than the preset range offers?
         fontSize->setCurrentIndex(9); // default font is size 10, index 9.
     }
+
     wrap_at_spinBox->setValue(pHost->mWrapAt);
     indent_wrapped_spinBox->setValue(pHost->mWrapIndentCount);
 
@@ -896,7 +897,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
 
     commandLineMinimumHeight->setValue(pHost->commandLineMinimumHeight);
-    checkBox_antiAlias->setChecked(!pHost->mNoAntiAlias);
+    mNoAntiAlias->setChecked(!pHost->mNoAntiAlias);
     mFORCE_MCCP_OFF->setChecked(pHost->mFORCE_NO_COMPRESSION);
     mFORCE_GA_OFF->setChecked(pHost->mFORCE_GA_OFF);
     mAlertOnNewData->setChecked(pHost->mAlertOnNewData);
@@ -1163,8 +1164,6 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     comboBox_caretModeKey->setCurrentIndex(static_cast<int>(pHost->mCaretShortcut));
     checkBox_largeAreaExitArrows->setChecked(pHost->getLargeAreaExitArrows());
     comboBox_blankLinesBehaviour->setCurrentIndex(static_cast<int>(pHost->mBlankLineBehaviour));
-
-    checkBox_boldIsBright->setChecked(pHost->mBoldIsBright);
 
     // Enable the controls that would be disabled if there wasn't a Host instance
     // on tab_general:
@@ -1436,7 +1435,7 @@ void dlgProfilePreferences::clearHostDetails()
     mIsToLogInHtml->setChecked(false);
     mIsLoggingTimestamps->setChecked(false);
     commandLineMinimumHeight->clear();
-    checkBox_antiAlias->setChecked(false);
+    mNoAntiAlias->setChecked(false);
     mFORCE_MCCP_OFF->setChecked(false);
     mFORCE_GA_OFF->setChecked(false);
     mAlertOnNewData->setChecked(false);
@@ -1879,7 +1878,6 @@ void dlgProfilePreferences::slot_setDisplayFont()
     }
     QFont newFont = fontComboBox->currentFont();
     newFont.setPointSize(mFontSize);
-    newFont.setWeight(TBuffer::csmFontWeight_normal);
 
     if (pHost->getDisplayFont() == newFont) {
         return;
@@ -1890,16 +1888,14 @@ void dlgProfilePreferences::slot_setDisplayFont()
     if (auto [validFont, errorMessage] = pHost->setDisplayFont(newFont); !validFont) {
         label_invalidFontError->show();
         return;
-    }
-
-    if (!QFontInfo(newFont).fixedPitch()) {
+    } else if (!QFontInfo(newFont).fixedPitch()) {
         label_variableWidthFontWarning->show();
     }
 
 #if defined(Q_OS_LINUX)
     // On Linux ensure that emojis are displayed in colour even if this font
     // doesn't support it:
-    QFont::insertSubstitution(newFont.family(), qsl("Noto Color Emoji"));
+    QFont::insertSubstitution(pHost->mDisplayFont.family(), qsl("Noto Color Emoji"));
 #endif
 
     auto mainConsole = pHost->mpConsole;
@@ -2888,7 +2884,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         pHost->mLogDir = mLogDirPath;
         pHost->mLogFileName = lineEdit_logFileName->text();
         pHost->mLogFileNameFormat = comboBox_logFileNameFormat->currentData().toString();
-        pHost->mNoAntiAlias = !checkBox_antiAlias->isChecked();
+        pHost->mNoAntiAlias = !mNoAntiAlias->isChecked();
         pHost->mAlertOnNewData = mAlertOnNewData->isChecked();
 
         pHost->mUseProxy = groupBox_proxy->isChecked();
@@ -3081,7 +3077,6 @@ void dlgProfilePreferences::slot_saveAndClose()
 
         pHost->setHaveColorSpaceId(checkBox_expectCSpaceIdInColonLessMColorCode->isChecked());
         pHost->setMayRedefineColors(checkBox_allowServerToRedefineColors->isChecked());
-        pHost->mBoldIsBright = checkBox_boldIsBright->isChecked();
         pHost->setDebugShowAllProblemCodepoints(checkBox_debugShowAllCodepointProblems->isChecked());
         pHost->mCaretShortcut = static_cast<Host::CaretShortcut>(comboBox_caretModeKey->currentIndex());
 

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017-2018, 2022-2023 by Stephen Lyons                   *
+ *   Copyright (C) 2017-2018, 2022 by Stephen Lyons                        *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -1236,7 +1236,6 @@ function getConfig(...)
       "askTlsAvailable",
       "autoClearInputLine",
       "blankLinesBehaviour",
-      "boldIsBright",
       "caretShortcut",
       "commandLineHistorySaveSize",
       "compactInputLine",

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -756,14 +756,11 @@
          <property name="title">
           <string>Font</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_groupBox_font" rowstretch="1,0,0" columnstretch="0,1,0,0,0">
+         <layout class="QGridLayout" name="gridLayout_groupBox_font">
           <item row="0" column="0">
            <widget class="QLabel" name="label_30">
             <property name="text">
              <string>Font:</string>
-            </property>
-            <property name="buddy">
-             <cstring>fontComboBox</cstring>
             </property>
            </widget>
           </item>
@@ -788,25 +785,12 @@
             <property name="text">
              <string>Size:</string>
             </property>
-            <property name="buddy">
-             <cstring>fontSize</cstring>
-            </property>
            </widget>
           </item>
           <item row="0" column="3">
            <widget class="QComboBox" name="fontSize"/>
           </item>
-          <item row="0" column="4">
-           <widget class="QCheckBox" name="checkBox_antiAlias">
-            <property name="toolTip">
-             <string>&lt;p&gt;Anti-aliasing use on the font for the &lt;b&gt;Main&lt;/b&gt; console. Smoothes fonts if you have a high screen resolution and you can use larger fonts. Note that on low resolutions and small font sizes, the font gets blurry. &lt;/p&gt;</string>
-            </property>
-            <property name="text">
-             <string>Enable anti-aliasing</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0" colspan="5">
+          <item row="1" column="0" colspan="2">
            <widget class="QLabel" name="label_invalidFontError">
             <property name="font">
              <font>
@@ -818,7 +802,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0" colspan="5">
+          <item row="2" column="0" colspan="4">
            <widget class="QLabel" name="label_variableWidthFontWarning">
             <property name="font">
              <font>
@@ -828,6 +812,16 @@
             <property name="text">
              <string comment="Note that this text is split into two lines so that the message is not too wide in English, please do the same for other locales where the text is the same or longer">This font is not monospace, which may not be ideal for playing some text games:
 you can use it but there could be issues with aligning columns of text</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="mNoAntiAlias">
+            <property name="toolTip">
+             <string>Use anti aliasing on fonts. Smoothes fonts if you have a high screen resolution and you can use larger fonts. Note that on low resolutions and small font sizes, the font gets blurry. </string>
+            </property>
+            <property name="text">
+             <string>Enable anti-aliasing</string>
             </property>
            </widget>
           </item>
@@ -1919,16 +1913,6 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QPushButton" name="pushButton_resetColors">
             <property name="text">
              <string>Reset all colors to default</string>
-            </property>
-           </widget>
-          </item>
-          <item row="14" column="0" colspan="4">
-           <widget class="QCheckBox" name="checkBox_boldIsBright">
-            <property name="toolTip">
-             <string>&lt;p&gt;Server uses BOLD to make Light 8 colors (only for some 16 Color MUDs)&lt;/p&gt;&lt;p&gt;Some older Game Servers support eight different colors which are selected by using the original eight &quot;Set Graphic Rendition&quot; &lt;tt&gt; &amp;lt;SGR&amp;gt; 30&lt;/tt&gt; (black) to &lt;tt&gt;37&lt;/tt&gt; (white)&lt;/tt&gt; ANSI ESC color codes and combine those with the &lt;tt&gt;&amp;lt;SGR&amp;gt; 1&lt;/tt&gt; (bold or more intense) code to provide a second set of eight colors for sixteen in total. This checkbox causes this use of the &lt;tt&gt;&amp;lt;SGR&amp;gt; 1&lt;/tt&gt; code however it should not be used if the Game Server:&lt;ul&gt;&lt;li&gt;only uses eight colors&lt;/li&gt;&lt;li&gt;uses more than sixteen colors&lt;/li&gt;&lt;li&gt;uses sixteen colors but selects the &quot;brighter&quot; eight colors with &lt;tt&gt;&amp;lt;SGR&amp;gt; 90&lt;/tt&gt; (light black) to &lt;tt&gt;&amp;lt;SGR&amp;gt; 97&lt;/tt&gt; (light white) {and &lt;tt&gt;100&lt;/tt&gt; to &lt;tt&gt;107&lt;/tt&gt; for the same as a background} of the sixteeen&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;&lt;i&gt;Older versions of Mudlet had code that effectively had this option permanently enabled. However nowadays it interferes with using the BOLD attribute to provide &lt;b&gt;bold&lt;/b&gt; text alongside the less often used FAINT attribute to provide &lt;span style=&quot; font-weight: 200&quot;&gt;faint&lt;/span&gt; and &lt;span style=&quot; font-weight: 600&quot;&gt;demi-bold&lt;/span&gt; text effects.&lt;/p&gt;</string>
-            </property>
-            <property name="text">
-             <string>BOLD is Bright</string>
             </property>
            </widget>
           </item>
@@ -4217,8 +4201,8 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>radioButton_userDictionary_profile</tabstop>
   <tabstop>radioButton_userDictionary_common</tabstop>
   <tabstop>fontComboBox</tabstop>
+  <tabstop>mNoAntiAlias</tabstop>
   <tabstop>fontSize</tabstop>
-  <tabstop>checkBox_antiAlias</tabstop>
   <tabstop>topBorderHeight</tabstop>
   <tabstop>bottomBorderHeight</tabstop>
   <tabstop>leftBorderWidth</tabstop>
@@ -4254,7 +4238,6 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>pushButton_cyan</tabstop>
   <tabstop>pushButton_white</tabstop>
   <tabstop>checkBox_allowServerToRedefineColors</tabstop>
-  <tabstop>checkBox_boldIsBright</tabstop>
   <tabstop>pushButton_lBlack</tabstop>
   <tabstop>pushButton_lRed</tabstop>
   <tabstop>pushButton_lGreen</tabstop>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Reverts https://github.com/Mudlet/Mudlet/pull/7010 and https://github.com/Mudlet/Mudlet/pull/7280 to bring back 4.17.2 look and feel on colours.
#### Motivation for adding to Mudlet
Community feedback has been almost-universal that the changes have affected them more negatively than positively and we've had a couple of attempts at fixing it since (https://github.com/Mudlet/Mudlet/pull/7280 and https://github.com/Mudlet/Mudlet/pull/7319) without any luck.
#### Other info (issues closed, discussion etc)
We can reintroduce this later in a way that doesn't change default behaviour yet allows servers to standardise on handling boldness and brightness in a common way.

When testing this PR, focus only on the fact that the behaviour is the same as 4.17.2.

Closes https://github.com/Mudlet/Mudlet/issues/7314.