### PR TITLE
Infrastructure: build with Qt6 for macOS, Linux

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -28,7 +28,7 @@ jobs:
             triplet: x64-linux
             compiler: gcc_64
             gcc_compiler_version: 10
-            qt: '5.14.2'
+            qt: '6.8.1'
             deploy: 'deploy'
             run_tests: 'true'
           - os: ubuntu-latest
@@ -36,7 +36,7 @@ jobs:
             triplet: x64-linux
             compiler: clang_64
             gcc_compiler_version: 10
-            qt: '5.14.2'
+            qt: '6.8.1'
           - os: macos-13
             buildname: 'macos (x86_64) / c++, lua tests'
             triplet: x64-osx
@@ -70,7 +70,7 @@ jobs:
         version: ${{matrix.qt}}
         dir: ${{runner.workspace}}
         cache: true
-        modules: ${{ startsWith(matrix.qt, '6') && 'qt5compat qtmultimedia' || '' }}
+        modules: qt5compat qtmultimedia
 
     - name: Restore Boost cache
       id: restore-boost

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -41,14 +41,14 @@ jobs:
             buildname: 'macos (x86_64) / c++, lua tests'
             triplet: x64-osx
             compiler: clang_64
-            qt: '5.14.2'
+            qt: '6.8.1'
             deploy: 'deploy'
             run_tests: 'true'
           - os: macos-14
             buildname: 'macos (arm64) / c++, lua tests'
             triplet: arm64-osx
             compiler: clang_64
-            qt: '5.15.13'
+            qt: '6.8.1'
             deploy: 'deploy'
             run_tests: 'true'
 
@@ -65,8 +65,6 @@ jobs:
         fetch-depth: 0
 
     - name: Install Qt
-      # need to install qt via homebrew for qt5 on arm64-osx
-      if: ${{ !(matrix.triplet == 'arm64-osx' && startsWith(matrix.qt, '5')) }}
       uses: jurplel/install-qt-action@v4
       with:
         version: ${{matrix.qt}}
@@ -116,11 +114,6 @@ jobs:
       run: |
         # dependencies needed for vcpkg specifically.
         BREWS=("automake" "autoconf" "pkg-config")
-
-        # for qt5 on arm64, also install libtool and qt@5
-        if [[ "$(uname -m)" = "arm64" && "$QT_VERSION" == 5* ]]; then
-         BREWS+=("libtool" "qt@5")
-        fi
 
         # Loop through each brew package
         for brew in "${BREWS[@]}"; do
@@ -192,17 +185,6 @@ jobs:
         eval "$(luarocks path --local --lua-version "5.1")"
         echo "LUA_PATH=$LUA_PATH" >> $GITHUB_ENV
         echo "LUA_CPATH=$LUA_CPATH" >> $GITHUB_ENV
-
-    - name: (macOS) Add additional paths for Qt5 on arm64 (1/1)
-      if: ${{ matrix.triplet == 'arm64-osx' && startsWith(matrix.qt, '5') }}
-      run: |
-        echo "LDFLAGS=-L$(brew --prefix qt@5)/lib" >> $GITHUB_ENV
-        echo "CPPFLAGS=-I$(brew --prefix qt@5)/include" >> $GITHUB_ENV
-        echo "PKG_CONFIG_PATH=$(brew --prefix qt@5)/lib/pkgconfig" >> $GITHUB_ENV
-        echo "QT_PREFIX=$(brew --prefix qt@5)" >> $GITHUB_ENV
-        # both of these needed for the packager / installer on Github
-        echo "PATH=$(brew --prefix qt@5)/bin:$PATH" >> $GITHUB_ENV
-        echo "QT_DIR=$(brew --prefix qt@5)" >> $GITHUB_ENV
 
       # though we vcpkg installs Lua for us, the way it arranges directories is not compatible with Luarocks,
       # so install it in a format that works

--- a/CI/travis.osx.install.sh
+++ b/CI/travis.osx.install.sh
@@ -4,7 +4,7 @@ set +e
 shopt -s expand_aliases
 #Removed boost as first item as a temporary workaround to prevent trying to
 #upgrade to boost version 1.68.0 which has not been bottled yet...
-BREWS="luarocks cmake hunspell libzip mudlet/dependencies/lua@5.1 pcre pkg-config qt5 yajl ccache pugixml"
+BREWS="luarocks cmake hunspell libzip mudlet/dependencies/lua@5.1 pcre pkg-config yajl ccache pugixml"
 OUTDATED_BREWS=$(brew outdated)
 
 for i in $BREWS; do

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@
 cmake_minimum_required(VERSION 3.25.1)
 
 if(APPLE)
-  # minimum supported version by Qt6 for our Qt5/Qt6 build compatibility
+  # minimum supported version by Qt6
   set(CMAKE_OSX_DEPLOYMENT_TARGET "12.0" CACHE STRING "")
 endif()
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Build with Qt6 for macOS and Linux
#### Motivation for adding to Mudlet
Allow us to use Qt6 features in official Mudlet releases
#### Other info (issues closed, discussion etc)
Windows 64bit is already built with Qt 6, and Windows 32bit is on its way out.