### PR TITLE
Fix: get Mudlet compiling with Qt 6.9

### DIFF
--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -768,7 +768,11 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
             } else if (oldCharacterCode > 32) {
                 // There is an old format unsigned short represeting a printable
                 // ASCII or ISO 8859-1 (Latin1) character:
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+                mSymbol = QChar(static_cast<uint>(oldCharacterCode));
+#else
                 mSymbol = QChar(oldCharacterCode);
+#endif
             }
         }
     }
@@ -1137,11 +1141,11 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
             const int exitRoomId = it.value();
             if (exitName.isEmpty()) {
                 if (mudlet::self()->showMapAuditErrors()) {
-                    const QString warnMsg = tr("[ WARN ]  - In room id:%1 removing invalid (special) exit to %2 {with no name!}").arg(id, 6, QLatin1Char('0')).arg(exitRoomId, 6, QLatin1Char('0'));
+                    const QString warnMsg = tr("[ WARN ]  - In room id:%1 removing invalid (special) exit to %2 {with no name!}").arg(id, 6, 10, QLatin1Char('0')).arg(exitRoomId, 6, 10, QLatin1Char('0'));
                     // If size is less than or equal to 0 then there is nothing to print!!!
                     mpRoomDB->mpMap->postMessage(warnMsg);
                 }
-                mpRoomDB->mpMap->appendRoomErrorMsg(id, tr("[ WARN ]  - Room had an invalid (special) exit to %1 {with no name!} it was removed.").arg(exitRoomId, 6, QLatin1Char('0')));
+                mpRoomDB->mpMap->appendRoomErrorMsg(id, tr("[ WARN ]  - Room had an invalid (special) exit to %1 {with no name!} it was removed.").arg(exitRoomId, 6, 10, QLatin1Char('0')));
                 it.remove();
                 continue;
             }

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2512,9 +2512,23 @@ void TTextEdit::slot_analyseSelection()
                 utf16Vals.append(
                         qsl("<td colspan=\"%1\" style=\"white-space:no-wrap vertical-align:top\"><center>%2</center>&#8232;<center>(0x%3:0x%4)</center></td>")
                                 .arg(QString::number(columnsToUse))
-                                .arg(qsl("%1").arg(QChar::surrogateToUcs4(mpBuffer->lineBuffer.at(line).at(index), mpBuffer->lineBuffer.at(line).at(index + 1)), 4, 16, zero).toUpper())
-                                .arg(mpBuffer->lineBuffer.at(line).at(index).unicode(), 4, 16, zero)
-                                .arg(mpBuffer->lineBuffer.at(line).at(index + 1).unicode(), 4, 16, zero));
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+                                .arg(qsl("%1").arg(static_cast<uint32_t>(QChar::surrogateToUcs4(mpBuffer->lineBuffer.at(line).at(index),
+                                                                                                mpBuffer->lineBuffer.at(line).at(index + 1))),
+                                                   4, 16, zero).toUpper())
+                                .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index).unicode()),
+                                     4, 16, zero)
+                                .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index + 1).unicode()),
+                                     4, 16, zero));
+#else
+                                .arg(qsl("%1").arg(QChar::surrogateToUcs4(mpBuffer->lineBuffer.at(line).at(index),
+                                                                          mpBuffer->lineBuffer.at(line).at(index + 1)),
+                                                   4, 16, zero).toUpper())
+                                .arg(mpBuffer->lineBuffer.at(line).at(index).unicode(),
+                                     4, 16, zero)
+                                .arg(mpBuffer->lineBuffer.at(line).at(index + 1).unicode(),
+                                     4, 16, zero));
+#endif
 
                 // Note the addition to the index here to jump over the low-surrogate:
                 graphemes.append(qsl("<td colspan=\"%1\">%2</td>")
@@ -2586,8 +2600,15 @@ void TTextEdit::slot_analyseSelection()
 
                 utf16Vals.append(qsl("<td colspan=\"%1\" style=\"white-space:no-wrap vertical-align:top\"><center>%2</center></td>")
                                          .arg(QString::number(columnsToUse))
-                                         .arg(mpBuffer->lineBuffer.at(line).at(index).unicode(), 4, 16, QChar('0'))
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+                                         .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index).unicode()),
+                                              4, 16, QChar('0'))
                                          .toUpper());
+#else
+                                         .arg(mpBuffer->lineBuffer.at(line).at(index).unicode(),
+                                              4, 16, QChar('0'))
+                                         .toUpper());
+#endif
 
                 graphemes.append(qsl("<td colspan=\"%1\">%2</td>").arg(QString::number(columnsToUse), convertWhitespaceToVisual(mpBuffer->lineBuffer.at(line).at(index))));
             }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Revised codebase to compile with latest Qt version which modified the QChar constructors such that some casts are needed now to keep things working. This also revealed a bug in:
`(void) TRoom::auditExits(const QHash<int, int>)` where there was a missing `10` as a number base argument which was silently being mishandled in prior versions of Qt.

#### Motivation for adding to Mudlet
Immediately needed for Windows x64 builds but will eventually be needed for all builds to compile.

#### Other info (issues closed, discussion etc)
Has only come to notice in the last 24 hours but is **HIGH** priority/ urgent.