### PR TITLE
Fix: correct bogus Qt build version check in QMake project file

### DIFF
--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -36,7 +36,7 @@
 #                                                                          #
 ############################################################################
 
-if(lessThan(QT_MAJOR_VERSION,6):lessThan(QT_MINOR_VERSION, 1)) {
+if(lessThan(QT_MAJOR_VERSION,6)) {
     error("Mudlet requires Qt 6.0 or later")
 }
 


### PR DESCRIPTION
### Brief overview of PR changes/additions
Remove bogus check for the `QT_MINOR_VERSION` being less than `1` which was being logically ANDed with the major version number being `6`.

### Motivation for adding to Mudlet
To correctly enforce the use of Qt 6.x for Mudlet nowadays. Some Discord users had been reporting issues with building when they were trying to use a Qt 5.x version - when they should have instead getting a clear message that they need to use the later Qt version.

#### Other info (issues closed, discussion etc)
I'm not going to name the guilty party here but I'm surprised that none of us Mudlet Makers spotted this before now!