### PR TITLE
Add: Closed Captioning for Media

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -701,6 +701,8 @@ public:
 
     bool mAnnounceIncomingText = true;
     bool mAdvertiseScreenReader = false;
+    bool mEnableClosedCaption = false;
+
     enum class BlankLineBehaviour {
         Show,
         Hide,

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7373,6 +7373,10 @@ int TLuaInterpreter::setConfig(lua_State * L)
         host.mAdvertiseScreenReader = getVerifiedBool(L, __func__, 2, "value");
         return success();
     }
+    if (key == qsl("enableClosedCaption")) {
+        host.mEnableClosedCaption = getVerifiedBool(L, __func__, 2, "value");
+        return success();
+    }
     if (key == qsl("blankLinesBehaviour")) {
         static const QStringList behaviours{"show", "hide", "replacewithspace"};
         const auto behaviour = getVerifiedString(L, __func__, 2, "value");

--- a/src/TLuaInterpreterMedia.cpp
+++ b/src/TLuaInterpreterMedia.cpp
@@ -1483,8 +1483,8 @@ int TLuaInterpreter::stopMusicAsTableArgument(lua_State* L, const char* func)
         QString key = getVerifiedString(L, func, -2, "table keys");
         key = key.toLower();
 
-        if (key == QLatin1String("name") || key == QLatin1String("key") || key == QLatin1String("tag") || key == QLatin1String("caption")) {
-            QString value = getVerifiedString(L, func, -1, key == QLatin1String("name") ? "value for name" : key == QLatin1String("key") ? "value for key" : key == QLatin1String("tag") ? "value for tag" : "value for caption");
+        if (key == QLatin1String("name") || key == QLatin1String("key") || key == QLatin1String("tag")) {
+            QString value = getVerifiedString(L, func, -1, key == QLatin1String("name") ? "value for name" : key == QLatin1String("key") ? "value for key" : "value for tag");
 
             if (key == QLatin1String("name") && !value.isEmpty()) {
                 if (QDir::homePath().contains('\\')) {
@@ -1498,8 +1498,6 @@ int TLuaInterpreter::stopMusicAsTableArgument(lua_State* L, const char* func)
                 mediaData.setMediaKey(value);
             } else if (key == QLatin1String("tag") && !value.isEmpty()) {
                 mediaData.setMediaTag(value);
-            } else if (key == QLatin1String("caption") && !value.isEmpty()) {
-                mediaData.setMediaCaption(value);
             }
         } else if (key == QLatin1String("fadeaway")) {
             const bool value = getVerifiedBool(L, func, -1, "value for fadeaway must be boolean");
@@ -1634,8 +1632,8 @@ int TLuaInterpreter::stopSoundsAsTableArgument(lua_State* L, const char* func)
         QString key = getVerifiedString(L, func, -2, "table keys");
         key = key.toLower();
 
-        if (key == QLatin1String("name") || key == QLatin1String("key") || key == QLatin1String("tag") || key == QLatin1String("caption")) {
-            QString value = getVerifiedString(L, func, -1, key == QLatin1String("name") ? "value for name" : key == QLatin1String("key") ? "value for key" : key == QLatin1String("tag") ? "value for tag" : "value for caption");
+        if (key == QLatin1String("name") || key == QLatin1String("key") || key == QLatin1String("tag")) {
+            QString value = getVerifiedString(L, func, -1, key == QLatin1String("name") ? "value for name" : key == QLatin1String("key") ? "value for key" : "value for tag");
 
             if (key == QLatin1String("name") && !value.isEmpty()) {
                 if (QDir::homePath().contains('\\')) {
@@ -1649,8 +1647,6 @@ int TLuaInterpreter::stopSoundsAsTableArgument(lua_State* L, const char* func)
                 mediaData.setMediaKey(value);
             } else if (key == QLatin1String("tag") && !value.isEmpty()) {
                 mediaData.setMediaTag(value);
-            } else if (key == QLatin1String("caption") && !value.isEmpty()) {
-                mediaData.setMediaCaption(value);
             }
         } else if (key == QLatin1String("priority")) {
             int value = getVerifiedInt(L, func, -1, "value for priority must be integer");
@@ -1725,8 +1721,8 @@ int TLuaInterpreter::stopVideosAsTableArgument(lua_State* L, const char* func)
         QString key = getVerifiedString(L, func, -2, "table keys");
         key = key.toLower();
 
-        if (key == QLatin1String("name") || key == QLatin1String("key") || key == QLatin1String("tag") || key == QLatin1String("caption")) {
-            QString value = getVerifiedString(L, func, -1, key == QLatin1String("name") ? "value for name" : key == QLatin1String("key") ? "value for key" : key == QLatin1String("tag") ? "value for tag" : "value for caption");
+        if (key == QLatin1String("name") || key == QLatin1String("key") || key == QLatin1String("tag")) {
+            QString value = getVerifiedString(L, func, -1, key == QLatin1String("name") ? "value for name" : key == QLatin1String("key") ? "value for key" : "value for tag");
 
             if (key == QLatin1String("name") && !value.isEmpty()) {
                 if (QDir::homePath().contains('\\')) {
@@ -1740,8 +1736,6 @@ int TLuaInterpreter::stopVideosAsTableArgument(lua_State* L, const char* func)
                 mediaData.setMediaKey(value);
             } else if (key == QLatin1String("tag") && !value.isEmpty()) {
                 mediaData.setMediaTag(value);
-            } else if (key == QLatin1String("caption") && !value.isEmpty()) {
-                mediaData.setMediaCaption(value);
             }
         } else if (key == QLatin1String("fadeaway")) {
             const bool value = getVerifiedBool(L, func, -1, "value for fadeaway must be boolean");

--- a/src/TLuaInterpreterMedia.cpp
+++ b/src/TLuaInterpreterMedia.cpp
@@ -325,15 +325,14 @@ int TLuaInterpreter::playMusicFileAsTableArgument(lua_State* L, const char* func
         QString key = getVerifiedString(L, func, -2, "table keys");
         key = key.toLower();
 
-        if (key == QLatin1String("name") || key == QLatin1String("url") || key == QLatin1String("key") || key == QLatin1String("tag") || key == QLatin1String("desc") || key == QLatin1String("sfx")) {
+        if (key == QLatin1String("name") || key == QLatin1String("url") || key == QLatin1String("key") || key == QLatin1String("tag") || key == QLatin1String("caption")) {
             QString value = getVerifiedString(L,
                                               func,
                                               -1,
                                               key == QLatin1String("name")  ? "value for name"
                                               : key == QLatin1String("key") ? "value for key"
                                               : key == QLatin1String("tag") ? "value for tag"
-                                              : key == QLatin1String("desc") ? "value for desc"
-                                              : key == QLatin1String("sfx") ? "value for sfx"
+                                              : key == QLatin1String("caption") ? "value for caption"
                                                                             : "value for url");
 
             if (key == QLatin1String("name") && !value.isEmpty()) {
@@ -350,10 +349,8 @@ int TLuaInterpreter::playMusicFileAsTableArgument(lua_State* L, const char* func
                 mediaData.setMediaKey(value);
             } else if (key == QLatin1String("tag") && !value.isEmpty()) {
                 mediaData.setMediaTag(value);
-            } else if (key == QLatin1String("desc") && !value.isEmpty()) {
-                mediaData.setMediaDesc(value);
-            } else if (key == QLatin1String("sfx") && !value.isEmpty()) {
-                mediaData.setMediaSfx(value);
+            } else if (key == QLatin1String("caption") && !value.isEmpty()) {
+                mediaData.setMediaCaption(value);
             }
         } else if (key == QLatin1String("volume") || key == QLatin1String("fadein") || key == QLatin1String("fadeout") || key == QLatin1String("start") || key == QLatin1String("finish") || key == QLatin1String("loops")) {
             int value = getVerifiedInt(L,
@@ -588,15 +585,14 @@ int TLuaInterpreter::playSoundFileAsTableArgument(lua_State* L, const char* func
         QString key = getVerifiedString(L, func, -2, "table keys");
         key = key.toLower();
 
-        if (key == QLatin1String("name") || key == QLatin1String("url") || key == QLatin1String("key") || key == QLatin1String("tag") || key == QLatin1String("desc") || key == QLatin1String("sfx")) {
+        if (key == QLatin1String("name") || key == QLatin1String("url") || key == QLatin1String("key") || key == QLatin1String("tag") || key == QLatin1String("caption")) {
             QString value = getVerifiedString(L,
                                               func,
                                               -1,
                                               key == QLatin1String("name")  ? "value for name"
                                               : key == QLatin1String("key") ? "value for key"
                                               : key == QLatin1String("tag") ? "value for tag"
-                                              : key == QLatin1String("desc") ? "value for desc"
-                                              : key == QLatin1String("sfx") ? "value for sfx"
+                                              : key == QLatin1String("caption") ? "value for caption"
                                                                             : "value for url");
 
             if (key == QLatin1String("name") && !value.isEmpty()) {
@@ -613,10 +609,8 @@ int TLuaInterpreter::playSoundFileAsTableArgument(lua_State* L, const char* func
                 mediaData.setMediaKey(value);
             } else if (key == QLatin1String("tag") && !value.isEmpty()) {
                 mediaData.setMediaTag(value);
-            } else if (key == QLatin1String("desc") && !value.isEmpty()) {
-                mediaData.setMediaDesc(value);
-            } else if (key == QLatin1String("sfx") && !value.isEmpty()) {
-                mediaData.setMediaSfx(value);
+            } else if (key == QLatin1String("caption") && !value.isEmpty()) {
+                mediaData.setMediaCaption(value);
             }
         } else if (key == QLatin1String("volume") || key == QLatin1String("fadein") || key == QLatin1String("fadeout") || key == QLatin1String("start") || key == QLatin1String("finish") || key == QLatin1String("loops")
                    || key == QLatin1String("priority")) {
@@ -1489,8 +1483,8 @@ int TLuaInterpreter::stopMusicAsTableArgument(lua_State* L, const char* func)
         QString key = getVerifiedString(L, func, -2, "table keys");
         key = key.toLower();
 
-        if (key == QLatin1String("name") || key == QLatin1String("key") || key == QLatin1String("tag") || key == QLatin1String("desc") || key == QLatin1String("sfx")) {
-            QString value = getVerifiedString(L, func, -1, key == QLatin1String("name") ? "value for name" : key == QLatin1String("key") ? "value for key" : key == QLatin1String("tag") ? "value for tag" : key == QLatin1String("desc") ? "value for desc" : "value for sfx");
+        if (key == QLatin1String("name") || key == QLatin1String("key") || key == QLatin1String("tag") || key == QLatin1String("caption")) {
+            QString value = getVerifiedString(L, func, -1, key == QLatin1String("name") ? "value for name" : key == QLatin1String("key") ? "value for key" : key == QLatin1String("tag") ? "value for tag" : "value for caption");
 
             if (key == QLatin1String("name") && !value.isEmpty()) {
                 if (QDir::homePath().contains('\\')) {
@@ -1504,10 +1498,8 @@ int TLuaInterpreter::stopMusicAsTableArgument(lua_State* L, const char* func)
                 mediaData.setMediaKey(value);
             } else if (key == QLatin1String("tag") && !value.isEmpty()) {
                 mediaData.setMediaTag(value);
-            } else if (key == QLatin1String("desc") && !value.isEmpty()) {
-                mediaData.setMediaDesc(value);
-            } else if (key == QLatin1String("sfx") && !value.isEmpty()) {
-                mediaData.setMediaSfx(value);
+            } else if (key == QLatin1String("caption") && !value.isEmpty()) {
+                mediaData.setMediaCaption(value);
             }
         } else if (key == QLatin1String("fadeaway")) {
             const bool value = getVerifiedBool(L, func, -1, "value for fadeaway must be boolean");
@@ -1642,8 +1634,8 @@ int TLuaInterpreter::stopSoundsAsTableArgument(lua_State* L, const char* func)
         QString key = getVerifiedString(L, func, -2, "table keys");
         key = key.toLower();
 
-        if (key == QLatin1String("name") || key == QLatin1String("key") || key == QLatin1String("tag") || key == QLatin1String("desc") || key == QLatin1String("sfx")) {
-            QString value = getVerifiedString(L, func, -1, key == QLatin1String("name") ? "value for name" : key == QLatin1String("key") ? "value for key" : key == QLatin1String("tag") ? "value for tag" : key == QLatin1String("desc") ? "value for desc" : "value for sfx");
+        if (key == QLatin1String("name") || key == QLatin1String("key") || key == QLatin1String("tag") || key == QLatin1String("caption")) {
+            QString value = getVerifiedString(L, func, -1, key == QLatin1String("name") ? "value for name" : key == QLatin1String("key") ? "value for key" : key == QLatin1String("tag") ? "value for tag" : "value for caption");
 
             if (key == QLatin1String("name") && !value.isEmpty()) {
                 if (QDir::homePath().contains('\\')) {
@@ -1657,10 +1649,8 @@ int TLuaInterpreter::stopSoundsAsTableArgument(lua_State* L, const char* func)
                 mediaData.setMediaKey(value);
             } else if (key == QLatin1String("tag") && !value.isEmpty()) {
                 mediaData.setMediaTag(value);
-            } else if (key == QLatin1String("desc") && !value.isEmpty()) {
-                mediaData.setMediaDesc(value);
-            } else if (key == QLatin1String("sfx") && !value.isEmpty()) {
-                mediaData.setMediaSfx(value);
+            } else if (key == QLatin1String("caption") && !value.isEmpty()) {
+                mediaData.setMediaCaption(value);
             }
         } else if (key == QLatin1String("priority")) {
             int value = getVerifiedInt(L, func, -1, "value for priority must be integer");
@@ -1735,8 +1725,8 @@ int TLuaInterpreter::stopVideosAsTableArgument(lua_State* L, const char* func)
         QString key = getVerifiedString(L, func, -2, "table keys");
         key = key.toLower();
 
-        if (key == QLatin1String("name") || key == QLatin1String("key") || key == QLatin1String("tag") || key == QLatin1String("desc") || key == QLatin1String("sfx")) {
-            QString value = getVerifiedString(L, func, -1, key == QLatin1String("name") ? "value for name" : key == QLatin1String("key") ? "value for key" : key == QLatin1String("tag") ? "value for tag" : key == QLatin1String("desc") ? "value for desc" : "value for sfx");
+        if (key == QLatin1String("name") || key == QLatin1String("key") || key == QLatin1String("tag") || key == QLatin1String("caption")) {
+            QString value = getVerifiedString(L, func, -1, key == QLatin1String("name") ? "value for name" : key == QLatin1String("key") ? "value for key" : key == QLatin1String("tag") ? "value for tag" : "value for caption");
 
             if (key == QLatin1String("name") && !value.isEmpty()) {
                 if (QDir::homePath().contains('\\')) {
@@ -1750,10 +1740,8 @@ int TLuaInterpreter::stopVideosAsTableArgument(lua_State* L, const char* func)
                 mediaData.setMediaKey(value);
             } else if (key == QLatin1String("tag") && !value.isEmpty()) {
                 mediaData.setMediaTag(value);
-            } else if (key == QLatin1String("desc") && !value.isEmpty()) {
-                mediaData.setMediaDesc(value);
-            } else if (key == QLatin1String("sfx") && !value.isEmpty()) {
-                mediaData.setMediaSfx(value);
+            } else if (key == QLatin1String("caption") && !value.isEmpty()) {
+                mediaData.setMediaCaption(value);
             }
         } else if (key == QLatin1String("fadeaway")) {
             const bool value = getVerifiedBool(L, func, -1, "value for fadeaway must be boolean");

--- a/src/TLuaInterpreterMedia.cpp
+++ b/src/TLuaInterpreterMedia.cpp
@@ -325,13 +325,15 @@ int TLuaInterpreter::playMusicFileAsTableArgument(lua_State* L, const char* func
         QString key = getVerifiedString(L, func, -2, "table keys");
         key = key.toLower();
 
-        if (key == QLatin1String("name") || key == QLatin1String("url") || key == QLatin1String("key") || key == QLatin1String("tag")) {
+        if (key == QLatin1String("name") || key == QLatin1String("url") || key == QLatin1String("key") || key == QLatin1String("tag") || key == QLatin1String("desc") || key == QLatin1String("sfx")) {
             QString value = getVerifiedString(L,
                                               func,
                                               -1,
                                               key == QLatin1String("name")  ? "value for name"
                                               : key == QLatin1String("key") ? "value for key"
                                               : key == QLatin1String("tag") ? "value for tag"
+                                              : key == QLatin1String("desc") ? "value for desc"
+                                              : key == QLatin1String("sfx") ? "value for sfx"
                                                                             : "value for url");
 
             if (key == QLatin1String("name") && !value.isEmpty()) {
@@ -348,6 +350,10 @@ int TLuaInterpreter::playMusicFileAsTableArgument(lua_State* L, const char* func
                 mediaData.setMediaKey(value);
             } else if (key == QLatin1String("tag") && !value.isEmpty()) {
                 mediaData.setMediaTag(value);
+            } else if (key == QLatin1String("desc") && !value.isEmpty()) {
+                mediaData.setMediaDesc(value);
+            } else if (key == QLatin1String("sfx") && !value.isEmpty()) {
+                mediaData.setMediaSfx(value);
             }
         } else if (key == QLatin1String("volume") || key == QLatin1String("fadein") || key == QLatin1String("fadeout") || key == QLatin1String("start") || key == QLatin1String("finish") || key == QLatin1String("loops")) {
             int value = getVerifiedInt(L,
@@ -582,13 +588,15 @@ int TLuaInterpreter::playSoundFileAsTableArgument(lua_State* L, const char* func
         QString key = getVerifiedString(L, func, -2, "table keys");
         key = key.toLower();
 
-        if (key == QLatin1String("name") || key == QLatin1String("url") || key == QLatin1String("key") || key == QLatin1String("tag")) {
+        if (key == QLatin1String("name") || key == QLatin1String("url") || key == QLatin1String("key") || key == QLatin1String("tag") || key == QLatin1String("desc") || key == QLatin1String("sfx")) {
             QString value = getVerifiedString(L,
                                               func,
                                               -1,
                                               key == QLatin1String("name")  ? "value for name"
                                               : key == QLatin1String("key") ? "value for key"
                                               : key == QLatin1String("tag") ? "value for tag"
+                                              : key == QLatin1String("desc") ? "value for desc"
+                                              : key == QLatin1String("sfx") ? "value for sfx"
                                                                             : "value for url");
 
             if (key == QLatin1String("name") && !value.isEmpty()) {
@@ -605,6 +613,10 @@ int TLuaInterpreter::playSoundFileAsTableArgument(lua_State* L, const char* func
                 mediaData.setMediaKey(value);
             } else if (key == QLatin1String("tag") && !value.isEmpty()) {
                 mediaData.setMediaTag(value);
+            } else if (key == QLatin1String("desc") && !value.isEmpty()) {
+                mediaData.setMediaDesc(value);
+            } else if (key == QLatin1String("sfx") && !value.isEmpty()) {
+                mediaData.setMediaSfx(value);
             }
         } else if (key == QLatin1String("volume") || key == QLatin1String("fadein") || key == QLatin1String("fadeout") || key == QLatin1String("start") || key == QLatin1String("finish") || key == QLatin1String("loops")
                    || key == QLatin1String("priority")) {
@@ -1477,8 +1489,8 @@ int TLuaInterpreter::stopMusicAsTableArgument(lua_State* L, const char* func)
         QString key = getVerifiedString(L, func, -2, "table keys");
         key = key.toLower();
 
-        if (key == QLatin1String("name") || key == QLatin1String("key") || key == QLatin1String("tag")) {
-            QString value = getVerifiedString(L, func, -1, key == QLatin1String("name") ? "value for name" : key == QLatin1String("key") ? "value for key" : "value for tag");
+        if (key == QLatin1String("name") || key == QLatin1String("key") || key == QLatin1String("tag") || key == QLatin1String("desc") || key == QLatin1String("sfx")) {
+            QString value = getVerifiedString(L, func, -1, key == QLatin1String("name") ? "value for name" : key == QLatin1String("key") ? "value for key" : key == QLatin1String("tag") ? "value for tag" : key == QLatin1String("desc") ? "value for desc" : "value for sfx");
 
             if (key == QLatin1String("name") && !value.isEmpty()) {
                 if (QDir::homePath().contains('\\')) {
@@ -1492,6 +1504,10 @@ int TLuaInterpreter::stopMusicAsTableArgument(lua_State* L, const char* func)
                 mediaData.setMediaKey(value);
             } else if (key == QLatin1String("tag") && !value.isEmpty()) {
                 mediaData.setMediaTag(value);
+            } else if (key == QLatin1String("desc") && !value.isEmpty()) {
+                mediaData.setMediaDesc(value);
+            } else if (key == QLatin1String("sfx") && !value.isEmpty()) {
+                mediaData.setMediaSfx(value);
             }
         } else if (key == QLatin1String("fadeaway")) {
             const bool value = getVerifiedBool(L, func, -1, "value for fadeaway must be boolean");
@@ -1626,8 +1642,8 @@ int TLuaInterpreter::stopSoundsAsTableArgument(lua_State* L, const char* func)
         QString key = getVerifiedString(L, func, -2, "table keys");
         key = key.toLower();
 
-        if (key == QLatin1String("name") || key == QLatin1String("key") || key == QLatin1String("tag")) {
-            QString value = getVerifiedString(L, func, -1, key == QLatin1String("name") ? "value for name" : key == QLatin1String("key") ? "value for key" : "value for tag");
+        if (key == QLatin1String("name") || key == QLatin1String("key") || key == QLatin1String("tag") || key == QLatin1String("desc") || key == QLatin1String("sfx")) {
+            QString value = getVerifiedString(L, func, -1, key == QLatin1String("name") ? "value for name" : key == QLatin1String("key") ? "value for key" : key == QLatin1String("tag") ? "value for tag" : key == QLatin1String("desc") ? "value for desc" : "value for sfx");
 
             if (key == QLatin1String("name") && !value.isEmpty()) {
                 if (QDir::homePath().contains('\\')) {
@@ -1641,6 +1657,10 @@ int TLuaInterpreter::stopSoundsAsTableArgument(lua_State* L, const char* func)
                 mediaData.setMediaKey(value);
             } else if (key == QLatin1String("tag") && !value.isEmpty()) {
                 mediaData.setMediaTag(value);
+            } else if (key == QLatin1String("desc") && !value.isEmpty()) {
+                mediaData.setMediaDesc(value);
+            } else if (key == QLatin1String("sfx") && !value.isEmpty()) {
+                mediaData.setMediaSfx(value);
             }
         } else if (key == QLatin1String("priority")) {
             int value = getVerifiedInt(L, func, -1, "value for priority must be integer");
@@ -1715,8 +1735,8 @@ int TLuaInterpreter::stopVideosAsTableArgument(lua_State* L, const char* func)
         QString key = getVerifiedString(L, func, -2, "table keys");
         key = key.toLower();
 
-        if (key == QLatin1String("name") || key == QLatin1String("key") || key == QLatin1String("tag")) {
-            QString value = getVerifiedString(L, func, -1, key == QLatin1String("name") ? "value for name" : key == QLatin1String("key") ? "value for key" : "value for tag");
+        if (key == QLatin1String("name") || key == QLatin1String("key") || key == QLatin1String("tag") || key == QLatin1String("desc") || key == QLatin1String("sfx")) {
+            QString value = getVerifiedString(L, func, -1, key == QLatin1String("name") ? "value for name" : key == QLatin1String("key") ? "value for key" : key == QLatin1String("tag") ? "value for tag" : key == QLatin1String("desc") ? "value for desc" : "value for sfx");
 
             if (key == QLatin1String("name") && !value.isEmpty()) {
                 if (QDir::homePath().contains('\\')) {
@@ -1730,6 +1750,10 @@ int TLuaInterpreter::stopVideosAsTableArgument(lua_State* L, const char* func)
                 mediaData.setMediaKey(value);
             } else if (key == QLatin1String("tag") && !value.isEmpty()) {
                 mediaData.setMediaTag(value);
+            } else if (key == QLatin1String("desc") && !value.isEmpty()) {
+                mediaData.setMediaDesc(value);
+            } else if (key == QLatin1String("sfx") && !value.isEmpty()) {
+                mediaData.setMediaSfx(value);
             }
         } else if (key == QLatin1String("fadeaway")) {
             const bool value = getVerifiedBool(L, func, -1, "value for fadeaway must be boolean");

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -274,21 +274,7 @@ void TMedia::pauseMedia(TMediaData& mediaData)
             continue;
         }
 
-        if (mpHost->mEnableClosedCaption) {
-            if (!pPlayer->mediaData().mediaCaption().isEmpty()) {
-                mpHost->mpConsole->print(qsl("[%1 pauses]\n").arg(pPlayer->mediaData().mediaCaption()));
-            } else {
-                const QString mediaType = pPlayer->mediaData().mediaType() == TMediaData::MediaTypeMusic ? tr("music") : pPlayer->mediaData().mediaType() == TMediaData::MediaTypeVideo ? tr("video") : tr("sound");
-                const QString mediaKey = pPlayer->mediaData().mediaKey();
-                const QString mediaFileName = pPlayer->mediaData().mediaFileName();
-
-                if (mediaKey.isEmpty()) {
-                    mpHost->mpConsole->print(qsl("[%1 \"%2\" pauses]\n").arg(mediaType, mediaFileName));
-                } else {
-                    mpHost->mpConsole->print(qsl("[%1 %2 \"%3\" pauses]\n").arg(mediaType, mediaKey, mediaFileName));
-                }
-            }
-        }
+        printClosedCaption(pPlayer->mediaData(), tr("pauses"));
 
         pPlayer->mediaPlayer()->pause();
     }
@@ -345,21 +331,7 @@ void TMedia::stopMedia(TMediaData& mediaData)
             const int endDuration = fadeOut != TMediaData::MediaFadeNotSet ? std::min(remainingDuration, fadeOut) : std::min(remainingDuration, 5000);
             const int endPosition = currentPosition + endDuration;
 
-            if (mpHost->mEnableClosedCaption) {
-                if (!pPlayer->mediaData().mediaCaption().isEmpty()) {
-                    mpHost->mpConsole->print(qsl("[%1 fades]\n").arg(pPlayer->mediaData().mediaCaption()));
-                } else {
-                    const QString mediaType = pPlayer->mediaData().mediaType() == TMediaData::MediaTypeMusic ? tr("music") : pPlayer->mediaData().mediaType() == TMediaData::MediaTypeVideo ? tr("video") : tr("sound");
-                    const QString mediaKey = pPlayer->mediaData().mediaKey();
-                    const QString mediaFileName = pPlayer->mediaData().mediaFileName();
-
-                    if (mediaKey.isEmpty()) {
-                        mpHost->mpConsole->print(qsl("[%1 \"%2\" fades]\n").arg(mediaType, mediaFileName));
-                    } else {
-                        mpHost->mpConsole->print(qsl("[%1 %2 \"%3\" fades]\n").arg(mediaType, mediaKey, mediaFileName));
-                    }
-                }
-            }
+            printClosedCaption(pPlayer->mediaData(), tr("fades"));
 
             TMediaData updateMediaData = pPlayer->mediaData();
             updateMediaData.setMediaFadeOut(endDuration);
@@ -370,20 +342,8 @@ void TMedia::stopMedia(TMediaData& mediaData)
             continue;
         }
 
-        if (mpHost->mEnableClosedCaption && pPlayer->getPlaybackState() == QMediaPlayer::PlayingState) {
-            if (!pPlayer->mediaData().mediaCaption().isEmpty()) {
-                mpHost->mpConsole->print(qsl("[%1 stops]\n").arg(pPlayer->mediaData().mediaCaption()));
-            } else {
-                const QString mediaType = pPlayer->mediaData().mediaType() == TMediaData::MediaTypeMusic ? tr("music") : pPlayer->mediaData().mediaType() == TMediaData::MediaTypeVideo ? tr("video") : tr("sound");
-                const QString mediaKey = pPlayer->mediaData().mediaKey();
-                const QString mediaFileName = pPlayer->mediaData().mediaFileName();
-
-                if (mediaKey.isEmpty()) {
-                    mpHost->mpConsole->print(qsl("[%1 \"%2\" stops]\n").arg(mediaType, mediaFileName));
-                } else {
-                    mpHost->mpConsole->print(qsl("[%1 %2 \"%3\" stops]\n").arg(mediaType, mediaKey, mediaFileName));
-                }
-            }
+        if (pPlayer->getPlaybackState() == QMediaPlayer::PlayingState) {
+            printClosedCaption(pPlayer->mediaData(), tr("stops"));
         }
 
         // **Stop the player but keep it for reuse**
@@ -582,21 +542,7 @@ bool TMedia::resume(TMediaData mediaData)
             continue;
         }
 
-        if (mpHost->mEnableClosedCaption) {
-            if (!pPlayer->mediaData().mediaCaption().isEmpty()) {
-                mpHost->mpConsole->print(qsl("[%1 resumes]\n").arg(pPlayer->mediaData().mediaCaption()));
-            } else {
-                const QString mediaType = pPlayer->mediaData().mediaType() == TMediaData::MediaTypeMusic ? tr("music") : pPlayer->mediaData().mediaType() == TMediaData::MediaTypeVideo ? tr("video") : tr("sound");
-                const QString mediaKey = pPlayer->mediaData().mediaKey();
-                const QString mediaFileName = pPlayer->mediaData().mediaFileName();
-
-                if (mediaKey.isEmpty()) {
-                    mpHost->mpConsole->print(qsl("[%1 \"%2\" resumes]\n").arg(mediaType, mediaFileName));
-                } else {
-                    mpHost->mpConsole->print(qsl("[%1 %2 \"%3\" resumes]\n").arg(mediaType, mediaKey, mediaFileName));
-                }
-            }
-        }
+        printClosedCaption(pPlayer->mediaData(), tr("resumes"));
 
         pPlayer->mediaPlayer()->play();
         resumed = true;
@@ -619,20 +565,8 @@ void TMedia::stopAllMediaPlayers()
             continue;
         }
 
-        if (mpHost->mEnableClosedCaption && pPlayer->getPlaybackState() == QMediaPlayer::PlayingState) {
-            if (!pPlayer->mediaData().mediaCaption().isEmpty()) {
-                mpHost->mpConsole->print(qsl("[%1 stops]\n").arg(pPlayer->mediaData().mediaCaption()));
-            } else {
-                const QString mediaType = pPlayer->mediaData().mediaType() == TMediaData::MediaTypeMusic ? tr("music") : pPlayer->mediaData().mediaType() == TMediaData::MediaTypeVideo ? tr("video") : tr("sound");
-                const QString mediaKey = pPlayer->mediaData().mediaKey();
-                const QString mediaFileName = pPlayer->mediaData().mediaFileName();
-
-                if (mediaKey.isEmpty()) {
-                    mpHost->mpConsole->print(qsl("[%1 \"%2\" stops]\n").arg(mediaType, mediaFileName));
-                } else {
-                    mpHost->mpConsole->print(qsl("[%1 %2 \"%3\" stops]\n").arg(mediaType, mediaKey, mediaFileName));
-                }
-            }
+        if (pPlayer->getPlaybackState() == QMediaPlayer::PlayingState) {
+            printClosedCaption(pPlayer->mediaData(), tr("stops"));
         }
 
         pPlayer->mediaPlayer()->stop();
@@ -1047,7 +981,7 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
 
     // Media status changed connection
     disconnect(player->mediaPlayer(), &QMediaPlayer::mediaStatusChanged, nullptr, nullptr);
-    connect(player->mediaPlayer(), &QMediaPlayer::mediaStatusChanged, this, [weakPlayer](QMediaPlayer::MediaStatus mediaStatus) {
+    connect(player->mediaPlayer(), &QMediaPlayer::mediaStatusChanged, this, [this, weakPlayer](QMediaPlayer::MediaStatus mediaStatus) {
         if (auto lockedPlayer = weakPlayer.lock()) {
             if (mediaStatus == QMediaPlayer::EndOfMedia) {
                 if (lockedPlayer->playlist() && !lockedPlayer->playlist()->isEmpty()) {
@@ -1055,21 +989,7 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
                     QUrl nextMedia = lockedPlayer->playlist()->next();
 
                     if (!nextMedia.isEmpty()) {
-                        if (lockedPlayerHost->mEnableClosedCaption) {
-                            if (!lockedPlayer->mediaData().mediaCaption().isEmpty()) {
-                                lockedPlayerHost->mpConsole->print(qsl("[%1 plays]\n").arg(lockedPlayer->mediaData().mediaCaption()));
-                            } else {
-                                const QString mediaType = lockedPlayer->mediaData().mediaType() == TMediaData::MediaTypeMusic ? tr("music") : lockedPlayer->mediaData().mediaType() == TMediaData::MediaTypeVideo ? tr("video") : tr("sound");
-                                const QString mediaKey = lockedPlayer->mediaData().mediaKey();
-                                const QString mediaFileName = lockedPlayer->mediaData().mediaFileName();
-
-                                if (mediaKey.isEmpty()) {
-                                    lockedPlayerHost->mpConsole->print(qsl("[%1 \"%2\" plays]\n").arg(mediaType, mediaFileName));
-                                } else {
-                                    lockedPlayerHost->mpConsole->print(qsl("[%1 %2 \"%3\" plays]\n").arg(mediaType, mediaKey, mediaFileName));
-                                }
-                            }
-                        }
+                        this->printClosedCaption(lockedPlayer->mediaData(), tr("plays"));
 
                         lockedPlayer->mediaPlayer()->setSource(nextMedia);
                         lockedPlayer->mediaPlayer()->play();
@@ -1095,8 +1015,9 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
 
     // Position changed connection (handles fade-in/fade-out effects)
     disconnect(player->mediaPlayer(), &QMediaPlayer::positionChanged, nullptr, nullptr);
-    connect(player->mediaPlayer(), &QMediaPlayer::positionChanged, this, [weakPlayer](qint64 progress) {
+    connect(player->mediaPlayer(), &QMediaPlayer::positionChanged, this, [this, weakPlayer](qint64 progress) {
         if (auto lockedPlayer = weakPlayer.lock()) { // Ensure the player is still valid
+            QPointer<Host> lockedPlayerHost = lockedPlayer->host();
             const int volume = lockedPlayer->mediaData().mediaVolume();
             const int duration = lockedPlayer->mediaPlayer()->duration();
             const int fadeInDuration = lockedPlayer->mediaData().mediaFadeIn();
@@ -1114,22 +1035,8 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
             bool actionTaken = false;
 
             if (progress > relativeDuration && (endUsed || finishUsed)) {
-                QPointer<Host> lockedPlayerHost = lockedPlayer->host();
-
-                if (lockedPlayerHost->mEnableClosedCaption && lockedPlayer->getPlaybackState() == QMediaPlayer::PlayingState) {
-                    if (!lockedPlayer->mediaData().mediaCaption().isEmpty()) {
-                        lockedPlayerHost->mpConsole->print(qsl("[%1 stops]\n").arg(lockedPlayer->mediaData().mediaCaption()));
-                    } else {
-                        const QString mediaType = lockedPlayer->mediaData().mediaType() == TMediaData::MediaTypeMusic ? tr("music") : lockedPlayer->mediaData().mediaType() == TMediaData::MediaTypeVideo ? tr("video") : tr("sound");
-                        const QString mediaKey = lockedPlayer->mediaData().mediaKey();
-                        const QString mediaFileName = lockedPlayer->mediaData().mediaFileName();
-
-                        if (mediaKey.isEmpty()) {
-                            lockedPlayerHost->mpConsole->print(qsl("[%1 \"%2\" stops]\n").arg(mediaType, mediaFileName));
-                        } else {
-                            lockedPlayerHost->mpConsole->print(qsl("[%1 %2 \"%3\" stops]\n").arg(mediaType, mediaKey, mediaFileName));
-                        }
-                    }
+                if (lockedPlayer->getPlaybackState() == QMediaPlayer::PlayingState) {
+                    printClosedCaption(lockedPlayer->mediaData(), tr("stops"));
                 }
 
                 lockedPlayer->mediaPlayer()->stop();
@@ -1736,20 +1643,8 @@ void TMedia::play(TMediaData& mediaData)
         return;
     }
 
-    if (mpHost->mEnableClosedCaption && mediaData.mediaVolume() != TMediaData::MediaVolumePreload) {
-        if (!pPlayer->mediaData().mediaCaption().isEmpty()) {
-            mpHost->mpConsole->print(qsl("[%1 plays]\n").arg(pPlayer->mediaData().mediaCaption()));
-        } else {
-            const QString mediaType = pPlayer->mediaData().mediaType() == TMediaData::MediaTypeMusic ? tr("music") : pPlayer->mediaData().mediaType() == TMediaData::MediaTypeVideo ? tr("video") : tr("sound");
-            const QString mediaKey = pPlayer->mediaData().mediaKey();
-            const QString mediaFileName = pPlayer->mediaData().mediaFileName();
-
-            if (mediaKey.isEmpty()) {
-                mpHost->mpConsole->print(qsl("[%1 \"%2\" plays]\n").arg(mediaType, mediaFileName));
-            } else {
-                mpHost->mpConsole->print(qsl("[%1 %2 \"%3\" plays]\n").arg(mediaType, mediaKey, mediaFileName));
-            }
-        }
+    if (mediaData.mediaVolume() != TMediaData::MediaVolumePreload) {
+        printClosedCaption(pPlayer->mediaData(), tr("plays"));
     }
 
     pPlayer->mediaPlayer()->play();
@@ -2130,5 +2025,29 @@ void TMedia::parseJSONForMediaStop(QJsonObject& json)
     mediaData.setMediaFadeOut(TMedia::parseJSONByMediaFadeOut(json));
 
     TMedia::stopMedia(mediaData);
+}
+
+void TMedia::printClosedCaption(const TMediaData& mediaData, const QString& action) const
+{
+    if (!mpHost || !mpHost->mEnableClosedCaption || !mpHost->mpConsole)
+        return;
+
+    QString message;
+
+    if (!mediaData.mediaCaption().isEmpty()) {
+        message = qsl("[%1 %2]\n").arg(mediaData.mediaCaption(), action);
+    } else {
+        const QString mediaType = mediaData.mediaType() == TMediaData::MediaTypeMusic ? tr("music") :
+                                  mediaData.mediaType() == TMediaData::MediaTypeVideo ? tr("video") : tr("sound");
+        const QString mediaKey = mediaData.mediaKey();
+        const QString mediaFileName = mediaData.mediaFileName();
+        if (mediaKey.isEmpty()) {
+            message = qsl("[%1 \"%2\" %3]\n").arg(mediaType, mediaFileName, action);
+        } else {
+            message = qsl("[%1 %2 \"%3\" %4]\n").arg(mediaType, mediaKey, mediaFileName, action);
+        }
+    }
+
+    mpHost->mpConsole->print(message);
 }
 // End Private

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -985,7 +985,6 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
         if (auto lockedPlayer = weakPlayer.lock()) {
             if (mediaStatus == QMediaPlayer::EndOfMedia) {
                 if (lockedPlayer->playlist() && !lockedPlayer->playlist()->isEmpty()) {
-                    auto lockedPlayerHost = lockedPlayer->host();
                     QUrl nextMedia = lockedPlayer->playlist()->next();
 
                     if (!nextMedia.isEmpty()) {
@@ -1016,7 +1015,6 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
     disconnect(player->mediaPlayer(), &QMediaPlayer::positionChanged, nullptr, nullptr);
     connect(player->mediaPlayer(), &QMediaPlayer::positionChanged, this, [this, weakPlayer](qint64 progress) {
         if (auto lockedPlayer = weakPlayer.lock()) { // Ensure the player is still valid
-            auto lockedPlayerHost = lockedPlayer->host();
             const int volume = lockedPlayer->mediaData().mediaVolume();
             const int duration = lockedPlayer->mediaPlayer()->duration();
             const int fadeInDuration = lockedPlayer->mediaData().mediaFadeIn();

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -1836,6 +1836,20 @@ TMediaData::MediaClose TMedia::parseJSONByMediaClose(QJsonObject& json)
     return mediaClose;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Scripting#desc
+QString TMedia::parseJSONByMediaDesc(QJsonObject& json)
+{
+    // Returns the 'desc' field if present, else empty string
+    return json.contains("desc") && json["desc"].isString() ? json["desc"].toString() : QString();
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Scripting#sfx
+QString TMedia::parseJSONByMediaSfx(QJsonObject& json)
+{
+    // Returns the 'sfx' field if present, else empty string
+    return json.contains("sfx") && json["sfx"].isString() ? json["sfx"].toString() : QString();
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Scripting#Loading_Media
 void TMedia::parseJSONForMediaDefault(QJsonObject& json)
 {
@@ -1903,6 +1917,8 @@ void TMedia::parseJSONForMediaPlay(QJsonObject& json)
     mediaData.setMediaPriority(TMedia::parseJSONByMediaPriority(json));
     mediaData.setMediaContinue(TMedia::parseJSONByMediaContinue(json));
     mediaData.setMediaClose(TMedia::parseJSONByMediaClose(json));
+    mediaData.setMediaDesc(TMedia::parseJSONByMediaDesc(json));
+    mediaData.setMediaSfx(TMedia::parseJSONByMediaSfx(json));
 
     TMedia::playMedia(mediaData);
 }
@@ -1935,6 +1951,8 @@ void TMedia::parseJSONForMediaStop(QJsonObject& json)
     mediaData.setMediaPriority(TMedia::parseJSONByMediaPriority(json));
     mediaData.setMediaFadeAway(TMedia::parseJSONByMediaFadeAway(json));
     mediaData.setMediaFadeOut(TMedia::parseJSONByMediaFadeOut(json));
+    mediaData.setMediaDesc(TMedia::parseJSONByMediaDesc(json));
+    mediaData.setMediaSfx(TMedia::parseJSONByMediaSfx(json));
 
     TMedia::stopMedia(mediaData);
 }

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -274,8 +274,6 @@ void TMedia::pauseMedia(TMediaData& mediaData)
             continue;
         }
 
-        printClosedCaption(pPlayer->mediaData(), tr("pauses"));
-
         pPlayer->mediaPlayer()->pause();
     }
 }
@@ -340,10 +338,6 @@ void TMedia::stopMedia(TMediaData& mediaData)
             TMedia::updateMediaPlayerList(std::move(pPlayer));
 
             continue;
-        }
-
-        if (pPlayer->getPlaybackState() == QMediaPlayer::PlayingState) {
-            printClosedCaption(pPlayer->mediaData(), tr("stops"));
         }
 
         // **Stop the player but keep it for reuse**
@@ -542,8 +536,6 @@ bool TMedia::resume(TMediaData mediaData)
             continue;
         }
 
-        printClosedCaption(pPlayer->mediaData(), tr("resumes"));
-
         pPlayer->mediaPlayer()->play();
         resumed = true;
     }
@@ -563,10 +555,6 @@ void TMedia::stopAllMediaPlayers()
     for (const auto& pPlayer : mTMediaPlayerList) {
         if (!pPlayer) {
             continue;
-        }
-
-        if (pPlayer->getPlaybackState() == QMediaPlayer::PlayingState) {
-            printClosedCaption(pPlayer->mediaData(), tr("stops"));
         }
 
         pPlayer->mediaPlayer()->stop();
@@ -988,8 +976,6 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
                     QUrl nextMedia = lockedPlayer->playlist()->next();
 
                     if (!nextMedia.isEmpty()) {
-                        this->printClosedCaption(lockedPlayer->mediaData(), tr("plays"));
-
                         lockedPlayer->mediaPlayer()->setSource(nextMedia);
                         lockedPlayer->mediaPlayer()->play();
                     } else if (lockedPlayer->playlist()->playbackMode() == TMediaPlaylist::Loop) {
@@ -1032,10 +1018,6 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
             bool actionTaken = false;
 
             if (progress > relativeDuration && (endUsed || finishUsed)) {
-                if (lockedPlayer->getPlaybackState() == QMediaPlayer::PlayingState) {
-                    printClosedCaption(lockedPlayer->mediaData(), tr("stops"));
-                }
-
                 lockedPlayer->mediaPlayer()->stop();
             } else {
                 if (fadeInUsed) {
@@ -1278,6 +1260,42 @@ void TMedia::handlePlayerPlaybackStateChanged(QMediaPlayerPlaybackState playback
                 }
             }
         }
+
+        printClosedCaption(player->mediaData(), tr("stops"));
+        return;
+    } else if (playbackState == QMediaPlayer::PlayingState && player->mediaData().mediaVolume() != TMediaData::MediaVolumePreload) {
+        TEvent mediaStarted{};
+        mediaStarted.mArgumentList.append("sysMediaStarted");
+
+        const QUrl mediaUrl = player->mediaPlayer()->source();
+        mediaStarted.mArgumentList.append(mediaUrl.fileName());
+        mediaStarted.mArgumentList.append(mediaUrl.path());
+        mediaStarted.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        mediaStarted.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        mediaStarted.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+
+        if (mpHost) {
+            mpHost->raiseEvent(mediaStarted);
+        }
+
+        printClosedCaption(player->mediaData(), tr("plays"));
+        return;
+    } else if (playbackState == QMediaPlayer::PausedState) {
+        TEvent mediaPaused{};
+        mediaPaused.mArgumentList.append("sysMediaPaused");
+
+        const QUrl mediaUrl = player->mediaPlayer()->source();
+        mediaPaused.mArgumentList.append(mediaUrl.fileName());
+        mediaPaused.mArgumentList.append(mediaUrl.path());
+        mediaPaused.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        mediaPaused.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        mediaPaused.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+
+        if (mpHost) {
+            mpHost->raiseEvent(mediaPaused);
+        }
+
+        printClosedCaption(player->mediaData(), tr("pauses"));
     }
 }
 
@@ -1638,10 +1656,6 @@ void TMedia::play(TMediaData& mediaData)
     // Handle video setup if applicable
     if (mediaData.mediaType() == TMediaData::MediaTypeVideo && !setupVideo(pPlayer)) {
         return;
-    }
-
-    if (mediaData.mediaVolume() != TMediaData::MediaVolumePreload) {
-        printClosedCaption(pPlayer->mediaData(), tr("plays"));
     }
 
     pPlayer->mediaPlayer()->play();

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -1888,18 +1888,11 @@ TMediaData::MediaClose TMedia::parseJSONByMediaClose(QJsonObject& json)
     return mediaClose;
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Scripting#desc
-QString TMedia::parseJSONByMediaDesc(QJsonObject& json)
+// Documentation: https://wiki.mudlet.org/w/Standards:MUD_Client_Media_Protocol#caption
+QString TMedia::parseJSONByMediaCaption(QJsonObject& json)
 {
-    // Returns the 'desc' field if present, else empty string
-    return json.contains("desc") && json["desc"].isString() ? json["desc"].toString() : QString();
-}
-
-// Documentation: https://wiki.mudlet.org/w/Manual:Scripting#sfx
-QString TMedia::parseJSONByMediaSfx(QJsonObject& json)
-{
-    // Returns the 'sfx' field if present, else empty string
-    return json.contains("sfx") && json["sfx"].isString() ? json["sfx"].toString() : QString();
+    // Returns the 'caption' field if present, else empty string
+    return json.contains("caption") && json["caption"].isString() ? json["caption"].toString() : QString();
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Scripting#Loading_Media
@@ -1924,6 +1917,7 @@ void TMedia::parseJSONForMediaLoad(QJsonObject& json)
     mediaData.setMediaUrl(TMedia::parseJSONByMediaUrl(json));
     mediaData.setMediaTag(TMedia::parseJSONByMediaTag(json));
     mediaData.setMediaVolume(TMediaData::MediaVolumePreload);
+    mediaData.setMediaCaption(TMedia::parseJSONByMediaCaption(json));
 
     mediaData.setMediaFileName(mediaData.mediaFileName().replace(QLatin1Char('\\'), QLatin1Char('/')));
 
@@ -1969,8 +1963,7 @@ void TMedia::parseJSONForMediaPlay(QJsonObject& json)
     mediaData.setMediaPriority(TMedia::parseJSONByMediaPriority(json));
     mediaData.setMediaContinue(TMedia::parseJSONByMediaContinue(json));
     mediaData.setMediaClose(TMedia::parseJSONByMediaClose(json));
-    mediaData.setMediaDesc(TMedia::parseJSONByMediaDesc(json));
-    mediaData.setMediaSfx(TMedia::parseJSONByMediaSfx(json));
+    mediaData.setMediaCaption(TMedia::parseJSONByMediaCaption(json));
 
     TMedia::playMedia(mediaData);
 }
@@ -2003,8 +1996,7 @@ void TMedia::parseJSONForMediaStop(QJsonObject& json)
     mediaData.setMediaPriority(TMedia::parseJSONByMediaPriority(json));
     mediaData.setMediaFadeAway(TMedia::parseJSONByMediaFadeAway(json));
     mediaData.setMediaFadeOut(TMedia::parseJSONByMediaFadeOut(json));
-    mediaData.setMediaDesc(TMedia::parseJSONByMediaDesc(json));
-    mediaData.setMediaSfx(TMedia::parseJSONByMediaSfx(json));
+    mediaData.setMediaCaption(TMedia::parseJSONByMediaCaption(json));
 
     TMedia::stopMedia(mediaData);
 }

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -329,6 +329,22 @@ void TMedia::stopMedia(TMediaData& mediaData)
             const int endDuration = fadeOut != TMediaData::MediaFadeNotSet ? std::min(remainingDuration, fadeOut) : std::min(remainingDuration, 5000);
             const int endPosition = currentPosition + endDuration;
 
+            if (mpHost->mEnableClosedCaption) {
+                if (!pPlayer->mediaData().mediaCaption().isEmpty()) {
+                    mpHost->mpConsole->print(qsl("\n[%1 fades]\n").arg(pPlayer->mediaData().mediaCaption()));
+                } else {
+                    const QString mediaType = pPlayer->mediaData().mediaType() == TMediaData::MediaTypeMusic ? tr("music") : pPlayer->mediaData().mediaType() == TMediaData::MediaTypeVideo ? tr("video") : tr("sound");
+                    const QString mediaKey = pPlayer->mediaData().mediaKey();
+                    const QString mediaFileName = pPlayer->mediaData().mediaFileName();
+
+                    if (mediaKey.isEmpty()) {
+                        mpHost->mpConsole->print(qsl("\n[%1 \"%2\" fades]\n").arg(mediaType, mediaFileName));
+                    } else {
+                        mpHost->mpConsole->print(qsl("\n[%1 %2 \"%3\" fades]\n").arg(mediaType, mediaKey, mediaFileName));
+                    }
+                }
+            }
+
             TMediaData updateMediaData = pPlayer->mediaData();
             updateMediaData.setMediaFadeOut(endDuration);
             updateMediaData.setMediaEnd(endPosition);
@@ -1996,7 +2012,6 @@ void TMedia::parseJSONForMediaStop(QJsonObject& json)
     mediaData.setMediaPriority(TMedia::parseJSONByMediaPriority(json));
     mediaData.setMediaFadeAway(TMedia::parseJSONByMediaFadeAway(json));
     mediaData.setMediaFadeOut(TMedia::parseJSONByMediaFadeOut(json));
-    mediaData.setMediaCaption(TMedia::parseJSONByMediaCaption(json));
 
     TMedia::stopMedia(mediaData);
 }

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -985,7 +985,7 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
         if (auto lockedPlayer = weakPlayer.lock()) {
             if (mediaStatus == QMediaPlayer::EndOfMedia) {
                 if (lockedPlayer->playlist() && !lockedPlayer->playlist()->isEmpty()) {
-                    QPointer<Host> lockedPlayerHost = lockedPlayer->host();
+                    auto lockedPlayerHost = lockedPlayer->host();
                     QUrl nextMedia = lockedPlayer->playlist()->next();
 
                     if (!nextMedia.isEmpty()) {
@@ -1007,7 +1007,6 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
     disconnect(player->mediaPlayer(), &QMediaPlayer::playbackStateChanged, nullptr, nullptr);
     connect(player->mediaPlayer(), &QMediaPlayer::playbackStateChanged, this, 
             [this, weakPlayer](QMediaPlayerPlaybackState playbackState) {
-                auto host = this->mpHost;
                 if (auto lockedPlayer = weakPlayer.lock()) {
                     handlePlayerPlaybackStateChanged(playbackState, lockedPlayer);
                 }
@@ -1017,7 +1016,7 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
     disconnect(player->mediaPlayer(), &QMediaPlayer::positionChanged, nullptr, nullptr);
     connect(player->mediaPlayer(), &QMediaPlayer::positionChanged, this, [this, weakPlayer](qint64 progress) {
         if (auto lockedPlayer = weakPlayer.lock()) { // Ensure the player is still valid
-            QPointer<Host> lockedPlayerHost = lockedPlayer->host();
+            auto lockedPlayerHost = lockedPlayer->host();
             const int volume = lockedPlayer->mediaData().mediaVolume();
             const int duration = lockedPlayer->mediaPlayer()->duration();
             const int fadeInDuration = lockedPlayer->mediaData().mediaFadeIn();

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -274,6 +274,22 @@ void TMedia::pauseMedia(TMediaData& mediaData)
             continue;
         }
 
+        if (mpHost->mEnableClosedCaption) {
+            if (!pPlayer->mediaData().mediaCaption().isEmpty()) {
+                mpHost->mpConsole->print(qsl("[%1 pauses]\n").arg(pPlayer->mediaData().mediaCaption()));
+            } else {
+                const QString mediaType = pPlayer->mediaData().mediaType() == TMediaData::MediaTypeMusic ? tr("music") : pPlayer->mediaData().mediaType() == TMediaData::MediaTypeVideo ? tr("video") : tr("sound");
+                const QString mediaKey = pPlayer->mediaData().mediaKey();
+                const QString mediaFileName = pPlayer->mediaData().mediaFileName();
+
+                if (mediaKey.isEmpty()) {
+                    mpHost->mpConsole->print(qsl("[%1 \"%2\" pauses]\n").arg(mediaType, mediaFileName));
+                } else {
+                    mpHost->mpConsole->print(qsl("[%1 %2 \"%3\" pauses]\n").arg(mediaType, mediaKey, mediaFileName));
+                }
+            }
+        }
+
         pPlayer->mediaPlayer()->pause();
     }
 }
@@ -331,16 +347,16 @@ void TMedia::stopMedia(TMediaData& mediaData)
 
             if (mpHost->mEnableClosedCaption) {
                 if (!pPlayer->mediaData().mediaCaption().isEmpty()) {
-                    mpHost->mpConsole->print(qsl("\n[%1 fades]\n").arg(pPlayer->mediaData().mediaCaption()));
+                    mpHost->mpConsole->print(qsl("[%1 fades]\n").arg(pPlayer->mediaData().mediaCaption()));
                 } else {
                     const QString mediaType = pPlayer->mediaData().mediaType() == TMediaData::MediaTypeMusic ? tr("music") : pPlayer->mediaData().mediaType() == TMediaData::MediaTypeVideo ? tr("video") : tr("sound");
                     const QString mediaKey = pPlayer->mediaData().mediaKey();
                     const QString mediaFileName = pPlayer->mediaData().mediaFileName();
 
                     if (mediaKey.isEmpty()) {
-                        mpHost->mpConsole->print(qsl("\n[%1 \"%2\" fades]\n").arg(mediaType, mediaFileName));
+                        mpHost->mpConsole->print(qsl("[%1 \"%2\" fades]\n").arg(mediaType, mediaFileName));
                     } else {
-                        mpHost->mpConsole->print(qsl("\n[%1 %2 \"%3\" fades]\n").arg(mediaType, mediaKey, mediaFileName));
+                        mpHost->mpConsole->print(qsl("[%1 %2 \"%3\" fades]\n").arg(mediaType, mediaKey, mediaFileName));
                     }
                 }
             }
@@ -352,6 +368,22 @@ void TMedia::stopMedia(TMediaData& mediaData)
             TMedia::updateMediaPlayerList(std::move(pPlayer));
 
             continue;
+        }
+
+        if (mpHost->mEnableClosedCaption && pPlayer->getPlaybackState() == QMediaPlayer::PlayingState) {
+            if (!pPlayer->mediaData().mediaCaption().isEmpty()) {
+                mpHost->mpConsole->print(qsl("[%1 stops]\n").arg(pPlayer->mediaData().mediaCaption()));
+            } else {
+                const QString mediaType = pPlayer->mediaData().mediaType() == TMediaData::MediaTypeMusic ? tr("music") : pPlayer->mediaData().mediaType() == TMediaData::MediaTypeVideo ? tr("video") : tr("sound");
+                const QString mediaKey = pPlayer->mediaData().mediaKey();
+                const QString mediaFileName = pPlayer->mediaData().mediaFileName();
+
+                if (mediaKey.isEmpty()) {
+                    mpHost->mpConsole->print(qsl("[%1 \"%2\" stops]\n").arg(mediaType, mediaFileName));
+                } else {
+                    mpHost->mpConsole->print(qsl("[%1 %2 \"%3\" stops]\n").arg(mediaType, mediaKey, mediaFileName));
+                }
+            }
         }
 
         // **Stop the player but keep it for reuse**
@@ -550,6 +582,22 @@ bool TMedia::resume(TMediaData mediaData)
             continue;
         }
 
+        if (mpHost->mEnableClosedCaption) {
+            if (!pPlayer->mediaData().mediaCaption().isEmpty()) {
+                mpHost->mpConsole->print(qsl("[%1 resumes]\n").arg(pPlayer->mediaData().mediaCaption()));
+            } else {
+                const QString mediaType = pPlayer->mediaData().mediaType() == TMediaData::MediaTypeMusic ? tr("music") : pPlayer->mediaData().mediaType() == TMediaData::MediaTypeVideo ? tr("video") : tr("sound");
+                const QString mediaKey = pPlayer->mediaData().mediaKey();
+                const QString mediaFileName = pPlayer->mediaData().mediaFileName();
+
+                if (mediaKey.isEmpty()) {
+                    mpHost->mpConsole->print(qsl("[%1 \"%2\" resumes]\n").arg(mediaType, mediaFileName));
+                } else {
+                    mpHost->mpConsole->print(qsl("[%1 %2 \"%3\" resumes]\n").arg(mediaType, mediaKey, mediaFileName));
+                }
+            }
+        }
+
         pPlayer->mediaPlayer()->play();
         resumed = true;
     }
@@ -569,6 +617,22 @@ void TMedia::stopAllMediaPlayers()
     for (const auto& pPlayer : mTMediaPlayerList) {
         if (!pPlayer) {
             continue;
+        }
+
+        if (mpHost->mEnableClosedCaption && pPlayer->getPlaybackState() == QMediaPlayer::PlayingState) {
+            if (!pPlayer->mediaData().mediaCaption().isEmpty()) {
+                mpHost->mpConsole->print(qsl("[%1 stops]\n").arg(pPlayer->mediaData().mediaCaption()));
+            } else {
+                const QString mediaType = pPlayer->mediaData().mediaType() == TMediaData::MediaTypeMusic ? tr("music") : pPlayer->mediaData().mediaType() == TMediaData::MediaTypeVideo ? tr("video") : tr("sound");
+                const QString mediaKey = pPlayer->mediaData().mediaKey();
+                const QString mediaFileName = pPlayer->mediaData().mediaFileName();
+
+                if (mediaKey.isEmpty()) {
+                    mpHost->mpConsole->print(qsl("[%1 \"%2\" stops]\n").arg(mediaType, mediaFileName));
+                } else {
+                    mpHost->mpConsole->print(qsl("[%1 %2 \"%3\" stops]\n").arg(mediaType, mediaKey, mediaFileName));
+                }
+            }
         }
 
         pPlayer->mediaPlayer()->stop();
@@ -987,9 +1051,26 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
         if (auto lockedPlayer = weakPlayer.lock()) {
             if (mediaStatus == QMediaPlayer::EndOfMedia) {
                 if (lockedPlayer->playlist() && !lockedPlayer->playlist()->isEmpty()) {
+                    QPointer<Host> lockedPlayerHost = lockedPlayer->host();
                     QUrl nextMedia = lockedPlayer->playlist()->next();
 
                     if (!nextMedia.isEmpty()) {
+                        if (lockedPlayerHost->mEnableClosedCaption) {
+                            if (!lockedPlayer->mediaData().mediaCaption().isEmpty()) {
+                                lockedPlayerHost->mpConsole->print(qsl("[%1 plays]\n").arg(lockedPlayer->mediaData().mediaCaption()));
+                            } else {
+                                const QString mediaType = lockedPlayer->mediaData().mediaType() == TMediaData::MediaTypeMusic ? tr("music") : lockedPlayer->mediaData().mediaType() == TMediaData::MediaTypeVideo ? tr("video") : tr("sound");
+                                const QString mediaKey = lockedPlayer->mediaData().mediaKey();
+                                const QString mediaFileName = lockedPlayer->mediaData().mediaFileName();
+
+                                if (mediaKey.isEmpty()) {
+                                    lockedPlayerHost->mpConsole->print(qsl("[%1 \"%2\" plays]\n").arg(mediaType, mediaFileName));
+                                } else {
+                                    lockedPlayerHost->mpConsole->print(qsl("[%1 %2 \"%3\" plays]\n").arg(mediaType, mediaKey, mediaFileName));
+                                }
+                            }
+                        }
+
                         lockedPlayer->mediaPlayer()->setSource(nextMedia);
                         lockedPlayer->mediaPlayer()->play();
                     } else if (lockedPlayer->playlist()->playbackMode() == TMediaPlaylist::Loop) {
@@ -1006,6 +1087,7 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
     disconnect(player->mediaPlayer(), &QMediaPlayer::playbackStateChanged, nullptr, nullptr);
     connect(player->mediaPlayer(), &QMediaPlayer::playbackStateChanged, this, 
             [this, weakPlayer](QMediaPlayerPlaybackState playbackState) {
+                auto host = this->mpHost;
                 if (auto lockedPlayer = weakPlayer.lock()) {
                     handlePlayerPlaybackStateChanged(playbackState, lockedPlayer);
                 }
@@ -1032,6 +1114,24 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
             bool actionTaken = false;
 
             if (progress > relativeDuration && (endUsed || finishUsed)) {
+                QPointer<Host> lockedPlayerHost = lockedPlayer->host();
+
+                if (lockedPlayerHost->mEnableClosedCaption && lockedPlayer->getPlaybackState() == QMediaPlayer::PlayingState) {
+                    if (!lockedPlayer->mediaData().mediaCaption().isEmpty()) {
+                        lockedPlayerHost->mpConsole->print(qsl("[%1 stops]\n").arg(lockedPlayer->mediaData().mediaCaption()));
+                    } else {
+                        const QString mediaType = lockedPlayer->mediaData().mediaType() == TMediaData::MediaTypeMusic ? tr("music") : lockedPlayer->mediaData().mediaType() == TMediaData::MediaTypeVideo ? tr("video") : tr("sound");
+                        const QString mediaKey = lockedPlayer->mediaData().mediaKey();
+                        const QString mediaFileName = lockedPlayer->mediaData().mediaFileName();
+
+                        if (mediaKey.isEmpty()) {
+                            lockedPlayerHost->mpConsole->print(qsl("[%1 \"%2\" stops]\n").arg(mediaType, mediaFileName));
+                        } else {
+                            lockedPlayerHost->mpConsole->print(qsl("[%1 %2 \"%3\" stops]\n").arg(mediaType, mediaKey, mediaFileName));
+                        }
+                    }
+                }
+
                 lockedPlayer->mediaPlayer()->stop();
             } else {
                 if (fadeInUsed) {
@@ -1634,6 +1734,22 @@ void TMedia::play(TMediaData& mediaData)
     // Handle video setup if applicable
     if (mediaData.mediaType() == TMediaData::MediaTypeVideo && !setupVideo(pPlayer)) {
         return;
+    }
+
+    if (mpHost->mEnableClosedCaption && mediaData.mediaVolume() != TMediaData::MediaVolumePreload) {
+        if (!pPlayer->mediaData().mediaCaption().isEmpty()) {
+            mpHost->mpConsole->print(qsl("[%1 plays]\n").arg(pPlayer->mediaData().mediaCaption()));
+        } else {
+            const QString mediaType = pPlayer->mediaData().mediaType() == TMediaData::MediaTypeMusic ? tr("music") : pPlayer->mediaData().mediaType() == TMediaData::MediaTypeVideo ? tr("video") : tr("sound");
+            const QString mediaKey = pPlayer->mediaData().mediaKey();
+            const QString mediaFileName = pPlayer->mediaData().mediaFileName();
+
+            if (mediaKey.isEmpty()) {
+                mpHost->mpConsole->print(qsl("[%1 \"%2\" plays]\n").arg(mediaType, mediaFileName));
+            } else {
+                mpHost->mpConsole->print(qsl("[%1 %2 \"%3\" plays]\n").arg(mediaType, mediaKey, mediaFileName));
+            }
+        }
     }
 
     pPlayer->mediaPlayer()->play();

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -113,6 +113,7 @@ public:
     bool purgeMediaCache();
     void muteMedia(const TMediaData::MediaProtocol mediaProtocol);
     void unmuteMedia(const TMediaData::MediaProtocol mediaProtocol);
+    void printClosedCaption(const TMediaData& mediaData, const QString& action) const;
 
 private slots:
     void slot_writeFile(QNetworkReply* reply);

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -154,6 +154,8 @@ private:
     static QString parseJSONByMediaKey(QJsonObject& json);
     static TMediaData::MediaFadeAway parseJSONByMediaFadeAway(QJsonObject& json);
     static TMediaData::MediaClose parseJSONByMediaClose(QJsonObject& json);
+    static QString parseJSONByMediaDesc(QJsonObject& json);
+    static QString parseJSONByMediaSfx(QJsonObject& json);
 
     void parseJSONForMediaDefault(QJsonObject& json);
     void parseJSONForMediaLoad(QJsonObject& json);

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -162,8 +162,7 @@ private:
     static QString parseJSONByMediaKey(QJsonObject& json);
     static TMediaData::MediaFadeAway parseJSONByMediaFadeAway(QJsonObject& json);
     static TMediaData::MediaClose parseJSONByMediaClose(QJsonObject& json);
-    static QString parseJSONByMediaDesc(QJsonObject& json);
-    static QString parseJSONByMediaSfx(QJsonObject& json);
+    static QString parseJSONByMediaCaption(QJsonObject& json);
 
     void parseJSONForMediaDefault(QJsonObject& json);
     void parseJSONForMediaLoad(QJsonObject& json);

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -69,6 +69,9 @@ public:
     void setVolume(int volume) const {
         return mMediaPlayer->audioOutput()->setVolume(volume / 100.0f);
     }
+    QPointer<Host> host() const {
+        return mpHost;
+    }
     TMediaPlaylist* playlist() const {
         return mPlaylist;
     }

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -69,9 +69,6 @@ public:
     void setVolume(int volume) const {
         return mMediaPlayer->audioOutput()->setVolume(volume / 100.0f);
     }
-    QPointer<Host> host() const {
-        return mpHost;
-    }
     TMediaPlaylist* playlist() const {
         return mPlaylist;
     }

--- a/src/TMediaData.h
+++ b/src/TMediaData.h
@@ -204,6 +204,12 @@ public:
     QString mediaAbsolutePathFileName() const { return mMediaAbsolutePathFileName; }
     void setMediaAbsolutePathFileName(QString mediaAbsolutePathFileName) { mMediaAbsolutePathFileName = mediaAbsolutePathFileName; }
 
+    QString mediaDesc() const { return mMediaDesc; }
+    void setMediaDesc(QString mediaDesc) { mMediaDesc = mediaDesc; }
+
+    QString mediaSfx() const { return mMediaSfx; }
+    void setMediaSfx(QString mediaSfx) { mMediaSfx = mediaSfx; }
+
 private:
     int mMediaProtocol = MediaProtocolNotSet;
     int mMediaType = MediaTypeNotSet;
@@ -225,6 +231,8 @@ private:
     QString mMediaKey;
     QString mMediaWidget = MediaWidgetLabel;
     QString mMediaAbsolutePathFileName;
+    QString mMediaDesc;
+    QString mMediaSfx;
 };
 
 #endif // MUDLET_TMEDIA_DATA_H

--- a/src/TMediaData.h
+++ b/src/TMediaData.h
@@ -204,11 +204,8 @@ public:
     QString mediaAbsolutePathFileName() const { return mMediaAbsolutePathFileName; }
     void setMediaAbsolutePathFileName(QString mediaAbsolutePathFileName) { mMediaAbsolutePathFileName = mediaAbsolutePathFileName; }
 
-    QString mediaDesc() const { return mMediaDesc; }
-    void setMediaDesc(QString mediaDesc) { mMediaDesc = mediaDesc; }
-
-    QString mediaSfx() const { return mMediaSfx; }
-    void setMediaSfx(QString mediaSfx) { mMediaSfx = mediaSfx; }
+    QString mediaCaption() const { return mMediaCaption; }
+    void setMediaCaption(QString mediaCaption) { mMediaCaption = mediaCaption; }
 
 private:
     int mMediaProtocol = MediaProtocolNotSet;
@@ -231,8 +228,7 @@ private:
     QString mMediaKey;
     QString mMediaWidget = MediaWidgetLabel;
     QString mMediaAbsolutePathFileName;
-    QString mMediaDesc;
-    QString mMediaSfx;
+    QString mMediaCaption;
 };
 
 #endif // MUDLET_TMEDIA_DATA_H

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -480,6 +480,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("DebugShowAllProblemCodepoints") = pHost->debugShowAllProblemCodepoints() ? "yes" : "no";
     host.append_attribute("announceIncomingText") = pHost->mAnnounceIncomingText ? "yes" : "no";
     host.append_attribute("advertiseScreenReader") = pHost->mAdvertiseScreenReader ? "yes" : "no";
+    host.append_attribute("enableClosedCaption") = pHost->mEnableClosedCaption ? "yes" : "no";
     host.append_attribute("caretShortcut") = QMetaEnum::fromType<Host::CaretShortcut>().valueToKey(
             static_cast<int>(pHost->mCaretShortcut));
     host.append_attribute("blankLineBehaviour") = QMetaEnum::fromType<Host::BlankLineBehaviour>().valueToKey(

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -725,6 +725,7 @@ void XMLimport::readHost(Host* pHost)
 
     setBoolAttributeWithDefault(qsl("announceIncomingText"), pHost->mAnnounceIncomingText, true);
     setBoolAttributeWithDefault(qsl("advertiseScreenReader"), pHost->mAdvertiseScreenReader, false);
+    setBoolAttributeWithDefault(qsl("enableClosedCaption"), pHost->mEnableClosedCaption, false);
     setBoolAttributeWithDefault(qsl("mEnableMTTS"), pHost->mEnableMTTS, true);
     setBoolAttributeWithDefault(qsl("mEnableMNES"), pHost->mEnableMNES, false);
     setBoolAttributeWithDefault(qsl("forceNewEnvironNegotiationOff"), pHost->mForceNewEnvironNegotiationOff, false);

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -487,6 +487,7 @@ void dlgProfilePreferences::disableHostDetails()
     label_caretModeKey->setEnabled(false);
     checkBox_announceIncomingText->setEnabled(false);
     checkBox_advertiseScreenReader->setEnabled(false);
+    checkBox_enableClosedCaption->setEnabled(false);
     comboBox_blankLinesBehaviour->setEnabled(false);
     comboBox_caretModeKey->setEnabled(false);
 
@@ -598,6 +599,7 @@ void dlgProfilePreferences::enableHostDetails()
     label_caretModeKey->setEnabled(true);
     checkBox_announceIncomingText->setEnabled(true);
     checkBox_advertiseScreenReader->setEnabled(true);
+    checkBox_enableClosedCaption->setEnabled(true);
     comboBox_blankLinesBehaviour->setEnabled(true);
     comboBox_caretModeKey->setEnabled(true);
 
@@ -744,6 +746,9 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     checkBox_announceIncomingText->setChecked(pHost->mAnnounceIncomingText);
     checkBox_advertiseScreenReader->setChecked(pHost->mAdvertiseScreenReader);
     connect(checkBox_advertiseScreenReader, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_toggleAdvertiseScreenReader);
+
+    checkBox_enableClosedCaption->setChecked(pHost->mEnableClosedCaption);
+    connect(checkBox_enableClosedCaption, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_toggleEnableClosedCaption);
 
     // Block signals before setting initial state to prevent toggled signal
     checkBox_f3SearchEnabled->blockSignals(true);
@@ -1473,6 +1478,7 @@ void dlgProfilePreferences::clearHostDetails()
     checkBox_debugShowAllCodepointProblems->setChecked(false);
     checkBox_announceIncomingText->setChecked(false);
     checkBox_advertiseScreenReader->setChecked(false);
+    checkBox_enableClosedCaption->setChecked(false);
     comboBox_blankLinesBehaviour->setCurrentIndex(0);
 
     groupBox_ssl_certificate->hide();
@@ -3142,6 +3148,7 @@ void dlgProfilePreferences::slot_saveAndClose()
 
         pHost->mAnnounceIncomingText = checkBox_announceIncomingText->isChecked();
         pHost->mAdvertiseScreenReader = checkBox_advertiseScreenReader->isChecked();
+        pHost->mEnableClosedCaption = checkBox_enableClosedCaption->isChecked();
 
         pHost->setHaveColorSpaceId(checkBox_expectCSpaceIdInColonLessMColorCode->isChecked());
         pHost->setMayRedefineColors(checkBox_allowServerToRedefineColors->isChecked());
@@ -4505,6 +4512,13 @@ void dlgProfilePreferences::slot_toggleAdvertiseScreenReader(const bool state)
         pHost->mAdvertiseScreenReader = state;
         pHost->mTelnet.sendInfoNewEnvironValue(qsl("SCREEN_READER"));
         pHost->mTelnet.sendInfoNewEnvironValue(qsl("MTTS"));
+    }
+}
+
+void dlgProfilePreferences::slot_toggleEnableClosedCaption(const bool state)
+{
+    if (mpHost && mpHost->mEnableClosedCaption != state) {
+        mpHost->mEnableClosedCaption = state;
     }
 }
 

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -121,6 +121,7 @@ public slots:
 
     // Media
     void slot_purgeMediaCache();
+    void slot_toggleEnableClosedCaption(const bool);
 
     // Log.
     void slot_setLogDir();

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -3860,7 +3860,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item row="2" column="0" colspan="2">
            <widget class="QCheckBox" name="checkBox_enableClosedCaption">
             <property name="text">
-             <string>Enable closed caption for media (MCMP, Lua API, MXP, MSP)</string>
+             <string>Enable closed caption for media</string>
             </property>
            </widget>
           </item>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -3860,7 +3860,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item row="2" column="0" colspan="2">
            <widget class="QCheckBox" name="checkBox_enableClosedCaption">
             <property name="text">
-             <string>Enable closed caption for media (MCMP, Lua API)</string>
+             <string>Enable closed caption for media (MCMP, Lua API, MXP, MSP)</string>
             </property>
            </widget>
           </item>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -3857,7 +3857,14 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="2" column="0" colspan="2">
+           <widget class="QCheckBox" name="checkBox_enableClosedCaption">
+            <property name="text">
+             <string>Enable closed caption for media (MCMP, Lua API)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
            <widget class="QLabel" name="label_blankLinesBehaviour">
             <property name="text">
              <string>When the game sends blank lines:</string>
@@ -3867,7 +3874,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="3" column="1">
            <widget class="QComboBox" name="comboBox_blankLinesBehaviour">
             <item>
              <property name="text">
@@ -3886,7 +3893,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </item>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="4" column="0">
            <widget class="QLabel" name="label_caretModeKey">
             <property name="text">
              <string>Switch between input line and main window using:</string>
@@ -3896,7 +3903,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="4" column="1">
            <widget class="QComboBox" name="comboBox_caretModeKey">
             <item>
              <property name="text">
@@ -3920,7 +3927,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </item>
            </widget>
           </item>
-          <item row="4" column="0" colspan="2">
+          <item row="5" column="0" colspan="2">
            <widget class="QCheckBox" name="checkBox_f3SearchEnabled">
             <property name="toolTip">
              <string>&lt;p&gt;Enable F3 and Shift+F3 shortcuts for searching up and down in the buffer.&lt;/p&gt;</string>
@@ -4502,6 +4509,7 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>toolButton_resetMainWindowShortcuts</tabstop>
   <tabstop>checkBox_announceIncomingText</tabstop>
   <tabstop>checkBox_advertiseScreenReader</tabstop>
+  <tabstop>checkBox_enableClosedCaption</tabstop>
   <tabstop>comboBox_blankLinesBehaviour</tabstop>
   <tabstop>comboBox_caretModeKey</tabstop>
   <tabstop>checkBox_f3SearchEnabled</tabstop>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

To improve accessibility for hearing impaired within the Media handling in Mudlet (or those who just want sound off while they game), this enhancement adds a closed captioning feature and the following optional parameter implemented in the GMCP syntax for `Client.Media.Play` and Lua API functions `playSoundFile`, `playMusicFile`, `playVideoFile` for playing media:

* `caption`:  A caption-friendly textual representation of the sound, such as onomatopoeia or sound cues (e.g., *thunderclap*, *blacksmith hammering*). 

Inspired by [Captioning Key – Sound Effects and Music](https://dcmp.org/learn/602-captioning-key---sound-effects-and-music%7CDCMP).

-----

To enable the closed caption capability in Mudlet, a checkbox was added into the Settings->Accessibility menu:

<img width="626" alt="Screenshot 2025-05-11 at 4 01 40 PM" src="https://github.com/user-attachments/assets/d8b68c79-ed4d-4b80-b4c1-4c3ada8326e2" />

-----

Here is the outcome [in brackets] where a caption is not set (the cow) and where a caption is set (rugby club):

<img width="821" alt="Screenshot 2025-05-11 at 9 57 55 AM" src="https://github.com/user-attachments/assets/026fa694-1bb7-46b8-837b-78f9d17b1d23" />

#### Motivation for adding to Mudlet

Discussions with @RahjIII who authors the LociTerm client.

#### Other info (issues closed, discussion etc)

Aligns with update 1.0.3 for the [Mud Client Media Protocol](https://wiki.mudlet.org/w/Standards:MUD_Client_Media_Protocol).
