### PR TITLE
Fix: disable connect and offline buttons when a profile is in use

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -949,6 +949,8 @@ void dlgConnectionProfiles::slot_itemClicked(QListWidgetItem* pItem)
     if (mudlet::self()->getHostManager().getHost(profile_name)) {
         remove_profile_button->setEnabled(false);
         remove_profile_button->setToolTip(utils::richText(tr("A profile that is in use cannot be removed")));
+        connect_button->setEnabled(false);
+        offline_button->setEnabled(false);
 
         profile_name_entry->setReadOnly(true);
         host_name_entry->setReadOnly(true);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Disable connect and offline buttons when a profile is in use
#### Motivation for adding to Mudlet
Prevent double-loading of module contents - see https://discord.com/channels/283581582550237184/283582068334526464/1330617636601598024
#### Other info (issues closed, discussion etc)
![image](https://github.com/user-attachments/assets/8abe40cd-5f91-4e3e-b463-cde7368e8520)
