### PR TITLE
Fix: use map symbol font when entering or showing Map Symbols

### DIFF
--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -91,6 +91,12 @@ void dlgRoomProperties::init(
             comboBox_roomSymbol->lineEdit()->selectAll();
         }
     }
+    if (!lineEdit_roomSymbol->isHidden()) {
+        lineEdit_roomSymbol->setFont(mpHost->mpMap->mMapSymbolFont);
+    }
+    if (!comboBox_roomSymbol->isHidden()) {
+        comboBox_roomSymbol->setFont(mpHost->mpMap->mMapSymbolFont);
+    }
     initSymbolInstructions();
 
     // Configure icon display


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Configures the widgets used in the "Room properties" dialog to use the same font that is actually used in the mapper.

#### Motivation for adding to Mudlet
The `QLineEdit` and `QComboBox` that are used during entry/selection of the `QString` to use for all the selected room(s) in that dialog were not using the "Map Symbol" font so - if the latter includes emoji glyphs (in particular) or any other that is not in the default "Application font" then what is displayed does not match up to what will be seen on-screen.

#### Other info (issues closed, discussion etc)
There is one case where the display in the room properties dialog will still not match what is shown in the map and that is the case where ***any*** glyph used is not available. The dialog will show each individual glyph whereas the map will just show the "Replacement character" (`�`) - the latter to indicate that there is a problem within the `QString` used for the symbol for that room as a whole.
