### PR TITLE
Infrastructure: remove hunspell from vcpkg dependencies for x64-osx triplet

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -157,6 +157,9 @@ jobs:
         # these aren't available or don't work well in vcpkg
         BREWS=("libzzip" "libzip" "ccache" "luarocks" "expect")
 
+        # these are available in vcpkg but not working in our old version
+        BREWS+=("hunspell")
+
         # Loop through each brew package
         for brew in "${BREWS[@]}"; do
           if ! brew list --formula "{brew}" &>/dev/null; then

--- a/3rdparty/our-vcpkg-dependencies/vcpkg-arm64-osx-dependencies
+++ b/3rdparty/our-vcpkg-dependencies/vcpkg-arm64-osx-dependencies
@@ -1,7 +1,6 @@
 --triplet
 arm64-osx
 yajl
-hunspell
 pugixml
 --overlay-ports=../our-vcpkg-dependencies/lua
 lua[core]

--- a/3rdparty/our-vcpkg-dependencies/vcpkg-x64-osx-dependencies
+++ b/3rdparty/our-vcpkg-dependencies/vcpkg-x64-osx-dependencies
@@ -1,7 +1,6 @@
 --triplet
 x64-osx
 yajl
-hunspell
 pugixml
 --overlay-ports=../our-vcpkg-dependencies/lua
 lua[core]


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove hunspell from vcpkg dependencies for x64-osx triplet
#### Motivation for adding to Mudlet
Fix failing builds - and perhaps we can do away without it in vcpkg.
#### Other info (issues closed, discussion etc)
