### PR TITLE
Improve: report SGR details that Mudlet does not currently reproduce

### DIFF
--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -158,6 +158,7 @@ public:
     bool isOverlined() const { return mFlags & Overline; }
     bool isStruckOut() const { return mFlags & StrikeOut; }
     bool isReversed() const { return mFlags & Reverse; }
+    bool isConcealed() const { return mFlags & Concealed; }
     bool isFound() const { return mFlags & Found; }
     // Special case - if fast blink is set then do NOT say that blink is set to
     // preserve priority of the former over the latter:

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -1187,29 +1187,48 @@ int TLuaInterpreter::getTextFormat(lua_State* L)
 
     lua_newtable(L);
 
-    TChar::AttributeFlags const format = result.second.allDisplayAttributes();
     lua_pushstring(L, "bold");
-    lua_pushboolean(L, format & TChar::Bold);
+    lua_pushboolean(L, result.second.isBold());
     lua_settable(L, -3);
 
     lua_pushstring(L, "italic");
-    lua_pushboolean(L, format & TChar::Italic);
+    lua_pushboolean(L, result.second.isItalic());
     lua_settable(L, -3);
 
     lua_pushstring(L, "overline");
-    lua_pushboolean(L, format & TChar::Overline);
+    lua_pushboolean(L, result.second.isOverlined());
     lua_settable(L, -3);
 
     lua_pushstring(L, "reverse");
-    lua_pushboolean(L, format & TChar::Reverse);
+    lua_pushboolean(L, result.second.isReversed());
     lua_settable(L, -3);
 
     lua_pushstring(L, "strikeout");
-    lua_pushboolean(L, format & TChar::StrikeOut);
+    lua_pushboolean(L, result.second.isStruckOut());
     lua_settable(L, -3);
 
     lua_pushstring(L, "underline");
-    lua_pushboolean(L, format & TChar::Underline);
+    lua_pushboolean(L, result.second.isUnderlined());
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "blinking");
+    if (Q_UNLIKELY(result.second.isFastBlinking())) {
+        lua_pushstring(L, "fast");
+    } else {
+        if (Q_UNLIKELY(result.second.isBlinking())) {
+            lua_pushstring(L, "slow");
+        } else {
+            lua_pushstring(L, "none");
+        }
+    }
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "concealed");
+    lua_pushboolean(L, result.second.isConcealed());
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "alternateFont");
+    lua_pushinteger(L, result.second.alternateFont());
     lua_settable(L, -3);
 
     const QColor foreground(result.second.foreground());
@@ -1242,6 +1261,7 @@ int TLuaInterpreter::getTextFormat(lua_State* L)
     lua_pushnumber(L, 3);
     lua_pushnumber(L, background.blue());
     lua_settable(L, -3);
+
     lua_settable(L, -3);
 
     return 1;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds some more details to the table that `getTextFormat(...)` reports for the aspects that Mudlet currently records but does not show on screen. These are "Concealed" (SGR codes: `8` on, `28` off); "Blinking" (SGR codes: `5` fast {at least 150Hz}, `6` slow {less than 150Hz}, `25` off); "Alternate font" `11` alternate font 1 to `19` alternate font 9, `10` off = primary font).

#### Motivation for adding to Mudlet
Some users want to know if the MUD Game Server is sending out one of these effects. This PR will extend the table output by `getTextFormat(...)` to include the following extra elements:
* `blinking`: one of `none`, `slow`, `fast`
* `concealed`: `true` or `false`
* `alternateFont`: `1` to `9`, `0` for the default (primary) font.

#### Other info (issues closed, discussion etc)
This should close #7779.