### PR TITLE
Fix: remove memory leak from use of QSignalMapper

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2904,7 +2904,7 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
         //add our actions
         QMapIterator<QString, QStringList> it2(mUserActions);
         auto mapper = new QSignalMapper(popup);
-        mapper->setObjectName(qsl("T2DMap_userActionsMapper_%1").arg(QDateTime::currentDateTime().toString("hh:mm:ss")));
+        
         while (it2.hasNext()) {
             it2.next();
             QStringList actionInfo = it2.value();

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2895,7 +2895,7 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
             it.next();
             QStringList menuInfo = it.value();
             const QString menuParent = menuInfo[0];
-            if (menuParent == "") { //parentless
+            if (menuParent.isEmpty()) { //parentless
                 popup->addMenu(userMenus[it.key()]);
             } else { //has a parent
                 userMenus[menuParent]->addMenu(userMenus[it.key()]);
@@ -2903,7 +2903,8 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
         }
         //add our actions
         QMapIterator<QString, QStringList> it2(mUserActions);
-        auto mapper = new QSignalMapper(this);
+        auto mapper = new QSignalMapper(popup);
+        mapper->setObjectName(qsl("T2DMap_userActionsMapper_%1").arg(QDateTime::currentDateTime().toString("hh:mm:ss")));
         while (it2.hasNext()) {
             it2.next();
             QStringList actionInfo = it2.value();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The context menu for the 2D mapper uses a `QSignalMapper` that is allocated off the heap with `new` however it is parented to the `T2DMap` class instance and is never explicitly `delete`d. As such, instances build up during the lifetime of a profile (one for every time a right-click on the 2D mapper generates a context menu). This PR fixes that by parenting the mapper to the menu itself which is itself short-term and does not persist longer than necessary.

#### Motivation for adding to Mudlet
Avoiding a memory leak that accumulates during the life-time of the mapper widget in a profile.

#### Other info (issues closed, discussion etc)
~~The first commit also assigns an "object name" which includes a dateTime stamp to each `QSignalMapper` as it is created - this makes it easier to spot when running a suitable Mudlet build and examining it with the [GammaRay](https://www.kdab.com/development-resources/qt-tools/gammaray/) tool.~~

~~This should be removed and the PR "un-drafted" before merging the PR - and this and the prior paragraphs not included in the commit message...~~

Also in passing I spotted a near-by `QString` being compared against a raw C empty string - which I fixed because we have a coding style that says we should be using `QString::isEmpty()` to better state the code intent and to avoid raw string literals.