### PR TITLE
Fix: install Qt translations for Windows builds

### DIFF
--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -102,6 +102,7 @@ if [ "${MSYSTEM}" = "MINGW64" ]; then
       "mingw-w64-${BUILDCOMPONENT}-qt6-svg" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-speech" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-imageformats" \
+      "mingw-w64-${BUILDCOMPONENT}-qt6-translations" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-tools" \
       "mingw-w64-${BUILDCOMPONENT}-qt6-5compat" \
       "mingw-w64-${BUILDCOMPONENT}-angleproject" \
@@ -130,7 +131,8 @@ else
       "mingw-w64-${BUILDCOMPONENT}-qt5-speech" \
       "mingw-w64-${BUILDCOMPONENT}-qt5-imageformats" \
       "mingw-w64-${BUILDCOMPONENT}-qt5-winextras" \
-      "mingw-w64-${BUILDCOMPONENT}-qt5-tools"; then
+      "mingw-w64-${BUILDCOMPONENT}-qt5-tools" \
+      "mingw-w64-${BUILDCOMPONENT}-qt5-translations"; then
         break
     fi
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add missing Qt translation packages so they can be included in the Windows builds.

#### Motivation for adding to Mudlet
Needed for the Qt library code that produces texual output to be rendered into the end-users selected GUI language - this is separate from the translations for Mudlet's own code and is also needed for a complete localisation.

#### Other info (issues closed, discussion etc)
In https://github.com/Mudlet/Mudlet/issues/6604#issuecomment-2448655625 I made the observation that NO Qt translations were present in the builds, rather than just the Chinese ones that were missing from Qt 5.14 builds due to the now solved [QTBUG-88002](https://bugreports-test.qt.io/browse/QTBUG-88002).

This should close #6604.
