### PR TITLE
Infrastructure: allow modern Qt Creator to load Mudlet properly

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5779,7 +5779,7 @@ void TLuaInterpreter::loadGlobal()
         // and in a "src" subdirectory (to match the relative source file
         // location to that top-level project file) of the main project
         // "mudlet" directory:
-        QDir::toNativeSeparators(qsl("%1/../../mudlet/src/mudlet-lua/lua/LuaGlobal.lua").arg(executablePath))
+        QDir::toNativeSeparators(qsl("%1/../../../src/mudlet-lua/lua/LuaGlobal.lua").arg(executablePath))
     };
 
     // Although it is relatively easy to detect whether something is #define d

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -1056,6 +1056,7 @@ function loadTranslations(packageName, fileName, languageCode, folder)
   folder = folder or io.exists("../translations/lua") and "../translations/lua/"
   folder = folder or io.exists("../../translations/lua") and "../../translations/lua/"
   folder = folder or io.exists(luaGlobalPath.."/../../translations/lua") and luaGlobalPath.."/../../translations/lua/"
+  folder = folder or io.exists(luaGlobalPath.."/../../../translations/lua") and luaGlobalPath.."/../../../translations/lua/"
   folder = folder or luaGlobalPath.."/translations/"
 
   assert(type(packageName) == "string", string.format("loadTranslations: bad argument #1 type (packageName as string expected, got %s)", type(packageName)))
@@ -1250,18 +1251,18 @@ function getConfig(...)
       "forceNewEnvironNegotiationOff",
       "inputLineStrictUnixEndings",
       "logInHTML",
-      "mapExitSize", 
+      "mapExitSize",
       "mapperPanelVisible",
       "mapRoomSize",
-      "mapRoundRooms", 
+      "mapRoundRooms",
       "mapShowRoomBorders",
       "show3dMapView",
       "showRoomIdsOnMap",
       "showSentText",
-      "specialForceCompressionOff", 
+      "specialForceCompressionOff",
       "specialForceCharsetNegotiationOff",
-      "specialForceGAOff", 
-      "specialForceMxpNegotiationOff", 
+      "specialForceGAOff",
+      "specialForceMxpNegotiationOff",
     }
     for _,v in ipairs(list) do
       result[v] = oldgetConfig(v)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Adjust LuaGlobal.lua search path for Qt Creator 14 to find it properly.

Without this:
![image](https://github.com/user-attachments/assets/991c9909-5863-46cd-b915-88afed2efbce)


With this:
![Screenshot from 2024-08-22 16-47-56](https://github.com/user-attachments/assets/bef58c03-a372-4b64-843a-cc8ea629e16d)

#### Motivation for adding to Mudlet
Better DevEx
#### Other info (issues closed, discussion etc)
