### PR TITLE
Infrastructure: Sign windows builds using Azure Trusted Signing

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -56,6 +56,35 @@ jobs:
         $GITHUB_WORKSPACE/CI/setup-windows-sdk.sh
         $GITHUB_WORKSPACE/CI/validate-deployment-for-windows.sh
 
+    - name: Debug Java Environment
+      shell: msys2 {0}
+      run: |
+        echo "=== System PATH ==="
+        echo $PATH
+        
+        echo "=== Java Home Variables ==="
+        echo "JAVA_HOME: $JAVA_HOME"
+        echo "JAVA_HOME_8_X64: $JAVA_HOME_8_X64"
+        echo "JAVA_HOME_11_X64: $JAVA_HOME_11_X64"
+        echo "JAVA_HOME_17_X64: $JAVA_HOME_17_X64"
+        echo "JAVA_HOME_21_X64: $JAVA_HOME_21_X64"
+        
+        echo "=== Which Java ==="
+        which java || echo "java not in PATH"
+        
+        echo "=== Java Version ==="
+        java -version || echo "java command failed"
+        
+        echo "=== Direct Java Executable Checks ==="
+        ls -l "$JAVA_HOME_8_X64/bin/java.exe" || echo "Not found in JAVA_HOME_8_X64"
+        ls -l "$JAVA_HOME_11_X64/bin/java.exe" || echo "Not found in JAVA_HOME_11_X64"
+        ls -l "$JAVA_HOME_17_X64/bin/java.exe" || echo "Not found in JAVA_HOME_17_X64"
+        ls -l "$JAVA_HOME_21_X64/bin/java.exe" || echo "Not found in JAVA_HOME_21_X64"
+        
+        echo "=== MSYS2 Environment Info ==="
+        uname -a
+        echo "MSYSTEM: $MSYSTEM"
+
     - name: restore ccache
       uses: actions/cache@v4
       with:

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -91,6 +91,7 @@ jobs:
         GITHUB_SCHEDULED_BUILD: ${{ github.event_name == 'schedule' || github.event.inputs.scheduled == 'true' }}
         GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         GITHUB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        JAVA_HOME: ${{ env.JAVA_HOME_21_X64 }}
       run: $GITHUB_WORKSPACE/CI/deploy-mudlet-for-windows.sh
 
     - name: Upload packaged Mudlet

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -96,7 +96,7 @@ jobs:
         DEPLOY_KEY_PASS: ${{secrets.DEPLOY_KEY_PASS}}
         DEPLOY_SSH_KEY: ${{secrets.DEPLOY_SSH_KEY}}
         DEPLOY_PATH: ${{secrets.DEPLOY_PATH}}
-        AZURE_ACCESS_TOKEN: ${{ secrets.AZURE_ACCESS_TOKEN }}
+        AZURE_ACCESS_TOKEN: ${{ env.AZURE_ACCESS_TOKEN }}
         GITHUB_REPO_NAME: ${{ github.repository }}
         GITHUB_REPO_TAG: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
         GITHUB_SCHEDULED_BUILD: ${{ github.event_name == 'schedule' || github.event.inputs.scheduled == 'true' }}

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -38,8 +38,12 @@ jobs:
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-    - name: Confirm Azure account
-      run: az account show
+    - name: Get Azure access token for code signing
+      run: |
+        token=$(az account get-access-token --resource https://codesigning.azure.net)
+        echo "::add-mask::$token"
+        echo "AZURE_ACCESS_TOKEN=$token" >> $GITHUB_ENV
+
 
     - name: (Windows 64) Setup MSYS2
       if: matrix.buildname == 'windows64'
@@ -54,10 +58,6 @@ jobs:
       with:
         msystem: MINGW32
         update: true
-
-    - name: Confirm Azure account in msys2
-      shell: msys2 {0}
-      run: az account show
 
     - name: (Windows) Build Environment Setup
       shell: msys2 {0}

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -91,7 +91,6 @@ jobs:
         GITHUB_SCHEDULED_BUILD: ${{ github.event_name == 'schedule' || github.event.inputs.scheduled == 'true' }}
         GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         GITHUB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        JAVA_HOME: ${{ env.JAVA_HOME_21_X64 }}
       run: $GITHUB_WORKSPACE/CI/deploy-mudlet-for-windows.sh
 
     - name: Upload packaged Mudlet

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -33,11 +33,6 @@ jobs:
       with:
         submodules: true
         fetch-depth: 0
-        
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      with:
-        limit-access-to-actor: true
 
     - name: (Windows 64) Setup MSYS2
       if: matrix.buildname == 'windows64'

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -59,31 +59,9 @@ jobs:
     - name: Debug Java Environment
       shell: msys2 {0}
       run: |
-        echo "=== System PATH ==="
-        echo $PATH
-        
-        echo "=== Java Home Variables ==="
-        echo "JAVA_HOME: $JAVA_HOME"
-        echo "JAVA_HOME_8_X64: $JAVA_HOME_8_X64"
-        echo "JAVA_HOME_11_X64: $JAVA_HOME_11_X64"
-        echo "JAVA_HOME_17_X64: $JAVA_HOME_17_X64"
-        echo "JAVA_HOME_21_X64: $JAVA_HOME_21_X64"
-        
-        echo "=== Which Java ==="
-        which java || echo "java not in PATH"
-        
-        echo "=== Java Version ==="
-        java -version || echo "java command failed"
-        
-        echo "=== Direct Java Executable Checks ==="
-        ls -l "$JAVA_HOME_8_X64/bin/java.exe" || echo "Not found in JAVA_HOME_8_X64"
-        ls -l "$JAVA_HOME_11_X64/bin/java.exe" || echo "Not found in JAVA_HOME_11_X64"
-        ls -l "$JAVA_HOME_17_X64/bin/java.exe" || echo "Not found in JAVA_HOME_17_X64"
-        ls -l "$JAVA_HOME_21_X64/bin/java.exe" || echo "Not found in JAVA_HOME_21_X64"
-        
-        echo "=== MSYS2 Environment Info ==="
-        uname -a
-        echo "MSYSTEM: $MSYSTEM"
+        export JAVA_HOME="$(cygpath -u $JAVA_HOME_21_X64)"
+        export PATH="$JAVA_HOME/bin:$PATH"
+        java -version
 
     - name: restore ccache
       uses: actions/cache@v4

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -34,6 +34,17 @@ jobs:
         submodules: true
         fetch-depth: 0
 
+    - uses: azure/login@v2
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - name: Azure CLI script
+      uses: azure/cli@v2
+      with:
+        azcliversion: latest
+        inlineScript: |
+          az account show
+
     - name: (Windows 64) Setup MSYS2
       if: matrix.buildname == 'windows64'
       uses: msys2/setup-msys2@v2
@@ -55,13 +66,6 @@ jobs:
       run: |
         $GITHUB_WORKSPACE/CI/setup-windows-sdk.sh
         $GITHUB_WORKSPACE/CI/validate-deployment-for-windows.sh
-
-    - name: Debug Java Environment
-      shell: msys2 {0}
-      run: |
-        export JAVA_HOME="$(cygpath -u $JAVA_HOME_21_X64)"
-        export PATH="$JAVA_HOME/bin:$PATH"
-        java -version
 
     - name: restore ccache
       uses: actions/cache@v4

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -77,7 +77,8 @@ jobs:
       shell: msys2 {0}
       run: $GITHUB_WORKSPACE/CI/package-mudlet-for-windows.sh
 
-    - uses: azure/login@v2
+    - name: (Windows) Login to Azure
+      uses: azure/login@v2
       if: github.repository == 'Mudlet/Mudlet'
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -34,17 +34,6 @@ jobs:
         submodules: true
         fetch-depth: 0
 
-    - uses: azure/login@v2
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-    - name: Get Azure access token for code signing
-      shell: pwsh
-      run: |
-        $token = (az account get-access-token --resource https://codesigning.azure.net | ConvertFrom-Json).accessToken
-        "::add-mask::$token"
-        "AZURE_ACCESS_TOKEN=$token" | Add-Content -Path $env:GITHUB_ENV
-
     - name: (Windows 64) Setup MSYS2
       if: matrix.buildname == 'windows64'
       uses: msys2/setup-msys2@v2
@@ -87,6 +76,19 @@ jobs:
     - name: (Windows) Package
       shell: msys2 {0}
       run: $GITHUB_WORKSPACE/CI/package-mudlet-for-windows.sh
+
+    - uses: azure/login@v2
+      if: github.repository == 'Mudlet/Mudlet'
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - name: Get Azure access token for code signing
+      shell: pwsh
+      if: github.repository == 'Mudlet/Mudlet'
+      run: |
+        $token = (az account get-access-token --resource https://codesigning.azure.net | ConvertFrom-Json).accessToken
+        "::add-mask::$token"
+        "AZURE_ACCESS_TOKEN=$token" | Add-Content -Path $env:GITHUB_ENV
 
     - name: (Windows) Deploy
       shell: msys2 {0}

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -39,11 +39,11 @@ jobs:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
     - name: Get Azure access token for code signing
+      shell: pwsh
       run: |
-        token=$(az account get-access-token --resource https://codesigning.azure.net)
-        echo "::add-mask::$token"
-        echo "AZURE_ACCESS_TOKEN=$token" >> $GITHUB_ENV
-
+        $token = (az account get-access-token --resource https://codesigning.azure.net | ConvertFrom-Json).accessToken
+        "::add-mask::$token"
+        "AZURE_ACCESS_TOKEN=$token" | Add-Content -Path $env:GITHUB_ENV
 
     - name: (Windows 64) Setup MSYS2
       if: matrix.buildname == 'windows64'

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -38,12 +38,8 @@ jobs:
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-    - name: Azure CLI script
-      uses: azure/cli@v2
-      with:
-        azcliversion: latest
-        inlineScript: |
-          az account show
+    - name: Confirm Azure account
+      run: az account show
 
     - name: (Windows 64) Setup MSYS2
       if: matrix.buildname == 'windows64'
@@ -58,6 +54,10 @@ jobs:
       with:
         msystem: MINGW32
         update: true
+
+    - name: Confirm Azure account in msys2
+      shell: msys2 {0}
+      run: az account show
 
     - name: (Windows) Build Environment Setup
       shell: msys2 {0}

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -33,6 +33,11 @@ jobs:
       with:
         submodules: true
         fetch-depth: 0
+        
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
 
     - name: (Windows 64) Setup MSYS2
       if: matrix.buildname == 'windows64'

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -255,7 +255,7 @@ else
         --keystore eus.codesigning.azure.net \
         --storepass ${AZURE_ACCESS_TOKEN} \
         --alias Mudlet/Mudlet \
-        "$PACKAGE_DIR/Mudlet PTB.exe"
+        "$(cygpath -w "$PACKAGE_DIR/Mudlet PTB.exe")"
   else
     java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
       --keystore eus.codesigning.azure.net \

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -173,6 +173,7 @@ else
     echo "=== Creating a public test build ==="
     # Squirrel uses Start menu name from the binary, renaming it
     mv "$PACKAGE_DIR/mudlet.exe" "$PACKAGE_DIR/Mudlet PTB.exe"
+    echo "moved mudlet.exe to $PACKAGE_DIR/Mudlet PTB.exe"
     # ensure sha part always starts with a character due to a known issue
     VersionAndSha="${VERSION}-ptb-${BUILD_COMMIT}"
 

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -245,8 +245,8 @@ else
   fi
 
   echo "=== Setting up Java 21 for signing ==="
-  JAVA_HOME="C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\21.0.5-11.0\x64"
-  PATH="$JAVA_HOME\bin:$PATH"
+  export JAVA_HOME="$(cygpath -u $JAVA_HOME_21_X64)"
+  export PATH="$JAVA_HOME/bin:$PATH"
 
   echo "=== Signing Mudlet.exe ==="
   java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -244,9 +244,11 @@ else
     exit 4
   fi
 
-  # sign Mudlet.exe
+  echo "=== Setting up Java 21 for signing ==="
+  JAVA_HOME="C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\21.0.5-11.0\x64"
+  PATH="$JAVA_HOME\bin:$PATH"
+
   echo "=== Signing Mudlet.exe ==="
-  JAVA_HOME="$JAVA_HOME_21_X64"
   java -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
       --keystore eus.codesigning.azure.net \
       --storepass ${AZURE_ACCESS_TOKEN} \

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -203,13 +203,20 @@ else
         --keystore eus.codesigning.azure.net \
         --storepass ${AZURE_ACCESS_TOKEN} \
         --alias Mudlet/Mudlet \
-        "$(cygpath -w "$PACKAGE_DIR/Mudlet PTB.exe")"
+        "$PACKAGE_DIR/**/*.dll"
+
   else
     java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
       --keystore eus.codesigning.azure.net \
       --storepass ${AZURE_ACCESS_TOKEN} \
       --alias Mudlet/Mudlet \
-      $PACKAGE_DIR/Mudlet.exe
+      "$PACKAGE_DIR/Mudlet.exe"
+    
+    java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
+      --keystore eus.codesigning.azure.net \
+      --storepass ${AZURE_ACCESS_TOKEN} \
+      --alias Mudlet/Mudlet \
+      "$PACKAGE_DIR/**/*.dll"
   fi
 
   echo "=== Installing Squirrel for Windows ==="

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -254,7 +254,7 @@ else
         --keystore eus.codesigning.azure.net \
         --storepass ${AZURE_ACCESS_TOKEN} \
         --alias Mudlet/Mudlet \
-        $PACKAGE_DIR/Mudlet PTB.exe
+        "$PACKAGE_DIR/Mudlet PTB.exe"
   else
     java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
       --keystore eus.codesigning.azure.net \

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -249,7 +249,7 @@ else
   PATH="$JAVA_HOME\bin:$PATH"
 
   echo "=== Signing Mudlet.exe ==="
-  java -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
+  java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
       --keystore eus.codesigning.azure.net \
       --storepass ${AZURE_ACCESS_TOKEN} \
       --alias Mudlet/Mudlet \
@@ -272,7 +272,7 @@ else
 
   # Sign the final installer
   echo "=== Signing installer ==="
-  java -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
+  java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
       --keystore eus.codesigning.azure.net \
       --storepass ${AZURE_ACCESS_TOKEN} \
       --alias Mudlet/Mudlet \

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -197,14 +197,26 @@ else
         --keystore eus.codesigning.azure.net \
         --storepass ${AZURE_ACCESS_TOKEN} \
         --alias Mudlet/Mudlet \
-        "$PACKAGE_DIR/Mudlet PTB.exe" "$PACKAGE_DIR/**/*.dll"
+        "$PACKAGE_DIR/Mudlet PTB.exe"
+
+    java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
+        --keystore eus.codesigning.azure.net \
+        --storepass ${AZURE_ACCESS_TOKEN} \
+        --alias Mudlet/Mudlet \
+        "$PACKAGE_DIR/**/*.dll"
 
   else
     java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
       --keystore eus.codesigning.azure.net \
       --storepass ${AZURE_ACCESS_TOKEN} \
       --alias Mudlet/Mudlet \
-      "$PACKAGE_DIR/Mudlet.exe" "$PACKAGE_DIR/**/*.dll"
+      "$PACKAGE_DIR/Mudlet.exe"
+    
+    java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
+      --keystore eus.codesigning.azure.net \
+      --storepass ${AZURE_ACCESS_TOKEN} \
+      --alias Mudlet/Mudlet \
+      "$PACKAGE_DIR/**/*.dll"
   fi
 
   echo "=== Installing Squirrel for Windows ==="

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -197,26 +197,14 @@ else
         --keystore eus.codesigning.azure.net \
         --storepass ${AZURE_ACCESS_TOKEN} \
         --alias Mudlet/Mudlet \
-        "$PACKAGE_DIR/Mudlet PTB.exe"
-
-    java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
-        --keystore eus.codesigning.azure.net \
-        --storepass ${AZURE_ACCESS_TOKEN} \
-        --alias Mudlet/Mudlet \
-        "$PACKAGE_DIR/**/*.dll"
+        "$PACKAGE_DIR/Mudlet PTB.exe" "$PACKAGE_DIR/**/*.dll"
 
   else
     java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
       --keystore eus.codesigning.azure.net \
       --storepass ${AZURE_ACCESS_TOKEN} \
       --alias Mudlet/Mudlet \
-      "$PACKAGE_DIR/Mudlet.exe"
-    
-    java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
-      --keystore eus.codesigning.azure.net \
-      --storepass ${AZURE_ACCESS_TOKEN} \
-      --alias Mudlet/Mudlet \
-      "$PACKAGE_DIR/**/*.dll"
+      "$PACKAGE_DIR/Mudlet.exe" "$PACKAGE_DIR/**/*.dll"
   fi
 
   echo "=== Installing Squirrel for Windows ==="

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -297,7 +297,7 @@ else
       --keystore eus.codesigning.azure.net \
       --storepass ${AZURE_ACCESS_TOKEN} \
       --alias Mudlet/Mudlet \
-      $installerExePath
+      "$installerExePath"
 
   # Check if the setup executable exists
   if [[ ! -f "$installerExePath" ]]; then

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -187,6 +187,31 @@ else
   git clone https://github.com/Mudlet/installers.git -b azure-cloud-signing "$GITHUB_WORKSPACE/installers"
   cd "$GITHUB_WORKSPACE/installers/windows" || exit 1
 
+  echo "=== Setting up Java 21 for signing ==="
+  export JAVA_HOME="$(cygpath -u $JAVA_HOME_21_X64)"
+  export PATH="$JAVA_HOME/bin:$PATH"
+
+  echo "=== Signing Mudlet.exe ==="
+  if [[ "$PublicTestBuild" == "true" ]]; then
+    java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
+        --keystore eus.codesigning.azure.net \
+        --storepass ${AZURE_ACCESS_TOKEN} \
+        --alias Mudlet/Mudlet \
+        "$PACKAGE_DIR/Mudlet PTB.exe"
+
+    java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
+        --keystore eus.codesigning.azure.net \
+        --storepass ${AZURE_ACCESS_TOKEN} \
+        --alias Mudlet/Mudlet \
+        "$(cygpath -w "$PACKAGE_DIR/Mudlet PTB.exe")"
+  else
+    java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
+      --keystore eus.codesigning.azure.net \
+      --storepass ${AZURE_ACCESS_TOKEN} \
+      --alias Mudlet/Mudlet \
+      $PACKAGE_DIR/Mudlet.exe
+  fi
+
   echo "=== Installing Squirrel for Windows ==="
   nuget install squirrel.windows -ExcludeVersion
 
@@ -243,25 +268,6 @@ else
   if [[ ! -f "$nupkg_path" ]]; then
     echo "=== ERROR: nupkg doesn't exist as expected! Build aborted."
     exit 4
-  fi
-
-  echo "=== Setting up Java 21 for signing ==="
-  export JAVA_HOME="$(cygpath -u $JAVA_HOME_21_X64)"
-  export PATH="$JAVA_HOME/bin:$PATH"
-
-  echo "=== Signing Mudlet.exe ==="
-  if [[ "$PublicTestBuild" == "true" ]]; then
-    java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
-        --keystore eus.codesigning.azure.net \
-        --storepass ${AZURE_ACCESS_TOKEN} \
-        --alias Mudlet/Mudlet \
-        "$(cygpath -w "$PACKAGE_DIR/Mudlet PTB.exe")"
-  else
-    java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
-      --keystore eus.codesigning.azure.net \
-      --storepass ${AZURE_ACCESS_TOKEN} \
-      --alias Mudlet/Mudlet \
-      $PACKAGE_DIR/Mudlet.exe
   fi
 
   # Execute Squirrel to create the installer

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -246,6 +246,7 @@ else
 
   # sign Mudlet.exe
   echo "=== Signing Mudlet.exe ==="
+  JAVA_HOME="$JAVA_HOME_21_X64"
   java -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
       --keystore eus.codesigning.azure.net \
       --storepass ${AZURE_ACCESS_TOKEN} \

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -224,7 +224,7 @@ else
   # Create NuGet package
   nuget pack "$NuSpec" -Version "$VersionAndSha" -BasePath "$SQUIRRELWIN" -OutputDirectory "$SQUIRRELWIN"
 
-  echo "=== Creating installers from Nuget package ==="
+  echo "=== Preparing to create installer ==="
   if [[ "$PublicTestBuild" == "true" ]]; then
     TestBuildString="-PublicTestBuild"
     InstallerIconFile="$GITHUB_WORKSPACE/src/icons/mudlet_ptb.ico"
@@ -245,13 +245,16 @@ else
   fi
 
   # sign Mudlet.exe
+  echo "=== Signing Mudlet.exe ==="
   java -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
       --keystore eus.codesigning.azure.net \
       --storepass ${AZURE_ACCESS_TOKEN} \
       --alias Mudlet/Mudlet \
       $PACKAGE_DIR/Mudlet.exe
 
+
   # Execute Squirrel to create the installer
+  echo "=== Creating installers from Nuget package ==="
   ./squirrel.windows/tools/Squirrel --releasify "$nupkg_path" \
     --releaseDir "$GITHUB_WORKSPACE/squirreloutput" \
     --loadingGif "$GITHUB_WORKSPACE/installers/windows/splash-installing-2x.png" \
@@ -265,6 +268,7 @@ else
   mv "$GITHUB_WORKSPACE/squirreloutput/Setup.exe" "${installerExePath}"
 
   # Sign the final installer
+  echo "=== Signing installer ==="
   java -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
       --keystore eus.codesigning.azure.net \
       --storepass ${AZURE_ACCESS_TOKEN} \

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -191,7 +191,7 @@ else
   export JAVA_HOME="$(cygpath -u $JAVA_HOME_21_X64)"
   export PATH="$JAVA_HOME/bin:$PATH"
 
-  echo "=== Signing Mudlet.exe ==="
+  echo "=== Signing Mudlet and dll files ==="
   if [[ "$PublicTestBuild" == "true" ]]; then
     java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
         --keystore eus.codesigning.azure.net \

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -249,12 +249,19 @@ else
   export PATH="$JAVA_HOME/bin:$PATH"
 
   echo "=== Signing Mudlet.exe ==="
-  java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
+  if [[ "$PublicTestBuild" == "true" ]]; then
+    java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
+        --keystore eus.codesigning.azure.net \
+        --storepass ${AZURE_ACCESS_TOKEN} \
+        --alias Mudlet/Mudlet \
+        $PACKAGE_DIR/Mudlet PTB.exe
+  else
+    java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
       --keystore eus.codesigning.azure.net \
       --storepass ${AZURE_ACCESS_TOKEN} \
       --alias Mudlet/Mudlet \
       $PACKAGE_DIR/Mudlet.exe
-
+  fi
 
   # Execute Squirrel to create the installer
   echo "=== Creating installers from Nuget package ==="

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -297,7 +297,7 @@ else
       --keystore eus.codesigning.azure.net \
       --storepass ${AZURE_ACCESS_TOKEN} \
       --alias Mudlet/Mudlet \
-      "$installerExePath"
+      $installerExePath
 
   # Check if the setup executable exists
   if [[ ! -f "$installerExePath" ]]; then


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Sign windows builds using Azure Trusted Signing, replacing the .p12 certificate used previously - according to the new industry practices.
#### Motivation for adding to Mudlet
Secure deployment of Mudlet on Windows
#### Other info (issues closed, discussion etc)
