### PR TITLE
Infrastructure: sort QGridLayout/polish items in `profilePreferences.ui` file

### DIFF
--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1056</width>
-    <height>866</height>
+    <width>965</width>
+    <height>694</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -42,7 +42,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab_general">
       <property name="sizePolicy">
@@ -65,6 +65,9 @@
            <widget class="QLabel" name="label_mainIconSize">
             <property name="text">
              <string>Icon size toolbars:</string>
+            </property>
+            <property name="buddy">
+             <cstring>MainIconSize</cstring>
             </property>
            </widget>
           </item>
@@ -89,6 +92,9 @@
             <property name="text">
              <string>Icon size in tree views:</string>
             </property>
+            <property name="buddy">
+             <cstring>TEFolderIconSize</cstring>
+            </property>
            </widget>
           </item>
           <item row="0" column="3" alignment="Qt::AlignLeft">
@@ -108,6 +114,9 @@
            <widget class="QLabel" name="label_menuBarVisiblity">
             <property name="text">
              <string>Show menu bar:</string>
+            </property>
+            <property name="buddy">
+             <cstring>comboBox_menuBarVisibility</cstring>
             </property>
            </widget>
           </item>
@@ -137,6 +146,9 @@
            <widget class="QLabel" name="label_toolBarVisibility">
             <property name="text">
              <string>Show main toolbar</string>
+            </property>
+            <property name="buddy">
+             <cstring>comboBox_toolBarVisibility</cstring>
             </property>
            </widget>
           </item>
@@ -223,35 +235,13 @@
           <string>Miscellaneous</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_groupBox_miscellaneous">
-          <item row="2" column="1">
-           <widget class="QCheckBox" name="mAlertOnNewData">
-            <property name="toolTip">
-             <string>&lt;p&gt;Show a toolbar notification if Mudlet is minimized and new data arrives.&lt;/p&gt;</string>
-            </property>
-            <property name="text">
-             <string>Notify on new data</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0" colspan="2">
-           <widget class="QLabel" name="label_darkEditorPrompt">
-            <property name="font">
-             <font>
-              <pointsize>8</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>Set dark theme in &lt;a href=&quot;dark-code-editor&quot;&gt;code editor&lt;/a&gt; as well?</string>
-            </property>
-            <property name="textFormat">
-             <enum>Qt::RichText</enum>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="label_appearance">
             <property name="text">
              <string>Appearance</string>
+            </property>
+            <property name="buddy">
+             <cstring>comboBox_appearance</cstring>
             </property>
            </widget>
           </item>
@@ -274,10 +264,35 @@
             </item>
            </widget>
           </item>
+          <item row="1" column="0" colspan="2">
+           <widget class="QLabel" name="label_darkEditorPrompt">
+            <property name="font">
+             <font>
+              <pointsize>8</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Set dark theme in &lt;a href=&quot;dark-code-editor&quot;&gt;code editor&lt;/a&gt; as well?</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::RichText</enum>
+            </property>
+           </widget>
+          </item>
           <item row="2" column="0">
            <widget class="QCheckBox" name="mFORCE_SAVE_ON_EXIT">
             <property name="text">
              <string>Auto save on exit</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QCheckBox" name="mAlertOnNewData">
+            <property name="toolTip">
+             <string>&lt;p&gt;Show a toolbar notification if Mudlet is minimized and new data arrives.&lt;/p&gt;</string>
+            </property>
+            <property name="text">
+             <string>Notify on new data</string>
             </property>
            </widget>
           </item>
@@ -290,27 +305,10 @@
           <string>Game protocols</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_groupBox_protocols">
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="acceptServerGUI">
-            <property name="text">
-             <string>Allow server to install script packages</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0">
            <widget class="QPushButton" name="pushButton_chooseProtocols">
             <property name="text">
              <string>Choose protocols</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QCheckBox" name="acceptServerMedia">
-            <property name="toolTip">
-             <string>&lt;p&gt;This also needs GMCP to be enabled in the protocols.&lt;/p&gt;</string>
-            </property>
-            <property name="text">
-             <string>Allow server to download and play media</string>
             </property>
            </widget>
           </item>
@@ -335,6 +333,23 @@
             </property>
             <property name="wordWrap">
              <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="acceptServerGUI">
+            <property name="text">
+             <string>Allow server to install script packages</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QCheckBox" name="acceptServerMedia">
+            <property name="toolTip">
+             <string>&lt;p&gt;This also needs GMCP to be enabled in the protocols.&lt;/p&gt;</string>
+            </property>
+            <property name="text">
+             <string>Allow server to download and play media</string>
             </property>
            </widget>
           </item>
@@ -475,36 +490,7 @@
          <property name="title">
           <string>Input</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_2">
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="show_sent_text_checkbox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>&lt;p&gt;Echo the text you send in the display box.&lt;/p&gt;&lt;p&gt;&lt;i&gt;This can be disabled by the game server if it negotiates to use the telnet ECHO option&lt;/i&gt;&lt;/p&gt;</string>
-            </property>
-            <property name="text">
-             <string>Show the text you sent</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_commandSeparator">
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="text">
-             <string>Command separator:</string>
-            </property>
-            <property name="buddy">
-             <cstring>command_separator_lineedit</cstring>
-            </property>
-           </widget>
-          </item>
+         <layout class="QGridLayout" name="gridLayout_groupBox_input">
           <item row="0" column="0">
            <widget class="QCheckBox" name="USE_UNIX_EOL">
             <property name="sizePolicy">
@@ -514,23 +500,10 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>use strict UNIX line endings on commands for old UNIX servers that can't handle windows line endings correctly</string>
+             <string>&lt;p&gt;Use strict UNIX line endings on commands for old UNIX servers that can't handle windows line endings correctly.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string>Strict UNIX line endings</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QLineEdit" name="command_separator_lineedit">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="placeholderText">
-             <string>Text to separate commands or blank to disable</string>
             </property>
            </widget>
           </item>
@@ -547,6 +520,22 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="show_sent_text_checkbox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>&lt;p&gt;Echo the text you send in the display box.&lt;/p&gt;&lt;p&gt;&lt;i&gt;This can be disabled by the game server if it negotiates to use the telnet ECHO option.&lt;/i&gt;&lt;/p&gt;</string>
+            </property>
+            <property name="text">
+             <string>Show the text you sent</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="1">
            <widget class="QCheckBox" name="checkBox_runAllKeyBindings">
             <property name="sizePolicy">
@@ -560,6 +549,45 @@
             </property>
             <property name="text">
              <string>React to all keybindings on the same key</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QCheckBox" name="checkBox_highlightHistory">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>&lt;p&gt;Highlights your input line text when scrolling through your history for easy cancellation.&lt;/p&gt;</string>
+            </property>
+            <property name="text">
+             <string>Highlight history</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_commandSeparator">
+            <property name="text">
+             <string>Command separator:</string>
+            </property>
+            <property name="buddy">
+             <cstring>command_separator_lineedit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLineEdit" name="command_separator_lineedit">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="placeholderText">
+             <string>Text to separate commands or blank to disable</string>
             </property>
            </widget>
           </item>
@@ -589,22 +617,6 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="3">
-           <widget class="QCheckBox" name="checkBox_highlightHistory">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>Highlights your input line text when scrolling through your history for easy cancellation</string>
-            </property>
-            <property name="text">
-             <string>Highlight history</string>
-            </property>
-           </widget>
-          </item>
          </layout>
         </widget>
        </item>
@@ -616,20 +628,7 @@
          <property name="title">
           <string>Spell checking</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout">
-          <item row="2" column="4">
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
+         <layout class="QGridLayout" name="gridLayout_groupBox_spellCheck">
           <item row="0" column="0">
            <widget class="QCheckBox" name="checkBox_spellCheck">
             <property name="toolTip">
@@ -640,18 +639,18 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="2">
-           <widget class="QRadioButton" name="radioButton_userDictionary_common">
-            <property name="toolTip">
-             <string>&lt;p&gt;A user dictionary that is shared between all profiles (which have this option selected) will be available. This will be on the command line (words which are in it will appear with a dashed cyan underline) and in the lua sub-system.&lt;/p&gt;</string>
-            </property>
-            <property name="text">
-             <string>Shared</string>
+          <item row="0" column="1" colspan="4">
+           <widget class="QComboBox" name="comboBox_dictionary">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="label_6">
+           <widget class="QLabel" name="label_radioButton_userDictionary">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -673,15 +672,28 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="1" colspan="4">
-           <widget class="QComboBox" name="comboBox_dictionary">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+          <item row="2" column="2">
+           <widget class="QRadioButton" name="radioButton_userDictionary_common">
+            <property name="toolTip">
+             <string>&lt;p&gt;A user dictionary that is shared between all profiles (which have this option selected) will be available. This will be on the command line (words which are in it will appear with a dashed cyan underline) and in the lua sub-system.&lt;/p&gt;</string>
+            </property>
+            <property name="text">
+             <string>Shared</string>
             </property>
            </widget>
+          </item>
+          <item row="2" column="4">
+           <spacer name="horizontalSpacer_radioButtons_userDictionary">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>
@@ -729,6 +741,9 @@
             <property name="text">
              <string>Font:</string>
             </property>
+            <property name="buddy">
+             <cstring>fontComboBox</cstring>
+            </property>
            </widget>
           </item>
           <item row="0" column="1">
@@ -752,12 +767,15 @@
             <property name="text">
              <string>Size:</string>
             </property>
+            <property name="buddy">
+             <cstring>fontSize</cstring>
+            </property>
            </widget>
           </item>
           <item row="0" column="3">
            <widget class="QComboBox" name="fontSize"/>
           </item>
-          <item row="1" column="0" colspan="2">
+          <item row="1" column="0" colspan="4">
            <widget class="QLabel" name="label_invalidFontError">
             <property name="font">
              <font>
@@ -782,10 +800,10 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="3" column="0" colspan="4">
            <widget class="QCheckBox" name="mNoAntiAlias">
             <property name="toolTip">
-             <string>Use anti aliasing on fonts. Smoothes fonts if you have a high screen resolution and you can use larger fonts. Note that on low resolutions and small font sizes, the font gets blurry. </string>
+             <string>&lt;p&gt;Use anti aliasing on fonts. Smoothes fonts if you have a high screen resolution and you can use larger fonts. Note that on low resolutions and small font sizes, the font gets blurry.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string>Enable anti-aliasing</string>
@@ -822,10 +840,13 @@ you can use it but there could be issues with aligning columns of text</string>
              </size>
             </property>
             <property name="toolTip">
-             <string>&lt;p&gt;Extra space to have before text on top - can be set to negative to move text up beyond the screen&lt;/p&gt;</string>
+             <string>&lt;p&gt;Extra space to have before text on top - can be set to negative to move text up beyond the screen.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string>Top border height:</string>
+            </property>
+            <property name="buddy">
+             <cstring>topBorderHeight</cstring>
             </property>
            </widget>
           </item>
@@ -838,7 +859,7 @@ you can use it but there could be issues with aligning columns of text</string>
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>&lt;p&gt;Extra space to have before text on top - can be set to negative to move text up beyond the screen&lt;/p&gt;</string>
+             <string>&lt;p&gt;Extra space to have before text on top - can be set to negative to move text up beyond the screen.&lt;/p&gt;</string>
             </property>
             <property name="minimum">
              <number>-1000000</number>
@@ -866,10 +887,13 @@ you can use it but there could be issues with aligning columns of text</string>
              </size>
             </property>
             <property name="toolTip">
-             <string>&lt;p&gt;Extra space to have before text on the left - can be set to negative to move text left beyond the screen&lt;/p&gt;</string>
+             <string>&lt;p&gt;Extra space to have before text on the left - can be set to negative to move text left beyond the screen.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string>Left border width:</string>
+            </property>
+            <property name="buddy">
+             <cstring>leftBorderWidth</cstring>
             </property>
            </widget>
           </item>
@@ -882,7 +906,7 @@ you can use it but there could be issues with aligning columns of text</string>
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>&lt;p&gt;Extra space to have before text on the left - can be set to negative to move text left beyond the screen&lt;/p&gt;</string>
+             <string>&lt;p&gt;Extra space to have before text on the left - can be set to negative to move text left beyond the screen.&lt;/p&gt;</string>
             </property>
             <property name="minimum">
              <number>-1000000</number>
@@ -910,10 +934,13 @@ you can use it but there could be issues with aligning columns of text</string>
              </size>
             </property>
             <property name="toolTip">
-             <string>&lt;p&gt;Extra space to have before text on the bottom - can be set to negative to allow text to go down beyond the screen&lt;/p&gt;</string>
+             <string>&lt;p&gt;Extra space to have before text on the bottom - can be set to negative to allow text to go down beyond the screen.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string>Bottom border height:</string>
+            </property>
+            <property name="buddy">
+             <cstring>bottomBorderHeight</cstring>
             </property>
            </widget>
           </item>
@@ -926,7 +953,7 @@ you can use it but there could be issues with aligning columns of text</string>
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>&lt;p&gt;Extra space to have before text on the bottom - can be set to negative to allow text to go down beyond the screen&lt;/p&gt;</string>
+             <string>&lt;p&gt;Extra space to have before text on the bottom - can be set to negative to allow text to go down beyond the screen.&lt;/p&gt;</string>
             </property>
             <property name="minimum">
              <number>-1000000</number>
@@ -954,10 +981,13 @@ you can use it but there could be issues with aligning columns of text</string>
              </size>
             </property>
             <property name="toolTip">
-             <string>&lt;p&gt;Extra space to have before text on the right - can be set to negative to move text right beyond the screen&lt;/p&gt;</string>
+             <string>&lt;p&gt;Extra space to have before text on the right - can be set to negative to move text right beyond the screen.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string>Right border width:</string>
+            </property>
+            <property name="buddy">
+             <cstring>rightBorderWidth</cstring>
             </property>
            </widget>
           </item>
@@ -970,7 +1000,7 @@ you can use it but there could be issues with aligning columns of text</string>
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>&lt;p&gt;Extra space to have before text on the right - can be set to negative to move text right beyond the screen&lt;/p&gt;</string>
+             <string>&lt;p&gt;Extra space to have before text on the right - can be set to negative to move text right beyond the screen.&lt;/p&gt;</string>
             </property>
             <property name="minimum">
              <number>-1000000</number>
@@ -1024,6 +1054,9 @@ you can use it but there could be issues with aligning columns of text</string>
                <property name="text">
                 <string>Wrap lines at:</string>
                </property>
+               <property name="buddy">
+                <cstring>wrap_at_spinBox</cstring>
+               </property>
               </widget>
              </item>
              <item>
@@ -1043,6 +1076,9 @@ you can use it but there could be issues with aligning columns of text</string>
               <widget class="QLabel" name="label_23">
                <property name="text">
                 <string>characters</string>
+               </property>
+               <property name="buddy">
+                <cstring>wrap_at_spinBox</cstring>
                </property>
               </widget>
              </item>
@@ -1072,6 +1108,9 @@ you can use it but there could be issues with aligning columns of text</string>
                <property name="text">
                 <string>Indent wrapped lines by:</string>
                </property>
+               <property name="buddy">
+                <cstring>indent_wrapped_spinBox</cstring>
+               </property>
               </widget>
              </item>
              <item>
@@ -1091,6 +1130,9 @@ you can use it but there could be issues with aligning columns of text</string>
               <widget class="QLabel" name="label_25">
                <property name="text">
                 <string>characters</string>
+               </property>
+               <property name="buddy">
+                <cstring>indent_wrapped_spinBox</cstring>
                </property>
               </widget>
              </item>
@@ -1118,10 +1160,13 @@ you can use it but there could be issues with aligning columns of text</string>
                 </size>
                </property>
                <property name="toolTip">
-                <string>&lt;p&gt;Subsequent wrapped lines will be indented by this amount&lt;/p&gt;</string>
+                <string>&lt;p&gt;Subsequent wrapped lines will be indented by this amount.&lt;/p&gt;</string>
                </property>
                <property name="text">
                 <string>Indent hanging wrapped lines by:</string>
+               </property>
+               <property name="buddy">
+                <cstring>hanging_indent_wrapped_spinBox</cstring>
                </property>
               </widget>
              </item>
@@ -1143,6 +1188,9 @@ you can use it but there could be issues with aligning columns of text</string>
                <property name="text">
                 <string>characters</string>
                </property>
+               <property name="buddy">
+                <cstring>hanging_indent_wrapped_spinBox</cstring>
+               </property>
               </widget>
              </item>
             </layout>
@@ -1161,6 +1209,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLabel" name="doubleclick_ignore_label">
             <property name="text">
              <string>Stop selecting a word on these characters:</string>
+            </property>
+            <property name="buddy">
+             <cstring>doubleclick_ignore_lineedit</cstring>
             </property>
            </widget>
           </item>
@@ -1227,6 +1278,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLabel" name="label_controlCharacterHandling">
             <property name="text">
              <string>Display control characters as:</string>
+            </property>
+            <property name="buddy">
+             <cstring>comboBox_controlCharacterHandling</cstring>
             </property>
            </widget>
           </item>
@@ -1401,7 +1455,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item row="1" column="0">
            <widget class="QCheckBox" name="checkBox_showBidi">
             <property name="toolTip">
-             <string>Shows bidirection Unicode characters which can be used to change the meaning of source code while remaining invisible to the eye</string>
+             <string>&lt;p&gt;Shows bidirection Unicode characters which can be used to change the meaning of source code while remaining invisible to the eye.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string>Show invisible Unicode control characters</string>
@@ -1452,6 +1506,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Foreground:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_foreground_color</cstring>
+            </property>
            </widget>
           </item>
           <item row="0" column="1">
@@ -1475,6 +1532,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Background:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_background_color</cstring>
+            </property>
            </widget>
           </item>
           <item row="0" column="3">
@@ -1495,6 +1555,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Command line foreground:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_command_line_foreground_color</cstring>
+            </property>
            </widget>
           </item>
           <item row="1" column="1">
@@ -1512,6 +1575,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Command line background:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_command_line_background_color</cstring>
+            </property>
            </widget>
           </item>
           <item row="1" column="3">
@@ -1528,6 +1594,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLabel" name="label_command_foreground_color">
             <property name="text">
              <string>Command foreground:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_command_foreground_color</cstring>
             </property>
            </widget>
           </item>
@@ -1548,6 +1617,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLabel" name="label_command_background_color">
             <property name="text">
              <string>Command background:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_command_background_color</cstring>
             </property>
            </widget>
           </item>
@@ -1592,6 +1664,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Black:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_black</cstring>
+            </property>
            </widget>
           </item>
           <item row="5" column="1">
@@ -1611,6 +1686,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLabel" name="label_lBlack">
             <property name="text">
              <string>Light black:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_lBlack</cstring>
             </property>
            </widget>
           </item>
@@ -1632,6 +1710,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Red:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_red</cstring>
+            </property>
            </widget>
           </item>
           <item row="6" column="1">
@@ -1651,6 +1732,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLabel" name="label_lRed">
             <property name="text">
              <string>Light red:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_lRed</cstring>
             </property>
            </widget>
           </item>
@@ -1672,6 +1756,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Green:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_green</cstring>
+            </property>
            </widget>
           </item>
           <item row="7" column="1">
@@ -1691,6 +1778,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLabel" name="label_lGreen">
             <property name="text">
              <string>Light green:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_lGreen</cstring>
             </property>
            </widget>
           </item>
@@ -1712,6 +1802,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Yellow:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_yellow</cstring>
+            </property>
            </widget>
           </item>
           <item row="8" column="1">
@@ -1731,6 +1824,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLabel" name="label_lYellow">
             <property name="text">
              <string>Light yellow:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_lYellow</cstring>
             </property>
            </widget>
           </item>
@@ -1752,6 +1848,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Blue:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_blue</cstring>
+            </property>
            </widget>
           </item>
           <item row="9" column="1">
@@ -1771,6 +1870,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLabel" name="label_lBlue">
             <property name="text">
              <string>Light blue:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_lBlue</cstring>
             </property>
            </widget>
           </item>
@@ -1792,6 +1894,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Magenta:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_magenta</cstring>
+            </property>
            </widget>
           </item>
           <item row="10" column="1">
@@ -1811,6 +1916,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLabel" name="label_lMagenta">
             <property name="text">
              <string>Light magenta:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_lMagenta</cstring>
             </property>
            </widget>
           </item>
@@ -1832,6 +1940,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Cyan:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_cyan</cstring>
+            </property>
            </widget>
           </item>
           <item row="11" column="1">
@@ -1851,6 +1962,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLabel" name="label_lCyan">
             <property name="text">
              <string>Light cyan:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_lCyan</cstring>
             </property>
            </widget>
           </item>
@@ -1872,6 +1986,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>White:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_white</cstring>
+            </property>
            </widget>
           </item>
           <item row="12" column="1">
@@ -1891,6 +2008,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLabel" name="label_lWhite">
             <property name="text">
              <string>Light white:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_lWhite</cstring>
             </property>
            </widget>
           </item>
@@ -2033,6 +2153,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Delete map:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_deleteMap</cstring>
+            </property>
            </widget>
           </item>
           <item row="4" column="1">
@@ -2061,7 +2184,7 @@ you can use it but there could be issues with aligning columns of text</string>
              <bool>false</bool>
             </property>
             <property name="toolTip">
-             <string>&lt;p&gt;Select profiles that you want to copy map to, then press the Copy button to the right&lt;/p&gt;</string>
+             <string>&lt;p&gt;Select profiles that you want to copy map to, then press the Copy button to the right.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string comment="text on button to select other profiles to receive the map from this profile, this is used when no profiles have been selected">pick destinations...</string>
@@ -2074,7 +2197,7 @@ you can use it but there could be issues with aligning columns of text</string>
              <bool>false</bool>
             </property>
             <property name="toolTip">
-             <string>&lt;p&gt;Copy map into the selected profiles on the left&lt;/p&gt;</string>
+             <string>&lt;p&gt;Copy map into the selected profiles on the left.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string notr="true" comment="text will be placed on this button by the C++ code"/>
@@ -2106,7 +2229,7 @@ you can use it but there could be issues with aligning columns of text</string>
              </size>
             </property>
             <property name="toolTip">
-             <string>&lt;p&gt;Change this to a lower version if you need to save your map in a format that can be read by older versions of Mudlet. Doing so will lose the extra data available in the current map format&lt;/p&gt;</string>
+             <string>&lt;p&gt;Change this to a lower version if you need to save your map in a format that can be read by older versions of Mudlet. Doing so will lose the extra data available in the current map format.&lt;/p&gt;</string>
             </property>
             <property name="editable">
              <bool>false</bool>
@@ -2145,7 +2268,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item>
            <widget class="QLabel" name="label_11">
             <property name="toolTip">
-             <string>&lt;p&gt;On games that provide maps for download, you can press this button to get the latest map. Note that this will &lt;span style=&quot; font-weight:600;&quot;&gt;overwrite&lt;/span&gt; any changes you've done to your map, and will use the new map only&lt;/p&gt;</string>
+             <string>&lt;p&gt;On games that provide maps for download, you can press this button to get the latest map. Note that this will &lt;span style=&quot; font-weight:600;&quot;&gt;overwrite&lt;/span&gt; any changes you've done to your map, and will use the new map only.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string>Download latest map provided by your game:</string>
@@ -2158,7 +2281,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item>
            <widget class="QPushButton" name="buttonDownloadMap">
             <property name="toolTip">
-             <string>&lt;p&gt;On games that provide maps for download, you can press this button to get the latest map. Note that this will &lt;span style=&quot; font-weight:600;&quot;&gt;overwrite&lt;/span&gt; any changes you've done to your map, and will use the new map only&lt;/p&gt;</string>
+             <string>&lt;p&gt;On games that provide maps for download, you can press this button to get the latest map. Note that this will &lt;span style=&quot; font-weight:600;&quot;&gt;overwrite&lt;/span&gt; any changes you've done to your map, and will use the new map only.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string>Download</string>
@@ -2187,7 +2310,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item row="0" column="1">
            <widget class="QCheckBox" name="checkBox_showDefaultArea">
             <property name="toolTip">
-             <string>&lt;p&gt;The default area (area id -1) is used by some mapper scripts as a temporary 'holding area' for rooms before they're placed in the correct area&lt;/p&gt;</string>
+             <string>&lt;p&gt;The default area (area id -1) is used by some mapper scripts as a temporary 'holding area' for rooms before they're placed in the correct area.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string>Show the default area in map area selection</string>
@@ -2200,7 +2323,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item row="1" column="0">
            <widget class="QCheckBox" name="checkbox_mMapperShowRoomBorders">
             <property name="toolTip">
-             <string>&lt;p&gt;This enables borders around room. Color can be set in Mapper colors tab&lt;/p&gt;</string>
+             <string>&lt;p&gt;This enables borders around room. Color can be set in Mapper colors tab.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string>Show room borders</string>
@@ -3083,7 +3206,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item row="3" column="0" colspan="3">
            <widget class="QCheckBox" name="checkBox_discordLuaAPI">
             <property name="toolTip">
-             <string>&lt;p&gt;Allow Lua to set Discord status&lt;/p&gt;</string>
+             <string>&lt;p&gt;Allow Lua to set Discord status.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string>Enable Lua API</string>
@@ -3589,7 +3712,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item>
            <widget class="QLineEdit" name="lineEdit_proxyUsername">
             <property name="toolTip">
-             <string>Username for logging into the proxy if required</string>
+             <string>&lt;p&gt;Username for logging into the proxy if required.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string/>
@@ -3605,7 +3728,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item>
            <widget class="QLineEdit" name="lineEdit_proxyPassword">
             <property name="toolTip">
-             <string>Password for logging into the proxy if required</string>
+             <string>&lt;p&gt;Password for logging into the proxy if required.&lt;/p&gt;</string>
             </property>
             <property name="echoMode">
              <enum>QLineEdit::Password</enum>
@@ -3720,7 +3843,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item row="0" column="0" colspan="2">
            <widget class="QCheckBox" name="checkBox_announceIncomingText">
             <property name="toolTip">
-             <string>On some platforms, like macOS, the screen reader tool has issues announcing incoming text fully, without skipping. You can opt into disabling announcing new text from the game with this option to use a custom TTS instead which avoids such issues</string>
+             <string>&lt;p&gt;On some platforms, like macOS, the screen reader tool has issues announcing incoming text fully, without skipping. You can opt into disabling announcing new text from the game with this option to use a custom TTS instead which avoids such issues.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string>Announce incoming text in screen reader</string>
@@ -3729,9 +3852,6 @@ you can use it but there could be issues with aligning columns of text</string>
           </item>
           <item row="1" column="0" colspan="2">
            <widget class="QCheckBox" name="checkBox_advertiseScreenReader">
-            <property name="toolTip">
-             <string/>
-            </property>
             <property name="text">
              <string>Advertise screen reader use via protocols supporting this notice (NEW-ENVIRON, MNES, MTTS)</string>
             </property>
@@ -3803,7 +3923,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item row="4" column="0" colspan="2">
            <widget class="QCheckBox" name="checkBox_f3SearchEnabled">
             <property name="toolTip">
-             <string>Enable F3 and Shift+F3 shortcuts for searching up and down in the buffer</string>
+             <string>&lt;p&gt;Enable F3 and Shift+F3 shortcuts for searching up and down in the buffer.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string>Enable F3 search shortcuts</string>
@@ -3852,8 +3972,8 @@ you can use it but there could be issues with aligning columns of text</string>
           <item row="0" column="1">
            <widget class="QCheckBox" name="checkBox_mUSE_FORCE_LF_AFTER_PROMPT">
             <property name="toolTip">
-             <string>This option adds a line line break &lt;LF&gt; or &quot;
-&quot; to your command input on empty commands. This option will rarely be necessary.</string>
+             <string>&lt;p&gt;This option adds a line line break &lt;LF&gt; or &quot;
+&quot; to your command input on empty commands. This option will rarely be necessary.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string>Force new line on empty commands</string>
@@ -4000,7 +4120,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item row="0" column="1">
            <widget class="QCheckBox" name="checkBox_expectCSpaceIdInColonLessMColorCode">
             <property name="toolTip">
-             <string>&lt;p&gt;Some MUDs use a flawed interpretation of the ANSI Set Graphics Rendition (&lt;b&gt;SGR&lt;/b&gt;) code sequences for 16M color mode which only uses semi-colons and not colons to separate parameter elements i.e. instead of using a code in the form: &lt;br&gt;&lt;tt&gt;\e[&lt;/tt&gt;...&lt;tt&gt;38:2:&lt;/tt&gt;&amp;lt;Color Space Id&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Red&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Green&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Blue&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Unused&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Tolerance&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Tolerance Color Space (0=CIELUV; 1=CIELAB)&amp;gt;&lt;tt&gt;;&lt;/tt&gt;...&lt;tt&gt;m&lt;/tt&gt;&lt;br&gt;where the &lt;i&gt;Color Space Id&lt;/i&gt; is expected to be an empty string to specify the usual (default) case and all of the &lt;i&gt;Parameter Elements&lt;/i&gt; (the &quot;2&quot; and the values in the &lt;tt&gt;&amp;lt;...&amp;gt;&lt;/tt&gt;s) may, technically, be omitted; they use: &lt;br&gt;&lt;tt&gt;\e[&lt;/tt&gt;...&lt;tt&gt;38;2;&lt;/tt&gt;&amp;lt;Red&amp;gt;&lt;tt&gt;;&lt;/tt&gt;&amp;lt;Green&amp;gt;&lt;tt&gt;;&lt;/tt&gt;&amp;lt;Blue&amp;gt;&lt;tt&gt;;&lt;/tt&gt;...&lt;tt&gt;m&lt;/tt&gt;&lt;br&gt;or: &lt;br&gt;&lt;tt&gt;\e[&lt;/tt&gt;...&lt;tt&gt;38;2;&lt;/tt&gt;&amp;lt;Color Space Id&amp;gt;&lt;tt&gt;;&lt;/tt&gt;&amp;lt;Red&amp;gt;&lt;tt&gt;;&lt;/tt&gt;&amp;lt;Green&amp;gt;&lt;tt&gt;;&lt;/tt&gt;&amp;lt;Blue&amp;gt;&lt;tt&gt;;&lt;/tt&gt;...&lt;tt&gt;m&lt;/tt&gt;&lt;/p&gt;&lt;p&gt;It is not possible to reliably detect the difference between these two so checking this option causes Mudlet to expect the last one with the additional (but empty!) parameter.&lt;/p&gt;</string>
+             <string>&lt;p&gt;Some MUDs use a flawed interpretation of the ANSI Set Graphics Rendition (&lt;b&gt;SGR&lt;/b&gt;) code sequences for 16M color mode which only uses semi-colons and not colons to separate parameter elements i.e. instead of using a code in the form: &lt;br&gt;&lt;tt&gt;\e[&lt;/tt&gt;...&lt;tt&gt;38:2:&lt;/tt&gt;&amp;lt;Color Space Id&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Red&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Green&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Blue&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Unused&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Tolerance&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Tolerance Color Space (0=CIELUV; 1=CIELAB)&amp;gt;&lt;tt&gt;;&lt;/tt&gt;...&lt;tt&gt;m&lt;/tt&gt;&lt;br&gt;where the &lt;i&gt;Color Space Id&lt;/i&gt; is expected to be an empty string to specify the usual (default) case and all of the &lt;i&gt;Parameter Elements&lt;/i&gt; (the &quot;2&quot; and the values in the &lt;tt&gt;&amp;lt;...&amp;gt;&lt;/tt&gt;s) may, technically, be omitted; they use: &lt;br&gt;&lt;tt&gt;\e[&lt;/tt&gt;...&lt;tt&gt;38;2;&lt;/tt&gt;&amp;lt;Red&amp;gt;&lt;tt&gt;;&lt;/tt&gt;&amp;lt;Green&amp;gt;&lt;tt&gt;;&lt;/tt&gt;&amp;lt;Blue&amp;gt;&lt;tt&gt;;&lt;/tt&gt;...&lt;tt&gt;m&lt;/tt&gt;&lt;br&gt;or: &lt;br&gt;&lt;tt&gt;\e[&lt;/tt&gt;...&lt;tt&gt;38;2;&lt;/tt&gt;&amp;lt;Color Space Id&amp;gt;&lt;tt&gt;;&lt;/tt&gt;&amp;lt;Red&amp;gt;&lt;tt&gt;;&lt;/tt&gt;&amp;lt;Green&amp;gt;&lt;tt&gt;;&lt;/tt&gt;&amp;lt;Blue&amp;gt;&lt;tt&gt;;&lt;/tt&gt;...&lt;tt&gt;m&lt;/tt&gt; .&lt;/p&gt;&lt;p&gt;It is not possible to reliably detect the difference between these two so checking this option causes Mudlet to expect the last one with the additional (but empty!) parameter.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string>Expect Color Space Id in SGR...(3|4)8;2;...m codes</string>
@@ -4237,7 +4357,12 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>comboBox_toolBarVisibility</tabstop>
   <tabstop>comboBox_guiLanguage</tabstop>
   <tabstop>comboBox_encoding</tabstop>
+  <tabstop>mFORCE_SAVE_ON_EXIT</tabstop>
   <tabstop>comboBox_appearance</tabstop>
+  <tabstop>mAlertOnNewData</tabstop>
+  <tabstop>pushButton_chooseProtocols</tabstop>
+  <tabstop>acceptServerGUI</tabstop>
+  <tabstop>acceptServerMedia</tabstop>
   <tabstop>mIsToLogInHtml</tabstop>
   <tabstop>lineEdit_logFileFolder</tabstop>
   <tabstop>comboBox_logFileNameFormat</tabstop>
@@ -4247,12 +4372,13 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>pushButton_resetLogDir</tabstop>
   <tabstop>USE_UNIX_EOL</tabstop>
   <tabstop>show_sent_text_checkbox</tabstop>
-  <tabstop>checkBox_runAllKeyBindings</tabstop>
   <tabstop>auto_clear_input_line_checkbox</tabstop>
+  <tabstop>checkBox_runAllKeyBindings</tabstop>
   <tabstop>checkBox_highlightHistory</tabstop>
   <tabstop>command_separator_lineedit</tabstop>
   <tabstop>commandLineMinimumHeight</tabstop>
   <tabstop>checkBox_spellCheck</tabstop>
+  <tabstop>comboBox_dictionary</tabstop>
   <tabstop>radioButton_userDictionary_profile</tabstop>
   <tabstop>radioButton_userDictionary_common</tabstop>
   <tabstop>fontComboBox</tabstop>
@@ -4267,16 +4393,16 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>hanging_indent_wrapped_spinBox</tabstop>
   <tabstop>doubleclick_ignore_lineedit</tabstop>
   <tabstop>checkBox_USE_IRE_DRIVER_BUGFIX</tabstop>
-  <tabstop>checkBox_echoLuaErrors</tabstop>
-  <tabstop>checkBox_enableTextAnalyzer</tabstop>
   <tabstop>checkBox_useWideAmbiguousEastAsianGlyphs</tabstop>
+  <tabstop>checkBox_enableTextAnalyzer</tabstop>
+  <tabstop>checkBox_echoLuaErrors</tabstop>
   <tabstop>comboBox_controlCharacterHandling</tabstop>
   <tabstop>code_editor_theme_selection_combobox</tabstop>
   <tabstop>script_preview_combobox</tabstop>
   <tabstop>checkBox_autocompleteLuaCode</tabstop>
   <tabstop>checkBox_showSpacesAndTabs</tabstop>
-  <tabstop>checkBox_showLineFeedsAndParagraphs</tabstop>
   <tabstop>checkBox_showBidi</tabstop>
+  <tabstop>checkBox_showLineFeedsAndParagraphs</tabstop>
   <tabstop>checkBox_showIdNumbers</tabstop>
   <tabstop>pushButton_foreground_color</tabstop>
   <tabstop>pushButton_command_line_foreground_color</tabstop>
@@ -4327,10 +4453,10 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>pushButton_foreground_color_2</tabstop>
   <tabstop>pushButton_roomBorderColor</tabstop>
   <tabstop>pushButton_lowerLevelColor</tabstop>
-  <tabstop>pushButton_upperLevelColor</tabstop>
   <tabstop>pushButton_roomCollisionBorderColor</tabstop>
   <tabstop>pushButton_background_color_2</tabstop>
   <tabstop>pushButton_mapInfoBg</tabstop>
+  <tabstop>pushButton_upperLevelColor</tabstop>
   <tabstop>pushButton_black_2</tabstop>
   <tabstop>pushButton_red_2</tabstop>
   <tabstop>pushButton_green_2</tabstop>
@@ -4378,6 +4504,7 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>checkBox_advertiseScreenReader</tabstop>
   <tabstop>comboBox_blankLinesBehaviour</tabstop>
   <tabstop>comboBox_caretModeKey</tabstop>
+  <tabstop>checkBox_f3SearchEnabled</tabstop>
   <tabstop>mFORCE_MCCP_OFF</tabstop>
   <tabstop>mFORCE_GA_OFF</tabstop>
   <tabstop>mFORCE_CHARSET_NEGOTIATION_OFF</tabstop>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
* Reorder back into ascending row/columns the items in the QGridLayout.
* Also adds better names to some of them which default (back) to `gridLayout_#` if freshly created and which can then clash if separate PRs are merged with identical such names.
* Also unify the presentation of tool-tips in this form (so they are all formatted as wrappable text sentences).
* Add "buddy" connections between labels and the buttons or other interactive widget they are associated with for labels that have not so far been so linked but which can be.
* Reorder widgets "tab-order" to accommodate recent changes.

#### Motivation for adding to Mudlet
It is almost impossible to track changes via `git`/`diff` in `.ui` forms if items in a `QGridLayout` are edited via the `Qt Designer` tool as it does not preserve the order. We did try and automate this in our CI but it was not reliable IIRC - so it falls back to manual edits if PR creators don't do it at the time of their PRs. Other polishes done for general improvements.

#### Other info (issues closed, discussion etc)