### PR TITLE
Fix: Process empty GMCP message bodies

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2881,7 +2881,7 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
 
     if (data.trimmed().isEmpty()) { // Example: Core.Ping
         // Pass empty table/object to Lua
-        mpHost->mLuaInterpreter.setGMCPTable(packageMessage, "{}");
+        mpHost->mLuaInterpreter.setGMCPTable(packageMessage, qsl("{}"));
         return;
     }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2879,6 +2879,12 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
         data = transcodedMsg.section(QChar::LineFeed, 1);
     }
 
+    if (data.trimmed().isEmpty()) { // Example: Core.Ping
+        // Pass empty table/object to Lua
+        mpHost->mLuaInterpreter.setGMCPTable(packageMessage, "{}");
+        return;
+    }
+
     if (transcodedMsg.startsWith(qsl("Client.GUI"), Qt::CaseInsensitive)) {
         if (!mpHost->mAcceptServerGUI) {
             return;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR adds a check in the GMCP message handler to gracefully handle empty GMCP message bodies. When a GMCP message with no data is received (e.g., Core.Ping), Mudlet now passes an empty table to Lua instead of attempting to parse an empty string as JSON, preventing a lua_yajl error.

#### Motivation for adding to Mudlet
Some MUD servers send GMCP messages with empty bodies, which previously caused a JSON parse error. This change ensures Mudlet remains stable and compliant with the GMCP protocol when handling such messages.

#### Other info (issues closed, discussion etc)
Closes #7831