### PR TITLE
Test: provide a function to report working directory and library paths

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5497,6 +5497,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getProfiles", TLuaInterpreter::getProfiles);
     lua_register(pGlobalLua, "loadProfile", TLuaInterpreter::loadProfile);
     lua_register(pGlobalLua, "closeProfile", TLuaInterpreter::closeProfile);
+    lua_register(pGlobalLua, "applicationPaths", TLuaInterpreter::applicationPaths);
     // PLACEMARKER: End of main Lua interpreter functions registration
     // check new functions against https://www.linguistic-antipatterns.com when creating them
 
@@ -7606,4 +7607,27 @@ void TLuaInterpreter::updateEditor()
     if (mpHost->mpEditorDialog) {
         mpHost->mpEditorDialog->mNeedUpdateData = true;
     }
+}
+
+int TLuaInterpreter::applicationPaths(lua_State* L)
+{
+    lua_newtable(L);
+    const QString appPath = qApp->applicationDirPath().append(QLatin1Char('/')).append(APP_TARGET);
+    const QStringList libPaths = qApp->libraryPaths();
+
+    lua_pushstring(L, "applicationPathFile");
+    lua_pushstring(L, appPath.toUtf8().constData());
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "libraryPaths");
+    lua_newtable(L);
+    int index = 0;
+    for (const auto& path : std::as_const(libPaths)) {
+        lua_pushnumber(L, ++index);
+        lua_pushstring(L, path.toUtf8().constData());
+        lua_settable(L, -3);
+    }
+    lua_settable(L, -3);
+
+    return 1;
 }

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -676,6 +676,7 @@ public:
     static int getProfiles(lua_State*);
     static int loadProfile(lua_State*);
     static int closeProfile(lua_State*);
+    static int applicationPaths(lua_State*);
     // PLACEMARKER: End of Lua functions declarations
     // check new functions against https://www.linguistic-antipatterns.com when creating them
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds `applicationPaths()` function to Lua API which reports the Mudlet application's idea of its current working directory and the location(s) from which it would look to find binary libraries.

#### Motivation for adding to Mudlet
A user was reporting issues where Mudlet would load their first profile, including loading all the Lua binary libraries (such as the Lua File System) one and then fail to find it for a second profile, given that in their case (Windows 64 bit) release version this would be from the same directory as the Mudlet executable itself (the `./lfs.dll` entry reported) in the error message in the main console. This function is intended to enable the "current" working directory to be monitored - so that if it gets changed it can be detected.

#### Other info (issues closed, discussion etc)
**This is a test/draft PR - it is not intended to be merged into the main code-base.** The user concerned with whom I have been helping with this is the Discord user `kyrus78`.
