### PR TITLE
Infrastructure: add retry logic for notarization in macOS CI script

### DIFF
--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -8,7 +8,12 @@ sign_and_notarize () {
   codesign --deep -o runtime -s "$IDENTITY" "${appBundle}"
   echo "Signed final .dmg"
 
-  xcrun notarytool submit "${appBundle}" --apple-id "$APPLE_USERNAME" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
+  for i in {1..3}; do
+    echo "Trying to notarize (attempt ${i})"
+    if xcrun notarytool submit "${appBundle}" --apple-id "$APPLE_USERNAME" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait; then
+      break
+    fi
+  done
 }
 
 BUILD_DIR="${BUILD_FOLDER}"


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
add retry logic for notarization in macOS CI script, as we used to have it before with `gon`.
#### Motivation for adding to Mudlet
Apple infrastructure is flakey and sometimes fails notarization.
#### Other info (issues closed, discussion etc)
