### PR TITLE
Fix: crash on empty theme file settings

### DIFF
--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -785,7 +785,13 @@ void XMLimport::readHost(Host* pHost)
     pHost->setUserDictionaryOptions(enableUserDictionary, useSharedDictionary);
     pHost->mMapperShowRoomBorders = readDefaultTrueBool(qsl("mMapperShowRoomBorders"));
     pHost->mEditorTheme = attributes().value(QLatin1String("mEditorTheme")).toString();
+    if (pHost->mEditorTheme.isEmpty()) {
+        pHost->mEditorTheme = qsl("Mudlet");
+    }
     pHost->mEditorThemeFile = attributes().value(QLatin1String("mEditorThemeFile")).toString();
+    if (pHost->mEditorThemeFile.isEmpty()) {
+        pHost->mEditorThemeFile = qsl("Mudlet.tmTheme");
+    }
     pHost->mThemePreviewItemID = attributes().value(QLatin1String("mThemePreviewItemID")).toInt();
     pHost->mThemePreviewType = attributes().value(QLatin1String("mThemePreviewType")).toString();
     pHost->setHaveColorSpaceId(attributes().value(QLatin1String("mSGRCodeHasColSpaceId")).toString() == QLatin1String("yes"));

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -785,11 +785,9 @@ void XMLimport::readHost(Host* pHost)
     pHost->setUserDictionaryOptions(enableUserDictionary, useSharedDictionary);
     pHost->mMapperShowRoomBorders = readDefaultTrueBool(qsl("mMapperShowRoomBorders"));
     pHost->mEditorTheme = attributes().value(QLatin1String("mEditorTheme")).toString();
-    if (pHost->mEditorTheme.isEmpty()) {
-        pHost->mEditorTheme = qsl("Mudlet");
-    }
     pHost->mEditorThemeFile = attributes().value(QLatin1String("mEditorThemeFile")).toString();
-    if (pHost->mEditorThemeFile.isEmpty()) {
+    if (pHost->mEditorTheme.isEmpty() || pHost->mEditorThemeFile.isEmpty()) {
+        pHost->mEditorTheme = qsl("Mudlet");
         pHost->mEditorThemeFile = qsl("Mudlet.tmTheme");
     }
     pHost->mThemePreviewItemID = attributes().value(QLatin1String("mThemePreviewItemID")).toInt();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix crash on empty theme file settings by assuming the default theme.
#### Motivation for adding to Mudlet
Closes https://github.com/Mudlet/Mudlet/issues/7557
#### Other info (issues closed, discussion etc)
An alternative to https://github.com/Mudlet/Mudlet/pull/7551 - this solution is more straightforward.