### PR TITLE
Infrastructure: remove support for building 32bit Windows applications

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -32,18 +32,11 @@ jobs:
         submodules: true
         fetch-depth: 0
 
-    - name: (Windows 64) Setup MSYS2
+    - name: (Windows) Setup MSYS2
       if: matrix.buildname == 'windows64'
       uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW64
-        update: true
-
-    - name: (Windows 32) Setup MSYS2
-      if: matrix.buildname == 'windows32'
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: MINGW32
         update: true
 
     - name: (Windows) Build Environment Setup

--- a/CI/build-mudlet-for-windows.sh
+++ b/CI/build-mudlet-for-windows.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ###########################################################################
 #   Copyright (C) 2024-2024  by John McKisson - john.mckisson@gmail.com   #
-#   Copyright (C) 2023-2024  by Stephen Lyons - slysven@virginmedia.com   #
+#   Copyright (C) 2023-2025  by Stephen Lyons - slysven@virginmedia.com   #
 #                                                                         #
 #   This program is free software; you can redistribute it and/or modify  #
 #   it under the terms of the GNU General Public License as published by  #
@@ -19,7 +19,8 @@
 #   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
 ###########################################################################
 
-# Version: 2.0.0    Rework to build on an MSYS2 MINGW64 Github workflow
+# Version: 2.1.0    Remove MINGW32 since upstream no longer supports it
+#          2.0.0    Rework to build on an MSYS2 MINGW64 Github workflow
 #          1.5.0    Change BUILD_TYPE to BUILD_CONFIG to avoid clash with
 #                   CI/CB system using same variable
 #          1.4.0    Rewrite Makefile to use ccache.exe if available
@@ -41,26 +42,25 @@
 # 3 - Unsupported build type
 
 if [ "${MSYSTEM}" = "MSYS" ]; then
-  echo "Please run this script from an MINGW64 type bash terminal appropriate"
-  echo "to the bitness you want to work on. You may do this once for each of them should"
-  echo "you wish to do both."
+  echo "Please run this script from a MINGW64 type bash terminal as the MSYS one"
+  echo "does not supported what is needed."
   exit 2
 elif [ "${MSYSTEM}" = "MINGW64" ]; then
   export BUILD_BITNESS="64"
   export BUILDCOMPONENT="x86_64"
 else
-  echo "This script is not set up to handle systems of type ${MSYSTEM}, only MINGW64"
-  echo "are currently supported. Please rerun this in a bash terminal of one"
-  echo "of those two types."
+  echo "This script is not set up to handle systems of type ${MSYSTEM}, only"
+  echo "MINGW64 is currently supported. Please rerun this in a bash terminal of"
+  echo "that type."
   exit 2
 fi
 
 # Check if GITHUB_REPO_TAG is "false"
-if [[ "$GITHUB_REPO_TAG" == "false" ]]; then
+if [[ "${GITHUB_REPO_TAG}" == "false" ]]; then
   echo "=== GITHUB_REPO_TAG is FALSE ==="
 
   # Check if this is a scheduled build
-  if [[ "$GITHUB_SCHEDULED_BUILD" == "true" ]]; then
+  if [[ "${GITHUB_SCHEDULED_BUILD}" == "true" ]]; then
     echo "=== GITHUB_SCHEDULED_BUILD is TRUE, this is a PTB ==="
     MUDLET_VERSION_BUILD="-ptb"
   else
@@ -68,17 +68,17 @@ if [[ "$GITHUB_REPO_TAG" == "false" ]]; then
   fi
 
   # Check if this is a pull request
-  if [[ -n "$GITHUB_PULL_REQUEST_NUMBER" ]]; then
+  if [[ -n "${GITHUB_PULL_REQUEST_NUMBER}" ]]; then
     # Use the specific commit SHA from the pull request head, since GitHub Actions merges the PR
-    BUILD_COMMIT=$(git rev-parse --short "$GITHUB_PULL_REQUEST_HEAD_SHA")
-    MUDLET_VERSION_BUILD="$MUDLET_VERSION_BUILD-PR$GITHUB_PULL_REQUEST_NUMBER"
+    BUILD_COMMIT=$(git rev-parse --short "${GITHUB_PULL_REQUEST_HEAD_SHA}")
+    MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD}-PR${GITHUB_PULL_REQUEST_NUMBER}"
   else
     BUILD_COMMIT=$(git rev-parse --short HEAD)
 
-    if [[ "$MUDLET_VERSION_BUILD" == "-ptb" ]]; then
+    if [[ "${MUDLET_VERSION_BUILD}" == "-ptb" ]]; then
       # Get current date in YYYY-MM-DD format
       DATE=$(date +%F)
-      MUDLET_VERSION_BUILD="$MUDLET_VERSION_BUILD-$DATE"
+      MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD}-${DATE}"
     fi
   fi
 fi
@@ -102,10 +102,10 @@ echo "PATH is now:"
 echo "${PATH}"
 echo ""
 
-cd $GITHUB_WORKSPACE || exit 1
+cd "${GITHUB_WORKSPACE}" || exit 1
 mkdir -p "build-${MSYSTEM}"
 
-cd ${GITHUB_WORKSPACE}/build-"${MSYSTEM}" || exit 1
+cd "${GITHUB_WORKSPACE}"/build-"${MSYSTEM}" || exit 1
 
 #### Qt Creator note ####
 # If one is planning to use qtcreator these will probably be wanted in a
@@ -139,11 +139,6 @@ else
     # Tagged build, this is a release or a PTB build, include the updater
     export WITH_UPDATER="YES"
 fi
-
-# This one is VITAL as some things in the code have to be tweaked to be
-# different compared to the CI/CB build environment (or the
-# setup-windows-sdk.ps) one!
-export WITH_MAIN_BUILD_SYSTEM="NO"
 
 echo "Running qmake to make MAKEFILE ..."
 echo ""

--- a/CI/build-mudlet-for-windows.sh
+++ b/CI/build-mudlet-for-windows.sh
@@ -29,7 +29,7 @@
 #          1.0.0    Original version
 
 # Script to build the Mudlet code currently checked out in
-# ${GITHUB_WORKSPACE} in a MINGW32 or MINGW64 shell
+# ${GITHUB_WORKSPACE} in a MINGW64 shell
 
 # To be used AFTER setup-windows-sdk.sh has been run; once this has completed
 # successfully, package-mudlet-for-windows.sh is run by the workflow
@@ -41,19 +41,16 @@
 # 3 - Unsupported build type
 
 if [ "${MSYSTEM}" = "MSYS" ]; then
-  echo "Please run this script from an MINGW32 or MINGW64 type bash terminal appropriate"
+  echo "Please run this script from an MINGW64 type bash terminal appropriate"
   echo "to the bitness you want to work on. You may do this once for each of them should"
   echo "you wish to do both."
   exit 2
-elif [ "${MSYSTEM}" = "MINGW32" ]; then
-  export BUILD_BITNESS="32"
-  export BUILDCOMPONENT="i686"
 elif [ "${MSYSTEM}" = "MINGW64" ]; then
   export BUILD_BITNESS="64"
   export BUILDCOMPONENT="x86_64"
 else
-  echo "This script is not set up to handle systems of type ${MSYSTEM}, only MINGW32 or"
-  echo "MINGW64 are currently supported. Please rerun this in a bash terminal of one"
+  echo "This script is not set up to handle systems of type ${MSYSTEM}, only MINGW64"
+  echo "are currently supported. Please rerun this in a bash terminal of one"
   echo "of those two types."
   exit 2
 fi

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ###########################################################################
 #   Copyright (C) 2024-2024  by John McKisson - john.mckisson@gmail.com   #
-#   Copyright (C) 2023-2024  by Stephen Lyons - slysven@virginmedia.com   #
+#   Copyright (C) 2023-2025  by Stephen Lyons - slysven@virginmedia.com   #
 #                                                                         #
 #   This program is free software; you can redistribute it and/or modify  #
 #   it under the terms of the GNU General Public License as published by  #
@@ -19,7 +19,8 @@
 #   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
 ###########################################################################
 
-# Version: 2.0.0    Rework to build on an MSYS2 MINGW64 Github workflow
+# Version: 2.1.0    Remove MINGW32 since upstream no longer supports it
+#          2.0.0    Rework to build on an MSYS2 MINGW64 Github workflow
 
 # Exit codes:
 # 0 - Everything is fine. 8-)
@@ -30,22 +31,20 @@
 # 5 - squirrel error
 
 if [ "${MSYSTEM}" = "MSYS" ]; then
-  echo "Please run this script from an MINGW64 type bash terminal appropriate"
-  echo "to the bitness you want to work on. You may do this once for each of them should"
-  echo "you wish to do both."
+  echo "Please run this script from a MINGW64 type bash terminal as the MSYS one"
+  echo "does not supported what is needed."
   exit 2
 elif [ "${MSYSTEM}" = "MINGW64" ]; then
   export BUILD_BITNESS="64"
   export BUILDCOMPONENT="x86_64"
-  export ARCH="x86_64"
 else
-  echo "This script is not set up to handle systems of type ${MSYSTEM}, only MINGW64"
-  echo "are currently supported. Please rerun this in a bash terminal of one"
-  echo "of those two types."
+  echo "This script is not set up to handle systems of type ${MSYSTEM}, only"
+  echo "MINGW64 is currently supported. Please rerun this in a bash terminal of"
+  echo "that type."
   exit 2
 fi
 
-cd "$GITHUB_WORKSPACE" || exit 1
+cd "${GITHUB_WORKSPACE}" || exit 1
 
 # Add nuget location to PATH
 PATH="/c/ProgramData/Chocolatey/bin:${PATH}"
@@ -53,11 +52,11 @@ export PATH
 
 PublicTestBuild=false
 # Check if GITHUB_REPO_TAG is "false"
-if [[ "$GITHUB_REPO_TAG" == "false" ]]; then
+if [[ "${GITHUB_REPO_TAG}" == "false" ]]; then
   echo "=== GITHUB_REPO_TAG is FALSE ==="
 
   # Check if this is a scheduled build
-  if [[ "$GITHUB_SCHEDULED_BUILD" == "true" ]]; then
+  if [[ "${GITHUB_SCHEDULED_BUILD}" == "true" ]]; then
     echo "=== GITHUB_SCHEDULED_BUILD is TRUE, this is a PTB ==="
     MUDLET_VERSION_BUILD="-ptb"
     PublicTestBuild=true
@@ -66,17 +65,17 @@ if [[ "$GITHUB_REPO_TAG" == "false" ]]; then
   fi
 
   # Check if this is a pull request
-  if [[ -n "$GITHUB_PULL_REQUEST_NUMBER" ]]; then
+  if [[ -n "${GITHUB_PULL_REQUEST_NUMBER}" ]]; then
     # Use the specific commit SHA from the pull request head, since GitHub Actions merges the PR
-    BUILD_COMMIT=$(git rev-parse --short "$GITHUB_PULL_REQUEST_HEAD_SHA")
-    MUDLET_VERSION_BUILD="$MUDLET_VERSION_BUILD-PR$GITHUB_PULL_REQUEST_NUMBER"
+    BUILD_COMMIT=$(git rev-parse --short "${GITHUB_PULL_REQUEST_HEAD_SHA}")
+    MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD}-PR${GITHUB_PULL_REQUEST_NUMBER}"
   else
     BUILD_COMMIT=$(git rev-parse --short HEAD)
 
-    if [[ "$MUDLET_VERSION_BUILD" == "-ptb" ]]; then
+    if [[ "${MUDLET_VERSION_BUILD}" == "-ptb" ]]; then
       # Get current date in YYYY-MM-DD format
       DATE=$(date +%F)
-      MUDLET_VERSION_BUILD="$MUDLET_VERSION_BUILD-$DATE"
+      MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD}-${DATE}"
     fi
   fi
 fi
@@ -86,124 +85,126 @@ export MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD,,}"
 export BUILD_COMMIT="${BUILD_COMMIT,,}"
 
 # Extract version from the mudlet.pro file
-VersionLine=$(grep "VERSION =" "$GITHUB_WORKSPACE/src/mudlet.pro")
+VersionLine=$(grep "VERSION =" "${GITHUB_WORKSPACE}/src/mudlet.pro")
 VersionRegex='= {1}(.+)$'
 
 # Use Bash regex matching to extract version
-if [[ $VersionLine =~ $VersionRegex ]]; then
+if [[ ${VersionLine} =~ ${VersionRegex} ]]; then
   VERSION="${BASH_REMATCH[1]}"
 fi
 
 # Check if MUDLET_VERSION_BUILD is empty and print accordingly
-if [[ -z "$MUDLET_VERSION_BUILD" ]]; then
+if [[ -z "${MUDLET_VERSION_BUILD}" ]]; then
   # Possible release build
-  echo "BUILDING MUDLET $VERSION"
+  echo "BUILDING MUDLET ${VERSION}"
 else
   # Include Git SHA1 in the build information
-  echo "BUILDING MUDLET $VERSION$MUDLET_VERSION_BUILD-$BUILD_COMMIT"
+  echo "BUILDING MUDLET ${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}"
 fi
 
 # Check if we're building from the Mudlet/Mudlet repository and not a fork
-if [[ "$GITHUB_REPO_NAME" != "Mudlet/Mudlet" ]]; then
+if [[ "${GITHUB_REPO_NAME}" != "Mudlet/Mudlet" ]]; then
   exit 2
 fi
 
 GITHUB_WORKSPACE_UNIX_PATH=$(echo "${GITHUB_WORKSPACE}" | sed 's|\\|/|g' | sed 's|D:|/d|g')
 PACKAGE_DIR="${GITHUB_WORKSPACE_UNIX_PATH}/package-${MSYSTEM}-release"
 
-cd "$PACKAGE_DIR" || exit 1
+cd "${PACKAGE_DIR}" || exit 1
 
 # Remove specific file types from the directory
 rm ./*.cpp ./*.o
 
 # Helper function to move a packaged mudlet to the upload directory and set up an artifact upload
-# We require the files to be uploaded to exist in $PACKAGE_DIR
+# We require the files to be uploaded to exist in ${PACKAGE_DIR}
 moveToUploadDir() {
   local uploadFilename=$1
   local unzip=$2
   echo "=== Setting up upload directory ==="
   local uploadDir="${GITHUB_WORKSPACE}\\upload"
-  local uploadDirUnix=$(echo "${uploadDir}" | sed 's|\\|/|g' | sed 's|D:|/d|g')
+  local uploadDirUnix
+  uploadDirUnix=$(echo "${uploadDir}" | sed 's|\\|/|g' | sed 's|D:|/d|g')
 
   # Check if the upload directory exists, if not, create it
-  if [[ ! -d "$uploadDirUnix" ]]; then
-    mkdir -p "$uploadDirUnix"
+  if [[ ! -d "${uploadDirUnix}" ]]; then
+    mkdir -p "${uploadDirUnix}"
   fi
 
   echo "=== Copying files to upload directory ==="
-  rsync -avR "${PACKAGE_DIR}"/./* "$uploadDirUnix"
+  rsync -avR "${PACKAGE_DIR}"/./* "${uploadDirUnix}"
 
   # Append these variables to the GITHUB_ENV to make them available in subsequent steps
   {
     echo "FOLDER_TO_UPLOAD=${uploadDir}\\"
-    echo "UPLOAD_FILENAME=$uploadFilename"
-    echo "PARAM_UNZIP=$unzip"
-  } >> "$GITHUB_ENV"
+    echo "UPLOAD_FILENAME=${uploadFilename}"
+    echo "PARAM_UNZIP=${unzip}"
+  } >> "${GITHUB_ENV}"
 }
 
 # Check if GITHUB_REPO_TAG and PublicTestBuild are "false" for a snapshot build
-if [[ "$GITHUB_REPO_TAG" == "false" ]] && [[ "$PublicTestBuild" == false ]]; then
+if [[ "${GITHUB_REPO_TAG}" == "false" ]] && [[ "${PublicTestBuild}" == false ]]; then
   echo "=== Creating a snapshot build ==="
-  mv "$PACKAGE_DIR/mudlet.exe" "Mudlet.exe"
+  mv "${PACKAGE_DIR}/mudlet.exe" "Mudlet.exe"
 
   # Define the upload filename
-  uploadFilename="Mudlet-$VERSION$MUDLET_VERSION_BUILD-$BUILD_COMMIT-windows-$BUILD_BITNESS"
+  uploadFilename="Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-windows-${BUILD_BITNESS}"
 
   # Move packaged files to the upload directory
-  moveToUploadDir "$uploadFilename" 0
+  moveToUploadDir "${uploadFilename}" 0
 else
 
   # Check if it's a Public Test Build
-  if [[ "$PublicTestBuild" == "true" ]]; then
+  if [[ "${PublicTestBuild}" == "true" ]]; then
 
     # Get the commit date of the last commit
     COMMIT_DATE=$(git show -s --format="%cs")
     # Get yesterday's date in the same format
     YESTERDAY_DATE=$(date --date="yesterday" +%Y-%m-%d)
 
-    if [[ "$COMMIT_DATE" < "$YESTERDAY_DATE" ]]; then
+    if [[ "${COMMIT_DATE}" < "${YESTERDAY_DATE}" ]]; then
       echo "=== No new commits, aborting public test build generation ==="
       exit 0
     fi
 
     echo "=== Creating a public test build ==="
     # Squirrel uses Start menu name from the binary, renaming it
-    mv "$PACKAGE_DIR/mudlet.exe" "$PACKAGE_DIR/Mudlet PTB.exe"
-    echo "moved mudlet.exe to $PACKAGE_DIR/Mudlet PTB.exe"
+    mv "${PACKAGE_DIR}/mudlet.exe" "${PACKAGE_DIR}/Mudlet PTB.exe"
+    echo "moved mudlet.exe to ${PACKAGE_DIR}/Mudlet PTB.exe"
     # ensure sha part always starts with a character due to a known issue
     VersionAndSha="${VERSION}-ptb-${BUILD_COMMIT}"
 
   else
     echo "=== Creating a release build ==="
-    mv "$PACKAGE_DIR/mudlet.exe" "$PACKAGE_DIR/Mudlet.exe"
-    VersionAndSha="$VERSION"
+    mv "${PACKAGE_DIR}/mudlet.exe" "${PACKAGE_DIR}/Mudlet.exe"
+    VersionAndSha="${VERSION}"
   fi
 
-  echo "VersionAndSha: $VersionAndSha"
+  echo "VersionAndSha: ${VersionAndSha}"
   echo "=== Cloning installer project ==="
-  git clone https://github.com/Mudlet/installers.git "$GITHUB_WORKSPACE/installers"
-  cd "$GITHUB_WORKSPACE/installers/windows" || exit 1
+  git clone https://github.com/Mudlet/installers.git "${GITHUB_WORKSPACE}/installers"
+  cd "${GITHUB_WORKSPACE}/installers/windows" || exit 1
 
   echo "=== Setting up Java 21 for signing ==="
-  export JAVA_HOME="$(cygpath -u $JAVA_HOME_21_X64)"
-  export PATH="$JAVA_HOME/bin:$PATH"
+  JAVA_HOME="$(cygpath -u "${JAVA_HOME_21_X64}")"
+  export JAVA_HOME
+  export PATH="${JAVA_HOME}/bin:${PATH}"
 
   if [ -z "${AZURE_ACCESS_TOKEN}" ]; then
       echo "=== Code signing skipped - no Azure token provided ==="
   else
       echo "=== Signing Mudlet and dll files ==="
-      if [[ "$PublicTestBuild" == "true" ]]; then
-          java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
+      if [[ "${PublicTestBuild}" == "true" ]]; then
+          java.exe -jar "${GITHUB_WORKSPACE}/installers/windows/jsign-7.0-SNAPSHOT.jar" --storetype TRUSTEDSIGNING \
               --keystore eus.codesigning.azure.net \
-              --storepass ${AZURE_ACCESS_TOKEN} \
+              --storepass "${AZURE_ACCESS_TOKEN}" \
               --alias Mudlet/Mudlet \
-              "$PACKAGE_DIR/Mudlet PTB.exe" "$PACKAGE_DIR/**/*.dll"
+              "${PACKAGE_DIR}/Mudlet PTB.exe" "${PACKAGE_DIR}/**/*.dll"
       else
-          java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
+          java.exe -jar "${GITHUB_WORKSPACE}/installers/windows/jsign-7.0-SNAPSHOT.jar" --storetype TRUSTEDSIGNING \
               --keystore eus.codesigning.azure.net \
-              --storepass ${AZURE_ACCESS_TOKEN} \
+              --storepass "${AZURE_ACCESS_TOKEN}" \
               --alias Mudlet/Mudlet \
-              "$PACKAGE_DIR/Mudlet.exe" "$PACKAGE_DIR/**/*.dll"
+              "${PACKAGE_DIR}/Mudlet.exe" "${PACKAGE_DIR}/**/*.dll"
       fi
   fi
 
@@ -211,89 +212,89 @@ else
   nuget install squirrel.windows -ExcludeVersion
 
   echo "=== Setting up directories ==="
-  SQUIRRELWIN="$GITHUB_WORKSPACE/squirrel-packaging-prep"
-  SQUIRRELWINBIN="$SQUIRRELWIN/lib/net45/"
+  SQUIRRELWIN="${GITHUB_WORKSPACE}/squirrel-packaging-prep"
+  SQUIRRELWINBIN="${SQUIRRELWIN}/lib/net45/"
 
-  if [[ ! -d "$SQUIRRELWINBIN" ]]; then
-    mkdir -p "$SQUIRRELWINBIN"
+  if [[ ! -d "${SQUIRRELWINBIN}" ]]; then
+    mkdir -p "${SQUIRRELWINBIN}"
   fi
 
   echo "=== Moving things to where Squirrel expects them ==="
-  mv "$PACKAGE_DIR/"* "$SQUIRRELWINBIN"
+  mv "${PACKAGE_DIR}/"* "${SQUIRRELWINBIN}"
 
   # Set the path to the nuspec file
-  NuSpec="$GITHUB_WORKSPACE/installers/windows/mudlet.nuspec"
+  NuSpec="${GITHUB_WORKSPACE}/installers/windows/mudlet.nuspec"
   echo "=== Creating Nuget package ==="
 
   # Rename the id and title for Squirrel
-  if [[ "$PublicTestBuild" == "true" ]]; then
+  if [[ "${PublicTestBuild}" == "true" ]]; then
     # Allow public test builds to be installed side by side with the release builds by renaming the app
     # No dots in the <id>: Guidelines by Squirrel
     if [ "${MSYSTEM}" = "MINGW64" ]; then
-      sed -i "s/<id>Mudlet<\/id>/<id>Mudlet_${BUILD_BITNESS}_-PublicTestBuild<\/id>/" "$NuSpec"
+      sed -i "s/<id>Mudlet<\/id>/<id>Mudlet_${BUILD_BITNESS}_-PublicTestBuild<\/id>/" "${NuSpec}"
     else
-      sed -i 's/<id>Mudlet<\/id>/<id>Mudlet-PublicTestBuild<\/id>/' "$NuSpec"
+      sed -i 's/<id>Mudlet<\/id>/<id>Mudlet-PublicTestBuild<\/id>/' "${NuSpec}"
     fi
-    sed -i "s/<title>Mudlet<\/title>/<title>Mudlet x${BUILD_BITNESS} (Public Test Build)<\/title>/" "$NuSpec"
+    sed -i "s/<title>Mudlet<\/title>/<title>Mudlet x${BUILD_BITNESS} (Public Test Build)<\/title>/" "${NuSpec}"
   else
     if [ "${MSYSTEM}" = "MINGW64" ]; then
-      sed -i "s/<id>Mudlet<\/id>/<id>Mudlet_${BUILD_BITNESS}_<\/id>/" "$NuSpec"
+      sed -i "s/<id>Mudlet<\/id>/<id>Mudlet_${BUILD_BITNESS}_<\/id>/" "${NuSpec}"
     fi
-    sed -i "s/<title>Mudlet<\/title>/<title>Mudlet x${BUILD_BITNESS}<\/title>/" "$NuSpec"
+    sed -i "s/<title>Mudlet<\/title>/<title>Mudlet x${BUILD_BITNESS}<\/title>/" "${NuSpec}"
   fi
 
   # Create NuGet package
-  nuget pack "$NuSpec" -Version "$VersionAndSha" -BasePath "$SQUIRRELWIN" -OutputDirectory "$SQUIRRELWIN"
+  nuget pack "${NuSpec}" -Version "${VersionAndSha}" -BasePath "${SQUIRRELWIN}" -OutputDirectory "${QUIRRELWIN}"
 
   echo "=== Preparing to create installer ==="
-  if [[ "$PublicTestBuild" == "true" ]]; then
+  if [[ "${PublicTestBuild}" == "true" ]]; then
     TestBuildString="-PublicTestBuild"
-    InstallerIconFile="$GITHUB_WORKSPACE/src/icons/mudlet_ptb.ico"
+    InstallerIconFile="${GITHUB_WORKSPACE}/src/icons/mudlet_ptb.ico"
   else
     TestBuildString=""
-    InstallerIconFile="$GITHUB_WORKSPACE/src/icons/mudlet.ico"
+    InstallerIconFile="${GITHUB_WORKSPACE}/src/icons/mudlet.ico"
   fi
 
   # Ensure 64 bit build is properly tagged
   if [ "${MSYSTEM}" = "MINGW64" ]; then
-    TestBuildString="_64_$TestBuildString"
+    TestBuildString="_64_${TestBuildString}"
   fi
 
-  nupkg_path="$GITHUB_WORKSPACE/squirrel-packaging-prep/Mudlet$TestBuildString.$VersionAndSha.nupkg"
-  if [[ ! -f "$nupkg_path" ]]; then
+  nupkg_path="${GITHUB_WORKSPACE}/squirrel-packaging-prep/Mudlet${TestBuildString}.${VersionAndSha}.nupkg"
+  if [[ ! -f "${nupkg_path}" ]]; then
     echo "=== ERROR: nupkg doesn't exist as expected! Build aborted."
     exit 4
   fi
 
   # Execute Squirrel to create the installer
   echo "=== Creating installers from Nuget package ==="
-  ./squirrel.windows/tools/Squirrel --releasify "$nupkg_path" \
-    --releaseDir "$GITHUB_WORKSPACE/squirreloutput" \
-    --loadingGif "$GITHUB_WORKSPACE/installers/windows/splash-installing-2x.png" \
-    --no-msi --setupIcon "$InstallerIconFile" 
+  ./squirrel.windows/tools/Squirrel --releasify "${nupkg_path}" \
+    --releaseDir "${GITHUB_WORKSPACE}/squirreloutput" \
+    --loadingGif "${GITHUB_WORKSPACE}/installers/windows/splash-installing-2x.png" \
+    --no-msi --setupIcon "${InstallerIconFile}"
     
   echo "=== Removing old directory content of release folder ==="
   rm -rf "${PACKAGE_DIR:?}/*"
 
   echo "=== Copying installer over ==="
-  if [[ "$PublicTestBuild" == "true" ]]; then
-    installerExePath="${PACKAGE_DIR}/Mudlet-$VERSION$MUDLET_VERSION_BUILD-$BUILD_COMMIT-windows-$BUILD_BITNESS.exe"
+  if [[ "${PublicTestBuild}" == "true" ]]; then
+    installerExePath="${PACKAGE_DIR}/Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-windows-${BUILD_BITNESS}.exe"
   else # release
-    installerExePath="${PACKAGE_DIR}/Mudlet-$VERSION-windows-$BUILD_BITNESS-installer.exe"
+    installerExePath="${PACKAGE_DIR}/Mudlet-${VERSION}-windows-${BUILD_BITNESS}-installer.exe"
   fi
-  echo  "installerExePath: $installerExePath"
-  mv "$GITHUB_WORKSPACE/squirreloutput/Setup.exe" "${installerExePath}"
+  echo  "installerExePath: ${installerExePath}"
+  mv "${GITHUB_WORKSPACE}/squirreloutput/Setup.exe" "${installerExePath}"
 
   # Sign the final installer
   echo "=== Signing installer ==="
-  java.exe -jar $GITHUB_WORKSPACE/installers/windows/jsign-7.0-SNAPSHOT.jar --storetype TRUSTEDSIGNING \
+  java.exe -jar "${GITHUB_WORKSPACE}/installers/windows/jsign-7.0-SNAPSHOT.jar" --storetype TRUSTEDSIGNING \
       --keystore eus.codesigning.azure.net \
-      --storepass ${AZURE_ACCESS_TOKEN} \
+      --storepass "${AZURE_ACCESS_TOKEN}" \
       --alias Mudlet/Mudlet \
-      "$installerExePath"
+      "${installerExePath}"
 
   # Check if the setup executable exists
-  if [[ ! -f "$installerExePath" ]]; then
+  if [[ ! -f "${installerExePath}" ]]; then
     echo "=== ERROR: Squirrel failed to generate the installer! Build aborted. Squirrel log is:"
 
     # Check if the SquirrelSetup.log exists and display its content
@@ -311,20 +312,20 @@ else
     exit 5
   fi
 
-  if [[ "$PublicTestBuild" == "true" ]]; then
+  if [[ "${PublicTestBuild}" == "true" ]]; then
     echo "=== Uploading public test build to make.mudlet.org ==="
 
-    uploadFilename="Mudlet-$VERSION$MUDLET_VERSION_BUILD-$BUILD_COMMIT-windows-$BUILD_BITNESS-installer.exe"
-    echo "uploadFilename: $uploadFilename"
+    uploadFilename="Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-windows-${BUILD_BITNESS}-installer.exe"
+    echo "uploadFilename: ${uploadFilename}"
 
-    # Installer named $uploadFilename should exist in $PACKAGE_DIR now, we're ok to proceed
-    moveToUploadDir "$uploadFilename" 1
+    # Installer named ${uploadFilename} should exist in ${PACKAGE_DIR} now, we're ok to proceed
+    moveToUploadDir "${uploadFilename}" 1
     RELEASE_TAG="public-test-build"
     CHANGELOG_MODE="ptb"
   else
 
     echo "=== Uploading installer to https://www.mudlet.org/wp-content/files/?C=M;O=D ==="
-    echo "$DEPLOY_SSH_KEY" > temp_key_file
+    echo "${DEPLOY_SSH_KEY}" > temp_key_file
 
     # chown doesn't work in msys2 and scp requires the not be globally readable
     # use a powershell workaround to set the permissions correctly
@@ -332,50 +333,50 @@ else
     powershell.exe -Command "icacls.exe temp_key_file /inheritance:r"
 
     powershell.exe <<EOF
-\$installerExePath = "$installerExePath"
-\$DEPLOY_PATH = "$DEPLOY_PATH"
+\$installerExePath = "${installerExePath}"
+\$DEPLOY_PATH = "${DEPLOY_PATH}"
 scp.exe -i temp_key_file -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \$installerExePath mudmachine@mudlet.org:\${DEPLOY_PATH}
 EOF
 
     shred -u temp_key_file
 
-    DEPLOY_URL="https://www.mudlet.org/wp-content/files/Mudlet-${VERSION}-windows-$BUILD_BITNESS-installer.exe"
+    DEPLOY_URL="https://www.mudlet.org/wp-content/files/Mudlet-${VERSION}-windows-${BUILD_BITNESS}-installer.exe"
 
-    if ! curl --output /dev/null --silent --head --fail "$DEPLOY_URL"; then
-      echo "Error: release not found as expected at $DEPLOY_URL"
+    if ! curl --output /dev/null --silent --head --fail "${DEPLOY_URL}"; then
+      echo "Error: release not found as expected at ${DEPLOY_URL}"
       exit 1
     fi
 
-    SHA256SUM=$(shasum -a 256 "$installerExePath" | awk '{print $1}')
+    SHA256SUM=$(shasum -a 256 "${installerExePath}" | awk '{print $1}')
 
     current_timestamp=$(date "+%-d %-m %Y %-H %-M %-S")
-    read -r day month year hour minute second <<< "$current_timestamp"
+    read -r day month year hour minute second <<< "${current_timestamp}"
 
     # blank echo to remove the stray 'PS D:\a\Mudlet\Mudlet\installers\windows> ' that shows up otherwise
 
     echo ""
     echo "=== Updating WP-Download-Manager ==="
-    echo "sha256 of installer: $SHA256SUM"
+    echo "sha256 of installer: ${SHA256SUM}"
 
     FILE_CATEGORY="2"
 
     current_timestamp=$(date "+%-d %-m %Y %-H %-M %-S")
-    read -r day month year hour minute second <<< "$current_timestamp"
+    read -r day month year hour minute second <<< "${current_timestamp}"
 
     curl --retry 5 -X POST 'https://www.mudlet.org/download-add.php' \
     -H "x-wp-download-token: ${X_WP_DOWNLOAD_TOKEN}" \
     -F "file_type=2" \
-    -F "file_remote=$DEPLOY_URL" \
-    -F "file_name=Mudlet ${VERSION} (windows-$BUILD_BITNESS)" \
-    -F "file_des=sha256: $SHA256SUM" \
+    -F "file_remote=${DEPLOY_URL}" \
+    -F "file_name=Mudlet ${VERSION} (windows-${BUILD_BITNESS})" \
+    -F "file_des=sha256: ${SHA256SUM}" \
     -F "file_cat=${FILE_CATEGORY}" \
     -F "file_permission=-1" \
-    -F "file_timestamp_day=$day" \
-    -F "file_timestamp_month=$month" \
-    -F "file_timestamp_year=$year" \
-    -F "file_timestamp_hour=$hour" \
-    -F "file_timestamp_minute=$minute" \
-    -F "file_timestamp_second=$second" \
+    -F "file_timestamp_day=${day}" \
+    -F "file_timestamp_month=${month}" \
+    -F "file_timestamp_year=${year}" \
+    -F "file_timestamp_hour=${hour}" \
+    -F "file_timestamp_minute=${minute}" \
+    -F "file_timestamp_second=${second}" \
     -F "output=json" \
     -F "do=Add File"
     
@@ -390,27 +391,27 @@ EOF
 
   echo "=== Installing dblsqd-cli ==="
   npm install -g dblsqd-cli
-  dblsqd login -e "https://api.dblsqd.com/v1/jsonrpc" -u "$DBLSQD_USER" -p "$DBLSQD_PASS"
+  dblsqd login -e "https://api.dblsqd.com/v1/jsonrpc" -u "${DBLSQD_USER}" -p "${DBLSQD_PASS}"
 
   echo "=== Downloading release feed ==="
   DownloadedFeed=$(mktemp)
-  curl "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/${RELEASE_TAG}/win/${ARCH}" -o "$DownloadedFeed"
+  curl "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/${RELEASE_TAG}/win/${ARCH}" -o "${DownloadedFeed}"
 
   echo "=== Generating a changelog ==="
-  cd "$GITHUB_WORKSPACE/CI" || exit 1
+  cd "${GITHUB_WORKSPACE}/CI" || exit 1
   
-  Changelog=$(lua5.1 "${GITHUB_WORKSPACE}/CI/generate-changelog.lua" --mode "$CHANGELOG_MODE" --releasefile "$DownloadedFeed")
+  Changelog=$(lua5.1 "${GITHUB_WORKSPACE}/CI/generate-changelog.lua" --mode "${CHANGELOG_MODE}" --releasefile "${DownloadedFeed}")
   cd - || exit 1
-  echo "$Changelog"
+  echo "${Changelog}"
 
   echo "=== Creating release in Dblsqd ==="
-  if [[ "$PublicTestBuild" == "true" ]]; then
+  if [[ "${PublicTestBuild}" == "true" ]]; then
     VersionString="${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT,,}"
   else # release
     VersionString="${VERSION}"
   fi
   
-  echo "VersionString: $VersionString"
+  echo "VersionString: ${VERSION}String"
   export VersionString
 
   # This may fail as a build from another architecture may have already registered a release with dblsqd,
@@ -419,16 +420,12 @@ EOF
   dblsqd release -a mudlet -c "${RELEASE_TAG}" -m "${Changelog}" "${VersionString}" || true
 
   # PTB's are handled by the register script, release builds are just pushed here
-  if [[ "$RELEASE_TAG" == "release" ]]; then
+  if [[ "${RELEASE_TAG}" == "release" ]]; then
     echo "=== Registering release with Dblsqd ==="
     echo "dblsqd push -a mudlet -c release -r \"${VersionString}\" -s mudlet --type 'standalone' --attach win:${ARCH} \"${DEPLOY_URL}\""
     dblsqd push -a mudlet -c release -r "${VersionString}" -s mudlet --type 'standalone' --attach win:"${ARCH}" "${DEPLOY_URL}"
   fi
 
-fi
-
-if [[ -n "$GITHUB_PULL_REQUEST_NUMBER" ]]; then
-  prId=" ,#$GITHUB_PULL_REQUEST_NUMBER"
 fi
 
 # Make PublicTestBuild available GHA to check if we need to run the register step
@@ -437,21 +434,21 @@ fi
   echo "ARCH=${ARCH}"
   echo "VERSION_STRING=${VersionString}"
   echo "BUILD_COMMIT=${BUILD_COMMIT}"
-} >> "$GITHUB_ENV"
+} >> "${GITHUB_ENV}"
 
 echo ""
 echo "******************************************************"
 echo ""
-if [[ -z "$MUDLET_VERSION_BUILD" ]]; then
+if [[ -z "${MUDLET_VERSION_BUILD}" ]]; then
   # A release build
-  echo "Finished building Mudlet $VERSION"
+  echo "Finished building Mudlet ${VERSION}"
 else
   # Not a release build so include the Git SHA1 in the message
-  echo "Finished building Mudlet $VERSION$MUDLET_VERSION_BUILD-$BUILD_COMMIT"
+  echo "Finished building Mudlet ${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}"
 fi
 
-if [[ -n "$DEPLOY_URL" ]]; then
-  echo "Deployed the output to $DEPLOY_URL"
+if [[ -n "${DEPLOY_URL}" ]]; then
+  echo "Deployed the output to ${DEPLOY_URL}"
 fi
 
 echo ""

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -30,21 +30,17 @@
 # 5 - squirrel error
 
 if [ "${MSYSTEM}" = "MSYS" ]; then
-  echo "Please run this script from an MINGW32 or MINGW64 type bash terminal appropriate"
+  echo "Please run this script from an MINGW64 type bash terminal appropriate"
   echo "to the bitness you want to work on. You may do this once for each of them should"
   echo "you wish to do both."
   exit 2
-elif [ "${MSYSTEM}" = "MINGW32" ]; then
-  export BUILD_BITNESS="32"
-  export BUILDCOMPONENT="i686"
-  export ARCH="x86"
 elif [ "${MSYSTEM}" = "MINGW64" ]; then
   export BUILD_BITNESS="64"
   export BUILDCOMPONENT="x86_64"
   export ARCH="x86_64"
 else
-  echo "This script is not set up to handle systems of type ${MSYSTEM}, only MINGW32 or"
-  echo "MINGW64 are currently supported. Please rerun this in a bash terminal of one"
+  echo "This script is not set up to handle systems of type ${MSYSTEM}, only MINGW64"
+  echo "are currently supported. Please rerun this in a bash terminal of one"
   echo "of those two types."
   exit 2
 fi
@@ -361,11 +357,7 @@ EOF
     echo "=== Updating WP-Download-Manager ==="
     echo "sha256 of installer: $SHA256SUM"
 
-    if [ "${BUILD_BITNESS}" = "32" ]; then
-      FILE_CATEGORY="1"
-    else
-      FILE_CATEGORY="2"
-    fi
+    FILE_CATEGORY="2"
 
     current_timestamp=$(date "+%-d %-m %Y %-H %-M %-S")
     read -r day month year hour minute second <<< "$current_timestamp"

--- a/CI/package-mudlet-for-windows.sh
+++ b/CI/package-mudlet-for-windows.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ###########################################################################
 #   Copyright (C) 2024-2024  by John McKisson - john.mckisson@gmail.com   #
-#   Copyright (C) 2023-2024  by Stephen Lyons - slysven@virginmedia.com   #
+#   Copyright (C) 2023-2025  by Stephen Lyons - slysven@virginmedia.com   #
 #                                                                         #
 #   This program is free software; you can redistribute it and/or modify  #
 #   it under the terms of the GNU General Public License as published by  #
@@ -19,7 +19,8 @@
 #   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
 ###########################################################################
 
-# Version: 2.0.0    Rework to build on an MSYS2 MINGW64 Github workflow
+# Version: 2.1.0    Remove MINGW32 since upstream no longer supports it
+#          2.0.0    Rework to build on an MSYS2 MINGW64 Github workflow
 #          1.5.0    Change BUILD_TYPE to BUILD_CONFIG to avoid clash with
 #                   CI/CB system using same variable
 #          1.4.0    No change
@@ -46,37 +47,36 @@
 # 6 - No Mudlet.exe file found to work with
 
 if [ "${MSYSTEM}" = "MSYS" ]; then
-  echo "Please run this script from an MINGW64 type bash terminal appropriate"
-  echo "to the bitness you want to work on. You may do this once for each of them should"
-  echo "you wish to do both."
+  echo "Please run this script from a MINGW64 type bash terminal as the MSYS one"
+  echo "does not supported what is needed."
   exit 2
 elif [ "${MSYSTEM}" = "MINGW64" ]; then
   export BUILD_BITNESS="64"
   export BUILDCOMPONENT="x86_64"
 else
-  echo "This script is not set up to handle systems of type ${MSYSTEM}, only MINGW64"
-  echo "are currently supported. Please rerun this in a bash terminal of one"
-  echo "of those two types."
+  echo "This script is not set up to handle systems of type ${MSYSTEM}, only"
+  echo "MINGW64 is currently supported. Please rerun this in a bash terminal of"
+  echo "that type."
   exit 2
 fi
 
 BUILD_CONFIG="release"
 MINGW_INTERNAL_BASE_DIR="/mingw${BUILD_BITNESS}"
 export MINGW_INTERNAL_BASE_DIR
-GITHUB_WORKSPACE_UNIX_PATH=$(echo ${GITHUB_WORKSPACE} | sed 's|\\|/|g' | sed 's|D:|/d|g')
+GITHUB_WORKSPACE_UNIX_PATH=$(echo "${GITHUB_WORKSPACE}" | sed 's|\\|/|g' | sed 's|D:|/d|g')
 PACKAGE_DIR="${GITHUB_WORKSPACE_UNIX_PATH}/package-${MSYSTEM}-${BUILD_CONFIG}"
 
 echo "MSYSTEM is: ${MSYSTEM}"
 echo ""
 
-cd $GITHUB_WORKSPACE_UNIX_PATH || exit 1
+cd "${GITHUB_WORKSPACE_UNIX_PATH}" || exit 1
 
 if [ -d "${PACKAGE_DIR}" ]; then
   # The wanted packaging dir exists - as is wanted
   echo ""
   echo "Checking for an empty ${PACKAGE_DIR} in which to assemble files..."
   echo ""
-  if [ -n "$(ls -A ${PACKAGE_DIR})" ]; then
+  if [ -n "$(ls -A "${PACKAGE_DIR}")" ]; then
     # But it isn't empty...
     echo "${PACKAGE_DIR} does not appear to be empty, please"
     echo "erase everything there and try again."
@@ -107,7 +107,6 @@ if [ -f "${GITHUB_WORKSPACE_UNIX_PATH}/build-${MSYSTEM}/${BUILD_CONFIG}/mudlet.e
 fi
 
 "${MINGW_INTERNAL_BASE_DIR}/bin/windeployqt6" ./mudlet.exe
-ZIP_FILE_NAME="Mudlet-${MSYSTEM}"
 
 
 
@@ -126,11 +125,12 @@ ZIP_FILE_NAME="Mudlet-${MSYSTEM}"
 echo ""
 echo "Examining Mudlet application to identify other needed libraries..."
 NEEDED_LIBS=$("${MINGW_INTERNAL_BASE_DIR}/bin/ntldd" --recursive ./mudlet.exe \
-  | /usr/bin/grep -v "Qt5" \
+  | /usr/bin/grep -v "Qt6" \
   | /usr/bin/grep -i "mingw" \
   | /usr/bin/cut -d ">" -f2 \
   | /usr/bin/cut -d "(" -f1 \
-  | /usr/bin/sort)
+  | /usr/bin/sort \
+  | /usr/bin/uniq)
 
 echo ""
 echo "Copying these identified libraries..."
@@ -154,10 +154,11 @@ cp -v -p -t . \
 
 echo ""
 echo "Copying OpenSSL libraries in..."
-# The openSSL libraries has a different name depending on the bitness:
-    cp -v -p -t . \
-        "${MINGW_INTERNAL_BASE_DIR}/bin/libcrypto-3-x64.dll" \
-        "${MINGW_INTERNAL_BASE_DIR}/bin/libssl-3-x64.dll"
+# The openSSL libraries has a different name depending on the bitness - but we
+# only do 64-bits now:
+cp -v -p -t . \
+    "${MINGW_INTERNAL_BASE_DIR}/bin/libcrypto-3-x64.dll" \
+    "${MINGW_INTERNAL_BASE_DIR}/bin/libssl-3-x64.dll"
 
 
 echo ""
@@ -192,26 +193,26 @@ echo "Copying Mudlet & Geyser Lua files and the Generic Mapper in..."
 
 # As written it copies every file but it should be polished up to skip unneeded
 # ones:
-rsync -avR ${GITHUB_WORKSPACE_UNIX_PATH}/src/mudlet-lua/./* ./mudlet-lua/
+rsync -avR "${GITHUB_WORKSPACE_UNIX_PATH}"/src/mudlet-lua/./* ./mudlet-lua/
 echo ""
 
 echo "Copying Lua code formatter Lua files in..."
 # As written it copies every file but it should be polished up to skip unneeded
 # ones:
-rsync -avR ${GITHUB_WORKSPACE_UNIX_PATH}/3rdparty/lcf/./* ./lcf/
+rsync -avR "${GITHUB_WORKSPACE_UNIX_PATH}"/3rdparty/lcf/./* ./lcf/
 echo ""
 
 echo "Copying Lua translation files in..."
 mkdir -p ./translations/lua/translated
 cp -v -p -t ./translations/lua/translated \
-    ${GITHUB_WORKSPACE_UNIX_PATH}/translations/lua/translated/mudlet-lua_??_??.json
-cp -v -p -t ./translations/lua ${GITHUB_WORKSPACE_UNIX_PATH}/translations/lua/mudlet-lua.json
+    "${GITHUB_WORKSPACE_UNIX_PATH}"/translations/lua/translated/mudlet-lua_??_??.json
+cp -v -p -t ./translations/lua "${GITHUB_WORKSPACE_UNIX_PATH}/translations/lua/mudlet-lua.json"
 echo ""
 
 echo "Copying Hunspell dictionaries in..."
 cp -v -p -t . \
-    ${GITHUB_WORKSPACE_UNIX_PATH}/src/*.aff \
-    ${GITHUB_WORKSPACE_UNIX_PATH}/src/*.dic
+    "${GITHUB_WORKSPACE_UNIX_PATH}"/src/*.aff \
+    "${GITHUB_WORKSPACE_UNIX_PATH}"/src/*.dic
 
 echo ""
 

--- a/CI/package-mudlet-for-windows.sh
+++ b/CI/package-mudlet-for-windows.sh
@@ -46,19 +46,16 @@
 # 6 - No Mudlet.exe file found to work with
 
 if [ "${MSYSTEM}" = "MSYS" ]; then
-  echo "Please run this script from an MINGW32 or MINGW64 type bash terminal appropriate"
+  echo "Please run this script from an MINGW64 type bash terminal appropriate"
   echo "to the bitness you want to work on. You may do this once for each of them should"
   echo "you wish to do both."
   exit 2
-elif [ "${MSYSTEM}" = "MINGW32" ]; then
-  export BUILD_BITNESS="32"
-  export BUILDCOMPONENT="i686"
 elif [ "${MSYSTEM}" = "MINGW64" ]; then
   export BUILD_BITNESS="64"
   export BUILDCOMPONENT="x86_64"
 else
-  echo "This script is not set up to handle systems of type ${MSYSTEM}, only MINGW32 or"
-  echo "MINGW64 are currently supported. Please rerun this in a bash terminal of one"
+  echo "This script is not set up to handle systems of type ${MSYSTEM}, only MINGW64"
+  echo "are currently supported. Please rerun this in a bash terminal of one"
   echo "of those two types."
   exit 2
 fi
@@ -109,11 +106,7 @@ if [ -f "${GITHUB_WORKSPACE_UNIX_PATH}/build-${MSYSTEM}/${BUILD_CONFIG}/mudlet.e
   cp "${GITHUB_WORKSPACE_UNIX_PATH}/build-${MSYSTEM}/${BUILD_CONFIG}/mudlet.exe.debug" "${PACKAGE_DIR}/"
 fi
 
-if [ "${MSYSTEM}" = "MINGW64" ]; then
-    "${MINGW_INTERNAL_BASE_DIR}/bin/windeployqt6" ./mudlet.exe
-else
-    "${MINGW_INTERNAL_BASE_DIR}/bin/windeployqt" ./mudlet.exe
-fi
+"${MINGW_INTERNAL_BASE_DIR}/bin/windeployqt6" ./mudlet.exe
 ZIP_FILE_NAME="Mudlet-${MSYSTEM}"
 
 
@@ -122,9 +115,8 @@ ZIP_FILE_NAME="Mudlet-${MSYSTEM}"
 # continually trying to run the executable on the target type system
 # and adding in the libraries to the same directory and repeating that
 # until the executable actually starts to run. Alternatively running
-# ntldd ./mudlet.exe | grep "/mingw32" {for the 32 bit case, use "64" for
-# the other one} inside an Mingw32 (or 64) shell as appropriate will
-# produce the libraries that are likely to be needed below. Unfortunetly
+# ntldd ./mudlet.exe | grep "/mingw64" inside an Mingw63 shell as appropriate 
+# will produce the libraries that are likely to be needed below. Unfortunately
 # this process is a little recursive in that you may have to repeat the
 # process for individual librarys. For ones used by lua modules this
 # can manifest as being unable to "require" the library within lua
@@ -133,21 +125,13 @@ ZIP_FILE_NAME="Mudlet-${MSYSTEM}"
 #
 echo ""
 echo "Examining Mudlet application to identify other needed libraries..."
-if [ "${MSYSTEM}" = "MINGW64" ]; then
-    NEEDED_LIBS=$("${MINGW_INTERNAL_BASE_DIR}/bin/ntldd" --recursive ./mudlet.exe \
-      | /usr/bin/grep -v "Qt5" \
-      | /usr/bin/grep -i "mingw" \
-      | /usr/bin/cut -d ">" -f2 \
-      | /usr/bin/cut -d "(" -f1 \
-      | /usr/bin/sort)
-else
-    NEEDED_LIBS=$("${MINGW_INTERNAL_BASE_DIR}/bin/ntldd" --recursive ./mudlet.exe \
-      | /usr/bin/grep -v "Qt6" \
-      | /usr/bin/grep -i "mingw" \
-      | /usr/bin/cut -d ">" -f2 \
-      | /usr/bin/cut -d "(" -f1 \
-      | /usr/bin/sort)
-fi
+NEEDED_LIBS=$("${MINGW_INTERNAL_BASE_DIR}/bin/ntldd" --recursive ./mudlet.exe \
+  | /usr/bin/grep -v "Qt5" \
+  | /usr/bin/grep -i "mingw" \
+  | /usr/bin/cut -d ">" -f2 \
+  | /usr/bin/cut -d "(" -f1 \
+  | /usr/bin/sort)
+
 echo ""
 echo "Copying these identified libraries..."
 for LIB in ${NEEDED_LIBS} ; do
@@ -168,42 +152,17 @@ cp -v -p -t . \
     "${MINGW_INTERNAL_BASE_DIR}/bin/libsqlite3-0.dll" \
     "${MINGW_INTERNAL_BASE_DIR}/bin/libyajl.dll"
 
-# For some reason as of September 2024 ntldd no longer identifies these
-# libraries for the 32-Bit case and our Qt5 (in this case) application
-# refuses to start without them. At a guess they are being loaded
-# dynamically so cannot be identified by static analysis like (nt)ldd
-# seems to do. Yet the same thing works for the now Qt6 based 64-Bit
-# application. Unfortunately this might bite us again for other libraries
-# I guess - I only deduced these omissions by comparing the file list
-# against an older working build. Slysven - 2024/11
-if [ "${MSYSTEM}" = "MINGW32" ]; then
-    cp -v -p -t . \
-        "${MINGW_INTERNAL_BASE_DIR}/bin/libbrotlicommon.dll" \
-        "${MINGW_INTERNAL_BASE_DIR}/bin/libbrotlidec.dll" \
-        "${MINGW_INTERNAL_BASE_DIR}/bin/libfreetype-6.dll"
-fi
 echo ""
 echo "Copying OpenSSL libraries in..."
 # The openSSL libraries has a different name depending on the bitness:
-if [ "${MSYSTEM}" = "MINGW32" ]; then
-    cp -v -p -t . \
-        "${MINGW_INTERNAL_BASE_DIR}/bin/libcrypto-3.dll" \
-        "${MINGW_INTERNAL_BASE_DIR}/bin/libssl-3.dll"
-
-elif [ "${MSYSTEM}" = "MINGW64" ]; then
     cp -v -p -t . \
         "${MINGW_INTERNAL_BASE_DIR}/bin/libcrypto-3-x64.dll" \
         "${MINGW_INTERNAL_BASE_DIR}/bin/libssl-3-x64.dll"
 
-fi
 
 echo ""
 echo "Copying discord-rpc library in..."
-if [ "${MSYSTEM}" = "MINGW32" ]; then
-    cp -v -p "${GITHUB_WORKSPACE_UNIX_PATH}/3rdparty/discord/rpc/lib/discord-rpc32.dll"  .
-elif [ "${MSYSTEM}" = "MINGW64" ]; then
-    cp -v -p "${GITHUB_WORKSPACE_UNIX_PATH}/3rdparty/discord/rpc/lib/discord-rpc64.dll"  .
-fi
+cp -v -p "${GITHUB_WORKSPACE_UNIX_PATH}/3rdparty/discord/rpc/lib/discord-rpc64.dll"  .
 echo ""
 
 # Lua libraries:

--- a/CI/register-windows-release.sh
+++ b/CI/register-windows-release.sh
@@ -22,7 +22,7 @@
 # BUILD_COMMIT and registers it with dblsqd. It will attempt this for up to
 # an hour, every minute until success.
 # GHA Env vars needed:
-#    ARCH - For registering wither 32 or 64 bit build with dblsqd
+#    ARCH - For registering wither 64 bit build with dblsqd
 #    BUILD_COMMIT - For listing the json feed
 #    PATH - For path of dblsqd
 #    VERSION_STRING - The version of Mudlet being released
@@ -60,13 +60,10 @@ FetchAndCheckURL() {
       return 1
     fi
 
-    # Determine the search pattern based on ARCH environment variable
-    if [ "$ARCH" == "x86" ]; then
-      search_pattern="windows-32.exe"
-    elif [ "$ARCH" == "x86_64" ]; then
+    if [ "$ARCH" == "x86_64" ]; then
       search_pattern="windows-64.exe"
     else
-      echo "ARCH environment variable is not set to x86 or x86_64."
+      echo "ARCH environment variable is not set to x86_64 as expected."
       exit 2
     fi
 

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ###########################################################################
 #   Copyright (C) 2024-2024  by John McKisson - john.mckisson@gmail.com   #
-#   Copyright (C) 2023-2024  by Stephen Lyons - slysven@virginmedia.com   #
+#   Copyright (C) 2023-2025  by Stephen Lyons - slysven@virginmedia.com   #
 #                                                                         #
 #   This program is free software; you can redistribute it and/or modify  #
 #   it under the terms of the GNU General Public License as published by  #
@@ -19,7 +19,8 @@
 #   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
 ###########################################################################
 
-# Version: 2.0.0    Rework to build on an MSYS2 MINGW64 Github workflow
+# Version: 2.1.0    Remove MINGW32 since upstream no longer supports it
+#          2.0.0    Rework to build on an MSYS2 MINGW64 Github workflow
 #          1.5.0    No change
 #          1.4.0    No change
 #          1.3.0    Don't explicitly install the no longer supported QT 5
@@ -50,23 +51,22 @@
 # 7 - One of more packages failed to install
 
 
-if [ "${MSYSTEM}" = "MINGW64" ]; then
+if [ "${MSYSTEM}" = "MSYS" ]; then
+  echo "Please run this script from a MINGW64 type bash terminal as the MSYS one"
+  echo "does not supported what is needed."
+  exit 2
+elif [ "${MSYSTEM}" = "MINGW64" ]; then
   export BUILD_BITNESS="64"
   export BUILDCOMPONENT="x86_64"
-elif [ "${MSYSTEM}" = "MSYS" ]; then
-  echo "Please run this script from an MINGW64 type bash terminal appropriate"
-  echo "to the bitness you want to work on. You may do this once for each of them should"
-  echo "you wish to do both."
-  exit 2
 else
-  echo "This script is not set up to handle systems of type ${MSYSTEM}, only MINGW64"
-  echo "are currently supported. Please rerun this in a bash terminal of one"
-  echo "of those two types."
+  echo "This script is not set up to handle systems of type ${MSYSTEM}, only"
+  echo "MINGW64 is currently supported. Please rerun this in a bash terminal of"
+  echo "that type."
   exit 2
 fi
 
 # We use this internally - but it is actually the same as ${MINGW_PREFIX}
-export MINGW_BASE_DIR=$MSYSTEM_PREFIX
+export MINGW_BASE_DIR=${MSYSTEM_PREFIX}
 # A more compact - but not necessarily understood by other than MSYS/MINGW
 # executables - path:
 export MINGW_INTERNAL_BASE_DIR="/mingw${BUILD_BITNESS}"
@@ -88,8 +88,8 @@ echo "    This could take a long time if it is needed to fetch everything, so fe
 echo "    to go and have a cup of tea (other beverages are available) in the meantime...!"
 echo ""
 
-echo "=== Installing Qt6 Packages ==="
-pacman_attempts=1
+echo "=== Installing needed packages ==="
+pacman_attempts=0
 while true; do
   if /usr/bin/pacman -Su --needed --noconfirm \
     "mingw-w64-${BUILDCOMPONENT}-qt6-base" \
@@ -102,22 +102,7 @@ while true; do
     "mingw-w64-${BUILDCOMPONENT}-qt6-tools" \
     "mingw-w64-${BUILDCOMPONENT}-qt6-5compat" \
     "mingw-w64-${BUILDCOMPONENT}-angleproject" \
-    "mingw-w64-${BUILDCOMPONENT}-qtkeychain-qt6"; then
-      break
-  fi
-
-  if [ $pacman_attempts -eq 10 ]; then
-    exit 7
-  fi
-  pacman_attempts=$((pacman_attempts +1))
-
-  echo "=== Some packages failed to install, waiting and trying again ==="
-  sleep 10
-done
-
-pacman_attempts=1
-while true; do
-  if /usr/bin/pacman -Su --needed --noconfirm \
+    "mingw-w64-${BUILDCOMPONENT}-qtkeychain-qt6" \
     git \
     man \
     rsync \
@@ -141,13 +126,15 @@ while true; do
       break
   fi
 
-  if [ $pacman_attempts -eq 10 ]; then
-    exit 7
-  fi
   pacman_attempts=$((pacman_attempts +1))
 
-  echo "=== Some packages failed to install, waiting and trying again ==="
-  sleep 10
+  if [ ${pacman_attempts} -lt 10 ]; then
+    echo "=== Some packages failed to install, waiting and trying again ==="
+    sleep 10
+  else
+    echo "=== Some packages failed to install after ${pacman_attempts} attempts, giving up ==="
+    exit 7
+  end
 done
 
 echo "Removing harfbuzz installed by qt"
@@ -155,7 +142,7 @@ pacman -Rdd --noconfirm mingw-w64-${BUILDCOMPONENT}-harfbuzz
 
 echo "Building harfbuzz without graphite2"
 git clone https://github.com/harfbuzz/harfbuzz.git
-cd harfbuzz
+cd harfbuzz || exit 1
 meson setup build --prefix=/mingw${BUILD_BITNESS} --buildtype=release -Dgraphite=disabled -Dtests=disabled
 meson compile -C build
 meson install -C build
@@ -231,7 +218,7 @@ echo "Copy the following lines into the build environment for a project in Qt Cr
 echo "See https://doc.qt.io/qtcreator/creator-how-set-project-environment.html#change-the-environment-for-a-project"
 echo ""
 MSYS_ROOT=$(cygpath -aw /)
-echo "MINGW_BASE_DIR=${MSYS_ROOT}$(echo ${MSYSTEM_PREFIX} | sed 's/\//\\/g')"
+echo "MINGW_BASE_DIR=${MSYS_ROOT}$(echo "${MSYSTEM_PREFIX}" | sed 's/\//\\/g')"
 echo "LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)"
 echo "LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)"
 

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -50,9 +50,9 @@
 # 7 - One of more packages failed to install
 
 
-if [ "${MSYSTEM}" = "MINGW32" ]; then
-  export BUILD_BITNESS="32"
-  export BUILDCOMPONENT="i686"
+if [ "${MSYSTEM}" = "MINGW64" ]; then
+  export BUILD_BITNESS="64"
+  export BUILDCOMPONENT="x86_64"
 elif [ "${MSYSTEM}" = "MSYS" ]; then
   echo "Please run this script from an MINGW64 type bash terminal appropriate"
   echo "to the bitness you want to work on. You may do this once for each of them should"

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -33,7 +33,7 @@
 #          1.0.0    Original version
 
 # Script to run once in a ${GITHUB_WORKFLOW} directory in a MSYS2 shell to
-# install as much as possible to be able to develop 64/32 Bit Windows
+# install as much as possible to be able to develop 64 Bit Windows
 # version of Mudlet
 
 # To be used prior to building Mudlet, after that run:
@@ -50,20 +50,17 @@
 # 7 - One of more packages failed to install
 
 
-if [ "${MSYSTEM}" = "MINGW64" ]; then
-  export BUILD_BITNESS="64"
-  export BUILDCOMPONENT="x86_64"
-elif [ "${MSYSTEM}" = "MINGW32" ]; then
+if [ "${MSYSTEM}" = "MINGW32" ]; then
   export BUILD_BITNESS="32"
   export BUILDCOMPONENT="i686"
 elif [ "${MSYSTEM}" = "MSYS" ]; then
-  echo "Please run this script from an MINGW32 or MINGW64 type bash terminal appropriate"
+  echo "Please run this script from an MINGW64 type bash terminal appropriate"
   echo "to the bitness you want to work on. You may do this once for each of them should"
   echo "you wish to do both."
   exit 2
 else
-  echo "This script is not set up to handle systems of type ${MSYSTEM}, only MINGW32 or"
-  echo "MINGW64 are currently supported. Please rerun this in a bash terminal of one"
+  echo "This script is not set up to handle systems of type ${MSYSTEM}, only MINGW64"
+  echo "are currently supported. Please rerun this in a bash terminal of one"
   echo "of those two types."
   exit 2
 fi
@@ -91,60 +88,32 @@ echo "    This could take a long time if it is needed to fetch everything, so fe
 echo "    to go and have a cup of tea (other beverages are available) in the meantime...!"
 echo ""
 
-if [ "${MSYSTEM}" = "MINGW64" ]; then
-  echo "=== Installing Qt6 Packages ==="
-  pacman_attempts=1
-  while true; do
-    if /usr/bin/pacman -Su --needed --noconfirm \
-      "mingw-w64-${BUILDCOMPONENT}-qt6-base" \
-      "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia" \
-      "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia-wmf" \
-      "mingw-w64-${BUILDCOMPONENT}-qt6-svg" \
-      "mingw-w64-${BUILDCOMPONENT}-qt6-speech" \
-      "mingw-w64-${BUILDCOMPONENT}-qt6-imageformats" \
-      "mingw-w64-${BUILDCOMPONENT}-qt6-translations" \
-      "mingw-w64-${BUILDCOMPONENT}-qt6-tools" \
-      "mingw-w64-${BUILDCOMPONENT}-qt6-5compat" \
-      "mingw-w64-${BUILDCOMPONENT}-angleproject" \
-      "mingw-w64-${BUILDCOMPONENT}-qtkeychain-qt6"; then
-        break
-    fi
+echo "=== Installing Qt6 Packages ==="
+pacman_attempts=1
+while true; do
+  if /usr/bin/pacman -Su --needed --noconfirm \
+    "mingw-w64-${BUILDCOMPONENT}-qt6-base" \
+    "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia" \
+    "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia-wmf" \
+    "mingw-w64-${BUILDCOMPONENT}-qt6-svg" \
+    "mingw-w64-${BUILDCOMPONENT}-qt6-speech" \
+    "mingw-w64-${BUILDCOMPONENT}-qt6-imageformats" \
+    "mingw-w64-${BUILDCOMPONENT}-qt6-translations" \
+    "mingw-w64-${BUILDCOMPONENT}-qt6-tools" \
+    "mingw-w64-${BUILDCOMPONENT}-qt6-5compat" \
+    "mingw-w64-${BUILDCOMPONENT}-angleproject" \
+    "mingw-w64-${BUILDCOMPONENT}-qtkeychain-qt6"; then
+      break
+  fi
 
-    if [ $pacman_attempts -eq 10 ]; then
-      exit 7
-    fi
-    pacman_attempts=$((pacman_attempts +1))
+  if [ $pacman_attempts -eq 10 ]; then
+    exit 7
+  fi
+  pacman_attempts=$((pacman_attempts +1))
 
-    echo "=== Some packages failed to install, waiting and trying again ==="
-    sleep 10
-  done
-
-else
-
-  echo "=== Installing Qt5 Packages ==="
-  pacman_attempts=1
-  while true; do
-    if /usr/bin/pacman -Su --needed --noconfirm \
-      "mingw-w64-${BUILDCOMPONENT}-qt5-base" \
-      "mingw-w64-${BUILDCOMPONENT}-qt5-multimedia" \
-      "mingw-w64-${BUILDCOMPONENT}-qt5-svg" \
-      "mingw-w64-${BUILDCOMPONENT}-qt5-speech" \
-      "mingw-w64-${BUILDCOMPONENT}-qt5-imageformats" \
-      "mingw-w64-${BUILDCOMPONENT}-qt5-winextras" \
-      "mingw-w64-${BUILDCOMPONENT}-qt5-tools" \
-      "mingw-w64-${BUILDCOMPONENT}-qt5-translations"; then
-        break
-    fi
-
-    if [ $pacman_attempts -eq 10 ]; then
-      exit 7
-    fi
-    pacman_attempts=$((pacman_attempts +1))
-
-    echo "=== Some packages failed to install, waiting and trying again ==="
-    sleep 10
-  done
-fi
+  echo "=== Some packages failed to install, waiting and trying again ==="
+  sleep 10
+done
 
 pacman_attempts=1
 while true; do

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -134,7 +134,7 @@ while true; do
   else
     echo "=== Some packages failed to install after ${pacman_attempts} attempts, giving up ==="
     exit 7
-  end
+  fi
 done
 
 echo "Removing harfbuzz installed by qt"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #    Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            #
-#    Copyright (C) 2015-2018, 2020, 2022, 2024 by Stephen Lyons            #
+#    Copyright (C) 2015-2018, 2020, 2022, 2024-2025 by Stephen Lyons       #
 #                                                - slysven@virginmedia.com #
 #                                                                          #
 #    This program is free software; you can redistribute it and/or modify  #
@@ -143,29 +143,13 @@ include_optional_module(ENVIRONMENT_VARIABLE WITH_VARIABLE_SPLASH_SCREEN
 include_optional_module(ENVIRONMENT_VARIABLE WITH_OWN_QTKEYCHAIN
                         OPTION_VARIABLE USE_OWN_QTKEYCHAIN
                         READABLE_NAME "own QtKeychain library")
-include_optional_module(ENVIRONMENT_VARIABLE WITH_QT6
-                        OPTION_VARIABLE USE_QT6
-                        READABLE_NAME "build with Qt6 (if installed)")
 
-if(USE_QT6)
-  find_package(
-          Qt6 6.2.0
-          QUIET)
-  if(NOT Qt6_FOUND)
-    message(STATUS "Qt6 >= 6.2.0 was not found. Building with Qt5.")
-  endif()
-endif()
+find_package(Qt6 6.4.0 REQUIRED)
 
-# Set Qt version for src, test, translations and communi
-set(WITH_QT6 ${Qt6_FOUND} CACHE BOOL "Whether to build with Qt6 or Qt5.")
 # Set Qt version for edbee-lib and dblsqd
-if(WITH_QT6)
-  option(BUILD_WITH_QT5 "" OFF)
-else()
-  option(BUILD_WITH_QT5 "" ON)
-endif()
+option(BUILD_WITH_QT5 "" OFF)
 # Set Qt version for qtkeychain
-option(BUILD_WITH_QT6 "" ${WITH_QT6})
+option(BUILD_WITH_QT6 "" ON)
 
 include(InitGitSubmodule)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #    Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       #
-#    Copyright (C) 2015-2018, 2020, 2023 by Stephen Lyons                  #
+#    Copyright (C) 2015-2018, 2020, 2023, 2025 by Stephen Lyons            #
 #                                                - slysven@virginmedia.com #
 #    Copyright (C) 2018 by Huadong Qi - novload@outlook.com                #
 #    Copyright (C) 2022 by Thiago Jung Bauermann - bauermann@kolabnow.com  #
@@ -420,23 +420,22 @@ add_sanitizer_support(${USE_SANITIZER})
 message(STATUS "Compiling with the following sanitizer(s) enabled: ${USE_SANITIZER}")
 
 
-if(WITH_QT6)
-find_package(
-  Qt6 6.2.0 REQUIRED
-  COMPONENTS Core
-             Multimedia
-             Network
-             OpenGL
-             UiTools
-             Widgets
-             Concurrent
-             Core5Compat)
-  find_package(Qt6 COMPONENTS TextToSpeech QUIET)
+find_package(Qt6 6.4.0 REQUIRED
+    COMPONENTS Core
+               Multimedia
+               Network
+               OpenGL
+               UiTools
+               Widgets
+               Concurrent
+               Core5Compat)
 
-  message(STATUS "Qt version: ${Qt6Core_VERSION}")
+find_package(Qt6 COMPONENTS TextToSpeech QUIET)
 
-  set(QT_MAJOR_VERSION 6)
-  set(QT_LIBS Qt6::Concurrent
+message(STATUS "Qt version: ${Qt6Core_VERSION}")
+
+set(QT_MAJOR_VERSION 6)
+set(QT_LIBS Qt6::Concurrent
               Qt6::Core
               Qt6::Network
               Qt6::Multimedia
@@ -446,38 +445,9 @@ find_package(
               Qt6::Core5Compat
               qt6keychain)
 
-  if(Qt6TextToSpeech_FOUND)
-    list(APPEND QT_LIBS Qt6::TextToSpeech)
-    message(STATUS "Using TextToSpeech module")
-  endif()
-else()
-  find_package(
-          Qt5 5.14 REQUIRED
-          COMPONENTS Core
-          Multimedia
-          Network
-          OpenGL
-          UiTools
-          Widgets
-          Concurrent)
-  find_package(Qt5 COMPONENTS TextToSpeech QUIET)
-
-  message(STATUS "Qt version: ${Qt5Core_VERSION}")
-
-  set(QT_MAJOR_VERSION 5)
-  set(QT_LIBS Qt5::Concurrent
-              Qt5::Core
-              Qt5::Network
-              Qt5::Multimedia
-              Qt5::OpenGL
-              Qt5::UiTools
-              Qt5::Widgets
-              qt5keychain)
-
-  if(Qt5TextToSpeech_FOUND)
-    list(APPEND QT_LIBS Qt5::TextToSpeech)
-    message(STATUS "Using TextToSpeech module")
-  endif()
+if(Qt6TextToSpeech_FOUND)
+  list(APPEND QT_LIBS Qt6::TextToSpeech)
+  message(STATUS "Using TextToSpeech module")
 endif()
 
 message(STATUS "Using ${CMAKE_CXX_COMPILER_ID} compiler")

--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -89,13 +89,7 @@ bool TAlias::match(const QString& haystack)
         return false; //regex compile error
     }
 
-#if defined(Q_OS_WINDOWS)
-    // strndup(3) - a safe strdup(3) does not seem to be available on mingw32 with GCC-4.9.2
-    char* haystackC = static_cast<char*>(malloc(strlen(haystack.toUtf8().constData()) + 1));
-    strcpy(haystackC, haystack.toUtf8().constData());
-#else
     char* haystackC = strndup(haystack.toUtf8().constData(), strlen(haystack.toUtf8().constData()));
-#endif
 
     // These must be initialised before any goto so the latter does not jump
     // over them:

--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -89,7 +89,14 @@ bool TAlias::match(const QString& haystack)
         return false; //regex compile error
     }
 
+#if defined(Q_OS_WINDOWS)
+    // strndup(3) - a safe strdup(3) does not seem to be available in the
+    // original Mingw or the replacement Mingw-w64 environment we use:
+    char* haystackC = static_cast<char*>(malloc(strlen(haystack.toUtf8().constData()) + 1));
+    strcpy(haystackC, haystack.toUtf8().constData());
+#else
     char* haystackC = strndup(haystack.toUtf8().constData(), strlen(haystack.toUtf8().constData()));
+#endif
 
     // These must be initialised before any goto so the latter does not jump
     // over them:

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -237,13 +237,7 @@ void TriggerUnit::processDataStream(const QString& data, int line)
         return;
     }
 
-#if defined(Q_OS_WINDOWS)
-    // strndup(3) - a safe strdup(3) does not seem to be available on mingw32 with GCC-4.9.2
-    char* subject = static_cast<char*>(malloc(strlen(data.toUtf8().data()) + 1));
-    strcpy(subject, data.toUtf8().data());
-#else
     char* subject = strndup(data.toUtf8().constData(), strlen(data.toUtf8().constData()));
-#endif
     for (auto trigger : mTriggerRootNodeList) {
         trigger->match(subject, data, line);
     }

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -237,7 +237,14 @@ void TriggerUnit::processDataStream(const QString& data, int line)
         return;
     }
 
+#if defined(Q_OS_WINDOWS)
+    // strndup(3) - a safe strdup(3) does not seem to be available in the
+    // original mingw or the replacement mingw-w64 enmvironment we use:
+    char* subject = static_cast<char*>(malloc(strlen(haystack.toUtf8().constData()) + 1));
+    strcpy(subject, data.toUtf8().constData());
+#else
     char* subject = strndup(data.toUtf8().constData(), strlen(data.toUtf8().constData()));
+#endif```
     for (auto trigger : mTriggerRootNodeList) {
         trigger->match(subject, data, line);
     }

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -244,7 +244,8 @@ void TriggerUnit::processDataStream(const QString& data, int line)
     strcpy(subject, data.toUtf8().constData());
 #else
     char* subject = strndup(data.toUtf8().constData(), strlen(data.toUtf8().constData()));
-#endif```
+#endif
+
     for (auto trigger : mTriggerRootNodeList) {
         trigger->match(subject, data, line);
     }

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -240,7 +240,7 @@ void TriggerUnit::processDataStream(const QString& data, int line)
 #if defined(Q_OS_WINDOWS)
     // strndup(3) - a safe strdup(3) does not seem to be available in the
     // original mingw or the replacement mingw-w64 enmvironment we use:
-    char* subject = static_cast<char*>(malloc(strlen(haystack.toUtf8().constData()) + 1));
+    char* subject = static_cast<char*>(malloc(strlen(data.toUtf8().constData()) + 1));
     strcpy(subject, data.toUtf8().constData());
 #else
     char* subject = strndup(data.toUtf8().constData(), strlen(data.toUtf8().constData()));

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -1,5 +1,5 @@
 ############################################################################
-#    Copyright (C) 2013-2015, 2017-2018, 2020-2024 by Stephen Lyons        #
+#    Copyright (C) 2013-2015, 2017-2018, 2020-2025 by Stephen Lyons        #
 #                                                - slysven@virginmedia.com #
 #    Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            #
 #    Copyright (C) 2017 by Ian Adkins - ieadkins@gmail.com                 #
@@ -375,6 +375,15 @@ unix:!macx {
 } else:win32 {
     MINGW_BASE_DIR_TEST = $$(MINGW_BASE_DIR)
     isEmpty( MINGW_BASE_DIR_TEST ) {
+        # 32-BIT Build systems have been obsolete since 2020/05/15
+        # https://www.msys2.org/news/#2020-05-17-32-bit-msys2-no-longer-actively-supported
+        #
+        # 32-Bit Targets have now been dropped - whilst a temporary reprieve
+        # for some Qt libraries that Mudlet needed was granted they are no
+        # longer available:
+        # https://www.msys2.org/news/#2023-12-13-starting-to-drop-some-32-bit-packages
+        # although it might be possible for dedicated parties to build them
+        # locally for a while:
         error($$escape_expand("Build aborted as environmental variable MINGW_BASE_DIR not set to the root of \\n"\
         "the Mingw32 or Mingw64 part (depending on the number of bits in your desired\\n"\
         "application build) typically this is one of:\\n"\

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,45 +11,24 @@ PROJECT(mudlet-tests
 
 ENABLE_TESTING()
 
-if (WITH_QT6)
-    find_package(Qt6 REQUIRED
-            COMPONENTS Core
-            Multimedia
-            Network
-            OpenGL
-            UiTools
-            Widgets
-            Concurrent
-            Test)
+find_package(Qt6 6.4.0 REQUIRED
+    COMPONENTS Core
+    Multimedia
+    Network
+    OpenGL
+    UiTools
+    Widgets
+    Concurrent
+    Test)
 
-    link_libraries(
-            Qt6::Test
-            Qt6::Concurrent
-            Qt6::Core
-            Qt6::Network
-            Qt6::Multimedia
-            Qt6::UiTools
-            Qt6::Widgets)
-else()
-    find_package(Qt5 REQUIRED
-            COMPONENTS Core
-            Multimedia
-            Network
-            OpenGL
-            UiTools
-            Widgets
-            Concurrent
-            Test)
-
-    link_libraries(
-            Qt5::Test
-            Qt5::Concurrent
-            Qt5::Core
-            Qt5::Network
-            Qt5::Multimedia
-            Qt5::UiTools
-            Qt5::Widgets)
-endif()
+link_libraries(
+    Qt6::Test
+    Qt6::Concurrent
+    Qt6::Core
+    Qt6::Network
+    Qt6::Multimedia
+    Qt6::UiTools
+    Qt6::Widgets)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake ${CMAKE_MODULE_PATH})
 

--- a/translations/translated/CMakeLists.txt
+++ b/translations/translated/CMakeLists.txt
@@ -1,6 +1,7 @@
 ############################################################################
 #    Copyright (C) 2018 by Vadim Peretokin - vperetokin@gmail.com          #
-#    Copyright (C) 2020, 2023 by Stephen Lyons - slysven@virginmedia.com   #
+#    Copyright (C) 2020, 2023, 2025 by Stephen Lyons                       #
+#                                                - slysven@virginmedia.com #
 #                                                                          #
 #    This program is free software; you can redistribute it and/or modify  #
 #    it under the terms of the GNU General Public License as published by  #
@@ -22,13 +23,8 @@
 
 message(STATUS "Building translations")
 
-if(WITH_QT6)
-  find_package(Qt6LinguistTools REQUIRED)
-  get_target_property(LRELEASE_LOCATION Qt6::lrelease LOCATION)
-else()
-  find_package(Qt5LinguistTools REQUIRED)
-  get_target_property(LRELEASE_LOCATION Qt5::lrelease LOCATION)
-endif()
+find_package(Qt6LinguistTools 6.4.0 REQUIRED)
+get_target_property(LRELEASE_LOCATION Qt6::lrelease LOCATION)
 
 file(GLOB TS_FILES *.ts)
 string(REPLACE ".ts" "" TS_FILES_NOEXT "${TS_FILES}")


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove support for building 32bit Windows applications
#### Motivation for adding to Mudlet
Dead code removal - we can't build them anymore as MSYS2 does not support them.
#### Other info (issues closed, discussion etc)
Let me know if anything else should be removed!
