### PR TITLE
Fix: db:Timestamp's usage throughout the db module

### DIFF
--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -1518,7 +1518,7 @@ db.__SheetMT = {
     local rt
     if assert(field, errormsg:format(k, sht_name, db_name)) then
       field_type = type(field)
-      if field_type == "table" and field._timestamp then
+      if field_type == "table" and field._timestamp ~= nil then
         field_type = "datetime"
       end
 

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -169,6 +169,8 @@ function db:_sql_values(values)
     elseif t == "table" and v._timestamp ~= nil then
       if not v._timestamp then
         s = "NULL"
+      elseif v._timestamp == "CURRENT_TIMESTAMP" then
+        s = "datetime('now', 'unixepoch')"
       else
         s = "datetime('" .. v._timestamp .. "', 'unixepoch')"
       end

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -613,10 +613,11 @@ function db:fetch_sql(sheet, sql)
   -- if we had a syntax error in our SQL, cur will be nil
   if cur and cur ~= 0 then
     local results = {}
+    local columns = cur:getcolnames()
     local row = cur:fetch({}, "a")
 
     while row do
-      results[#results + 1] = db:_coerce_sheet(sheet, row)
+      results[#results + 1] = db:_coerce_sheet(columns, sheet, row)
       row = cur:fetch({}, "a")
     end
     cur:close()
@@ -1050,20 +1051,24 @@ end
 -- After a table so retrieved from the database, this function coerces values to
 -- their proper types. Specifically, numbers and datetimes become the proper
 -- types.
-function db:_coerce_sheet(sheet, tbl)
+function db:_coerce_sheet(columns, sheet, tbl)
   if tbl then
     tbl._row_id = tonumber(tbl._row_id)
 
-    for k, v in pairs(tbl) do
+    for _, k in pairs(columns) do
       if k ~= "_row_id" then
         local field = sheet[k]
         if field.type == "number" then
           tbl[k] = tonumber(tbl[k]) or tbl[k]
         elseif field.type == "datetime" then
-          -- the value, tbl[k], is currently in a UTC timestamp
-          local localtime = datetime:parse(tbl[k], nil, true)
-          -- convert it into a UTC timestamp as datetime:parse parses it in the local time context
-          tbl[k] = db:Timestamp(localtime + datetime:calculate_UTCdiff(localtime))
+          if (tbl[k] == nil) then
+            tbl[k] = db:Timestamp(nil)
+          else
+            -- the value, tbl[k], is currently in a UTC timestamp
+            local localtime = datetime:parse(tbl[k], nil, true)
+            -- convert it into a UTC timestamp as datetime:parse parses it in the local time context
+            tbl[k] = db:Timestamp(localtime + datetime:calculate_UTCdiff(localtime))
+          end
         end
       end
     end

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -751,7 +751,9 @@ function db:aggregate(field, fn, query, distinct)
       return count
     end
     -- Only datetime left
-    return db:Timestamp(count)
+    local utc_epoch = datetime:parse(count, nil, true)
+    local locale_diff = datetime:calculate_UTCdiff(utc_epoch)
+    return db:Timestamp(utc_epoch + locale_diff)
   else
     return 0
   end
@@ -1060,7 +1062,10 @@ function db:_coerce_sheet(columns, sheet, tbl)
           if (tbl[k] == nil) then
             tbl[k] = db:Timestamp(nil)
           else
-            tbl[k] = db:Timestamp(tbl[k])
+            -- the value, tbl[k], is a UTC timestamp
+            local utc_epoch = datetime:parse(tbl[k], nil, true)
+            local locale_diff = datetime:calculate_UTCdiff(utc_epoch)
+            tbl[k] = db:Timestamp(utc_epoch + locale_diff)
           end
         end
       end

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -170,7 +170,7 @@ function db:_sql_values(values)
       if not v._timestamp then
         s = "NULL"
       elseif v._timestamp == "CURRENT_TIMESTAMP" then
-        s = "datetime('now', 'unixepoch')"
+        s = "datetime('now')"
       else
         s = "datetime('" .. v._timestamp .. "', 'unixepoch')"
       end

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -1083,6 +1083,8 @@ function db:_coerce(field, value)
   elseif field.type == "datetime" then
     if value._timestamp == false then
       return "NULL"
+    elseif value._timestamp == "CURRENT_TIMESTAMP" then
+      return "datetime('now')"
     else
       return "datetime('" .. value._timestamp .. "', 'unixepoch')" or "'" .. value .. "'"
     end

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -751,11 +751,7 @@ function db:aggregate(field, fn, query, distinct)
       return count
     end
     -- Only datetime left
-    -- the value, count, is currently in a UTC timestamp
-    local localtime = datetime:parse(count, nil, true)
-    -- convert it into a UTC timestamp as datetime:parse parses it in the local time context
-    count = db:Timestamp(localtime + datetime:calculate_UTCdiff(localtime))
-    return count
+    return db:Timestamp(count)
   else
     return 0
   end
@@ -1064,10 +1060,7 @@ function db:_coerce_sheet(columns, sheet, tbl)
           if (tbl[k] == nil) then
             tbl[k] = db:Timestamp(nil)
           else
-            -- the value, tbl[k], is currently in a UTC timestamp
-            local localtime = datetime:parse(tbl[k], nil, true)
-            -- convert it into a UTC timestamp as datetime:parse parses it in the local time context
-            tbl[k] = db:Timestamp(localtime + datetime:calculate_UTCdiff(localtime))
+            tbl[k] = db:Timestamp(tbl[k])
           end
         end
       end
@@ -1467,17 +1460,22 @@ end
 --- <b><u>TODO</u></b>
 function db:Timestamp(ts, fmt)
   local dt = {}
-  if type(ts) == "table" then
-    dt._timestamp = os.time(ts)
-  elseif type(ts) == "number" then
-    dt._timestamp = ts
-  elseif type(ts) == "string" and
-  assert(ts == "CURRENT_TIMESTAMP", "The only strings supported by db.DateTime:new is CURRENT_TIMESTAMP") then
-    dt._timestamp = "CURRENT_TIMESTAMP"
-  elseif ts == nil then
-    dt._timestamp = false
+
+  if ts == nil then
+      dt._timestamp = false
+  elseif ts == "CURRENT_TIMESTAMP" then
+      dt._timestamp = "CURRENT_TIMESTAMP"
   else
-    assert(nil, "Invalid value passed to db.Timestamp()")
+    local t = type(ts)
+    if t == "table" then
+      dt._timestamp = os.time(ts)
+    elseif t == "number" then
+      dt._timestamp = ts
+    elseif t == "string" then
+      dt._timestamp = datetime:parse(ts, fmt, true)
+    else
+      error("Invalid value passed to db.Timestamp()")
+    end
   end
   return setmetatable(dt, db.__TimestampMT)
 end

--- a/src/mudlet-lua/lua/DateTime.lua
+++ b/src/mudlet-lua/lua/DateTime.lua
@@ -52,7 +52,7 @@ function datetime:calculate_UTCdiff(ts)
   local date, time = os.date, os.time
   local utc = date('!*t', ts)
   local lcl = date('*t', ts)
-  lcl.isdst = os.date("*t")["isdst"]
+  lcl.isdst = false
   return os.difftime(time(lcl), time(utc))
 end
 

--- a/src/mudlet-lua/lua/DateTime.lua
+++ b/src/mudlet-lua/lua/DateTime.lua
@@ -140,7 +140,7 @@ function datetime:parse(source, format, as_epoch)
 
     dt.min = tonumber(m.minute)
     dt.sec = tonumber(m.second)
-    dt.isdst = os.date("*t")["isdst"]
+    dt.isdst = os.date("*t", os.time(dt))["isdst"]
 
     if as_epoch then
       return os.time(dt)

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -1049,7 +1049,7 @@ describe("Tests DB.lua functions", function()
 
     after_each(function()
       db:close()
-      local filename = getMudletHomeDir() .. "/mydbttimestamptesting.db"
+      local filename = getMudletHomeDir() .. "/Database_mydbttimestamptesting.db"
       os.remove(filename)
       mydb = nil
     end)

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -1055,16 +1055,14 @@ describe("Tests DB.lua functions", function()
     end)
 
 
-    it("should fetch the same current timestamp as what was put in.",
+    it("should fetch a timestamp for CURRENT_TIMESTAMP.",
     function()
       db:add(mydb.sheet, input)
       local results = db:fetch(mydb.sheet)
       assert.is_true(#results == 1)
 
       local result = results[1]
-      assert.are.same(result.current:as_number(), input.current:as_number())
-      assert.are.same(result.current:as_string(), input.current:as_string())
-      assert.are.same(result.current:as_table(), input.current:as_table())
+      assert.is_true(result.current._timestamp ~= nil)
     end)
 
     it("should fetch the same epoch timestamp as what was put in.",
@@ -1098,35 +1096,36 @@ describe("Tests DB.lua functions", function()
       assert.is_true(#results == 1)
 
       local result = results[1]
-      display(input)
-      display(result)
       assert.are.same(result.niled._timestamp, input.niled._timestamp)
     end)
 
     it("should update without changing a timestamp's value.",
     function()
       db:add(mydb.sheet, input)
+
       local results = db:fetch(mydb.sheet)
       assert.is_true(#results == 1)
+      local first_result = results[1]
 
       db:update(mydb.sheet, results[1])
+
       results = db:fetch(mydb.sheet)
       assert.is_true(#results == 1)
-      local result = results[1]
+      local second_result = results[1]
 
-      assert.are.same(result.current:as_number(), input.current:as_number())
-      assert.are.same(result.current:as_string(), input.current:as_string())
-      assert.are.same(result.current:as_table(), input.current:as_table())
+      assert.are.same(first_result.current:as_number(), second_result.current:as_number())
+      assert.are.same(first_result.current:as_string(), second_result.current:as_string())
+      assert.are.same(first_result.current:as_table(), second_result.current:as_table())
 
-      assert.are.same(result.epoched:as_number(), input.epoched:as_number())
-      assert.are.same(result.epoched:as_string(), input.epoched:as_string())
-      assert.are.same(result.epoched:as_table(), input.epoched:as_table())
+      assert.are.same(first_result.epoched:as_number(), second_result.epoched:as_number())
+      assert.are.same(first_result.epoched:as_string(), second_result.epoched:as_string())
+      assert.are.same(first_result.epoched:as_table(), second_result.epoched:as_table())
 
-      assert.are.same(result.tabled:as_number(), input.tabled:as_number())
-      assert.are.same(result.tabled:as_string(), input.tabled:as_string())
-      assert.are.same(result.tabled:as_table(), input.tabled:as_table())
+      assert.are.same(first_result.tabled:as_number(), second_result.tabled:as_number())
+      assert.are.same(first_result.tabled:as_string(), second_result.tabled:as_string())
+      assert.are.same(first_result.tabled:as_table(), second_result.tabled:as_table())
 
-      assert.are.same(result.niled._timestamp, result.niled._timestamp)
+      assert.are.same(first_result.niled._timestamp, second_result.niled._timestamp)
     end)
   end)
 end)

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -1055,6 +1055,18 @@ describe("Tests DB.lua functions", function()
     end)
 
 
+    it("should fetch the same current timestamp as what was put in.",
+    function()
+      db:add(mydb.sheet, input)
+      local results = db:fetch(mydb.sheet)
+      assert.is_true(#results == 1)
+
+      local result = results[1]
+      assert.are.same(result.current:as_number(), input.current:as_number())
+      assert.are.same(result.current:as_string(), input.current:as_string())
+      assert.are.same(result.current:as_table(), input.current:as_table())
+    end)
+
     it("should fetch the same epoch timestamp as what was put in.",
     function()
       db:add(mydb.sheet, input)
@@ -1086,6 +1098,8 @@ describe("Tests DB.lua functions", function()
       assert.is_true(#results == 1)
 
       local result = results[1]
+      display(input)
+      display(result)
       assert.are.same(result.niled._timestamp, input.niled._timestamp)
     end)
 

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -1033,4 +1033,86 @@ describe("Tests DB.lua functions", function()
       assert.are.same(results, test)
     end)
   end)
+
+  describe("Tests, if timestamp handling works as intended",
+  function()
+    local input = {
+      current = db:Timestamp("CURRENT_TIMESTAMP"),
+      niled = db:Timestamp(nil),
+      epoched = db:Timestamp(1748288082), -- 2025-05-26T19:34:42+00:00
+      tabled = db:Timestamp({year=1970, month=1, day=1, hour=10, sec=1})
+    }
+
+    before_each(function()
+      mydb = db:create("mydbttimestamptesting", { sheet = input })
+    end)
+
+    after_each(function()
+      db:close()
+      local filename = getMudletHomeDir() .. "/mydbttimestamptesting.db"
+      os.remove(filename)
+      mydb = nil
+    end)
+
+
+    it("should fetch the same epoch timestamp as what was put in.",
+    function()
+      db:add(mydb.sheet, input)
+      local results = db:fetch(mydb.sheet)
+      assert.is_true(#results == 1)
+
+      local result = results[1]
+      assert.are.same(result.epoched:as_number(), input.epoched:as_number())
+      assert.are.same(result.epoched:as_string(), input.epoched:as_string())
+      assert.are.same(result.epoched:as_table(), input.epoched:as_table())
+    end)
+
+    it("should fetch the same table timestamp as what was put in.",
+    function()
+      db:add(mydb.sheet, input)
+      local results = db:fetch(mydb.sheet)
+      assert.is_true(#results == 1)
+
+      local result = results[1]
+      assert.are.same(result.tabled:as_number(), input.tabled:as_number())
+      assert.are.same(result.tabled:as_string(), input.tabled:as_string())
+      assert.are.same(result.tabled:as_table(), input.tabled:as_table())
+    end)
+
+    it("should fetch the same niled timestamp as what was put in.",
+    function()
+      db:add(mydb.sheet, input)
+      local results = db:fetch(mydb.sheet)
+      assert.is_true(#results == 1)
+
+      local result = results[1]
+      assert.are.same(result.niled._timestamp, input.niled._timestamp)
+    end)
+
+    it("should update without changing a timestamp's value.",
+    function()
+      db:add(mydb.sheet, input)
+      local results = db:fetch(mydb.sheet)
+      assert.is_true(#results == 1)
+
+      db:update(mydb.sheet, results[1])
+      results = db:fetch(mydb.sheet)
+      assert.is_true(#results == 1)
+      local result = results[1]
+
+      assert.are.same(result.current:as_number(), input.current:as_number())
+      assert.are.same(result.current:as_string(), input.current:as_string())
+      assert.are.same(result.current:as_table(), input.current:as_table())
+
+      assert.are.same(result.epoched:as_number(), input.epoched:as_number())
+      assert.are.same(result.epoched:as_string(), input.epoched:as_string())
+      assert.are.same(result.epoched:as_table(), input.epoched:as_table())
+
+      assert.are.same(result.tabled:as_number(), input.tabled:as_number())
+      assert.are.same(result.tabled:as_string(), input.tabled:as_string())
+      assert.are.same(result.tabled:as_table(), input.tabled:as_table())
+
+      assert.are.same(result.niled._timestamp, result.niled._timestamp)
+    end)
+  end)
 end)


### PR DESCRIPTION
### Brief overview of PR changes/additions
* Add: tests cases for `db:Timestamp`
* Fix: `datetime:calculate_UTCdiff` should NOT include DST into its offset.
* Fix: `datetime:parse` to use the source's time instead of current time to determine DST.
* Fix: `db:Timestamp("CURRENT_TIMESTAMP")` so it generates the correct SQL during table inserts.
* Fix: `db:_coerce_sheet`'s conversion of Null timestamps so they are proper `db:Timestamp` tables.
* Fix: `db.__SheetMT`'s mistreatement of `db:Timestamp(nil)` as a non-timestamp field.

### Motivation for adding to Mudlet
When we put a value into the database we should get the same value out. As the logic is right now, if we looped back and forth between fetching and updating a timestamp value from sqlite, it'll change on every iteration of the loop by the locale's offset from UTC, and their daylight savings value if the timestamp is far enough in the past.

### Other info (issues closed, discussion etc)
#### Discord Discussion:
https://discord.com/channels/283581582550237184/283582439002210305/1376590435597947020

##### missionz3r0 `May 26, 2025 @ 1158 EST`
> Well, I just uncovered what was going on here.
> 
> When I put a time *into* the database, it's treated as a UTC time.  Sqlite will also give it back in UTC.  But then `db._coerce_sheet` turns it into a localtime. (despite what the comments say)
> ```lua
>         elseif field.type == "datetime" then
>           -- the value, tbl[k], is currently in a UTC timestamp
>           local localtime = datetime:parse(tbl[k], nil, true)
>           -- convert it into a UTC timestamp as datetime:parse parses it in the local time context
>           tbl[k] = db:Timestamp(localtime + datetime:calculate_UTCdiff(localtime))
>         end
> ```
> 
> I'm not seeing anything in `datetime:parse` that looks like it's converting to a local time.  So what it is really doing is taking a UTC timestamp and turning it into local time.
> 
> Which does a funny thing.  Everytime you fetch a row and use it for an update, the timestamp will change by your UTC offset.