### PR TITLE
Fix: Remove duplicate scrolling functions in Miniconsole.

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -132,16 +132,6 @@ function Geyser.MiniConsole:disableHorizontalScrollBar()
   self.horizontalScrollBar = false
 end
 
---- Enables scrolling in the miniconsole
-function Geyser.MiniConsole:enableScrolling()
-  enableScrolling(self.name)
-end
-
---- Disables scrolling in the miniconsole
-function Geyser.MiniConsole:disableScrolling()
-  disableScrolling(self.name)
-end
-
 --- Check if scrolling is enabled in the miniconsole
 function Geyser.MiniConsole:scrollingActive()
   return scrollingActive(self.name)


### PR DESCRIPTION
Remove one of two identically named functions; enableScrolling() and disableScrolling()

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Two functions have been made with the same duplicate names.  Remove the earlier one.

#### Motivation for adding to Mudlet
bug fix, better developer experience

#### Other info (issues closed, discussion etc)
Also fixes documentation generated by LDoc
https://discord.com/channels/283581582550237184/283582068334526464/1293042141945397341
