### PR TITLE
Fix newline not registering when calling 'echo' programatically

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -852,7 +852,8 @@ COMMIT_LINE:
             mpHost->mpConsole->runTriggers(line);
             // Only use of TBuffer::wrap(), breaks up new text
             // NOTE: it MAY have been clobbered by the trigger engine!
-            wrap(line);
+            const int latestLine = lineBuffer.size() - 1;
+            wrap(line > latestLine ? latestLine : line);
 
             // Start a new, but empty line in the various buffers
             ++localBufferPosition;


### PR DESCRIPTION
This PR attempts to fix new word-wrapping issues which seem to come from [here](https://github.com/Mudlet/Mudlet/pull/7643)