### PR TITLE
Fix: ensure we include the right Lua header files

### DIFF
--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -109,7 +109,7 @@ if [[ "${GITHUB_REPO_NAME}" != "Mudlet/Mudlet" ]]; then
   exit 2
 fi
 
-GITHUB_WORKSPACE_UNIX_PATH=$(echo "${GITHUB_WORKSPACE}" | sed 's|\\|/|g' | sed 's|D:|/d|g| sed 's|C:|/c|g')
+GITHUB_WORKSPACE_UNIX_PATH=$(echo "${GITHUB_WORKSPACE}" | sed 's|\\|/|g' | sed 's|D:|/d|g' | sed 's|C:|/c|g')
 PACKAGE_DIR="${GITHUB_WORKSPACE_UNIX_PATH}/package-${MSYSTEM}-release"
 
 cd "${PACKAGE_DIR}" || exit 1

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -123,9 +123,9 @@ moveToUploadDir() {
   local uploadFilename=$1
   local unzip=$2
   echo "=== Setting up upload directory ==="
-  local uploadDir="${GITHUB_WORKSPACE}\\upload"
+  local uploadDir="${GITHUB_WORKSPACE}/upload"
   local uploadDirUnix
-  uploadDirUnix=$(echo "${uploadDir}" | sed 's|\\|/|g' | sed 's|D:|/d|g')
+  uploadDirUnix=$(echo "${uploadDir}" | sed 's|\\|/|g' | sed 's|D:|/d|g' | sed 's|C:|/c|g')
 
   # Check if the upload directory exists, if not, create it
   if [[ ! -d "${uploadDirUnix}" ]]; then
@@ -137,7 +137,7 @@ moveToUploadDir() {
 
   # Append these variables to the GITHUB_ENV to make them available in subsequent steps
   {
-    echo "FOLDER_TO_UPLOAD=${uploadDir}\\"
+    echo "FOLDER_TO_UPLOAD=${uploadDir}/"
     echo "UPLOAD_FILENAME=${uploadFilename}"
     echo "PARAM_UNZIP=${unzip}"
   } >> "${GITHUB_ENV}"

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -109,7 +109,7 @@ if [[ "${GITHUB_REPO_NAME}" != "Mudlet/Mudlet" ]]; then
   exit 2
 fi
 
-GITHUB_WORKSPACE_UNIX_PATH=$(echo "${GITHUB_WORKSPACE}" | sed 's|\\|/|g' | sed 's|D:|/d|g')
+GITHUB_WORKSPACE_UNIX_PATH=$(echo "${GITHUB_WORKSPACE}" | sed 's|\\|/|g' | sed 's|D:|/d|g| sed 's|C:|/c|g')
 PACKAGE_DIR="${GITHUB_WORKSPACE_UNIX_PATH}/package-${MSYSTEM}-release"
 
 cd "${PACKAGE_DIR}" || exit 1

--- a/CI/package-mudlet-for-windows.sh
+++ b/CI/package-mudlet-for-windows.sh
@@ -63,7 +63,7 @@ fi
 BUILD_CONFIG="release"
 MINGW_INTERNAL_BASE_DIR="/mingw${BUILD_BITNESS}"
 export MINGW_INTERNAL_BASE_DIR
-GITHUB_WORKSPACE_UNIX_PATH=$(echo "${GITHUB_WORKSPACE}" | sed 's|\\|/|g' | sed 's|D:|/d|g| sed 's|C:|/c|g')
+GITHUB_WORKSPACE_UNIX_PATH=$(echo "${GITHUB_WORKSPACE}" | sed 's|\\|/|g' | sed 's|D:|/d|g' | sed 's|C:|/c|g')
 PACKAGE_DIR="${GITHUB_WORKSPACE_UNIX_PATH}/package-${MSYSTEM}-${BUILD_CONFIG}"
 
 echo "MSYSTEM is: ${MSYSTEM}"

--- a/CI/package-mudlet-for-windows.sh
+++ b/CI/package-mudlet-for-windows.sh
@@ -63,7 +63,7 @@ fi
 BUILD_CONFIG="release"
 MINGW_INTERNAL_BASE_DIR="/mingw${BUILD_BITNESS}"
 export MINGW_INTERNAL_BASE_DIR
-GITHUB_WORKSPACE_UNIX_PATH=$(echo "${GITHUB_WORKSPACE}" | sed 's|\\|/|g' | sed 's|D:|/d|g')
+GITHUB_WORKSPACE_UNIX_PATH=$(echo "${GITHUB_WORKSPACE}" | sed 's|\\|/|g' | sed 's|D:|/d|g| sed 's|C:|/c|g')
 PACKAGE_DIR="${GITHUB_WORKSPACE_UNIX_PATH}/package-${MSYSTEM}-${BUILD_CONFIG}"
 
 echo "MSYSTEM is: ${MSYSTEM}"

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -28,13 +28,11 @@
 #include <csetjmp>
 
 extern "C" {
-#if defined(Q_OS_WINDOWS)
-// We need to be version specific here as the Windows CI/CB environment
-// includes Lua 5.4 in the "standard" place
+#if defined(INCLUDE_VERSIONED_LUA_HEADERS)
 #include <lua5.1/lauxlib.h>
 #include <lua5.1/lua.h>
 #include <lua5.1/lualib.h>
-#else // Not Windows
+#else
 #include <lauxlib.h>
 #include <lua.h>
 #include <lualib.h>

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -28,9 +28,17 @@
 #include <csetjmp>
 
 extern "C" {
-    #include <lauxlib.h>
-    #include <lua.h>
-    #include <lualib.h>
+#if defined(Q_OS_WINDOWS)
+// We need to be version specific here as the Windows CI/CB environment
+// includes Lua 5.4 in the "standard" place
+#include <lua5.1/lauxlib.h>
+#include <lua5.1/lua.h>
+#include <lua5.1/lualib.h>
+#else // Not Windows
+#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
+#endif
 }
 
 static jmp_buf buf;

--- a/src/LuaInterface.h
+++ b/src/LuaInterface.h
@@ -31,11 +31,9 @@
 #include "post_guard.h"
 
 extern "C" {
-#if defined(Q_OS_WINDOWS)
-// We need to be version specific here as the Windows CI/CB environment
-// includes Lua 5.4 in the "standard" place
+#if defined(INCLUDE_VERSIONED_LUA_HEADERS)
 #include <lua5.1/lua.h>
-#else // Not Windows
+#else
 #include <lua.h>
 #endif
 }

--- a/src/LuaInterface.h
+++ b/src/LuaInterface.h
@@ -31,7 +31,13 @@
 #include "post_guard.h"
 
 extern "C" {
-    #include <lua.h>
+#if defined(Q_OS_WINDOWS)
+// We need to be version specific here as the Windows CI/CB environment
+// includes Lua 5.4 in the "standard" place
+#include <lua5.1/lua.h>
+#else // Not Windows
+#include <lua.h>
+#endif
 }
 
 

--- a/src/TKey.h
+++ b/src/TKey.h
@@ -32,7 +32,13 @@
 #include "post_guard.h"
 
 extern "C" {
-    #include <lua.h>
+#if defined(Q_OS_WINDOWS)
+// We need to be version specific here as the Windows CI/CB environment
+// includes Lua 5.4 in the "standard" place
+#include <lua5.1/lua.h>
+#else // Not Windows
+#include <lua.h>
+#endif
 }
 
 class Host;

--- a/src/TKey.h
+++ b/src/TKey.h
@@ -32,11 +32,9 @@
 #include "post_guard.h"
 
 extern "C" {
-#if defined(Q_OS_WINDOWS)
-// We need to be version specific here as the Windows CI/CB environment
-// includes Lua 5.4 in the "standard" place
+#if defined(INCLUDE_VERSIONED_LUA_HEADERS)
 #include <lua5.1/lua.h>
-#else // Not Windows
+#else
 #include <lua.h>
 #endif
 }

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -50,13 +50,11 @@
 #include "post_guard.h"
 
 extern "C" {
-#if defined(Q_OS_WINDOWS)
-// We need to be version specific here as the Windows CI/CB environment
-// includes Lua 5.4 in the "standard" place
+#if defined(INCLUDE_VERSIONED_LUA_HEADERS)
 #include <lua5.1/lauxlib.h>
 #include <lua5.1/lua.h>
 #include <lua5.1/lualib.h>
-#else // Not Windows
+#else
 #include <lauxlib.h>
 #include <lua.h>
 #include <lualib.h>

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -50,9 +50,17 @@
 #include "post_guard.h"
 
 extern "C" {
-    #include <lauxlib.h>
-    #include <lua.h>
-    #include <lualib.h>
+#if defined(Q_OS_WINDOWS)
+// We need to be version specific here as the Windows CI/CB environment
+// includes Lua 5.4 in the "standard" place
+#include <lua5.1/lauxlib.h>
+#include <lua5.1/lua.h>
+#include <lua5.1/lualib.h>
+#else // Not Windows
+#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
+#endif
 }
 
 #include <list>

--- a/src/TVar.h
+++ b/src/TVar.h
@@ -30,7 +30,13 @@
 #include "post_guard.h"
 
 extern "C" {
-    #include <lua.h>
+#if defined(Q_OS_WINDOWS)
+// We need to be version specific here as the Windows CI/CB environment
+// includes Lua 5.4 in the "standard" place
+#include <lua5.1/lua.h>
+#else // Not Windows
+#include <lua.h>
+#endif
 }
 
 class TVar

--- a/src/TVar.h
+++ b/src/TVar.h
@@ -30,11 +30,9 @@
 #include "post_guard.h"
 
 extern "C" {
-#if defined(Q_OS_WINDOWS)
-// We need to be version specific here as the Windows CI/CB environment
-// includes Lua 5.4 in the "standard" place
+#if defined(INCLUDE_VERSIONED_LUA_HEADERS)
 #include <lua5.1/lua.h>
-#else // Not Windows
+#else
 #include <lua.h>
 #endif
 }

--- a/src/dlgVarsMainArea.cpp
+++ b/src/dlgVarsMainArea.cpp
@@ -27,11 +27,9 @@
 #include "post_guard.h"
 
 extern "C" {
-#if defined(Q_OS_WINDOWS)
-// We need to be version specific here as the Windows CI/CB environment
-// includes Lua 5.4 in the "standard" place
+#if defined(INCLUDE_VERSIONED_LUA_HEADERS)
 #include <lua5.1/lua.h>
-#else // Not Windows
+#else
 #include <lua.h>
 #endif
 }

--- a/src/dlgVarsMainArea.cpp
+++ b/src/dlgVarsMainArea.cpp
@@ -27,7 +27,13 @@
 #include "post_guard.h"
 
 extern "C" {
-    #include <lua.h>
+#if defined(Q_OS_WINDOWS)
+// We need to be version specific here as the Windows CI/CB environment
+// includes Lua 5.4 in the "standard" place
+#include <lua5.1/lua.h>
+#else // Not Windows
+#include <lua.h>
+#endif
 }
 
 dlgVarsMainArea::dlgVarsMainArea(QWidget* pParentWidget)

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -389,7 +389,7 @@ unix:!macx {
         -L$${MINGW_BASE_DIR_TEST}/bin \
         -llua5.1 \
         -llibhunspell-1.7 \
-        -lpcre-1 \
+        -lpcre \
         -lzip \                 # for dlgPackageExporter
         -lz \                   # for ctelnet.cpp
         -lpugixml \

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -380,58 +380,25 @@ unix:!macx {
         # although it might be possible for dedicated parties to build them
         # locally for a while:
         error($$escape_expand("Build aborted as environmental variable MINGW_BASE_DIR not set to the root of \\n"\
-        "the Mingw32 or Mingw64 part (depending on the number of bits in your desired\\n"\
-        "application build) typically this is one of:\\n"\
-        "'C:\msys32\mingw32' {32 Bit Mudlet built on a 32 Bit Host}\\n"\
-        "'C:\msys64\mingw32' {32 Bit Mudlet built on a 64 Bit Host}\\n"\
-        "'C:\msys64\mingw64' {64 Bit Mudlet built on a 64 Bit Host}\\n"))
+        "the MINGW64/CLANG64/UCRT64 part typically this:\\n"\
+        "'C:\msys64\mingw64' {64 Bit (MINGW64) Mudlet built on a 64 Bit Host}\\n"))
     }
-    GITHUB_WORKSPACE_TEST = $$(GITHUB_WORKSPACE)
-    isEmpty( GITHUB_WORKSPACE_TEST ) {
-        # For users/developers building with MSYS2 on Windows:
-        LIBS +=  \
-            -L$${MINGW_BASE_DIR_TEST}/bin \
-            -llua5.1 \
-            -llibhunspell-1.7
-
-        INCLUDEPATH += \
-            $${MINGW_BASE_DIR_TEST}/include/lua5.1 \
-            $${MINGW_BASE_DIR_TEST}/include/pugixml
-    } else {
-        # For CI building with MSYS2 for Windows in a GH Workflow:
-        contains(QMAKE_HOST.arch, x86_64) {
-
-            LIBS +=  \
-                -LD:\\a\\_temp\\msys64\\mingw64/lib \
-                -LD:\\a\\_temp\\msys64\\mingw64/bin \
-                -llua5.1 \
-                -llibhunspell-1.7
-
-            INCLUDEPATH += \
-                D:\\a\\_temp\\msys64\\mingw64/include \
-                D:/a/_temp/msys64/mingw64/include/lua5.1 \
-                $${MINGW_BASE_DIR_TEST}/include/pugixml
-        } else {
-            LIBS +=  \
-                -LD:\\a\\_temp\\msys64\\mingw32/lib \
-                -LD:\\a\\_temp\\msys64\\mingw32/bin \
-                -llua5.1 \
-                -llibhunspell-1.7
-
-            INCLUDEPATH += \
-                D:\\a\\_temp\\msys64\\mingw32/include \
-                D:/a/_temp/msys64/mingw32/include/lua5.1 \
-                $${MINGW_BASE_DIR_TEST}/include/pugixml
-        }
-    }
-
-    LIBS += \
+    # For users/developers building with MSYS2 on Windows:
+    # AND for CI building with MSYS2 for Windows in a GH Workflow:
+    LIBS +=  \
+        -L$${MINGW_BASE_DIR_TEST}/bin \
+        -llua5.1 \
+        -llibhunspell-1.7 \
         -lpcre-1 \
         -lzip \                 # for dlgPackageExporter
         -lz \                   # for ctelnet.cpp
         -lpugixml \
         -lws2_32 \
         -loleaut32
+
+    INCLUDEPATH += \
+        $${MINGW_BASE_DIR_TEST}/include/lua5.1 \
+        $${MINGW_BASE_DIR_TEST}/include/pugixml
 
     # Leave this unset - we do not need it on Windows:
     # LUA_DEFAULT_DIR =

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -171,6 +171,20 @@ macx {
 # executables with an ".exe" extension!
 DEFINES += APP_TARGET=\\\"$${TARGET}$${TARGET_EXT}\\\"
 
+# Some use-cases - currently Windows builds in a MSYS2+Mingw-w64 environment
+# put the Lua 5.1 headers in a version numbered sub-directory of the main/normal
+# system "includes" (header files) location and if there are newer version files
+# they could be put in that main/normal location - in which case the wrong ones
+# will be used if we don't modify the '#include' lines.
+win32 {
+    MSYSTEM_TEST = $$(MSYSTEM)
+    # At some point in the future we might also want to check for CLANGARM64
+    # as GH Actions is going to add that...
+    equals(MSYSTEM_TEST, "MINGW64") | equals(MSYSTEM_TEST, "CLANG64") | equals(MSYSTEM_TEST, "UCRT64") {
+        DEFINES += INCLUDE_VERSIONED_LUA_HEADERS
+    }
+}
+
 ################## DejuVu and Ubuntu Fonts inclusion detection #################
 # To skip bundling Bitstream Vera Sans and Ubuntu Mono fonts with Mudlet,
 # set the environment WITH_FONTS variable to "NO"

--- a/test/TLuaInterfaceTest.cpp
+++ b/test/TLuaInterfaceTest.cpp
@@ -23,13 +23,11 @@
 #include <QtTest/QtTest>
 
 extern "C" {
-#if defined(Q_OS_WINDOWS)
-// We need to be version specific here as the Windows CI/CB environment
-// includes Lua 5.4 in the "standard" place
+#if defined(INCLUDE_VERSIONED_LUA_HEADERS)
 #include <lua5.1/lauxlib.h>
 #include <lua5.1/lua.h>
 #include <lua5.1/lualib.h>
-#else // Not Windows
+#else
 #include <lauxlib.h>
 #include <lua.h>
 #include <lualib.h>

--- a/test/TLuaInterfaceTest.cpp
+++ b/test/TLuaInterfaceTest.cpp
@@ -23,10 +23,19 @@
 #include <QtTest/QtTest>
 
 extern "C" {
-    #include <lauxlib.h>
-    #include <lua.h>
-    #include <lualib.h>
+#if defined(Q_OS_WINDOWS)
+// We need to be version specific here as the Windows CI/CB environment
+// includes Lua 5.4 in the "standard" place
+#include <lua5.1/lauxlib.h>
+#include <lua5.1/lua.h>
+#include <lua5.1/lualib.h>
+#else // Not Windows
+#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
+#endif
 }
+
 
 class TVarTest : public QObject {
 Q_OBJECT


### PR DESCRIPTION
#### Brief overview of PR changes/additions
For Windows builds modify the `#include` lines for Lua header files to specify the 5.1 version. Also accommodate some changes in our CI build environment:
* For some reason (maybe because of a more modern linker) we need to specify the original PCRE library with `-lpcre` rather than `-lpcre-1` - the exact cause of this is not clear but thanks to @jmckisson for finding it (and using it in his attempt to solve the same problems this PR is doing).
* It seems the Window building is now being done in the `C:` drive rather than the previous `D:` one, so a tweak to clean the colon containing file-system root specifier to the alternative that MSYS2+Mingw-w64 uses which instead uses a (POSIX) `/` root directory followed by a single lower-case letter to specify the drive needs to be extended to handle both drives. This is because the scripts use `rsync` and that treats any `:` as the separator between host and path and gets confused when it sees a "Windows" path containing it!

#### Motivation for adding to Mudlet
The default version - and the one needed for some packages like Luarocks is a 5.4 one - and that includes header files in the "default" `include` directory. So the headers that get pulled in are the wrong ones, which fail to work as they are not compatible with Lua 5.1; to get the 5.1 instead I believe we need to explicitly include the version specific sub-directory in the `#include` lines.

Other tweaks are also needed "to get things working nowadays."

#### Other info (issues closed, discussion etc)
This should be simpler to do than what is being attempted by #7841.