### PR TITLE
Add: StickMUD to about menu

### DIFF
--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -1033,7 +1033,7 @@ void dlgAboutDialog::setThirdPartyTab(const QString& htmlHead) const
 void dlgAboutDialog::setSupportersTab(const QString& htmlHead)
 {
     // see https://www.patreon.com/mudlet if you'd like to be added!
-    QStringList mightier_than_swords = {/* active */"Joshua C. Burt", "Stick In the MUD 🎙", "Medievia", /* inactive */ "Qwindor Rousseau", "Maiyannah Bishop"};
+    QStringList mightier_than_swords = {/* active */"Joshua C. Burt", "StickMUD", "Medievia", /* inactive */ "Qwindor Rousseau", "Maiyannah Bishop", "Stick In the MUD 🎙"};
     QStringList on_a_plaque = {"demonnic", "Henry Hsiao"};
     int image_counter{1};
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add StickMUD to About menu
#### Motivation for adding to Mudlet
They are a Patreon supporter, see https://www.patreon.com/mudlet
#### Other info (issues closed, discussion etc)
Stick in the MUD podcast is not the same as [StickMUD](https://www.stickmud.com/)!