### PR TITLE
Fix: runtime errors aren't visible until trigger editor is opened

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -526,10 +526,6 @@ mudlet::mudlet()
         if (!host) {
             return;
         }
-        host->mpEditorDialog = createMudletEditor();
-        if (!host->mpEditorDialog) {
-            return;
-        }
 
         host->mpEditorDialog->showCurrentTriggerItem();
         host->mpEditorDialog->raise();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1492,6 +1492,12 @@ void mudlet::addConsoleForNewHost(Host* pH)
 
     pConsole->show();
 
+    auto pEditor = new dlgTriggerEditor(pH);
+    pH->mpEditorDialog = pEditor;
+    connect(pH, &Host::profileSaveStarted,  pH->mpEditorDialog, &dlgTriggerEditor::slot_profileSaveStarted);
+    connect(pH, &Host::profileSaveFinished,  pH->mpEditorDialog, &dlgTriggerEditor::slot_profileSaveFinished);
+    pEditor->fillout_form();
+
     pH->getActionUnit()->updateToolbar();
 
     pH->mpConsole->show();
@@ -2056,33 +2062,13 @@ void mudlet::slot_showConnectionDialog()
     mpConnectionDialog->show();
 }
 
-dlgTriggerEditor* mudlet::createMudletEditor()
-{
-    Host* pHost = getActiveHost();
-    if (pHost == nullptr) {
-        return nullptr;
-    }
-
-    if (pHost->mpEditorDialog != nullptr) {
-        return pHost->mpEditorDialog;
-    }
-
-    auto* pEditor = new dlgTriggerEditor(pHost);
-    pHost->mpEditorDialog = pEditor;
-    connect(pHost, &Host::profileSaveStarted, pHost->mpEditorDialog, &dlgTriggerEditor::slot_profileSaveStarted);
-    connect(pHost, &Host::profileSaveFinished, pHost->mpEditorDialog, &dlgTriggerEditor::slot_profileSaveFinished);
-    pEditor->fillout_form();
-
-    return pEditor;
-}
-
 void mudlet::slot_showEditorDialog()
 {
     Host* pHost = getActiveHost();
     if (!pHost) {
         return;
     }
-    dlgTriggerEditor* pEditor = createMudletEditor();
+    dlgTriggerEditor* pEditor = pHost->mpEditorDialog;
     if (!pEditor) {
         return;
     }
@@ -2098,7 +2084,7 @@ void mudlet::slot_showTriggerDialog()
     if (!pHost) {
         return;
     }
-    dlgTriggerEditor* pEditor = createMudletEditor();
+    dlgTriggerEditor* pEditor = pHost->mpEditorDialog;
     if (!pEditor) {
         return;
     }
@@ -2114,7 +2100,7 @@ void mudlet::slot_showAliasDialog()
     if (!pHost) {
         return;
     }
-    dlgTriggerEditor* pEditor = createMudletEditor();
+    dlgTriggerEditor* pEditor = pHost->mpEditorDialog;
     if (!pEditor) {
         return;
     }
@@ -2130,7 +2116,7 @@ void mudlet::slot_showTimerDialog()
     if (!pHost) {
         return;
     }
-    dlgTriggerEditor* pEditor = createMudletEditor();
+    dlgTriggerEditor* pEditor = pHost->mpEditorDialog;
     if (!pEditor) {
         return;
     }
@@ -2146,7 +2132,7 @@ void mudlet::slot_showScriptDialog()
     if (!pHost) {
         return;
     }
-    dlgTriggerEditor* pEditor = createMudletEditor();
+    dlgTriggerEditor* pEditor = pHost->mpEditorDialog;
     if (!pEditor) {
         return;
     }
@@ -2162,7 +2148,7 @@ void mudlet::slot_showKeyDialog()
     if (!pHost) {
         return;
     }
-    dlgTriggerEditor* pEditor = createMudletEditor();
+    dlgTriggerEditor* pEditor = pHost->mpEditorDialog;
     if (!pEditor) {
         return;
     }
@@ -2178,7 +2164,7 @@ void mudlet::slot_showVariableDialog()
     if (!pHost) {
         return;
     }
-    dlgTriggerEditor* pEditor = createMudletEditor();
+    dlgTriggerEditor* pEditor = pHost->mpEditorDialog;
     if (!pEditor) {
         return;
     }
@@ -2194,7 +2180,7 @@ void mudlet::slot_showActionDialog()
     if (!pHost) {
         return;
     }
-    dlgTriggerEditor* pEditor = createMudletEditor();
+    dlgTriggerEditor* pEditor = pHost->mpEditorDialog;
     if (!pEditor) {
         return;
     }

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -609,7 +609,7 @@ private:
     int scanWordList(QStringList&, QHash<QString, unsigned int>&);
     void setupTrayIcon();
     void reshowRequiredMainConsoles();
-    void toggleMuteForProtocol(bool state, QAction* toolbarAction, QAction* menuAction, TMediaData::MediaProtocol protocol, const QString& unmuteText, const QString& muteText);
+    void toggleMute(bool state, QAction* toolbarAction, QAction* menuAction, bool isAPINotGame, const QString& unmuteText, const QString& muteText);
 
     inline static QPointer<mudlet> smpSelf = nullptr;
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -609,8 +609,7 @@ private:
     int scanWordList(QStringList&, QHash<QString, unsigned int>&);
     void setupTrayIcon();
     void reshowRequiredMainConsoles();
-    void toggleMute(bool state, QAction* toolbarAction, QAction* menuAction, bool isAPINotGame, const QString& unmuteText, const QString& muteText);
-    dlgTriggerEditor* createMudletEditor();
+    void toggleMuteForProtocol(bool state, QAction* toolbarAction, QAction* menuAction, TMediaData::MediaProtocol protocol, const QString& unmuteText, const QString& muteText);
 
     inline static QPointer<mudlet> smpSelf = nullptr;
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix errors not being visible until trigger editor is opened
#### Motivation for adding to Mudlet
Bugfix
#### Other info (issues closed, discussion etc)
This reverts commit fb6b4ee8124afb71516792fd79d973e7ae893a2c and closes https://github.com/Mudlet/Mudlet/issues/7317.