### PR TITLE
Fix: Increase command line height more when input is wrapped so previous text doesn't become hidden.

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -624,11 +624,8 @@ void TCommandLine::adjustHeight()
     }
     const int fontH = QFontMetrics(font()).height();
     // Adjust height margin based on font size and if it is more than one row
-    int marginH = lines > 1 ? 2+fontH/3 : 5;
-    if (lines > 1 && marginH < 8) {
-        marginH = 8; // needed for very small fonts
-    }
-    int _height = fontH * lines + marginH;
+    int marginH = lines > 1 ? 10 : 5;
+    int _height = (fontH + 1) * lines + marginH;
     if (_height < mpHost->commandLineMinimumHeight) {
         _height = mpHost->commandLineMinimumHeight;
     }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Modify the commandline adjustheight function to scale the input box properly (more) with multiple lines.

#### Motivation for adding to Mudlet
This bug was really starting to irritate me! 

#### Other info (issues closed, discussion etc)

I think this should work for all fonts/sizes/# of lines, but I haven't tested every single combination.

Fixes #7863

e.g.
![image](https://github.com/user-attachments/assets/9ef126db-0963-4953-a17a-147cd1b43670)
