### PR TITLE
Infrastructure: revert "update CI workflows to use Ubuntu 22.04 (#7711)"

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         include:
           # oldest OS supported for maximum compatibility of built AppImage
-          - os: ubuntu-22.04
+          - os: ubuntu-20.04
             buildname: 'ubuntu / gcc / lua tests'
             triplet: x64-linux
             compiler: gcc_64

--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-20.04
             buildname: 'clang-tidy'
             triplet: x64-linux
             compiler: clang_64


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
This reverts commit 3e2964dd4f44c42841e0672904a4e948dc7a85cd.
#### Motivation for adding to Mudlet
linuxdeployqt refuses to work with Ubuntu 22.04.

However, Github is shutting down access to Ubuntu 20.04 soon: https://public.hey.com/p/7sV4K7YEREm5JAoXEw8Z7XQA so we'll be in some trouble when that happens.
#### Other info (issues closed, discussion etc)
