### PR TITLE
Fix: prevent crashes when trying to open a non-zip file

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -41,11 +41,12 @@
 #include <QMimeData>
 #include "post_guard.h"
 
-// We are now using code that won't work with really old versions of libzip:
-// Unfortunately libzip 1.70 forgot to include these defines and thus broke the
-// original tests:
-#if defined(LIBZIP_VERSION_MAJOR) && defined(LIBZIP_VERSION_MINOR) && (LIBZIP_VERSION_MAJOR < 1) && (LIBZIP_VERSION_MINOR < 11)
-#error Mudlet requires a version of libzip of at least 0.11
+// We are now using code that won't work with really old versions of libzip;
+// some of the error handling was improved in 1.0 . Unfortunately libzip 1.7.0
+// (and one or two other recent versions) forgot to include the version defines
+// and thus broke a test depending on them:
+#if defined(LIBZIP_VERSION_MAJOR) && (LIBZIP_VERSION_MAJOR < 1)
+#error Mudlet requires a version of libzip of at least 1.0
 #endif
 
 dlgPackageExporter::dlgPackageExporter(QWidget *parent, Host* pHost)
@@ -895,10 +896,12 @@ std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDi
     if (!archive) {
         zip_error_t zipError;
         zip_error_init_with_code(&zipError, ze);
-        /*:
-        This zipError message is shown when the libzip library code is unable to open the file that was to be the end result of the export process. As this may be an existing
-        file anywhere
-        in the computer's file-system(s) it is possible that permissions on the directory or an existing file that is to be overwritten may be a source of problems here.
+        /*: This zipError message is shown when the libzip library code is unable
+         * to open the file that was to be the end result of the export process.
+         * As this may be an existing file anywhere in the computer's
+         * file-system(s) it is possible that permissions on the directory or an
+         * existing file that is to be overwritten may be a source of problems
+         * here.
         */
         const QString errMsg = tr("Failed to open package file. Error is: \"%1\".")
                                  .arg(zip_error_strerror(&zipError));
@@ -1058,10 +1061,12 @@ std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDi
                 return {false, tr("Export cancelled.")};
             }
 
-            /*:
-            This error message is displayed at the final stage of exporting a package when all the sourced files are finally put into the archive. Unfortunately this may be
-            the point at which something breaks because a problem was not spotted/detected in the process earlier...
-            */
+            /*: This error message is displayed at the final stage of exporting
+             * a package when all the sourced files are finally put into the
+             * archive. Unfortunately this may be the point at which something
+             * breaks because a problem was not spotted/detected in the process
+             * earlier...
+             */
             const QString errorMsg = tr("Failed to zip up the package. Error is: \"%1\".").arg(zipError);
             zip_discard(archive);
             // In libzip 0.11 a function was added to clean up
@@ -1070,10 +1075,10 @@ std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDi
             // - before that version the memory just leaked away...
             return {false, errorMsg};
         }
+
     } else {
         zip_discard(archive);
     }
-
 
     return {isOk, error};
 }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Don't try and dereference a nullptr returned from a failed `zip_open(...)` call. Instead use the recommended method that constructs a `zip_error_t` instance from the `int` error code set by that failed `zip_open(...)`.

#### Motivation for adding to Mudlet
Prevent the crashes reported by @gesslar in #7495 and on Discord.

#### Other info (issues closed, discussion etc)
Also:
* clean up better after a failure in `(void) Host::updateModuleZips(...)` which was failing to call `zip_discard(zip*)` should a `zip_close(zip*)` fail.
* Move a `char[]` buffer in `(bool) mudlet::zip(...)` closer to where it is used.
* Add error message production (to the OS command line) to a stage in `(void) Host::updateModuleZips(...)`.

This should close #7495.