### PR TITLE
Add: Medievia Patreon sponsorship

### DIFF
--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -1033,7 +1033,7 @@ void dlgAboutDialog::setThirdPartyTab(const QString& htmlHead) const
 void dlgAboutDialog::setSupportersTab(const QString& htmlHead)
 {
     // see https://www.patreon.com/mudlet if you'd like to be added!
-    QStringList mightier_than_swords = {"Joshua C. Burt", "Maiyannah Bishop", "Qwindor Rousseau", "Stick In the MUD 🎙"};
+    QStringList mightier_than_swords = {/* active */"Joshua C. Burt", "Stick In the MUD 🎙", "Medievia", /* inactive */ "Qwindor Rousseau", "Maiyannah Bishop"};
     QStringList on_a_plaque = {"demonnic", "Henry Hsiao"};
     int image_counter{1};
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add: Medievia Patreon sponsorship to the About menu
#### Motivation for adding to Mudlet
They are supporting Mudlet financially via https://www.patreon.com/mudlet
#### Other info (issues closed, discussion etc)
