### PR TITLE
Fix: Windows updater 'deletes' Mudlet

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -734,10 +734,11 @@ int main(int argc, char* argv[])
 }
 
 #if defined(Q_OS_WIN32) && defined(INCLUDE_UPDATER)
-// small detour for Windows - check if there's an updated Mudlet
+// Small detour for Windows - check if there's an updated Mudlet
 // available to install. If there is, quit and run it - Squirrel
-// will update Mudlet and then launch it once it's done
-// return true if we should abort the current launch since the updater got started
+// will update Mudlet and then launch it once it's done.
+// 
+// Return true if we should abort the current launch since the updater got started
 bool runUpdate()
 {
     QFileInfo updatedInstaller(qsl("%1/new-mudlet-setup.exe").arg(QCoreApplication::applicationDirPath()));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -741,7 +741,7 @@ int main(int argc, char* argv[])
 // Return true if we should abort the current launch since the updater got started
 bool runUpdate()
 {
-    QFileInfo updatedInstaller(qsl("%1/new-mudlet-setup.exe").arg(QCoreApplication::applicationDirPath()));
+    QFileInfo updatedInstaller(qsl("%1/new-mudlet-setup.exe").arg(QStandardPaths::writableLocation(QStandardPaths::TempLocation)));
     QFileInfo seenUpdatedInstaller(qsl("%1/new-mudlet-setup-seen.exe").arg(QCoreApplication::applicationDirPath()));
     QDir updateDir;
     if (updatedInstaller.exists() && updatedInstaller.isFile() && updatedInstaller.isExecutable()) {

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -228,7 +228,7 @@ void Updater::setupOnWindows()
 void Updater::prepareSetupOnWindows(const QString& downloadedSetupName)
 {
     QDir dir;
-    auto newPath = QString(QCoreApplication::applicationDirPath() + qsl("/new-mudlet-setup.exe"));
+    auto newPath = qsl("%1/new-mudlet-setup.exe").arg(QStandardPaths::writableLocation(QStandardPaths::TempLocation));
     QFileInfo newPathFileInfo(newPath);
     if (newPathFileInfo.exists() && !dir.remove(newPathFileInfo.absoluteFilePath())) {
         qDebug() << "Couldn't delete the old installer";


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Change the location of the newly downloaded installer from the same folder that mudlet.exe to a different, temporary writable directory. This is because Squirrel tries to delete the folder where mudlet.exe is fully first, which sometimes is an issue because that's the same location that the installer is running from.
#### Motivation for adding to Mudlet
Fix the important https://github.com/Mudlet/Mudlet/issues/7313 issue.
#### Other info (issues closed, discussion etc)
