### PR TITLE
Fix: incorrect initialisation of Host::mEnableMSDP

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -456,7 +456,7 @@ public:
     QString mCommandSeparator;
     bool mEnableGMCP = true;
     bool mEnableMSSP = true;
-    bool mEnableMSDP = true;
+    bool mEnableMSDP = false;
     bool mEnableMSP = true;
     bool mEnableMTTS = true;
     bool mEnableMNES = false;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Changes the initialisation of `(bool) Host::mEnableMSDP` to the value `false`.

#### Motivation for adding to Mudlet
Revert code behaviour to how it was prior to #7224.

#### Other info (issues closed, discussion etc)
This will close #7757 - although it doesn't *seem* to have manifested as an actual bug.