### PR TITLE
Add sysMapDeleteRoom event.

### DIFF
--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -25,6 +25,7 @@
 #include "Host.h"
 #include "TArea.h"
 #include "T2DMap.h"
+#include "TEvent.h"
 #include "mudlet.h"
 
 #include "pre_guard.h"
@@ -296,6 +297,14 @@ bool TRoomDB::removeRoom(int id)
         }
         TRoom* pR = getRoom(id);
         delete pR;
+
+        TEvent event{};
+        event.mArgumentList.append(QLatin1String("sysMapDeleteRoom"));
+        event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        event.mArgumentList.append(QString::number(id));
+        event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+        mpMap->mpHost->raiseEvent(event);
+
         return true;
     }
     return false;
@@ -322,6 +331,13 @@ void TRoomDB::removeRoom(QSet<int>& ids)
             delete pR;
         }
         mpTempRoomDeletionSet->remove(deleteRoomId);
+
+        TEvent event{};
+        event.mArgumentList.append(QLatin1String("sysMapDeleteRoom"));
+        event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        event.mArgumentList.append(QString::number(deleteRoomId));
+        event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+        mpMap->mpHost->raiseEvent(event);
     }
     for (auto deleteRoomId : deletedRoomIds) {
         entranceMap.remove(deleteRoomId); // This has been deferred from __removeRoom()


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add a sysMapDeleteRoom event for when a room is deleted via the API or GUI.  Delete room ID is appended an argument.

#### Motivation for adding to Mudlet
Events are good and offer a better scripting experience.

#### Other info (issues closed, discussion etc)
closes #2116

I debated about whether adding a `sysMapAddRoom` event but didn't want to undo any performance gains from the recent mapper updates.  Please discuss.