### PR TITLE
Fix miniconsole indentation

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2259,6 +2259,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
         // to "unit" character width (whatever we work THAT out to be)
         // multiplied by mWrap:
         if (lineBuffer.back().size() >= mWrapAt) {
+            const TChar indentSpace(mBackGroundColor, mBackGroundColor, TChar::None);
             const QString qIndent(mWrapIndent, QChar::Space);
             const QString qHangingIndent(mWrapHangingIndent, QChar::Space);
             for (int i = lineBuffer.back().size() - 1 - indent; i >= hangingIndent; --i) {
@@ -2266,7 +2267,6 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
                     const int linebreakPos = (i != hangingIndent) ? i + 1 : lineBuffer.back().size() - indent;
                     const QString tmp = lineBuffer.back().mid(0, linebreakPos);
                     const QString lineRest = lineBuffer.back().mid(linebreakPos);
-                    const TChar indentSpace(mpConsole);
                     if (indent > 0) {
                         lineBuffer.back() = qIndent + tmp;
                         while (indent > 0) {
@@ -2289,9 +2289,8 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
                         }
                     }
 
-                    const TChar hangingSpace(mpConsole);
                     for (int i = 0; i < hangingIndent; ++i) {
-                        newLine.push_front(hangingSpace);
+                        newLine.push_front(indentSpace);
                     }
                     buffer.push_back(newLine);
 
@@ -2386,6 +2385,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
         // to "unit" character width (whatever we work THAT out to be)
         // multiplied by mWrap:
         if (lineBuffer.back().size() >= mWrapAt) {
+            const TChar indentSpace(mBackGroundColor, mBackGroundColor, TChar::None);
             const QString qIndent(mWrapIndent, QChar::Space);
             const QString qHangingIndent(mWrapHangingIndent, QChar::Space);
             for (int i = lineBuffer.back().size() - 1 - indent; i >= hangingIndent; --i) {
@@ -2395,7 +2395,6 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
                     const QString tmp = lineBuffer.back().mid(0, linebreakPos);
                     const QString lineRest = lineBuffer.back().mid(linebreakPos);
 
-                    const TChar indentSpace(mpConsole);
                     if (indent > 0) {
                         lineBuffer.back() = qIndent + tmp;
                         while (indent > 0) {
@@ -2418,9 +2417,8 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
                         }
                     }
 
-                    const TChar hangingSpace(mpConsole);
                     for (int i = 0; i < hangingIndent; ++i) {
-                        newLine.push_front(hangingSpace);
+                        newLine.push_front(indentSpace);
                     }
                     buffer.push_back(newLine);
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2259,6 +2259,12 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
         // to "unit" character width (whatever we work THAT out to be)
         // multiplied by mWrap:
         if (lineBuffer.back().size() >= mWrapAt) {
+            // if the line starts with a space we consider it to already be aligned and prevent the firstline indentation:
+            if (lineBuffer.back().at(0) == QChar::Space) {
+                indent = 0;
+                hangingIndent = (mWrapHangingIndent < mWrapAt) ? mWrapHangingIndent : 0;
+            }
+
             const TChar indentSpace(mBackGroundColor, mBackGroundColor, TChar::None);
             const QString qIndent(mWrapIndent, QChar::Space);
             const QString qHangingIndent(mWrapHangingIndent, QChar::Space);
@@ -2385,6 +2391,12 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
         // to "unit" character width (whatever we work THAT out to be)
         // multiplied by mWrap:
         if (lineBuffer.back().size() >= mWrapAt) {
+            // if the line starts with a space we consider it to already be aligned and prevent the firstline indentation:
+            if (lineBuffer.back().at(0) == QChar::Space) {
+                indent = 0;
+                hangingIndent = (mWrapHangingIndent < mWrapAt) ? mWrapHangingIndent : 0;
+            }
+
             const TChar indentSpace(mBackGroundColor, mBackGroundColor, TChar::None);
             const QString qIndent(mWrapIndent, QChar::Space);
             const QString qHangingIndent(mWrapHangingIndent, QChar::Space);

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2263,7 +2263,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
             const QString qHangingIndent(mWrapHangingIndent, QChar::Space);
             for (int i = lineBuffer.back().size() - 1 - indent; i >= hangingIndent; --i) {
                 if (lineBreaks.indexOf(lineBuffer.back().at(i)) > -1 || i == hangingIndent) {
-                    const int linebreakPos = (i != hangingIndent) ? i + 1 : lineBuffer.back().size();
+                    const int linebreakPos = (i != hangingIndent) ? i + 1 : lineBuffer.back().size() - indent;
                     const QString tmp = lineBuffer.back().mid(0, linebreakPos);
                     const QString lineRest = lineBuffer.back().mid(linebreakPos);
                     const TChar indentSpace(mpConsole);
@@ -2391,7 +2391,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
             for (int i = lineBuffer.back().size() - 1 - indent; i >= hangingIndent; --i) {
                 // insert linebreak either at linebreaking character location or at last character of line
                 if (lineBreaks.indexOf(lineBuffer.back().at(i)) > -1 || i == hangingIndent) {
-                    const int linebreakPos = (i != hangingIndent) ? i + 1 : lineBuffer.back().size();
+                    const int linebreakPos = (i != hangingIndent) ? i + 1 : lineBuffer.back().size() - indent;
                     const QString tmp = lineBuffer.back().mid(0, linebreakPos);
                     const QString lineRest = lineBuffer.back().mid(linebreakPos);
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2302,7 +2302,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
 
                     if (lineRest.size() > 0) {
                         lineBuffer.append(qHangingIndent + lineRest);
-                    } {
+                    } else {
                         lineBuffer.append(qHangingIndent);
                     } 
                     timeBuffer << csmBlankTimeStamp;

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2237,7 +2237,8 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
         sub_end = text.size() - 1;
     }
 
-    int indent = 0;
+    int indent = (mWrapIndent < mWrapAt) ? mWrapIndent : 0;
+    int hangingIndent = 0;
     for (int i = sub_start; i < length; ++i) {
         //FIXME <=substart+sub_end must check whether sub-ranges are still needed
         if (text.at(i) == QChar::LineFeed) {
@@ -2248,7 +2249,9 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
             timeBuffer << csmBlankTimeStamp;
             promptBuffer << false;
             firstChar = true;
-            indent = 0;
+            // after newline, re-enable first indent and disable hanging
+            indent = mWrapIndent;
+            hangingIndent = 0;
             continue;
         }
 
@@ -2256,15 +2259,27 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
         // to "unit" character width (whatever we work THAT out to be)
         // multiplied by mWrap:
         if (lineBuffer.back().size() >= mWrapAt) {
-            for (int i = lineBuffer.back().size() - 1; i >= indent; --i) {
-                if (lineBreaks.indexOf(lineBuffer.back().at(i)) > -1 || i == indent) {
-                    const int linebreakPos = (i != indent) ? i + 1 : lineBuffer.back().size();
-                    indent = mWrapIndent;
+            const QString qIndent(mWrapIndent, QChar::Space);
+            const QString qHangingIndent(mWrapHangingIndent, QChar::Space);
+            for (int i = lineBuffer.back().size() - 1 - indent; i >= hangingIndent; --i) {
+                if (lineBreaks.indexOf(lineBuffer.back().at(i)) > -1 || i == hangingIndent) {
+                    const int linebreakPos = (i != hangingIndent) ? i + 1 : lineBuffer.back().size();
                     const QString tmp = lineBuffer.back().mid(0, linebreakPos);
                     const QString lineRest = lineBuffer.back().mid(linebreakPos);
-                    lineBuffer.back() = tmp;
-                    std::deque<TChar> newLine;
+                    const TChar indentSpace(mpConsole);
+                    if (indent > 0) {
+                        lineBuffer.back() = qIndent + tmp;
+                        while (indent > 0) {
+                            buffer.back().push_front(indentSpace);
+                            indent--;
+                        }
+                    } else {
+                        lineBuffer.back() = tmp;
+                    }
+                    // after the first-line indentation, we enable the hanging-indent
+                    hangingIndent = (mWrapHangingIndent < mWrapAt) ? mWrapHangingIndent : 0;
 
+                    std::deque<TChar> newLine;
                     int restOfLine = lineRest.size();
                     if (restOfLine > 0) {
                         while (restOfLine > 0) {
@@ -2274,17 +2289,16 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
                         }
                     }
 
-                    const TChar pSpace(mpConsole);
-                    for (int i = 0; i < indent; ++i) {
-                        newLine.push_front(pSpace);
+                    const TChar hangingSpace(mpConsole);
+                    for (int i = 0; i < hangingIndent; ++i) {
+                        newLine.push_front(hangingSpace);
                     }
                     buffer.push_back(newLine);
 
-                    const QString qIndent(indent, QChar::Space);
                     if (lineRest.size() > 0) {
-                        lineBuffer.append(qIndent + lineRest);
+                        lineBuffer.append(qHangingIndent + lineRest);
                     } {
-                        lineBuffer.append(qIndent);
+                        lineBuffer.append(qHangingIndent);
                     } 
                     timeBuffer << csmBlankTimeStamp;
                     promptBuffer << false;
@@ -2351,7 +2365,8 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
         sub_end = text.size() - 1;
     }
 
-    int indent = 0;
+    int indent = (mWrapIndent < mWrapAt) ? mWrapIndent : 0;
+    int hangingIndent = 0;
     for (int i = sub_start; i < length; ++i) {
         if (text.at(i) == '\n') {
             log(size() - 1, size() - 1);
@@ -2361,7 +2376,9 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
             timeBuffer << csmBlankTimeStamp;
             promptBuffer << false;
             firstChar = true;
-            indent = 0;
+            // after newline, re-enable first indent and disable hanging
+            indent = mWrapIndent;
+            hangingIndent = 0;
             continue;
         }
 
@@ -2369,16 +2386,29 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
         // to "unit" character width (whatever we work THAT out to be)
         // multiplied by mWrap:
         if (lineBuffer.back().size() >= mWrapAt) {
-            for (int i = lineBuffer.back().size() - 1; i >= indent; --i) {
+            const QString qIndent(mWrapIndent, QChar::Space);
+            const QString qHangingIndent(mWrapHangingIndent, QChar::Space);
+            for (int i = lineBuffer.back().size() - 1 - indent; i >= hangingIndent; --i) {
                 // insert linebreak either at linebreaking character location or at last character of line
-                if (lineBreaks.indexOf(lineBuffer.back().at(i)) > -1 || i == indent) {
-                    const int linebreakPos = (i != indent) ? i + 1 : lineBuffer.back().size();
-                    indent = mWrapIndent;
+                if (lineBreaks.indexOf(lineBuffer.back().at(i)) > -1 || i == hangingIndent) {
+                    const int linebreakPos = (i != hangingIndent) ? i + 1 : lineBuffer.back().size();
                     const QString tmp = lineBuffer.back().mid(0, linebreakPos);
                     const QString lineRest = lineBuffer.back().mid(linebreakPos);
-                    lineBuffer.back() = tmp;
-                    std::deque<TChar> newLine;
 
+                    const TChar indentSpace(mpConsole);
+                    if (indent > 0) {
+                        lineBuffer.back() = qIndent + tmp;
+                        while (indent > 0) {
+                            buffer.back().push_front(indentSpace);
+                            indent--;
+                        }
+                    } else {
+                        lineBuffer.back() = tmp;
+                    }
+                    // after the first-line indentation, we enable the hanging-indent
+                    hangingIndent = (mWrapHangingIndent < mWrapAt) ? mWrapHangingIndent : 0;
+
+                    std::deque<TChar> newLine;
                     int restOfLine = lineRest.size();
                     if (restOfLine > 0) {
                         while (restOfLine > 0) {
@@ -2388,17 +2418,16 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
                         }
                     }
 
-                    const TChar pSpace(mpConsole);
-                    for (int i = 0; i < indent; ++i) {
-                        newLine.push_front(pSpace);
+                    const TChar hangingSpace(mpConsole);
+                    for (int i = 0; i < hangingIndent; ++i) {
+                        newLine.push_front(hangingSpace);
                     }
                     buffer.push_back(newLine);
 
-                    const QString qIndent(indent, QChar::Space);
                     if (lineRest.size() > 0) {
-                        lineBuffer.append(qIndent + lineRest);
+                        lineBuffer.append(qHangingIndent + lineRest);
                     } else {
-                        lineBuffer.append(qIndent);
+                        lineBuffer.append(qHangingIndent);
                     }
                     timeBuffer << csmBlankTimeStamp;
                     promptBuffer << false;

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2237,6 +2237,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
         sub_end = text.size() - 1;
     }
 
+    int indent = 0;
     for (int i = sub_start; i < length; ++i) {
         //FIXME <=substart+sub_end must check whether sub-ranges are still needed
         if (text.at(i) == QChar::LineFeed) {
@@ -2247,6 +2248,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
             timeBuffer << csmBlankTimeStamp;
             promptBuffer << false;
             firstChar = true;
+            indent = 0;
             continue;
         }
 
@@ -2254,9 +2256,10 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
         // to "unit" character width (whatever we work THAT out to be)
         // multiplied by mWrap:
         if (lineBuffer.back().size() >= mWrapAt) {
-            for (int i = lineBuffer.back().size() - 1; i >= 0; --i) {
-                if (lineBreaks.indexOf(lineBuffer.back().at(i)) > -1) {
-                    const int linebreakPos = (i != 0) ? i + 1 : lineBuffer.back().size();
+            for (int i = lineBuffer.back().size() - 1; i >= indent; --i) {
+                if (lineBreaks.indexOf(lineBuffer.back().at(i)) > -1 || i == indent) {
+                    const int linebreakPos = (i != indent) ? i + 1 : lineBuffer.back().size();
+                    indent = mWrapIndent;
                     const QString tmp = lineBuffer.back().mid(0, linebreakPos);
                     const QString lineRest = lineBuffer.back().mid(linebreakPos);
                     lineBuffer.back() = tmp;
@@ -2271,12 +2274,18 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
                         }
                     }
 
-                    buffer.push_back(newLine);
-                    if (lineRest.size() > 0) {
-                        lineBuffer.append(lineRest);
-                    } else {
-                        lineBuffer.append(QString());
+                    const TChar pSpace(mpConsole);
+                    for (int i = 0; i < indent; ++i) {
+                        newLine.push_front(pSpace);
                     }
+                    buffer.push_back(newLine);
+
+                    const QString qIndent(indent, QChar::Space);
+                    if (lineRest.size() > 0) {
+                        lineBuffer.append(qIndent + lineRest);
+                    } {
+                        lineBuffer.append(qIndent);
+                    } 
                     timeBuffer << csmBlankTimeStamp;
                     promptBuffer << false;
                     log(size() - 2, size() - 2);
@@ -2342,6 +2351,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
         sub_end = text.size() - 1;
     }
 
+    int indent = 0;
     for (int i = sub_start; i < length; ++i) {
         if (text.at(i) == '\n') {
             log(size() - 1, size() - 1);
@@ -2351,6 +2361,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
             timeBuffer << csmBlankTimeStamp;
             promptBuffer << false;
             firstChar = true;
+            indent = 0;
             continue;
         }
 
@@ -2358,10 +2369,11 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
         // to "unit" character width (whatever we work THAT out to be)
         // multiplied by mWrap:
         if (lineBuffer.back().size() >= mWrapAt) {
-            for (int i = lineBuffer.back().size() - 1; i >= 0; --i) {
+            for (int i = lineBuffer.back().size() - 1; i >= indent; --i) {
                 // insert linebreak either at linebreaking character location or at last character of line
-                if (lineBreaks.indexOf(lineBuffer.back().at(i)) > -1 || i == 0) {
-                    const int linebreakPos = (i != 0) ? i + 1 : lineBuffer.back().size();
+                if (lineBreaks.indexOf(lineBuffer.back().at(i)) > -1 || i == indent) {
+                    const int linebreakPos = (i != indent) ? i + 1 : lineBuffer.back().size();
+                    indent = mWrapIndent;
                     const QString tmp = lineBuffer.back().mid(0, linebreakPos);
                     const QString lineRest = lineBuffer.back().mid(linebreakPos);
                     lineBuffer.back() = tmp;
@@ -2376,11 +2388,17 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
                         }
                     }
 
+                    const TChar pSpace(mpConsole);
+                    for (int i = 0; i < indent; ++i) {
+                        newLine.push_front(pSpace);
+                    }
                     buffer.push_back(newLine);
+
+                    const QString qIndent(indent, QChar::Space);
                     if (lineRest.size() > 0) {
-                        lineBuffer.append(lineRest);
+                        lineBuffer.append(qIndent + lineRest);
                     } else {
-                        lineBuffer.append(QString());
+                        lineBuffer.append(qIndent);
                     }
                     timeBuffer << csmBlankTimeStamp;
                     promptBuffer << false;

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2250,7 +2250,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
             promptBuffer << false;
             firstChar = true;
             // after newline, re-enable first indent and disable hanging
-            indent = mWrapIndent;
+            indent = (mWrapIndent < mWrapAt) ? mWrapIndent : 0;
             hangingIndent = 0;
             continue;
         }
@@ -2382,7 +2382,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
             promptBuffer << false;
             firstChar = true;
             // after newline, re-enable first indent and disable hanging
-            indent = mWrapIndent;
+            indent = (mWrapIndent < mWrapAt) ? mWrapIndent : 0;
             hangingIndent = 0;
             continue;
         }

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -284,6 +284,7 @@ public:
     void appendLine(const QString& chunk, const int sub_start, const int sub_end, const QColor& fg, const QColor& bg, TChar::AttributeFlags flags = TChar::None, const int linkID = 0);
     void setWrapAt(int i) { mWrapAt = i; }
     void setWrapIndent(int i) { mWrapIndent = i; }
+    void setWrapHangingIndent(int i) { mWrapHangingIndent = i; }
     void updateColors();
     TBuffer copy(QPoint&, QPoint&);
     TBuffer cut(QPoint&, QPoint&);

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -143,6 +143,12 @@ public:
         mIndentCount = count;
         buffer.setWrapIndent(count);
     }
+    
+    void setHangingIndentCount(int count)
+    {
+        mHangingIndentCount = count;
+        buffer.setWrapHangingIndent(count);
+    }
 
     TLinkStore &getLinkStore() { return buffer.mLinkStore; }
     void echo(const QString&);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5040,6 +5040,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "setWindowWrap", TLuaInterpreter::setWindowWrap);
     lua_register(pGlobalLua, "getWindowWrap", TLuaInterpreter::getWindowWrap);
     lua_register(pGlobalLua, "setWindowWrapIndent", TLuaInterpreter::setWindowWrapIndent);
+    lua_register(pGlobalLua, "setWindowWrapHangingIndent", TLuaInterpreter::setWindowWrapHangingIndent);
     lua_register(pGlobalLua, "resetFormat", TLuaInterpreter::resetFormat);
     lua_register(pGlobalLua, "moveCursorEnd", TLuaInterpreter::moveCursorEnd);
     lua_register(pGlobalLua, "getLastLineNumber", TLuaInterpreter::getLastLineNumber);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -358,6 +358,7 @@ public:
     static int setWindowWrap(lua_State*);
     static int getWindowWrap(lua_State*);
     static int setWindowWrapIndent(lua_State*);
+    static int setWindowWrapHangingIndent(lua_State*);
     static int resetFormat(lua_State*);
     static int moveCursorEnd(lua_State*);
     static int getLastLineNumber(lua_State*);

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -2964,7 +2964,7 @@ int TLuaInterpreter::setWindowWrapIndent(lua_State* L)
     return 0;
 }
 
-//TODO: add Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setWindowWrapHangingIndent
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setWindowWrapHangingIndent
 int TLuaInterpreter::setWindowWrapHangingIndent(lua_State* L)
 {
     const QString windowName {WINDOW_NAME(L, 1)};

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -2964,6 +2964,15 @@ int TLuaInterpreter::setWindowWrapIndent(lua_State* L)
     return 0;
 }
 
+//TODO: add Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setWindowWrapHangingIndent
+int TLuaInterpreter::setWindowWrapHangingIndent(lua_State* L)
+{
+    const QString windowName {WINDOW_NAME(L, 1)};
+    const int luaFrom = getVerifiedInt(L, __func__, 2, "wrapTo");
+    auto console = CONSOLE(L, windowName);
+    console->setHangingIndentCount(luaFrom);
+    return 0;
+}
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#showWindow
 int TLuaInterpreter::showWindow(lua_State* L)
 {

--- a/src/lua-function-list.json
+++ b/src/lua-function-list.json
@@ -528,6 +528,7 @@
     "setWindow": "setWindow(windowName, name, [Xpos, Ypos, show])",
     "setWindowWrap": "setWindowWrap(windowName, wrapAt)",
     "setWindowWrapIndent": "setWindowWrapIndent(windowName, wrapTo)",
+    "setWindowWrapHangingIndent": "setWindowWrapHangingIndent(windowName, wrapTo)",
     "shms": "shms(seconds, bool)",
     "showCaptureGroups": "showCaptureGroups()",
     "showColors": "showColors([columns], [filterColor], [sort])",

--- a/src/mudlet-lua/lua/CoreMudlet.lua
+++ b/src/mudlet-lua/lua/CoreMudlet.lua
@@ -1096,8 +1096,13 @@ if false then
   end
 
 
-  --- <b><u>TODO</u></b>  setWindowWrapIndent - TLuaInterpreter::setWindowWrapIndent
+  ---- <b><u>TODO</u></b>  setWindowWrapIndent - TLuaInterpreter::setWindowWrapIndent
   function setWindowWrapIndent()
+  end
+
+
+-- <b><u>TODO</u></b>  setWindowWrapHangingIndent - TLuaInterpreter::setWindowWrapHangingIndent
+  function setWindowWrapHangingIndent()
   end
 
 

--- a/src/mudlet-lua/lua/CoreMudlet.lua
+++ b/src/mudlet-lua/lua/CoreMudlet.lua
@@ -1096,12 +1096,12 @@ if false then
   end
 
 
-  ---- <b><u>TODO</u></b>  setWindowWrapIndent - TLuaInterpreter::setWindowWrapIndent
+  --- <b><u>TODO</u></b>  setWindowWrapIndent - TLuaInterpreter::setWindowWrapIndent
   function setWindowWrapIndent()
   end
 
 
--- <b><u>TODO</u></b>  setWindowWrapHangingIndent - TLuaInterpreter::setWindowWrapHangingIndent
+  --- <b><u>TODO</u></b>  setWindowWrapHangingIndent - TLuaInterpreter::setWindowWrapHangingIndent
   function setWindowWrapHangingIndent()
   end
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Added: setWindowWrapHangingIndent so that main window and miniconsole indentation behaviors can match.
Modified the two TBuffer.append methods to apply indent and hangingIndent.
#### Motivation for adding to Mudlet
Hopefully this resolves https://github.com/Mudlet/Mudlet/issues/5936

/claim #5936

#### Other info (issues closed, discussion etc)
The (modified) motivating test:
```
Geyser.MiniConsole:new({name = "indent-test"})
setWindowWrapIndent("indent-test", 10)
setWindowWrapHangingIndent("indent-test", 5)
setWindowWrap("indent-test", 30)
echo("indent-test", "This is the song that doesn't end, yes it goes on and on my friend, some people started singing it not knowing what it was, and they'll continue singing it forever just because this is the song that doesn't end...")
```
Is now rendered like this:
![image](https://github.com/user-attachments/assets/4a755818-603f-4582-8d9b-bf687cdb82ed)

I see this to be an adequate resolution, but it still does have some minor drawbacks: Multiple echo/print actions to the same line will set the last line in the buffer to be treated as a _firstline_ for the purpose of indentation. This can be an issue if it already has hanging indentation. Some users may find it to be a strange behavior using both indentation and hanging indentation, but I expect this is uncommon.

For example:
```
Geyser.MiniConsole:new({name = "indent-test"})
setWindowWrapIndent("indent-test", 10)
setWindowWrapHangingIndent("indent-test", 5)
setWindowWrap("indent-test", 30)
for i=1,50 do
  cecho("indent-test","<white:red>" .. i)
end
```

ends up looking like this:
![image](https://github.com/user-attachments/assets/03abb4e3-7910-4043-9e85-6a02f2ad228b)

Finally, this is my first PR, apologies if I made any mistakes with the styling/approach. I'm happy for any pointers on how to more effectively contribute.
