### PR TITLE
fix: change SingeLineTextEdit to a QPlainTextEdit to avoid html parsing

### DIFF
--- a/src/SingleLineTextEdit.cpp
+++ b/src/SingleLineTextEdit.cpp
@@ -23,11 +23,10 @@
 #include "post_guard.h"
 
 SingleLineTextEdit::SingleLineTextEdit(QWidget *parent)
-    : QTextEdit(parent)
+    : QPlainTextEdit(parent)
 {
     highlighter = new TriggerHighlighter(this->document());
     highlighter->setHighlightingEnabled(true);
-    setAcceptRichText(false);
     setWordWrapMode(QTextOption::NoWrap);
     setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -40,13 +39,13 @@ void SingleLineTextEdit::keyPressEvent(QKeyEvent *event)
     if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) {
         return;
     }
-    QTextEdit::keyPressEvent(event);
+    QPlainTextEdit::keyPressEvent(event);
 }
 
 // ensure height remains on single line
 void SingleLineTextEdit::resizeEvent(QResizeEvent *event)
 {
-    QTextEdit::resizeEvent(event);
+    QPlainTextEdit::resizeEvent(event);
 }
 
 // ensure we can't paste multiple lines
@@ -55,14 +54,14 @@ void SingleLineTextEdit::insertFromMimeData(const QMimeData *source)
     if (source->hasText()) {
         QString text = source->text();
         QString firstLine = text.split(QRegularExpression("[\r\n]"), Qt::SkipEmptyParts).first();
-        QTextEdit::insertPlainText(firstLine);
+        QPlainTextEdit::insertPlainText(firstLine);
     }
 }
 
 // remove selection when focus is lost
 void SingleLineTextEdit::focusOutEvent(QFocusEvent* event)
 {
-    QTextEdit::focusOutEvent(event);
+    QPlainTextEdit::focusOutEvent(event);
     QTextCursor cursor = textCursor();
     cursor.clearSelection();
     setTextCursor(cursor);

--- a/src/SingleLineTextEdit.h
+++ b/src/SingleLineTextEdit.h
@@ -22,10 +22,10 @@
 
 #include "pre_guard.h"
 #include <QMimeData>
-#include <QTextEdit>
+#include <QPlainTextEdit>
 #include "post_guard.h"
 
-class SingleLineTextEdit : public QTextEdit
+class SingleLineTextEdit : public QPlainTextEdit
 {
     Q_OBJECT
 

--- a/src/TrailingWhitespaceMarker.cpp
+++ b/src/TrailingWhitespaceMarker.cpp
@@ -94,7 +94,7 @@ void unmarkQLineEdit(QLineEdit* lineEdit)
     lineEdit->blockSignals(false);
 }
 
-void markQTextEdit(QTextEdit* textEdit)
+void markQTextEdit(QPlainTextEdit* textEdit)
 {
     QString text = textEdit->toPlainText();
 
@@ -103,7 +103,7 @@ void markQTextEdit(QTextEdit* textEdit)
 
     textEdit->blockSignals(true);
     int cursorPos = textEdit->textCursor().position();
-    textEdit->setText(text);
+    textEdit->setPlainText(text);
 
     QTextCursor cursor = textEdit->textCursor();
     cursor.setPosition(cursorPos);
@@ -111,7 +111,7 @@ void markQTextEdit(QTextEdit* textEdit)
     textEdit->blockSignals(false);
 }
 
-void unmarkQTextEdit(QTextEdit* textEdit)
+void unmarkQTextEdit(QPlainTextEdit* textEdit)
 {
     QString text = textEdit->toPlainText();
 
@@ -119,7 +119,7 @@ void unmarkQTextEdit(QTextEdit* textEdit)
 
     textEdit->blockSignals(true);
     int cursorPos = textEdit->textCursor().position();
-    textEdit->setText(text);
+    textEdit->setPlainText(text);
 
     QTextCursor cursor = textEdit->textCursor();
     cursor.setPosition(cursorPos);

--- a/src/TrailingWhitespaceMarker.h
+++ b/src/TrailingWhitespaceMarker.h
@@ -27,6 +27,6 @@ void markQString(QString* input);
 void unmarkQString(QString* input);
 void markQLineEdit(QLineEdit* lineEdit);
 void unmarkQLineEdit(QLineEdit* lineEdit);
-void markQTextEdit(QTextEdit* textEdit);
-void unmarkQTextEdit(QTextEdit* textEdit);
+void markQTextEdit(QPlainTextEdit* textEdit);
+void unmarkQTextEdit(QPlainTextEdit* textEdit);
 #endif // MUDLET_TRAILINGWHITESPACEMARKER_H

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -903,8 +903,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
         connect(pBox, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgTriggerEditor::slot_setupPatternControls);
         connect(pItem->pushButton_fgColor, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_colorTriggerFg);
         connect(pItem->pushButton_bgColor, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_colorTriggerBg);
-        connect(pItem->singleLineTextEdit_pattern, &QTextEdit::textChanged, this, &dlgTriggerEditor::slot_changedPattern);
-        connect(pItem->singleLineTextEdit_pattern, &QTextEdit::textChanged, this, &dlgTriggerEditor::slot_itemEdited);
+        connect(pItem->singleLineTextEdit_pattern, &QPlainTextEdit::textChanged, this, &dlgTriggerEditor::slot_changedPattern);
+        connect(pItem->singleLineTextEdit_pattern, &QPlainTextEdit::textChanged, this, &dlgTriggerEditor::slot_itemEdited);
 
         mpWidget_triggerItems->layout()->addWidget(pItem);
 
@@ -5815,7 +5815,7 @@ void dlgTriggerEditor::slot_setupPatternControls(int type)
             // So set it to the default (ignore both) - which will generate an
             // error if saved without setting a color for at least one element:
 
-            pPatternItem->singleLineTextEdit_pattern->setText(TTrigger::createColorPatternText(TTrigger::scmIgnored, TTrigger::scmIgnored));
+            pPatternItem->singleLineTextEdit_pattern->setPlainText(TTrigger::createColorPatternText(TTrigger::scmIgnored, TTrigger::scmIgnored));
         }
 
         // Only process the text if it looks like it should:
@@ -5936,7 +5936,7 @@ void dlgTriggerEditor::slot_triggerSelected(QTreeWidgetItem* pItem)
                 pPatternItem->singleLineTextEdit_pattern->clear();
 
             } else if (pType == REGEX_COLOR_PATTERN) {
-                pPatternItem->singleLineTextEdit_pattern->setText(patternList.at(i));
+                pPatternItem->singleLineTextEdit_pattern->setPlainText(patternList.at(i));
                 if (pT->mColorPatternList.at(i)) {
                     if (pT->mColorPatternList.at(i)->ansiFg == TTrigger::scmIgnored) {
                         pPatternItem->pushButton_fgColor->setStyleSheet(QString());
@@ -5984,7 +5984,7 @@ void dlgTriggerEditor::slot_triggerSelected(QTreeWidgetItem* pItem)
                 if (pType == REGEX_PERL) {
                     lineEditShouldMarkSpaces[pPatternItem->singleLineTextEdit_pattern] = true;
                 }
-                pPatternItem->singleLineTextEdit_pattern->setText(patternList.at(i));
+                pPatternItem->singleLineTextEdit_pattern->setPlainText(patternList.at(i));
             }
         }
 
@@ -9778,7 +9778,7 @@ void dlgTriggerEditor::slot_colorTriggerFg()
     }
     pB->setStyleSheet(styleSheet);
 
-    pPatternItem->singleLineTextEdit_pattern->setText(TTrigger::createColorPatternText(pT->mColorTriggerFgAnsi, pT->mColorTriggerBgAnsi));
+    pPatternItem->singleLineTextEdit_pattern->setPlainText(TTrigger::createColorPatternText(pT->mColorTriggerFgAnsi, pT->mColorTriggerBgAnsi));
 
     if (pT->mColorTriggerFgAnsi == TTrigger::scmIgnored) {
         //: Color trigger ignored foreground color button, ensure all three instances have the same text
@@ -9840,7 +9840,7 @@ void dlgTriggerEditor::slot_colorTriggerBg()
     }
     pB->setStyleSheet(styleSheet);
 
-    pPatternItem->singleLineTextEdit_pattern->setText(TTrigger::createColorPatternText(pT->mColorTriggerFgAnsi, pT->mColorTriggerBgAnsi));
+    pPatternItem->singleLineTextEdit_pattern->setPlainText(TTrigger::createColorPatternText(pT->mColorTriggerFgAnsi, pT->mColorTriggerBgAnsi));
 
     if (pT->mColorTriggerBgAnsi == TTrigger::scmIgnored) {
         //: Color trigger ignored background color button, ensure all three instances have the same text


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Switch to `SingeLineTextEdit` to a `QPlainTextEdit` to avoid html parsing when using named captures similiar to html code (ie., `<b>` or `<s>`)

#### Motivation for adding to Mudlet
fixes unexpected results when interacting with the trigger editor, better user experience

#### Other info (issues closed, discussion etc)
fixes #7815
