### PR TITLE
infrastructure: set cmake and codeql cmake version to 3.30

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -97,9 +97,8 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         queries: security-extended, security-and-quality
 
-    # workaround a poor interaction between github actions/cmake/vcpkg, see https://github.com/lukka/run-vcpkg/issues/88#issuecomment-885758902
-    - name: Use CMake 3.20.1
-      uses: lukka/get-cmake@v3.20.1
+    - name: Use CMake 3.30.3
+      uses: lukka/get-cmake@v3.30.3
 
     - name: (Linux) Install non-vcpkg dependencies (1/2)
       if: runner.os == 'Linux'

--- a/.github/workflows/performance-analysis.yml
+++ b/.github/workflows/performance-analysis.yml
@@ -27,6 +27,9 @@ jobs:
         fetch-depth: 0
         submodules: true
 
+    - name: Use CMake 3.30.3
+      uses: lukka/get-cmake@v3.30.3
+
       # run-vcpkg action does not run on arm64 (https://github.com/lukka/run-vcpkg/issues/152)
       # so install dependencies manually
     - name: Install dependencies


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Set cmake and codeql cmake version to 3.30
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/actions/runs/12493902794/job/34862921976 and https://github.com/Mudlet/Mudlet/actions/runs/12493902793/job/34862922280
#### Other info (issues closed, discussion etc)
