### PR TITLE
Fix: make installPackage(...) return the boolean it is supposed to

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2667,6 +2667,7 @@ int TLuaInterpreter::installPackage(lua_State* L)
     if (auto [success, message] = host.installPackage(location, enums::PackageModuleType::Package); !success) {
         return warnArgumentValue(L, __func__, message);
     }
+    lua_pushboolean(L, true);
     return 1;
 }
 
@@ -2675,8 +2676,13 @@ int TLuaInterpreter::uninstallPackage(lua_State* L)
 {
     const QString packageName = getVerifiedString(L, __func__, 1, "package name");
     Host& host = getHostFromLua(L);
-    host.uninstallPackage(packageName, enums::PackageModuleType::Package);
-    return 0;
+    const bool result = host.uninstallPackage(packageName, enums::PackageModuleType::Package);
+    if (!result) {
+        lua_pushnil(L);
+    } else {
+        lua_pushboolean(L, result);
+    }
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#installModule


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Put in the code needed for this Lua API function to return `true` on success. Also put in code that ensures that the related `uninstallPackage(...)` also returns a `true`/`nil` return value at least (although with no error messages upon any cause for failure).

#### Motivation for adding to Mudlet
Make Mudlet do what the documentation says it does.

#### Other info (issues closed, discussion etc)
#5785 introduced the change that meant a failure to install a package (or module) would return an error message but it failed to ensure a `true` was returned for a successful package installation. :facepalm:

The lack of a return value (although only on success) was noted by **weisluke** ("WotMUD" Mudlet packages maintainer) in our Discord **Help** channel on 2025/04/23 17:37 UTC:
https://canary.discord.com/channels/283581582550237184/283582068334526464/1364656328550645781