### PR TITLE
Add: Quick clear input-line functionality

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -382,11 +382,11 @@ bool TCommandLine::event(QEvent* event)
 #endif
                 // If EXACTLY Down is pressed without modifiers (special case
                 // for macOs - also sets KeyPad modifier)
-                bool bShouldClearInput = historyMove(MOVE_DOWN);
+                bool shouldClearInput = historyMove(MOVE_DOWN);
 
                 // If the user has pressed DOWN while in the middle of typing a command
                 // the command line should be cleared
-                if (bShouldClearInput) {
+                if (shouldClearInput) {
                     clear();
                 }
                 ke->accept();
@@ -1128,7 +1128,7 @@ void TCommandLine::handleAutoCompletion()
 
 bool TCommandLine::historyMove(MoveDirection direction)
 {
-    bool bShouldClearInput = false;
+    bool shouldClearInput = false;
     
     if (mHistoryList.empty()) {
         // If the history is empty, we may still want to clear the input line...
@@ -1152,7 +1152,7 @@ bool TCommandLine::historyMove(MoveDirection direction)
         }
     } else {
         if (direction == MOVE_DOWN && !toPlainText().isEmpty()) {
-            bShouldClearInput = true;
+            shouldClearInput = true;
         } else {
             mAutoCompletionCount += shift;
             handleAutoCompletion();
@@ -1160,7 +1160,7 @@ bool TCommandLine::historyMove(MoveDirection direction)
     }
     adjustHeight();
 
-    return bShouldClearInput;
+    return shouldClearInput;
 }
 
 void TCommandLine::slot_clearSelection(bool yes)

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1131,7 +1131,8 @@ bool TCommandLine::historyMove(MoveDirection direction)
     bool bShouldClearInput = false;
     
     if (mHistoryList.empty()) {
-        return bShouldClearInput;
+        // If the history is empty, we may still want to clear the input line...
+        return true;
     }
     const int shift = (direction == MOVE_UP ? 1 : -1);
     if ((textCursor().selectedText().size() == toPlainText().size()) || (toPlainText().isEmpty()) || !mpHost->mHighlightHistory) {

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -382,7 +382,13 @@ bool TCommandLine::event(QEvent* event)
 #endif
                 // If EXACTLY Down is pressed without modifiers (special case
                 // for macOs - also sets KeyPad modifier)
-                historyMove(MOVE_DOWN);
+                bool bShouldClearInput = historyMove(MOVE_DOWN);
+
+                // If the user has pressed DOWN while in the middle of typing a command
+                // the command line should be cleared
+                if (bShouldClearInput) {
+                    clear();
+                }
                 ke->accept();
                 return true;
             }
@@ -1117,11 +1123,15 @@ void TCommandLine::handleAutoCompletion()
 // cursor up/down: turns on autocompletion mode and cycles through all possible matches
 // In case nothing has been typed it cycles through the command history in
 // reverse order compared to cursor down.
+// If the user is currently typing in the command line, a DOWN key will indicate
+// that the input line should be cleared
 
-void TCommandLine::historyMove(MoveDirection direction)
+bool TCommandLine::historyMove(MoveDirection direction)
 {
+    bool bShouldClearInput = false;
+    
     if (mHistoryList.empty()) {
-        return;
+        return bShouldClearInput;
     }
     const int shift = (direction == MOVE_UP ? 1 : -1);
     if ((textCursor().selectedText().size() == toPlainText().size()) || (toPlainText().isEmpty()) || !mpHost->mHighlightHistory) {
@@ -1140,10 +1150,16 @@ void TCommandLine::historyMove(MoveDirection direction)
             moveCursor(QTextCursor::End);
         }
     } else {
-        mAutoCompletionCount += shift;
-        handleAutoCompletion();
+        if (direction == MOVE_DOWN && !toPlainText().isEmpty()) {
+            bShouldClearInput = true;
+        } else {
+            mAutoCompletionCount += shift;
+            handleAutoCompletion();
+        }
     }
     adjustHeight();
+
+    return bShouldClearInput;
 }
 
 void TCommandLine::slot_clearSelection(bool yes)

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -105,7 +105,7 @@ private:
     void spellCheck();
     void fillSpellCheckList(QMouseEvent*, QMenu*);
     void handleTabCompletion(bool);
-    void historyMove(MoveDirection);
+    bool historyMove(MoveDirection);
     void enterCommand(QKeyEvent*);
     void processNormalKey(QEvent*);
     bool keybindingMatched(QKeyEvent*);


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This adds functionality to handle input line clearing as described in Issue https://github.com/Mudlet/Mudlet/issues/7177

A user may press DOWN (with no modifiers) to quickly clear what they have typed in the command line.

The clearing functionality will only trigger if the user is in the middle of typing a command (nothing *selected* on the command line), and while not navigating through their command history. This allows history navigation and autocompletion to function as normal while allowing an additional feature of quickly clearing the command line.

#### Motivation for adding to Mudlet

Occasionally a player may find themself in the middle of typing a command when they wish to quickly switch to another command. Previously the options to clear the command line and start typing again involved either sending the unwanted command which could cause unwanted game lag set for the player (for example a backstab command on someone not there may result in a combat round of lag on a *miss*), or using multiple keystrokes to select all and clear with backspace.

#### Other info (issues closed, discussion etc)