### PR TITLE
fix debug message in getNamedTimers

### DIFF
--- a/src/mudlet-lua/lua/IDManager.lua
+++ b/src/mudlet-lua/lua/IDManager.lua
@@ -367,7 +367,7 @@ end
 
 -- Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getNamedTimers
 function getNamedTimers(user)
-  local funcName = "stopNamedTimers"
+  local funcName = "getNamedTimers"
   local userType = type(user)
   if userType ~= "string" then
     printError(userErrorMsg(funcName, userType), true, true)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
fix debug message in getNamedTimers where message showed stopNamedTimers instead

#### Motivation for adding to Mudlet
better user experience

#### Other info (issues closed, discussion etc)
