### PR TITLE
Improve: update minimum CMake version to 3.25.1 (try 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@
 ############################################################################
 
 # Should be called before PROJECT.
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.25.1)
 
 if(APPLE)
   # needed for fetching Sparkle

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -517,6 +517,11 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 add_executable(mudlet ${mudlet_SRCS} ${mudlet_RCCS} ${mudlet_HDRS} ${mudlet_UIS})
 
+# Enable symbol exports from the main executable so that dynamically loaded Lua modules
+# can find and use Lua API symbols (like lua_gettop) at runtime. Without this, modules
+# will fail to load with "undefined symbol" errors.
+set_target_properties(mudlet PROPERTIES ENABLE_EXPORTS ON)
+
 ########################### Debugging code inclusions ##########################
 # Controls the include/selection of extra code to aide developers debug various
 # features of Mudlet, generally speaking they will not be '#define'd in


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Alternative PR to https://github.com/Mudlet/Mudlet/pull/7287 to investigate why is raising the minimum cmake version breaking loading of Lua modules.
#### Motivation for adding to Mudlet
Original https://github.com/Mudlet/Mudlet/pull/7287 is breaking on a weird thing - Mudlet compiles fine, but the Lua modules fail to load:

```
ain| [ ERROR ] - 
main| Cannot find Lua module lfs (Lua File System).

main|             Lua error: error loading module 'lfs' from file '/home/runner/.luarocks/lib/lua/5.1/lfs.so':
                    /home/runner/.luarocks/lib/lua/5.1/lfs.so: undefined symbol: lua_gettop
            Probably will not be able to access Mudlet Lua code.

main| [ ERROR ] - 
main| Cannot find Lua module lua-zip.

main|             Lua error: error loading module 'brimworks.zip' from file '/home/runner/.luarocks/lib/lua/5.1/brimworks/zip.so':
                    /home/runner/.luarocks/lib/lua/5.1/brimworks/zip.so: undefined symbol: lua_gettop

main| [ ERROR ] - 
main| Cannot find Lua module luazip.
```
#### Other info (issues closed, discussion etc)
