### PR TITLE
Fix: update map colours when changed in preferences

### DIFF
--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -3314,15 +3314,61 @@ int TLuaInterpreter::setAreaUserData(lua_State* L)
 int TLuaInterpreter::setCustomEnvColor(lua_State* L)
 {
     const int id = getVerifiedInt(L, __func__, 1, "environmentID");
-    const int r = getVerifiedInt(L, __func__, 2, "r");
-    const int g = getVerifiedInt(L, __func__, 3, "g");
-    const int b = getVerifiedInt(L, __func__, 4, "b");
-    const int alpha = getVerifiedInt(L, __func__, 5, "a");
-    const Host& host = getHostFromLua(L);
-    host.mpMap->mCustomEnvColors[id] = QColor(r, g, b, alpha);
+    const int r = getVerifiedInt(L, __func__, 2, "red color component");
+    const int g = getVerifiedInt(L, __func__, 3, "green color component");
+    const int b = getVerifiedInt(L, __func__, 4, "blue color component");
+    int alpha = 255;
+    if (lua_gettop(L) > 4) {
+        alpha = getVerifiedInt(L, __func__, 5, "alpha color component", true);
+    }
+
+    if ((r < 0)||(r > 255)) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "red color component %d out of range {0 to 255}", r);
+        return 2;
+    }
+    if ((g < 0)||(g > 255)) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "green color component %d out of range {0 to 255}", g);
+        return 2;
+    }
+    if ((b < 0)||(b > 255)) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "blue color component %d out of range {0 to 255}", b);
+        return 2;
+    }
+    if ((alpha < 0)||(alpha > 255)) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "alpha color component %d out of range {0 to 255}", alpha);
+        return 2;
+    }
+    const QColor& newColor = QColor(r, g, b, alpha);
+    Host& host = getHostFromLua(L);
+    host.mpMap->mCustomEnvColors[id] = newColor;
+    switch (id) { // See TMap::restore16ColorSet() for mapping of indexes:
+    case 257:   host.mRed_2 = newColor;             break;
+    case 258:   host.mGreen_2 = newColor;           break;
+    case 259:   host.mYellow_2 = newColor;          break;
+    case 260:   host.mBlue_2 = newColor;            break;
+    case 261:   host.mMagenta_2 = newColor;         break;
+    case 262:   host.mCyan_2 = newColor;            break;
+    case 263:   host.mWhite_2 = newColor;           break;
+    case 264:   host.mBlack_2 = newColor;           break;
+    case 265:   host.mLightRed_2 = newColor;        break;
+    case 266:   host.mLightGreen_2 = newColor;      break;
+    case 267:   host.mLightYellow_2 = newColor;     break;
+    case 268:   host.mLightBlue_2 = newColor;       break;
+    case 269:   host.mLightMagenta_2 = newColor;    break;
+    case 270:   host.mLightCyan_2 = newColor;       break;
+    case 271:   host.mLightWhite_2 = newColor;      break;
+    case 272:   host.mLightBlack_2 = newColor;      break;
+    default: {} // No-op
+    }
+
     host.mpMap->setUnsaved(__func__);
     host.mpMap->update();
-    return 0;
+    lua_pushboolean(L, true);
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setDoor

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -3322,22 +3322,22 @@ int TLuaInterpreter::setCustomEnvColor(lua_State* L)
         alpha = getVerifiedInt(L, __func__, 5, "alpha color component", true);
     }
 
-    if ((r < 0)||(r > 255)) {
+    if ((r < 0) || (r > 255)) {
         lua_pushnil(L);
         lua_pushfstring(L, "red color component %d out of range {0 to 255}", r);
         return 2;
     }
-    if ((g < 0)||(g > 255)) {
+    if ((g < 0) || (g > 255)) {
         lua_pushnil(L);
         lua_pushfstring(L, "green color component %d out of range {0 to 255}", g);
         return 2;
     }
-    if ((b < 0)||(b > 255)) {
+    if ((b < 0) || (b > 255)) {
         lua_pushnil(L);
         lua_pushfstring(L, "blue color component %d out of range {0 to 255}", b);
         return 2;
     }
-    if ((alpha < 0)||(alpha > 255)) {
+    if ((alpha < 0) || (alpha > 255)) {
         lua_pushnil(L);
         lua_pushfstring(L, "alpha color component %d out of range {0 to 255}", alpha);
         return 2;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1018,8 +1018,8 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         spinBox_playerRoomInnerDiameter->setValue(pHost->mpMap->mPlayerRoomInnerDiameterPercentage);
         // Adjustable inner diameter not available for style '0' (original):
         spinBox_playerRoomInnerDiameter->setEnabled(pHost->mpMap->mPlayerRoomStyle != 0);
-        setButtonColor(pushButton_playerRoomPrimaryColor, pHost->mpMap->mPlayerRoomOuterColor);
-        setButtonColor(pushButton_playerRoomSecondaryColor, pHost->mpMap->mPlayerRoomInnerColor);
+        setButtonColor(pushButton_playerRoomPrimaryColor, pHost->mpMap->mPlayerRoomOuterColor, true);
+        setButtonColor(pushButton_playerRoomSecondaryColor, pHost->mpMap->mPlayerRoomInnerColor, true);
 
         connect(checkBox_enablMapDeleteButton, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_toggleMapDeleteButton);
         connect(pushButton_deleteMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_deleteMap);
@@ -1449,8 +1449,6 @@ void dlgProfilePreferences::clearHostDetails()
         mpMenu = nullptr;
     }
 
-    pushButton_chooseProfiles->setEnabled(false);
-
     label_mapFileActionResult->hide();
 
     slot_hidePasswordMigrationLabel();
@@ -1619,55 +1617,56 @@ void dlgProfilePreferences::setColors2()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        pushButton_black_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mBlack_2.name()));
-        pushButton_Lblack_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mLightBlack_2.name()));
-        pushButton_green_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mGreen_2.name()));
-        pushButton_Lgreen_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mLightGreen_2.name()));
-        pushButton_red_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mRed_2.name()));
-        pushButton_Lred_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mLightRed_2.name()));
-        pushButton_blue_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mBlue_2.name()));
-        pushButton_Lblue_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mLightBlue_2.name()));
-        pushButton_yellow_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mYellow_2.name()));
-        pushButton_Lyellow_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mLightYellow_2.name()));
-        pushButton_cyan_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mCyan_2.name()));
-        pushButton_Lcyan_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mLightCyan_2.name()));
-        pushButton_magenta_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mMagenta_2.name()));
-        pushButton_Lmagenta_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mLightMagenta_2.name()));
-        pushButton_white_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mWhite_2.name()));
-        pushButton_Lwhite_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mLightWhite_2.name()));
+        setButtonColor(pushButton_black_2, pHost->mBlack_2, true);
+        setButtonColor(pushButton_Lblack_2, pHost->mLightBlack_2, true);
+        setButtonColor(pushButton_green_2, pHost->mGreen_2, true);
+        setButtonColor(pushButton_Lgreen_2, pHost->mLightGreen_2, true);
+        setButtonColor(pushButton_red_2, pHost->mRed_2, true);
+        setButtonColor(pushButton_Lred_2, pHost->mLightRed_2, true);
+        setButtonColor(pushButton_blue_2, pHost->mBlue_2, true);
+        setButtonColor(pushButton_Lblue_2, pHost->mLightBlue_2, true);
+        setButtonColor(pushButton_yellow_2, pHost->mYellow_2, true);
+        setButtonColor(pushButton_Lyellow_2, pHost->mLightYellow_2, true);
+        setButtonColor(pushButton_cyan_2, pHost->mCyan_2, true);
+        setButtonColor(pushButton_Lcyan_2, pHost->mLightCyan_2, true);
+        setButtonColor(pushButton_magenta_2, pHost->mMagenta_2, true);
+        setButtonColor(pushButton_Lmagenta_2, pHost->mLightMagenta_2, true);
+        setButtonColor(pushButton_white_2, pHost->mWhite_2, true);
+        setButtonColor(pushButton_Lwhite_2, pHost->mLightWhite_2, true);
 
-        pushButton_foreground_color_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mFgColor_2.name()));
-        pushButton_background_color_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mBgColor_2.name()));
-        pushButton_lowerLevelColor->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mLowerLevelColor.name()));
-        pushButton_upperLevelColor->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mUpperLevelColor.name()));
-        pushButton_roomBorderColor->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mRoomBorderColor.name()));
-        pushButton_mapInfoBg->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mMapInfoBg.name()));
-        pushButton_roomCollisionBorderColor->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mRoomCollisionBorderColor.name()));
+        setButtonColor(pushButton_foreground_color_2, pHost->mFgColor_2);
+        setButtonColor(pushButton_background_color_2, pHost->mBgColor_2);
+        setButtonColor(pushButton_lowerLevelColor, pHost->mLowerLevelColor);
+        setButtonColor(pushButton_upperLevelColor, pHost->mUpperLevelColor);
+        setButtonColor(pushButton_roomBorderColor, pHost->mRoomBorderColor);
+        setButtonColor(pushButton_mapInfoBg, pHost->mMapInfoBg, true);
+        setButtonColor(pushButton_roomCollisionBorderColor, pHost->mRoomCollisionBorderColor);
     } else {
-        pushButton_black_2->setStyleSheet(QString());
-        pushButton_Lblack_2->setStyleSheet(QString());
-        pushButton_green_2->setStyleSheet(QString());
-        pushButton_Lgreen_2->setStyleSheet(QString());
-        pushButton_red_2->setStyleSheet(QString());
-        pushButton_Lred_2->setStyleSheet(QString());
-        pushButton_blue_2->setStyleSheet(QString());
-        pushButton_Lblue_2->setStyleSheet(QString());
-        pushButton_yellow_2->setStyleSheet(QString());
-        pushButton_Lyellow_2->setStyleSheet(QString());
-        pushButton_cyan_2->setStyleSheet(QString());
-        pushButton_Lcyan_2->setStyleSheet(QString());
-        pushButton_magenta_2->setStyleSheet(QString());
-        pushButton_Lmagenta_2->setStyleSheet(QString());
-        pushButton_white_2->setStyleSheet(QString());
-        pushButton_Lwhite_2->setStyleSheet(QString());
+        // Using QColor() gives an "invalid" color:
+        setButtonColor(pushButton_black_2, QColor());
+        setButtonColor(pushButton_Lblack_2, QColor());
+        setButtonColor(pushButton_green_2, QColor());
+        setButtonColor(pushButton_Lgreen_2, QColor());
+        setButtonColor(pushButton_red_2, QColor());
+        setButtonColor(pushButton_Lred_2, QColor());
+        setButtonColor(pushButton_blue_2, QColor());
+        setButtonColor(pushButton_Lblue_2, QColor());
+        setButtonColor(pushButton_yellow_2, QColor());
+        setButtonColor(pushButton_Lyellow_2, QColor());
+        setButtonColor(pushButton_cyan_2, QColor());
+        setButtonColor(pushButton_Lcyan_2, QColor());
+        setButtonColor(pushButton_magenta_2, QColor());
+        setButtonColor(pushButton_Lmagenta_2, QColor());
+        setButtonColor(pushButton_white_2, QColor());
+        setButtonColor(pushButton_Lwhite_2, QColor());
 
-        pushButton_foreground_color_2->setStyleSheet(QString());
-        pushButton_background_color_2->setStyleSheet(QString());
-        pushButton_lowerLevelColor->setStyleSheet(QString());
-        pushButton_upperLevelColor->setStyleSheet(QString());
-        pushButton_roomBorderColor->setStyleSheet(QString());
-        pushButton_mapInfoBg->setStyleSheet(QString());
-        pushButton_roomCollisionBorderColor->setStyleSheet(QString());
+        setButtonColor(pushButton_foreground_color_2, QColor());
+        setButtonColor(pushButton_background_color_2, QColor());
+        setButtonColor(pushButton_lowerLevelColor, QColor());
+        setButtonColor(pushButton_upperLevelColor, QColor());
+        setButtonColor(pushButton_roomBorderColor, QColor());
+        setButtonColor(pushButton_mapInfoBg, QColor());
+        setButtonColor(pushButton_roomCollisionBorderColor, QColor());
     }
 }
 
@@ -1740,31 +1739,37 @@ void dlgProfilePreferences::slot_resetMapColors()
         return;
     }
 
-    pHost->mFgColor_2 = Qt::lightGray;
-    pHost->mBgColor_2 = Qt::black;
-    pHost->mLowerLevelColor = Qt::darkGray;
-    pHost->mUpperLevelColor = Qt::white;
-    pHost->mRoomBorderColor = Qt::lightGray;
-    pHost->mRoomCollisionBorderColor = Qt::yellow;
-    pHost->mBlack_2 = Qt::black;
-    pHost->mLightBlack_2 = Qt::darkGray;
-    pHost->mRed_2 = Qt::darkRed;
-    pHost->mLightRed_2 = Qt::red;
-    pHost->mGreen_2 = Qt::darkGreen;
-    pHost->mLightGreen_2 = Qt::green;
-    pHost->mBlue_2 = Qt::darkBlue;
-    pHost->mLightBlue_2 = Qt::blue;
-    pHost->mYellow_2 = Qt::darkYellow;
-    pHost->mLightYellow_2 = Qt::yellow;
-    pHost->mCyan_2 = Qt::darkCyan;
-    pHost->mLightCyan_2 = Qt::cyan;
-    pHost->mMagenta_2 = Qt::darkMagenta;
-    pHost->mLightMagenta_2 = Qt::magenta;
-    pHost->mWhite_2 = Qt::lightGray;
-    pHost->mLightWhite_2 = Qt::white;
+    // As per values in Host.h:
+    pHost->mFgColor_2 = QColorConstants::LightGray;
+    pHost->mBgColor_2 = QColorConstants::Black;
+    pHost->mLowerLevelColor = QColorConstants::DarkGray;
+    pHost->mUpperLevelColor = QColorConstants::White;
+    pHost->mRoomBorderColor = QColorConstants::LightGray;
+    pHost->mRoomCollisionBorderColor = QColorConstants::Yellow;
+    pHost->mBlack_2 = QColorConstants::Black;
+    pHost->mLightBlack_2 = QColorConstants::DarkGray;
+    pHost->mRed_2 = QColorConstants::DarkRed;
+    pHost->mLightRed_2 = QColorConstants::Red;
+    pHost->mGreen_2 = QColorConstants::DarkGreen;
+    pHost->mLightGreen_2 = QColorConstants::Green;
+    pHost->mBlue_2 = QColorConstants::DarkBlue;
+    pHost->mLightBlue_2 = QColorConstants::Blue;
+    pHost->mYellow_2 = QColorConstants::DarkYellow;
+    pHost->mLightYellow_2 = QColorConstants::Yellow;
+    pHost->mCyan_2 = QColorConstants::DarkCyan;
+    pHost->mLightCyan_2 = QColorConstants::Cyan;
+    pHost->mMagenta_2 = QColorConstants::DarkMagenta;
+    pHost->mLightMagenta_2 = QColorConstants::Magenta;
+    pHost->mWhite_2 = QColorConstants::LightGray;
+    pHost->mLightWhite_2 = QColorConstants::White;
     pHost->mMapInfoBg = QColor(150, 150, 150, 120);
 
+    // This aplies the above colors to the buttons on display:
     setColors2();
+
+    if (pHost->mpMap) {
+        pHost->mpMap->update();
+    }
 }
 
 void dlgProfilePreferences::setButtonAndProfileColor(QPushButton* button, QColor& presentColor, bool allowAlpha)
@@ -1805,10 +1810,37 @@ void dlgProfilePreferences::setButtonAndProfileColor(QPushButton* button, QColor
             pHost->updateAnsi16ColorsInTable();
         }
 
+        const bool isAMapEnvColor = (button == pushButton_black_2 || button == pushButton_Lblack_2
+                                     || button == pushButton_red_2 || button == pushButton_Lred_2
+                                     || button == pushButton_green_2 || button == pushButton_Lgreen_2
+                                     || button == pushButton_yellow_2 || button == pushButton_Lyellow_2
+                                     || button == pushButton_blue_2 || button == pushButton_Lblue_2
+                                     || button == pushButton_magenta_2 || button == pushButton_Lmagenta_2
+                                     || button == pushButton_cyan_2 || button == pushButton_Lcyan_2
+                                     || button == pushButton_white_2 || button == pushButton_Lwhite_2);
+
+        if (isAMapEnvColor
+                || button == pushButton_foreground_color_2
+                || button == pushButton_background_color_2
+                || button == pushButton_lowerLevelColor
+                || button == pushButton_upperLevelColor
+                || button == pushButton_mapInfoBg
+                || button == pushButton_roomBorderColor
+                || button == pushButton_roomCollisionBorderColor) {
+
+            if (pHost->mpMap) {
+                // Update the custom environment (room colors)
+                if (isAMapEnvColor) {
+                    pHost->mpMap->restore16ColorSet();
+                }
+                // Redraw the map with the modified color:
+                pHost->mpMap->update();
+            }
+        }
+
         // Also set a contrasting foreground color so text will always be
-        // visible - if the button is disabled the colors will be somewhat
-        // "greyed-out":
-        setButtonColor(button, color);
+        // visible:
+        setButtonColor(button, color, allowAlpha);
     }
 }
 
@@ -2129,7 +2161,7 @@ void dlgProfilePreferences::slot_setMapColorBlack()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_black_2, pHost->mBlack_2);
+        setButtonAndProfileColor(pushButton_black_2, pHost->mBlack_2, true);
     }
 }
 
@@ -2137,7 +2169,7 @@ void dlgProfilePreferences::slot_setMapColorLightBlack()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_Lblack_2, pHost->mLightBlack_2);
+        setButtonAndProfileColor(pushButton_Lblack_2, pHost->mLightBlack_2, true);
     }
 }
 
@@ -2145,7 +2177,7 @@ void dlgProfilePreferences::slot_setMapColorRed()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_red_2, pHost->mRed_2);
+        setButtonAndProfileColor(pushButton_red_2, pHost->mRed_2, true);
     }
 }
 
@@ -2153,7 +2185,7 @@ void dlgProfilePreferences::slot_setMapColorLightRed()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_Lred_2, pHost->mLightRed_2);
+        setButtonAndProfileColor(pushButton_Lred_2, pHost->mLightRed_2, true);
     }
 }
 
@@ -2161,7 +2193,7 @@ void dlgProfilePreferences::slot_setMapColorGreen()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_green_2, pHost->mGreen_2);
+        setButtonAndProfileColor(pushButton_green_2, pHost->mGreen_2, true);
     }
 }
 
@@ -2169,7 +2201,7 @@ void dlgProfilePreferences::slot_setMapColorLightGreen()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_Lgreen_2, pHost->mLightGreen_2);
+        setButtonAndProfileColor(pushButton_Lgreen_2, pHost->mLightGreen_2, true);
     }
 }
 
@@ -2177,7 +2209,7 @@ void dlgProfilePreferences::slot_setMapColorBlue()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_blue_2, pHost->mBlue_2);
+        setButtonAndProfileColor(pushButton_blue_2, pHost->mBlue_2, true);
     }
 }
 
@@ -2185,7 +2217,7 @@ void dlgProfilePreferences::slot_setMapColorLightBlue()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_Lblue_2, pHost->mLightBlue_2);
+        setButtonAndProfileColor(pushButton_Lblue_2, pHost->mLightBlue_2, true);
     }
 }
 
@@ -2193,7 +2225,7 @@ void dlgProfilePreferences::slot_setMapColorYellow()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_yellow_2, pHost->mYellow_2);
+        setButtonAndProfileColor(pushButton_yellow_2, pHost->mYellow_2, true);
     }
 }
 
@@ -2201,7 +2233,7 @@ void dlgProfilePreferences::slot_setMapColorLightYellow()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_Lyellow_2, pHost->mLightYellow_2);
+        setButtonAndProfileColor(pushButton_Lyellow_2, pHost->mLightYellow_2, true);
     }
 }
 
@@ -2209,7 +2241,7 @@ void dlgProfilePreferences::slot_setMapColorCyan()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_cyan_2, pHost->mCyan_2);
+        setButtonAndProfileColor(pushButton_cyan_2, pHost->mCyan_2, true);
     }
 }
 
@@ -2217,7 +2249,7 @@ void dlgProfilePreferences::slot_setMapColorLightCyan()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_Lcyan_2, pHost->mLightCyan_2);
+        setButtonAndProfileColor(pushButton_Lcyan_2, pHost->mLightCyan_2, true);
     }
 }
 
@@ -2225,7 +2257,7 @@ void dlgProfilePreferences::slot_setMapColorMagenta()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_magenta_2, pHost->mMagenta_2);
+        setButtonAndProfileColor(pushButton_magenta_2, pHost->mMagenta_2, true);
     }
 }
 
@@ -2233,7 +2265,7 @@ void dlgProfilePreferences::slot_setMapColorLightMagenta()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_Lmagenta_2, pHost->mLightMagenta_2);
+        setButtonAndProfileColor(pushButton_Lmagenta_2, pHost->mLightMagenta_2, true);
     }
 }
 
@@ -2241,7 +2273,7 @@ void dlgProfilePreferences::slot_setMapColorWhite()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_white_2, pHost->mWhite_2);
+        setButtonAndProfileColor(pushButton_white_2, pHost->mWhite_2, true);
     }
 }
 
@@ -2249,7 +2281,7 @@ void dlgProfilePreferences::slot_setMapColorLightWhite()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_Lwhite_2, pHost->mLightWhite_2);
+        setButtonAndProfileColor(pushButton_Lwhite_2, pHost->mLightWhite_2, true);
     }
 }
 
@@ -4046,17 +4078,17 @@ void dlgProfilePreferences::slot_changeLogFileAsHtml(const bool isHtml)
     }
 }
 
-void dlgProfilePreferences::setButtonColor(QPushButton* button, const QColor& color)
+void dlgProfilePreferences::setButtonColor(QPushButton* button, const QColor& color, const bool hasAlpha)
 {
     if (color.isValid()) {
         if (button->isEnabled()) {
-            if (button == pushButton_playerRoomPrimaryColor || button == pushButton_playerRoomSecondaryColor) {
+            if (hasAlpha) {
 
-                // These two buttons show a color that may have transparency; so,
-                // instead of colouring the background, we include a generated
-                // black/white checkerboard pattern overlaid with the colour which
-                // when its alpha is not a 100% opaque will (partly) show the
-                // checkerboard.
+                // This is for buttons that show a color that may have
+                // transparency; so,instead of colouring the background, we
+                // include a generated black/white checkerboard pattern overlaid
+                // with the colour which, when its alpha is not 100% opaque,
+                // will (partly) show the checkerboard.
 
                 // Ensure the icon has a 3:1 aspect ratio:
                 if (auto iconWidth{button->iconSize().width()}, iconHeight{button->iconSize().height()}; iconWidth != iconHeight * 3) {
@@ -4082,15 +4114,8 @@ void dlgProfilePreferences::setButtonColor(QPushButton* button, const QColor& co
         }
 
         const QColor disabledColor = QColor::fromHsl(color.hslHue(), color.hslSaturation()/4, color.lightness(), color.alpha());
-        if (button == pushButton_playerRoomPrimaryColor || button == pushButton_playerRoomSecondaryColor) {
-
-            // These two buttons show a color that may have transparency; so,
-            // instead of colouring the background, we include a generated
-            // black/white checkerboard pattern overlaid with the colour which
-            // when its alpha is not a 100% opaque will (partly) show the
-            // checkerboard.
-
-            // Ensure the icon has a 3:1 aspect ratio:
+        if (hasAlpha) {
+            // As above for buttons showing a potentially transparent color:
             if (auto iconWidth{button->iconSize().width()}, iconHeight{button->iconSize().height()}; iconWidth != iconHeight * 3) {
                 button->setIconSize(QSize(iconHeight * 3, iconHeight));
             }
@@ -4332,8 +4357,8 @@ void dlgProfilePreferences::slot_changePlayerRoomStyle(const int index)
         pushButton_playerRoomSecondaryColor->setEnabled(false);
         spinBox_playerRoomInnerDiameter->setEnabled(false);
     }
-    setButtonColor(pushButton_playerRoomPrimaryColor, pHost->mpMap->mPlayerRoomOuterColor);
-    setButtonColor(pushButton_playerRoomSecondaryColor, pHost->mpMap->mPlayerRoomInnerColor);
+    setButtonColor(pushButton_playerRoomPrimaryColor, pHost->mpMap->mPlayerRoomOuterColor, true);
+    setButtonColor(pushButton_playerRoomSecondaryColor, pHost->mpMap->mPlayerRoomInnerColor, true);
     pHost->mpMap->mPlayerRoomStyle = static_cast<quint8>(style);
     if (!pHost->mpMap->mpMapper || !pHost->mpMap->mpMapper->mp2dMap) {
         return;

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -187,7 +187,7 @@ private:
     void setColors2();
     void setButtonAndProfileColor(QPushButton*, QColor&, bool allowAlpha = false);
     void setPlayerRoomColor(QPushButton*, QColor&);
-    void setButtonColor(QPushButton*, const QColor&);
+    void setButtonColor(QPushButton*, const QColor&, const bool hasAlpha = false);
     void loadEditorTab();
     void populateThemesList();
     void populateScriptsList();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Several fixes related to the predefined/preset colours shown in the preferences and mapped to the Map room environments/colours 257 to 272:
* changing the colours in the preferences immediately changes them in the map.
* changing the colours via the Lua `setCustomEnvColor(...)` also changes them immediately - and updates the stored values for those particular indexes in the custom room colours.
* since the Lua API exposes/allows for an alpha (transparency) the UI in the preferences now also allows it to be set there - this means the alternative presentation of the colour superimposed on a black/white checker-board is used for those elements rather than the whole button being coloured as is used for permanently 100% opaque colours.
* the above change has also been applied to the map info background as that already uses transparency but it wasn't available in the settings.

#### Motivation for adding to Mudlet
Makes the UX match the facilities offered.

#### Other info (issues closed, discussion etc)
The original issue was pointed out by @ZookaOnGit in our Discord **#mudlet-development** channel as of 2025/03/03#06:10 https://www.discord.com/channels/283581582550237184/283582439002210305/1346001658051694686
