### PR TITLE
Fix missing qt6 reference in Travis script

### DIFF
--- a/CI/travis.osx.install.sh
+++ b/CI/travis.osx.install.sh
@@ -4,7 +4,7 @@ set +e
 shopt -s expand_aliases
 #Removed boost as first item as a temporary workaround to prevent trying to
 #upgrade to boost version 1.68.0 which has not been bottled yet...
-BREWS="luarocks cmake hunspell libzip mudlet/dependencies/lua@5.1 pcre pkg-config yajl ccache pugixml"
+BREWS="luarocks cmake hunspell libzip mudlet/dependencies/lua@5.1 pcre pkg-config yajl ccache pugixml qt6"
 OUTDATED_BREWS=$(brew outdated)
 
 for i in $BREWS; do


### PR DESCRIPTION
Fixes #7708

Add qt6 to the BREWS variable in CI/travis.osx.install.sh

* Update the BREWS variable to include qt6, ensuring it is installed during the build process on macOS.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Mudlet/Mudlet/pull/7709?shareId=2d9e462a-0780-487a-8287-e0a04085c639).