### PR TITLE
Infrastructure: update Windows Github runner image used

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2019
+          - os: windows-2022
             buildname: 'windows64'
 
     steps:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Change from the `windows-2019` to the `windows-2022` image for Windows GHA runs of our CI/CB process.

#### Motivation for adding to Mudlet
The oldest image we were using is, as of 2025/06/01, deprecated and will be removed shortly; as it is, it is being browned out for part of today! See: https://github.com/actions/runner-images/issues/12045

#### Other info (issues closed, discussion etc)
Unlike the removal of the oldest Linux image this should not be too much of a faff to sort out...