### PR TITLE
Fix: restore use of F3 for keybindings when not used for searching

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -243,7 +243,6 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mpAuth(new GMCPAuthenticator(this))
 , mpNotePad(nullptr)
 , mPrintCommand(true)
-, mF3SearchEnabled(false)
 , mIsRemoteEchoingActive(false)
 , mIsCurrentLogFileInHtmlFormat(false)
 , mIsNextLogFileInHtmlFormat(false)

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2373,20 +2373,20 @@ void TConsole::setF3SearchEnabled(const bool enabled)
     mF3SearchEnabled = enabled;
     if (mF3SearchEnabled) {
         // Create F3/Shift+F3 shortcuts for search navigation if needed
-        if (!mpSearchNextShortcut) {
+        if (mpSearchNextShortcut.isNull()) {
             mpSearchNextShortcut = new QShortcut(QKeySequence(Qt::Key_F3), this);
         }
-        if (!mpSearchPrevShortcut) {
+        if (mpSearchPrevShortcut.isNull()) {
             mpSearchPrevShortcut = new QShortcut(QKeySequence(Qt::SHIFT | Qt::Key_F3), this);
         }
         connect(mpSearchNextShortcut, &QShortcut::activated, this, &TConsole::slot_searchBufferDown, Qt::UniqueConnection);
         connect(mpSearchPrevShortcut, &QShortcut::activated, this, &TConsole::slot_searchBufferUp, Qt::UniqueConnection);
     } else {
-        if (mpSearchNextShortcut) {
+        if (!mpSearchNextShortcut.isNull()) {
             disconnect(mpSearchNextShortcut, &QShortcut::activated, this, &TConsole::slot_searchBufferDown);
             mpSearchNextShortcut->deleteLater();
         }
-        if (!mpSearchPrevShortcut) {
+        if (!mpSearchPrevShortcut.isNull()) {
             disconnect(mpSearchPrevShortcut, &QShortcut::activated, this, &TConsole::slot_searchBufferUp);
             mpSearchPrevShortcut->deleteLater();
         }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -411,10 +411,6 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     mpBufferSearchBox->setToolTip(utils::richText(tr("Search buffer.")));
     connect(mpBufferSearchBox, &QLineEdit::returnPressed, this, &TConsole::slot_searchBufferUp);
 
-    // Create F3/Shift+F3 shortcuts for search navigation
-    searchNextShortcut = new QShortcut(QKeySequence(Qt::Key_F3), this);
-    searchPrevShortcut = new QShortcut(QKeySequence(Qt::SHIFT | Qt::Key_F3), this);
-
     mpAction_searchOptions = new QAction(tr("Search Options"), this);
     mpAction_searchOptions->setObjectName(qsl("mpAction_searchOptions"));
 
@@ -451,6 +447,9 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     mpBufferSearchDown->setIcon(QIcon(qsl(":/icons/import.png")));
     connect(mpBufferSearchDown, &QAbstractButton::clicked, this, &TConsole::slot_searchBufferDown);
 
+    if (mType == MainConsole) {
+        setF3SearchEnabled(mpHost->getF3SearchEnabled());
+    }
 
     if (mpCommandLine) {
         layoutLayer2->addWidget(mpCommandLine);
@@ -1817,7 +1816,8 @@ void TConsole::slot_stopAllItems(bool b)
     }
 }
 
-void TConsole::focusOnSearchResultAndAnnounce(int searchX, int searchY) {
+void TConsole::focusOnSearchResultAndAnnounce(int searchX, int searchY)
+{
     mpHost->setCaretEnabled(true);
     mUpperPane->initializeCaret();
     moveCursor(searchX, searchY);
@@ -1831,7 +1831,10 @@ void TConsole::focusOnSearchResultAndAnnounce(int searchX, int searchY) {
 
 void TConsole::slot_searchBufferUp()
 {
-    if (mpHost->getF3SearchEnabled()) buffer.clearSearchHighlights();
+    if (mpHost->getF3SearchEnabled()) {
+        buffer.clearSearchHighlights();
+    }
+
     // The search term entry box is one widget that does not pass a mouse press
     // event up to the main TConsole and thus does not cause the focus to shift
     // to the profile's tab when in multi-view mode - so add a call to make that
@@ -1846,7 +1849,8 @@ void TConsole::slot_searchBufferUp()
         // make sure the line to search from does not exceed the buffer, which can grow and shrink dynamically
         mCurrentSearchResult = std::min<qsizetype>(mCurrentSearchResult, buffer.lineBuffer.size());
     }
-    if (buffer.lineBuffer.empty()) {
+    if (mSearchQuery.isEmpty() || buffer.lineBuffer.empty()) {
+        // Don't try and search for anything if the search term OR the console is empty:
         return;
     }
 
@@ -1857,7 +1861,9 @@ void TConsole::slot_searchBufferUp()
             searchX = buffer.lineBuffer[searchY].indexOf(mSearchQuery, searchX + 1, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive));
             if (searchX > -1) {
                 buffer.applyAttribute(QPoint(searchX, searchY), QPoint(searchX + mSearchQuery.size(), searchY), TChar::Found, true);
-                if (mpHost->getF3SearchEnabled()) focusOnSearchResultAndAnnounce(searchX, searchY);
+                if (mpHost->getF3SearchEnabled()) {
+                    focusOnSearchResultAndAnnounce(searchX, searchY);
+                }
                 found = true;
             }
         } while (searchX > -1);
@@ -1876,13 +1882,16 @@ void TConsole::slot_searchBufferUp()
 
 void TConsole::slot_searchBufferDown()
 {
-    if (mpHost->getF3SearchEnabled()) buffer.clearSearchHighlights();
+    if (mpHost->getF3SearchEnabled()) {
+        buffer.clearSearchHighlights();
+    }
     if (mSearchQuery != mpBufferSearchBox->text()) {
         mSearchQuery = mpBufferSearchBox->text();
         buffer.clearSearchHighlights();
         mCurrentSearchResult = buffer.lineBuffer.size();
     }
-    if (buffer.lineBuffer.empty()) {
+    if (mSearchQuery.isEmpty() || buffer.lineBuffer.empty()) {
+        // Don't try and search for anything if the search term OR the console is empty:
         return;
     }
     if (mCurrentSearchResult >= buffer.lineBuffer.size()) {
@@ -1896,7 +1905,9 @@ void TConsole::slot_searchBufferDown()
             searchX = buffer.lineBuffer[searchY].indexOf(mSearchQuery, searchX + 1, ((mSearchOptions & SearchOptionCaseSensitive) ? Qt::CaseSensitive : Qt::CaseInsensitive));
             if (searchX > -1) {
                 buffer.applyAttribute(QPoint(searchX, searchY), QPoint(searchX + mSearchQuery.size(), searchY), TChar::Found, true);
-                if (mpHost->getF3SearchEnabled()) focusOnSearchResultAndAnnounce(searchX, searchY);
+                if (mpHost->getF3SearchEnabled()) {
+                    focusOnSearchResultAndAnnounce(searchX, searchY);
+                }
                 found = true;
             }
         } while (searchX > -1);
@@ -2349,16 +2360,36 @@ void TConsole::slot_toggleSearchCaseSensitivity(const bool state)
 
 void TConsole::setF3SearchEnabled(const bool enabled)
 {
-    if (!searchNextShortcut || !searchPrevShortcut) {
+    if (mType != MainConsole) {
+        // Don't do anything if we are NOT the main console:
         return;
     }
 
-    if (enabled) {
-        connect(searchNextShortcut, &QShortcut::activated, this, &TConsole::slot_searchBufferDown);
-        connect(searchPrevShortcut, &QShortcut::activated, this, &TConsole::slot_searchBufferUp);
+    if (mF3SearchEnabled == enabled) {
+        // Don't do anything if the stored setting already matches the wanted one
+        return;
+    }
+
+    mF3SearchEnabled = enabled;
+    if (mF3SearchEnabled) {
+        // Create F3/Shift+F3 shortcuts for search navigation if needed
+        if (!mpSearchNextShortcut) {
+            mpSearchNextShortcut = new QShortcut(QKeySequence(Qt::Key_F3), this);
+        }
+        if (!mpSearchPrevShortcut) {
+            mpSearchPrevShortcut = new QShortcut(QKeySequence(Qt::SHIFT | Qt::Key_F3), this);
+        }
+        connect(mpSearchNextShortcut, &QShortcut::activated, this, &TConsole::slot_searchBufferDown, Qt::UniqueConnection);
+        connect(mpSearchPrevShortcut, &QShortcut::activated, this, &TConsole::slot_searchBufferUp, Qt::UniqueConnection);
     } else {
-        disconnect(searchNextShortcut, &QShortcut::activated, this, &TConsole::slot_searchBufferDown);
-        disconnect(searchPrevShortcut, &QShortcut::activated, this, &TConsole::slot_searchBufferUp);
+        if (mpSearchNextShortcut) {
+            disconnect(mpSearchNextShortcut, &QShortcut::activated, this, &TConsole::slot_searchBufferDown);
+            mpSearchNextShortcut->deleteLater();
+        }
+        if (!mpSearchPrevShortcut) {
+            disconnect(mpSearchPrevShortcut, &QShortcut::activated, this, &TConsole::slot_searchBufferUp);
+            mpSearchPrevShortcut->deleteLater();
+        }
     }
 }
 

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -346,8 +346,9 @@ private:
     QAction* mpAction_searchOptions = nullptr;
     QIcon mIcon_searchOptions;
     bool mScrollingEnabled = true;
-    QShortcut* searchNextShortcut = nullptr;
-    QShortcut* searchPrevShortcut = nullptr;
+    bool mF3SearchEnabled = false;
+    QPointer<QShortcut> mpSearchNextShortcut;
+    QPointer<QShortcut> mpSearchPrevShortcut;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(TConsole::ConsoleType)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Only create (and destroy if not wanted) shortcuts used to provide F3 and Shift+F3 backwards and forwards search in the main console for those with accessibility requirements.

#### Motivation for adding to Mudlet
I was using the F3 key for a keybinding and after #7579 I found that it stopped working - even when I disabled the functionality that it offered. It turns out that the enabling/disabling steps that the creator used were not sufficient as it left the "shortcuts" in place even though they didn't do anything and that was enough to bypass the normal handling of that key.

#### Other info (issues closed, discussion etc
There was a superfluous initialisation of the `(bool) Host::mF3SearchEnabled` flag in the Host initialisation list which was also out of order and producing a compilation warning.

Also cleans up some code miss-formatting (omission of braces around `if` code blocks and no new line after the condition part).
