### PR TITLE
Add: appendLog(string) to add some text to an open log file

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2796,6 +2796,17 @@ void TBuffer::logRemainingOutput()
     mpHost->mpConsole->mLogStream.flush();
 }
 
+// logs a string directly to the log file
+void TBuffer::appendLog(const QString &text)
+{
+    TBuffer* pB = &mpHost->mpConsole->buffer;
+    if (pB != this || !mpHost->mpConsole->mLogToLogFile) {
+        return;
+    }
+
+    mpHost->mpConsole->mLogStream << text;
+}
+
 // returns how many new lines have been inserted by the wrapping action
 int TBuffer::wrapLine(int startLine, int screenWidth, int indentSize, TChar& format)
 {

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -292,6 +292,8 @@ public:
     int getMaxBufferSize();
     static const QList<QByteArray> getEncodingNames();
     void logRemainingOutput();
+    void appendLog(const QString &text);
+
     // It would have been nice to do this with Qt's signals and slots but that
     // is apparently incompatible with using a default constructor - sigh!
     void encodingChanged(const QByteArray &);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1523,6 +1523,18 @@ int TLuaInterpreter::startLogging(lua_State* L)
     return 4;
 }
 
+int TLuaInterpreter::appendLog(lua_State* L)
+{
+    const QString text = getVerifiedString(L, __func__, 1, "text to append to logfile", true);
+
+    const Host& host = getHostFromLua(L);
+
+    host.mpConsole->buffer.appendLog(text);
+
+    return 0;
+}
+
+
 // No documentation available in wiki - internal function
 int TLuaInterpreter::setLabelCallback(lua_State* L, const QString& funcName)
 {
@@ -5123,6 +5135,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "enableCommandLine", TLuaInterpreter::enableCommandLine);
     lua_register(pGlobalLua, "disableCommandLine", TLuaInterpreter::disableCommandLine);
     lua_register(pGlobalLua, "startLogging", TLuaInterpreter::startLogging);
+    lua_register(pGlobalLua, "appendLog", TLuaInterpreter::appendLog);
     lua_register(pGlobalLua, "calcFontSize", TLuaInterpreter::calcFontSize);
     lua_register(pGlobalLua, "permRegexTrigger", TLuaInterpreter::permRegexTrigger);
     lua_register(pGlobalLua, "permSubstringTrigger", TLuaInterpreter::permSubstringTrigger);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -481,6 +481,7 @@ public:
     static int enableClickthrough(lua_State*);
     static int disableClickthrough(lua_State*);
     static int startLogging(lua_State*);
+    static int appendLog(lua_State*);
     static int calcFontWidth(int size);
     static int calcFontHeight(int size);
     static int calcFontSize(lua_State*);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add a new Lua function; appendLog(string), which takes a string and writes it to the log file if the current state of logging is true.  Does nothing if logging is not turned on.

Supports whatever format the open log file is in (html, txt)

#### Motivation for adding to Mudlet
Support for better logging facilities.

#### Other info (issues closed, discussion etc)
closes #5903, #2375, #1507
I think this way is more flexible than discussed in the issue as users can add custom strings to the log file instead of only text outputted by the server