### PR TITLE
Fix: RFC 854 compliance for DONT/WONT

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1670,18 +1670,18 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
 
         if (option == OPT_MSDP) {
             //MSDP support
-            std::string output;
             if (!mpHost->mEnableMSDP) {
-                output += TN_IAC;
-                output += TN_DONT;
-                output += OPT_MSDP; // disable MSDP per http://tintin.sourceforge.net/msdp/
-                // This will be unaffected by Mud Server encoding:
-                socketOutRaw(output);
-#ifdef DEBUG_TELNET
-                qDebug() << "WE send telnet IAC DONT MSDP";
-#endif
+                sendTelnetOption(TN_DONT, OPT_MSDP);
+
+                if (enableMSDP) {
+                    raiseProtocolEvent("sysProtocolDisabled", "MSDP");
+                }
+
+                enableMSDP = false;
                 break;
             } else {
+                std::string output;
+
                 enableMSDP = true;
                 sendTelnetOption(TN_DO, OPT_MSDP);
                 //need to send MSDP start sequence: IAC   SB MSDP MSDP_VAR "LIST" MSDP_VAL "COMMANDS" IAC SE
@@ -1724,8 +1724,14 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
 
         if (option == OPT_ATCP) {
             // ATCP support
-            //FIXME: this is a bug, some muds offer both atcp + gmcp
             if (mpHost->mEnableGMCP) {
+                sendTelnetOption(TN_DONT, OPT_ATCP);
+
+                if (enableATCP) {
+                    raiseProtocolEvent("sysProtocolDisabled", "ATCP");
+                }
+
+                enableATCP = false;
                 break;
             }
 
@@ -1737,7 +1743,6 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             output += TN_IAC;
             output += TN_SB;
             output += OPT_ATCP;
-            // mudlet::self()->mAppBuild could, conceivably contain a non ASCII character:
             std::string atcpOptions = std::string("hello Mudlet ") + std::string(APP_VERSION) + mudlet::self()->mAppBuild.toUtf8().constData() + "\ncomposer 1\nchar_vitals 1\nroom_brief 1\nroom_exits 1\nmap_display 1\n";
             output += encodeAndCookBytes(atcpOptions);
             output += TN_IAC;
@@ -1750,6 +1755,13 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
 
         if (option == OPT_GMCP) {
             if (!mpHost->mEnableGMCP) {
+                sendTelnetOption(TN_DONT, OPT_GMCP);
+
+                if (enableGMCP) {
+                    raiseProtocolEvent("sysProtocolDisabled", "GMCP");
+                }
+
+                enableGMCP = false;
                 break;
             }
 
@@ -1792,6 +1804,13 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
 
         if (option == OPT_MSSP) {
             if (!mpHost->mEnableMSSP) {
+                sendTelnetOption(TN_DONT, OPT_MSSP);
+
+                if (enableMSSP) {
+                    raiseProtocolEvent("sysProtocolDisabled", "MSSP");
+                }
+
+                enableMSSP = false;
                 break;
             }
 
@@ -1804,6 +1823,13 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
 
         if (option == OPT_MSP) {
             if (!mpHost->mEnableMSP) {
+                sendTelnetOption(TN_DONT, OPT_MSP);
+
+                if (enableMSP) {
+                    raiseProtocolEvent("sysProtocolDisabled", "MSP");
+                }
+
+                enableMSP = false;
                 break;
             }
 
@@ -1820,6 +1846,15 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 mpHost->mServerMXPenabled = true;
                 mpHost->mMxpProcessor.enable();
                 raiseProtocolEvent("sysProtocolEnabled", "MXP");
+                break;
+            } else {
+                sendTelnetOption(TN_DONT, OPT_MXP);
+
+                if (mpHost->mServerMXPenabled) {
+                    raiseProtocolEvent("sysProtocolDisabled", "MXP");
+                }
+
+                mpHost->mServerMXPenabled = false;
                 break;
             }
         }
@@ -2031,6 +2066,15 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             sendTelnetOption(TN_WILL, OPT_MSDP);
             raiseProtocolEvent("sysProtocolEnabled", "MSDP");
             break;
+        } else if (option == OPT_MSDP) {
+            sendTelnetOption(TN_WONT, OPT_MSDP);
+
+            if (enableMSDP) {
+                raiseProtocolEvent("sysProtocolDisabled", "MSDP");
+            }
+
+            enableMSDP = false;
+            break;
         }
 
         if (option == OPT_ATCP && !mpHost->mEnableGMCP) {
@@ -2038,6 +2082,15 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             enableATCP = true;
             sendTelnetOption(TN_WILL, OPT_ATCP);
             raiseProtocolEvent("sysProtocolEnabled", "ATCP");
+            break;
+        } else if (option == OPT_ATCP) {
+            sendTelnetOption(TN_WONT, OPT_ATCP);
+
+            if (enableATCP) {
+                raiseProtocolEvent("sysProtocolDisabled", "ATCP");
+            }
+
+            enableATCP = false;
             break;
         }
 
@@ -2047,6 +2100,15 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             sendTelnetOption(TN_WILL, OPT_GMCP);
             raiseProtocolEvent("sysProtocolEnabled", "GMCP");
             break;
+        } else if (option == OPT_GMCP) {
+            sendTelnetOption(TN_WONT, OPT_GMCP);
+
+            if (enableGMCP) {
+                raiseProtocolEvent("sysProtocolDisabled", "GMCP");
+            }
+
+            enableGMCP = false;
+            break;
         }
 
         if (option == OPT_MSSP && mpHost->mEnableMSSP) {
@@ -2054,6 +2116,15 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             enableMSSP = true;
             sendTelnetOption(TN_WILL, OPT_MSSP);
             raiseProtocolEvent("sysProtocolEnabled", "MSSP");
+            break;
+        } else if (option == OPT_MSSP) {
+            sendTelnetOption(TN_WONT, OPT_MSSP);
+
+            if (enableMSSP) {
+                raiseProtocolEvent("sysProtocolDisabled", "MSSP");
+            }
+
+            enableMSSP = false;
             break;
         }
 
@@ -2063,13 +2134,26 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             sendTelnetOption(TN_WILL, OPT_MSP);
             raiseProtocolEvent("sysProtocolEnabled", "MSP");
             break;
+        } else if (option == OPT_MSP) {
+            sendTelnetOption(TN_WONT, OPT_MSP);
+
+            if (enableMSP) {
+                raiseProtocolEvent("sysProtocolDisabled", "MSP");
+            }
+
+            enableMSP = false;
+            break;
         }
 
         if (option == OPT_MXP && !mpHost->mFORCE_MXP_NEGOTIATION_OFF) {
             // MXP support
             sendTelnetOption(TN_WILL, OPT_MXP);
-            mpHost->mpConsole->print("\n<MXP support enabled>\n");
+            mpHost->mpConsole->print(tr("\n<MXP support enabled>\n"));
             raiseProtocolEvent("sysProtocolEnabled", "MXP");
+            break;
+        } else if (option == OPT_MXP) {
+            sendTelnetOption(TN_WONT, OPT_MXP);
+            raiseProtocolEvent("sysProtocolDisabled", "MXP");
             break;
         }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2060,100 +2060,90 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             break;
         }
 
-        if (option == OPT_MSDP && mpHost->mEnableMSDP) {
-            // MSDP support
-            enableMSDP = true;
-            sendTelnetOption(TN_WILL, OPT_MSDP);
-            raiseProtocolEvent("sysProtocolEnabled", "MSDP");
-            break;
-        } else if (option == OPT_MSDP) {
-            sendTelnetOption(TN_WONT, OPT_MSDP);
-
-            if (enableMSDP) {
-                raiseProtocolEvent("sysProtocolDisabled", "MSDP");
+        if (option == OPT_MSDP) {
+            if (mpHost->mEnableMSDP) {
+                enableMSDP = true;
+                sendTelnetOption(TN_WILL, OPT_MSDP);
+                raiseProtocolEvent("sysProtocolEnabled", "MSDP");
+            } else {
+                sendTelnetOption(TN_WONT, OPT_MSDP);
+                if (enableMSDP) {
+                    raiseProtocolEvent("sysProtocolDisabled", "MSDP");
+                }
+                enableMSDP = false;
             }
-
-            enableMSDP = false;
             break;
         }
 
-        if (option == OPT_ATCP && !mpHost->mEnableGMCP) {
-            // ATCP support, enable only if GMCP is off as GMCP is better
-            enableATCP = true;
-            sendTelnetOption(TN_WILL, OPT_ATCP);
-            raiseProtocolEvent("sysProtocolEnabled", "ATCP");
-            break;
-        } else if (option == OPT_ATCP) {
-            sendTelnetOption(TN_WONT, OPT_ATCP);
-
-            if (enableATCP) {
-                raiseProtocolEvent("sysProtocolDisabled", "ATCP");
+        if (option == OPT_ATCP) {
+            if (!mpHost->mEnableGMCP) {
+                enableATCP = true;
+                sendTelnetOption(TN_WILL, OPT_ATCP);
+                raiseProtocolEvent("sysProtocolEnabled", "ATCP");
+            } else {
+                sendTelnetOption(TN_WONT, OPT_ATCP);
+                if (enableATCP) {
+                    raiseProtocolEvent("sysProtocolDisabled", "ATCP");
+                }
+                enableATCP = false;
             }
-
-            enableATCP = false;
             break;
         }
 
-        if (option == OPT_GMCP && mpHost->mEnableGMCP) {
-            // GMCP support
-            enableGMCP = true;
-            sendTelnetOption(TN_WILL, OPT_GMCP);
-            raiseProtocolEvent("sysProtocolEnabled", "GMCP");
-            break;
-        } else if (option == OPT_GMCP) {
-            sendTelnetOption(TN_WONT, OPT_GMCP);
-
-            if (enableGMCP) {
-                raiseProtocolEvent("sysProtocolDisabled", "GMCP");
+        if (option == OPT_GMCP) {
+            if (mpHost->mEnableGMCP) {
+                enableGMCP = true;
+                sendTelnetOption(TN_WILL, OPT_GMCP);
+                raiseProtocolEvent("sysProtocolEnabled", "GMCP");
+            } else {
+                sendTelnetOption(TN_WONT, OPT_GMCP);
+                if (enableGMCP) {
+                    raiseProtocolEvent("sysProtocolDisabled", "GMCP");
+                }
+                enableGMCP = false;
             }
-
-            enableGMCP = false;
             break;
         }
 
-        if (option == OPT_MSSP && mpHost->mEnableMSSP) {
-            // MSSP support
-            enableMSSP = true;
-            sendTelnetOption(TN_WILL, OPT_MSSP);
-            raiseProtocolEvent("sysProtocolEnabled", "MSSP");
-            break;
-        } else if (option == OPT_MSSP) {
-            sendTelnetOption(TN_WONT, OPT_MSSP);
-
-            if (enableMSSP) {
-                raiseProtocolEvent("sysProtocolDisabled", "MSSP");
+        if (option == OPT_MSSP) {
+            if (mpHost->mEnableMSSP) {
+                enableMSSP = true;
+                sendTelnetOption(TN_WILL, OPT_MSSP);
+                raiseProtocolEvent("sysProtocolEnabled", "MSSP");
+            } else {
+                sendTelnetOption(TN_WONT, OPT_MSSP);
+                if (enableMSSP) {
+                    raiseProtocolEvent("sysProtocolDisabled", "MSSP");
+                }
+                enableMSSP = false;
             }
-
-            enableMSSP = false;
             break;
         }
 
-        if (option == OPT_MSP && mpHost->mEnableMSP) {
-            // MSP support
-            enableMSP = true;
-            sendTelnetOption(TN_WILL, OPT_MSP);
-            raiseProtocolEvent("sysProtocolEnabled", "MSP");
-            break;
-        } else if (option == OPT_MSP) {
-            sendTelnetOption(TN_WONT, OPT_MSP);
-
-            if (enableMSP) {
-                raiseProtocolEvent("sysProtocolDisabled", "MSP");
+        if (option == OPT_MSP) {
+            if (mpHost->mEnableMSP) {
+                enableMSP = true;
+                sendTelnetOption(TN_WILL, OPT_MSP);
+                raiseProtocolEvent("sysProtocolEnabled", "MSP");
+            } else {
+                sendTelnetOption(TN_WONT, OPT_MSP);
+                if (enableMSP) {
+                    raiseProtocolEvent("sysProtocolDisabled", "MSP");
+                }
+                enableMSP = false;
             }
-
-            enableMSP = false;
             break;
         }
 
-        if (option == OPT_MXP && !mpHost->mFORCE_MXP_NEGOTIATION_OFF) {
-            // MXP support
-            sendTelnetOption(TN_WILL, OPT_MXP);
-            mpHost->mpConsole->print(tr("\n<MXP support enabled>\n"));
-            raiseProtocolEvent("sysProtocolEnabled", "MXP");
-            break;
-        } else if (option == OPT_MXP) {
-            sendTelnetOption(TN_WONT, OPT_MXP);
-            raiseProtocolEvent("sysProtocolDisabled", "MXP");
+        if (option == OPT_MXP) {
+            if (!mpHost->mFORCE_MXP_NEGOTIATION_OFF) {
+                sendTelnetOption(TN_WILL, OPT_MXP);
+                mpHost->mpConsole->print(tr("\n<MXP support enabled>\n"));
+                raiseProtocolEvent("sysProtocolEnabled", "MXP");
+            } else {
+                sendTelnetOption(TN_WONT, OPT_MXP);
+                raiseProtocolEvent("sysProtocolDisabled", "MXP");
+            }
             break;
         }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2067,9 +2067,11 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 raiseProtocolEvent("sysProtocolEnabled", "MSDP");
             } else {
                 sendTelnetOption(TN_WONT, OPT_MSDP);
+
                 if (enableMSDP) {
                     raiseProtocolEvent("sysProtocolDisabled", "MSDP");
                 }
+
                 enableMSDP = false;
             }
             break;
@@ -2082,9 +2084,11 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 raiseProtocolEvent("sysProtocolEnabled", "ATCP");
             } else {
                 sendTelnetOption(TN_WONT, OPT_ATCP);
+
                 if (enableATCP) {
                     raiseProtocolEvent("sysProtocolDisabled", "ATCP");
                 }
+
                 enableATCP = false;
             }
             break;
@@ -2097,9 +2101,11 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 raiseProtocolEvent("sysProtocolEnabled", "GMCP");
             } else {
                 sendTelnetOption(TN_WONT, OPT_GMCP);
+
                 if (enableGMCP) {
                     raiseProtocolEvent("sysProtocolDisabled", "GMCP");
                 }
+
                 enableGMCP = false;
             }
             break;
@@ -2112,9 +2118,11 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 raiseProtocolEvent("sysProtocolEnabled", "MSSP");
             } else {
                 sendTelnetOption(TN_WONT, OPT_MSSP);
+
                 if (enableMSSP) {
                     raiseProtocolEvent("sysProtocolDisabled", "MSSP");
                 }
+
                 enableMSSP = false;
             }
             break;
@@ -2127,9 +2135,11 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 raiseProtocolEvent("sysProtocolEnabled", "MSP");
             } else {
                 sendTelnetOption(TN_WONT, OPT_MSP);
+
                 if (enableMSP) {
                     raiseProtocolEvent("sysProtocolDisabled", "MSP");
                 }
+
                 enableMSP = false;
             }
             break;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

This pull request ensures compliance with RFC 854 (Telnet Protocol Specification) by explicitly sending DONT and WONT responses for unsupported or disabled Telnet options in both WILL and DO negotiations.

Previously, Mudlet silently ignored some WILL/DO requests, which could result in inconsistent negotiation states between the MUD server and the client.

##### What this PR fixes

* Missing DONT replies in TN_WILL handling when options are not supported or forcibly disabled (e.g., GMCP, MSSP, MSP, MXP)
* Missing WONT replies in TN_DO handling when options are not supported or forcibly disabled
* Now explicitly calls raiseProtocolEvent("sysProtocolDisabled", ...) in all negative response branches to ensure correct signaling

#### Motivation for adding to Mudlet

* RFC 854 compliance
* Telnet negotiation mismatches on servers expecting explicit DONT/WONT

#### Other info (issues closed, discussion etc)

##### Testing performed
* Verified that unsupported protocol options now send appropriate DONT/WONT responses
* Confirmed that servers no longer hang waiting for a response during Telnet negotiation

Here is the debug before the change where there was no response to the server:
-----
<img width="579" alt="Screenshot 2025-05-18 at 1 02 40 PM" src="https://github.com/user-attachments/assets/6e8f3804-09e1-45c3-b37d-2f300c7ef398" />

Here is the debug after the change where there is a response to the server:
-----
<img width="584" alt="Screenshot 2025-05-18 at 1 04 49 PM" src="https://github.com/user-attachments/assets/fa59de49-13c2-4921-b59c-8a12f91ef5b1" />

Here is how it looks when protocols are enabled:
-----
<img width="581" alt="Screenshot 2025-05-18 at 1 06 07 PM" src="https://github.com/user-attachments/assets/cfb9c9ef-dfd6-4c85-a58d-2b0b91031c81" />