### PR TITLE
Infrastructure: update Linux runner to Ubuntu 22.04

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -73,8 +73,9 @@ jobs:
       with:
         # This SHOULD NOT be needed both the CMAke and qmake metabuild systems
         # contain conditional code to pull in the required submodules themselves
-        # except vcpkg...
-        submodules: 'true'
+        # except vcpkg - if that can be handled we could avoid this setting that
+        # fetches everything...
+        submodules: true
         fetch-depth: 0
 
     - name: Install Qt
@@ -354,8 +355,8 @@ jobs:
         # Lua-based tests
         run-luarocks install --local busted
 
-        # necessary for Qt multimedia and modern Qt,
-        # libfuse2 is needed for linuxdeployqt on Ubuntu 22.04:
+        # necessary for Qt multimedia and modern Qt
+        # libfuse2 could be needed for linuxdeployqt on Ubuntu 22.04:
         if [ "${RUNNER_OS}" = "Linux" ]; then
           sudo apt-get install libgstreamer-plugins-base1.0-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xinerama0 xvfb libfuse2 -y
         fi

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -34,13 +34,6 @@ jobs:
             qt: '6.9.0'
             deploy: 'deploy'
             run_tests: 'true'
-          - os: ubuntu-22.04
-            # Just to check with the later GCC
-            buildname: 'ubuntu / gcc12'
-            triplet: x64-linux
-            compiler: gcc_64
-            gcc_compiler_version: 12
-            qt: '6.9.0'
           - os: ubuntu-latest
             buildname: 'ubuntu / clang'
             triplet: x64-linux

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -344,9 +344,10 @@ jobs:
         # Lua-based tests
         run-luarocks install --local busted
 
-        # necessary for Qt multimedia and modern Qt
+        # necessary for Qt multimedia and modern Qt,
+        # libfuse2 is needed for linuxdeployqt on Ubuntu 22.04:
         if [ "${RUNNER_OS}" = "Linux" ]; then
-          sudo apt-get install libgstreamer-plugins-base1.0-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xinerama0 xvfb -y
+          sudo apt-get install libgstreamer-plugins-base1.0-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xinerama0 xvfb libfuse2 -y
         fi
       env:
         BUILD_FOLDER: ${{runner.workspace}}/b/ninja

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -26,7 +26,7 @@ jobs:
           # ',' in some of the following with a '/' seemed to cause extra
           # spurious steps in the build and broke things! - SlySven
           # oldest OS supported for maximum compatibility of built AppImage
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             buildname: 'ubuntu / gcc / lua tests'
             triplet: x64-linux
             compiler: gcc_64

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -34,6 +34,13 @@ jobs:
             qt: '6.9.0'
             deploy: 'deploy'
             run_tests: 'true'
+          - os: ubuntu-22.04
+            # Just to check with the later GCC
+            buildname: 'ubuntu / gcc12'
+            triplet: x64-linux
+            compiler: gcc_64
+            gcc_compiler_version: 12
+            qt: '6.9.0'
           - os: ubuntu-latest
             buildname: 'ubuntu / clang'
             triplet: x64-linux

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -34,6 +34,13 @@ jobs:
             qt: '6.9.0'
             deploy: 'deploy'
             run_tests: 'true'
+          - os: ubuntu-22.04
+            # Another try to use GCC12
+            buildname: 'ubuntu (x86_64)'
+            triplet: x64-linux
+            compiler: gcc_64
+            gcc_compiler_version: 12
+            qt: '6.9.0'
           - os: ubuntu-latest
             buildname: 'ubuntu / clang'
             triplet: x64-linux
@@ -64,7 +71,10 @@ jobs:
     - name: Checkout Mudlet source code
       uses: actions/checkout@v4
       with:
-        submodules: true
+        # This SHOULD NOT be needed both the CMAke and qmake metabuild systems
+        # contain conditional code to pull in the required submodules themselves
+        # submodules: true
+        submodules: 'false'
         fetch-depth: 0
 
     - name: Install Qt

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -73,8 +73,8 @@ jobs:
       with:
         # This SHOULD NOT be needed both the CMAke and qmake metabuild systems
         # contain conditional code to pull in the required submodules themselves
-        # submodules: true
-        submodules: 'false'
+        # except vcpkg...
+        submodules: 'true'
         fetch-depth: 0
 
     - name: Install Qt

--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -42,7 +42,9 @@ then
   COMMIT_DATE=$(git show -s --format="%cs" | tr -d '-')
   YESTERDAY_DATE=$(date -d "yesterday" '+%F' | tr -d '-')
 
-  git clone https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
+  # TODO: revert to master branch once https://github.com/Mudlet/installers/pull/124 is merged:
+  git clone --branch Infrastructure_add_-unsupported-bundle-everything_optionTo_linuxdeployqt https://github.com/SlySven/installers.git "${BUILD_DIR}/../installers"
+  # git clone https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
 
   cd "${BUILD_DIR}/../installers/generic-linux"
 

--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -42,9 +42,7 @@ then
   COMMIT_DATE=$(git show -s --format="%cs" | tr -d '-')
   YESTERDAY_DATE=$(date -d "yesterday" '+%F' | tr -d '-')
 
-  # TODO: revert to master branch once https://github.com/Mudlet/installers/pull/124 is merged:
-  git clone --branch Infrastructure_add_-unsupported-bundle-everything_optionTo_linuxdeployqt https://github.com/SlySven/installers.git "${BUILD_DIR}/../installers"
-  # git clone https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
+  git clone https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
 
   cd "${BUILD_DIR}/../installers/generic-linux"
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Change the Linux Ci/CB runner used to make the AppImage for that OS from the Ubuntu 20.04 LTS one to the 22.04 one.

#### Motivation for adding to Mudlet
This is unavoidable because the older one is being removed tomorrow.

#### Other info (issues closed, discussion etc)
Because of some intransigence by the maintainer of the `linuxdeployqt` tool we use to make the AppImage it is not being updated to work with the 22.04 one until the 20.04 reached its official EOL next month. This seems to mean that the AppImages produced in the newer runner will NOT work on systems with the older `libc` that was used in the 20.04 version and others such as Debian 11 ("Bullseye") and Devuan 4 ("Chimaera").

I have been trying to find a solution but have not got a workable one yet.

(See: https://github.com/Mudlet/Mudlet/pull/7806 and https://github.com/Mudlet/installers/pull/123).