### PR TITLE
Fix: don't downgrade 64bit Windows installs to 32bit

### DIFF
--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -495,6 +495,7 @@ QString Updater::getPreviousVersion() const
 }
 
 #if defined(Q_OS_WIN32)
+// we are trying to detect machines running a 32-Bit build of Mudlet on a 64-Bit Intel/AMD processor
 bool Updater::is64BitCompatible() const 
 {
 #if defined(Q_OS_WIN64)

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -497,6 +497,16 @@ QString Updater::getPreviousVersion() const
 #if defined(Q_OS_WIN32)
 bool Updater::is64BitCompatible() const 
 {
+#if defined(Q_OS_WIN64)
+    const bool is64BitBuild = true;
+#else
+    const bool is64BitBuild = false;
+#endif
+
+    if (is64BitBuild) {
+        return true;
+    }
+
     BOOL isWow64 = FALSE;
     typedef BOOL (WINAPI *LPFN_ISWOW64PROCESS)(HANDLE, PBOOL);
     LPFN_ISWOW64PROCESS fnIsWow64Process = (LPFN_ISWOW64PROCESS)

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -498,14 +498,8 @@ QString Updater::getPreviousVersion() const
 bool Updater::is64BitCompatible() const 
 {
 #if defined(Q_OS_WIN64)
-    const bool is64BitBuild = true;
-#else
-    const bool is64BitBuild = false;
+    return true;
 #endif
-
-    if (is64BitBuild) {
-        return true;
-    }
 
     BOOL isWow64 = FALSE;
     typedef BOOL (WINAPI *LPFN_ISWOW64PROCESS)(HANDLE, PBOOL);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Don't downgrade 64bit Windows installs to 32bit
#### Motivation for adding to Mudlet
Bugfix
#### Other info (issues closed, discussion etc)
