### PR TITLE
Improve: more intuitive package exporter & remove required fields

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -357,16 +357,36 @@ void dlgPackageExporter::slot_updateLocationPlaceholder()
     ui->lineEdit_filePath->setPlaceholderText(path);
 }
 
-void dlgPackageExporter::checkToEnableExportButton()
+void dlgPackageExporter::checkToEnableExportButton() 
 {
-    if (ui->lineEdit_packageName->text().isEmpty() ||
-        ui->lineEdit_author->text().isEmpty() ||
-        ui->lineEdit_title->text().isEmpty() ||
-        ui->lineEdit_version->text().isEmpty() ||
-        ui->textEdit_description->toPlainText().isEmpty() || mExportingPackage) {
+    QStringList missingFields;
+    if (ui->lineEdit_packageName->text().isEmpty()) {
+        //: package name will be added to other fields in the 'required fields missing: ...' tooltip when it's missing
+        missingFields << tr("package name");
+    }
+    if (ui->lineEdit_author->text().isEmpty()) {
+        //: package author will be added to other fields in the 'required fields missing: ...' tooltip when it's missing
+        missingFields << tr("author"); 
+    }
+    if (ui->lineEdit_title->text().isEmpty()) {
+        //: package title will be added to other fields in the 'required fields missing: ...' tooltip when it's missing
+        missingFields << tr("title");
+    }
+    if (ui->lineEdit_version->text().isEmpty()) {
+        //: package version will be added to other fields in the 'required fields missing: ...' tooltip when it's missing
+        missingFields << tr("version");
+    }
+    if (ui->textEdit_description->toPlainText().isEmpty() || mExportingPackage) {
+        //: package description will be added to other fields in the 'required fields missing: ...' tooltip when it's missing
+        missingFields << tr("description");
+    }
+
+    if (!missingFields.isEmpty()) {
         mExportButton->setEnabled(false);
+        mExportButton->setToolTip(tr("Required fields missing: %1").arg(missingFields.join(qsl(", "))));
     } else {
-        mExportButton->setEnabled(true);
+        mExportButton->setEnabled(!mExportingPackage);
+        mExportButton->setToolTip(tr("Export package"));
     }
 }
 

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -364,26 +364,27 @@ void dlgPackageExporter::checkToEnableExportButton()
         //: package name will be added to other fields in the 'required fields missing: ...' tooltip when it's missing
         missingFields << tr("package name");
     }
-    if (ui->lineEdit_author->text().isEmpty()) {
-        //: package author will be added to other fields in the 'required fields missing: ...' tooltip when it's missing
-        missingFields << tr("author"); 
-    }
-    if (ui->lineEdit_title->text().isEmpty()) {
-        //: package title will be added to other fields in the 'required fields missing: ...' tooltip when it's missing
-        missingFields << tr("title");
-    }
-    if (ui->lineEdit_version->text().isEmpty()) {
-        //: package version will be added to other fields in the 'required fields missing: ...' tooltip when it's missing
-        missingFields << tr("version");
-    }
-    if (ui->textEdit_description->toPlainText().isEmpty() || mExportingPackage) {
-        //: package description will be added to other fields in the 'required fields missing: ...' tooltip when it's missing
-        missingFields << tr("description");
-    }
+    // intentionally disabled for now until mpkg gains wider adoption
+    // if (ui->lineEdit_author->text().isEmpty()) {
+    //     //: package author will be added to other fields in the 'required fields missing: ...' tooltip when it's missing
+    //     missingFields << tr("author");
+    // }
+    // if (ui->lineEdit_title->text().isEmpty()) {
+    //     //: package title will be added to other fields in the 'required fields missing: ...' tooltip when it's missing
+    //     missingFields << tr("title");
+    // }
+    // if (ui->lineEdit_version->text().isEmpty()) {
+    //     //: package version will be added to other fields in the 'required fields missing: ...' tooltip when it's missing
+    //     missingFields << tr("version");
+    // }
+    // if (ui->textEdit_description->toPlainText().isEmpty() || mExportingPackage) {
+    //     //: package description will be added to other fields in the 'required fields missing: ...' tooltip when it's missing
+    //     missingFields << tr("description");
+    // }
 
     if (!missingFields.isEmpty()) {
         mExportButton->setEnabled(false);
-        mExportButton->setToolTip(tr("Required fields missing: %1").arg(missingFields.join(qsl(", "))));
+        mExportButton->setToolTip(tr("Required field missing: %1").arg(missingFields.join(qsl(", "))));
     } else {
         mExportButton->setEnabled(!mExportingPackage);
         mExportButton->setToolTip(tr("Export package"));

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -142,7 +142,9 @@ dlgPackageExporter::dlgPackageExporter(QWidget *parent, Host* pHost)
     // Set the previous details if saved
     QSettings settings("mudlet", "Mudlet");
     auto packageAuthor = settings.value(qsl("packageAuthor"), QString()).toString();
-    ui->lineEdit_author->setText(packageAuthor);
+    if (!packageAuthor.isEmpty()) {
+        ui->lineEdit_author->setText(packageAuthor);
+    }
 
     // Ensure this dialog goes away if the Host (profile) is closed while we are
     // open - as this is parented to the mudlet instance rather than the Host

--- a/src/ui/dlgPackageExporter.ui
+++ b/src/ui/dlgPackageExporter.ui
@@ -172,7 +172,7 @@
               <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
              <property name="placeholderText">
-              <string>(required)</string>
+              <string>(recommended)</string>
              </property>
             </widget>
            </item>
@@ -265,7 +265,7 @@
               <number>140</number>
              </property>
              <property name="placeholderText">
-              <string>one-line description (required)</string>
+              <string>one-line description (recommended)</string>
              </property>
             </widget>
            </item>
@@ -286,7 +286,7 @@
               <bool>true</bool>
              </property>
              <property name="text">
-              <string>(required)
+              <string>(recommended)
 
 This package description is shown in the package manager.  The editor supports Commonmark markdown.  Follow the description below for a thorough example of what to include in your package description.
 
@@ -327,7 +327,7 @@ Further reading material. e.g. a link to the Mudlet wiki, forums, Github package
            <item row="4" column="1">
             <widget class="QLineEdit" name="lineEdit_version">
              <property name="placeholderText">
-              <string>(required)</string>
+              <string>(recommended)</string>
              </property>
             </widget>
            </item>

--- a/src/ui/dlgPackageExporter.ui
+++ b/src/ui/dlgPackageExporter.ui
@@ -59,7 +59,7 @@
       </sizepolicy>
      </property>
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <widget class="QGroupBox" name="groupBox_exportSelection">
       <property name="title">
@@ -94,16 +94,16 @@
        </sizepolicy>
       </property>
       <property name="frameShape">
-       <enum>QFrame::StyledPanel</enum>
+       <enum>QFrame::Shape::StyledPanel</enum>
       </property>
       <property name="frameShadow">
-       <enum>QFrame::Raised</enum>
+       <enum>QFrame::Shadow::Raised</enum>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
         <widget class="QPushButton" name="pushButton_openInfos">
          <property name="focusPolicy">
-          <enum>Qt::TabFocus</enum>
+          <enum>Qt::FocusPolicy::TabFocus</enum>
          </property>
          <property name="text">
           <string>Describe your package. Add a description, icons, assets and more.</string>
@@ -128,7 +128,7 @@
           </sizepolicy>
          </property>
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <widget class="QWidget" name="widget_optionalsForm" native="true">
           <property name="sizePolicy">
@@ -169,10 +169,10 @@
               </sizepolicy>
              </property>
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
              <property name="placeholderText">
-              <string>For attribution, displayed in the Package Manager. Required.</string>
+              <string>(required)</string>
              </property>
             </widget>
            </item>
@@ -265,14 +265,15 @@
               <number>140</number>
              </property>
              <property name="placeholderText">
-              <string>One-line package description shown in the Package Manager. Required.</string>
+              <string>one-line description (required)</string>
              </property>
             </widget>
            </item>
            <item row="3" column="0">
             <widget class="QLabel" name="label_detailedDescription">
              <property name="text">
-              <string>Description</string>
+              <string>Description
+(e.g. how to use)</string>
              </property>
              <property name="buddy">
               <cstring>textEdit_description</cstring>
@@ -284,8 +285,9 @@
              <property name="tabChangesFocus">
               <bool>true</bool>
              </property>
-             <property name="text">
-              <string>
+             <property name="text" stdset="0">
+              <string>(required)
+
 This package description is shown in the package manager.  The editor supports Commonmark markdown.  Follow the description below for a thorough example of what to include in your package description.
 
 ### Description
@@ -296,7 +298,7 @@ A full description of what this package achieves. If the package is game specifi
 
 If this package uses aliases, show a few examples and expected output.
 
-`> alias_1`
+`&gt; alias_1`
 
     output of alias_1  -- indent by four spaces
     more output        -- for code blocks
@@ -325,7 +327,7 @@ Further reading material. e.g. a link to the Mudlet wiki, forums, Github package
            <item row="4" column="1">
             <widget class="QLineEdit" name="lineEdit_version">
              <property name="placeholderText">
-              <string>Version number. Required.</string>
+              <string>(required)</string>
              </property>
             </widget>
            </item>
@@ -373,7 +375,7 @@ Further reading material. e.g. a link to the Mudlet wiki, forums, Github package
                 </property>
                </widget>
               </item>
-              <item alignment="Qt::AlignHCenter">
+              <item alignment="Qt::AlignmentFlag::AlignHCenter">
                <widget class="QPushButton" name="addDependency">
                 <property name="enabled">
                  <bool>true</bool>
@@ -460,7 +462,7 @@ Further reading material. e.g. a link to the Mudlet wiki, forums, Github package
               <item>
                <spacer name="horizontalSpacer_2">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -479,7 +481,7 @@ Further reading material. e.g. a link to the Mudlet wiki, forums, Github package
                  </sizepolicy>
                 </property>
                 <property name="layoutDirection">
-                 <enum>Qt::LeftToRight</enum>
+                 <enum>Qt::LayoutDirection::LeftToRight</enum>
                 </property>
                 <property name="text">
                  <string>Select files to include in package</string>
@@ -489,7 +491,7 @@ Further reading material. e.g. a link to the Mudlet wiki, forums, Github package
               <item>
                <spacer name="horizontalSpacer">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -550,7 +552,7 @@ Further reading material. e.g. a link to the Mudlet wiki, forums, Github package
       <string/>
      </property>
      <property name="alignment">
-      <set>Qt::AlignCenter</set>
+      <set>Qt::AlignmentFlag::AlignCenter</set>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -560,7 +562,7 @@ Further reading material. e.g. a link to the Mudlet wiki, forums, Github package
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Close</set>
+      <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Close</set>
      </property>
     </widget>
    </item>

--- a/src/ui/dlgPackageExporter.ui
+++ b/src/ui/dlgPackageExporter.ui
@@ -285,7 +285,7 @@
              <property name="tabChangesFocus">
               <bool>true</bool>
              </property>
-             <property name="text" stdset="0">
+             <property name="text">
               <string>(required)
 
 This package description is shown in the package manager.  The editor supports Commonmark markdown.  Follow the description below for a thorough example of what to include in your package description.

--- a/src/ui/dlgPackageExporter.ui
+++ b/src/ui/dlgPackageExporter.ui
@@ -326,6 +326,9 @@ Further reading material. e.g. a link to the Mudlet wiki, forums, Github package
            </item>
            <item row="4" column="1">
             <widget class="QLineEdit" name="lineEdit_version">
+             <property name="text">
+              <string>1</string>
+             </property>
              <property name="placeholderText">
               <string>(recommended)</string>
              </property>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
A few improvements to make the package manager more intuitive, collaborated with @ZookaOnGit:
* show a tooltip for which fields are missing when exporting a package
* shorten field placeholders so you can tell which fields are required
* don't clear author placeholder if the author name is empty
* don't require package author, short description, usage field or version - this makes packages still "easy" to export
#### Motivation for adding to Mudlet
Better user experience
#### Other info (issues closed, discussion etc)
How it looks like now:
[Screencast from 2024-12-23 07-15-58.webm](https://github.com/user-attachments/assets/994b5c62-0614-43cd-b51a-7e9a13365408)
