### PR TITLE
Fix: Clear event handler field for new scripts

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4373,6 +4373,7 @@ void dlgTriggerEditor::addScript(bool isFolder)
     }
     mpScriptsMainArea->lineEdit_script_name->clear();
     mpScriptsMainArea->label_idNumber->clear();
+    mpScriptsMainArea->lineEdit_script_event_handler_entry->clear();
 
     clearDocument(mpSourceEditorEdbee, script);
     mpCurrentScriptItem = pNewItem;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
The GUI event handler entry field doesn't get cleared when a new script is created via the Add Item button.  This fixes the issue.

#### Motivation for adding to Mudlet
Better user experience.

#### Other info (issues closed, discussion etc)
/closes #7631