### PR TITLE
Infrastructure: remove redundant ';'s from Q_UNUSED(...) macro

### DIFF
--- a/src/AnnouncerMac.mm
+++ b/src/AnnouncerMac.mm
@@ -34,7 +34,7 @@ Announcer::Announcer(QWidget *parent)
 
 void Announcer::announce(const QString& text, const QString& processing)
 {
-    Q_UNUSED(processing);
+    Q_UNUSED(processing)
     NSDictionary *announcementInfo = @{
         NSAccessibilityAnnouncementKey : text.toNSString(),
         NSAccessibilityPriorityKey : @(NSAccessibilityPriorityHigh),

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -565,7 +565,7 @@ void Host::startMapAutosave(const int interval)
 
 void Host::timerEvent(QTimerEvent *event)
 {
-    Q_UNUSED(event);
+    Q_UNUSED(event)
 
     autoSaveMap();
 }
@@ -1187,7 +1187,7 @@ bool Host::checkForCustomSpeedwalk()
 void Host::startSpeedWalk()
 {
     const int totalWeight = assemblePath();
-    Q_UNUSED(totalWeight);
+    Q_UNUSED(totalWeight)
     const QString f = qsl("doSpeedWalk");
     const QString n = QString();
     mLuaInterpreter.call(f, n);
@@ -2829,7 +2829,7 @@ void Host::setSpellDic(const QString& newDict)
 // DISABLED: - Prevent "None" option for user dictionary - modified to prevent original useDictionary argument from being false:
 void Host::setUserDictionaryOptions(const bool _useDictionary, const bool useShared)
 {
-    Q_UNUSED(_useDictionary);
+    Q_UNUSED(_useDictionary)
     const bool useDictionary = true;
     bool dictionaryChanged {};
     // Copy the value while we have the lock:

--- a/src/Host.h
+++ b/src/Host.h
@@ -129,7 +129,7 @@ private:
 inline QDebug& operator<<(QDebug& debug, const stopWatch& stopwatch)
 {
     const QDebugStateSaver saver(debug);
-    Q_UNUSED(saver);
+    Q_UNUSED(saver)
     debug.nospace() << qsl("stopwatch(mIsRunning: %1 mInitialised: %2 mIsPersistent: %3 mEffectiveStartDateTime: %4 mElapsedTime: %5)")
                        .arg((stopwatch.running() ? QLatin1String("true") : QLatin1String("false")),
                             (stopwatch.initialised() ? QLatin1String("true") : QLatin1String("false")),

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -5155,7 +5155,7 @@ void T2DMap::slot_setCustomLine2()
 
 void T2DMap::slot_setCustomLine2B(QTreeWidgetItem* special_exit, int column)
 {
-    Q_UNUSED(column);
+    Q_UNUSED(column)
     if (!special_exit) {
         return;
     }

--- a/src/TAction.h
+++ b/src/TAction.h
@@ -164,7 +164,7 @@ private:
 inline QDebug& operator<<(QDebug& debug, const TAction* action)
 {
     QDebugStateSaver saver(debug);
-    Q_UNUSED(saver);
+    Q_UNUSED(saver)
     debug.nospace() << "TAction(" << action->getName() << ")";
     debug.nospace() << ", commandButtonUp=" << action->getCommandButtonUp();
     debug.nospace() << ", commandButtonDown=" << action->getCommandButtonDown();

--- a/src/TAlias.h
+++ b/src/TAlias.h
@@ -94,7 +94,7 @@ private:
 inline QDebug& operator<<(QDebug& debug, const TAlias* alias)
 {
     QDebugStateSaver saver(debug);
-    Q_UNUSED(saver);
+    Q_UNUSED(saver)
 
     if (!alias) {
         return debug << "TAlias(0x0) ";

--- a/src/TFlipButton.cpp
+++ b/src/TFlipButton.cpp
@@ -93,7 +93,7 @@ QSize TFlipButton::minimumSizeHint() const
 
 void TFlipButton::paintEvent(QPaintEvent* event)
 {
-    Q_UNUSED(event);
+    Q_UNUSED(event)
     QStylePainter painter(this);
 
     switch (mOrientation) {

--- a/src/TForkedProcess.cpp
+++ b/src/TForkedProcess.cpp
@@ -72,9 +72,8 @@ TForkedProcess::TForkedProcess(TLuaInterpreter* pInterpreter, lua_State* L)
 
 void TForkedProcess::slot_finished(int exitCode, QProcess::ExitStatus exitStatus)
 {
-    Q_UNUSED(exitCode);
-    Q_UNUSED(exitStatus);
-
+    Q_UNUSED(exitCode)
+    Q_UNUSED(exitStatus)
     running = false;
 }
 

--- a/src/TKey.h
+++ b/src/TKey.h
@@ -107,7 +107,7 @@ private:
 inline QDebug& operator<<(QDebug& debug, const TKey* key)
 {
     QDebugStateSaver saver(debug);
-    Q_UNUSED(saver);
+    Q_UNUSED(saver)
     debug.nospace() << "TKey(" << key->getName();
     debug.nospace() << ", keyCode=" << key->getKeyCode();
     debug.nospace() << ", keyModifiers=" << key->getKeyModifiers();

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -570,8 +570,8 @@ void TLuaInterpreter::slot_pathChanged(const QString& path)
 // No documentation available in wiki - internal function
 void TLuaInterpreter::slot_deleteSender(int exitCode, QProcess::ExitStatus exitStatus)
 {
-    Q_UNUSED(exitCode);
-    Q_UNUSED(exitStatus);
+    Q_UNUSED(exitCode)
+    Q_UNUSED(exitStatus)
 
     objectsToDelete.append(sender());
 }

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -2378,7 +2378,7 @@ int TLuaInterpreter::gotoRoom(lua_State* L)
 
     if (!host.mpMap->gotoRoom(targetRoomId)) {
         const int totalWeight = host.assemblePath(); // Needed if unsuccessful to clear lua speedwalk tables
-        Q_UNUSED(totalWeight);
+        Q_UNUSED(totalWeight)
         return warnArgumentValue(L, __func__, qsl("no path found from current room to room with id %1").arg(targetRoomId), true);
     }
     host.startSpeedWalk();
@@ -2655,7 +2655,7 @@ int TLuaInterpreter::registerMapInfo(lua_State* L)
 
     auto& host = getHostFromLua(L);
     host.mpMap->mMapInfoContributorManager->registerContributor(name, [=](int roomID, int selectionSize, int areaId, int displayAreaId, QColor& infoColor) {
-        Q_UNUSED(infoColor);
+        Q_UNUSED(infoColor)
         lua_rawgeti(L, LUA_REGISTRYINDEX, callback);
         if (roomID > 0) {
             lua_pushinteger(L, roomID);

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -3520,7 +3520,7 @@ void TMap::restore16ColorSet()
 void TMap::setUnsaved(const char* fromWhere)
 {
 #if !defined(DEBUG_MAPAUTOSAVE)
-    Q_UNUSED(fromWhere);
+    Q_UNUSED(fromWhere)
 #else
     QString nowString = QDateTime::currentDateTimeUtc().toString("HH:mm:ss.zzz");
     qDebug().nospace().noquote() << "TMap::setUnsaved(...) INFO - called at: " << nowString << " from: " << fromWhere << ".";

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -228,7 +228,7 @@ inline QDebug operator<<(QDebug debug, const TRoom* room)
         return debug << "TRoom(0x0) ";
     }
     QDebugStateSaver saver(debug);
-    Q_UNUSED(saver);
+    Q_UNUSED(saver)
 
     debug.nospace() << "TRoom(" << room->getId() << ")";
     debug.nospace() << ", name=" << room->name;

--- a/src/TScript.h
+++ b/src/TScript.h
@@ -83,7 +83,7 @@ private:
 inline QDebug& operator<<(QDebug& debug, const TScript* script)
 {
     QDebugStateSaver saver(debug);
-    Q_UNUSED(saver);
+    Q_UNUSED(saver)
     debug.nospace() << "TScript(" << script->getName() << ")";
     debug.nospace() << ", script=" << script->getScript();
     debug.nospace() << ", event handlers=" << script->getEventHandlerList();

--- a/src/TScrollBox.cpp
+++ b/src/TScrollBox.cpp
@@ -58,7 +58,7 @@ void TScrollBoxWidget::childEvent(QChildEvent* event)
 
 bool TScrollBoxWidget::eventFilter(QObject* object, QEvent* event)
 {
-    Q_UNUSED(object);
+    Q_UNUSED(object)
 
     if (event->type() == QMoveEvent::Move || event->type() == QResizeEvent::Resize || event->type() == QHideEvent::Hide || event->type() == QShowEvent::Show)
     {

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -184,7 +184,7 @@ void TTabBar::applyPrefixToDisplayedText(int index, const QString& prefix)
 
 void TTabBar::paintEvent(QPaintEvent* event)
 {
-    Q_UNUSED(event);
+    Q_UNUSED(event)
     QStylePainter painter(this);
     QStyleOptionTab opt;
 

--- a/src/TTimer.h
+++ b/src/TTimer.h
@@ -133,7 +133,7 @@ private:
 inline QDebug& operator<<(QDebug& debug, const TTimer* timer)
 {
     QDebugStateSaver saver(debug);
-    Q_UNUSED(saver);
+    Q_UNUSED(saver)
     debug.nospace() << "TTimer("
                     << "name= " << timer->getName()
                     << " time= " << timer->getTime()

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -219,7 +219,7 @@ private:
 inline QDebug& operator<<(QDebug& debug, const TTrigger* trigger)
 {
     QDebugStateSaver saver(debug);
-    Q_UNUSED(saver);
+    Q_UNUSED(saver)
 
     if (!trigger) {
         return debug << "TTrigger(0x0) ";

--- a/src/TVar.h
+++ b/src/TVar.h
@@ -82,7 +82,7 @@ private:
 inline QDebug& operator<<(QDebug& debug, const TVar* var)
 {
   QDebugStateSaver saver(debug);
-  Q_UNUSED(saver);
+  Q_UNUSED(saver)
   debug.nospace() << "TVar(" << var->getName() << ")";
 
   switch (var->getKeyType()) {

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -853,7 +853,7 @@ void XMLexport::exportToClipboard(TTrigger* pT)
     // The use of pT is a cludge - it was already used in the previously invoked
     // in this XMLexport instance's constructor (and stored in mpTrigger) and it
     // is only used here for its signature.
-    Q_UNUSED(pT);
+    Q_UNUSED(pT)
 
     auto mudletPackage = writeXmlHeader();
     auto triggerPackage = mudletPackage.append_child("TriggerPackage");
@@ -936,7 +936,7 @@ void XMLexport::exportToClipboard(TAlias* pT)
     // The use of pT is a cludge - it was already used in the previously invoked
     // in this XMLexport instance's constructor (and stored in mpAlias) and it
     // is only used here for its signature.
-    Q_UNUSED(pT);
+    Q_UNUSED(pT)
 
     auto mudletPackage = writeXmlHeader();
     auto aliasPackage = mudletPackage.append_child("AliasPackage");
@@ -989,7 +989,7 @@ void XMLexport::exportToClipboard(TAction* pT)
     // The use of pT is a cludge - it was already used in the previously invoked
     // in this XMLexport instance's constructor (and stored in mpAction) and it
     // is only used here for its signature.
-    Q_UNUSED(pT);
+    Q_UNUSED(pT)
 
     auto mudletPackage = writeXmlHeader();
     auto actionPackage = mudletPackage.append_child("ActionPackage");
@@ -1058,7 +1058,7 @@ void XMLexport::exportToClipboard(TTimer* pT)
     // The use of pT is a cludge - it was already used in the previously invoked
     // in this XMLexport instance's constructor (and stored in mpTimer) and it
     // is only used here for its signature.
-    Q_UNUSED(pT);
+    Q_UNUSED(pT)
 
     auto mudletPackage = writeXmlHeader();
     auto timerPackage = mudletPackage.append_child("TimerPackage");
@@ -1114,7 +1114,7 @@ void XMLexport::exportToClipboard(TScript* pT)
     // The use of pT is a cludge - it was already used in the previously invoked
     // in this XMLexport instance's constructor (and stored in mpScript) and it
     // is only used here for its signature.
-    Q_UNUSED(pT);
+    Q_UNUSED(pT)
 
     auto mudletPackage = writeXmlHeader();
     auto scriptPackage = mudletPackage.append_child("ScriptPackage");
@@ -1169,7 +1169,7 @@ void XMLexport::exportToClipboard(TKey* pT)
     // The use of pT is a cludge - it was already used in the previously invoked
     // in this XMLexport instance's constructor (and stored in mpKey) and it
     // is only used here for its signature.
-    Q_UNUSED(pT);
+    Q_UNUSED(pT)
 
     auto mudletPackage = writeXmlHeader();
     auto keyPackage = mudletPackage.append_child("KeyPackage");

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1281,7 +1281,7 @@ void XMLimport::readHost(Host* pHost)
                 // We still check for them so that we avoid falling into the
                 // QDebug() error reporting associated with the following
                 // readUnknownElement(...) for "anything not otherwise parsed"
-                Q_UNUSED(readElementText());
+                Q_UNUSED(readElementText())
             } else if (name() == qsl("mMapInfoContributors")) {
                 readLegacyMapInfoContributors();
             } else if (name() == qsl("mapInfoContributor")) {

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -259,7 +259,7 @@ void Discord::setParty(Host* pHost, int partySize, int partyMax)
 
 void Discord::timerEvent(QTimerEvent* event)
 {
-    Q_UNUSED(event);
+    Q_UNUSED(event)
 
     if (mLoaded) {
         Discord_RunCallbacks();

--- a/src/discord.h
+++ b/src/discord.h
@@ -137,7 +137,7 @@ private:
 inline QDebug& operator<<(QDebug& debug, const localDiscordPresence& ldp)
 {
     const QDebugStateSaver saver(debug);
-    Q_UNUSED(saver);
+    Q_UNUSED(saver)
 
     QString result = qsl("localDiscordPresence(\n"
                                     "    mDetails: \"%1\"  mState: \"%2\" mInstance: %3\n"

--- a/src/dlgNotepad.cpp
+++ b/src/dlgNotepad.cpp
@@ -126,7 +126,7 @@ void dlgNotepad::slot_textWritten()
 
 void dlgNotepad::timerEvent(QTimerEvent* event)
 {
-    Q_UNUSED(event);
+    Q_UNUSED(event)
 
     if (!mNeedToSave) {
         return;

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -980,7 +980,7 @@ std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDi
     QMap<QString, QString> fileEntries;
     while (stagingFile.hasNext() && isOk) {
         const QString itEntry = stagingFile.next();
-        Q_UNUSED(itEntry);
+        Q_UNUSED(itEntry)
         // Dot and DotDot entries are no use to us so skip them
         if (!(stagingFile.fileName().compare(qsl(".")) && stagingFile.fileName().compare(qsl("..")))) {
             // Dot and DotDot entries are no use to us so skip them

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2850,7 +2850,7 @@ void dlgProfilePreferences::slot_resetLogDir()
 
 void dlgProfilePreferences::slot_logFileNameFormatChange(const int index)
 {
-    Q_UNUSED(index);
+    Q_UNUSED(index)
 
     Host* pHost = mpHost;
     if (!pHost) {
@@ -3215,7 +3215,7 @@ void dlgProfilePreferences::slot_saveAndClose()
 
 void dlgProfilePreferences::slot_chosenProfilesChanged(QAction* _action)
 {
-    Q_UNUSED(_action);
+    Q_UNUSED(_action)
 
     QMenu* _menu = pushButton_chooseProfiles->menu();
     QListIterator<QAction*> itAction(_menu->actions());
@@ -4243,7 +4243,7 @@ void dlgProfilePreferences::slot_changeShowIconsOnMenus(const Qt::CheckState sta
 // is changed by the user.
 void dlgProfilePreferences::slot_changeGuiLanguage(int languageIndex)
 {
-    Q_UNUSED(languageIndex);
+    Q_UNUSED(languageIndex)
 
     auto languageCode = comboBox_guiLanguage->currentData().toString();
     mudlet::self()->setInterfaceLanguage(languageCode);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -7705,7 +7705,7 @@ void dlgTriggerEditor::saveOpenChanges()
 
 void dlgTriggerEditor::timerEvent(QTimerEvent *event)
 {
-    Q_UNUSED(event);
+    Q_UNUSED(event)
 
     if (isActiveWindow()) {
         autoSave();
@@ -7783,7 +7783,7 @@ void dlgTriggerEditor::focusInEvent(QFocusEvent* pE)
 
 void dlgTriggerEditor::focusOutEvent(QFocusEvent* pE)
 {
-    Q_UNUSED(pE);
+    Q_UNUSED(pE)
 
     saveOpenChanges();
 }

--- a/src/mapInfoContributorManager.cpp
+++ b/src/mapInfoContributorManager.cpp
@@ -86,8 +86,8 @@ QList<QString> &MapInfoContributorManager::getContributorKeys()
 
 MapInfoProperties MapInfoContributorManager::shortInfo(int roomID, int selectionSize, int areaId, int displayAreaId, QColor& infoColor)
 {
-    Q_UNUSED(selectionSize);
-    Q_UNUSED(displayAreaId);
+    Q_UNUSED(selectionSize)
+    Q_UNUSED(displayAreaId)
 
     QString infoText;
     TRoom* room = mpHost->mpMap->mpRoomDB->getRoom(roomID);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
In all places in our code where we use `Q_UNUSED(...)` to silence a warning about an argument to a method/function that isn't used this PR removes any following `;` as this macro does NOT need it.

#### Motivation for adding to Mudlet
For consistency across the entirety of our code, so that all our usage of this macro is "correct" and doesn't include something that is unneeded.

#### Other info (issues closed, discussion etc)
There are places in third-party code that does include it but it isn't our job to clean those up!