### PR TITLE
Improve: move 'report codepoints errors' under a compile-time option

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -714,7 +714,7 @@ signals:
     void profileSaveFinished();
     void signal_changeSpellDict(const QString&);
     // To tell all TConsole's upper TTextEdit panes to report all Codepoint
-    // problems as they arrive as well as a summery upon destruction:
+    // problems as they arrive as well as a summary upon destruction:
     void signal_changeDebugShowAllProblemCodepoints(const bool);
     // Tells all consoles associated with this Host (but NOT the Central Debug
     // one) to change the way they show  control characters:

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -553,10 +553,12 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
 
 TConsole::~TConsole()
 {
+#if defined(DEBUG_UTF8_PROCESSING)
     if (mType & ~CentralDebugConsole) {
         // Codepoint issues reporting is not enabled for the CDC:
         mUpperPane->reportCodepointErrors();
     }
+#endif
 }
 
 Host* TConsole::getHost()

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -93,7 +93,11 @@ public:
     void searchSelectionOnline();
     int getColumnCount();
     int getRowCount();
+
+#if defined(DEBUG_UTF8_PROCESSING)
     void reportCodepointErrors();
+#endif
+
     void initializeCaret();
     void setCaretPosition(int line, int column);
     void updateCaret();
@@ -144,7 +148,9 @@ public slots:
     void slot_searchSelectionOnline();
     void slot_analyseSelection();
     void slot_changeIsAmbigousWidthGlyphsToBeWide(bool);
+#if defined(DEBUG_UTF8_PROCESSING)
     void slot_changeDebugShowAllProblemCodepoints(const bool);
+#endif
     void slot_mouseAction(const QString&);
 
 protected:
@@ -222,10 +228,14 @@ private:
     // would only be valid to change this by clearing the buffer first - so
     // making this a const value for the moment:
     const int mTimeStampWidth;
+
+#if defined(DEBUG_UTF8_PROCESSING)
     bool mShowAllCodepointIssues;
     // Marked mutable so that it is permissible to change this in class methods
     // that are otherwise const!
     mutable QHash<uint, std::tuple<uint, std::string>> mProblemCodepoints;
+#endif
+
     // We scroll on the basis that one vertical mouse wheel click is one line
     // (vertically, not really concerned about horizontal stuff at present).
     // According to Qt: "Most mouse types work in steps of 15 degrees, in which

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -767,7 +767,12 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     setColors2();
 
+
+#if defined(DEBUG_UTF8_PROCESSING)
     checkBox_debugShowAllCodepointProblems->setChecked(pHost->debugShowAllProblemCodepoints());
+#else
+    checkBox_debugShowAllCodepointProblems->hide();
+#endif
     // the GMCP warning is hidden by default and is only enabled when the value is toggled
     need_reconnect_for_data_protocol->hide();
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Move 'report codepoints errors' under a compile-time option, `DEBUG_UTF8_PROCESSING`, for developers to use as they see fit when they are debugging codepoint errors.

While the original idea was that ordinary Mudlet users would report these codepoint errors to Mudlet Makers, the feature since its introduction 5 years ago has not yielded that many fixes. It did cause some users to be confused upon seeing the message and unfortunately it is triggering a crash that we are not able to pinpoint and fix.
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/6811 which has been around for a while and is heavily affecting a user in https://discord.com/channels/283581582550237184/1260071395279503381 today.
#### Other info (issues closed, discussion etc)
In retrospect enrolling ordinary Mudlet users into what really is a developer-oriented, highly technical reporting program didn't pay dividends and we should keep that in mind in the future for any other such initiatives.