### PR TITLE
Infrastructure: rename MUDLET_SANITIZIER variable back to USE_SANITIZER

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -306,6 +306,7 @@ jobs:
           -G Ninja
           -DCMAKE_PREFIX_PATH=${{ env.QT_PREFIX != '' && env.QT_PREFIX || env.MINGW_BASE_DIR }}
           -DVCPKG_APPLOCAL_DEPS=OFF
+          -DMUDLET_SANITIZIER=""
       env:
         NINJA_STATUS: '[%f/%t %o/sec] '
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -306,7 +306,7 @@ jobs:
           -G Ninja
           -DCMAKE_PREFIX_PATH=${{ env.QT_PREFIX != '' && env.QT_PREFIX || env.MINGW_BASE_DIR }}
           -DVCPKG_APPLOCAL_DEPS=OFF
-          -DMUDLET_SANITIZIER=""
+          -DUSE_SANITIZER=""
       env:
         NINJA_STATUS: '[%f/%t %o/sec] '
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -404,13 +404,13 @@ include(../3rdparty/cmake-scripts/sanitizers.cmake)
 set_sanitizer_options(address DEFAULT -fno-omit-frame-pointer)
 set_sanitizer_options(thread DEFAULT -fno-omit-frame-pointer)
 
-set(MUDLET_SANITIZER
+set(USE_SANITIZER
       "address"
       CACHE STRING
       "Compile with sanitizers. Available sanitizers are: Address, Memory, MemoryWithOrigins, Undefined, Thread, or Leak")
 
-add_sanitizer_support(${MUDLET_SANITIZER})
-message(STATUS "Compiling with the following sanitizer(s) enabled: ${MUDLET_SANITIZER}")
+add_sanitizer_support(${USE_SANITIZER})
+message(STATUS "Compiling with the following sanitizer(s) enabled: ${USE_SANITIZER}")
 
 
 if(WITH_QT6)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Rename MUDLET_SANITIZIER variable back to USE_SANITIZER
#### Motivation for adding to Mudlet
Alignment with other `USE_` settings, see 
![image](https://github.com/user-attachments/assets/b2fcbc4e-fb1e-4c3a-b228-3d1c64e60934)

#### Other info (issues closed, discussion etc)
See https://github.com/google/sanitizers/wiki/AddressSanitizer