### PR TITLE
Infrastructure: fix macOS dblsqd linking

### DIFF
--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -50,10 +50,10 @@ jobs:
         echo "LINUX_PTB_URL=${LINUX_PTB_URL}" >> "$GITHUB_ENV"
         
         echo "macOS x64 PTB link: $MACOS_X64_PTB_URL"
-        echo "MACOS_X64_PTB_URL=${MACOS_X64_PTB_URL}" >> "$GITHUB_ENV"
+        echo "MACOS_X64_PTB_URL=\"${MACOS_X64_PTB_URL}\"" >> "${GITHUB_ENV}"
 
         echo "macOS ARM64 PTB link: $MACOS_ARM64_PTB_URL"
-        echo "MACOS_ARM64_PTB_URL=${MACOS_ARM64_PTB_URL}" >> "$GITHUB_ENV"
+        echo "MACOS_ARM64_PTB_URL=\"${MACOS_ARM64_PTB_URL}\"" >> "$GITHUB_ENV"
 
     - name: Setup dblsqd client
       run: |

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -43,20 +43,18 @@ jobs:
         fi
 
         export LINUX_PTB_URL=$(cat $LATEST_FEED | jq --raw-output '.data[] | select(.platform == "linux" and (.url | contains("-ptb-"))) | .url')
-        export MACOS_X64_PTB_URL=$(cat $LATEST_FEED | jq --raw-output '.data[] | select(.platform == "macos" and (.url | contains("x86_64"))) | .url')
-        export MACOS_ARM64_PTB_URL=$(cat $LATEST_FEED | jq --raw-output '.data[] | select(.platform == "macos" and (.url | contains("arm64"))) | .url')
+        export MACOS_X64_PTB_URL=$(cat $LATEST_FEED | jq --raw-output '.data[] | select(.platform == "macos" and (.url | contains("x86_64")) and (.url | contains("-ptb-"))) | .url')
+        export MACOS_ARM64_PTB_URL=$(cat $LATEST_FEED | jq --raw-output '.data[] | select(.platform == "macos" and (.url | contains("arm64")) and (.url | contains("-ptb-"))) | .url')
 
         echo "Linux PTB link: $LINUX_PTB_URL"
-        echo "LINUX_PTB_URL=${LINUX_PTB_URL}" >> "$GITHUB_ENV"
-        
         echo "macOS x64 PTB link: $MACOS_X64_PTB_URL"
-        echo "MACOS_X64_PTB_URL<<EOF" >> $GITHUB_ENV
-        echo "$MACOS_X64_PTB_URL" >> $GITHUB_ENV
-        echo "EOF" >> $GITHUB_ENV
+        echo "macOS ARM64 PTB link: $MACOS_ARM64_PTB_URL"
 
-
-        # echo "macOS ARM64 PTB link: $MACOS_ARM64_PTB_URL"
-        # echo "MACOS_ARM64_PTB_URL=\"${MACOS_ARM64_PTB_URL}\"" >> "$GITHUB_ENV"
+        {
+          echo "LINUX_PTB_URL=${LINUX_PTB_URL}"
+          echo "MACOS_X64_PTB_URL=${MACOS_X64_PTB_URL}"
+          echo "MACOS_ARM64_PTB_URL=${MACOS_ARM64_PTB_URL}"
+        } >> "$GITHUB_ENV"
 
     - name: Setup dblsqd client
       run: |

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -50,10 +50,10 @@ jobs:
         echo "LINUX_PTB_URL=${LINUX_PTB_URL}" >> "$GITHUB_ENV"
         
         echo "macOS x64 PTB link: $MACOS_X64_PTB_URL"
-        echo "MACOS_X64_PTB_URL=\"${MACOS_X64_PTB_URL}\"" >> "${GITHUB_ENV}"
+        echo "MACOS_X64_PTB_URL=${MACOS_X64_PTB_URL//:/\:}" >> $GITHUB_ENV
 
-        echo "macOS ARM64 PTB link: $MACOS_ARM64_PTB_URL"
-        echo "MACOS_ARM64_PTB_URL=\"${MACOS_ARM64_PTB_URL}\"" >> "$GITHUB_ENV"
+        # echo "macOS ARM64 PTB link: $MACOS_ARM64_PTB_URL"
+        # echo "MACOS_ARM64_PTB_URL=\"${MACOS_ARM64_PTB_URL}\"" >> "$GITHUB_ENV"
 
     - name: Setup dblsqd client
       run: |

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -50,7 +50,10 @@ jobs:
         echo "LINUX_PTB_URL=${LINUX_PTB_URL}" >> "$GITHUB_ENV"
         
         echo "macOS x64 PTB link: $MACOS_X64_PTB_URL"
-        echo "MACOS_X64_PTB_URL=${MACOS_X64_PTB_URL//:/\:}" >> $GITHUB_ENV
+        echo "MACOS_X64_PTB_URL<<EOF" >> $GITHUB_ENV
+        echo "$MACOS_X64_PTB_URL" >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
+
 
         # echo "macOS ARM64 PTB link: $MACOS_ARM64_PTB_URL"
         # echo "MACOS_ARM64_PTB_URL=\"${MACOS_ARM64_PTB_URL}\"" >> "$GITHUB_ENV"


### PR DESCRIPTION
<!-- Keep the title short and easy to understand for non-technical readers; it will appear in the PTB changelogs -->
#### Summary of PR Changes/Additions
Completes https://github.com/Mudlet/Mudlet/pull/7522.

The issue addressed is the lack of filtering between test builds and PTB builds, causing two URLs to be in a single environment variable.
#### Motivation for Adding to Mudlet
Enables macOS PTBs to seamlessly update from one version to the next.
#### Additional Information (related issues, discussions, etc.)
