### PR TITLE
Fix: Restore Raw Telnet Client.GUI Package Processing

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2804,18 +2804,18 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
             if (lines.size() < 2) {
                 return;
             }
-        
+
             QString version = lines[0].remove(QLatin1String("Client.GUI "), Qt::CaseInsensitive).trimmed();
             QString url = lines[1].trimmed();
-        
+
             if (version.isEmpty() || url.isEmpty()) {
                 return;
             }
-        
+
             rawTelnet = true;
             document = QJsonDocument(QJsonObject{{"version", version}, {"url", url}});
         }
-        
+
         handleGUIPackageInstallationAndUpgrade(document);
 
         if (rawTelnet) {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2795,27 +2795,28 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
         //
         // If the data does not parse as JSON, we'll try Raw telnet.
 
-        bool rawTelnet = false;
         auto document = QJsonDocument::fromJson(data.toUtf8());
+        bool rawTelnet = false;
 
         if (!document.isObject()) {
-            // This is raw telnet, not JSON
-            QString version = transcodedMsg.section(QChar::LineFeed, 0);
-
-            version.remove(QLatin1String("Client.GUI "), Qt::CaseInsensitive);
-            version.replace(QChar::LineFeed, QChar::Space);
-            version = version.section(QChar::Space, 0, 0);
-
-            QString url = transcodedMsg.section(QChar::LineFeed, 1);
-
-            if (version.isEmpty() || url.isEmpty()) {
-                return;  // Exit if version or URL is missing
+            // Raw Telnet fallback
+            QStringList lines = transcodedMsg.split(QChar::LineFeed);
+            if (lines.size() < 2) {
+                return;
             }
-
+        
+            QString version = lines[0].remove(QLatin1String("Client.GUI "), Qt::CaseInsensitive).trimmed();
+            QString url = lines[1].trimmed();
+        
+            if (version.isEmpty() || url.isEmpty()) {
+                return;
+            }
+        
             rawTelnet = true;
-        } else {
-            handleGUIPackageInstallationAndUpgrade(document);
+            document = QJsonDocument(QJsonObject{{"version", version}, {"url", url}});
         }
+        
+        handleGUIPackageInstallationAndUpgrade(document);
 
         if (rawTelnet) {
             return; // Do not add to the GMCP table


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

I unintentionally removed the installation and upgrade capability for raw telnet processing of Client.GUI in PR #7456. 

#### Motivation for adding to Mudlet

Closes an issue.

#### Other info (issues closed, discussion etc)

Closes Issue #7641

I tested raw telnet installs, upgrades, as well as JSON installs and upgrades.

https://github.com/user-attachments/assets/02822d69-2ee6-4e0b-a66b-9026421f3a13


