### PR TITLE
Add: Retrieve log directory with getConfig() 

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7529,7 +7529,16 @@ int TLuaInterpreter::getConfig(lua_State *L)
         { qsl("enableMTTS"), [&](){ lua_pushboolean(L, host.mEnableMTTS); } },
         { qsl("enableMNES"), [&](){ lua_pushboolean(L, host.mEnableMNES); } },
         { qsl("enableMXP"), [&](){ lua_pushboolean(L, host.mEnableMXP); } },
-        { qsl("askTlsAvailable"), [&](){ lua_pushboolean(L, host.mAskTlsAvailable); } },
+        { qsl("logDirectory"), [&](){
+            const auto logDir = host.mLogDir;
+
+            if (logDir == nullptr || logDir.isEmpty()) {
+                lua_pushstring(L, mudlet::getMudletPath(enums::profileReplayAndLogFilesPath, getHostFromLua(L).getName()).toUtf8().constData());
+            } else {
+                lua_pushstring(L, host.mLogDir.toUtf8().constData());
+            }
+        } },
+        { qsl("askTlsAvailable"), [&](){lua_pushboolean(L, host.mAskTlsAvailable); } },
         { qsl("inputLineStrictUnixEndings"), [&](){ lua_pushboolean(L, host.mUSE_UNIX_EOL); } },
         { qsl("autoClearInputLine"), [&](){ lua_pushboolean(L, host.mAutoClearCommandLineAfterSend); } },
         { qsl("showSentText"), [&](){ lua_pushboolean(L, host.mPrintCommand); } },


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Added support for `getConfig("logDirectory")` in the Lua API. Scripts can now retrieve the current profile's log directory path as a string.

#### Motivation for adding to Mudlet
Previously, there was no way for Lua scripts or packages to programmatically discover where log files are stored. This addition enables automation and scripting scenarios that need to access or display the log directory, as requested in #7823.

#### Other info (issues closed, discussion etc)
Closes #7823.
No impact on existing functionality; other getConfig options are unaffected.
Tested to ensure the correct directory is returned for the active profile.

<img width="459" alt="Screenshot 2025-05-31 at 9 32 53 AM" src="https://github.com/user-attachments/assets/686ae543-59c4-43fa-9677-93f319443e7d" />
