### PR TITLE
Infrastructure: Make Linux PTB linking more resilient

### DIFF
--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -42,7 +42,7 @@ jobs:
           cat "${LATEST_FEED}" | jq
         fi
 
-        export LINUX_PTB_URL=$(cat $LATEST_FEED | jq --raw-output ".data[] | select(.platform == \"linux\") | .url")
+        export LINUX_PTB_URL=$(cat $LATEST_FEED | jq --raw-output '.data[] | select(.platform == "linux" and (.url | contains("-ptb-"))) | .url')
         export MACOS_PTB_URL=$(cat $LATEST_FEED | jq --raw-output ".data[] | select(.platform == \"macos\") | .url")
 
         echo "Linux PTB link: $LINUX_PTB_URL"


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
I noticed that when our snapshots service is queries for builds related to a commit, it [can return](https://make.mudlet.org/snapshots/json.php?commitid=e474d16d) both PTB and test builds:

![image](https://github.com/user-attachments/assets/dcea8e33-b22c-4e98-adfa-7d111116faaa)

The previous check for fetching the Linux URL would grab both, when only the PTB URL was desired. This is fixed now with this PR:

```
(base) vadi@penguin:~/Desktop$ export LINUX_PTB_URL=$(cat $LATEST_FEED | jq --raw-output ".data[] | select(.platform == \"linux\") | .url")
(base) vadi@penguin:~/Desktop$ echo $LINUX_PTB_URL 
https://make.mudlet.org/snapshots/3634e6/Mudlet-4.18.5-ptb-2024-10-23-e474d16d-linux-x64.AppImage.tar https://make.mudlet.org/snapshots/5a2f9a/Mudlet-4.18.5-testing-e474d16d-linux-x64.AppImage.tar
(base) vadi@penguin:~/Desktop$ export LINUX_PTB_URL=$(cat $LATEST_FEED | jq --raw-output '.data[] | select(.platform == "linux" and (.url | contains("-ptb-"))) | .url')
(base) vadi@penguin:~/Desktop$ echo $LINUX_PTB_URL 
https://make.mudlet.org/snapshots/3634e6/Mudlet-4.18.5-ptb-2024-10-23-e474d16d-linux-x64.AppImage.tar
```
#### Motivation for adding to Mudlet
More resilience in the PTB infrastructure.
#### Other info (issues closed, discussion etc)
