### PR TITLE
Fix: system latency time not visible anymore

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -392,8 +392,8 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
         }
     }
 
-    mpBufferSearchBox->setMinimumSize(QSize(150, 30));
-    mpBufferSearchBox->setMaximumSize(QSize(250, 30));
+    mpBufferSearchBox->setMinimumSize(QSize(100, 30));
+    mpBufferSearchBox->setMaximumSize(QSize(150, 30));
     mpBufferSearchBox->setSizePolicy(sizePolicy5);
     mpBufferSearchBox->setFont(mpHost->mCommandLineFont);
     mpBufferSearchBox->setFocusPolicy(Qt::ClickFocus);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix: system latency time not visible anymore because the larger search box pushes it offscreen
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/7315
#### Other info (issues closed, discussion etc)
This does make the search box a bit too small for comfort, so a follow-up improvement in this area is welcome.