### PR TITLE
Infrastructure: ignore .cache folder from Qt Creator's clangd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ qrc_*.cpp
 mudlet
 app-build.txt
 
+# Qt creator's clangd cache
+.cache
+
 # ignore macOS apps in general, but keep the Autoupdater from Sparkle
 3rdparty/boost/*
 3rdparty/cocoapods/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,10 +4,12 @@
   // files to exclude from clang-tidy code analysis
   "C_Cpp.files.exclude": {
     "**/3rdparty": true,
-    "**/ui_*.h": true
+    "**/ui_*.h": true,
+    ".cache": true,
   },
   // don't show 3rdparty files in explorer nor search
   "files.exclude": {
-    "3rdparty/": true
+    "3rdparty/": true,
+    ".cache": true,
   }
 }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Ignore .cache folder from Qt Creator's clangd, which is large and doesn't need to be checked in
#### Motivation for adding to Mudlet
Keeping things tidy
#### Other info (issues closed, discussion etc)
