### PR TITLE
Fix skipping word-wrapped lines

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -852,7 +852,7 @@ COMMIT_LINE:
             mpHost->mpConsole->runTriggers(line);
             // Only use of TBuffer::wrap(), breaks up new text
             // NOTE: it MAY have been clobbered by the trigger engine!
-            wrap(lineBuffer.size() - 1);
+            wrap(line);
 
             // Start a new, but empty line in the various buffers
             ++localBufferPosition;
@@ -2739,7 +2739,7 @@ inline int TBuffer::wrap(int startLine)
         }
     }
 
-    log(startLine - (lineBuffer.size() - tempList.size()), startLine + tempList.size());
+    log(startLine, startLine + tempList.size());
     return insertedLines > 0 ? insertedLines : 0;
 }
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2739,7 +2739,7 @@ inline int TBuffer::wrap(int startLine)
         }
     }
 
-    log(startLine, startLine + tempList.size());
+    log(startLine - (lineBuffer.size() - tempList.size()), startLine + tempList.size());
     return insertedLines > 0 ? insertedLines : 0;
 }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixed all word-wrapped lines but the last one being skipped when using the `^$` regex pattern with `deleteLine()` code in the trigger.
Explanation: Offset the word-wrapped lines so they aren't skipped. Fixes #2213

/claim #2213

[proof.webm](https://github.com/user-attachments/assets/7ab73d7b-4ce6-4eaf-bbc1-d0daf1b669de)
