### PR TITLE
Infrastructure: make TRoom coordinates private

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -233,10 +233,10 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
             if (mAreaID == playerAreaID) {
                 // We are switching back to the area that has the player in it
                 // recenter view on that room!
-                mMapCenterX = pPlayerRoom->x;
+                mMapCenterX = pPlayerRoom->x();
                 // Map y coordinates are reversed on 2D map!
-                mMapCenterY = -pPlayerRoom->y;
-                mMapCenterZ = pPlayerRoom->z;
+                mMapCenterY = -pPlayerRoom->y();
+                mMapCenterZ = pPlayerRoom->z();
                 xyzoom = mpMap->mpRoomDB->get2DMapZoom(mAreaID);
                 repaint();
                 // Pass the coordinates to the TMap instance to pass to the 3D
@@ -263,10 +263,10 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
                     TRoom* room = mpMap->mpRoomDB->getRoom(checkRoomID);
                     if (room) {
                         validRoomFound = true;
-                        if (roomsCountLevelMap.contains(room->z)) {
-                            ++roomsCountLevelMap[room->z];
+                        if (roomsCountLevelMap.contains(room->z())) {
+                            ++roomsCountLevelMap[room->z()];
                         } else {
-                            roomsCountLevelMap[room->z] = 1;
+                            roomsCountLevelMap[room->z()] = 1;
                         }
                     }
                 }
@@ -302,13 +302,13 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
                                          // following step
                     while (itRoom.hasNext()) {
                         TRoom* room = mpMap->mpRoomDB->getRoom(itRoom.next());
-                        if (!room || room->z != minLevelWithMaxRoomCount) {
+                        if (!room || room->z() != minLevelWithMaxRoomCount) {
                             continue;
                         }
 
                         roomsToConsider.insert(room);
-                        mean_x += (static_cast<float>(room->x - mean_x)) / ++processedRoomCount;
-                        mean_y += (static_cast<float>(room->y - mean_y)) / processedRoomCount;
+                        mean_x += (static_cast<float>(room->x() - mean_x)) / ++processedRoomCount;
+                        mean_y += (static_cast<float>(room->y() - mean_y)) / processedRoomCount;
                     }
 
                     // We now have the position that is the "centre" of the
@@ -319,7 +319,7 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
                     TRoom* closestCenterRoom = nullptr;
                     while (itpRoom.hasNext()) {
                         TRoom* room = itpRoom.next();
-                        const QVector2D meanToRoom(static_cast<float>(room->x) - mean_x, static_cast<float>(room->y) - mean_y);
+                        const QVector2D meanToRoom(static_cast<float>(room->x()) - mean_x, static_cast<float>(room->y()) - mean_y);
                         if (closestSquareDistance < -0.5) {
                             // Test for first time around loop - for initialisation
                             // Don't use an equality to zero test, we are using
@@ -337,10 +337,10 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
                     }
 
                     if (closestCenterRoom) {
-                        mMapCenterX = closestCenterRoom->x;
+                        mMapCenterX = closestCenterRoom->x();
                         // Map y coordinates are reversed on 2D map!
-                        mMapCenterY = -closestCenterRoom->y;
-                        mMapCenterZ = closestCenterRoom->z;
+                        mMapCenterY = -closestCenterRoom->y();
+                        mMapCenterZ = closestCenterRoom->z();
                     } else {
                         mMapCenterX = mMapCenterY = mMapCenterZ = 0;
                     }
@@ -365,13 +365,13 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
                 QSetIterator<int> itRoom(area->getAreaRooms());
                 while (itRoom.hasNext()) {
                     TRoom* room = mpMap->mpRoomDB->getRoom(itRoom.next());
-                    if (!room || room->z != mMapCenterZ) {
+                    if (!room || room->z() != mMapCenterZ) {
                         continue;
                     }
 
                     roomsToConsider.insert(room);
-                    mean_x += (static_cast<float>(room->x - mean_x)) / ++processedRoomCount;
-                    mean_y += (static_cast<float>(room->y - mean_y)) / processedRoomCount;
+                    mean_x += (static_cast<float>(room->x() - mean_x)) / ++processedRoomCount;
+                    mean_y += (static_cast<float>(room->y() - mean_y)) / processedRoomCount;
                 }
 
                 // We now have the position that is the "centre" of the
@@ -382,7 +382,7 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
                 TRoom* closestCenterRoom = nullptr;
                 while (itpRoom.hasNext()) {
                     TRoom* room = itpRoom.next();
-                    const QVector2D meanToRoom(static_cast<float>(room->x) - mean_x, static_cast<float>(room->y) - mean_y);
+                    const QVector2D meanToRoom(static_cast<float>(room->x()) - mean_x, static_cast<float>(room->y()) - mean_y);
                     if (closestSquareDistance < -0.5) {
                         // Test for first time around loop - for initialisation
                         // Don't use an equality to zero test, we are using
@@ -400,9 +400,9 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
                 }
 
                 if (closestCenterRoom) {
-                    mMapCenterX = closestCenterRoom->x;
+                    mMapCenterX = closestCenterRoom->x();
                     // Map y coordinates are reversed on 2D map!
-                    mMapCenterY = -closestCenterRoom->y;
+                    mMapCenterY = -closestCenterRoom->y();
                 }
             }
             xyzoom = mpMap->mpRoomDB->get2DMapZoom(mAreaID);
@@ -1265,9 +1265,9 @@ void T2DMap::paintEvent(QPaintEvent* e)
             mLastViewedAreaID = mAreaID;
         }
 
-        mMapCenterX = pPlayerRoom->x;
-        mMapCenterY = pPlayerRoom->y * -1;
-        mMapCenterZ = pPlayerRoom->z;
+        mMapCenterX = pPlayerRoom->x();
+        mMapCenterY = pPlayerRoom->y() * -1;
+        mMapCenterZ = pPlayerRoom->z();
     }
 
     TArea* pDrawnArea = mpMap->mpRoomDB->getArea(mAreaID);
@@ -1418,12 +1418,12 @@ void T2DMap::paintEvent(QPaintEvent* e)
             continue;
         }
 
-        if (room->z != zLevel) {
+        if (room->z() != zLevel) {
             continue;
         }
 
-        const float rx = room->x *       mRoomWidth + static_cast<float>(mRX);
-        const float ry = room->y * -1 * mRoomHeight + static_cast<float>(mRY);
+        const float rx = room->x() *       mRoomWidth + static_cast<float>(mRX);
+        const float ry = room->y() * -1 * mRoomHeight + static_cast<float>(mRY);
         if (rx < 0 || ry < 0 || rx > widgetWidth || ry > widgetHeight) {
             continue;
         }
@@ -1524,8 +1524,8 @@ void T2DMap::paintEvent(QPaintEvent* e)
     if (mMultiSelectionHighlightRoomId > 0 && mMultiSelectionSet.size() > 1) {
         TRoom* pR_multiSelectionHighlight = mpMap->mpRoomDB->getRoom(mMultiSelectionHighlightRoomId);
         if (pR_multiSelectionHighlight) {
-            const float r_mSx = pR_multiSelectionHighlight->x * mRoomWidth + mRX;
-            const float r_mSy = pR_multiSelectionHighlight->y * -1 * mRoomHeight + mRY;
+            const float r_mSx = pR_multiSelectionHighlight->x() * mRoomWidth + mRX;
+            const float r_mSy = pR_multiSelectionHighlight->y() * -1 * mRoomHeight + mRY;
             const QPen savePen = painter.pen();
             const QBrush saveBrush = painter.brush();
             const float roomRadius = mRoomWidth * 1.2;
@@ -1726,9 +1726,9 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
         if (!room) {
             continue;
         }
-        const float rx = room->x * mRoomWidth + mRX;
-        const float ry = room->y * -1 * mRoomHeight + mRY;
-        const int rz = room->z;
+        const float rx = room->x() * mRoomWidth + mRX;
+        const float ry = room->y() * -1 * mRoomHeight + mRY;
+        const int rz = room->z();
 
         if (rz != zLevel) {
             continue;
@@ -1935,8 +1935,8 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                     customLineColor = room->customLinesColor.value(itk.key(), Qt::red);
                 }
 
-                const float ex = room->x * mRoomWidth + mRX;
-                const float ey = room->y * mRoomHeight * -1 + mRY;
+                const float ex = room->x() * mRoomWidth + mRX;
+                const float ey = room->y() * mRoomHeight * -1 + mRY;
                 const QPointF origin = QPointF(ex, ey);
                 // The following sets a point offset from the room center
                 // that depends on the exit direction that the custom line
@@ -2107,9 +2107,9 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
             }
 
             areaExit = pE->getArea() != mAreaID;
-            const float ex = pE->x * mRoomWidth + mRX;
-            const float ey = pE->y * mRoomHeight * -1 + mRY;
-            const int ez = pE->z;
+            const float ex = pE->x() * mRoomWidth + mRX;
+            const float ey = pE->y() * mRoomHeight * -1 + mRY;
+            const int ez = pE->z();
 
             const QVector3D p1(ex, ey, ez);
             const QVector3D p2(rx, ry, rz);
@@ -2619,9 +2619,9 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
                     if (!room) {
                         continue;
                     }
-                    const int rx = room->x * mRoomWidth + fx;
-                    const int ry = room->y * -1 * mRoomHeight + fy;
-                    const int rz = room->z;
+                    const int rx = room->x() * mRoomWidth + fx;
+                    const int ry = room->y() * -1 * mRoomHeight + fy;
+                    const int rz = room->z();
 
                     const int mx = event->pos().x();
                     const int my = event->pos().y();
@@ -3029,8 +3029,8 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                                 if (pointIndex == 0) {
                                     // First segment of a custom line
                                     // start it at the centre of the room
-                                    oldX = room->x;
-                                    oldY = room->y;
+                                    oldX = room->x();
+                                    oldY = room->y();
                                     //FIXME: use exit direction to calculate start of line
                                     newX = linePoints[0].x();
                                     newY = linePoints[0].y();
@@ -3120,9 +3120,9 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                 if (!room) {
                     continue;
                 }
-                const int rx = room->x * mRoomWidth + fx;
-                const int ry = room->y * -1 * mRoomHeight + fy;
-                const int rz = room->z;
+                const int rx = room->x() * mRoomWidth + fx;
+                const int ry = room->y() * -1 * mRoomHeight + fy;
+                const int rz = room->z();
 
                 const int mx = event->pos().x();
                 const int my = event->pos().y();
@@ -3427,23 +3427,23 @@ void T2DMap::slot_customLineAddPoint()
         // the offset point and the previous first point
         QPointF customLineStartPoint;
         if (mCustomLineSelectedExit == key_n) {
-            customLineStartPoint = QPointF(room->x, room->y + 0.5);
+            customLineStartPoint = QPointF(room->x(), room->y() + 0.5);
         } else if (mCustomLineSelectedExit == key_s) {
-            customLineStartPoint = QPointF(room->x, room->y - 0.5);
+            customLineStartPoint = QPointF(room->x(), room->y() - 0.5);
         } else if (mCustomLineSelectedExit == key_e) {
-            customLineStartPoint = QPointF(room->x + 0.5, room->y);
+            customLineStartPoint = QPointF(room->x() + 0.5, room->y());
         } else if (mCustomLineSelectedExit == key_w) {
-            customLineStartPoint = QPointF(room->x - 0.5, room->y);
+            customLineStartPoint = QPointF(room->x() - 0.5, room->y());
         } else if (mCustomLineSelectedExit == key_ne) {
-            customLineStartPoint = QPointF(room->x + 0.5, room->y + 0.5);
+            customLineStartPoint = QPointF(room->x() + 0.5, room->y() + 0.5);
         } else if (mCustomLineSelectedExit == key_nw) {
-            customLineStartPoint = QPointF(room->x - 0.5, room->y + 0.5);
+            customLineStartPoint = QPointF(room->x() - 0.5, room->y() + 0.5);
         } else if (mCustomLineSelectedExit == key_se) {
-            customLineStartPoint = QPointF(room->x + 0.5, room->y - 0.5);
+            customLineStartPoint = QPointF(room->x() + 0.5, room->y() - 0.5);
         } else if (mCustomLineSelectedExit == key_sw) {
-            customLineStartPoint = QPointF(room->x - 0.5, room->y - 0.5);
+            customLineStartPoint = QPointF(room->x() - 0.5, room->y() - 0.5);
         } else {
-            customLineStartPoint = QPointF(room->x, room->y);
+            customLineStartPoint = QPointF(room->x(), room->y());
         }
         segment = QLineF(customLineStartPoint, room->customLines.value(mCustomLineSelectedExit).at(0));
     }
@@ -3675,18 +3675,18 @@ void T2DMap::slot_movePosition()
     auto pLEy = new QLineEdit(dialog);
     auto pLEz = new QLineEdit(dialog);
 
-    pLEx->setText(QString::number(pR_start->x));
-    pLEy->setText(QString::number(pR_start->y));
-    pLEz->setText(QString::number(pR_start->z));
+    pLEx->setText(QString::number(pR_start->x()));
+    pLEy->setText(QString::number(pR_start->y()));
+    pLEz->setText(QString::number(pR_start->z()));
     QLabel* pLa0 = new QLabel(tr("Move the selection, centered on the highlighted room (%1) to:",
                                  // Intentional comment to separate arguments
                                  "%1 is a room number")
                               .arg(mMultiSelectionHighlightRoomId));
     pLa0->setWordWrap(true);
     // Record the starting coordinates - can be a help when working out how to move a block of rooms!
-    QLabel* pLa1 = new QLabel(tr("x coordinate (was %1):").arg(pR_start->x));
-    QLabel* pLa2 = new QLabel(tr("y coordinate (was %1):").arg(pR_start->y));
-    QLabel* pLa3 = new QLabel(tr("z coordinate (was %1):").arg(pR_start->z));
+    QLabel* pLa1 = new QLabel(tr("x coordinate (was %1):").arg(pR_start->x()));
+    QLabel* pLa2 = new QLabel(tr("y coordinate (was %1):").arg(pR_start->y()));
+    QLabel* pLa3 = new QLabel(tr("z coordinate (was %1):").arg(pR_start->z()));
     gridLayout->addWidget(pLa0, 0, 0, 1, 2, Qt::AlignCenter);
     gridLayout->addWidget(pLa1, 1, 0, Qt::AlignVCenter | Qt::AlignRight);
     gridLayout->addWidget(pLEx, 1, 1, Qt::AlignVCenter | Qt::AlignLeft);
@@ -3719,27 +3719,34 @@ void T2DMap::slot_movePosition()
     }
 
     if (dialog->exec() == QDialog::Accepted) {
-        const int dx = pLEx->text().toInt() - pR_start->x;
-        const int dy = pLEy->text().toInt() - pR_start->y;
-        const int dz = pLEz->text().toInt() - pR_start->z;
+        const int dx = pLEx->text().toInt() - pR_start->x();
+        const int dy = pLEy->text().toInt() - pR_start->y();
+        const int dz = pLEz->text().toInt() - pR_start->z();
 
         mMultiRect = QRect(0, 0, 0, 0);
 
         QSetIterator<int> itRoom = mMultiSelectionSet;
+        QSet<int> dirtyAreas;
         while (itRoom.hasNext()) {
             TRoom* room = mpMap->mpRoomDB->getRoom(itRoom.next());
             if (!room) {
                 continue;
             }
 
-            room->x += dx;
-            room->y += dy;
-            room->z += dz;
+            room->offset(dx, dy, dz);
+            dirtyAreas.insert(room->getArea());
         }
+        QSetIterator<int> itAreaID(dirtyAreas);
+        while (itAreaID.hasNext()) {
+            auto pArea = mpMap->mpRoomDB->getArea(itAreaID.next());
+            if (pArea) {
+                pArea->calcSpan();
+            }
+        }
+        mpMap->setUnsaved(__func__);
     }
     dialog->deleteLater();
     repaint();
-    mpMap->setUnsaved(__func__);
 }
 
 
@@ -3956,8 +3963,11 @@ void T2DMap::slot_spread()
     }
 
     mMultiRect = QRect(0, 0, 0, 0);
-    const int dx = pR_centerRoom->x;
-    const int dy = pR_centerRoom->y;
+    const int dx = pR_centerRoom->x();
+    const int dy = pR_centerRoom->y();
+    const int areaID = pR_centerRoom->getArea();
+    auto pArea = mpMap->mpRoomDB->getArea(areaID);
+    bool doneSomething = false;
     QSetIterator<int> itSelectionRoom = mMultiSelectionSet;
     while (itSelectionRoom.hasNext()) {
         TRoom* pMovingR = mpMap->mpRoomDB->getRoom(itSelectionRoom.next());
@@ -3965,8 +3975,10 @@ void T2DMap::slot_spread()
             continue;
         }
 
-        pMovingR->x = (pMovingR->x - dx) * spread + dx;
-        pMovingR->y = (pMovingR->y - dy) * spread + dy;
+        doneSomething = true;
+        pMovingR->setCoordinates(((pMovingR->x() - dx) * spread + dx),
+                                 ((pMovingR->y() - dy) * spread + dy),
+                                 pMovingR->z());
         QMapIterator<QString, QList<QPointF>> itCustomLine(pMovingR->customLines);
         QMap<QString, QList<QPointF>> newCustomLinePointsMap;
         while (itCustomLine.hasNext()) {
@@ -3982,8 +3994,14 @@ void T2DMap::slot_spread()
         pMovingR->customLines = newCustomLinePointsMap;
         pMovingR->calcRoomDimensions();
     }
-    repaint();
-    mpMap->setUnsaved(__func__);
+    if (doneSomething) {
+        if (pArea) {
+            pArea->mIsDirty = true;
+            pArea->clean();
+        }
+        repaint();
+        mpMap->setUnsaved(__func__);
+    }
 }
 
 void T2DMap::slot_shrink()
@@ -4017,17 +4035,22 @@ void T2DMap::slot_shrink()
     }
 
     mMultiRect = QRect(0, 0, 0, 0);
-    const int dx = pR_centerRoom->x;
-    const int dy = pR_centerRoom->y;
-
+    const int dx = pR_centerRoom->x();
+    const int dy = pR_centerRoom->y();
+    const int areaID = pR_centerRoom->getArea();
+    auto pArea = mpMap->mpRoomDB->getArea(areaID);
+    bool doneSomething = false;
     QSetIterator<int> itSelectionRoom(mMultiSelectionSet);
     while (itSelectionRoom.hasNext()) {
         TRoom* pMovingR = mpMap->mpRoomDB->getRoom(itSelectionRoom.next());
         if (!pMovingR) {
             continue;
         }
-        pMovingR->x = (pMovingR->x - dx) / spread + dx;
-        pMovingR->y = (pMovingR->y - dy) / spread + dy;
+
+        doneSomething = true;
+        pMovingR->setCoordinates(((pMovingR->x() - dx) / spread + dx),
+                                 ((pMovingR->y() - dy) / spread + dy),
+                                 pMovingR->z());
         QMapIterator<QString, QList<QPointF>> itCustomLine(pMovingR->customLines);
         QMap<QString, QList<QPointF>> newCustomLinePointsMap;
         while (itCustomLine.hasNext()) {
@@ -4043,8 +4066,14 @@ void T2DMap::slot_shrink()
         pMovingR->customLines = newCustomLinePointsMap;
         pMovingR->calcRoomDimensions();
     }
-    repaint();
-    mpMap->setUnsaved(__func__);
+    if (doneSomething) {
+        if (pArea) {
+            pArea->mIsDirty = true;
+            pArea->clean();
+        }
+        repaint();
+        mpMap->setUnsaved(__func__);
+    }
 }
 
 void T2DMap::slot_setExits()
@@ -4219,11 +4248,7 @@ void T2DMap::slot_setArea()
                     QSetIterator<TArea*> itpArea{areaPtrsSet};
                     while (itpArea.hasNext()) {
                         TArea* pArea = itpArea.next();
-                        if (pArea->mIsDirty) {
-                            pArea->determineAreaExits();
-                            pArea->calcSpan();
-                            pArea->mIsDirty = false;
-                        }
+                        pArea->clean();
                     }
                 }
                 const auto &targetAreaName = mpMap->mpRoomDB->getAreaNamesMap().value(newAreaId);
@@ -4361,12 +4386,12 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
 
                 // copy rooms on all z-levels if the shift key is being pressed
                 // CHECK: Consider adding z-level to multi-selection Widget?
-                if ((room->z != mMapCenterZ) && !(event->modifiers().testFlag(Qt::ShiftModifier))) {
+                if ((room->z() != mMapCenterZ) && !(event->modifiers().testFlag(Qt::ShiftModifier))) {
                     continue;
                 }
 
-                const float rx = static_cast<float>(room->x) * mRoomWidth  + fx;
-                const float ry = static_cast<float>(room->y * -1) * mRoomHeight + fy;
+                const float rx = static_cast<float>(room->x()) * mRoomWidth  + fx;
+                const float ry = static_cast<float>(room->y() * -1) * mRoomHeight + fy;
                 QRectF dr;
                 if (pArea->gridMode) {
                     dr = QRectF(static_cast<qreal>(rx - (mRoomWidth / 2.0f)), static_cast<qreal>(ry - (mRoomHeight / 2.0f)), static_cast<qreal>(mRoomWidth), static_cast<qreal>(mRoomHeight));
@@ -4454,15 +4479,16 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
             return;
         }
 
-        const int dx = qRound((event->pos().x() / mRoomWidth) + mMapCenterX - (xspan / 2.0)) - room->x;
-        const int dy = qRound((yspan / 2.0) - (event->pos().y() / mRoomHeight) - mMapCenterY) - room->y;
+        const int dx = qRound((event->pos().x() / mRoomWidth) + mMapCenterX - (xspan / 2.0)) - room->x();
+        const int dy = qRound((yspan / 2.0) - (event->pos().y() / mRoomHeight) - mMapCenterY) - room->y();
         QSetIterator<int> itRoom = mMultiSelectionSet;
         while (itRoom.hasNext()) {
             room = mpMap->mpRoomDB->getRoom(itRoom.next());
             if (room) {
-                room->x += dx;
-                room->y += dy;
-                room->z = mMapCenterZ; // allow groups to be moved to a different z-level with the map editor
+                room->offset(dx, dy, 0);
+                // Previously we would move all the rooms to the same level as
+                // the center room but this is not really helpful as it
+                // squashes mulitple levels of rooms all onto the same level!
 
                 QMapIterator<QString, QList<QPointF>> itk(room->customLines);
                 QMap<QString, QList<QPointF>> newMap;
@@ -4508,9 +4534,9 @@ bool T2DMap::getCenterSelection()
             continue;
         }
 
-        mean_x += (static_cast<float>(room->x - mean_x)) / ++processedRoomCount;
-        mean_y += (static_cast<float>(room->y - mean_y)) / processedRoomCount;
-        mean_z += (static_cast<float>(room->z - mean_z)) / processedRoomCount;
+        mean_x += (static_cast<float>(room->x() - mean_x)) / ++processedRoomCount;
+        mean_y += (static_cast<float>(room->y() - mean_y)) / processedRoomCount;
+        mean_z += (static_cast<float>(room->z() - mean_z)) / processedRoomCount;
     }
 
     if (processedRoomCount) {
@@ -4523,7 +4549,7 @@ bool T2DMap::getCenterSelection()
                 continue;
             }
 
-            const QVector3D meanToRoom(static_cast<float>(room->x) - mean_x, static_cast<float>(room->y) - mean_y, static_cast<float>(room->z) - mean_z);
+            const QVector3D meanToRoom(static_cast<float>(room->x()) - mean_x, static_cast<float>(room->y()) - mean_y, static_cast<float>(room->z()) - mean_z);
             if (closestSquareDistance < -0.5) {
                 // Don't use an equality to zero test, we are using floats so
                 // need to allow for a little bit of fuzzzyness!

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -43,7 +43,7 @@ class Host;
 class TArea;
 class TMap;
 class TRoom;
-class MapInfoProperties;
+struct MapInfoProperties;
 
 class QCheckBox;
 class QComboBox;

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -80,9 +80,9 @@ QMap<int, QMap<int, QMultiMap<int, int>>> TArea::koordinatenSystem()
     QList<TRoom*> const roomList = mpRoomDB->getRoomPtrList();
     for (auto room : roomList) {
         const int id = room->getId();
-        const int x = room->x;
-        const int y = room->y;
-        const int z = room->z;
+        const int x = room->x();
+        const int y = room->y();
+        const int z = room->z();
         QMap<int, QMultiMap<int, int>> const _y;
         QMultiMap<int, int> const _z;
         if (!kS.contains(x)) {
@@ -104,7 +104,7 @@ QList<int> TArea::getRoomsByPosition(int x, int y, int z)
         const int roomId = itAreaRoom.next();
         TRoom* pR = mpRoomDB->getRoom(roomId);
         if (pR) {
-            if (pR->x == x && pR->y == y && pR->z == z) {
+            if (pR->x() == x && pR->y() == y && pR->z() == z) {
                 dL.push_back(roomId);
             }
         }
@@ -332,9 +332,9 @@ void TArea::fast_calcSpan(int id)
         return;
     }
 
-    const int x = pR->x;
-    const int y = pR->y;
-    const int z = pR->z;
+    const int x = pR->x();
+    const int y = pR->y();
+    const int z = pR->z();
     if (x > max_x) {
         max_x = x;
     }
@@ -389,72 +389,72 @@ void TArea::calcSpan()
 
         if (!isFirstDone) {
             // Only do this initialization for the first valid room
-            min_x = pR->x;
+            min_x = pR->x();
             max_x = min_x;
-            min_y = pR->y * -1;
+            min_y = pR->y() * -1;
             max_y = min_y;
-            min_z = pR->z;
+            min_z = pR->z();
             max_z = min_z;
-            zLevels.push_back(pR->z);
-            xminForZ.insert(pR->z, pR->x);
-            xmaxForZ.insert(pR->z, pR->x);
-            yminForZ.insert(pR->z, pR->y);
-            ymaxForZ.insert(pR->z, pR->y);
+            zLevels.push_back(pR->z());
+            xminForZ.insert(pR->z(), pR->x());
+            xmaxForZ.insert(pR->z(), pR->x());
+            yminForZ.insert(pR->z(), pR->y());
+            ymaxForZ.insert(pR->z(), pR->y());
             isFirstDone = true;
             continue;
         } else {
             // Already had one valid room so now must check more things
 
-            if (!zLevels.contains(pR->z)) {
-                zLevels.push_back(pR->z);
+            if (!zLevels.contains(pR->z())) {
+                zLevels.push_back(pR->z());
             }
 
-            if (!xminForZ.contains(pR->z)) {
-                xminForZ.insert(pR->z, pR->x);
-            } else if (pR->x < xminForZ.value(pR->z)) {
-                xminForZ.insert(pR->z, pR->x);
+            if (!xminForZ.contains(pR->z())) {
+                xminForZ.insert(pR->z(), pR->x());
+            } else if (pR->x() < xminForZ.value(pR->z())) {
+                xminForZ.insert(pR->z(), pR->x());
             }
 
-            if (pR->x < min_x) {
-                min_x = pR->x;
+            if (pR->x() < min_x) {
+                min_x = pR->x();
             }
 
-            if (!xmaxForZ.contains(pR->z)) {
-                xmaxForZ.insert(pR->z, pR->x);
-            } else if (pR->x > xmaxForZ.value(pR->z)) {
-                xmaxForZ.insert(pR->z, pR->x);
+            if (!xmaxForZ.contains(pR->z())) {
+                xmaxForZ.insert(pR->z(), pR->x());
+            } else if (pR->x() > xmaxForZ.value(pR->z())) {
+                xmaxForZ.insert(pR->z(), pR->x());
             }
 
-            if (pR->x > max_x) {
-                max_x = pR->x;
+            if (pR->x() > max_x) {
+                max_x = pR->x();
             }
 
-            if (!yminForZ.contains(pR->z)) {
-                yminForZ.insert(pR->z, (-1 * pR->y));
-            } else if ((-1 * pR->y) < yminForZ.value(pR->z)) {
-                yminForZ.insert(pR->z, (-1 * pR->y));
+            if (!yminForZ.contains(pR->z())) {
+                yminForZ.insert(pR->z(), (-1 * pR->y()));
+            } else if ((-1 * pR->y()) < yminForZ.value(pR->z())) {
+                yminForZ.insert(pR->z(), (-1 * pR->y()));
             }
 
-            if ((-1 * pR->y) < min_y) {
-                min_y = (-1 * pR->y);
+            if ((-1 * pR->y()) < min_y) {
+                min_y = (-1 * pR->y());
             }
 
-            if ((-1 * pR->y) > max_y) {
-                max_y = (-1 * pR->y);
+            if ((-1 * pR->y()) > max_y) {
+                max_y = (-1 * pR->y());
             }
 
-            if (!ymaxForZ.contains(pR->z)) {
-                ymaxForZ.insert(pR->z, (-1 * pR->y));
-            } else if ((-1 * pR->y) > ymaxForZ.value(pR->z)) {
-                ymaxForZ.insert(pR->z, (-1 * pR->y));
+            if (!ymaxForZ.contains(pR->z())) {
+                ymaxForZ.insert(pR->z(), (-1 * pR->y()));
+            } else if ((-1 * pR->y()) > ymaxForZ.value(pR->z())) {
+                ymaxForZ.insert(pR->z(), (-1 * pR->y()));
             }
 
-            if (pR->z < min_z) {
-                min_z = pR->z;
+            if (pR->z() < min_z) {
+                min_z = pR->z();
             }
 
-            if (pR->z > max_z) {
-                max_z = pR->z;
+            if (pR->z() > max_z) {
+                max_z = pR->z();
             }
         }
     }
@@ -487,15 +487,15 @@ void TArea::removeRoom(int room, bool deferAreaRecalculations)
         if (pR) {
             // Now see if the room is on an extreme - if it the only room on a
             // particular z-coordinate it will be on all four
-            if (xminForZ.contains(pR->z) && xminForZ.value(pR->z) >= pR->x) {
+            if (xminForZ.contains(pR->z()) && xminForZ.value(pR->z()) >= pR->x()) {
                 isOnExtreme = true;
-            } else if (xmaxForZ.contains(pR->z) && xmaxForZ.value(pR->z) <= pR->x) {
+            } else if (xmaxForZ.contains(pR->z()) && xmaxForZ.value(pR->z()) <= pR->x()) {
                 isOnExtreme = true;
-            } else if (yminForZ.contains(pR->z) && yminForZ.value(pR->z) >= (-1 * pR->y)) {
+            } else if (yminForZ.contains(pR->z()) && yminForZ.value(pR->z()) >= (-1 * pR->y())) {
                 isOnExtreme = true;
-            } else if (ymaxForZ.contains(pR->z) && ymaxForZ.value(pR->z) <= (-1 * pR->y)) {
+            } else if (ymaxForZ.contains(pR->z()) && ymaxForZ.value(pR->z()) <= (-1 * pR->y())) {
                 isOnExtreme = true;
-            } else if (min_x >= pR->x || min_y >= (-1 * pR->y) || max_x <= pR->x || max_y <= (-1 * pR->y)) {
+            } else if (min_x >= pR->x() || min_y >= (-1 * pR->y()) || max_x <= pR->x() || max_y <= (-1 * pR->y())) {
                 isOnExtreme = true;
             }
         }
@@ -979,5 +979,14 @@ void TArea::set2DMapZoom(const qreal zoom)
 {
     if (zoom >= T2DMap::csmMinXYZoom) {
         mLast2DMapZoom = zoom;
+    }
+}
+
+void TArea::clean()
+{
+    if (mIsDirty) {
+        determineAreaExits();
+        calcSpan();
+        mIsDirty = false;
     }
 }

--- a/src/TArea.h
+++ b/src/TArea.h
@@ -68,6 +68,7 @@ public:
     bool hasPermanentLabels() const;
     qreal get2DMapZoom() const { return mLast2DMapZoom; }
     void set2DMapZoom(const qreal zoom);
+    void clean();
 
 
     QSet<int> rooms; // rooms of this area

--- a/src/TAstar.h
+++ b/src/TAstar.h
@@ -78,9 +78,9 @@ public:
         if (m_location[m_goal].pR->getArea() != m_location[u].pR->getArea()) {
             return 1;
         }
-        CostType dx = m_location[m_goal].pR->x - m_location[u].pR->x;
-        CostType dy = m_location[m_goal].pR->y - m_location[u].pR->y;
-        CostType dz = m_location[m_goal].pR->z - m_location[u].pR->z;
+        CostType dx = m_location[m_goal].pR->x() - m_location[u].pR->x();
+        CostType dy = m_location[m_goal].pR->y() - m_location[u].pR->y();
+        CostType dz = m_location[m_goal].pR->z() - m_location[u].pR->z();
 
         return std::sqrt(dx * dx + dy * dy + dz * dz);
     }

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -231,7 +231,7 @@ int TLuaInterpreter::getCustomLines1(lua_State* L)
             lua_pushnumber(L, pointL.at(k).y());
             lua_settable(L, -3);
             lua_pushinteger(L, 3);
-            lua_pushnumber(L, pR->z);
+            lua_pushnumber(L, pR->z());
             lua_settable(L, -3);
             lua_settable(L, -3); //customLines[direction]["points"][3 x coordinates]
         }
@@ -339,9 +339,9 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
                         (host.mpMap->mpRoomDB->getAreaNamesMap()).value(area), QString::number(area)));
         }
 
-        x.append(static_cast<qreal>(pR_to->x));
-        y.append(static_cast<qreal>(pR_to->y));
-        z.append(pR->z);
+        x.append(static_cast<qreal>(pR_to->x()));
+        y.append(static_cast<qreal>(pR_to->y()));
+        z.append(pR->z());
     } else if (lua_istable(L, 2)) {
         lua_pushnil(L);
         int i = 0; // Indexes groups of coordinates in the table
@@ -1988,9 +1988,9 @@ int TLuaInterpreter::getRoomCoordinates(lua_State* L)
         lua_pushnil(L);
         return 3;
     } else {
-        lua_pushnumber(L, pR->x);
-        lua_pushnumber(L, pR->y);
-        lua_pushnumber(L, pR->z);
+        lua_pushnumber(L, pR->x());
+        lua_pushnumber(L, pR->y());
+        lua_pushnumber(L, pR->z());
         return 3;
     }
 }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -180,9 +180,7 @@ bool TMap::setRoomCoordinates(int id, int x, int y, int z)
         return false;
     }
 
-    pR->x = x;
-    pR->y = y;
-    pR->z = z;
+    pR->setCoordinates(x, y, z);
 
     setUnsaved(__func__);
     return true;
@@ -225,9 +223,9 @@ QString TMap::connectExitStubByDirection(const int fromRoomId, const int dirType
     const int ux = qRound(unitVector.x());
     const int uy = qRound(unitVector.y());
     const int uz = qRound(unitVector.z());
-    const int rx = pFromR->x;
-    const int ry = pFromR->y;
-    const int rz = pFromR->z;
+    const int rx = pFromR->x();
+    const int ry = pFromR->y();
+    const int rz = pFromR->z();
     int dx = 0;
     int dy = 0;
     int dz = 0;
@@ -251,20 +249,20 @@ QString TMap::connectExitStubByDirection(const int fromRoomId, const int dirType
         }
 
         if (uz) {
-            dz = pToR->z - rz;
+            dz = pToR->z() - rz;
             if (!compSign(dz, uz) || !dz) {
                 continue;
             }
 
         } else {
             //to avoid lower/upper floors from stealing stubs
-            if (pToR->z != rz) {
+            if (pToR->z() != rz) {
                 continue;
             }
         }
 
         if (ux) {
-            dx = pToR->x - rx;
+            dx = pToR->x() - rx;
             if (!compSign(dx, ux) || !dx) {
                 //we do !dx pRto make sure we have a component in the desired direction
                 continue;
@@ -272,13 +270,13 @@ QString TMap::connectExitStubByDirection(const int fromRoomId, const int dirType
 
         } else {
             //to avoid rooms on same plane from stealing stubs
-            if (pToR->x != rx) {
+            if (pToR->x() != rx) {
                 continue;
             }
         }
 
         if (uy) {
-            dy = pToR->y - ry;
+            dy = pToR->y() - ry;
             //if the sign is the SAME here we keep it b/c we flip our y coordinate.
             if (compSign(dy, uy) || !dy) {
                 continue;
@@ -286,7 +284,7 @@ QString TMap::connectExitStubByDirection(const int fromRoomId, const int dirType
 
         } else {
             //to avoid rooms on same plane from stealing stubs
-            if (pToR->y != ry) {
+            if (pToR->y() != ry) {
                 continue;
             }
         }
@@ -588,9 +586,7 @@ void TMap::audit()
     QMapIterator<int, TArea*> itArea(mpRoomDB->getAreaMap());
     while (itArea.hasNext()) {
         itArea.next();
-        itArea.value()->determineAreaExits();
-        itArea.value()->calcSpan();
-        itArea.value()->mIsDirty = false;
+        itArea.value()->clean();
     }
 
     { // Blocked - just to limit the scope of infoMsg...!
@@ -606,6 +602,7 @@ void TMap::audit()
     }
 }
 
+// This may be duplicating TArea class functionality:
 QList<int> TMap::detectRoomCollisions(int id)
 {
     QList<int> collList;
@@ -614,9 +611,9 @@ QList<int> TMap::detectRoomCollisions(int id)
         return collList;
     }
     const int area = pR->getArea();
-    const int x = pR->x;
-    const int y = pR->y;
-    const int z = pR->z;
+    const int x = pR->x();
+    const int y = pR->y();
+    const int z = pR->z();
     TArea* pA = mpRoomDB->getArea(area);
     if (!pA) {
         return collList;
@@ -629,7 +626,7 @@ QList<int> TMap::detectRoomCollisions(int id)
         if (!pR) {
             continue;
         }
-        if (pR->x == x && pR->y == y && pR->z == z) {
+        if (pR->x() == x && pR->y() == y && pR->z() == z) {
             collList.push_back(checkRoomId);
         }
     }
@@ -1304,9 +1301,9 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
             }
         }
         ofs << pR->getArea();
-        ofs << pR->x;
-        ofs << pR->y;
-        ofs << pR->z;
+        ofs << pR->x();
+        ofs << pR->y();
+        ofs << pR->z();
         ofs << pR->getNorth();
         ofs << pR->getNortheast();
         ofs << pR->getEast();

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -1748,7 +1748,7 @@ int TRoom::readJsonRoom(const QJsonArray& array, const int index, const int area
 
     const QJsonArray coordinatesArray = roomObj.value(QLatin1String("coordinates")).toArray();
     mX = coordinatesArray.at(0).toInt();
-    mY= coordinatesArray.at(1).toInt();
+    mY = coordinatesArray.at(1).toInt();
     mZ = coordinatesArray.at(2).toInt();
 
     if (roomObj.contains(QLatin1String("locked")) && roomObj.value(QLatin1String("locked")).toBool()) {

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -343,9 +343,7 @@ bool TRoom::setArea(int areaID, bool deferAreaRecalculations)
         QSetIterator<TArea*> itpArea = dirtyAreas;
         while (itpArea.hasNext()) {
             TArea* pArea = itpArea.next();
-            pArea->calcSpan();
-            pArea->determineAreaExits();
-            pArea->mIsDirty = false;
+            pArea->clean();
         }
         dirtyAreas.clear();
     }
@@ -646,10 +644,10 @@ void TRoom::removeAllSpecialExitsToRoom(const int roomId)
 
 void TRoom::calcRoomDimensions()
 {
-    min_x = x;
-    max_x = x;
-    min_y = y;
-    max_y = y;
+    min_x = mX;
+    max_x = mX;
+    min_y = mY;
+    max_y = mY;
 
     if (customLines.empty()) {
         return;
@@ -687,9 +685,9 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
     ifs >> area;
     // Can be useful when analysing suspect map files!
     //     qDebug() << "TRoom::restore(...," << roomID << ",...) has AreaId:" << area;
-    ifs >> x;
-    ifs >> y;
-    ifs >> z;
+    ifs >> mX;
+    ifs >> mY;
+    ifs >> mZ;
     ifs >> north;
     ifs >> northeast;
     ifs >> east;
@@ -1698,9 +1696,9 @@ void TRoom::writeJsonRoom(QJsonArray& obj) const
     }
 
     QJsonArray coordinateArray;
-    coordinateArray.append(static_cast<double>(x));
-    coordinateArray.append(static_cast<double>(y));
-    coordinateArray.append(static_cast<double>(z));
+    coordinateArray.append(static_cast<double>(mX));
+    coordinateArray.append(static_cast<double>(mY));
+    coordinateArray.append(static_cast<double>(mZ));
     const QJsonValue coordinatesValue{coordinateArray};
     roomObj.insert(QLatin1String("coordinates"), coordinatesValue);
 
@@ -1749,9 +1747,9 @@ int TRoom::readJsonRoom(const QJsonArray& array, const int index, const int area
     readJsonUserData(roomObj.value(QLatin1String("userData")).toObject());
 
     const QJsonArray coordinatesArray = roomObj.value(QLatin1String("coordinates")).toArray();
-    x = coordinatesArray.at(0).toInt();
-    y = coordinatesArray.at(1).toInt();
-    z = coordinatesArray.at(2).toInt();
+    mX = coordinatesArray.at(0).toInt();
+    mY= coordinatesArray.at(1).toInt();
+    mZ = coordinatesArray.at(2).toInt();
 
     if (roomObj.contains(QLatin1String("locked")) && roomObj.value(QLatin1String("locked")).toBool()) {
         isLocked = true;
@@ -2363,3 +2361,4 @@ void TRoom::readJsonSymbol(const QJsonObject& roomObj)
         mSymbolColor = color;
     }
 }
+

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -76,6 +76,19 @@ public:
     bool setArea(int, bool deferAreaRecalculations = false);
     int getExitWeight(const QString& cmd);
 
+    inline int x() const { return mX; }
+    inline int y() const { return mY; }
+    inline int z() const { return mZ; }
+    inline void setCoordinates(const int x, const int y, const int z) {
+        mX = x;
+        mY = y;
+        mZ = z;
+    }
+    inline void offset(const int deltaX, const int deltaY, const int deltaZ) {
+        mX += deltaX;
+        mY += deltaY;
+        mZ += deltaZ;
+    }
     int getWeight() const { return weight; }
     int getNorth() const { return north; }
     void setNorth(int id) { north = id; }
@@ -127,10 +140,6 @@ public:
     void writeJsonRoom(QJsonArray&) const;
     int readJsonRoom(const QJsonArray&, const int, const int);
 
-
-    int x = 0;
-    int y = 0;
-    int z = 0;
     int environment = -1;
 
     bool isLocked = false;
@@ -185,6 +194,10 @@ private:
     int id = 0;
     int area = -1;
     int weight = 1;
+    // Made private so we can catch all cases where they are to be modified:
+    int mX = 0;
+    int mY = 0;
+    int mZ = 0;
     // Uses "shortStrings" as keys for normal exits:
     QMap<QString, int> exitWeights;
     int north = -1;
@@ -220,7 +233,7 @@ inline QDebug operator<<(QDebug debug, const TRoom* room)
     debug.nospace() << "TRoom(" << room->getId() << ")";
     debug.nospace() << ", name=" << room->name;
     debug.nospace() << ", area=" << room->getArea();
-    debug.nospace() << ", pos=" << room->x << "," << room->y << "," << room->z;
+    debug.nospace() << ", pos=" << room->x() << "," << room->y() << "," << room->z();
 
     debug.nospace() << ", exits:";
     if (room->getNorth() != -1) {

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -564,9 +564,9 @@ void XMLimport::readRoom(QMultiHash<int, int>& areamRoomMultiHash, unsigned int*
                 continue;
             }
 
-            pT->x = attributes().value(qsl("x")).toString().toInt();
-            pT->y = attributes().value(qsl("y")).toString().toInt();
-            pT->z = attributes().value(qsl("z")).toString().toInt();
+            pT->setCoordinates(attributes().value(qsl("x")).toString().toInt(),
+                               attributes().value(qsl("y")).toString().toInt(),
+                               attributes().value(qsl("z")).toString().toInt());
             continue;
         } else if (name() == qsl("features")) {
             readRoomFeatures(pT);

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -292,9 +292,9 @@ void GLWidget::paintGL()
             return;
         }
         mAID = pRID->getArea();
-        ox = pRID->x;
-        oy = pRID->y;
-        oz = pRID->z;
+        ox = pRID->x();
+        oy = pRID->y();
+        oz = pRID->z();
         mMapCenterX = ox;
         mMapCenterY = oy;
         mMapCenterZ = oz;
@@ -363,8 +363,6 @@ void GLWidget::paintGL()
     glEnable(GL_LINE_SMOOTH);
     glEnable(GL_LINE_STIPPLE);
     glLineWidth(1.0);
-    int quads = 0;
-    int verts = 0;
     float planeColor2[][4] = {{0.9, 0.5, 0.0, 1.0},
                                {165.0 / 255.0, 102.0 / 255.0, 167.0 / 255.0, 1.0},
                                {170.0 / 255.0, 10.0 / 255.0, 127.0 / 255.0, 1.0},
@@ -436,9 +434,9 @@ void GLWidget::paintGL()
             if (!pR) {
                 continue;
             }
-            auto rx = static_cast<float>(pR->x);
-            auto ry = static_cast<float>(pR->y);
-            auto rz = static_cast<float>(pR->z);
+            auto rx = static_cast<float>(pR->x());
+            auto ry = static_cast<float>(pR->y());
+            auto rz = static_cast<float>(pR->z());
             if (rz != zPlane) {
                 continue;
             }
@@ -463,7 +461,7 @@ void GLWidget::paintGL()
             exitList.push_back(pR->getNorthwest());
             exitList.push_back(pR->getUp());
             exitList.push_back(pR->getDown());
-            const int e = pR->z;
+            const int e = pR->z();
             const int ef = abs(e % 26);
             glMaterialfv(GL_FRONT, GL_AMBIENT_AND_DIFFUSE, planeColor[ef]);
             glMateriali(GL_FRONT, GL_SHININESS, 1);
@@ -500,9 +498,9 @@ void GLWidget::paintGL()
                     } else {
                         areaExit = false;
                     }
-                    auto ex = static_cast<float>(pExit->x);
-                    auto ey = static_cast<float>(pExit->y);
-                    auto ez = static_cast<float>(pExit->z);
+                    auto ex = static_cast<float>(pExit->x());
+                    auto ey = static_cast<float>(pExit->y());
+                    auto ez = static_cast<float>(pExit->z());
                     const QVector3D p1(ex, ey, ez);
                     const QVector3D p2(rx, ry, rz);
                     glLoadIdentity();
@@ -558,7 +556,6 @@ void GLWidget::paintGL()
                     }
                     glVertex3f(p2.x(), p2.y(), p2.z());
                     glEnd();
-                    verts++;
                     if (areaExit) {
                         glDisable(GL_BLEND);
                         glEnable(GL_LIGHTING);
@@ -597,7 +594,6 @@ void GLWidget::paintGL()
                         glMateriali(GL_FRONT, GL_SHININESS, 96);
 
                         glLoadName(k);
-                        quads++;
                         glBegin(GL_QUADS);
                         glNormal3f(0.57735, -0.57735, 0.57735);
                         glVertex3f(1.0 / scale, -1.0 / scale, 1.0 / scale);
@@ -912,9 +908,9 @@ void GLWidget::paintGL()
                         areaExit = false;
                     }
 
-                    auto ex = static_cast<float>(pExit->x);
-                    auto ey = static_cast<float>(pExit->y);
-                    auto ez = static_cast<float>(pExit->z);
+                    auto ex = static_cast<float>(pExit->x());
+                    auto ey = static_cast<float>(pExit->y());
+                    auto ez = static_cast<float>(pExit->z());
                     const QVector3D p1(ex, ey, ez);
                     const QVector3D p2(rx, ry, rz);
                     glLoadIdentity();
@@ -972,7 +968,6 @@ void GLWidget::paintGL()
                     }
                     glVertex3f(p2.x(), p2.y(), p2.z());
                     glEnd();
-                    verts++;
                     if (areaExit) {
                         glDisable(GL_BLEND);
                         glEnable(GL_LIGHTING);
@@ -1007,7 +1002,6 @@ void GLWidget::paintGL()
                         }
 
                         glLoadName(k);
-                        quads++;
                         glBegin(GL_QUADS);
                         glNormal3f(0.57735, -0.57735, 0.57735);
                         glVertex3f(1.0 / scale, -1.0 / scale, 1.0 / scale);
@@ -1317,7 +1311,6 @@ void GLWidget::paintGL()
         }
     }
 
-    quads = 0;
     zPlane = zmin;
     glDisable(GL_DEPTH_TEST);
     glEnable(GL_CULL_FACE);
@@ -1335,9 +1328,9 @@ void GLWidget::paintGL()
             if (!pR) {
                 continue;
             }
-            auto rx = static_cast<float>(pR->x);
-            auto ry = static_cast<float>(pR->y);
-            auto rz = static_cast<float>(pR->z);
+            auto rx = static_cast<float>(pR->x());
+            auto ry = static_cast<float>(pR->y());
+            auto rz = static_cast<float>(pR->z());
             if (rz != zPlane) {
                 continue;
             }
@@ -1353,7 +1346,7 @@ void GLWidget::paintGL()
                 }
             }
 
-            const int e = pR->z;
+            const int e = pR->z();
             const int ef = abs(e % 26);
             glMaterialfv(GL_FRONT, GL_AMBIENT_AND_DIFFUSE, planeColor[ef]);
             glMateriali(GL_FRONT, GL_SHININESS, 36); //gut:96
@@ -1400,7 +1393,7 @@ void GLWidget::paintGL()
                 }
 
                 glLoadName(currentRoomId);
-                quads++;
+
                 glBegin(GL_QUADS);
                 glNormal3f(0.57735, -0.57735, 0.57735);
                 glVertex3f(1.0 / scale, -1.0 / scale, 1.0 / scale);
@@ -1705,7 +1698,6 @@ void GLWidget::paintGL()
             }
 
             glLoadName(currentRoomId);
-            quads++;
             glBegin(GL_QUADS);
             glNormal3f(0.57735, -0.57735, 0.57735);
             glVertex3f(1.0 / scale, -1.0 / scale, 1.0 / scale);

--- a/src/mapInfoContributorManager.cpp
+++ b/src/mapInfoContributorManager.cpp
@@ -167,9 +167,9 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
                                tr("Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1current player location")
                                     .arg(QChar(160),
                                         QString::number(roomID),
-                                        QString::number(room->x),
-                                        QString::number(room->y),
-                                        QString::number(room->z))));
+                                        QString::number(room->x()),
+                                        QString::number(room->y()),
+                                        QString::number(room->z()))));
             if (areaId != displayAreaId) {
                 isItalic = true;
             } else {
@@ -190,9 +190,9 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
                                tr("Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1selected room")
                                     .arg(QChar(160),
                                         QString::number(roomID),
-                                        QString::number(room->x),
-                                        QString::number(room->y),
-                                        QString::number(room->z))));
+                                        QString::number(room->x()),
+                                        QString::number(room->y()),
+                                        QString::number(room->z()))));
             isBold = true;
             if (infoColor.lightness() > 127) {
                 color = QColor(255, 223, 191); // Slightly orange white
@@ -218,9 +218,9 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
                                tr("Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1center of %n selected rooms", nullptr, selectionSize)
                                     .arg(QChar(160),
                                         QString::number(roomID),
-                                        QString::number(room->x),
-                                        QString::number(room->y),
-                                        QString::number(room->z))));
+                                        QString::number(room->x()),
+                                        QString::number(room->y()),
+                                        QString::number(room->z()))));
             isBold = true;
             if (infoColor.lightness() > 127) {
                 color = QColor(255, 223, 191); // Slightly orange white


### PR DESCRIPTION
#### Summary of PR Changes/Additions
Makes the coordinate members of the `TRoom` class private so that access to them can be tracked via methods to set and get them.

#### Motivation for Adding to Mudlet
This is so that the setters can then subsequently include any extra code that needs to be aware when the room is moved. I intend to improve the detection of rooms being placed in the same position but realised this would be a good preliminary step.

#### Additional Information (related issues, discussions, etc.)
Removes some dead code setting but not using `(int) quads` and `(int) verts` in `(void) GLWidget::paintGL()`

Also using the mouse to drag and thus move selected rooms when those rooms were on different levels would squash them all down to be on the same z-coordinate as the "highlighted centre of the selection" room. This is not as helpful it might seem and instead increased the likelihood of causing room collisions - so now each room will retain it's z coordinate if it is not on the same level as the centre of the multiple room selection.

Also move code that likely needs to be run whenever rooms are added/removed/moved within an area to a common block of code (`(void) TArea::clean()`) to help keep things DRY. I intend to put code to update a per area record of rooms that are in the same place within that block in the future - so that the record can be reused without having to be repeatedly recalculated, especially in the paint event for the 2D mapper.