### PR TITLE
Infrastructure: don't sign into azure for dependabot

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -86,13 +86,13 @@ jobs:
 
     - name: (Windows) Login to Azure
       uses: azure/login@v2
-      if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      if: github.actor != 'dependabot[bot]' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
     - name: Get Azure access token for code signing
       shell: pwsh
-      if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      if: github.actor != 'dependabot[bot]' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
       run: |
         $token = (az account get-access-token --resource https://codesigning.azure.net | ConvertFrom-Json).accessToken
         "::add-mask::$token"

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -192,20 +192,23 @@ else
   export JAVA_HOME="$(cygpath -u $JAVA_HOME_21_X64)"
   export PATH="$JAVA_HOME/bin:$PATH"
 
-  echo "=== Signing Mudlet and dll files ==="
-  if [[ "$PublicTestBuild" == "true" ]]; then
-    java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
-        --keystore eus.codesigning.azure.net \
-        --storepass ${AZURE_ACCESS_TOKEN} \
-        --alias Mudlet/Mudlet \
-        "$PACKAGE_DIR/Mudlet PTB.exe" "$PACKAGE_DIR/**/*.dll"
-
+  if [ -z "${AZURE_ACCESS_TOKEN}" ]; then
+      echo "=== Code signing skipped - no Azure token provided ==="
   else
-    java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
-      --keystore eus.codesigning.azure.net \
-      --storepass ${AZURE_ACCESS_TOKEN} \
-      --alias Mudlet/Mudlet \
-      "$PACKAGE_DIR/Mudlet.exe" "$PACKAGE_DIR/**/*.dll"
+      echo "=== Signing Mudlet and dll files ==="
+      if [[ "$PublicTestBuild" == "true" ]]; then
+          java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
+              --keystore eus.codesigning.azure.net \
+              --storepass ${AZURE_ACCESS_TOKEN} \
+              --alias Mudlet/Mudlet \
+              "$PACKAGE_DIR/Mudlet PTB.exe" "$PACKAGE_DIR/**/*.dll"
+      else
+          java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
+              --keystore eus.codesigning.azure.net \
+              --storepass ${AZURE_ACCESS_TOKEN} \
+              --alias Mudlet/Mudlet \
+              "$PACKAGE_DIR/Mudlet.exe" "$PACKAGE_DIR/**/*.dll"
+      fi
   fi
 
   echo "=== Installing Squirrel for Windows ==="


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Don't sign into azure for dependabot
#### Motivation for adding to Mudlet
Address https://github.com/Mudlet/Mudlet/pull/7657 where we try to sign in yet there is no secrets available to dependabot.
#### Other info (issues closed, discussion etc)
