### PR TITLE
Fix : potential issue shutting down Mudlet with package manager open

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -205,8 +205,6 @@ QString stopWatch::getElapsedDayTimeString() const
 Host::Host(int port, const QString& hostname, const QString& login, const QString& pass, int id)
 : mTelnet(this, hostname)
 , mpConsole(nullptr)
-, mpPackageManager(nullptr)
-, mpModuleManager(nullptr)
 , mLuaInterpreter(this, hostname, id)
 , commandLineMinimumHeight(30)
 , mAlertOnNewData(true)

--- a/src/Host.h
+++ b/src/Host.h
@@ -426,8 +426,8 @@ public:
 
     cTelnet mTelnet;
     QPointer<TMainConsole> mpConsole;
-    dlgPackageManager* mpPackageManager;
-    dlgModuleManager* mpModuleManager;
+    QPointer<dlgPackageManager> mpPackageManager;
+    QPointer<dlgModuleManager> mpModuleManager;
     TLuaInterpreter mLuaInterpreter;
 
     int commandLineMinimumHeight;

--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -49,7 +49,6 @@ dlgModuleManager::dlgModuleManager(QWidget* parent, Host* pHost)
 
 dlgModuleManager::~dlgModuleManager()
 {
-    mpHost->mpModuleManager = nullptr;
 }
 
 void dlgModuleManager::layoutModules()

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -59,7 +59,9 @@ dlgPackageManager::dlgPackageManager(QWidget* parent, Host* pHost)
 
 dlgPackageManager::~dlgPackageManager()
 {
-    mpHost->mpPackageManager = nullptr;
+    if (mpHost) {
+        mpHost->mpPackageManager = nullptr;
+    }
 }
 
 void dlgPackageManager::resetPackageTable()

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -59,9 +59,6 @@ dlgPackageManager::dlgPackageManager(QWidget* parent, Host* pHost)
 
 dlgPackageManager::~dlgPackageManager()
 {
-    if (mpHost) {
-        mpHost->mpPackageManager = nullptr;
-    }
 }
 
 void dlgPackageManager::resetPackageTable()


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix a potential crash on closing Mudlet. Address sanitizer (ASAN) found this:
```
/home/vadi/Programs/Mudlet/src/dlgPackageManager.cpp:62:13: runtime error: member access within address 0x5708325fe370 which does not point to an object of type 'Host'
0x5708325fe370: note: object has a possibly invalid vptr: abs(offset to top) too big
 00 00 00 00  b0 25 75 34 08 57 00 00  90 67 6f 34 08 57 00 00  60 91 62 31 08 57 00 00  90 67 6f 34
              ^~~~~~~~~~~~~~~~~~~~~~~
              possibly invalid vptr
```
#### Motivation for adding to Mudlet
Stability
#### Other info (issues closed, discussion etc)
Found by ASAN using Qt Creator 14.0 where it seems to be enabled by default.

ASAN can also be enabled manually using https://wiki.mudlet.org/w/Compiling_Mudlet#Checking_memory_leaks_.26_other_issues_.28sanitizers.29_3