### PR TITLE
Improved: Add optional folder location to invokeFileDialog

### DIFF
--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -850,7 +850,7 @@ int TLuaInterpreter::invokeFileDialog(lua_State* L)
 {
     const int n = lua_gettop(L);
     Host& host = getHostFromLua(L);
-    const QString location = mudlet::getMudletPath(mudlet::profileHomePath, host.getName());
+    QString location = mudlet::getMudletPath(mudlet::profileHomePath, host.getName());
     const bool luaDir = getVerifiedBool(L, __func__, 1, "fileOrFolder");
     const QString title = getVerifiedString(L, __func__, 2, "dialogTitle");
 

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -848,15 +848,26 @@ int TLuaInterpreter::getScript(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#invokeFileDialog
 int TLuaInterpreter::invokeFileDialog(lua_State* L)
 {
+    const int n = lua_gettop(L);
+    QString location = QDir::currentPath();
     const bool luaDir = getVerifiedBool(L, __func__, 1, "fileOrFolder");
     const QString title = getVerifiedString(L, __func__, 2, "dialogTitle");
 
+    if (n > 2) {
+        QString target = getVerifiedString(L, __func__, 3, "dialogLocation");
+        QDir dir(target);
+
+        if (dir.exists()) {
+            location = target;
+        }
+    }
+
     if (!luaDir) {
-        const QString fileName = QFileDialog::getExistingDirectory(nullptr, title, QDir::currentPath());
+        const QString fileName = QFileDialog::getExistingDirectory(nullptr, title, location);
         lua_pushstring(L, fileName.toUtf8().constData());
         return 1;
     } else {
-        const QString fileName = QFileDialog::getOpenFileName(nullptr, title, QDir::currentPath());
+        const QString fileName = QFileDialog::getOpenFileName(nullptr, title, location);
         lua_pushstring(L, fileName.toUtf8().constData());
         return 1;
     }

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -849,7 +849,8 @@ int TLuaInterpreter::getScript(lua_State* L)
 int TLuaInterpreter::invokeFileDialog(lua_State* L)
 {
     const int n = lua_gettop(L);
-    QString location = QDir::currentPath();
+    Host& host = getHostFromLua(L);
+    const QString location = mudlet::getMudletPath(mudlet::profileHomePath, host.getName());
     const bool luaDir = getVerifiedBool(L, __func__, 1, "fileOrFolder");
     const QString title = getVerifiedString(L, __func__, 2, "dialogTitle");
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Allow `invokeFileDialog()` to open at an optional specified directory.  If not a valid dir or dir not specified, simply continue as per default operation.

#### Motivation for adding to Mudlet
Allow scripters to open file dialogs at a specified place (e.g. their scripts data location)

#### Other info (issues closed, discussion etc)
