### PR TITLE
Improve: add means to close-by-mouse Mudlet when it is full-screen

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -268,9 +268,15 @@ void mudlet::init()
     mpActionCloseProfile->setIconText(tr("Close profile"));
     mpActionCloseProfile->setObjectName(qsl("close_profile"));
 
+    mpActionCloseApplication = new QAction(tr("Close Mudlet"), this);
+    mpActionCloseApplication->setIcon(QIcon::fromTheme(qsl("application-exit"), QIcon(qsl(":/icons/application-exit.png"))));
+    mpActionCloseApplication->setIconText(tr("Close Mudlet"));
+    mpActionCloseApplication->setObjectName(qsl("close_application"));
+
     mpButtonConnect->addAction(mpActionConnect);
     mpButtonConnect->addAction(mpActionDisconnect);
     mpButtonConnect->addAction(mpActionCloseProfile);
+    mpButtonConnect->addAction(mpActionCloseApplication);
     mpButtonConnect->setDefaultAction(mpActionConnect);
 
     mpActionTriggers = new QAction(QIcon(qsl(":/icons/tools-wizard.png")), tr("Triggers"), this);
@@ -526,6 +532,8 @@ void mudlet::init()
     connect(dactionReconnect, &QAction::triggered, this, &mudlet::slot_reconnect);
     connect(dactionDisconnect, &QAction::triggered, this, &mudlet::slot_disconnect);
     connect(dactionCloseProfile, &QAction::triggered, this, &mudlet::slot_closeCurrentProfile);
+    connect(dactionCloseApplication, &QAction::triggered, this, &mudlet::close);
+    connect(mpActionCloseApplication, &QAction::triggered, this, &mudlet::close);
     connect(dactionNotepad, &QAction::triggered, this, &mudlet::slot_notes);
     connect(dactionReplay, &QAction::triggered, this, &mudlet::slot_replay);
 
@@ -1940,7 +1948,8 @@ Host* mudlet::getActiveHost()
 }
 
 // Received when the OS/DE/WM tells Mudlet to close (or we force the close
-// ourselves):
+// ourselves or the user hits the close application menu option or action on
+// the "Connect" buttion):
 void mudlet::closeEvent(QCloseEvent* event)
 {
     qDebug() << "mudlet::closeEvent(...) INFO - called!";

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -581,6 +581,7 @@ private:
     QPointer<QAction> mpActionAliases;
     QPointer<QAction> mpActionButtons;
     QPointer<QAction> mpActionCloseProfile;
+    QPointer<QAction> mpActionCloseApplication;
     QPointer<QAction> mpActionConnect;
     QPointer<QAction> mpActionDisconnect;
     QPointer<QAction> mpActionDiscord;

--- a/src/ui/main_window.ui
+++ b/src/ui/main_window.ui
@@ -156,6 +156,7 @@
     <addaction name="dactionReconnect"/>
     <addaction name="separator"/>
     <addaction name="dactionCloseProfile"/>
+    <addaction name="dactionCloseApplication"/>
    </widget>
    <addaction name="menuGames"/>
    <addaction name="menuEditor"/>
@@ -193,6 +194,9 @@
    </property>
    <property name="toolTip">
     <string>&lt;p&gt;Configure setting for the Mudlet application globally and for the current profile.&lt;/p&gt;</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::PreferencesRole</enum>
    </property>
   </action>
   <action name="dactionScriptEditor">
@@ -233,6 +237,9 @@
    </property>
    <property name="toolTip">
     <string comment="Tooltip for About Mudlet sub-menu item and main toolbar button (or menu item if an update has changed that control to have a popup menu instead) (Used in 3 places - please ensure all have the same translation).">&lt;p&gt;Inform yourself about this version of Mudlet, the people who made it and the licence under which you can share it.&lt;/p&gt;</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::AboutRole</enum>
    </property>
   </action>
   <action name="dactionIRC">
@@ -415,6 +422,14 @@
   <action name="dactionCloseProfile">
    <property name="text">
     <string>Close profile</string>
+   </property>
+  </action>
+  <action name="dactionCloseApplication">
+   <property name="text">
+    <string>Close Mudlet</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::QuitRole</enum>
    </property>
   </action>
   <action name="dactionChangelog">


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a "Close Mudlet" item to the main menu and to the drop down button of the "Connect" main toolbar button so that it is possible to close Mudlet using a mouse when it is running in Full-Screen mode - when there won't be a title bar with a close button on it to use.

#### Motivation for adding to Mudlet
Improved UX when used in the Full-screen case - and given recent PRs like #7773 or my alternative #7753 which makes the prior code work "as expected" then this will likely be more often the case.

#### Other info (issues closed, discussion etc)
Whilst developing this I assigned the `QAction::QuitRole` to the menu item and also the special ones that should have been on a couple of others. This only has effect on MacOS but causes them to be handled specially when moved onto the "Application menu" on that platform.

I also experimented with adding a menu item for the *built-in* "About Qt" dialogue which reports something about the Qt framework generally and the version actually being used. However I discovered that it is implemented as a modal dialogue that freezes the event loop, at least on GNU/Linux which is not suitable for Mudlet (unless we only allow it to be shown if there is not profiles loaded). Given that we now display the Qt version, (both the build and run-time ones if they differ) in our own "About Mudlet" dialogue then this did not seem a useful addition after all.