### PR TITLE
improve: Changed std::string windowNames to QStrings

### DIFF
--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -3262,9 +3262,9 @@ int TLuaInterpreter::windowType(lua_State* L)
 int TLuaInterpreter::wrapLine(lua_State* L)
 {
     int s = 1;
-    std::string windowName;
+    QString windowName;
     if (lua_gettop(L)) {
-        windowName = getVerifiedString(L, __func__, s++, "window name").toStdString();
+        windowName = getVerifiedString(L, __func__, s++, "window name");
     }
     const int lineNumber = getVerifiedInt(L, __func__, s, "line");
 

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -803,9 +803,9 @@ int TLuaInterpreter::getBackgroundColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBgColor
 int TLuaInterpreter::getBgColor(lua_State* L)
 {
-    std::string windowName = "main";
+    QString windowName = qsl("main");
     if (lua_gettop(L) > 0) {
-        windowName = getVerifiedString(L, __func__, 1, "window name", true).toStdString();
+        windowName = getVerifiedString(L, __func__, 1, "window name", true);
     }
 
     const Host& host = getHostFromLua(L);
@@ -917,9 +917,9 @@ int TLuaInterpreter::getCurrentLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getFgColor
 int TLuaInterpreter::getFgColor(lua_State* L)
 {
-    std::string windowName = "main";
+    QString windowName = qsl("main");
     if (lua_gettop(L) > 0) {
-        windowName = getVerifiedString(L, __func__, 1, "window name", true).toStdString();
+        windowName = getVerifiedString(L, __func__, 1, "window name", true);
     }
 
     const Host& host = getHostFromLua(L);
@@ -1512,7 +1512,7 @@ int TLuaInterpreter::insertText(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#isAnsiBgColor
 int TLuaInterpreter::isAnsiBgColor(lua_State* L)
 {
-    std::string windowName = "main";
+    QString windowName = qsl("main");
     const int ansiBg = getVerifiedInt(L, __func__, 1, "ANSI color");
 
     std::list<int> result;
@@ -1606,7 +1606,7 @@ int TLuaInterpreter::isAnsiBgColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#isAnsiFgColor
 int TLuaInterpreter::isAnsiFgColor(lua_State* L)
 {
-    std::string windowName = "main";
+    QString windowName = "main";
     const int ansiFg = getVerifiedInt(L, __func__, 1, "ANSI color");
 
     std::list<int> result;
@@ -3262,7 +3262,7 @@ int TLuaInterpreter::windowType(lua_State* L)
 int TLuaInterpreter::wrapLine(lua_State* L)
 {
     int s = 1;
-    QString windowName;
+    QString windowName = qsl("main");
     if (lua_gettop(L)) {
         windowName = getVerifiedString(L, __func__, s++, "window name");
     }

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -392,14 +392,13 @@ QPair<quint8, TChar> TMainConsole::getTextAttributes(const QString& name) const
     return qMakePair(1, TChar());
 }
 
-void TMainConsole::luaWrapLine(std::string& buf, int line)
+void TMainConsole::luaWrapLine(QString& buf, int line)
 {
-    const QString key = buf.c_str();
-    if (key.isEmpty() || key == QLatin1String("main")) {
+    if (buf.isEmpty() || buf == QLatin1String("main")) {
         TConsole::luaWrapLine(line);
         return;
     }
-    auto pC = mSubConsoleMap.value(key);
+    auto pC = mSubConsoleMap.value(buf);
     if (pC) {
         pC->luaWrapLine(line);
     }

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -350,13 +350,12 @@ void TMainConsole::selectCurrentLine(std::string& buf)
     }
 }
 
-std::list<int> TMainConsole::getFgColor(std::string& buf)
+std::list<int> TMainConsole::getFgColor(QString& buf)
 {
-    const QString key = buf.c_str();
-    if (key.isEmpty() || key == QLatin1String("main")) {
+    if (buf.isEmpty() || buf == QLatin1String("main")) {
         return TConsole::getFgColor();
     }
-    auto pC = mSubConsoleMap.value(key);
+    auto pC = mSubConsoleMap.value(buf);
     if (pC) {
         return pC->getFgColor();
     }
@@ -364,13 +363,12 @@ std::list<int> TMainConsole::getFgColor(std::string& buf)
     return {};
 }
 
-std::list<int> TMainConsole::getBgColor(std::string& buf)
+std::list<int> TMainConsole::getBgColor(QString& buf)
 {
-    const QString key = buf.c_str();
-    if (key.isEmpty() || key == QLatin1String("main")) {
+    if (buf.isEmpty() || buf == QLatin1String("main")) {
         return TConsole::getBgColor();
     }
-    auto pC = mSubConsoleMap.value(key);
+    auto pC = mSubConsoleMap.value(buf);
     if (pC) {
         return pC->getBgColor();
     }

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -62,7 +62,7 @@ public:
     std::list<int> getFgColor(std::string& buf);
     std::list<int> getBgColor(std::string& buf);
     QPair<quint8, TChar> getTextAttributes(const QString&) const;
-    void luaWrapLine(std::string& buf, int line);
+    void luaWrapLine(QString& buf, int line);
     QString getCurrentLine(std::string&);
     TConsole* createBuffer(const QString& name);
     std::pair<bool, QString> setUserWindowStyleSheet(const QString& name, const QString& userWindowStyleSheet);

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -59,8 +59,8 @@ public:
     bool clear(const QString& name);
     void setProfileName(const QString&) override;
     void selectCurrentLine(std::string&);
-    std::list<int> getFgColor(std::string& buf);
-    std::list<int> getBgColor(std::string& buf);
+    std::list<int> getFgColor(QString& buf);
+    std::list<int> getBgColor(QString& buf);
     QPair<quint8, TChar> getTextAttributes(const QString&) const;
     void luaWrapLine(QString& buf, int line);
     QString getCurrentLine(std::string&);


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This is my solution to issue #4729. It changes any window name that is an std::string into a QString in numerous functions.

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)

This is my first ever pull request. Let me know if there is anything I need to change!