### PR TITLE
improve: don't show tray icon for notifications

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7178,6 +7178,7 @@ int TLuaInterpreter::showNotification(lua_State* L)
     } else {
         mudlet::self()->mTrayIcon.showMessage(title, text, mudlet::self()->mTrayIcon.icon());
     }
+    mudlet::self()->mTrayIcon.hide();
     lua_pushboolean(L, true);
     return 1;
 }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Don't show tray icon for showNotifications()

Before:
[Peek 2025-02-25 13-16-old.webm](https://github.com/user-attachments/assets/57933be3-55db-4072-b4c7-7ba03e2b5e31)

After:
[Peek 2025-02-25 13-16.webm](https://github.com/user-attachments/assets/15f66fd9-248e-4bd2-80c4-83f03e1aefdf)

#### Motivation for adding to Mudlet
decluttering

#### Other info (issues closed, discussion etc)
closes #4918 (other requests in that PR will not be implemented)