### PR TITLE
add windows lua test

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -151,6 +151,15 @@ jobs:
         AUTORUN_BUSTED_TESTS: 'true'
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
+    
+    - name: Passed Lua tests
+      if: matrix.buildname == 'windows64' || matrix.buildname == 'windows32'
+      shell: msys2 {0}
+      run: |
+        if [ -e /tmp/busted-tests-failed ] || [ -e "C:/tmp/busted-tests-failed" ]; then
+          echo "Lua tests failed - see the action called 'Run Lua tests' above for detailed output."
+          exit 1
+        fi
         
     - name: Submit to make.mudlet.org
       if: env.UPLOAD_FILENAME

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -122,6 +122,36 @@ jobs:
         name: ${{env.UPLOAD_FILENAME}}
         path: ${{env.FOLDER_TO_UPLOAD}}
 
+    - name: (Windows) Prep for Lua tests
+      if: matrix.buildname == 'windows64' || matrix.buildname == 'windows32'
+      shell: msys2 {0}
+      run: |
+        # Create required directories and copy files
+        mkdir -p "${GITHUB_WORKSPACE}/src/release"
+        cp -r "${GITHUB_WORKSPACE}/package-${MSYSTEM}-release/"* "${GITHUB_WORKSPACE}/src/release/"
+
+        # Install test dependencies with specific paths
+        PATH="${MINGW_BASE_DIR}/bin:$PATH"
+        luarocks --tree="${MINGW_BASE_DIR}" --lua-version 5.1 install busted
+        luarocks --tree="${MINGW_BASE_DIR}" --lua-version 5.1 install luafilesystem
+        luarocks --tree="${MINGW_BASE_DIR}" --lua-version 5.1 install luautf8
+        luarocks --tree="${MINGW_BASE_DIR}" --lua-version 5.1 install lua-zip
+        luarocks --tree="${MINGW_BASE_DIR}" --lua-version 5.1 install luasql-sqlite3
+        luarocks --tree="${MINGW_BASE_DIR}" --lua-version 5.1 install lrexlib-pcre
+
+    - name: (Windows) Run Lua tests
+      if: matrix.buildname == 'windows64' || matrix.buildname == 'windows32'
+      shell: msys2 {0}
+      timeout-minutes: 5
+      run: |
+        cd "${GITHUB_WORKSPACE}/src/release"
+        ./mudlet.exe --profile "Mudlet self-test" --mirror --no-dialog
+      env:
+        PATH: ${{env.MINGW_BASE_DIR}}/bin:${{env.PATH}}
+        AUTORUN_BUSTED_TESTS: 'true'
+        TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
+        QUIT_MUDLET_AFTER_TESTS: 'true'
+        
     - name: Submit to make.mudlet.org
       if: env.UPLOAD_FILENAME
       run: |


### PR DESCRIPTION
Add Lua tests to Windows CI builds

Added infrastructure to run Lua tests on Windows CI environment 

Added:
- Installation of required Lua packages for tests

/claim #6688