### PR TITLE
Fix: F3 Search Accessibility Checkbox Profile Saves

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7529,7 +7529,16 @@ int TLuaInterpreter::getConfig(lua_State *L)
         { qsl("enableMTTS"), [&](){ lua_pushboolean(L, host.mEnableMTTS); } },
         { qsl("enableMNES"), [&](){ lua_pushboolean(L, host.mEnableMNES); } },
         { qsl("enableMXP"), [&](){ lua_pushboolean(L, host.mEnableMXP); } },
-        { qsl("askTlsAvailable"), [&](){ lua_pushboolean(L, host.mAskTlsAvailable); } },
+        { qsl("logDirectory"), [&](){
+            const auto logDir = host.mLogDir;
+
+            if (logDir == nullptr || logDir.isEmpty()) {
+                lua_pushstring(L, mudlet::getMudletPath(enums::profileReplayAndLogFilesPath, getHostFromLua(L).getName()).toUtf8().constData());
+            } else {
+                lua_pushstring(L, host.mLogDir.toUtf8().constData());
+            }
+        } },
+        { qsl("askTlsAvailable"), [&](){lua_pushboolean(L, host.mAskTlsAvailable); } },
         { qsl("inputLineStrictUnixEndings"), [&](){ lua_pushboolean(L, host.mUSE_UNIX_EOL); } },
         { qsl("autoClearInputLine"), [&](){ lua_pushboolean(L, host.mAutoClearCommandLineAfterSend); } },
         { qsl("showSentText"), [&](){ lua_pushboolean(L, host.mPrintCommand); } },

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7529,16 +7529,7 @@ int TLuaInterpreter::getConfig(lua_State *L)
         { qsl("enableMTTS"), [&](){ lua_pushboolean(L, host.mEnableMTTS); } },
         { qsl("enableMNES"), [&](){ lua_pushboolean(L, host.mEnableMNES); } },
         { qsl("enableMXP"), [&](){ lua_pushboolean(L, host.mEnableMXP); } },
-        { qsl("logDirectory"), [&](){
-            const auto logDir = host.mLogDir;
-
-            if (logDir == nullptr || logDir.isEmpty()) {
-                lua_pushstring(L, mudlet::getMudletPath(enums::profileReplayAndLogFilesPath, getHostFromLua(L).getName()).toUtf8().constData());
-            } else {
-                lua_pushstring(L, host.mLogDir.toUtf8().constData());
-            }
-        } },
-        { qsl("askTlsAvailable"), [&](){lua_pushboolean(L, host.mAskTlsAvailable); } },
+        { qsl("askTlsAvailable"), [&](){ lua_pushboolean(L, host.mAskTlsAvailable); } },
         { qsl("inputLineStrictUnixEndings"), [&](){ lua_pushboolean(L, host.mUSE_UNIX_EOL); } },
         { qsl("autoClearInputLine"), [&](){ lua_pushboolean(L, host.mAutoClearCommandLineAfterSend); } },
         { qsl("showSentText"), [&](){ lua_pushboolean(L, host.mPrintCommand); } },

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -480,6 +480,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("DebugShowAllProblemCodepoints") = pHost->debugShowAllProblemCodepoints() ? "yes" : "no";
     host.append_attribute("announceIncomingText") = pHost->mAnnounceIncomingText ? "yes" : "no";
     host.append_attribute("advertiseScreenReader") = pHost->mAdvertiseScreenReader ? "yes" : "no";
+    host.append_attribute("f3SearchEnabled") = pHost->mF3SearchEnabled ? "yes" : "no";
     host.append_attribute("enableClosedCaption") = pHost->mEnableClosedCaption ? "yes" : "no";
     host.append_attribute("caretShortcut") = QMetaEnum::fromType<Host::CaretShortcut>().valueToKey(
             static_cast<int>(pHost->mCaretShortcut));

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -766,6 +766,7 @@ void XMLimport::readHost(Host* pHost)
     setBoolAttribute(qsl("mSslIgnoreAll"), pHost->mSslIgnoreAll);
     setBoolAttribute(qsl("mAskTlsAvailable"), pHost->mAskTlsAvailable);
     setBoolAttribute(qsl("mUseProxy"), pHost->mUseProxy);
+    setBoolAttribute(qsl("f3SearchEnabled"), pHost->mF3SearchEnabled);
 
     pHost->mProxyAddress = attributes().value(qsl("mProxyAddress")).toString();
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR fixes an issue where the "F3 Search" accessibility checkbox in Preferences → Accessibility would not persist its checked state after restarting the profile or when set as a global preference (without a profile loaded). The setting is now correctly saved and restored per profile and globally.

#### Motivation for adding to Mudlet
Addresses #7770: Users reported that enabling the F3 Search accessibility shortcut was not being saved, causing accessibility features to be lost after restarting or reopening Preferences.

#### Other info (issues closed, discussion etc)
Closes #7770
Ensures accessibility settings are reliably saved and restored for all users.
Testing results here:

https://github.com/user-attachments/assets/04a31e66-ef1a-4a36-8c01-76a86eda8ae2