### PR TITLE
Add: enhance CLI profile handling with environment variable support

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -455,7 +455,21 @@ int main(int argc, char* argv[])
 #endif
 #endif
 
-    const QStringList cliProfiles = parser.values(profileToOpen);
+    QStringList cliProfiles = parser.values(profileToOpen);
+    qDebug() << "Got CLI profiles:" << cliProfiles;
+    
+    if (cliProfiles.isEmpty()) {
+        qDebug() << "No CLI profiles specified, checking environment variable";
+        const QString envProfiles = QString::fromLocal8Bit(qgetenv("MUDLET_PROFILES"));
+        qDebug() << "Environment MUDLET_PROFILES value:" << envProfiles;
+        if (!envProfiles.isEmpty()) {
+            qDebug() << "Found environment profiles, splitting on ':'";
+            // : is not an allowed character in a profile name, so we can use it to split the list
+            cliProfiles = envProfiles.split(':');
+            qDebug() << "Final profile list from environment:" << cliProfiles;
+        }
+    }
+
     const QStringList onlyProfiles = parser.values(onlyPredefinedProfileToShow);
     
     const bool showSplash = parser.isSet(showSplashscreen);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Enable `MUDLET_PROFILES` environment variable to be used to load profiles on start. Multiple profiles can be given using a `:` (which is not allowed in profile names).

Example:

```
MUDLET_PROFILES="Achaea:Lusternia" ./mudlet
```
#### Motivation for adding to Mudlet
Enable global installer to launch Mudlet asap for a specific game
#### Other info (issues closed, discussion etc)
