### PR TITLE
Improve: AdjustableContainer:setTitle() formatting codes in documentation

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -57,7 +57,7 @@ end
 --- function to give your adjustable container a new title
 -- @param text new title text
 -- @param color title text color
--- @param format title format
+-- @param format A format list to use. 'c' - center, 'l' - left, 'r' - right,  'b' - bold, 'i' - italics, 'u' - underline, 's' - strikethrough,  '##' - font size.  For example, "cb18" specifies center bold 18pt font be used.  Order doesn't matter.
 function Adjustable.Container:setTitle(text, color, format)
     self.titleFormat = format or self.titleFormat or "l"
     self.titleText = text or self.titleText or string.format("%s - Adjustable Container")
@@ -1038,6 +1038,7 @@ end
 --@param cons.customItemsLabel.txt  text of the "custom menu" item
 --@param[opt="green"] cons.titleTxtColor  color of the title text
 --@param cons.titleText  title text
+--@param cons.titleFormat  a format list to use. 'c' - center, 'l' - left, 'r' - right,  'b' - bold, 'i' - italics, 'u' - underline, 's' - strikethrough,  '##' - font size.
 --@param[opt="standard"] cons.lockStyle  choose lockstyle at creation. possible integrated lockstyle are: "standard", "border", "light" and "full"
 --@param[opt=false] cons.noLimit  there is a minimum size limit if this constraint is set to false.
 --@param[opt=true] cons.raiseOnClick  raise your container if you click on it with your left mouse button


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add formatting codes for title text in constructor and `setTitle()`
#### Motivation for adding to Mudlet
Better user experience.

#### Other info (issues closed, discussion etc)
closes #5319 