### PR TITLE
Improve: bulkify execution of db:add sql

### DIFF
--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -660,6 +660,9 @@ function db:_migrate_indexes(conn, s_name, schema, current_columns)
 end
 
 
+-- format with table_name, column_names, value expressions
+local SQL_INSERT = "INSERT INTO %s %s VALUES %s"
+
 --- Adds one or more new rows to the specified sheet. If any of these rows would violate a UNIQUE index,
 --- a lua error will be thrown and execution will cancel. As such it is advisable that if you use a UNIQUE
 --- index, you test those values before you attempt to insert a new row. <br/><br/>
@@ -691,34 +694,36 @@ function db:add(sheet, ...)
     assert(type(t) == "table", "db:add - Records must be a table of key-value pairs.")
   end
 
-  local clean_records = {}
+  local conn = db.__conn[sheet._db_name]
   local db_name = sheet._db_name
   local s_name = sheet._sht_name
-  local sql = ""
 
-  local conn = db.__conn[db_name]
-  local sql_insert = "INSERT INTO %s %s VALUES %s"
+  local columns = db.__schema[db_name][s_name]['columns']
+
+  local sql = ""
+  local sql_columns = db:_sql_fields(columns)
+  local sql_value_expressions = {}
 
   -- Create a copy of provided records so we
   -- do not modify user's records.
-  for i, t in ipairs(raw_records) do
-    clean_records[i] = {}
-    for k, v in pairs(t) do
-      clean_records[i][k] = v
+  local clean_record = {}
+  for i, raw_record in ipairs(raw_records) do
+    for col_name, _ in pairs(columns) do
+      if (raw_record[col_name] == nil) then
+        clean_record[col_name] = db:Null()
+      else
+        clean_record[col_name] = raw_record[col_name]
+      end
     end
-    -- You are not permitted to change a _row_id
-    clean_records[i]._row_id = nil
+    sql_value_expressions[i] = db:_sql_values(clean_record)
+    clean_record = {}
   end
 
-  for _, t in ipairs(clean_records) do
-    sql = sql + sql_insert:format(
-      s_name,
-      db:_sql_fields(t),
-      db:_sql_values(t)
-    )
-  end
-
-  sql = sql .. "COMMIT;"
+  sql = SQL_INSERT:format(
+    s_name,
+    sql_columns,
+    table.concat(sql_value_expressions, ',')
+  )
 
   db:echo_sql(sql)
   local result, msg = conn:execute(sql)

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -138,14 +138,8 @@ end
 -- NOT LUADOC
 -- This serves as a very similar function to db:_sql_columns, quoting column names properly but for
 -- uses outside of INSERTs.
-function db:_sql_fields(values)
-  local sql_fields = {}
-
-  for k, v in pairs(values) do
-    sql_fields[#sql_fields + 1] = '"' .. k .. '"'
-  end
-
-  return "(" .. table.concat(sql_fields, ",") .. ")"
+function db:_sql_fields(fields)
+  return "(\"" .. table.concat(fields, "\",\"") .. "\")"
 end
 
 
@@ -698,7 +692,7 @@ function db:add(sheet, ...)
   local db_name = sheet._db_name
   local s_name = sheet._sht_name
 
-  local columns = db.__schema[db_name][s_name]['columns']
+  local columns = table.keys(db.__schema[db_name][s_name]['columns'])
 
   local sql = ""
   local sql_columns = db:_sql_fields(columns)
@@ -708,7 +702,7 @@ function db:add(sheet, ...)
   -- do not modify user's records.
   local clean_record = {}
   for i, raw_record in ipairs(raw_records) do
-    for col_name, _ in pairs(columns) do
+    for _, col_name in ipairs(columns) do
       if (raw_record[col_name] == nil) then
         clean_record[col_name] = db:Null()
       else

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -680,35 +680,55 @@ end
 ---   )
 ---   </pre>
 function db:add(sheet, ...)
+  assert(type(sheet) == "table", "db:add - first argument to must be a Sheet object.")
+  assert(sheet._db_name, "db:add - first argument to db:add must be a proper Sheet object.  _db_name is missing.")
+  assert(sheet._sht_name, "db:add - first argument to db:add must be a proper Sheet object.  _sht_name is missing.")
+  assert(db:_isActiveDBName(sheet._db_name), "db:add - Can not add to db("..sheet._db_name..") because it does not exist.  Did you forget to call db:create?")
+
+  local raw_records = {...}
+  assert(raw_records[1], "db:add - Called with no records.")
+  for _, t in ipairs(raw_records) do
+    assert(type(t) == "table", "db:add - Records must be a table of key-value pairs.")
+  end
+
+  local clean_records = {}
   local db_name = sheet._db_name
   local s_name = sheet._sht_name
-  assert(s_name, "First argument to db:add must be a proper Sheet object.")
+  local sql = ""
 
   local conn = db.__conn[db_name]
   local sql_insert = "INSERT INTO %s %s VALUES %s"
 
-  for _, t in ipairs({ ... }) do
-    if t._row_id then
-      -- You are not permitted to change a _row_id
-      t._row_id = nil
+  -- Create a copy of provided records so we
+  -- do not modify user's records.
+  for i, t in ipairs(raw_records) do
+    clean_records[i] = {}
+    for k, v in pairs(t) do
+      clean_records[i][k] = v
     end
+    -- You are not permitted to change a _row_id
+    clean_records[i]._row_id = nil
+  end
 
-    local sql = sql_insert:format(
+  for _, t in ipairs(clean_records) do
+    sql = sql + sql_insert:format(
       s_name,
       db:_sql_fields(t),
       db:_sql_values(t)
     )
-    db:echo_sql(sql)
-
-    local result, msg = conn:execute(sql)
-    if result == nil then
-      printError(msg, true, false)
-      return nil, msg
-    end
   end
+
+  db:echo_sql(sql)
+  local result, msg = conn:execute(sql)
+  if result == nil then
+    printError(msg, true, false)
+    return nil, msg
+  end
+
   if db.__autocommit[db_name] then
     conn:commit()
   end
+
   return true
 end
 

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -718,6 +718,8 @@ function db:add(sheet, ...)
     )
   end
 
+  sql = sql .. "COMMIT;"
+
   db:echo_sql(sql)
   local result, msg = conn:execute(sql)
   if result == nil then


### PR DESCRIPTION
### Brief overview of PR changes/additions
* Add more assertions against `db:add`'s arguments.
* Create clean_records table from variadic argument records.
* Gather sql insert statements into one string to execute.

### Motivation for adding to Mudlet
* The verbose assertions point consumers of `db:add` towards why their call failed (or would of failed).
* Editing the records passed in (setting `_row_id` to nil) would also edit the records the user passed in as a side affect.
* Rather than sending the sql statements one at a time, we can send them all at once.

### Other info (issues closed, discussion etc)

#### Conflicts
Gonna conflict with another PR I made, #7852

#### Issues
Closes #7851

#### Why not one Insert statement with multiple values?
##### 1. It's not any faster
One might think that doing one insert statement instead of multiple would be faster, but the performance is comparable to sending multiple inserts wrapped in a transaction.  

Don't take my word for it: https://stackoverflow.com/a/5209093
##### 2. Problems with records that don't define columns
`db:add` allows a user to pass in records that do not have a key/value for every column.  This just means the default value should be used instead of an explicit value.  But, if we were to try to use a single insert statement, we'd have to define the columns in the sql statement.  If we are inserting multiple records that aren't of a uniform format, then the values will not match up to their columns properly.