### PR TITLE
Add: sysConsoleSizeChanged event triggered on resize and timestamps toggling

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -821,7 +821,7 @@ COMMIT_LINE:
                     lineBuffer << QString();
                 }
                 buffer.push_back(mMudBuffer);
-                timeBuffer << QTime::currentTime().toString(csmTimeStampFormat);
+                timeBuffer << QTime::currentTime().toString(mudlet::smTimeStampFormat);
                 if (ch == '\xff') {
                     promptBuffer.append(true);
                 } else {
@@ -838,7 +838,7 @@ COMMIT_LINE:
                     lineBuffer.back().append(QString());
                 }
                 buffer.back() = mMudBuffer;
-                timeBuffer.back() = QTime::currentTime().toString(csmTimeStampFormat);
+                timeBuffer.back() = QTime::currentTime().toString(mudlet::smTimeStampFormat);
                 if (ch == '\xff') {
                     promptBuffer.back() = true;
                 } else {
@@ -2218,7 +2218,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
         newLine.push_back(c);
         buffer.push_back(newLine);
         lineBuffer.push_back(QString());
-        timeBuffer << QTime::currentTime().toString(csmTimeStampFormat);
+        timeBuffer << QTime::currentTime().toString(mudlet::smTimeStampFormat);
         promptBuffer << false;
         last = 0;
     }
@@ -2238,7 +2238,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
             std::deque<TChar> const newLine;
             buffer.push_back(newLine);
             lineBuffer.push_back(QString());
-            timeBuffer << csmBlankTimeStamp;
+            timeBuffer << mudlet::smBlankTimeStamp;
             promptBuffer << false;
             firstChar = true;
             continue;
@@ -2271,7 +2271,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
                     } else {
                         lineBuffer.append(QString());
                     }
-                    timeBuffer << csmBlankTimeStamp;
+                    timeBuffer << mudlet::smBlankTimeStamp;
                     promptBuffer << false;
                     log(size() - 2, size() - 2);
                     // Was absent causing loss of all but last line of wrapped
@@ -2289,7 +2289,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
                 linkID);
         buffer.back().push_back(c);
         if (firstChar) {
-            timeBuffer.back() = QTime::currentTime().toString(csmTimeStampFormat);
+            timeBuffer.back() = QTime::currentTime().toString(mudlet::smTimeStampFormat);
             firstChar = false;
         }
     }
@@ -2319,7 +2319,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
         newLine.push_back(c);
         buffer.push_back(newLine);
         lineBuffer.push_back(QString());
-        timeBuffer << QTime::currentTime().toString(csmTimeStampFormat);
+        timeBuffer << QTime::currentTime().toString(mudlet::smTimeStampFormat);
         promptBuffer << false;
         last = 0;
     }
@@ -2338,7 +2338,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
             std::deque<TChar> const newLine;
             buffer.push_back(newLine);
             lineBuffer.push_back(QString());
-            timeBuffer << csmBlankTimeStamp;
+            timeBuffer << mudlet::smBlankTimeStamp;
             promptBuffer << false;
             firstChar = true;
             continue;
@@ -2372,7 +2372,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
                     } else {
                         lineBuffer.append(QString());
                     }
-                    timeBuffer << csmBlankTimeStamp;
+                    timeBuffer << mudlet::smBlankTimeStamp;
                     promptBuffer << false;
                     log(size() - 2, size() - 2);
                     // Was absent causing loss of all but last line of wrapped
@@ -2386,7 +2386,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
         const TChar c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags), linkID);
         buffer.back().push_back(c);
         if (firstChar) {
-            timeBuffer.back() = QTime::currentTime().toString(csmTimeStampFormat);
+            timeBuffer.back() = QTime::currentTime().toString(mudlet::smTimeStampFormat);
             firstChar = false;
         }
     }
@@ -2415,7 +2415,7 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
         newLine.push_back(c);
         buffer.push_back(newLine);
         lineBuffer.push_back(QString());
-        timeBuffer << QTime::currentTime().toString(csmTimeStampFormat);
+        timeBuffer << QTime::currentTime().toString(mudlet::smTimeStampFormat);
         promptBuffer << false;
         lastLine = 0;
     }
@@ -2435,7 +2435,7 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
         const TChar c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags), linkID);
         buffer.back().push_back(c);
         if (firstChar) {
-            timeBuffer.back() = QTime::currentTime().toString(csmTimeStampFormat);
+            timeBuffer.back() = QTime::currentTime().toString(mudlet::smTimeStampFormat);
             firstChar = false;
         }
     }
@@ -2770,7 +2770,7 @@ void TBuffer::log(int fromLine, int toLine)
             // This only handles a single line of logged text at a time:
             linesToLog << bufferToHtml(mpHost->mIsLoggingTimestamps, i);
         } else {
-            linesToLog << ((mpHost->mIsLoggingTimestamps && !timeBuffer.at(i).isEmpty()) ? timeBuffer.at(i).left(csmTimeStampFormat.length()) : QString()) % lineBuffer.at(i) % QChar::LineFeed;
+            linesToLog << ((mpHost->mIsLoggingTimestamps && !timeBuffer.at(i).isEmpty()) ? timeBuffer.at(i).left(mudlet::smTimeStampFormat.length()) : QString()) % lineBuffer.at(i) % QChar::LineFeed;
         }
     }
 
@@ -3318,7 +3318,7 @@ QString TBuffer::bufferToHtml(const bool showTimeStamp /*= false*/, const int ro
     // we will NOT need a closing "</span>"
     if (showTimeStamp && !timeBuffer.at(row).isEmpty()) {
         // TODO: formatting according to TTextEdit.cpp: if( i2 < timeOffset ) - needs updating if we allow the colours to be user set:
-        s.append(qsl("<span style=\"color: rgb(200,150,0); background: rgb(22,22,22); \">%1").arg(timeBuffer.at(row).left(csmTimeStampFormat.length())));
+        s.append(qsl("<span style=\"color: rgb(200,150,0); background: rgb(22,22,22); \">%1").arg(timeBuffer.at(row).left(mudlet::smTimeStampFormat.length())));
         // Set the current idea of what the formatting is so we can spot if it
         // changes:
         currentFgColor = QColor(200, 150, 0);

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -321,8 +321,6 @@ public:
     int mCursorY = 0;
     bool mEchoingText = false;
 
-    inline static const QString csmTimeStampFormat = qsl("hh:mm:ss.zzz ");
-    inline static const QString csmBlankTimeStamp  = qsl("------------ ");
 
 private:
     void shrinkBuffer();

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -191,7 +191,6 @@ public:
     void hideEvent(QHideEvent* event) override;
     void setConsoleBgColor(int, int, int, int);
     QColor getConsoleBgColor() const { return mBgColor; }
-
 // Not used:    void setConsoleFgColor(int, int, int);
     std::list<int> getFgColor();
     std::list<int> getBgColor();
@@ -218,6 +217,8 @@ public:
     // non-scrolling window:
     void handleLinesOverflowEvent(const int lineCount);
     void clearSplit();
+    bool showTimeStamps() const { return mShowTimeStamps; }
+    void raiseMudletResizeEvent();
 
 
     QPointer<Host> mpHost;
@@ -319,6 +320,7 @@ public slots:
     void slot_toggleLogging();
     void slot_changeControlCharacterHandling(const ControlCharacterMode);
     void slot_toggleSearchCaseSensitivity(bool);
+    void slot_toggleTimeStamps(const bool);
 
 signals:
     void resized(QResizeEvent* event);
@@ -349,6 +351,11 @@ private:
     bool mF3SearchEnabled = false;
     QPointer<QShortcut> mpSearchNextShortcut;
     QPointer<QShortcut> mpSearchPrevShortcut;
+    // The size of the TConsole in (normal) "character" cells:
+    QSize mDimensions;
+    // Whether to show (a 13 character by default) timestamp to the left of
+    // each line of text:
+    bool mShowTimeStamps = false;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(TConsole::ConsoleType)

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5549,6 +5549,9 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "loadProfile", TLuaInterpreter::loadProfile);
     lua_register(pGlobalLua, "closeProfile", TLuaInterpreter::closeProfile);
     lua_register(pGlobalLua, "getCollisionLocationsInArea", TLuaInterpreter::getCollisionLocationsInArea);
+    lua_register(pGlobalLua, "disableTimeStamps", TLuaInterpreter::disableTimeStamps);
+    lua_register(pGlobalLua, "enableTimeStamps", TLuaInterpreter::enableTimeStamps);
+    lua_register(pGlobalLua, "timeStampsEnabled", TLuaInterpreter::timeStampsEnabled);
     // PLACEMARKER: End of main Lua interpreter functions registration
     // check new functions against https://www.linguistic-antipatterns.com when creating them
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -689,6 +689,9 @@ public:
     static int loadProfile(lua_State*);
     static int closeProfile(lua_State*);
     static int getCollisionLocationsInArea(lua_State*);
+    static int disableTimeStamps(lua_State*);
+    static int enableTimeStamps(lua_State*);
+    static int timeStampsEnabled(lua_State*);
     // PLACEMARKER: End of Lua functions declarations
     // check new functions against https://www.linguistic-antipatterns.com when creating them
 

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -543,6 +543,27 @@ int TLuaInterpreter::disableScrollBar(lua_State* L)
     return 0;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableTimeStamps
+int TLuaInterpreter::disableTimeStamps(lua_State* L)
+{
+    const QString windowName {WINDOW_NAME(L, 1)};
+    auto pConsole = CONSOLE(L, windowName);
+    // *pConsole can be the main console as well as any user one
+    if (!pConsole->showTimeStamps()) {
+        lua_pushnil(L);
+        if (windowName.isEmpty()) {
+            lua_pushstring(L, qsl("timestamps were not enabled for the main console").toUtf8().constData());
+        } else {
+            lua_pushstring(L, qsl("timestamps were not enabled for the \"%1\" console").arg(windowName).toUtf8().constData());
+        }
+        return 2;
+    }
+
+    pConsole->slot_toggleTimeStamps(false);
+    lua_pushboolean(L, true);
+    return 1;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#echoLink
 int TLuaInterpreter::echoLink(lua_State* L)
 {
@@ -715,6 +736,27 @@ int TLuaInterpreter::enableScrollBar(lua_State* L)
     auto console = CONSOLE(L, windowName);
     console->setScrollBarVisible(true);
     return 0;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableTimeStamps
+int TLuaInterpreter::enableTimeStamps(lua_State* L)
+{
+    const QString windowName {WINDOW_NAME(L, 1)};
+    auto pConsole = CONSOLE(L, windowName);
+    // *pConsole can be the main console as well as any user one
+    if (pConsole->showTimeStamps()) {
+        lua_pushnil(L);
+        if (windowName.isEmpty()) {
+            lua_pushstring(L, qsl("timestamps were not enabled for the main console").toUtf8().constData());
+        } else {
+            lua_pushstring(L, qsl("timestamps were not enabled for the \"%1\" console").arg(windowName).toUtf8().constData());
+        }
+        return 2;
+    }
+
+    pConsole->slot_toggleTimeStamps(true);
+    lua_pushboolean(L, true);
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getAvailableFonts
@@ -1264,6 +1306,16 @@ int TLuaInterpreter::getTextFormat(lua_State* L)
 
     lua_settable(L, -3);
 
+    return 1;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#timeStampsEnabled
+int TLuaInterpreter::timeStampsEnabled(lua_State* L)
+{
+    const QString windowName {WINDOW_NAME(L, 1)};
+    auto pConsole = CONSOLE(L, windowName);
+    // *pConsole can be the main console as well as any user one
+    lua_pushboolean(L, pConsole->showTimeStamps());
     return 1;
 }
 

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -91,8 +91,9 @@ public:
     void resetHScrollbar() { mScreenOffset = 0; mMaxHRange = 0; }
     int getScreenHeight() const { return mScreenHeight; }
     void searchSelectionOnline();
-    int getColumnCount();
-    int getRowCount();
+    int getColumnCount() const;
+    int getRowCount() const;
+    void toggleTimeStamps(const bool);
 
 #if defined(DEBUG_CODEPOINT_PROBLEMS)
     void reportCodepointErrors();
@@ -135,10 +136,8 @@ public:
     // How many lines the screen scrolled since it was last rendered.
     int mScrollVector;
     QRegion mSelectedRegion;
-    bool mShowTimeStamps;
 
 public slots:
-    void slot_toggleTimeStamps(const bool);
     void slot_copySelectionToClipboard();
     void slot_selectAll();
     void slot_scrollBarMoved(int);
@@ -224,10 +223,6 @@ private:
     // probably be 1 (so that a tab is just treated as a space), 2, 4 and 8,
     // in the past it was typically 8 and this is what we'll use at present:
     int mTabStopwidth;
-    // How many normal width characters that are used for the time stamps; it
-    // would only be valid to change this by clearing the buffer first - so
-    // making this a const value for the moment:
-    const int mTimeStampWidth;
 
 #if defined(DEBUG_CODEPOINT_PROBLEMS)
     bool mShowAllCodepointIssues = false;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -735,7 +735,7 @@ void cTelnet::checkNAWS()
     }
     // Use the smaller of the screen width or the wrapAt, then subtract the
     // width of the time stamps if they are showing:
-    int naws_x = std::min(pHost->mScreenWidth, pHost->mWrapAt) - (pHost->mpConsole->mUpperPane->mShowTimeStamps ? TBuffer::csmTimeStampFormat.size() : 0);
+    int naws_x = std::min(pHost->mScreenWidth, pHost->mWrapAt) - (pHost->mpConsole->showTimeStamps() ? mudlet::smTimeStampFormat.size() : 0);
     int naws_y = pHost->mScreenHeight;
     if ((naws_y > 0) && (myOptionState[static_cast<size_t>(OPT_NAWS)]) && ((mNaws_x != naws_x) || (mNaws_y != naws_y))) {
         sendNAWS(naws_x, naws_y);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -321,8 +321,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     // option areas
     mpErrorConsole = new TConsole(mpHost, qsl("errors_%1").arg(hostName), TConsole::ErrorConsole, this);
     mpErrorConsole->setWrapAt(100);
-    mpErrorConsole->mUpperPane->slot_toggleTimeStamps(true);
-    mpErrorConsole->mLowerPane->slot_toggleTimeStamps(true);
+    mpErrorConsole->slot_toggleTimeStamps(true);
     mpErrorConsole->print(qsl("%1\n").arg(tr("*** starting new session ***")));
     mpErrorConsole->setMinimumHeight(100);
     mpErrorConsole->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Minimum);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -712,8 +712,8 @@ void mudlet::init()
     // load bundled fonts
     mFontManager.addFonts();
 
-    // Initialise a couple of QMaps with elements that must be translated into
-    // the current GUI Language
+    // Initialise a couple of QMaps and some other elements that must be
+    // translated into the current GUI Language
     loadMaps();
 
     setupTrayIcon();
@@ -1245,6 +1245,18 @@ void mudlet::loadMaps()
                         {"WINDOWS-1257", tr("WINDOWS-1257 (Baltic)")},
                         //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
                         {"WINDOWS-1258", tr("WINDOWS-1258 (Vietnamese)")}};
+
+    /*: This represents the format of the timestamps shown alongside the texts
+     * in a console and might require translation for a few locales; the content
+     * is as per QDateTime::toString(...) and needs to follow the rules for that
+     * function as well as being suitable for the translation locale.
+     */
+    smTimeStampFormat = tr("hh:mm:ss.zzz ");
+    /*: This represents the format of the timestamps shown for lines that do not
+     * have a timestamp in a console that is showing them. If localised this
+     * should be set to the same format and length as the smTimeStampFormat:
+     */
+    smBlankTimeStamp = tr("------------ ");
 }
 
 // migrates the Central Debug Console to the next available host, if any

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -208,6 +208,11 @@ public:
     inline static bool smMirrorToStdOut = false;
     // adjust Mudlet settings to match Steam's requirements
     inline static bool smSteamMode = false;
+    // This may need to be localised, it represents the format of the timestamp
+    inline static QString smTimeStampFormat = qsl("hh:mm:ss.zzz ");
+    // If localised this should be set to the same format and length as the
+    // smTimeStampFormat:
+    inline static QString smBlankTimeStamp = qsl("------------ ");
 
 
     void showEvent(QShowEvent*) override;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds functions to enable/disable and find out the state of timestamps on all user accessible windows. Also adds a `sysConsoleSizeChanged` event that reports changes in the number of columns, rows and ~~rows~~ (Edit:) *columns* occupied by the time-stamp (which is now localiseable for the end-users UI) for any user window as well as the main Window.

#### Motivation for adding to Mudlet
Allow UI designers to accommodate the space used for timestamps. Also allow time-stamps to be enabled on other console besides the main one if the end- user desired. This is done with three new Lua API functions:
* `disableTimeStamps([windowName])` - turns off the timestamps if they are on for the main (if no windowName is provided or it is `"main"`, or the specified subconsole or user windows if it exists) - or returns a `nil` + error message if they are already turned off.
* `enableTimeStamps([windowName])` - turns on the timestamps if they are off for the main (if no windowName is provided or it is `"main"`, or the specified subconsole or user windows if it exists) - or returns a `nil` + error message if they are already turned on.
* `timeStampsEnabled([windowName])` - returns `true` or `false` to indicate for the main (if no windowName is provided or it is `"main"`, or the specified subconsole or user windows if it exists) whether timestamps are shown for the particular console.

#### Other info (issues closed, discussion etc)
These additions were prompted by the Discord user **missionz3r0** in our mudlet-development channel on 2025/05/20 04:30 UTC https://www.discord.com/channels/283581582550237184/283582439002210305/1374242960299786352
> Gonna add  this to things I'd like to fix/improve when I'm no longer
> moving houses/dead tired.
>
> **Context,**
> As far as I am aware, there is no way to know if the main console is showing timestamps, nor is there a way to listen in on if they are toggled.  If a package dev tries to borders such that the main console is exactly the size of the wrap_at * font-size, timestamps will cause the window to overflow.
>
> **What I'd like to do,**
>* Add a lua function that'll return boolean representing the state of the timestamp toggle,
>* Raise a `sysSettingChanged` event when timestamps are toggled,
>* Include timestamp characters when calculating `getMainConsoleWidth`

In implementing these changes I realised that there was some duplication of code for each `TTextEdit` instance in a `TConsole` which was better done in the parent `TConsole`; it also meant the "slot" that processed the time-stamp button was moved from the `TTextEdit`s to the `TConsole` so that it could also update the relevant toolbutton in the bottom button collection for the `TMainConsole` instance.