### PR TITLE
Improve: better drawing of proportional fonts

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -740,7 +740,7 @@ void TTextEdit::drawGraphemeForeground(QPainter& painter, const QColor& fgColor,
     if (painter.pen().color() != fgColor) {
         painter.setPen(fgColor);
     }
-    painter.drawText(textRect.x(), textRect.bottom() - mFontDescent, grapheme);
+    painter.drawText(textRect, Qt::AlignHCenter|Qt::TextDontClip|Qt::TextSingleLine, grapheme);
 }
 
 int TTextEdit::getGraphemeWidth(uint unicode) const


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Changes the method used to paint characters into `TConsole`s so that they are "centred" rather than the default "left-aligned" in the space allocated to them.

#### Motivation for adding to Mudlet
For those that choose - against Mudlet's recommendation - to use a proportional font the squashing of narrow characters like `i` and `l` against their neighbour that happens because of the left alignment in the space we provide for each grapheme is particularly visually disturbing. E.g. as witnessed by this user reported in Discord less than a day ago: https://canary.discord.com/channels/283581582550237184/283582068334526464/1345919386938114059 by switching to centre alignment I believe we can improve things somewhat even though it does not render proportional fonts "proportionally".

#### Other info (issues closed, discussion etc)
The change in Qt `QPainter` method used is necessary to achieve the wanted modification however the way the vertical position is determined differs. Previously, the y-position is used as the baseline of the font in this form:
`QPainter::drawText(int x, int y, const QString& text)` whereas the one now used has the y-coordinate of the rectangle is used as the top of the font:
`QPainter::drawText(QRect textRect, int flags, const QString& text)`

I believe I have adjusted the code to position the text correctly in the vertical axis.

This does not fundamentally solve the problems of using a proportional font in a non-proportional way - but it does mean that it doesn't look *quite* so bad when it is!