### PR TITLE
Fix: `matches[]` in temp*Trigger functions not always working

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -79,9 +79,6 @@ extern "C" {
 int luaopen_yajl(lua_State*);
 }
 
-// Used temporarily where we need to supply a name to constructor which we
-// cannot obtain until after the item has been constructed:
-static const QString scDummyName{qsl("a")};
 
 // No documentation available in wiki - internal function
 static bool isMain(const QString& name)
@@ -6069,14 +6066,13 @@ std::pair<int, QString> TLuaInterpreter::startPermAlias(const QString& name, con
     TAlias* pT;
 
     if (parent.isEmpty()) {
-        pT = new TAlias(name, mpHost);
+        pT = new TAlias("a", mpHost);
     } else {
         TAlias* pP = mpHost->getAliasUnit()->findFirstAlias(parent);
         if (!pP) {
             return {-1, qsl("parent '%1' not found").arg(parent)};
         }
         pT = new TAlias(pP, mpHost);
-        pT->setName(name);
     }
     pT->setRegexCode(regex);
     pT->setIsFolder((regex.isEmpty() && function.isEmpty()));
@@ -6084,6 +6080,7 @@ std::pair<int, QString> TLuaInterpreter::startPermAlias(const QString& name, con
     pT->setTemporary(false);
     pT->registerAlias();
     pT->setScript(function);
+    pT->setName(name);
     updateEditor();
     return {pT->getID(), QString()};
 }
@@ -6092,7 +6089,7 @@ std::pair<int, QString> TLuaInterpreter::startPermAlias(const QString& name, con
 int TLuaInterpreter::startTempAlias(const QString& regex, const QString& function)
 {
     TAlias* pT;
-    pT = new TAlias(scDummyName, mpHost);
+    pT = new TAlias("a", mpHost);
     pT->setRegexCode(regex);
     pT->setIsFolder(false);
     pT->setIsActive(true);
@@ -6112,14 +6109,13 @@ std::pair<int, QString> TLuaInterpreter::startPermKey(QString& name, QString& pa
     TKey* pT;
 
     if (parent.isEmpty()) {
-        pT = new TKey(name, mpHost);
+        pT = new TKey("a", mpHost); // The use of "a" seems a bit arbitrary...!
     } else {
         TKey* pP = mpHost->getKeyUnit()->findFirstKey(parent);
         if (!pP) {
             return {-1, qsl("parent '%1' not found").arg(parent)};
         }
         pT = new TKey(pP, mpHost);
-        pT->setName(name);
     }
     pT->setKeyCode(keycode);
     pT->setKeyModifiers(modifier);
@@ -6129,6 +6125,7 @@ std::pair<int, QString> TLuaInterpreter::startPermKey(QString& name, QString& pa
     pT->registerKey();
     // CHECK: The lua code in function could fail to compile - but there is no feedback here to the caller.
     pT->setScript(function);
+    pT->setName(name);
     updateEditor();
     return {pT->getID(), QString()};
 }
@@ -6137,7 +6134,7 @@ std::pair<int, QString> TLuaInterpreter::startPermKey(QString& name, QString& pa
 int TLuaInterpreter::startTempKey(int& modifier, int& keycode, const QString& function)
 {
     TKey* pT;
-    pT = new TKey(scDummyName, mpHost);
+    pT = new TKey("a", mpHost);
     pT->setKeyCode(keycode);
     pT->setKeyModifiers(modifier);
     pT->setIsFolder(false);
@@ -6158,7 +6155,7 @@ int TLuaInterpreter::startTempExactMatchTrigger(const QString& regex, const QStr
     TTrigger* pT = nullptr;
     const QStringList sList {regex};
     QList<int> const propertyList {REGEX_EXACT_MATCH};
-    pT = new TTrigger(scDummyName, sList, propertyList, mpHost);
+    pT = new TTrigger("a", sList, propertyList, false, mpHost);
     pT->setIsFolder(false);
     pT->setIsActive(true);
     pT->setTemporary(true);
@@ -6176,7 +6173,7 @@ int TLuaInterpreter::startTempBeginOfLineTrigger(const QString& regex, const QSt
     TTrigger* pT = nullptr;
     const QStringList sList {regex};
     QList<int> const propertyList {REGEX_BEGIN_OF_LINE_SUBSTRING};
-    pT = new TTrigger(scDummyName, sList, propertyList, mpHost);
+    pT = new TTrigger("a", sList, propertyList, false, mpHost);
     pT->setIsFolder(false);
     pT->setIsActive(true);
     pT->setTemporary(true);
@@ -6194,7 +6191,7 @@ int TLuaInterpreter::startTempTrigger(const QString& regex, const QString& funct
     TTrigger* pT = nullptr;
     const QStringList sList {regex};
     QList<int> const propertyList {REGEX_SUBSTRING};
-    pT = new TTrigger(scDummyName, sList, propertyList, mpHost);
+    pT = new TTrigger("a", sList, propertyList, false, mpHost);
     pT->setIsFolder(false);
     pT->setIsActive(true);
     pT->setTemporary(true);
@@ -6212,7 +6209,7 @@ int TLuaInterpreter::startTempPromptTrigger(const QString& function, int expiryC
     TTrigger* pT;
     const QStringList sList = {QString()};
     QList<int> const propertyList = {REGEX_PROMPT};
-    pT = new TTrigger(scDummyName, sList, propertyList, mpHost);
+    pT = new TTrigger("a", sList, propertyList, false, mpHost);
     pT->setIsFolder(false);
     pT->setIsActive(true);
     pT->setTemporary(true);
@@ -6231,7 +6228,7 @@ int TLuaInterpreter::startTempLineTrigger(int from, int howmany, const QString& 
     //    QStringList sList;
     //    QList<int> propertyList;
     //    propertyList << REGEX_SUBSTRING;// substring trigger is default
-    //    pT = new TTrigger(scDummyName, sList, propertyList, mpHost );
+    //    pT = new TTrigger("a", sList, propertyList, false, mpHost );
     pT = new TTrigger(nullptr, mpHost);
     pT->setIsFolder(false);
     pT->setIsActive(true);
@@ -6254,7 +6251,7 @@ int TLuaInterpreter::startTempColorTrigger(int fg, int bg, const QString& functi
     //    QStringList sList;
     //    QList<int> propertyList;
     //    propertyList << REGEX_SUBSTRING;// substring trigger is default
-    //    pT = new TTrigger(scDummyName, sList, propertyList, mpHost );
+    //    pT = new TTrigger("a", sList, propertyList, false, mpHost );
     pT = new TTrigger(nullptr, mpHost);
     pT->setIsFolder(false);
     pT->setIsActive(true);
@@ -6275,7 +6272,7 @@ int TLuaInterpreter::startTempRegexTrigger(const QString& regex, const QString& 
     TTrigger* pT = nullptr;
     const QStringList sList {regex};
     QList<int> const propertyList {REGEX_PERL};
-    pT = new TTrigger(scDummyName, sList, propertyList, mpHost);
+    pT = new TTrigger("a", sList, propertyList, false, mpHost);
     pT->setIsFolder(false);
     pT->setIsActive(true);
     pT->setTemporary(true);
@@ -6288,7 +6285,7 @@ int TLuaInterpreter::startTempRegexTrigger(const QString& regex, const QString& 
 }
 
 // No documentation available in wiki - internal function
-std::pair<int, QString> TLuaInterpreter::startPermRegexTrigger(const QString& name, const QString& parent, QStringList& patterns, const QString& function, const int multilineDelta)
+std::pair<int, QString> TLuaInterpreter::startPermRegexTrigger(const QString& name, const QString& parent, QStringList& patterns, const QString& function)
 {
     TTrigger* pT;
     QList<int> propertyList;
@@ -6296,30 +6293,27 @@ std::pair<int, QString> TLuaInterpreter::startPermRegexTrigger(const QString& na
         propertyList << REGEX_PERL;
     }
     if (parent.isEmpty()) {
-        pT = new TTrigger(name, patterns, propertyList, mpHost);
+        pT = new TTrigger("a", patterns, propertyList, (patterns.size() > 1), mpHost);
     } else {
         TTrigger* pP = mpHost->getTriggerUnit()->findTrigger(parent);
         if (!pP) {
             return std::pair(-1, qsl("parent '%1' not found").arg(parent));
         }
         pT = new TTrigger(pP, mpHost);
-        pT->setName(name);
         pT->setRegexCodeList(patterns, propertyList);
     }
     pT->setIsFolder(patterns.empty());
     pT->setIsActive(true);
     pT->setTemporary(false);
-    pT->setIsMultiline(multilineDelta >= 0);
-    pT->setConditionLineDelta(std::max(0, multilineDelta));
     pT->registerTrigger();
     pT->setScript(function);
-
+    pT->setName(name);
     updateEditor();
     return std::pair(pT->getID(), QString());
 }
 
 // No documentation available in wiki - internal function
-std::pair<int, QString> TLuaInterpreter::startPermBeginOfLineStringTrigger(const QString& name, const QString& parent, QStringList& patterns, const QString& function, const int multilineDelta)
+std::pair<int, QString> TLuaInterpreter::startPermBeginOfLineStringTrigger(const QString& name, const QString& parent, QStringList& patterns, const QString& function)
 {
     TTrigger* pT;
     QList<int> propertyList;
@@ -6327,30 +6321,27 @@ std::pair<int, QString> TLuaInterpreter::startPermBeginOfLineStringTrigger(const
         propertyList << REGEX_BEGIN_OF_LINE_SUBSTRING;
     }
     if (parent.isEmpty()) {
-        pT = new TTrigger(name, patterns, propertyList, mpHost);
+        pT = new TTrigger("a", patterns, propertyList, (patterns.size() > 1), mpHost);
     } else {
         TTrigger* pP = mpHost->getTriggerUnit()->findTrigger(parent);
         if (!pP) {
             return {-1, qsl("parent '%1' not found").arg(parent)};
         }
         pT = new TTrigger(pP, mpHost);
-        pT->setName(name);
         pT->setRegexCodeList(patterns, propertyList);
     }
     pT->setIsFolder(patterns.empty());
     pT->setIsActive(true);
     pT->setTemporary(false);
-    pT->setIsMultiline(multilineDelta >= 0);
-    pT->setConditionLineDelta(std::max(0, multilineDelta));
     pT->registerTrigger();
     pT->setScript(function);
-
+    pT->setName(name);
     updateEditor();
     return std::pair(pT->getID(), QString());
 }
 
 // No documentation available in wiki - internal function
-std::pair<int, QString> TLuaInterpreter::startPermSubstringTrigger(const QString& name, const QString& parent, const QStringList& patterns, const QString& function, const int multilineDelta)
+std::pair<int, QString> TLuaInterpreter::startPermSubstringTrigger(const QString& name, const QString& parent, const QStringList& patterns, const QString& function)
 {
     TTrigger* pT;
     QList<int> propertyList;
@@ -6358,24 +6349,21 @@ std::pair<int, QString> TLuaInterpreter::startPermSubstringTrigger(const QString
         propertyList << REGEX_SUBSTRING;
     }
     if (parent.isEmpty()) {
-        pT = new TTrigger(name, patterns, propertyList, mpHost);
+        pT = new TTrigger("a", patterns, propertyList, (patterns.size() > 1), mpHost);
     } else {
         TTrigger* pP = mpHost->getTriggerUnit()->findTrigger(parent);
         if (!pP) {
             return {-1, qsl("parent '%1' not found").arg(parent)};
         }
         pT = new TTrigger(pP, mpHost);
-        pT->setName(name);
         pT->setRegexCodeList(patterns, propertyList);
     }
     pT->setIsFolder(patterns.empty());
     pT->setIsActive(true);
     pT->setTemporary(false);
-    pT->setIsMultiline(multilineDelta >= 0);
-    pT->setConditionLineDelta(std::max(0, multilineDelta));
     pT->registerTrigger();
     pT->setScript(function);
-
+    pT->setName(name);
     updateEditor();
     return {pT->getID(), QString()};
 }
@@ -6388,14 +6376,13 @@ std::pair<int, QString> TLuaInterpreter::startPermPromptTrigger(const QString& n
     const QStringList patterns = {QString()};
 
     if (parent.isEmpty()) {
-        pT = new TTrigger(name, patterns, propertyList, mpHost);
+        pT = new TTrigger("a", patterns, propertyList, false, mpHost);
     } else {
         TTrigger* pP = mpHost->getTriggerUnit()->findTrigger(parent);
         if (!pP) {
             return {-1, qsl("parent '%1' not found").arg(parent)};
         }
         pT = new TTrigger(pP, mpHost);
-        pT->setName(name);
         pT->setRegexCodeList(patterns, propertyList);
     }
     pT->setIsFolder(false);
@@ -6403,6 +6390,7 @@ std::pair<int, QString> TLuaInterpreter::startPermPromptTrigger(const QString& n
     pT->setTemporary(false);
     pT->registerTrigger();
     pT->setScript(function);
+    pT->setName(name);
     updateEditor();
     return {pT->getID(), QString()};
 }

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -147,9 +147,9 @@ public:
     int startTempRegexTrigger(const QString&, const QString&, int expiryCount = -1);
     int startTempColorTrigger(int, int, const QString&, int expiryCount = -1);
     int startTempPromptTrigger(const QString& function, int expiryCount = -1);
-    std::pair<int, QString> startPermRegexTrigger(const QString& name, const QString& parent, QStringList& patterns, const QString& function, const int multilineDelta = -1);
-    std::pair<int, QString> startPermSubstringTrigger(const QString& name, const QString& parent, const QStringList& patterns, const QString& function, const int multilineDelta = -1);
-    std::pair<int, QString> startPermBeginOfLineStringTrigger(const QString& name, const QString& parent, QStringList& patterns, const QString& function, const int multilineDelta = -1);
+    std::pair<int, QString> startPermRegexTrigger(const QString& name, const QString& parent, QStringList& patterns, const QString& function);
+    std::pair<int, QString> startPermSubstringTrigger(const QString& name, const QString& parent, const QStringList& patterns, const QString& function);
+    std::pair<int, QString> startPermBeginOfLineStringTrigger(const QString& name, const QString& parent, QStringList& patterns, const QString& function);
     std::pair<int, QString> startPermPromptTrigger(const QString& name, const QString& parent, const QString& function);
     std::pair<int, QString> startPermTimer(const QString& name, const QString& parent, double timeout, const QString& function);
     std::pair<int, QString> createPermScript(const QString& name, const QString& parent, const QString& luaCode);

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -1128,17 +1128,7 @@ int TLuaInterpreter::permRegexTrigger(lua_State* L)
     }
 
     const QString script{lua_tostring(L, 4)};
-    int multilineDelta = -1;
-    if (lua_gettop(L) > 4) {
-        multilineDelta = getVerifiedInt(L, __func__, 5, "AND/Multi-line trigger delta (>=0), OR/Multi-item (<0, default)", true);
-    } else {
-        // Reproduce old, prior to 4.19, behaviour, in absence of flag:
-        if (parent.isEmpty() && regList.count() > 1) {
-            multilineDelta = 0;
-        }
-    }
-
-    auto [triggerId, message] = pLuaInterpreter->startPermRegexTrigger(name, parent, regList, script, multilineDelta);
+    auto [triggerId, message] = pLuaInterpreter->startPermRegexTrigger(name, parent, regList, script);
     if (triggerId == -1) {
         lua_pushfstring(L, "permRegexTrigger: cannot create trigger (%s)", message.toUtf8().constData());
         return lua_error(L);
@@ -1177,17 +1167,7 @@ int TLuaInterpreter::permBeginOfLineStringTrigger(lua_State* L)
     }
 
     const QString script{lua_tostring(L, 4)};
-    int multilineDelta = -1;
-    if (lua_gettop(L) > 4) {
-        multilineDelta = getVerifiedInt(L, __func__, 5, "AND/Multi-line trigger delta (>=0), OR/Multi-item (<0, default)", true);
-    } else {
-        // Reproduce old, prior to 4.19, behaviour, in absence of flag:
-        if (parent.isEmpty() && regList.count() > 1) {
-            multilineDelta = 0;
-        }
-    }
-
-    auto [triggerId, message] = pLuaInterpreter->startPermBeginOfLineStringTrigger(name, parent, regList, script, multilineDelta);
+    auto [triggerId, message] = pLuaInterpreter->startPermBeginOfLineStringTrigger(name, parent, regList, script);
     if (triggerId == -1) {
         lua_pushfstring(L, "permRegexTrigger: cannot create trigger (%s)", message.toUtf8().constData());
         return lua_error(L);
@@ -1225,17 +1205,7 @@ int TLuaInterpreter::permSubstringTrigger(lua_State* L)
     }
 
     const QString script{lua_tostring(L, 4)};
-    int multilineDelta = -1;
-    if (lua_gettop(L) > 4) {
-        multilineDelta = getVerifiedInt(L, __func__, 5, "AND/Multi-line trigger delta (>=0), OR/Multi-item (<0, default)", true);
-    } else {
-        // Reproduce old, prior to 4.19, behaviour, in absence of flag:
-        if (parent.isEmpty() && regList.count() > 1) {
-            multilineDelta = 0;
-        }
-    }
-
-    auto [triggerID, message] = pLuaInterpreter->startPermSubstringTrigger(name, parent, regList, script, multilineDelta);
+    auto [triggerID, message] = pLuaInterpreter->startPermSubstringTrigger(name, parent, regList, script);
     if(triggerID == - 1) {
         lua_pushfstring(L, "permSubstringTrigger: cannot create trigger (%s)", message.toUtf8().constData());
         return lua_error(L);
@@ -2281,12 +2251,12 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
         propertyList << REGEX_PERL;
     }
 
-    auto pT = new TTrigger(triggerName, patterns, propertyList, &host);
+    auto pT = new TTrigger("a", patterns, propertyList, multiLine, &host);
     pT->setIsFolder(false);
     pT->setIsActive(true);
     pT->setTemporary(true);
-    pT->setIsMultiline(multiLine);
     pT->registerTrigger();
+    pT->setName(triggerName);
     pT->mPerlSlashGOption = matchAll; //match all
     pT->mFilterTrigger = filter;
     pT->setConditionLineDelta(lineDelta); //line delta

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -75,7 +75,7 @@ TTrigger::TTrigger( TTrigger * parent, Host * pHost )
 {
 }
 
-TTrigger::TTrigger(const QString& name, const QStringList& patterns, const QList<int>& patternKinds, Host* pHost)
+TTrigger::TTrigger(const QString& name, const QStringList& patterns, const QList<int>& patternKinds, bool isMultiline, Host* pHost)
 : Tree<TTrigger>(nullptr)
 , mTriggerContainsPerlRegex(false)
 , mPerlSlashGOption(false)
@@ -98,6 +98,7 @@ TTrigger::TTrigger(const QString& name, const QStringList& patterns, const QList
 , mIsLineTrigger(false)
 , mStartOfLineDelta(0)
 , mLineDelta(3)
+, mIsMultiline(isMultiline)
 , mConditionLineDelta(0)
 , mpLua(mpHost->getLuaInterpreter())
 , mFgColor(QColor(Qt::red))

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -73,7 +73,7 @@ class TTrigger : public Tree<TTrigger>
 public:
     virtual ~TTrigger();
     TTrigger(TTrigger* parent, Host* pHost);
-    TTrigger(const QString& name, const QStringList& patterns, const QList<int>& patternKinds, Host* pHost); //throws exception ExObjNoCreate
+    TTrigger(const QString& name, const QStringList& patterns, const QList<int>& patternKinds, bool isMultiline, Host* pHost); //throws exception ExObjNoCreate
 
     // Used as ANSI color code for either fore or back ground in color triggers
     // that is not considered when checking the color - both being set to this

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -3751,7 +3751,7 @@ void dlgTriggerEditor::addTrigger(bool isFolder)
     } else {
     //insert a new root item
     ROOT_TRIGGER:
-        pT = new TTrigger(name, patterns, patternKinds, mpHost);
+        pT = new TTrigger(name, patterns, patternKinds, false, mpHost);
         pNewItem = new QTreeWidgetItem(mpTriggerBaseItem, nameL);
         treeWidget_triggers->insertTopLevelItem(0, pNewItem);
     }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
 `matches[]` in temp*Trigger functions not always being populated as it should
#### Motivation for adding to Mudlet
High importance bugfix
#### Other info (issues closed, discussion etc)
This reverts commit cac74ca5943bdee4192943adc5f7161d6fbbfa0e.