### PR TITLE
improve: allow db:close to accept a db_name

### DIFF
--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -1542,26 +1542,32 @@ end
 
 --- Closes all databases.
 --- @return boolean result Returns true if all databases closed successfully and false otherwise 
---- @return string messsage
+--- @return string message
 function db:_closeAll()
   if db.__env == nil then
     return false, "database environment is nil, did you forget to call db:create?"
   end
 
-  for _, c in pairs(db.__conn) do
-    c:close()
+  local result, msgs = true, {}
+  for db_name, conn in pairs(db.__conn) do
+    if not conn:close() then
+      result = false
+      table.insert(msgs, "database object for "..db_name.." is already closed.")
+    end
   end
+
   db.__conn = {}
   db.__env:close()
   db.__env = nil
-  return result, ""
+
+  return result, table.concat(msgs, "\n")
 end
 
 
 --- Closes the named database or all databases if no name is provided.
 --- @param db_name string|nil The name of the database to close.
 --- @return boolean result Returns true in case of success and false otherwise.
---- @return string messsage Why the database failed to close.
+--- @return string message Why the database failed to close.
 function db:close(db_name)
   if db.__env == nil then
     return false, "database environment is nil, did you forget to call db:create?"
@@ -1571,14 +1577,26 @@ function db:close(db_name)
     return db:_closeAll()
   end
 
-  assert(type(db_name) == "string", "expected db_name to be string or nil but recieved "..type(db_name))
+  assert(
+    type(db_name) == "string",
+    "expected db_name to be string or nil but recieved "..type(db_name).."."
+  )
+
   db_name = db:safe_name(db_name)
   if not db:_isActiveDBName(db_name) then
     return false, "can not close "..db_name.." because it does not exist.  Did you forget to call db:create?"
   end
 
-  db.__conn[db_name]:close()
-  return true, ""
+  if db.__conn[db_name]:close() then
+    db.__conn[db_name] = nil
+    
+    return true, ""
+  else
+    
+    return false, "database object is already closed."
+  end
+
+  
 end
 
 

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -386,7 +386,15 @@ function db:safe_name(name)
   return name
 end
 
+function db:_isActiveDBName(db_name)
+  db_name = db:safe_name(db_name)
 
+  return (
+    db.__conn[db_name]
+    and db.__conn[db_name] ~= 'SQLite3 connection (closed)'
+    and io.exists(getMudletHomeDir() .. "/Database_" .. db_name .. ".db")
+  )
+end
 
 --- Creates and/or modifies an existing database. This function is safe to define at a top-level of a Mudlet
 --- script: in fact it is recommended you run this function at a top-level without any kind of guards.
@@ -443,7 +451,7 @@ function db:create(db_name, sheets, force)
 
   db_name = db:safe_name(db_name)
 
-  if not db.__conn[db_name] or db.__conn[db_name] == 'SQLite3 connection (closed)' or (not io.exists(getMudletHomeDir() .. "/Database_" .. db_name .. ".db")) then
+  if not db:_isActiveDBName(db_name) then
     db.__conn[db_name] = db.__env:connect(getMudletHomeDir() .. "/Database_" .. db_name .. ".db")
     db.__conn[db_name]:setautocommit(false)
     db.__autocommit[db_name] = true
@@ -1532,15 +1540,45 @@ function db:OR(left, right)
 end
 
 
+--- Closes all databases.
+--- @return boolean result Returns true if all databases closed successfully and false otherwise 
+--- @return string messsage
+function db:_closeAll()
+  if db.__env == nil then
+    return false, "database environment is nil, did you forget to call db:create?"
+  end
 
---- <b><u>TODO</u></b>
-function db:close()
   for _, c in pairs(db.__conn) do
     c:close()
   end
   db.__conn = {}
   db.__env:close()
   db.__env = nil
+  return result, ""
+end
+
+
+--- Closes the named database or all databases if no name is provided.
+--- @param db_name string|nil The name of the database to close.
+--- @return boolean result Returns true in case of success and false otherwise.
+--- @return string messsage Why the database failed to close.
+function db:close(db_name)
+  if db.__env == nil then
+    return false, "database environment is nil, did you forget to call db:create?"
+  end
+
+  if db_name == nil then
+    return db:_closeAll()
+  end
+
+  assert(type(db_name) == "string", "expected db_name to be string or nil but recieved "..type(db_name))
+  db_name = db:safe_name(db_name)
+  if not db:_isActiveDBName(db_name) then
+    return false, "can not close "..db_name.." because it does not exist.  Did you forget to call db:create?"
+  end
+
+  db.__conn[db_name]:close()
+  return true, ""
 end
 
 


### PR DESCRIPTION
### Brief overview of PR changes/additions
* Added helper method to test if a `db_name` is active/valid.
* Added nil check for db._env.
* Added `db_name` argument to `db:close`.
* Added return values for `db:close`.

### Motivation for adding to Mudlet
1. Alignment with wiki docs
2. Prevent nil exceptions if close is called when there is no environment.
   *  Instead of an ugly error, close will do nothing and return false with a message.
3. The new return values can provide guidance on what went wrong in the event a db does not close.

### Other info (issues closed, discussion etc)

#### Discord discussion
I first brought this issue up in discord.
https://discord.com/channels/283581582550237184/283582439002210305/1371820647210156072

#### Wiki on db:close
![image](https://github.com/user-attachments/assets/270d5e79-a695-4bcb-8aa6-b092fdf79d98)
source: https://wiki.mudlet.org/w/Manual:Lua_Functions#db:close

#### LuaSQL's conn:close()
lausql does return a value when calling `close` but, according to their documentation, it only returns false when the connection is already closed. 

source: https://lunarmodules.github.io/luasql/manual.html#conn_close

#### Relevant Issues
The nil exception has shown up before, see: https://github.com/Mudlet/Mudlet/issues/1220#issuecomment-316262748