### PR TITLE
Add: Caps and Purges for Playing Media

### DIFF
--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -1047,9 +1047,48 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
     });
 }
 
+void TMedia::purgeStoppedMediaPlayers(QList<std::shared_ptr<TMediaPlayer>>& mediaList)
+{
+    mediaList.erase(std::remove_if(mediaList.begin(), mediaList.end(),
+                                   [](const std::shared_ptr<TMediaPlayer>& player) {
+                                       return player->getPlaybackState() == QMediaPlayer::StoppedState;
+                                   }),
+                    mediaList.end());
+}
+
+// Helper for updating media player lists (now a static TMedia method)
+template<typename T>
+void TMedia::updateList(QList<std::shared_ptr<T>>& list, int index, std::shared_ptr<T> player)
+{
+    if (index == -1) {
+        qDebug() << "TMedia::updateList() - Adding new player to list (index == -1)";
+        list.append(std::move(player));
+    } else if (index >= 0 && index < list.size()) {
+        qDebug() << "TMedia::updateList() - Replacing existing player at index:" << index;
+        list[index] = std::move(player);
+    } else {
+        qWarning() << "TMedia::updateList() - Invalid index:" << index
+                   << " for list size:" << list.size() << ". Appending instead.";
+        list.append(std::move(player));
+    }
+
+    if (list.size() > TMedia::MaxUnprunedPlayers) {
+        qDebug() << "TMedia::updateList() - List exceeded max allowed size (" << TMedia::MaxUnprunedPlayers << "). Purging stopped players.";
+        TMedia::purgeStoppedMediaPlayers(list);
+
+        if (list.size() > TMedia::MaxUnprunedPlayers) {
+            qWarning() << "TMedia::updateList() - List still exceeds max size after purging. Removing oldest active player.";
+            list.removeFirst(); // Evict the oldest player to enforce cap
+        }
+    }
+
+    qDebug() << "TMedia::updateList() - List size after update:" << list.size();
+}
+
 void TMedia::updateMediaPlayerList(std::shared_ptr<TMediaPlayer> player)
 {
     if (!player) {
+        qDebug() << "TMedia::updateMediaPlayerList() - Player is null. Aborting update.";
         return;
     }
 
@@ -1058,6 +1097,7 @@ void TMedia::updateMediaPlayerList(std::shared_ptr<TMediaPlayer> player)
 
     QList<std::shared_ptr<TMediaPlayer>> mTMediaPlayerList = findMediaPlayersByCriteria(mediaData);
 
+    qDebug() << "TMedia::updateMediaPlayerList() - Searching for existing player in list.";
     for (int i = 0; i < mTMediaPlayerList.size(); ++i) {
         if (mTMediaPlayerList[i] && mTMediaPlayerList[i]->mediaPlayer() == player->mediaPlayer()) {
             matchedMediaPlayerIndex = i;
@@ -1065,78 +1105,35 @@ void TMedia::updateMediaPlayerList(std::shared_ptr<TMediaPlayer> player)
             break;
         }
     }
+    if (matchedMediaPlayerIndex != -1) {
+        qDebug() << "TMedia::updateMediaPlayerList() - Found existing player at index:" << matchedMediaPlayerIndex;
+    } else {
+        qDebug() << "TMedia::updateMediaPlayerList() - No existing player found. Appending new one.";
+    }
 
+    QList<std::shared_ptr<TMediaPlayer>>* list = nullptr;
+
+    qDebug() << "TMedia::updateMediaPlayerList() - Updating list for protocol:"
+             << mediaData.mediaProtocol()
+             << "and type:" << mediaData.mediaType();
     switch (mediaData.mediaProtocol()) {
     case TMediaData::MediaProtocolMSP:
-        switch (mediaData.mediaType()) {
-        case TMediaData::MediaTypeSound:
-            if (matchedMediaPlayerIndex == -1) {
-                mMSPSoundList.append(std::move(player));
-            } else {
-                mMSPSoundList[matchedMediaPlayerIndex] = std::move(player);
-            }
-            break;
-        case TMediaData::MediaTypeMusic:
-            if (matchedMediaPlayerIndex == -1) {
-                mMSPMusicList.append(std::move(player));
-            } else {
-                mMSPMusicList[matchedMediaPlayerIndex] = std::move(player);
-            }
-            break;
-        }
+        list = (mediaData.mediaType() == TMediaData::MediaTypeMusic) ? &mMSPMusicList : &mMSPSoundList;
         break;
-
     case TMediaData::MediaProtocolGMCP:
-        switch (mediaData.mediaType()) {
-        case TMediaData::MediaTypeSound:
-            if (matchedMediaPlayerIndex == -1) {
-                mGMCPSoundList.append(std::move(player));
-            } else {
-                mGMCPSoundList[matchedMediaPlayerIndex] = std::move(player);
-            }
-            break;
-        case TMediaData::MediaTypeMusic:
-            if (matchedMediaPlayerIndex == -1) {
-                mGMCPMusicList.append(std::move(player));
-            } else {
-                mGMCPMusicList[matchedMediaPlayerIndex] = std::move(player);
-            }
-            break;
-        case TMediaData::MediaTypeVideo:
-            if (matchedMediaPlayerIndex == -1) {
-                mGMCPVideoList.append(std::move(player));
-            } else {
-                mGMCPVideoList[matchedMediaPlayerIndex] = std::move(player);
-            }
-            break;
-        }
+        list = (mediaData.mediaType() == TMediaData::MediaTypeMusic) ? &mGMCPMusicList :
+               (mediaData.mediaType() == TMediaData::MediaTypeVideo) ? &mGMCPVideoList : &mGMCPSoundList;
         break;
-
     case TMediaData::MediaProtocolAPI:
-        switch (mediaData.mediaType()) {
-        case TMediaData::MediaTypeSound:
-            if (matchedMediaPlayerIndex == -1) {
-                mAPISoundList.append(std::move(player));
-            } else {
-                mAPISoundList[matchedMediaPlayerIndex] = std::move(player);
-            }
-            break;
-        case TMediaData::MediaTypeMusic:
-            if (matchedMediaPlayerIndex == -1) {
-                mAPIMusicList.append(std::move(player));
-            } else {
-                mAPIMusicList[matchedMediaPlayerIndex] = std::move(player);
-            }
-            break;
-        case TMediaData::MediaTypeVideo:
-            if (matchedMediaPlayerIndex == -1) {
-                mAPIVideoList.append(std::move(player));
-            } else {
-                mAPIVideoList[matchedMediaPlayerIndex] = std::move(player);
-            }
-            break;
-        }
+        list = (mediaData.mediaType() == TMediaData::MediaTypeMusic) ? &mAPIMusicList :
+               (mediaData.mediaType() == TMediaData::MediaTypeVideo) ? &mAPIVideoList : &mAPISoundList;
         break;
+    }
+
+    if (list) {
+        TMedia::updateList<TMediaPlayer>(*list, matchedMediaPlayerIndex, std::move(player));
+    } else {
+        qWarning() << "TMedia::updateMediaPlayerList() - Could not determine appropriate list for player.";
     }
 }
 
@@ -1155,6 +1152,27 @@ std::shared_ptr<TMediaPlayer> TMedia::getMediaPlayer(TMediaData& mediaData)
             existingPlayer->setMediaData(mediaData);
             return existingPlayer;  // Reuse existing player
         }
+    }
+
+    // Cap to prevent overflow per media type
+    int maxAllowed = MaxAllowedSoundPlayers; // Default fallback
+
+    switch (mediaData.mediaType()) {
+        case TMediaData::MediaTypeMusic:
+            maxAllowed = MaxAllowedMusicPlayers;
+            break;
+        case TMediaData::MediaTypeVideo:
+            maxAllowed = MaxAllowedVideoPlayers;
+            break;
+        case TMediaData::MediaTypeSound:
+        default:
+            maxAllowed = MaxAllowedSoundPlayers;
+            break;
+    }
+
+    if (mediaPlayerList.size() >= maxAllowed) {
+        qWarning() << "TMedia::getMediaPlayer() - Too many active players for media type. Skipping creation.";
+        return nullptr;
     }
 
     // No available player, create a new one

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -1076,9 +1076,17 @@ void TMedia::updateList(QList<std::shared_ptr<T>>& list, int index, std::shared_
         qDebug() << "TMedia::updateList() - List exceeded max allowed size (" << mediaInstance->getMaxUnprunedPlayers() << "). Purging stopped players.";
         TMedia::purgeStoppedMediaPlayers(list);
 
+        if (mudlet::smDebugMode && mediaInstance && mediaInstance->mpHost && mediaInstance->mpHost->mpConsole) {
+            mediaInstance->mpHost->mpConsole->printSystemMessage(qsl("%1\n").arg(tr("Too many stopped media players. Purging stopped players.")));
+        }
+
         if (list.size() > mediaInstance->getMaxUnprunedPlayers()) {
             qWarning() << "TMedia::updateList() - List still exceeds max size after purging. Removing oldest active player.";
             list.removeFirst(); // Evict the oldest player to enforce cap
+
+            if (mudlet::smDebugMode && mediaInstance && mediaInstance->mpHost && mediaInstance->mpHost->mpConsole) {
+                mediaInstance->mpHost->mpConsole->printSystemMessage(qsl("%1\n").arg(tr("Too many stopped media players. Removed oldest active player.")));
+            }
         }
     }
 
@@ -1172,6 +1180,11 @@ std::shared_ptr<TMediaPlayer> TMedia::getMediaPlayer(TMediaData& mediaData)
 
     if (mediaPlayerList.size() >= maxAllowed) {
         qWarning() << "TMedia::getMediaPlayer() - Too many active players for media type. Skipping creation.";
+
+        if (mudlet::smDebugMode && mpHost && mpHost->mpConsole) {
+            mpHost->mpConsole->printSystemMessage(qsl("%1\n").arg(tr("Maximum allowed active media players reached for media type. Cannot play additional media.")));
+        }
+
         return nullptr;
     }
 

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -1058,7 +1058,7 @@ void TMedia::purgeStoppedMediaPlayers(QList<std::shared_ptr<TMediaPlayer>>& medi
 
 // Helper for updating media player lists (now a static TMedia method)
 template<typename T>
-void TMedia::updateList(QList<std::shared_ptr<T>>& list, int index, std::shared_ptr<T> player)
+void TMedia::updateList(QList<std::shared_ptr<T>>& list, int index, std::shared_ptr<T> player, TMedia* mediaInstance)
 {
     if (index == -1) {
         qDebug() << "TMedia::updateList() - Adding new player to list (index == -1)";
@@ -1072,11 +1072,11 @@ void TMedia::updateList(QList<std::shared_ptr<T>>& list, int index, std::shared_
         list.append(std::move(player));
     }
 
-    if (list.size() > TMedia::MaxUnprunedPlayers) {
-        qDebug() << "TMedia::updateList() - List exceeded max allowed size (" << TMedia::MaxUnprunedPlayers << "). Purging stopped players.";
+    if (list.size() > mediaInstance->getMaxUnprunedPlayers()) {
+        qDebug() << "TMedia::updateList() - List exceeded max allowed size (" << mediaInstance->getMaxUnprunedPlayers() << "). Purging stopped players.";
         TMedia::purgeStoppedMediaPlayers(list);
 
-        if (list.size() > TMedia::MaxUnprunedPlayers) {
+        if (list.size() > mediaInstance->getMaxUnprunedPlayers()) {
             qWarning() << "TMedia::updateList() - List still exceeds max size after purging. Removing oldest active player.";
             list.removeFirst(); // Evict the oldest player to enforce cap
         }
@@ -1131,7 +1131,7 @@ void TMedia::updateMediaPlayerList(std::shared_ptr<TMediaPlayer> player)
     }
 
     if (list) {
-        TMedia::updateList<TMediaPlayer>(*list, matchedMediaPlayerIndex, std::move(player));
+        TMedia::updateList<TMediaPlayer>(*list, matchedMediaPlayerIndex, std::move(player), this);
     } else {
         qWarning() << "TMedia::updateMediaPlayerList() - Could not determine appropriate list for player.";
     }
@@ -1155,18 +1155,18 @@ std::shared_ptr<TMediaPlayer> TMedia::getMediaPlayer(TMediaData& mediaData)
     }
 
     // Cap to prevent overflow per media type
-    int maxAllowed = MaxAllowedSoundPlayers; // Default fallback
+    int maxAllowed = getMaxAllowedSoundPlayers(); // Default fallback
 
     switch (mediaData.mediaType()) {
         case TMediaData::MediaTypeMusic:
-            maxAllowed = MaxAllowedMusicPlayers;
+            maxAllowed = getMaxAllowedMusicPlayers();
             break;
         case TMediaData::MediaTypeVideo:
-            maxAllowed = MaxAllowedVideoPlayers;
+            maxAllowed = getMaxAllowedVideoPlayers();
             break;
         case TMediaData::MediaTypeSound:
         default:
-            maxAllowed = MaxAllowedSoundPlayers;
+            maxAllowed = getMaxAllowedSoundPlayers();
             break;
     }
 
@@ -1188,6 +1188,27 @@ std::shared_ptr<TMediaPlayer> TMedia::getMediaPlayer(TMediaData& mediaData)
     mediaPlayerList.append(newPlayer);
 
     return newPlayer;
+}
+
+// Dynamic limits for media players, based on host count
+int TMedia::getMaxUnprunedPlayers() const {
+    int hostCount = std::max(1, mudlet::self()->getHostManager().getHostCount());
+    return std::max(10, 25 / hostCount);
+}
+
+int TMedia::getMaxAllowedSoundPlayers() const {
+    int hostCount = std::max(1, mudlet::self()->getHostManager().getHostCount());
+    return std::max(16, 65 / hostCount);
+}
+
+int TMedia::getMaxAllowedMusicPlayers() const {
+    int hostCount = std::max(1, mudlet::self()->getHostManager().getHostCount());
+    return std::max(4, 20 / hostCount);
+}
+
+int TMedia::getMaxAllowedVideoPlayers() const {
+    int hostCount = std::max(1, mudlet::self()->getHostManager().getHostCount());
+    return std::max(2, 10 / hostCount);
 }
 
 void TMedia::handlePlayerPlaybackStateChanged(QMediaPlayerPlaybackState playbackState, const std::shared_ptr<TMediaPlayer>& player)

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -96,10 +96,10 @@ public:
     TMedia(Host* pHost, const QString& profileName);
     ~TMedia() = default;
 
-    static constexpr int MaxUnprunedPlayers = 25;
-    static constexpr int MaxAllowedSoundPlayers = 48;
-    static constexpr int MaxAllowedMusicPlayers = 6;
-    static constexpr int MaxAllowedVideoPlayers = 4;
+    int getMaxUnprunedPlayers() const;
+    int getMaxAllowedSoundPlayers() const;
+    int getMaxAllowedMusicPlayers() const;
+    int getMaxAllowedVideoPlayers() const;
 
     void playMedia(TMediaData& mediaData);
     QList<TMediaData> playingMedia(TMediaData& mediaData);
@@ -135,7 +135,7 @@ private:
     void connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player);
     static void purgeStoppedMediaPlayers(QList<std::shared_ptr<TMediaPlayer>>& mediaList);
     template<typename T>
-    static void updateList(QList<std::shared_ptr<T>>& list, int index, std::shared_ptr<T> player);
+    static void updateList(QList<std::shared_ptr<T>>& list, int index, std::shared_ptr<T> player, TMedia* mediaInstance);
     void updateMediaPlayerList(std::shared_ptr<TMediaPlayer> player);
     std::shared_ptr<TMediaPlayer> getMediaPlayer(TMediaData& mediaData);
     std::shared_ptr<TMediaPlayer> matchMediaPlayer(TMediaData& mediaData);

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -96,6 +96,11 @@ public:
     TMedia(Host* pHost, const QString& profileName);
     ~TMedia() = default;
 
+    static constexpr int MaxUnprunedPlayers = 25;
+    static constexpr int MaxAllowedSoundPlayers = 48;
+    static constexpr int MaxAllowedMusicPlayers = 6;
+    static constexpr int MaxAllowedVideoPlayers = 4;
+
     void playMedia(TMediaData& mediaData);
     QList<TMediaData> playingMedia(TMediaData& mediaData);
     QList<TMediaData> pausedMedia(TMediaData& mediaData);
@@ -128,6 +133,9 @@ private:
     void downloadFile(TMediaData& mediaData);
     QString setupMediaAbsolutePathFileName(TMediaData& mediaData);
     void connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player);
+    static void purgeStoppedMediaPlayers(QList<std::shared_ptr<TMediaPlayer>>& mediaList);
+    template<typename T>
+    static void updateList(QList<std::shared_ptr<T>>& list, int index, std::shared_ptr<T> player);
     void updateMediaPlayerList(std::shared_ptr<TMediaPlayer> player);
     std::shared_ptr<TMediaPlayer> getMediaPlayer(TMediaData& mediaData);
     std::shared_ptr<TMediaPlayer> matchMediaPlayer(TMediaData& mediaData);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Added logic to cap the number of playing media players of various types and purging of stopped media players. The number of stopped players and maximum allowed players per media type (sound, music, video) scale based on the number of open profiles.

#### Motivation for adding to Mudlet

See #7801

#### Other info (issues closed, discussion etc)

Closes #7801

<img width="1728" alt="Screenshot 2025-05-04 at 10 43 32 AM" src="https://github.com/user-attachments/assets/beaab204-a89f-4ea4-a595-b3ecce938c96" />
