### PR TITLE
Fix: allow running PTB builds on demand

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -266,6 +266,8 @@ jobs:
 
     - name: (Linux) Set build info
       if: runner.os == 'Linux'
+      env:
+        GITHUB_EVENT_INPUTS_SCHEDULED: ${{inputs.scheduled}}
       run: |
         sudo apt-get -y install pcregrep
         ${{github.workspace}}/CI/travis.validate_deployment.sh

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -275,6 +275,8 @@ jobs:
 
     - name: (macOS) Set build info
       if: runner.os == 'macOS'
+      env:
+        GITHUB_EVENT_INPUTS_SCHEDULED: ${{inputs.scheduled}}
       run: |
         brew install pcre
         ${{github.workspace}}/CI/travis.validate_deployment.sh

--- a/CI/travis.set-build-info.sh
+++ b/CI/travis.set-build-info.sh
@@ -3,6 +3,8 @@
 MUDLET_VERSION_BUILD=""
 
 if [ -z "${TRAVIS_TAG}" ] && ! [[ "$GITHUB_REF" =~ ^"refs/tags/" ]]; then
+  # print all environment variables to see which maps to the `inputs` context: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#inputs-context
+  env
   if [ "$TRAVIS_EVENT_TYPE" = "cron" ] || [[ "$GITHUB_EVENT_NAME" = "schedule" ]] || [[ "$GITHUB_EVENT_INPUTS_SCHEDULED" = "true" ]]; then
     MUDLET_VERSION_BUILD="-ptb"
   else
@@ -59,7 +61,5 @@ if [ -n "$GITHUB_REPOSITORY" ]; then
 fi
 
 export VERSION
-# This no longer has a Git SHA1 appended, which it did previously for anything
-# other than a "Release" build:
 export MUDLET_VERSION_BUILD
 export BUILD_COMMIT

--- a/CI/travis.set-build-info.sh
+++ b/CI/travis.set-build-info.sh
@@ -3,8 +3,6 @@
 MUDLET_VERSION_BUILD=""
 
 if [ -z "${TRAVIS_TAG}" ] && ! [[ "$GITHUB_REF" =~ ^"refs/tags/" ]]; then
-  # print all environment variables to see which maps to the `inputs` context: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#inputs-context
-  env
   if [ "$TRAVIS_EVENT_TYPE" = "cron" ] || [[ "$GITHUB_EVENT_NAME" = "schedule" ]] || [[ "$GITHUB_EVENT_INPUTS_SCHEDULED" = "true" ]]; then
     MUDLET_VERSION_BUILD="-ptb"
   else


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
https://github.com/Mudlet/Mudlet/pull/7254 added the ability to run PTB builds on demand for macOS and Linux, however that solution was incomplete and didn't actually work in practice. 

This fixes it to work.
#### Motivation for adding to Mudlet
So we can run PTBs on demand instead of waiting 24h between each run when we need to debug something related to them.
#### Other info (issues closed, discussion etc)
