### PR TITLE
Fix: Mac ⌘ for Mute All Media & Max Tutorial 

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -742,7 +742,7 @@ void TTextEdit::drawGraphemeForeground(QPainter& painter, const QColor& fgColor,
 int TTextEdit::getGraphemeWidth(uint unicode) const
 {
     // https://github.com/ridiculousfish/widecharwidth/issues/11
-    if (unicode == 0x1F6E1) {
+    if (unicode == 0x1F6E1 || unicode == 0x2318) {
         return 2;
     }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3015,14 +3015,14 @@ void mudlet::toggleMute(bool state, QAction* toolbarAction, QAction* menuAction,
         mpActionMuteGame->setIcon(QIcon(mMuteGame ? qsl(":/icons/unmute.png") : qsl(":/icons/mute.png")));
     }
 
-    // Toolbar icon. "Mute" when any protocol is unmuted. "Unmute" only when all protocols are muted.
+    // Toolbar icon. "Mute all media" when any protocol is unmuted. "Unmute all media" only when all protocols are muted.
     const bool isMediaMuted = mediaMuted();
     mpActionMuteMedia->setIcon(QIcon(isMediaMuted ? qsl(":/icons/unmute.png") : qsl(":/icons/mute.png")));
     mpActionMuteMedia->setText(isMediaMuted ? tr("Unmute all media") : tr("Mute all media"));
     mpActionMuteMedia->setChecked(isMediaMuted);
     dactionMuteMedia->setChecked(isMediaMuted);
-    mpButtonMute->setText(isMediaMuted ? tr("Unmute") : tr("Mute"));
-    mpButtonMute->setChecked(false);
+    mpButtonMute->setText(isMediaMuted ? tr("Unmute all media") : tr("Mute all media"));
+    mpButtonMute->setChecked(isMediaMuted);
     mpButtonMute->setEnabled(true);
 
     // Notify when all media is muted or all media is unmuted. Helps if the shortcut is hit accidentally.
@@ -3030,17 +3030,22 @@ void mudlet::toggleMute(bool state, QAction* toolbarAction, QAction* menuAction,
         QString message;
 
         for (auto pHost : mHostManager) {
-            const QKeySequence* sequence = pHost->profileShortcuts.value(qsl("Mute all media"));
+            if (mudlet::self()->showMuteAllMediaTutorial()) {
+                const QKeySequence* sequence = pHost->profileShortcuts.value(qsl("Mute all media"));
 
-            if (sequence && !sequence->toString().isEmpty()) {
-                message = isMediaMuted
-                    ? tr("[ INFO ]  - Mudlet and game sounds are muted. Use %1 to unmute.").arg(sequence->toString())
-                    : tr("[ INFO ]  - Mudlet and game sounds are unmuted. Use %1 to mute.").arg(sequence->toString());
-            } else {
-                message = isMediaMuted ? tr("[ INFO ]  - Mudlet and game sounds are muted.") : tr("[ INFO ]  - Mudlet and game sounds are unmuted.");
+                if (sequence && !sequence->toString().isEmpty()) {
+                    const QString seq = sequence->toString(QKeySequence::NativeText).split("", Qt::SkipEmptyParts).join(">+<");
+
+                    message = isMediaMuted
+                        ? tr("[ INFO ]  - Mudlet and game sounds are muted. Use <%1> to unmute.").arg(seq)
+                        : tr("[ INFO ]  - Mudlet and game sounds are unmuted. Use <%1> to mute.").arg(seq);
+                } else {
+                    message = isMediaMuted ? tr("[ INFO ]  - Mudlet and game sounds are muted.") : tr("[ INFO ]  - Mudlet and game sounds are unmuted.");
+                }
+
+                pHost->postMessage(message);
+                mudlet::self()->showedMuteAllMediaTutorial();
             }
-
-            pHost->postMessage(message);
         }
     }
 }
@@ -4995,6 +5000,16 @@ bool mudlet::showSplitscreenTutorial()
 void mudlet::showedSplitscreenTutorial()
 {
     mScrollbackTutorialsShown++;
+}
+
+bool mudlet::showMuteAllMediaTutorial()
+{
+    return !experiencedMudletPlayer() && mMuteAllMediaTutorialsShown < mMuteAllMediaTutorialsMax;
+}
+
+void mudlet::showedMuteAllMediaTutorial()
+{
+    mMuteAllMediaTutorialsShown++;
 }
 
 // returns true if the Mudlet player is considered 'experienced' and doesn't need to be shown the basic

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -420,6 +420,8 @@ public:
     bool mediaUnmuted() const { return !mMuteAPI && !mMuteGame; }
     bool showSplitscreenTutorial();
     void showedSplitscreenTutorial();
+    bool showMuteAllMediaTutorial();
+    void showedMuteAllMediaTutorial();
     bool experiencedMudletPlayer();
 
     Appearance mAppearance = Appearance::systemSetting;
@@ -743,10 +745,12 @@ private:
     // The collection of words in what mpHunspell_sharedDictionary points to:
     QSet<QString> mWordSet_shared;
 
-    // amount of times the shortcut to cancel split screen has been shown help educate new users
-    int mScrollbackTutorialsShown = 0;
-    // show the split screen tutorial maximum 3 times on a new Mudlet
-    static const int mScrollbackTutorialsMax = 3;
+    // amount of times the shortcut has been shown help educate new users
+    int mScrollbackTutorialsShown = 0; // Cancel split screen
+    int mMuteAllMediaTutorialsShown = 0; // Mute all media
+    // show the tutorial maximum 3 times on a new Mudlet
+    static const int mScrollbackTutorialsMax = 3; // Split screen
+    static const int mMuteAllMediaTutorialsMax = 3; // Mute all media
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(mudlet::controlsVisibility)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Update the [INFO] message when using `⌘K` to toggle Mute All / Unmute All. Align with the tutorial for split screen. Implement max tutorial check.


#### Motivation for adding to Mudlet
Correct user experience, similar PRs

#### Other info (issues closed, discussion etc)
Before on Mac:
<img width="550" alt="Screenshot 2024-09-15 at 3 03 48 PM" src="https://github.com/user-attachments/assets/1d3c79b2-45d1-402b-950a-f3f9068787f8">
After on Mac:
<img width="925" alt="Screenshot 2024-09-19 at 6 54 26 AM" src="https://github.com/user-attachments/assets/e71700ac-b7ee-467d-b454-bba3004cb602">