### PR TITLE
Fix: repair missing libraries for 32 bit Windows builds

### DIFF
--- a/CI/package-mudlet-for-windows.sh
+++ b/CI/package-mudlet-for-windows.sh
@@ -147,15 +147,6 @@ else
       | /usr/bin/cut -d ">" -f2 \
       | /usr/bin/cut -d "(" -f1 \
       | /usr/bin/sort)
-    # For some reason as of September 2024 ntldd no longer identifies these
-    # libraries for the 32-Bit case and our Qt5 (in this case) application
-    # refuses to start without them. At a guess they are being loaded
-    # dynamically so cannot be identified by static analysis like (nt)ldd
-    # seems to do. Yet the same thing works for the now Qt6 based 64-Bit
-    # application. Unfortunately this might bite us again for other libraries
-    # I guess - I only deduced these omissions by comparing the file list
-    # against an older working build. Slysven - 2024/11
-    NEEDED_LIBS=${NEEDED_LIBS} "${MINGW_INTERNAL_BASE_DIR}/bin/libbrotlicommon.dll" "${MINGW_INTERNAL_BASE_DIR}/libbrotlidec.dll" "${MINGW_INTERNAL_BASE_DIR}/libfreetype-6.dll"
 fi
 echo ""
 echo "Copying these identified libraries..."
@@ -177,6 +168,20 @@ cp -v -p -t . \
     "${MINGW_INTERNAL_BASE_DIR}/bin/libsqlite3-0.dll" \
     "${MINGW_INTERNAL_BASE_DIR}/bin/libyajl.dll"
 
+# For some reason as of September 2024 ntldd no longer identifies these
+# libraries for the 32-Bit case and our Qt5 (in this case) application
+# refuses to start without them. At a guess they are being loaded
+# dynamically so cannot be identified by static analysis like (nt)ldd
+# seems to do. Yet the same thing works for the now Qt6 based 64-Bit
+# application. Unfortunately this might bite us again for other libraries
+# I guess - I only deduced these omissions by comparing the file list
+# against an older working build. Slysven - 2024/11
+if [ "${MSYSTEM}" = "MINGW32" ]; then
+    cp -v -p -t . \
+        "${MINGW_INTERNAL_BASE_DIR}/bin/libbrotlicommon.dll" \
+        "${MINGW_INTERNAL_BASE_DIR}/bin/libbrotlidec.dll" \
+        "${MINGW_INTERNAL_BASE_DIR}/bin/libfreetype-6.dll"
+fi
 echo ""
 echo "Copying OpenSSL libraries in..."
 # The openSSL libraries has a different name depending on the bitness:

--- a/CI/package-mudlet-for-windows.sh
+++ b/CI/package-mudlet-for-windows.sh
@@ -147,6 +147,16 @@ else
       | /usr/bin/cut -d ">" -f2 \
       | /usr/bin/cut -d "(" -f1 \
       | /usr/bin/sort)
+    # For some reason as of September 2024 ntldd no longer identifies these
+    # libraries for the 32-Bit case and our Qt5 (in this case) application
+    # refuses to start without them. At a guess they are being loaded
+    # dynamically so cannot be identified by static analysis like (nt)ldd
+    # seems to do. Yet the same thing works for the now Qt6 based 64-Bit
+    # application. Unfortunately this might bite us again for other libraries
+    # I guess - I only deduced these omissions by comparing the file list
+    # against an older working build. Slysven - 2024/11
+    NEEDED_LIBS=${NEEDED_LIBS} "${MINGW_INTERNAL_BASE_DIR}/bin/libbrotlicommon.dll" "${MINGW_INTERNAL_BASE_DIR}/libbrotlidec.dll" "${MINGW_INTERNAL_BASE_DIR}/libfreetype-6.dll"
+"
 fi
 echo ""
 echo "Copying these identified libraries..."

--- a/CI/package-mudlet-for-windows.sh
+++ b/CI/package-mudlet-for-windows.sh
@@ -156,7 +156,6 @@ else
     # I guess - I only deduced these omissions by comparing the file list
     # against an older working build. Slysven - 2024/11
     NEEDED_LIBS=${NEEDED_LIBS} "${MINGW_INTERNAL_BASE_DIR}/bin/libbrotlicommon.dll" "${MINGW_INTERNAL_BASE_DIR}/libbrotlidec.dll" "${MINGW_INTERNAL_BASE_DIR}/libfreetype-6.dll"
-"
 fi
 echo ""
 echo "Copying these identified libraries..."


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add three libraries to those included in the packaged application for 32-Bits Windows builds. They not longer seem to be detected by the `ntldd` tool (even though the 64-Bits one does does so) - whether the loading mechanism has changed so that they are loaded dynamically now so no longer show up in the 32-Bit build seems a possible but weird explaination given that some testing I've done with 64 Bit builds in both Qt 5 and 6 do show them.

#### Motivation for adding to Mudlet
This is essential for getting 32-Bit builds working again after https://github.com/msys2/MINGW-packages/pull/22130 restored two Qt5 packages that had gotten dropped.

#### Other info (issues closed, discussion etc)
This was first reported on Discord by **@bcross32** in the Discord **[#mudlet-testing](https://www.discord.com/channels/283581582550237184/427919962561052673/1293540881818845215)** channel at 2024/10/09 11:49 UTC and also by **@karahd** (gesslar) in the **[#help](https://canary.discord.com/channels/283581582550237184/283582068334526464/1293753289116221543)** one at 2024/10/10 01:53 UTC.