### PR TITLE
Infrastructure: remove Windows 32 bit builds

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -24,8 +24,6 @@ jobs:
         include:
           - os: windows-2019
             buildname: 'windows64'
-          - os: windows-2019
-            buildname: 'windows32'
 
     steps:
     - name: Checkout Mudlet source code


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove Windows 32 bit builds
#### Motivation for adding to Mudlet
MSYS2 no longer supports them, so we cannot builds them.
#### Other info (issues closed, discussion etc)
Some cleanup should be done in scripts and [links bot](https://github.com/Mudlet/deployment-link-probot/issues/100) to remove traces of 32bit Windows.