### PR TITLE
Fix: prevent crash with empty theme details in game save

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -895,8 +895,21 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
 void dlgTriggerEditor::slot_editorThemeChanged()
 {
+    auto pEdbee = edbee::Edbee::instance();
+    edbee::TextThemeManager* pThemeManager = nullptr;
+    edbee::TextTheme* pTheme = nullptr;
+    if (pEdbee) {
+        pThemeManager = pEdbee->themeManager();
+        if (pThemeManager) {
+            pTheme = pThemeManager->theme(mpHost->mEditorTheme);
+        }
+    }
+    if (!pTheme) {
+        qDebug().noquote().nospace() << "dlgTriggerEditor::slot_editorThemeChanged() WARNING - no valid theme set falling back to built-in \"Mudlet\" one.";
+    }
+
     for (int i = 0; i < 50; i++) {
-        mTriggerPatternEdit.at(i)->singleLineTextEdit_pattern->setTheme(mpHost->mEditorTheme);
+        mTriggerPatternEdit.at(i)->singleLineTextEdit_pattern->setTheme(pTheme ? mpHost->mEditorTheme : qsl("Mudlet"));
     }
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3725,7 +3725,7 @@ QString mudlet::getMudletPath(const mudletPathType mode, const QString& extra1, 
     case editorWidgetThemePathFile:
         // Takes two extra arguments (profile name, theme name) that returns the
         // pathFileName of the theme file used by the edbee editor - also
-        // handles the special case of the default theme "mudlet.tmTheme" that
+        // handles the special case of the default theme "Mudlet.tmTheme" that
         // is carried internally in the resource file:
         if (extra1.compare(qsl("Mudlet.tmTheme"), Qt::CaseSensitive)) {
             // No match

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -215,7 +215,7 @@ public:
         profileLogErrorsFilePath,
         // Takes two extra arguments (profile name, theme name) that returns the
         // pathFileName of the theme file used by the edbee editor - also
-        // handles the special case of the default theme "mudlet.thTheme" that
+        // handles the special case of the default theme "Mudlet.tmTheme" that
         // is carried internally in the resource file:
         editorWidgetThemePathFile,
         // Returns the pathFileName to the external JSON file needed to process


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Checks that `dlgTriggerEditor::slot_editorThemeChanged()` is invoked with a valid theme set up and to fall-back to the built in "Mudlet" one if it isn't.

#### Motivation for adding to Mudlet
Prevent crashes caused by faulty saved games where the editor theme settings held as "attributes" in the `<Host >` element of the XML file (`mEditorTheme` and `mEditorThemeFile`) were empty strings. The mechanism that caused this on my PC is not clear but it is worth preventing it causing problems for other users should they get in the same state.

#### Other info (issues closed, discussion etc)
Ideally I would have liked to have put a `nullptr` check into `(void) SingleLineTextEdit::setTheme(const QString& themeName)` but I chose not to do so for two reasons:
1. Any error message would be spammed 50 times, once for each of the fifty trigger items in each trigger - whether used or not.
2. That file was put into Mudlet under unclear licensing terms (it has the GPL2+ header text but is missing the Copyright line of the original author, if I were to apply my Copyright for a contribution in that file it would look as though I authored the whole file - which is NOT the case!) Until this is cleared up I am reluctant to touch the file.

Also correct the text in a couple of comments that refer to the file name of the editor "Mudlet" theme we bundle within the application.