### PR TITLE
Fix: ensure a script editor list item is always selected

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -942,6 +942,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     if (mAutosaveInterval > 0) {
         startTimer(mAutosaveInterval * 1min);
     }
+
 }
 
 void dlgTriggerEditor::slot_searchSplitterMoved(const int pos, const int index)
@@ -2688,12 +2689,15 @@ void dlgTriggerEditor::delete_alias()
 
     if (pParent) {
         pParent->removeChild(pItem);
+        mpCurrentAliasItem = pParent;
+        treeWidget_aliases->setCurrentItem(pParent);
+        slot_aliasSelected(treeWidget_aliases->currentItem());
     } else {
         qDebug() << "ERROR: dlgTriggerEditor::delete_alias() child to be deleted does not have a parent";
+        mpCurrentAliasItem = nullptr;
+        clearAliasForm();
     }
     delete pT;
-    mpCurrentAliasItem = nullptr;
-    clearAliasForm();
 }
 
 void dlgTriggerEditor::delete_action()
@@ -2718,13 +2722,16 @@ void dlgTriggerEditor::delete_action()
 
     if (pParent) {
         pParent->removeChild(pItem);
+        mpCurrentActionItem = pParent;
+        treeWidget_actions->setCurrentItem(pParent);
+        slot_actionSelected(treeWidget_actions->currentItem());
     } else {
         qDebug() << "ERROR: dlgTriggerEditor::delete_action() child to be deleted does not have a parent";
+        mpCurrentActionItem = nullptr;
+        clearActionForm();
     }
     delete pT;
-    mpCurrentActionItem = nullptr;
     mpHost->getActionUnit()->updateToolbar();
-    clearActionForm();
 }
 
 void dlgTriggerEditor::delete_variable()
@@ -2748,11 +2755,15 @@ void dlgTriggerEditor::delete_variable()
     }
     if (pParent) {
         pParent->removeChild(pItem);
+        mpCurrentVarItem = pParent;
+        treeWidget_variables->setCurrentItem(pParent);
+        slot_variableSelected(treeWidget_variables->currentItem());
     } else {
         qDebug() << "ERROR: dlgTriggerEditor::delete_action() child to be deleted does not have a parent";
+        mpCurrentVarItem = nullptr;
+        clearVarForm();
     }
-    mpCurrentVarItem = nullptr;
-    clearVarForm();
+
 }
 
 void dlgTriggerEditor::delete_script()
@@ -2769,12 +2780,15 @@ void dlgTriggerEditor::delete_script()
 
     if (pParent) {
         pParent->removeChild(pItem);
+        mpCurrentScriptItem = pParent;
+        treeWidget_scripts->setCurrentItem(pParent);
+        slot_scriptsSelected(treeWidget_scripts->currentItem());
     } else {
         qDebug() << "ERROR: dlgTriggerEditor::delete_script() child to be deleted does not have a parent";
+        mpCurrentScriptItem = nullptr;
+        clearScriptForm();
     }
     delete pT;
-    mpCurrentScriptItem = nullptr;
-    clearScriptForm();
 }
 
 void dlgTriggerEditor::delete_key()
@@ -2792,12 +2806,15 @@ void dlgTriggerEditor::delete_key()
 
     if (pParent) {
         pParent->removeChild(pItem);
+        mpCurrentKeyItem = pParent;
+        treeWidget_keys->setCurrentItem(pParent);
+        slot_keySelected(treeWidget_keys->currentItem());
     } else {
         qDebug() << "ERROR: dlgTriggerEditor::delete_key() child to be deleted does not have a parent";
+        mpCurrentKeyItem = nullptr;
+        clearKeyForm();
     }
     delete pT;
-    mpCurrentKeyItem = nullptr;
-    clearKeyForm();
 }
 
 void dlgTriggerEditor::delete_trigger()
@@ -2815,12 +2832,16 @@ void dlgTriggerEditor::delete_trigger()
 
     if (pParent) {
         pParent->removeChild(pItem);
+        mpCurrentTriggerItem = pParent;
+        treeWidget_triggers->setCurrentItem(pParent);
+        slot_triggerSelected(treeWidget_triggers->currentItem());
     } else {
         qDebug() << "ERROR: dlgTriggerEditor::delete_trigger() child to be deleted does not have a parent";
+        mpCurrentTriggerItem = nullptr;
+        clearTriggerForm();
     }
     delete pT;
-    mpCurrentTriggerItem = nullptr;
-    clearTriggerForm();
+
 }
 
 void dlgTriggerEditor::delete_timer()
@@ -2838,12 +2859,15 @@ void dlgTriggerEditor::delete_timer()
 
     if (pParent) {
         pParent->removeChild(pItem);
+        mpCurrentTimerItem = pParent;
+        treeWidget_timers->setCurrentItem(pParent);
+        slot_timerSelected(treeWidget_timers->currentItem());
     } else {
         qDebug() << "ERROR: dlgTriggerEditor::delete_timer() child to be deleted does not have a parent";
+        mpCurrentTimerItem = nullptr;
+        clearTimerForm();
     }
     delete pT;
-    mpCurrentTimerItem = nullptr;
-    clearTimerForm();
 }
 
 
@@ -6686,36 +6710,42 @@ void dlgTriggerEditor::fillout_form()
     treeWidget_triggers->insertTopLevelItem(0, mpTriggerBaseItem);
     populateTriggers();
     mpTriggerBaseItem->setExpanded(true);
+    treeWidget_triggers->setCurrentItem(mpTriggerBaseItem);
 
     mpTimerBaseItem = new QTreeWidgetItem(static_cast<QTreeWidgetItem*>(nullptr), QStringList(tr("Timers")));
     mpTimerBaseItem->setIcon(0, QPixmap(qsl(":/icons/chronometer.png")));
     treeWidget_timers->insertTopLevelItem(0, mpTimerBaseItem);
     populateTimers();
     mpTimerBaseItem->setExpanded(true);
+    treeWidget_timers->setCurrentItem(mpTimerBaseItem);
 
     mpScriptsBaseItem = new QTreeWidgetItem(static_cast<QTreeWidgetItem*>(nullptr), QStringList(tr("Scripts")));
     mpScriptsBaseItem->setIcon(0, QPixmap(qsl(":/icons/accessories-text-editor.png")));
     treeWidget_scripts->insertTopLevelItem(0, mpScriptsBaseItem);
     populateScripts();
     mpScriptsBaseItem->setExpanded(true);
+    treeWidget_scripts->setCurrentItem(mpScriptsBaseItem);
 
     mpAliasBaseItem = new QTreeWidgetItem(static_cast<QTreeWidgetItem*>(nullptr), QStringList(tr("Aliases - Input Triggers")));
     mpAliasBaseItem->setIcon(0, QPixmap(qsl(":/icons/system-users.png")));
     treeWidget_aliases->insertTopLevelItem(0, mpAliasBaseItem);
     populateAliases();
     mpAliasBaseItem->setExpanded(true);
+    treeWidget_aliases->setCurrentItem(mpAliasBaseItem);
 
     mpActionBaseItem = new QTreeWidgetItem(static_cast<QTreeWidgetItem*>(nullptr), QStringList(tr("Buttons")));
     mpActionBaseItem->setIcon(0, QPixmap(qsl(":/icons/bookmarks.png")));
     treeWidget_actions->insertTopLevelItem(0, mpActionBaseItem);
     populateActions();
     mpActionBaseItem->setExpanded(true);
+    treeWidget_actions->setCurrentItem(mpActionBaseItem);
 
     mpKeyBaseItem = new QTreeWidgetItem(static_cast<QTreeWidgetItem*>(nullptr), QStringList(tr("Key Bindings")));
     mpKeyBaseItem->setIcon(0, QPixmap(qsl(":/icons/preferences-desktop-keyboard.png")));
     treeWidget_keys->insertTopLevelItem(0, mpKeyBaseItem);
     populateKeys();
     mpKeyBaseItem->setExpanded(true);
+    treeWidget_keys->setCurrentItem(mpKeyBaseItem);
 }
 
 void dlgTriggerEditor::populateKeys()
@@ -7211,6 +7241,8 @@ void dlgTriggerEditor::repopulateVars()
     vu->buildVarTree(mpVarBaseItem, vu->getBase(), showHiddenVars);
     mpVarBaseItem->setExpanded(true);
     treeWidget_variables->setUpdatesEnabled(true);
+    treeWidget_variables->setCurrentItem(mpVarBaseItem);
+
 }
 
 void dlgTriggerEditor::expand_child_triggers(TTrigger* pTriggerParent, QTreeWidgetItem* pWidgetItemParent)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
In the Script Editor, ensure the root item is selected on startup.  When deleting an item, ensure the parent folder (or root) is selected.  This clearly shows which folder is being worked on and prevents a new item being added to an unexpected bottom folder.

#### Motivation for adding to Mudlet
Prevents unexpected behavior, better user experience.  

#### Other info (issues closed, discussion etc)
[Peek 2025-01-15 05-20.webm](https://github.com/user-attachments/assets/de08cff3-e34c-4121-b27b-58b3a2354df2)

/closes #7632