### PR TITLE
Improve: Add tags to profiles, for filtering, sorting, and organization

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5465,6 +5465,10 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "holdingModifiers", TLuaInterpreter::holdingModifiers);
     lua_register(pGlobalLua, "getProfiles", TLuaInterpreter::getProfiles);
     lua_register(pGlobalLua, "loadProfile", TLuaInterpreter::loadProfile);
+    lua_register(pGlobalLua, "addTag", TLuaInterpreter::addTag);
+    lua_register(pGlobalLua, "clearTags", TLuaInterpreter::addTag);
+    lua_register(pGlobalLua, "getTags", TLuaInterpreter::getTags);
+    lua_register(pGlobalLua, "removeTag", TLuaInterpreter::removeTag);
     // PLACEMARKER: End of main Lua interpreter functions registration
     // check new functions against https://www.linguistic-antipatterns.com when creating them
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -671,6 +671,10 @@ public:
     static int holdingModifiers(lua_State*);
     static int getProfiles(lua_State*);
     static int loadProfile(lua_State*);
+    static int addTag(lua_State*);
+    static int clearTags(lua_State*);
+    static int getTags(lua_State*);
+    static int removeTag(lua_State*);
     // PLACEMARKER: End of Lua functions declarations
     // check new functions against https://www.linguistic-antipatterns.com when creating them
 

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -2806,4 +2806,4 @@ int TLuaInterpreter::removeTag(lua_State* L)
     }
 
     return 1;
-}  
+}

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -2738,7 +2738,13 @@ int TLuaInterpreter::addTag(lua_State* L)
     if (!result.first) {
         return warnArgumentValue(L, __func__, qsl("unable to add tag, reason: %1").arg(result.second));
     }
-    lua_pushboolean(L, true);
+
+    lua_newtable(L);
+    int tagIndex = 1;
+    for (const QString &tag : tagString.split(",")) {
+        lua_pushstring(L, tag.toUtf8().constData());
+        lua_rawseti(L, -2, tagIndex++);
+    }
     return 1;
 }
 
@@ -2760,14 +2766,11 @@ int TLuaInterpreter::getTags(lua_State* L)
     QString tagString = host.readProfileData(qsl("tags"));
 
     lua_newtable(L);
-    lua_newtable(L);
     int tagIndex = 1;
     for (const QString &tag : tagString.split(",")) {
         lua_pushstring(L, tag.toUtf8().constData());
         lua_rawseti(L, -2, tagIndex++);
     }
-
-    lua_setfield(L, -2, "tags");
     return 1;  
 }
 
@@ -2794,6 +2797,13 @@ int TLuaInterpreter::removeTag(lua_State* L)
     if (!result.first) {
         return warnArgumentValue(L, __func__, qsl("unable to remove tag, reason: %1").arg(result.second));
     }
-    lua_pushboolean(L, true);
+
+    lua_newtable(L);
+    int tagIndex = 1;
+    for (const QString &tag : tagString.split(",")) {
+        lua_pushstring(L, tag.toUtf8().constData());
+        lua_rawseti(L, -2, tagIndex++);
+    }
+
     return 1;
 }  

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -2613,6 +2613,7 @@ int TLuaInterpreter::getProfiles(lua_State* L)
 
         QString url = mudlet::self()->readProfileData(profile, qsl("url"));
         QString port = mudlet::self()->readProfileData(profile, qsl("port"));
+        QString tags = mudlet::self()->readProfileData(profile, qsl("tags"));
 
         // if url/port haven't been written to disk yet (which is what happens
         // when a default profile is opened for the first time), fetch this data from game details
@@ -2640,6 +2641,17 @@ int TLuaInterpreter::getProfiles(lua_State* L)
             lua_pushstring(L, port.toUtf8().constData());
             lua_settable(L, -3);
         }
+
+        lua_newtable(L);
+        if (!tags.isEmpty()) {            
+
+            int tagIndex = 1;
+            for (const QString &tag : tags.split(",")) {
+                lua_pushstring(L, tag.toUtf8().constData());
+                lua_rawseti(L, -2, tagIndex++);
+            }
+        }
+        lua_setfield(L, -2, "tags");        
 
         auto host = hostManager.getHost(profile);
         const auto loaded = static_cast<bool>(host);
@@ -2672,7 +2684,7 @@ int TLuaInterpreter::loadProfile(lua_State* L)
         offline = getVerifiedBool(L, __func__, 2, "offline mode", true);
     }
 
-    Host& host = getHostFromLua(L);
+    // Host& host = getHostFromLua(L);
 
     if (profileName.isEmpty()) {
         lua_pushnil(L);
@@ -2705,3 +2717,86 @@ int TLuaInterpreter::loadProfile(lua_State* L)
     lua_pushboolean(L, true);
     return 1;
 }
+
+int TLuaInterpreter::addTag(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
+    QString tagString = host.readProfileData(qsl("tags"));
+    QStringList tagList;
+    QSet<QString> tagSet;
+    const QString newTag = getVerifiedString(L, __func__, 1, "new tag");
+    if (!lua_isstring(L, 1)) {
+        return lua_error(L);    
+    }
+
+    if (!tagString.isEmpty()) {
+        tagList = tagString.split(",", Qt::SkipEmptyParts, Qt::CaseInsensitive);
+        tagSet = QSet<QString>::fromList(tagList);
+    }
+
+    tagSet.insert(newTag);
+    tagString = tagSet.values().join(",");
+    QPair<bool, QString> result = host.writeProfileData(qsl("tags"), tagString);
+    if (!result.first) {
+        return warnArgumentValue(L, __func__, qsl("unable to add tag, reason: %1").arg(result.second));
+    }
+    lua_pushboolean(L, true);
+    return 1;
+}
+
+int TLuaInterpreter::clearTags(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
+    QPair<bool, QString> result = host.writeProfileData(qsl("tags"), "");
+    if (!result.first) {
+        return warnArgumentValue(L, __func__, qsl("unable to clear tags, reason: %1").arg(result.second));
+    }
+
+    lua_pushboolean(L, true);
+    return 1;  
+}
+
+int TLuaInterpreter::getTags(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
+    QString tagString = host.readProfileData(qsl("tags"));
+
+    lua_newtable(L);
+    lua_newtable(L);
+    int tagIndex = 1;
+    for (const QString &tag : tagString.split(",")) {
+        lua_pushstring(L, tag.toUtf8().constData());
+        lua_rawseti(L, -2, tagIndex++);
+    }
+
+    lua_setfield(L, -2, "tags");
+    return 1;  
+}
+
+int TLuaInterpreter::removeTag(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
+    QString tagString = host.readProfileData(qsl("tags"));
+    QSet<QString> tagSet;
+    QStringList tagList;
+    const QString remTag = getVerifiedString(L, __func__, 1, "removed tag");
+    
+    if (!lua_isstring(L, 1)) {
+        return lua_error(L);    
+    }
+
+    if (!tagString.isEmpty()) {
+        tagList = tagString.split(",", Qt::SkipEmptyParts, Qt::CaseInsensitive);
+        tagSet = QSet<QString>::fromList(tagList);
+    }
+    lua_newtable(L);
+
+    tagSet.remove(remTag);
+    tagString = tagSet.values().join(",");
+    QPair<bool, QString> result = host.writeProfileData(qsl("tags"), tagString);
+    if (!result.first) {
+        return warnArgumentValue(L, __func__, qsl("unable to remove tag, reason: %1").arg(result.second));
+    }
+    lua_pushboolean(L, true);
+    return 1;
+}  

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -2684,8 +2684,6 @@ int TLuaInterpreter::loadProfile(lua_State* L)
         offline = getVerifiedBool(L, __func__, 2, "offline mode", true);
     }
 
-    // Host& host = getHostFromLua(L);
-
     if (profileName.isEmpty()) {
         lua_pushnil(L);
         lua_pushstring(L, "loadProfile: profile name cannot be empty");
@@ -2789,7 +2787,6 @@ int TLuaInterpreter::removeTag(lua_State* L)
         tagList = tagString.split(",", Qt::SkipEmptyParts, Qt::CaseInsensitive);
         tagSet = QSet<QString>::fromList(tagList);
     }
-    lua_newtable(L);
 
     tagSet.remove(remTag);
     tagString = tagSet.values().join(",");

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -2729,7 +2729,7 @@ int TLuaInterpreter::addTag(lua_State* L)
 
     if (!tagString.isEmpty()) {
         tagList = tagString.split(",", Qt::SkipEmptyParts, Qt::CaseInsensitive);
-        tagSet = QSet<QString>::fromList(tagList);
+        QSet<QString> tagSet(tagList.begin(), tagList.end());
     }
 
     tagSet.insert(newTag);
@@ -2778,8 +2778,8 @@ int TLuaInterpreter::removeTag(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     QString tagString = host.readProfileData(qsl("tags"));
-    QSet<QString> tagSet;
     QStringList tagList;
+    QSet<QString> tagSet;
     const QString remTag = getVerifiedString(L, __func__, 1, "removed tag");
     
     if (!lua_isstring(L, 1)) {
@@ -2788,7 +2788,7 @@ int TLuaInterpreter::removeTag(lua_State* L)
 
     if (!tagString.isEmpty()) {
         tagList = tagString.split(",", Qt::SkipEmptyParts, Qt::CaseInsensitive);
-        tagSet = QSet<QString>::fromList(tagList);
+        QSet<QString> tagSet(tagList.begin(), tagList.end());
     }
 
     tagSet.remove(remTag);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Added functions for add, remove, clear, and get tags from a profile.
Tags are returned in the getProfiles output

#### Motivation for adding to Mudlet
To allow users with large numbers of profiles to better manage their profiles, in conjunction with the loadProfile and getProfiles functionality. 

#### Other info (issues closed, discussion etc)
