### PR TITLE
Infra: Diagnose Qt 6.8 crashing for 64-bit Windows builds

### DIFF
--- a/CI/build-mudlet-for-windows.sh
+++ b/CI/build-mudlet-for-windows.sh
@@ -150,6 +150,9 @@ export WITH_MAIN_BUILD_SYSTEM="NO"
 echo "Running qmake to make MAKEFILE ..."
 echo ""
 
+# Disable 3D Mapper for Qt 6.8 crash diagnosis
+export WITH_3DMAPPER="NO"
+
 if [ "${MSYSTEM}" = "MINGW64" ]; then
     qmake6 ../src/mudlet.pro -spec win32-g++ "CONFIG-=qml_debug" "CONFIG-=qtquickcompiler"
 else


### PR DESCRIPTION
#### Brief overview of PR changes/additions

MSYS2 has deployed Qt 6.8 as the default Qt6 version but it unfortunately is crashing Mudlet shortly after launch. 6.8 *should* have been a drop-in upgrade from 6.7, but may be causing some issues with us. This PR aims to investigate the cause of these issues.

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
