### PR TITLE
Improve script editor UI for editing event handlers

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8449,7 +8449,7 @@ void dlgTriggerEditor::slot_scriptMainAreaEditHandler()
     mpScriptsMainArea->lineEdit_script_event_handler_entry->setText(regex);
 }
 
-void dlgTriggerEditor::slot_scriptMainAreaClearHandlerSelection(QListWidgetItem *)
+void dlgTriggerEditor::slot_scriptMainAreaClearHandlerSelection(QListWidgetItem*)
 {
     mpScriptsMainArea->listWidget_script_registered_event_handlers->clearSelection();
     mpScriptsMainArea->lineEdit_script_event_handler_entry->clear();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8435,6 +8435,16 @@ void dlgTriggerEditor::slot_scriptMainAreaEditHandler(QListWidgetItem*)
     if (!pItem) {
         return;
     }
+
+    // deselect if already selected and turn off edit mode
+    if (mpScriptsMainAreaEditHandlerItem == pItem) {
+        mpScriptsMainArea->listWidget_script_registered_event_handlers->clearSelection();
+        mpScriptsMainArea->lineEdit_script_event_handler_entry->clear();
+        mIsScriptsMainAreaEditHandler = false;
+        mpScriptsMainAreaEditHandlerItem = nullptr;
+        return;
+    }
+
     mIsScriptsMainAreaEditHandler = true;
     mpScriptsMainAreaEditHandlerItem = pItem;
     const QString regex = pItem->text();
@@ -8448,13 +8458,28 @@ void dlgTriggerEditor::slot_scriptMainAreaEditHandler(QListWidgetItem*)
 void dlgTriggerEditor::slot_scriptMainAreaDeleteHandler()
 {
     mpScriptsMainArea->listWidget_script_registered_event_handlers->takeItem(mpScriptsMainArea->listWidget_script_registered_event_handlers->currentRow());
+    mIsScriptsMainAreaEditHandler = false;
+    mpScriptsMainAreaEditHandlerItem = nullptr;
 }
 
 void dlgTriggerEditor::slot_scriptMainAreaAddHandler()
 {
     auto addEventHandler = [&] () {
+        if (mpScriptsMainArea->lineEdit_script_event_handler_entry->text().isEmpty()) {
+            return;
+        }
+
+        // check for duplicate handlers
+        QString newHandlerText = mpScriptsMainArea->lineEdit_script_event_handler_entry->text();
+        QListWidget* list = mpScriptsMainArea->listWidget_script_registered_event_handlers;
+        for(int i = 0; i < list->count(); i++) {
+            if(list->item(i)->text() == newHandlerText) {
+                return;
+            }
+        }
+
         auto pItem = new QListWidgetItem;
-        pItem->setText(mpScriptsMainArea->lineEdit_script_event_handler_entry->text());
+        pItem->setText(newHandlerText);
         mpScriptsMainArea->listWidget_script_registered_event_handlers->addItem(pItem);
     };
 
@@ -8464,17 +8489,20 @@ void dlgTriggerEditor::slot_scriptMainAreaAddHandler()
             mIsScriptsMainAreaEditHandler = false;
             addEventHandler();
         } else {
-            QListWidgetItem* pItem = mpScriptsMainArea->listWidget_script_registered_event_handlers->currentItem();
-            if (!pItem) {
-                addEventHandler();
+            if (mpScriptsMainAreaEditHandlerItem->text() == mpScriptsMainArea->lineEdit_script_event_handler_entry->text()
+            || mpScriptsMainArea->lineEdit_script_event_handler_entry->text().isEmpty()) {
+                return;
             }
+            mpScriptsMainAreaEditHandlerItem->setText(mpScriptsMainArea->lineEdit_script_event_handler_entry->text());
+            mpScriptsMainArea->listWidget_script_registered_event_handlers->clearSelection();
         }
-        mIsScriptsMainAreaEditHandler = false;
-        mpScriptsMainAreaEditHandlerItem = nullptr;
     } else {
         addEventHandler();
     }
     mpScriptsMainArea->lineEdit_script_event_handler_entry->clear();
+    mpScriptsMainArea->listWidget_script_registered_event_handlers->clearSelection();
+    mIsScriptsMainAreaEditHandler = false;
+    mpScriptsMainAreaEditHandlerItem = nullptr;
 }
 
 void dlgTriggerEditor::slot_toggleCentralDebugConsole()

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -218,7 +218,9 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     layoutColumn->addWidget(mpScriptsMainArea, 1);
 
     connect(mpScriptsMainArea->lineEdit_script_event_handler_entry, &QLineEdit::returnPressed, this, &dlgTriggerEditor::slot_scriptMainAreaAddHandler);
-    connect(mpScriptsMainArea->listWidget_script_registered_event_handlers, &QListWidget::itemClicked, this, &dlgTriggerEditor::slot_scriptMainAreaEditHandler);
+    connect(mpScriptsMainArea->listWidget_script_registered_event_handlers, &QListWidget::itemSelectionChanged, this, &dlgTriggerEditor::slot_scriptMainAreaEditHandler);
+    connect(mpScriptsMainArea->listWidget_script_registered_event_handlers, &QListWidget::itemActivated, this, &dlgTriggerEditor::slot_scriptMainAreaClearHandlerSelection);
+
 
     // source editor area
     mpSourceEditorArea = new dlgSourceEditorArea(this);
@@ -8426,22 +8428,14 @@ void dlgTriggerEditor::slot_saveSelectedItem(QTreeWidgetItem* pItem)
     }
 }
 
+
 // Should the functionality change in this method be sure to review the code
 // for "case SearchResultIsEventHandler" for "Scripts" in:
 // slot_itemSelectedInSearchResults(...)
-void dlgTriggerEditor::slot_scriptMainAreaEditHandler(QListWidgetItem*)
+void dlgTriggerEditor::slot_scriptMainAreaEditHandler()
 {
     QListWidgetItem* pItem = mpScriptsMainArea->listWidget_script_registered_event_handlers->currentItem();
     if (!pItem) {
-        return;
-    }
-
-    // deselect if already selected and turn off edit mode
-    if (mpScriptsMainAreaEditHandlerItem == pItem) {
-        mpScriptsMainArea->listWidget_script_registered_event_handlers->clearSelection();
-        mpScriptsMainArea->lineEdit_script_event_handler_entry->clear();
-        mIsScriptsMainAreaEditHandler = false;
-        mpScriptsMainAreaEditHandlerItem = nullptr;
         return;
     }
 
@@ -8455,11 +8449,18 @@ void dlgTriggerEditor::slot_scriptMainAreaEditHandler(QListWidgetItem*)
     mpScriptsMainArea->lineEdit_script_event_handler_entry->setText(regex);
 }
 
+void dlgTriggerEditor::slot_scriptMainAreaClearHandlerSelection(QListWidgetItem *)
+{
+    mpScriptsMainArea->listWidget_script_registered_event_handlers->clearSelection();
+    mpScriptsMainArea->lineEdit_script_event_handler_entry->clear();
+    mIsScriptsMainAreaEditHandler = false;
+    mpScriptsMainAreaEditHandlerItem = nullptr;
+}
+
 void dlgTriggerEditor::slot_scriptMainAreaDeleteHandler()
 {
     mpScriptsMainArea->listWidget_script_registered_event_handlers->takeItem(mpScriptsMainArea->listWidget_script_registered_event_handlers->currentRow());
-    mIsScriptsMainAreaEditHandler = false;
-    mpScriptsMainAreaEditHandlerItem = nullptr;
+    slot_scriptMainAreaClearHandlerSelection(nullptr);
 }
 
 void dlgTriggerEditor::slot_scriptMainAreaAddHandler()
@@ -8499,10 +8500,8 @@ void dlgTriggerEditor::slot_scriptMainAreaAddHandler()
     } else {
         addEventHandler();
     }
-    mpScriptsMainArea->lineEdit_script_event_handler_entry->clear();
-    mpScriptsMainArea->listWidget_script_registered_event_handlers->clearSelection();
-    mIsScriptsMainAreaEditHandler = false;
-    mpScriptsMainAreaEditHandlerItem = nullptr;
+
+    slot_scriptMainAreaClearHandlerSelection(nullptr);
 }
 
 void dlgTriggerEditor::slot_toggleCentralDebugConsole()

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8472,8 +8472,8 @@ void dlgTriggerEditor::slot_scriptMainAreaAddHandler()
         // check for duplicate handlers
         QString newHandlerText = mpScriptsMainArea->lineEdit_script_event_handler_entry->text();
         QListWidget* list = mpScriptsMainArea->listWidget_script_registered_event_handlers;
-        for(int i = 0; i < list->count(); i++) {
-            if(list->item(i)->text() == newHandlerText) {
+        for (int i = 0; i < list->count(); i++) {
+            if (list->item(i)->text() == newHandlerText) {
                 return;
             }
         }

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -282,7 +282,8 @@ public slots:
     void slot_rightSplitterMoved(const int pos, const int handle);
     void slot_scriptMainAreaDeleteHandler();
     void slot_scriptMainAreaAddHandler();
-    void slot_scriptMainAreaEditHandler(QListWidgetItem*);
+    void slot_scriptMainAreaEditHandler();
+    void slot_scriptMainAreaClearHandlerSelection(QListWidgetItem *);
     void slot_keyGrab();
     void slot_profileSaveAction();
     void slot_profileSaveAsAction();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Modifying event handlers for scripts had a number of bugs including allowing duplicates, unable to edit current entries and allowing zero length text (i.e., `""`) entries.  This attempts to fix these problems by denying duplicates or zero length entries and allowing a click to select/deselect UI for editing entries.

#### Motivation for adding to Mudlet
UI responds more consistently.

#### Other info (issues closed, discussion etc)
[Peek 2025-01-15 16-09.webm](https://github.com/user-attachments/assets/f2f4b7c7-efe3-40a6-905e-ad151ba3a0f5)

/closes #7630
