### PR TITLE
infrastructure: fix update architecture handling for macos PTBs in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -375,8 +375,10 @@ jobs:
         echo "ARCH=$ARCH" >> $GITHUB_ENV
         if [ "$RUNNER_OS" = "macOS" ] && [ "$ARCH" = "arm64" ]; then
           # dblsqd only supports 'arm' as an architecture and not 'arm64'
+          export ARCH_DBLSQD=arm
           echo "ARCH_DBLSQD=arm" >> $GITHUB_ENV
         else
+          export ARCH_DBLSQD=$ARCH
           echo "ARCH_DBLSQD=$ARCH" >> $GITHUB_ENV
         fi
         ${{github.workspace}}/CI/travis.after_success.sh


### PR DESCRIPTION
Brief Overview of PR Changes/Additions:
This PR resolves an issue where macOS PTBs weren't being submitted to dblsqd due to an incorrectly exported architecture variable. See details here: [GitHub Action Run](https://github.com/Mudlet/Mudlet/actions/runs/11639248587/job/32415153816#step:27:298).

Motivation for Adding to Mudlet:
Restores the functionality for submitting macOS PTBs to dblsqd.

Other Info:
No additional information (issues closed, discussion, etc.).