### PR TITLE
Fix: prevent crashes when shortcuts are empty

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1281,9 +1281,8 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         shortcutsRow++;
         connect(sequenceEdit, &QKeySequenceEdit::editingFinished, this, [=]() {
             QKeySequence* newSequence = nullptr;
-            if (sequenceEdit->keySequence().isEmpty()) {
-                newSequence = sequence;
-            } else if (sequenceEdit->keySequence().matches(QKeySequence(Qt::Key_Escape))) {
+            if (sequenceEdit->keySequence().isEmpty()
+                    || sequenceEdit->keySequence().matches(QKeySequence(Qt::Key_Escape))) {
                 newSequence = new QKeySequence();
             } else {
                 newSequence = new QKeySequence(sequenceEdit->keySequence());


### PR DESCRIPTION
#### Brief overview of PR changes/additions
When a short-cut was empty in the preferences and editing was finished on it - e.g. the end-user clicked on something else the previous code was not generating a new (empty) `QKeySequence` to be swapped over for the existing (also empty one). Instead a pointer was set to point to the existing one. However that is a mistake as the code following would use `QKeySequence::swap(QKeySequence* other)` in **ALL** code paths - but since both pointers were pointing at the same `QKeySequence` that was ineffective and led to the (wanted) existing (but empty) `QKeySequence` immediately being `delete`d... This fix ensures that a replacement (but also) empty instance is created so that when the swap occurs there is still a valid (but empty) `QKeySequence` in place.

#### Motivation for adding to Mudlet
To stop Mudlet from crashing when used with any short-cuts erased.

#### Other info (issues closed, discussion etc)
This should close #7689.
