### PR TITLE
improve: Consolidate profile loading logic

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2750,6 +2750,13 @@ void mudlet::doAutoLogin(const QString& profile_name)
     LuaInterface* lI = pHost->getLuaInterface();
     lI->getVars(true);
 
+    const auto it = TGameDetails::findGame(profile_name);
+    if (it != TGameDetails::scmDefaultGames.end()) {
+        pHost->setUrl((*it).hostUrl);
+        pHost->setPort((*it).port);
+        pHost->mSslTsl = (*it).tlsEnabled;
+    }
+
     const QString folder = getMudletPath(profileXmlFilesPath, profile_name);
     QDir dir(folder);
     dir.setSorting(QDir::Time);
@@ -2759,13 +2766,6 @@ void mudlet::doAutoLogin(const QString& profile_name)
     if (entries.isEmpty()) {
         preInstallPackages = true;
         pHost->mLoadedOk = true;
-
-        const auto it = TGameDetails::findGame(profile_name);
-        if (it != TGameDetails::scmDefaultGames.end()) {
-            pHost->setUrl((*it).hostUrl);
-            pHost->setPort((*it).port);
-            pHost->mSslTsl = (*it).tlsEnabled;
-        }
     } else {
         QFile file(qsl("%1%2").arg(folder, entries.at(0)));
         file.open(QFile::ReadOnly | QFile::Text);

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -346,6 +346,7 @@ public:
     // operating without either menubar or main toolbar showing.
     bool isControlsVisible() const;
     bool isGoingDown() { return mIsGoingDown; }
+    Host* loadProfile(const QString&, bool);
     bool loadReplay(Host*, const QString&, QString* pErrMsg = nullptr);
     bool loadWindowLayout();
     controlsVisibility menuBarVisibility() const { return mMenuBarVisibility; }


### PR DESCRIPTION
/claim #7334
/claim #7357

#### Brief overview of PR changes/additions

- Consolidates profile loading logic for both GUI dialogue loads and CLI loads in one function
- fixes bugs caused by predefined games not loading settings correctly in certain cases

#### Motivation for adding to Mudlet

Gets rid of errors about an empty URLs/ports and possibly unwanted SSL connections.

#### Other info (issues closed, discussion etc)

I decided to go with the approach of unconditionally loading settings for predefined games from `TGameDetails` because this would fix all existing cases of "broken" profiles, as opposed to the approach I suggested earlier, which would only have prevented further broken profiles being created. 

Unifying the duped logic was a bit intimidating seeing as most of those lines haven't been touched in a decade or so, but I tried to keep actual changes in what is being executed minimal. Though I did find a few things that were being done in only one branch but not the other, which seemed to me like they should have really been in both, and them not being so was a bug.

I'm actually not 100% sure if this solves #7357 (I can't reproduce it; config dumps from someone who can would be great), but logically this change _should_ fix any issues with loading settings for default games.