### PR TITLE
Fix: 64bit Mudlet on Windows does not play sounds

### DIFF
--- a/CI/package-mudlet-for-windows.sh
+++ b/CI/package-mudlet-for-windows.sh
@@ -44,7 +44,6 @@
 # 3 - Unsupported build type
 # 4 - Directory to be used to assemble the package is NOT empty
 # 6 - No Mudlet.exe file found to work with
-# 7 - Mudlet will not have sound because windowsmediaplugin.dll not found
 
 if [ "${MSYSTEM}" = "MSYS" ]; then
   echo "Please run this script from an MINGW32 or MINGW64 type bash terminal appropriate"
@@ -117,19 +116,7 @@ else
 fi
 ZIP_FILE_NAME="Mudlet-${MSYSTEM}"
 
-# Making sure that the WMF backend DLL is being copied
-if [ "${BUILD_BITNESS}" = "64" ]; then
-    if [ ! -f "${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/windowsmediaplugin.dll" ]; then
-        echo "ERROR: windowsmediaplugin.dll not found - Mudlet will no have sound in windows"
-        echo "Install package mingw-w64-x86_64-qt6-multimedia-wmf to solve"
-        exit 7
-    fi
 
-    mkdir -p "./multimedia/"
-    cp -v -p -t "./multimedia/" \
-        "${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/windowsmediaplugin.dll"
-    echo "Copied ${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/windowsmediaplugin.dll"
-fi
 
 # To determine which system libraries have to be copied in it requires
 # continually trying to run the executable on the target type system

--- a/CI/package-mudlet-for-windows.sh
+++ b/CI/package-mudlet-for-windows.sh
@@ -120,9 +120,9 @@ ZIP_FILE_NAME="Mudlet-${MSYSTEM}"
 # Making sure that the WMF backend DLL is being copied
 if [ "${BUILD_BITNESS}" = "64" ]; then
     if [ ! -f "${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/windowsmediaplugin.dll" ]; then
-      echo "ERROR: windowsmediaplugin.dll not found - Mudlet will no have sound in windows"
-      echo "Install package mingw-w64-x86_64-qt6-multimedia-wmf to solve"
-      exit 7
+        echo "ERROR: windowsmediaplugin.dll not found - Mudlet will no have sound in windows"
+        echo "Install package mingw-w64-x86_64-qt6-multimedia-wmf to solve"
+        exit 7
     fi
 
     mkdir -p "./multimedia/"

--- a/CI/package-mudlet-for-windows.sh
+++ b/CI/package-mudlet-for-windows.sh
@@ -119,16 +119,16 @@ ZIP_FILE_NAME="Mudlet-${MSYSTEM}"
 
 # Making sure that the WMF backend DLL is being copied
 if [ "${BUILD_BITNESS}" = "64" ]; then
-	if [ ! -f "${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/windowsmediaplugin.dll" ]; then
-	  echo "ERROR: windowsmediaplugin.dll not found - Mudlet will no have sound in windows"
-	  echo "Install package mingw-w64-x86_64-qt6-multimedia-wmf to solve"
-	  exit 7
-	fi
+    if [ ! -f "${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/windowsmediaplugin.dll" ]; then
+      echo "ERROR: windowsmediaplugin.dll not found - Mudlet will no have sound in windows"
+      echo "Install package mingw-w64-x86_64-qt6-multimedia-wmf to solve"
+      exit 7
+    fi
 
-	mkdir -p "./multimedia/"
-	cp -v -p -t "./multimedia/" \
-		"${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/windowsmediaplugin.dll"
-	echo "Copied ${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/windowsmediaplugin.dll"
+    mkdir -p "./multimedia/"
+    cp -v -p -t "./multimedia/" \
+        "${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/windowsmediaplugin.dll"
+    echo "Copied ${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/windowsmediaplugin.dll"
 fi
 
 # To determine which system libraries have to be copied in it requires

--- a/CI/package-mudlet-for-windows.sh
+++ b/CI/package-mudlet-for-windows.sh
@@ -44,6 +44,7 @@
 # 3 - Unsupported build type
 # 4 - Directory to be used to assemble the package is NOT empty
 # 6 - No Mudlet.exe file found to work with
+# 7 - Mudlet will not have sound because windowsmediaplugin.dll not found
 
 if [ "${MSYSTEM}" = "MSYS" ]; then
   echo "Please run this script from an MINGW32 or MINGW64 type bash terminal appropriate"
@@ -116,7 +117,19 @@ else
 fi
 ZIP_FILE_NAME="Mudlet-${MSYSTEM}"
 
+# Making sure that the WMF backend DLL is being copied
+if [ "${BUILD_BITNESS}" = "64" ]; then
+	if [ ! -f "${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/windowsmediaplugin.dll" ]; then
+	  echo "ERROR: windowsmediaplugin.dll not found - Mudlet will no have sound in windows"
+	  echo "Install package mingw-w64-x86_64-qt6-multimedia-wmf to solve"
+	  exit 7
+	fi
 
+	mkdir -p "./multimedia/"
+	cp -v -p -t "./multimedia/" \
+		"${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/windowsmediaplugin.dll"
+	echo "Copied ${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/windowsmediaplugin.dll"
+fi
 
 # To determine which system libraries have to be copied in it requires
 # continually trying to run the executable on the target type system

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -98,7 +98,7 @@ if [ "${MSYSTEM}" = "MINGW64" ]; then
     if /usr/bin/pacman -Su --needed --noconfirm \
       "mingw-w64-${BUILDCOMPONENT}-qt6-base" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia" \
-	  "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia-wmf" \
+      "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia-wmf" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-svg" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-speech" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-imageformats" \

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -98,13 +98,13 @@ if [ "${MSYSTEM}" = "MINGW64" ]; then
     if /usr/bin/pacman -Su --needed --noconfirm \
       "mingw-w64-${BUILDCOMPONENT}-qt6-base" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia" \
+	  "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia-wmf" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-svg" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-speech" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-imageformats" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-tools" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-5compat" \
-      "mingw-w64-${BUILDCOMPONENT}-qtkeychain-qt6" \
-	  "mingw-w64-${BUILDCOMPONENT}-qt6-declarative"; then
+      "mingw-w64-${BUILDCOMPONENT}-qtkeychain-qt6"; then
         break
     fi
 

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -103,7 +103,8 @@ if [ "${MSYSTEM}" = "MINGW64" ]; then
       "mingw-w64-${BUILDCOMPONENT}-qt6-imageformats" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-tools" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-5compat" \
-      "mingw-w64-${BUILDCOMPONENT}-qtkeychain-qt6"; then
+      "mingw-w64-${BUILDCOMPONENT}-qtkeychain-qt6" \
+	  "mingw-w64-${BUILDCOMPONENT}-qt6-declarative"; then
         break
     fi
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -157,6 +157,9 @@ int main(int argc, char* argv[])
     // print stdout to console if Mudlet is started in a console in Windows
     // credit to https://stackoverflow.com/a/41701133 for the workaround
 #ifdef Q_OS_WIN32
+#ifdef Q_PROCESSOR_X86_64
+    qputenv("QT_MEDIA_BACKEND", "windows");
+#endif
     if (AttachConsole(ATTACH_PARENT_PROCESS)) {
         freopen("CONOUT$", "w", stdout);
         freopen("CONOUT$", "w", stderr);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -429,7 +429,7 @@ int main(int argc, char* argv[])
         QCoreApplication::removeTranslator(commandLineTranslator);
         commandLineTranslator.clear();
     }
-	
+
     // Needed for Qt6 on Windows (at least) - and does not work in mudlet class c'tor
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
 #if defined(Q_OS_WIN32)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -430,19 +430,19 @@ int main(int argc, char* argv[])
         commandLineTranslator.clear();
     }
 	
-	// Needed for Qt6 on Windows (at least) - and does not work in mudlet class c'tor
+    // Needed for Qt6 on Windows (at least) - and does not work in mudlet class c'tor
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
 #if defined(Q_OS_WIN32)
     if (qEnvironmentVariableIsEmpty("QT_MEDIA_BACKEND")) {
         // This variable is not set - and later versions of Qt 6.x need it for
         // sound to work:
         if (qputenv("QT_MEDIA_BACKEND", QByteArray("windows"))) {
-            qDebug().noquote() << "main(...) INFO - setting QT_MEDIA_BACKEND enviromental varable to: \"windows\".";
+            qDebug().noquote() << "main(...) INFO - setting QT_MEDIA_BACKEND enviromental variable to: \"windows\".";
         } else {
-            qWarning().noquote() << "main(...) WARNING - failed to set QT_MEDIA_BACKEND enviromental varable to: \"windows\", sound may not work.";
+            qWarning().noquote() << "main(...) WARNING - failed to set QT_MEDIA_BACKEND enviromental variable to: \"windows\", sound may not work.";
         }
     } else {
-        qDebug().noquote().nospace() << "main(...) INFO - QT_MEDIA_BACKEND enviromental varable is set to: \"" << qgetenv("QT_MEDIA_BACKEND") << "\".";
+        qDebug().noquote().nospace() << "main(...) INFO - QT_MEDIA_BACKEND enviromental variable is set to: \"" << qgetenv("QT_MEDIA_BACKEND") << "\".";
     }
 #endif
 #endif


### PR DESCRIPTION

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Added package `mingw-w64-x86_64-qt6-multimedia-wmf` to Windows 64bits build and added enviroment variable `QT_MEDIA_BACKEND=windows` in the main function (code by @SlySven).

#### Motivation for adding to Mudlet

Solving audio problem in Windows and earning bounty

#### Other info (issues closed, discussion etc)

Closes #7311.
/claim #7311