### PR TITLE
Fix: Add windowname arg to Lua replace and replaceLine

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -672,12 +672,10 @@ function replaceLine(window, text)
   assert(type(window) == 'string', 'replaceLine: bad argument #1 type (expected string, got '..type(window)..'!)')
   if not text then
     selectCurrentLine()
-    text = window
   else
     selectCurrentLine(window)
   end
-  replace("")
-  insertText(text)
+  replace(window, text)
 end
 
 
@@ -1994,7 +1992,7 @@ end
 do
   local oldreplace = replace
   function replace(arg1, arg2, arg3)
-    local windowname, text, keepcolor
+    local windowname, text, keepcolor = "main", nil, false
 
     if arg1 and arg2 and arg3 ~= nil then
       windowname, text, keepcolor = arg1, arg2, arg3
@@ -2006,27 +2004,18 @@ do
       text = arg1
     end
 
-    local selection = {getSelection()}
+    local selection = {getSelection(windowname)}
     if _comp(selection, {"", 0, 0}) then
       return nil, "replace: nothing is selected to be replaced. Did selectString return -1?"
     end
     text = text or ""
 
     if keepcolor then
-      if not windowname then
-        setBgColor(getBgColor())
-        setFgColor(getFgColor())
-      else
-        setBgColor(windowname, getBgColor(windowname))
-        setFgColor(windowname, getFgColor(windowname))
-      end
+      setBgColor(windowname, getBgColor(windowname))
+      setFgColor(windowname, getFgColor(windowname))
     end
 
-    if windowname then
-      oldreplace(windowname, text)
-    else
-      oldreplace(text)
-    end
+    oldreplace(windowname, text)
   end
 end
 

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -21,7 +21,7 @@ end
 --- Replaces the currently selected text.
 -- @param with The text to use as a replacement.
 function Geyser.MiniConsole:replace (with)
-  replace(self.name, with)
+  return replace(self.name, with)
 end
 
 --- Replaces the entire line the cursor is on


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

* `replaceLine`:  passes window & text to replace
  * replace handles the case where window is the text and text is nil.
* `replace`: pass windowname to `getselection`.
* Geyser `MiniConsole:replace()`: return results of `replace` call.
  * `replace` returns useful debug information if there is no selection.  Information that we lose because we don't return.

#### Motivation for adding to Mudlet

Fix: https://github.com/Mudlet/Mudlet/issues/6891

#### Other info (issues closed, discussion etc)

Closes #6891

*I was unable to build mudlet to test these changes on my local machine* due to incompatibilities with Mudlet's required versions of cmake and qt.  I did try switching to a docker build, but ran into a similar issue #7796.  I am not willing to attempt the cmake upgrade on my machine (PopOS 22.04), as I do not wish to run the risk of breaking other parts of my system.