### PR TITLE
improve "move to area" to preselect current shown area in combobox

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2904,7 +2904,7 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
         //add our actions
         QMapIterator<QString, QStringList> it2(mUserActions);
         auto mapper = new QSignalMapper(popup);
-        
+
         while (it2.hasNext()) {
             it2.next();
             QStringList actionInfo = it2.value();
@@ -4265,6 +4265,8 @@ void T2DMap::slot_setArea()
 
     set_room_area_dialog->show();
     set_room_area_dialog->raise();
+
+    arealist_combobox->setCurrentIndex(mpMap->mpMapper->getCurrentShownAreaIndex());
 }
 
 

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -134,6 +134,11 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
 
 }
 
+int dlgMapper::getCurrentShownAreaIndex()
+{
+    return comboBox_showArea->currentIndex();
+}
+
 void dlgMapper::updateAreaComboBox()
 {
     if (!mpMap) {

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -53,6 +53,7 @@ public:
     // The button is the goto source for this bit of information:
     bool isIn3DMode() const { return pushButton_3D->isDown(); }
     bool isFloatAndDockable() const;
+    int getCurrentShownAreaIndex();
 
 public slots:
     void slot_toggleRoundRooms(const bool);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
On the mapper, when right-click -> "move to area" is chosen it defaults to the first entry of areas.  This improvement now selects the current area shown in the mapper.

#### Motivation for adding to Mudlet
Better user experience.
/claim #5221

#### Other info (issues closed, discussion etc)
closes #5221 
