### PR TITLE
Improve: add profiling for auto-login process and log loading times

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2869,30 +2869,41 @@ void mudlet::deleteProfileData(const QString& profile, const QString& item)
 
 void mudlet::startAutoLogin(const QStringList& cliProfiles)
 {
+    QElapsedTimer timer;
+    timer.start();
+
     QStringList hostList = QDir(getMudletPath(profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
     hostList += TGameDetails::keys();
     hostList << qsl("Mudlet self-test");
     hostList.removeDuplicates();
-    bool openedProfile = false;
-
+    int loadedProfiles = 0;
+    
     for (auto& hostName : cliProfiles){
         if (hostList.contains(hostName)) {
+            QElapsedTimer timer;
+            timer.start();
             doAutoLogin(hostName);
-            openedProfile = true;
             hostList.removeOne(hostName);
+            loadedProfiles++;
+            qDebug() << "Profile" << hostName << "loaded in" << timer.elapsed()/1000.0 << "seconds";
         }
     }
 
     for (auto& hostName : hostList) {
         const QString val = readProfileData(hostName, qsl("autologin"));
         if (val.toInt() == Qt::Checked) {
+            QElapsedTimer timer;
+            timer.start();
             doAutoLogin(hostName);
-            openedProfile = true;
+            loadedProfiles++;
+            qDebug() << "Profile" << hostName << "loaded in" << timer.elapsed()/1000.0 << "seconds";
         }
     }
 
-    if (!openedProfile) {
+    if (loadedProfiles == 0) {
         slot_showConnectionDialog();
+    } else {
+        qDebug() << "All" << loadedProfiles << "profiles in" << timer.elapsed()/1000.0 << "seconds";
     }
 }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add profiling for auto-login process and log loading times. A single profile load will show this:

> Profile "mud.pkuxkx.net 8081" loaded in 0.458 seconds

At the completion time, all profiles will show this:

> All 28 profiles in 18.167 seconds
#### Motivation for adding to Mudlet
Help improve Mudlet load times for those who multiplay many characters at once on Windows, where Defender makes loading profiles really slow.
#### Other info (issues closed, discussion etc)
This doesn't affect profiles loaded manually or via loadProfle() function, this is only for those marked as autologin or ones loaded from the CLI.

Load Mudlet from the CLI using https://wiki.mudlet.org/w/HowTo:OpenInWindowsCmd to see the #'s.