### PR TITLE
Fix: slow text rendering in 4.18

### DIFF
--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -183,7 +183,7 @@ pacman -Rdd mingw-w64-${BUILDCOMPONENT}-harfbuzz
 echo "Building harfbuzz without graphite2"
 git clone https://github.com/harfbuzz/harfbuzz.git
 cd harfbuzz
-meson setup build --prefix=/mingw64 --buildtype=release -Dgraphite=disabled -Dtests=disabled
+meson setup build --prefix=/mingw${BUILD_BITNESS} --buildtype=release -Dgraphite=disabled -Dtests=disabled
 meson compile -C build
 meson install -C build
 

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -183,7 +183,7 @@ pacman -Rdd mingw-w64-${BUILDCOMPONENT}-harfbuzz
 echo "Building harfbuzz without graphite2"
 git clone https://github.com/harfbuzz/harfbuzz.git
 cd harfbuzz
-meson setup build --prefix=/clang64 --buildtype=release -Dgraphite=disabled -Dtests=disabled
+meson setup build --prefix=/mingw64 --buildtype=release -Dgraphite=disabled -Dtests=disabled
 meson compile -C build
 meson install -C build
 

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -178,7 +178,7 @@ while true; do
 done
 
 echo "Removing harfbuzz installed by qt"
-pacman -Rdd mingw-w64-${BUILDCOMPONENT}-harfbuzz
+pacman -Rdd --noconfirm mingw-w64-${BUILDCOMPONENT}-harfbuzz
 
 echo "Building harfbuzz without graphite2"
 git clone https://github.com/harfbuzz/harfbuzz.git

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -162,6 +162,8 @@ while true; do
     "mingw-w64-${BUILDCOMPONENT}-boost" \
     "mingw-w64-${BUILDCOMPONENT}-yajl" \
     "mingw-w64-${BUILDCOMPONENT}-lua-luarocks" \
+    "mingw-w64-${BUILDCOMPONENT}-meson" \
+    "mingw-w64-${BUILDCOMPONENT}-ninja" \
     "mingw-w64-${BUILDCOMPONENT}-jq"; then
       break
   fi
@@ -174,6 +176,16 @@ while true; do
   echo "=== Some packages failed to install, waiting and trying again ==="
   sleep 10
 done
+
+echo "Removing harfbuzz installed by qt"
+pacman -Rdd mingw-w64-${BUILDCOMPONENT}-harfbuzz
+
+echo "Building harfbuzz without graphite2"
+git clone https://github.com/harfbuzz/harfbuzz.git
+cd harfbuzz
+meson setup build --prefix=/clang64 --buildtype=release -Dgraphite=disabled -Dtests=disabled
+meson compile -C build
+meson install -C build
 
 echo ""
 echo "    Completed"


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This removes the qt-installed harfbuzz and installs from source a harfbuzz without the graphite2 shaper

#### Motivation for adding to Mudlet

Windows builds post-msys2 are using the graphite2 text shaper which apparently runs slower on some machines than other text shapers that Qt will default to. 

#### Other info (issues closed, discussion etc)

On older versions of Qt it was possible to disable this with a switch but it is now hardcoded so our options include removing graphite2 entirely from harfbuzz, and/or digging deeper into why graphite2 is slow. Further testing and analysis of possible manually compiled graphite2 and such will continue in my other PR https://github.com/Mudlet/Mudlet/pull/7392

Fix https://github.com/Mudlet/Mudlet/issues/7312
