### PR TITLE
Infrastructure: name the two panes and splitter in each TConsole

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -27,7 +27,6 @@
 #include "Host.h"
 #include "TConsole.h"
 #include "TMainConsole.h"
-#include "TSplitter.h"
 #include "TTabBar.h"
 #include "TTextEdit.h"
 #include "TEvent.h"

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -217,22 +217,23 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     mpScrollBar->setFixedWidth(15);
     mpHScrollBar->setFixedHeight(15);
 
-    splitter = new TSplitter(Qt::Vertical);
+    splitter = new TSplitter(Qt::Vertical, layer);
+    splitter->setObjectName(qsl("splitter_%1_%2").arg(mProfileName, mConsoleName));
     splitter->setContentsMargins(0, 0, 0, 0);
     splitter->setSizePolicy(sizePolicy);
-    splitter->setOrientation(Qt::Vertical);
     splitter->setHandleWidth(3);
     //QSplitter covers the background if not set to transparent and a new AppStyleSheet is set for example by DarkTheme
     auto styleSheet = qsl("QSplitter { background-color: rgba(0,0,0,0) }");
     splitter->setStyleSheet(styleSheet);
-    splitter->setParent(layer);
 
     mUpperPane = new TTextEdit(this, splitter, &buffer, mpHost, false);
+    mUpperPane->setObjectName(qsl("upperPane_%1_%2").arg(mProfileName, mConsoleName));
     mUpperPane->setContentsMargins(0, 0, 0, 0);
     mUpperPane->setSizePolicy(sizePolicy3);
     mUpperPane->setAccessibleName(tr("main window"));
 
     mLowerPane = new TTextEdit(this, splitter, &buffer, mpHost, true);
+    mLowerPane->setObjectName(qsl("lowerPane_%1_%2").arg(mProfileName, mConsoleName));
     mLowerPane->setContentsMargins(0, 0, 0, 0);
     mLowerPane->setSizePolicy(sizePolicy3);
 

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -32,7 +32,6 @@
 #include "TLabel.h"
 #include "TMap.h"
 #include "TRoomDB.h"
-#include "TSplitter.h"
 #include "TTextEdit.h"
 #include "dlgMapper.h"
 #include "mudlet.h"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Assigns a distinct `objectName` to these three elements of a `TConsole`:
* "splitter_" + Profile Name + "_" + Console Name - the layout for both panes and the "handle" between them.
* "upperPane_" + Profile Name + "_" + Console Name - the always visible one that can be scrolled back to see historic text
* "lowerPane_" + Profile Name + "_" + Console Name - the hide-able one that shows the current text as it arrives whiles the upper pane is scrolled back.

#### Motivation for adding to Mudlet
To make it possible to target these items (via a suitable selector) in styles.

#### Other info (issues closed, discussion etc)
This also removes a few unneeded lines from a couple of files.