### PR TITLE
Improve: provide "NewLoad/NotReset" flag to sysLoadEvent

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -874,6 +874,12 @@ void Host::resetProfile_phase2()
     TEvent event {};
     event.mArgumentList.append(QLatin1String("sysLoadEvent"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+
+    // A zero value is how we send a "false" value - which indicates that
+    // this is for a reset profile and NOT a freshly loaded one:
+    event.mArgumentList.append(QString::number(0));
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_BOOLEAN);
+
     raiseEvent(event);
     qDebug() << "resetProfile() DONE";
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3101,6 +3101,10 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
     TEvent event {};
     event.mArgumentList.append(QLatin1String("sysLoadEvent"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    // A non-zero value is how we send a "true" value - which indicates that
+    // this is for a freshly loaded profile (and NOT one after a resetProfile()):
+    event.mArgumentList.append(QString::number(1));
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_BOOLEAN);
     pHost->raiseEvent(event);
 
     // Now load the default (latest stored) map file:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a boolean argument to the Mudlet `sysLoadEvent` which is `true` for a profile being loaded and `false` after a use of `resetProfile()`.

#### Motivation for adding to Mudlet
Packages/scripts might need to behave differently if they get this event when the profile is already in use as opposed to being freshly started. For instance in the former case they may already be connected and active on the Game Server or they may need to reacquire data/variables/tables in a different manner.

#### Other info (issues closed, discussion etc)
