### PR TITLE
improve: move proxy settings in preferences to a single line

### DIFF
--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -3572,7 +3572,7 @@ you can use it but there could be issues with aligning columns of text</string>
          <property name="checked">
           <bool>false</bool>
          </property>
-         <layout class="QVBoxLayout" name="vBoxLayout_groupBox_proxy">
+         <layout class="QHBoxLayout" name="hBoxLayout_groupBox_proxy">
           <item>
            <widget class="QLineEdit" name="lineEdit_proxyAddress">
             <property name="text">
@@ -4272,7 +4272,6 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>checkBox_highlightHistory</tabstop>
   <tabstop>command_separator_lineedit</tabstop>
   <tabstop>commandLineMinimumHeight</tabstop>
-  <tabstop>comboBox_commandLineHistorySaveSize</tabstop>
   <tabstop>checkBox_spellCheck</tabstop>
   <tabstop>radioButton_userDictionary_profile</tabstop>
   <tabstop>radioButton_userDictionary_common</tabstop>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Move proxy settings in preferences to a single line.

Before:
![Screenshot_20250306_123112](https://github.com/user-attachments/assets/281ac88a-886d-4955-9729-7ee78731f3fa)


After:
![Screenshot_20250306_123231](https://github.com/user-attachments/assets/f67d5640-20d3-4794-ab33-baa25972d4fe)


#### Motivation for adding to Mudlet
Preferences UI improvements.

#### Other info (issues closed, discussion etc)
https://discord.com/channels/283581582550237184/283582439002210305/1346877473098301631