### PR TITLE
Fix: Single-click to deselect mapper rooms after context menu use

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3293,6 +3293,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
 
     updateSelectionWidget();
     update();
+    }
 }
 
 void T2DMap::updateSelectionWidget()

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2655,6 +2655,7 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
         auto popup = new QMenu(this);
         popup->setToolTipsVisible(true);
         popup->setAttribute(Qt::WA_DeleteOnClose);
+        connect(popup, &QMenu::aboutToHide, this, [this]() { mPopupMenu = false; });
 
         if (mCustomLinesRoomFrom > 0) {
             if (mDialogLock) {
@@ -3283,11 +3284,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                 mHelpMsg.clear();
             }
 
-        } else { // In popup menu, so end that
-            mPopupMenu = false;
         }
-
-    }
 
     TEvent sysMapWindowMousePressEvent{};
     sysMapWindowMousePressEvent.mArgumentList.append(QLatin1String("sysMapWindowMousePressEvent"));


### PR DESCRIPTION
## Fix: Single-click to deselect mapper rooms after context menu use
### Solution - 
- Reset `mPopupMenu` immediately when the context menu closes by connecting to `QMenu::aboutToHide`.
- Removed the deferred reset (`else { mPopupMenu = false; }`) from `mousePressEvent`.
- Now, a single click in empty space after any context menu operation will immediately clear the selection.

## Summary of Changes
- Connect all context menu popups to reset `mPopupMenu` on `aboutToHide`.
- Remove deferred popup state reset from `mousePressEvent`.
- No changes to multi-select, drag-select, or modifier key logic.

Solves - #5094
/claim #5094