### PR TITLE
Infrastructure: ensure QSettings files are backward compatible for Qt5

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -785,6 +785,10 @@ void mudlet::setupConfig()
     qDebug() << "mudlet::setupConfig() INFO:" << "using config dir:" << confPath;
 
     mpSettings = new QSettings(qsl("%1/Mudlet.ini").arg(confPath), QSettings::IniFormat);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    // This will ensure compatibility going forward and backward
+    mpSettings->setIniCodec(QTextCodec::codecForName("UTF-8"));
+#endif
     migrateConfig(*mpSettings);
 }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Conditionally on being built with Qt 5.x libraries ensure that the codec used for accessing an INI format Mudlet `QSettings` file uses the UTF-8 encoding that Qt 6.x is fixed on.

#### Motivation for adding to Mudlet
I've previously put in the exact same "fix" in other places where I used `QSettings` for some *per-profile* details.

#### Other info (issues closed, discussion etc)
I spotting this in the documentation for the Qt6 `QSettings` class about the `QSettings::IniFormat` type:
> In line with most implementations today, QSettings will assume that
> values in the INI file are utf-8 encoded. This means that values will be
> decoded as utf-8 encoded entries and written back as utf-8. To retain
> backward compatibility with older Qt versions, keys in the INI file are
> written in %-encoded format, but can be read in both %-encoded and utf-8
> formats.
>
> **Compatibility with older Qt versions**
> Please note that this behavior is different to how QSettings behaved in
> versions of Qt prior to Qt 6. INI files written with Qt 5 or earlier are
> however fully readable by a Qt 6 based application (unless a ini codec
> different from utf8 had been set). But INI files written with Qt 6 will
> only be readable by older Qt versions if you set the "iniCodec" to a
> utf-8 textcodec.