### PR TITLE
Infrastructure: separate debug #DEFINEs for UTF-8 decoding & Unicoode graphemes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -510,9 +510,40 @@ add_executable(mudlet ${mudlet_SRCS} ${mudlet_RCCS} ${mudlet_HDRS} ${mudlet_UIS}
 # target_compile_definitions(mudlet PRIVATE DEBUG_EASTER_EGGS)
 #
 # * Comment this to not get debugging messages about WILL/WONT/DO/DONT and other
-# commands for suboptions - change the value to 2 to get a bit more detail
-# about the size or nature of the command:
+#   commands for suboptions - change the value to 2 to get a bit more detail
+#   about the size or nature of the command:
 target_compile_definitions(mudlet PRIVATE DEBUG_TELNET=1)
+#
+# * Produce qDebug() messages about the decoding of UTF-8 data when it is not
+#   the single bytes of pure ASCII text:
+# target_compile_definitions(mudlet PRIVATE DEBUG_UTF8_PROCESSING)
+#
+# * Produce qDebug() messages about the decoding of GB2312/GBK/GB18030 data when
+#   it is not the single bytes of pure ASCII text:
+# target_compile_definitions(mudlet PRIVATE DEBUG_GB_PROCESSING)
+#
+# * Produce qDebug() messages about the decoding of BIG5 data when it is not the
+#   single bytes of pure ASCII text:
+# target_compile_definitions(mudlet PRIVATE DEBUG_BIG5_PROCESSING)
+#
+# * Produce qDebug() messages about the decoding of EUC-KR data when it is not
+#   the single bytes of pure ASCII text:
+# target_compile_definitions(mudlet PRIVATE DEBUG_EUC_KR_PROCESSING)
+#
+# * Produce qDebug() messages about the decoding of ANSI SGR sequences:
+#   target_compile_definitions(mudlet PRIVATE DEBUG_SGR_PROCESSING)
+#
+# * Produce qDebug() messages about the decoding of ANSI OSC sequences:
+# target_compile_definitions(mudlet PRIVATE DEBUG_OSC_PROCESSING)
+#
+# * Produce qDebug() messages about the decoding of ANSI MXP sequences although
+#   there is not much against this item at present {only an announcement of the
+#   type (?) of an `\x1b[?z` received}:
+# target_compile_definitions(mudlet PRIVATE DEBUG_MXP_PROCESSING)
+#
+# * Enable the features associated with reporting problems in processing Unicode
+#   codepoints that cannot be displayed on screen in a `TConsole`:
+# target_compile_definitions(mudlet PRIVATE DEBUG_CODEPOINT_PROBLEMS)
 
 target_sources(mudlet PRIVATE "${mudlet_BINARY_DIR}/translations/translated/qm.qrc")
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -33,28 +33,6 @@
 #include <QRegularExpression>
 #include "post_guard.h"
 
-// Define this to get qDebug() messages about the decoding of UTF-8 data when it
-// is not the single bytes of pure ASCII text:
-// #define DEBUG_UTF8_PROCESSING
-// Define this to get qDebug() messages about the decoding of GB2312/GBK/GB18030
-// data when it is not the single bytes of pure ASCII text:
-// #define DEBUG_GB_PROCESSING
-// Define this to get qDebug() messages about the decoding of BIG5
-// data when it is not the single bytes of pure ASCII text:
-// #define DEBUG_BIG5_PROCESSING
-// Define this to get qDebug() messages about the decoding of EUC-KR
-// data when it is not the single bytes of pure ASCII text:
-// #define DEBUG_EUC_KR_PROCESSING
-// Define this to get qDebug() messages about the decoding of ANSI SGR sequences:
-// #define DEBUG_SGR_PROCESSING
-// Define this to get qDebug() messages about the decoding of ANSI OSC sequences:
-// #define DEBUG_OSC_PROCESSING
-// Define this to get qDebug() messages about the decoding of ANSI MXP sequences
-// although there is not much against this item at present {only an announcement
-// of the type (?) of an `\x1b[?z` received}:
-//#define DEBUG_MXP_PROCESSING
-
-
 TChar::TChar(const QColor& foreground, const QColor& background, const TChar::AttributeFlags flags, const int linkIndex)
 : mFgColor(foreground)
 , mBgColor(background)

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -553,7 +553,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
 
 TConsole::~TConsole()
 {
-#if defined(DEBUG_UTF8_PROCESSING)
+#if defined(DEBUG_CODEPOINT_PROBLEMS)
     if (mType & ~CentralDebugConsole) {
         // Codepoint issues reporting is not enabled for the CDC:
         mUpperPane->reportCodepointErrors();

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -85,9 +85,6 @@ TTextEdit::TTextEdit(TConsole* pC, QWidget* pW, TBuffer* pB, Host* pH, bool isLo
 // Should be the same as the size of the timeStampFormat constant in the TBuffer
 // class:
 , mTimeStampWidth(13)
-#if defined(DEBUG_UTF8_PROCESSING)
-, mShowAllCodepointIssues(false)
-#endif
 , mMouseWheelRemainder()
 {
     mLastClickTimer.start();
@@ -99,7 +96,7 @@ TTextEdit::TTextEdit(TConsole* pC, QWidget* pW, TBuffer* pB, Host* pH, bool isLo
         mpHost->setDisplayFontFixedPitch(true);
         setFont(hostFont);
 
-#if defined(DEBUG_UTF8_PROCESSING)
+#if defined(DEBUG_CODEPOINT_PROBLEMS)
         // There is no point in setting this option on the Central Debug Console
         // as A) it is shared and B) any codepoints that it can't handle will
         // probably have already cropped up on another TConsole:
@@ -755,7 +752,7 @@ int TTextEdit::getGraphemeWidth(uint unicode) const
     case 2: // Draw as wide
         return 2;
     case widechar_nonprint:
-#if defined(DEBUG_UTF8_PROCESSING)
+#if defined(DEBUG_CODEPOINT_PROBLEMS)
         // -1 = The character is not printable - so put in a replacement
         // character instead - and so it can be seen it need a space:
         if (!mIsLowerPane) {
@@ -774,7 +771,7 @@ int TTextEdit::getGraphemeWidth(uint unicode) const
 #endif
         return 0;
     case widechar_non_character:
-#if defined(DEBUG_UTF8_PROCESSING)
+#if defined(DEBUG_CODEPOINT_PROBLEMS)
         // -7 = The character is a non-character - we might make use of some of them for
         // internal purposes in the future (in which case we might need additional code here
         // or elsewhere) but we don't right now:
@@ -794,7 +791,7 @@ int TTextEdit::getGraphemeWidth(uint unicode) const
 #endif
         return 0;
     case widechar_combining:
-#if defined(DEBUG_UTF8_PROCESSING)
+#if defined(DEBUG_CODEPOINT_PROBLEMS)
         // -2 = The character is a zero-width combiner - and should not be
         // present as the FIRST codepoint in a grapheme so this indicates an
         // error somewhere - so put in the replacement character
@@ -817,7 +814,7 @@ int TTextEdit::getGraphemeWidth(uint unicode) const
         // -3 = The character is East-Asian ambiguous width.
         return mWideAmbigousWidthGlyphs ? 2 : 1;
     case widechar_private_use:
-#if defined(DEBUG_UTF8_PROCESSING)
+#if defined(DEBUG_CODEPOINT_PROBLEMS)
         // -4 = The character is for private use - we cannot know for certain
         // what width to used - let's assume 1 for the moment:
         if (!mIsLowerPane) {
@@ -836,7 +833,7 @@ int TTextEdit::getGraphemeWidth(uint unicode) const
 #endif
         return 1;
     case widechar_unassigned:
-#if defined(DEBUG_UTF8_PROCESSING)
+#if defined(DEBUG_CODEPOINT_PROBLEMS)
         // -5 = The character is unassigned - at least for the Unicode version
         // that our widechar_wcwidth(...) was built for - assume 1:
         if (!mIsLowerPane) {
@@ -2805,7 +2802,7 @@ void TTextEdit::slot_changeIsAmbigousWidthGlyphsToBeWide(const bool state)
     }
 }
 
-#if defined(DEBUG_UTF8_PROCESSING)
+#if defined(DEBUG_CODEPOINT_PROBLEMS)
 void TTextEdit::slot_changeDebugShowAllProblemCodepoints(const bool state)
 {
     if (mShowAllCodepointIssues != state) {
@@ -2838,7 +2835,7 @@ void TTextEdit::slot_mouseAction(const QString &uniqueName)
 }
 
 
-#if defined(DEBUG_UTF8_PROCESSING)
+#if defined(DEBUG_CODEPOINT_PROBLEMS)
 // Originally this was going to be part of the destructor - but it was unable
 // to get the parent Console and Profile names at that point:
 void TTextEdit::reportCodepointErrors()

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -94,7 +94,7 @@ public:
     int getColumnCount();
     int getRowCount();
 
-#if defined(DEBUG_UTF8_PROCESSING)
+#if defined(DEBUG_CODEPOINT_PROBLEMS)
     void reportCodepointErrors();
 #endif
 
@@ -148,7 +148,7 @@ public slots:
     void slot_searchSelectionOnline();
     void slot_analyseSelection();
     void slot_changeIsAmbigousWidthGlyphsToBeWide(bool);
-#if defined(DEBUG_UTF8_PROCESSING)
+#if defined(DEBUG_CODEPOINT_PROBLEMS)
     void slot_changeDebugShowAllProblemCodepoints(const bool);
 #endif
     void slot_mouseAction(const QString&);
@@ -229,8 +229,8 @@ private:
     // making this a const value for the moment:
     const int mTimeStampWidth;
 
-#if defined(DEBUG_UTF8_PROCESSING)
-    bool mShowAllCodepointIssues;
+#if defined(DEBUG_CODEPOINT_PROBLEMS)
+    bool mShowAllCodepointIssues = false;
     // Marked mutable so that it is permissible to change this in class methods
     // that are otherwise const!
     mutable QHash<uint, std::tuple<uint, std::string>> mProblemCodepoints;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -768,7 +768,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     setColors2();
 
 
-#if defined(DEBUG_UTF8_PROCESSING)
+#if defined(DEBUG_CODEPOINT_PROBLEMS)
     checkBox_debugShowAllCodepointProblems->setChecked(pHost->debugShowAllProblemCodepoints());
 #else
     checkBox_debugShowAllCodepointProblems->hide();

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -280,6 +280,37 @@ isEmpty( OWN_QTKEYCHAIN_TEST ) | !equals( OWN_QTKEYCHAIN_TEST, "NO" ) {
 # commands for suboptions - change the value to 2 to get a bit more detail
 # about the size or nature of the command:
 DEFINES+=DEBUG_TELNET=1
+#
+# * Produce qDebug() messages about the decoding of UTF-8 data when it is not
+# the single bytes of pure ASCII text:
+# DEFINES+=DEBUG_UTF8_PROCESSING
+#
+# * Produce qDebug() messages about the decoding of GB2312/GBK/GB18030 data when
+# it is not the single bytes of pure ASCII text:
+# DEFINES+=DEBUG_GB_PROCESSING
+#
+# * Produce qDebug() messages about the decoding of BIG5 data when it is not the
+# single bytes of pure ASCII text:
+# DEFINES+=DEBUG_BIG5_PROCESSING
+#
+# * Produce qDebug() messages about the decoding of EUC-KR data when it is not
+# the single bytes of pure ASCII text:
+# DEFINES+=DEBUG_EUC_KR_PROCESSING
+#
+# * Produce qDebug() messages about the decoding of ANSI SGR sequences:
+# DEFINES+=DEBUG_SGR_PROCESSING
+#
+# * Produce qDebug() messages about the decoding of ANSI OSC sequences:
+# DEFINES+=DEBUG_OSC_PROCESSING
+#
+# * Produce qDebug() messages about the decoding of ANSI MXP sequences although
+# there is not much against this item at present {only an announcement of the
+# type (?) of an `\x1b[?z` received}:
+# DEFINES+=DEBUG_MXP_PROCESSING
+#
+# * Enable the features associated with reporting problems in processing Unicode
+# codepoints that cannot be displayed on screen in a `TConsole`:
+# DEFINES+=DEBUG_CODEPOINT_PROBLEMS
 
 unix:!macx {
 # Distribution packagers would be using PREFIX = /usr but this is accepted


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Move the code that was made to be conditionally compiled by PR #7332 to be dependent on a different symbol `DEBUG_CODEPOINT_PROBLEMS` than the one it had been assigned to by that (PR `DEBUG_UTF8_PROCESSING`). Also move the place where several such `DEBUG_XXXX` symbols would be specified from the top of `src/TBuffer.cpp` to the project build files as I suggested we did in issue #6314.

#### Motivation for adding to Mudlet
The mentioned PR added some conditional compilation around prior code of mine that would report problems in processing/displaying codepoints. Unfortunately, IMHO, this was arranged to be gated by a symbol which I had created for a somewhat different purpose such that they were lumped together and when I wanted to enable the original extra bit of code whilst working on #7431 I found that I was getting more than I expected (or I would have done if the `#define` would have been visible to the other "compilation units" that had been modified to use it.

#### Other info (issues closed, discussion etc)
