### PR TITLE
Improve: add delay functionality to sendAll

### DIFF
--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -100,8 +100,9 @@ SavedVariables = {}
 
 
 --- Sends a list of commands to the MUD. You can use this to send some things at once instead of having
---- to use multiple send() commands one after another.
+--- to use multiple send() commands one after another.  Optionally you can delay the sends using a number.
 ---
+--- @param seconds [optional] number of seconds to delay the sending of commands
 --- @param ... list of commands
 --- @param echoTheValue optional boolean flag (default value is true) which determine if value should
 ---   be echoed back on client.
@@ -116,6 +117,10 @@ SavedVariables = {}
 ---   send ("wield shield")
 ---   send ("say ha!")
 ---   </pre>
+---   with a time delay of 2 seconds between each command:
+---   <pre>
+---   sendAll(2, "stand", "wield shield", "say ha!")
+---   </pre>
 --- @usage Use sendAll and do not echo sent command on the main window.
 ---   <pre>
 ---   sendAll("stand", "wield shield", "say ha!", false)
@@ -123,14 +128,18 @@ SavedVariables = {}
 ---
 --- @see send
 function sendAll(...)
+  local time = 0
   local args = { ... }
   local echo = true
+  if type(args[1]) == 'number' then
+    time = table.remove(args, 1)
+  end
   if type(args[#args]) == 'boolean' then
     echo = table.remove(args, #args)
   end
   for i, v in ipairs(args) do
     if type(v) == 'string' then
-      send(v, echo)
+      tempTimer(time*i, function() send(v, echo) end, false)
     end
   end
 end


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add an optional timer delay to sendAll.
`sendAll(2, "stand", "wield shield", "say ha!")` sends the commands two seconds apart.  I have opted to delay the first command send as well as this will give the user more flexibility.

#### Motivation for adding to Mudlet
It's a common mistake for rookies to use tempTimers without the knowledge that they start countdown immediately upon execution. e.g.
![image](https://github.com/user-attachments/assets/11eae099-0f9f-41b4-98bc-d9ef80b4e6ce)
Better scripting experience without need to write an (admittedly trivial for veterans) custom function to handle the use case.

#### Other info (issues closed, discussion etc)
https://discord.com/channels/283581582550237184/283582068334526464/1309084014761607262
and may help with #6943 (the delayed aspect)