### PR TITLE
Fix: put an outline around command lines

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -55,7 +55,14 @@ TCommandLine::TCommandLine(Host* pHost, const QString& name, CommandLineType typ
     setFont(mpHost->getDisplayFont());
     document()->setDocumentMargin(2);
 
-    setFrameShape(QFrame::Box);
+    if (mType & (MainCommandLine|ConsoleCommandLine)) {
+        // put an outline around the command line when it is integrated into
+        // bottom of a TConsole - so that it can be visually separated from
+        // the text output area - particulary when "dark" mode is in effect
+        // as that modified "Fusion" style suffers from the division being
+        // invisible without this:
+        setFrameShape(QFrame::Box);
+    }
 
     mRegularPalette.setColor(QPalette::Text, mpHost->mCommandLineFgColor);
     mRegularPalette.setColor(QPalette::Highlight, QColor(0, 0, 192));

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2018-2020, 2022-2024 by Stephen Lyons                   *
+ *   Copyright (C) 2018-2020, 2022-2025 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2023 by Lecker Kebap - Leris@mudlet.org                 *
  *                                                                         *
@@ -54,6 +54,8 @@ TCommandLine::TCommandLine(Host* pHost, const QString& name, CommandLineType typ
 
     setFont(mpHost->getDisplayFont());
     document()->setDocumentMargin(2);
+
+    setFrameShape(QFrame::Box);
 
     mRegularPalette.setColor(QPalette::Text, mpHost->mCommandLineFgColor);
     mRegularPalette.setColor(QPalette::Highlight, QColor(0, 0, 192));


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a frame around the `QPlainLineEdit` used for every command line.

#### Motivation for adding to Mudlet
Reported by the Discord user "cressie007" in the Mudlet Discord Guild **Help** channel - in the thread "Issue I had after updating to 4.19,1", was the fact that there was no visible demarcation between the input and output areas in the main console. A closer examination showed me that it was consistent across recent versions (4.18.5 at least to present) and visible with the dark mode (which is based on a modified "Fusion" theme that ALL builds of Mudlet will use on all OSes.) The reporter did note that when they reverted to 4.17.1 they did not have this issue however I had it to be present in both 4.17.0 and 4.17.2 release version.

#### Other info (issues closed, discussion etc)
The colour of the boarder/frame can be style specific but there is now definitely something showing after this PR.