### PR TITLE
Add: draw upper and lower levels in the mapper

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -4278,17 +4278,6 @@ void Host::setLargeAreaExitArrows(const bool state)
     }
 }
 
-void Host::setDrawUpperLowerLevels(const bool state)
-{
-    if (mDrawUpperLowerLevels != state) {
-        mDrawUpperLowerLevels = state;
-        if (mpMap && mpMap->mpMapper && mpMap->mpMapper->mp2dMap) {
-            mpMap->mpMapper->mp2dMap->mDrawUpperLowerLevels = state;
-            mpMap->mpMapper->mp2dMap->update();
-        }
-    }
-}
-
 void Host::setEditorShowBidi(const bool state)
 {
     if (mEditorShowBidi != state) {

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1770,7 +1770,7 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, enums::Pa
     // method can be re-entered, it is best to use a local rather than a class
     // pointer just in case we accidentally re-enter this method in the future.
     QDialog* pUnzipDialog = nullptr;
-    
+
     QString actualFileName = fileName;
     std::unique_ptr<QTemporaryFile> tempFile;
 
@@ -4273,6 +4273,17 @@ void Host::setLargeAreaExitArrows(const bool state)
         mLargeAreaExitArrows = state;
         if (mpMap && mpMap->mpMapper && mpMap->mpMapper->mp2dMap) {
             mpMap->mpMapper->mp2dMap->mLargeAreaExitArrows = state;
+            mpMap->mpMapper->mp2dMap->update();
+        }
+    }
+}
+
+void Host::setDrawUpperLowerLevels(const bool state)
+{
+    if (mDrawUpperLowerLevels != state) {
+        mDrawUpperLowerLevels = state;
+        if (mpMap && mpMap->mpMapper && mpMap->mpMapper->mp2dMap) {
+            mpMap->mpMapper->mp2dMap->mDrawUpperLowerLevels = state;
             mpMap->mpMapper->mp2dMap->update();
         }
     }

--- a/src/Host.h
+++ b/src/Host.h
@@ -213,9 +213,7 @@ public:
     void            setControlCharacterMode(const ControlCharacterMode mode);
     ControlCharacterMode  getControlCharacterMode() const { return mControlCharacter; }
     bool            getLargeAreaExitArrows() const { return mLargeAreaExitArrows; }
-    bool            getDrawUpperLowerLevels() const { return mDrawUpperLowerLevels; }
     void            setLargeAreaExitArrows(const bool);
-    void            setDrawUpperLowerLevels(const bool);
 
     void            forceClose();
     bool            isClosingDown() const { return mIsClosingDown; }
@@ -896,7 +894,6 @@ private:
     ControlCharacterMode mControlCharacter = ControlCharacterMode::AsIs;
 
     bool mLargeAreaExitArrows = false;
-    bool mDrawUpperLowerLevels = false;
     bool mEditorShowBidi = true;
     // should focus should be on the main window with the caret enabled?
     bool mCaretEnabled = false;

--- a/src/Host.h
+++ b/src/Host.h
@@ -213,7 +213,9 @@ public:
     void            setControlCharacterMode(const ControlCharacterMode mode);
     ControlCharacterMode  getControlCharacterMode() const { return mControlCharacter; }
     bool            getLargeAreaExitArrows() const { return mLargeAreaExitArrows; }
+    bool            getDrawUpperLowerLevels() const { return mDrawUpperLowerLevels; }
     void            setLargeAreaExitArrows(const bool);
+    void            setDrawUpperLowerLevels(const bool);
 
     void            forceClose();
     bool            isClosingDown() const { return mIsClosingDown; }
@@ -619,6 +621,8 @@ public:
     QColor mWhite_2{QColorConstants::LightGray};
     QColor mFgColor_2{QColorConstants::LightGray};
     QColor mBgColor_2{QColorConstants::Black};
+    QColor mLowerLevelColor{QColorConstants::DarkGray};
+    QColor mUpperLevelColor{QColorConstants::White};
     QColor mRoomBorderColor{QColorConstants::LightGray};
     QColor mRoomCollisionBorderColor{QColorConstants::Yellow};
 
@@ -892,6 +896,7 @@ private:
     ControlCharacterMode mControlCharacter = ControlCharacterMode::AsIs;
 
     bool mLargeAreaExitArrows = false;
+    bool mDrawUpperLowerLevels = false;
     bool mEditorShowBidi = true;
     // should focus should be on the main window with the caret enabled?
     bool mCaretEnabled = false;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -133,6 +133,7 @@ void T2DMap::init()
     }
     flushSymbolPixmapCache();
     mLargeAreaExitArrows = mpHost->getLargeAreaExitArrows();
+    mDrawUpperLowerLevels = mpHost->getDrawUpperLowerLevels();
 }
 
 void T2DMap::slot_shiftDown()
@@ -1403,10 +1404,6 @@ void T2DMap::paintEvent(QPaintEvent* e)
         }
     }
 
-    if (!pDrawnArea->gridMode) {
-        paintRoomExits(painter, pen, exitList, oneWayExits, pDrawnArea, zLevel, exitWidth, areaExitsMap);
-    }
-
     // Draw label sizing or group selection box
     if (mSizeLabel) {
         painter.fillRect(mMultiRect, QColor(250, 190, 0, 190));
@@ -1420,6 +1417,59 @@ void T2DMap::paintEvent(QPaintEvent* e)
     QSet<QPair<int, int>> usedRoomPositions;
     // Draw the rooms:
     QSetIterator<int> itRoom(pDrawnArea->getAreaRooms());
+
+    if (mDrawUpperLowerLevels) {
+        // draw room on lower z-levels
+        while (itRoom.hasNext()) {
+            const int currentAreaRoom = itRoom.next();
+            TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
+            if (!room) {
+                continue;
+            }
+
+            if (room->z() == zLevel - 1) {
+                const float rx = room->x() * mRoomWidth + static_cast<float>(mRX);
+                const float ry = room->y() * -1 * mRoomHeight + static_cast<float>(mRY);
+                if (rx >= 0 && ry >= 0 && rx <= widgetWidth && ry <= widgetHeight) {
+                    painter.save();
+                    painter.setPen(Qt::NoPen);
+                    painter.setBrush(mpHost->mLowerLevelColor);
+                    painter.drawRect(rx - (mRoomWidth * rSize * 0.8), ry - (mRoomHeight * rSize * 0.2), mRoomWidth * rSize, mRoomHeight * rSize);
+                    painter.restore();
+                }
+            }
+        }
+        itRoom.toFront();
+
+        // draw rooms on upper z-levels
+        while (itRoom.hasNext()) {
+            const int currentAreaRoom = itRoom.next();
+            TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
+            if (!room) {
+                continue;
+            }
+
+            if (room->z() == zLevel + 1) {
+                const float rx = room->x() * mRoomWidth + static_cast<float>(mRX);
+                const float ry = room->y() * -1 * mRoomHeight + static_cast<float>(mRY);
+                if (rx >= 0 && ry >= 0 && rx <= widgetWidth && ry <= widgetHeight) {
+                    painter.save();
+                    painter.setPen(QPen(mpHost->mUpperLevelColor, 1));
+                    painter.setBrush(Qt::transparent);
+                    painter.drawRect(rx - (mRoomWidth * rSize * 0.2), ry - (mRoomHeight * rSize * 0.8), mRoomWidth * rSize, mRoomHeight * rSize);
+                    painter.restore();
+                }
+            }
+        }
+        itRoom.toFront();
+    }
+
+    // draw room exits
+    if (!pDrawnArea->gridMode) {
+        paintRoomExits(painter, pen, exitList, oneWayExits, pDrawnArea, zLevel, exitWidth, areaExitsMap);
+    }
+
+    // now draw rooms on selected z-level
     while (itRoom.hasNext()) {
         const int currentAreaRoom = itRoom.next();
         TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -133,7 +133,6 @@ void T2DMap::init()
     }
     flushSymbolPixmapCache();
     mLargeAreaExitArrows = mpHost->getLargeAreaExitArrows();
-    mDrawUpperLowerLevels = mpHost->getDrawUpperLowerLevels();
 }
 
 void T2DMap::slot_shiftDown()
@@ -1418,7 +1417,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
     // Draw the rooms:
     QSetIterator<int> itRoom(pDrawnArea->getAreaRooms());
 
-    if (mDrawUpperLowerLevels) {
+    if (mudlet::self()->mDrawUpperLowerLevels) {
         // draw room on lower z-levels
         while (itRoom.hasNext()) {
             const int currentAreaRoom = itRoom.next();

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1439,9 +1439,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
                         QPainterPath diameterPath;
                         diameterPath.addEllipse(roomCenter, roomRadius, roomRadius);
                         painter.drawPath(diameterPath);
-                    }
-                    else
-                    {
+                    } else {
                         painter.drawRect(rx - (mRoomWidth * rSize * 0.8), ry - (mRoomHeight * rSize * 0.2), mRoomWidth * rSize, mRoomHeight * rSize);
                     }
                 painter.restore();
@@ -1471,9 +1469,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
                         QPainterPath diameterPath;
                         diameterPath.addEllipse(roomCenter, roomRadius, roomRadius);
                         painter.drawPath(diameterPath);
-                    }
-                    else
-                    {
+                    } else {
                         painter.drawRect(rx - (mRoomWidth * rSize * 0.2), ry - (mRoomHeight * rSize * 0.8), mRoomWidth * rSize, mRoomHeight * rSize);
                     }
                     painter.restore();

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1434,8 +1434,18 @@ void T2DMap::paintEvent(QPaintEvent* e)
                     painter.save();
                     painter.setPen(Qt::NoPen);
                     painter.setBrush(mpHost->mLowerLevelColor);
-                    painter.drawRect(rx - (mRoomWidth * rSize * 0.8), ry - (mRoomHeight * rSize * 0.2), mRoomWidth * rSize, mRoomHeight * rSize);
-                    painter.restore();
+                    if (mBubbleMode) {
+                        const float roomRadius = 0.5 * rSize * mRoomWidth;
+                        const QPointF roomCenter = QPointF(rx - (roomRadius * rSize * 0.5), ry + (roomRadius * rSize * 0.5));
+                        QPainterPath diameterPath;
+                        diameterPath.addEllipse(roomCenter, roomRadius, roomRadius);
+                        painter.drawPath(diameterPath);
+                    }
+                    else
+                    {
+                        painter.drawRect(rx - (mRoomWidth * rSize * 0.8), ry - (mRoomHeight * rSize * 0.2), mRoomWidth * rSize, mRoomHeight * rSize);
+                    }
+                painter.restore();
                 }
             }
         }
@@ -1456,7 +1466,17 @@ void T2DMap::paintEvent(QPaintEvent* e)
                     painter.save();
                     painter.setPen(QPen(mpHost->mUpperLevelColor, 1));
                     painter.setBrush(Qt::transparent);
-                    painter.drawRect(rx - (mRoomWidth * rSize * 0.2), ry - (mRoomHeight * rSize * 0.8), mRoomWidth * rSize, mRoomHeight * rSize);
+                    if (mBubbleMode) {
+                        const float roomRadius = 0.5 * rSize * mRoomWidth;
+                        const QPointF roomCenter = QPointF(rx + (roomRadius * rSize * 0.5), ry - (roomRadius * rSize * 0.5));
+                        QPainterPath diameterPath;
+                        diameterPath.addEllipse(roomCenter, roomRadius, roomRadius);
+                        painter.drawPath(diameterPath);
+                    }
+                    else
+                    {
+                        painter.drawRect(rx - (mRoomWidth * rSize * 0.2), ry - (mRoomHeight * rSize * 0.8), mRoomWidth * rSize, mRoomHeight * rSize);
+                    }
                     painter.restore();
                 }
             }

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -195,6 +195,7 @@ public:
     // always work well on existing maps - so allow for them to be reverted
     // almost back to how they were before that PR:
     bool mLargeAreaExitArrows = false;
+    bool mDrawUpperLowerLevels = false;
 
 public slots:
     void slot_roomSelectionChanged();

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -195,7 +195,6 @@ public:
     // always work well on existing maps - so allow for them to be reverted
     // almost back to how they were before that PR:
     bool mLargeAreaExitArrows = false;
-    bool mDrawUpperLowerLevels = false;
 
 public slots:
     void slot_roomSelectionChanged();

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7195,6 +7195,13 @@ int TLuaInterpreter::setConfig(lua_State * L)
             host.mMapperShowRoomBorders = getVerifiedBool(L, __func__, 2, "value");
             return success();
         }
+        if (key == qsl("showUpperLowerLevels")) {
+            mudlet::self()->mDrawUpperLowerLevels = getVerifiedBool(L, __func__, 2, "value");;
+            if (host.mpMap->mpMapper->mp2dMap) {
+                host.mpMap->mpMapper->mp2dMap->update();
+            }
+            return success();
+        }
     }
 
     if (key == qsl("enableGMCP")) {

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -497,6 +497,10 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
         host.append_attribute("Large2DMapAreaExitArrows") = "yes";
     }
 
+    if (pHost->getDrawUpperLowerLevels()) {
+        host.append_attribute("DrawUpperLowerLevels") = "yes";
+    }
+
     { // Blocked so that indentation reflects that of the XML file
         host.append_child("name").text().set(pHost->mHostName.toUtf8().constData());
 
@@ -570,6 +574,8 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
 
         host.append_child("mFgColor2").text().set(pHost->mFgColor_2.name().toUtf8().constData());
         host.append_child("mBgColor2").text().set(pHost->mBgColor_2.name().toUtf8().constData());
+        host.append_child("mLowerLevelColor").text().set(pHost->mLowerLevelColor.name().toUtf8().constData());
+        host.append_child("mUpperLevelColor").text().set(pHost->mUpperLevelColor.name().toUtf8().constData());
         host.append_child("mRoomBorderColor").text().set(pHost->mRoomBorderColor.name().toUtf8().constData());
         host.append_child("mRoomCollisionBorderColor").text().set(pHost->mRoomCollisionBorderColor.name().toUtf8().constData());
         auto mapInfoBgNode = host.append_child("mMapInfoBg");

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -497,10 +497,6 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
         host.append_attribute("Large2DMapAreaExitArrows") = "yes";
     }
 
-    if (pHost->getDrawUpperLowerLevels()) {
-        host.append_attribute("DrawUpperLowerLevels") = "yes";
-    }
-
     { // Blocked so that indentation reflects that of the XML file
         host.append_child("name").text().set(pHost->mHostName.toUtf8().constData());
 

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -995,12 +995,6 @@ void XMLimport::readHost(Host* pHost)
         pHost->setLargeAreaExitArrows(false);
     }
 
-    if (attributes().hasAttribute(qsl("DrawUpperLowerLevels"))) {
-        pHost->setDrawUpperLowerLevels(attributes().value(qsl("DrawUpperLowerLevels")) == YES);
-    } else {
-        pHost->setDrawUpperLowerLevels(false);
-    }
-
     if (attributes().value(qsl("mShowInfo")) == qsl("no")) {
         mpHost->mMapInfoContributors.clear();
     }

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -995,6 +995,12 @@ void XMLimport::readHost(Host* pHost)
         pHost->setLargeAreaExitArrows(false);
     }
 
+    if (attributes().hasAttribute(qsl("DrawUpperLowerLevels"))) {
+        pHost->setDrawUpperLowerLevels(attributes().value(qsl("DrawUpperLowerLevels")) == YES);
+    } else {
+        pHost->setDrawUpperLowerLevels(false);
+    }
+
     if (attributes().value(qsl("mShowInfo")) == qsl("no")) {
         mpHost->mMapInfoContributors.clear();
     }
@@ -1182,6 +1188,10 @@ void XMLimport::readHost(Host* pHost)
                 pHost->mFgColor_2.setNamedColor(readElementText());
             } else if (name() == qsl("mBgColor2")) {
                 pHost->mBgColor_2.setNamedColor(readElementText());
+            } else if (name() == qsl("mLowerLevelColor")) {
+                pHost->mLowerLevelColor.setNamedColor(readElementText());
+            } else if (name() == qsl("mUpperLevelColor")) {
+                pHost->mUpperLevelColor.setNamedColor(readElementText());
             } else if (name() == qsl("mRoomBorderColor")) {
                 pHost->mRoomBorderColor.setNamedColor(readElementText());
             } else if (name() == qsl("mRoomCollisionBorderColor")) {

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1169,6 +1169,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     doubleSpinBox_networkPacketTimeout->setValue(pHost->mTelnet.getPostingTimeout() / 1000.0);
     comboBox_caretModeKey->setCurrentIndex(static_cast<int>(pHost->mCaretShortcut));
     checkBox_largeAreaExitArrows->setChecked(pHost->getLargeAreaExitArrows());
+    checkBox_drawUpperLowerLevels->setChecked(pHost->getDrawUpperLowerLevels());
     comboBox_blankLinesBehaviour->setCurrentIndex(static_cast<int>(pHost->mBlankLineBehaviour));
 
     // Enable the controls that would be disabled if there wasn't a Host instance
@@ -1231,6 +1232,8 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     connect(pushButton_foreground_color_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapExitsColor);
     connect(pushButton_background_color_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapBgColor);
+    connect(pushButton_lowerLevelColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setLowerLevelColor);
+    connect(pushButton_upperLevelColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setUpperLevelColor);
     connect(pushButton_roomBorderColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapRoomBorderColor);
     connect(pushButton_mapInfoBg, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapInfoBgColor);
     connect(pushButton_roomCollisionBorderColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapRoomCollisionBorderColor);
@@ -1257,6 +1260,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     connect(mIsToLogInHtml, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_changeLogFileAsHtml);
     connect(doubleSpinBox_networkPacketTimeout, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &dlgProfilePreferences::slot_setPostingTimeout);
     connect(checkBox_largeAreaExitArrows, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_changeLargeAreaExitArrows);
+    connect(checkBox_drawUpperLowerLevels, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_changeDrawUpperLowerLevels);
 
     //Shortcuts tab
     auto shortcutKeys = mudlet::self()->mpShortcutsManager->iterator();
@@ -1350,6 +1354,8 @@ void dlgProfilePreferences::disconnectHostRelatedControls()
 
     disconnect(pushButton_foreground_color_2, &QAbstractButton::clicked, nullptr, nullptr);
     disconnect(pushButton_background_color_2, &QAbstractButton::clicked, nullptr, nullptr);
+    disconnect(pushButton_lowerLevelColor, &QAbstractButton::clicked, nullptr, nullptr);
+    disconnect(pushButton_upperLevelColor, &QAbstractButton::clicked, nullptr, nullptr);
     disconnect(pushButton_roomBorderColor, &QAbstractButton::clicked, nullptr, nullptr);
     disconnect(pushButton_mapInfoBg, &QAbstractButton::clicked, nullptr, nullptr);
     disconnect(pushButton_roomCollisionBorderColor, &QAbstractButton::clicked, nullptr, nullptr);
@@ -1382,6 +1388,7 @@ void dlgProfilePreferences::disconnectHostRelatedControls()
     disconnect(spinBox_playerRoomOuterDiameter, qOverload<int>(&QSpinBox::valueChanged), nullptr, nullptr);
     disconnect(spinBox_playerRoomInnerDiameter, qOverload<int>(&QSpinBox::valueChanged), nullptr, nullptr);
     disconnect(checkBox_largeAreaExitArrows, &QCheckBox::toggled, nullptr, nullptr);
+    disconnect(checkBox_drawUpperLowerLevels, &QCheckBox::toggled, nullptr, nullptr);
 }
 
 void dlgProfilePreferences::clearHostDetails()
@@ -1651,6 +1658,8 @@ void dlgProfilePreferences::setColors2()
 
         pushButton_foreground_color_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mFgColor_2.name()));
         pushButton_background_color_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mBgColor_2.name()));
+        pushButton_lowerLevelColor->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mLowerLevelColor.name()));
+        pushButton_upperLevelColor->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mUpperLevelColor.name()));
         pushButton_roomBorderColor->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mRoomBorderColor.name()));
         pushButton_mapInfoBg->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mMapInfoBg.name()));
         pushButton_roomCollisionBorderColor->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mRoomCollisionBorderColor.name()));
@@ -1674,6 +1683,8 @@ void dlgProfilePreferences::setColors2()
 
         pushButton_foreground_color_2->setStyleSheet(QString());
         pushButton_background_color_2->setStyleSheet(QString());
+        pushButton_lowerLevelColor->setStyleSheet(QString());
+        pushButton_upperLevelColor->setStyleSheet(QString());
         pushButton_roomBorderColor->setStyleSheet(QString());
         pushButton_mapInfoBg->setStyleSheet(QString());
         pushButton_roomCollisionBorderColor->setStyleSheet(QString());
@@ -1751,6 +1762,8 @@ void dlgProfilePreferences::slot_resetMapColors()
 
     pHost->mFgColor_2 = Qt::lightGray;
     pHost->mBgColor_2 = Qt::black;
+    pHost->mLowerLevelColor = Qt::darkGray;
+    pHost->mUpperLevelColor = Qt::white;
     pHost->mRoomBorderColor = Qt::lightGray;
     pHost->mRoomCollisionBorderColor = Qt::yellow;
     pHost->mBlack_2 = Qt::black;
@@ -2094,6 +2107,22 @@ void dlgProfilePreferences::slot_setMapBgColor()
     Host* pHost = mpHost;
     if (pHost) {
         setButtonAndProfileColor(pushButton_background_color_2, pHost->mBgColor_2);
+    }
+}
+
+void dlgProfilePreferences::slot_setLowerLevelColor()
+{
+    Host* pHost = mpHost;
+    if (pHost) {
+        setButtonAndProfileColor(pushButton_lowerLevelColor, pHost->mLowerLevelColor);
+    }
+}
+
+void dlgProfilePreferences::slot_setUpperLevelColor()
+{
+    Host* pHost = mpHost;
+    if (pHost) {
+        setButtonAndProfileColor(pushButton_upperLevelColor, pHost->mUpperLevelColor);
     }
 }
 
@@ -4558,4 +4587,14 @@ void dlgProfilePreferences::slot_changeLargeAreaExitArrows(const bool state)
     }
 
     pHost->setLargeAreaExitArrows(state);
+}
+
+void dlgProfilePreferences::slot_changeDrawUpperLowerLevels(const bool state)
+{
+    Host* pHost = mpHost;
+    if (!pHost) {
+        return;
+    }
+
+    pHost->setDrawUpperLowerLevels(state);
 }

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1169,7 +1169,6 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     doubleSpinBox_networkPacketTimeout->setValue(pHost->mTelnet.getPostingTimeout() / 1000.0);
     comboBox_caretModeKey->setCurrentIndex(static_cast<int>(pHost->mCaretShortcut));
     checkBox_largeAreaExitArrows->setChecked(pHost->getLargeAreaExitArrows());
-    checkBox_drawUpperLowerLevels->setChecked(pHost->getDrawUpperLowerLevels());
     comboBox_blankLinesBehaviour->setCurrentIndex(static_cast<int>(pHost->mBlankLineBehaviour));
 
     // Enable the controls that would be disabled if there wasn't a Host instance
@@ -1260,7 +1259,6 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     connect(mIsToLogInHtml, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_changeLogFileAsHtml);
     connect(doubleSpinBox_networkPacketTimeout, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &dlgProfilePreferences::slot_setPostingTimeout);
     connect(checkBox_largeAreaExitArrows, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_changeLargeAreaExitArrows);
-    connect(checkBox_drawUpperLowerLevels, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_changeDrawUpperLowerLevels);
 
     //Shortcuts tab
     auto shortcutKeys = mudlet::self()->mpShortcutsManager->iterator();
@@ -1388,7 +1386,6 @@ void dlgProfilePreferences::disconnectHostRelatedControls()
     disconnect(spinBox_playerRoomOuterDiameter, qOverload<int>(&QSpinBox::valueChanged), nullptr, nullptr);
     disconnect(spinBox_playerRoomInnerDiameter, qOverload<int>(&QSpinBox::valueChanged), nullptr, nullptr);
     disconnect(checkBox_largeAreaExitArrows, &QCheckBox::toggled, nullptr, nullptr);
-    disconnect(checkBox_drawUpperLowerLevels, &QCheckBox::toggled, nullptr, nullptr);
 }
 
 void dlgProfilePreferences::clearHostDetails()
@@ -4587,14 +4584,4 @@ void dlgProfilePreferences::slot_changeLargeAreaExitArrows(const bool state)
     }
 
     pHost->setLargeAreaExitArrows(state);
-}
-
-void dlgProfilePreferences::slot_changeDrawUpperLowerLevels(const bool state)
-{
-    Host* pHost = mpHost;
-    if (!pHost) {
-        return;
-    }
-
-    pHost->setDrawUpperLowerLevels(state);
 }

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -107,6 +107,8 @@ public slots:
     void slot_setMapRoomBorderColor();
     void slot_setMapInfoBgColor();
     void slot_setMapRoomCollisionBorderColor();
+    void slot_setLowerLevelColor();
+    void slot_setUpperLevelColor();
     void slot_resetMapColors();
 
     // Map.
@@ -172,6 +174,7 @@ private slots:
     void slot_changeWrapAt();
     void slot_deleteMap();
     void slot_changeLargeAreaExitArrows(const bool);
+    void slot_changeDrawUpperLowerLevels(const bool);
     void slot_hidePasswordMigrationLabel();
     void slot_loadHistoryMap();
 

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -174,7 +174,6 @@ private slots:
     void slot_changeWrapAt();
     void slot_deleteMap();
     void slot_changeLargeAreaExitArrows(const bool);
-    void slot_changeDrawUpperLowerLevels(const bool);
     void slot_hidePasswordMigrationLabel();
     void slot_loadHistoryMap();
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2089,7 +2089,7 @@ void mudlet::readLateSettings(const QSettings& settings)
     mCopyAsImageTimeout = settings.value(qsl("copyAsImageTimeout"), mCopyAsImageTimeout).toInt();
 
     mMinLengthForSpellCheck = settings.value("minLengthForSpellCheck", 3).toInt();
-
+    mDrawUpperLowerLevels = settings.value("drawUpperLowerLevels", QVariant(true)).toBool();
     // Make a local version of the value so that we can update the real one
     // by calling the slot method that does that and ALSO carry out the
     // other things needed for it:
@@ -2246,6 +2246,7 @@ void mudlet::writeSettings()
     settings.setValue(qsl("enableMultiViewMode"), mMultiView);
     settings.setValue(qsl("enableMuteAPI"), mMuteAPI);
     settings.setValue(qsl("enableMuteGame"), mMuteGame);
+    settings.setValue(qsl("drawUpperLowerLevels"), mDrawUpperLowerLevels);
 }
 
 void mudlet::slot_showConnectionDialog()
@@ -2877,7 +2878,7 @@ void mudlet::startAutoLogin(const QStringList& cliProfiles)
     hostList << qsl("Mudlet self-test");
     hostList.removeDuplicates();
     int loadedProfiles = 0;
-    
+
     for (auto& hostName : cliProfiles){
         if (hostList.contains(hostName)) {
             QElapsedTimer timer;

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -402,6 +402,8 @@ public:
     std::unique_ptr<MudletInstanceCoordinator> mInstanceCoordinator;
     // How many graphemes do we need before we run the spell checker on a "word" in the command line:
     int mMinLengthForSpellCheck = 3;
+    bool mDrawUpperLowerLevels = true;
+
 
 #if defined(INCLUDE_UPDATER)
     Updater* pUpdater = nullptr;

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -2222,41 +2222,31 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QCheckBox" name="checkBox_drawUpperLowerLevels">
-            <property name="text">
-             <string>Draw rooms on upper and lower levels</string>
-            </property>
-            <property name="checked">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0" alignment="Qt::AlignRight">
+          <item row="2" column="0" alignment="Qt::AlignRight">
            <widget class="QLabel" name="label_mapSymbolsFont">
             <property name="text">
              <string>2D Map Room Symbol Font</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1" alignment="Qt::AlignLeft">
+          <item row="2" column="1" alignment="Qt::AlignLeft">
            <widget class="QFontComboBox" name="fontComboBox_mapSymbols"/>
           </item>
-          <item row="4" column="0">
+          <item row="3" column="0">
            <widget class="QCheckBox" name="checkBox_isOnlyMapSymbolFontToBeUsed">
             <property name="text">
              <string>Only use symbols (glyphs) from chosen font</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="3" column="1">
            <widget class="QPushButton" name="pushButton_showGlyphUsage">
             <property name="text">
              <string>Show symbol usage...</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="0" colspan="2">
+          <item row="4" column="0" colspan="2">
            <widget class="QWidget" name="widget_playerRoomStyle" native="true">
             <layout class="QGridLayout" name="gridLayout_widget_playerRoomStyle">
              <property name="leftMargin">
@@ -4334,7 +4324,6 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>comboBox_playerRoomStyle</tabstop>
   <tabstop>checkBox_showDefaultArea</tabstop>
   <tabstop>checkBox_largeAreaExitArrows</tabstop>
-  <tabstop>checkBox_drawUpperLowerLevels</tabstop>
   <tabstop>fontComboBox_mapSymbols</tabstop>
   <tabstop>pushButton_showGlyphUsage</tabstop>
   <tabstop>pushButton_playerRoomPrimaryColor</tabstop>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -2222,31 +2222,41 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="0" alignment="Qt::AlignRight">
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="checkBox_drawUpperLowerLevels">
+            <property name="text">
+             <string>Draw rooms on upper and lower levels</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" alignment="Qt::AlignRight">
            <widget class="QLabel" name="label_mapSymbolsFont">
             <property name="text">
              <string>2D Map Room Symbol Font</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1" alignment="Qt::AlignLeft">
+          <item row="3" column="1" alignment="Qt::AlignLeft">
            <widget class="QFontComboBox" name="fontComboBox_mapSymbols"/>
           </item>
-          <item row="3" column="0">
+          <item row="4" column="0">
            <widget class="QCheckBox" name="checkBox_isOnlyMapSymbolFontToBeUsed">
             <property name="text">
              <string>Only use symbols (glyphs) from chosen font</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="4" column="1">
            <widget class="QPushButton" name="pushButton_showGlyphUsage">
             <property name="text">
              <string>Show symbol usage...</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="0" colspan="2">
+          <item row="5" column="0" colspan="2">
            <widget class="QWidget" name="widget_playerRoomStyle" native="true">
             <layout class="QGridLayout" name="gridLayout_widget_playerRoomStyle">
              <property name="leftMargin">
@@ -2481,6 +2491,46 @@ you can use it but there could be issues with aligning columns of text</string>
            </widget>
           </item>
           <item row="2" column="0">
+           <widget class="QLabel" name="label_lowerLevelColor">
+            <property name="text">
+             <string>Lower level color:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_lowerLevelColor</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QPushButton" name="pushButton_lowerLevelColor">
+            <property name="autoFillBackground">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QLabel" name="label_upperLevelColor">
+            <property name="text">
+             <string>Upper level color:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_upperLevelColor</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3">
+           <widget class="QPushButton" name="pushButton_upperLevelColor">
+            <property name="autoFillBackground">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
            <widget class="QLabel" name="label_pushButton_roomCollisionBorderColor">
             <property name="text">
              <string>Overlapping rooms border:</string>
@@ -2490,7 +2540,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="3" column="1">
            <widget class="QPushButton" name="pushButton_roomCollisionBorderColor">
             <property name="autoFillBackground">
              <bool>true</bool>
@@ -2500,14 +2550,14 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0" colspan="4">
+          <item row="4" column="0" colspan="4">
            <widget class="Line" name="line_mapperColorsSeparator">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
+          <item row="5" column="0">
            <widget class="QLabel" name="label_17">
             <property name="text">
              <string>Black:</string>
@@ -2517,7 +2567,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="5" column="1">
            <widget class="QPushButton" name="pushButton_black_2">
             <property name="autoFillBackground">
              <bool>true</bool>
@@ -2527,7 +2577,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="2">
+          <item row="5" column="2">
            <widget class="QLabel" name="label_49">
             <property name="text">
              <string>Light black:</string>
@@ -2537,7 +2587,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="3">
+          <item row="5" column="3">
            <widget class="QPushButton" name="pushButton_Lblack_2">
             <property name="autoFillBackground">
              <bool>true</bool>
@@ -2547,7 +2597,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
+          <item row="6" column="0">
            <widget class="QLabel" name="label_42">
             <property name="text">
              <string>Red:</string>
@@ -2557,7 +2607,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
+          <item row="6" column="1">
            <widget class="QPushButton" name="pushButton_red_2">
             <property name="autoFillBackground">
              <bool>true</bool>
@@ -2567,7 +2617,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="2">
+          <item row="6" column="2">
            <widget class="QLabel" name="label_50">
             <property name="text">
              <string>Light red:</string>
@@ -2577,7 +2627,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="3">
+          <item row="6" column="3">
            <widget class="QPushButton" name="pushButton_Lred_2">
             <property name="autoFillBackground">
              <bool>true</bool>
@@ -2587,7 +2637,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="6" column="0">
+          <item row="7" column="0">
            <widget class="QLabel" name="label_43">
             <property name="text">
              <string>Green:</string>
@@ -2597,7 +2647,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="6" column="1">
+          <item row="7" column="1">
            <widget class="QPushButton" name="pushButton_green_2">
             <property name="autoFillBackground">
              <bool>true</bool>
@@ -2607,7 +2657,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="6" column="2">
+          <item row="7" column="2">
            <widget class="QLabel" name="label_51">
             <property name="text">
              <string>Light green:</string>
@@ -2617,7 +2667,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="6" column="3">
+          <item row="7" column="3">
            <widget class="QPushButton" name="pushButton_Lgreen_2">
             <property name="autoFillBackground">
              <bool>true</bool>
@@ -2627,7 +2677,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="0">
+          <item row="8" column="0">
            <widget class="QLabel" name="label_48">
             <property name="text">
              <string>Yellow:</string>
@@ -2637,7 +2687,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="1">
+          <item row="8" column="1">
            <widget class="QPushButton" name="pushButton_yellow_2">
             <property name="autoFillBackground">
              <bool>true</bool>
@@ -2647,7 +2697,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="2">
+          <item row="8" column="2">
            <widget class="QLabel" name="label_52">
             <property name="text">
              <string>Light yellow:</string>
@@ -2657,7 +2707,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="3">
+          <item row="8" column="3">
            <widget class="QPushButton" name="pushButton_Lyellow_2">
             <property name="autoFillBackground">
              <bool>true</bool>
@@ -2667,7 +2717,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="8" column="0">
+          <item row="9" column="0">
            <widget class="QLabel" name="label_44">
             <property name="text">
              <string>Blue:</string>
@@ -2677,7 +2727,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="8" column="1">
+          <item row="9" column="1">
            <widget class="QPushButton" name="pushButton_blue_2">
             <property name="autoFillBackground">
              <bool>true</bool>
@@ -2687,7 +2737,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="8" column="2">
+          <item row="9" column="2">
            <widget class="QLabel" name="label_53">
             <property name="text">
              <string>Light blue:</string>
@@ -2697,7 +2747,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="8" column="3">
+          <item row="9" column="3">
            <widget class="QPushButton" name="pushButton_Lblue_2">
             <property name="autoFillBackground">
              <bool>true</bool>
@@ -2707,7 +2757,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="9" column="0">
+          <item row="10" column="0">
            <widget class="QLabel" name="label_45">
             <property name="text">
              <string>Magenta:</string>
@@ -2717,7 +2767,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="9" column="1">
+          <item row="10" column="1">
            <widget class="QPushButton" name="pushButton_magenta_2">
             <property name="autoFillBackground">
              <bool>true</bool>
@@ -2727,7 +2777,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="9" column="2">
+          <item row="10" column="2">
            <widget class="QLabel" name="label_54">
             <property name="text">
              <string>Light magenta:</string>
@@ -2737,7 +2787,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="9" column="3">
+          <item row="10" column="3">
            <widget class="QPushButton" name="pushButton_Lmagenta_2">
             <property name="autoFillBackground">
              <bool>true</bool>
@@ -2747,7 +2797,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="10" column="0">
+          <item row="11" column="0">
            <widget class="QLabel" name="label_46">
             <property name="text">
              <string>Cyan:</string>
@@ -2757,7 +2807,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="10" column="1">
+          <item row="11" column="1">
            <widget class="QPushButton" name="pushButton_cyan_2">
             <property name="autoFillBackground">
              <bool>true</bool>
@@ -2767,7 +2817,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="10" column="2">
+          <item row="11" column="2">
            <widget class="QLabel" name="label_55">
             <property name="text">
              <string>Light cyan:</string>
@@ -2777,7 +2827,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="10" column="3">
+          <item row="11" column="3">
            <widget class="QPushButton" name="pushButton_Lcyan_2">
             <property name="autoFillBackground">
              <bool>true</bool>
@@ -2787,7 +2837,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="11" column="0">
+          <item row="12" column="0">
            <widget class="QLabel" name="label_47">
             <property name="text">
              <string>White:</string>
@@ -2797,7 +2847,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="11" column="1">
+          <item row="12" column="1">
            <widget class="QPushButton" name="pushButton_white_2">
             <property name="autoFillBackground">
              <bool>true</bool>
@@ -2807,7 +2857,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="11" column="2">
+          <item row="12" column="2">
            <widget class="QLabel" name="label_56">
             <property name="text">
              <string>Light white:</string>
@@ -2817,7 +2867,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="11" column="3">
+          <item row="12" column="3">
            <widget class="QPushButton" name="pushButton_Lwhite_2">
             <property name="autoFillBackground">
              <bool>true</bool>
@@ -2827,7 +2877,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="12" column="2" colspan="2">
+          <item row="13" column="2" colspan="2">
            <widget class="QPushButton" name="reset_colors_button_2">
             <property name="text">
              <string>Reset all colors to default</string>
@@ -4284,6 +4334,7 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>comboBox_playerRoomStyle</tabstop>
   <tabstop>checkBox_showDefaultArea</tabstop>
   <tabstop>checkBox_largeAreaExitArrows</tabstop>
+  <tabstop>checkBox_drawUpperLowerLevels</tabstop>
   <tabstop>fontComboBox_mapSymbols</tabstop>
   <tabstop>pushButton_showGlyphUsage</tabstop>
   <tabstop>pushButton_playerRoomPrimaryColor</tabstop>
@@ -4292,6 +4343,8 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>spinBox_playerRoomInnerDiameter</tabstop>
   <tabstop>pushButton_foreground_color_2</tabstop>
   <tabstop>pushButton_roomBorderColor</tabstop>
+  <tabstop>pushButton_lowerLevelColor</tabstop>
+  <tabstop>pushButton_upperLevelColor</tabstop>
   <tabstop>pushButton_roomCollisionBorderColor</tabstop>
   <tabstop>pushButton_background_color_2</tabstop>
   <tabstop>pushButton_mapInfoBg</tabstop>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add optional drawing of upper and lower levels in the mapper.  User selectable colours and toggle to turn it all off.

#### Motivation for adding to Mudlet
Better user experience.

#### Other info (issues closed, discussion etc)
[Peek 2025-01-10 07-10.webm](https://github.com/user-attachments/assets/33d39d0e-7b72-4d04-8246-d797028ea7fb)

/closes #4188
/claim #4188