### PR TITLE
Fix: compiling Mudlet using older Qt 6.4

### DIFF
--- a/src/TLuaInterpreterTextToSpeech.cpp
+++ b/src/TLuaInterpreterTextToSpeech.cpp
@@ -137,7 +137,7 @@ void TLuaInterpreter::ttsStateChanged(QTextToSpeech::State state)
         case QTextToSpeech::State::Ready:
             event.mArgumentList.append(QLatin1String("ttsSpeechReady"));
             break;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
         // The Qt documentation is not clear exactly when this change was made
         // (it says nothing!) but it isn't present in 5.15.13 but is in 6.6.2
         case QTextToSpeech::State::Synthesizing:


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix: compiling Mudlet using older Qt 6.4, `TextToSpeech::State::Synthesizing` only became available in Qt 6.6 and is not available in Qt 6.4.
#### Motivation for adding to Mudlet
Fix compilation for Ubuntu 24.04 LTS.
#### Other info (issues closed, discussion etc)
Would be nice to have this straightforward fix merged quick.