### PR TITLE
fix: broken AND-Triggers with only one item

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4632,9 +4632,9 @@ void dlgTriggerEditor::saveTrigger()
     mpTriggersMainArea->trimName();
     const QString name = mpTriggersMainArea->lineEdit_trigger_name->text();
     const QString command = mpTriggersMainArea->lineEdit_trigger_command->text();
-    const bool isMultiline = (mpTriggersMainArea->spinBox_lineMargin->value() > -1);
     QStringList patterns;
     QList<int> patternKinds;
+    int  validItems = 0;
     for (int i = 0; i < 50; i++) {
         QString pattern = mTriggerPatternEdit.at(i)->singleLineTextEdit_pattern->toPlainText();
 
@@ -4646,6 +4646,7 @@ void dlgTriggerEditor::saveTrigger()
             continue;
         }
 
+        ++validItems;
         switch (patternType) {
         case 0:
             patternKinds << REGEX_SUBSTRING;
@@ -4675,7 +4676,7 @@ void dlgTriggerEditor::saveTrigger()
         }
         patterns << pattern;
     }
-
+    const bool isMultiline = (mpTriggersMainArea->spinBox_lineMargin->value() > -1) && (validItems > 1);
     const QString script = mpSourceEditorEdbeeDocument->text();
 
     const int triggerID = pItem->data(0, Qt::UserRole).toInt();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Prevent a trigger with only one "item" from being recorded as a multi-line (AND) trigger. The prior code meant that after setting the multi-line delta to a value greater than `-1` which now flags that a trigger is of the AND rather than the OR type ignored the later deletion of all but one of the "Items" with the result that later on the trigger failed to operate correctly.


#### Motivation for adding to Mudlet
Prevent a stupid oddity in the behaviour which borked the trigger concerned.

#### Other info (issues closed, discussion etc)
This was brought to my attention by a Discord user who kindly also raised the issued which this
PR should close #7894.

