### PR TITLE
fix: luaGlobalpath and revise LuaGlobal.lua file

### DIFF
--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -145,11 +145,7 @@ nativeLuaGlobalPath = toNativeSeparators(luaGlobalPath)
 
 if debugLoading then
   echo("Path separator is: '" .. package.config:sub(1,1) .. "'\n\n")
-  echo([[Directory separator conversion gives: "]] .. nativeLuaGlobalPath .. [[".
-
-Current directory is: "]] .. lfs.currentdir() .. [[".
-
-]])
+  echo("Directory separator conversion gives: \"" .. nativeLuaGlobalPath .. "\".\n\nCurrent directory is: \"" .. lfs.currentdir() .. "\".\n\n")
 end
 
 for _, packageName in ipairs(packages) do

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -10,9 +10,9 @@ debugLoading = debugLoading or false
 if debugLoading then
   if luaGlobalPath == nil then
     luaGlobalPath = lfs.currentdir() .. package.config:sub(1,1) .. "LuaGlobal.lua"
-    echo('luaGlobalPath was nil so has been defaulted to: "' .. luaGlobalPath .. '".\n\n')
+    echo("luaGlobalPath was nil so has been defaulted to: \"" .. luaGlobalPath .. "\".\n\n")
   else
-    echo('luaGlobalPath has been preset to: "' .. luaGlobalPath .. '".\n\n')
+    echo("luaGlobalPath has been preset to: \"" .. luaGlobalPath .. "\".\n\n")
   end
 else
   luaGlobalPath = luaGlobalPath or lfs.currentdir() .. package.config:sub(1,1) .. "LuaGlobal.lua"
@@ -151,20 +151,14 @@ end
 for _, packageName in ipairs(packages) do
   local packagePath = nativeLuaGlobalPath .. package.config:sub(1,1) .. toNativeSeparators(packageName)
   if debugLoading then
-    echo([[Trying to load: "]] .. packagePath .. [["
-]])
+    echo("Trying to load: \"" .. packagePath .. "\"\n")
   end
   local result, msg = pcall(dofile, packagePath)
   if debugLoading then
     if result then
-      echo([[Loaded: "]] .. packageName .. [[".
-
-]])
+      echo("Loaded: \"" .. packageName .. "\".\n\n")
     else
-      echo([[Error attempting to load file:
-  ]] .. msg .. [[.
-
-]])
+      echo("Error attempting to load file:\n" .. msg .. ".\n\n")
     end
   end
   assert(result, msg)

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -138,23 +138,25 @@ if debugLoading then
   else
     echo("luaGlobalPath has been preset to: \"" .. luaGlobalPath .. "\".\n\n")
   end
-
   nativeLuaGlobalPath = toNativeSeparators(luaGlobalPath)
   echo("Directory separator conversion gives: \"" .. nativeLuaGlobalPath .. "\".\n\nCurrent directory is: \"" .. lfs.currentdir() .. "\".\n\n")
 
+  local packagePath, status, result = "", false, ""
   for _, packageName in ipairs(packages) do
-    local packagePath = nativeLuaGlobalPath .. package.config:sub(1,1) .. toNativeSeparators(packageName)
+    packagePath = nativeLuaGlobalPath .. package.config:sub(1,1) .. toNativeSeparators(packageName)
     echo("Trying to load: \"" .. packagePath .. "\"\n")
-    local result, msg = pcall(dofile, packagePath)
-    assert(result, "Error attempting to load package("..packageName..") file:\n" .. msg .. ".\n\n")
+    status, result = pcall(dofile, packagePath)
+    assert(status, "Error attempting to load package("..packageName..") file:\n" .. result .. ".\n\n")
     echo("Loaded: \"" .. packageName .. "\".\n\n")
   end
 else
   luaGlobalPath = luaGlobalPath or lfs.currentdir() .. package.config:sub(1,1) .. "LuaGlobal.lua"
   nativeLuaGlobalPath = toNativeSeparators(luaGlobalPath)
+
+  local packagePath, status, result = "", false, ""
   for _, packageName in ipairs(packages) do
-    local packagePath = nativeLuaGlobalPath .. package.config:sub(1,1) .. toNativeSeparators(packageName)
-    local result, msg = pcall(dofile, packagePath)
-    assert(result, "Error attempting to load package("..packageName..") file:\n" .. msg .. ".\n\n")
+    packagePath = nativeLuaGlobalPath .. package.config:sub(1,1) .. toNativeSeparators(packageName)
+    status, result = pcall(dofile, packagePath)
+    assert(status, "Error attempting to load package("..packageName..") file:\n" .. result .. ".\n\n")
   end
 end

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -141,13 +141,10 @@ local packages = {
   "IDManager.lua",
 }
 
-if debugLoading then
-   echo("Path separator is: '" .. package.config:sub(1,1) .. "'\n\n")
-end
-
 nativeLuaGlobalPath = toNativeSeparators(luaGlobalPath)
 
 if debugLoading then
+  echo("Path separator is: '" .. package.config:sub(1,1) .. "'\n\n")
   echo([[Directory separator conversion gives: "]] .. nativeLuaGlobalPath .. [[".
 
 Current directory is: "]] .. lfs.currentdir() .. [[".

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -132,8 +132,8 @@ local sep = package.config:sub(1,1)
 if debugLoading then
   echo("Path separator is: '" .. sep .. "'\n\n")
 
--- Set via code in C++ TLuaInterpreter::loadGlobal() but fall back to current
--- directory if nil.
+  -- Set via code in C++ TLuaInterpreter::loadGlobal() but fall back to current
+  -- directory if nil.
   if luaGlobalPath == nil then
     luaGlobalPath = lfs.currentdir()
     echo("luaGlobalPath was nil so has been defaulted to: \"" .. luaGlobalPath .. "\".\n\n")

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -160,7 +160,7 @@ else
   luaGlobalPath = luaGlobalPath or lfs.currentdir()
   nativeLuaGlobalPath = toNativeSeparators(luaGlobalPath)
 
-  local packagePath, status, result = "", false, ""
+  local packagePath = ""
   for _, packageName in ipairs(packages) do
     packagePath = nativeLuaGlobalPath .. sep .. toNativeSeparators(packageName)
     dofile(packagePath)

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -1,23 +1,5 @@
 -- Mudlet Lua packages loader
 
--- Set to true (possibly via code in the C++ TLuaInterpreter::loadGlobal()
--- method) to report on the determination of what path to use to load the other
--- Mudlet and Geyser provided Lua files...
-debugLoading = debugLoading or false
-
--- Set via code in C++ TLuaInterpreter::loadGlobal() but fall back to current
--- directory if nil.
-if debugLoading then
-  if luaGlobalPath == nil then
-    luaGlobalPath = lfs.currentdir() .. package.config:sub(1,1) .. "LuaGlobal.lua"
-    echo("luaGlobalPath was nil so has been defaulted to: \"" .. luaGlobalPath .. "\".\n\n")
-  else
-    echo("luaGlobalPath has been preset to: \"" .. luaGlobalPath .. "\".\n\n")
-  end
-else
-  luaGlobalPath = luaGlobalPath or lfs.currentdir() .. package.config:sub(1,1) .. "LuaGlobal.lua"
-end
-
 if package.loaded["rex_pcre"] then
   rex = require "rex_pcre"
 end
@@ -141,10 +123,23 @@ local packages = {
   "IDManager.lua",
 }
 
-nativeLuaGlobalPath = toNativeSeparators(luaGlobalPath)
+-- Set to true (possibly via code in the C++ TLuaInterpreter::loadGlobal()
+-- method) to report on the determination of what path to use to load the other
+-- Mudlet and Geyser provided Lua files...
+debugLoading = debugLoading or false
 
+-- Set via code in C++ TLuaInterpreter::loadGlobal() but fall back to current
+-- directory if nil.
 if debugLoading then
   echo("Path separator is: '" .. package.config:sub(1,1) .. "'\n\n")
+  if luaGlobalPath == nil then
+    luaGlobalPath = lfs.currentdir() .. package.config:sub(1,1) .. "LuaGlobal.lua"
+    echo("luaGlobalPath was nil so has been defaulted to: \"" .. luaGlobalPath .. "\".\n\n")
+  else
+    echo("luaGlobalPath has been preset to: \"" .. luaGlobalPath .. "\".\n\n")
+  end
+
+  nativeLuaGlobalPath = toNativeSeparators(luaGlobalPath)
   echo("Directory separator conversion gives: \"" .. nativeLuaGlobalPath .. "\".\n\nCurrent directory is: \"" .. lfs.currentdir() .. "\".\n\n")
 
   for _, packageName in ipairs(packages) do
@@ -155,6 +150,8 @@ if debugLoading then
     echo("Loaded: \"" .. packageName .. "\".\n\n")
   end
 else
+  luaGlobalPath = luaGlobalPath or lfs.currentdir() .. package.config:sub(1,1) .. "LuaGlobal.lua"
+  nativeLuaGlobalPath = toNativeSeparators(luaGlobalPath)
   for _, packageName in ipairs(packages) do
     local packagePath = nativeLuaGlobalPath .. package.config:sub(1,1) .. toNativeSeparators(packageName)
     local result, msg = pcall(dofile, packagePath)

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -129,10 +129,11 @@ local packages = {
 debugLoading = debugLoading or false
 local sep = package.config:sub(1,1)
 
--- Set via code in C++ TLuaInterpreter::loadGlobal() but fall back to current
--- directory if nil.
 if debugLoading then
   echo("Path separator is: '" .. sep .. "'\n\n")
+
+-- Set via code in C++ TLuaInterpreter::loadGlobal() but fall back to current
+-- directory if nil.
   if luaGlobalPath == nil then
     luaGlobalPath = lfs.currentdir() .. sep .. "LuaGlobal.lua"
     echo("luaGlobalPath was nil so has been defaulted to: \"" .. luaGlobalPath .. "\".\n\n")
@@ -151,6 +152,8 @@ if debugLoading then
     echo("Loaded: \"" .. packageName .. "\".\n\n")
   end
 else
+  -- Set via code in C++ TLuaInterpreter::loadGlobal() but fall back to current
+  -- directory if nil.
   luaGlobalPath = luaGlobalPath or lfs.currentdir() .. sep .. "LuaGlobal.lua"
   nativeLuaGlobalPath = toNativeSeparators(luaGlobalPath)
 

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -135,7 +135,7 @@ if debugLoading then
 -- Set via code in C++ TLuaInterpreter::loadGlobal() but fall back to current
 -- directory if nil.
   if luaGlobalPath == nil then
-    luaGlobalPath = lfs.currentdir() .. sep .. "LuaGlobal.lua"
+    luaGlobalPath = lfs.currentdir()
     echo("luaGlobalPath was nil so has been defaulted to: \"" .. luaGlobalPath .. "\".\n\n")
   else
     echo("luaGlobalPath has been preset to: \"" .. luaGlobalPath .. "\".\n\n")
@@ -154,7 +154,7 @@ if debugLoading then
 else
   -- Set via code in C++ TLuaInterpreter::loadGlobal() but fall back to current
   -- directory if nil.
-  luaGlobalPath = luaGlobalPath or lfs.currentdir() .. sep .. "LuaGlobal.lua"
+  luaGlobalPath = luaGlobalPath or lfs.currentdir()
   nativeLuaGlobalPath = toNativeSeparators(luaGlobalPath)
 
   local packagePath, status, result = "", false, ""

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -150,7 +150,7 @@ if debugLoading then
     echo("Trying to load: \"" .. packagePath .. "\"\n")
     status, result = pcall(dofile, packagePath)
     if (status == false) then
-        assert(status, "Error attempting to load package("..packageName..") file:\n  " .. result .. ".\n\n")
+        error("Error attempting to load package("..packageName..") file:\n  " .. result .. ".\n\n")
     end
     echo("Loaded: \"" .. packageName .. "\".\n\n")
   end
@@ -165,7 +165,7 @@ else
     packagePath = nativeLuaGlobalPath .. sep .. toNativeSeparators(packageName)
     status, result = pcall(dofile, packagePath)
     if (status == false) then
-        assert(status, "Error attempting to load package("..packageName..") file:\n  " .. result .. ".\n\n")
+        error("Error attempting to load package("..packageName..") file:\n  " .. result .. ".\n\n")
     end
   end
 end

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -149,7 +149,9 @@ if debugLoading then
     packagePath = nativeLuaGlobalPath .. sep .. toNativeSeparators(packageName)
     echo("Trying to load: \"" .. packagePath .. "\"\n")
     status, result = pcall(dofile, packagePath)
-    assert(status, "Error attempting to load package("..packageName..") file:\n  " .. result .. ".\n\n")
+    if (status == false) then
+        assert(status, "Error attempting to load package("..packageName..") file:\n  " .. result .. ".\n\n")
+    end
     echo("Loaded: \"" .. packageName .. "\".\n\n")
   end
 else
@@ -162,6 +164,8 @@ else
   for _, packageName in ipairs(packages) do
     packagePath = nativeLuaGlobalPath .. sep .. toNativeSeparators(packageName)
     status, result = pcall(dofile, packagePath)
-    assert(status, "Error attempting to load package("..packageName..") file:\n  " .. result .. ".\n\n")
+    if (status == false) then
+        assert(status, "Error attempting to load package("..packageName..") file:\n  " .. result .. ".\n\n")
+    end
   end
 end

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -163,6 +163,6 @@ else
   local packagePath, status, result = "", false, ""
   for _, packageName in ipairs(packages) do
     packagePath = nativeLuaGlobalPath .. sep .. toNativeSeparators(packageName)
-    assert(pcall(dofile, packagePath))
+    dofile(packagePath)
   end
 end

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -141,14 +141,15 @@ if debugLoading then
     echo("luaGlobalPath has been preset to: \"" .. luaGlobalPath .. "\".\n\n")
   end
   nativeLuaGlobalPath = toNativeSeparators(luaGlobalPath)
-  echo("Directory separator conversion gives: \"" .. nativeLuaGlobalPath .. "\".\n\nCurrent directory is: \"" .. lfs.currentdir() .. "\".\n\n")
+  echo("Directory separator conversion gives: \"" .. nativeLuaGlobalPath .. "\".\n\n")
+  echo("Current directory is: \"" .. lfs.currentdir() .. "\".\n\n")
 
   local packagePath, status, result = "", false, ""
   for _, packageName in ipairs(packages) do
     packagePath = nativeLuaGlobalPath .. sep .. toNativeSeparators(packageName)
     echo("Trying to load: \"" .. packagePath .. "\"\n")
     status, result = pcall(dofile, packagePath)
-    assert(status, "Error attempting to load package("..packageName..") file:\n" .. result .. ".\n\n")
+    assert(status, "Error attempting to load package("..packageName..") file:\n  " .. result .. ".\n\n")
     echo("Loaded: \"" .. packageName .. "\".\n\n")
   end
 else
@@ -161,6 +162,6 @@ else
   for _, packageName in ipairs(packages) do
     packagePath = nativeLuaGlobalPath .. sep .. toNativeSeparators(packageName)
     status, result = pcall(dofile, packagePath)
-    assert(status, "Error attempting to load package("..packageName..") file:\n" .. result .. ".\n\n")
+    assert(status, "Error attempting to load package("..packageName..") file:\n  " .. result .. ".\n\n")
   end
 end

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -163,9 +163,6 @@ else
   local packagePath, status, result = "", false, ""
   for _, packageName in ipairs(packages) do
     packagePath = nativeLuaGlobalPath .. sep .. toNativeSeparators(packageName)
-    status, result = pcall(dofile, packagePath)
-    if (status == false) then
-        error("Error attempting to load package("..packageName..") file:\n  " .. result .. ".\n\n")
-    end
+    assert(pcall(dofile, packagePath))
   end
 end

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -146,20 +146,18 @@ nativeLuaGlobalPath = toNativeSeparators(luaGlobalPath)
 if debugLoading then
   echo("Path separator is: '" .. package.config:sub(1,1) .. "'\n\n")
   echo("Directory separator conversion gives: \"" .. nativeLuaGlobalPath .. "\".\n\nCurrent directory is: \"" .. lfs.currentdir() .. "\".\n\n")
-end
 
-for _, packageName in ipairs(packages) do
-  local packagePath = nativeLuaGlobalPath .. package.config:sub(1,1) .. toNativeSeparators(packageName)
-  if debugLoading then
+  for _, packageName in ipairs(packages) do
+    local packagePath = nativeLuaGlobalPath .. package.config:sub(1,1) .. toNativeSeparators(packageName)
     echo("Trying to load: \"" .. packagePath .. "\"\n")
+    local result, msg = pcall(dofile, packagePath)
+    assert(result, "Error attempting to load package("..packageName..") file:\n" .. msg .. ".\n\n")
+    echo("Loaded: \"" .. packageName .. "\".\n\n")
   end
-  local result, msg = pcall(dofile, packagePath)
-  if debugLoading then
-    if result then
-      echo("Loaded: \"" .. packageName .. "\".\n\n")
-    else
-      echo("Error attempting to load file:\n" .. msg .. ".\n\n")
-    end
+else
+  for _, packageName in ipairs(packages) do
+    local packagePath = nativeLuaGlobalPath .. package.config:sub(1,1) .. toNativeSeparators(packageName)
+    local result, msg = pcall(dofile, packagePath)
+    assert(result, "Error attempting to load package("..packageName..") file:\n" .. msg .. ".\n\n")
   end
-  assert(result, msg)
 end

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -7,17 +7,15 @@ debugLoading = debugLoading or false
 
 -- Set via code in C++ TLuaInterpreter::loadGlobal() but fall back to current
 -- directory if nil.
-if luaGlobalPath == nil then
-  luaGlobalPath = lfs.currentdir() .. package.config:sub(1,1) .. "LuaGlobal.lua"
-  if debugLoading then
-    echo([[luaGlobalPath was nil so has been defaulted to: "]] .. luaGlobalPath .. [[".
-
-]])
+if debugLoading then
+  if luaGlobalPath == nil then
+    luaGlobalPath = lfs.currentdir() .. package.config:sub(1,1) .. "LuaGlobal.lua"
+    echo('luaGlobalPath was nil so has been defaulted to: "' .. luaGlobalPath .. '".\n\n')
+  else
+    echo('luaGlobalPath has been preset to: "' .. luaGlobalPath .. '".\n\n')
   end
-elseif debugLoading then
-  echo([[luaGlobalPath has been preset to: "]] .. luaGlobalPath .. [[".
-
-]])
+else
+  luaGlobalPath = luaGlobalPath or lfs.currentdir() .. package.config:sub(1,1) .. "LuaGlobal.lua"
 end
 
 if package.loaded["rex_pcre"] then

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -127,13 +127,14 @@ local packages = {
 -- method) to report on the determination of what path to use to load the other
 -- Mudlet and Geyser provided Lua files...
 debugLoading = debugLoading or false
+local sep = package.config:sub(1,1)
 
 -- Set via code in C++ TLuaInterpreter::loadGlobal() but fall back to current
 -- directory if nil.
 if debugLoading then
-  echo("Path separator is: '" .. package.config:sub(1,1) .. "'\n\n")
+  echo("Path separator is: '" .. sep .. "'\n\n")
   if luaGlobalPath == nil then
-    luaGlobalPath = lfs.currentdir() .. package.config:sub(1,1) .. "LuaGlobal.lua"
+    luaGlobalPath = lfs.currentdir() .. sep .. "LuaGlobal.lua"
     echo("luaGlobalPath was nil so has been defaulted to: \"" .. luaGlobalPath .. "\".\n\n")
   else
     echo("luaGlobalPath has been preset to: \"" .. luaGlobalPath .. "\".\n\n")
@@ -143,19 +144,19 @@ if debugLoading then
 
   local packagePath, status, result = "", false, ""
   for _, packageName in ipairs(packages) do
-    packagePath = nativeLuaGlobalPath .. package.config:sub(1,1) .. toNativeSeparators(packageName)
+    packagePath = nativeLuaGlobalPath .. sep .. toNativeSeparators(packageName)
     echo("Trying to load: \"" .. packagePath .. "\"\n")
     status, result = pcall(dofile, packagePath)
     assert(status, "Error attempting to load package("..packageName..") file:\n" .. result .. ".\n\n")
     echo("Loaded: \"" .. packageName .. "\".\n\n")
   end
 else
-  luaGlobalPath = luaGlobalPath or lfs.currentdir() .. package.config:sub(1,1) .. "LuaGlobal.lua"
+  luaGlobalPath = luaGlobalPath or lfs.currentdir() .. sep .. "LuaGlobal.lua"
   nativeLuaGlobalPath = toNativeSeparators(luaGlobalPath)
 
   local packagePath, status, result = "", false, ""
   for _, packageName in ipairs(packages) do
-    packagePath = nativeLuaGlobalPath .. package.config:sub(1,1) .. toNativeSeparators(packageName)
+    packagePath = nativeLuaGlobalPath .. sep .. toNativeSeparators(packageName)
     status, result = pcall(dofile, packagePath)
     assert(status, "Error attempting to load package("..packageName..") file:\n" .. result .. ".\n\n")
   end


### PR DESCRIPTION
### Brief overview of PR changes/additions
* fix: luaGlobalPath's fallback path to exclude `LuaGlobal.lua`
* revise: LuaGlobal.lua

### Motivation for adding to Mudlet
* if we end up using the fallback path, the path we'll be trying to import a package from would be `[some_dir]/LuaGlobal.lua/[package_file_name].lua`.
* Reasoning through the logic of LuaGlobal was a tad difficult.  There were many branches in the logic and it was split up throughout the file.  With the revisions, it's easier to reason through the logic (at least I think so).  It's what lead me to notice the bug with the fallback path.

### Other info (issues closed, discussion etc)
This is a cherry-picked out of an experiment I was working on to reduce the use of globals in the lua files.  The idea was to expose them in LuaGlobal but have everything else as modules.  But, when I started digging into LuaGlobal, I ended up making the changes you see here before getting on with what I was trying to do.
