### PR TITLE
Fix: don't display titlebar in certain locked positions

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -62,7 +62,7 @@ function Adjustable.Container:setTitle(text, color, format)
     self.titleFormat = format or self.titleFormat or "l"
     self.titleText = text or self.titleText or string.format("%s - Adjustable Container")
     self.titleTxtColor = color or self.titleTxtColor or "green"
-    if self.locked and self.connectedContainers then
+    if self.locked and (self.connectedContainers or self.lockStyle == "standard" or self.lockStyle == "border" or self.lockStyle == "full") then
         return
     end
     self.adjLabel:echo(string.format("&nbsp;&nbsp;%s", self.titleText), self.titleTxtColor, self.titleFormat)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Upon calling `setTitle()` on a locked `AdjustableContainer` the title would show regardless of locked position when only one locked position actually supports showing of titlebar ("light").

#### Motivation for adding to Mudlet
Better user experience.

#### Other info (issues closed, discussion etc)
closes #4550 