### PR TITLE
Improve: set timers to a finer precision

### DIFF
--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -40,6 +40,7 @@ TTimer::TTimer(TTimer* parent, Host* pHost)
     mpQTimer->setProperty(scmProperty_HostName, mpHost->getName());
     mpHost->getTimerUnit()->mQTimerSet.insert(mpQTimer);
     mpQTimer->setProperty(scmProperty_TTimerId, 0);
+    mpQTimer->setTimerType(Qt::PreciseTimer);
 }
 
 TTimer::TTimer(const QString& name, QTime time, Host* pHost, bool repeating)
@@ -54,6 +55,7 @@ TTimer::TTimer(const QString& name, QTime time, Host* pHost, bool repeating)
     mpHost->getTimerUnit()->mQTimerSet.insert(mpQTimer);
     mpQTimer->setProperty(scmProperty_TTimerId, 0);
     mRepeating = repeating;
+    mpQTimer->setTimerType(Qt::PreciseTimer);
 }
 
 TTimer::~TTimer()


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Set timers to `Qt::PreciseTimer` type.

#### Motivation for adding to Mudlet
Timers fire much closer to expected time.

#### Other info (issues closed, discussion etc)
Need to see if this affects performance.  I found no adverse affects in my testing.

closes #7444 