### PR TITLE
Fix: update console after clearWindow(...)

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3305,22 +3305,14 @@ bool Host::createBuffer(const QString& name)
     return false;
 }
 
-
+// Doesn't work on the errors or central debug consoles:
 bool Host::clearWindow(const QString& name)
 {
     if (!mpConsole) {
         return false;
     }
 
-    auto pC = mpConsole->mSubConsoleMap.value(name);
-    if (pC) {
-        pC->mUpperPane->resetHScrollbar();
-        pC->buffer.clear();
-        pC->mUpperPane->update();
-        return true;
-    } else {
-        return false;
-    }
+    return mpConsole->clear(name);
 }
 
 bool Host::showWindow(const QString& name)

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -708,6 +708,15 @@ void TConsole::refresh()
     QApplication::sendEvent(this, &event);
 }
 
+void TConsole::clear()
+{
+    mUpperPane->resetHScrollbar();
+    buffer.clear();
+    clearSplit();
+    mUpperPane->update();
+    mLowerPane->update();
+}
+
 void TConsole::clearSelection() const
 {
     mLowerPane->unHighlight();

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -115,6 +115,7 @@ public:
     void copy();
     void cut();
     void paste();
+    void clear();
     void appendBuffer();
     void appendBuffer(const TBuffer&);
     int getButtonState();

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -272,21 +272,20 @@ int TLuaInterpreter::calcFontSize(lua_State* L)
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearUserWindow
+// Note that this is registered as both clearUserWindow(...) AND clearWindow(...)
 int TLuaInterpreter::clearUserWindow(lua_State* L)
 {
-    if (!lua_isstring(L, 1)) {
-        const Host& host = getHostFromLua(L);
-        host.mpConsole->mUpperPane->resetHScrollbar();
-        host.mpConsole->buffer.clear();
-        host.mpConsole->mUpperPane->showNewLines();
-        //host.mpConsole->mUpperPane->forceUpdate();
-        return 0;
+    QString windowName;
+    if (lua_gettop(L)) {
+        windowName = getVerifiedString(L, __func__, 1, "window name", true);
     }
-    const QString text = lua_tostring(L, 1);
 
     Host& host = getHostFromLua(L);
-    host.clearWindow(text);
-
+    host.clearWindow(windowName);
+    // Note that exceptionally THIS function does not return a true/nil+error
+    // message on failure - because on success this could plonk a "true" on the
+    // main screen if run from the command line - which sort of messes with the
+    // idea of clearing it of text!
     return 0;
 }
 

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -1641,3 +1641,22 @@ void TMainConsole::closeEvent(QCloseEvent* event)
         event->accept();
     }
 }
+
+bool TMainConsole::clear(const QString& name)
+{
+    if (name.isEmpty() || !name.compare(QLatin1String("main"))) {
+        TConsole::clear();
+        mUpperPane->showNewLines();
+        mUpperPane->forceUpdate();
+        mLowerPane->forceUpdate();
+        return true;
+    }
+
+    auto pC = mSubConsoleMap.value(name);
+    if (pC) {
+        pC->clear();
+        return true;
+    }
+
+    return false;
+}

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -56,6 +56,7 @@ public:
     bool showWindow(const QString& name);
     bool hideWindow(const QString& name);
     bool printWindow(const QString& name, const QString& text);
+    bool clear(const QString& name);
     void setProfileName(const QString&) override;
     void selectCurrentLine(std::string&);
     std::list<int> getFgColor(std::string& buf);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Clean up the distribution of code associated with clearing a `TConsole` amongst the classes and add extra calls to methods that remove the display of the lower `TTextEdit` (i.e. remove the split) and ensure that the upper one is redrawn after the contents have been removed.

#### Motivation for adding to Mudlet
This - not clearing the lower pane and the split even though all the data has gone so there is no need for the split - has been an issue (though not recorded as one) for a long time as far as I can determine.

#### Other info (issues closed, discussion etc)
This should close #7463.