### PR TITLE
Improve: remove unused pattern 'type' box in aliases UI

### DIFF
--- a/src/ui/aliases_main_area.ui
+++ b/src/ui/aliases_main_area.ui
@@ -130,55 +130,6 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1" colspan="2">
-    <widget class="QLineEdit" name="lineEdit_alias_pattern">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>21</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>21</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string>enter a perl regex pattern for your alias; alias are triggers on your input</string>
-     </property>
-     <property name="placeholderText">
-      <string>^mycommand$ (example)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="3">
-    <widget class="QLabel" name="label_alias_regex">
-     <property name="text">
-      <string>Type:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="4">
-    <widget class="QComboBox" name="comboBox_alias_regex">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <item>
-      <property name="text">
-       <string>Regex</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Plain</string>
-      </property>
-     </item>
-    </widget>
-   </item>
    <item row="2" column="0" alignment="Qt::AlignRight">
     <widget class="QLabel" name="label_alias_command">
      <property name="sizePolicy">
@@ -220,6 +171,28 @@
      </property>
      <property name="placeholderText">
       <string>Replacement text (optional)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" colspan="4">
+    <widget class="QLineEdit" name="lineEdit_alias_pattern">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>enter a perl regex pattern for your alias; alias are triggers on your input</string>
+     </property>
+     <property name="placeholderText">
+      <string>^mycommand$ (example)</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove "Type:" label and associated drop down box from the aliases pattern UI.  No longer required as it was a feature that was not implemented.

#### Motivation for adding to Mudlet
Better UI experience.

#### Other info (issues closed, discussion etc)
https://discord.com/channels/283581582550237184/283582439002210305/1298563603242418211