### PR TITLE
Fix: get Ctrl+# to work on AZERTY keyboards

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1250,11 +1250,13 @@ void TCommandLine::spellCheckWord(QTextCursor& c)
 
 bool TCommandLine::handleCtrlTabChange(QKeyEvent* ke, int tabNumber)
 {
-    const Qt::KeyboardModifiers allModifiers = Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier | Qt::KeypadModifier | Qt::GroupSwitchModifier;
+    const Qt::KeyboardModifiers allExceptShiftModifiers = Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier | Qt::KeypadModifier | Qt::GroupSwitchModifier;
 
-    if ((ke->modifiers() & allModifiers) == Qt::ControlModifier) {
-        // let user-defined Ctrl+# keys match first - and only if the user hasn't created
-        // then we fallback to tab switching
+    if ((ke->modifiers() & allExceptShiftModifiers) == Qt::ControlModifier) {
+        // let user-defined Ctrl+# keys match first - and only if the user
+        // hasn't created one then we fallback to tab switching - however
+        // since some locales need the SHIFT modifier to enter numbers from the
+        // top keyboard row (e.g. French AZERTY) we must ignore that one!
         if (keybindingMatched(ke)) {
             // Ah the user HAS created a matching binding:
             return true;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Revise processing of keyboard events so that users of French AZERTY keyboards can still pass "number" keys into Mudlet. That type of keyboard layout requires the use of the SHIFT modifier to enter the numeric value on the top row (excluding functions keys) of the keyboard.

#### Brief overview of PR changes/additions
Allow French users to switch between multiple profiles when multi-playing.

#### Other info (issues closed, discussion etc)
This can be tested from "US" and other "English" keyboards by selecting a "FR (AZERTY)" layout *without* having to source a specimen of that particular keyboard (you do have to remember to hold the SHIFT key down as well as the CTRL one when pressing a number key)!
