### PR TITLE
Fix: key down button to work as before (Revert "Add: Quick clear input-line functionality)

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -382,13 +382,7 @@ bool TCommandLine::event(QEvent* event)
 #endif
                 // If EXACTLY Down is pressed without modifiers (special case
                 // for macOs - also sets KeyPad modifier)
-                bool shouldClearInput = historyMove(MOVE_DOWN);
-
-                // If the user has pressed DOWN while in the middle of typing a command
-                // the command line should be cleared
-                if (shouldClearInput) {
-                    clear();
-                }
+                historyMove(MOVE_DOWN);
                 ke->accept();
                 return true;
             }
@@ -1123,16 +1117,11 @@ void TCommandLine::handleAutoCompletion()
 // cursor up/down: turns on autocompletion mode and cycles through all possible matches
 // In case nothing has been typed it cycles through the command history in
 // reverse order compared to cursor down.
-// If the user is currently typing in the command line, a DOWN key will indicate
-// that the input line should be cleared
 
-bool TCommandLine::historyMove(MoveDirection direction)
+void TCommandLine::historyMove(MoveDirection direction)
 {
-    bool shouldClearInput = false;
-    
     if (mHistoryList.empty()) {
-        // If the history is empty, we may still want to clear the input line...
-        return true;
+        return;
     }
     const int shift = (direction == MOVE_UP ? 1 : -1);
     if ((textCursor().selectedText().size() == toPlainText().size()) || (toPlainText().isEmpty()) || !mpHost->mHighlightHistory) {
@@ -1151,16 +1140,10 @@ bool TCommandLine::historyMove(MoveDirection direction)
             moveCursor(QTextCursor::End);
         }
     } else {
-        if (direction == MOVE_DOWN && !toPlainText().isEmpty()) {
-            shouldClearInput = true;
-        } else {
-            mAutoCompletionCount += shift;
-            handleAutoCompletion();
-        }
+        mAutoCompletionCount += shift;
+        handleAutoCompletion();
     }
     adjustHeight();
-
-    return shouldClearInput;
 }
 
 void TCommandLine::slot_clearSelection(bool yes)

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -105,7 +105,7 @@ private:
     void spellCheck();
     void fillSpellCheckList(QMouseEvent*, QMenu*);
     void handleTabCompletion(bool);
-    bool historyMove(MoveDirection);
+    void historyMove(MoveDirection);
     void enterCommand(QKeyEvent*);
     void processNormalKey(QEvent*);
     bool keybindingMatched(QKeyEvent*);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix key down button to work as before by reverting the recent quick button down functionality. Lets add it back when we iron it out, and not stress about it for the 4.19 release.

This reverts https://github.com/Mudlet/Mudlet/pull/7450
#### Motivation for adding to Mudlet
Fix issue discovered with it in https://discord.com/channels/283581582550237184/427919962561052673/1317858376209797171
#### Other info (issues closed, discussion etc)

