### PR TITLE
improve: allow hotkeys added in #7538 to be customised

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -306,42 +306,20 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     timeStampButton->setMaximumSize(QSize(30, 30));
     timeStampButton->setSizePolicy(sizePolicy5);
     timeStampButton->setFocusPolicy(Qt::NoFocus);
-#if defined(Q_OS_MACOS)
-    timeStampButton->setToolTip(utils::richText(tr("Show Time Stamps (⌘+T)")));
-#else
-    timeStampButton->setToolTip(utils::richText(tr("Show Time Stamps (CTRL+T)")));
-#endif
     timeStampButton->setIcon(QIcon(qsl(":/icons/dialog-information.png")));
-
-    QShortcut *timestampsShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_T), this);
-    connect(timestampsShortcut, &QShortcut::activated, this, [this]() {
-        if (mUpperPane->mShowTimeStamps == true) {
-            mUpperPane->slot_toggleTimeStamps(false);
-            mLowerPane->slot_toggleTimeStamps(false);
-        } else {
-            mUpperPane->slot_toggleTimeStamps(true);
-            mLowerPane->slot_toggleTimeStamps(true);
-        }
-    });
+    timeStampButton->setToolTip(utils::richText(tr("Toggle time stamps")));
 
     connect(timeStampButton, &QAbstractButton::toggled, mUpperPane, &TTextEdit::slot_toggleTimeStamps);
     connect(timeStampButton, &QAbstractButton::toggled, mLowerPane, &TTextEdit::slot_toggleTimeStamps);
 
-    auto replayButton = new QToolButton;
+    replayButton = new QToolButton;
     replayButton->setCheckable(true);
     replayButton->setMinimumSize(QSize(30, 30));
     replayButton->setMaximumSize(QSize(30, 30));
     replayButton->setSizePolicy(sizePolicy5);
     replayButton->setFocusPolicy(Qt::NoFocus);
-#if defined(Q_OS_MACOS)
-    replayButton->setToolTip(utils::richText(tr("Record a replay (⌘+R)")));
-#else
-    replayButton->setToolTip(utils::richText(tr("Record a replay (CTRL+R)")));
-#endif
-    QShortcut *replayShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_R), this);
-    connect(replayShortcut, &QShortcut::activated, this, &TConsole::slot_toggleReplayRecording);
-
     replayButton->setIcon(QIcon(qsl(":/icons/media-tape.png")));
+    replayButton->setToolTip(utils::richText(tr("Toggle recording of replays")));
     connect(replayButton, &QAbstractButton::clicked, this, &TConsole::slot_toggleReplayRecording);
 
     logButton = new QToolButton;
@@ -350,13 +328,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     logButton->setCheckable(true);
     logButton->setSizePolicy(sizePolicy5);
     logButton->setFocusPolicy(Qt::NoFocus);
-#if defined(Q_OS_MACOS)
-    logButton->setToolTip(utils::richText(tr("Start logging game output to log file. (⌘+L)")));
-#else
-    logButton->setToolTip(utils::richText(tr("Start logging game output to log file. (CTRL+L)")));
-#endif
-    QShortcut *loggingShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_L), this);
-    connect(loggingShortcut, &QShortcut::activated, this, &TConsole::slot_toggleLogging);
+    logButton->setToolTip(utils::richText(tr("Toggle logging")));
 
     QIcon logIcon;
     logIcon.addPixmap(QPixmap(qsl(":/icons/folder-downloads.png")), QIcon::Normal, QIcon::Off);
@@ -411,19 +383,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     emergencyStop->setSizePolicy(sizePolicy4);
     emergencyStop->setFocusPolicy(Qt::NoFocus);
     emergencyStop->setCheckable(true);
-#if defined(Q_OS_MACOS)
-    emergencyStop->setToolTip(utils::richText(tr("Emergency Stop. Stops all timers and triggers. (⌘+P)")));
-#else
-    emergencyStop->setToolTip(utils::richText(tr("Emergency Stop. Stops all timers and triggers. (CTRL+P)")));
-#endif
-    QShortcut *emergencyShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_P), this);
-    connect(emergencyShortcut, &QShortcut::activated, this, [this]() {
-        if (emergencyStopEnabled) {
-            slot_stopAllItems(false);
-        } else {
-            slot_stopAllItems(true);
-        }
-    });
+    emergencyStop->setToolTip(utils::richText(tr("Emergency stop! Stop all scripts")));
 
     connect(emergencyStop, &QAbstractButton::clicked, this, &TConsole::slot_stopAllItems);
 
@@ -1840,11 +1800,9 @@ void TConsole::appendBuffer(const TBuffer& bufferSlice)
 void TConsole::slot_stopAllItems(bool b)
 {
     if (b) {
-        emergencyStopEnabled = true;
         mpHost->stopAllTriggers();
         emergencyStop->setIcon(QIcon(qsl(":/icons/red-bomb.png")));
     } else {
-        emergencyStopEnabled = false;
         mpHost->reenableAllTriggers();
         emergencyStop->setIcon(QIcon(qsl(":/icons/edit-bomb.png")));
     }

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -287,6 +287,7 @@ public:
     bool mIsPromptLine = false;
     QToolButton* logButton = nullptr;
     QToolButton* timeStampButton = nullptr;
+    QToolButton* replayButton = nullptr;
     QLineEdit* mpBufferSearchBox = nullptr;
     QAction* mpAction_searchCaseSensitive = nullptr;
     QToolButton* mpBufferSearchUp = nullptr;
@@ -304,7 +305,6 @@ public:
     QString mBgImagePath;
     bool mHScrollBarEnabled = false;
     ControlCharacterMode mControlCharacter = ControlCharacterMode::AsIs;
-    bool emergencyStopEnabled = false;
 
 
 public slots:

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -545,6 +545,10 @@ public slots:
     void slot_timerFires();
     void slot_toggleFullScreenView();
     void slot_toggleMultiView();
+    void slot_toggleTimeStamp();
+    void slot_toggleReplay();
+    void slot_toggleLogging();
+    void slot_toggleEmergencyStop();
 
 
 protected:
@@ -656,6 +660,10 @@ private:
     QKeySequence mKeySequenceReconnect;
     QKeySequence mKeySequenceShowMap;
     QKeySequence mKeySequenceTriggers;
+    QKeySequence mKeySequenceToggleTimeStamp;
+    QKeySequence mKeySequenceToggleReplay;
+    QKeySequence mKeySequenceToggleLogging;
+    QKeySequence mKeySequenceToggleEmergencyStop;
     bool mIsGoingDown = false;
     // Whether multi-view is in effect:
     controlsVisibility mMenuBarVisibility = visibleAlways;
@@ -730,6 +738,10 @@ private:
     QPointer<QShortcut> mpShortcutReconnect;
     QPointer<QShortcut> mpShortcutShowMap;
     QPointer<QShortcut> mpShortcutTriggers;
+    QPointer<QShortcut> mpShortcutToggleTimeStamp;
+    QPointer<QShortcut> mpShortcutToggleReplay;
+    QPointer<QShortcut> mpShortcutToggleLogging;
+    QPointer<QShortcut> mpShortcutToggleEmergencyStop;
     QPointer<QTimer> mpTimerReplay;
     QPointer<QToolBar> mpToolBarReplay;
     QWidget* mpWidget_profileContainer = nullptr;

--- a/src/ui/main_window.ui
+++ b/src/ui/main_window.ui
@@ -104,6 +104,10 @@
     <addaction name="dactionReplay"/>
     <addaction name="dactionModuleManager"/>
     <addaction name="dactionPackageExporter"/>
+    <addaction name="dactionToggleTimeStamp"/>
+    <addaction name="dactionToggleReplay"/>
+    <addaction name="dactionToggleLogging"/>
+    <addaction name="dactionToggleEmergencyStop"/>
    </widget>
    <widget class="QMenu" name="menuOptions">
     <property name="title">
@@ -410,6 +414,38 @@
   <action name="dactionCloseProfile">
    <property name="text">
     <string>Close profile</string>
+   </property>
+  </action>
+  <action name="dactionToggleTimeStamp">
+   <property name="text">
+    <string>Time Stamps</string>
+   </property>
+   <property name="toolTip">
+    <string>&lt;p&gt;Toggle time stamps on the main console.&lt;/p&gt;</string>
+   </property>
+  </action>
+  <action name="dactionToggleReplay">
+   <property name="text">
+    <string>Replay</string>
+   </property>
+   <property name="toolTip">
+    <string>&lt;p&gt;Toggle recording of replays.&lt;/p&gt;</string>
+   </property>
+  </action>
+  <action name="dactionToggleLogging">
+   <property name="text">
+    <string>Logging</string>
+   </property>
+   <property name="toolTip">
+    <string>&lt;p&gt;Toggle logging facilities.&lt;/p&gt;</string>
+   </property>
+  </action>
+  <action name="dactionToggleEmergencyStop">
+   <property name="text">
+    <string>Emergency Stop</string>
+   </property>
+   <property name="toolTip">
+    <string>&lt;p&gt;Toggle all scripting on or off..&lt;/p&gt;</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Allow hotkeys added in #7538 (timestamps, logging, replays, emergency stop) to be customised in Preferences.

#### Motivation for adding to Mudlet
Improve user experience, allow Mudlet to be user customised.  Do not intrude into user keybinding space.

#### Other info (issues closed, discussion etc)
Thanks for the nudge lads.
