### PR TITLE
Fix: when closing multiple profiles wait for quiescence before proceeding

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1463,11 +1463,6 @@ void mudlet::slot_closeCurrentProfile()
         return;
     }
     slot_closeProfileRequested(mpTabBar->currentIndex());
-
-    if (!getActiveHost()) {
-        disableToolbarButtons();
-        slot_showConnectionDialog();
-    }
 }
 
 void mudlet::slot_closeProfileRequested(int tab)
@@ -1482,7 +1477,15 @@ void mudlet::slot_closeProfileRequested(int tab)
         return;
     }
 
-    closeHost(name);
+    QTimer::singleShot(0, this, [this, name] {
+        closeHost(name);
+        // Check to see if there are any profiles left...
+        if (!mHostManager.getHostCount() && !mIsGoingDown) {
+            disableToolbarButtons();
+            slot_showConnectionDialog();
+            setWindowTitle(scmVersion);
+        }
+    });
 }
 
 // This removes the Host (profile) from this class's QMainWindow and related

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1493,6 +1493,10 @@ void mudlet::slot_closeProfileRequested(int tab)
 void mudlet::closeHost(const QString& name)
 {
     Host* pH = mHostManager.getHost(name);
+    if (!pH) {
+        // Don't try and close a non-existant profile:
+        return;
+    }
     migrateDebugConsole(pH);
 
     mpTabBar->removeTab(name);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Wait for the Mudlet application to not be busy before trying to close (multiple) profiles - e.g. by holding down the keys set to do the "Close profile" short-cut.

#### Motivation for adding to Mudlet
Stopping it from going :boom: for end-users.

#### Other info (issues closed, discussion etc)
It was really hard to determine why the crashes were occurring and running Mudlet inside the Qt Creator debugger (`gdb`) didn't positively give an answer. The problems seem to be because a `Host` pointer wasn't working properly - according to the debug what was pointed to was still valid (the values in the pointed to `Host` instance looked reasonable) but the actual de-referencing was failing inside Qt library code. At that point there was a stack of several hundred nested/repeating frames for each of the multiple profiles that were in the process of being closed so that is what inspired me to reorganise the process to not call `mudlet::closeHost(const QString&)` directly from `mudlet::slot_closeProfileRequested(int)` but instead do it via a "zero-timer" which will wait for pending stuff to be done before trying to close the next profile. This is not IMVHO a perfect solution because the actual cause of the problem has not been precisely determined, however it does seem to be "good enough" providing other testers confirm the improvement I think this makes.
