### PR TITLE
Add portable support

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -3385,7 +3385,7 @@ void dlgProfilePreferences::slot_tabChanged(int tabIndex)
         return;
     }
 
-    QSettings settings("mudlet", "Mudlet");
+    QSettings& settings = *mudlet::getQSettings();
     const QString themesURL = settings.value("colorSublimeThemesURL", qsl("https://github.com/Colorsublime/Colorsublime-Themes/archive/master.zip")).toString();
     // a default update period is 24h
     // it would be nice to use C++14's numeric separator but Qt Creator still

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -964,14 +964,7 @@ void dlgTriggerEditor::closeEvent(QCloseEvent* event)
 
 void dlgTriggerEditor::readSettings()
 {
-    /* In case sensitive environments, two different config directories
-       were used: "Mudlet" for QSettings, and "mudlet" anywhere else.
-       Furthermore, we skip the version from the application name to follow the convention.
-       For compatibility with older settings, if no config is loaded
-       from the config directory "mudlet", application "Mudlet", we try to load from the config
-       directory "Mudlet", application "Mudlet 1.0". */
-    const QSettings settings_new("mudlet", "Mudlet");
-    const QSettings settings((settings_new.contains("pos") ? "mudlet" : "Mudlet"), (settings_new.contains("pos") ? "Mudlet" : "Mudlet 1.0"));
+    QSettings& settings = *mudlet::getQSettings();
 
     const QPoint pos = settings.value("script_editor_pos", QPoint(10, 10)).toPoint();
     const QSize size = settings.value("script_editor_size", QSize(600, 400)).toSize();
@@ -991,11 +984,7 @@ void dlgTriggerEditor::readSettings()
 
 void dlgTriggerEditor::writeSettings()
 {
-    /* In case sensitive environments, two different config directories
-       were used: "Mudlet" for QSettings, and "mudlet" anywhere else. We change the QSettings directory
-       (the organization name) to "mudlet".
-       Furthermore, we skip the version from the application name to follow the convention.*/
-    QSettings settings("mudlet", "Mudlet");
+    QSettings& settings = *mudlet::getQSettings();
     settings.setValue("script_editor_pos", pos());
     settings.setValue("script_editor_size", size());
     settings.setValue("autosaveIntervalMinutes", mAutosaveInterval);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -619,6 +619,7 @@ int main(int argc, char* argv[])
 #endif
 
     mudlet::start();
+    mudlet::self()->init();
 
 #if defined(Q_OS_WIN)
     // Associate mudlet with .mpackage files

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -247,6 +247,10 @@ int main(int argc, char* argv[])
         app->setApplicationVersion(QString(APP_VERSION) + appBuild);
     }
 
+    mudlet::start();
+    // Detect config path before any files are read
+    mudlet::self()->setupConfig();
+
     QPointer<QTranslator> commandLineTranslator(loadTranslationsForCommandLine());
     QCommandLineParser parser;
     // The third (and fourth if provided) arguments are used to populate the
@@ -618,7 +622,6 @@ int main(int argc, char* argv[])
     }
 #endif
 
-    mudlet::start();
     mudlet::self()->init();
 
 #if defined(Q_OS_WIN)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -131,9 +131,7 @@ void removeOldNoteColorEmojiFonts()
 
 QTranslator* loadTranslationsForCommandLine()
 {
-    const QSettings settings_new(QLatin1String("mudlet"), QLatin1String("Mudlet"));
-    auto pSettings = new QSettings((settings_new.contains(QLatin1String("pos")) ? QLatin1String("mudlet") : QLatin1String("Mudlet")),
-                                   (settings_new.contains(QLatin1String("pos")) ? QLatin1String("Mudlet") : QLatin1String("Mudlet 1.0")));
+    QSettings* pSettings = mudlet::getQSettings();
     auto interfaceLanguage = pSettings->value(QLatin1String("interfaceLanguage")).toString();
     auto userLocale = interfaceLanguage.isEmpty() ? QLocale::system() : QLocale(interfaceLanguage);
     if (userLocale == QLocale::c()) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -696,6 +696,12 @@ void mudlet::init()
 //    });
 }
 
+void mudlet::setupConfig()
+{
+    confPath = qsl("%1/.config/mudlet").arg(QDir::homePath());
+    qDebug() << "mudlet::setupConfig() INFO:" << "using config dir:" << confPath;
+}
+
 QSettings* mudlet::getQSettings()
 {
     /*In case sensitive environments, two different config directories
@@ -3416,11 +3422,11 @@ bool mudlet::loadEdbeeTheme(const QString& themeName, const QString& themeFile)
     return true;
 }
 
-// Convenience helper - may aide things if we want to put files in a different
-// place...!
+// This is a static wrapper for singleton instance method
+// Should only be called after mudlet has been initialised
 QString mudlet::getMudletPath(const mudletPathType mode, const QString& extra1, const QString& extra2)
 {
-    QString confPath = qsl("%1/.config/mudlet").arg(QDir::homePath());
+    QString confPath = self()->confPath;
     switch (mode) {
     case mainPath:
         // The root of all mudlet data for the user - does not end in a '/'

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -694,6 +694,17 @@ void mudlet::init()
 //    });
 }
 
+static QString findExecutableDir()
+{
+    // Linux AppImage support
+    QProcessEnvironment systemEnvironment = QProcessEnvironment::systemEnvironment();
+    if (systemEnvironment.contains(qsl("APPIMAGE"))) {
+        QString appimgPath = systemEnvironment.value(qsl("APPIMAGE"), QString());
+        return QFileInfo(appimgPath).dir().path();
+    }
+    return QCoreApplication::applicationDirPath();
+}
+
 static void migrateConfig(QSettings& settings)
 {
     if (settings.contains(qsl("pos"))) {
@@ -718,7 +729,14 @@ static void migrateConfig(QSettings& settings)
 
 void mudlet::setupConfig()
 {
-    confPath = qsl("%1/.config/mudlet").arg(QDir::homePath());
+    QString confDirDefault = qsl("%1/.config/mudlet").arg(QDir::homePath());
+    QString execDir = findExecutableDir();
+    QString markerExecDir = qsl("%1/portable.txt").arg(execDir);
+    if (QFileInfo(markerExecDir).isFile()) {
+        confPath = qsl("%1/portable").arg(execDir);
+    } else {
+        confPath = confDirDefault;
+    }
     qDebug() << "mudlet::setupConfig() INFO:" << "using config dir:" << confPath;
 
     mpSettings = new QSettings(qsl("%1/Mudlet.ini").arg(confPath), QSettings::IniFormat);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -763,7 +763,15 @@ void mudlet::setupConfig()
     QString markerExecDir = qsl("%1/portable.txt").arg(execDir);
     QString markerHomeDir = qsl("%1/portable.txt").arg(confDirDefault);
     if (QFileInfo(markerExecDir).isFile()) {
-        confPath = qsl("%1/portable").arg(execDir);
+        QString portPath = readMarkerFile(markerExecDir);
+        if (portPath.isEmpty()) {
+            portPath = qsl("./portable"); // fallback value for empty portable.txt
+        }
+        portPath = utils::pathResolveRelative(QDir::cleanPath(portPath), execDir);
+        if (!validateConfDir(portPath)) {
+            qFatal("FATAL: portable data path invalid");
+        }
+        confPath = portPath;
     } else if (QFileInfo(markerHomeDir).isFile()) {
         QString portPath = readMarkerFile(markerHomeDir);
         portPath = utils::pathResolveRelative(QDir::cleanPath(portPath), execDir);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -131,6 +131,11 @@ bool TConsoleMonitor::eventFilter(QObject* obj, QEvent* event)
 mudlet::mudlet()
 : QMainWindow()
 {
+    // Initialisation happens later in setupConfig() and init()
+}
+
+void mudlet::init()
+{
     smFirstLaunch = !QFile::exists(mudlet::getMudletPath(mudlet::profilesPath));
 
     QFile gitShaFile(":/app-build.txt");

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3415,86 +3415,87 @@ bool mudlet::loadEdbeeTheme(const QString& themeName, const QString& themeFile)
 // place...!
 QString mudlet::getMudletPath(const mudletPathType mode, const QString& extra1, const QString& extra2)
 {
+    QString confPath = qsl("%1/.config/mudlet").arg(QDir::homePath());
     switch (mode) {
     case mainPath:
         // The root of all mudlet data for the user - does not end in a '/'
-        return qsl("%1/.config/mudlet").arg(QDir::homePath());
+        return confPath;
     case mainDataItemPath:
         // Takes one extra argument as a file (or directory) relating to
         // (profile independent) mudlet data - may end with a '/' if the extra
         // argument does:
-        return qsl("%1/.config/mudlet/%2").arg(QDir::homePath(), extra1);
+        return qsl("%1/%2").arg(confPath, extra1);
     case mainFontsPath:
         // (Added for 3.5.0) a revised location to store Mudlet provided fonts
-        return qsl("%1/.config/mudlet/fonts").arg(QDir::homePath());
+        return qsl("%1/fonts").arg(confPath);
     case profilesPath:
         // The directory containing all the saved user's profiles - does not end
         // in '/'
-        return qsl("%1/.config/mudlet/profiles").arg(QDir::homePath());
+        return qsl("%1/profiles").arg(confPath);
     case profileHomePath:
         // Takes one extra argument (profile name) that returns the base
         // directory for that profile - does NOT end in a '/' unless the
         // supplied profle name does:
-        return qsl("%1/.config/mudlet/profiles/%2").arg(QDir::homePath(), extra1);
+        return qsl("%1/profiles/%2").arg(confPath, extra1);
     case profileMediaPath:
         // Takes one extra argument (profile name) that returns the directory
         // for the profile's cached media files - does NOT end in a '/'
-        return qsl("%1/.config/mudlet/profiles/%2/media").arg(QDir::homePath(), extra1);
+        return qsl("%1/profiles/%2/media").arg(confPath, extra1);
     case profileMediaPathFileName:
         // Takes two extra arguments (profile name, mediaFileName) that returns
         // the pathFile name for any media file:
-        return qsl("%1/.config/mudlet/profiles/%2/media/%3").arg(QDir::homePath(), extra1, extra2);
+        return qsl("%1/profiles/%2/media/%3").arg(confPath, extra1, extra2);
     case profileXmlFilesPath:
         // Takes one extra argument (profile name) that returns the directory
         // for the profile game save XML files - ends in a '/'
-        return qsl("%1/.config/mudlet/profiles/%2/current/").arg(QDir::homePath(), extra1);
+        return qsl("%1/profiles/%2/current/").arg(confPath, extra1);
     case profileMapsPath:
         // Takes one extra argument (profile name) that returns the directory
         // for the profile game save maps files - does NOT end in a '/'
-        return qsl("%1/.config/mudlet/profiles/%2/map").arg(QDir::homePath(), extra1);
+        return qsl("%1/profiles/%2/map").arg(confPath, extra1);
     case profileDateTimeStampedMapPathFileName:
         // Takes two extra arguments (profile name, dataTime stamp) that returns
         // the pathFile name for a dateTime stamped map file:
-        return qsl("%1/.config/mudlet/profiles/%2/map/%3map.dat").arg(QDir::homePath(), extra1, extra2);
+        return qsl("%1/profiles/%2/map/%3map.dat").arg(confPath, extra1, extra2);
     case profileDateTimeStampedJsonMapPathFileName:
         // Takes two extra arguments (profile name, dataTime stamp) that returns
         // the pathFile name for a dateTime stamped JSON map file:
-        return qsl("%1/.config/mudlet/profiles/%2/map/%3map.json").arg(QDir::homePath(), extra1, extra2);
+        return qsl("%1/profiles/%2/map/%3map.json").arg(confPath, extra1, extra2);
     case profileMapPathFileName:
         // Takes two extra arguments (profile name, mapFileName) that returns
         // the pathFile name for any map file:
-        return qsl("%1/.config/mudlet/profiles/%2/map/%3").arg(QDir::homePath(), extra1, extra2);
+        return qsl("%1/profiles/%2/map/%3").arg(confPath, extra1, extra2);
     case profileXmlMapPathFileName:
         // Takes one extra argument (profile name) that returns the pathFile
         // name for the downloaded IRE Server provided XML map:
-        return qsl("%1/.config/mudlet/profiles/%2/map.xml").arg(QDir::homePath(), extra1);
+        return qsl("%1/profiles/%2/map.xml").arg(confPath, extra1);
     case profileDataItemPath:
         // Takes two extra arguments (profile name, data item) that gives a
         // path file name for, typically a data item stored as a single item
         // (binary) profile data) file (ideally these can be moved to a per
         // profile QSettings file but that is a future pipe-dream on my part
         // SlySven):
-        return qsl("%1/.config/mudlet/profiles/%2/%3").arg(QDir::homePath(), extra1, extra2);
+        return qsl("%1/profiles/%2/%3").arg(confPath, extra1, extra2);
     case profilePackagePath:
         // Takes two extra arguments (profile name, package name) returns the
         // per profile directory used to store (unpacked) package contents
         // - ends with a '/':
-        return qsl("%1/.config/mudlet/profiles/%2/%3/").arg(QDir::homePath(), extra1, extra2);
+        return qsl("%1/profiles/%2/%3/").arg(confPath, extra1, extra2);
     case profilePackagePathFileName:
         // Takes two extra arguments (profile name, package name) returns the
         // filename of the XML file that contains the (per profile, unpacked)
         // package mudlet items in that package/module:
-        return qsl("%1/.config/mudlet/profiles/%2/%3/%3.xml").arg(QDir::homePath(), extra1, extra2);
+        return qsl("%1/profiles/%2/%3/%3.xml").arg(confPath, extra1, extra2);
     case profileReplayAndLogFilesPath:
         // Takes one extra argument (profile name) that returns the directory
         // that contains replays (*.dat files) and logs (*.html or *.txt) files
         // for that profile - does NOT end in '/':
-        return qsl("%1/.config/mudlet/profiles/%2/log").arg(QDir::homePath(), extra1);
+        return qsl("%1/profiles/%2/log").arg(confPath, extra1);
     case profileLogErrorsFilePath:
         // Takes one extra argument (profile name) that returns the pathFileName
         // to the map auditing report file that is appended to each time a
         // map is loaded:
-        return qsl("%1/.config/mudlet/profiles/%2/log/errors.txt").arg(QDir::homePath(), extra1);
+        return qsl("%1/profiles/%2/log/errors.txt").arg(confPath, extra1);
     case editorWidgetThemePathFile:
         // Takes two extra arguments (profile name, theme name) that returns the
         // pathFileName of the theme file used by the edbee editor - also
@@ -3502,7 +3503,7 @@ QString mudlet::getMudletPath(const mudletPathType mode, const QString& extra1, 
         // is carried internally in the resource file:
         if (extra1.compare(qsl("Mudlet.tmTheme"), Qt::CaseSensitive)) {
             // No match
-            return qsl("%1/.config/mudlet/edbee/Colorsublime-Themes-master/themes/%2").arg(QDir::homePath(), extra1);
+            return qsl("%1/edbee/Colorsublime-Themes-master/themes/%2").arg(confPath, extra1);
         } else {
             // Match - return path to copy held in resource file
             return qsl(":/edbee_defaults/Mudlet.tmTheme");
@@ -3510,11 +3511,11 @@ QString mudlet::getMudletPath(const mudletPathType mode, const QString& extra1, 
     case editorWidgetThemeJsonFile:
         // Returns the pathFileName to the external JSON file needed to process
         // an edbee editor widget theme:
-        return qsl("%1/.config/mudlet/edbee/Colorsublime-Themes-master/themes.json").arg(QDir::homePath());
+        return qsl("%1/edbee/Colorsublime-Themes-master/themes.json").arg(confPath);
     case moduleBackupsPath:
         // Returns the directory used to store module backups that is used in
         // when saving/resyncing packages/modules - ends in a '/'
-        return qsl("%1/.config/mudlet/moduleBackups/").arg(QDir::homePath());
+        return qsl("%1/moduleBackups/").arg(confPath);
     case qtTranslationsPath:
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
         return QLibraryInfo::location(QLibraryInfo::TranslationsPath);

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -297,6 +297,7 @@ public:
     // as well as encourage translators to maintain it
     static const int scmTranslationGoldStar = 95;
     QString scmVersion;
+    QString confPath;
     // These have to be "inline" to satisfy the ODR (One Definition Rule):
     inline static bool smDebugMode = false;
     inline static bool smFirstLaunch = false;
@@ -314,6 +315,7 @@ public:
 
 
     void init();
+    void setupConfig();
     void activateProfile(Host*);
     void takeOwnershipOfInstanceCoordinator(std::unique_ptr<MudletInstanceCoordinator>);
     MudletInstanceCoordinator* getInstanceCoordinator();

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -313,6 +313,7 @@ public:
     void hideEvent(QHideEvent*) override;
 
 
+    void init();
     void activateProfile(Host*);
     void takeOwnershipOfInstanceCoordinator(std::unique_ptr<MudletInstanceCoordinator>);
     MudletInstanceCoordinator* getInstanceCoordinator();

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -235,6 +235,7 @@ public:
 
 
     static QString getMudletPath(mudletPathType, const QString& extra1 = QString(), const QString& extra2 = QString());
+    static QSettings* getQSettings();
     // From https://stackoverflow.com/a/14678964/4805858 an answer to:
     // "How to find and replace string?" by "Czarek Tomczak":
     static bool loadEdbeeTheme(const QString& themeName, const QString& themeFile);
@@ -341,7 +342,6 @@ public:
     std::optional<QSize> getImageSize(const QString&);
     const QString& getInterfaceLanguage() const { return mInterfaceLanguage; }
     int64_t getPhysicalMemoryTotal();
-    QSettings* getQSettings();
     const QLocale& getUserLocale() const { return mUserLocale; }
     QSet<QString> getWordSet();
     bool inDarkMode() const { return mDarkMode; }

--- a/src/utils.h
+++ b/src/utils.h
@@ -26,6 +26,7 @@
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <QEnterEvent>
 #endif
+#include <QDir>
 #include <QString>
 #include "post_guard.h"
 
@@ -52,6 +53,19 @@ public:
     // defining a static function/method here we can save using the same
     // qsl all over the place:
     static QString richText(const QString& text) { return qsl("<p>%1</p>").arg(text); }
+
+    // Return a new QString with path made absolute, resolved against base and cleaned if it was relative
+    // Returns path unchanged if it was already absolute or an empty string
+    static QString pathResolveRelative(const QString& path, const QString& base)
+    {
+        if (path.size() == 0) {
+            return path;
+        }
+        if (QDir::isAbsolutePath(path)) {
+            return path;
+        }
+        return QDir::cleanPath(base + "/" + path);
+    }
 };
 
 #endif // UPDATER_H


### PR DESCRIPTION
/claim #888

#### Brief overview of PR changes/additions

This PR:
- refactors Mudlet initialisation code to use a single source of truth for config directory paths
- change QSettings storage to an `IniFormat` file in the config directory and adds migration code from old formats
- adds support for a `<executable_dir>/portable.txt` marker which sets the config directory to `<executable_dir>/portable`

#### Motivation for adding to Mudlet

This PR teaches Mudlet to store data portably.

#### Usage Instructions

If you're interested in trying out this PR, you can download the CI builds from the **add-deployment-links** bot below.

There are currently two ways to enable portable mode for Mudlet (in order of importance):
- You can create an empty `portable.txt` file in the same folder as the Mudlet executable (or appimage etc.)
  - This will tell Mudlet to use a folder named `portable` (in the same folder as the executable) for its data
- You can create an `~/.config/mudlet/portable.txt` file with its contents being a path on your filesystem
  - This will tell Mudlet to use the path written in the file as the folder for its data
    -  e.g. the contents could be `/mount/media/flashdrive/mudlet_data` or `D:\games\portable\mudlet_data`
  - The path can be relative, in which case it will be interpreted relative to the Mudlet executable's folder
  - Mudlet will create _exactly_ one folder, that is, the last part of the given path, if it doesn't exist already. At least everything up to its parent folder must exist already or it will lead to an error.
    - e.g. if given `D:\games\portable\mudlet_data`, at least `D:\games\portable` must be an existing folder
    - This is to avoid taking unintended input. If you see this error but this actually is what you want, just create those folders manually

Any errors will result in the issue being printed to stderr and the program terminating. You probably won't see the error outputs if launched from GUI so it's recommended to start Mudlet from the terminal.

Ofc when you first launch Mudlet in portable mode, it will start with a new clean config in the respective folder, just like a new install. If you wish to migrate your existing config data to be portable:
- You need to launch this build at least once (without any `portable.txt`)
  - This is because it needs to migrate config files from the old format to the new, portable-friendly one
- Then you can just copy/move your default data directory `~/.config/mudlet` to wherever you want and use one of the above `portable.txt`s to point Mudlet to that path.