### PR TITLE
Infrastructure: add libsecret-1-dev dependency for Ubuntu 24.04

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -225,7 +225,7 @@ jobs:
         # Install from vcpkg everything we can for cross-platform consistency
         # If not available, use other methods
         # imagemagick is for the desktop screenshot
-        sudo apt-get install ccache pkg-config pcregrep expect libzip-dev libglu1-mesa-dev libpulse-dev g++-${{matrix.gcc_compiler_version}} \
+        sudo apt-get install libsecret-1-dev ccache pkg-config pcregrep expect libzip-dev libglu1-mesa-dev libpulse-dev g++-${{matrix.gcc_compiler_version}} \
           libxkbcommon-x11-0 imagemagick -y
 
         # switch to GCC that supports C++20 while retaining support for older OS's

--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -100,7 +100,7 @@ jobs:
       run: |
         # Install from vcpkg everything we can for cross-platform consistency
         # If not available, use other methods
-        sudo apt-get install pkg-config libzip-dev libglu1-mesa-dev libpulse-dev -y
+        sudo apt-get install libsecret-1-dev pkg-config libzip-dev libglu1-mesa-dev libpulse-dev -y
 
         echo "Skipping generation of translation stats, so not installing lua-yajl."
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -119,7 +119,7 @@ jobs:
       run: |
         # Install from vcpkg everything we can for cross-platform consistency
         # If not available, use other methods
-        sudo apt-get install ccache pkg-config pcregrep luarocks expect libzip-dev libglu1-mesa-dev libpulse-dev g++-${{matrix.gcc_compiler_version}} -y
+        sudo apt-get install libsecret-1-dev ccache pkg-config pcregrep luarocks expect libzip-dev libglu1-mesa-dev libpulse-dev g++-${{matrix.gcc_compiler_version}} -y
 
         # switch to GCC that supports C++20 while retaining support for older OS's
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{matrix.gcc_compiler_version}} ${{matrix.gcc_compiler_version}}


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add libsecret-1-dev dependency for Ubuntu 24.04
#### Motivation for adding to Mudlet
Keep the builds working
#### Other info (issues closed, discussion etc)
