### PR TITLE
FIX: update flatpak manifest with QT6

### DIFF
--- a/CI/org.mudlet.mudlet.yml
+++ b/CI/org.mudlet.mudlet.yml
@@ -1,6 +1,6 @@
 id: org.mudlet.mudlet
 runtime: org.kde.Platform
-runtime-version: '5.15-23.08'
+runtime-version: '6.8'
 sdk: org.kde.Sdk
 command: mudlet
 rename-desktop-file: mudlet.desktop


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This updates the flatpak manifest to org.kde.Platform version 6.8

#### Motivation for adding to Mudlet
Mudlet is moving to QT 6

#### Other info (issues closed, discussion etc)
