### PR TITLE
Improve: make map label input box handle more than one line.

### DIFF
--- a/src/dlgMapLabel.cpp
+++ b/src/dlgMapLabel.cpp
@@ -21,7 +21,9 @@
 #include "dlgMapLabel.h"
 #include "mudlet.h"
 #include "utils.h"
+#include "pre_guard.h"
 #include <QSettings>
+#include "post_guard.h"
 
 static QString BUTTON_STYLESHEET = qsl("QPushButton { background-color: rgba(%1, %2, %3, %4); }");
 
@@ -38,8 +40,8 @@ dlgMapLabel::dlgMapLabel(QWidget* pParentWidget)
     connect(comboBox_type, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &dlgMapLabel::updated);
     connect(toolButton_imagePick, &QToolButton::released, this, &dlgMapLabel::slot_pickFile);
     connect(checkBox_stretchImage, &QCheckBox::stateChanged, this, &dlgMapLabel::updated);
-    connect(lineEdit_text, &QLineEdit::textChanged, this, [&](const QString& pText) {
-        text = pText;
+    connect(plainTextEdit_labelText, &QPlainTextEdit::textChanged, this, [&]() {
+        text = plainTextEdit_labelText->toPlainText();
         emit updated();
     });
     connect(pushButton_bgColor, &QPushButton::released, this, &dlgMapLabel::slot_pickBgColor);
@@ -54,7 +56,7 @@ dlgMapLabel::dlgMapLabel(QWidget* pParentWidget)
 
     font = QApplication::font();
     font.setStyle(QFont::StyleNormal);
-    text = lineEdit_text->placeholderText();
+    text = plainTextEdit_labelText->placeholderText();
 
     QSettings& settings = *mudlet::getQSettings();
     fgColor = settings.value("fgColorDialogMapLabel", fgColor).value<QColor>();
@@ -244,7 +246,7 @@ void dlgMapLabel::slot_updateControlsVisibility()
     checkBox_stretchImage->setVisible(!isText);
     toolButton_imagePick->setVisible(!isText);
     label_text->setVisible(isText);
-    lineEdit_text->setVisible(isText);
+    plainTextEdit_labelText->setVisible(isText);
     label_font->setVisible(isText);
     lineEdit_font->setVisible(isText);
     toolButton_fontPick->setVisible(isText);

--- a/src/ui/map_label.ui
+++ b/src/ui/map_label.ui
@@ -93,12 +93,18 @@
          <string>Label text:</string>
         </property>
         <property name="buddy">
-         <cstring>lineEdit_text</cstring>
+         <cstring>plainTextEdit_labelText</cstring>
         </property>
        </widget>
       </item>
       <item row="3" column="1" colspan="2">
-       <widget class="QLineEdit" name="lineEdit_text">
+       <widget class="QPlainTextEdit" name="plainTextEdit_labelText">
+        <property name="tabChangesFocus">
+         <bool>true</bool>
+        </property>
+        <property name="lineWrapMode">
+         <enum>QTextEdit::LineWrapMode::NoWrap</enum>
+        </property>
         <property name="placeholderText">
          <string>My Label</string>
         </property>

--- a/src/ui/map_label.ui
+++ b/src/ui/map_label.ui
@@ -103,7 +103,7 @@
          <bool>true</bool>
         </property>
         <property name="lineWrapMode">
-         <enum>QTextEdit::LineWrapMode::NoWrap</enum>
+         <enum>QPlainTextEdit::LineWrapMode::NoWrap</enum>
         </property>
         <property name="placeholderText">
          <string>My Label</string>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Changes the text entry widget for the text content for that type of "Map Label" from a `QLineEdit` to a `QPlainTextEdit`.

#### Motivation for adding to Mudlet
To make it possible to enter multi-line texts into text Map Labels. The existing widget does not show/enable the native entry of line-feeds and the only way to get them into such texts is to prepare them in an external location and paste them in - and after doing so they look just like spaces.

#### Other info (issues closed, discussion etc)
This the first (I hope) of some improvements I want to make to the map label user-experience. I found out that this was needed whilst MUDding on After the Plague MUD where, when map making I wanted to label area exits with some extra details and to include textual information about locations within the map.

I also discovered the `(bool) tabChangesFocus` property which several text entry widgets possess which if set (and it is normally `false`) allows the `<Tab>` key to be used to move the focus out of that widget; when it is `false` it is used to enter *tabs* into the text itself. For this widget I have set it to `true` - but I do wonder if there are other widgets in the Mudlet application where this needs to be reviewed because it does impact on the user experience particularly for visually-impaired persons.