### PR TITLE
Add TRoomDB destructor to prevent memory leaks (#5897)

### DIFF
--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -46,6 +46,23 @@ TRoomDB::TRoomDB(TMap* pMap)
     addArea(-1, mpMap->getDefaultAreaName());
 }
 
+TRoomDB::~TRoomDB()
+{
+    // Delete all rooms
+    QList<TRoom*> const rPtrL = getRoomPtrList();
+    for (auto room : rPtrL) {
+        delete room;
+    }
+    rooms.clear();
+
+    // Delete all areas
+    QList<TArea*> const areaList = getAreaPtrList();
+    for (auto area : areaList) {
+        delete area;
+    }
+    areas.clear();
+}
+
 TRoom* TRoomDB::getRoom(int id)
 {
     if (id < 0) {

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -49,6 +49,7 @@ class TRoomDB
 
 public:
     explicit TRoomDB(TMap*);
+    ~TRoomDB();
 
     TRoom* getRoom(int id);
     TArea* getArea(int id);


### PR DESCRIPTION
Add TRoomDB destructor to prevent memory leaks (#5897)

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Added a destructor to TRoomDB that properly cleans up rooms and areas when profiles are closed, preventing memory leaks that were previously occurring.

#### Motivation for adding to Mudlet
Fixes memory leaks that occur when closing profiles, making the application more memory efficient.
/claim #5897

#### Other info (issues closed, discussion etc)
closes #5897