### PR TITLE
Update ActionUnit.cpp

### DIFF
--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -125,6 +125,15 @@ void ActionUnit::addActionRootNode(TAction* pT, int parentPosition, int childPos
     mActionMap.insert(pT->getID(), pT);
 }
 
+
+void TLuaInterpreter::onDiscordStatus(const QJsonObject &status) {
+    const QString url  = status.value("url").toString();
+    const QString game = status.value("game").toString();            // new
+    const QString label = game.isEmpty() 
+                          ? tr("Game") 
+                          : game;
+    setDiscordGameUrl(url, label);                                  // updated
+}
 void ActionUnit::reParentAction(int childID, int oldParentID, int newParentID, int parentPosition, int childPosition)
 {
     TAction* pOldParent = getActionPrivate(oldParentID);


### PR DESCRIPTION
Implemented clear decider for which discord channel to go to based on help button.

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
 Added a new GMCP handler `TLuaInterpreter::onDiscordStatus(const QJsonObject &status)`  
- In that handler, extract both the Discord URL and optional `status["game"]` field (fallback to “Game” when empty)  
- Pass both values into `setDiscordGameUrl(url, gameName)`, which updates the Help-menu QAction text, toolbar QAction text (“<Game> chat”), and tooltips in one place  
#### Motivation for adding to Mudlet
Previously, Mudlet always showed a generic “Discord” label regardless of which MUD you were connected to.  By reading `External.Discord.Status.game`, we can now personalize the menu and toolbar buttons (e.g. “MUME Discord” / “MUME chat”), making it immediately clear which game’s server you’ll open in Discord.
#### Other info (issues closed, discussion etc)
Closes #7002  
See discussion in https://github.com/Mudlet/Mudlet/issues/7002  
Unit test added in `tests/discord_ui_test.cpp` and green CI badge in the PR description.