### PR TITLE
Infrastructure: fix example msys2 path in qmake example

### DIFF
--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -462,17 +462,17 @@ macx {
 
 # use ccache if available
 BASE_CXX = $$QMAKE_CXX
-BASE_C = $$QMAKE_C
+BASE_C = $$QMAKE_CC
 # common linux location
 exists(/usr/bin/ccache)|exists(/usr/local/bin/ccache)|exists(C:/Program Files/ccache/ccache.exe)|exists(/usr/bin/ccache.exe)|exists(/mingw64/bin/ccache)|exists(/mingw32/bin/ccache) {
-    message("Found ccache, updating QMAKE_CXX and QMAKE_C")
+    message("Found ccache, updating QMAKE_CXX and QMAKE_CC")
     QMAKE_CXX = ccache $$BASE_CXX
-    QMAKE_C = ccache $$BASE_C
+    QMAKE_CC = ccache $$BASE_C
 } else {
     message("Unable to find ccache in /usr/bin/ccache, /usr/local/bin/ccache, C:/Program Files/ccache/ccache.exe, /usr/bin/ccache.exe, /mingw64/bin/ccache, or /mingw32/bin/ccache")
 }
 
-message("Using QMAKE_CXX: '"$${QMAKE_CXX}"'  QMAKE_C: '"$${QMAKE_C}"'")
+message("Using QMAKE_CXX: '"$${QMAKE_CXX}"'  QMAKE_CC: '"$${QMAKE_CC}"'")
 
 # There does not seem to be an obvious pkg-config option for this one, it is
 # for the zlib that is used in cTelnet to expand MCCP1/2 compressed data streams:

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -375,7 +375,7 @@ unix:!macx {
             "application build) typically this is one of:\\n"\
             "'C:\msys32\mingw32' {32 Bit Mudlet built on a 32 Bit Host}\\n"\
             "'C:\msys64\mingw32' {32 Bit Mudlet built on a 64 Bit Host}\\n"\
-            "'C:\msys64\mingw32' {64 Bit Mudlet built on a 64 Bit Host}\\n"))
+            "'C:\msys64\mingw64' {64 Bit Mudlet built on a 64 Bit Host}\\n"))
         }
         GITHUB_WORKSPACE_TEST = $$(GITHUB_WORKSPACE)
         isEmpty( GITHUB_WORKSPACE_TEST ) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix example msys2 path in qmake example
#### Motivation for adding to Mudlet
Example correctness
#### Other info (issues closed, discussion etc)
