### PR TITLE
add Lua getExitStubsNames() function

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5281,6 +5281,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "connectExitStub", TLuaInterpreter::connectExitStub);
     lua_register(pGlobalLua, "getExitStubs", TLuaInterpreter::getExitStubs);
     lua_register(pGlobalLua, "getExitStubs1", TLuaInterpreter::getExitStubs1);
+    lua_register(pGlobalLua, "getExitStubsNames", TLuaInterpreter::getExitStubsNames);
     lua_register(pGlobalLua, "setModulePriority", TLuaInterpreter::setModulePriority);
     lua_register(pGlobalLua, "getModulePriority", TLuaInterpreter::getModulePriority);
     lua_register(pGlobalLua, "updateMap", TLuaInterpreter::updateMap);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -523,6 +523,7 @@ public:
     static int connectExitStub(lua_State*);
     static int getExitStubs(lua_State*);
     static int getExitStubs1(lua_State*);
+    static int getExitStubsNames(lua_State*);
     static int getModulePriority(lua_State*);
     static int setModulePriority(lua_State*);
     static int updateMap(lua_State*);

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -1560,6 +1560,36 @@ int TLuaInterpreter::getExitStubs1(lua_State* L)
     return 1;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getExitStubsNames
+int TLuaInterpreter::getExitStubsNames(lua_State* L)
+{
+    const QStringList stubmap = { "north", "northeast", "northwest", "east", "west",
+                                  "south", "southeast", "southwest", "up", "down", "in",
+                                  "out", "other"
+    };
+
+    const Host& host = getHostFromLua(L);
+    if (!host.mpMap || !host.mpMap->mpRoomDB) {
+        return warnArgumentValue(L, __func__, "no map present or loaded");
+    }
+
+    const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
+
+    // Previously threw a Lua error on non-existent room!
+    TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
+    if (!pR) {
+        return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
+    }
+    QList<int> const stubs = pR->exitStubs;
+    lua_newtable(L);
+    for (int i = 0, total = stubs.size(); i < total; ++i) {
+        lua_pushnumber(L, i + 1);
+        lua_pushstring(L, stubmap[stubs.at(i) - 1].toUtf8().constData());
+        lua_settable(L, -3);
+    }
+    return 1;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getGridMode
 int TLuaInterpreter::getGridMode(lua_State* L)
 {

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -1520,7 +1520,6 @@ int TLuaInterpreter::getExitStubs(lua_State* L)
 
     const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
 
-    // Previously threw a Lua error on non-existent room!
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
@@ -1545,7 +1544,6 @@ int TLuaInterpreter::getExitStubs1(lua_State* L)
 
     const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
 
-    // Previously threw a Lua error on non-existent room!
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
@@ -1575,7 +1573,6 @@ int TLuaInterpreter::getExitStubsNames(lua_State* L)
 
     const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
 
-    // Previously threw a Lua error on non-existent room!
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
The current `getExitStubs` functions only return a table containing direction _numbers_, which users then have to map to a corresponding direction name.  This function, `getExitStubsNames()`, returns a table containing the actual direction names (ie. north, south, up, etc), or an empty table if none.

#### Motivation for adding to Mudlet
So users don't have to map exit numbers to exit names, saves a step, offers less confusion.  Better scripting experience.

#### Other info (issues closed, discussion etc)
