### PR TITLE
Infrastructure: update Linux and MacOS builds to Qt 6.9.0

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -28,7 +28,7 @@ jobs:
             triplet: x64-linux
             compiler: gcc_64
             gcc_compiler_version: 10
-            qt: '6.8.1'
+            qt: '6.9.0'
             deploy: 'deploy'
             run_tests: 'true'
           - os: ubuntu-latest
@@ -36,19 +36,19 @@ jobs:
             triplet: x64-linux
             compiler: clang_64
             gcc_compiler_version: 10
-            qt: '6.8.1'
+            qt: '6.9.0'
           - os: macos-13
-            buildname: 'macos (x86_64) / c++, lua tests'
+            buildname: 'macos (x86_64) / c++ / lua tests'
             triplet: x64-osx
             compiler: clang_64
-            qt: '6.8.1'
+            qt: '6.9.0'
             deploy: 'deploy'
             run_tests: 'true'
           - os: macos-14
-            buildname: 'macos (arm64) / c++, lua tests'
+            buildname: 'macos (arm64) / c++ / lua tests'
             triplet: arm64-osx
             compiler: clang_64
-            qt: '6.8.1'
+            qt: '6.9.0'
             deploy: 'deploy'
             run_tests: 'true'
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -22,6 +22,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Note: using / in the "buildname" has significance - replacing the
+          # ',' in some of the following with a '/' seemed to cause extra
+          # spurious steps in the build and broke things! - SlySven
           # oldest OS supported for maximum compatibility of built AppImage
           - os: ubuntu-20.04
             buildname: 'ubuntu / gcc / lua tests'
@@ -38,14 +41,14 @@ jobs:
             gcc_compiler_version: 10
             qt: '6.9.0'
           - os: macos-13
-            buildname: 'macos (x86_64) / c++ / lua tests'
+            buildname: 'macos (x86_64) / c++, lua tests'
             triplet: x64-osx
             compiler: clang_64
             qt: '6.9.0'
             deploy: 'deploy'
             run_tests: 'true'
           - os: macos-14
-            buildname: 'macos (arm64) / c++ / lua tests'
+            buildname: 'macos (arm64) / c++, lua tests'
             triplet: arm64-osx
             compiler: clang_64
             qt: '6.9.0'


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Update the Linux and MacOS CI/CB systems to build with Qt 6.9.0 which is the latest released version.

#### Motivation for adding to Mudlet
I've recently updated the codebase to compile with this version as the Windows CI/CB has automagically updated to that version and was breaking until I fixed it in #7805 so it makes sense to change those other OSes to match.

#### Other info (issues closed, discussion etc)
