### PR TITLE
Add: New-Environ to support Bold Is Bright

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1016,6 +1016,11 @@ QString cTelnet::getNewEnvironValueSystemType()
     return systemType.isEmpty() ? QString(): systemType;
 }
 
+QString cTelnet::getNewEnvironBoldIsBright()
+{
+    return qsl("%1").arg(mpHost->mBoldIsBright);
+}
+
 QString cTelnet::getNewEnvironCharset()
 {
     const QString charsetEncoding = getEncoding();
@@ -1190,6 +1195,7 @@ QMap<QString, QPair<bool, QString>> cTelnet::getNewEnvironDataMap()
     //newEnvironDataMap.insert(qsl("FONT"), qMakePair(isUserVar, getNewEnvironFont())); // Needs an OPT-IN to be enabled, next PR
     //newEnvironDataMap.insert(qsl("FONT_SIZE"), qMakePair(isUserVar, getNewEnvironFontSize())); // Needs an OPT-IN to be enabled, next PR
     newEnvironDataMap.insert(qsl("WORD_WRAP"), qMakePair(isUserVar, getNewEnvironWordWrap()));
+    newEnvironDataMap.insert(qsl("BOLD_IS_BRIGHT"), qMakePair(isUserVar, getNewEnvironBoldIsBright()));
 
     return newEnvironDataMap;
 }

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -282,6 +282,7 @@ private:
     QByteArray prepareNewEnvironData(const QString&);
     QString getNewEnvironValueUser();
     QString getNewEnvironValueSystemType();
+    QString getNewEnvironBoldIsBright();
     QString getNewEnvironCharset();
     QString getNewEnvironClientName();
     QString getNewEnvironClientVersion();

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -3081,7 +3081,14 @@ void dlgProfilePreferences::slot_saveAndClose()
 
         pHost->setHaveColorSpaceId(checkBox_expectCSpaceIdInColonLessMColorCode->isChecked());
         pHost->setMayRedefineColors(checkBox_allowServerToRedefineColors->isChecked());
-        pHost->mBoldIsBright = checkBox_boldIsBright->isChecked();
+
+        const int priorBoldIsBright = pHost->mBoldIsBright;
+        pHost->mBoldIsBright = checkBox_boldIsBright->checkState();
+
+        if (priorBoldIsBright != pHost->mBoldIsBright) {
+            slot_changeBoldIsBright();
+        }
+
         pHost->setDebugShowAllProblemCodepoints(checkBox_debugShowAllCodepointProblems->isChecked());
         pHost->mCaretShortcut = static_cast<Host::CaretShortcut>(comboBox_caretModeKey->currentIndex());
 
@@ -4469,6 +4476,17 @@ void dlgProfilePreferences::slot_changeWrapAt()
     }
 
     pHost->mTelnet.sendInfoNewEnvironValue(qsl("WORD_WRAP"));
+}
+
+void dlgProfilePreferences::slot_changeBoldIsBright()
+{
+    Host* pHost = mpHost;
+
+    if (!pHost) {
+        return;
+    }
+
+    pHost->mTelnet.sendInfoNewEnvironValue(qsl("BOLD_IS_BRIGHT"));
 }
 
 void dlgProfilePreferences::slot_toggleMapDeleteButton(const bool state)

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -3082,7 +3082,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         pHost->setHaveColorSpaceId(checkBox_expectCSpaceIdInColonLessMColorCode->isChecked());
         pHost->setMayRedefineColors(checkBox_allowServerToRedefineColors->isChecked());
 
-        const int priorBoldIsBright = pHost->mBoldIsBright;
+        const auto priorBoldIsBright = pHost->mBoldIsBright;
         pHost->mBoldIsBright = checkBox_boldIsBright->checkState();
 
         if (priorBoldIsBright != pHost->mBoldIsBright) {

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -169,6 +169,7 @@ private slots:
     void slot_toggleMapDeleteButton(const bool);
     void slot_toggleAdvertiseScreenReader(const bool);
     void slot_changeWrapAt();
+    void slot_changeBoldIsBright();
     void slot_deleteMap();
     void slot_changeLargeAreaExitArrows(const bool);
     void slot_hidePasswordMigrationLabel();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
To provide the best player experience, empower games to query the state of "Bold is Bright" on the game client. Add a BOLD_IS_BRIGHT environmental variable to show the state of the "Bold is Bright" checkbox in Settings.

#### Motivation for adding to Mudlet
More information for game servers to guide players to choose the best setting on the client.

#### Other info (issues closed, discussion etc)

This is an example of the debug statements that shows the state upon connection, then in the Settings menu checking, saving, then unchecking saving the Info messages sent to the games.

<img width="1090" alt="Screenshot 2024-07-14 at 12 17 14 PM" src="https://github.com/user-attachments/assets/722e6b9b-02f5-466b-a254-ef677b3fd531">
