### PR TITLE
fix: preferences font dialog would crash without a valid host

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -268,8 +268,10 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
         emit signal_resetMainWindowShortcutsToDefaults();
     });
 
-    mDisplayFont = pHost->getDisplayFont();
-    pushButton_fontDialog->setText(QString("%1, %2, %3pt").arg(mDisplayFont.family()).arg(mDisplayFont.styleName()).arg(mDisplayFont.pointSize()));
+    if (pHost) {
+        mDisplayFont = pHost->getDisplayFont();
+        pushButton_fontDialog->setText(QString("%1, %2, %3pt").arg(mDisplayFont.family()).arg(mDisplayFont.styleName()).arg(mDisplayFont.pointSize()));
+    }
 
     connect(pushButton_fontDialog, &QPushButton::clicked, this, [this, pHost](){
         bool ok;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Perform a check to see if host is valid before asking for its font.  This is used to populate the font dialog button with the chosen font for the profile.

#### Motivation for adding to Mudlet
Fixes crash when opening preferences window before opening a profile

#### Other info (issues closed, discussion etc)
