### PR TITLE
Fix: vertical alignment of glyphs

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -740,7 +740,7 @@ void TTextEdit::drawGraphemeForeground(QPainter& painter, const QColor& fgColor,
     if (painter.pen().color() != fgColor) {
         painter.setPen(fgColor);
     }
-    painter.drawText(textRect, Qt::AlignHCenter|Qt::TextDontClip|Qt::TextSingleLine, grapheme);
+    painter.drawText(textRect, Qt::AlignCenter|Qt::TextDontClip|Qt::TextSingleLine, grapheme);
 }
 
 int TTextEdit::getGraphemeWidth(uint unicode) const


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Revises the code I originated in #7766 to also centre the text vertically within the space allocated for it as well as horizontally.

#### Motivation for adding to Mudlet
Large emojis were being drawn too far down and then being clipped by the following line - this made a regression from how things were before 7766.

#### Other info (issues closed, discussion etc)
This will introduce the fix I posited in and also close #7839.