### PR TITLE
Fix: crash when a profile with errors is set to autostart

### DIFF
--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -197,17 +197,6 @@ void TAction::expandToolbar(TToolBar* pT)
         // This applies the CSS for THIS TAction to a CHILD's representation on the Toolbar
         button->setStyleSheet(css);
 
-        /*
-         * CHECK: The other expandToolbar(...) has the following in this position:
-         *       //FIXME: Heiko April 2012: only run checkbox button scripts, but run them even if unchecked
-         *       if( action->mIsPushDownButton && mpHost->mIsProfileLoadingSequence )
-         *       {
-         *          qDebug()<<"expandToolBar() name="<<action->mName<<" executing script";
-         *          action->execute();
-         *       }
-         * Why does it have this and we do not? - Slysven
-         */
-
         if (action->isFolder()) {
             auto newMenu = new QMenu(pT);
             // This applies the CSS for THIS TAction to a CHILD's own menu - is this right

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -7910,7 +7910,9 @@ void dlgTriggerEditor::showError(const QString& error)
     mpSystemMessageArea->notificationAreaIconLabelWarning->hide();
     mpSystemMessageArea->notificationAreaMessageBox->setText(error);
     mpSystemMessageArea->show();
-    mudlet::self()->announce(error);
+    if (!mpHost->mIsProfileLoadingSequence) {
+        mudlet::self()->announce(error);
+    }
 }
 
 void dlgTriggerEditor::showInfo(const QString& error)
@@ -7920,7 +7922,9 @@ void dlgTriggerEditor::showInfo(const QString& error)
     mpSystemMessageArea->notificationAreaIconLabelInformation->show();
     mpSystemMessageArea->notificationAreaMessageBox->setText(error);
     mpSystemMessageArea->show();
-    mudlet::self()->announce(error);
+    if (!mpHost->mIsProfileLoadingSequence) {
+        mudlet::self()->announce(error);
+    }
 }
 
 void dlgTriggerEditor::showWarning(const QString& error)
@@ -7930,7 +7934,9 @@ void dlgTriggerEditor::showWarning(const QString& error)
     mpSystemMessageArea->notificationAreaIconLabelWarning->show();
     mpSystemMessageArea->notificationAreaMessageBox->setText(error);
     mpSystemMessageArea->show();
-    mudlet::self()->announce(error);
+    if (!mpHost->mIsProfileLoadingSequence) {
+        mudlet::self()->announce(error);
+    }
 }
 
 void dlgTriggerEditor::slot_showActions()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -662,7 +662,10 @@ int main(int argc, char* argv[])
     }
     mudlet::self()->show();
 
-    mudlet::self()->startAutoLogin(cliProfiles);
+    QTimer::singleShot(0, qApp, [cliProfiles]() {
+        // ensure Mudlet singleton is initialised before calling profile loading
+        mudlet::self()->startAutoLogin(cliProfiles);
+    });
 
 #if defined(INCLUDE_UPDATER)
     mudlet::self()->checkUpdatesOnStart();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2599,7 +2599,6 @@ void mudlet::deleteProfileData(const QString& profile, const QString& item)
     }
 }
 
-// this slot is called via a timer in the constructor of mudlet::mudlet()
 void mudlet::startAutoLogin(const QStringList& cliProfiles)
 {
     QStringList hostList = QDir(getMudletPath(profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix crash when a profile with errors is set to autostart
#### Motivation for adding to Mudlet
Bugfix
#### Other info (issues closed, discussion etc)
The error announcer was falsely reporting errors to the accessibility framework at launch (it's too early to be reporting the errors), and the Mudlet singleton wasn't ready yet which was causing the crash.

Originally reported in https://discord.com/channels/283581582550237184/283582068334526464/1267086280932593704