### PR TITLE
Infrastrcture: Fix macOS PTB linking

### DIFF
--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -47,15 +47,13 @@ jobs:
         export MACOS_ARM64_PTB_URL=$(cat $LATEST_FEED | jq --raw-output '.data[] | select(.platform == "macos" and (.url | contains("arm64"))) | .url')
 
         echo "Linux PTB link: $LINUX_PTB_URL"
+        echo "LINUX_PTB_URL=${LINUX_PTB_URL}" >> "$GITHUB_ENV"
+        
         echo "macOS x64 PTB link: $MACOS_X64_PTB_URL"
+        echo "MACOS_X64_PTB_URL=${MACOS_X64_PTB_URL}" >> "$GITHUB_ENV"
+
         echo "macOS ARM64 PTB link: $MACOS_ARM64_PTB_URL"
-
-        {
-          echo "LINUX_PTB_URL=$LINUX_PTB_URL"
-          echo "MACOS_X64_PTB_URL=$MACOS_X64_PTB_URL"
-          echo "MACOS_ARM64_PTB_URL=$MACOS_ARM64_PTB_URL"
-        } >> "$GITHUB_ENV"
-
+        echo "MACOS_ARM64_PTB_URL=${MACOS_ARM64_PTB_URL}" >> "$GITHUB_ENV"
 
     - name: Setup dblsqd client
       run: |


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix it so macOS PTBs can be linked to dblsqd, enabling updates from one mac version to another.
#### Motivation for adding to Mudlet
The previous syntax didn't seem to work: https://github.com/Mudlet/Mudlet/actions/runs/11676857599/job/32513823530
#### Other info (issues closed, discussion etc)
