### PR TITLE
Infra: switch to linuxdeploy

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -27,7 +27,7 @@ jobs:
             buildname: 'ubuntu / gcc / lua tests'
             triplet: x64-linux
             compiler: gcc_64
-            gcc_compiler_version: 12
+            gcc_compiler_version: 10
             qt: '6.8.1'
             deploy: 'deploy'
             run_tests: 'true'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -23,11 +23,11 @@ jobs:
       matrix:
         include:
           # oldest OS supported for maximum compatibility of built AppImage
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             buildname: 'ubuntu / gcc / lua tests'
             triplet: x64-linux
             compiler: gcc_64
-            gcc_compiler_version: 10
+            gcc_compiler_version: 12
             qt: '6.8.1'
             deploy: 'deploy'
             run_tests: 'true'
@@ -35,7 +35,7 @@ jobs:
             buildname: 'ubuntu / clang'
             triplet: x64-linux
             compiler: clang_64
-            gcc_compiler_version: 10
+            gcc_compiler_version: 12
             qt: '6.8.1'
           - os: macos-13
             buildname: 'macos (x86_64) / c++ / lua tests'
@@ -63,14 +63,6 @@ jobs:
       with:
         submodules: true
         fetch-depth: 0
-
-    - name: Manually install old version of the python wheel package
-      run: |
-        pip install 'wheel<0.46.0' --force-reinstall -v
-        # We need to install older wheel otherwise the below will fail
-        # with "invalid command 'bdist_wheel'"
-        # See https://github.com/jurplel/install-qt-action/issues/281
-      shell: bash
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v4

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -28,7 +28,7 @@ jobs:
             triplet: x64-linux
             compiler: gcc_64
             gcc_compiler_version: 12
-            qt: '6.8.1'
+            qt: '6.9.0'
             deploy: 'deploy'
             run_tests: 'true'
           - os: ubuntu-latest
@@ -69,8 +69,9 @@ jobs:
       with:
         version: ${{matrix.qt}}
         dir: ${{runner.workspace}}
-        cache: true
-        modules: qt5compat qtmultimedia
+        cache: 'false'
+        setup-python: 'false'
+        modules: 'qt5compat qtmultimedia'
 
     - name: Restore Boost cache
       id: restore-boost

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -31,7 +31,7 @@ jobs:
             triplet: x64-linux
             compiler: gcc_64
             # 22.04 provides 10.5.0; 11.4.0 and 12.3.0; 20.04 provided 10.5.0
-            gcc_compiler_version: 12
+            gcc_compiler_version: 10
             qt: '6.9.0'
             # This triggers the process that ends up running the make-installer
             # script in the installer repository part:

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -64,10 +64,10 @@ jobs:
         submodules: true
         fetch-depth: 0
 
-    - name: Manually install python wheel
+    - name: Manually install old version of the python wheel package
       run: |
-        pip install wheel
-        # We need to install wheel otherwise the below will fail
+        pip install 'wheel<0.46.0' --force-reinstall -v
+        # We need to install older wheel otherwise the below will fail
         # with "invalid command 'bdist_wheel'"
         # See https://github.com/jurplel/install-qt-action/issues/281
       shell: bash

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -27,7 +27,7 @@ jobs:
             buildname: 'ubuntu / gcc / lua tests'
             triplet: x64-linux
             compiler: gcc_64
-            gcc_compiler_version: 10
+            gcc_compiler_version: 12
             qt: '6.8.1'
             deploy: 'deploy'
             run_tests: 'true'
@@ -35,20 +35,20 @@ jobs:
             buildname: 'ubuntu / clang'
             triplet: x64-linux
             compiler: clang_64
-            gcc_compiler_version: 10
-            qt: '6.8.1'
+            gcc_compiler_version: 12
+            qt: '6.9.0'
           - os: macos-13
             buildname: 'macos (x86_64) / c++ / lua tests'
             triplet: x64-osx
             compiler: clang_64
-            qt: '6.8.1'
+            qt: '6.9.0'
             deploy: 'deploy'
             run_tests: 'true'
           - os: macos-14
             buildname: 'macos (arm64) / c++ / lua tests'
             triplet: arm64-osx
             compiler: clang_64
-            qt: '6.8.1'
+            qt: '6.9.0'
             deploy: 'deploy'
             run_tests: 'true'
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -23,32 +23,32 @@ jobs:
       matrix:
         include:
           # oldest OS supported for maximum compatibility of built AppImage
-          - os: ubuntu-22.04
+          - os: ubuntu-20.04
             buildname: 'ubuntu / gcc / lua tests'
             triplet: x64-linux
             compiler: gcc_64
-            gcc_compiler_version: 12
-            qt: '6.9.0'
+            gcc_compiler_version: 10
+            qt: '6.8.1'
             deploy: 'deploy'
             run_tests: 'true'
           - os: ubuntu-latest
             buildname: 'ubuntu / clang'
             triplet: x64-linux
             compiler: clang_64
-            gcc_compiler_version: 12
-            qt: '6.9.0'
+            gcc_compiler_version: 10
+            qt: '6.8.1'
           - os: macos-13
             buildname: 'macos (x86_64) / c++ / lua tests'
             triplet: x64-osx
             compiler: clang_64
-            qt: '6.9.0'
+            qt: '6.8.1'
             deploy: 'deploy'
             run_tests: 'true'
           - os: macos-14
             buildname: 'macos (arm64) / c++ / lua tests'
             triplet: arm64-osx
             compiler: clang_64
-            qt: '6.9.0'
+            qt: '6.8.1'
             deploy: 'deploy'
             run_tests: 'true'
 
@@ -69,8 +69,6 @@ jobs:
       with:
         version: ${{matrix.qt}}
         dir: ${{runner.workspace}}
-        cache: 'false'
-        setup-python: 'false'
         modules: 'qt5compat qtmultimedia'
 
     - name: Restore Boost cache

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -30,15 +30,22 @@ jobs:
             buildname: 'ubuntu / gcc / lua tests'
             triplet: x64-linux
             compiler: gcc_64
-            gcc_compiler_version: 10
+            # 22.04 provides 10.5.0; 11.4.0 and 12.3.0
+            # 20.04 provided 10.5.0
+            gcc_compiler_version: 12
             qt: '6.9.0'
+            # This triggers the process that ends up running the make-installer
+            # script in the installer repository part:
             deploy: 'deploy'
             run_tests: 'true'
           - os: ubuntu-latest
             buildname: 'ubuntu / clang'
             triplet: x64-linux
+            # 24.04 provides 16.0.6, 17.0.6, 18.1.3
+            # (with 19 being added and becoming the default from 2025-05-09)
             compiler: clang_64
-            gcc_compiler_version: 12
+            # 24.04 provides 12.3.0; 13.3.0 and 14.2.0
+            gcc_compiler_version: 14
             qt: '6.9.0'
           - os: macos-13
             buildname: 'macos (x86_64) / c++, lua tests'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         include:
           # oldest OS supported for maximum compatibility of built AppImage
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             buildname: 'ubuntu / gcc / lua tests'
             triplet: x64-linux
             compiler: gcc_64
@@ -38,14 +38,14 @@ jobs:
             gcc_compiler_version: 10
             qt: '6.8.1'
           - os: macos-13
-            buildname: 'macos (x86_64) / c++, lua tests'
+            buildname: 'macos (x86_64) / c++ / lua tests'
             triplet: x64-osx
             compiler: clang_64
             qt: '6.8.1'
             deploy: 'deploy'
             run_tests: 'true'
           - os: macos-14
-            buildname: 'macos (arm64) / c++, lua tests'
+            buildname: 'macos (arm64) / c++ / lua tests'
             triplet: arm64-osx
             compiler: clang_64
             qt: '6.8.1'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -30,8 +30,7 @@ jobs:
             buildname: 'ubuntu / gcc / lua tests'
             triplet: x64-linux
             compiler: gcc_64
-            # 22.04 provides 10.5.0; 11.4.0 and 12.3.0
-            # 20.04 provided 10.5.0
+            # 22.04 provides 10.5.0; 11.4.0 and 12.3.0; 20.04 provided 10.5.0
             gcc_compiler_version: 12
             qt: '6.9.0'
             # This triggers the process that ends up running the make-installer

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -64,13 +64,11 @@ jobs:
         submodules: true
         fetch-depth: 0
 
-    - name: Install wheel manually to fix next steps
-    # We need to install wheel otherwise the below will fail
-    # with "invalid command 'bdist_wheel'"
-    # See https://github.com/jurplel/install-qt-action/issues/281
-    - run: pip install wheel
-
     - name: Install Qt
+      run: pip install wheel
+      # We need to install wheel otherwise the below will fail
+      # with "invalid command 'bdist_wheel'"
+      # See https://github.com/jurplel/install-qt-action/issues/281
       uses: jurplel/install-qt-action@v4
       with:
         version: ${{matrix.qt}}

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -38,14 +38,14 @@ jobs:
             gcc_compiler_version: 12
             qt: '6.8.1'
           - os: macos-13
-            buildname: 'macos (x86_64) / c++ / lua tests'
+            buildname: 'macos (x86_64) / c++, lua tests'
             triplet: x64-osx
             compiler: clang_64
             qt: '6.8.1'
             deploy: 'deploy'
             run_tests: 'true'
           - os: macos-14
-            buildname: 'macos (arm64) / c++ / lua tests'
+            buildname: 'macos (arm64) / c++, lua tests'
             triplet: arm64-osx
             compiler: clang_64
             qt: '6.8.1'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -64,11 +64,14 @@ jobs:
         submodules: true
         fetch-depth: 0
 
+    - name: Manually install python wheel
+      run: |
+        pip install wheel
+        # We need to install wheel otherwise the below will fail
+        # with "invalid command 'bdist_wheel'"
+        # See https://github.com/jurplel/install-qt-action/issues/281
+
     - name: Install Qt
-      run: pip install wheel
-      # We need to install wheel otherwise the below will fail
-      # with "invalid command 'bdist_wheel'"
-      # See https://github.com/jurplel/install-qt-action/issues/281
       uses: jurplel/install-qt-action@v4
       with:
         version: ${{matrix.qt}}

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -79,6 +79,7 @@ jobs:
         version: ${{matrix.qt}}
         dir: ${{runner.workspace}}
         modules: 'qt5compat qtmultimedia'
+        setup-python: 'false'
 
     - name: Restore Boost cache
       id: restore-boost

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -70,6 +70,7 @@ jobs:
         # We need to install wheel otherwise the below will fail
         # with "invalid command 'bdist_wheel'"
         # See https://github.com/jurplel/install-qt-action/issues/281
+      shell: bash
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v4

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -64,6 +64,12 @@ jobs:
         submodules: true
         fetch-depth: 0
 
+    - name: Install wheel manually to fix next steps
+    # We need to install wheel otherwise the below will fail
+    # with "invalid command 'bdist_wheel'"
+    # See https://github.com/jurplel/install-qt-action/issues/281
+    - run: pip install wheel
+
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:

--- a/CI/travis.after_success.sh
+++ b/CI/travis.after_success.sh
@@ -22,7 +22,7 @@ else
   # Not a release build so include the details including the Git SHA1 in the message
   echo "Finished building Mudlet ${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}"
 fi
-if [ ! -z "${DEPLOY_URL}" ]; then
+if [ -n "${DEPLOY_URL}" ]; then
   echo "Deployed the output to ${DEPLOY_URL}"
 fi
 echo ""

--- a/CI/travis.install.sh
+++ b/CI/travis.install.sh
@@ -8,7 +8,7 @@ if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
   echo Install on linux.
   source CI/travis.linux.install.sh;
 fi
-if [ ! -z "${CXX}" ]; then
+if [ -n "${CXX}" ]; then
   echo "Testing (possibly updated) compiler version:"
   ${CXX} --version;
 fi

--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -7,7 +7,7 @@ BUILD_DIR="${BUILD_FOLDER}"
 SOURCE_DIR="${GITHUB_WORKSPACE}"
 
 if [[ "${MUDLET_VERSION_BUILD}" == -ptb* ]]; then
-  public_test_build="true"
+  PUBLIC_TEST_BUILD="true"
 fi
 
 # we deploy only if told to deploy or we run a cron+clang+cmake job (for PTB)
@@ -16,7 +16,7 @@ if { [ "${DEPLOY}" = "deploy" ]; } \
 then
 
 # coverity is currently defunct as it was dependent on our travis infrastructure. See #4887
-#  if [ "$TRAVIS_EVENT_TYPE" = "cron" ] && [ "${DEPLOY}" = "deploy" ]; then
+#  if [ "${TRAVIS_EVENT_TYPE}" = "cron" ] && [ "${DEPLOY}" = "deploy" ]; then
 #    # instead of deployment, we upload to coverity for cron jobs
 #    cd build
 #    tar czf Mudlet.tgz cov-int
@@ -35,26 +35,27 @@ then
 #      echo Upload to Coverity failed, curl returned $CURL_RESULT
 #      exit 1
 #    fi
-#    exit
+#    exit 0
 #  fi
 
   # We refer to $BUILD_COMMIT in the environment to get the commit data now
   COMMIT_DATE=$(git show -s --format="%cs" | tr -d '-')
   YESTERDAY_DATE=$(date -d "yesterday" '+%F' | tr -d '-')
 
-  git clone https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
+  # TODO: revert to master branch once https://github.com/Mudlet/installers/pull/123 is merged:
+  git clone --branch Improve_switchTo_linuxdeploy https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
 
-  cd "${BUILD_DIR}/../installers/generic-linux"
+  cd "${BUILD_DIR}/../installers/generic-linux" || exit 1
 
   ln -s "${BUILD_DIR}" source
 
-  # unset LD_LIBRARY_PATH as it upsets linuxdeployqt
-  export LD_LIBRARY_PATH=
+  # unset LD_LIBRARY_PATH as it upsets linuxdeployqt - CHECK whether linuxdeploy is also upset?
+  # export LD_LIBRARY_PATH=
 
-  if ! [[ "$GITHUB_REF" =~ ^"refs/tags/" ]] && [ "${public_test_build}" != "true" ]; then
+  if ! [[ "${GITHUB_REF}" =~ ^"refs/tags/" ]] && [ "${PUBLIC_TEST_BUILD}" != "true" ]; then
     echo "== Creating a snapshot build =="
     ./make-installer.sh "${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}"
-    cd "${BUILD_DIR}/../installers/generic-linux"
+    cd "${BUILD_DIR}/../installers/generic-linux" || exit 1
 
     chmod +x "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}.AppImage"
     tar -cvf "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-linux-x64.AppImage.tar" "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}.AppImage"
@@ -67,11 +68,11 @@ then
     {
       echo "FOLDER_TO_UPLOAD=$(pwd)/upload"
       echo "UPLOAD_FILENAME=Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-linux-x64"
-    } >> "$GITHUB_ENV"
-    DEPLOY_URL="Github artifact, see https://github.com/$GITHUB_REPOSITORY/runs/$GITHUB_RUN_ID"
+    } >> "${GITHUB_ENV}"
+    DEPLOY_URL="Github artifact, see https://github.com/${GITHUB_REPOSITORY}/runs/${GITHUB_RUN_ID}"
 
   else # ptb/release build
-    if [ "${public_test_build}" == "true" ]; then
+    if [ "${PUBLIC_TEST_BUILD}" == "true" ]; then
 
       if [[ "${COMMIT_DATE}" -lt "${YESTERDAY_DATE}" ]]; then
         echo "== No new commits, aborting public test build generation =="
@@ -83,40 +84,40 @@ then
       echo "== Creating a release build =="
     fi
 
-    if [ "${public_test_build}" == "true" ]; then
+    if [ "${PUBLIC_TEST_BUILD}" == "true" ]; then
       ./make-installer.sh -pr "${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}"
     else
       ./make-installer.sh -r "${VERSION}"
     fi
 
-    if [ "${public_test_build}" == "true" ]; then
+    if [ "${PUBLIC_TEST_BUILD}" == "true" ]; then
       chmod +x "Mudlet PTB.AppImage"
     else
       chmod +x "Mudlet.AppImage"
     fi
 
-    if [ "${public_test_build}" == "true" ]; then
+    if [ "${PUBLIC_TEST_BUILD}" == "true" ]; then
       tar -cvf "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-linux-x64.AppImage.tar" "Mudlet PTB.AppImage"
     else
       tar -cvf "Mudlet-${VERSION}-linux-x64.AppImage.tar" "Mudlet.AppImage"
     fi
 
-    if [ "${public_test_build}" == "true" ]; then
+    if [ "${PUBLIC_TEST_BUILD}" == "true" ]; then
       echo "=== Setting up for Github upload ==="
       mkdir "upload/"
       mv "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-linux-x64.AppImage.tar" "upload/"
       {
         echo "FOLDER_TO_UPLOAD=$(pwd)/upload"
         echo "UPLOAD_FILENAME=Mudlet-$VERSION$MUDLET_VERSION_BUILD-${BUILD_COMMIT}-linux-x64"
-      } >> "$GITHUB_ENV"
+      } >> "${GITHUB_ENV}"
       DEPLOY_URL="Github artifact, see https://github.com/$GITHUB_REPOSITORY/runs/$GITHUB_RUN_ID"
     else
       echo "=== Uploading installer to https://www.mudlet.org/wp-content/files/?C=M;O=D ==="
       scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "Mudlet-${VERSION}-linux-x64.AppImage.tar" "mudmachine@mudlet.org:${DEPLOY_PATH}"
 
       DEPLOY_URL="https://www.mudlet.org/wp-content/files/Mudlet-${VERSION}-linux-x64.AppImage.tar"
-      if ! curl --output /dev/null --silent --head --fail "$DEPLOY_URL"; then
-        echo "Error: release not found as expected at $DEPLOY_URL"
+      if ! curl --output /dev/null --silent --head --fail "${DEPLOY_URL}"; then
+        echo "Error: release not found as expected at ${DEPLOY_URL}"
         exit 1
       fi
 
@@ -125,23 +126,23 @@ then
       DEPLOY_URL="https://www.mudlet.org/wp-content/files/Mudlet-${VERSION}-linux-x64.AppImage.tar"
 
       SHA256SUM=$(shasum -a 256 "Mudlet-${VERSION}-linux-x64.AppImage.tar" | awk '{print $1}')
-      current_timestamp=$(date "+%-d %-m %Y %-H %-M %-S")
-      read -r day month year hour minute second <<< "$current_timestamp"
+      CURRENT_TIMESTAMP=$(date "+%-d %-m %Y %-H %-M %-S")
+      read -r DAY MONTH YEAR HOUR MINUTE SECOND <<< "${CURRENT_TIMESTAMP}"
 
       curl --retry 5 -X POST 'https://www.mudlet.org/download-add.php' \
-      -H "x-wp-download-token: $X_WP_DOWNLOAD_TOKEN" \
+      -H "x-wp-download-token: ${X_WP_DOWNLOAD_TOKEN}" \
       -F "file_type=2" \
-      -F "file_remote=$DEPLOY_URL" \
+      -F "file_remote=${DEPLOY_URL}" \
       -F "file_name=Mudlet ${VERSION} (Linux)" \
-      -F "file_des=sha256: $SHA256SUM" \
+      -F "file_des=sha256: ${SHA256SUM}" \
       -F "file_cat=5" \
       -F "file_permission=-1" \
-      -F "file_timestamp_day=$day" \
-      -F "file_timestamp_month=$month" \
-      -F "file_timestamp_year=$year" \
-      -F "file_timestamp_hour=$hour" \
-      -F "file_timestamp_minute=$minute" \
-      -F "file_timestamp_second=$second" \
+      -F "file_timestamp_day=${DAY}" \
+      -F "file_timestamp_month=${MONTH}" \
+      -F "file_timestamp_year=${YEAR}" \
+      -F "file_timestamp_hour=${HOUR}" \
+      -F "file_timestamp_minute=${MINUTE}" \
+      -F "file_timestamp_second=${SECOND}" \
       -F "output=json" \
       -F "do=Add File"
     fi
@@ -150,16 +151,16 @@ then
     sudo npm install -g dblsqd-cli
     dblsqd login -e "https://api.dblsqd.com/v1/jsonrpc" -u "${DBLSQD_USER}" -p "${DBLSQD_PASS}"
 
-    if [ "${public_test_build}" == "true" ]; then
+    if [ "${PUBLIC_TEST_BUILD}" == "true" ]; then
       echo "=== Downloading release feed ==="
-      downloadedfeed=$(mktemp)
-      wget "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/linux/x86_64" --output-document="$downloadedfeed"
+      DONWLOADFEED=$(mktemp)
+      wget "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/linux/x86_64" --output-document="${DONWLOADFEED}"
       echo "=== Generating a changelog ==="
-      cd "${SOURCE_DIR}" || exit
-      changelog=$(lua "${SOURCE_DIR}/CI/generate-changelog.lua" --mode ptb --releasefile "${downloadedfeed}")
+      cd "${SOURCE_DIR}" || exit 1
+      CHANGELONG=$(lua "${SOURCE_DIR}/CI/generate-changelog.lua" --mode ptb --releasefile "${DONWLOADFEED}")
 
       echo "=== Creating release in Dblsqd ==="
-      dblsqd release -a mudlet -c public-test-build -m "${changelog}" "${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}" || true
+      dblsqd release -a mudlet -c public-test-build -m "${CHANGELONG}" "${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}" || true
 
       # release registration and uploading will be manual for the time being
     else
@@ -167,13 +168,13 @@ then
       dblsqd push -a mudlet -c release -r "${VERSION}" -s mudlet --type "standalone" --attach linux:x86_64 "${DEPLOY_URL}"
     fi
 
-    if [ "${public_test_build}" != "true" ]; then
+    if [ "${PUBLIC_TEST_BUILD}" != "true" ]; then
       # generate and deploy source tarball
-      cd "${HOME}" || exit
+      cd "${HOME}" || exit 1
       # get the archive script
       wget https://raw.githubusercontent.com/meitar/git-archive-all.sh/master/git-archive-all.sh
 
-      cd "${SOURCE_DIR}" || exit
+      cd "${SOURCE_DIR}" || exit 1
       # generate and upload the tarball
       chmod +x "${HOME}/git-archive-all.sh"
       "${HOME}/git-archive-all.sh" "Mudlet-${VERSION}.tar"
@@ -181,8 +182,8 @@ then
       scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "Mudlet-${VERSION}.tar.xz" "mudmachine@mudlet.org:${DEPLOY_PATH}"
       FILE_URL="https://www.mudlet.org/wp-content/files/Mudlet-${VERSION}.tar.xz"
       SHA256SUM=$(shasum -a 256 "Mudlet-${VERSION}.tar.xz" | awk '{print $1}')
-      current_timestamp=$(date "+%-d %-m %Y %-H %-M %-S")
-      read -r day month year hour minute second <<< "$current_timestamp"
+      CURRENT_TIMESTAMP=$(date "+%-d %-m %Y %-H %-M %-S")
+      read -r DAY MONTH YEAR HOUR MINUTE SECOND <<< "${CURRENT_TIMESTAMP}"
 
       curl --retry 5 -X POST 'https://www.mudlet.org/download-add.php' \
       -H "x-wp-download-token: $X_WP_DOWNLOAD_TOKEN" \
@@ -192,12 +193,12 @@ then
       -F "file_des=sha256: $SHA256SUM" \
       -F "file_cat=6" \
       -F "file_permission=-1" \
-      -F "file_timestamp_day=$day" \
-      -F "file_timestamp_month=$month" \
-      -F "file_timestamp_year=$year" \
-      -F "file_timestamp_hour=$hour" \
-      -F "file_timestamp_minute=$minute" \
-      -F "file_timestamp_second=$second" \
+      -F "file_timestamp_day=${DAY}" \
+      -F "file_timestamp_month=${MONTH}" \
+      -F "file_timestamp_year=${YEAR}" \
+      -F "file_timestamp_hour=${HOUR}" \
+      -F "file_timestamp_minute=${MINUTE}" \
+      -F "file_timestamp_second=${SECOND}" \
       -F "output=json" \
       -F "do=Add File"
     fi

--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -43,7 +43,7 @@ then
   YESTERDAY_DATE=$(date -d "yesterday" '+%F' | tr -d '-')
 
   # TODO: revert to master branch once https://github.com/Mudlet/installers/pull/123 is merged:
-  git clone --branch Improve_switchTo_linuxdeploy https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
+  git clone --branch Improve_switchTo_linuxdeploy https://github.com/SlySven/installers.git "${BUILD_DIR}/../installers"
 
   cd "${BUILD_DIR}/../installers/generic-linux" || exit 1
 

--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -64,6 +64,17 @@ then
     QMAKE=$(which qmake6)
     export QMAKE
   fi
+
+  # Debug: print out the locations of all copies of the buult mudlet file
+  echo "Checking for the mudlet file we should have:
+  # Currently we seem to be looking in:
+  # /home/runner/work/Mudlet/b/ninja/mudlet
+  # but that doesn't seem to be correct now...
+  find /home/runner/work -name mudlet -type f -print0 | xargs -0 ls -lh
+
+  # fail quickly now:
+  exit 1
+
   if ! [[ "${GITHUB_REF}" =~ ^"refs/tags/" ]] && [ "${PUBLIC_TEST_BUILD}" != "true" ]; then
     echo "== Creating a snapshot build =="
     ./make-installer.sh "${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}"

--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -52,6 +52,18 @@ then
   # unset LD_LIBRARY_PATH as it upsets linuxdeployqt - CHECK whether linuxdeploy is also upset?
   # export LD_LIBRARY_PATH=
 
+  # The linuxdeploy-qt pluging to linuxdeploy needs to know the Qt version it
+  # is being run for when it is run inside the ./make-installer.sh script.
+  # This is established from the QMAKE environment variable - see:
+  # https://github.com/linuxdeploy/linuxdeploy-plugin-qt
+  # The (currently unused) installer repository file
+  # ${BUILD_DIR}/../installers/generic-linux/build-and-make-installer.sh sets
+  # this before it calls
+  # ${BUILD_DIR}/../installers/generic-linux/make-installer.sh
+  if [ -z "${QMAKE}" ]; then
+    QMAKE=$(which qmake6)
+    export QMAKE
+  fi
   if ! [[ "${GITHUB_REF}" =~ ^"refs/tags/" ]] && [ "${PUBLIC_TEST_BUILD}" != "true" ]; then
     echo "== Creating a snapshot build =="
     ./make-installer.sh "${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}"

--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -66,7 +66,7 @@ then
   fi
 
   # Debug: print out the locations of all copies of the buult mudlet file
-  echo "Checking for the mudlet file we should have:
+  echo "Checking for the mudlet file we should have:"
   # Currently we seem to be looking in:
   # /home/runner/work/Mudlet/b/ninja/mudlet
   # but that doesn't seem to be correct now...

--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -69,11 +69,8 @@ then
   echo "Checking for the mudlet file we should have:"
   # Currently we seem to be looking in:
   # /home/runner/work/Mudlet/b/ninja/mudlet
-  # but that doesn't seem to be correct now...
-  find /home/runner/work -name mudlet -type f -print0 | xargs -0 ls -lh
-
-  # fail quickly now:
-  exit 1
+  # but a subsequent test put it in:
+  # /home/runner/work/Mudlet/b/ninja/src/mudlet
 
   if ! [[ "${GITHUB_REF}" =~ ^"refs/tags/" ]] && [ "${PUBLIC_TEST_BUILD}" != "true" ]; then
     echo "== Creating a snapshot build =="

--- a/CI/travis.linux.install.sh
+++ b/CI/travis.linux.install.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-mkdir -p "${HOME}/latest-gcc-symlinks"
-ln -s /usr/bin/g++-8 "${HOME}/latest-gcc-symlinks/g++"
-ln -s /usr/bin/gcc-8 "${HOME}/latest-gcc-symlinks/gcc"
-
 # lua-utf8 is not in the repositories...
 luarocks install --local luautf8
 YAJL_PATH="$(pkg-config --variable=libdir yajl)"
@@ -14,19 +10,20 @@ luarocks install --local lua-yajl YAJL_LIBDIR="${YAJL_PATH}"
 luarocks install --local argparse
 luarocks install --local lunajson
 
-  # download coverity tool only for cron+deploy jobs
-if [ "${TRAVIS_EVENT_TYPE}" = "cron" ] && [ "${DEPLOY}" = "deploy" ]; then
-  mkdir coverity
-  cd coverity
-  wget https://scan.coverity.com/download/linux64 --post-data "token=${COVERITY_SCAN_TOKEN}&project=Mudlet%2FMudlet" -O coverity_tool.tgz
-  if [ $? -ne 0 ]; then
-	  echo Download Coverity analysis tool failed!
-	  exit 1
-  fi
-  tar xzf coverity_tool.tgz
-  rm -f coverity_tool.tgz
-  export PATH="$(pwd)/$(ls -d cov*)/bin:$PATH"
-  echo The new PATH is now "${PATH}"
-  cd ..
+# Coverity is not used as we haven't been able to build on Travis for several years!
+# download coverity tool only for cron+deploy jobs
+#if [ "${TRAVIS_EVENT_TYPE}" = "cron" ] && [ "${DEPLOY}" = "deploy" ]; then
+#  mkdir coverity
+#  cd coverity
+#  wget https://scan.coverity.com/download/linux64 --post-data "token=${COVERITY_SCAN_TOKEN}&project=Mudlet%2FMudlet" -O coverity_tool.tgz
+#  if [ $? -ne 0 ]; then
+#	  echo Download Coverity analysis tool failed!
+#	  exit 1
+#  fi
+#  tar xzf coverity_tool.tgz
+#  rm -f coverity_tool.tgz
+#  export PATH="$(pwd)/$(ls -d cov*)/bin:$PATH"
+#  echo The new PATH is now "${PATH}"
+#  cd ..
 # Coverity scan tool installed
-fi
+#fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -550,6 +550,9 @@ target_compile_definitions(mudlet PRIVATE DEBUG_TELNET=1)
 # * Enable the features associated with reporting problems in processing Unicode
 #   codepoints that cannot be displayed on screen in a `TConsole`:
 # target_compile_definitions(mudlet PRIVATE DEBUG_CODEPOINT_PROBLEMS)
+#
+# * Produce qDebug() messages about the loading of translation files
+target_compile_definitions(mudlet PRIVATE DEBUG_TRANSLATIONS_LOADING)
 
 target_sources(mudlet PRIVATE "${mudlet_BINARY_DIR}/translations/translated/qm.qrc")
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5898,7 +5898,9 @@ void TLuaInterpreter::loadGlobal()
         // linuxdeployqt) has a quite LHS structure and we should look in
         // tempDir/usr/share/applications/mudlet/lua/ but do so for the executable
         // being in tempDir/usr/bin (and arrange for the files to be there):
+#if defined (Q_OS_LINUX)
         QDir::toNativeSeparators(qsl("%1/../share/applications/mudlet/lua/LuaGlobal.lua").arg(executablePath)),
+#endif
 
         // CMake builds from Qt Creator on Windows 11 appear to use this directory:
         QDir::toNativeSeparators(qsl("%1/../../../mudlet-lua/lua/LuaGlobal.lua").arg(executablePath))

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5568,7 +5568,7 @@ void TLuaInterpreter::initLuaGlobals()
     // sub-directory, library files in a ./lib/ one and other files in a
     // ./usr/share/application/mudlet tree - so we should have the lua binary
     // modules (libraries) in ../lib/ relative to executable:
-    additionalCPaths << qsl("../lib/?.so").arg(appPath);
+    additionalCPaths << qsl("%1/../lib/?.so").arg(appPath);
 #elif defined(Q_OS_MACOS)
     // macOS app bundle would like the search path to also be set to the current
     // binary directory for both modules and binary libraries:
@@ -5787,7 +5787,7 @@ void TLuaInterpreter::initIndenterGlobals()
     // sub-directory, library files in a ./lib/ one and other files in a
     // ./usr/share/application/mudlet tree - so we should have the lua binary
     // modules (libraries) in ../lib/ relative to executable:
-    additionalCPaths << qsl("../lib/?.so").arg(appPath);
+    additionalCPaths << qsl("%1/../lib/?.so").arg(appPath);
 #endif
 
     insertNativeSeparatorsFunction(pIndenterState.get());

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5563,6 +5563,12 @@ void TLuaInterpreter::initLuaGlobals()
     // AppInstaller on Linux would like the C search path to also be set to
     // a ./lib sub-directory of the current binary directory:
     additionalCPaths << qsl("%1/lib/?.so").arg(appPath);
+    // Switching to linuxdeploy with the separate linuxdeploy-qt plugin puts
+    // in a more FHS sort of filesystem with the mudlet executable in a ./bin/
+    // sub-directory, library files in a ./lib/ one and other files in a
+    // ./usr/share/application/mudlet tree - so we should have the lua binary
+    // modules (libraries) in ../lib/ relative to executable:
+    additionalCPaths << qsl("../lib/?.so").arg(appPath);
 #elif defined(Q_OS_MACOS)
     // macOS app bundle would like the search path to also be set to the current
     // binary directory for both modules and binary libraries:
@@ -5776,6 +5782,12 @@ void TLuaInterpreter::initIndenterGlobals()
     // AppInstaller on Linux would like the search path for the binary modules
     // to also be set to a lib sub-directory of the application directory:
     additionalCPaths << qsl("%1/lib/?.so").arg(appPath);
+    // Switching to linuxdeploy with the separate linuxdeploy-qt plugin puts
+    // in a more FHS sort of filesystem with the mudlet executable in a ./bin/
+    // sub-directory, library files in a ./lib/ one and other files in a
+    // ./usr/share/application/mudlet tree - so we should have the lua binary
+    // modules (libraries) in ../lib/ relative to executable:
+    additionalCPaths << qsl("../lib/?.so").arg(appPath);
 #endif
 
     insertNativeSeparatorsFunction(pIndenterState.get());
@@ -5801,6 +5813,11 @@ void TLuaInterpreter::initIndenterGlobals()
     // 5 CMake shadow builds
     //    "<applicationDirectory>/../../mudlet/3rdparty/?.lua"
     additionalLuaPaths << qsl("%1/../../mudlet/3rdparty/?.lua").arg(appPath);
+    // 6 New linuxdeploy (replacement for linuxdeployqt):
+    //    "<applicationDirectory>/../share/applications/mudlet/lcf/?.lua"
+#if defined (Q_OS_LINUX)
+    additionalLuaPaths << qsl("%1/../share/applications/mudlet/lcf/?.lua").arg(appPath);
+#endif
 
     int error = luaL_dostring(pIndenterState.get(), qsl("package.path = toNativeSeparators([[%1;]] .. package.path)")
                               .arg(additionalLuaPaths.join(QLatin1Char(';'))).toUtf8().constData());
@@ -5876,6 +5893,12 @@ void TLuaInterpreter::loadGlobal()
         // location to that top-level project file) of the main project
         // "mudlet" directory:
         QDir::toNativeSeparators(qsl("%1/../../../src/mudlet-lua/lua/LuaGlobal.lua").arg(executablePath)),
+
+        // linuxdeploy with linuxdeploy-qt plugin (replacement for
+        // linuxdeployqt) has a quite LHS structure and we should look in
+        // tempDir/usr/share/applications/mudlet/lua/ but do so for the executable
+        // being in tempDir/usr/bin (and arrange for the files to be there):
+        QDir::toNativeSeparators(qsl("%1/../share/applications/mudlet/lua/LuaGlobal.lua").arg(executablePath)),
 
         // CMake builds from Qt Creator on Windows 11 appear to use this directory:
         QDir::toNativeSeparators(qsl("%1/../../../mudlet-lua/lua/LuaGlobal.lua").arg(executablePath))

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5814,9 +5814,9 @@ void TLuaInterpreter::initIndenterGlobals()
     //    "<applicationDirectory>/../../mudlet/3rdparty/?.lua"
     additionalLuaPaths << qsl("%1/../../mudlet/3rdparty/?.lua").arg(appPath);
     // 6 New linuxdeploy (replacement for linuxdeployqt):
-    //    "<applicationDirectory>/../share/applications/mudlet/lcf/?.lua"
+    //    "<applicationDirectory>/../share/applications/mudlet/?.lua"
 #if defined (Q_OS_LINUX)
-    additionalLuaPaths << qsl("%1/../share/applications/mudlet/lcf/?.lua").arg(appPath);
+    additionalLuaPaths << qsl("%1/../share/applications/mudlet/?.lua").arg(appPath);
 #endif
 
     int error = luaL_dostring(pIndenterState.get(), qsl("package.path = toNativeSeparators([[%1;]] .. package.path)")

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1274,7 +1274,9 @@ void mudlet::migrateDebugConsole(Host* currentHost)
 void mudlet::scanForMudletTranslations(const QString& path)
 {
     mPathNameMudletTranslations = path;
-    // qDebug().nospace().noquote() << "mudlet::scanForMudletTranslations(\"" << path << "\") INFO - Seeking Mudlet translation files:";
+#if defined(DEBUG_TRANSLATIONS_LOADING)
+    qDebug().nospace().noquote() << "mudlet::scanForMudletTranslations(\"" << path << "\") INFO - Seeking Mudlet translation files:";
+#endif
     mTranslationsMap.clear();
 
     QDir translationDir(path);
@@ -1302,7 +1304,9 @@ void mudlet::scanForMudletTranslations(const QString& path)
 
         std::unique_ptr<QTranslator> pMudletTranslator = std::make_unique<QTranslator>();
         if (Q_LIKELY(pMudletTranslator->load(translationFileName, path))) {
-            // qDebug().noquote().nospace() << "    found a Mudlet translation for locale code: \"" << languageCode << "\".";
+#if defined(DEBUG_TRANSLATIONS_LOADING)
+            qDebug().noquote().nospace() << "    found a Mudlet translation for locale code: \"" << languageCode << "\".";
+#endif
             if (!translationStats.isEmpty()) {
                 // For this to not be empty then we are reading the translations
                 // from the expected resource file and the translation
@@ -1376,7 +1380,9 @@ void mudlet::scanForMudletTranslations(const QString& path)
 void mudlet::scanForQtTranslations(const QString& path)
 {
     mPathNameQtTranslations = path;
-    // qDebug().nospace().noquote() << "mudlet::scanForQtTranslations(\"" << path << "\") INFO - Seeking Qt translation files:";
+#if defined(DEBUG_TRANSLATIONS_LOADING)
+    qDebug().nospace().noquote() << "mudlet::scanForQtTranslations(\"" << path << "\") INFO - Seeking Qt translation files:";
+#endif
     QMutableMapIterator<QString, translation> itTranslation(mTranslationsMap);
     while (itTranslation.hasNext()) {
         itTranslation.next();
@@ -1384,7 +1390,9 @@ void mudlet::scanForQtTranslations(const QString& path)
         std::unique_ptr<QTranslator> pQtTranslator = std::make_unique<QTranslator>();
         const QString translationFileName(qsl("qt_%1.qm").arg(languageCode));
         if (pQtTranslator->load(translationFileName, path)) {
-            // qDebug().noquote().nospace() << "    found a Qt translation for locale code: \"" << languageCode << "\"";
+#if defined(DEBUG_TRANSLATIONS_LOADING)
+            qDebug().noquote().nospace() << "    found a Qt translation for locale code: \"" << languageCode << "\"";
+#endif
             /*
              * Unfortunately, success in this operation does not mean that
              * a qt_xx_YY.qm translation file has been located, as the
@@ -1400,7 +1408,9 @@ void mudlet::scanForQtTranslations(const QString& path)
             current.mQtTranslationFileName = translationFileName;
             itTranslation.setValue(current);
         } else {
-            // qDebug().noquote().nospace() << "    no Qt translation found for locale code: \"" << languageCode << "\"";
+#if defined(DEBUG_TRANSLATIONS_LOADING)
+            qDebug().noquote().nospace() << "    no Qt translation found for locale code: \"" << languageCode << "\"";
+#endif
         }
     }
 }
@@ -1408,7 +1418,9 @@ void mudlet::scanForQtTranslations(const QString& path)
 void mudlet::loadTranslators(const QString& languageCode)
 {
     if (!mTranslatorsLoadedList.isEmpty()) {
-        // qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - uninstalling existing translation previously loaded...";
+#if defined(DEBUG_TRANSLATIONS_LOADING)
+        qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - uninstalling existing translation previously loaded...";
+#endif
         QMutableListIterator<QPointer<QTranslator>> itTranslator(mTranslatorsLoadedList);
         itTranslator.toBack();
         while (itTranslator.hasPrevious()) {
@@ -1431,7 +1443,9 @@ void mudlet::loadTranslators(const QString& languageCode)
         // up the process of locating the file:
         const bool isOk = pQtTranslator->load(qtTranslatorFileName, mPathNameQtTranslations);
         if (isOk && !pQtTranslator->isEmpty()) {
-            // qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - installing Qt libraries' translation from a path and file name specified as: \"" << mPathNameQtTranslations << "/"<< qtTranslatorFileName << "\"...";
+#if defined(DEBUG_TRANSLATIONS_LOADING)
+            qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - installing Qt libraries' translation from a path and file name specified as: \"" << mPathNameQtTranslations << "/"<< qtTranslatorFileName << "\"...";
+#endif
             qApp->installTranslator(pQtTranslator);
             mTranslatorsLoadedList.append(pQtTranslator);
         }
@@ -1442,8 +1456,10 @@ void mudlet::loadTranslators(const QString& languageCode)
     if (!mudletTranslatorFileName.isEmpty()) {
         const bool isOk = pMudletTranslator->load(mudletTranslatorFileName, mPathNameMudletTranslations);
         if (isOk && !pMudletTranslator->isEmpty()) {
-//            qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - installing Mudlet translation from: \"" << mPathNameMudletTranslations << "/"
-//                                         << mudletTranslatorFileName << "\"...";
+#if defined(DEBUG_TRANSLATIONS_LOADING)
+            qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - installing Mudlet translation from: \"" << mPathNameMudletTranslations << "/"
+                                         << mudletTranslatorFileName << "\"...";
+#endif
             qApp->installTranslator(pMudletTranslator);
             mTranslatorsLoadedList.append(pMudletTranslator);
         }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3874,6 +3874,11 @@ QString mudlet::getMudletPath(const enums::mudletPathType mode, const QString& e
             // unpacked/placed in a directory called 'mudlet'}:
             mudlet::self()->mUsingMudletDictionaries = true;
             return qsl("%1/../../mudlet/src/").arg(QCoreApplication::applicationDirPath());
+        } else if (QFile::exists(qsl("%1/../share/hunspell/%2.aff").arg(QCoreApplication::applicationDirPath(), extra1))) {
+            // From later linuxdeploy installer builds that bundle dictionaries
+            // in a FHS directory:
+            mudlet::self()->mUsingMudletDictionaries = true;
+            return qsl("%1/../share/hunspell/").arg(QCoreApplication::applicationDirPath());
         } else {
             // From build within ./src AND installer builds that bundle
             // dictionaries in the same directory as the executable:

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -1698,6 +1698,9 @@ OTHER_FILES += \
     ../docker/docker-compose.override.linux.yml \
     ../docker/docker-compose.yml \
     ../docker/Dockerfile \
+    ../templates/README \
+    ../templates/cpp \
+    ../templates/h \
     ../test/CMakeLists.txt \
     ../test/GUIConsoleTests.mpackage \
     ../test/TEntityHandlerTest.cpp \

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -307,6 +307,9 @@ DEFINES+=DEBUG_TELNET=1
 # * Enable the features associated with reporting problems in processing Unicode
 # codepoints that cannot be displayed on screen in a `TConsole`:
 # DEFINES+=DEBUG_CODEPOINT_PROBLEMS
+#
+# * Produce qDebug() messages about the loading of translation files
+DEFINES+=DEBUG_TRANSLATIONS_LOADING
 
 unix:!macx {
 # Distribution packagers would be using PREFIX = /usr but this is accepted

--- a/translations/translated/CMakeLists.txt
+++ b/translations/translated/CMakeLists.txt
@@ -37,6 +37,12 @@ if(NOT WIN32)
 #  message(STATUS "The environmental variable LANG is now set to: $ENV{LANG}")
 endif()
 
+message(STATUS "Using ${LRELEASE_LOCATION} version")
+execute_process(
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  COMMAND ${LRELEASE_LOCATION} -version
+)
+
 foreach(ts_file ${TS_FILES_NOEXT})
   string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}" qm_file ${ts_file})
   execute_process(

--- a/translations/translated/updateqm.pri
+++ b/translations/translated/updateqm.pri
@@ -38,6 +38,9 @@ isEmpty(QMAKE_LRELEASE) {
     }
 }
 
+message("Using lrelease executable:")
+system($$QMAKE_LRELEASE -version)
+
 write_file(lrelease_output.txt)
 message("Building translations")
 TS_FILES_NOEXT = $$replace(TS_FILES, ".ts", "")


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Revises the Linux CI/CB process to use [`linuxdeploy`](https://github.com/linuxdeploy/linuxdeploy) instead of `linuxdeployqt`.

#### Motivation for adding to Mudlet
`linuxdeployqt` won't work next week as GitHub are removing the Ubuntu 20.04 runner and that tool will not work with the later `22.04` one until the maintainer updates it to do so (the CRT is too new).

#### Other info (issues closed, discussion etc)
The maintainer of linuxdeployqt is refusing to updating to Ubuntu 22.04 until it officially reaches EOL (in a month or so) but GitHub will not provide Ubuntu 20.04 from 2025/04/15 and has been "browning it out intermittently for the past few months.

This also switches the Linux run that is used for deployment to Ubuntu 22.04 it remains to be seen whether this is still usable for the oldest versions of the Linux OS which we provide AppImages for.

Some variables in the `bash` scripts used for Linux CI that were not have been made SCREAMING_SNAKE_CASE so that they can be picked out better.

Some issues that [ShellCheck](https://www.shellcheck.net/) highlighted have been "fixed" as well.

THIS IS A DRAFT CURRENTLY AS IT USES A PR FROM THE **INSTALLERS** REPO. It can not be merged until that PR is debugged and merged into that repository.