### PR TITLE
Fix: allow revised addRoom(...) to work without an area as second argument

### DIFF
--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -577,18 +577,53 @@ int TLuaInterpreter::addRoom(lua_State* L)
     const int id = getVerifiedInt(L, __func__, 1, "roomID");
     const Host& host = getHostFromLua(L);
     const bool added = host.mpMap->addRoom(id);
-    lua_pushboolean(L, added);
     if (added) {
         int areaID = -1;
-        if (lua_gettop(L) >= 2) {
+        if (lua_gettop(L) > 1) {
             areaID = getVerifiedInt(L, __func__, 2, "areaID");
         }
         // defer area calculations as all new rooms are initialised at 0,0,0 anyway
-        host.mpMap->setRoomArea(id, areaID, true);
-        host.mpMap->setUnsaved(__func__);
+        bool setArea = false;
+        if (areaID != -1) {
+            // The TMap::addRoom(...) call will have put the room in the -1 area
+            if (host.mpMap->setRoomArea(id, areaID, true)) {
+                setArea = true;
+            } else {
+                // However setRoomArea(...) fails when the area does not exist
+                // so force the area to -1 as a failback - though this happens
+                // automatically merely by creating the room we need to call
+                // the setRoomArea(...) WITHOUT deferring the area
+                // recalculations otherwise the room becomes a ghost that is not
+                // revealed without reloading the map or running the auditArea()
+                // Lua API function:
+                areaID = -1;
+            }
+
+        } else {
+            // setting the Area to the default area always works but we need to
+            // set the flag that says we managed it to avoid returning the nil +
+            // error message in the other case where we failed to set another
+            // area:
+            setArea = true;
+        }
+
+        if (!setArea) {
+            lua_pushnil(L);
+            lua_pushfstring(L, "addRoom: created roomID %d but failed to place it in areaID %d, does that area actually exist?", id, areaID);
+            return 2;
+        }
+
+        // in testing it was found that deferring the recalcualation for
+        // the default area ended up hiding the rooms even if (as it is by
+        // default) the default area is viewable - they only became visible
+        // after saving and reloading the map or by running auditAreas()
+        host.mpMap->setRoomArea(id, areaID, false);
+
+        // a previous version had calls to functions that would be done anyway
+        // so they do not need repeating here
         host.mpMap->update();
-        host.mpMap->mMapGraphNeedsUpdate = true;
     }
+    lua_pushboolean(L, added);
     return 1;
 }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Moves a line of code that was clobbering the Lua <==> C argument passing "stack" (it was outputting a boolean value and overwriting a value that was needed as an input for code later in the function) so that it now acts after the inputting parts are done.

#### Motivation for adding to Mudlet
To fix a defect introduced by #7184 which meant that not providing a second argument to the revised `addRoom(...)` function meant it read a `true` value that it had itself placed into the argument stack.

#### Other info (issues closed, discussion etc)
Also fixed an more minor issue where providing an invalid area still seemed to work correctly in that a `true` value was returned to the caller. The room was and now still is created but it now causes a nil+error message to be returned. The room would instead be placed in the "Default Area" - HOWEVER deferring the recalculations for that area seems to hide the room in the map - it becomes a "ghost" that does have the right coordinates and area number (as revealed by `getRoomCoordinates(...)` and `getRoomArea(...)`) but it does not show in the mapper until the map is saved and reloaded (or the Lua `auditAreas()` function is used - which happens during a map load).
