### PR TITLE
Fix: revert/advance to luasql-sqlite3 2.6.1 on all OSes

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ ENV DBUS_SESSION_BUS_ADDRESS="autolaunch:" DISPLAY=":1" LANG="en_US.UTF-8" LANGU
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends build-essential git liblua5.1-dev  \
         zlib1g-dev libhunspell-dev libpcre3-dev libzip-dev libboost-dev libyajl-dev  \
-        libpulse-dev lua-rex-pcre lua-filesystem lua-zip lua-sql-sqlite3 qtbase5-dev \
+        libpulse-dev lua-rex-pcre lua-filesystem lua-zip qtbase5-dev \
         qtchooser qt5-qmake qtbase5-dev-tools qtmultimedia5-dev qttools5-dev luarocks\
         ccache libpugixml-dev libqt5texttospeech5-dev qtspeech5-flite-plugin         \
         qtspeech5-speechd-plugin libqt5opengl5-dev ninja-build firefox-esr           \
@@ -19,4 +19,5 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 # Install Lua dependencies
 RUN luarocks install luautf8     \
     && luarocks install lua-yajl \
+    && luarocks install lua-sql-sqlite3 2.6.1 \
     && luarocks install busted

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -345,7 +345,7 @@ jobs:
         run-luarocks install --local LuaFileSystem
         run-luarocks install --local luautf8
         run-luarocks install --local lua-zip
-        run-luarocks install SQLITE_INCDIR="${{env.VCPKG_ROOT}}/installed/${{matrix.triplet}}/include" --local LuaSQL-SQLite3
+        run-luarocks install SQLITE_INCDIR="${{env.VCPKG_ROOT}}/installed/${{matrix.triplet}}/include" --local LuaSQL-SQLite3 2.6.1
         run-luarocks install PCRE_INCDIR="${{env.VCPKG_ROOT}}/installed/${{matrix.triplet}}/include" --local lrexlib-pcre
 
         # CI changelog generation dependencies

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -186,13 +186,19 @@ for ROCK in "${WANTED_ROCKS[@]}"; do
     # This rock is not present
     echo "    ${ROCK}..."
     echo ""
-    ${ROCKCOMMAND} install "${ROCK}"
-	if [ "$(luarocks --lua-version 5.1 list | grep -c "${ROCK}")" -eq 0 ]; then
-	    echo "    ${ROCK} didn't get installed - try rerunning this script..."
-		success="false"
-	else
-        echo "    ${ROCK} now installed"
-	fi
+    # We need to force a particular version for the moment as 2.7.0-1 doesn't
+    # seem to work on Windows:
+    if [ "${ROCK}" = "luasql-sqlite3" ];  then
+      ${ROCKCOMMAND} install "${ROCK}" "2.6.1"
+    else
+      ${ROCKCOMMAND} install "${ROCK}"
+    fi
+    if [ "$(luarocks --lua-version 5.1 list | grep -c "${ROCK}")" -eq 0 ]; then
+      echo "    ${ROCK} didn't get installed - try rerunning this script..."
+      success="false"
+    else
+      echo "    ${ROCK} now installed"
+    fi
   else
     # We have it already
     echo "    ${ROCK} is already present"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Ensure the Windows CI/CB builds are done with the luasql-sqlite3 version **2.6.1** rather than the **2.7.0** one released (partially) yesterday as it seems to be breaking Lua database tests that were working the day before it was release.

#### Motivation for adding to Mudlet
To get Windows builds completing - and passing the Lua tests they did before 2025/04/23.

#### Other info (issues closed, discussion etc)
~~This only acts on the Windows builds - the GNU/Linux and MacOS ones may have to be addressed in some other way - I haven't found the point at which the rock gets installed at this point...~~ *This acts on ALL builds now.*