### PR TITLE
Fix: prevent crashes on closing a profile with dockable toolbars or mapper

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1149,7 +1149,7 @@ inline void T2DMap::drawRoom(QPainter& painter,
 void T2DMap::paintEvent(QPaintEvent* e)
 {
     Q_UNUSED(e)
-    if (!mpMap) {
+    if (!mpMap||mpHost.isNull()) {
         return;
     }
     QElapsedTimer renderTimer;

--- a/src/TToolBar.cpp
+++ b/src/TToolBar.cpp
@@ -62,6 +62,9 @@ TToolBar::TToolBar(Host* pHost, TAction* pA, const QString& name, QWidget* pW)
 void TToolBar::resizeEvent(QResizeEvent* e)
 {
     Q_UNUSED(e)
+    if (mpHost.isNull()) {
+        return;
+    }
     mpHost->setToolbarLayoutUpdated(this);
 }
 
@@ -77,7 +80,7 @@ void TToolBar::setName(const QString& name)
 
 void TToolBar::moveEvent(QMoveEvent* e)
 {
-    if (!mpTAction) {
+    if (!mpTAction||mpHost.isNull()) {
         return;
     }
 
@@ -238,6 +241,9 @@ void TToolBar::clear()
 // Needed to detect mouse clicking on areas not covered by a button or menu:
 void TToolBar::mousePressEvent(QMouseEvent* e)
 {
+    if (mpHost.isNull()) {
+        return;
+    }
     if (e->button() & Qt::AllButtons) {
         // move focus back to the active console / command line
         mpHost->setFocusOnHostActiveCommandLine();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add some nullptr checks in some event handlers that use a `Host` pointer at a time when it may no longer be valid.

#### Motivation for adding to Mudlet
Somehow one of the profiles I used regularly has now started crashing on closing (not the whole application, just from closing the profile) and when I tried to `git bisect` it it still happened going back as far as Mudlet **4.16.0**. Given that I don't recall having this problem going back a couple of year I have to conclude something has changed in the way the underlying Qt libraries operate - I was testing throughout with Qt 5.15.8 on GNU/Linux. In all the cases I found that various events were being triggered but at the time their `Host` pointer was no longer valid - so the fix was to check that and abort their code from trying to de-reference it.

#### Other info (issues closed, discussion etc)
I did not check back before Mudlet 4.16.0 because at that point in its history it was crashing for unrelated reasons (trying to de-reference a `dlgTriggerEditor` pointer on profile closing which would have masked this problem AFAICT anyhow).