### PR TITLE
Infrastructure: clean up missing line-feeds at start of methods

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1996,7 +1996,8 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, enums::Pa
 }
 
 
-QString Host::sanitizePackageName(const QString packageName) const {
+QString Host::sanitizePackageName(const QString packageName) const
+{
     auto tempName = packageName.section(qsl("/"), -1);
     tempName.remove(qsl(".trigger"), Qt::CaseInsensitive);
     tempName.remove(qsl(".xml"), Qt::CaseInsensitive);
@@ -2030,7 +2031,8 @@ bool Host::removeDir(const QString& dirName, const QString& originalPath)
     return result;
 }
 
-void Host::removePackageInfo(const QString &packageName, const bool isModule) {
+void Host::removePackageInfo(const QString &packageName, const bool isModule)
+{
     if (isModule) {
         mModuleInfo.remove(packageName);
     } else {
@@ -4276,11 +4278,13 @@ void Host::setEditorShowBidi(const bool state)
     }
 }
 
-bool Host::caretEnabled() const {
+bool Host::caretEnabled() const
+{
     return mCaretEnabled;
 }
 
-void Host::setCaretEnabled(bool enabled) {
+void Host::setCaretEnabled(bool enabled)
+{
     mCaretEnabled = enabled;
     mpConsole->setCaretMode(enabled);
 }

--- a/src/MudletInstanceCoordinator.cpp
+++ b/src/MudletInstanceCoordinator.cpp
@@ -24,7 +24,10 @@
 
 const int WAIT_FOR_RESPONSE_MS = 500;
 
-MudletInstanceCoordinator::MudletInstanceCoordinator(const QString& serverName, QObject* parent) : QLocalServer(parent), mServerName(serverName) {}
+MudletInstanceCoordinator::MudletInstanceCoordinator(const QString& serverName, QObject* parent)
+: QLocalServer(parent)
+, mServerName(serverName)
+{}
 
 void MudletInstanceCoordinator::queuePackage(const QString& packageName)
 {

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4182,7 +4182,8 @@ void T2DMap::slot_setUserData()
 {
 }
 
-void T2DMap::slot_loadMap() {
+void T2DMap::slot_loadMap()
+{
     if (!mpHost) {
         return;
     }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1817,7 +1817,8 @@ void TConsole::slot_stopAllItems(bool b)
     }
 }
 
-void TConsole::focusOnSearchResultAndAnnounce(int searchX, int searchY) {
+void TConsole::focusOnSearchResultAndAnnounce(int searchX, int searchY)
+{
     mpHost->setCaretEnabled(true);
     mUpperPane->initializeCaret();
     moveCursor(searchX, searchY);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3411,7 +3411,8 @@ void TLuaInterpreter::setAtcpTable(const QString& var, const QString& arg)
 }
 
 // No documentation available in wiki - internal function
-void TLuaInterpreter::signalMXPEvent(const QString &type, const QMap<QString, QString> &attrs, const QStringList &actions) {
+void TLuaInterpreter::signalMXPEvent(const QString &type, const QMap<QString, QString> &attrs, const QStringList &actions)
+{
     lua_State *L = pGlobalLua;
     lua_getglobal(L, "mxp");
     if (!lua_istable(L, -1)) {
@@ -5650,7 +5651,8 @@ void TLuaInterpreter::initLuaGlobals()
 }
 
 // No documentation available in wiki - internal function
-lua_State* TLuaInterpreter::getLuaGlobalState() {
+lua_State* TLuaInterpreter::getLuaGlobalState()
+{
     return pGlobalLua;
 }
 
@@ -6513,7 +6515,8 @@ Host& getHostFromLua(lua_State* L)
 // No documentation available in wiki - internal function
 // Used to unref lua objects in the registry to avoid memory leaks
 // i.e. Unrefing tables passed into TLabel's event parameters.
-void TLuaInterpreter::freeLuaRegistryIndex(int index) {
+void TLuaInterpreter::freeLuaRegistryIndex(int index)
+{
     luaL_unref(pGlobalLua, LUA_REGISTRYINDEX, index);
 }
 
@@ -7444,7 +7447,8 @@ int TLuaInterpreter::setConfig(lua_State * L)
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#announce
-int TLuaInterpreter::announce(lua_State *L) {
+int TLuaInterpreter::announce(lua_State *L)
+{
     const QString text = getVerifiedString(L, __func__, 1, "text to announce");
     static const QStringList processingKinds{"importantall", "importantmostrecent", "all", "mostrecent", "currentthenmostrecent"};
     QString processing;

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -1145,7 +1145,8 @@ void TMedia::updateMediaPlayerList(std::shared_ptr<TMediaPlayer> player)
     }
 }
 
-std::shared_ptr<TMediaPlayer> TMedia::getMediaPlayer(TMediaData& mediaData) {
+std::shared_ptr<TMediaPlayer> TMedia::getMediaPlayer(TMediaData& mediaData)
+{
     QList<std::shared_ptr<TMediaPlayer>>& mediaPlayerList = findMediaPlayersByCriteria(mediaData);
 
     for (auto& existingPlayer : mediaPlayerList) {

--- a/src/TMediaPlaylist.cpp
+++ b/src/TMediaPlaylist.cpp
@@ -24,15 +24,20 @@
 #include "post_guard.h"
 
 TMediaPlaylist::TMediaPlaylist()
-    : mCurrentIndex(0), mPlaybackMode(Sequential) {}
+: mCurrentIndex(0)
+, mPlaybackMode(Sequential)
+{}
 
-TMediaPlaylist::~TMediaPlaylist() {}
+TMediaPlaylist::~TMediaPlaylist()
+{}
 
-void TMediaPlaylist::addMedia(const QUrl &url) {
+void TMediaPlaylist::addMedia(const QUrl &url)
+{
     mMediaList.append(url);
 }
 
-void TMediaPlaylist::removeMedia(int startIndex, int endIndex) {
+void TMediaPlaylist::removeMedia(int startIndex, int endIndex)
+{
     if (endIndex >= startIndex && startIndex >= 0 && endIndex < mMediaList.size()) {
         for (int i = endIndex; i >= startIndex; --i) {
             mMediaList.removeAt(i);
@@ -40,11 +45,13 @@ void TMediaPlaylist::removeMedia(int startIndex, int endIndex) {
     }
 }
 
-void TMediaPlaylist::clear() {
+void TMediaPlaylist::clear()
+{
     mMediaList.clear();
 }
 
-int TMediaPlaylist::mediaCount() const {
+int TMediaPlaylist::mediaCount() const
+{
     return mMediaList.count();
 }
 
@@ -52,22 +59,26 @@ bool TMediaPlaylist::isEmpty() const {
     return mMediaList.isEmpty();
 }
 
-void TMediaPlaylist::setPlaybackMode(PlaybackMode mode) {
+void TMediaPlaylist::setPlaybackMode(PlaybackMode mode)
+{
     mPlaybackMode = mode;
 }
 
-TMediaPlaylist::PlaybackMode TMediaPlaylist::playbackMode() const {
+TMediaPlaylist::PlaybackMode TMediaPlaylist::playbackMode() const
+{
     return mPlaybackMode;
 }
 
-QUrl TMediaPlaylist::currentMedia() const {
+QUrl TMediaPlaylist::currentMedia() const
+{
     if (!mMediaList.isEmpty() && mCurrentIndex >= 0 && mCurrentIndex < mMediaList.size()) {
         return mMediaList.at(mCurrentIndex);
     }
     return QUrl();
 }
 
-bool TMediaPlaylist::setCurrentIndex(int index) {
+bool TMediaPlaylist::setCurrentIndex(int index)
+{
     if (index >= 0 && index < mMediaList.size()) {
         mCurrentIndex = index;
         return true;
@@ -75,11 +86,13 @@ bool TMediaPlaylist::setCurrentIndex(int index) {
     return false;
 }
 
-int TMediaPlaylist::currentIndex() const {
+int TMediaPlaylist::currentIndex() const
+{
     return mCurrentIndex;
 }
 
-int TMediaPlaylist::nextIndex() const {
+int TMediaPlaylist::nextIndex() const
+{
     if (mPlaybackMode == Loop && (mCurrentIndex + 1 == mMediaList.size())) {
         return 0;
     } else if (mPlaybackMode == Random) {
@@ -90,7 +103,8 @@ int TMediaPlaylist::nextIndex() const {
     return -1; // No valid next index if out of range
 }
 
-QUrl TMediaPlaylist::next() {
+QUrl TMediaPlaylist::next()
+{
     if (mMediaList.isEmpty()) {
         return QUrl();
     }
@@ -110,7 +124,8 @@ QUrl TMediaPlaylist::next() {
     return QUrl();
 }
 
-QUrl TMediaPlaylist::previous() {
+QUrl TMediaPlaylist::previous()
+{
     if (mPlaybackMode == Loop && mCurrentIndex == 0) {
         mCurrentIndex = mMediaList.size() - 1;
     } else {

--- a/src/TScrollBox.cpp
+++ b/src/TScrollBox.cpp
@@ -36,8 +36,12 @@ TScrollBox::TScrollBox(Host* pH, QWidget* pW)
 }
 
 
-TScrollBoxWidget::TScrollBoxWidget(QWidget* pW) : QWidget(pW) {}
-TScrollBoxWidget::~TScrollBoxWidget() {}
+TScrollBoxWidget::TScrollBoxWidget(QWidget* pW)
+: QWidget(pW)
+{}
+
+TScrollBoxWidget::~TScrollBoxWidget()
+{}
 
 void TScrollBoxWidget::childEvent(QChildEvent* event)
 {

--- a/src/Tree.h
+++ b/src/Tree.h
@@ -154,7 +154,8 @@ Tree<T>::~Tree()
 }
 
 template <class T>
-void Tree<T>::setTemporary(const bool state) {
+void Tree<T>::setTemporary(const bool state)
+{
     mTemporary = state;
 }
 

--- a/src/TriggerHighlighter.cpp
+++ b/src/TriggerHighlighter.cpp
@@ -28,7 +28,8 @@ TriggerHighlighter::TriggerHighlighter(QTextDocument *parent)
     setTheme("Mudlet"); // start with the default theme
 }
 
-void TriggerHighlighter::setHighlightingEnabled(bool enabled) {
+void TriggerHighlighter::setHighlightingEnabled(bool enabled)
+{
     highlightingEnabled = enabled;
     rehighlight();
 }
@@ -107,7 +108,8 @@ void TriggerHighlighter::setTheme(const QString& themeName)
     rehighlight();
 }
 
-void TriggerHighlighter::applyFormatting(QTextCharFormat& format, edbee::TextThemeRule* rule) {
+void TriggerHighlighter::applyFormatting(QTextCharFormat& format, edbee::TextThemeRule* rule)
+{
     QColor foreground = rule->foregroundColor();
     QColor background = rule->backgroundColor();
 

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1300,7 +1300,8 @@ void XMLimport::readHost(Host* pHost)
     pHost->loadPackageInfo();
 }
 
-bool XMLimport::readDefaultTrueBool(QString name) {
+bool XMLimport::readDefaultTrueBool(QString name)
+{
     return attributes().value(name) == YES || !attributes().hasAttribute(name);
 }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2667,7 +2667,8 @@ void cTelnet::setATCPVariables(const QByteArray& msg)
 }
 
 // Helper function to parse the GUI version from JSON
-QString cTelnet::parseGUIVersionFromJSON(const QJsonObject& json) {
+QString cTelnet::parseGUIVersionFromJSON(const QJsonObject& json)
+{
     QString version;
     auto versionJSON = json.value(qsl("version"));
 
@@ -2681,7 +2682,8 @@ QString cTelnet::parseGUIVersionFromJSON(const QJsonObject& json) {
 }
 
 // Helper function to parse the GUI URL from JSON
-QString cTelnet::parseGUIUrlFromJSON(const QJsonObject& json) {
+QString cTelnet::parseGUIUrlFromJSON(const QJsonObject& json)
+{
     QString url;
     auto urlJSON = json.value(qsl("url"));
 
@@ -2693,7 +2695,8 @@ QString cTelnet::parseGUIUrlFromJSON(const QJsonObject& json) {
 }
 
 // Helper function to download and install the GUI package
-void cTelnet::downloadAndInstallGUIPackage(const QString& packageName, const QString& fileName, const QString& url) {
+void cTelnet::downloadAndInstallGUIPackage(const QString& packageName, const QString& fileName, const QString& url)
+{
     postMessage(tr("[ INFO ]  - Downloading and installing package '%1' (url='%2').").arg(packageName, url));
 
     mServerPackage = mudlet::getMudletPath(enums::profileDataItemPath, mProfileName, fileName);
@@ -2711,7 +2714,8 @@ void cTelnet::downloadAndInstallGUIPackage(const QString& packageName, const QSt
 }
 
 // Main logic for handling GUI package installation and upgrades
-void cTelnet::handleGUIPackageInstallationAndUpgrade(QJsonDocument document) {
+void cTelnet::handleGUIPackageInstallationAndUpgrade(QJsonDocument document)
+{
     // Parse the JSON response
     auto json = document.object();
     if (json.isEmpty()) {

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -1593,8 +1593,12 @@ void dlgPackageExporter::slot_cancelExport()
 }
 
 //Description Class TextEdit
-dlgPackageExporterDescription::dlgPackageExporterDescription(QWidget* pW) : QTextEdit(pW) {}
-dlgPackageExporterDescription::~dlgPackageExporterDescription() {}
+dlgPackageExporterDescription::dlgPackageExporterDescription(QWidget* pW)
+: QTextEdit(pW)
+{}
+
+dlgPackageExporterDescription::~dlgPackageExporterDescription()
+{}
 
 bool dlgPackageExporterDescription::canInsertFromMimeData(const QMimeData* source) const
 {

--- a/src/mapInfoContributorManager.cpp
+++ b/src/mapInfoContributorManager.cpp
@@ -52,7 +52,8 @@ bool MapInfoContributorManager::removeContributor(const QString& name)
     return contributors.remove(name) > 0;
 }
 
-bool MapInfoContributorManager::enableContributor(const QString &name) {
+bool MapInfoContributorManager::enableContributor(const QString &name)
+{
     if (!contributors.contains(name)) {
         return false;
     }
@@ -62,7 +63,8 @@ bool MapInfoContributorManager::enableContributor(const QString &name) {
     return true;
 }
 
-bool MapInfoContributorManager::disableContributor(const QString &name) {
+bool MapInfoContributorManager::disableContributor(const QString &name)
+{
     if (!contributors.contains(name)) {
         return false;
     }

--- a/src/uiawrapper.cpp
+++ b/src/uiawrapper.cpp
@@ -26,76 +26,84 @@
 
 // this class is largely inspired from Qt's QWindowsUiaWrapper:
 // https://github.com/qt/qtbase/blob/dev/src/gui/accessible/windows/apisupport/qwindowsuiawrapper.cpp
-UiaWrapper::UiaWrapper() {
-  QLibrary uiaLibrary(qsl("UIAutomationCore"));
-  if (uiaLibrary.load()) {
-    m_pUiaRaiseNotificationEvent =
-        reinterpret_cast<PtrUiaRaiseNotificationEvent>(
-            uiaLibrary.resolve("UiaRaiseNotificationEvent"));
-    m_pUiaDisconnectAllProviders =
-        reinterpret_cast<PtrUiaDisconnectAllProviders>(
-            uiaLibrary.resolve("UiaDisconnectAllProviders"));
-    m_pUiaDisconnectProvider = reinterpret_cast<PtrUiaDisconnectProvider>(
-        uiaLibrary.resolve("UiaDisconnectProvider"));
-    m_pUiaHostProviderFromHwnd = reinterpret_cast<PtrUiaHostProviderFromHwnd>(
-        uiaLibrary.resolve("UiaHostProviderFromHwnd"));
-    m_pUiaClientsAreListening = reinterpret_cast<PtrUiaClientsAreListening>(
-        uiaLibrary.resolve("UiaClientsAreListening"));
-  }
+UiaWrapper::UiaWrapper()
+{
+    QLibrary uiaLibrary(qsl("UIAutomationCore"));
+    if (uiaLibrary.load()) {
+        m_pUiaRaiseNotificationEvent =
+                reinterpret_cast<PtrUiaRaiseNotificationEvent>(
+                        uiaLibrary.resolve("UiaRaiseNotificationEvent"));
+        m_pUiaDisconnectAllProviders =
+                reinterpret_cast<PtrUiaDisconnectAllProviders>(
+                        uiaLibrary.resolve("UiaDisconnectAllProviders"));
+        m_pUiaDisconnectProvider = reinterpret_cast<PtrUiaDisconnectProvider>(
+                uiaLibrary.resolve("UiaDisconnectProvider"));
+        m_pUiaHostProviderFromHwnd = reinterpret_cast<PtrUiaHostProviderFromHwnd>(
+                uiaLibrary.resolve("UiaHostProviderFromHwnd"));
+        m_pUiaClientsAreListening = reinterpret_cast<PtrUiaClientsAreListening>(
+                uiaLibrary.resolve("UiaClientsAreListening"));
+    }
 }
 
-UiaWrapper::~UiaWrapper(){};
+UiaWrapper::~UiaWrapper()
+{}
 
-UiaWrapper *UiaWrapper::self() {
-  static UiaWrapper wrapper;
-  return &wrapper;
+UiaWrapper *UiaWrapper::self()
+{
+    static UiaWrapper wrapper;
+    return &wrapper;
 }
 
-BOOL UiaWrapper::ready() {
-  return m_pUiaRaiseNotificationEvent && m_pUiaDisconnectAllProviders &&
-         m_pUiaDisconnectProvider && m_pUiaHostProviderFromHwnd &&
-         m_pUiaClientsAreListening;
+BOOL UiaWrapper::ready()
+{
+    return m_pUiaRaiseNotificationEvent && m_pUiaDisconnectAllProviders &&
+           m_pUiaDisconnectProvider && m_pUiaHostProviderFromHwnd &&
+           m_pUiaClientsAreListening;
 }
 
 HRESULT UiaWrapper::raiseNotificationEvent(
-    IRawElementProviderSimple *provider, NotificationKind notificationKind,
-    NotificationProcessing notificationProcessing, BSTR displayString,
-    BSTR activityId) {
-  if (!m_pUiaRaiseNotificationEvent) {
-    return UIA_E_NOTSUPPORTED;
-  }
+        IRawElementProviderSimple *provider, NotificationKind notificationKind,
+        NotificationProcessing notificationProcessing, BSTR displayString,
+        BSTR activityId)
+{
+    if (!m_pUiaRaiseNotificationEvent) {
+        return UIA_E_NOTSUPPORTED;
+    }
 
-  return m_pUiaRaiseNotificationEvent(provider, notificationKind,
-                                      notificationProcessing, displayString,
-                                      activityId);
+    return m_pUiaRaiseNotificationEvent(provider, notificationKind,
+                                        notificationProcessing, displayString,
+                                        activityId);
 }
 
-HRESULT UiaWrapper::disconnectAllProviders() {
-  if (!m_pUiaDisconnectAllProviders) {
-    return UIA_E_NOTSUPPORTED;
-  }
-  return m_pUiaDisconnectAllProviders();
+HRESULT UiaWrapper::disconnectAllProviders()
+{
+    if (!m_pUiaDisconnectAllProviders) {
+        return UIA_E_NOTSUPPORTED;
+    }
+    return m_pUiaDisconnectAllProviders();
 }
 
-HRESULT UiaWrapper::disconnectProvider(IRawElementProviderSimple *pProvider) {
-  if (!m_pUiaDisconnectProvider) {
-    return UIA_E_NOTSUPPORTED;
-  }
-  return m_pUiaDisconnectProvider(pProvider);
+HRESULT UiaWrapper::disconnectProvider(IRawElementProviderSimple *pProvider)
+{
+    if (!m_pUiaDisconnectProvider) {
+        return UIA_E_NOTSUPPORTED;
+    }
+    return m_pUiaDisconnectProvider(pProvider);
 }
 
-BOOL UiaWrapper::clientsAreListening() {
-  if (!m_pUiaClientsAreListening) {
-    return FALSE;
-  }
-  return m_pUiaClientsAreListening();
+BOOL UiaWrapper::clientsAreListening()
+{
+    if (!m_pUiaClientsAreListening) {
+        return FALSE;
+    }
+    return m_pUiaClientsAreListening();
 }
 
-HRESULT
-UiaWrapper::hostProviderFromHwnd(HWND hwnd,
-                                 IRawElementProviderSimple **ppProvider) {
-  if (!m_pUiaHostProviderFromHwnd) {
-    return UIA_E_NOTSUPPORTED;
-  }
-  return m_pUiaHostProviderFromHwnd(hwnd, ppProvider);
+HRESULT UiaWrapper::hostProviderFromHwnd(HWND hwnd,
+                                         IRawElementProviderSimple **ppProvider)
+{
+    if (!m_pUiaHostProviderFromHwnd) {
+        return UIA_E_NOTSUPPORTED;
+    }
+    return m_pUiaHostProviderFromHwnd(hwnd, ppProvider);
 }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR adds a missing Line-Feed to those methods that are missing them after the closing `)` or the `) const` of the arguments to that method.

#### Motivation for adding to Mudlet
We intend for the opening `{` to be in the first column of the next line but some PRs in the past have added methods (functions) where this hasn't been done and this is not something that the `clang-format` that we bundle can fix-up for us automatically.

#### Other info (issues closed, discussion etc)