### PR TITLE
Improve: make Notepad font track Main Console one

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015-2024 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2015-2025 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *   Copyright (C) 2018 by Huadong Qi - novload@outlook.com                *
  *   Copyright (C) 2023 by Lecker Kebap - Leris@mudlet.org                 *
@@ -1044,9 +1044,14 @@ void Host::updateConsolesFont()
         mpEditorDialog->mpErrorConsole->setFont(mDisplayFont.family());
         mpEditorDialog->mpErrorConsole->setFontSize(mDisplayFont.pointSize());
     }
+
     if (mudlet::self()->smpDebugArea) {
         mudlet::self()->smpDebugConsole->setFont(mDisplayFont.family());
         mudlet::self()->smpDebugConsole->setFontSize(mDisplayFont.pointSize());
+    }
+
+    if (mpNotePad) {
+        mpNotePad->setFont(mDisplayFont);
     }
 }
 
@@ -1103,17 +1108,11 @@ std::pair<bool, QString> Host::setDisplayFont(const QFont& font)
     return {true, QString()};
 }
 
-std::pair<bool, QString> Host::setDisplayFont(const QString& fontName)
-{
-    const auto result = setDisplayFont(QFont(fontName));
-    updateConsolesFont();
-    return result;
-}
-
 void Host::setDisplayFontFromString(const QString& fontData)
 {
-    mDisplayFont.fromString(fontData);
-    updateConsolesFont();
+    QFont font;
+    font.fromString(fontData);
+    setDisplayFont(font);
 }
 
 void Host::setDisplayFontSize(int size)

--- a/src/Host.h
+++ b/src/Host.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015-2020, 2022-2023 by Stephen Lyons                   *
+ *   Copyright (C) 2015-2020, 2022-2023, 2025 by Stephen Lyons             *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *   Copyright (C) 2018 by Huadong Qi - novload@outlook.com                *
@@ -340,9 +340,8 @@ public:
     void setMediaLocationMSP(const QString& mediaUrl);
     QString mediaLocationMSP() const;
     const QFont& getDisplayFont() const { return mDisplayFont; }
-    std::pair<bool, QString> setDisplayFont(const QFont& font);
-    std::pair<bool, QString> setDisplayFont(const QString& fontName);
-    void setDisplayFontFromString(const QString& fontData);
+    std::pair<bool, QString> setDisplayFont(const QFont&);
+    void setDisplayFontFromString(const QString&);
     void setDisplayFontSize(int size);
     void setDisplayFontSpacing(const qreal spacing);
     void setDisplayFontStyle(QFont::StyleStrategy s);

--- a/src/dlgNotepad.cpp
+++ b/src/dlgNotepad.cpp
@@ -1,7 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017-2018 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2017-2018, 2025 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -43,11 +44,17 @@ dlgNotepad::dlgNotepad(Host* pH)
 
     if (mpHost) {
         restore();
+        notesEdit->setFont(mpHost->getDisplayFont());
     }
 
     connect(notesEdit, &QPlainTextEdit::textChanged, this, &dlgNotepad::slot_textWritten);
 
     startTimer(2min);
+}
+
+void dlgNotepad::setFont(const QFont& font)
+{
+    notesEdit->setFont(font);
 }
 
 dlgNotepad::~dlgNotepad()

--- a/src/dlgNotepad.h
+++ b/src/dlgNotepad.h
@@ -4,7 +4,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2018, 2022 by Stephen Lyons - slysven@virginmedia.com   *
+ *   Copyright (C) 2018, 2022, 2025 by Stephen Lyons                       *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -42,6 +43,7 @@ public:
 
     void save();
     void restore();
+    void setFont(const QFont &);
 
 private slots:
     void slot_textWritten();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The font (including size) used for the main console font is now applied to the Notepad window.

#### Motivation for adding to Mudlet
Raised by the Discord user `@missionz3r0` in our Discord `#help` channel in the message:
https://wwww.discord.com/channels/283581582550237184/283582068334526464/1357767687471632466
> **missionz3r0** — 2025/04/04 at 17:24 UTC
> 
> Is there a way to change the font  settings in the Notepad?
> 
> Neither the editor or main settings affect it.
> 
> **SlySven** ☕ — 2025/04/04 at 19:07 UTC
> The "Main" setting might affect it if you restart Mudlet after changing it... but I'll look to see if it can be made to track the main console font in the future.

#### Other info (issues closed, discussion etc)
I also discovered that there was a dead (unused) method: `(std::pair<bool, QString>) Host::setDisplayFont(const QString&)` which I could remove and that I could restructure:`(void) Host::setDisplayFontFromString(const QString&)` so that a redundent duplicate call to `(void) Host::updateConsolesFont()` could be removed.
