### PR TITLE
add get/setProfileInformation() to modify profile information field

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -38,6 +38,7 @@
 #include "TEvent.h"
 #include "TFlipButton.h"
 #include "TForkedProcess.h"
+#include "TGameDetails.h"
 #include "TLabel.h"
 #include "TMapLabel.h"
 #include "TMedia.h"
@@ -6640,8 +6641,26 @@ int TLuaInterpreter::getProfileInformation(lua_State* L)
 int TLuaInterpreter::setProfileInformation(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    const QString text = getVerifiedString(L, __func__, 1, "text");
-    host.writeProfileData(qsl("description"), text);
+
+    if (lua_type(L, 1) == LUA_TSTRING) {
+        const QString text = getVerifiedString(L, __func__, 1, "text");
+        if (!text.isEmpty()) {
+            host.writeProfileData(qsl("description"), text);
+            lua_pushboolean(L, true);
+            return 1;
+        }
+    }
+
+    QString desc = "";
+    // if this is a default game, return to the orginal text
+    auto itDetails = TGameDetails::findGame(host.getName().toUtf8().constData());
+    if (itDetails != TGameDetails::scmDefaultGames.constEnd()) {
+        if (!(*itDetails).description.isEmpty()) {
+            desc = (*itDetails).description;
+        }
+    }
+
+    host.writeProfileData(qsl("description"), desc);
     lua_pushboolean(L, true);
     return 1;
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5411,6 +5411,8 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getDictionaryWordList", TLuaInterpreter::getDictionaryWordList);
     lua_register(pGlobalLua, "getTextFormat", TLuaInterpreter::getTextFormat);
     lua_register(pGlobalLua, "getCharacterName", TLuaInterpreter::getCharacterName);
+    lua_register(pGlobalLua, "getProfileInformation", TLuaInterpreter::getProfileInformation);
+    lua_register(pGlobalLua, "setProfileInformation", TLuaInterpreter::setProfileInformation);
     lua_register(pGlobalLua, "getWindowsCodepage", TLuaInterpreter::getWindowsCodepage);
     lua_register(pGlobalLua, "getHTTP", TLuaInterpreter::getHTTP);
     lua_register(pGlobalLua, "customHTTP", TLuaInterpreter::customHTTP);
@@ -6622,6 +6624,25 @@ int TLuaInterpreter::getCharacterName(lua_State* L)
     }
 
     lua_pushstring(L, name.toUtf8().constData());
+    return 1;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Miscellaneous_Functions#getProfileInformation
+int TLuaInterpreter::getProfileInformation(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
+    QString info = host.readProfileData(qsl("description"));
+    lua_pushstring(L, info.toUtf8().constData());
+    return 1;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Miscellaneous_Functions#setProfileInformation
+int TLuaInterpreter::setProfileInformation(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
+    const QString text = getVerifiedString(L, __func__, 1, "text");
+    host.writeProfileData(qsl("description"), text);
+    lua_pushboolean(L, true);
     return 1;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5414,6 +5414,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getCharacterName", TLuaInterpreter::getCharacterName);
     lua_register(pGlobalLua, "getProfileInformation", TLuaInterpreter::getProfileInformation);
     lua_register(pGlobalLua, "setProfileInformation", TLuaInterpreter::setProfileInformation);
+    lua_register(pGlobalLua, "clearProfileInformation", TLuaInterpreter::clearProfileInformation);
     lua_register(pGlobalLua, "getWindowsCodepage", TLuaInterpreter::getWindowsCodepage);
     lua_register(pGlobalLua, "getHTTP", TLuaInterpreter::getHTTP);
     lua_register(pGlobalLua, "customHTTP", TLuaInterpreter::customHTTP);
@@ -6641,17 +6642,21 @@ int TLuaInterpreter::getProfileInformation(lua_State* L)
 int TLuaInterpreter::setProfileInformation(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-
-    if (lua_type(L, 1) == LUA_TSTRING) {
-        const QString text = getVerifiedString(L, __func__, 1, "text");
-        if (!text.isEmpty()) {
-            host.writeProfileData(qsl("description"), text);
-            lua_pushboolean(L, true);
-            return 1;
-        }
+    const QString text = getVerifiedString(L, __func__, 1, "text");
+    if (text.isEmpty()) {
+        return warnArgumentValue(L, __func__, "empty text supplied to setProfileInformation");
     }
+    host.writeProfileData(qsl("description"), text);
+    lua_pushboolean(L, true);
+    return 1;
+}
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Miscellaneous_Functions#clearProfileInformation
+int TLuaInterpreter::clearProfileInformation(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
     QString desc = "";
+
     // if this is a default game, return to the orginal text
     auto itDetails = TGameDetails::findGame(host.getName().toUtf8().constData());
     if (itDetails != TGameDetails::scmDefaultGames.constEnd()) {

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -619,6 +619,8 @@ public:
     static int getDictionaryWordList(lua_State*);
     static int getTextFormat(lua_State*);
     static int getCharacterName(lua_State*);
+    static int getProfileInformation(lua_State*);
+    static int setProfileInformation(lua_State*);
     static int getWindowsCodepage(lua_State*);
     static int getHTTP(lua_State*);
     static int customHTTP(lua_State*);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -621,6 +621,7 @@ public:
     static int getCharacterName(lua_State*);
     static int getProfileInformation(lua_State*);
     static int setProfileInformation(lua_State*);
+    static int clearProfileInformation(lua_State*);
     static int getWindowsCodepage(lua_State*);
     static int getHTTP(lua_State*);
     static int customHTTP(lua_State*);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -610,7 +610,7 @@ void dlgConnectionProfiles::slot_addProfile()
     fillout_form();
     welcome_message->hide();
 
-    informationalArea->show();
+    informationArea->show();
     tabWidget_connectionInfo->show();
 
     const QString newname = tr("new profile name");
@@ -778,16 +778,18 @@ QPair<bool, QString> dlgConnectionProfiles::writeProfileData(const QString& prof
 
 QString dlgConnectionProfiles::getDescription(const QString& profile_name) const
 {
-    auto itDetails = TGameDetails::findGame(profile_name);
-    if (itDetails != TGameDetails::scmDefaultGames.constEnd()) {
-        if (!(*itDetails).description.isEmpty()) {
-            return (*itDetails).description;
+    QString profileDesc = readProfileData(profile_name, qsl("description"));
+
+    if (profileDesc.isEmpty()) {
+        auto itDetails = TGameDetails::findGame(profile_name);
+        if (itDetails != TGameDetails::scmDefaultGames.constEnd()) {
+            if (!(*itDetails).description.isEmpty()) {
+                return (*itDetails).description;
+            }
         }
     }
 
-    // Else, if there isn't a predefined text, return whatever the user might
-    // have stored:
-    return readProfileData(profile_name, qsl("description"));
+    return profileDesc;
 }
 
 void dlgConnectionProfiles::slot_itemClicked(QListWidgetItem* pItem)
@@ -1020,7 +1022,7 @@ void dlgConnectionProfiles::fillout_form()
     if (mProfileList.isEmpty()) {
         welcome_message->show();
         tabWidget_connectionInfo->hide();
-        informationalArea->hide();
+        informationArea->hide();
 
 // collapse the width as the default is too big and set the height to a reasonable default
 // to fit all of the 'Welcome' message
@@ -1034,7 +1036,7 @@ void dlgConnectionProfiles::fillout_form()
         welcome_message->hide();
 
         tabWidget_connectionInfo->show();
-        informationalArea->show();
+        informationArea->show();
     }
 
     profiles_tree_widget->setIconSize(QSize(120, 30));

--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -794,7 +794,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QGroupBox" name="informationalArea">
+          <widget class="QGroupBox" name="informationArea">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
              <horstretch>0</horstretch>
@@ -808,7 +808,7 @@
             </size>
            </property>
            <property name="title">
-            <string>Informational</string>
+            <string>Information</string>
            </property>
            <layout class="QVBoxLayout" name="vBoxLayout_4">
             <property name="leftMargin">


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
1. Add `getProfileInformation()` and `setProfileInformation(string)` functions to Lua to read/write to the profile information displayed on the profile connection window.
2. Changed profile connection window text from "Informational" to "Information" to match functions and read clearer.
3. Fix bug where one could not modify default games information text.  Now load user information first if present, fallback to default.  Clearing user set information (ie. `setProfileInformation("")`) also reverts to default game information.

#### Motivation for adding to Mudlet
Gives the ability to add profile specific information via the Lua API which can then be seen on the profile connection window.

#### Other info (issues closed, discussion etc)
closes #5333 