### PR TITLE
Improve: New event sysSettingChanged

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1040,7 +1040,9 @@ void Host::updateConsolesFont()
         mpConsole->refreshView();
 
         TEvent event{};
-        event.mArgumentList.append(qsl("sysMainWindowFontChanged"));
+        event.mArgumentList.append(qsl("sysSettingChanged"));
+        event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        event.mArgumentList.append(qsl("font"));
         event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         event.mArgumentList.append(mDisplayFont.family());
         event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1042,7 +1042,7 @@ void Host::updateConsolesFont()
         TEvent event{};
         event.mArgumentList.append(qsl("sysSettingChanged"));
         event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-        event.mArgumentList.append(qsl("font"));
+        event.mArgumentList.append(qsl("main window font"));
         event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         event.mArgumentList.append(mDisplayFont.family());
         event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1038,6 +1038,15 @@ void Host::updateConsolesFont()
 {
     if (mpConsole) {
         mpConsole->refreshView();
+
+        TEvent event{};
+        event.mArgumentList.append(qsl("sysMainWindowFontChanged"));
+        event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        event.mArgumentList.append(mDisplayFont.family());
+        event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        event.mArgumentList.append(QString::number(mDisplayFont.pointSize()));
+        event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+        raiseEvent(event);
     }
 
     if (mpEditorDialog && mpEditorDialog->mpErrorConsole) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add new event for when a preference setting has changed.  This PR implements a font family or font size change in the main console and can be expanded to other preferences as required (discussed below).  Arguments to the event are; "font", the font family and font size.  Changing either via API or Preferences window will raise this event.

#### Motivation for adding to Mudlet
Better scripting experience.

#### Other info (issues closed, discussion etc)
closes #5598 