### PR TITLE
Fix: Avoid corner cases by reconnecting if the same profile #7698

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1566,6 +1566,16 @@ void dlgConnectionProfiles::loadProfile(bool alsoConnect)
 
     // overwrite the generic profile with user supplied name, url and login information
     if (pHost) {
+
+        Host* pActiveHost = mudlet::self()->getActiveHost();
+        if (pActiveHost && pActiveHost->getName() == profile_name) {
+            // The intention here is to do as little as possible if the same profile is chosen again
+            // this replicates function of mudlet::slot_reconnect to avoid #7395
+            pActiveHost->mTelnet.reconnect();
+            QDialog::accept();
+            return;
+        }
+        
         pHost->setName(profile_name);
 
         if (!host_name_entry->text().trimmed().isEmpty()) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
After a brief discussion on discord about the expected behavior when the same profile is chosen on opening the "Connect" menubar button being to simply reconnect the telnet session, I added logic to accomplish that to the dlgConnectionProfiles::loadProfile function.

#### Motivation for adding to Mudlet
This should avoid corner cases like lua events getting deregistered by doing as little as possible for existing profile connections.

#### Other info (issues closed, discussion etc)
Fixes #7698