### PR TITLE
Add: extend GUI Languages to support Hebrew

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1307,6 +1307,8 @@ void mudlet::scanForMudletTranslations(const QString& path)
                 currentTranslation.mNativeName = qsl("العربية");
             } else if (!languageCode.compare(QLatin1String("ko_KR"), Qt::CaseInsensitive)) {
                 currentTranslation.mNativeName = qsl("한국어");
+            } else if (!languageCode.compare(QLatin1String("he_IL"), Qt::CaseInsensitive)) {
+                currentTranslation.mNativeName = qsl("עִברִית");
             } else {
                 currentTranslation.mNativeName = languageCode;
             }

--- a/translations/lua/translated/mudlet-lua_he_IL.json
+++ b/translations/lua/translated/mudlet-lua_he_IL.json
@@ -1,0 +1,102 @@
+{
+  "AdjustableContainer.attach": {
+    "message": "צרף ל:",
+    "description": "attaches your container to a border"
+  },
+  "AdjustableContainer.bottom": {
+    "message": "תַחתִית",
+    "description": "one of the borders the container can be attached to"
+  },
+  "AdjustableContainer.top": {
+    "message": "עֶלִיוֹן",
+    "description": "one of the borders the container can be attached to"
+  },
+  "AdjustableContainer.left": {
+    "message": "שְׁמֹאל",
+    "description": "one of the borders the container can be attached to"
+  },
+  "AdjustableContainer.right": {
+    "message": "יָמִין",
+    "description": "one of the borders the container can be attached to"
+  },
+  "AdjustableContainer.custom": {
+    "message": "מִנְהָג:",
+    "description": "a menu item in the right click menu. it contains user/package made custom items"
+  },
+  "AdjustableContainer.lock": {
+    "message": "לִנְעוֹל:",
+    "description": "locks your container. Which means it's not movable/resizable anymore and changes some other properties depending on the Lockstyle (like hiding the borders)"
+  },
+  "AdjustableContainer.lockstyle": {
+    "message": "סגנון נעילה:",
+    "description": "different modes/styles to choose which will be the lock behaviour of the container"
+  },
+  "AdjustableContainer.standard": {
+    "message": "רָגִיל",
+    "description": "one of the Lockstyles. This Lockstyle is the standard setting, with a small margin on top to keep the right click menu usable"
+  },
+  "AdjustableContainer.light": {
+    "message": "דַל",
+    "description": "one of the Lockstyles. Can also be translated as simple. It is only hiding the min/restore labels the borders and margin stay intact"
+  },
+  "AdjustableContainer.full": {
+    "message": "מלא",
+    "description": "one of the Lockstyles. Can also be translated as complete as it's locking the container without any margin left for the right click menu."
+  },
+  "AdjustableContainer.border": {
+    "message": "לִגבּוֹל",
+    "description": "one of the Lockstyles which keeps the borders of the container visible."
+  },
+  "AdjustableContainer.save": {
+    "message": "לְהַצִיל",
+    "description": "saves the containers settings"
+  },
+  "AdjustableContainer.load": {
+    "message": "לִטעוֹן",
+    "description": "loads the previously saved settings of the container"
+  },
+  "AdjustableContainer.min_restore": {
+    "message": "דקות/שחזור",
+    "description": "label to minimize/restore the container"
+  },
+  "AdjustableContainer.connectTo": {
+    "message": "התחבר ל:",
+    "description": "connect your container to a border to create a frame"
+  },
+  "AdjustableContainer.disconnect": {
+    "message": "לְנַתֵק",
+    "description": "disconnect your container from the border frame"
+  },
+  "Mudlet.packageInstallSuccess": {
+    "message": "חבילה '%s' הותקנה בהצלחה.",
+    "description": "Success message after drag&drop of package file onto Mudlet - %s is the file name"
+  },
+  "Mudlet.packageInstallFail": {
+    "message": "התקנת '%s' נכשלה: %s",
+    "description": "Failure message after drag&drop of package file onto Mudlet - %s is the file name"
+  },
+  "Mudlet.moduleInstallSuccess": {
+    "message": "מודול '%s' הותקן בהצלחה.",
+    "description": "Success message after drag&drop of module file onto Mudlet - %s is the file name"
+  },
+  "Mudlet.moduleInstallFail": {
+    "message": "התקנת '%s' נכשלה: %s",
+    "description": "Failure message after drag&drop of module file onto Mudlet - %s is the file name"
+  },
+  "Mudlet.packageDownloading": {
+    "message": "הורדת חבילה מ- %s.",
+    "description": "Download package from Url for installation - %s is source url"
+  },
+  "Mudlet.prefixOk": {
+    "message": "[בסדר] -",
+    "description": "Start of the line for messages telling the player something is okay. Keep at 12 characters length for nice alignment!"
+  },
+  "Mudlet.prefixWarn": {
+    "message": "[אזהרה] -",
+    "description": "Start of the line for messages warning the player about something. Keep at 12 characters length for nice alignment!"
+  },
+  "Mudlet.prefixInfo": {
+    "message": "[מידע] -",
+    "description": "Start of the line for messages informing the player about something. Keep at 12 characters length for nice alignment!"
+  }
+}

--- a/translations/translated/mudlet_he_IL.ts
+++ b/translations/translated/mudlet_he_IL.ts
@@ -1,0 +1,14385 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="he_IL">
+<context>
+    <name>Discord</name>
+    <message>
+        <location filename="../src/discord.cpp" line="151"/>
+        <source>via Mudlet</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Feed</name>
+    <message>
+        <location filename="../3rdparty/dblsqd/dblsqd/feed.cpp" line="275"/>
+        <source>Too many redirects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/dblsqd/dblsqd/feed.cpp" line="284"/>
+        <source>No data received from server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/dblsqd/dblsqd/feed.cpp" line="295"/>
+        <source>Could not verify download integrity.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GLWidget</name>
+    <message>
+        <location filename="../src/glwidget.cpp" line="280"/>
+        <source>No rooms in the map - load another one, or start mapping from scratch to begin.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/glwidget.cpp" line="285"/>
+        <source>You do not have a map yet - load one, or start mapping from scratch to begin.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/glwidget.cpp" line="2110"/>
+        <source>Mapper: Cannot find a path from %1 to %2 using known exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/glwidget.cpp" line="282"/>
+        <source>You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>GMCPAuthenticator</name>
+    <message>
+        <location filename="../src/GMCPAuthenticator.cpp" line="96"/>
+        <source>[ WARN ]  - Could not log in to the game, is the login information correct?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/GMCPAuthenticator.cpp" line="99"/>
+        <source>[ WARN ]  - Could not log in to the game: %1</source>
+        <extracomment>%1 shows the reason for failure, could be authentication, etc.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Host</name>
+    <message>
+        <location filename="../src/Host.cpp" line="442"/>
+        <source>Text to send to the game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Host.cpp" line="487"/>
+        <source>[ ALERT ] - This profile will now save and close.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Host.cpp" line="747"/>
+        <source>Failed to open xml file &quot;%1&quot; inside module %2 to update it. Error message was: &quot;%3&quot;.</source>
+        <extracomment>This error message will appear when the xml file inside the module zip cannot be updated for some reason.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Host.cpp" line="758"/>
+        <source>Failed to save &quot;%1&quot; to module &quot;%2&quot;. Error message was: &quot;%3&quot;.</source>
+        <extracomment>This error message will appear when a module is saved as package but cannot be done for some reason.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Host.cpp" line="1058"/>
+        <source>[  OK  ]  - %1 Thanks a lot for using the Public Test Build!</source>
+        <comment>%1 will be a random happy emoji</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Host.cpp" line="1059"/>
+        <source>[  OK  ]  - %1 Help us make Mudlet better by reporting any problems.</source>
+        <comment>%1 will be a random happy emoji</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Host.cpp" line="1834"/>
+        <source>Unpacking module:
+&quot;%1&quot;
+please wait...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Host.cpp" line="1836"/>
+        <source>Unpacking package:
+&quot;%1&quot;
+please wait...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Host.cpp" line="1840"/>
+        <source>Unpacking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Host.cpp" line="2614"/>
+        <source>Playing %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Host.cpp" line="2617"/>
+        <location filename="../src/Host.cpp" line="2624"/>
+        <source>%1 at %2:%3</source>
+        <extracomment>%1 is the game name and %2:%3 is game server address like: mudlet.org:23</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Host.cpp" line="3030"/>
+        <location filename="../src/Host.cpp" line="4088"/>
+        <source>Map - %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Host.cpp" line="4104"/>
+        <source>Pre-Map loading(3) report</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Host.cpp" line="4114"/>
+        <source>Loading map(3) at %1 report</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>InvisibleNotification</name>
+    <message>
+        <location filename="../src/AnnouncerUnix.cpp" line="34"/>
+        <source>InvisibleNotification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnnouncerUnix.cpp" line="35"/>
+        <source>An invisible widget used as a workaround to announce text to the screen reader</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KeyUnit</name>
+    <message>
+        <location filename="../src/KeyUnit.cpp" line="352"/>
+        <source>%1undefined key (code: 0x%2)</source>
+        <comment>%1 is a string describing the modifier keys (e.g. &quot;shift&quot; or &quot;control&quot;) used with the key, whose &apos;code&apos; number, in %2 is not one that we have a name for. This is probably one of those extra keys around the edge of the keyboard that some people have.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MapInfoContributorManager</name>
+    <message>
+        <location filename="../src/mapInfoContributorManager.cpp" line="128"/>
+        <source>Area:%1%2 ID:%1%3 x:%1%4%1&lt;‑&gt;%1%5 y:%1%6%1&lt;‑&gt;%1%7 z:%1%8%1&lt;‑&gt;%1%9</source>
+        <extracomment>This text uses non-breaking spaces (as &apos;%1&apos;s, as Qt Creator cannot handle them literally in raw strings) and non-breaking hyphens which are used to prevent the line being split at some places it might otherwise be; when translating please consider at which points the text may be divided to fit onto more than one line. %2 is the (text) name of the area, %3 is the number for it, %4 to %9 are pairs (min &lt;-&gt; max) of extremes for each of x,y and z coordinates</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mapInfoContributorManager.cpp" line="144"/>
+        <source>Room Name: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mapInfoContributorManager.cpp" line="167"/>
+        <source>Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1current player location</source>
+        <extracomment>This text uses non-breaking spaces (as &apos;%1&apos;s, as Qt Creator cannot handle them literally in raw strings) and a non-breaking hyphen which are used to prevent the line being split at some places it might otherwise be; when translating please consider at which points the text may be divided to fit onto more than one line. This text is for when NO rooms are selected, %3 is the room number of, and %4-%6 are the x,y and z coordinates for, the current player&apos;s room.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mapInfoContributorManager.cpp" line="190"/>
+        <source>Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1selected room</source>
+        <extracomment>This text uses non-breaking spaces (as &apos;%1&apos;s, as Qt Creator cannot handle them literally in raw strings) and a non-breaking hyphen which are used to prevent the line being split at some places it might otherwise be; when translating please consider at which points the text may be divided to fit onto more than one line. This text is for when ONE room is selected, %3 is the room number of, and %4-%6 are the x,y and z coordinates for, the selected Room.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/mapInfoContributorManager.cpp" line="218"/>
+        <source>Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1center of %n selected rooms</source>
+        <extracomment>This text uses non-breaking spaces (as &apos;%1&apos;s, as Qt Creator cannot handle them literally in raw strings) and a non-breaking hyphen which are used to prevent the line being split at some places it might otherwise be; when translating please consider at which points the text may be divided to fit onto more than one line. This text is for when TWO or MORE rooms are selected; %1 is the room number for which %2-%4 are the x,y and z coordinates of the room nearest the middle of the selection. This room has the yellow cross-hairs. %n is the count of rooms selected and will ALWAYS be greater than 1 in this situation. It is provided so that non-English translations can select required plural forms as needed.</extracomment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="142"/>
+        <source>! %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="144"/>
+        <source>! %1 is away (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="146"/>
+        <source>! %1 is back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="153"/>
+        <source>! invited %1 to %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="156"/>
+        <source>! %2 invited to %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="163"/>
+        <source>! You have joined %1 as %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="165"/>
+        <source>! %1 has joined %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="172"/>
+        <source>! %1 kicked %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="180"/>
+        <source>! %1 mode is %2 %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="182"/>
+        <source>! %1 sets mode %2 %3 %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="199"/>
+        <source>[MOTD] %1%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="211"/>
+        <source>! %1 has %2 users: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="213"/>
+        <source>! %1 has %2 users</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="220"/>
+        <source>! %1 has changed nick to %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="230"/>
+        <source>! %1 replied in %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="233"/>
+        <location filename="../src/ircmessageformatter.cpp" line="282"/>
+        <source>! %1 time is %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="236"/>
+        <location filename="../src/ircmessageformatter.cpp" line="279"/>
+        <source>! %1 version is %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="252"/>
+        <source>[%1%2] %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="260"/>
+        <source>&amp;lt;%1%2&amp;gt; [%3] %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="274"/>
+        <source>[INFO] %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="301"/>
+        <location filename="../src/ircmessageformatter.cpp" line="327"/>
+        <source>[ERROR] %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="311"/>
+        <source>[Channel URL] %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="320"/>
+        <source>[%1] %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="334"/>
+        <source>! %1 has left %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="336"/>
+        <source>! %1 has left %2 (%3)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="345"/>
+        <source>! %1 replied in %2 seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="359"/>
+        <source>* %1 %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="365"/>
+        <source>&lt;b&gt;&amp;lt;%1&amp;gt;&lt;/b&gt; %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="374"/>
+        <source>! %1 has quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="376"/>
+        <source>! %1 has quit (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="384"/>
+        <source>! no topic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="393"/>
+        <source>[TOPIC] %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="397"/>
+        <source>! %2 cleared topic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="400"/>
+        <source>! %2 changed topic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="406"/>
+        <source>? %2 %3 %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="413"/>
+        <source>[WHOIS] %1 is %2@%3 (%4)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="414"/>
+        <source>[WHOIS] %1 is connected via %2 (%3)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="415"/>
+        <source>[WHOIS] %1 is connected since %2 (idle %3)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="417"/>
+        <source>[WHOIS] %1 is away: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="420"/>
+        <source>[WHOIS] %1 is logged in as %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="423"/>
+        <source>[WHOIS] %1 is connected from %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="426"/>
+        <source>[WHOIS] %1 is using a secure connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="429"/>
+        <source>[WHOIS] %1 is on %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="438"/>
+        <source>[WHOWAS] %1 was %2@%3 (%4)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="439"/>
+        <source>[WHOWAS] %1 was connected via %2 (%3)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="441"/>
+        <source>[WHOWAS] %1 was logged in as %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="449"/>
+        <source>[WHO] %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="451"/>
+        <source> - away</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="454"/>
+        <source> - server operator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="462"/>
+        <source>%1s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="469"/>
+        <source>%1 days</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="473"/>
+        <source>%1 hours</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="477"/>
+        <source>%1 mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ircmessageformatter.cpp" line="479"/>
+        <source>%1 secs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/io/baseplistparser.cpp" line="55"/>
+        <source>Start element not found!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/io/baseplistparser.cpp" line="67"/>
+        <source>line %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/io/baseplistparser.cpp" line="149"/>
+        <source>Expected %1 while parsing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/io/jsonparser.cpp" line="145"/>
+        <source>%1 @ line %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/io/keymapparser.cpp" line="82"/>
+        <source>No data found!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/io/keymapparser.cpp" line="89"/>
+        <source>Expected object in keymap
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/io/keymapparser.cpp" line="129"/>
+        <source>Invalid keysequence used %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/models/texteditorkeymap.cpp" line="379"/>
+        <source>Error parsing %1: %2 </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/models/textgrammar.cpp" line="306"/>
+        <source>Error reading file %1:%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/texteditorcontroller.cpp" line="435"/>
+        <source>%1 ranges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/texteditorcontroller.cpp" line="441"/>
+        <source>Line %1, Column %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/texteditorcontroller.cpp" line="444"/>
+        <source>, Offset %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/texteditorcontroller.cpp" line="448"/>
+        <source> | %1 chars selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/texteditorcontroller.cpp" line="452"/>
+        <source> | scope: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/texteditorcontroller.cpp" line="462"/>
+        <source> (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/views/texttheme.cpp" line="399"/>
+        <source>Error parsing theme %1:%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/views/texttheme.cpp" line="404"/>
+        <source>Error theme not found %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RoomIdLineEditDelegate</name>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="142"/>
+        <location filename="../src/dlgRoomExits.cpp" line="222"/>
+        <source>Entered number is invalid. If left like this, this exit will be deleted when &lt;tt&gt;save&lt;/tt&gt; is clicked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="143"/>
+        <location filename="../src/dlgRoomExits.cpp" line="147"/>
+        <location filename="../src/dlgRoomExits.cpp" line="223"/>
+        <location filename="../src/dlgRoomExits.cpp" line="227"/>
+        <source>Set the number of the room that this special exit goes to.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="151"/>
+        <location filename="../src/dlgRoomExits.cpp" line="231"/>
+        <source>The roomID of the room that this special exit leads to is expected here. If left like this, this exit will be deleted when &lt;tt&gt;save&lt;/tt&gt; is clicked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>T2DMap</name>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2575"/>
+        <source>Undo</source>
+        <extracomment>2D Mapper context menu (drawing custom exit line) item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2577"/>
+        <source>Undo last point</source>
+        <extracomment>2D Mapper context menu (drawing custom exit line) item tooltip</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2584"/>
+        <location filename="../src/T2DMap.cpp" line="2859"/>
+        <source>Properties</source>
+        <extracomment>2D Mapper context menu (drawing custom exit line) item name (but not used as display text as that is set separately)
+----------
+2D Mapper context menu (custom line editing) item name (but not used as display text as that is set separately)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2586"/>
+        <location filename="../src/T2DMap.cpp" line="2863"/>
+        <source>properties...</source>
+        <extracomment>2D Mapper context menu (drawing custom exit line) item display text (has to be entered separately as the ... would get stripped off otherwise)
+----------
+2D Mapper context menu (custom line editing) item display text (has to be entered separately as the ... would get stripped off otherwise</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2588"/>
+        <source>Change the properties of this line</source>
+        <extracomment>2D Mapper context menu (drawing custom exit line) item tooltip</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2591"/>
+        <source>Finish</source>
+        <extracomment>2D Mapper context menu (drawing custom exit line) item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2593"/>
+        <source>Finish drawing this line</source>
+        <extracomment>2D Mapper context menu (drawing custom exit line) item tooltip</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2660"/>
+        <source>Create new map</source>
+        <extracomment>2D Mapper context menu (no map found) item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2663"/>
+        <source>Load map</source>
+        <extracomment>2D Mapper context menu (no map found) item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2680"/>
+        <source>Create new room here</source>
+        <extracomment>Menu option to create a new room in the mapper</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2687"/>
+        <location filename="../src/T2DMap.cpp" line="2795"/>
+        <source>Move</source>
+        <extracomment>2D Mapper context menu (room) item
+----------
+2D Mapper context menu (label) item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2694"/>
+        <source>Configure room...</source>
+        <extracomment>2D Mapper context menu (room) item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2696"/>
+        <source>Set room&apos;s name and color of icon, weight and lock for speed walks, and a symbol to mark special rooms</source>
+        <extracomment>2D Mapper context menu (room) item tooltip</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2703"/>
+        <source>Set exits...</source>
+        <extracomment>2D Mapper context menu (room) item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2710"/>
+        <source>Create exit line...</source>
+        <extracomment>2D Mapper context menu (room) item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2713"/>
+        <source>Replace an exit line with a custom line</source>
+        <extracomment>2D Mapper context menu (room) item tooltip (enabled state)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2718"/>
+        <source>Custom exit lines are not shown and are not editable in grid mode</source>
+        <extracomment>2D Mapper context menu (room) item tooltip (disabled state)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2727"/>
+        <source>Spread...</source>
+        <extracomment>2D Mapper context menu (room) item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2729"/>
+        <source>Increase map X-Y spacing for the selected group of rooms</source>
+        <extracomment>2D Mapper context menu (room) item tooltip</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2736"/>
+        <source>Shrink...</source>
+        <extracomment>2D Mapper context menu (room) item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2738"/>
+        <source>Decrease map X-Y spacing for the selected group of rooms</source>
+        <extracomment>2D Mapper context menu (room) item tooltip</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2745"/>
+        <location filename="../src/T2DMap.cpp" line="2800"/>
+        <source>Delete</source>
+        <extracomment>2D Mapper context menu (room) item
+----------
+2D Mapper context menu (label) item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2752"/>
+        <source>Move to position...</source>
+        <extracomment>2D Mapper context menu (room) item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2754"/>
+        <source>Move selected room or group of rooms to the given coordinates in this area</source>
+        <extracomment>2D Mapper context menu (room) item tooltip</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2761"/>
+        <source>Move to area...</source>
+        <extracomment>2D Mapper context menu (room) item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2766"/>
+        <source>Create label...</source>
+        <extracomment>2D Mapper context menu (room) item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2768"/>
+        <source>Create label to show text or an image</source>
+        <extracomment>2D Mapper context menu (room) item tooltip</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2775"/>
+        <source>Set player location</source>
+        <extracomment>2D Mapper context menu (room) item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2777"/>
+        <source>Set the player&apos;s current location to here</source>
+        <extracomment>2D Mapper context menu (room) item tooltip (enabled state)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2786"/>
+        <source>Switch to editing mode</source>
+        <extracomment>2D Mapper context menu (room) item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2788"/>
+        <source>Switch to viewing mode</source>
+        <extracomment>2D Mapper context menu (room) item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2797"/>
+        <source>Move label</source>
+        <extracomment>2D Mapper context menu item (label) tooltip</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2802"/>
+        <source>Delete label</source>
+        <extracomment>2D Mapper context menu (label) item tooltip</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2817"/>
+        <source>Add point</source>
+        <extracomment>2D Mapper context menu (custom line editing) item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2825"/>
+        <source>Divide segment by adding a new point mid-way along</source>
+        <extracomment>2D Mapper context menu (custom line editing) item tooltip (enabled state)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2829"/>
+        <source>Select a point first, then add a new point mid-way along the segment towards room</source>
+        <extracomment>2D Mapper context menu (custom line editing) item tooltip (disabled state, i.e must do the suggested action first)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2833"/>
+        <source>Remove point</source>
+        <extracomment>2D Mapper context menu (custom line editing) item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2841"/>
+        <source>Merge pair of segments by removing this point</source>
+        <extracomment>2D Mapper context menu (custom line editing) item tooltip (enabled state but will be able to be done again on this item)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2845"/>
+        <source>Remove last segment by removing this point</source>
+        <extracomment>2D Mapper context menu (custom line editing) item tooltip (enabled state but is the last time this action can be done on this item)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2850"/>
+        <source>use &quot;delete line&quot; to remove the only segment ending in an editable point</source>
+        <extracomment>(2D Mapper context menu (custom line editing) item tooltip (disabled state this action can not be done again on this item but something else can be the quoted action &quot;delete line&quot; should match the translation for that action))</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2855"/>
+        <source>Select a point first, then remove it</source>
+        <extracomment>2D Mapper context menu (custom line editing) item tooltip (disabled state, user will need to do something before it can be used)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2864"/>
+        <source>Change the properties of this custom line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2868"/>
+        <source>Delete line</source>
+        <extracomment>2D Mapper context menu (custom line editing) item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2870"/>
+        <source>Delete all of this custom line</source>
+        <extracomment>2D Mapper context menu (custom line editing) item tooltip</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="3104"/>
+        <source>Drag to select multiple rooms or labels, release to finish...</source>
+        <extracomment>2D Mapper big, bottom of screen help message</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="3367"/>
+        <location filename="../src/T2DMap.cpp" line="4885"/>
+        <source>Solid line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="3368"/>
+        <location filename="../src/T2DMap.cpp" line="4886"/>
+        <source>Dot line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="3369"/>
+        <location filename="../src/T2DMap.cpp" line="4887"/>
+        <source>Dash line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="3370"/>
+        <location filename="../src/T2DMap.cpp" line="4888"/>
+        <source>Dash-dot line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="3371"/>
+        <location filename="../src/T2DMap.cpp" line="4889"/>
+        <source>Dash-dot-dot line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="3674"/>
+        <source>Move the selection, centered on the highlighted room (%1) to:</source>
+        <comment>%1 is a room number</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="3680"/>
+        <source>x coordinate (was %1):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="3681"/>
+        <source>y coordinate (was %1):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="3682"/>
+        <source>z coordinate (was %1):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="3698"/>
+        <source>OK</source>
+        <extracomment>dialog (room(s) move) button</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="3704"/>
+        <source>Cancel</source>
+        <extracomment>dialog (room(s) move) button</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="5033"/>
+        <location filename="../src/T2DMap.cpp" line="5067"/>
+        <source>Left-click to add point, right-click to undo/change/finish...</source>
+        <extracomment>2D Mapper big, bottom of screen help message</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="5078"/>
+        <source>Left-click and drag a square for the size and position of your label</source>
+        <extracomment>2D Mapper big, bottom of screen help message</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="579"/>
+        <source>Mapper: Cannot find a path from %1 to %2 using known exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="1225"/>
+        <source>You do not have a map yet - load one, or start mapping from scratch to begin.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/T2DMap.cpp" line="1222"/>
+        <source>You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="92"/>
+        <source>ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="94"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="1220"/>
+        <source>No rooms in the map - load another one, or start mapping from scratch to begin.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="1363"/>
+        <location filename="../src/T2DMap.cpp" line="1485"/>
+        <source>no text</source>
+        <extracomment>Default text if a label is created in mapper with no text</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="2382"/>
+        <source>render time: %1S mO: (%2,%3,%4)</source>
+        <comment>This is debug information that is not expected to be seen in release versions, %1 is a decimal time period and %2-%4 are the x,y and z coordinates at the center of the view (but y will be negative compared to previous room related ones as it represents the real coordinate system for this widget which has y increasing in a downward direction!)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="96"/>
+        <source>Click on a line to select or deselect that room number (with the given name if the rooms are named) to add or remove the room from the selection.  Click on the relevant header to sort by that method.  Note that the name column will only show if at least one of the rooms has a name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="3936"/>
+        <source>Spread out rooms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="3937"/>
+        <source>Increase the spacing of
+the selected rooms,
+centered on the
+highlighted room by a
+factor of:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="3997"/>
+        <source>Shrink in rooms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="3998"/>
+        <source>Decrease the spacing of
+the selected rooms,
+centered on the
+highlighted room by a
+factor of:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="4068"/>
+        <source>Load Mudlet map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="4070"/>
+        <source>Mudlet map (*.dat);;Xml map data (*.xml);;Any file (*)</source>
+        <comment>Do not change extensions (in braces) or the ;;s as they are used programmatically</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="4161"/>
+        <source>This will create new area: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="4177"/>
+        <source>[ ERROR ] - Unable to add &quot;%1&quot; as an area to the map.
+See the &quot;[MAP ERROR:]&quot; message for the reason.</source>
+        <comment>The &apos;[MAP ERROR:]&apos; text should be the same as that used for the translation of &quot;[MAP ERROR:]%1
+&quot; in the &apos;TMAP::logerror(...)&apos; function.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/T2DMap.cpp" line="4185"/>
+        <source>[  OK  ]  - Added &quot;%1&quot; (%2) area to map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TAlias</name>
+    <message>
+        <location filename="../src/TAlias.cpp" line="127"/>
+        <location filename="../src/TAlias.cpp" line="200"/>
+        <source>[Alias Error:] %1 capture group limit exceeded, capture less groups.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TAlias.cpp" line="272"/>
+        <source>Error: in &quot;Pattern:&quot;, faulty regular expression, reason: &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TArea</name>
+    <message>
+        <location filename="../src/TArea.cpp" line="368"/>
+        <source>roomID=%1 does not exist, can not set properties of a non-existent room!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TArea.cpp" line="756"/>
+        <source>no text</source>
+        <extracomment>Default text if a label is created in mapper with no text</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TCommandLine</name>
+    <message>
+        <location filename="../src/TCommandLine.cpp" line="701"/>
+        <source>Add to user dictionary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TCommandLine.cpp" line="703"/>
+        <source>Remove from user dictionary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TCommandLine.cpp" line="716"/>
+        <source>▼Mudlet▼ │ dictionary suggestions │ ▲User▲</source>
+        <extracomment>This line is shown in the list of spelling suggestions on the profile&apos;s command line context menu to clearly divide up where the suggestions for correct spellings are coming from. The precise format might be modified as long as it is clear that the entries below this line in the menu come from the spelling dictionary that the user has chosen in the profile setting which we have bundled with Mudlet; the entries about this line are the ones that the user has personally added.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TCommandLine.cpp" line="727"/>
+        <source>▼System▼ │ dictionary suggestions │ ▲User▲</source>
+        <extracomment>This line is shown in the list of spelling suggestions on the profile&apos;s command line context menu to clearly divide up where the suggestions for correct spellings are coming from. The precise format might be modified as long as it is clear that the entries below this line in the menu come from the spelling dictionary that the user has chosen in the profile setting which is provided as part of the OS; the entries about this line are the ones that the user has personally added.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TCommandLine.cpp" line="797"/>
+        <source>no suggestions (system)</source>
+        <extracomment>Used when the command spelling checker using the selected system dictionary has no words to suggest.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TCommandLine.cpp" line="826"/>
+        <source>no suggestions (shared)</source>
+        <extracomment>Used when the command spelling checker using the dictionary shared between profile has no words to suggest.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TCommandLine.cpp" line="832"/>
+        <source>no suggestions (profile)</source>
+        <extracomment>Used when the command spelling checker using the profile&apos;s own dictionary has no words to suggest.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TCommandLine.cpp" line="1376"/>
+        <source>Input line for &quot;%1&quot; profile.</source>
+        <extracomment>Accessibility-friendly name to describe the main command line for a Mudlet profile when more than one profile is loaded, %1 is the profile name. Because this is likely to be used often it should be kept as short as possible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TCommandLine.cpp" line="1383"/>
+        <location filename="../src/TCommandLine.cpp" line="1416"/>
+        <location filename="../src/TCommandLine.cpp" line="1450"/>
+        <source>Type in text to send to the game server for the &quot;%1&quot; profile, or enter an alias to run commands locally.</source>
+        <extracomment>Accessibility-friendly description for the main command line for a Mudlet profile when more than one profile is loaded, %1 is the profile name. Because this is likely to be used often it should be kept as short as possible.
+----------
+Accessibility-friendly description for an extra command line on top of a console/window when more than one profile is loaded, %1 is the profile name.
+----------
+Accessibility-friendly description for the built-in command line of a console/window other than the main window&apos;s one when more than one profile is loaded, %1 is the profile name.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TCommandLine.cpp" line="1391"/>
+        <source>Input line.</source>
+        <extracomment>Accessibility-friendly name to describe the main command line for a Mudlet profile when only one profile is loaded. Because this is likely to be used often it should be kept as short as possible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TCommandLine.cpp" line="1397"/>
+        <location filename="../src/TCommandLine.cpp" line="1431"/>
+        <location filename="../src/TCommandLine.cpp" line="1465"/>
+        <source>Type in text to send to the game server, or enter an alias to run commands locally.</source>
+        <extracomment>Accessibility-friendly description for the main command line for a Mudlet profile when only one profile is loaded. Because this is likely to be used often it should be kept as short as possible.
+----------
+Accessibility-friendly description for an extra command line on top of a console/window when only one profile is loaded.
+----------
+Accessibility-friendly description for the built-in command line of a console/window other than the main window&apos;s one when only one profile is loaded.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TCommandLine.cpp" line="1409"/>
+        <source>Additional input line &quot;%1&quot; on &quot;%2&quot; window of &quot;%3&quot;profile.</source>
+        <extracomment>Accessibility-friendly name to describe an extra command line on top of console/window when more than one profile is loaded, %1 is the command line name, %2 is the name of the window/console that it is on and %3 is the name of the profile.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TCommandLine.cpp" line="1425"/>
+        <source>Additional input line &quot;%1&quot; on &quot;%2&quot; window.</source>
+        <extracomment>Accessibility-friendly name to describe an extra command line on top of console/window when only one profile is loaded, %1 is the command line name and %2 is the name of the window/console that it is on.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TCommandLine.cpp" line="1444"/>
+        <source>Input line of &quot;%1&quot; window of &quot;%2&quot; profile.</source>
+        <extracomment>Accessibility-friendly name to describe the built-in command line of a console/window other than the main one, when more than one profile is loaded, %1 is the name of the window/console and %2 is the name of the profile.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TCommandLine.cpp" line="1458"/>
+        <source>Input line of &quot;%1&quot; window.</source>
+        <extracomment>Accessibility-friendly name to describe the built-in command line of a console/window other than the main one, when only one profile is loaded, %1 is the name of the window/console.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TConsole</name>
+    <message>
+        <location filename="../src/TConsole.cpp" line="89"/>
+        <source>Debug Console</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="341"/>
+        <source>&lt;i&gt;N:&lt;/i&gt; is the latency of the game server and network (aka ping, in seconds),&lt;br&gt;&lt;i&gt;S:&lt;/i&gt; is the system processing time - how long your triggers took to process the last line(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="356"/>
+        <source>N:%1 S:%2</source>
+        <extracomment>The first argument &apos;N&apos; represents the &apos;N&apos;etwork latency; the second &apos;S&apos; the &apos;S&apos;ystem (processing) time</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="364"/>
+        <source>&lt;no GA&gt; S:%1</source>
+        <extracomment>The argument &apos;S&apos; represents the &apos;S&apos;ystem (processing) time, in this situation the Game Server is not sending &quot;GoAhead&quot; signals so we cannot deduce the network latency...</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="1734"/>
+        <source>System Message: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="308"/>
+        <source>Show Time Stamps.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="1028"/>
+        <source>[ INFO ]  - Split-screen scrollback activated. Press &lt;⌘&gt;+&lt;ENTER&gt; to cancel.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="1030"/>
+        <source>[ INFO ]  - Split-screen scrollback activated. Press &lt;CTRL&gt;+&lt;ENTER&gt; to cancel.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2057"/>
+        <source>Debug messages from all profiles are shown here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2060"/>
+        <source>Central debug console past content.</source>
+        <extracomment>accessibility-friendly name to describe the upper half of the Mudlet central debug window when you&apos;ve scrolled up</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2062"/>
+        <source>Central debug console live content.</source>
+        <extracomment>accessibility-friendly name to describe the lower half of the Mudlet central debug when you&apos;ve scrolled up</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2065"/>
+        <source>Central debug console.</source>
+        <extracomment>accessibility-friendly name to describe the upper half of the Mudlet central debug window when it is not scrolled up</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2074"/>
+        <source>Editor&apos;s error window for profile &quot;%1&quot;, past content.</source>
+        <extracomment>accessibility-friendly name to describe the upper half of the Mudlet profile&apos;s editor error window when you&apos;ve scrolled up, %1 is the name of the profile when more than one is loaded.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2076"/>
+        <source>Editor&apos;s error window for profile &quot;%1&quot;, live content.</source>
+        <extracomment>accessibility-friendly name to describe the lower half of the Mudlet profile&apos;s editor error window when you&apos;ve scrolled up, %1 is the name of the profile when more than one is loaded.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2079"/>
+        <source>Editor&apos;s error window past content.</source>
+        <extracomment>accessibility-friendly name to describe the upper half of the Mudlet profile&apos;s editor error window when you&apos;ve scrolled up and only one profile is loaded.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2081"/>
+        <source>Editor&apos;s error window live content.</source>
+        <extracomment>accessibility-friendly name to describe the lower half of the Mudlet profile&apos;s editor error window when you&apos;ve scrolled up and only one profile is loaded.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2087"/>
+        <source>Editor&apos;s error window for profile &quot;%1&quot;.</source>
+        <extracomment>accessibility-friendly name to describe the upper half of the Mudlet profile&apos;s editor error window when it is not scrolled up, %1 is the name of the profile when more than one is loaded.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2090"/>
+        <source>Editor&apos;s error window</source>
+        <extracomment>accessibility-friendly name to describe the upper half of the Mudlet profile&apos;s editor error window when it is not scrolled up and only one profile is loaded.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2097"/>
+        <source>Game content is shown here. It may contain subconsoles and a mapper window.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="233"/>
+        <source>main window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="319"/>
+        <source>Record a replay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="329"/>
+        <source>Start logging game output to log file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="383"/>
+        <source>Emergency Stop. Stops all timers and triggers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="407"/>
+        <source>Search buffer.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="410"/>
+        <location filename="../src/TConsole.cpp" line="413"/>
+        <source>Search Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="417"/>
+        <source>Case sensitive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="419"/>
+        <source>Match case precisely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="432"/>
+        <source>Earlier search result.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="442"/>
+        <source>Later search result.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="834"/>
+        <source>Replay recording has started. File: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="838"/>
+        <source>Replay recording has been stopped, but couldn&apos;t be saved.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="840"/>
+        <source>Replay recording has been stopped. File: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="1838"/>
+        <location filename="../src/TConsole.cpp" line="1873"/>
+        <source>No search results, sorry!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2056"/>
+        <source>Debug Console.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2106"/>
+        <source>Profile &quot;%1&quot; main window past content.</source>
+        <extracomment>accessibility-friendly name to describe the upper half of a Mudlet profile&apos;s main window when you&apos;ve scrolled up, %1 is the name of the profile when more than one is loaded.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2108"/>
+        <source>Profile &quot;%1&quot; main window live content.</source>
+        <extracomment>accessibility-friendly name to describe the lower half of a Mudlet profile&apos;s main window when you&apos;ve scrolled up, %1 is the name of the profile when more than one is loaded.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2111"/>
+        <source>Profile main window past content.</source>
+        <extracomment>accessibility-friendly name to describe the upper half of a Mudlet profile&apos;s main window when you&apos;ve scrolled up and only one profile is loaded.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2113"/>
+        <source>Profile main window live content.</source>
+        <extracomment>accessibility-friendly name to describe the lower half of a Mudlet profile&apos;s main window when you&apos;ve scrolled up and only one profile is loaded.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2118"/>
+        <source>Profile &quot;%1&quot; main window.</source>
+        <extracomment>accessibility-friendly name to describe the upper half of a Mudlet profile&apos;s main window when it is not scrolled up, %1 is the name of the profile when more than one is loaded.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2121"/>
+        <source>Profile main window.</source>
+        <extracomment>accessibility-friendly name to describe the upper half of a Mudlet profile&apos;s main window when it is not scrolled up and only one profile is loaded.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2136"/>
+        <source>Profile &quot;%1&quot; embedded window &quot;%2&quot; past content.</source>
+        <extracomment>accessibility-friendly name to describe the upper half of a Mudlet profile&apos;s sub-console window when you&apos;ve scrolled up, %1 is the name of the profile when more than one is loaded and %2 is the name of the window.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2138"/>
+        <source>Profile &quot;%1&quot; embedded window &quot;%2&quot; live content.</source>
+        <extracomment>accessibility-friendly name to describe the lower half of a Mudlet profile&apos;s sub-console window when you&apos;ve scrolled up, %1 is the name of the profile when more than one is loaded and %2 is the name of the window.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2141"/>
+        <source>Profile embedded window &quot;%1&quot; past content.</source>
+        <extracomment>accessibility-friendly name to describe the upper half of a Mudlet profile&apos;s sub-console window when you&apos;ve scrolled up, %1 is the name of the window.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2143"/>
+        <source>Profile embedded window &quot;%1&quot; live content.</source>
+        <extracomment>accessibility-friendly name to describe the lower half of a Mudlet profile&apos;s sub-console window when you&apos;ve scrolled up, %1 is the name of the window.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2148"/>
+        <source>Profile &quot;%1&quot; embedded window &quot;%2&quot;.</source>
+        <extracomment>accessibility-friendly name to describe the upper half of a Mudlet profile&apos;s sub-console window when it is not scrolled up, %1 is the name of the profile when more than one is loaded and %2 is the name of the window.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2151"/>
+        <source>Profile embedded window &quot;%1&quot;.</source>
+        <extracomment>accessibility-friendly name to describe the upper half of a Mudlet profile&apos;s sub-console window when it is not scrolled up, %1 is the name of the window.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2166"/>
+        <source>Profile &quot;%1&quot; user window &quot;%2&quot; past content.</source>
+        <extracomment>accessibility-friendly name to describe the upper half of a Mudlet profile&apos;s floating/dockable user window when you&apos;ve scrolled up, %1 is the name of the profile when more than one is loaded and %2 is the name of the window.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2168"/>
+        <source>Profile &quot;%1&quot; user window &quot;%2&quot; live content.</source>
+        <extracomment>accessibility-friendly name to describe the lower half of a Mudlet profile&apos;s floating/dockable user window window when you&apos;ve scrolled up, %1 is the name of the profile when more than one is loaded and %2 is the name of the window.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2171"/>
+        <source>Profile user window &quot;%1&quot; past content.</source>
+        <extracomment>accessibility-friendly name to describe the upper half of a Mudlet profile&apos;s sub-console window when you&apos;ve scrolled up, %1 is the name of the window.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2173"/>
+        <source>Profile user window &quot;%1&quot; live content.</source>
+        <extracomment>accessibility-friendly name to describe the lower half of a Mudlet profile&apos;s sub-console window when you&apos;ve scrolled up, %1 is the name of the window.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2178"/>
+        <source>Profile &quot;%1&quot; user window &quot;%2&quot;.</source>
+        <extracomment>accessibility-friendly name to describe the upper half of a Mudlet profile&apos;s floating/dockable user window window when it is not scrolled up, %1 is the name of the profile when more than one is loaded and %2 is the name of the window.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2181"/>
+        <source>Profile user window &quot;%1&quot;.</source>
+        <extracomment>accessibility-friendly name to describe the upper half of a Mudlet profile&apos;s floating/dockable user window window when it is not scrolled up, %1 is the name of the window.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2070"/>
+        <source>Error Console in editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2083"/>
+        <source>Error messages for the &quot;%1&quot; profile are shown here in the editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2093"/>
+        <source>Error messages are shown here in the editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2099"/>
+        <source>Main Window for &quot;%1&quot; profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2101"/>
+        <source>Main Window.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2128"/>
+        <source>Embedded window &quot;%1&quot; for &quot;%2&quot; profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2130"/>
+        <source>Embedded window &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2132"/>
+        <source>Game content or locally generated text may be sent here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2158"/>
+        <source>User window &quot;%1&quot; for &quot;%2&quot; profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2160"/>
+        <source>User window &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TConsole.cpp" line="2162"/>
+        <source>Game content or locally generated text may be sent to this window that may be floated away from the Mudlet application or docked within the main application window.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TEasyButtonBar</name>
+    <message>
+        <location filename="../src/TEasyButtonBar.cpp" line="66"/>
+        <source>Easybutton Bar - %1 - %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TLuaInterpreter</name>
+    <message>
+        <location filename="../src/TLuaInterpreterDiscord.cpp" line="367"/>
+        <source>Playing %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="4082"/>
+        <location filename="../src/TLuaInterpreter.cpp" line="4116"/>
+        <source>ERROR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5521"/>
+        <source>Some functions may not be available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="4880"/>
+        <source>No error message available from Lua</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="4085"/>
+        <location filename="../src/TLuaInterpreter.cpp" line="4104"/>
+        <source>object</source>
+        <extracomment>object is the Mudlet alias/trigger/script, used in this sample message: object:&lt;Alias1&gt; function:&lt;cure_me&gt;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="4088"/>
+        <location filename="../src/TLuaInterpreter.cpp" line="4107"/>
+        <source>function</source>
+        <extracomment>function is the Lua function, used in this sample message: object:&lt;Alias1&gt; function:&lt;cure_me&gt;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="4882"/>
+        <source>Lua error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="4890"/>
+        <source>[ ERROR ] - Cannot find Lua module %1.%2%3%4</source>
+        <extracomment>%1 is the name of the module; %2 will be a line-feed inserted to put the next argument on a new line; %3 is the error message from the lua sub-system; %4 can be an additional message about the expected effect (but may be blank).</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5508"/>
+        <source>Probably will not be able to access Mudlet Lua code.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5526"/>
+        <source>Database support will not be available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5533"/>
+        <source>utf8.* Lua functions won&apos;t be available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5539"/>
+        <source>yajl.* Lua functions won&apos;t be available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5726"/>
+        <source>No error message available from Lua.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5728"/>
+        <source>Lua error: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5730"/>
+        <source>[ ERROR ] - Cannot load code formatter, indenting functionality won&apos;t be available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5809"/>
+        <source>%1 (doesn&apos;t exist)</source>
+        <comment>This file doesn&apos;t exist</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5814"/>
+        <source>%1 (isn&apos;t a file or symlink to a file)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5827"/>
+        <source>%1 (isn&apos;t a readable file or symlink to a readable file)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5849"/>
+        <source>%1 (couldn&apos;t read file)</source>
+        <comment>This file could not be read for some reason (for example, no permission)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5855"/>
+        <source>[  OK  ]  - Mudlet-lua API &amp; Geyser Layout manager loaded.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5862"/>
+        <source>[ ERROR ] - Couldn&apos;t find, load and successfully run LuaGlobal.lua - your Mudlet is broken!
+Tried these locations:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TMainConsole</name>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="263"/>
+        <source>Mudlet MUD Client version: %1%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="265"/>
+        <source>Mudlet, log from %1 profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="327"/>
+        <source>Stop logging game output to log file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="223"/>
+        <source>Logging has started. Log file is %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="181"/>
+        <source>logfile</source>
+        <extracomment>Must be a valid default filename for a log-file and is used if the user does not enter any other value (Ensure all instances have the same translation {one of two copies}).</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="233"/>
+        <source>Logging has been stopped. Log file is %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="302"/>
+        <location filename="../src/TMainConsole.cpp" line="324"/>
+        <source>&apos;Log session starting at &apos;hh:mm:ss&apos; on &apos;dddd&apos;, &apos;d&apos; &apos;MMMM&apos; &apos;yyyy&apos;.</source>
+        <extracomment>This is the format argument to QDateTime::toString(...) and needs to follow the rules for that function {literal text must be single quoted} as well as being suitable for the translation locale</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="332"/>
+        <source>&apos;Log session ending at &apos;hh:mm:ss&apos; on &apos;dddd&apos;, &apos;d&apos; &apos;MMMM&apos; &apos;yyyy&apos;.</source>
+        <extracomment>This is the format argument to QDateTime::toString(...) and needs to follow the rules for that function {literal text must be single quoted} as well as being suitable for the translation locale</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="343"/>
+        <source>Start logging game output to log file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="698"/>
+        <source>Pre-Map loading(2) report</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="709"/>
+        <source>Loading map(2) at %1 report</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1121"/>
+        <source>User window - %1 - %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1174"/>
+        <source>N:%1 S:%2</source>
+        <extracomment>The first argument &apos;N&apos; represents the &apos;N&apos;etwork latency; the second &apos;S&apos; the &apos;S&apos;ystem (processing) time</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1183"/>
+        <source>&lt;no GA&gt; S:%1</source>
+        <extracomment>The argument &apos;S&apos; represents the &apos;S&apos;ystem (processing) time, in this situation the Game Server is not sending &quot;GoAhead&quot; signals so we cannot deduce the network latency...</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1281"/>
+        <source>Pre-Map loading(1) report</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1299"/>
+        <source>Loading map(1) at %1 report</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1301"/>
+        <source>Loading map(1) &quot;%1&quot; at %2 report</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1345"/>
+        <source>Pre-Map importing(1) report</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1368"/>
+        <source>[ ERROR ]  - Map file not found, path and name used was:
+%1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1374"/>
+        <source>loadMap: bad argument #1 value (filename used: 
+&quot;%1&quot; was not found).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1383"/>
+        <source>[ INFO ]  - Map file located and opened, now parsing it...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1390"/>
+        <source>Importing map(1) &quot;%1&quot; at %2 report</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1393"/>
+        <source>[ INFO ]  - Map file located but it could not opened, please check permissions on:&quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1396"/>
+        <source>loadMap: bad argument #1 value (filename used: 
+&quot;%1&quot; could not be opened for reading).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1420"/>
+        <source>[ INFO ]  - Map reload request received from system...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1425"/>
+        <source>[  OK  ]  - ... System Map reload request completed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1427"/>
+        <source>[ WARN ]  - ... System Map reload request failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1454"/>
+        <source>+--------------------------------------------------------------+
+|                      system statistics                       |
++--------------------------------------------------------------+</source>
+        <comment>Header for the system&apos;s statistics information displayed in the console, it is 64 &apos;narrow&apos; characters wide</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1465"/>
+        <source>GMCP events:</source>
+        <extracomment>Heading for the system&apos;s statistics information displayed in the console</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1470"/>
+        <source>ATCP events:</source>
+        <extracomment>Heading for the system&apos;s statistics information displayed in the console</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1475"/>
+        <source>Channel102 events:</source>
+        <extracomment>Heading for the system&apos;s statistics information displayed in the console</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1480"/>
+        <source>MSSP events:</source>
+        <extracomment>Heading for the system&apos;s statistics information displayed in the console</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1486"/>
+        <source>MSDP events:</source>
+        <extracomment>Heading for the system&apos;s statistics information displayed in the console</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1498"/>
+        <source>Trigger Report:</source>
+        <extracomment>Heading for the system&apos;s statistics information displayed in the console</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1503"/>
+        <source>Timer Report:</source>
+        <extracomment>Heading for the system&apos;s statistics information displayed in the console</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1508"/>
+        <source>Alias Report:</source>
+        <extracomment>Heading for the system&apos;s statistics information displayed in the console</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1513"/>
+        <source>Keybinding Report:</source>
+        <extracomment>Heading for the system&apos;s statistics information displayed in the console</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1518"/>
+        <source>Script Report:</source>
+        <extracomment>Heading for the system&apos;s statistics information displayed in the console</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1523"/>
+        <source>Gif Report:</source>
+        <extracomment>Heading for the system&apos;s statistics information displayed in the console</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1578"/>
+        <source>Save profile?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1578"/>
+        <source>Do you want to save the profile %1?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1592"/>
+        <source>Could not save profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMainConsole.cpp" line="1593"/>
+        <source>Sorry, could not save your profile as &quot;%1&quot; - got the following error: &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TMap</name>
+    <message>
+        <location filename="../src/TMap.cpp" line="136"/>
+        <source>RoomID=%1 does not exist, can not set AreaID=%2 for non-existing room!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="147"/>
+        <source>AreaID=%2 does not exist, can not set RoomID=%1 to non-existing area!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="557"/>
+        <source>[ INFO ] - CONVERTING: old style label, areaID:%1 labelID:%2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="560"/>
+        <source>[ INFO ] - Converting old style label id: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="565"/>
+        <source>[ WARN ] - CONVERTING: cannot convert old style label in area with id: %1,  label id is: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="568"/>
+        <source>[ WARN ] - CONVERTING: cannot convert old style label with id: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="597"/>
+        <source>[  OK  ]  - Auditing of map completed (%1s). Enjoy your game...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="604"/>
+        <source>[  OK  ]  - Map loaded successfully (%1s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="48"/>
+        <source>Default Area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="49"/>
+        <source>Unnamed Area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="113"/>
+        <source>[MAP ERROR:]%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="527"/>
+        <source>[ INFO ]  - Map audit starting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="1559"/>
+        <source>[ INFO ]  - You might wish to donate THIS map file to the Mudlet Museum!
+There is so much data that it DOES NOT have that you could be
+better off starting again...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="1622"/>
+        <source>[ ALERT ] - Failed to load a Mudlet JSON Map file, reason:
+%1; the file is:
+&quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="1627"/>
+        <source>[ INFO ]  - Ignoring this map file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="1798"/>
+        <source>[ INFO ]  - Default (reset) area (for rooms that have not been assigned to an
+area) not found, adding reserved -1 id.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="1877"/>
+        <source>[ INFO ]  - Successfully read the map file (%1s), checking some
+consistency details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="1892"/>
+        <source>No map found. Would you like to download the map or start your own?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="1893"/>
+        <source>Download the map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="1894"/>
+        <source>Start my own</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2368"/>
+        <source>Map issues</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2375"/>
+        <source>Area issues</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2381"/>
+        <source>Area id: %1 &quot;%2&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2383"/>
+        <source>Area id: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2392"/>
+        <source>Room issues</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2399"/>
+        <source>Room id: %1 &quot;%2&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2401"/>
+        <source>Room id: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2411"/>
+        <source>End of report</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2417"/>
+        <source>[ ALERT ] - At least one thing was detected during that last map operation
+that it is recommended that you review the most recent report in
+the file:
+&quot;%1&quot;
+- look for the (last) report with the title:
+&quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2425"/>
+        <source>[ INFO ]  - The equivalent to the above information about that last map
+operation has been saved for review as the most recent report in
+the file:
+&quot;%1&quot;
+- look for the (last) report with the title:
+&quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2446"/>
+        <source>[ WARN ]  - Attempt made to download an XML map when one has already been
+requested or is being imported from a local file - wait for that
+operation to complete (if it cannot be canceled) before retrying!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2467"/>
+        <source>[ WARN ]  - Attempt made to download an XML from an invalid URL.  The URL was:
+%1
+and the error message (may contain technical details) was:&quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2481"/>
+        <source>[ ERROR ] - Unable to use or create directory to store map.
+Please check that you have permissions/access to:
+&quot;%1&quot;
+and there is enough space. The download operation has failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2507"/>
+        <source>[ INFO ]  - Map download initiated, please wait...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2674"/>
+        <source>[ ERROR ] - Map download encountered an error:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2908"/>
+        <source>Map JSON export</source>
+        <extracomment>This is a title of a progress window.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="3145"/>
+        <source>Map JSON import</source>
+        <extracomment>This is a title of a progress window.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2892"/>
+        <location filename="../src/TMap.cpp" line="3384"/>
+        <source>Exporting JSON map data from %1
+Areas: %2 of: %3   Rooms: %4 of: %5   Labels: %6 of: %7...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="3037"/>
+        <source>Exporting JSON map file from %1 - writing data to file:
+%2 ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="3065"/>
+        <source>import or export already in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="3073"/>
+        <source>could not open file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="3083"/>
+        <source>could not parse file, reason: &quot;%1&quot; at offset %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="3092"/>
+        <source>empty Json file, no map data detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="3107"/>
+        <source>invalid format version &quot;%1&quot; detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="3113"/>
+        <source>no format version detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="3119"/>
+        <source>no areas detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="3244"/>
+        <source>aborted by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="3129"/>
+        <location filename="../src/TMap.cpp" line="3394"/>
+        <source>Importing JSON map data to %1
+Areas: %2 of: %3   Rooms: %4 of: %5   Labels: %6 of: %7...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="1118"/>
+        <source>[ ERROR ] - The format version &quot;%1&quot; you are trying to save the map with is too new
+for this version of Mudlet. Supported are only formats up to version %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="1134"/>
+        <source>[ ALERT ] - Saving map in format version &quot;%1&quot; that is different than &quot;%2&quot; which
+it was loaded as. This may be an issue if you want to share the resulting
+map with others relying on the original format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="1144"/>
+        <source>[ WARN ]  - Saving map in format version &quot;%1&quot; different from the
+recommended map version %2 for this version of Mudlet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="1499"/>
+        <location filename="../src/TMap.cpp" line="1936"/>
+        <source>[ ERROR ] - Unable to open map file for reading: &quot;%1&quot;!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="1521"/>
+        <source>[ ALERT ] - File does not seem to be a Mudlet Map file. The part that indicates
+its format version seems to be &quot;%1&quot; and that doesn&apos;t make sense. The file is:
+&quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="1536"/>
+        <source>[ ALERT ] - Map file is too new. Its format version &quot;%1&quot; is higher than this version of
+Mudlet can handle (%2)! The file is:
+&quot;%3&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="1543"/>
+        <source>[ INFO ]  - You will need to update your Mudlet to read the map file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="1552"/>
+        <source>[ ALERT ] - Map file is really old. Its format version &quot;%1&quot; is so ancient that
+this version of Mudlet may not gain enough information from
+it but it will try! The file is: &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="1566"/>
+        <source>[ INFO ]  - Reading map. Format version: %1. File:
+&quot;%2&quot;,
+please wait...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="1569"/>
+        <source>[ INFO ]  - Reading map. Format version: %1. File: &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="1952"/>
+        <source>[ INFO ]  - Checking map file &quot;%1&quot;, format version &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2516"/>
+        <source>Downloading map file for use in %1...</source>
+        <extracomment>%1 is the name of the current Mudlet profile</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2517"/>
+        <location filename="../src/TMap.cpp" line="2901"/>
+        <location filename="../src/TMap.cpp" line="3138"/>
+        <source>Abort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="1528"/>
+        <source>[ INFO ]  - Ignoring this unlikely map file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2519"/>
+        <source>Map download</source>
+        <extracomment>This is a title of a progress window.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2550"/>
+        <source>loadMap: unable to perform request, a map is already being downloaded or
+imported at user request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2581"/>
+        <source>Importing XML map file for use in %1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2583"/>
+        <source>Map import</source>
+        <extracomment>This is a title of a progress window.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2611"/>
+        <location filename="../src/TMap.cpp" line="2618"/>
+        <source>loadMap: failure to import XML map file, further information may be available
+in main console!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2655"/>
+        <source>[ ALERT ] - Map download was canceled, on user&apos;s request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2713"/>
+        <source>[ ALERT ] - Map download failed, unable to open destination file:
+%1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2720"/>
+        <source>[ ALERT ] - Map download failed, unable to write destination file:
+%1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2736"/>
+        <source>[ INFO ]  - ... map downloaded and stored, now parsing it...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2772"/>
+        <source>[ ERROR ] - Map download problem, failure in parsing destination file:
+%1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TMap.cpp" line="2752"/>
+        <source>[ ERROR ] - Map download problem, unable to read destination file:
+%1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TRoom</name>
+    <message>
+        <location filename="../src/TRoom.cpp" line="86"/>
+        <location filename="../src/TRoom.cpp" line="967"/>
+        <source>North</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="87"/>
+        <source>North-east</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="88"/>
+        <source>North-west</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="89"/>
+        <location filename="../src/TRoom.cpp" line="1009"/>
+        <source>South</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="90"/>
+        <source>South-east</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="91"/>
+        <source>South-west</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="92"/>
+        <location filename="../src/TRoom.cpp" line="1051"/>
+        <source>East</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="93"/>
+        <location filename="../src/TRoom.cpp" line="1065"/>
+        <source>West</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="94"/>
+        <location filename="../src/TRoom.cpp" line="1079"/>
+        <source>Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="95"/>
+        <location filename="../src/TRoom.cpp" line="1093"/>
+        <source>Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="96"/>
+        <location filename="../src/TRoom.cpp" line="1107"/>
+        <source>In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="97"/>
+        <location filename="../src/TRoom.cpp" line="1121"/>
+        <source>Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="98"/>
+        <source>Other</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="99"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="310"/>
+        <source>No area created!  Requested area ID=%1. Note: Area IDs must be &gt; 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="332"/>
+        <source>Warning: When setting the Area for Room (Id: %1) it did not have a current area!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="981"/>
+        <source>Northeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="995"/>
+        <source>Northwest</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1023"/>
+        <source>Southeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1037"/>
+        <source>Southwest</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1142"/>
+        <source>[ WARN ]  - In room id:%1 removing invalid (special) exit to %2 {with no name!}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1146"/>
+        <source>[ WARN ]  - Room had an invalid (special) exit to %1 {with no name!} it was removed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1155"/>
+        <source>[ INFO ]  - In room with id: %1 correcting special exit &quot;%2&quot; that
+was to room with an exit to invalid room: %3 to now go
+to: %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1165"/>
+        <source>[ INFO ]  - Room needed correcting of special exit &quot;%1&quot; that was to room with an exit to invalid room: %2 to now go to: %3.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1190"/>
+        <source>[ WARN ]  - Room with id: %1 has a special exit &quot;%2&quot; with an
+exit to: %3 but that room does not exist.  The exit will
+be removed (but the destination room id will be stored in
+the room user data under a key:
+&quot;%4&quot;).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1203"/>
+        <source>[ WARN ]  - Room has a special exit &quot;%1&quot; with an exit to: %2 but that room does not exist.  The exit will be removed (but the destination room id will be stored in the room user data under a key:&quot;%3&quot;).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1242"/>
+        <source>[ INFO ]  - In room with id: %1 special exit &quot;%2&quot;
+that was to room with an invalid room: %3 that does not exist.
+The exit will be removed (the bad destination room id will be stored in the
+room user data under a key:
+&quot;%4&quot;).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1255"/>
+        <source>[ INFO ]  - Room had special exit &quot;%1&quot; that was to room with an invalid room: %2 that does not exist.  The exit will be removed (the bad destination room id will be stored in the room user data under a key:&quot;%3&quot;).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1288"/>
+        <source>%1 {none}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1291"/>
+        <source>%1 (open)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1294"/>
+        <source>%1 (closed)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1297"/>
+        <source>%1 (locked)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1300"/>
+        <source>%1 {invalid}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1304"/>
+        <source>[ INFO ]  - In room with id: %1 found one or more surplus door items that were removed:
+%2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1311"/>
+        <source>[ INFO ]  - Room had one or more surplus door items that were removed:%1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1327"/>
+        <source>[ INFO ]  - In room with id: %1 found one or more surplus weight items that were removed:
+%2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1334"/>
+        <source>[ INFO ]  - Room had one or more surplus weight items that were removed: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1350"/>
+        <source>[ INFO ]  - In room with id: %1 found one or more surplus exit lock items that were removed:
+%2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1357"/>
+        <source>[ INFO ]  - Room had one or more surplus exit lock items that were removed: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1436"/>
+        <source>[ INFO ]  - In room with id: %1 found one or more surplus custom line elements that
+were removed: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1442"/>
+        <source>[ INFO ]  - Room had one or more surplus custom line elements that were removed: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1465"/>
+        <source>[ INFO ]  - In room with id: %1 correcting exit &quot;%2&quot; that was to room with
+an exit to invalid room: %3 to now go to: %4.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1474"/>
+        <source>[ INFO ]  - Correcting exit &quot;%1&quot; that was to invalid room id: %2 to now go to: %3.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1485"/>
+        <source>[ WARN ]  - Room with id: %1 has an exit &quot;%2&quot; to: %3 but that room
+does not exist.  The exit will be removed (but the destination room
+Id will be stored in the room user data under a key:
+&quot;%4&quot;)
+and the exit will be turned into a stub.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1498"/>
+        <source>[ WARN ]  - Room has an exit &quot;%1&quot; to: %2 but that room does not exist.  The exit will be removed (but the destination room id will be stored in the room user data under a key: &quot;%4&quot;) and the exit will be turned into a stub.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1542"/>
+        <source>[ ALERT ] - Room with id: %1 has an exit &quot;%2&quot; to: %3 but also
+has a stub exit!  As a real exit precludes a stub, the latter will
+be removed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1552"/>
+        <source>[ ALERT ] - Room has an exit &quot;%1&quot; to: %2 but also has a stub exit in the same direction!  As a real exit precludes a stub, the latter will be removed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1608"/>
+        <source>[ INFO ]  - In room with id: %1 exit &quot;%2&quot; that was to room with an invalid
+room: %3 that does not exist.  The exit will be removed (the bad destination
+room id will be stored in the room user data under a key:
+&quot;%4&quot;)
+and the exit will be turned into a stub.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1619"/>
+        <source>[ INFO ]  - Room exit &quot;%1&quot; that was to a room with an invalid id: %2 that does not exist.  The exit will be removed (the bad destination room id will be stored in the room user data under a key:&quot;%4&quot;) and the exit will be turned into a stub.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1637"/>
+        <source>It was locked, this is recorded as user data with key:
+&quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1640"/>
+        <source>It was locked, this is recorded as user data with key: &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1650"/>
+        <source>It had a weight, this is recorded as user data with key:
+&quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1653"/>
+        <source>It had a weight, this is recorded as user data with key: &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1664"/>
+        <source>[ WARN ]  - There was a custom exit line associated with the invalid exit but
+it has not been possible to salvage this, it has been lost!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoom.cpp" line="1669"/>
+        <source>[ WARN ]  - There was a custom exit line associated with the invalid exit but it has not been possible to salvage this, it has been lost!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TRoomDB</name>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="504"/>
+        <source>Area with ID %1 already exists!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="523"/>
+        <source>An Unnamed Area is (no longer) permitted!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="527"/>
+        <source>An area called %1 already exists!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="626"/>
+        <source>[ WARN ]  - Problem with data structure associated with room id: %1 - that
+room&apos;s data has been lost so the id is now being deleted.  This
+suggests serious problems with the currently running version of
+Mudlet - is your system running out of memory?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="634"/>
+        <source>[ WARN ]  - Problem with data structure associated with this room.  The room&apos;s data has been lost so the id is now being deleted.  This suggests serious problems with the currently running version of Mudlet - is your system running out of memory?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="683"/>
+        <source>[ ALERT ] - Area with id: %1 expected but not found, will be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="686"/>
+        <source>[ ALERT ] - Area with this id expected but not found, will be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/TRoomDB.cpp" line="715"/>
+        <source>[ ALERT ] - %n area(s) detected as missing in map: adding it/them in.
+Look for further messages related to the rooms that are supposed
+to be in this/these area(s)...</source>
+        <comment>Making use of %n to allow quantity dependent message form 8-) !</comment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/TRoomDB.cpp" line="731"/>
+        <source>[ INFO ]  - The missing area(s) are now called:
+(ID) ==&gt; &quot;name&quot;</source>
+        <comment>Making use of %n to allow quantity dependent message form 8-) !</comment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="766"/>
+        <source>[ ALERT ] - Bad, (less than +1 and not the reserved -1) area ids found (count: %1)
+in map, now working out what new id numbers to use...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="778"/>
+        <source>[ INFO ]  - The renumbered area ids will be:
+Old ==&gt; New</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="796"/>
+        <source>[ INFO ]  - The area with this bad id was renumbered to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="797"/>
+        <source>[ INFO ]  - This area was renumbered from the bad id: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="834"/>
+        <location filename="../src/TRoomDB.cpp" line="837"/>
+        <source>[ INFO ]  - Area id numbering is satisfactory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="845"/>
+        <source>[ ALERT ] - Bad, (less than +1) room ids found (count: %1) in map, now working
+out what new id numbers to use.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="857"/>
+        <source>[ INFO ]  - The renumbered rooms will be:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="1177"/>
+        <source>[  OK  ]  - The changes made are:
+(ID) &quot;old name&quot; ==&gt; &quot;new name&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="771"/>
+        <source>[ ALERT ] - Bad, (less than +1 and not the reserved -1) area ids found (count: %1) in map!  Look for further messages related to this for each affected area ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/TRoomDB.cpp" line="722"/>
+        <source>[ ALERT ] - %n area(s) detected as missing in map: adding it/them in.
+Look for further messages related to the rooms that is/are supposed to
+be in this/these area(s)...</source>
+        <comment>Making use of %n to allow quantity dependent message form 8-) !</comment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="850"/>
+        <source>[ ALERT ] - Bad, (less than +1) room ids found (count: %1) in map!  Look for further messages related to this for each affected room ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="873"/>
+        <source>[ INFO ]  - This room with the bad id was renumbered to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="874"/>
+        <source>[ INFO ]  - This room was renumbered from the bad id: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="910"/>
+        <location filename="../src/TRoomDB.cpp" line="913"/>
+        <source>[ INFO ]  - Room id numbering is satisfactory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="933"/>
+        <source>[ INFO ]  - Duplicate exit stub identifiers found in room id: %1, this is an
+anomaly but has been cleaned up easily.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="938"/>
+        <source>[ INFO ]  - Duplicate exit stub identifiers found in room, this is an anomaly but has been cleaned up easily.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="947"/>
+        <source>[ INFO ]  - Duplicate exit lock identifiers found in room id: %1, this is an
+anomaly but has been cleaned up easily.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="952"/>
+        <source>[ INFO ]  - Duplicate exit lock identifiers found in room, this is an anomaly but has been cleaned up easily.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="1025"/>
+        <source>[ INFO ]  - This room claims to be in area id: %1, but that did not have a record of it.  The area has been updated to include this room.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="1031"/>
+        <source>[ INFO ]  - In area with id: %1 there were %2 rooms missing from those it
+should be recording as possessing, they were:
+%3
+they have been added.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="1039"/>
+        <source>[ INFO ]  - In this area there were %1 rooms missing from those it should be recorded as possessing.  They are: %2.  They have been added.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="1060"/>
+        <source>[ INFO ]  - This room was claimed by area id: %1, but it does not belong there.  The area has been updated to not include this room.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="1066"/>
+        <source>[ INFO ]  - In area with id: %1 there were %2 extra rooms compared to those it
+should be recording as possessing, they were:
+%3
+they have been removed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="1074"/>
+        <source>[ INFO ]  - In this area there were %1 extra rooms that it should not be recorded as possessing.  They were: %2.  They have been removed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="1173"/>
+        <source>It has been detected that &quot;_###&quot; form suffixes have already been used, for simplicity in the renaming algorithm these will have been removed and possibly changed as Mudlet sorts this matter out, if a number assigned in this way &lt;b&gt;is&lt;/b&gt; important to you, you can change it back, provided you rename the area that has been allocated the suffix that was wanted first...!&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="1184"/>
+        <source>&lt;nothing&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="1187"/>
+        <source>[ INFO ]  - Area name changed to prevent duplicates or unnamed ones; old name: &quot;%1&quot;, new name: &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="1196"/>
+        <source>[ ALERT ] - Empty and duplicate area names detected in Map file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="1197"/>
+        <source>[ INFO ]  - Mudlet had previously allowed the map to have more than one area
+with the same or no name. To resolve these cases, an area without a name
+here (or created in the future) will automatically be assigned the name &quot;%1&quot;.
+Duplicated area names will cause all but the first encountered one to gain a
+&quot;_###&quot; style suffix.
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="1205"/>
+        <source>[ ALERT ] - Duplicate area names detected in the Map file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="1206"/>
+        <source>[ INFO ]  - Due to some situations not being checked in the past, Mudlet had
+allowed the user to have more than one area with the same name.
+These make some things confusing and are now disallowed.
+  Duplicated area names will cause all but the first encountered one
+to gain a &quot;_###&quot; style suffix where each &quot;###&quot; is an increasing
+number; you may wish to change these, perhaps by replacing them with
+a &quot;(sub-area name)&quot; but it is entirely up to you how you do this,
+other then you will not be able to set one area&apos;s name to that of
+another that exists at the time.
+  If there were more than one area without a name then all but the
+first will also gain a suffix in this manner.
+%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="1221"/>
+        <source>[ ALERT ] - An empty area name was detected in the Map file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="1224"/>
+        <source>[  OK  ]  - Due to some situations not being checked in the past, Mudlet had
+allowed the map to have an area with no name. This can make some
+things confusing and is now disallowed.
+  To resolve this case, the area without a name here (or one created
+in the future) will automatically be assigned the name &quot;%1&quot;.
+  If this happens more then once the duplication of area names will
+cause all but the first encountered one to gain a &quot;_###&quot; style
+suffix where each &quot;###&quot; is an increasing number; you may wish to
+change these, perhaps by adding more meaningful area names but it is
+entirely up to you what is used, other then you will not be able to
+set one area&apos;s name to that of another that exists at the time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TRoomDB.cpp" line="1248"/>
+        <source>[ INFO ]  - Default (reset) area name (for rooms that have not been assigned to an
+area) not found, adding &quot;%1&quot; against the reserved -1 id.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TTextEdit</name>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="1947"/>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="1958"/>
+        <source>Copy HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="1962"/>
+        <source>Copy as image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="1965"/>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="1970"/>
+        <source>Search on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="1989"/>
+        <source>Analyse characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="1998"/>
+        <source>Hover on this item to display the Unicode codepoints in the selection &lt;i&gt;(only the first line!)&lt;/i&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2007"/>
+        <source>restore Main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2009"/>
+        <source>Use this to restore the Main menu to get access to controls.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2011"/>
+        <source>restore Main Toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2013"/>
+        <source>Use this to restore the Main Toolbar to get access to controls.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2021"/>
+        <source>Clear console</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2024"/>
+        <source>*** starting new session ***</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2236"/>
+        <source>{tab}</source>
+        <extracomment>Unicode U+0009 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2238"/>
+        <source>{line-feed}</source>
+        <extracomment>Unicode U+000A codepoint. Not likely to be seen as it gets filtered out.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2240"/>
+        <source>{carriage-return}</source>
+        <extracomment>Unicode U+000D codepoint. Not likely to be seen as it gets filtered out.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2242"/>
+        <source>{space}</source>
+        <extracomment>Unicode U+0020 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2244"/>
+        <source>{non-breaking space}</source>
+        <extracomment>Unicode U+00A0 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2246"/>
+        <source>{soft hyphen}</source>
+        <extracomment>Unicode U+00AD codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2248"/>
+        <source>{combining grapheme joiner}</source>
+        <extracomment>Unicode U+034F codepoint (badly named apparently - see Wikipedia!)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2250"/>
+        <source>{ogham space mark}</source>
+        <extracomment>Unicode U+1680 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2252"/>
+        <source>{&apos;n&apos; quad}</source>
+        <extracomment>Unicode U+2000 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2254"/>
+        <source>{&apos;m&apos; quad}</source>
+        <extracomment>Unicode U+2001 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2256"/>
+        <source>{&apos;n&apos; space}</source>
+        <extracomment>Unicode U+2002 codepoint - En (&apos;n&apos;) wide space.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2258"/>
+        <source>{&apos;m&apos; space}</source>
+        <extracomment>Unicode U+2003 codepoint - Em (&apos;m&apos;) wide space.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2260"/>
+        <source>{3-per-em space}</source>
+        <extracomment>Unicode U+2004 codepoint - three-per-em (&apos;m&apos;) wide (thick) space.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2262"/>
+        <source>{4-per-em space}</source>
+        <extracomment>Unicode U+2005 codepoint - four-per-em (&apos;m&apos;) wide (Middle) space.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2264"/>
+        <source>{6-per-em space}</source>
+        <extracomment>Unicode U+2006 codepoint - six-per-em (&apos;m&apos;) wide (Sometimes the same as a Thin) space.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2266"/>
+        <source>{digit space}</source>
+        <extracomment>Unicode U+2007 codepoint - figure (digit) wide space.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2268"/>
+        <source>{punctuation wide space}</source>
+        <extracomment>Unicode U+2008 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2270"/>
+        <source>{5-per-em space}</source>
+        <extracomment>Unicode U+2009 codepoint - five-per-em (&apos;m&apos;) wide space.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2272"/>
+        <source>{hair width space}</source>
+        <extracomment>Unicode U+200A codepoint - thinnest space.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2274"/>
+        <source>{zero width space}</source>
+        <extracomment>Unicode U+200B codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2276"/>
+        <source>{Zero width non-joiner}</source>
+        <extracomment>Unicode U+200C codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2278"/>
+        <source>{zero width joiner}</source>
+        <extracomment>Unicode U+200D codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2280"/>
+        <source>{left-to-right mark}</source>
+        <extracomment>Unicode U+200E codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2282"/>
+        <source>{right-to-left mark}</source>
+        <extracomment>Unicode U+200F codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2284"/>
+        <source>{line separator}</source>
+        <extracomment>Unicode 0x2028 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2286"/>
+        <source>{paragraph separator}</source>
+        <extracomment>Unicode U+2029 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2288"/>
+        <source>{Left-to-right embedding}</source>
+        <extracomment>Unicode U+202A codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2290"/>
+        <source>{right-to-left embedding}</source>
+        <extracomment>Unicode U+202B codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2292"/>
+        <source>{pop directional formatting}</source>
+        <extracomment>Unicode U+202C codepoint - pop (undo last) directional formatting.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2294"/>
+        <source>{Left-to-right override}</source>
+        <extracomment>Unicode U+202D codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2296"/>
+        <source>{right-to-left override}</source>
+        <extracomment>Unicode U+202E codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2298"/>
+        <source>{narrow width no-break space}</source>
+        <extracomment>Unicode U+202F codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2300"/>
+        <source>{medium width mathematical space}</source>
+        <extracomment>Unicode U+205F codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2302"/>
+        <source>{zero width non-breaking space}</source>
+        <extracomment>Unicode U+2060 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2304"/>
+        <source>{function application}</source>
+        <extracomment>Unicode U+2061 codepoint - function application (whatever that means!)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2306"/>
+        <source>{invisible times}</source>
+        <extracomment>Unicode U+2062 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2308"/>
+        <source>{invisible separator}</source>
+        <extracomment>Unicode U+2063 codepoint - invisible separator or comma.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2310"/>
+        <source>{invisible plus}</source>
+        <extracomment>Unicode U+2064 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2312"/>
+        <source>{left-to-right isolate}</source>
+        <extracomment>Unicode U+2066 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2314"/>
+        <source>{right-to-left isolate}</source>
+        <extracomment>Unicode U+2067 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2316"/>
+        <source>{first strong isolate}</source>
+        <extracomment>Unicode U+2068 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2318"/>
+        <source>{pop directional isolate}</source>
+        <extracomment>Unicode U+2069 codepoint - pop (undo last) directional isolate.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2320"/>
+        <source>{inhibit symmetrical swapping}</source>
+        <extracomment>Unicode U+206A codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2322"/>
+        <source>{activate symmetrical swapping}</source>
+        <extracomment>Unicode U+206B codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2324"/>
+        <source>{inhibit arabic form-shaping}</source>
+        <extracomment>Unicode U+206C codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2326"/>
+        <source>{activate arabic form-shaping}</source>
+        <extracomment>Unicode U+206D codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2328"/>
+        <source>{national digit shapes}</source>
+        <extracomment>Unicode U+206E codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2330"/>
+        <source>{nominal Digit shapes}</source>
+        <extracomment>Unicode U+206F codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2332"/>
+        <source>{ideographic space}</source>
+        <extracomment>Unicode U+3000 codepoint - ideographic (CJK Wide) space</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2334"/>
+        <source>{variation selector 1}</source>
+        <extracomment>Unicode U+FE00 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2336"/>
+        <source>{variation selector 2}</source>
+        <extracomment>Unicode U+FE01 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2338"/>
+        <source>{variation selector 3}</source>
+        <extracomment>Unicode U+FE02 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2340"/>
+        <source>{variation selector 4}</source>
+        <extracomment>Unicode U+FE03 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2342"/>
+        <source>{variation selector 5}</source>
+        <extracomment>Unicode U+FE04 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2344"/>
+        <source>{variation selector 6}</source>
+        <extracomment>Unicode U+FE05 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2346"/>
+        <source>{variation selector 7}</source>
+        <extracomment>Unicode U+FE06 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2348"/>
+        <source>{variation selector 8}</source>
+        <extracomment>Unicode U+FE07 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2350"/>
+        <source>{variation selector 9}</source>
+        <extracomment>Unicode U+FE08 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2352"/>
+        <source>{variation selector 10}</source>
+        <extracomment>Unicode U+FE09 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2354"/>
+        <source>{variation selector 11}</source>
+        <extracomment>Unicode U+FE0A codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2356"/>
+        <source>{variation selector 12}</source>
+        <extracomment>Unicode U+FE0B codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2358"/>
+        <source>{variation selector 13}</source>
+        <extracomment>Unicode U+FE0C codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2360"/>
+        <source>{variation selector 14}</source>
+        <extracomment>Unicode U+FE0D codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2362"/>
+        <source>{variation selector 15}</source>
+        <extracomment>Unicode U+FE0E codepoint - after an Emoji codepoint forces the textual (black &amp; white) rendition.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2364"/>
+        <source>{variation selector 16}</source>
+        <extracomment>Unicode U+FE0F codepoint - after an Emoji codepoint forces the proper coloured &apos;Emoji&apos; rendition.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2366"/>
+        <source>{zero width no-break space}</source>
+        <extracomment>Unicode U+FEFF codepoint - also known as the Byte-order-mark at start of text!).</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2374"/>
+        <source>{interlinear annotation anchor}</source>
+        <extracomment>Unicode U+FFF9 codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2376"/>
+        <source>{interlinear annotation separator}</source>
+        <extracomment>Unicode U+FFFA codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2378"/>
+        <source>{interlinear annotation terminator}</source>
+        <extracomment>Unicode U+FFFB codepoint</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2380"/>
+        <source>{object replacement character}</source>
+        <extracomment>Unicode U+FFFC codepoint.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2393"/>
+        <location filename="../src/TTextEdit.cpp" line="2396"/>
+        <location filename="../src/TTextEdit.cpp" line="2419"/>
+        <source>{noncharacter}</source>
+        <extracomment>Unicode codepoint in range U+FFD0 to U+FDEF - not a character
+----------
+Unicode codepoint in range U+FFFx - not a character.
+----------
+Unicode codepoint is U+00xxFFFE or U+00xxFFFF - not a character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2406"/>
+        <source>{FitzPatrick modifier 1 or 2}</source>
+        <extracomment>Unicode codepoint U+0001F3FB - FitzPatrick modifier (Emoji Human skin-tone) 1-2.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2408"/>
+        <source>{FitzPatrick modifier 3}</source>
+        <extracomment>Unicode codepoint U+0001F3FC - FitzPatrick modifier (Emoji Human skin-tone) 3.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2410"/>
+        <source>{FitzPatrick modifier 4}</source>
+        <extracomment>Unicode codepoint U+0001F3FD - FitzPatrick modifier (Emoji Human skin-tone) 4.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2412"/>
+        <source>{FitzPatrick modifier 5}</source>
+        <extracomment>Unicode codepoint U+0001F3FE - FitzPatrick modifier (Emoji Human skin-tone) 5.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2414"/>
+        <source>{FitzPatrick modifier 6}</source>
+        <extracomment>Unicode codepoint U+0001F3FF - FitzPatrick modifier (Emoji Human skin-tone) 6.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2691"/>
+        <location filename="../src/TTextEdit.cpp" line="2757"/>
+        <source>Index (UTF-16)</source>
+        <extracomment>1st Row heading for Text analyser output, table item is the count into the QChars/TChars that make up the text {this translation used 2 times}</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2696"/>
+        <location filename="../src/TTextEdit.cpp" line="2762"/>
+        <source>U+&lt;i&gt;####&lt;/i&gt; Unicode Code-point &lt;i&gt;(High:Low Surrogates)&lt;/i&gt;</source>
+        <extracomment>2nd Row heading for Text analyser output, table item is the unicode code point (will be between 000001 and 10FFFF in hexadecimal) {this translation used 2 times}</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2701"/>
+        <location filename="../src/TTextEdit.cpp" line="2767"/>
+        <source>Visual</source>
+        <extracomment>3rd Row heading for Text analyser output, table item is a visual representation of the character/part of the character or a &apos;{&apos;...&apos;}&apos; wrapped letter code if the character is whitespace or otherwise unshowable {this translation used 2 times}</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2706"/>
+        <location filename="../src/TTextEdit.cpp" line="2772"/>
+        <source>Index (UTF-8)</source>
+        <extracomment>4th Row heading for Text analyser output, table item is the count into the bytes that make up the UTF-8 form of the text that the Lua system uses {this translation used 2 times}</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2711"/>
+        <location filename="../src/TTextEdit.cpp" line="2777"/>
+        <source>Byte</source>
+        <extracomment>5th Row heading for Text analyser output, table item is the unsigned 8-bit integer for the particular byte in the UTF-8 form of the text that the Lua system uses {this translation used 2 times}</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="2717"/>
+        <location filename="../src/TTextEdit.cpp" line="2783"/>
+        <source>Lua character or code</source>
+        <extracomment>6th Row heading for Text analyser output, table item is either the ASCII character or the numeric code for the byte in the row about this item in the table, as displayed the thing shown can be used in a Lua string entry to reproduce this byte {this translation used 2 times}&quot;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="1582"/>
+        <source>Mudlet, debug console extract</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="1584"/>
+        <source>Mudlet, %1 mini-console extract from %2 profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="1586"/>
+        <source>Mudlet, %1 user window extract from %2 profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTextEdit.cpp" line="1588"/>
+        <source>Mudlet, main console extract from %1 profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TToolBar</name>
+    <message>
+        <location filename="../src/TToolBar.cpp" line="75"/>
+        <source>Toolbar - %1 - %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TTrigger</name>
+    <message>
+        <location filename="../src/TTrigger.cpp" line="195"/>
+        <source>Error: This trigger has no patterns defined, yet. Add some to activate it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTrigger.cpp" line="226"/>
+        <source>Error: in item %1, perl regex &quot;%2&quot; failed to compile, reason: &quot;%3&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTrigger.cpp" line="247"/>
+        <source>Error: in item %1, lua function &quot;%2&quot; failed to compile, reason: &quot;%3&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTrigger.cpp" line="267"/>
+        <source>Error: in item %1, no colors to match were set - at least &lt;i&gt;one&lt;/i&gt; of the foreground or background must not be &lt;i&gt;ignored&lt;/i&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTrigger.cpp" line="326"/>
+        <source>[Trigger Error:] %1 capture group limit exceeded, capture less groups.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTrigger.cpp" line="412"/>
+        <source>[Trigger Error:] %1 capture group limit exceeded, capture less groups.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TTrigger.cpp" line="1164"/>
+        <source>Trigger name=%1 expired.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/TTrigger.cpp" line="1169"/>
+        <source>Trigger name=%1 will fire %n more time(s).</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>UpdateDialog</name>
+    <message>
+        <location filename="../3rdparty/dblsqd/dblsqd/update_dialog.ui" line="20"/>
+        <source>%APPNAME% update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/dblsqd/dblsqd/update_dialog.ui" line="50"/>
+        <source>Loading update information …</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/dblsqd/dblsqd/update_dialog.ui" line="87"/>
+        <source>A new version of %APPNAME% is available!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/dblsqd/dblsqd/update_dialog.ui" line="113"/>
+        <source>%APPNAME% %UPDATE_VERSION% is available (you have %CURRENT_VERSION%).
+Would you like to update now?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/dblsqd/dblsqd/update_dialog.ui" line="151"/>
+        <source>Changelog for %APPNAME%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/dblsqd/dblsqd/update_dialog.ui" line="161"/>
+        <source>You are using version %CURRENT_VERSION%.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/dblsqd/dblsqd/update_dialog.ui" line="192"/>
+        <source>There are currently no updates available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/dblsqd/dblsqd/update_dialog.ui" line="208"/>
+        <source>You are using %APPNAME% %CURRENT_VERSION%.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/dblsqd/dblsqd/update_dialog.ui" line="321"/>
+        <source>Automatically download future updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/dblsqd/dblsqd/update_dialog.ui" line="368"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/dblsqd/dblsqd/update_dialog.ui" line="388"/>
+        <source>Install update now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/dblsqd/dblsqd/update_dialog.ui" line="395"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/dblsqd/dblsqd/update_dialog.ui" line="405"/>
+        <source>Remind me later</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/dblsqd/dblsqd/update_dialog.ui" line="410"/>
+        <source>Skip this version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/dblsqd/dblsqd/update_dialog.cpp" line="555"/>
+        <source>Could not open downloaded file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Updater</name>
+    <message>
+        <location filename="../src/updater.cpp" line="46"/>
+        <location filename="../src/updater.cpp" line="197"/>
+        <location filename="../src/updater.cpp" line="263"/>
+        <source>Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/updater.cpp" line="361"/>
+        <source>Restart to apply update</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>VarUnit</name>
+    <message>
+        <location filename="../src/VarUnit.cpp" line="90"/>
+        <source>Checked variables will be saved and loaded with your profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>XMLimport</name>
+    <message>
+        <location filename="../src/XMLimport.cpp" line="166"/>
+        <source>[ ALERT ] - Sorry, the file being read:
+&quot;%1&quot;
+reports it has a version (%2) it must have come from a later Mudlet version,
+and this one cannot read it, you need a newer Mudlet!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/XMLimport.cpp" line="359"/>
+        <source>Parsing area data...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/XMLimport.cpp" line="363"/>
+        <source>Parsing room data...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/XMLimport.cpp" line="367"/>
+        <source>Parsing environment data...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/XMLimport.cpp" line="375"/>
+        <source>Assigning rooms to their areas...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/XMLimport.cpp" line="584"/>
+        <source>Parsing room data [count: %1]...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>about_dialog</name>
+    <message>
+        <location filename="../src/ui/about_dialog.ui" line="41"/>
+        <source>About Mudlet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/about_dialog.ui" line="101"/>
+        <source>Mudlet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/about_dialog.ui" line="164"/>
+        <source>Supporters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/about_dialog.ui" line="193"/>
+        <source>License</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/about_dialog.ui" line="228"/>
+        <source>Third Party</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>actions_main_area</name>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="62"/>
+        <source>Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="100"/>
+        <source>ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="165"/>
+        <source>Button Bar Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="177"/>
+        <source>Number of columns/rows (depending on orientation):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="200"/>
+        <source>Orientation Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="205"/>
+        <source>Orientation Vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="220"/>
+        <source>Dock Area Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="225"/>
+        <source>Dock Area Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="230"/>
+        <source>Dock Area Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="235"/>
+        <source>Floating Toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="258"/>
+        <source>Button Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="264"/>
+        <source>Button Rotation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="281"/>
+        <source>no rotation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="286"/>
+        <source>90° rotation to the left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="291"/>
+        <source>90° rotation to the right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="299"/>
+        <source>Push down button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="306"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="319"/>
+        <location filename="../src/ui/actions_main_area.ui" line="339"/>
+        <source>Text to send to the game as-is (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="326"/>
+        <source>Command (up):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="72"/>
+        <source>&lt;p&gt;Choose a good, ideally unique, name for your button, menu or toolbar. This will be displayed in the buttons tree.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="316"/>
+        <source>&lt;p&gt;Type in one or more commands you want the button to send directly to the game if it is pressed. (Optional)&lt;/p&gt;&lt;p&gt;If this is a &lt;i&gt;push-down&lt;/i&gt; button then this is sent only when the button goes from the &lt;i&gt;up&lt;/i&gt; to &lt;i&gt;down&lt;/i&gt; state.&lt;/p&gt;&lt;p&gt;To send more complex commands, that could depend on or need to modifies variables within this profile a Lua script should be entered &lt;i&gt;instead&lt;/i&gt; in the editor area below.  Anything entered here is, literally, just sent to the game server.&lt;/p&gt;&lt;p&gt;It is permissible to use both this &lt;i&gt;and&lt;/i&gt; a Lua script - this will be sent &lt;b&gt;before&lt;/b&gt; the script is run.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="336"/>
+        <source>&lt;p&gt;Type in one or more commands you want the button to send directly to the game when this button goes from the &lt;i&gt;down&lt;/i&gt; to &lt;i&gt;up&lt;/i&gt; state.&lt;/p&gt;&lt;p&gt;To send more complex commands, that could depend on or need to modifies variables within this profile a Lua script should be entered &lt;i&gt;instead&lt;/i&gt; in the editor area below.  Anything entered here is, literally, just sent to the game server.&lt;/p&gt;&lt;p&gt;It is permissible to use both this &lt;i&gt;and&lt;/i&gt; a Lua script - this will be sent &lt;b&gt;before&lt;/b&gt; the script is run.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actions_main_area.ui" line="358"/>
+        <source>Stylesheet:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>aliases_main_area</name>
+    <message>
+        <location filename="../src/ui/aliases_main_area.ui" line="35"/>
+        <source>Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/aliases_main_area.ui" line="57"/>
+        <source>choose a unique name for your alias; it will show in the tree and is needed for scripting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/aliases_main_area.ui" line="85"/>
+        <source>ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/aliases_main_area.ui" line="126"/>
+        <source>Pattern:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/aliases_main_area.ui" line="148"/>
+        <source>enter a perl regex pattern for your alias; alias are triggers on your input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/aliases_main_area.ui" line="151"/>
+        <source>^mycommand$ (example)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/aliases_main_area.ui" line="158"/>
+        <source>Type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/aliases_main_area.ui" line="172"/>
+        <source>Regex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/aliases_main_area.ui" line="177"/>
+        <source>Plain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/aliases_main_area.ui" line="197"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/aliases_main_area.ui" line="219"/>
+        <source>&lt;p&gt;Enter one or more commands to use if the given command matches the pattern. (Optional)&lt;/p&gt;&lt;p&gt;This could be another alias or a command to send directly to the game. For complex commands that require modification of variables within this profile, use a Lua script in the editor area below instead. It&apos;s possible to use both this field and a Lua script - the contents of this field will be used before running the script.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/aliases_main_area.ui" line="222"/>
+        <source>Replacement text (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>cTelnet</name>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="605"/>
+        <source>[ ERROR ] - Host name lookup Failure!
+Connection cannot be established.
+The server name is not correct, not working properly,
+or your nameservers are not working properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="462"/>
+        <source>[ INFO ]  - A secure connection has been established successfully.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="464"/>
+        <source>[ INFO ]  - A connection has been established successfully.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="500"/>
+        <source>[ INFO ]  - Connection time: %1
+    </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="507"/>
+        <source>hh:mm:ss.zzz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="544"/>
+        <source>Secure connections aren&apos;t supported by this game on this port - try turning the option off.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="2400"/>
+        <location filename="../src/ctelnet.cpp" line="2795"/>
+        <source>[ INFO ]  - The server wants to upgrade the GUI to new version &apos;%1&apos;.
+Uninstalling old version &apos;%2&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="2411"/>
+        <location filename="../src/ctelnet.cpp" line="2806"/>
+        <source>[  OK  ]  - Package is already installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="2420"/>
+        <location filename="../src/ctelnet.cpp" line="2813"/>
+        <source>downloading game GUI from server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="2409"/>
+        <location filename="../src/ctelnet.cpp" line="2804"/>
+        <source>[ INFO ]  - Server offers downloadable GUI (url=&apos;%1&apos;) (package=&apos;%2&apos;).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="403"/>
+        <source>[ INFO ]  - Looking up the IP address of server: %1:%2 ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="534"/>
+        <location filename="../src/ctelnet.cpp" line="546"/>
+        <source>[ ALERT ] - Socket got disconnected.
+Reason: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="589"/>
+        <source>[ INFO ]  - Trying secure connection to %1: %2 ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="596"/>
+        <source>[ INFO ]  - The IP address of %1 has been found. It is: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="598"/>
+        <source>[ INFO ]  - Trying to connect to %1:%2 ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="600"/>
+        <source>[ INFO ]  - Trying to connect to %1:%2 via proxy...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="647"/>
+        <source>[ ERROR ] - Internal error, no codec found for current setting of {&quot;%1&quot;}
+so Mudlet cannot send data in that format to the Game Server. Please
+check to see if there is an alternative that the MUD and Mudlet can
+use. Mudlet will attempt to send the data using the ASCII encoding
+but will be limited to only unaccented characters of basic English.
+Note: this warning will only be issued once, until the encoding is
+changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="2422"/>
+        <location filename="../src/ctelnet.cpp" line="2815"/>
+        <source>Cancel</source>
+        <extracomment>Cancel download of GUI package from Server</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="3006"/>
+        <source>[ INFO ]  - A more secure connection on port %1 is available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="3011"/>
+        <source>For data transfer protection and privacy, this connection advertises a secure port.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="3012"/>
+        <source>Update to port %1 and connect with encryption?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="3162"/>
+        <source>ERROR</source>
+        <extracomment>Keep the capitalisation, the translated text at 7 letters max so it aligns nicely</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="3175"/>
+        <source>LUA</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="3187"/>
+        <source>WARN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="3199"/>
+        <source>ALERT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="3211"/>
+        <source>INFO</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="3223"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="3421"/>
+        <source>[ INFO ]  - Loading replay file:
+&quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="3445"/>
+        <source>Cannot replay file &quot;%1&quot;, error message was: &quot;replay file seems to be corrupt&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="3447"/>
+        <source>[ WARN ]  - The replay has been aborted as the file seems to be corrupt.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="3456"/>
+        <source>Cannot perform replay, another one may already be in progress. Try again when it has finished.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="3458"/>
+        <source>[ WARN ]  - Cannot perform replay, another one may already be in progress.
+Try again when it has finished.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="3466"/>
+        <source>Cannot read file &quot;%1&quot;, error message was: &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="3469"/>
+        <source>[ ERROR ] - Cannot read file &quot;%1&quot;,
+error message was: &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ctelnet.cpp" line="3508"/>
+        <source>[  OK  ]  - The replay has ended.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>color_trigger</name>
+    <message>
+        <location filename="../src/ui/color_trigger.ui" line="17"/>
+        <source>ANSI 256 Color chooser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/color_trigger.ui" line="40"/>
+        <source>&lt;small&gt;Choose:&lt;ul&gt;&lt;li&gt;one of the basic 16 colors below&lt;/li&gt;
+&lt;li&gt;click the &lt;i&gt;more&lt;/i&gt; button to get access to other colors in the 256-color set, then follow the instructions to select a color from that part of the 256 colors supported; if such a color is already in use then that part will already be showing&lt;/li&gt;
+&lt;li&gt;click the &lt;i&gt;Default&lt;/i&gt; or &lt;i&gt;Ignore&lt;/i&gt; buttons at the bottom for a pair of other special cases&lt;/li&gt;
+&lt;li&gt;click &lt;i&gt;Cancel&lt;/i&gt; to close this dialog without making any changes&lt;/li&gt;&lt;/ul&gt;&lt;/small&gt;</source>
+        <comment>Ensure that &quot;Default&quot;, &quot;Ignore&quot; and &quot;Cancel&quot; in this instruction are the same as used for the controls elsewhere on this dialog.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/color_trigger.ui" line="59"/>
+        <source>Basic ANSI Colors [0-15] - click a button to select that color number directly:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/color_trigger.ui" line="241"/>
+        <source>ANSI 6R x 6G x 6B Colors [16-231] - adjust red, green, blue and click button to select matching color number:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/color_trigger.ui" line="253"/>
+        <source>Red (0-5)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/color_trigger.ui" line="263"/>
+        <source>Green (0-5)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/color_trigger.ui" line="273"/>
+        <source>Blue (0-5)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/color_trigger.ui" line="283"/>
+        <source>16 + 36 x R + 6 x G + B =</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/color_trigger.ui" line="344"/>
+        <source>[16]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/color_trigger.ui" line="354"/>
+        <source>Set to RGB value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/color_trigger.ui" line="364"/>
+        <source>ANSI 24 Grays scale [232-255] - adjust gray and click button to select matching color number:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/color_trigger.ui" line="376"/>
+        <source>Gray (0-23)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/color_trigger.ui" line="383"/>
+        <source>232 + Gr =</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/color_trigger.ui" line="415"/>
+        <source>[232]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/color_trigger.ui" line="425"/>
+        <source>Set to Grayscale value</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>composer</name>
+    <message>
+        <location filename="../src/ui/composer.ui" line="14"/>
+        <source>News and Message Composer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/composer.ui" line="86"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/composer.ui" line="99"/>
+        <source>&lt;p&gt;Save (&lt;span style=&quot; color:#565656;&quot;&gt;Shift+Tab&lt;/span&gt;)&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/composer.ui" line="102"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>connection_profiles</name>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="25"/>
+        <source>Select a profile to connect with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="106"/>
+        <source>profiles list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="367"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="386"/>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="411"/>
+        <source>New</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="466"/>
+        <source>welcome message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="492"/>
+        <source>Profile name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="507"/>
+        <source>Profile name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="510"/>
+        <source>A unique name for the profile but which is limited to a subset of ascii characters only.</source>
+        <comment>Using lower case letters for &apos;ASCII&apos; may make speech synthesisers say &apos;askey&apos; which is quicker than &apos;Aay Ess Cee Eye Eye&apos;!</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="520"/>
+        <source>Server address:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="541"/>
+        <source>Game server URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="544"/>
+        <source>The Internet host name or IP address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="551"/>
+        <source>Port:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="578"/>
+        <source>Game server port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="486"/>
+        <source>Connect to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="581"/>
+        <source>The port that is used together with the server name to make the connection to the game server. If not specified a default of 23 for &quot;Telnet&quot; connections is used. Secure connections may require a different port number.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="600"/>
+        <source>Connect via a secure protocol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="603"/>
+        <source>Make Mudlet use a secure SSL/TLS protocol instead of an unencrypted one</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="609"/>
+        <source>Secure:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="630"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="688"/>
+        <source>Profile history:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="711"/>
+        <source>load newest profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="716"/>
+        <source>load oldest profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="636"/>
+        <source>Character name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="646"/>
+        <source>The characters name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="649"/>
+        <source>Character name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="652"/>
+        <source>If provided will be sent, along with password to identify the user in the game.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="763"/>
+        <source>Auto-open profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="766"/>
+        <source>Automatically start this profile when Mudlet is run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="779"/>
+        <source>Auto-reconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="782"/>
+        <source>Automatically reconnect this profile if it should become disconnected for any reason other than the user disconnecting from the game server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="675"/>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="678"/>
+        <source>If provided will be sent, along with the character name to identify the user in the game.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="727"/>
+        <source>Enable Discord integration (not supported by game)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="733"/>
+        <source>Allow this profile to use Mudlet&apos;s Discord &quot;Rich Presence&quot;  features</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="868"/>
+        <location filename="../src/ui/connection_profiles.ui" line="871"/>
+        <source>Game description or your notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="662"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="672"/>
+        <source>Characters password. Note that the password isn&apos;t encrypted in storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="760"/>
+        <source>With this enabled, Mudlet will automatically start and connect on this profile when it is launched</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="772"/>
+        <source>Open profile on Mudlet start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="788"/>
+        <source>Reconnect automatically</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="730"/>
+        <source>Discord integration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/connection_profiles.ui" line="811"/>
+        <source>Informational</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>custom_line_properties</name>
+    <message>
+        <location filename="../src/ui/custom_lines_properties.ui" line="27"/>
+        <source>Custom Line Properties [*]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines_properties.ui" line="47"/>
+        <source>Line Settings:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines_properties.ui" line="85"/>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines_properties.ui" line="59"/>
+        <source>Style:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines_properties.ui" line="44"/>
+        <source>&lt;p&gt;Select Style, Color and whether to end the line with an arrow head.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines_properties.ui" line="123"/>
+        <source>Ends with an arrow:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines_properties.ui" line="139"/>
+        <source>Exit Details:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines_properties.ui" line="154"/>
+        <source>Origin:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines_properties.ui" line="227"/>
+        <source>Destination:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines_properties.ui" line="189"/>
+        <source>    Direction/Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>custom_lines</name>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="14"/>
+        <source>Custom Line selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="45"/>
+        <source>Choose line format, color and arrow option and then select the exit to start drawing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="64"/>
+        <source>Line Settings:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="172"/>
+        <source>Ends with an arrow:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="76"/>
+        <source>Style:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="118"/>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="48"/>
+        <source>&lt;p&gt;Selecting an exit immediately proceeds to drawing the first line segment from the centre point of the room.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="61"/>
+        <source>&lt;p&gt;Select Style, Color and whether to end the line with an arrow head BEFORE then choosing the exit to draw the line for...&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="188"/>
+        <source>&lt;p&gt;Select a normal exit to commence drawing a line for it, buttons are shown depressed if they already have such a custom line and disabled if there is not exit in that direction.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="191"/>
+        <source>Normal Exits:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="213"/>
+        <source>NW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="236"/>
+        <source>N</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="259"/>
+        <source>NE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="298"/>
+        <source>UP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="337"/>
+        <source>W</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="347"/>
+        <source>E</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="357"/>
+        <source>IN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="383"/>
+        <source>OUT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="393"/>
+        <source>SW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="403"/>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="413"/>
+        <source>SE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="423"/>
+        <source>DOWN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="445"/>
+        <source>&lt;p&gt;Select a special exit to commence drawing a line for it, the first column is checked if the exit already has such a custom line.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="504"/>
+        <source>&lt;p&gt;Indicates if there is already a custom line for this special exit, will be replaced if the exit is selected.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="515"/>
+        <source>&lt;p&gt;The room this special exit leads to.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="526"/>
+        <source>&lt;p&gt;The command or LUA script that goes to the given room.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="562"/>
+        <source>&lt;p&gt;To remove a custom line: cancel this dialog, select the line and right-click to obtain a &amp;quot;delete&amp;quot; option.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="448"/>
+        <source>Special Exits:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="500"/>
+        <source>Has
+custom line?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="512"/>
+        <source> Destination </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="523"/>
+        <source> Command</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/custom_lines.ui" line="568"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>delete_profile_confirmation</name>
+    <message>
+        <location filename="../src/ui/delete_profile_confirmation.ui" line="14"/>
+        <source>Confirm permanent profile deletion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/delete_profile_confirmation.ui" line="26"/>
+        <source>Are you sure that you&apos;d like to delete this profile? Everything (aliases, triggers, backups, etc) will be gone.
+
+If you are, please type in the profile name as a confirmation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/delete_profile_confirmation.ui" line="77"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/delete_profile_confirmation.ui" line="67"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dialog</name>
+    <message>
+        <location filename="../src/ui/glyph_usage.ui" line="39"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/glyph_usage.ui" line="44"/>
+        <source>Symbol
+(Set Font)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/glyph_usage.ui" line="50"/>
+        <source>Symbol
+(All Fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/glyph_usage.ui" line="56"/>
+        <source>Codepoints</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/glyph_usage.ui" line="61"/>
+        <source>Usage
+Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/glyph_usage.ui" line="67"/>
+        <source>Rooms</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>directions</name>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5575"/>
+        <source>north</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5577"/>
+        <source>n</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5579"/>
+        <source>east</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5581"/>
+        <source>e</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5583"/>
+        <source>south</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5585"/>
+        <source>s</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5587"/>
+        <source>west</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5589"/>
+        <source>w</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5591"/>
+        <source>northeast</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5593"/>
+        <source>ne</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5595"/>
+        <source>southeast</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5597"/>
+        <source>se</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5599"/>
+        <source>southwest</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5601"/>
+        <source>sw</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5603"/>
+        <source>northwest</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5605"/>
+        <source>nw</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5607"/>
+        <source>in</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5609"/>
+        <source>i</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5611"/>
+        <source>out</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5613"/>
+        <source>o</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5615"/>
+        <source>up</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5617"/>
+        <source>u</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5619"/>
+        <source>down</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/TLuaInterpreter.cpp" line="5621"/>
+        <source>d</source>
+        <comment>Entering this direction will move the player in the game</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dlgAboutDialog</name>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="143"/>
+        <source>&lt;tr&gt;&lt;td&gt;&lt;span style=&quot;color:#bc8942;&quot;&gt;&lt;b&gt;Homepage&lt;/b&gt;&lt;/span&gt;&lt;/td&gt;&lt;td&gt;&lt;a href=&quot;http://www.mudlet.org/&quot;&gt;www.mudlet.org&lt;/a&gt;&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;&lt;span style=&quot;color:#bc8942;&quot;&gt;&lt;b&gt;Forums&lt;/b&gt;&lt;/span&gt;&lt;/td&gt;&lt;td&gt;&lt;a href=&quot;http://forums.mudlet.org/&quot;&gt;forums.mudlet.org&lt;/a&gt;&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;&lt;span style=&quot;color:#bc8942;&quot;&gt;&lt;b&gt;Documentation&lt;/b&gt;&lt;/span&gt;&lt;/td&gt;&lt;td&gt;&lt;a href=&quot;http://wiki.mudlet.org/w/Main_Page&quot;&gt;wiki.mudlet.org/w/Main_Page&lt;/a&gt;&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;&lt;span style=&quot;color:#7289DA;&quot;&gt;&lt;b&gt;Discord&lt;/b&gt;&lt;/span&gt;&lt;/td&gt;&lt;td&gt;&lt;a href=&quot;https://www.mudlet.org/chat&quot;&gt;discord.gg&lt;/a&gt;&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;&lt;span style=&quot;color:#40b040;&quot;&gt;&lt;b&gt;Source code&lt;/b&gt;&lt;/span&gt;&lt;/td&gt;&lt;td&gt;&lt;a href=&quot;https://github.com/Mudlet/Mudlet&quot;&gt;github.com/Mudlet/Mudlet&lt;/a&gt;&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;&lt;span style=&quot;color:#40b040;&quot;&gt;&lt;b&gt;Features/bugs&lt;/b&gt;&lt;/span&gt;&lt;/td&gt;&lt;td&gt;&lt;a href=&quot;https://github.com/Mudlet/Mudlet/issues&quot;&gt;github.com/Mudlet/Mudlet/issues&lt;/a&gt;&lt;/td&gt;&lt;/tr&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="246"/>
+        <source>&lt;p&gt;Others too, have make their mark on different aspects of the Mudlet project and if they have not been mentioned here it is by no means intentional! For past contributors you may see them mentioned in the &lt;b&gt;&lt;a href=&quot;https://launchpad.net/~mudlet-makers/+members#active&quot;&gt;Mudlet Makers&lt;/a&gt;&lt;/b&gt; list (on our former bug-tracking site), or for on-going contributors they may well be included in the &lt;b&gt;&lt;a href=&quot;https://github.com/Mudlet/Mudlet/graphs/contributors&quot;&gt;Contributors&lt;/a&gt;&lt;/b&gt; list on GitHub.&lt;/p&gt;
+&lt;br&gt;
+&lt;p&gt;Many icons are taken from the &lt;span style=&quot;color:#bc8942;&quot;&gt;&lt;b&gt;&lt;u&gt;KDE4 oxygen icon theme&lt;/u&gt;&lt;/b&gt;&lt;/span&gt; at &lt;a href=&quot;https://web.archive.org/web/20130921230632/http://www.oxygen-icons.org/&quot;&gt;www.oxygen-icons.org &lt;sup&gt;{wayback machine archive}&lt;/sup&gt;&lt;/a&gt; or &lt;a href=&quot;http://www.kde.org&quot;&gt;www.kde.org&lt;/a&gt;.  Most of the rest are from Thorsten Wilms, or from Stephen Lyons combining bits of Thorsten&apos;s work with the other sources.&lt;/p&gt;
+&lt;p&gt;Special thanks to &lt;span style=&quot;color:#bc8942;&quot;&gt;&lt;b&gt;Brett Duzevich&lt;/b&gt;&lt;/span&gt; and &lt;span style=&quot;color:#bc8942;&quot;&gt;&lt;b&gt;Ronny Ho&lt;/b&gt;&lt;/span&gt;. They have contributed many good ideas and thus helped improve the scripting framework substantially.&lt;/p&gt;
+&lt;p&gt;Thanks to &lt;span style=&quot;color:#bc8942;&quot;&gt;&lt;b&gt;Tomas Mecir&lt;/b&gt;&lt;/span&gt; (&lt;span style=&quot;color:#0000ff;&quot;&gt;kmuddy@kmuddy.com&lt;/span&gt;) who brought us all together and inspired us with his KMuddy project. Mudlet is using some of the telnet code he wrote for his KMuddy project (&lt;a href=&quot;https://cgit.kde.org/kmuddy.git/&quot;&gt;cgit.kde.org/kmuddy.git/&lt;/a&gt;).&lt;/p&gt;
+&lt;p&gt;Special thanks to &lt;span style=&quot;color:#bc8942;&quot;&gt;&lt;b&gt;Nick Gammon&lt;/b&gt;&lt;/span&gt; (&lt;a href=&quot;http://www.gammon.com.au/mushclient/mushclient.htm&quot;&gt;www.gammon.com.au/mushclient/mushclient.htm&lt;/a&gt;) for giving us some valued pieces of advice.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="291"/>
+        <source>&lt;p&gt;Mudlet was originally written by Heiko Köhn, KoehnHeiko@googlemail.com.&lt;/p&gt;
+&lt;p&gt;Mudlet is released under the GPL license version 2, which is reproduced below:&lt;/p&gt;</source>
+        <comment>For non-english language versions please append a translation of the following to explain why the GPL is NOT reproduced in the relevant language: &apos;but only the English form is considered the official version of the license, so the following is reproduced in that language:&apos; to replace &apos;which is reproduced below:&apos;...</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="587"/>
+        <source>&lt;p align=&quot;center&quot;&gt;&lt;b&gt;Mudlet&lt;/b&gt; is built upon the shoulders of other projects in the FOSS world; as well as using many GPL components we also make use of some third-party software with other licenses:&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="829"/>
+        <source>&lt;h2&gt;&lt;u&gt;Communi IRC Library&lt;/u&gt;&lt;/h2&gt;&lt;h3&gt;Copyright © 2008-2020 The Communi Project&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="832"/>
+        <source>&lt;p&gt;Parts of &lt;tt&gt;irctextformat.cpp&lt;/t&gt; code come from Konversation and are copyrighted to:&lt;br&gt;Copyright © 2002 Dario Abatianni &amp;lt;eisfuchs@tigress.com&amp;gt;&lt;br&gt;Copyright © 2004 Peter Simonsson &amp;lt;psn@linux.se&amp;gt;&lt;br&gt;Copyright © 2006-2008 Eike Hein &amp;lt;hein@kde.org&amp;gt;&lt;br&gt;Copyright © 2004-2009 Eli Mackenzie &amp;lt;argonel@gmail.com&amp;gt;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="838"/>
+        <source>&lt;h2&gt;&lt;u&gt;Lua - Lua 5.1&lt;/u&gt;&lt;/h2&gt;&lt;h3&gt;Copyright © 1994–2017 Lua.org, PUC-Rio.&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="841"/>
+        <source>&lt;h2&gt;&lt;u&gt;LuaFileSystem&lt;/u&gt;&lt;/h2&gt;&lt;h3&gt;Copyright © 2003-2020, Kepler Project&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="844"/>
+        <source>&lt;h2&gt;&lt;u&gt;Lua_yajl - Lua 5.1 interface to yajl&lt;/u&gt;&lt;/h2&gt;&lt;h3&gt;Author: Brian Maher &amp;lt;maherb at brimworks dot com&amp;gt;&lt;br&gt;Copyright © 2009 Brian Maher&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="848"/>
+        <source>&lt;h2&gt;&lt;u&gt;Luautf8 - A UTF-8 support module for Lua.&lt;/u&gt;&lt;/h2&gt;&lt;h3&gt;Copyright © 2018 Xavier Wang&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="851"/>
+        <source>&lt;h2&gt;&lt;u&gt;LuaSql-Sqlite3 - Database connectivity for the Lua programming language (Sqlite3 component).&lt;/u&gt;&lt;/h2&gt;&lt;h3&gt;Copyright © 2003-2019, The Kepler Project&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="854"/>
+        <source>&lt;h2&gt;&lt;u&gt;Lrexlib-pcre -  Regular expression library binding (PCRE flavour).&lt;/u&gt;&lt;/h2&gt;&lt;h3&gt;Copyright © Reuben Thomas 2000-2020&lt;br&gt;Copyright © Shmuel Zeigerman 2004-2020 &lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="865"/>
+        <source>&lt;h2&gt;&lt;u&gt;Edbee - multi-feature editor widget&lt;/u&gt;&lt;/h2&gt;&lt;h3&gt;Copyright © 2012-2014 by Reliable Bits Software by Blommers IT&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="883"/>
+        <source>&lt;h2&gt;&lt;u&gt;Qt-Components, QsLog&lt;/u&gt;&lt;/h2&gt;&lt;h3&gt;(&lt;span style=&quot;color:red&quot;&gt;&lt;u&gt;https://bitbucket.org/razvapetru/qt-components [broken link]&lt;/u&gt;&lt;/span&gt;&lt;/h3&gt;&lt;h3&gt;&lt;small&gt;&lt;a href=&quot;https://web.archive.org/web/20131220072148/https://bitbucket.org/razvanpetru/qt-components&quot;&gt; {&amp;quot;Wayback Machine&amp;quot; archived version}&lt;/a&gt;&lt;/small&gt;)&lt;br&gt;Copyright © 2013, Razvan Petru&lt;br&gt;All rights reserved.&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="890"/>
+        <source>&lt;h2&gt;&lt;u&gt;Dblsqd&lt;/u&gt;&lt;/h2&gt;&lt;h3&gt;Copyright © 2017 Philipp Medien&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="911"/>
+        <source>&lt;h2&gt;&lt;u&gt;Sparkle-glue&lt;/u&gt;&lt;/h2&gt;&lt;h3&gt;Copyright © 2008 Remko Troncon&lt;br&gt;Copyright © 2017 Vadim Peretokin&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="923"/>
+        <source>&lt;h2&gt;&lt;u&gt;singleshot_connect.h - part of KDToolBox&lt;/u&gt;&lt;br&gt;Github: &lt;a href=&quot;https://github.com/KDAB/KDToolBox&quot;&gt;KDToolBox&lt;/a&gt;&lt;/h2&gt;&lt;h3&gt;Copyright © 2020-2021 Klarälvdalens Datakonsult AB, a KDAB Group company, &amp;lt;info@kdab.comF&amp;gt;.&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="927"/>
+        <source>&lt;h2&gt;&lt;u&gt;utf8_filenames.lua - modifies standard Lua functions so that they work with UTF-8 filenames on Windows&lt;/u&gt;&lt;br&gt;&lt;a href=&quot;https://gist.github.com/Egor-Skriptunoff/2458547aa3b9210a8b5f686ac08ecbf0&quot;&gt;Github GIST&lt;/a&gt;&lt;/h2&gt;&lt;h3&gt;Copyright © 2019 Egor-Skriptunoff&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="859"/>
+        <source>&lt;h2&gt;&lt;u&gt;LuaZip - Reading files inside zip files&lt;/u&gt;&lt;/h2&gt;&lt;h3&gt;Author: Danilo Tuler&lt;br&gt;Copyright © 2003-2007 Kepler Project&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="153"/>
+        <source>Original author, original project lead, Mudlet core coding, retired.</source>
+        <extracomment>about:Heiko</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="156"/>
+        <source>GUI design and initial feature planning. He is responsible for the project homepage and the user manual. Maintainer of the Windows, macOS, Ubuntu and generic Linux installers. Maintains the Mudlet wiki, Lua API, and handles project management, public relations &amp;amp; user help. With the project from the very beginning and is an official spokesman of the project. Since the retirement of Heiko, he has become the head of the Mudlet project.</source>
+        <extracomment>about:Vadi</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="163"/>
+        <source>After joining in 2013, he has been poking various bits of the C++ code and GUI with a pointy stick; subsequently trying to patch over some of the holes made/found. Most recently he has been working on I18n and L10n for Mudlet 4.0.0 so if you are playing Mudlet in a language other than American English you will be seeing the results of him getting fed up with the spelling differences between what was being used and the British English his brain wanted to see.</source>
+        <extracomment>about:SlySven</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="170"/>
+        <source>Former maintainer of the early Windows and Apple OSX packages. He also administers our server and helps the project in many ways.</source>
+        <extracomment>about:demonnic</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="174"/>
+        <source>Contributed many improvements to Mudlet&apos;s db: interface, event system, and has been around the project for a very long while assisting users.</source>
+        <extracomment>about:keneanung</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="178"/>
+        <source>Does a ton of work in making Mudlet, the website and the wiki accessible to you regardless of the language you speak - and promoting our genre!</source>
+        <extracomment>about:Leris</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="182"/>
+        <source>Contributions to the Travis integration, CMake and Visual C++ build, a lot of code quality and memory management improvements.</source>
+        <extracomment>about:ahmedcharles</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="186"/>
+        <source>Developed a shared module system that allows script packages to be shared among profiles, a UI for viewing Lua variables, improvements in the mapper and all around.</source>
+        <extracomment>about:Chris7</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="190"/>
+        <source>Developed the first version of our Mac OSX installer. He is the former maintainer of the Mac version of Mudlet.</source>
+        <extracomment>about:Ben Carlsen</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="194"/>
+        <source>Joined in December 2009 though he&apos;s been around much longer. Contributed to the Lua API and is the former maintainer of the Lua API.</source>
+        <extracomment>about:Ben Smith</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="198"/>
+        <source>Joined in December 2009. He has contributed to the Lua API, submitted small bugfix patches and has helped with release management of 1.0.5.</source>
+        <extracomment>about:Blaine von Roeder</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="202"/>
+        <source>Developed the original cmake build script and he has committed a number of patches.</source>
+        <extracomment>about:Bruno Bigras</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="205"/>
+        <source>Contributed to the Lua API.</source>
+        <extracomment>about:Carter Dewey</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="208"/>
+        <source>Developed the Vyzor GUI Manager for Mudlet.</source>
+        <extracomment>about:Oneymus</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="211"/>
+        <source>Worked wonders in rejuvenating our Website in 2017 but who prefers a little anonymity - if you are a &lt;i&gt;SpamBot&lt;/i&gt; you will not get onto our Fora now. They have also made some useful C++ core code contributions and we look forward to future reviews on and work in that area.</source>
+        <extracomment>about:TheFae</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="216"/>
+        <source>Joining us 2017 they have given us some useful C++ and Lua contributions.</source>
+        <extracomment>about:Dicene</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="219"/>
+        <source>Contributed the Geyser layout manager for Mudlet in March 2010. It is written in Lua and aims at simplifying user GUI scripting.</source>
+        <extracomment>about:James Younquist</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="223"/>
+        <source>Helped develop and debug the Lua API.</source>
+        <extracomment>about:John Dahlström</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="226"/>
+        <source>Contributed several improvements and new features for Geyser.</source>
+        <extracomment>about:Beliaar</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="229"/>
+        <source>The original author of our Windows installer.</source>
+        <extracomment>about:Leigh Stillard</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="232"/>
+        <source>Worked on the manual, forum help and helps with GUI design and documentation.</source>
+        <extracomment>about:Maksym Grinenko</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="235"/>
+        <source>Developed a database Lua API that allows for far easier use of databases and one of the original OSX installers.</source>
+        <extracomment>about:Stephen Hansen</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="238"/>
+        <source>Designed our beautiful logo, our splash screen, the about dialog, our website, several icons and badges. Visit his homepage at &lt;a href=&quot;http://thorwil.wordpress.com/&quot;&gt;thorwil.wordpress.com&lt;/a&gt;.</source>
+        <extracomment>about:Thorsten Wilms</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="868"/>
+        <source>The &lt;b&gt;edbee-lib&lt;/b&gt; widget itself incorporates other components with licences that must be noted as well, they are:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="870"/>
+        <source>&lt;h2&gt;&lt;u&gt;Onigmo (Oniguruma-mod) LICENSE&lt;/u&gt;&lt;/h2&gt;&lt;h3&gt;Copyright © 2002-2009 K.Kosako &amp;lt;sndgk393 AT ybb DOT ne DOT jp&amp;gt;&lt;br&gt;Copyright © 2011-2014 K.Takata &amp;lt;kentkt AT csc DOT jp&amp;gt;&lt;br&gt;All rights reserved.&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="875"/>
+        <source>&lt;h2&gt;&lt;u&gt;Oniguruma LICENSE&lt;/u&gt;&lt;/h2&gt;&lt;h3&gt;Copyright © 2002-2009 K.Kosako &amp;lt;sndgk393 AT ybb DOT ne DOT jp&amp;gt;&lt;br&gt;All rights reserved.&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="879"/>
+        <source>&lt;h2&gt;&lt;u&gt;Ruby BSDL&lt;/u&gt;&lt;/h2&gt;&lt;h3&gt;Copyright © 1993-2013 Yukihiro Matsumoto.&lt;br&gt;All rights reserved.&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="893"/>
+        <source>&lt;h2&gt;&lt;u&gt;Sparkle - macOS updater&lt;/u&gt;&lt;/h2&gt;&lt;h3&gt;Copyright © 2006-2013 Andy Matuschak.&lt;br&gt;Copyright © 2009-2013 Elgato Systems GmbH.&lt;br&gt;Copyright © 2011-2014 Kornel Lesiński.&lt;br&gt;Copyright © 2015-2017 Mayur Pawashe.&lt;br&gt;Copyright © 2014 C.W. Betts.&lt;br&gt;Copyright © 2014 Petroules Corporation.&lt;br&gt;Copyright © 2014 Big Nerd Ranch.&lt;br&gt;All rights reserved.&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="903"/>
+        <source>&lt;h4&gt;bspatch.c and bsdiff.c, from bsdiff 4.3 &lt;a href=&quot;http://www.daemonology.net/bsdiff/&quot;&gt;http://www.daemonology.net/bsdiff&lt;/a&gt;:&lt;/h4&gt;&lt;h3&gt;Copyright © 2003-2005 Colin Percival.&lt;/h3&gt;&lt;h4&gt;sais.c and sais.c, from sais-lite (2010/08/07) &lt;a href=&quot;https://sites.google.com/site/yuta256/sais&quot;&gt;https://sites.google.com/site/yuta256/sais&lt;/a&gt;:&lt;/h4&gt;&lt;h3&gt;Copyright © 2008-2010 Yuta Mori.&lt;/h3&gt;&lt;h4&gt;SUDSAVerifier.m:&lt;/h4&gt;&lt;h3&gt;Copyright © 2011 Mark Hamlin.&lt;br&gt;All rights reserved.&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="917"/>
+        <source>&lt;h2&gt;&lt;u&gt;Discord - Rich Presence - RPC library&lt;/u&gt;&lt;/h2&gt;&lt;h3&gt;Copyright © 2017 Discord, Inc.&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="920"/>
+        <source>&lt;h2&gt;&lt;u&gt;QtKeyChain - Platform-independent Qt API for storing passwords securely&lt;/u&gt;&lt;/h2&gt;&lt;h3&gt;Copyright © 2011-2019 Frank Osterfeld &amp;lt;frank.osterfeld@gmail.com&amp;gt;.&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="1089"/>
+        <source>
+                            These formidable folks will be fondly remembered forever&lt;br&gt;for their generous financial support on Mudlet&apos;s patreon:
+                            </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="1097"/>
+        <source>
+                            These formidable folks will be fondly remembered forever&lt;br&gt;for their generous financial support on &lt;a href=&quot;https://www.patreon.com/mudlet&quot;&gt;Mudlet&apos;s patreon&lt;/a&gt;:
+                            </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="1133"/>
+        <source>You are using the 32-Bit version of Mudlet on a 64-Bit version of Windows. You may wish to upgrade (by downloading and then installing the 64-Bit version now available from Mudlet&apos;s website).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="1136"/>
+        <source>This is a 32-Bit build of Mudlet running on a 64-Bit version of Windows.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="1149"/>
+        <location filename="../src/dlgAboutDialog.cpp" line="1195"/>
+        <location filename="../src/dlgAboutDialog.cpp" line="1236"/>
+        <location filename="../src/dlgAboutDialog.cpp" line="1266"/>
+        <source>Technical information:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="1150"/>
+        <location filename="../src/dlgAboutDialog.cpp" line="1196"/>
+        <location filename="../src/dlgAboutDialog.cpp" line="1237"/>
+        <location filename="../src/dlgAboutDialog.cpp" line="1267"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="1152"/>
+        <location filename="../src/dlgAboutDialog.cpp" line="1198"/>
+        <location filename="../src/dlgAboutDialog.cpp" line="1239"/>
+        <location filename="../src/dlgAboutDialog.cpp" line="1269"/>
+        <source>OS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="1157"/>
+        <location filename="../src/dlgAboutDialog.cpp" line="1203"/>
+        <source>CPU (WoW64)</source>
+        <extracomment>This is shown for 32-Bit Windows builds when run on a *64-Bit OS. &quot;WoW64&quot; stands for WindowOnWindows64.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="1164"/>
+        <location filename="../src/dlgAboutDialog.cpp" line="1210"/>
+        <source>CPU (%1-bits)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="1169"/>
+        <location filename="../src/dlgAboutDialog.cpp" line="1216"/>
+        <location filename="../src/dlgAboutDialog.cpp" line="1242"/>
+        <location filename="../src/dlgAboutDialog.cpp" line="1272"/>
+        <source>CPU</source>
+        <extracomment>This is shown for all other OSes than Windows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="1175"/>
+        <location filename="../src/dlgAboutDialog.cpp" line="1248"/>
+        <source>Qt version (compilation)</source>
+        <extracomment>This is shown when the Qt version used at run-time *is different to that used during compilation - it not *the usual case.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="1181"/>
+        <location filename="../src/dlgAboutDialog.cpp" line="1254"/>
+        <source>Qt version (run-time)</source>
+        <extracomment>This is shown when the Qt version used at run-time *is different to that used during compilation - it not *the usual case.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgAboutDialog.cpp" line="1221"/>
+        <location filename="../src/dlgAboutDialog.cpp" line="1277"/>
+        <source>Qt version</source>
+        <extracomment>This is shown when the same Qt version is used at run-time *as was used during compilation - it is the usual case.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dlgAliasMainArea</name>
+    <message>
+        <location filename="../src/dlgAliasMainArea.cpp" line="37"/>
+        <source>for example, ^myalias$ to match &apos;myalias&apos;</source>
+        <extracomment>This text is shown as placeholder in the pattern box when no real pattern was entered, yet.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dlgColorTrigger</name>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="52"/>
+        <source>More colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="54"/>
+        <source>Click to access all 256 ANSI colors.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="64"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="59"/>
+        <source>Click to make the color trigger ignore the text&apos;s background color - however choosing this for both foreground and background is an error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="60"/>
+        <source>Click to make the color trigger ignore the text&apos;s foreground color - however choosing this for both foreground and background is an error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="66"/>
+        <source>Click to make the color trigger when the text&apos;s background color has not been modified from its normal value.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="67"/>
+        <source>Click to make the color trigger when the text&apos;s foreground color has not been modified from its normal value.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="71"/>
+        <source>Click a color to make the trigger fire only when the text&apos;s background color matches the color number indicated.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="72"/>
+        <source>Click a color to make the trigger fire only when the text&apos;s foreground color matches the color number indicated.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="77"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="78"/>
+        <source>Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="79"/>
+        <source>Green</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="80"/>
+        <source>Yellow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="81"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="82"/>
+        <source>Magenta</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="83"/>
+        <source>Cyan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="84"/>
+        <source>White (Light gray)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="86"/>
+        <source>Light black (Dark gray)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="87"/>
+        <source>Light red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="88"/>
+        <source>Light green</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="89"/>
+        <source>Light yellow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="90"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="91"/>
+        <source>Light magenta</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="92"/>
+        <source>Light cyan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="93"/>
+        <source>Light white</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="219"/>
+        <source>%1 [%2]</source>
+        <extracomment>Color Trigger dialog button in basic 16-color set, the first value is the name of the color, the second is the ANSI color number - for most languages modification is not likely to be needed - this text is used in two places</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgColorTrigger.cpp" line="373"/>
+        <source>All color options are showing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dlgConnectionProfiles</name>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="100"/>
+        <source>Connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="228"/>
+        <source>Characters password. Note that the password is not encrypted in storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="278"/>
+        <source>Game name: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="280"/>
+        <source>Button to select a mud game to play, double-click it to connect and start playing it.</source>
+        <extracomment>Some text to speech engines will spell out initials like MUD so stick to lower case if that is a better option</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="945"/>
+        <source>This profile is currently loaded - close it before changing the connection parameters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1255"/>
+        <source>Reset icon</source>
+        <extracomment>Reset the custom picture for this profile in the connection dialog and show the default one instead</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1259"/>
+        <source>Set custom icon</source>
+        <extracomment>Set a custom picture to show for the profile in the connection dialog</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1264"/>
+        <source>Set custom color</source>
+        <extracomment>Set a custom color to show for the profile in the connection dialog</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1628"/>
+        <source>The %1 character is not permitted. Use one of the following:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1651"/>
+        <source>You have to enter a number. Other characters are not permitted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1640"/>
+        <source>This profile name is already in use.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="562"/>
+        <source>Could not rename your profile data on the computer.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="112"/>
+        <source>&lt;p&gt;&lt;center&gt;&lt;big&gt;&lt;b&gt;Welcome to Mudlet!&lt;/b&gt;&lt;/big&gt;&lt;/center&gt;&lt;/p&gt;&lt;p&gt;&lt;center&gt;&lt;b&gt;Click on one of the games on the list to play.&lt;/b&gt;&lt;/center&gt;&lt;/p&gt;&lt;p&gt;To play a game not in the list, click on %1 &lt;span style=&quot; color:#555753;&quot;&gt;New&lt;/span&gt;, fill in the &lt;i&gt;Profile Name&lt;/i&gt;, &lt;i&gt;Server address&lt;/i&gt;, and &lt;i&gt;Port&lt;/i&gt; fields in the &lt;i&gt;Required &lt;/i&gt; area.&lt;/p&gt;&lt;p&gt;After that, click %2 &lt;span style=&quot; color:#555753;&quot;&gt;Connect&lt;/span&gt; to play.&lt;/p&gt;&lt;p&gt;Have fun!&lt;/p&gt;&lt;p align=&quot;right&quot;&gt;&lt;span style=&quot; font-family:&apos;Sans&apos;;&quot;&gt;The Mudlet Team &lt;/span&gt;&lt;img src=&quot;:/icons/mudlet_main_16px.png&quot;/&gt;&lt;/p&gt;</source>
+        <comment>Welcome message. Both %1 and %2 may be replaced by icons when this text is used.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="102"/>
+        <source>Offline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="125"/>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1385"/>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="127"/>
+        <source>Copy settings only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="147"/>
+        <source>copy profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="148"/>
+        <source>copy the entire profile to new one that will require a different new name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="163"/>
+        <source>copy profile settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="164"/>
+        <source>copy the settings and some other parts of the profile to a new one that will require a different new name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="226"/>
+        <source>Characters password, stored securely in the computer&apos;s credential manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="275"/>
+        <source>Click to load but not connect the selected profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="276"/>
+        <source>Click to load and connect the selected profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="277"/>
+        <source>Need to have a valid profile name, game server address and port before this button can be enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="570"/>
+        <source>Could not create the new profile folder on your computer.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="616"/>
+        <source>new profile name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="734"/>
+        <source>Deleting &apos;%1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="992"/>
+        <source>Discord integration not available on this platform</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="998"/>
+        <source>Discord integration not supported by game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1001"/>
+        <source>Check to enable Discord integration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1277"/>
+        <source>Select custom image for profile (should be 120x30)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1277"/>
+        <source>Images (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1367"/>
+        <source>Copying...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1661"/>
+        <source>Port number must be above zero and below 65535.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1681"/>
+        <source>Mudlet can not load support for secure connections.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1703"/>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1713"/>
+        <source>Please enter the URL or IP address of the Game server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1724"/>
+        <source>SSL connections require the URL of the Game server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1741"/>
+        <source>Load profile without connecting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1757"/>
+        <source>Please set a valid profile name, game server address and the game port before loading.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1762"/>
+        <source>Please set a valid profile name, game server address and the game port before connecting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1816"/>
+        <source>Click to hide the password; it will also hide if another profile is selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1820"/>
+        <source>Click to reveal the password for this profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1669"/>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1672"/>
+        <source>Mudlet is not configured for secure connections.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dlgIRC</name>
+    <message>
+        <location filename="../src/dlgIRC.cpp" line="104"/>
+        <source>%1 closed their client.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgIRC.cpp" line="116"/>
+        <source>Mudlet IRC Client - %1 - %2 on %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgIRC.cpp" line="130"/>
+        <source>$ Starting Mudlet IRC Client...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgIRC.cpp" line="131"/>
+        <source>$ Host: %1:%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgIRC.cpp" line="132"/>
+        <source>$ Nick: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgIRC.cpp" line="133"/>
+        <source>$ Auto-Join Channels: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgIRC.cpp" line="134"/>
+        <source>$ This client supports Auto-Completion using the Tab key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgIRC.cpp" line="135"/>
+        <source>$ Type &lt;b&gt;/help&lt;/b&gt; for commands or &lt;b&gt;/help [command]&lt;/b&gt; for command syntax.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgIRC.cpp" line="196"/>
+        <source>Restarting IRC Client</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgIRC.cpp" line="374"/>
+        <source>[Error] MSGLIMIT requires &lt;limit&gt; to be a whole number greater than zero!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgIRC.cpp" line="404"/>
+        <source>[HELP] Available Commands: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgIRC.cpp" line="406"/>
+        <source>[HELP] Syntax: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgIRC.cpp" line="414"/>
+        <source>! Connected to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgIRC.cpp" line="415"/>
+        <source>! Joining %1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgIRC.cpp" line="420"/>
+        <source>! Connecting %1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgIRC.cpp" line="425"/>
+        <source>! Disconnected from %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgIRC.cpp" line="487"/>
+        <source>[ERROR] Syntax: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgIRC.cpp" line="489"/>
+        <source>[ERROR] Unknown command: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgIRC.cpp" line="635"/>
+        <source>! The Nickname %1 is reserved. Automatically changing Nickname to: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgIRC.cpp" line="646"/>
+        <source>Your nick has changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dlgMapLabel</name>
+    <message>
+        <location filename="../src/dlgMapLabel.cpp" line="34"/>
+        <source>Create label</source>
+        <extracomment>Create label dialog title</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgMapLabel.cpp" line="75"/>
+        <source>Foreground color</source>
+        <extracomment>2D mapper create label color dialog title</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgMapLabel.cpp" line="96"/>
+        <source>Background color</source>
+        <extracomment>2D mapper create label color dialog title</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgMapLabel.cpp" line="116"/>
+        <source>Label font</source>
+        <extracomment>2D mapper create label font dialog title</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgMapLabel.cpp" line="134"/>
+        <source>Select image</source>
+        <extracomment>2D Mapper create label file dialog title</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dlgMapper</name>
+    <message>
+        <location filename="../src/dlgMapper.cpp" line="375"/>
+        <source>None</source>
+        <extracomment>Don&apos;t show the map overlay, &apos;none&apos; meaning no map overlay styled are enabled</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dlgModuleManager</name>
+    <message>
+        <location filename="../src/dlgModuleManager.cpp" line="46"/>
+        <source>Module Manager - %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgModuleManager.cpp" line="62"/>
+        <source>Module Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgModuleManager.cpp" line="62"/>
+        <source>Priority</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgModuleManager.cpp" line="62"/>
+        <source>Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgModuleManager.cpp" line="62"/>
+        <source>Module Location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgModuleManager.cpp" line="102"/>
+        <source>Checking this box will cause the module to be saved and &lt;i&gt;resynchronised&lt;/i&gt; across all sessions that share it when the &lt;i&gt;Save Profile&lt;/i&gt; button is clicked in the Editor or if it is saved at the end of the session.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgModuleManager.cpp" line="132"/>
+        <source>Load Mudlet Module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgModuleManager.cpp" line="139"/>
+        <source>Load Mudlet Module:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgModuleManager.cpp" line="139"/>
+        <source>Cannot read file %1:
+%2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dlgPackageExporter</name>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="29"/>
+        <source>Package name here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="36"/>
+        <source>or</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="82"/>
+        <source>Check items to export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="156"/>
+        <source>Author</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="328"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="213"/>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="235"/>
+        <source>Icon size of 512x512 recommended</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="245"/>
+        <source>512x512 recommended</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="182"/>
+        <source>Icon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="66"/>
+        <source>Select what to export</source>
+        <comment>This is the text shown at the top of a groupbox initially and when there is NO items to export in the Package exporter dialogue.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="109"/>
+        <source>Describe your package. Add a description, icons, assets and more.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="175"/>
+        <source>For attribution, displayed in the Package Manager.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="216"/>
+        <source>Add icon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="255"/>
+        <source>Short description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="268"/>
+        <source>One-line package description shown in the Package Manager.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="275"/>
+        <source>Description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="288"/>
+        <source>
+This package description is shown in the package manager.  The editor supports Commonmark markdown.  Follow the description below for a thorough example of what to include in your package description.
+
+### Description
+
+A full description of what this package achieves. If the package is game specific then mention that here.  Specify if the package has autoupdating or, if not, add a link in the See Also section below to the code repository.
+
+### Usage
+
+If this package uses aliases, show a few examples and expected output.
+
+`&gt; alias_1`
+
+    output of alias_1  -- indent by four spaces
+    more output        -- for code blocks
+
+If this package is a GUI implementation consider adding screenshots by directly dragging and dropping images into this editor.
+
+### See Also
+
+Further reading material. e.g. a link to the Mudlet wiki, forums, Github package repository or webpage.
+
+* https://wiki.mudlet.org/w/Manual:Best_Practices#Package_and_Module_best_practices
+* [Link 2 might be a webpage](https://example.org)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="318"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="338"/>
+        <source>Required packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="395"/>
+        <source>Does this package make use of other packages? List them here as requirements. Press &apos;Delete&apos; to remove a package.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="427"/>
+        <source>Include assets (images, sounds, fonts)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="437"/>
+        <source>Drag and drop files and folders, or use the browse button below</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="485"/>
+        <source>Select files to include in package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="20"/>
+        <source>Package Exporter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="335"/>
+        <source>Does this package make use of other packages? List them here as requirements.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/dlgPackageExporter.ui" line="535"/>
+        <source>Select export location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="63"/>
+        <source>Triggers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="64"/>
+        <source>Aliases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="65"/>
+        <source>Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="66"/>
+        <source>Scripts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="67"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="68"/>
+        <source>Buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="91"/>
+        <source>Export</source>
+        <extracomment>Text for button to perform the package export on the items the user has selected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="135"/>
+        <source>Package Exporter - %1</source>
+        <extracomment>Title of the window. The %1 will be replaced by the current profile&apos;s name</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="187"/>
+        <source>Failed to open file &quot;%1&quot; to place into package. Error message was: &quot;%2&quot;.</source>
+        <extracomment>This error message will appear when a file is to be placed into the package but the code cannot open it.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="196"/>
+        <source>Failed to add file &quot;%1&quot; to package. Error message was: &quot;%3&quot;.</source>
+        <extracomment>This error message will appear when a file is to be placed into the package but cannot be done for some reason.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="903"/>
+        <source>Failed to open package file. Error is: &quot;%1&quot;.</source>
+        <extracomment>This zipError message is shown when the libzip library code is unable to open the file that was to be the end result of the export process. As this may be an existing file anywhere in the computer&apos;s file-system(s) it is possible that permissions on the directory or an existing file that is to be overwritten may be a source of problems here.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="1065"/>
+        <source>Failed to zip up the package. Error is: &quot;%1&quot;.</source>
+        <extracomment>This error message is displayed at the final stage of exporting a package when all the sourced files are finally put into the archive. Unfortunately this may be the point at which something breaks because a problem was not spotted/detected in the process earlier...</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="1475"/>
+        <source>Why not &lt;a href=&quot;https://forums.mudlet.org/viewforum.php?f=6&quot;&gt;upload&lt;/a&gt; your package for other Mudlet users?</source>
+        <extracomment>Only the text outside of the &apos;a&apos; (HTML anchor) tags PLUS the verb &apos;upload&apos; in between them in the source text, (associated with uploading the resulting package to the Mudlet forums) should be translated.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/dlgPackageExporter.cpp" line="1493"/>
+        <source>Select what to export (%n item(s))</source>
+        <extracomment>This is the text shown at the top of a groupbox when there is %n (one or more) items to export in the Package exporter dialogue; the initial (and when there is no items selected) is a separate text.</extracomment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="1496"/>
+        <source>Select what to export</source>
+        <extracomment>This is the text shown at the top of a groupbox initially and when there is NO items to export in the Package exporter dialogue.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="115"/>
+        <source>update installed package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="116"/>
+        <source>add dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="338"/>
+        <location filename="../src/dlgPackageExporter.cpp" line="340"/>
+        <source>Export to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="873"/>
+        <source>cannot copy %1 to the temporary location %2 - can you double-check it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="359"/>
+        <source>Open Icon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="359"/>
+        <source>Image Files (*.png *.jpg *.jpeg *.bmp *.tif *.ico *.icns)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="482"/>
+        <source>Please enter the package name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="520"/>
+        <location filename="../src/dlgPackageExporter.cpp" line="596"/>
+        <source>Exporting package...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="540"/>
+        <source>Failed to export. Could not open the folder &quot;%1&quot; for writing. Do you have the necessary permissions and free disk-space to write to that folder?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="796"/>
+        <source>Failed to export. Could not write Mudlet items to the file &quot;%1&quot;.</source>
+        <extracomment>This error message is shown when all the Mudlet items cannot be written to the &apos;packageName&apos;.xml file in the base directory of the place where all the files are staged before being compressed into the package file. The full path and filename are shown in %1 to help the user diagnose what might have happened</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="868"/>
+        <source>%1 doesn&apos;t seem to exist anymore - can you double-check it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="986"/>
+        <source>Failed to add directory &quot;%1&quot; to package. Error is: &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="1029"/>
+        <source>Required file &quot;%1&quot; was not found in the staging area. This area contains the Mudlet items chosen for the package, which you selected to be included in the package file. This suggests there may be a problem with that directory: &quot;%2&quot; - Do you have the necessary permissions and free disk-space?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="582"/>
+        <source>Package &quot;%1&quot; exported to: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="1058"/>
+        <source>Export cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageExporter.cpp" line="1119"/>
+        <source>Where do you want to save the package?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dlgPackageManager</name>
+    <message>
+        <location filename="../src/dlgPackageManager.cpp" line="47"/>
+        <source>Package Manager - %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageManager.cpp" line="99"/>
+        <source>Import Mudlet Package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageManager.cpp" line="106"/>
+        <source>Import Mudlet Package:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageManager.cpp" line="106"/>
+        <source>Cannot read file %1:
+%2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageManager.cpp" line="166"/>
+        <source>Author</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageManager.cpp" line="166"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageManager.cpp" line="166"/>
+        <source>Created</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageManager.cpp" line="166"/>
+        <source>Dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/dlgPackageManager.cpp" line="235"/>
+        <source>Remove %n package(s)</source>
+        <extracomment>Message on button in package manager to remove one or more (%n is the count of) selected package(s).</extracomment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/dlgPackageManager.cpp" line="238"/>
+        <source>Remove package</source>
+        <extracomment>Message on button in package manager initially and when there is no packages to remove</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dlgProfilePreferences</name>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="141"/>
+        <source>Location which will be used to store log files - matching logs will be appended to.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="142"/>
+        <source>Select a directory where logs will be saved.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="143"/>
+        <source>Reset the directory so that logs are saved to the profile&apos;s &lt;i&gt;log&lt;/i&gt; directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="147"/>
+        <source>Set a custom name for your log. (New logs are appended if a log file of the same name already exists).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="176"/>
+        <source>Automatic updates are disabled in development builds to prevent an update from overwriting your Mudlet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="203"/>
+        <source>This will bring up a display showing all the symbols used in the current map and whether they can be drawn using just the specified font, any other font, or not at all.  It also shows the sequence of Unicode &lt;i&gt;code-points&lt;/i&gt; that make up that symbol, so that they can be identified even if they cannot be displayed; also, up to the first thirty two rooms that are using that symbol are listed, which may help to identify any unexpected or odd cases.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="209"/>
+        <source>Select the only or the primary font used (depending on &lt;i&gt;Only use symbols (glyphs) from chosen font&lt;/i&gt; setting) to produce the 2D mapper room symbols.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="211"/>
+        <source>Using a single font is likely to produce a more consistent style but may cause the &lt;i&gt;font replacement character&lt;/i&gt; &apos;&lt;b&gt;�&lt;/b&gt;&apos; to show if the font does not have a needed glyph (a font&apos;s individual character/symbol) to represent the grapheme (what is to be represented).  Clearing this checkbox will allow the best alternative glyph from another font to be used to draw that grapheme.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="307"/>
+        <source>%1 (%2% done)</source>
+        <comment>%1 is the (not-translated so users of the language can read it!) language name, %2 is percentage done.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="363"/>
+        <source>Migrated all passwords to secure storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="374"/>
+        <source>Migrated all passwords to profile storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="721"/>
+        <source>From the dictionary file &lt;tt&gt;%1.dic&lt;/tt&gt; (and its companion affix &lt;tt&gt;.aff&lt;/tt&gt; file).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="882"/>
+        <source>yyyy-MM-dd#HH-mm-ss (e.g., 1970-01-01#00-00-00%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="884"/>
+        <source>yyyy-MM-ddTHH-mm-ss (e.g., 1970-01-01T00-00-00%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="885"/>
+        <source>yyyy-MM-dd (concatenate daily logs in, e.g. 1970-01-01%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="888"/>
+        <source>yyyy-MM (concatenate month logs in, e.g. 1970-01%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="889"/>
+        <source>Named file (concatenate logs in one file)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="927"/>
+        <source>Other profiles to Map to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="968"/>
+        <source>%1 {Default, recommended}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="980"/>
+        <source>%1 {Upgraded, experimental/testing, NOT recommended}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="982"/>
+        <source>%1 {Downgraded, for sharing with older version users, NOT recommended}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="991"/>
+        <source>2D Map Room Symbol scaling factor:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="1011"/>
+        <source>Show &quot;%1&quot; in the map area selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="1052"/>
+        <source>%1 (*Error, report to Mudlet Makers*)</source>
+        <comment>The encoder code name is not in the mudlet class mEncodingNamesMap when it should be and the Mudlet Makers need to fix it!</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="1179"/>
+        <location filename="../src/dlgProfilePreferences.cpp" line="4258"/>
+        <source>Profile preferences - %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="1502"/>
+        <source>Profile preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2411"/>
+        <source>Load Mudlet map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2351"/>
+        <source>Loading map - please wait...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="150"/>
+        <source>logfile</source>
+        <extracomment>Must be a valid default filename for a log-file and is used if the user does not enter any other value (Ensure all instances have the same translation {one of two copies}).</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/dlgProfilePreferences.cpp" line="161"/>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3175"/>
+        <source>copy to %n destination(s)</source>
+        <extracomment>text on button to put the map from this profile into the other profiles to receive the map from this profile, %n is the number of other profiles that have already been selected to receive it and will be zero or more. The button will also be disabled (greyed out) in the zero case but the text will still be visible.</extracomment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="370"/>
+        <source>Migrated %1...</source>
+        <extracomment>This notifies the user that progress is being made on profile migration by saying what profile was just migrated to store passwords securely</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="687"/>
+        <source>Mudlet dictionaries:</source>
+        <extracomment>On Windows and MacOs, we have to bundle our own dictionaries with our application - and we also use them on *nix systems where we do not find the system ones</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="690"/>
+        <source>System dictionaries:</source>
+        <extracomment>On *nix systems where we find the system ones we use them</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="810"/>
+        <source>None</source>
+        <comment>Special value for number of command line history size to save that does not save any at all!</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="811"/>
+        <source>10</source>
+        <comment>Value for number of command line history size to save, can be formatted for a locale&apos;s number grouping conventions</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="812"/>
+        <source>20</source>
+        <comment>Value for number of command line history size to save, can be formatted for a locale&apos;s number grouping conventions</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="813"/>
+        <source>50</source>
+        <comment>Value for number of command line history size to save, can be formatted for a locale&apos;s number grouping conventions</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="814"/>
+        <source>100</source>
+        <comment>Value for number of command line history size to save, can be formatted for a locale&apos;s number grouping conventions</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="815"/>
+        <source>200</source>
+        <comment>Value for number of command line history size to save, can be formatted for a locale&apos;s number grouping conventions</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="816"/>
+        <source>500</source>
+        <comment>Value for number of command line history size to save, can be formatted for a locale&apos;s number grouping conventions</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="817"/>
+        <source>1,000</source>
+        <comment>Value for number of command line history size to save, can be formatted for a locale&apos;s number grouping conventions</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="818"/>
+        <source>2,000</source>
+        <comment>Value for number of command line history size to save, can be formatted for a locale&apos;s number grouping conventions</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="819"/>
+        <source>5,000</source>
+        <comment>Value for number of command line history size to save, can be formatted for a locale&apos;s number grouping conventions</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="820"/>
+        <source>10,000</source>
+        <comment>Value for number of command line history size to save, can be formatted for a locale&apos;s number grouping conventions</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="1779"/>
+        <source>Pick color</source>
+        <extracomment>Generic pick color dialog title</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2375"/>
+        <source>Loaded map from %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2377"/>
+        <source>Could not load map from %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2438"/>
+        <source>Save Mudlet map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2460"/>
+        <source>Saving map - please wait...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2477"/>
+        <source>Saved map to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2479"/>
+        <source>Could not save map to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2510"/>
+        <source>Migrating passwords to secure storage...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2517"/>
+        <source>Migrating passwords to profiles...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2549"/>
+        <source>[ ERROR ] - Unable to use or create directory to store map for other profile &quot;%1&quot;.
+Please check that you have permissions/access to:
+&quot;%2&quot;
+and there is enough space. The copying operation has failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2556"/>
+        <source>Creating a destination directory failed...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2640"/>
+        <source>Backing up current map - please wait...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2650"/>
+        <source>Could not backup the map - saving it failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2675"/>
+        <source>Could not copy the map - failed to work out which map file we just saved the map as!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2687"/>
+        <source>Copying over map to %1 - please wait...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2693"/>
+        <source>Could not copy the map to %1 - unable to copy the new map file over.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2697"/>
+        <source>Map copied successfully to other profile %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2709"/>
+        <source>Map copied, now signalling other profiles to reload it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2745"/>
+        <source>Where should Mudlet save log files?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/dlgProfilePreferences.cpp" line="3182"/>
+        <source>%n selected - change destinations...</source>
+        <extracomment>text on button to select other profiles to receive the map from this profile, %n is the number of other profiles that have already been selected to receive it and will always be 1 or more</extracomment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3189"/>
+        <source>pick destinations...</source>
+        <extracomment>text on button to select other profiles to receive the map from this profile, this is used when no profiles have been selected</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3430"/>
+        <source>Could not update themes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3433"/>
+        <source>Updating themes from colorsublime.github.io...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3552"/>
+        <source>{missing, possibly recently deleted trigger item}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3555"/>
+        <source>{missing, possibly recently deleted alias item}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3558"/>
+        <source>{missing, possibly recently deleted script item}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3561"/>
+        <source>{missing, possibly recently deleted timer item}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3564"/>
+        <source>{missing, possibly recently deleted key item}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3567"/>
+        <source>{missing, possibly recently deleted button item}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3691"/>
+        <source>The room symbol will appear like this if only symbols (glyphs) from the specific font are used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3696"/>
+        <source>The room symbol will appear like this if symbols (glyphs) from any font can be used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3736"/>
+        <source>How many rooms in the whole map have this symbol.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3754"/>
+        <source>The rooms with this symbol, up to a maximum of thirty-two, if there are more than this, it is indicated but they are not shown.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3762"/>
+        <source>The symbol can be made entirely from glyphs in the specified font.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3780"/>
+        <source>The symbol cannot be drawn using any of the fonts in the system, either an invalid string was entered as the symbol for the indicated rooms or the map was created on a different systems with a different set of fonts available to use. You may be able to correct this by installing an additional font using whatever method is appropriate for this system or by editing the map to use a different symbol. It may be possible to do the latter via a lua script using the &lt;i&gt;getRoomChar&lt;/i&gt; and &lt;i&gt;setRoomChar&lt;/i&gt; functions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3873"/>
+        <source>Large icon</source>
+        <extracomment>Discord Rich Presence large icon</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3875"/>
+        <source>Detail</source>
+        <extracomment>Discord Rich Presence detail</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3878"/>
+        <source>Small icon</source>
+        <extracomment>Discord Rich Presence small icon&quot;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3880"/>
+        <source>State</source>
+        <extracomment>Discord Rich Presence state</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3883"/>
+        <source>Party size</source>
+        <extracomment>Discord Rich Presence party size</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3885"/>
+        <source>Party max</source>
+        <extracomment>Discord Rich Presence maximum party size</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3887"/>
+        <source>Time</source>
+        <extracomment>Discord Rich Presence time until or time elapsed</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="4390"/>
+        <source>Set outer color of player room mark.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="4391"/>
+        <source>Set inner color of player room mark.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="144"/>
+        <source>&lt;p&gt;This option sets the format of the log name.&lt;/p&gt;&lt;p&gt;If &lt;i&gt;Named file&lt;/i&gt; is selected, you can set a custom file name. (Logs are appended if a log file of the same name already exists.)&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="197"/>
+        <source>&lt;p&gt;A timer with a short interval will quickly fill up the &lt;i&gt;Central Debug Console&lt;/i&gt; windows with messages that it ran correctly on &lt;i&gt;each&lt;/i&gt; occasion it is called.  This (per profile) control adjusts a threshold that will hide those messages in just that window for those timers which run &lt;b&gt;correctly&lt;/b&gt; when the timer&apos;s interval is less than this setting.&lt;/p&gt;&lt;p&gt;&lt;u&gt;Any timer script that has errors will still have its error messages reported whatever the setting.&lt;/u&gt;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="216"/>
+        <source>&lt;p&gt;If &lt;b&gt;not&lt;/b&gt; checked Mudlet will only react to the first matching keybinding (combination of key and modifiers) even if more than one of them is set to be active. This means that a temporary keybinding (not visible in the Editor) created by a script or package may be used in preference to a permanent one that is shown and is set to be active. If checked then all matching keybindings will be run.&lt;/p&gt;&lt;p&gt;&lt;i&gt;It is recommended to not enable this option if you need to maintain compatibility with scripts or packages for Mudlet versions prior to &lt;b&gt;3.9.0&lt;/b&gt;.&lt;/i&gt;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="224"/>
+        <source>&lt;p&gt;Some East Asian MUDs may use glyphs (characters) that Unicode classifies as being of &lt;i&gt;Ambiguous&lt;/i&gt; width when drawn in a font with a so-called &lt;i&gt;fixed&lt;/i&gt; pitch; in fact such text is &lt;i&gt;duo-spaced&lt;/i&gt; when not using a proportional font. These symbols can be drawn using either a half or the whole space of a full character. By default Mudlet tries to chose the right width automatically but you can override the setting for each profile.&lt;/p&gt;&lt;p&gt;This control has three settings:&lt;ul&gt;&lt;li&gt;&lt;b&gt;Unchecked&lt;/b&gt; &apos;&lt;i&gt;narrow&lt;/i&gt;&apos; = Draw ambiguous width characters in a single &apos;space&apos;.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Checked&lt;/b&gt; &apos;&lt;i&gt;wide&lt;/i&gt;&apos; = Draw ambiguous width characters two &apos;spaces&apos; wide.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Partly checked&lt;/b&gt; &lt;i&gt;(Default) &apos;auto&apos;&lt;/i&gt; = Use &apos;wide&apos; setting for MUD Server encodings of &lt;b&gt;Big5&lt;/b&gt;/&lt;b&gt;Big5-HKSCS&lt;/b&gt;, &lt;b&gt;GBK&lt;/b&gt;, &lt;b&gt;GBK18030&lt;/b&gt; or &lt;b&gt;EUC-KR&lt;/b&gt; and &apos;narrow&apos; for all others.&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;&lt;i&gt;This is a temporary arrangement and will probably change when Mudlet gains full support for languages other than English.&lt;/i&gt;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="236"/>
+        <source>&lt;p&gt;Enable a context (right click) menu action on any console/user window that, when the mouse cursor is hovered over it, will display the UTF-16 and UTF-8 items that make up each Unicode codepoint on the &lt;b&gt;first&lt;/b&gt; line of any selection.&lt;/p&gt;&lt;p&gt;This utility feature is intended to help the user identify any grapheme (visual equivalent to a &lt;i&gt;character&lt;/i&gt;) that a Game server may send even if it is composed of multiple bytes as any non-ASCII character will be in the Lua sub-system which uses the UTF-8 encoding system.&lt;p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="243"/>
+        <source>&lt;p&gt;Some Desktop Environments tell Qt applications like Mudlet whether they should shown icons on menus, others, however do not. This control allows the user to override the setting, if needed, as follows:&lt;ul&gt;&lt;li&gt;&lt;b&gt;Unchecked&lt;/b&gt; &apos;&lt;i&gt;off&lt;/i&gt;&apos; = Prevent menus from being drawn with icons.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Checked&lt;/b&gt; &apos;&lt;i&gt;on&lt;/i&gt;&apos; = Allow menus to be drawn with icons.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Partly checked&lt;/b&gt; &lt;i&gt;(Default) &apos;auto&apos;&lt;/i&gt; = Use the setting that the system provides.&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;&lt;i&gt;This setting is only processed when individual menus are created and changes may not propagate everywhere until Mudlet is restarted.&lt;/i&gt;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="723"/>
+        <source>%1 - not recognised</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="724"/>
+        <source>&lt;p&gt;Mudlet does not recognise the code &quot;%1&quot;, please report it to the Mudlet developers so we can describe it properly in future Mudlet versions!&lt;/p&gt;&lt;p&gt;The file &lt;tt&gt;%2.dic&lt;/tt&gt; (and its companion affix &lt;tt&gt;.aff&lt;/tt&gt; file) is still usable.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="749"/>
+        <source>No Hunspell dictionary files found, spell-checking will not be available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2362"/>
+        <source>[ ERROR ] - Unable to load JSON map file: %1
+reason: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2403"/>
+        <source>Any map file (*.dat *.json *.xml)</source>
+        <comment>Do not change extensions (in braces) as they are used programmatically</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2404"/>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2433"/>
+        <source>Mudlet binary map (*.dat)</source>
+        <comment>Do not change extensions (in braces) as they are used programmatically</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2405"/>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2434"/>
+        <source>Mudlet JSON map (*.json)</source>
+        <comment>Do not change extensions (in braces) as they are used programmatically</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2406"/>
+        <source>Mudlet XML map (*.xml)</source>
+        <comment>Do not change extensions (in braces) as they are used programmatically</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="2407"/>
+        <source>Any file (*)</source>
+        <comment>Do not change extensions (in braces) as they are used programmatically</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3724"/>
+        <source>&lt;p&gt;These are the sequence of hexadecimal numbers that are used by the Unicode consortium to identify the graphemes needed to create the symbol.  These numbers can be utilised to determine precisely what is to be drawn even if some fonts have glyphs that are the same for different codepoints or combination of codepoints.&lt;/p&gt;&lt;p&gt;Character entry utilities such as &lt;i&gt;charmap.exe&lt;/i&gt; on &lt;i&gt;Windows&lt;/i&gt; or &lt;i&gt;gucharmap&lt;/i&gt; on many Unix type operating systems will also use these numbers which cover everything from U+0020 {Space} to U+10FFFD the last usable number in the &lt;i&gt;Private Use Plane 16&lt;/i&gt; via most of the written marks that humanity has ever made.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3748"/>
+        <source>more - not shown...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3771"/>
+        <source>&lt;p&gt;The symbol cannot be made entirely from glyphs in the specified font, but, using other fonts in the system, it can. Either un-check the &lt;i&gt;Only use symbols (glyphs) from chosen font&lt;/i&gt; option or try and choose another font that does have the needed glyphs.&lt;/p&gt;&lt;p&gt;&lt;i&gt;You need not close this table to try another font, changing it on the main preferences dialogue will update this table after a slight delay.&lt;/i&gt;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="3922"/>
+        <source>Map symbol usage - %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="4003"/>
+        <source>yyyy-MM-dd#HH-mm-ss (e.g., 1970-01-01#00-00-00.html)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="4004"/>
+        <source>yyyy-MM-ddTHH-mm-ss (e.g., 1970-01-01T00-00-00.html)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="4005"/>
+        <source>yyyy-MM-dd (concatenate daily logs in, e.g. 1970-01-01.html)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="4006"/>
+        <source>yyyy-MM (concatenate month logs in, e.g. 1970-01.html)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="4009"/>
+        <source>yyyy-MM-dd#HH-mm-ss (e.g., 1970-01-01#00-00-00.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="4010"/>
+        <source>yyyy-MM-ddTHH-mm-ss (e.g., 1970-01-01T00-00-00.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="4011"/>
+        <source>yyyy-MM-dd (concatenate daily logs in, e.g. 1970-01-01.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="4012"/>
+        <source>yyyy-MM (concatenate month logs in, e.g. 1970-01.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="4502"/>
+        <source>Deleting map - please wait...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgProfilePreferences.cpp" line="4514"/>
+        <source>Deleted map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dlgRoomExits</name>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="274"/>
+        <source>(roomID)</source>
+        <comment>Placeholder, if no roomID is set for an exit.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="275"/>
+        <source>(command or Lua script)</source>
+        <comment>Placeholder, if a special exit has no name/script set.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="441"/>
+        <location filename="../src/dlgRoomExits.cpp" line="445"/>
+        <location filename="../src/dlgRoomExits.cpp" line="988"/>
+        <source>Set the number of the room that this special exit goes to.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="447"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1587"/>
+        <source>Prevent a route being created via this exit, equivalent to an infinite exit weight.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="452"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1593"/>
+        <source>Set to a positive value to override the default (Room) Weight for using this Exit route, zero value assigns the default.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="455"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1602"/>
+        <source>No door symbol is drawn on 2D Map for this exit (only functional choice currently).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="457"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1603"/>
+        <source>Green (Open) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="459"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1604"/>
+        <source>Orange (Closed) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="461"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1605"/>
+        <source>Red (Locked) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="967"/>
+        <location filename="../src/dlgRoomExits.cpp" line="992"/>
+        <source>The roomID of the room that this special exit leads to is expected here. If left like this, this exit will be deleted when &lt;tt&gt;save&lt;/tt&gt; is clicked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="983"/>
+        <source>Entered number is invalid. If left like this, this exit will be deleted when &lt;tt&gt;save&lt;/tt&gt; is clicked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="984"/>
+        <source>Set the number of the room that this special exit leads to.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="997"/>
+        <source>No command or Lua script entered, if left like this, this exit will be deleted when &lt;tt&gt;save&lt;/tt&gt; is clicked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1048"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1060"/>
+        <source>Exit to &quot;%1&quot; in area: &quot;%2&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1511"/>
+        <source>This is the Room ID number for this room; this &lt;b&gt;room is locked&lt;/b&gt; so it will not be used for speed-walks at all.</source>
+        <extracomment>This text is a revision to the default tooltip text set for this widget in the &apos;room_exits.ui&apos; file. Bold HTML tags are used to emphasis that this room&apos;s locked status overrides any weight or lock (&quot;No route&quot;) setting of any exit that comes to it.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1073"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1085"/>
+        <source>Exit to unnamed room in area: &quot;%1&quot;, is valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="999"/>
+        <source>Some mapper scripts may require prefixing the keyword &quot;script:&quot;).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1079"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1091"/>
+        <source>Exit to unnamed room is valid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1187"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1188"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1296"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1531"/>
+        <source>Set the number of the room northwest of this one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1196"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1197"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1304"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1533"/>
+        <source>Set the number of the room north of this one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1205"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1206"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1312"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1535"/>
+        <source>Set the number of the room northeast of this one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1214"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1215"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1320"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1537"/>
+        <source>Set the number of the room up from this one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1223"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1224"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1328"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1539"/>
+        <source>Set the number of the room west of this one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1232"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1233"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1336"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1541"/>
+        <source>Set the number of the room east of this one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1241"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1242"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1344"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1543"/>
+        <source>Set the number of the room down from this one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1250"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1251"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1352"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1545"/>
+        <source>Set the number of the room southwest of this one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1259"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1260"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1360"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1547"/>
+        <source>Set the number of the room south of this one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1268"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1269"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1368"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1549"/>
+        <source>Set the number of the room southeast of this one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1277"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1278"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1376"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1551"/>
+        <source>Set the number of the room in from this one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1286"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1287"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1384"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1553"/>
+        <source>Set the number of the room out from this one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1053"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1065"/>
+        <source>Exit to &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1051"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1056"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1076"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1081"/>
+        <source>&lt;b&gt;Room is locked&lt;/b&gt;, it will not be used for speed-walks for any exit that leads to it.</source>
+        <extracomment>Bold HTML tags are used to emphasis that destination room locked status overrides any weight or lock (&quot;No route&quot;) setting of any exit that goes to it.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1063"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1068"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1088"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1093"/>
+        <source>&lt;b&gt;Room&lt;/b&gt; Weight of destination: %1.</source>
+        <extracomment>Bold HTML tags are used to emphasis that the value is destination room&apos;s weight whether overridden by a non-zero exit weight here or not
+----------
+Bold HTML tags are used to emphasis that the value is destination room&apos;s weight whether overridden by a non-zero exit weight here or not.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1159"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1480"/>
+        <source>Clear the stub exit for this exit to enter an exit roomID.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1187"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1196"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1205"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1214"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1223"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1232"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1241"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1250"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1259"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1268"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1277"/>
+        <location filename="../src/dlgRoomExits.cpp" line="1286"/>
+        <source>Entered number is invalid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1521"/>
+        <source>Exits for room: &quot;%1&quot; [*]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomExits.cpp" line="1523"/>
+        <source>Exits for room Id: %1 [*]</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dlgRoomProperties</name>
+    <message numerus="yes">
+        <location filename="../src/dlgRoomProperties.cpp" line="150"/>
+        <source>Lock room(s), so it/they will never be used for speedwalking</source>
+        <comment>This text will be shown at a checkbox, where you can set/unset a number of room&apos;s lock.</comment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/dlgRoomProperties.cpp" line="167"/>
+        <source>Enter a new room weight to use as the travel time for all of the %n selected room(s). This will be used for calculating the best path. The minimum and default is 1.</source>
+        <comment>%n is the total number of rooms involved.</comment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/dlgRoomProperties.cpp" line="173"/>
+        <source>To change the room weight for all of the %n selected room(s), please choose:
+ • an existing room weight from the list below (sorted by most commonly used first)
+ • enter a new positive integer value to use as a new weight. The default is 1.</source>
+        <comment>This is for when applying a new room weight to one or more rooms and some have different weights at present. %n is the total number of rooms involved.</comment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/dlgRoomProperties.cpp" line="195"/>
+        <source>Type one or more graphemes (&quot;visible characters&quot;) to use as a symbol for all of the %n selected room(s), or enter a space to clear the symbol:</source>
+        <comment>%n is the total number of rooms involved.</comment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/dlgRoomProperties.cpp" line="201"/>
+        <source>To change the symbol for all of the %n selected room(s), please choose:
+ • an existing symbol from the list below (sorted by most commonly used first)
+ • enter one or more graphemes (&quot;visible characters&quot;) as a new symbol
+ • enter a space to clear any existing symbols</source>
+        <comment>This is for when applying a new room symbol to one or more rooms and some have different symbols or no symbol at present. %n is the total number of rooms involved.</comment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomProperties.cpp" line="246"/>
+        <location filename="../src/dlgRoomProperties.cpp" line="286"/>
+        <source>count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomProperties.cpp" line="517"/>
+        <source>Delete room color</source>
+        <extracomment>This action deletes a color from the list of all room colors</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomProperties.cpp" line="545"/>
+        <source>OK</source>
+        <extracomment>confirm room color selection dialog</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomProperties.cpp" line="551"/>
+        <source>Cancel</source>
+        <extracomment>cancel room color selection dialog</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomProperties.cpp" line="442"/>
+        <source>Set symbol color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomProperties.cpp" line="479"/>
+        <location filename="../src/dlgRoomProperties.cpp" line="536"/>
+        <source>Define new room color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomProperties.cpp" line="502"/>
+        <source>Set room color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgRoomProperties.h" line="79"/>
+        <source>(Multiple values...)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dlgTriggerEditor</name>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="406"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="6501"/>
+        <location filename="../src/dlgTriggerEditor.h" line="461"/>
+        <source>Triggers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="407"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="408"/>
+        <source>Show Triggers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="436"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="6525"/>
+        <location filename="../src/dlgTriggerEditor.h" line="467"/>
+        <source>Buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="437"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="438"/>
+        <source>Show Buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="411"/>
+        <location filename="../src/dlgTriggerEditor.h" line="462"/>
+        <source>Aliases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="412"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="413"/>
+        <source>Show Aliases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="421"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="6507"/>
+        <location filename="../src/dlgTriggerEditor.h" line="464"/>
+        <source>Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="422"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="423"/>
+        <source>Show Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="416"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="6513"/>
+        <location filename="../src/dlgTriggerEditor.h" line="463"/>
+        <source>Scripts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="417"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="418"/>
+        <source>Show Scripts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="426"/>
+        <location filename="../src/dlgTriggerEditor.h" line="465"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="427"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="428"/>
+        <source>Show Keybindings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="431"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7018"/>
+        <location filename="../src/dlgTriggerEditor.h" line="466"/>
+        <source>Variables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="432"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="433"/>
+        <source>Show Variables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="458"/>
+        <source>Activate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="459"/>
+        <source>Toggle Active or Non-Active Mode for Triggers, Scripts etc.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="477"/>
+        <source>Delete Item</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.h" line="452"/>
+        <location filename="../src/dlgTriggerEditor.h" line="453"/>
+        <location filename="../src/dlgTriggerEditor.h" line="454"/>
+        <location filename="../src/dlgTriggerEditor.h" line="455"/>
+        <location filename="../src/dlgTriggerEditor.h" line="456"/>
+        <location filename="../src/dlgTriggerEditor.h" line="457"/>
+        <location filename="../src/dlgTriggerEditor.h" line="458"/>
+        <location filename="../src/dlgTriggerEditor.h" line="459"/>
+        <source>Ctrl+S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="498"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9791"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9797"/>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="502"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="503"/>
+        <source>Copy the trigger/script/alias/etc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="512"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9792"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9798"/>
+        <source>Paste</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="516"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="517"/>
+        <source>Paste triggers/scripts/aliases/etc from the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="531"/>
+        <source>Import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="535"/>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="539"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9633"/>
+        <location filename="../src/dlgTriggerEditor.h" line="460"/>
+        <source>Save Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.h" line="460"/>
+        <source>Ctrl+Shift+S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="550"/>
+        <source>Saves your entire profile (triggers, aliases, scripts, timers, buttons and keys, but not the map or script-specific settings); also &quot;synchronizes&quot; modules that are so marked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="552"/>
+        <source>Save Profile As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="447"/>
+        <location filename="../src/dlgTriggerEditor.h" line="469"/>
+        <source>Statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="71"/>
+        <source>&lt;p&gt;Alias react on user input. To add a new alias:&lt;ol&gt;&lt;li&gt;Click on the &apos;Add Item&apos; icon above.&lt;/li&gt;&lt;li&gt;Define an input &lt;strong&gt;pattern&lt;/strong&gt; either literally or with a Perl regular expression.&lt;/li&gt;&lt;li&gt;Define a &apos;substitution&apos; &lt;strong&gt;command&lt;/strong&gt; to send to the game in clear text &lt;strong&gt;instead of the alias pattern&lt;/strong&gt;, or write a script for more complicated needs.&lt;/li&gt;&lt;li&gt;&lt;strong&gt;Activate&lt;/strong&gt; the alias.&lt;/li&gt;&lt;/ol&gt;&lt;/p&gt;&lt;p&gt;That&apos;s it! If you&apos;d like to be able to create aliases from the input line, there are a &lt;a href=&apos;https://forums.mudlet.org/viewtopic.php?f=6&amp;t=22609&apos;&gt;couple&lt;/a&gt; of &lt;a href=&apos;https://forums.mudlet.org/viewtopic.php?f=6&amp;t=16462&apos;&gt;packages&lt;/a&gt; that can help you.&lt;p&gt;Check the manual for &lt;a href=&apos;http://wiki.mudlet.org/w/Manual:Introduction#Aliases&apos;&gt;more information&lt;/a&gt;.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="79"/>
+        <source>&lt;p&gt;Triggers react on game output. To add a new trigger:&lt;ol&gt;&lt;li&gt;Click on the &apos;Add Item&apos; icon above.&lt;/li&gt;&lt;li&gt;Define a &lt;strong&gt;pattern&lt;/strong&gt; that you want to trigger on.&lt;/li&gt;&lt;li&gt;Select the appropriate pattern &lt;strong&gt;type&lt;/strong&gt;.&lt;/li&gt;&lt;li&gt;Define a clear text &lt;strong&gt;command&lt;/strong&gt; that you want to send to the game if the trigger finds the pattern in the text from the game, or write a script for more complicated needs..&lt;/li&gt;&lt;li&gt;&lt;strong&gt;Activate&lt;/strong&gt; the trigger.&lt;/li&gt;&lt;/ol&gt;&lt;/p&gt;&lt;p&gt;That&apos;s it! If you&apos;d like to be able to create triggers from the input line, there are a &lt;a href=&apos;https://forums.mudlet.org/viewtopic.php?f=6&amp;t=22609&apos;&gt;couple&lt;/a&gt; of &lt;a href=&apos;https://forums.mudlet.org/viewtopic.php?f=6&amp;t=16462&apos;&gt;packages&lt;/a&gt; that can help you.&lt;p&gt;Check the manual for &lt;a href=&apos;http://wiki.mudlet.org/w/Manual:Introduction#Triggers&apos;&gt;more information&lt;/a&gt;.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="163"/>
+        <source>new folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="164"/>
+        <source>new item</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="168"/>
+        <source>%1 - Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="236"/>
+        <source>-- Enter your lua code here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="318"/>
+        <source>*** starting new session ***</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="452"/>
+        <location filename="../src/dlgTriggerEditor.h" line="470"/>
+        <source>Debug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="493"/>
+        <source>&lt;p&gt;Saves the selected item. (Ctrl+S)&lt;/p&gt;&lt;p&gt;Saving causes any changes to the item to take effect. It will not save to disk, so changes will be lost in case of a computer/program crash (but Save Profile to the right will be secure.)&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="540"/>
+        <source>&lt;p&gt;Saves your profile. (Ctrl+Shift+S)&lt;/p&gt;&lt;p&gt;Saves your entire profile (triggers, aliases, scripts, timers, buttons and keys, but not the map or script-specific settings) to your computer disk, so in case of a computer or program crash, all changes you have done will be retained.&lt;/p&gt;&lt;p&gt;It also makes a backup of your profile, you can load an older version of it when connecting.&lt;/p&gt;&lt;p&gt;Should there be any modules that are marked to be &quot;&lt;i&gt;synced&lt;/i&gt;&quot; this will also cause them to be saved and reloaded into other profiles if they too are active.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="560"/>
+        <source>Something went wrong loading your Mudlet profile and it could not be loaded. Try loading an older version in &apos;Connect - Options - Profile history&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="587"/>
+        <source>Editor Toolbar - %1 - Actions</source>
+        <extracomment>This is the toolbar that is initially placed at the top of the editor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="621"/>
+        <source>Editor Toolbar - %1 - Items</source>
+        <extracomment>This is the toolbar that is initially placed at the left side of the editor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="631"/>
+        <source>Restore Actions toolbar</source>
+        <extracomment>This will restore that toolbar in the editor window, after a user has hidden it or moved it to another docking location or floated it elsewhere.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="634"/>
+        <source>Restore Items toolbar</source>
+        <extracomment>This will restore that toolbar in the editor window, after a user has hidden it or moved it to another docking location or floated it elsewhere.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="721"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="724"/>
+        <source>Search Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="728"/>
+        <source>Case sensitive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="833"/>
+        <source>start of line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="872"/>
+        <source>Text to find (trigger pattern)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2848"/>
+        <source>Trying to activate a trigger group, filter or trigger or the part of a module &quot;&lt;tt&gt;%1&lt;/tt&gt;&quot; that contains them &lt;em&gt;succeeded&lt;/em&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2850"/>
+        <source>Trying to deactivate a trigger group, filter or trigger or the part of a module &quot;&lt;tt&gt;%1&lt;/tt&gt;&quot; that contains them &lt;em&gt;succeeded&lt;/em&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2854"/>
+        <source>&lt;b&gt;Unable to activate a filter or trigger or the part of a module &quot;&lt;tt&gt;%1&lt;/tt&gt;&quot; that contains them; reason: %2.&lt;/b&gt;&lt;/p&gt;
+                     &lt;p&gt;&lt;i&gt;You will need to reactivate this after the problem has been corrected.&lt;/i&gt;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3043"/>
+        <source>Trying to activate a timer group, offset timer, timer or the part of a module &quot;&lt;tt&gt;%1&lt;/tt&gt;&quot; that contains them &lt;em&gt;succeeded&lt;/em&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3045"/>
+        <source>Trying to deactivate a timer group, offset timer, timer or the part of a module &quot;&lt;tt&gt;%1&lt;/tt&gt;&quot; that contains them &lt;em&gt;succeeded&lt;/em&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3049"/>
+        <source>&lt;p&gt;&lt;b&gt;Unable to activate an offset timer or timer or the part of a module &quot;&lt;tt&gt;%1&lt;/tt&gt;&quot; that contains them; reason: %2.&lt;/b&gt;&lt;/p&gt;
+                     &lt;p&gt;&lt;i&gt;You will need to reactivate this after the problem has been corrected.&lt;/i&gt;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3186"/>
+        <source>Trying to activate an alias group, alias or the part of a module &quot;&lt;tt&gt;%1&lt;/tt&gt;&quot; that contains them &lt;em&gt;succeeded&lt;/em&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3188"/>
+        <source>Trying to deactivate an alias group, alias or the part of a module &quot;&lt;tt&gt;%1&lt;/tt&gt;&quot; that contains them &lt;em&gt;succeeded&lt;/em&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3192"/>
+        <source>&lt;p&gt;&lt;b&gt;Unable to activate an alias or the part of a module &quot;&lt;tt&gt;%1&lt;/tt&gt;&quot; that contains them; reason: %2.&lt;/b&gt;&lt;/p&gt;
+                     &lt;p&gt;&lt;i&gt;You will need to reactivate this after the problem has been corrected.&lt;/i&gt;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3311"/>
+        <source>Trying to activate a script group, script or the part of a module &quot;&lt;tt&gt;%1&lt;/tt&gt;&quot; that contains them &lt;em&gt;succeeded&lt;/em&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3313"/>
+        <source>Trying to deactivate a script group, script or the part of a module &quot;&lt;tt&gt;%1&lt;/tt&gt;&quot; that contains them &lt;em&gt;succeeded&lt;/em&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3317"/>
+        <source>&lt;p&gt;&lt;b&gt;Unable to activate a script group or script or the part of a module &quot;&lt;tt&gt;%1&lt;/tt&gt;&quot; that contains them; reason: %2.&lt;/b&gt;&lt;/p&gt;
+                     &lt;p&gt;&lt;i&gt;You will need to reactivate this after the problem has been corrected.&lt;/i&gt;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3470"/>
+        <source>Trying to activate a button/menu/toolbar or the part of a module &quot;&lt;tt&gt;%1&lt;/tt&gt;&quot; that contains them &lt;em&gt;succeeded&lt;/em&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3472"/>
+        <source>Trying to deactivate a button/menu/toolbar or the part of a module &quot;&lt;tt&gt;%1&lt;/tt&gt;&quot; that contains them &lt;em&gt;succeeded&lt;/em&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3476"/>
+        <source>&lt;p&gt;&lt;b&gt;Unable to activate a button/menu/toolbar or the part of a module &quot;&lt;tt&gt;%1&lt;/tt&gt;&quot; that contains them; reason: %2.&lt;/b&gt;&lt;/p&gt;
+                     &lt;p&gt;&lt;i&gt;You will need to reactivate this after the problem has been corrected.&lt;/i&gt;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3711"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="4587"/>
+        <source>New trigger group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3713"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="4587"/>
+        <source>New trigger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3817"/>
+        <source>New timer group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3819"/>
+        <source>New timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3912"/>
+        <source>Table name...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3919"/>
+        <source>Variable name...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3928"/>
+        <source>New table name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3928"/>
+        <source>New variable name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3978"/>
+        <source>New key group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="3980"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5422"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5490"/>
+        <source>New key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="4066"/>
+        <source>New alias group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="4068"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="4745"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="4831"/>
+        <source>New alias</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="4163"/>
+        <source>New menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="4165"/>
+        <source>New button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="4196"/>
+        <source>New toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="4253"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5134"/>
+        <source>New script group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="4255"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5134"/>
+        <source>New script</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="4761"/>
+        <source>Alias &lt;em&gt;%1&lt;/em&gt; has an infinite loop - substitution matches its own pattern. Please fix it - this alias isn&apos;t good as it&apos;ll call itself forever.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5127"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="6419"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="10213"/>
+        <source>While loading the profile, this script had an error that has since been fixed, possibly by another script. The error was:%2%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5386"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="6215"/>
+        <source>Checked variables will be saved and loaded with your profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5561"/>
+        <source>match on the prompt line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5564"/>
+        <source>match on the prompt line (disabled)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5565"/>
+        <source>A Go-Ahead (GA) signal from the game is required to make this feature work</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5765"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5767"/>
+        <source>fault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5624"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5733"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9535"/>
+        <source>Foreground color ignored</source>
+        <extracomment>Color trigger ignored foreground color button, ensure all three instances have the same text</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="88"/>
+        <source>&lt;p&gt;Scripts organize code and can react to events. To add a new script:&lt;ol&gt;&lt;li&gt;Click on the &apos;Add Item&apos; icon above.&lt;/li&gt;&lt;li&gt;Enter a script in the box below. You can for example define &lt;strong&gt;functions&lt;/strong&gt; to be called by other triggers, aliases, etc.&lt;/li&gt;&lt;li&gt;If you write lua &lt;strong&gt;commands&lt;/strong&gt; without defining a function, they will be run on Mudlet startup and each time you open the script for editing.&lt;/li&gt;&lt;li&gt;If needed, you can register a list of &lt;strong&gt;events&lt;/strong&gt; with the + and - symbols. If one of these events take place, the function with the same name as the script item itself will be called.&lt;/li&gt;&lt;li&gt;&lt;strong&gt;Activate&lt;/strong&gt; the script.&lt;/li&gt;&lt;/ol&gt;&lt;/p&gt;&lt;p&gt;&lt;strong&gt;Note:&lt;/strong&gt; Scripts are run automatically when viewed, even if they are deactivated.&lt;/p&gt;&lt;p&gt;&lt;strong&gt;Note:&lt;/strong&gt; Events can also be added to a script from the command line in the main profile window like this:&lt;/p&gt;&lt;p&gt;&lt;code&gt;lua registerAnonymousEventHandler(&amp;quot;nameOfTheMudletEvent&amp;quot;, &amp;quot;nameOfYourFunctionToBeCalled&amp;quot;)&lt;/code&gt;&lt;/p&gt;&lt;p&gt;Check the manual for &lt;a href=&apos;http://wiki.mudlet.org/w/Manual:Introduction#Scripts&apos;&gt;more information&lt;/a&gt;.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="99"/>
+        <source>&lt;p&gt;Timers react after a timespan once or regularly. To add a new timer:&lt;ol&gt;&lt;li&gt;Click on the &apos;Add Item&apos; icon above.&lt;/li&gt;&lt;li&gt;Define the &lt;strong&gt;timespan&lt;/strong&gt; after which the timer should react in a this format: hours : minutes : seconds.&lt;/li&gt;&lt;li&gt;Define a clear text &lt;strong&gt;command&lt;/strong&gt; that you want to send to the game when the time has passed, or write a script for more complicated needs.&lt;/li&gt;&lt;li&gt;&lt;strong&gt;Activate&lt;/strong&gt; the timer.&lt;/li&gt;&lt;/ol&gt;&lt;/p&gt;&lt;p&gt;&lt;strong&gt;Note:&lt;/strong&gt; If you want the trigger to react only once and not regularly, use the Lua tempTimer() function instead.&lt;/p&gt;&lt;p&gt;&lt;strong&gt;Note:&lt;/strong&gt; Timers can also be defined from the command line in the main profile window like this:&lt;/p&gt;&lt;p&gt;&lt;code&gt;lua tempTimer(3, function() echo(&amp;quot;hello!
+&amp;quot;) end)&lt;/code&gt;&lt;/p&gt;&lt;p&gt;This will greet you exactly 3 seconds after it was made.&lt;/p&gt;&lt;p&gt;Check the manual for &lt;a href=&apos;http://wiki.mudlet.org/w/Manual:Introduction#Timers&apos;&gt;more information&lt;/a&gt;.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="110"/>
+        <source>&lt;p&gt;Buttons react on mouse clicks. To add a new button:&lt;ol&gt;&lt;li&gt;Add a new group to define a new &lt;strong&gt;button bar&lt;/strong&gt; in case you don&apos;t have any.&lt;/li&gt;&lt;li&gt;Add new groups as &lt;strong&gt;menus&lt;/strong&gt; to a button bar or sub-menus to menus.&lt;li&gt;&lt;li&gt;Add new items as &lt;strong&gt;buttons&lt;/strong&gt; to a button bar or menu or sub-menu.&lt;/li&gt;&lt;li&gt;Define a clear text &lt;strong&gt;command&lt;/strong&gt; that you want to send to the game if the button is pressed, or write a script for more complicated needs.&lt;/li&gt;&lt;li&gt;&lt;strong&gt;Activate&lt;/strong&gt; the toolbar, menu or button. &lt;/li&gt;&lt;/ol&gt;&lt;p&gt;&lt;strong&gt;Note:&lt;/strong&gt; Deactivated items will be hidden and if they are toolbars or menus then all the items they contain will be also be hidden.&lt;/p&gt;&lt;p&gt;&lt;strong&gt;Note:&lt;/strong&gt; If a button is made a &lt;strong&gt;click-down&lt;/strong&gt; button then you may also define a clear text command that you want to send to the game when the button is pressed a second time to uncheck it or to write a script to run when it happens - within such a script the Lua &apos;getButtonState()&apos; function reports whether the button is up or down.&lt;/p&gt;&lt;p&gt;Check the manual for &lt;a href=&apos;http://wiki.mudlet.org/w/Manual:Introduction#Buttons&apos;&gt;more information&lt;/a&gt;.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="120"/>
+        <source>&lt;p&gt;Keys react on keyboard presses. To add a new key binding:&lt;ol&gt;&lt;li&gt;Click on the &apos;Add Item&apos; icon above.&lt;/li&gt;&lt;li&gt;Click on &lt;strong&gt;&apos;grab key&apos;&lt;/strong&gt; and then press your key combination, e.g. including modifier keys like Control, Shift, etc.&lt;/li&gt;&lt;li&gt;Define a clear text &lt;strong&gt;command&lt;/strong&gt; that you want to send to the game if the button is pressed, or write a script for more complicated needs.&lt;/li&gt;&lt;li&gt;&lt;strong&gt;Activate&lt;/strong&gt; the new key binding.&lt;/li&gt;&lt;/ol&gt;&lt;/p&gt;&lt;p&gt;&lt;strong&gt;Note:&lt;/strong&gt; Keys can also be defined from the command line in the main profile window like this:&lt;/p&gt;&lt;p&gt;&lt;code&gt;lua permKey(&amp;quot;my jump key&amp;quot;, &amp;quot;&amp;quot;, mudlet.key.F8, [[send(&amp;quot;jump&amp;quot;]]) end)&lt;/code&gt;&lt;/p&gt;&lt;p&gt;Pressing F8 will make you jump.&lt;/p&gt;&lt;p&gt;Check the manual for &lt;a href=&apos;http://wiki.mudlet.org/w/Manual:Introduction#Keybindings&apos;&gt;more information&lt;/a&gt;.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="130"/>
+        <source>&lt;p&gt;Variables store information. To make a new variable:&lt;ol&gt;&lt;li&gt;Click on the &apos;Add Item&apos; icon above. To add a table instead click &apos;Add Group&apos;.&lt;/li&gt;&lt;li&gt;Select type of variable value (can be a string, integer, boolean)&lt;/li&gt;&lt;li&gt;Enter the value you want to store in this variable.&lt;/li&gt;&lt;li&gt;If you want to keep the variable in your next Mudlet sessions, check the checkbox in the list of variables to the left.&lt;/li&gt;&lt;li&gt;To remove a variable manually, set it to &apos;nil&apos; or click on the &apos;Delete&apos; icon above.&lt;/li&gt;&lt;/ol&gt;&lt;/p&gt;&lt;p&gt;&lt;strong&gt;Note:&lt;/strong&gt; Variables created here won&apos;t be saved when Mudlet shuts down unless you check their checkbox in the list of variables to the left. You could also create scripts with the variables instead.&lt;/p&gt;&lt;p&gt;&lt;strong&gt;Note:&lt;/strong&gt; Variables and tables can also be defined from the command line in the main profile window like this:&lt;/p&gt;&lt;p&gt;&lt;code&gt;lua foo = &amp;quot;bar&amp;quot;&lt;/code&gt;&lt;/p&gt;&lt;p&gt;This will create a string called &apos;foo&apos; with &apos;bar&apos; as its value.&lt;/p&gt;&lt;p&gt;Check the manual for &lt;a href=&apos;http://wiki.mudlet.org/w/Manual:Introduction#Variables&apos;&gt;more information&lt;/a&gt;.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="470"/>
+        <source>Add Item</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="484"/>
+        <source>Add Group (Control+Shift+N)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5628"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5737"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9538"/>
+        <source>Default foreground color</source>
+        <extracomment>Color trigger default foreground color button, ensure all three instances have the same text</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5632"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5741"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9541"/>
+        <source>Foreground color [ANSI %1]</source>
+        <extracomment>Color trigger ANSI foreground color button, ensure all three instances have the same text</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5638"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5747"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9597"/>
+        <source>Background color ignored</source>
+        <extracomment>Color trigger ignored background color button, ensure all three instances have the same text</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5642"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5751"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9600"/>
+        <source>Default background color</source>
+        <extracomment>Color trigger default background color button, ensure all three instances have the same text</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5646"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5755"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9603"/>
+        <source>Background color [ANSI %1]</source>
+        <extracomment>Color trigger ANSI background color button, ensure all three instances have the same text</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5821"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="5825"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9428"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9450"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9946"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9948"/>
+        <source>keep</source>
+        <extracomment>Keep the existing colour on matches to highlight. Use shortest word possible so it fits on the button</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="6276"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9406"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="6315"/>
+        <source>Menu properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="6325"/>
+        <source>Button properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="6333"/>
+        <source>Command (down);</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="6519"/>
+        <source>Aliases - Input Triggers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="6531"/>
+        <source>Key Bindings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7639"/>
+        <source>Add Trigger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7640"/>
+        <source>Add new trigger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7641"/>
+        <source>Add Trigger Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7642"/>
+        <source>Add new group of triggers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7643"/>
+        <source>Delete Trigger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7644"/>
+        <source>Delete the selected trigger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7645"/>
+        <location filename="../src/dlgTriggerEditor.h" line="453"/>
+        <source>Save Trigger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7646"/>
+        <source>Saves the selected trigger, causing new changes to take effect - does not save to disk though...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7649"/>
+        <source>Add Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7650"/>
+        <source>Add new timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7651"/>
+        <source>Add Timer Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7652"/>
+        <source>Add new group of timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7653"/>
+        <source>Delete Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7654"/>
+        <source>Delete the selected timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7655"/>
+        <location filename="../src/dlgTriggerEditor.h" line="454"/>
+        <source>Save Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7656"/>
+        <source>Saves the selected timer, causing new changes to take effect - does not save to disk though...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7659"/>
+        <source>Add Alias</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7660"/>
+        <source>Add new alias</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7661"/>
+        <source>Add Alias Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7662"/>
+        <source>Add new group of aliases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7663"/>
+        <source>Delete Alias</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7664"/>
+        <source>Delete the selected alias</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7665"/>
+        <location filename="../src/dlgTriggerEditor.h" line="455"/>
+        <source>Save Alias</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7666"/>
+        <source>Saves the selected alias, causing new changes to take effect - does not save to disk though...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7669"/>
+        <source>Add Script</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7670"/>
+        <source>Add new script</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7671"/>
+        <source>Add Script Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7672"/>
+        <source>Add new group of scripts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7673"/>
+        <source>Delete Script</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7674"/>
+        <source>Delete the selected script</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7675"/>
+        <location filename="../src/dlgTriggerEditor.h" line="456"/>
+        <source>Save Script</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7676"/>
+        <source>Saves the selected script, causing new changes to take effect - does not save to disk though...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7679"/>
+        <source>Add Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7680"/>
+        <source>Add new button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7681"/>
+        <source>Add Button Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7682"/>
+        <source>Add new group of buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7683"/>
+        <source>Delete Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7684"/>
+        <source>Delete the selected button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7685"/>
+        <location filename="../src/dlgTriggerEditor.h" line="457"/>
+        <source>Save Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7686"/>
+        <source>Saves the selected button, causing new changes to take effect - does not save to disk though...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7689"/>
+        <source>Add Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7690"/>
+        <source>Add new key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7691"/>
+        <source>Add Key Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7692"/>
+        <source>Add new group of keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7693"/>
+        <source>Delete Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7694"/>
+        <source>Delete the selected key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7695"/>
+        <location filename="../src/dlgTriggerEditor.h" line="458"/>
+        <source>Save Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7696"/>
+        <source>Saves the selected key, causing new changes to take effect - does not save to disk though...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7699"/>
+        <source>Add Variable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7700"/>
+        <source>Add new variable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7701"/>
+        <source>Add Lua table</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7702"/>
+        <source>Add new Lua table</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7703"/>
+        <source>Delete Variable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7704"/>
+        <source>Delete the selected variable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7705"/>
+        <location filename="../src/dlgTriggerEditor.h" line="459"/>
+        <source>Save Variable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="7706"/>
+        <source>Saves the selected variable, causing new changes to take effect - does not save to disk though...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8322"/>
+        <source>Central Debug Console</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8604"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8608"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8628"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8632"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8652"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8656"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8676"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8680"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8700"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8704"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8724"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8729"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8749"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8753"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8772"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8776"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8795"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8799"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8818"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8822"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8841"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8845"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8864"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8869"/>
+        <source>Export Package:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8604"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8608"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8628"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8632"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8652"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8656"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8676"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8680"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8700"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8704"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8724"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8729"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8749"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8753"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8772"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8776"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8795"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8799"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8818"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8822"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8841"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8845"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8864"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8869"/>
+        <source>You have to choose an item for export first. Please select a tree item and then click on export again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8613"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8637"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8661"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8685"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8709"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8734"/>
+        <source>Package %1 saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8758"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8781"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8804"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8827"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8850"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8874"/>
+        <source>Copied %1 to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8884"/>
+        <source>Mudlet packages (*.xml)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8884"/>
+        <source>Export Item</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8898"/>
+        <source>export package:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="8898"/>
+        <source>Cannot write file %1:
+%2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9165"/>
+        <source>Import Mudlet Package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9259"/>
+        <source>Couldn&apos;t save profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9259"/>
+        <source>Sorry, couldn&apos;t save your profile - got the following error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9266"/>
+        <source>Backup Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9266"/>
+        <source>trigger files (*.trigger *.xml)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9464"/>
+        <source>Audio files(*.aac *.mp3 *.mp4a *.oga *.ogg *.pcm *.wav *.wma);;Advanced Audio Coding-stream(*.aac);;MPEG-2 Audio Layer 3(*.mp3);;MPEG-4 Audio(*.mp4a);;Ogg Vorbis(*.oga *.ogg);;PCM Audio(*.pcm);;Wave(*.wav);;Windows Media Audio(*.wma);;All files(*.*)</source>
+        <extracomment>This the list of file extensions that are considered for sounds from triggers, the terms inside of the &apos;(&apos;...&apos;)&apos; and the &quot;;;&quot; are used programmatically and should not be changed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.h" line="470"/>
+        <source>Ctrl+0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9402"/>
+        <source>Command (down):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9423"/>
+        <source>Select foreground color to apply to matches</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9445"/>
+        <source>Select background color to apply to matches</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9459"/>
+        <source>Choose sound file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9515"/>
+        <source>Select foreground trigger color for item %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9578"/>
+        <source>Select background trigger color for item %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9626"/>
+        <source>Saving…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9787"/>
+        <source>Format All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9790"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9796"/>
+        <source>Cut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9794"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9800"/>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="9962"/>
+        <source>Sound file to play when the trigger fires.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="831"/>
+        <source>substring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="144"/>
+        <source>activated</source>
+        <extracomment>Item is currently on, short enough to be spoken</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="146"/>
+        <source>deactivated</source>
+        <extracomment>Item is currently off, short enough to be spoken</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="148"/>
+        <source>activated folder</source>
+        <extracomment>Folder is currently turned on</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="150"/>
+        <source>deactivated folder</source>
+        <extracomment>Folder is currently turned off</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="152"/>
+        <source>deactivated due to error</source>
+        <extracomment>Item is currently inactive because of errors, short enough to be spoken</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="154"/>
+        <source>%1 in a deactivated group</source>
+        <extracomment>Item is currently turned on individually, but is member of an inactive group</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="156"/>
+        <source>activated filter chain</source>
+        <extracomment>A trigger that unlocks other triggers is currently turned on, short enough to be spoken</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="158"/>
+        <source>deactivated filter chain</source>
+        <extracomment>A trigger that unlocks other triggers is currently turned off, short enough to be spoken</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="160"/>
+        <source>activated offset timer</source>
+        <extracomment>A timer that starts after another timer is currently turned on</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="162"/>
+        <source>deactivated offset timer</source>
+        <extracomment>A timer that starts after another timer is currently turned off</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="227"/>
+        <source>-- add your Lua code here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="408"/>
+        <location filename="../src/dlgTriggerEditor.h" line="461"/>
+        <source>Ctrl+1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="413"/>
+        <location filename="../src/dlgTriggerEditor.h" line="462"/>
+        <source>Ctrl+2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="418"/>
+        <location filename="../src/dlgTriggerEditor.h" line="463"/>
+        <source>Ctrl+3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="423"/>
+        <location filename="../src/dlgTriggerEditor.h" line="464"/>
+        <source>Ctrl+4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="428"/>
+        <location filename="../src/dlgTriggerEditor.h" line="465"/>
+        <source>Ctrl+5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="433"/>
+        <location filename="../src/dlgTriggerEditor.h" line="466"/>
+        <source>Ctrl+6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="438"/>
+        <location filename="../src/dlgTriggerEditor.h" line="467"/>
+        <source>Ctrl+7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="442"/>
+        <location filename="../src/dlgTriggerEditor.h" line="468"/>
+        <source>Errors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="443"/>
+        <source>Show/Hide the errors console in the bottom right of this editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="444"/>
+        <source>Show/Hide errors console</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="444"/>
+        <location filename="../src/dlgTriggerEditor.h" line="468"/>
+        <source>Ctrl+8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="448"/>
+        <source>Generate a statistics summary display on the main profile console.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="449"/>
+        <source>Generate statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="449"/>
+        <location filename="../src/dlgTriggerEditor.h" line="469"/>
+        <source>Ctrl+9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="453"/>
+        <source>Show/Hide the separate Central Debug Console - when being displayed the system will be slower.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="454"/>
+        <source>Show/Hide Debug Console (Ctrl+0) -&gt; system will be &lt;b&gt;&lt;i&gt;slower&lt;/i&gt;&lt;/b&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="730"/>
+        <source>Match case precisely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="734"/>
+        <source>Include variables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="736"/>
+        <source>Search variables (slower)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="780"/>
+        <source>Type</source>
+        <extracomment>Heading for the first column of the search results</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="784"/>
+        <source>Where</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="786"/>
+        <source>What</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="832"/>
+        <source>perl regex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="834"/>
+        <source>exact match</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="835"/>
+        <source>lua function</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="836"/>
+        <source>line spacer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="837"/>
+        <source>color trigger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="838"/>
+        <source>prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1960"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1972"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2000"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2032"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2062"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2074"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2101"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2136"/>
+        <source>Trigger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="782"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1480"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1523"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1595"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1667"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1789"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1873"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1960"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2062"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2168"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2257"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2343"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2467"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2541"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1535"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1540"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1607"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1612"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1679"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1684"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1883"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1888"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1972"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1977"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2074"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2079"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2178"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2183"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2355"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2360"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2479"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2484"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2553"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2558"/>
+        <source>Command</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2000"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2005"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2101"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2106"/>
+        <source>Pattern {%1}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1565"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1570"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1637"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1642"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1759"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1764"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1843"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1848"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1930"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1935"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2032"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2037"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2136"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2141"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2225"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2230"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2311"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2316"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2435"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2440"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2509"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2514"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2583"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2588"/>
+        <source>Lua code (%1:%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1873"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1883"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1900"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1930"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2168"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2178"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2195"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2225"/>
+        <source>Alias</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1900"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1905"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2195"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2200"/>
+        <source>Pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1789"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1811"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1843"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2257"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2279"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2311"/>
+        <source>Script</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1811"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1816"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2279"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2284"/>
+        <source>Event Handler</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1667"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1679"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1698"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1759"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2343"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2355"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2374"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2435"/>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1679"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1684"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2355"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2360"/>
+        <source>Command {Down}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1698"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1703"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2374"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2379"/>
+        <source>Command {Up}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1727"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2403"/>
+        <source>Action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1727"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1732"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2403"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2408"/>
+        <source>Stylesheet {L: %1 C: %2}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1595"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1607"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1637"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2467"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2479"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2509"/>
+        <source>Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1523"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1535"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1565"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2541"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2553"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="2583"/>
+        <source>Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1480"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1494"/>
+        <source>Variable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1494"/>
+        <location filename="../src/dlgTriggerEditor.cpp" line="1500"/>
+        <source>Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dlgTriggerPatternEdit</name>
+    <message>
+        <location filename="../src/dlgTriggerPatternEdit.cpp" line="51"/>
+        <source>Text to find (anywhere in the game output)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerPatternEdit.cpp" line="54"/>
+        <source>Text to find (as a regular expression pattern)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerPatternEdit.cpp" line="57"/>
+        <source>Text to find (from beginning of the line)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerPatternEdit.cpp" line="60"/>
+        <source>Exact line to match</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgTriggerPatternEdit.cpp" line="63"/>
+        <source>Lua code to run (return true to match)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dlgVarsMainArea</name>
+    <message>
+        <location filename="../src/dlgVarsMainArea.cpp" line="52"/>
+        <location filename="../src/dlgVarsMainArea.cpp" line="79"/>
+        <source>Auto-Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgVarsMainArea.cpp" line="53"/>
+        <source>key (string)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgVarsMainArea.cpp" line="54"/>
+        <source>index (integer number)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgVarsMainArea.cpp" line="55"/>
+        <source>table (use &quot;Add Group&quot; to create)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgVarsMainArea.cpp" line="56"/>
+        <source>function (cannot create from GUI)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgVarsMainArea.cpp" line="80"/>
+        <source>string</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgVarsMainArea.cpp" line="81"/>
+        <source>number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgVarsMainArea.cpp" line="82"/>
+        <source>boolean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgVarsMainArea.cpp" line="83"/>
+        <source>table</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgVarsMainArea.cpp" line="84"/>
+        <source>function</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>edbee::TextEditorComponent</name>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/views/components/texteditorcomponent.cpp" line="585"/>
+        <source>Cut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/views/components/texteditorcomponent.cpp" line="586"/>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/views/components/texteditorcomponent.cpp" line="587"/>
+        <source>Paste</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/edbee-lib/edbee-lib/edbee/views/components/texteditorcomponent.cpp" line="589"/>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>irc</name>
+    <message>
+        <location filename="../src/ui/irc.ui" line="25"/>
+        <source>Mudlet IRC Client</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>keybindings_main_area</name>
+    <message>
+        <location filename="../src/ui/keybindings_main_area.ui" line="23"/>
+        <source>Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/keybindings_main_area.ui" line="33"/>
+        <source>&lt;p&gt;Choose a good, ideally unique, name for your key or key group. This will be displayed in the key tree.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/keybindings_main_area.ui" line="61"/>
+        <source>ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/keybindings_main_area.ui" line="90"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/keybindings_main_area.ui" line="100"/>
+        <source>&lt;p&gt;Enter one or more commands to use if the given command matches the pattern. (Optional)&lt;/p&gt;&lt;p&gt;This could be another alias or a command to send directly to the game. For complex commands that require modification of variables within this profile, use a Lua script in the editor area below instead. It&apos;s possible to use both this field and a Lua script - the contents of this field will be used before running the script.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/keybindings_main_area.ui" line="103"/>
+        <source>Text to send to the game (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/keybindings_main_area.ui" line="110"/>
+        <source>Key Binding:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/keybindings_main_area.ui" line="127"/>
+        <source>Grab New Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>lacking_mapper_script</name>
+    <message>
+        <location filename="../src/ui/lacking_mapper_script.ui" line="23"/>
+        <source>No mapping script found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/lacking_mapper_script.ui" line="35"/>
+        <source>&lt;p&gt;It seems that you don&apos;t have any &lt;a href=&quot;http://wiki.mudlet.org/w/Mapping_script&quot;&gt;mapping scripts&lt;/a&gt; installed yet - the mapper needs you to have one for your game, so it can track where you are and autowalk you. You can either make one yourself, or import an existing one that someone else made.&lt;/p&gt;&lt;p&gt;Would you like to see if any are available?&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/lacking_mapper_script.ui" line="86"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/lacking_mapper_script.ui" line="93"/>
+        <source>Find some scripts</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../src/main.cpp" line="304"/>
+        <source>Warning: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="314"/>
+        <source>       -h, --help                   displays this message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="315"/>
+        <source>       -v, --version                displays version information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="317"/>
+        <source>       -p, --profile=&lt;profile&gt;      additional profile to open, may be
+                                    repeated.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="319"/>
+        <source>       -o, --only=&lt;predefined&gt;      make Mudlet only show the specific
+                                    predefined game, may be repeated.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="321"/>
+        <source>       --steammode                  adjusts Mudlet settings to match
+                                    Steam&apos;s requirements.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="323"/>
+        <source>There are other inherited options that arise from the Qt Libraries which are
+less likely to be useful for normal use of this application:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="326"/>
+        <source>       --dograb                     ignore any implicit or explicit -nograb.
+                                    --dograb wins over --nograb even when --nograb is last on
+                                    the command line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="330"/>
+        <source>       --nograb                     the application should never grab the mouse or the
+                                    keyboard. This option is set by default when Mudlet is
+                                    running in the gdb debugger under Linux.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="334"/>
+        <source>       --nograb                     the application should never grab the mouse or the
+                                    keyboard.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="337"/>
+        <source>       --reverse                    sets the application&apos;s layout direction to right to left.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="338"/>
+        <source>       --style=style                sets the application GUI style. Possible values depend on
+                                    your system configuration. If Qt was compiled with
+                                    additional styles or has additional styles as plugins
+                                    these will be available to the -style command line
+                                    option. You can also set the style for all Qt
+                                    applications by setting the QT_STYLE_OVERRIDE environment
+                                    variable.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="345"/>
+        <source>       --style style                is the same as listed above.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="346"/>
+        <source>       --stylesheet=stylesheet      sets the application styleSheet.
+                                    The value must be a path to a file that contains the
+                                    Style Sheet. Note: Relative URLs in the Style Sheet file
+                                    are relative to the Style Sheet file&apos;s path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="351"/>
+        <source>       --stylesheet stylesheet      is the same as listed above.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="354"/>
+        <source>       --sync                       forces the X server to perform each X client request
+                                    immediately and not use buffer optimization. It makes the
+                                    program easier to debug and often much slower. The --sync
+                                    option is only valid for the X11 version of Qt.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="359"/>
+        <source>       --widgetcount                prints debug message at the end about number of widgets
+                                    left undestroyed and maximum number of widgets existing
+                                    at the same time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="362"/>
+        <source>       --qmljsdebugger=1234[,block] activates the QML/JS debugger with a
+                                    specified port. The number is the port value and block is
+                                    optional and will make the application wait until a
+                                    debugger connects to it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="366"/>
+        <source>Arguments:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="367"/>
+        <source>        [FILE]                       File to install as a package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="368"/>
+        <source>Report bugs to: https://github.com/Mudlet/Mudlet/issues</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="309"/>
+        <source>Usage: %1 [OPTION...] [FILE] </source>
+        <comment>%1 is the name of the executable as it is on this OS.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="313"/>
+        <source>Options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="316"/>
+        <source>       -s, --splashscreen           show splashscreen on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="369"/>
+        <source>Project home page: http://www.mudlet.org/</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="377"/>
+        <source>%1 %2%3 (with debug symbols, without optimisations)</source>
+        <comment>%1 is the name of the application like mudlet or Mudlet.exe, %2 is the version number like 3.20 and %3 is a build suffix like -dev</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="383"/>
+        <source>Qt libraries %1 (compilation) %2 (runtime)</source>
+        <comment>%1 and %2 are version numbers</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="386"/>
+        <source>Copyright © 2008-2024  Mudlet developers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="387"/>
+        <source>Licence GPLv2+: GNU GPL version 2 or later - http://gnu.org/licenses/gpl.html</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="388"/>
+        <source>This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="459"/>
+        <source>Version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main_window</name>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="95"/>
+        <source>Toolbox</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="110"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="119"/>
+        <source>Mute media</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="127"/>
+        <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="138"/>
+        <source>About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="146"/>
+        <source>Games</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="163"/>
+        <source>Play</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="166"/>
+        <source>&lt;p&gt;Configure connection details of, and make a connection to, game servers.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="174"/>
+        <source>&lt;p&gt;Disconnect from the current game server.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="182"/>
+        <source>&lt;p&gt;Disconnect and then reconnect to the current game server.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="190"/>
+        <source>&lt;p&gt;Configure setting for the Mudlet application globally and for the current profile.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="198"/>
+        <source>&lt;p&gt;Opens the Editor for the different types of things that can be scripted by the user.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="203"/>
+        <source>Show errors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="206"/>
+        <source>&lt;p&gt;Show errors from scripts that you have running&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="235"/>
+        <source>IRC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="246"/>
+        <source>&lt;p&gt;Opens an (on-line) collection of &quot;Educational Mudlet screencasts&quot; in your system web-browser.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="254"/>
+        <source>&lt;p&gt;Load a previous saved game session that can be used to test Mudlet lua systems (off-line!).&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="262"/>
+        <source>&lt;p&gt;Opens the (on-line) Mudlet Forum in your system web-browser.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="283"/>
+        <source>&lt;p&gt;Show or hide the game map.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="291"/>
+        <source>&lt;p&gt;Install and remove collections of Mudlet lua items (packages).&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="299"/>
+        <source>&lt;p&gt;Install and remove (share- &amp; sync-able) collections of Mudlet lua items (modules).&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="304"/>
+        <source>Package exporter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="307"/>
+        <source>&lt;p&gt;Gather and bundle up collections of Mudlet Lua items and other reasources into a module.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="338"/>
+        <source>Mute all media</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="341"/>
+        <source>&lt;p&gt;Mutes all media played.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="355"/>
+        <source>Mute sounds from Mudlet (triggers, scripts, etc.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="358"/>
+        <source>&lt;p&gt;Mutes media played by the Lua API and scripts.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="389"/>
+        <source>&lt;p&gt;Hide / show the search area and buttons at the bottom of the screen.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="394"/>
+        <source>Discord</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="397"/>
+        <source>&lt;p&gt;Open a link to Discord.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="405"/>
+        <source>Discord help channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="408"/>
+        <source>&lt;p&gt;Open a link to the Mudlet server on Discord.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="413"/>
+        <location filename="../src/ui/main_window.ui" line="416"/>
+        <source>Report an issue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="419"/>
+        <source>The public test build gets newer features to you quicker, and you help us find issues in them quicker. Spotted something odd? Let us know asap!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="424"/>
+        <source>Close profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="171"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="179"/>
+        <source>Reconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="187"/>
+        <source>Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="195"/>
+        <source>Script editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="211"/>
+        <source>Notepad</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="219"/>
+        <source>API Reference</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="259"/>
+        <source>Online forum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="227"/>
+        <source>About Mudlet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="214"/>
+        <source>&lt;p&gt;Opens a free form text editor window for this profile that is saved between sessions.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="222"/>
+        <source>&lt;p&gt;Opens the Mudlet manual in your web browser.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="230"/>
+        <source>&lt;p&gt;Inform yourself about this version of Mudlet, the people who made it and the licence under which you can share it.&lt;/p&gt;</source>
+        <comment>Tooltip for About Mudlet sub-menu item and main toolbar button (or menu item if an update has changed that control to have a popup menu instead) (Used in 3 places - please ensure all have the same translation).</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="238"/>
+        <location filename="../src/ui/main_window.ui" line="275"/>
+        <source>&lt;p&gt;Opens a built-in IRC chat.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="243"/>
+        <source>Video tutorials</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="251"/>
+        <source>Load replay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="267"/>
+        <source>Check for updates...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="272"/>
+        <source>Live help chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="280"/>
+        <source>Show map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="288"/>
+        <source>Package manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="296"/>
+        <source>Module manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="321"/>
+        <source>MultiView</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="324"/>
+        <source>&lt;p&gt;Splits the Mudlet screen to show multiple profiles at once; disabled when less than two are loaded.&lt;/p&gt;</source>
+        <comment>Same text is used in 2 places.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="372"/>
+        <source>Mute sounds from the game (MCMP, MSP)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="375"/>
+        <source>&lt;p&gt;Mutes media played by the game (MCMP, MSP).&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/main_window.ui" line="386"/>
+        <source>Compact input line</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>map_label</name>
+    <message>
+        <location filename="../src/ui/map_label.ui" line="20"/>
+        <source>Map label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/map_label.ui" line="38"/>
+        <source>Type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/map_label.ui" line="49"/>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/map_label.ui" line="54"/>
+        <source>Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/map_label.ui" line="62"/>
+        <source>Image:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/map_label.ui" line="79"/>
+        <location filename="../src/ui/map_label.ui" line="127"/>
+        <source>...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/map_label.ui" line="86"/>
+        <source>Stretch image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/map_label.ui" line="93"/>
+        <source>Label text:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/map_label.ui" line="103"/>
+        <source>My Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/map_label.ui" line="110"/>
+        <source>Font:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/map_label.ui" line="134"/>
+        <source>Foreground:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/map_label.ui" line="151"/>
+        <source>Background:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/map_label.ui" line="179"/>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/map_label.ui" line="184"/>
+        <source>Foreground</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/map_label.ui" line="192"/>
+        <source>&lt;p&gt;If deselected the label will have the same size when you zoom in and out in the mapper. If it is selected the label will scale when you zoom the mapper.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/map_label.ui" line="168"/>
+        <source>Position:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/map_label.ui" line="195"/>
+        <source>Scale with zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/map_label.ui" line="243"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/map_label.ui" line="250"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mapper</name>
+    <message>
+        <location filename="../src/ui/mapper.ui" line="60"/>
+        <source>^</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/mapper.ui" line="432"/>
+        <source>Area:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/mapper.ui" line="501"/>
+        <source>Rooms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/mapper.ui" line="530"/>
+        <source>Exits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/mapper.ui" line="559"/>
+        <source>Round</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/mapper.ui" line="566"/>
+        <source>Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/mapper.ui" line="582"/>
+        <source>IDs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/mapper.ui" line="598"/>
+        <source>Names</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/mapper.ui" line="751"/>
+        <source>top + 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/mapper.ui" line="725"/>
+        <source>bottom + 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/mapper.ui" line="738"/>
+        <source>bottom -1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/mapper.ui" line="764"/>
+        <source>top - 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/mapper.ui" line="712"/>
+        <source>1 level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/mapper.ui" line="407"/>
+        <source>3D</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/mapper.ui" line="660"/>
+        <source>default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/mapper.ui" line="673"/>
+        <source>top view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/mapper.ui" line="686"/>
+        <source>side view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/mapper.ui" line="699"/>
+        <source>all levels</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>module_manager</name>
+    <message>
+        <location filename="../src/ui/module_manager.ui" line="79"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Modules are a way to utilize a common package across many sessions - unlike packages, which are installed per-profile.&lt;/p&gt;
+&lt;p&gt;Modules are loaded in ascending priority (1 will get loaded before 2 and so on), modules with the same priority will be loaded in alphabetical order.&lt;/p&gt;
+&lt;p&gt;Modules with negative priority will be loaded before script packages.&lt;/p&gt;
+&lt;p&gt;The &lt;b&gt;&lt;i&gt;Sync&lt;/i&gt;&lt;/b&gt; option, if it is enabled, will, when the module in &lt;b&gt;this profile&lt;/b&gt; is saved &lt;b&gt;to disk&lt;/b&gt;, cause it to be then reloaded into all profiles which also are using the same file that contains the module. To make several profiles use the same module, install it in each profile through this module manager (which should be opened when the particular profile is the one currently in the foreground).&lt;/p&gt;&lt;p&gt;
+&lt;p&gt;For each save operation, modules are backed up to a directory, &lt;i&gt;moduleBackups&lt;/i&gt;, within your Mudlet profile directory.&lt;/p&gt;
+&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/module_manager.ui" line="128"/>
+        <source>Uninstall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/module_manager.ui" line="141"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/module_manager.ui" line="148"/>
+        <source>Module Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mudlet</name>
+    <message>
+        <location filename="../src/mudlet.cpp" line="834"/>
+        <source>Afrikaans</source>
+        <extracomment>In the translation source texts the language is the leading term, with, generally, the (primary) country(ies) in the brackets, with a trailing language disabiguation after a &apos;-&apos; Chinese is an exception!</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="835"/>
+        <source>Afrikaans (South Africa)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="836"/>
+        <source>Aragonese</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="837"/>
+        <source>Aragonese (Spain)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="838"/>
+        <source>Arabic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="839"/>
+        <source>Arabic (United Arab Emirates)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="840"/>
+        <source>Arabic (Bahrain)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="841"/>
+        <source>Arabic (Algeria)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="843"/>
+        <source>Arabic (India)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="844"/>
+        <source>Arabic (Iraq)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="845"/>
+        <source>Arabic (Jordan)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="846"/>
+        <source>Arabic (Kuwait)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="847"/>
+        <source>Arabic (Lebanon)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="848"/>
+        <source>Arabic (Libya)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="849"/>
+        <source>Arabic (Morocco)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="850"/>
+        <source>Arabic (Oman)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="851"/>
+        <source>Arabic (Qatar)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="852"/>
+        <source>Arabic (Saudi Arabia)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="853"/>
+        <source>Arabic (Sudan)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="854"/>
+        <source>Arabic (Syria)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="855"/>
+        <source>Arabic (Tunisia)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="856"/>
+        <source>Arabic (Yemen)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="857"/>
+        <source>Belarusian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="858"/>
+        <source>Belarusian (Belarus)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="859"/>
+        <source>Belarusian (Russia)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="860"/>
+        <source>Bulgarian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="861"/>
+        <source>Bulgarian (Bulgaria)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="862"/>
+        <source>Bangla</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="863"/>
+        <source>Bangla (Bangladesh)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="864"/>
+        <source>Bangla (India)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="865"/>
+        <source>Tibetan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="866"/>
+        <source>Tibetan (China)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="867"/>
+        <source>Tibetan (India)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="868"/>
+        <source>Breton</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="869"/>
+        <source>Breton (France)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="870"/>
+        <source>Bosnian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="871"/>
+        <source>Bosnian (Bosnia/Herzegovina)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="872"/>
+        <source>Bosnian (Bosnia/Herzegovina - Cyrillic alphabet)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="873"/>
+        <source>Catalan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="874"/>
+        <source>Catalan (Spain)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="875"/>
+        <source>Catalan (Spain - Valencian)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="876"/>
+        <source>Central Kurdish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="877"/>
+        <source>Central Kurdish (Iraq)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="878"/>
+        <source>Czech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="879"/>
+        <source>Czech (Czechia)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="882"/>
+        <source>Danish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="883"/>
+        <source>Danish (Denmark)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="884"/>
+        <source>German</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="885"/>
+        <source>German (Austria)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="886"/>
+        <source>German (Austria, revised by F M Baumann)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="887"/>
+        <source>German (Belgium)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="888"/>
+        <source>German (Switzerland)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="889"/>
+        <source>German (Switzerland, revised by F M Baumann)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="890"/>
+        <source>German (Germany/Belgium/Luxemburg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="891"/>
+        <source>German (Germany/Belgium/Luxemburg, revised by F M Baumann)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="892"/>
+        <source>German (Liechtenstein)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="893"/>
+        <source>German (Luxembourg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="896"/>
+        <source>Greek</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="897"/>
+        <source>Greek (Greece)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="898"/>
+        <source>English</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="899"/>
+        <source>English (Antigua/Barbuda)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="900"/>
+        <source>English (Australia)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="902"/>
+        <source>English (Bahamas)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="903"/>
+        <source>English (Botswana)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="904"/>
+        <source>English (Belize)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="842"/>
+        <source>Arabic (Egypt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="263"/>
+        <location filename="../src/mudlet.cpp" line="265"/>
+        <location filename="../src/mudlet.cpp" line="628"/>
+        <source>Close profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="318"/>
+        <location filename="../src/mudlet.cpp" line="3024"/>
+        <source>Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="325"/>
+        <location filename="../src/mudlet.cpp" line="327"/>
+        <location filename="../src/mudlet.cpp" line="624"/>
+        <location filename="../src/mudlet.cpp" line="3021"/>
+        <source>Mute all media</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="331"/>
+        <location filename="../src/mudlet.cpp" line="333"/>
+        <location filename="../src/mudlet.cpp" line="3050"/>
+        <source>Mute sounds from Mudlet (triggers, scripts, etc.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="361"/>
+        <source>Mudlet chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="362"/>
+        <source>Open a link to the Mudlet server on Discord</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="453"/>
+        <source>Report issue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="616"/>
+        <source>Script editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="617"/>
+        <source>Show Map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="618"/>
+        <source>Compact input line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="619"/>
+        <source>Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="621"/>
+        <source>Package manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="622"/>
+        <source>Module manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="625"/>
+        <source>Play</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="880"/>
+        <source>Welsh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="881"/>
+        <source>Welsh (United Kingdom {Wales})</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="894"/>
+        <source>Dzongkha</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="895"/>
+        <source>Dzongkha (Bhutan)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="901"/>
+        <source>English (Australia, Large)</source>
+        <comment>This dictionary contains larger vocabulary.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="905"/>
+        <source>English (Canada)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="906"/>
+        <source>English (Canada, Large)</source>
+        <comment>This dictionary contains larger vocabulary.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="907"/>
+        <source>English (Denmark)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="908"/>
+        <source>English (United Kingdom)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="909"/>
+        <source>English (United Kingdom, Large)</source>
+        <comment>This dictionary contains larger vocabulary.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="910"/>
+        <source>English (United Kingdom - &apos;ise&apos; not &apos;ize&apos;)</source>
+        <comment>This dictionary prefers the British &apos;ise&apos; form over the American &apos;ize&apos; one.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="911"/>
+        <source>English (Ghana)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="912"/>
+        <source>English (Hong Kong SAR China)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="913"/>
+        <source>English (Ireland)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="914"/>
+        <source>English (India)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="915"/>
+        <source>English (Jamaica)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="916"/>
+        <source>English (Namibia)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="917"/>
+        <source>English (Nigeria)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="918"/>
+        <source>English (New Zealand)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="919"/>
+        <source>English (Philippines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="920"/>
+        <source>English (Singapore)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="921"/>
+        <source>English (Trinidad/Tobago)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="922"/>
+        <source>English (United States)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="923"/>
+        <source>English (United States, Large)</source>
+        <comment>This dictionary contains larger vocabulary.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="924"/>
+        <source>English (South Africa)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="925"/>
+        <source>English (Zimbabwe)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="926"/>
+        <source>Spanish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="927"/>
+        <source>Spanish (Argentina)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="928"/>
+        <source>Spanish (Bolivia)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="929"/>
+        <source>Spanish (Chile)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="930"/>
+        <source>Spanish (Colombia)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="931"/>
+        <source>Spanish (Costa Rica)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="932"/>
+        <source>Spanish (Cuba)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="933"/>
+        <source>Spanish (Dominican Republic)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="934"/>
+        <source>Spanish (Ecuador)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="935"/>
+        <source>Spanish (Spain)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="936"/>
+        <source>Spanish (Guatemala)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="937"/>
+        <source>Spanish (Honduras)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="938"/>
+        <source>Spanish (Mexico)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="939"/>
+        <source>Spanish (Nicaragua)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="940"/>
+        <source>Spanish (Panama)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="941"/>
+        <source>Spanish (Peru)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="942"/>
+        <source>Spanish (Puerto Rico)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="943"/>
+        <source>Spanish (Paraguay)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="944"/>
+        <source>Spanish (El Savador)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="945"/>
+        <source>Spanish (United States)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="946"/>
+        <source>Spanish (Uruguay)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="947"/>
+        <source>Spanish (Venezuela)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="948"/>
+        <source>Estonian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="949"/>
+        <source>Estonian (Estonia)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="950"/>
+        <source>Basque</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="951"/>
+        <source>Basque (Spain)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="952"/>
+        <source>Basque (France)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="953"/>
+        <location filename="../src/mudlet.cpp" line="954"/>
+        <source>Finnish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="955"/>
+        <location filename="../src/mudlet.cpp" line="959"/>
+        <source>French</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="960"/>
+        <source>French (Belgium)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="961"/>
+        <source>French (Catalan)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="962"/>
+        <source>French (Switzerland)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="963"/>
+        <source>French (France)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="964"/>
+        <source>French (Luxemburg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="965"/>
+        <source>French (Monaco)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="966"/>
+        <source>Irish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="967"/>
+        <source>Gaelic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="968"/>
+        <source>Gaelic (United Kingdom {Scots})</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="969"/>
+        <source>Galician</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="970"/>
+        <source>Galician (Spain)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="971"/>
+        <location filename="../src/mudlet.cpp" line="976"/>
+        <source>Guarani</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="972"/>
+        <location filename="../src/mudlet.cpp" line="977"/>
+        <source>Guarani (Paraguay)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="973"/>
+        <source>Gujarati</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="974"/>
+        <source>Gujarati (India)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="978"/>
+        <source>Hebrew</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="979"/>
+        <source>Hebrew (Israel)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="980"/>
+        <source>Hindi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="981"/>
+        <source>Hindi (India)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="982"/>
+        <source>Croatian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="983"/>
+        <source>Croatian (Croatia)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="984"/>
+        <source>Hungarian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="985"/>
+        <source>Hungarian (Hungary)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="986"/>
+        <source>Armenian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="987"/>
+        <source>Armenian (Armenia)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="988"/>
+        <source>Indonesian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="989"/>
+        <source>Indonesian (Indonesia)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1183"/>
+        <source>Medievia {Custom codec for that MUD}</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="3021"/>
+        <source>Unmute all media</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="3024"/>
+        <source>Unmute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/mudlet.cpp" line="3708"/>
+        <source>&lt;p&gt;About Mudlet&lt;/p&gt;&lt;p&gt;&lt;i&gt;%n update(s) is/are now available!&lt;/i&gt;&lt;p&gt;</source>
+        <extracomment>This is the tooltip text for the &apos;About&apos; Mudlet main toolbar button when it has been changed by adding a menu which now contains the original &apos;About Mudlet&apos; action and a new one to access the manual update process</extracomment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/mudlet.cpp" line="3726"/>
+        <source>Review %n update(s)...</source>
+        <extracomment>Review update(s) menu item, %n is the count of how many updates are available</extracomment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/mudlet.cpp" line="3729"/>
+        <source>Review the update(s) available...</source>
+        <extracomment>Tool-tip for review update(s) menu item, given that the count of how many updates are available is already shown in the menu, the %n parameter that is that number need not be used here</extracomment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="992"/>
+        <source>Icelandic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="337"/>
+        <location filename="../src/mudlet.cpp" line="339"/>
+        <location filename="../src/mudlet.cpp" line="3055"/>
+        <source>Mute sounds from the game (MCMP, MSP)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="993"/>
+        <source>Icelandic (Iceland)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="994"/>
+        <source>Italian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="995"/>
+        <source>Italian (Switzerland)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="996"/>
+        <source>Italian (Italy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="997"/>
+        <source>Kazakh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="998"/>
+        <source>Kazakh (Kazakhstan)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="999"/>
+        <source>Kurmanji</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1000"/>
+        <source>Kurmanji {Latin-alphabet Kurdish}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1001"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1002"/>
+        <source>Korean (South Korea)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1003"/>
+        <source>Kurdish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1004"/>
+        <source>Kurdish (Syria)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1005"/>
+        <source>Kurdish (Turkey)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1006"/>
+        <source>Latin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1007"/>
+        <source>Luxembourgish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1008"/>
+        <source>Luxembourgish (Luxembourg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1009"/>
+        <source>Lao</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1010"/>
+        <source>Lao (Laos)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1011"/>
+        <source>Lithuanian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1012"/>
+        <source>Lithuanian (Lithuania)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1013"/>
+        <source>Latvian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1014"/>
+        <source>Latvian (Latvia)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1015"/>
+        <source>Malayalam</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1016"/>
+        <source>Malayalam (India)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1017"/>
+        <source>Norwegian Bokmål</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1018"/>
+        <source>Norwegian Bokmål (Norway)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1019"/>
+        <source>Nepali</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1020"/>
+        <source>Nepali (Nepal)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1021"/>
+        <source>Dutch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1022"/>
+        <source>Dutch (Netherlands Antilles)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1023"/>
+        <source>Dutch (Aruba)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1024"/>
+        <source>Dutch (Belgium)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1025"/>
+        <source>Dutch (Netherlands)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1026"/>
+        <source>Dutch (Suriname)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1027"/>
+        <source>Norwegian Nynorsk</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1028"/>
+        <source>Norwegian Nynorsk (Norway)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1029"/>
+        <source>Occitan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1030"/>
+        <source>Occitan (France)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1031"/>
+        <source>Polish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1032"/>
+        <source>Polish (Poland)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1033"/>
+        <source>Portuguese</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1034"/>
+        <source>Portuguese (Brazil)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1035"/>
+        <source>Portuguese (Portugal)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1036"/>
+        <source>Romanian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1037"/>
+        <source>Romanian (Romania)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1038"/>
+        <source>Russian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1039"/>
+        <source>Russian (Russia)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1040"/>
+        <source>Northern Sami</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1041"/>
+        <source>Northern Sami (Finland)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1042"/>
+        <source>Northern Sami (Norway)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1043"/>
+        <source>Northern Sami (Sweden)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1048"/>
+        <source>Sinhala</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1049"/>
+        <source>Sinhala (Sri Lanka)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1050"/>
+        <source>Slovak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1051"/>
+        <source>Slovak (Slovakia)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1052"/>
+        <source>Slovenian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1053"/>
+        <source>Slovenian (Slovenia)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1054"/>
+        <source>Somali</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1055"/>
+        <source>Somali (Somalia)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1056"/>
+        <source>Albanian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1057"/>
+        <source>Albanian (Albania)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1058"/>
+        <source>Serbian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1059"/>
+        <source>Serbian (Montenegro)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1060"/>
+        <source>Serbian (Serbia)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1061"/>
+        <source>Serbian (Serbia - Latin-alphabet)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1062"/>
+        <source>Serbian (former state of Yugoslavia)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1063"/>
+        <source>Swati</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1064"/>
+        <source>Swati (Swaziland)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1065"/>
+        <source>Swati (South Africa)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1066"/>
+        <source>Swedish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1067"/>
+        <source>Swedish (Sweden)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1068"/>
+        <source>Swedish (Finland)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1069"/>
+        <source>Swahili</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1070"/>
+        <source>Swahili (Kenya)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1071"/>
+        <source>Swahili (Tanzania)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1084"/>
+        <source>Turkish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1072"/>
+        <source>Telugu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1073"/>
+        <source>Telugu (India)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1074"/>
+        <source>Thai</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1075"/>
+        <source>Thai (Thailand)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1076"/>
+        <source>Tigrinya</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1077"/>
+        <source>Tigrinya (Eritrea)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1078"/>
+        <source>Tigrinya (Ethiopia)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1079"/>
+        <source>Turkmen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1080"/>
+        <source>Turkmen (Turkmenistan)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1081"/>
+        <source>Tswana</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1082"/>
+        <source>Tswana (Botswana)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1083"/>
+        <source>Tswana (South Africa)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1086"/>
+        <source>Tsonga</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1087"/>
+        <source>Tsonga (South Africa)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1088"/>
+        <source>Ukrainian</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1089"/>
+        <source>Ukrainian (Ukraine)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1090"/>
+        <source>Uzbek</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1091"/>
+        <source>Uzbek (Uzbekistan)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1092"/>
+        <source>Venda</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1093"/>
+        <source>Vietnamese</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1094"/>
+        <source>Vietnamese (Vietnam)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1101"/>
+        <source>Walloon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1102"/>
+        <source>Xhosa</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1103"/>
+        <source>Yiddish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1104"/>
+        <source>Chinese</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1105"/>
+        <source>Chinese (China - simplified)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1106"/>
+        <source>Chinese (Taiwan - traditional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1107"/>
+        <source>Zulu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1111"/>
+        <source>ASCII (Basic)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1113"/>
+        <source>UTF-8 (Recommended)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1115"/>
+        <source>EUC-KR (Korean)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1117"/>
+        <source>GBK (Chinese)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1119"/>
+        <source>GB18030 (Chinese)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1121"/>
+        <source>Big5-ETen (Taiwan)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1123"/>
+        <source>Big5-HKSCS (Hong Kong)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1125"/>
+        <source>ISO 8859-1 (Western European)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1127"/>
+        <source>ISO 8859-2 (Central European)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1129"/>
+        <source>ISO 8859-3 (South European)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1131"/>
+        <source>ISO 8859-4 (Baltic)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1133"/>
+        <source>ISO 8859-5 (Cyrillic)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1135"/>
+        <source>ISO 8859-6 (Arabic)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1137"/>
+        <source>ISO 8859-7 (Greek)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1139"/>
+        <source>ISO 8859-8 (Hebrew Visual)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1141"/>
+        <source>ISO 8859-9 (Turkish)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1143"/>
+        <source>ISO 8859-10 (Nordic)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1145"/>
+        <source>ISO 8859-11 (Latin/Thai)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1147"/>
+        <source>ISO 8859-13 (Baltic)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1149"/>
+        <source>ISO 8859-14 (Celtic)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1151"/>
+        <source>ISO 8859-15 (Western)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1153"/>
+        <source>ISO 8859-16 (Romanian)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1155"/>
+        <location filename="../src/mudlet.cpp" line="1157"/>
+        <source>CP437 (OEM Font)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1159"/>
+        <location filename="../src/mudlet.cpp" line="1161"/>
+        <source>CP667 (Mazovia)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1163"/>
+        <location filename="../src/mudlet.cpp" line="1165"/>
+        <source>CP737 (DOS Greek)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1167"/>
+        <source>CP850 (Western Europe)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1169"/>
+        <source>CP866 (Cyrillic/Russian)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1171"/>
+        <location filename="../src/mudlet.cpp" line="1173"/>
+        <source>CP869 (DOS Greek 2)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1175"/>
+        <source>CP1161 (Latin/Thai)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1177"/>
+        <source>KOI8-R (Cyrillic)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1179"/>
+        <source>KOI8-U (Cyrillic/Ukrainian)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1181"/>
+        <source>MACINTOSH</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1185"/>
+        <source>WINDOWS-1250 (Central European)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1187"/>
+        <source>WINDOWS-1251 (Cyrillic)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1189"/>
+        <source>WINDOWS-1252 (Western)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1191"/>
+        <source>WINDOWS-1253 (Greek)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1193"/>
+        <source>WINDOWS-1254 (Turkish)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1195"/>
+        <source>WINDOWS-1255 (Hebrew)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1197"/>
+        <source>WINDOWS-1256 (Arabic)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1199"/>
+        <source>WINDOWS-1257 (Baltic)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1201"/>
+        <source>WINDOWS-1258 (Vietnamese)</source>
+        <extracomment>Keep the English translation intact, so if a user accidentally changes to a language they don&apos;t understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="3813"/>
+        <source>[ ERROR ] - Something went wrong loading your Mudlet profile and it could not be loaded.
+Try loading an older version in &apos;Connect - Options - Profile history&apos; or double-check that %1 looks correct.</source>
+        <extracomment>%1 is the path and file name (i.e. the location) of the problem fil</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="3037"/>
+        <source>[ INFO ]  - Mudlet and game sounds are muted. Use %1 to unmute.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="3038"/>
+        <source>[ INFO ]  - Mudlet and game sounds are unmuted. Use %1 to mute.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="3040"/>
+        <source>[ INFO ]  - Mudlet and game sounds are muted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="3040"/>
+        <source>[ INFO ]  - Mudlet and game sounds are unmuted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="3050"/>
+        <source>Unmute sounds from Mudlet (Triggers, Scripts, etc.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="3055"/>
+        <source>Unmute sounds from the game (MCMP, MSP)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="3094"/>
+        <source>[ INFO ]  - Compact input line set. Press %1 to show bottom-right buttons again.</source>
+        <extracomment>Here %1 will be replaced with the keyboard shortcut, default is ALT+L.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="3153"/>
+        <source>Cannot load a replay as one is already in progress in this or another profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="3172"/>
+        <source>Replay each step with a shorter time interval between steps.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="3178"/>
+        <source>Replay each step with a longer time interval between steps.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="4803"/>
+        <source>Hide tray icon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="4808"/>
+        <source>Quit Mudlet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="211"/>
+        <source>Main Toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="248"/>
+        <location filename="../src/mudlet.cpp" line="255"/>
+        <location filename="../src/mudlet.cpp" line="257"/>
+        <source>Connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="260"/>
+        <location filename="../src/mudlet.cpp" line="626"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="356"/>
+        <source>Open Discord</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="368"/>
+        <source>Open IRC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="273"/>
+        <source>Triggers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="178"/>
+        <source>hh:mm:ss</source>
+        <extracomment>Formatting string for elapsed time display in replay playback - see QDateTime::toString(const QString&amp;) for the gory details...!</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="274"/>
+        <source>Show and edit triggers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="281"/>
+        <source>Aliases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="282"/>
+        <source>Show and edit aliases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="287"/>
+        <source>Timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="288"/>
+        <source>Show and edit timers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="293"/>
+        <source>Buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="294"/>
+        <source>Show and edit easy buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="299"/>
+        <source>Scripts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="300"/>
+        <source>Show and edit scripts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="305"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="306"/>
+        <source>Show and edit keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="311"/>
+        <source>Variables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="312"/>
+        <source>Show and edit Lua variables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="376"/>
+        <source>Map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="377"/>
+        <source>Show/hide the map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="382"/>
+        <source>Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="383"/>
+        <source>Browse reference material and documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="388"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="389"/>
+        <source>See and edit profile preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="397"/>
+        <location filename="../src/mudlet.cpp" line="620"/>
+        <source>Notepad</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="398"/>
+        <source>Open a notepad that you can store your notes in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="404"/>
+        <location filename="../src/mudlet.cpp" line="413"/>
+        <source>Packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="411"/>
+        <source>Package Manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="416"/>
+        <source>Module Manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="420"/>
+        <source>Package Exporter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="430"/>
+        <source>Replay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="435"/>
+        <location filename="../src/mudlet.cpp" line="627"/>
+        <source>Reconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="436"/>
+        <source>Disconnects you from the game and connects once again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="441"/>
+        <location filename="../src/mudlet.cpp" line="623"/>
+        <source>MultiView</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="443"/>
+        <source>Splits the Mudlet screen to show multiple profiles at once; disabled when less than two are loaded.</source>
+        <extracomment>Same text is used in 2 places.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="464"/>
+        <location filename="../src/mudlet.cpp" line="3713"/>
+        <source>About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="466"/>
+        <location filename="../src/mudlet.cpp" line="3696"/>
+        <source>Inform yourself about this version of Mudlet, the people who made it and the licence under which you can share it.</source>
+        <extracomment>Tooltip for About Mudlet sub-menu item and main toolbar button (or menu item if an update has changed that control to have a popup menu instead) (Used in 3 places - please ensure all have the same translation).</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="991"/>
+        <source>Interlingue</source>
+        <extracomment>, formerly known as Occidental, and not to be mistaken for Interlingua</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1045"/>
+        <source>Shtokavian</source>
+        <extracomment>This code seems to be the identifier for the prestige dialect for several languages used in the region of the former Yugoslavia state without a state indication</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1047"/>
+        <source>Shtokavian (former state of Yugoslavia)</source>
+        <extracomment>This code seems to be the identifier for the prestige dialect for several languages used in the region of the former Yugoslavia state with a (withdrawn from ISO 3166) state indication</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1085"/>
+        <source>Turkish (Turkey)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1095"/>
+        <location filename="../src/mudlet.cpp" line="1099"/>
+        <source>Vietnamese (DauCu variant - old-style diacritics)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1096"/>
+        <location filename="../src/mudlet.cpp" line="1100"/>
+        <source>Vietnamese (DauMoi variant - new-style diacritics)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1719"/>
+        <location filename="../src/mudlet.cpp" line="3249"/>
+        <source>Load a Mudlet replay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="2809"/>
+        <source>Central Debug Console</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="475"/>
+        <location filename="../src/mudlet.cpp" line="476"/>
+        <source>Toggle Full Screen View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="457"/>
+        <source>The public test build gets newer features to you quicker, and you help us find issues in them quicker. Spotted something odd? Let us know asap!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="1682"/>
+        <source>&lt;p&gt;Load a Mudlet replay.&lt;/p&gt;&lt;p&gt;&lt;i&gt;Disabled until a profile is loaded.&lt;/i&gt;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="2557"/>
+        <source>%1 - notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="2641"/>
+        <source>Select Replay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="2643"/>
+        <source>*.dat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="2921"/>
+        <source>[  OK  ]  - Profile &quot;%1&quot; loaded in offline mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="3170"/>
+        <source>Faster</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="3176"/>
+        <source>Slower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="3188"/>
+        <location filename="../src/mudlet.cpp" line="3257"/>
+        <location filename="../src/mudlet.cpp" line="3266"/>
+        <source>Speed: X%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="3195"/>
+        <location filename="../src/mudlet.cpp" line="3212"/>
+        <source>Time: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="3751"/>
+        <source>Update installed - restart to apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mudlet.cpp" line="3863"/>
+        <source>[ WARN ]  - Cannot perform replay, another one may already be in progress,
+try again when it has finished.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>package_manager</name>
+    <message>
+        <location filename="../src/ui/package_manager.ui" line="122"/>
+        <source>Details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/package_manager.ui" line="203"/>
+        <source>Install new package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/package_manager.ui" line="219"/>
+        <source>Remove package</source>
+        <comment>Message on button in package manager initially and when there is no packages to remove.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>package_manager_unpack</name>
+    <message>
+        <location filename="../src/ui/package_manager_unpack.ui" line="24"/>
+        <source>unpacking please wait ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>profile_preferences</name>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="20"/>
+        <source>Profile preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="56"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="62"/>
+        <source>Icon sizes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="68"/>
+        <source>Icon size toolbars:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="91"/>
+        <source>Icon size in tree views:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="111"/>
+        <source>Show menu bar:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="122"/>
+        <location filename="../src/ui/profile_preferences.ui" line="151"/>
+        <source>Never</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="127"/>
+        <location filename="../src/ui/profile_preferences.ui" line="156"/>
+        <source>Until a profile is loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="132"/>
+        <location filename="../src/ui/profile_preferences.ui" line="161"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="140"/>
+        <source>Show main toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="281"/>
+        <source>Allow server to install script packages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="308"/>
+        <source>Game protocols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="385"/>
+        <location filename="../src/ui/profile_preferences.ui" line="3837"/>
+        <source>Please reconnect to your game for the change to take effect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="401"/>
+        <source>Log options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="410"/>
+        <source>Save log files in HTML format instead of plain text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="417"/>
+        <source>Add timestamps at the beginning of log lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="424"/>
+        <source>Save log files in:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="441"/>
+        <source>Browse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="448"/>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="455"/>
+        <source>Log format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="468"/>
+        <source>Log name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="488"/>
+        <source>.txt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="521"/>
+        <source>Input line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="530"/>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="536"/>
+        <source>use strict UNIX line endings on commands for old UNIX servers that can&apos;t handle windows line endings correctly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="539"/>
+        <source>Strict UNIX line endings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="556"/>
+        <source>Show the text you sent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="546"/>
+        <source>Auto clear the input line after you sent text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="202"/>
+        <source>&lt;p&gt;If you are playing a non-English game and seeing � instead of text, or special letters like &lt;span style=&quot; font-weight:600;&quot;&gt;ñ&lt;/span&gt; aren&apos;t showing right - try changing the encoding to UTF-8 or to one suggested by your game.&lt;/p&gt;&lt;p&gt;For some encodings on some Operating Systems Mudlet itself has to provide the codec needed; if that is the case for this Mudlet then there will be a &lt;tt&gt;m &lt;/tt&gt; prefixed applied to those encoding names (so if they have errors the blame can be applied correctly!)&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="344"/>
+        <source>&lt;p&gt;Enables MSP - provides Mud Sound Protocol messages during game play for supported games&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="407"/>
+        <source>&lt;p&gt;When checked will cause the date-stamp named log file to be HTML (file extension &apos;.html&apos;) which can convey color, font and other formatting information rather than a plain text (file extension &apos;.txt&apos;) format.  If changed while logging is already in progress it is necessary to stop and restart logging for this setting to take effect in a new log file.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="576"/>
+        <source>React to all keybindings on the same key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="586"/>
+        <source>Command separator:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="596"/>
+        <source>Enter text to separate commands with or leave blank to disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="603"/>
+        <source>Command line minimum height in pixels:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="745"/>
+        <source>Main display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="757"/>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="763"/>
+        <source>Font:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="786"/>
+        <source>Size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="824"/>
+        <source>Enable anti-aliasing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="840"/>
+        <source>Display Border</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="861"/>
+        <source>Top border height:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="905"/>
+        <source>Left border width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="949"/>
+        <source>Bottom border height:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="993"/>
+        <source>Right border width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1034"/>
+        <source>Word wrapping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1058"/>
+        <source>Wrap lines at:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1078"/>
+        <location filename="../src/ui/profile_preferences.ui" line="1126"/>
+        <source>characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1106"/>
+        <source>Indent wrapped lines by:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1139"/>
+        <source>Double-click</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1145"/>
+        <source>Stop selecting a word on these characters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1155"/>
+        <source>&apos;&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1168"/>
+        <location filename="../src/ui/profile_preferences.ui" line="1370"/>
+        <source>Display options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1177"/>
+        <source>Fix unnecessary linebreaks on GA servers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1379"/>
+        <source>Show Spaces/Tabs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1194"/>
+        <source>Use Mudlet on a netbook with a small screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1389"/>
+        <source>Show Line/Paragraphs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1214"/>
+        <source>Echo Lua errors to the main console</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1201"/>
+        <source>Make &apos;Ambiguous&apos; E. Asian width characters wide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1270"/>
+        <source>Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1276"/>
+        <source>Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1344"/>
+        <source>Updating themes from colorsublime.github.io...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1433"/>
+        <source>Color view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1439"/>
+        <source>Select your color preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1445"/>
+        <source>Foreground:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1468"/>
+        <source>Background:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1488"/>
+        <source>Command line foreground:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1505"/>
+        <source>Command line background:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1522"/>
+        <source>Command foreground:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1542"/>
+        <source>Command background:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="314"/>
+        <source>&lt;p&gt;Enables GMCP - note that if you have MSDP enabled as well, some servers will prefer one over the other&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="334"/>
+        <source>&lt;p&gt;Enables MSDP - note that if you have GMCP enabled as well, some servers will prefer one over the other&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="172"/>
+        <source>Language &amp;&amp; data encoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="178"/>
+        <source>Interface language:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="192"/>
+        <source>Server data encoding:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="214"/>
+        <source>Please restart Mudlet to apply the new language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="224"/>
+        <source>Miscellaneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="317"/>
+        <source>Enable GMCP  (Generic Mud Communication Protocol)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="337"/>
+        <source>Enable MSDP  (Mud Server Data Protocol)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="324"/>
+        <source>&lt;p&gt;Enables MSSP - provides Mud Server Status Protocol information upon connection for supported games&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="327"/>
+        <source>Enable MSSP  (Mud Server Status Protocol)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="553"/>
+        <source>&lt;p&gt;Echo the text you send in the display box.&lt;/p&gt;&lt;p&gt;&lt;i&gt;This can be disabled by the game server if it negotiates to use the telnet ECHO option&lt;/i&gt;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="573"/>
+        <source>&lt;p&gt;Check all Key-bindings against key-presses.&lt;/p&gt;&lt;p&gt;&lt;i&gt;Versions of Mudlet prior to &lt;b&gt;3.9.0&lt;/b&gt; would stop checking after the first matching combination of&lt;/i&gt; KeyCode &lt;i&gt;and&lt;/i&gt; KeyModifier &lt;i&gt;was found and then send the command and/or run the script of that Key-binding only.  This&lt;/i&gt; per-profile &lt;i&gt;option tells Mudlet to check and run the remaining matches; but, to retain compatibility with previous versions, defaults to the &lt;b&gt;un&lt;/b&gt;-checked state.&lt;/i&gt;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="649"/>
+        <source>Spell checking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="655"/>
+        <source>&lt;p&gt;This option controls spell-checking on the command line in the main console for this profile.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="658"/>
+        <source>System/Mudlet dictionary:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="665"/>
+        <source>&lt;p&gt;Select one dictionary which will be available on the command line and in the lua sub-system.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="693"/>
+        <source>User dictionary:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="699"/>
+        <source>&lt;p&gt;A user dictionary specific to this profile will be available. This will be on the command line (words which are in it will appear with a dashed cyan underline) and in the lua sub-system.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="702"/>
+        <source>Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="709"/>
+        <source>&lt;p&gt;A user dictionary that is shared between all profiles (which have this option selected) will be available. This will be on the command line (words which are in it will appear with a dashed cyan underline) and in the lua sub-system.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="712"/>
+        <source>Shared</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="801"/>
+        <source>The selected font doesn&apos;t work with Mudlet, please pick another</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="858"/>
+        <location filename="../src/ui/profile_preferences.ui" line="874"/>
+        <source>&lt;p&gt;Extra space to have before text on top - can be set to negative to move text up beyond the screen&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="902"/>
+        <location filename="../src/ui/profile_preferences.ui" line="918"/>
+        <source>&lt;p&gt;Extra space to have before text on the left - can be set to negative to move text left beyond the screen&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="946"/>
+        <location filename="../src/ui/profile_preferences.ui" line="962"/>
+        <source>&lt;p&gt;Extra space to have before text on the bottom - can be set to negative to allow text to go down beyond the screen&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="990"/>
+        <location filename="../src/ui/profile_preferences.ui" line="1006"/>
+        <source>&lt;p&gt;Extra space to have before text on the right - can be set to negative to move text right beyond the screen&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1152"/>
+        <source>&lt;p&gt;Enter the characters you&apos;d like double-clicking to stop selecting text on here. If you don&apos;t enter any, double-clicking on a word will only stop at a space, and will include characters like a double or a single quote. For example, double-clicking on the word &lt;span style=&quot; font-style:italic;&quot;&gt;Hello&lt;/span&gt; in the following will select &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;quot;&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Hello!&amp;quot;&lt;/span&gt;&lt;/p&gt;&lt;p&gt;You say, &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;Hello!&amp;quot;&lt;/span&gt;&lt;/p&gt;&lt;p&gt;If you set the characters in the field to &lt;span style=&quot; font-weight:600;&quot;&gt;&apos;&amp;quot;! &lt;/span&gt;which will mean it should stop selecting on &apos; &lt;span style=&quot; font-style:italic;&quot;&gt;or&lt;/span&gt; &amp;quot; &lt;span style=&quot; font-style:italic;&quot;&gt;or&lt;/span&gt; ! then double-clicking on &lt;span style=&quot; font-style:italic;&quot;&gt;Hello&lt;/span&gt; will just select &lt;span style=&quot; font-style:italic;&quot;&gt;Hello&lt;/span&gt;&lt;/p&gt;&lt;p&gt;You say, &amp;quot;&lt;span style=&quot; font-weight:600;&quot;&gt;Hello&lt;/span&gt;!&amp;quot;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1158"/>
+        <source>(characters to ignore in selection, for example &apos; or &quot;)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1174"/>
+        <source>&lt;p&gt;Some games (notably all IRE MUDs) suffer from a bug where they don&apos;t properly communicate with the client on where a newline should be. Enable this to fix text from getting appended to the previous prompt line.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1376"/>
+        <source>&lt;body&gt;&lt;p&gt;When displaying Lua contents in the main text editor area of the Editor show tabs and spaces with visible marks instead of whitespace.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1386"/>
+        <source>&lt;body&gt;&lt;p&gt;When displaying Lua contents in the main text editor area of the Editor show  line and paragraphs ends with visible marks as well as whitespace.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1211"/>
+        <source>&lt;p&gt;Prints Lua errors to the main console in addition to the error tab in the editor.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1184"/>
+        <source>Enable text analyzer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2026"/>
+        <source>Delete map:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2218"/>
+        <source>Use large area exit arrows in 2D view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2469"/>
+        <source>Map info background:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2923"/>
+        <source>Server password: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2943"/>
+        <source>&lt;p&gt;TLS/SSL is usually on port 6697. IRC networks often use a &lt;b&gt;+&lt;/b&gt; when listing secure ports offered.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2946"/>
+        <source>Use a secure connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3476"/>
+        <source>Allow secure connection reminder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3473"/>
+        <source>&lt;p&gt;To encourage enhanced data transfer protection and privacy, be prompted for a choice to switch to an encrypted port when advertised via Mud Server Status Protocol (MSSP).&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3583"/>
+        <source>Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3598"/>
+        <source>Main window shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3610"/>
+        <source>To disable shortcut input &apos;Esc&apos; key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3629"/>
+        <source>Reset to defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3678"/>
+        <source>Advertise screen reader use via protocols supporting this notice (NEW-ENVIRON, MNES, MTTS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3819"/>
+        <source>Force NEW_ENVIRON negotiation off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3853"/>
+        <source>Clear stored media</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3859"/>
+        <location filename="../src/ui/profile_preferences.ui" line="3872"/>
+        <source>&lt;p&gt;Media files used with Mudlet&apos;s Lua API, Mud Client Media Protocol (MCMP), and Mud Sound Protocol (MSP) are cached with the game profile. You can press this button to clear the media cache. For many games the media will get downloaded again upon demand.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3862"/>
+        <source>Purge stored media files for the current profile:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3875"/>
+        <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="4039"/>
+        <source>h:mm:ss.zzz</source>
+        <comment>Used to set a time interval only</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1354"/>
+        <source>Autocomplete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="274"/>
+        <source>Notify on new data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="271"/>
+        <source>&lt;p&gt;Show a toolbar notification if Mudlet is minimized and new data arrives.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="288"/>
+        <source>Auto save on exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="298"/>
+        <source>Allow server to download and play media</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="295"/>
+        <source>&lt;p&gt;This also needs GMCP to be enabled in the next group below.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="238"/>
+        <source>System setting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="243"/>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="248"/>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="230"/>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="261"/>
+        <source>Set dark theme in &lt;a href=&quot;dark-code-editor&quot;&gt;code editor&lt;/a&gt; as well?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="347"/>
+        <source>Enable MSP  (Mud Sound Protocol)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="354"/>
+        <source>&lt;p&gt;Enables MTTS - provides information about your client settings at logon for supported gamesr&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="357"/>
+        <source>Enable MTTS  (Mud Terminal Type Standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="364"/>
+        <source>&lt;p&gt;Enables MNES - provides information about your client settings during game play for supported games&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="367"/>
+        <source>Enable MNES  (Mud New-Environ Standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="563"/>
+        <source>Highlights your input line text when scrolling through your history for easy cancellation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="566"/>
+        <source>Highlight history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="623"/>
+        <source>Number of lines of command line history to save:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="636"/>
+        <source>&lt;p&gt;Sets the maximum number of the most recent entries used in each separate command line that are now stored between sessions.&lt;/p&gt;&lt;p&gt;&lt;i&gt;This limit is only applied when the data is stored at the end of a session; whilst a profile is active the command history is unlimited with any reused entries returned to the front of the list.&lt;/i&gt;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="813"/>
+        <source>This font is not monospace, which may not be ideal for playing some text games:
+you can use it but there could be issues with aligning columns of text</source>
+        <comment>Note that this text is split into two lines so that the message is not too wide in English, please do the same for other locales where the text is the same or longer</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="821"/>
+        <source>Use anti aliasing on fonts. Smoothes fonts if you have a high screen resolution and you can use larger fonts. Note that on low resolutions and small font sizes, the font gets blurry. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1191"/>
+        <source>&lt;p&gt;Select this option for better compatibility if you are using a netbook, or some other computer model that has a small screen.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1221"/>
+        <source>Display control characters as:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1235"/>
+        <source>nothing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1240"/>
+        <source>Unicode Control Pictures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1245"/>
+        <source>CP437 (OEM Font)- like</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1360"/>
+        <source>Autocomplete Lua functions in code editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1396"/>
+        <source>Shows bidirection Unicode characters which can be used to change the meaning of source code while remaining invisible to the eye</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1399"/>
+        <source>Show invisible Unicode control characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1406"/>
+        <source>&lt;p&gt;Shows the &lt;b&gt;unique&lt;/b&gt; ID number that Mudlet uses internally to identify each instance of an item this is the same number that the Lua API functions that create aliases, key-binding, etc. return on success. This may be useful to know when there are multiple items of the same type with the same name and will be incorporated in the names of the related items&apos; Lua scripts in the Central Debug Console output.&lt;/p&gt;&lt;p&gt;Note that although the number assigned to an item is constant during a session of the profile it may be different the next time the profile is loaded if other items are added or removed.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1409"/>
+        <source>Show Items&apos; ID number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1452"/>
+        <source>&lt;p&gt;The foreground color used by default for the main console (unless changed by a lua command or the game server).&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1475"/>
+        <source>&lt;p&gt;The background color used by default for the main console (unless changed by a lua command or the game server).&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1495"/>
+        <source>&lt;p&gt;The foreground color used for the main input area.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1512"/>
+        <source>&lt;p&gt;The background color used for the main input area.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1529"/>
+        <source>&lt;p&gt;The foreground color used for text sent to the game server.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1549"/>
+        <source>&lt;p&gt;The background color used for text sent to the game server.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1575"/>
+        <source>These preferences set how you want a particular color to be represented visually in the main display:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1585"/>
+        <location filename="../src/ui/profile_preferences.ui" line="2493"/>
+        <source>Black:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1592"/>
+        <source>ANSI Color Number 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1605"/>
+        <location filename="../src/ui/profile_preferences.ui" line="2513"/>
+        <source>Light black:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1612"/>
+        <source>ANSI Color Number 8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1625"/>
+        <location filename="../src/ui/profile_preferences.ui" line="2533"/>
+        <source>Red:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1632"/>
+        <source>ANSI Color Number 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1645"/>
+        <location filename="../src/ui/profile_preferences.ui" line="2553"/>
+        <source>Light red:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1652"/>
+        <source>ANSI Color Number 9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1665"/>
+        <location filename="../src/ui/profile_preferences.ui" line="2573"/>
+        <source>Green:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1672"/>
+        <source>ANSI Color Number 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1685"/>
+        <location filename="../src/ui/profile_preferences.ui" line="2593"/>
+        <source>Light green:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1692"/>
+        <source>ANSI Color Number 10</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1705"/>
+        <location filename="../src/ui/profile_preferences.ui" line="2613"/>
+        <source>Yellow:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1712"/>
+        <source>ANSI Color Number 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1725"/>
+        <location filename="../src/ui/profile_preferences.ui" line="2633"/>
+        <source>Light yellow:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1732"/>
+        <source>ANSI Color Number 11</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1745"/>
+        <location filename="../src/ui/profile_preferences.ui" line="2653"/>
+        <source>Blue:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1752"/>
+        <source>ANSI Color Number 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1765"/>
+        <location filename="../src/ui/profile_preferences.ui" line="2673"/>
+        <source>Light blue:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1772"/>
+        <source>ANSI Color Number 12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1785"/>
+        <location filename="../src/ui/profile_preferences.ui" line="2693"/>
+        <source>Magenta:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1792"/>
+        <source>ANSI Color Number 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1805"/>
+        <location filename="../src/ui/profile_preferences.ui" line="2713"/>
+        <source>Light magenta:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1812"/>
+        <source>ANSI Color Number 13</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1825"/>
+        <location filename="../src/ui/profile_preferences.ui" line="2733"/>
+        <source>Cyan:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1832"/>
+        <source>ANSI Color Number 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1845"/>
+        <location filename="../src/ui/profile_preferences.ui" line="2753"/>
+        <source>Light cyan:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1852"/>
+        <source>ANSI Color Number 14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1865"/>
+        <location filename="../src/ui/profile_preferences.ui" line="2773"/>
+        <source>White:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1872"/>
+        <source>ANSI Color Number 7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1885"/>
+        <location filename="../src/ui/profile_preferences.ui" line="2793"/>
+        <source>Light white:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1892"/>
+        <source>ANSI Color Number 15</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1915"/>
+        <location filename="../src/ui/profile_preferences.ui" line="2813"/>
+        <source>Reset all colors to default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1905"/>
+        <source>&lt;p&gt;If this option is checked the Mud Server may send codes to change the above 16 colors or to reset them to their defaults by using standard ANSI &lt;tt&gt;OSC&lt;/tt&gt; Escape codes.&lt;/p&gt;&lt;p&gt;Specifically &lt;tt&gt;&amp;lt;OSC&amp;gt;Pirrggbb&amp;lt;ST&amp;gt;&lt;/tt&gt; will set the color with index &lt;i&gt;i&lt;/i&gt; to have the color with the given &lt;i&gt;rr&lt;/i&gt; red, &lt;i&gt;gg&lt;/i&gt; green and &lt;i&gt;bb&lt;/i&gt;  blue components where i is a single hex-digit (&apos;0&apos; to &apos;9&apos; or &apos;a&apos; to &apos;f&apos; or &apos;A&apos; to &apos;F&apos; to give a number between 0 an d15) and rr, gg and bb are two digit hex-digits numbers (between 0 to 255); &amp;lt;OSC&amp;gt; is &lt;i&gt;Operating System Command&lt;/i&gt; which is normally encoded as the ASCII &amp;lt;ESC&amp;gt; character followed by &lt;tt&gt;[&lt;/tt&gt; and &amp;lt;ST&amp;gt; is the &lt;i&gt;String Terminator&lt;/i&gt; which is normally encoded as the ASCII &amp;lt;ESC&amp;gt; character followed by &lt;tt&gt;\&lt;tt&gt;.&lt;/p&gt;&lt;p&gt;Conversely &lt;tt&gt;&amp;lt;OSC&amp;gt;R&amp;lt;ST&amp;gt;&lt;/tt&gt; will reset the colors to the defaults like the button to the right does.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1908"/>
+        <source>Server allowed to redefine these colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1939"/>
+        <source>Mapper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1945"/>
+        <source>Map files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1951"/>
+        <source>Save your current map:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1978"/>
+        <source>Load another map file in:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1968"/>
+        <source>&lt;p&gt;Mudlet now does some sanity checking and repairing to clean up issues that may have arisen in previous version due to faulty code or badly documented commands. However if significant problems are found the report can be quite extensive, in particular for larger maps.&lt;/p&gt;&lt;p&gt;Unless this option is set, Mudlet will reduce the amount of on-screen messages by hiding many texts and showing a suggestion to review the report file instead.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1971"/>
+        <source>report map issues on screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1988"/>
+        <source>choose map...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1995"/>
+        <source>Or load an older version:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2012"/>
+        <source>◀ load this map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2039"/>
+        <source>delete</source>
+        <comment>Text on the button to delete a map, ensure the text matches the word or words `quoted` for the adjacent checkbox</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2046"/>
+        <source>enable &apos;delete&apos; button</source>
+        <comment>Text for a checkbox adjacent to the delete map button, ensure the text &apos;quoted&apos; matches the word or words on the button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2069"/>
+        <source>pick destinations...</source>
+        <comment>text on button to select other profiles to receive the map from this profile, this is used when no profiles have been selected</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2111"/>
+        <source>&lt;p&gt;Change this to a lower version if you need to save your map in a format that can be read by older versions of Mudlet. Doing so will lose the extra data available in the current map format&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2153"/>
+        <source>Download latest map provided by your game:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2182"/>
+        <source>&lt;p&gt;This enables anti-aliasing (AA) for the 2D map view, making it look smoother and nicer. Disable this if you&apos;re on a very slow computer.&lt;/p&gt;&lt;p&gt;3D map view always has anti-aliasing enabled.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2192"/>
+        <source>&lt;p&gt;The default area (area id -1) is used by some mapper scripts as a temporary &apos;holding area&apos; for rooms before they&apos;re placed in the correct area&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2267"/>
+        <source>2D map player room marker style:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2277"/>
+        <source>Outer ring color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2287"/>
+        <source>Inner ring color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2301"/>
+        <source>Original</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2306"/>
+        <source>Red ring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2311"/>
+        <source>Blue/Yellow ring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2316"/>
+        <source>Custom ring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2324"/>
+        <source>&lt;p&gt;Percentage ratio (&lt;i&gt;the default is 120%&lt;/i&gt;) of the marker symbol to the space available for the room.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2330"/>
+        <location filename="../src/ui/profile_preferences.ui" line="2358"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2333"/>
+        <source>Outer diameter: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2352"/>
+        <source>&lt;p&gt;Percentage ratio of the inner diameter of the marker symbol to the outer one (&lt;i&gt;the default is 70%&lt;/i&gt;).&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2361"/>
+        <source>Inner diameter: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2205"/>
+        <source>&lt;p&gt;This enables borders around room. Color can be set in Mapper colors tab&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2208"/>
+        <source>Show room borders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2449"/>
+        <source>Room border color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2837"/>
+        <source>Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3534"/>
+        <source>Username for logging into the proxy if required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3550"/>
+        <source>Password for logging into the proxy if required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3774"/>
+        <source>Special options needed for some older game drivers (needs client restart to take effect)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3812"/>
+        <source>Force CHARSET negotiation off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3956"/>
+        <source>the computer&apos;s password manager (secure)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3961"/>
+        <source>plaintext with the profile (portable)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="4049"/>
+        <source>&lt;p&gt;If checked this will cause all problem Unicode codepoints to be reported in the debug output as they occur; if cleared then each different one will only be reported once and summarized in as a table when the console in which they occurred is finally destroyed (when the profile is closed).&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3935"/>
+        <source>&lt;p&gt;Some MUDs use a flawed interpretation of the ANSI Set Graphics Rendition (&lt;b&gt;SGR&lt;/b&gt;) code sequences for 16M color mode which only uses semi-colons and not colons to separate parameter elements i.e. instead of using a code in the form: &lt;br&gt;&lt;tt&gt;\e[&lt;/tt&gt;...&lt;tt&gt;38:2:&lt;/tt&gt;&amp;lt;Color Space Id&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Red&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Green&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Blue&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Unused&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Tolerance&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Tolerance Color Space (0=CIELUV; 1=CIELAB)&amp;gt;&lt;tt&gt;;&lt;/tt&gt;...&lt;tt&gt;m&lt;/tt&gt;&lt;br&gt;where the &lt;i&gt;Color Space Id&lt;/i&gt; is expected to be an empty string to specify the usual (default) case and all of the &lt;i&gt;Parameter Elements&lt;/i&gt; (the &quot;2&quot; and the values in the &lt;tt&gt;&amp;lt;...&amp;gt;&lt;/tt&gt;s) may, technically, be omitted; they use: &lt;br&gt;&lt;tt&gt;\e[&lt;/tt&gt;...&lt;tt&gt;38;2;&lt;/tt&gt;&amp;lt;Red&amp;gt;&lt;tt&gt;;&lt;/tt&gt;&amp;lt;Green&amp;gt;&lt;tt&gt;;&lt;/tt&gt;&amp;lt;Blue&amp;gt;&lt;tt&gt;;&lt;/tt&gt;...&lt;tt&gt;m&lt;/tt&gt;&lt;br&gt;or: &lt;br&gt;&lt;tt&gt;\e[&lt;/tt&gt;...&lt;tt&gt;38;2;&lt;/tt&gt;&amp;lt;Color Space Id&amp;gt;&lt;tt&gt;;&lt;/tt&gt;&amp;lt;Red&amp;gt;&lt;tt&gt;;&lt;/tt&gt;&amp;lt;Green&amp;gt;&lt;tt&gt;;&lt;/tt&gt;&amp;lt;Blue&amp;gt;&lt;tt&gt;;&lt;/tt&gt;...&lt;tt&gt;m&lt;/tt&gt;&lt;/p&gt;&lt;p&gt;It is not possible to reliably detect the difference between these two so checking this option causes Mudlet to expect the last one with the additional (but empty!) parameter.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3938"/>
+        <source>Expect Color Space Id in SGR...(3|4)8;2;...m codes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3945"/>
+        <source>Store character login passwords in:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3140"/>
+        <source>TLS/SSL secure connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3241"/>
+        <source>Accept self-signed certificates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3251"/>
+        <source>Accept expired certificates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3158"/>
+        <source>Certificate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3218"/>
+        <source>Serial:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3167"/>
+        <source>Issuer:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3184"/>
+        <source>Issued to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3201"/>
+        <source>Expires:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3261"/>
+        <source>Accept all certificate errors       (unsecure)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2053"/>
+        <source>Copy map to other profile(s):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2134"/>
+        <source>An action above happened</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2089"/>
+        <source>Map format version:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2117"/>
+        <location filename="../src/ui/profile_preferences.ui" line="2121"/>
+        <source># {default version}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2144"/>
+        <source>Map download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2166"/>
+        <source>Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2176"/>
+        <source>Map view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2228"/>
+        <source>2D Map Room Symbol Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2185"/>
+        <source>Use high quality graphics in 2D view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="185"/>
+        <source>&lt;p&gt;Can you help translate Mudlet?&lt;/p&gt;&lt;p&gt;If so, please visit: &lt;b&gt;https://www.mudlet.org/translate&lt;/b&gt;.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="1961"/>
+        <source>choose location...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2066"/>
+        <source>&lt;p&gt;Select profiles that you want to copy map to, then press the Copy button to the right&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2079"/>
+        <source>&lt;p&gt;Copy map into the selected profiles on the left&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2150"/>
+        <location filename="../src/ui/profile_preferences.ui" line="2163"/>
+        <source>&lt;p&gt;On games that provide maps for download, you can press this button to get the latest map. Note that this will &lt;span style=&quot; font-weight:600;&quot;&gt;overwrite&lt;/span&gt; any changes you&apos;ve done to your map, and will use the new map only&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2195"/>
+        <source>Show the default area in map area selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2238"/>
+        <source>Only use symbols (glyphs) from chosen font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2245"/>
+        <source>Show symbol usage...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2394"/>
+        <source>Mapper colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2400"/>
+        <source>Select your color preferences for the map display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2406"/>
+        <source>Link color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2429"/>
+        <source>Background color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3768"/>
+        <source>Special Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3780"/>
+        <source>Force compression off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3798"/>
+        <source>Force telnet GA signal interpretation off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3787"/>
+        <source>This option adds a line line break &lt;LF&gt; or &quot;
+&quot; to your command input on empty commands. This option will rarely be necessary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3791"/>
+        <source>Force new line on empty commands</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3805"/>
+        <source>Force MXP negotiation off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2956"/>
+        <source>Discord privacy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2989"/>
+        <source>Don&apos;t hide small icon or tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2994"/>
+        <source>Hide small icon tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2999"/>
+        <source>Hide small icon and tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3021"/>
+        <source>Hide timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3044"/>
+        <location filename="../src/ui/profile_preferences.ui" line="3060"/>
+        <location filename="../src/ui/profile_preferences.ui" line="3076"/>
+        <location filename="../src/ui/profile_preferences.ui" line="3092"/>
+        <source>&lt;p&gt;Mudlet will only show Rich Presence information while you use this Discord username (useful if you have multiple Discord accounts). Leave empty to show it for any Discord account you log in to.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3050"/>
+        <source>Restrict to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2963"/>
+        <source>Don&apos;t hide large icon or tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2968"/>
+        <source>Hide large icon tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2973"/>
+        <source>Hide large icon and tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3028"/>
+        <source>&lt;p&gt;Allow Lua to set Discord status&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3031"/>
+        <source>Enable Lua API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3066"/>
+        <source>specific Discord username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3007"/>
+        <source>Hide state</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3014"/>
+        <source>Hide party details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2981"/>
+        <source>Hide detail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2843"/>
+        <source>IRC client options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2862"/>
+        <source>irc.example.net</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2869"/>
+        <source>Port:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2916"/>
+        <source>#channel1 #channel2 #etc...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2899"/>
+        <source>MudletUser123</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2849"/>
+        <source>Server address:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2906"/>
+        <source>Auto-join channels: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2889"/>
+        <source>Nickname:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2882"/>
+        <source>6667</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3901"/>
+        <source>Search Engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3885"/>
+        <source>Mudlet updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3891"/>
+        <source>Disable automatic updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3913"/>
+        <source>Other Special options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3919"/>
+        <source>Show icons on menus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3134"/>
+        <source>Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3489"/>
+        <source>Connect to the game via proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3504"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3524"/>
+        <source>port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3540"/>
+        <source>username (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="2936"/>
+        <location filename="../src/ui/profile_preferences.ui" line="3556"/>
+        <source>password (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="4005"/>
+        <source>Show debug messages for timers not smaller than:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="4002"/>
+        <source>&lt;p&gt;Show &apos;LUA OK&apos; messages for Timers with the specified minimum interval (h:mm:ss.zzz), the minimum value (the default) shows all such messages but can render the &lt;i&gt;Central Debug Console&lt;/i&gt; useless if there is a very small interval timer running.&lt;/p&gt;</source>
+        <comment>The term in &apos;...&apos; refer to a Mudlet specific thing and ought to match the corresponding translation elsewhere.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="4052"/>
+        <source>Report all Codepoint problems immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="4059"/>
+        <source>Additional text wait time:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="4069"/>
+        <source>&lt;p&gt;&lt;i&gt;Go-Ahead&lt;/i&gt; (&lt;tt&gt;GA&lt;/tt&gt;) and &lt;i&gt;End-of-record&lt;/i&gt; (&lt;tt&gt;EOR&lt;/tt&gt;) signalling tells Mudlet when the game server is done sending text. On games that do not provide &lt;tt&gt;GA&lt;/tt&gt; or &lt;tt&gt;EOR&lt;/tt&gt;, this option controls how long Mudlet will wait for more text to arrive. Greater values will help reduce the risk that Mudlet will split a large piece of text (with unintended line-breaks in the middle) which can stop some triggers from working. Lesser values increases the risk of text getting broken up, but may make the game feel more responsive.&lt;/p&gt;&lt;p&gt;&lt;i&gt;The default value, which was what Mudlet used before this control was added, is 0.300 Seconds.&lt;/i&gt;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="4072"/>
+        <source> seconds</source>
+        <extracomment>For most locales a space should be included so that the text is separated from the number!</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3653"/>
+        <location filename="../src/ui/profile_preferences.ui" line="3659"/>
+        <source>Accessibility</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3665"/>
+        <source>On some platforms, like macOS, the screen reader tool has issues announcing incoming text fully, without skipping. You can opt into disabling announcing new text from the game with this option to use a custom TTS instead which avoids such issues</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3668"/>
+        <source>Announce incoming text in screen reader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3696"/>
+        <source>show them</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3701"/>
+        <source>hide them</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3706"/>
+        <source>replace with a space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3685"/>
+        <source>When the game sends blank lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3714"/>
+        <source>Switch between input line and main window using:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3725"/>
+        <source>no key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3730"/>
+        <source>Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3735"/>
+        <source>Ctrl+Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="3740"/>
+        <source>F6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/profile_preferences.ui" line="4142"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>room_exits</name>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="38"/>
+        <source>General exits:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="91"/>
+        <source>NW exit...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="101"/>
+        <location filename="../src/ui/room_exits.ui" line="235"/>
+        <location filename="../src/ui/room_exits.ui" line="369"/>
+        <location filename="../src/ui/room_exits.ui" line="503"/>
+        <location filename="../src/ui/room_exits.ui" line="640"/>
+        <location filename="../src/ui/room_exits.ui" line="887"/>
+        <location filename="../src/ui/room_exits.ui" line="1021"/>
+        <location filename="../src/ui/room_exits.ui" line="1173"/>
+        <location filename="../src/ui/room_exits.ui" line="1307"/>
+        <location filename="../src/ui/room_exits.ui" line="1441"/>
+        <location filename="../src/ui/room_exits.ui" line="1575"/>
+        <location filename="../src/ui/room_exits.ui" line="1838"/>
+        <source>&lt;p&gt;Set to a positive value to override the default (Room) Weight for using this Exit route, zero value assigns the default.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="225"/>
+        <source>N exit...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="359"/>
+        <source>NE exit...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="493"/>
+        <source>Up exit...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="630"/>
+        <source>W exit...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="735"/>
+        <source>ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="769"/>
+        <source>&lt;p&gt;This is the Room ID Number for this room.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="804"/>
+        <source>Weight:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="817"/>
+        <source>&lt;p&gt;This is the default weight for this room, which will be used for any exit &lt;i&gt;that leads to &lt;u&gt;this room&lt;/u&gt;&lt;/i&gt; which does not have its own value set.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="880"/>
+        <source>E exit...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1011"/>
+        <source>Down exit...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1157"/>
+        <source>SW exit...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1297"/>
+        <source>S exit...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1431"/>
+        <source>SE exit...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1565"/>
+        <source>In exit...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1828"/>
+        <source>Out exit...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1681"/>
+        <source>No route</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1696"/>
+        <source>Stub Exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="65"/>
+        <location filename="../src/ui/room_exits.ui" line="199"/>
+        <location filename="../src/ui/room_exits.ui" line="333"/>
+        <location filename="../src/ui/room_exits.ui" line="467"/>
+        <location filename="../src/ui/room_exits.ui" line="601"/>
+        <location filename="../src/ui/room_exits.ui" line="854"/>
+        <location filename="../src/ui/room_exits.ui" line="985"/>
+        <location filename="../src/ui/room_exits.ui" line="1125"/>
+        <location filename="../src/ui/room_exits.ui" line="1271"/>
+        <location filename="../src/ui/room_exits.ui" line="1405"/>
+        <location filename="../src/ui/room_exits.ui" line="1539"/>
+        <location filename="../src/ui/room_exits.ui" line="1802"/>
+        <location filename="../src/ui/room_exits.ui" line="1986"/>
+        <source>&lt;p&gt;Prevent a route being created via this exit, equivalent to an infinite exit weight.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="53"/>
+        <source>Northwest</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="81"/>
+        <location filename="../src/ui/room_exits.ui" line="215"/>
+        <location filename="../src/ui/room_exits.ui" line="349"/>
+        <location filename="../src/ui/room_exits.ui" line="483"/>
+        <location filename="../src/ui/room_exits.ui" line="617"/>
+        <location filename="../src/ui/room_exits.ui" line="870"/>
+        <location filename="../src/ui/room_exits.ui" line="1001"/>
+        <location filename="../src/ui/room_exits.ui" line="1147"/>
+        <location filename="../src/ui/room_exits.ui" line="1287"/>
+        <location filename="../src/ui/room_exits.ui" line="1421"/>
+        <location filename="../src/ui/room_exits.ui" line="1555"/>
+        <location filename="../src/ui/room_exits.ui" line="1818"/>
+        <source>&lt;p&gt;Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="114"/>
+        <location filename="../src/ui/room_exits.ui" line="248"/>
+        <location filename="../src/ui/room_exits.ui" line="382"/>
+        <location filename="../src/ui/room_exits.ui" line="516"/>
+        <location filename="../src/ui/room_exits.ui" line="653"/>
+        <location filename="../src/ui/room_exits.ui" line="900"/>
+        <location filename="../src/ui/room_exits.ui" line="1034"/>
+        <location filename="../src/ui/room_exits.ui" line="1186"/>
+        <location filename="../src/ui/room_exits.ui" line="1320"/>
+        <location filename="../src/ui/room_exits.ui" line="1454"/>
+        <location filename="../src/ui/room_exits.ui" line="1588"/>
+        <location filename="../src/ui/room_exits.ui" line="1851"/>
+        <location filename="../src/ui/room_exits.ui" line="2004"/>
+        <source>&lt;p&gt;No door symbol is drawn on 2D Map for this exit.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="133"/>
+        <location filename="../src/ui/room_exits.ui" line="267"/>
+        <location filename="../src/ui/room_exits.ui" line="401"/>
+        <location filename="../src/ui/room_exits.ui" line="672"/>
+        <location filename="../src/ui/room_exits.ui" line="919"/>
+        <location filename="../src/ui/room_exits.ui" line="1205"/>
+        <location filename="../src/ui/room_exits.ui" line="1339"/>
+        <location filename="../src/ui/room_exits.ui" line="1473"/>
+        <source>&lt;p&gt;Green (Open) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="149"/>
+        <location filename="../src/ui/room_exits.ui" line="283"/>
+        <location filename="../src/ui/room_exits.ui" line="417"/>
+        <location filename="../src/ui/room_exits.ui" line="688"/>
+        <location filename="../src/ui/room_exits.ui" line="935"/>
+        <location filename="../src/ui/room_exits.ui" line="1221"/>
+        <location filename="../src/ui/room_exits.ui" line="1355"/>
+        <location filename="../src/ui/room_exits.ui" line="1489"/>
+        <source>&lt;p&gt;Orange (Closed) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="165"/>
+        <location filename="../src/ui/room_exits.ui" line="299"/>
+        <location filename="../src/ui/room_exits.ui" line="433"/>
+        <location filename="../src/ui/room_exits.ui" line="704"/>
+        <location filename="../src/ui/room_exits.ui" line="951"/>
+        <location filename="../src/ui/room_exits.ui" line="1237"/>
+        <location filename="../src/ui/room_exits.ui" line="1371"/>
+        <location filename="../src/ui/room_exits.ui" line="1505"/>
+        <source>&lt;p&gt;Red (Locked) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="187"/>
+        <source>North</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="321"/>
+        <source>Northeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="455"/>
+        <source>Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="535"/>
+        <location filename="../src/ui/room_exits.ui" line="1053"/>
+        <location filename="../src/ui/room_exits.ui" line="1607"/>
+        <location filename="../src/ui/room_exits.ui" line="1870"/>
+        <source>&lt;p&gt;A symbol is drawn with a green (Open) fill color on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="551"/>
+        <location filename="../src/ui/room_exits.ui" line="1069"/>
+        <location filename="../src/ui/room_exits.ui" line="1623"/>
+        <location filename="../src/ui/room_exits.ui" line="1886"/>
+        <source>&lt;p&gt;A symbol is drawn with an orange (Closed) fill color on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="567"/>
+        <location filename="../src/ui/room_exits.ui" line="1085"/>
+        <location filename="../src/ui/room_exits.ui" line="1639"/>
+        <location filename="../src/ui/room_exits.ui" line="1902"/>
+        <source>&lt;p&gt;A symbol is drawn with a red (Locked) fill color on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="589"/>
+        <source>West</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="729"/>
+        <source>This room</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="842"/>
+        <source>East</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="973"/>
+        <source>Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1107"/>
+        <source>Southwest</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1259"/>
+        <source>South</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1393"/>
+        <source>Southeast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1527"/>
+        <source>In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1667"/>
+        <source>Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1708"/>
+        <source>Exit RoomID number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1735"/>
+        <source>No door</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1750"/>
+        <source>Open door</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1762"/>
+        <source>Closed door</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1774"/>
+        <source>Locked door</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1790"/>
+        <source>Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1930"/>
+        <source>&lt;p&gt;Click on an item to edit/change it. To delete a Special Exit, ether: select it and press the keyboard Delete key; or set its Exit roomID to less than one; or clear the name/command entry.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1973"/>
+        <source>Exit
+Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1977"/>
+        <source>&lt;p&gt;Indicates whether the exit is invalid, leads to another room in this area or leads to a room in another area.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="2013"/>
+        <source>&lt;p&gt;Green (Open) door symbol is drawn on 2D Map.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="2022"/>
+        <source>&lt;p&gt;Orange (Closed) door symbol is drawn on 2D Map.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="2031"/>
+        <source>&lt;p&gt;Red (Locked) door symbol is drawn on 2D Map.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="2108"/>
+        <source>&lt;p&gt;Use this button to save any changes, will also remove any invalid Special exits.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="2124"/>
+        <source>&lt;p&gt;Use this button to close the dialogue without changing anything.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1968"/>
+        <source>&lt;p&gt;Set the number of the room that this exit leads to, if set to zero the exit will be removed on saving the exits.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="2057"/>
+        <source>&lt;p&gt;Add an empty item to Special exits to be edited as required.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="2076"/>
+        <source>&lt;p&gt;Press this button to deactivate the selection of a Special exit.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="2111"/>
+        <source>&amp;Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1720"/>
+        <source>Exit Weight (0=No override)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="2127"/>
+        <source>&amp;Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1921"/>
+        <source>Special exits:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1964"/>
+        <source>Exit
+Room ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1982"/>
+        <source>No
+Route</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1991"/>
+        <source>Exit
+Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="1995"/>
+        <source>&lt;p&gt;Set to a positive integer value to override the default (Room) Weight for using this Exit route, a zero value assigns the default.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="2000"/>
+        <source>Door
+None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="2009"/>
+        <source>Door
+Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="2018"/>
+        <source>Door
+Closed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="2027"/>
+        <source>Door
+Locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="2036"/>
+        <source>Command
+or LUA script</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="2040"/>
+        <source>&lt;p&gt;Some mapper scripts may require prefixing the keyword &quot;script:&quot;.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="2060"/>
+        <source>&amp;Add special exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_exits.ui" line="2079"/>
+        <source>&amp;End S. Exits editing</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>room_properties</name>
+    <message>
+        <location filename="../src/ui/room_properties.ui" line="20"/>
+        <source>Room properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_properties.ui" line="47"/>
+        <source>Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_properties.ui" line="54"/>
+        <source>Room name...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_properties.ui" line="61"/>
+        <source>Icon:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_properties.ui" line="111"/>
+        <source>Set room color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_properties.ui" line="127"/>
+        <source>Symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_properties.ui" line="167"/>
+        <source>Room symbol...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_properties.ui" line="210"/>
+        <source>Color of to use for the room symbol(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_properties.ui" line="216"/>
+        <source>Set symbol color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_properties.ui" line="229"/>
+        <source>Reset</source>
+        <extracomment>This button is located next to the button &quot;Set symbol color&quot; and will reset the symbol color back to the original color.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_properties.ui" line="242"/>
+        <source>Pathfinding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/room_properties.ui" line="288"/>
+        <source>1 (default)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>scripts_main_area</name>
+    <message>
+        <location filename="../src/ui/scripts_main_area.ui" line="23"/>
+        <source>Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/scripts_main_area.ui" line="33"/>
+        <source>&lt;p&gt;Choose a good, (ideally, though it need not be, unique) name for your script or script group. This will be displayed in the script tree.&lt;/p&gt;&lt;p&gt;If a function within the script is to be used to handle events entered in the list below &lt;b&gt;&lt;u&gt;it must have the same name as is entered here.&lt;/u&gt;&lt;/b&gt;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/scripts_main_area.ui" line="61"/>
+        <source>ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/scripts_main_area.ui" line="90"/>
+        <source>Registered Event Handlers:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/scripts_main_area.ui" line="137"/>
+        <source>&lt;p&gt;Remove (selected) event handler from list.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/scripts_main_area.ui" line="140"/>
+        <source>-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/scripts_main_area.ui" line="147"/>
+        <source>Add User Event Handler:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/scripts_main_area.ui" line="181"/>
+        <source>&lt;p&gt;Add entered event handler name to list.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/scripts_main_area.ui" line="184"/>
+        <source>+</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>set_room_area</name>
+    <message>
+        <location filename="../src/ui/set_room_area.ui" line="14"/>
+        <source>Move rooms to another area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/set_room_area.ui" line="20"/>
+        <source>Which area would you like to move the room(s) to?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/set_room_area.ui" line="36"/>
+        <source>Input new area name to create one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>source_editor_area</name>
+    <message>
+        <location filename="../src/ui/source_editor_area.ui" line="26"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>source_editor_find_area</name>
+    <message>
+        <location filename="../src/ui/source_editor_find_area.ui" line="41"/>
+        <source>Find</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/source_editor_find_area.ui" line="87"/>
+        <source>Replace</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>timers_main_area</name>
+    <message>
+        <location filename="../src/ui/timers_main_area.ui" line="29"/>
+        <source>Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/timers_main_area.ui" line="116"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/timers_main_area.ui" line="186"/>
+        <source>&lt;p&gt;milliseconds&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/timers_main_area.ui" line="220"/>
+        <source>Time:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/timers_main_area.ui" line="39"/>
+        <source>&lt;p&gt;Choose a good, (ideally, though it need not be, unique) name for your timer, offset-timer or timer group. This will be displayed in the timer tree.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/timers_main_area.ui" line="67"/>
+        <source>ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/timers_main_area.ui" line="141"/>
+        <source>&lt;p&gt;hours&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/timers_main_area.ui" line="156"/>
+        <source>&lt;p&gt;minutes&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/timers_main_area.ui" line="171"/>
+        <source>&lt;p&gt;seconds&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/timers_main_area.ui" line="235"/>
+        <source>&lt;p&gt;The &lt;b&gt;hour&lt;/b&gt; part of the interval that the timer will go off at.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/timers_main_area.ui" line="440"/>
+        <source>&lt;p&gt;The &lt;b&gt;millisecond&lt;/b&gt; part of the interval that the timer will go off at (1000 milliseconds = 1 second).&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/timers_main_area.ui" line="310"/>
+        <source>&lt;p&gt;The &lt;b&gt;minute&lt;/b&gt; part of the interval that the timer will go off at.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/timers_main_area.ui" line="126"/>
+        <source>&lt;p&gt;Enter one or more commands to use if the given command matches the pattern. (Optional)&lt;/p&gt;&lt;p&gt;This could be another alias or a command to send directly to the game. For complex commands that require modification of variables within this profile, use a Lua script in the editor area below instead. It&apos;s possible to use both this field and a Lua script - the contents of this field will be used before running the script.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/timers_main_area.ui" line="129"/>
+        <source>Text to send to the game (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/timers_main_area.ui" line="375"/>
+        <source>&lt;p&gt;The &lt;b&gt;second&lt;/b&gt; part of the interval that the timer will go off at.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>trigger_editor</name>
+    <message>
+        <location filename="../src/ui/trigger_editor.ui" line="152"/>
+        <location filename="../src/ui/trigger_editor.ui" line="200"/>
+        <location filename="../src/ui/trigger_editor.ui" line="245"/>
+        <location filename="../src/ui/trigger_editor.ui" line="290"/>
+        <location filename="../src/ui/trigger_editor.ui" line="335"/>
+        <location filename="../src/ui/trigger_editor.ui" line="380"/>
+        <location filename="../src/ui/trigger_editor.ui" line="428"/>
+        <location filename="../src/ui/trigger_editor.ui" line="590"/>
+        <source>1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/trigger_editor.ui" line="436"/>
+        <source>Show normally hidden variables</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/trigger_editor.ui" line="476"/>
+        <source>&lt;p&gt;Enter text here to search through your code.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/trigger_editor.ui" line="510"/>
+        <source>&lt;p&gt;Toggles the display of the search results area.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>trigger_main_area</name>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="65"/>
+        <source>Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="85"/>
+        <source>&lt;p&gt;Use this control to show or hide the extra controls for the trigger; this can be used to allow more space to show the trigger &lt;i&gt;items&lt;/i&gt; on smaller screen.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="111"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="155"/>
+        <source>ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="251"/>
+        <source>&lt;p&gt;The trigger will only fire if &lt;u&gt;all&lt;/u&gt; conditions on the list have been met within the specified line delta, and captures will be saved in &lt;tt&gt;multimatches&lt;/tt&gt; instead of &lt;tt&gt;matches&lt;/tt&gt;.&lt;/p&gt;
+&lt;p&gt;If this option is &lt;b&gt;not&lt;/b&gt; set the trigger will fire if &lt;u&gt;any&lt;/u&gt; condition on the list have been met.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="258"/>
+        <source>AND / Multi-line (delta)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="310"/>
+        <source>&lt;p&gt;When checked, only the filtered content (=capture groups) will be passed on to child triggers, not the initial line (see manual on filters).&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="316"/>
+        <source>only pass matches</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="352"/>
+        <source>Do not pass whole line to children.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="374"/>
+        <source>&lt;p&gt;Choose this option if you want to include all possible matches of the pattern in the line.&lt;/p&gt;&lt;p&gt;Without this option, the pattern matching will stop after the first successful match.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="465"/>
+        <source>&lt;p&gt;Keep firing the script for this many more lines, after the trigger or chain has matched.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="471"/>
+        <source>fire length (extra lines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="529"/>
+        <source>&lt;p&gt;Play a sound file if the trigger fires.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="574"/>
+        <source>&lt;p&gt;Use this to open a file selection dialogue to find a sound file to play when the trigger fires.&lt;/p&gt;
+&lt;p&gt;&lt;i&gt;Cancelling from the file dialogue will not make any changes; to clear the file use the clear button to the right of the file name display.&lt;/i&gt;&lt;/p&gt;</source>
+        <comment>This is the button used to select a sound file to be played when a trigger fires.</comment>
+        <extracomment>Please ensure the text used here is duplicated within the tooltip for the QLineEdit that displays the file name selected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="578"/>
+        <source>Choose file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="609"/>
+        <source>no file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="670"/>
+        <source>&lt;p&gt;Enable this to highlight the matching text by changing the fore and background colors to the ones selected here.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="713"/>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="729"/>
+        <location filename="../src/ui/triggers_main_area.ui" line="742"/>
+        <source>keep</source>
+        <comment>Keep the existing colour on matches to highlight. Use shortest word possible so it fits on the button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="703"/>
+        <source>Foreground</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="532"/>
+        <source>play sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="78"/>
+        <source>&lt;p&gt;Choose a good, (ideally, though it need not be, unique) name for your trigger or trigger group. This will be displayed in the trigger tree.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="124"/>
+        <source>&lt;p&gt;Enter one or more commands to use if the given command matches the pattern. (Optional)&lt;/p&gt;&lt;p&gt;This could be another alias or a command to send directly to the game. For complex commands that require modification of variables within this profile, use a Lua script in the editor area below instead. It&apos;s possible to use both this field and a Lua script - the contents of this field will be used before running the script.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="127"/>
+        <source>Text to send to the game (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="297"/>
+        <source>&lt;p&gt;Within how many lines must all conditions be true to fire the trigger?&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="380"/>
+        <source>match all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="410"/>
+        <source>Match all occurrences of the pattern in the line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="513"/>
+        <source>&lt;p&gt;How many more lines, after the one that fired the trigger, should be passed to the trigger&apos;s children?&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="600"/>
+        <source>&lt;p&gt;Sound file to play when the trigger fires.&lt;/p&gt;</source>
+        <comment>This is the tooltip for the QLineEdit that shows - but does not permit changing - the sound file used for a trigger.</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="622"/>
+        <source>&lt;p&gt;Click to remove the sound file set for this trigger.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/triggers_main_area.ui" line="676"/>
+        <source>highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>trigger_pattern_edit</name>
+    <message>
+        <location filename="../src/ui/trigger_pattern_edit.ui" line="124"/>
+        <source>Foreground color ignored</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/trigger_pattern_edit.ui" line="148"/>
+        <source>Background color ignored</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/trigger_pattern_edit.ui" line="175"/>
+        <source>match on the prompt line</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>vars_main_area</name>
+    <message>
+        <location filename="../src/ui/vars_main_area.ui" line="62"/>
+        <source>Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/vars_main_area.ui" line="94"/>
+        <source>⏴ Key type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/vars_main_area.ui" line="81"/>
+        <source>&lt;p&gt;Set the &lt;i&gt;global variable&lt;/i&gt; or the &lt;i&gt;table entry&lt;/i&gt; name here. The name has to start with a letter, but can contain a mix of letters and numbers.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/vars_main_area.ui" line="114"/>
+        <location filename="../src/ui/vars_main_area.ui" line="171"/>
+        <source>Auto-Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/vars_main_area.ui" line="84"/>
+        <source>Variable name ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/vars_main_area.ui" line="107"/>
+        <source>&lt;p&gt;Tables can store values either in a list, and/or a hashmap.&lt;/p&gt;&lt;p&gt;In a &lt;b&gt;list&lt;/b&gt;, &lt;i&gt;unique indexed keys&lt;/i&gt; represent values - so you can have values at &lt;i&gt;1, 2, 3...&lt;/i&gt;&lt;/p&gt;&lt;p&gt;In a &lt;b&gt;map&lt;/b&gt; {a.k.a. an &lt;i&gt;associative array}&lt;/i&gt;, &lt;i&gt;unique keys&lt;/i&gt; represent values - so you can have values under any identifier you would like (theoretically even a function or other lua entity although this GUI only supports strings).&lt;/p&gt;&lt;p&gt;This, for a newly created table (group) selects whenever you would like your table to be an indexed or an associative one.&lt;/p&gt;&lt;p&gt;In other cases it displays other entities (&lt;span style=&quot; font-style:italic;&quot;&gt;functions&lt;/span&gt;) which cannot be modified from here.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/vars_main_area.ui" line="119"/>
+        <source>key (string)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/vars_main_area.ui" line="124"/>
+        <source>index (integer)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/vars_main_area.ui" line="129"/>
+        <location filename="../src/ui/vars_main_area.ui" line="191"/>
+        <source>table</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/vars_main_area.ui" line="134"/>
+        <source>function
+(cannot create
+from GUI)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/vars_main_area.ui" line="144"/>
+        <source>&lt;p&gt;If checked this item (and its children, if applicable) does not show in area to the left unless &lt;b&gt;Show normally hidden variables&lt;/b&gt; is checked.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/vars_main_area.ui" line="147"/>
+        <source>hidden variable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/vars_main_area.ui" line="154"/>
+        <source>⏷ Value type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/vars_main_area.ui" line="176"/>
+        <source>string</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/vars_main_area.ui" line="181"/>
+        <source>number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/vars_main_area.ui" line="186"/>
+        <source>boolean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/vars_main_area.ui" line="196"/>
+        <source>function</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/translations/translated/qm.qrc
+++ b/translations/translated/qm.qrc
@@ -1,22 +1,23 @@
 <RCC>
     <qresource prefix="/lang">
-        <file>mudlet_de_DE.qm</file>
-        <file>mudlet_ru_RU.qm</file>
-        <file>mudlet_es_ES.qm</file>
-        <file>mudlet_en_GB.qm</file>
-        <file>mudlet_it_IT.qm</file>
-        <file>mudlet_zh_CN.qm</file>
-        <file>mudlet_pl_PL.qm</file>
-        <file>mudlet_nl_NL.qm</file>
-        <file>mudlet_fr_FR.qm</file>
-        <file>mudlet_zh_TW.qm</file>
-        <file>mudlet_en_US.qm</file>
-        <file>mudlet_el_GR.qm</file>
-        <file>mudlet_pt_PT.qm</file>
-        <file>mudlet_pt_BR.qm</file>
-        <file>mudlet_tr_TR.qm</file>
-        <file>mudlet_fi_FI.qm</file>
         <file>mudlet_ar_SA.qm</file>
+        <file>mudlet_de_DE.qm</file>
+        <file>mudlet_el_GR.qm</file>
+        <file>mudlet_en_GB.qm</file>
+        <file>mudlet_en_US.qm</file>
+        <file>mudlet_es_ES.qm</file>
+        <file>mudlet_fi_FI.qm</file>
+        <file>mudlet_fr_FR.qm</file>
+        <file>mudlet_he_IL.qm</file>
+        <file>mudlet_it_IT.qm</file>
         <file>mudlet_ko_KR.qm</file>
+        <file>mudlet_nl_NL.qm</file>
+        <file>mudlet_pt_BR.qm</file>
+        <file>mudlet_pl_PL.qm</file>
+        <file>mudlet_pt_PT.qm</file>
+        <file>mudlet_ru_RU.qm</file>
+        <file>mudlet_tr_TR.qm</file>
+        <file>mudlet_zh_CN.qm</file>
+        <file>mudlet_zh_TW.qm</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a new language to the selection available on the first tab of the preferences.

#### Motivation for adding to Mudlet
Extends potential locale support for Mudlet to include Israel.

#### Other info (issues closed, discussion etc)
This PR comes about following a discussion between myself, @vadi2 and a speaker of Hebrew in the Mudlet's **#translation** Discord channel on 2024/10/04 18:50 (UTC):
https://www.discord.com/channels/283581582550237184/603289809116725248/1291834973485142158 **NOTE: Hebrew script is a Right-to-Left one and selecting it will cause the GUI to reverse. Some quick testing has suggested that this might generate some oddities in our UI design that will need addressing, particularly where the GUI had assumed (or encoded - via "alignment" settings a Left-to-Right basis - the Qt framework is intelligent to swap things around correctly in the opposite case but only if the correct "flags" are used - i.e. ones that automagically swap over when the layout direction is reversed.) See: https://doc.qt.io/qt-6/qt.html#AlignmentFlag-enum particularly to make use of: `Qt::AlignLeading` and `Qt::AlignTrailing` instead of `Qt::AlignLeft` and `Qt::AlignRight`.**

This PR includes a couple of "dummy files":
* translations/translated/mudlet_he_IL.ts
* translations/lua/translated/mudlet-lua_he_IL.json

these are expected to be overwritten by the first upload of proper translations from CrowdIn to include the `he_IL` {Hebrew (Israel)} locale which have already been instigated on that platform by @vadi2. The first of these is a copy of the source `translations/mudlet.ts` with no changes except the target language marker, and the second is a quick and probably faulty set of translations for the Lua sub-systen which I cobbled together with Google translate and which is probably wrong anyhow.