### PR TITLE
add hotkeys to toggle timestamps, logging, recording, emergency stop

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -306,7 +306,12 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     timeStampButton->setMaximumSize(QSize(30, 30));
     timeStampButton->setSizePolicy(sizePolicy5);
     timeStampButton->setFocusPolicy(Qt::NoFocus);
-    timeStampButton->setToolTip(utils::richText(tr("Show Time Stamps.")));
+#if defined(Q_OS_MACOS)
+    timeStampButton->setToolTip(utils::richText(tr("Show Time Stamps (<⌘>+T)")));
+#else
+    timeStampButton->setToolTip(utils::richText(tr("Show Time Stamps (<CTRL>+T)")));
+#endif
+    timeStampButton->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_T));
     timeStampButton->setIcon(QIcon(qsl(":/icons/dialog-information.png")));
     connect(timeStampButton, &QAbstractButton::toggled, mUpperPane, &TTextEdit::slot_toggleTimeStamps);
     connect(timeStampButton, &QAbstractButton::toggled, mLowerPane, &TTextEdit::slot_toggleTimeStamps);
@@ -317,7 +322,12 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     replayButton->setMaximumSize(QSize(30, 30));
     replayButton->setSizePolicy(sizePolicy5);
     replayButton->setFocusPolicy(Qt::NoFocus);
-    replayButton->setToolTip(utils::richText(tr("Record a replay.")));
+#if defined(Q_OS_MACOS)
+    replayButton->setToolTip(utils::richText(tr("Record a replay (<⌘>+R)")));
+#else
+    replayButton->setToolTip(utils::richText(tr("Record a replay (<CTRL>+R)")));
+#endif
+    replayButton->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_R));
     replayButton->setIcon(QIcon(qsl(":/icons/media-tape.png")));
     connect(replayButton, &QAbstractButton::clicked, this, &TConsole::slot_toggleReplayRecording);
 
@@ -327,7 +337,12 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     logButton->setCheckable(true);
     logButton->setSizePolicy(sizePolicy5);
     logButton->setFocusPolicy(Qt::NoFocus);
-    logButton->setToolTip(utils::richText(tr("Start logging game output to log file.")));
+#if defined(Q_OS_MACOS)
+    logButton->setToolTip(utils::richText(tr("Start logging game output to log file. (<⌘>+L)")));
+#else
+    logButton->setToolTip(utils::richText(tr("Start logging game output to log file. (<CTRL>+L)")));
+#endif
+    logButton->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_L));
     QIcon logIcon;
     logIcon.addPixmap(QPixmap(qsl(":/icons/folder-downloads.png")), QIcon::Normal, QIcon::Off);
     logIcon.addPixmap(QPixmap(qsl(":/icons/folder-downloads-red-cross.png")), QIcon::Normal, QIcon::On);
@@ -381,7 +396,12 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     emergencyStop->setSizePolicy(sizePolicy4);
     emergencyStop->setFocusPolicy(Qt::NoFocus);
     emergencyStop->setCheckable(true);
-    emergencyStop->setToolTip(utils::richText(tr("Emergency Stop. Stops all timers and triggers.")));
+#if defined(Q_OS_MACOS)
+    emergencyStop->setToolTip(utils::richText(tr("Emergency Stop. Stops all timers and triggers. (<⌘>+P)")));
+#else
+    emergencyStop->setToolTip(utils::richText(tr("Emergency Stop. Stops all timers and triggers. (<CTRL>+P)")));
+#endif
+    emergencyStop->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_P));
     connect(emergencyStop, &QAbstractButton::clicked, this, &TConsole::slot_stopAllItems);
 
     mpBufferSearchBox->setClearButtonEnabled(true);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -307,12 +307,23 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     timeStampButton->setSizePolicy(sizePolicy5);
     timeStampButton->setFocusPolicy(Qt::NoFocus);
 #if defined(Q_OS_MACOS)
-    timeStampButton->setToolTip(utils::richText(tr("Show Time Stamps (<⌘>+T)")));
+    timeStampButton->setToolTip(utils::richText(tr("Show Time Stamps (⌘+T)")));
 #else
-    timeStampButton->setToolTip(utils::richText(tr("Show Time Stamps (<CTRL>+T)")));
+    timeStampButton->setToolTip(utils::richText(tr("Show Time Stamps (CTRL+T)")));
 #endif
-    timeStampButton->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_T));
     timeStampButton->setIcon(QIcon(qsl(":/icons/dialog-information.png")));
+
+    QShortcut *timestampsShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_T), this);
+    connect(timestampsShortcut, &QShortcut::activated, this, [this]() {
+        if (mUpperPane->mShowTimeStamps == true) {
+            mUpperPane->slot_toggleTimeStamps(false);
+            mLowerPane->slot_toggleTimeStamps(false);
+        } else {
+            mUpperPane->slot_toggleTimeStamps(true);
+            mLowerPane->slot_toggleTimeStamps(true);
+        }
+    });
+
     connect(timeStampButton, &QAbstractButton::toggled, mUpperPane, &TTextEdit::slot_toggleTimeStamps);
     connect(timeStampButton, &QAbstractButton::toggled, mLowerPane, &TTextEdit::slot_toggleTimeStamps);
 
@@ -323,11 +334,13 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     replayButton->setSizePolicy(sizePolicy5);
     replayButton->setFocusPolicy(Qt::NoFocus);
 #if defined(Q_OS_MACOS)
-    replayButton->setToolTip(utils::richText(tr("Record a replay (<⌘>+R)")));
+    replayButton->setToolTip(utils::richText(tr("Record a replay (⌘+R)")));
 #else
-    replayButton->setToolTip(utils::richText(tr("Record a replay (<CTRL>+R)")));
+    replayButton->setToolTip(utils::richText(tr("Record a replay (CTRL+R)")));
 #endif
-    replayButton->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_R));
+    QShortcut *replayShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_R), this);
+    connect(replayShortcut, &QShortcut::activated, this, &TConsole::slot_toggleReplayRecording);
+
     replayButton->setIcon(QIcon(qsl(":/icons/media-tape.png")));
     connect(replayButton, &QAbstractButton::clicked, this, &TConsole::slot_toggleReplayRecording);
 
@@ -338,11 +351,13 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     logButton->setSizePolicy(sizePolicy5);
     logButton->setFocusPolicy(Qt::NoFocus);
 #if defined(Q_OS_MACOS)
-    logButton->setToolTip(utils::richText(tr("Start logging game output to log file. (<⌘>+L)")));
+    logButton->setToolTip(utils::richText(tr("Start logging game output to log file. (⌘+L)")));
 #else
-    logButton->setToolTip(utils::richText(tr("Start logging game output to log file. (<CTRL>+L)")));
+    logButton->setToolTip(utils::richText(tr("Start logging game output to log file. (CTRL+L)")));
 #endif
-    logButton->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_L));
+    QShortcut *loggingShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_L), this);
+    connect(loggingShortcut, &QShortcut::activated, this, &TConsole::slot_toggleLogging);
+
     QIcon logIcon;
     logIcon.addPixmap(QPixmap(qsl(":/icons/folder-downloads.png")), QIcon::Normal, QIcon::Off);
     logIcon.addPixmap(QPixmap(qsl(":/icons/folder-downloads-red-cross.png")), QIcon::Normal, QIcon::On);
@@ -397,11 +412,19 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     emergencyStop->setFocusPolicy(Qt::NoFocus);
     emergencyStop->setCheckable(true);
 #if defined(Q_OS_MACOS)
-    emergencyStop->setToolTip(utils::richText(tr("Emergency Stop. Stops all timers and triggers. (<⌘>+P)")));
+    emergencyStop->setToolTip(utils::richText(tr("Emergency Stop. Stops all timers and triggers. (⌘+P)")));
 #else
-    emergencyStop->setToolTip(utils::richText(tr("Emergency Stop. Stops all timers and triggers. (<CTRL>+P)")));
+    emergencyStop->setToolTip(utils::richText(tr("Emergency Stop. Stops all timers and triggers. (CTRL+P)")));
 #endif
-    emergencyStop->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_P));
+    QShortcut *emergencyShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_P), this);
+    connect(emergencyShortcut, &QShortcut::activated, this, [this]() {
+        if (emergencyStopEnabled) {
+            slot_stopAllItems(false);
+        } else {
+            slot_stopAllItems(true);
+        }
+    });
+
     connect(emergencyStop, &QAbstractButton::clicked, this, &TConsole::slot_stopAllItems);
 
     mpBufferSearchBox->setClearButtonEnabled(true);
@@ -1817,9 +1840,11 @@ void TConsole::appendBuffer(const TBuffer& bufferSlice)
 void TConsole::slot_stopAllItems(bool b)
 {
     if (b) {
+        emergencyStopEnabled = true;
         mpHost->stopAllTriggers();
         emergencyStop->setIcon(QIcon(qsl(":/icons/red-bomb.png")));
     } else {
+        emergencyStopEnabled = false;
         mpHost->reenableAllTriggers();
         emergencyStop->setIcon(QIcon(qsl(":/icons/edit-bomb.png")));
     }

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -304,6 +304,7 @@ public:
     QString mBgImagePath;
     bool mHScrollBarEnabled = false;
     ControlCharacterMode mControlCharacter = ControlCharacterMode::AsIs;
+    bool emergencyStopEnabled = false;
 
 
 public slots:


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add keyboard shortcuts to toggle timestamps, logging, recording, emergency stop buttons located near the search area.  Since Search uses Ctrl+F, I went with Ctrl+T (timestamps), Ctrl+L (logging), Ctrl+R (recording), Ctrl+P (pause scripts).

#### Motivation for adding to Mudlet
Some users utilise the compact format to save command line space which requires multiple clicks to renable button area and click required buttons.
Shortcuts allow users to not have to move to the mouse to perform actions.

#### Other info (issues closed, discussion etc)
closes #2014 

