### PR TITLE
fix: disable recently added toolbar actions until profile is opened

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1745,6 +1745,11 @@ void mudlet::disableToolbarButtons()
     dactionModuleManager->setEnabled(false);
     dactionPackageExporter->setEnabled(false);
 
+    dactionToggleTimeStamp->setEnabled(false);
+    dactionToggleReplay->setEnabled(false);
+    dactionToggleLogging->setEnabled(false);
+    dactionToggleEmergencyStop->setEnabled(false);
+
     mpActionIRC->setEnabled(false);
     dactionIRC->setEnabled(false);
 
@@ -1801,6 +1806,11 @@ void mudlet::enableToolbarButtons()
     dactionPackageManager->setEnabled(true);
     dactionModuleManager->setEnabled(true);
     dactionPackageExporter->setEnabled(true);
+
+    dactionToggleTimeStamp->setEnabled(true);
+    dactionToggleReplay->setEnabled(true);
+    dactionToggleLogging->setEnabled(true);
+    dactionToggleEmergencyStop->setEnabled(true);
 
     mpActionIRC->setEnabled(true);
     dactionIRC->setEnabled(true);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Disable actions added in #7538 until a profile is loaded, along the same lines as other toolbar actions.

#### Motivation for adding to Mudlet
Bug fix for previous commit.  Better stability.

#### Other info (issues closed, discussion etc)
Introduced hotkeys in #7538 but toolbar action was enabled by default, meaning an action could be selected without a profile open which would crash Mudlet.  