### PR TITLE
Infrastructure: Fix code signing to only run on the main repo

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -86,13 +86,13 @@ jobs:
 
     - name: (Windows) Login to Azure
       uses: azure/login@v2
-      if: ${{ github.event.pull_request.head.repo.full_name == 'Mudlet/Mudlet' }}
+      if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
     - name: Get Azure access token for code signing
       shell: pwsh
-      if: ${{ github.event.pull_request.head.repo.full_name == 'Mudlet/Mudlet' }}
+      if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
       run: |
         $token = (az account get-access-token --resource https://codesigning.azure.net | ConvertFrom-Json).accessToken
         "::add-mask::$token"


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix code signing to only run on the main repo - so far it either tried to run on forks or refused to run in the main repo.
#### Motivation for adding to Mudlet
Sign builds for Mudlet only when the Azure secret is available.
#### Other info (issues closed, discussion etc)
