### PR TITLE
fix: update Geyser.Label doc to correct color parameter

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -971,7 +971,7 @@ end
 -- @param[opt=false] cons.flyOut allows labels to show up when mouse is hovered over
 -- @param[opt=''] cons.message initial message to show on the label
 -- @param[opt='white'] cons.fgColor optional foreground colour - colour to use for text on the label
--- @param[opt='black'] cons.bgColor optional background colour - colour of the whole label
+-- @param[opt='dark grey'] cons.color optional background colour - colour of the whole label
 -- @param[opt=1] cons.fillBg 1 if the background is to be filled, 0 for no background
 -- @param container the container to add as a child
 function Geyser.Label:addChild(cons, container)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix an incorrect parameter (`color` instead of `bgColor`) in the Geyser API docs.

#### Motivation for adding to Mudlet
Better documentation.

#### Other info (issues closed, discussion etc)
https://discord.com/channels/283581582550237184/283582068334526464/1355142486175125687
