### PR TITLE
fix: move font dialog to appropriate host related functions

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -268,24 +268,6 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
         emit signal_resetMainWindowShortcutsToDefaults();
     });
 
-    if (pHost) {
-        mDisplayFont = pHost->getDisplayFont();
-        pushButton_fontDialog->setText(QString("%1, %2, %3pt").arg(mDisplayFont.family()).arg(mDisplayFont.styleName()).arg(mDisplayFont.pointSize()));
-    }
-
-    connect(pushButton_fontDialog, &QPushButton::clicked, this, [this, pHost](){
-        bool ok;
-        QFont font = QFontDialog::getFont(&ok, pHost->getDisplayFont(), this->window());
-        if (ok) {
-            qDebug() << "Font selected: " << font.toString();
-            qDebug() << "Font family: " << font.family();
-            qDebug() << "Font size: " << font.pointSize();
-            mDisplayFont = font;
-            mFontSize = font.pointSize();
-            slot_setFontSize();
-            pushButton_fontDialog->setText(QString("%1, %2, %3pt").arg(mDisplayFont.family()).arg(mDisplayFont.styleName()).arg(mDisplayFont.pointSize()));
-        }
-    });
     generateDiscordTooltips();
 
     label_languageChangeWarning->hide();
@@ -636,6 +618,23 @@ void dlgProfilePreferences::enableHostDetails()
 void dlgProfilePreferences::initWithHost(Host* pHost)
 {
     loadEditorTab();
+
+    mDisplayFont = pHost->getDisplayFont();
+    pushButton_fontDialog->setText(QString("%1, %2, %3pt").arg(mDisplayFont.family()).arg(mDisplayFont.styleName()).arg(mDisplayFont.pointSize()));
+
+    connect(pushButton_fontDialog, &QPushButton::clicked, this, [this, pHost](){
+        bool ok;
+        QFont font = QFontDialog::getFont(&ok, pHost->getDisplayFont(), this->window());
+        if (ok) {
+            qDebug() << "Font selected: " << font.toString();
+            qDebug() << "Font family: " << font.family();
+            qDebug() << "Font size: " << font.pointSize();
+            mDisplayFont = font;
+            mFontSize = font.pointSize();
+            slot_setFontSize();
+            pushButton_fontDialog->setText(QString("%1, %2, %3pt").arg(mDisplayFont.family()).arg(mDisplayFont.styleName()).arg(mDisplayFont.pointSize()));
+        }
+    });
 
     // search engine load
     search_engine_combobox->addItems(QStringList(mpHost->mSearchEngineData.keys()));
@@ -1290,6 +1289,7 @@ void dlgProfilePreferences::disconnectHostRelatedControls()
     // disconnect(...) counterparts - so we need to provide the "dummy"
     // arguments to get the wanted wild-card behaviour for them:
 
+    disconnect(pushButton_fontDialog, &QAbstractButton::clicked, nullptr, nullptr);
     disconnect(buttonDownloadMap, &QAbstractButton::clicked, nullptr, nullptr);
 
     disconnect(pushButton_foreground_color, &QAbstractButton::clicked, nullptr, nullptr);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Move font dialog button connect and disconnect to initWithHost and disconnectHostRelatedControls for consistency.

#### Motivation for adding to Mudlet
Mudlet code consistency.  Fixes crash when opening preferences window before opening a profile.

#### Other info (issues closed, discussion etc)
This reverts #7885.