### PR TITLE
Fix: Lua send('', false) sends a new line

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1266,7 +1266,7 @@ void Host::send(QString cmd, bool wantPrint, bool dontExpandAliases)
 
         // allow sending blank commands
 
-    if (!dontExpandAliases && commandList.empty()) {
+    if (commandList.empty()) {
         QString payload(QChar::LineFeed);
         mTelnet.sendData(payload);
         return;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixes an issue where calling `send('', false)` in Lua would not send anything to the server. Now, sending an empty string with send('', false) correctly sends a single newline to the server, matching the behavior of send('') and send('', true).

#### Motivation for adding to Mudlet
Some MUDs require the client to send a newline to receive additional output (e.g., after a "press enter for more" prompt). Previously, using send('', false) did nothing, making it impossible to automate this behavior without workarounds. This change ensures all variants of send('') behave consistently and as expected.

#### Other info (issues closed, discussion etc)
Closes #7745.
Thanks to @Thiez for reporting and investigating the issue.

---

Video shows production release `send('', false)` behavior, and then the new behavior where the prompt appears.

https://github.com/user-attachments/assets/3cea2f2b-bddf-41cf-9338-0d7e86bb02bd

