### PR TITLE
Infra: add support for clang64 compiler

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -55,6 +55,9 @@ jobs:
       run: |
         $GITHUB_WORKSPACE/CI/setup-windows-sdk.sh
         printenv
+        jemalloc-config --libdir
+        jemalloc-config --includedir
+        jemalloc-config --libs
         $GITHUB_WORKSPACE/CI/validate-deployment-for-windows.sh
         
     - name: restore ccache

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -54,7 +54,7 @@ jobs:
         GITHUB_REPO_TAG: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
       run: |
         $GITHUB_WORKSPACE/CI/setup-windows-sdk.sh
-        echo "$env"
+        printenv
         $GITHUB_WORKSPACE/CI/validate-deployment-for-windows.sh
         
     - name: restore ccache

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -55,6 +55,7 @@ jobs:
       run: |
         $GITHUB_WORKSPACE/CI/setup-windows-sdk.sh
         $GITHUB_WORKSPACE/CI/validate-deployment-for-windows.sh
+        echo "$env"
 
     - name: restore ccache
       uses: actions/cache@v4

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -38,7 +38,7 @@ jobs:
       if: matrix.buildname == 'windows64'
       uses: msys2/setup-msys2@v2
       with:
-        msystem: MINGW64
+        msystem: CLANG64
         update: true
 
     - name: (Windows 32) Setup MSYS2

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -54,10 +54,6 @@ jobs:
         GITHUB_REPO_TAG: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
       run: |
         $GITHUB_WORKSPACE/CI/setup-windows-sdk.sh
-        printenv
-        jemalloc-config --libdir
-        jemalloc-config --includedir
-        jemalloc-config --libs
         $GITHUB_WORKSPACE/CI/validate-deployment-for-windows.sh
         
     - name: restore ccache

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -54,9 +54,9 @@ jobs:
         GITHUB_REPO_TAG: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
       run: |
         $GITHUB_WORKSPACE/CI/setup-windows-sdk.sh
-        $GITHUB_WORKSPACE/CI/validate-deployment-for-windows.sh
         echo "$env"
-
+        $GITHUB_WORKSPACE/CI/validate-deployment-for-windows.sh
+        
     - name: restore ccache
       uses: actions/cache@v4
       with:

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -36,11 +36,9 @@ if [ "${MSYSTEM}" = "MSYS" ]; then
   exit 2
 elif [ "${MSYSTEM}" = "MINGW32" ]; then
   export BUILD_BITNESS="32"
-  export BUILDCOMPONENT="i686"
   export ARCH="x86"
-elif [ "${MSYSTEM}" = "MINGW64" ]; then
+elif [ "${MSYSTEM}" = "MINGW64" ] || [ "${MSYSTEM}" = "CLANG64" ]; then
   export BUILD_BITNESS="64"
-  export BUILDCOMPONENT="x86_64"
   export ARCH="x86_64"
 else
   echo "This script is not set up to handle systems of type ${MSYSTEM}, only MINGW32 or"
@@ -208,14 +206,14 @@ else
   if [[ "$PublicTestBuild" == "true" ]]; then
     # Allow public test builds to be installed side by side with the release builds by renaming the app
     # No dots in the <id>: Guidelines by Squirrel
-    if [ "${MSYSTEM}" = "MINGW64" ]; then
+    if [ "${BUILD_BITNESS}" = "64" ]; then
       sed -i "s/<id>Mudlet<\/id>/<id>Mudlet_${BUILD_BITNESS}_-PublicTestBuild<\/id>/" "$NuSpec"
     else
       sed -i 's/<id>Mudlet<\/id>/<id>Mudlet-PublicTestBuild<\/id>/' "$NuSpec"
     fi
     sed -i "s/<title>Mudlet<\/title>/<title>Mudlet x${BUILD_BITNESS} (Public Test Build)<\/title>/" "$NuSpec"
   else
-    if [ "${MSYSTEM}" = "MINGW64" ]; then
+    if [ "${BUILD_BITNESS}" = "64" ]; then
       sed -i "s/<id>Mudlet<\/id>/<id>Mudlet_${BUILD_BITNESS}_<\/id>/" "$NuSpec"
     fi
     sed -i "s/<title>Mudlet<\/title>/<title>Mudlet x${BUILD_BITNESS}<\/title>/" "$NuSpec"
@@ -234,7 +232,7 @@ else
   fi
 
   # Ensure 64 bit build is properly tagged
-  if [ "${MSYSTEM}" = "MINGW64" ]; then
+  if [ "${BUILD_BITNESS}" = "64" ]; then
     TestBuildString="_64_$TestBuildString"
   fi
 

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -100,6 +100,7 @@ if [ "${BUILD_BITNESS}" = "64" ]; then
   pacman_attempts=1
   while true; do
     if /usr/bin/pacman -Su --needed --noconfirm \
+      "mingw-w64-${BUILDCOMPONENT}-gcc-compat" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-base" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-svg" \
@@ -152,9 +153,9 @@ while true; do
     git \
     man \
     rsync \
-    "mingw-w64-${BUILDCOMPONENT}-gcc-compat" \
     "mingw-w64-${BUILDCOMPONENT}-ccache" \
     "mingw-w64-${BUILDCOMPONENT}-toolchain" \
+    "mingw-w64-${BUILDCOMPONENT}-mimalloc" \
     "mingw-w64-${BUILDCOMPONENT}-pcre" \
     "mingw-w64-${BUILDCOMPONENT}-libzip" \
     "mingw-w64-${BUILDCOMPONENT}-ntldd" \

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -96,11 +96,41 @@ echo "    to go and have a cup of tea (other beverages are available) in the mea
 echo ""
 
 if [ "${BUILD_BITNESS}" = "64" ]; then
+  echo "=== Installing Harfbuzz from source ==="
+  pacman_attempts=1
+  while true; do
+    if /usr/bin/pacman -Su --needed --noconfirm \
+      "mingw-w64-${BUILDCOMPONENT}-toolchain" \
+      "mingw-w64-${BUILDCOMPONENT}-gcc-compat" \
+      "mingw-w64-${BUILDCOMPONENT}-meson" \
+      "mingw-w64-${BUILDCOMPONENT}-ninja"; then
+        break
+    fi
+    
+    if [ $pacman_attempts -eq 10 ]; then
+      exit 7
+    fi
+    pacman_attempts=$((pacman_attempts +1))
+    
+    echo "=== Some packages failed to install, waiting and trying again ==="
+    sleep 10
+  done
+  
+  git clone https://github.com/harfbuzz/harfbuzz.git
+  cd harfbuzz
+  meson setup build --prefix=/msys64/clang64 --buildtype=release -Dgraphite=disabled
+  meson compile -C build
+  meson install -C build
+  
+fi
+
+
+
+if [ "${BUILD_BITNESS}" = "64" ]; then
   echo "=== Installing Qt6 Packages ==="
   pacman_attempts=1
   while true; do
     if /usr/bin/pacman -Su --needed --noconfirm \
-      "mingw-w64-${BUILDCOMPONENT}-gcc-compat" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-base" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-svg" \
@@ -154,8 +184,6 @@ while true; do
     man \
     rsync \
     "mingw-w64-${BUILDCOMPONENT}-ccache" \
-    "mingw-w64-${BUILDCOMPONENT}-toolchain" \
-    "mingw-w64-${BUILDCOMPONENT}-jemalloc" \
     "mingw-w64-${BUILDCOMPONENT}-pcre" \
     "mingw-w64-${BUILDCOMPONENT}-libzip" \
     "mingw-w64-${BUILDCOMPONENT}-ntldd" \

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -132,7 +132,7 @@ if [ "${BUILD_BITNESS}" = "64" ]; then
   pacman_attempts=1
   while true; do
     if /usr/bin/pacman -Su --needed --noconfirm \
-      "mingw-w64-${BUILDCOMPONENT}-qt6-base" \
+      "--assume-installed=mingw-w64-clang-x86_64-harfbuzz mingw-w64-${BUILDCOMPONENT}-qt6-base" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-svg" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-speech" \

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -100,6 +100,7 @@ if [ "${BUILD_BITNESS}" = "64" ]; then
   pacman_attempts=1
   while true; do
     if /usr/bin/pacman -Su --needed --noconfirm \
+      git \
       "mingw-w64-${BUILDCOMPONENT}-toolchain" \
       "mingw-w64-${BUILDCOMPONENT}-gcc-compat" \
       "mingw-w64-${BUILDCOMPONENT}-meson" \
@@ -180,7 +181,6 @@ fi
 pacman_attempts=1
 while true; do
   if /usr/bin/pacman -Su --needed --noconfirm \
-    git \
     man \
     rsync \
     "mingw-w64-${BUILDCOMPONENT}-ccache" \

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -49,13 +49,21 @@
 # 6 - One or more Luarocks could not be installed
 # 7 - One of more packages failed to install
 
+# We use this internally - but it is actually the same as ${MINGW_PREFIX}
+export MINGW_BASE_DIR=$MSYSTEM_PREFIX
 
-if [ "${MSYSTEM}" = "MINGW64" ]; then
+if [ "${MSYSTEM}" = "CLANG64" ]; then
   export BUILD_BITNESS="64"
-  export BUILDCOMPONENT="x86_64"
+  export BUILDCOMPONENT="clang-x86_64"
+  export MINGW_INTERNAL_BASE_DIR="/clang${BUILD_BITNESS}"
 elif [ "${MSYSTEM}" = "MINGW32" ]; then
   export BUILD_BITNESS="32"
   export BUILDCOMPONENT="i686"
+  export MINGW_INTERNAL_BASE_DIR="/mingw${BUILD_BITNESS}"
+elif [ "${MSYSTEM}" = "MINGW64" ]; then
+  export BUILD_BITNESS="64"
+  export BUILDCOMPONENT="x86_64"
+  export MINGW_INTERNAL_BASE_DIR="/mingw${BUILD_BITNESS}"
 elif [ "${MSYSTEM}" = "MSYS" ]; then
   echo "Please run this script from an MINGW32 or MINGW64 type bash terminal appropriate"
   echo "to the bitness you want to work on. You may do this once for each of them should"
@@ -68,11 +76,7 @@ else
   exit 2
 fi
 
-# We use this internally - but it is actually the same as ${MINGW_PREFIX}
-export MINGW_BASE_DIR=$MSYSTEM_PREFIX
-# A more compact - but not necessarily understood by other than MSYS/MINGW
-# executables - path:
-export MINGW_INTERNAL_BASE_DIR="/mingw${BUILD_BITNESS}"
+
 #
 # FIXME: don't add duplicates but rearrange instead to put them in the "right" order:
 #
@@ -91,7 +95,7 @@ echo "    This could take a long time if it is needed to fetch everything, so fe
 echo "    to go and have a cup of tea (other beverages are available) in the meantime...!"
 echo ""
 
-if [ "${MSYSTEM}" = "MINGW64" ]; then
+if [ "${BUILD_BITNESS}" = "64" ]; then
   echo "=== Installing Qt6 Packages ==="
   pacman_attempts=1
   while true; do
@@ -148,6 +152,7 @@ while true; do
     git \
     man \
     rsync \
+    "mingw-w64-${BUILDCOMPONENT}-gcc-compat" \
     "mingw-w64-${BUILDCOMPONENT}-ccache" \
     "mingw-w64-${BUILDCOMPONENT}-toolchain" \
     "mingw-w64-${BUILDCOMPONENT}-pcre" \

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -131,8 +131,8 @@ if [ "${BUILD_BITNESS}" = "64" ]; then
   echo "=== Installing Qt6 Packages ==="
   pacman_attempts=1
   while true; do
-    if /usr/bin/pacman -Su --needed --noconfirm \
-      "--assume-installed=mingw-w64-clang-x86_64-harfbuzz mingw-w64-${BUILDCOMPONENT}-qt6-base" \
+    if /usr/bin/pacman -Su --noconfirm \
+      "--assume-installed=mingw-w64-clang-x86_64-harfbuzz-9.0.0-1 mingw-w64-${BUILDCOMPONENT}-qt6-base" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-svg" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-speech" \

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -159,7 +159,6 @@ if [ "${BUILD_BITNESS}" = "64" ]; then
   mv /msys64/clang64/bin/harfbuzz.bak /msys64/clang64/bin/harfbuzz
   mv /msys64/clang64/lib/libharfbuzz.bak.* /msys64/clang64/lib/libharfbuzz.*
   mv /msys64/clang64/include/harfbuzz_backup /msys64/clang64/include/harfbuzz
-
   
 else
 

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -155,7 +155,7 @@ while true; do
     rsync \
     "mingw-w64-${BUILDCOMPONENT}-ccache" \
     "mingw-w64-${BUILDCOMPONENT}-toolchain" \
-    "mingw-w64-${BUILDCOMPONENT}-mimalloc" \
+    "mingw-w64-${BUILDCOMPONENT}-jemalloc" \
     "mingw-w64-${BUILDCOMPONENT}-pcre" \
     "mingw-w64-${BUILDCOMPONENT}-libzip" \
     "mingw-w64-${BUILDCOMPONENT}-ntldd" \

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -119,9 +119,13 @@ if [ "${BUILD_BITNESS}" = "64" ]; then
   
   git clone https://github.com/harfbuzz/harfbuzz.git
   cd harfbuzz
-  meson setup build --prefix=/msys64/clang64 --buildtype=release -Dgraphite=disabled
+  meson setup build --prefix=/msys64/clang64 --buildtype=release -Dgraphite=disabled -Dtests=disabled
   meson compile -C build
   meson install -C build
+  
+  mv /msys64/clang64/bin/harfbuzz /msys64/clang64/bin/harfbuzz.bak
+  mv /msys64/clang64/lib/libharfbuzz.* /msys64/clang64/lib/libharfbuzz.bak.*
+  mv /msys64/clang64/include/harfbuzz /msys64/clang64/include/harfbuzz_backup
   
 fi
 
@@ -131,8 +135,8 @@ if [ "${BUILD_BITNESS}" = "64" ]; then
   echo "=== Installing Qt6 Packages ==="
   pacman_attempts=1
   while true; do
-    if /usr/bin/pacman -Su --noconfirm \
-      "--assume-installed=mingw-w64-clang-x86_64-harfbuzz-9.0.0-1 mingw-w64-${BUILDCOMPONENT}-qt6-base" \
+    if /usr/bin/pacman -S --noconfirm \
+      "mingw-w64-${BUILDCOMPONENT}-qt6-base" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-svg" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-speech" \
@@ -151,6 +155,11 @@ if [ "${BUILD_BITNESS}" = "64" ]; then
     echo "=== Some packages failed to install, waiting and trying again ==="
     sleep 10
   done
+  
+  mv /msys64/clang64/bin/harfbuzz.bak /msys64/clang64/bin/harfbuzz
+  mv /msys64/clang64/lib/libharfbuzz.bak.* /msys64/clang64/lib/libharfbuzz.*
+  mv /msys64/clang64/include/harfbuzz_backup /msys64/clang64/include/harfbuzz
+
   
 else
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,6 @@
 #include "Announcer.h"
 #include "FileOpenHandler.h"
 
-#include <mimalloc-new-delete.h>
 
 using namespace std::chrono_literals;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,8 @@
 #include "Announcer.h"
 #include "FileOpenHandler.h"
 
+#include <mimalloc-new-delete.h>
+
 using namespace std::chrono_literals;
 
 
@@ -163,6 +165,8 @@ int main(int argc, char* argv[])
         freopen("CONOUT$", "w", stdout);
         freopen("CONOUT$", "w", stderr);
     }
+    
+    mi_version();
 #endif
 #if defined(_MSC_VER) && defined(_DEBUG)
     // Enable leak detection for MSVC debug builds.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,8 @@
 #include "Announcer.h"
 #include "FileOpenHandler.h"
 
+#include <jemalloc/jemalloc.h>
+
 
 using namespace std::chrono_literals;
 
@@ -686,7 +688,12 @@ int main(int argc, char* argv[])
     // click something in a parent process to the application when you are stuck
     // with some OS's choice of wait cursor - you might wish to temporarily disable
     // the earlier setOverrideCursor() line and this one.
-    return app->exec();
+    int ret = app->exec();
+    
+    // Dump allocator statistics to stderr.
+    malloc_stats_print(NULL, NULL, NULL);
+    
+    return ret;
 }
 
 #if defined(Q_OS_WIN32) && defined(INCLUDE_UPDATER)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -691,7 +691,7 @@ int main(int argc, char* argv[])
     int ret = app->exec();
     
     // Dump allocator statistics to stderr.
-    malloc_stats_print(NULL, NULL, NULL);
+    je_malloc_stats_print(NULL, NULL, NULL);
     
     return ret;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,6 @@
 #include "Announcer.h"
 #include "FileOpenHandler.h"
 
-#include <jemalloc/jemalloc.h>
 
 
 using namespace std::chrono_literals;
@@ -688,12 +687,7 @@ int main(int argc, char* argv[])
     // click something in a parent process to the application when you are stuck
     // with some OS's choice of wait cursor - you might wish to temporarily disable
     // the earlier setOverrideCursor() line and this one.
-    int ret = app->exec();
-    
-    // Dump allocator statistics to stderr.
-    je_malloc_stats_print(NULL, NULL, NULL);
-    
-    return ret;
+    return app->exec();
 }
 
 #if defined(Q_OS_WIN32) && defined(INCLUDE_UPDATER)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -164,8 +164,6 @@ int main(int argc, char* argv[])
         freopen("CONOUT$", "w", stdout);
         freopen("CONOUT$", "w", stderr);
     }
-    
-    mi_version();
 #endif
 #if defined(_MSC_VER) && defined(_DEBUG)
     // Enable leak detection for MSVC debug builds.

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -102,7 +102,6 @@ namespace coreMacOS {
 
 // PLACEMARKER: sample benchmarking code
 // #include <nanobench.h>
-#include <jemalloc/jemalloc.h>
 #include "post_guard.h"
 
 using namespace std::chrono_literals;
@@ -3094,9 +3093,6 @@ mudlet::~mudlet()
         }
     }
     mudlet::smpSelf = nullptr;
-    
-    // Dump allocator statistics to stderr.
-    je_malloc_stats_print(NULL, NULL, NULL);
 }
 
 void mudlet::slot_toggleFullScreenView()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -100,6 +100,8 @@ namespace coreMacOS {
 }
 #endif
 
+#include <mimalloc-new-delete.h>
+
 // PLACEMARKER: sample benchmarking code
 // #include <nanobench.h>
 #include "post_guard.h"

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -100,7 +100,7 @@ namespace coreMacOS {
 }
 #endif
 
-#include <mimalloc-new-delete.h>
+//#include <mimalloc-new-delete.h>
 
 // PLACEMARKER: sample benchmarking code
 // #include <nanobench.h>

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -100,8 +100,6 @@ namespace coreMacOS {
 }
 #endif
 
-//#include <mimalloc-new-delete.h>
-
 // PLACEMARKER: sample benchmarking code
 // #include <nanobench.h>
 #include "post_guard.h"

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -102,6 +102,7 @@ namespace coreMacOS {
 
 // PLACEMARKER: sample benchmarking code
 // #include <nanobench.h>
+#include <jemalloc/jemalloc.h>
 #include "post_guard.h"
 
 using namespace std::chrono_literals;
@@ -3093,6 +3094,9 @@ mudlet::~mudlet()
         }
     }
     mudlet::smpSelf = nullptr;
+    
+    // Dump allocator statistics to stderr.
+    je_malloc_stats_print(NULL, NULL, NULL);
 }
 
 void mudlet::slot_toggleFullScreenView()

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -95,6 +95,9 @@
 #else
 // Any other OS?
 #endif
+
+#include <mimalloc.h>
+
 #include "post_guard.h"
 
 class QCloseEvent;

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -96,8 +96,6 @@
 // Any other OS?
 #endif
 
-#include <mimalloc.h>
-
 #include "post_guard.h"
 
 class QCloseEvent;

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -351,6 +351,10 @@ unix:!macx {
         "'C:\msys64\mingw64' {64 Bit Mudlet built on a 64 Bit Host}\\n"))
     }
     GITHUB_WORKSPACE_TEST = $$(GITHUB_WORKSPACE)
+    
+    message("MINGW_BASE_DIR_TEST=$${MINGW_BASE_DIR_TEST}")
+    message("GITHUB_WORKSPACE_TEST=$${GITHUB_WORKSPACE_TEST}")
+    
     isEmpty( GITHUB_WORKSPACE_TEST ) {
         # For users/developers building with MSYS2 on Windows:
         LIBS +=  \
@@ -364,16 +368,16 @@ unix:!macx {
     } else {
         # For CI building with MSYS2 for Windows in a GH Workflow:
         contains(QMAKE_HOST.arch, x86_64) {
-
+        
             LIBS +=  \
-                -LD:\\a\\_temp\\msys64\\mingw64/lib \
-                -LD:\\a\\_temp\\msys64\\mingw64/bin \
+                -LD:\\a\\_temp\\msys64\\clang64/lib \
+                -LD:\\a\\_temp\\msys64\\clang64/bin \
                 -llua5.1 \
                 -llibhunspell-1.7
 
             INCLUDEPATH += \
-                D:\\a\\_temp\\msys64\\mingw64/include \
-                D:/a/_temp/msys64/mingw64/include/lua5.1 \
+                D:\\a\\_temp\\msys64\\clang64/include \
+                D:/a/_temp/msys64/clang64/include/lua5.1 \
                 $${MINGW_BASE_DIR_TEST}/include/pugixml
         } else {
             LIBS +=  \

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -41,8 +41,8 @@ lessThan(QT_MAJOR_VERSION, 5)|if(lessThan(QT_MAJOR_VERSION,6):lessThan(QT_MINOR_
 }
 
 win32 {
-    INCLUDEPATH += $${MINGW_PREFIX}/include
-    LIBS += -L$${MINGW_PREFIX}/lib \
+    INCLUDEPATH += D:/a/_temp/msys64/clang64/include
+    LIBS += -LD:/a/_temp/msys64/clang64/lib \
             -ljemalloc
     QMAKE_LFLAGS += -ljemalloc
 }

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -41,10 +41,10 @@ lessThan(QT_MAJOR_VERSION, 5)|if(lessThan(QT_MAJOR_VERSION,6):lessThan(QT_MINOR_
 }
 
 win32 {
-    INCLUDEPATH += /clang64/include
-    LIBS += -L/clang64/lib \
+    INCLUDEPATH += $${MINGW_PREFIX}/include
+    LIBS += -L$${MINGW_PREFIX}/lib \
             -ljemalloc
-    QMAKE_LFLAGS += -Wl,-rpath,/clang64/lib
+    QMAKE_LFLAGS += -Wl,-rpath,$${MINGW_PREFIX}/lib
 }
 
 # Including IRC Library
@@ -378,17 +378,23 @@ unix:!macx {
         contains(QMAKE_HOST.arch, x86_64) {
         
             # For Clang builds MINGW_BASE_DIR is wrong, we probably need to use a CLANG_BASE_DIR?
+            
+            #LIBS +=  \
+            #    -LD:\\a\\_temp\\msys64\\clang64/lib \
+            #    -LD:\\a\\_temp\\msys64\\clang64/bin \
+            #    -llua5.1 \
+            #    -llibhunspell-1.7
         
             LIBS +=  \
-                -LD:\\a\\_temp\\msys64\\clang64/lib \
-                -LD:\\a\\_temp\\msys64\\clang64/bin \
+                -L$${RUNNER_TEMP}/msys64$${MINGW_PREFIX}/lib \
+                -L$${RUNNER_TEMP}/msys64$${MINGW_PREFIX}/bin \
                 -llua5.1 \
                 -llibhunspell-1.7
 
             INCLUDEPATH += \
-                D:\\a\\_temp\\msys64\\clang64/include \
-                D:/a/_temp/msys64/clang64/include/lua5.1 \
-                D:/a/_temp/msys64/clang64/include/pugixml
+                $${RUNNER_TEMP}/msys64$${MINGW_PREFIX}/include \
+                $${RUNNER_TEMP}/msys64$${MINGW_PREFIX}/include/lua5.1 \
+                $${RUNNER_TEMP}/msys64$${MINGW_PREFIX}/include/pugixml
         } else {
             LIBS +=  \
                 -LD:\\a\\_temp\\msys64\\mingw32/lib \

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -41,7 +41,10 @@ lessThan(QT_MAJOR_VERSION, 5)|if(lessThan(QT_MAJOR_VERSION,6):lessThan(QT_MINOR_
 }
 
 win32 {
-    QMAKE_LFLAGS += -lmimalloc
+    INCLUDEPATH += -I/clang64/include
+    LIBS += -L/clang64/lib \
+            -ljemalloc
+    QMAKE_LFLAGS += -Wl,-rpath,/clang64/lib
 }
 
 # Including IRC Library
@@ -370,8 +373,6 @@ unix:!macx {
             $${MINGW_BASE_DIR_TEST}/include/lua5.1 \
             $${MINGW_BASE_DIR_TEST}/include/pugixml
     } else {
-        message("Printing entire GitHub Env for build environment debugging...")
-        message("GITHUB_ENV=$${GITHUB_ENV}")
     
         # For CI building with MSYS2 for Windows in a GH Workflow:
         contains(QMAKE_HOST.arch, x86_64) {

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -44,7 +44,6 @@ win32 {
     INCLUDEPATH += $${MINGW_PREFIX}/include
     LIBS += -L$${MINGW_PREFIX}/lib \
             -ljemalloc
-    QMAKE_LFLAGS += -Wl,-rpath,$${MINGW_PREFIX}/lib
 }
 
 # Including IRC Library

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -40,6 +40,10 @@ lessThan(QT_MAJOR_VERSION, 5)|if(lessThan(QT_MAJOR_VERSION,6):lessThan(QT_MINOR_
     error("Mudlet requires Qt 5.14 or later")
 }
 
+win32 {
+    QMAKE_LFLAGS += -lmimalloc
+}
+
 # Including IRC Library
 include(../3rdparty/communi/communi.pri)
 
@@ -57,7 +61,6 @@ include(../3rdparty/communi/communi.pri)
 # NOW we can put ours in:
     QMAKE_CXXFLAGS_RELEASE += -O3
     QMAKE_CFLAGS_RELEASE += -O3
-    QMAKE_LFLAGS += -lmimalloc
 # There is NO need to put in the -g option as it is done already for debug bugs
 # For gdb type debugging it helps if there is NO optimisations so use -O0.
     QMAKE_CXXFLAGS_DEBUG += -O0
@@ -368,7 +371,7 @@ unix:!macx {
             $${MINGW_BASE_DIR_TEST}/include/pugixml
     } else {
         message("Printing entire GitHub Env for build environment debugging...")
-        message($${GITHUB_ENV})
+        message("GITHUB_ENV=$${GITHUB_ENV}")
     
         # For CI building with MSYS2 for Windows in a GH Workflow:
         contains(QMAKE_HOST.arch, x86_64) {

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -40,13 +40,6 @@ lessThan(QT_MAJOR_VERSION, 5)|if(lessThan(QT_MAJOR_VERSION,6):lessThan(QT_MINOR_
     error("Mudlet requires Qt 5.14 or later")
 }
 
-win32 {
-    INCLUDEPATH += D:/a/_temp/msys64/clang64/include
-    LIBS += -LD:/a/_temp/msys64/clang64/lib \
-            -ljemalloc
-    QMAKE_LFLAGS += -ljemalloc
-}
-
 # Including IRC Library
 include(../3rdparty/communi/communi.pri)
 

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -41,7 +41,7 @@ lessThan(QT_MAJOR_VERSION, 5)|if(lessThan(QT_MAJOR_VERSION,6):lessThan(QT_MINOR_
 }
 
 win32 {
-    INCLUDEPATH += -I/clang64/include
+    INCLUDEPATH += /clang64/include
     LIBS += -L/clang64/lib \
             -ljemalloc
     QMAKE_LFLAGS += -Wl,-rpath,/clang64/lib

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -57,6 +57,7 @@ include(../3rdparty/communi/communi.pri)
 # NOW we can put ours in:
     QMAKE_CXXFLAGS_RELEASE += -O3
     QMAKE_CFLAGS_RELEASE += -O3
+    QMAKE_LFLAGS += -lmimalloc
 # There is NO need to put in the -g option as it is done already for debug bugs
 # For gdb type debugging it helps if there is NO optimisations so use -O0.
     QMAKE_CXXFLAGS_DEBUG += -O0
@@ -366,8 +367,13 @@ unix:!macx {
             $${MINGW_BASE_DIR_TEST}/include/lua5.1 \
             $${MINGW_BASE_DIR_TEST}/include/pugixml
     } else {
+        message("Printing entire GitHub Env for build environment debugging...")
+        message($${GITHUB_ENV})
+    
         # For CI building with MSYS2 for Windows in a GH Workflow:
         contains(QMAKE_HOST.arch, x86_64) {
+        
+            # For Clang builds MINGW_BASE_DIR is wrong, we probably need to use a CLANG_BASE_DIR?
         
             LIBS +=  \
                 -LD:\\a\\_temp\\msys64\\clang64/lib \
@@ -378,7 +384,7 @@ unix:!macx {
             INCLUDEPATH += \
                 D:\\a\\_temp\\msys64\\clang64/include \
                 D:/a/_temp/msys64/clang64/include/lua5.1 \
-                $${MINGW_BASE_DIR_TEST}/include/pugixml
+                D:/a/_temp/msys64/clang64/include/pugixml
         } else {
             LIBS +=  \
                 -LD:\\a\\_temp\\msys64\\mingw32/lib \

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -44,6 +44,7 @@ win32 {
     INCLUDEPATH += $${MINGW_PREFIX}/include
     LIBS += -L$${MINGW_PREFIX}/lib \
             -ljemalloc
+    QMAKE_LFLAGS += -ljemalloc
 }
 
 # Including IRC Library

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -379,22 +379,16 @@ unix:!macx {
         
             # For Clang builds MINGW_BASE_DIR is wrong, we probably need to use a CLANG_BASE_DIR?
             
-            #LIBS +=  \
-            #    -LD:\\a\\_temp\\msys64\\clang64/lib \
-            #    -LD:\\a\\_temp\\msys64\\clang64/bin \
-            #    -llua5.1 \
-            #    -llibhunspell-1.7
-        
             LIBS +=  \
-                -L$${RUNNER_TEMP}/msys64$${MINGW_PREFIX}/lib \
-                -L$${RUNNER_TEMP}/msys64$${MINGW_PREFIX}/bin \
+                -LD:\\a\\_temp\\msys64\\clang64/lib \
+                -LD:\\a\\_temp\\msys64\\clang64/bin \
                 -llua5.1 \
                 -llibhunspell-1.7
 
             INCLUDEPATH += \
-                $${RUNNER_TEMP}/msys64$${MINGW_PREFIX}/include \
-                $${RUNNER_TEMP}/msys64$${MINGW_PREFIX}/include/lua5.1 \
-                $${RUNNER_TEMP}/msys64$${MINGW_PREFIX}/include/pugixml
+                D:/a/_temp/msys64/clang64/include \
+                D:/a/_temp/msys64/clang64/include/lua5.1 \
+                D:/a/_temp/msys64/clang64/include/pugixml
         } else {
             LIBS +=  \
                 -LD:\\a\\_temp\\msys64\\mingw32/lib \


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Modify the CI scripts to allow for a CLANG64 compiler toolchain

#### Motivation for adding to Mudlet

The MSYS2 CI builds seem to have introduced some lagginess in the text drawing, my own local tests seem to indicate that using clang as the compiler alleviates some of the issues that I am able to notice on my own machine.

#### Other info (issues closed, discussion etc)
