### PR TITLE
Fix: crash on installing packages on Windows/macOS

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -908,6 +908,7 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
     }
 
     if (mIsProfileLoadingSequence) {
+        // If we're inside of profile loading sequence modules might not be loaded yet, thus we can accidentally clear their contents
         return {false, filename_xml, qsl("profile loading is in progress")};
     }
 
@@ -922,6 +923,7 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
     }
 
     if (saveFolder.isEmpty() && saveName.isEmpty()) {
+        // This is likely to be the save as the profile is closed
         qDebug().noquote().nospace() << "Host::saveProfile(...) INFO - called with no saveFolder or saveName arguments for profile '" << mHostName
                                      << "' so assuming it is an end of session save and the TCommandLines' histories need saving...";
         emit signal_saveCommandLinesHistory();
@@ -940,10 +942,12 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
 
     auto watcher = new QFutureWatcher<void>;
     mModuleFuture = QtConcurrent::run([=]() {
+        // wait for the host xml to be ready before starting to sync modules
         waitForAsyncXmlSave();
         saveModules(saveName != qsl("autosave"));
     });
     connect(watcher, &QFutureWatcher<void>::finished, this, [=]() {
+        // reload, or queue module reload for when xml is ready
         if (syncModules) {
             reloadModules();
         }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -888,7 +888,6 @@ void Host::resetProfile_phase2()
 std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, const QString& saveName, bool syncModules)
 {
     QString directory_xml;
-
     if (saveFolder.isEmpty()) {
         directory_xml = mudlet::getMudletPath(mudlet::profileXmlFilesPath, getName());
     } else {
@@ -896,7 +895,6 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
     }
 
     QString filename_xml;
-
     if (saveName.isEmpty()) {
         filename_xml = qsl("%1/%2.xml").arg(directory_xml, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
     } else {
@@ -913,7 +911,6 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
     }
 
     const QDir dir_xml;
-
     if (!dir_xml.exists(directory_xml)) {
         dir_xml.mkpath(directory_xml);
     }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -887,69 +887,70 @@ void Host::resetProfile_phase2()
 // returns true+filepath if successful or false+error message otherwise
 std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, const QString& saveName, bool syncModules)
 {
-        QString directory_xml;
-        
+    QString directory_xml;
+
     if (saveFolder.isEmpty()) {
-                directory_xml = mudlet::getMudletPath(mudlet::profileXmlFilesPath, getName());
+        directory_xml = mudlet::getMudletPath(mudlet::profileXmlFilesPath, getName());
     } else {
-                directory_xml = saveFolder;
+        directory_xml = saveFolder;
     }
 
     QString filename_xml;
-        
+
     if (saveName.isEmpty()) {
-                filename_xml = qsl("%1/%2.xml").arg(directory_xml, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
+        filename_xml = qsl("%1/%2.xml").arg(directory_xml, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
     } else {
-                filename_xml = qsl("%1/%2.xml").arg(directory_xml, saveName);
+        filename_xml = qsl("%1/%2.xml").arg(directory_xml, saveName);
     }
 
     if (!mLoadedOk) {
-                return {false, filename_xml, qsl("profile was not loaded correctly to begin with")};
+        return {false, filename_xml, qsl("profile was not loaded correctly to begin with")};
     }
 
     if (mIsProfileLoadingSequence) {
-                return {false, filename_xml, qsl("profile loading is in progress")};
+        return {false, filename_xml, qsl("profile loading is in progress")};
     }
 
     const QDir dir_xml;
-        
+
     if (!dir_xml.exists(directory_xml)) {
-                dir_xml.mkpath(directory_xml);
+        dir_xml.mkpath(directory_xml);
     }
 
     if (currentlySavingProfile()) {
-                return {false, QString(), qsl("a save is already in progress")};
+        return {false, QString(), qsl("a save is already in progress")};
     }
 
     if (saveFolder.isEmpty() && saveName.isEmpty()) {
-                qDebug().noquote().nospace() << "Host::saveProfile(...) INFO - called with no saveFolder or saveName arguments for profile '"
-                                     << mHostName
+        qDebug().noquote().nospace() << "Host::saveProfile(...) INFO - called with no saveFolder or saveName arguments for profile '" << mHostName
                                      << "' so assuming it is an end of session save and the TCommandLines' histories need saving...";
         emit signal_saveCommandLinesHistory();
     }
 
-        auto writer = new XMLexport(this);
-        writers.insert(qsl("profile"), writer);
-        writer->exportHost(filename_xml);
-        mWritingHostAndModules = true;
+    auto writer = new XMLexport(this);
+    writers.insert(qsl("profile"), writer);
+    writer->exportHost(filename_xml);
+    mWritingHostAndModules = true;
 
-        // emit signal to notify the UI that the save button should get disabled momentarily
+    // emit signal to notify the UI that the save button should get disabled momentarily
+    // this needs to run after `writers` and `mWritingHostAndModules` have been set
+    // so that currentlySavingProfile() can check properly
     emit profileSaveStarted();
-        qApp->processEvents();
+    qApp->processEvents();
 
-        auto watcher = new QFutureWatcher<void>;
-        mModuleFuture = QtConcurrent::run([=]() {
-                waitForAsyncXmlSave();
-                saveModules(saveName != qsl("autosave"));
+    auto watcher = new QFutureWatcher<void>;
+    mModuleFuture = QtConcurrent::run([=]() {
+        waitForAsyncXmlSave();
+        saveModules(saveName != qsl("autosave"));
     });
-        connect(watcher, &QFutureWatcher<void>::finished, this, [=]() {
-                if (syncModules) {
-                        reloadModules();
+    connect(watcher, &QFutureWatcher<void>::finished, this, [=]() {
+        if (syncModules) {
+            reloadModules();
         }
-                mWritingHostAndModules = false;
+        mWritingHostAndModules = false;
     });
-        watcher->setFuture(mModuleFuture);
-        return {true, filename_xml, QString()};
+    watcher->setFuture(mModuleFuture);
+    return {true, filename_xml, QString()};
 }
 
 // exports without the host settings for some reason

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -887,67 +887,97 @@ void Host::resetProfile_phase2()
 // returns true+filepath if successful or false+error message otherwise
 std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, const QString& saveName, bool syncModules)
 {
+    qDebug() << "Starting saveProfile function";
     QString directory_xml;
+    qDebug() << "Declaring directory_xml";
+    
     if (saveFolder.isEmpty()) {
+        qDebug() << "saveFolder is empty, using default path";
         directory_xml = mudlet::getMudletPath(mudlet::profileXmlFilesPath, getName());
     } else {
+        qDebug() << "Using provided saveFolder:" << saveFolder;
         directory_xml = saveFolder;
     }
 
     QString filename_xml;
+    qDebug() << "Declaring filename_xml";
+    
     if (saveName.isEmpty()) {
+        qDebug() << "saveName is empty, generating timestamp-based filename";
         filename_xml = qsl("%1/%2.xml").arg(directory_xml, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
     } else {
+        qDebug() << "Using provided saveName:" << saveName;
         filename_xml = qsl("%1/%2.xml").arg(directory_xml, saveName);
     }
 
     if (!mLoadedOk) {
+        qDebug() << "Profile was not loaded correctly, returning false";
         return {false, filename_xml, qsl("profile was not loaded correctly to begin with")};
     }
 
     if (mIsProfileLoadingSequence) {
-        //If we're inside of profile loading sequence modules might not be loaded yet, thus we can accidentally clear their contents
+        qDebug() << "Profile loading in progress, returning false";
         return {false, filename_xml, qsl("profile loading is in progress")};
     }
 
     const QDir dir_xml;
+    qDebug() << "Created QDir object";
+    
     if (!dir_xml.exists(directory_xml)) {
+        qDebug() << "Creating directory:" << directory_xml;
         dir_xml.mkpath(directory_xml);
     }
 
     if (currentlySavingProfile()) {
+        qDebug() << "Save already in progress, returning false";
         return {false, QString(), qsl("a save is already in progress")};
     }
 
     if (saveFolder.isEmpty() && saveName.isEmpty()) {
-        // This is likely to be the save as the profile is closed
+        qDebug() << "End of session save detected, saving command line histories";
         qDebug().noquote().nospace() << "Host::saveProfile(...) INFO - called with no saveFolder or saveName arguments for profile '"
                                      << mHostName
                                      << "' so assuming it is an end of session save and the TCommandLines' histories need saving...";
         emit signal_saveCommandLinesHistory();
     }
 
+    qDebug() << "Creating XMLexport writer";
+    auto writer = new XMLexport(this);
+    qDebug() << "Inserting writer into writers map";
+    writers.insert(qsl("profile"), writer);
+    qDebug() << "Exporting host to XML file:" << filename_xml;
+    writer->exportHost(filename_xml);
+    qDebug() << "Setting mWritingHostAndModules to true";
+    mWritingHostAndModules = true;
+
+    qDebug() << "Emitting profileSaveStarted signal";
+    // emit signal to notify the UI that the save button should get disabled momentarily
     emit profileSaveStarted();
+    qDebug() << "Processing events";
     qApp->processEvents();
 
-    auto writer = new XMLexport(this);
-    writers.insert(qsl("profile"), writer);
-    writer->exportHost(filename_xml);
-    mWritingHostAndModules = true;
+    qDebug() << "Creating QFutureWatcher";
     auto watcher = new QFutureWatcher<void>;
+    qDebug() << "Starting concurrent module save operation";
     mModuleFuture = QtConcurrent::run([=]() {
-        //wait for the host xml to be ready before starting to sync modules
+        qDebug() << "Waiting for async XML save";
         waitForAsyncXmlSave();
+        qDebug() << "Saving modules";
         saveModules(saveName != qsl("autosave"));
     });
+    qDebug() << "Connecting watcher finished signal";
     connect(watcher, &QFutureWatcher<void>::finished, this, [=]() {
-        // reload, or queue module reload for when xml is ready
+        qDebug() << "Watcher finished signal received";
         if (syncModules) {
+            qDebug() << "Reloading modules";
             reloadModules();
         }
+        qDebug() << "Setting mWritingHostAndModules to false";
         mWritingHostAndModules = false;
     });
+    qDebug() << "Setting future to watcher";
     watcher->setFuture(mModuleFuture);
+    qDebug() << "Returning success";
     return {true, filename_xml, QString()};
 }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -887,98 +887,69 @@ void Host::resetProfile_phase2()
 // returns true+filepath if successful or false+error message otherwise
 std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, const QString& saveName, bool syncModules)
 {
-    qDebug() << "Starting saveProfile function";
-    QString directory_xml;
-    qDebug() << "Declaring directory_xml";
-    
+        QString directory_xml;
+        
     if (saveFolder.isEmpty()) {
-        qDebug() << "saveFolder is empty, using default path";
-        directory_xml = mudlet::getMudletPath(mudlet::profileXmlFilesPath, getName());
+                directory_xml = mudlet::getMudletPath(mudlet::profileXmlFilesPath, getName());
     } else {
-        qDebug() << "Using provided saveFolder:" << saveFolder;
-        directory_xml = saveFolder;
+                directory_xml = saveFolder;
     }
 
     QString filename_xml;
-    qDebug() << "Declaring filename_xml";
-    
+        
     if (saveName.isEmpty()) {
-        qDebug() << "saveName is empty, generating timestamp-based filename";
-        filename_xml = qsl("%1/%2.xml").arg(directory_xml, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
+                filename_xml = qsl("%1/%2.xml").arg(directory_xml, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
     } else {
-        qDebug() << "Using provided saveName:" << saveName;
-        filename_xml = qsl("%1/%2.xml").arg(directory_xml, saveName);
+                filename_xml = qsl("%1/%2.xml").arg(directory_xml, saveName);
     }
 
     if (!mLoadedOk) {
-        qDebug() << "Profile was not loaded correctly, returning false";
-        return {false, filename_xml, qsl("profile was not loaded correctly to begin with")};
+                return {false, filename_xml, qsl("profile was not loaded correctly to begin with")};
     }
 
     if (mIsProfileLoadingSequence) {
-        qDebug() << "Profile loading in progress, returning false";
-        return {false, filename_xml, qsl("profile loading is in progress")};
+                return {false, filename_xml, qsl("profile loading is in progress")};
     }
 
     const QDir dir_xml;
-    qDebug() << "Created QDir object";
-    
+        
     if (!dir_xml.exists(directory_xml)) {
-        qDebug() << "Creating directory:" << directory_xml;
-        dir_xml.mkpath(directory_xml);
+                dir_xml.mkpath(directory_xml);
     }
 
     if (currentlySavingProfile()) {
-        qDebug() << "Save already in progress, returning false";
-        return {false, QString(), qsl("a save is already in progress")};
+                return {false, QString(), qsl("a save is already in progress")};
     }
 
     if (saveFolder.isEmpty() && saveName.isEmpty()) {
-        qDebug() << "End of session save detected, saving command line histories";
-        qDebug().noquote().nospace() << "Host::saveProfile(...) INFO - called with no saveFolder or saveName arguments for profile '"
+                qDebug().noquote().nospace() << "Host::saveProfile(...) INFO - called with no saveFolder or saveName arguments for profile '"
                                      << mHostName
                                      << "' so assuming it is an end of session save and the TCommandLines' histories need saving...";
         emit signal_saveCommandLinesHistory();
     }
 
-    qDebug() << "Creating XMLexport writer";
-    auto writer = new XMLexport(this);
-    qDebug() << "Inserting writer into writers map";
-    writers.insert(qsl("profile"), writer);
-    qDebug() << "Exporting host to XML file:" << filename_xml;
-    writer->exportHost(filename_xml);
-    qDebug() << "Setting mWritingHostAndModules to true";
-    mWritingHostAndModules = true;
+        auto writer = new XMLexport(this);
+        writers.insert(qsl("profile"), writer);
+        writer->exportHost(filename_xml);
+        mWritingHostAndModules = true;
 
-    qDebug() << "Emitting profileSaveStarted signal";
-    // emit signal to notify the UI that the save button should get disabled momentarily
+        // emit signal to notify the UI that the save button should get disabled momentarily
     emit profileSaveStarted();
-    qDebug() << "Processing events";
-    qApp->processEvents();
+        qApp->processEvents();
 
-    qDebug() << "Creating QFutureWatcher";
-    auto watcher = new QFutureWatcher<void>;
-    qDebug() << "Starting concurrent module save operation";
-    mModuleFuture = QtConcurrent::run([=]() {
-        qDebug() << "Waiting for async XML save";
-        waitForAsyncXmlSave();
-        qDebug() << "Saving modules";
-        saveModules(saveName != qsl("autosave"));
+        auto watcher = new QFutureWatcher<void>;
+        mModuleFuture = QtConcurrent::run([=]() {
+                waitForAsyncXmlSave();
+                saveModules(saveName != qsl("autosave"));
     });
-    qDebug() << "Connecting watcher finished signal";
-    connect(watcher, &QFutureWatcher<void>::finished, this, [=]() {
-        qDebug() << "Watcher finished signal received";
-        if (syncModules) {
-            qDebug() << "Reloading modules";
-            reloadModules();
+        connect(watcher, &QFutureWatcher<void>::finished, this, [=]() {
+                if (syncModules) {
+                        reloadModules();
         }
-        qDebug() << "Setting mWritingHostAndModules to false";
-        mWritingHostAndModules = false;
+                mWritingHostAndModules = false;
     });
-    qDebug() << "Setting future to watcher";
-    watcher->setFuture(mModuleFuture);
-    qDebug() << "Returning success";
-    return {true, filename_xml, QString()};
+        watcher->setFuture(mModuleFuture);
+        return {true, filename_xml, QString()};
 }
 
 // exports without the host settings for some reason

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -933,7 +933,7 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
 
     // emit signal to notify the UI that the save button should get disabled momentarily
     // this needs to run after `writers` and `mWritingHostAndModules` have been set
-    // so that currentlySavingProfile() can check properly
+    // so that the currentlySavingProfile() check can run properly
     emit profileSaveStarted();
     qApp->processEvents();
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fixed a crash when installing packages on Windows/macOS
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/7255
#### Other info (issues closed, discussion etc)
It boils down to the issue of the 'are we saving a profile?' check being _before_ we have set 'we are saving a profile'. Now the check is correctly set afterwards.

Longer version:
Installing a package necessitated saving the profile - however, in the middle of the save profile operation, control was being returned back to the running code. The next step in installing a package that already existed was to uninstall it, which started the save profile operation for the second time - while the first save profile was still ongoing! 

This seems to have caused the issues. How, installing a package still saves the profile, but control is not returned to the running code until we have set the fact that we are now saving the profile. This means that when the second save profile operation is attempted to be during package uninstall, it doesn't go through, and we don't have two profile save operations happening in parallel.

