### PR TITLE
Fix: add correct mudlet-lua path for win11 QtCreator builds

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5875,7 +5875,10 @@ void TLuaInterpreter::loadGlobal()
         // and in a "src" subdirectory (to match the relative source file
         // location to that top-level project file) of the main project
         // "mudlet" directory:
-        QDir::toNativeSeparators(qsl("%1/../../../src/mudlet-lua/lua/LuaGlobal.lua").arg(executablePath))
+        QDir::toNativeSeparators(qsl("%1/../../../src/mudlet-lua/lua/LuaGlobal.lua").arg(executablePath)),
+
+        // CMake builds from Qt Creator on Windows 11 appear to use this directory:
+        QDir::toNativeSeparators(qsl("%1/../../../mudlet-lua/lua/LuaGlobal.lua").arg(executablePath))
     };
 
     // Although it is relatively easy to detect whether something is #define d


### PR DESCRIPTION
**Brief overview of PR changes/additions**
Add the path that my win11 QtCreator compilation of mudlet defaulted to for the mudlet-lua directory.

**Motivation for adding to Mudlet**
Mudlet compiled on win11 using QtCreator would be broken by failing to find the mudlet-lua directory.

![image](https://github.com/user-attachments/assets/106483b2-7e54-471b-8d4a-a03e76f69b1a)


**Other info (issues closed, discussion etc)**