### PR TITLE
Fix: restore ability to load older profile versions

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1568,7 +1568,7 @@ void dlgConnectionProfiles::loadProfile(bool alsoConnect)
         return;
     }
 
-    Host *pHost = mudlet::self()->loadProfile(profile_name, alsoConnect);
+    Host *pHost = mudlet::self()->loadProfile(profile_name, alsoConnect, profile_history->currentData().toString());
 
     // overwrite the generic profile with user supplied name, url and login information
     if (pHost) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3957,7 +3957,7 @@ void mudlet::showChangelogIfUpdated()
 }
 #endif // INCLUDE_UPDATER
 
-Host* mudlet::loadProfile(const QString& profile_name, bool playOnline)
+Host* mudlet::loadProfile(const QString& profile_name, const bool playOnline, const QString& saveFileName)
 {
     Host* pHost = mHostManager.getHost(profile_name);
     if (pHost) {
@@ -3998,7 +3998,7 @@ Host* mudlet::loadProfile(const QString& profile_name, bool playOnline)
         preInstallPackages = true;
         pHost->mLoadedOk = true;
     } else {
-        QFile file(qsl("%1%2").arg(folder, entries.at(0)));
+        QFile file(qsl("%1%2").arg(folder, saveFileName.isEmpty() ? entries.at(0) : saveFileName));
         file.open(QFile::ReadOnly | QFile::Text);
         XMLimport importer(pHost);
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -350,7 +350,7 @@ public:
     // operating without either menubar or main toolbar showing.
     bool isControlsVisible() const;
     bool isGoingDown() { return mIsGoingDown; }
-    Host* loadProfile(const QString&, bool);
+    Host* loadProfile(const QString&, const bool, const QString& saveFileName = QString());
     bool loadReplay(Host*, const QString&, QString* pErrMsg = nullptr);
     bool loadWindowLayout();
     controlsVisibility menuBarVisibility() const { return mMenuBarVisibility; }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Ensures that the case where the profile to load is selected from the GUI dialogue passes the particular file that the user can select via that form is loaded rather than automatically loading the newest file that other uses of the profile loading code refactored by #7395 uses.

#### Motivation for adding to Mudlet
Fixes a bug introduced by the PR 7395.

#### Other info (issues closed, discussion etc)
This is obviously something that was not spotted when the original PR was "tested" - though to be honest it was something that the creator of that did seem to worry about:
> Unifying the duped logic was a bit intimidating seeing as most of those lines haven't been touched in a decade or so, but I tried to keep actual changes in what is being executed minimal. Though I did find a few things that were being done in only one branch but not the other, which seemed to me like they should have really been in both, and them not being so was a bug.