### PR TITLE
Improve: revise splitscreen tutorial (try 2)

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -683,7 +683,6 @@ public:
     QMap<QString, QKeySequence*> profileShortcuts;
 
     bool mTutorialForCompactLineAlreadyShown;
-    bool mTutorialForSplitscreenScrollbackAlreadyShown = false;
 
     bool mAnnounceIncomingText = true;
     bool mAdvertiseScreenReader = false;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1021,14 +1021,14 @@ void TConsole::scrollUp(int lines)
 
     if (lowerAppears) {
         QTimer::singleShot(0, this, [this]() {  mUpperPane->scrollUp(mLowerPane->getRowCount()); });
-        if (!mpHost->mTutorialForSplitscreenScrollbackAlreadyShown) {
+        if (mudlet::self()->showSplitscreenTutorial()) {
 #if defined(Q_OS_MACOS)
             const QString infoMsg = tr("[ INFO ]  - Split-screen scrollback activated. Press <⌘>+<ENTER> to cancel.");
 #else
             const QString infoMsg = tr("[ INFO ]  - Split-screen scrollback activated. Press <CTRL>+<ENTER> to cancel.");
 #endif
             mpHost->postMessage(infoMsg);
-            mpHost->mTutorialForSplitscreenScrollbackAlreadyShown = true;
+            mudlet::self()->showedSplitscreenTutorial();
         }
     }
     mUpperPane->scrollUp(lines);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4891,6 +4891,11 @@ void mudlet::showedSplitscreenTutorial()
 // tutorial tips, such as splitscreen cancel shortcut
 bool mudlet::experiencedMudletPlayer()
 {
+    static std::optional<bool> cachedResult;
+    if (cachedResult.has_value()) {
+        return cachedResult.value();
+    }
+
     // crude metric to check if the player is experienced in Mudlet: see if any of the profiles is more than 6mo old
     QDir profilesDir(mudlet::getMudletPath(mudlet::profilesPath));
     QFileInfoList entries = profilesDir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
@@ -4898,8 +4903,10 @@ bool mudlet::experiencedMudletPlayer()
 
     for (const QFileInfo &entry : entries) {
         if (entry.lastModified() < sixMonthsAgo) {
+            cachedResult = true;
             return true;
         }
     }
+    cachedResult = false;
     return false;
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4879,10 +4879,27 @@ void mudlet::armForceClose()
 
 bool mudlet::showSplitscreenTutorial()
 {
-    return mScrollbackTutorialsShown < mScrollbackTutorialsMax;
+    return !experiencedMudletPlayer() && mScrollbackTutorialsShown < mScrollbackTutorialsMax;
 }
 
 void mudlet::showedSplitscreenTutorial()
 {
     mScrollbackTutorialsShown++;
+}
+
+// returns true if the Mudlet player is considered 'experienced' and doesn't need to be shown the basic
+// tutorial tips, such as splitscreen cancel shortcut
+bool mudlet::experiencedMudletPlayer()
+{
+    // crude metric to check if the player is experienced in Mudlet: see if any of the profiles is more than 6mo old
+    QDir profilesDir(mudlet::getMudletPath(mudlet::profilesPath));
+    QFileInfoList entries = profilesDir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
+    QDateTime sixMonthsAgo = QDateTime::currentDateTime().addMonths(-2);
+
+    for (const QFileInfo &entry : entries) {
+        if (entry.lastModified() < sixMonthsAgo) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1864,6 +1864,7 @@ void mudlet::readLateSettings(const QSettings& settings)
         setToolBarIconSize(settings.value(qsl("mainiconsize")).toInt());
     }
     setEditorTreeWidgetIconSize(settings.value("tefoldericonsize", QVariant(3)).toInt());
+    mScrollbackTutorialsShown = settings.value("scrollbackTutorialsShown", QVariant(0)).toInt();
     // We have abandoned previous "showMenuBar" / "showToolBar" booleans
     // although we provide a backwards compatible value
     // of: (bool) showXXXXBar = (XXXXBarVisibilty != visibleNever) for, until,
@@ -2016,6 +2017,7 @@ void mudlet::writeSettings()
     settings.setValue("size", size());
     settings.setValue("mainiconsize", mToolbarIconSize);
     settings.setValue("tefoldericonsize", mEditorTreeWidgetIconSize);
+    settings.setValue("scrollbackTutorialsShown", mScrollbackTutorialsShown);
     // This pair are only for backwards compatibility and will be ignored for
     // this and future Mudlet versions - suggest they get removed in Mudlet 4.x
     settings.setValue("showMenuBar", mMenuBarVisibility != visibleNever);
@@ -4873,4 +4875,14 @@ void mudlet::armForceClose()
     QTimer::singleShot(0, this, [this]() {
         forceClose();
     });
+}
+
+bool mudlet::showSplitscreenTutorial()
+{
+    return mScrollbackTutorialsShown < mScrollbackTutorialsMax;
+}
+
+void mudlet::showedSplitscreenTutorial()
+{
+    mScrollbackTutorialsShown++;
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4899,7 +4899,7 @@ bool mudlet::experiencedMudletPlayer()
     // crude metric to check if the player is experienced in Mudlet: see if any of the profiles is more than 6mo old
     QDir profilesDir(mudlet::getMudletPath(mudlet::profilesPath));
     QFileInfoList entries = profilesDir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
-    QDateTime sixMonthsAgo = QDateTime::currentDateTime().addMonths(-2);
+    QDateTime sixMonthsAgo = QDateTime::currentDateTime().addMonths(-6);
 
     for (const QFileInfo &entry : entries) {
         if (entry.lastModified() < sixMonthsAgo) {

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -416,6 +416,7 @@ public:
     bool mediaUnmuted() const { return !mMuteAPI && !mMuteGame; }
     auto showSplitscreenTutorial() -> bool;
     auto showedSplitscreenTutorial() -> void;
+    auto experiencedMudletPlayer() -> bool;
 
     Appearance mAppearance = Appearance::systemSetting;
     // 1 (of 2) needed to work around a (Windows/MacOs specific QStyleFactory)

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -414,6 +414,8 @@ public:
     bool muteGame() const { return mMuteGame; }
     bool mediaMuted() const { return mMuteAPI && mMuteGame; }
     bool mediaUnmuted() const { return !mMuteAPI && !mMuteGame; }
+    auto showSplitscreenTutorial() -> bool;
+    auto showedSplitscreenTutorial() -> void;
 
     Appearance mAppearance = Appearance::systemSetting;
     // 1 (of 2) needed to work around a (Windows/MacOs specific QStyleFactory)
@@ -422,6 +424,7 @@ public:
     // approximate max duration that 'Copy as image' is allowed to take
     // (seconds):
     int mCopyAsImageTimeout = 3;
+
     // A list of potential dictionary languages - probably will cover a much
     // wider range of languages compared to the translations - and is intended
     // for Dictionary identification - there is a request for users to submit
@@ -733,6 +736,11 @@ private:
     QMap<Host*, QToolBar*> mUserToolbarMap;
     // The collection of words in what mpHunspell_sharedDictionary points to:
     QSet<QString> mWordSet_shared;
+
+    // amount of times the shortcut to cancel split screen has been shown help educate new users
+    int mScrollbackTutorialsShown = 0;
+    // show the split screen tutorial maximum 5 times on a new Mudlet
+    static const int mScrollbackTutorialsMax = 5;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(mudlet::controlsVisibility)

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -740,8 +740,8 @@ private:
 
     // amount of times the shortcut to cancel split screen has been shown help educate new users
     int mScrollbackTutorialsShown = 0;
-    // show the split screen tutorial maximum 5 times on a new Mudlet
-    static const int mScrollbackTutorialsMax = 5;
+    // show the split screen tutorial maximum 3 times on a new Mudlet
+    static const int mScrollbackTutorialsMax = 3;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(mudlet::controlsVisibility)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Show the splitscreen tutorial to only new Mudlet players (who have had Mudlet installed for less than 6 months) and only the first 3 times ever.
#### Motivation for adding to Mudlet
Showing it once per profile launch was a little too much.
#### Other info (issues closed, discussion etc)
I'm not sure if the first 3 times ever is enough, but let's judge and see based on feedback in Discord.

Fixes https://github.com/Mudlet/Mudlet/issues/7336.