### PR TITLE
Infrastructure: adjust name of TConsole::setFont(...)

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1042,12 +1042,12 @@ void Host::updateConsolesFont()
     }
 
     if (mpEditorDialog && mpEditorDialog->mpErrorConsole) {
-        mpEditorDialog->mpErrorConsole->setFont(mDisplayFont.family());
+        mpEditorDialog->mpErrorConsole->setFontName(mDisplayFont.family());
         mpEditorDialog->mpErrorConsole->setFontSize(mDisplayFont.pointSize());
     }
 
     if (mudlet::self()->smpDebugArea) {
-        mudlet::self()->smpDebugConsole->setFont(mDisplayFont.family());
+        mudlet::self()->smpDebugConsole->setFontName(mDisplayFont.family());
         mudlet::self()->smpDebugConsole->setFontSize(mDisplayFont.pointSize());
     }
 

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1459,9 +1459,9 @@ void TConsole::refreshView() const
     mLowerPane->forceUpdate();
 }
 
-bool TConsole::setFont(const QString& font)
+bool TConsole::setFontName(const QString& fontName)
 {
-    mDisplayFontName = font;
+    mDisplayFontName = fontName;
 
     refreshView();
     return true;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -181,7 +181,7 @@ public:
     void refreshView() const;
     void raiseMudletMousePressOrReleaseEvent(QMouseEvent*, const bool);
     bool setFontSize(int);
-    bool setFont(const QString& font);
+    bool setFontName(const QString& fontName);
     bool setConsoleBackgroundImage(const QString&, int);
     bool resetConsoleBackgroundImage();
     void setLink(const QStringList& linkFunction, const QStringList& linkHint, const QVector<int> linkReference = QVector<int>());


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Renames `(bool) TConsole::setFont(const QString&)` to `setFontName` because it does actually do the latter (stores the NAME of the font to use) and could otherwise be mistaken for the base class `(void) QWidget::setFont(const QFont&)` method.


#### Motivation for adding to Mudlet
To reduce the chance of misinterpreting what the method does in comparison with what the base class function performs.

#### Other info (issues closed, discussion etc)
It is not impossible that we might restructure things so that we send a reference to an actual font instance rather than the name of a font in this class. Such a `setFont` method then would then have the `override` "label" applied to it so as to flag that it is replacing the base class function, which the method renamed in this PR does **not**.
