### PR TITLE
Fix: Single-click to clear mapper room selection 

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2969,10 +2969,34 @@ bool T2DMap::event(QEvent* event)
     return QWidget::event(event);
 }
 
+bool T2DMap::isClickInEmptySpace(const QPoint& pos) {
+    const float mx = (pos.x() / mRoomWidth) + mMapCenterX - (xspan / 2.0);
+    const float my = (yspan / 2.0) - (pos.y() / mRoomHeight) - mMapCenterY;
+
+    for (const auto& roomId : mpMap->mpRoomDB->getArea(mAreaID)->getAreaRooms()) {
+        TRoom* room = mpMap->mpRoomDB->getRoom(roomId);
+        if (!room) continue;
+
+        if (fabs(mx - room->x()) < mRoomWidth / 2.0 && fabs(my - room->y()) < mRoomHeight / 2.0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+
 void T2DMap::mousePressEvent(QMouseEvent* event)
 {
     if (!mpMap) {
         return;
+    }
+    if (event->button() == Qt::LeftButton) {
+        if (isClickInEmptySpace(event->pos())) {
+            mMultiSelectionSet.clear();
+            mMultiSelectionHighlightRoomId = 0;
+            update();
+            return;
+        }
     }
     mudlet::self()->activateProfile(mpHost);
     mNewMoveAction = true;

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -63,6 +63,7 @@ public:
     std::pair<bool, QString> setMapZoom(const qreal zoom, const int areaId = 0);
     void init();
     void paintEvent(QPaintEvent*) override;
+    bool isClickInEmptySpace(const QPoint& pos);
     void mousePressEvent(QMouseEvent*) override;
     void mouseDoubleClickEvent(QMouseEvent* event) override;
     bool event(QEvent* event) override;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Implemented functionality to clear the selection of rooms in the mapper when the user clicks in an empty space. To complement this added the method `isClickInEmptySpace` to detect whether a mouse click occurred in empty space. and also updated the `mousePressEvent` in `T2DMap` to clear room selections on single-click in empty space.

#### Motivation for adding to Mudlet
Improves the user experience by resolving  the inconvenience of needing multiple clicks to deselect rooms,
#### Other info (issues closed, discussion etc)

Closes #5094 
/claim #5094 
