### PR TITLE
improve: script editor search results can be resized

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -802,33 +802,42 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     QFrame *searchContainer = new QFrame();
     QVBoxLayout *searchLayout = new QVBoxLayout(searchContainer);
-    searchLayout->addWidget(comboBox_searchTerms, 0, Qt::AlignTop);
+    searchLayout->addWidget(checkBox_displayAllVariables);
+    searchLayout->addWidget(comboBox_searchTerms);
     searchLayout->addWidget(treeWidget_searchResults);
 
     searchSplitter = new QSplitter(Qt::Vertical);
 
     connect(searchSplitter, &QSplitter::splitterMoved, this, &dlgTriggerEditor::slot_searchSplitterMoved);
-    searchSplitter->addWidget(treeWidget_triggers);
-    searchSplitter->addWidget(treeWidget_aliases);
-    searchSplitter->addWidget(treeWidget_actions);
-    searchSplitter->addWidget(treeWidget_timers);
-    searchSplitter->addWidget(treeWidget_scripts);
-    searchSplitter->addWidget(treeWidget_keys);
-    searchSplitter->addWidget(searchContainer);
 
+    QFrame *itemContainer = new QFrame();
+    QVBoxLayout *itemLayout = new QVBoxLayout(itemContainer);
+
+    itemLayout->addWidget(treeWidget_triggers);
+    itemLayout->addWidget(treeWidget_aliases);
+    itemLayout->addWidget(treeWidget_actions);
+    itemLayout->addWidget(treeWidget_timers);
+    itemLayout->addWidget(treeWidget_scripts);
+    itemLayout->addWidget(treeWidget_keys);
+    itemLayout->addWidget(treeWidget_variables);
+
+    searchSplitter->addWidget(itemContainer);
     searchSplitter->setStretchFactor(0, 1);
-    searchSplitter->setCollapsible(0, false);
+    searchSplitter->setCollapsible(1, true);
+    searchSplitter->addWidget(searchContainer);
     searchSplitter->setStretchFactor(1, 1);
     searchSplitter->setCollapsible(1, true);
+
     verticalLayout_frame_left->addWidget(searchSplitter);
 
     bool state = searchSplitter->restoreState(mSearchSplitterState);
+    /*
     if (!state) {
         QList<int> sizes;
         // set widget sizes to preferred hints, but bump up search area size
-        sizes << 1 << 1 << 1 << 1 << 1 << 1 << 300;
+        sizes << 1000 << 1000 << 1000 << 1000 << 1000 << 1000 << 300;
         searchSplitter->setSizes(sizes);
-    }
+    }*/
 
     mpScrollArea = mpTriggersMainArea->scrollArea;
     mpWidget_triggerItems = new QWidget;

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -331,12 +331,6 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     mpErrorConsole->hide();
 
-    button_toggleSearchAreaResults->setStyleSheet(qsl("QToolButton::on {border-image: url(:/icons/arrow-down_grey.png);} "
-                                                                 "QToolButton {border-image: url(:/icons/arrow-right_grey.png);} "
-                                                                 "QToolButton::on:hover {border-image: url(:/icons/arrow-down.png);} "
-                                                                 "QToolButton:hover {border-image: url(:/icons/arrow-right.png);}"));
-    connect(button_toggleSearchAreaResults, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_showSearchAreaResults);
-
     connect(mpTriggersMainArea->toolButton_toggleExtraControls, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_showAllTriggerControls);
     slot_showAllTriggerControls(true);
 
@@ -717,15 +711,6 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     connect(mpActionsMainArea->lineEdit_action_name, &QLineEdit::textEdited, this, &dlgTriggerEditor::slot_itemEdited);
     connect(mpActionsMainArea->lineEdit_action_name, &QLineEdit::textEdited, this, &dlgTriggerEditor::slot_itemEdited);
 
-
-
-    // Force the size of the triangle icon button that shows/hides the search
-    // results to be 3/4 of the height of the combo-box used to enter the search
-    // term - this is to prevent an overlarge button on MacOS platforms where it
-    // was found to be an issue!
-    button_toggleSearchAreaResults->setMaximumSize(QSize((3 * comboBox_searchTerms->height()) / 4, (3 * comboBox_searchTerms->height()) / 4));
-    button_toggleSearchAreaResults->setMinimumSize(QSize((3 * comboBox_searchTerms->height()) / 4, (3 * comboBox_searchTerms->height()) / 4));
-
     comboBox_searchTerms->lineEdit()->setClearButtonEnabled(true);
     auto pLineEdit_searchTerm = comboBox_searchTerms->lineEdit();
 
@@ -813,19 +798,16 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
               << tr("What");
     treeWidget_searchResults->setHeaderLabels(labelList);
 
-
     comboBox_searchTerms->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-    QFrame *searchTerms = new QFrame();
-    QHBoxLayout *searchTermsLayout = new QHBoxLayout(searchTerms);
-    searchTermsLayout->addWidget(comboBox_searchTerms);
-    searchTermsLayout->addWidget(button_toggleSearchAreaResults);
 
     QFrame *searchContainer = new QFrame();
     QVBoxLayout *searchLayout = new QVBoxLayout(searchContainer);
-    searchLayout->addWidget(searchTerms, 0, Qt::AlignTop);
+    searchLayout->addWidget(comboBox_searchTerms, 0, Qt::AlignTop);
     searchLayout->addWidget(treeWidget_searchResults);
 
-    QSplitter *searchSplitter = new QSplitter(Qt::Vertical);
+    searchSplitter = new QSplitter(Qt::Vertical);
+
+    connect(searchSplitter, &QSplitter::splitterMoved, this, &dlgTriggerEditor::slot_searchSplitterMoved);
     searchSplitter->addWidget(treeWidget_triggers);
     searchSplitter->addWidget(treeWidget_aliases);
     searchSplitter->addWidget(treeWidget_actions);
@@ -840,7 +822,13 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     searchSplitter->setCollapsible(1, true);
     verticalLayout_frame_left->addWidget(searchSplitter);
 
-    slot_showSearchAreaResults(false);
+    bool state = searchSplitter->restoreState(mSearchSplitterState);
+    if (!state) {
+        QList<int> sizes;
+        // set widget sizes to preferred hints, but bump up search area size
+        sizes << 1 << 1 << 1 << 1 << 1 << 1 << 300;
+        searchSplitter->setSizes(sizes);
+    }
 
     mpScrollArea = mpTriggersMainArea->scrollArea;
     mpWidget_triggerItems = new QWidget;
@@ -954,6 +942,11 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     }
 }
 
+void dlgTriggerEditor::slot_searchSplitterMoved(const int pos, const int index)
+{
+    mSearchSplitterState = searchSplitter->saveState();
+}
+
 void dlgTriggerEditor::slot_editorThemeChanged()
 {
     for (int i = 0; i < 50; i++) {
@@ -1056,6 +1049,7 @@ void dlgTriggerEditor::readSettings()
     mKeyEditorSplitterState = settings.value("mKeyEditorSplitterState", QByteArray()).toByteArray();
     mTimerEditorSplitterState = settings.value("mTimerEditorSplitterState", QByteArray()).toByteArray();
     mVarEditorSplitterState = settings.value("mVarEditorSplitterState", QByteArray()).toByteArray();
+    mSearchSplitterState = settings.value("mSearchSplitterState", QByteArray()).toByteArray();
 }
 
 void dlgTriggerEditor::writeSettings()
@@ -1072,6 +1066,7 @@ void dlgTriggerEditor::writeSettings()
     settings.setValue("mKeyEditorSplitterState", mKeyEditorSplitterState);
     settings.setValue("mTimerEditorSplitterState", mTimerEditorSplitterState);
     settings.setValue("mVarEditorSplitterState", mVarEditorSplitterState);
+    settings.setValue("mSearchSplitterState", mSearchSplitterState);
 }
 
 void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
@@ -1459,7 +1454,6 @@ void dlgTriggerEditor::slot_searchMudletItems(const int index)
     }
 
     treeWidget_searchResults->clear();
-    slot_showSearchAreaResults(true);
     treeWidget_searchResults->setUpdatesEnabled(false);
 
     searchTriggers(s);
@@ -7634,26 +7628,6 @@ void dlgTriggerEditor::expand_child_timers(TTimer* pTimerParent, QTreeWidgetItem
             showError(timer->getError());
         }
         pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
-    }
-}
-
-void dlgTriggerEditor::slot_showSearchAreaResults(const bool isChecked)
-{
-    if (isChecked) {
-        if (!button_toggleSearchAreaResults->isChecked()) {
-            // If this slot is called "manually" the checked state of the button
-            // may not match the setting, so make it do so, note that the
-            // setChecked(bool) method does NOT invoke the clicked(bool) signal
-            // that is connected to here in the constructor, but it does the
-            // toggled(bool) one, which is why we use the former...
-            button_toggleSearchAreaResults->setChecked(true);
-        }
-        treeWidget_searchResults->show();
-    } else {
-        if (button_toggleSearchAreaResults->isChecked()) {
-            button_toggleSearchAreaResults->setChecked(false);
-        }
-        treeWidget_searchResults->hide();
     }
 }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -838,7 +838,6 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     searchSplitter->setCollapsible(0, false);
     searchSplitter->setStretchFactor(1, 1);
     searchSplitter->setCollapsible(1, true);
-    // Add the splitter to the main layout
     verticalLayout_frame_left->addWidget(searchSplitter);
 
     slot_showSearchAreaResults(false);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -823,7 +823,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     searchSplitter->addWidget(itemContainer);
     searchSplitter->setStretchFactor(0, 1);
-    searchSplitter->setCollapsible(1, true);
+    searchSplitter->setCollapsible(0, false);
     searchSplitter->addWidget(searchContainer);
     searchSplitter->setStretchFactor(1, 1);
     searchSplitter->setCollapsible(1, true);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -830,14 +830,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     verticalLayout_frame_left->addWidget(searchSplitter);
 
-    bool state = searchSplitter->restoreState(mSearchSplitterState);
-    /*
-    if (!state) {
-        QList<int> sizes;
-        // set widget sizes to preferred hints, but bump up search area size
-        sizes << 1000 << 1000 << 1000 << 1000 << 1000 << 1000 << 300;
-        searchSplitter->setSizes(sizes);
-    }*/
+    searchSplitter->restoreState(mSearchSplitterState);
 
     mpScrollArea = mpTriggersMainArea->scrollArea;
     mpWidget_triggerItems = new QWidget;

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -813,6 +813,34 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
               << tr("What");
     treeWidget_searchResults->setHeaderLabels(labelList);
 
+
+    comboBox_searchTerms->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    QFrame *searchTerms = new QFrame();
+    QHBoxLayout *searchTermsLayout = new QHBoxLayout(searchTerms);
+    searchTermsLayout->addWidget(comboBox_searchTerms);
+    searchTermsLayout->addWidget(button_toggleSearchAreaResults);
+
+    QFrame *searchContainer = new QFrame();
+    QVBoxLayout *searchLayout = new QVBoxLayout(searchContainer);
+    searchLayout->addWidget(searchTerms, 0, Qt::AlignTop);
+    searchLayout->addWidget(treeWidget_searchResults);
+
+    QSplitter *searchSplitter = new QSplitter(Qt::Vertical);
+    searchSplitter->addWidget(treeWidget_triggers);
+    searchSplitter->addWidget(treeWidget_aliases);
+    searchSplitter->addWidget(treeWidget_actions);
+    searchSplitter->addWidget(treeWidget_timers);
+    searchSplitter->addWidget(treeWidget_scripts);
+    searchSplitter->addWidget(treeWidget_keys);
+    searchSplitter->addWidget(searchContainer);
+
+    searchSplitter->setStretchFactor(0, 1);
+    searchSplitter->setCollapsible(0, false);
+    searchSplitter->setStretchFactor(1, 1);
+    searchSplitter->setCollapsible(1, true);
+    // Add the splitter to the main layout
+    verticalLayout_frame_left->addWidget(searchSplitter);
+
     slot_showSearchAreaResults(false);
 
     mpScrollArea = mpTriggersMainArea->scrollArea;

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -278,7 +278,6 @@ public slots:
     void slot_copyXml();
     void slot_pasteXml();
 // Not used:    void slot_choseActionIcon();
-    void slot_showSearchAreaResults(bool);
     void slot_showAllTriggerControls(const bool);
     void slot_rightSplitterMoved(const int pos, const int handle);
     void slot_scriptMainAreaDeleteHandler();
@@ -313,6 +312,7 @@ private slots:
     void slot_restoreEditorActionsToolbar();
     void slot_restoreEditorItemsToolbar();
     void slot_itemEdited();
+    void slot_searchSplitterMoved(const int pos, const int index);
 
 public:
     TConsole* mpErrorConsole = nullptr;
@@ -542,6 +542,7 @@ private:
     QAction* mSaveItem = nullptr;
 
     SearchOptions mSearchOptions = SearchOptionNone;
+    QSplitter* searchSplitter;
 
     // This has a menu which the following QActions are inserted into:
     QAction* mpAction_searchOptions = nullptr;
@@ -587,6 +588,7 @@ private:
     QByteArray mKeyEditorSplitterState;
     QByteArray mTimerEditorSplitterState;
     QByteArray mVarEditorSplitterState;
+    QByteArray mSearchSplitterState;
 
     // approximate max duration "Copy as image" can take in seconds
     int mCopyAsImageMax = 0;

--- a/src/ui/trigger_editor.ui
+++ b/src/ui/trigger_editor.ui
@@ -486,46 +486,6 @@
              </property>
             </widget>
            </item>
-           <item>
-            <widget class="QToolButton" name="button_toggleSearchAreaResults">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>16</width>
-               <height>16</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>32</width>
-               <height>32</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string>&lt;p&gt;Toggles the display of the search results area.&lt;/p&gt;</string>
-             </property>
-             <property name="text">
-              <string/>
-             </property>
-             <property name="iconSize">
-              <size>
-               <width>16</width>
-               <height>16</height>
-              </size>
-             </property>
-             <property name="checkable">
-              <bool>true</bool>
-             </property>
-             <property name="arrowType">
-              <enum>Qt::NoArrow</enum>
-             </property>
-            </widget>
-           </item>
           </layout>
          </widget>
         </item>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Allow the script editor search results to be resized.  It can be resized all the way to hidden.

#### Motivation for adding to Mudlet
Improves user experience.

#### Other info (issues closed, discussion etc)
Wondering if the toggle show/hide results button is really necessary now?

[Peek 2025-01-01 16-59.webm](https://github.com/user-attachments/assets/0fe52012-657e-4f7d-a52f-8439b948a8bc)

closes #2905
/claim #2905 