### PR TITLE
Fix: Use Apple Emoji on MacOS

### DIFF
--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -2389,6 +2389,11 @@ int TLuaInterpreter::setFont(lua_State* L)
     // TODO issue #4159: a nonexisting font breaks the console
 #endif
 
+#if defined(Q_OS_MACOS) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    // Add Apple Color Emoji fallback.
+    QFont::insertSubstitution(font, qsl("Apple Color Emoji"));
+#endif
+
     auto console = CONSOLE(L, windowName);
     if (console == host.mpConsole) {
         // apply changes to main console and its while-scrolling component too.

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1160,6 +1160,10 @@ void XMLimport::readHost(Host* pHost)
                 // this font doesn't support it:
                 QFont::insertSubstitution(pHost->mDisplayFont.family(), qsl("Noto Color Emoji"));
 #endif
+#if defined(Q_OS_MACOS) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+                // Add Apple Color Emoji fallback.
+                QFont::insertSubstitution(pHost->mDisplayFont.family(), qsl("Apple Color Emoji"));
+#endif
                 pHost->setDisplayFontFixedPitch(true);
             } else if (name() == qsl("mCommandLineFont")) {
                 pHost->mCommandLineFont.fromString(readElementText());

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1903,6 +1903,11 @@ void dlgProfilePreferences::slot_setDisplayFont()
     QFont::insertSubstitution(pHost->mDisplayFont.family(), qsl("Noto Color Emoji"));
 #endif
 
+#if defined(Q_OS_MACOS) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    // Add Apple Color Emoji fallback.
+    QFont::insertSubstitution(pHost->mDisplayFont.family(), qsl("Apple Color Emoji"));
+#endif
+
     auto mainConsole = pHost->mpConsole;
     if (!mainConsole) {
         return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -215,6 +215,14 @@ int main(int argc, char* argv[])
     QAccessible::installFactory(Announcer::accessibleFactory);
 #endif
 
+#if defined(Q_OS_MACOS) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    // Apple Color Emoji Fallback
+    QFont defaultFont;
+    defaultFont.setFamily(defaultFont.defaultFamily());
+    QFont::insertSubstitution(defaultFont.family(), qsl("Apple Color Emoji"));
+    app->setFont(defaultFont);
+#endif
+
 #if defined(Q_OS_WIN32) && defined(INCLUDE_UPDATER)
     auto abortLaunch = runUpdate();
     if (abortLaunch) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -481,6 +481,10 @@ void mudlet::init()
     }
 
     const QFont mainFont = QFont(qsl("Bitstream Vera Sans Mono"), 8, QFont::Normal);
+    #if defined(Q_OS_MACOS) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    // Add Apple Color Emoji fallback.
+    QFont::insertSubstitution(mainFont.family(), qsl("Apple Color Emoji"));
+    #endif
     mpWidget_profileContainer->setFont(mainFont);
     mpWidget_profileContainer->show();
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Mudlet built with Qt5 on MacOS doesn't correctly fall back to using Apple Color Emoji for either user-selected or default system fonts.
This change adds Apple Color Emoji to the font family of both the user-selected font and the default system fonts, allowing for correct emoji display. This is especially visible with compound emoji that use ZWJ. 

As far as I can tell, this issue is greatly improved or non-existent in Qt6 on MacOS, so I've put these changes behind a QT_VERSION_CHECK for that reason.

#### Motivation for adding to Mudlet
I would like emoji to render nicely on the Mac. 


#### Other info (issues closed, discussion etc)
