### PR TITLE
Fix: Process MXP per negotiation (Part 2)

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -411,8 +411,21 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
         });
     }
 
-    connect(&mTelnet, &cTelnet::signal_disconnected, this, [this](){ purgeTimer.start(1min); });
-    connect(&mTelnet, &cTelnet::signal_connected, this, [this](){ purgeTimer.stop(); });
+    connect(&mTelnet, &cTelnet::signal_disconnected, this, [this](){
+        purgeTimer.start(1min);
+
+        if (mForceMXPProcessorOn) {
+            mMxpProcessor.disable();
+        }
+    });
+    connect(&mTelnet, &cTelnet::signal_connected, this, [this](){
+        purgeTimer.stop();
+
+        if (mForceMXPProcessorOn) {
+            mMxpProcessor.enable();
+            qDebug() << "MXP enabled (forced)";
+        }
+    });
     connect(&purgeTimer, &QTimer::timeout, this, &Host::slot_purgeTemps);
 
     // enable by default in case of offline connection; if the profile connects - timer will be disabled

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -414,19 +414,30 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
     connect(&mTelnet, &cTelnet::signal_disconnected, this, [this](){
         purgeTimer.start(1min);
 
-        if (mForceMXPProcessorOn) {
+        if (getForceMXPProcessorOn()) {
             mMxpProcessor.disable();
         }
     });
     connect(&mTelnet, &cTelnet::signal_connected, this, [this](){
         purgeTimer.stop();
 
-        if (mForceMXPProcessorOn) {
+        if (getForceMXPProcessorOn()) {
             mMxpProcessor.enable();
             qDebug() << "MXP enabled (forced)";
         }
     });
     connect(&purgeTimer, &QTimer::timeout, this, &Host::slot_purgeTemps);
+    connect(this, &Host::signal_forceMXPProcessorOnChanged, this, [this](bool enabled) {
+        if (enabled) {
+            if (!mMxpProcessor.isEnabled()) {
+                mMxpProcessor.enable();
+                qDebug() << "MXP enabled (forced)";
+            }
+        } else if (mMxpProcessor.isEnabled() && !mTelnet.isMXPEnabled()) {
+            mMxpProcessor.disable();
+            qDebug() << "MXP disabled (forced)";
+        }
+    });
 
     // enable by default in case of offline connection; if the profile connects - timer will be disabled
     purgeTimer.start(1min);

--- a/src/Host.h
+++ b/src/Host.h
@@ -432,7 +432,13 @@ public:
             mpConsole->setF3SearchEnabled(enabled);
         }
     }
-
+    bool getForceMXPProcessorOn() const { return mForceMXPProcessorOn; }
+    void setForceMXPProcessorOn(bool value) {
+        if (mForceMXPProcessorOn != value) {
+            mForceMXPProcessorOn = value;
+            emit signal_forceMXPProcessorOnChanged(value);
+        }
+    }
     void sendCmdLine(const QString& cmd);
 
     cTelnet mTelnet;
@@ -462,7 +468,6 @@ public:
     bool mEnableMTTS = true;
     bool mEnableMNES = false;
     bool mEnableMXP = true;
-    bool mForceMXPProcessorOn = false;
     bool mPromptedForMXPProcessorOn = false;
     bool mAskTlsAvailable = true;
     bool mPromptedForVersionInTTYPE = false;
@@ -749,6 +754,7 @@ signals:
     void signal_saveCommandLinesHistory();
     void signal_editorThemeChanged();
     void signal_remoteEchoChanged(bool enabled);
+    void signal_forceMXPProcessorOnChanged(bool enabled);
 
 private slots:
     void slot_purgeTemps();
@@ -943,6 +949,10 @@ private:
 
     // Whether F3 search functionality is enabled
     bool mF3SearchEnabled = false;
+
+    // Whether to force the MXP processor to be on, even if not negotiated with the
+    // MUD Server
+    bool mForceMXPProcessorOn = false;
 
     // Set when the mudlet singleton demands that we close - used to force an
     // attempt to save the profile and map - without asking:

--- a/src/Host.h
+++ b/src/Host.h
@@ -462,6 +462,8 @@ public:
     bool mEnableMTTS = true;
     bool mEnableMNES = false;
     bool mEnableMXP = true;
+    bool mForceMXPProcessorOn = false;
+    bool mPromptedForMXPProcessorOn = false;
     bool mAskTlsAvailable = true;
     bool mPromptedForVersionInTTYPE = false;
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -549,7 +549,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
 #if defined(DEBUG_MXP_PROCESSING)
                     qDebug().nospace().noquote() << "    Consider the MXP control sequence: \"" << localBuffer.substr(localBufferPosition, spanEnd - spanStart).c_str() << "\"";
 #endif
-                    if ((mpHost->mEnableMXP || mpHost->mForceMXPProcessorOn) && isFromServer) {
+                    if (isFromServer && (mpHost->mTelnet.isMXPEnabled() || mpHost->getForceMXPProcessorOn())) {
                         mGotCSI = false;
 
                         const QString code = QString(localBuffer.substr(localBufferPosition, spanEnd - spanStart).c_str());
@@ -681,7 +681,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
         // We are outside of a CSI or OSC sequence if we get to here:
 
         if (localBufferPosition >= endOfLiteralEntity && mpHost->mMxpProcessor.isEnabled()) {
-            if (mpHost->mEnableMXP || mpHost->mForceMXPProcessorOn) {
+            if (mpHost->mTelnet.isMXPEnabled() || mpHost->getForceMXPProcessorOn()) {
                 if (mpHost->mMxpProcessor.mode() != MXP_MODE_LOCKED) {
                     // The comparison signals to the processor, if custom entities may be resolved
                     // (countermeasure against infinite recursion)

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -549,14 +549,13 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
 #if defined(DEBUG_MXP_PROCESSING)
                     qDebug().nospace().noquote() << "    Consider the MXP control sequence: \"" << localBuffer.substr(localBufferPosition, spanEnd - spanStart).c_str() << "\"";
 #endif
-                    if (!mpHost->mEnableMXP && isFromServer) {
+                    if ((mpHost->mEnableMXP || mpHost->mForceMXPProcessorOn) && isFromServer) {
                         mGotCSI = false;
 
                         const QString code = QString(localBuffer.substr(localBufferPosition, spanEnd - spanStart).c_str());
                         mpHost->mMxpProcessor.setMode(code);
                     }
-                    // end of if (!mpHost->mEnableMXP)
-                    // We have manually disabled MXP negotiation
+
                     break;
 
                 case static_cast<quint8>('C'): {
@@ -682,7 +681,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
         // We are outside of a CSI or OSC sequence if we get to here:
 
         if (localBufferPosition >= endOfLiteralEntity && mpHost->mMxpProcessor.isEnabled()) {
-            if (mpHost->mEnableMXP) {
+            if (mpHost->mEnableMXP || mpHost->mForceMXPProcessorOn) {
                 if (mpHost->mMxpProcessor.mode() != MXP_MODE_LOCKED) {
                     // The comparison signals to the processor, if custom entities may be resolved
                     // (countermeasure against infinite recursion)

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7340,8 +7340,13 @@ int TLuaInterpreter::setConfig(lua_State * L)
         host.mEnableMNES = getVerifiedBool(L, __func__, 2, "value");
         return success();
     }
-    if (key == qsl("enableMXP") || key == qsl("specialForceMxpNegotiationOff")) {
+    if (key == qsl("specialForceMxpNegotiationOff")) {
         // specialForceMxpNegotiationOff should not be used anymore, but we support it for compatibility
+        // it will be the inverse of enableMXP
+        host.mEnableMXP = !getVerifiedBool(L, __func__, 2, "value");
+        return success();
+    }
+    if (key == qsl("enableMXP") {
         host.mEnableMXP = getVerifiedBool(L, __func__, 2, "value");
         return success();
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7558,6 +7558,8 @@ int TLuaInterpreter::getConfig(lua_State *L)
         { qsl("enableMTTS"), [&](){ lua_pushboolean(L, host.mEnableMTTS); } },
         { qsl("enableMNES"), [&](){ lua_pushboolean(L, host.mEnableMNES); } },
         { qsl("enableMXP"), [&](){ lua_pushboolean(L, host.mEnableMXP); } },
+        { qsl("advertiseScreenReader"), [&](){ lua_pushboolean(L, host.mAdvertiseScreenReader); } },
+        { qsl("enableClosedCaption"), [&](){ lua_pushboolean(L, host.mEnableClosedCaption); } },
         { qsl("logDirectory"), [&](){
             const auto logDir = host.mLogDir;
 
@@ -7576,6 +7578,11 @@ int TLuaInterpreter::getConfig(lua_State *L)
         { qsl("fixUnnecessaryLinebreaks"), [&](){ lua_pushboolean(L, host.mUSE_IRE_DRIVER_BUGFIX); } },
         { qsl("specialForceCompressionOff"), [&](){ lua_pushboolean(L, host.mFORCE_NO_COMPRESSION); } },
         { qsl("specialForceGAOff"), [&](){ lua_pushboolean(L, host.mFORCE_GA_OFF); } },
+        { qsl("specialForceMxpNegotiationOff"), [&](){
+            // specialForceMxpNegotiationOff should not be used anymore, but we support it for compatibility
+            // it will be the inverse of enableMXP
+            lua_pushboolean(L, !host.mEnableMXP);
+        } },
         { qsl("specialForceCharsetNegotiationOff"), [&](){ lua_pushboolean(L, host.mFORCE_CHARSET_NEGOTIATION_OFF); } },
         { qsl("forceNewEnvironNegotiationOff"), [&](){ lua_pushboolean(L, host.mForceNewEnvironNegotiationOff); } },
         { qsl("compactInputLine"), [&](){ lua_pushboolean(L, host.getCompactInputLine()); } },

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7340,7 +7340,8 @@ int TLuaInterpreter::setConfig(lua_State * L)
         host.mEnableMNES = getVerifiedBool(L, __func__, 2, "value");
         return success();
     }
-    if (key == qsl("enableMXP")) {
+    if (key == qsl("enableMXP") || key == qsl("specialForceMxpNegotiationOff")) {
+        // specialForceMxpNegotiationOff should not be used anymore, but we support it for compatibility
         host.mEnableMXP = getVerifiedBool(L, __func__, 2, "value");
         return success();
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7355,10 +7355,6 @@ int TLuaInterpreter::setConfig(lua_State * L)
         host.mAskTlsAvailable = getVerifiedBool(L, __func__, 2, "value");
         return success();
     }
-    if (key == qsl("specialForceMXPProcessorOn")) {
-        host.mForceMXPProcessorOn = getVerifiedBool(L, __func__, 2, "value");
-        return success();
-    }
     if (key == qsl("promptForMXPProcessorOn")) {
         host.mPromptedForMXPProcessorOn = getVerifiedBool(L, __func__, 2, "value");
         return success();
@@ -7577,6 +7573,8 @@ int TLuaInterpreter::getConfig(lua_State *L)
             }
         } },
         { qsl("askTlsAvailable"), [&](){lua_pushboolean(L, host.mAskTlsAvailable); } },
+        { qsl("promptForMXPProcessorOn"), [&](){lua_pushboolean(L, host.mPromptedForMXPProcessorOn); } },
+        { qsl("specialForceMXPProcessorOn"), [&](){lua_pushboolean(L, host.mForceMXPProcessorOn); } },
         { qsl("promptForVersionInTTYPE"), [&](){lua_pushboolean(L, host.mPromptedForVersionInTTYPE); } },
         { qsl("versionInTTYPE"), [&](){ lua_pushboolean(L, host.mVersionInTTYPE); } },
         { qsl("inputLineStrictUnixEndings"), [&](){ lua_pushboolean(L, host.mUSE_UNIX_EOL); } },

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7355,6 +7355,14 @@ int TLuaInterpreter::setConfig(lua_State * L)
         host.mAskTlsAvailable = getVerifiedBool(L, __func__, 2, "value");
         return success();
     }
+    if (key == qsl("specialForceMXPProcessorOn")) {
+        host.mForceMXPProcessorOn = getVerifiedBool(L, __func__, 2, "value");
+        return success();
+    }
+    if (key == qsl("promptForMXPProcessorOn")) {
+        host.mPromptedForMXPProcessorOn = getVerifiedBool(L, __func__, 2, "value");
+        return success();
+    }
     if (key == qsl("promptForVersionInTTYPE")) {
         host.mPromptedForVersionInTTYPE = getVerifiedBool(L, __func__, 2, "value");
         return success();

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7346,7 +7346,7 @@ int TLuaInterpreter::setConfig(lua_State * L)
         host.mEnableMXP = !getVerifiedBool(L, __func__, 2, "value");
         return success();
     }
-    if (key == qsl("enableMXP") {
+    if (key == qsl("enableMXP")) {
         host.mEnableMXP = getVerifiedBool(L, __func__, 2, "value");
         return success();
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7574,7 +7574,7 @@ int TLuaInterpreter::getConfig(lua_State *L)
         } },
         { qsl("askTlsAvailable"), [&](){lua_pushboolean(L, host.mAskTlsAvailable); } },
         { qsl("promptForMXPProcessorOn"), [&](){lua_pushboolean(L, host.mPromptedForMXPProcessorOn); } },
-        { qsl("specialForceMXPProcessorOn"), [&](){lua_pushboolean(L, host.mForceMXPProcessorOn); } },
+        { qsl("specialForceMXPProcessorOn"), [&](){lua_pushboolean(L, host.getForceMXPProcessorOn()); } },
         { qsl("promptForVersionInTTYPE"), [&](){lua_pushboolean(L, host.mPromptedForVersionInTTYPE); } },
         { qsl("versionInTTYPE"), [&](){ lua_pushboolean(L, host.mVersionInTTYPE); } },
         { qsl("inputLineStrictUnixEndings"), [&](){ lua_pushboolean(L, host.mUSE_UNIX_EOL); } },

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7558,8 +7558,6 @@ int TLuaInterpreter::getConfig(lua_State *L)
         { qsl("enableMTTS"), [&](){ lua_pushboolean(L, host.mEnableMTTS); } },
         { qsl("enableMNES"), [&](){ lua_pushboolean(L, host.mEnableMNES); } },
         { qsl("enableMXP"), [&](){ lua_pushboolean(L, host.mEnableMXP); } },
-        { qsl("advertiseScreenReader"), [&](){ lua_pushboolean(L, host.mAdvertiseScreenReader); } },
-        { qsl("enableClosedCaption"), [&](){ lua_pushboolean(L, host.mEnableClosedCaption); } },
         { qsl("logDirectory"), [&](){
             const auto logDir = host.mLogDir;
 

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -426,7 +426,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mFORCE_CHARSET_NEGOTIATION_OFF") = pHost->mFORCE_CHARSET_NEGOTIATION_OFF ? "yes" : "no";
     host.append_attribute("mVersionInTTYPE") = pHost->mVersionInTTYPE ? "yes" : "no";
     host.append_attribute("mPromptedForVersionInTTYPE") = pHost->mPromptedForVersionInTTYPE ? "yes" : "no";
-    host.append_attribute("mForceMXPProcessorOn") = pHost->mForceMXPProcessorOn ? "yes" : "no";
+    host.append_attribute("mForceMXPProcessorOn") = pHost->getForceMXPProcessorOn() ? "yes" : "no";
     host.append_attribute("mPromptedForMXPProcessorOn") = pHost->mPromptedForMXPProcessorOn ? "yes" : "no";
     host.append_attribute("forceNewEnvironNegotiationOff") = pHost->mForceNewEnvironNegotiationOff ? "yes" : "no";
     host.append_attribute("enableTextAnalyzer") = pHost->mEnableTextAnalyzer ? "yes" : "no";

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -426,6 +426,8 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mFORCE_CHARSET_NEGOTIATION_OFF") = pHost->mFORCE_CHARSET_NEGOTIATION_OFF ? "yes" : "no";
     host.append_attribute("mVersionInTTYPE") = pHost->mVersionInTTYPE ? "yes" : "no";
     host.append_attribute("mPromptedForVersionInTTYPE") = pHost->mPromptedForVersionInTTYPE ? "yes" : "no";
+    host.append_attribute("mForceMXPProcessorOn") = pHost->mForceMXPProcessorOn ? "yes" : "no";
+    host.append_attribute("mPromptedForMXPProcessorOn") = pHost->mPromptedForMXPProcessorOn ? "yes" : "no";
     host.append_attribute("forceNewEnvironNegotiationOff") = pHost->mForceNewEnvironNegotiationOff ? "yes" : "no";
     host.append_attribute("enableTextAnalyzer") = pHost->mEnableTextAnalyzer ? "yes" : "no";
     host.append_attribute("mRoomSize") = QString::number(pHost->mRoomSize, 'f', 1).toUtf8().constData();

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -715,6 +715,19 @@ void XMLimport::readHostPackage()
 
 void XMLimport::readHost(Host* pHost)
 {
+    // This is an inline helper function to get a boolean value from a legacy attribute
+    // or return a default value. It also allows for inverting the result which is useful
+    // for attributes that have been negated in the past (e.g., mFORCE_MXP_NEGOTIATION_OFF
+    // which is now mEnableMXP).
+    auto getBoolValueFromLegacyAttributeOrDefault = [&](const QString& legacyAttribute, const bool defaultsTo, bool invert = false) -> bool {
+        if (attributes().hasAttribute(legacyAttribute)) {
+            bool value = attributes().value(legacyAttribute) == YES;
+            return invert ? !value : value;
+        } else {
+            return defaultsTo;
+        }
+    };
+
     auto setBoolAttributeWithDefault = [&](const QString& attribute, bool& target, const bool defaultsTo) {
         target = attributes().hasAttribute(attribute) ? attributes().value(attribute) == YES : defaultsTo;
     };
@@ -728,6 +741,7 @@ void XMLimport::readHost(Host* pHost)
     setBoolAttributeWithDefault(qsl("enableClosedCaption"), pHost->mEnableClosedCaption, false);
     setBoolAttributeWithDefault(qsl("mEnableMTTS"), pHost->mEnableMTTS, true);
     setBoolAttributeWithDefault(qsl("mEnableMNES"), pHost->mEnableMNES, false);
+    setBoolAttributeWithDefault(qsl("mEnableMXP"), pHost->mEnableMXP, getBoolValueFromLegacyAttributeOrDefault(qsl("mFORCE_MXP_NEGOTIATION_OFF"), true, true));
     setBoolAttributeWithDefault(qsl("forceNewEnvironNegotiationOff"), pHost->mForceNewEnvironNegotiationOff, false);
 
     setBoolAttribute(qsl("autoClearCommandLineAfterSend"), pHost->mAutoClearCommandLineAfterSend);
@@ -746,7 +760,6 @@ void XMLimport::readHost(Host* pHost)
     setBoolAttribute(qsl("mEnableMSSP"), pHost->mEnableMSSP);
     setBoolAttribute(qsl("mEnableMSDP"), pHost->mEnableMSDP);
     setBoolAttribute(qsl("mEnableMSP"), pHost->mEnableMSP);
-    setBoolAttribute(qsl("mEnableMXP"), pHost->mEnableMXP);
     setBoolAttribute(qsl("mMapStrongHighlight"), pHost->mMapStrongHighlight);
     setBoolAttribute(qsl("mEnableSpellCheck"), pHost->mEnableSpellCheck);
     setBoolAttribute(qsl("mAcceptServerGUI"), pHost->mAcceptServerGUI);

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -769,7 +769,6 @@ void XMLimport::readHost(Host* pHost)
     setBoolAttribute(qsl("mFORCE_CHARSET_NEGOTIATION_OFF"), pHost->mFORCE_CHARSET_NEGOTIATION_OFF);
     setBoolAttribute(qsl("mVersionInTTYPE"), pHost->mVersionInTTYPE);
     setBoolAttribute(qsl("mPromptedForVersionInTTYPE"), pHost->mPromptedForVersionInTTYPE);
-    setBoolAttribute(qsl("mForceMXPProcessorOn"), pHost->mForceMXPProcessorOn);
     setBoolAttribute(qsl("mPromptedForMXPProcessorOn"), pHost->mPromptedForMXPProcessorOn);
     setBoolAttribute(qsl("enableTextAnalyzer"), pHost->mEnableTextAnalyzer);
     setBoolAttribute(qsl("mBubbleMode"), pHost->mBubbleMode);
@@ -785,6 +784,7 @@ void XMLimport::readHost(Host* pHost)
     setBoolAttribute(qsl("mUseProxy"), pHost->mUseProxy);
     setBoolAttribute(qsl("f3SearchEnabled"), pHost->mF3SearchEnabled);
 
+    pHost->setForceMXPProcessorOn(attributes().value(qsl("mForceMXPProcessorOn")) == YES);
     pHost->mProxyAddress = attributes().value(qsl("mProxyAddress")).toString();
 
     if (attributes().hasAttribute(QLatin1String("mProxyPort"))) {

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -769,6 +769,8 @@ void XMLimport::readHost(Host* pHost)
     setBoolAttribute(qsl("mFORCE_CHARSET_NEGOTIATION_OFF"), pHost->mFORCE_CHARSET_NEGOTIATION_OFF);
     setBoolAttribute(qsl("mVersionInTTYPE"), pHost->mVersionInTTYPE);
     setBoolAttribute(qsl("mPromptedForVersionInTTYPE"), pHost->mPromptedForVersionInTTYPE);
+    setBoolAttribute(qsl("mForceMXPProcessorOn"), pHost->mForceMXPProcessorOn);
+    setBoolAttribute(qsl("mPromptedForMXPProcessorOn"), pHost->mPromptedForMXPProcessorOn);
     setBoolAttribute(qsl("enableTextAnalyzer"), pHost->mEnableTextAnalyzer);
     setBoolAttribute(qsl("mBubbleMode"), pHost->mBubbleMode);
     setBoolAttribute(qsl("mMapViewOnly"), pHost->mMapViewOnly);

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1595,26 +1595,14 @@ void cTelnet::promptEnableTTYPEVersion()
     }
 }
 
-// Prompt user to enable MXP processor
-void cTelnet::promptEnableMXPProcessor()
+// Auto-enable MXP processor when indicators are detected
+void cTelnet::autoEnableMXPProcessor()
 {
     mpHost->mPromptedForMXPProcessorOn = true;
 
-    auto msgBox = new QMessageBox();
-    msgBox->setIcon(QMessageBox::Question);
-    msgBox->setText(tr("This game appears to support MXP (Mud eXtension Protocol).\n\nEnable this feature for clickable links, room info, and richer interactions?"));
-    msgBox->setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-    msgBox->setDefaultButton(QMessageBox::Yes);
-
-    int ret = msgBox->exec();
-    delete msgBox;
-
-    if (ret == QMessageBox::Yes) {
-        mpHost->setForceMXPProcessorOn(true);
-        postMessage(tr("[ INFO ]  - MXP processing force enabled for this profile. You can disable it later in Special Options."));
-    } else {
-        postMessage(tr("[ INFO ]  - MXP processing not force enabled. You can enable it later in Special Options."));
-    }
+    // Automatically enable MXP processing
+    mpHost->setForceMXPProcessorOn(true);
+    postMessage(tr("[ INFO ]  - This game appears to support MXP (Mud eXtension Protocol), but may not negotiate it. MXP processing has been automatically enabled for clickable links, room info, and richer interactions. You can disable this forced setting in Settings > Special Options."));
 }
 
 void cTelnet::processTelnetCommand(const std::string& telnetCommand)
@@ -3533,7 +3521,7 @@ void cTelnet::trackMXPElementDetection(const std::string& line)
 
     for (const auto& indicator : mxpIndicators) {
         if (lowerLine.find(indicator) != std::string::npos) {
-            promptEnableMXPProcessor();
+            autoEnableMXPProcessor();
             return;
         }
     }
@@ -3545,7 +3533,7 @@ void cTelnet::trackMXPElementDetection(const std::string& line)
 
     for (const auto& esc : mxpEscapes) {
         if (line.find(esc) != std::string::npos) {
-            promptEnableMXPProcessor();
+            autoEnableMXPProcessor();
             return;
         }
     }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1595,6 +1595,30 @@ void cTelnet::promptEnableTTYPEVersion()
     }
 }
 
+// Prompt user to enable MXP processor and reconnect
+void cTelnet::promptEnableMXPProcessor()
+{
+    mpHost->mPromptedForMXPProcessorOn = true;
+
+    auto msgBox = new QMessageBox();
+    msgBox->setIcon(QMessageBox::Question);
+    msgBox->setText(tr("This game appears to support MXP (Mud eXtension Protocol).\n\nEnable this feature for clickable links, room info, richer interactions and reconnect?"));
+    msgBox->setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+    msgBox->setDefaultButton(QMessageBox::Yes);
+
+    int ret = msgBox->exec();
+    delete msgBox;
+
+    if (ret == QMessageBox::Yes) {
+        disconnectIt();
+        mpHost->mForceMXPProcessorOn = true;
+        postMessage(tr("[ INFO ]  - MXP processing force enabled for this profile. Reconnecting..."));
+        reconnect();
+    } else {
+        postMessage(tr("[ INFO ]  - MXP processing not force enabled. You can enable it later in Special Options."));
+    }
+}
+
 void cTelnet::processTelnetCommand(const std::string& telnetCommand)
 {
     char ch = telnetCommand[1];
@@ -3478,21 +3502,65 @@ void cTelnet::gotPrompt(std::string& mud_data)
     mIsTimerPosting = false;
 }
 
+void cTelnet::trackMXPElementDetection(const std::string& line)
+{
+    if (!mpHost || mpHost->mPromptedForMXPProcessorOn) {
+        return;
+    }
+
+    // List of MXP startup indicators
+    static const std::vector<std::string> mxpIndicators = {
+        "<version>", "<support>", "<!element", "<!entity", "<!attlist", "<!doctype>", "<reset>", "<send"
+    };
+
+    // Convert line to lower-case for case-insensitive search
+    std::string lowerLine = line;
+    std::transform(lowerLine.begin(), lowerLine.end(), lowerLine.begin(), ::tolower);
+
+    for (const auto& indicator : mxpIndicators) {
+        if (lowerLine.find(indicator) != std::string::npos) {
+            promptEnableMXPProcessor();
+            return;
+        }
+    }
+
+    // MXP escape tags (case-sensitive, as they are control codes)
+    static const std::vector<std::string> mxpEscapes = {
+        "\x1B[0z", "\x1B[1z", "\x1B[2z", "\x1B[3z", "\x1B[4z"
+    };
+    for (const auto& esc : mxpEscapes) {
+        if (line.find(esc) != std::string::npos) {
+            promptEnableMXPProcessor();
+            return;
+        }
+    }
+}
+
 void cTelnet::gotRest(std::string& mud_data)
 {
     if (mud_data.empty()) {
         return;
     }
+
+    // MXP detection scan
+    if (!mpHost->mPromptedForMXPProcessorOn && !mpHost->mMxpProcessor.isEnabled()) {
+        trackMXPElementDetection(mud_data);
+    }
+
     if (!mGA_Driver) {
         size_t i = mud_data.rfind('\n');
+
         if (i != std::string::npos) {
             mMudData += mud_data.substr(0, i + 1);
             postData();
+
             if (!mIsTimerPosting && (mpPostingTimer->interval() != mTimeOut)) {
                 mpPostingTimer->setInterval(mTimeOut);
             }
+
             mpPostingTimer->start();
             mIsTimerPosting = true;
+
             if (i + 1 < mud_data.size()) {
                 mMudData = mud_data.substr(i + 1, mud_data.size());
             } else {
@@ -3500,15 +3568,16 @@ void cTelnet::gotRest(std::string& mud_data)
             }
         } else {
             mMudData += mud_data;
+
             if (!mIsTimerPosting) {
                 if (mpPostingTimer->interval() != mTimeOut) {
                     mpPostingTimer->setInterval(mTimeOut);
                 }
+
                 mpPostingTimer->start();
                 mIsTimerPosting = true;
             }
         }
-
     } else {
         mMudData += mud_data;
         postData();

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1610,7 +1610,7 @@ void cTelnet::promptEnableMXPProcessor()
     delete msgBox;
 
     if (ret == QMessageBox::Yes) {
-        mpHost->mForceMXPProcessorOn = true;
+        mpHost->setForceMXPProcessorOn(true);
         postMessage(tr("[ INFO ]  - MXP processing force enabled for this profile."));
     } else {
         postMessage(tr("[ INFO ]  - MXP processing not force enabled. You can enable it later in Special Options."));
@@ -1932,7 +1932,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             if (!mpHost->mEnableMXP) {
                 sendTelnetOption(TN_DONT, OPT_MXP);
 
-                if (!mpHost->mForceMXPProcessorOn) {
+                if (!mpHost->getForceMXPProcessorOn()) {
                     mpHost->mMxpProcessor.disable();
                 }
 
@@ -2073,7 +2073,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 // MXP got turned off
                 enableMXP = false;
 
-                if (!mpHost->mForceMXPProcessorOn) {
+                if (!mpHost->getForceMXPProcessorOn()) {
                     mpHost->mMxpProcessor.disable();
                 }
 
@@ -2254,7 +2254,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             } else {
                 sendTelnetOption(TN_WONT, OPT_MXP);
 
-                if (!mpHost->mForceMXPProcessorOn) {
+                if (!mpHost->getForceMXPProcessorOn()) {
                     mpHost->mMxpProcessor.disable();
                 }
 
@@ -2368,7 +2368,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             // MXP got turned off
             enableMXP = false;
 
-            if (!mpHost->mForceMXPProcessorOn) {
+            if (!mpHost->getForceMXPProcessorOn()) {
                 mpHost->mMxpProcessor.disable();
             }
 
@@ -3556,7 +3556,7 @@ void cTelnet::gotRest(std::string& mud_data)
     }
 
     // MXP detection scan
-    if (!mpHost->mPromptedForMXPProcessorOn && !mpHost->mMxpProcessor.isEnabled()) {
+    if (!mpHost->mPromptedForMXPProcessorOn && !mpHost->getForceMXPProcessorOn() && !isMXPEnabled()) {
         trackMXPElementDetection(mud_data);
     }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1602,7 +1602,7 @@ void cTelnet::promptEnableMXPProcessor()
 
     auto msgBox = new QMessageBox();
     msgBox->setIcon(QMessageBox::Question);
-    msgBox->setText(tr("This game appears to support MXP (Mud eXtension Protocol).\n\nEnable this feature for clickable links, room info, richer interactions and reconnect?"));
+    msgBox->setText(tr("This game appears to support MXP (Mud eXtension Protocol).\n\nEnable this feature for clickable links, room info, and richer interactions?"));
     msgBox->setStandardButtons(QMessageBox::Yes | QMessageBox::No);
     msgBox->setDefaultButton(QMessageBox::Yes);
 
@@ -1610,10 +1610,8 @@ void cTelnet::promptEnableMXPProcessor()
     delete msgBox;
 
     if (ret == QMessageBox::Yes) {
-        disconnectIt();
         mpHost->mForceMXPProcessorOn = true;
-        postMessage(tr("[ INFO ]  - MXP processing force enabled for this profile. Reconnecting..."));
-        reconnect();
+        postMessage(tr("[ INFO ]  - MXP processing force enabled for this profile."));
     } else {
         postMessage(tr("[ INFO ]  - MXP processing not force enabled. You can enable it later in Special Options."));
     }
@@ -1933,7 +1931,10 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
         if (option == OPT_MXP) {
             if (!mpHost->mEnableMXP) {
                 sendTelnetOption(TN_DONT, OPT_MXP);
-                mpHost->mMxpProcessor.disable();
+
+                if (!mpHost->mForceMXPProcessorOn) {
+                    mpHost->mMxpProcessor.disable();
+                }
 
                 if (enableMXP) {
                     raiseProtocolEvent("sysProtocolDisabled", "MXP");
@@ -2071,7 +2072,11 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             if (option == OPT_MXP) {
                 // MXP got turned off
                 enableMXP = false;
-                mpHost->mMxpProcessor.disable();
+
+                if (!mpHost->mForceMXPProcessorOn) {
+                    mpHost->mMxpProcessor.disable();
+                }
+
                 raiseProtocolEvent("sysProtocolDisabled", "MXP");
             }
 
@@ -2248,7 +2253,10 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 raiseProtocolEvent("sysProtocolEnabled", "MXP");
             } else {
                 sendTelnetOption(TN_WONT, OPT_MXP);
-                mpHost->mMxpProcessor.disable();
+
+                if (!mpHost->mForceMXPProcessorOn) {
+                    mpHost->mMxpProcessor.disable();
+                }
 
                 if (enableMXP) {
                     raiseProtocolEvent("sysProtocolDisabled", "MXP");
@@ -2359,7 +2367,11 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
         if (option == OPT_MXP) {
             // MXP got turned off
             enableMXP = false;
-            mpHost->mMxpProcessor.disable();
+
+            if (!mpHost->mForceMXPProcessorOn) {
+                mpHost->mMxpProcessor.disable();
+            }
+
             raiseProtocolEvent("sysProtocolDisabled", "MXP");
         }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1611,7 +1611,7 @@ void cTelnet::promptEnableMXPProcessor()
 
     if (ret == QMessageBox::Yes) {
         mpHost->setForceMXPProcessorOn(true);
-        postMessage(tr("[ INFO ]  - MXP processing force enabled for this profile."));
+        postMessage(tr("[ INFO ]  - MXP processing force enabled for this profile. You can disable it later in Special Options."));
     } else {
         postMessage(tr("[ INFO ]  - MXP processing not force enabled. You can enable it later in Special Options."));
     }
@@ -3467,24 +3467,25 @@ void cTelnet::postMessage(QString msg)
 }
 
 //forward data for further processing
-
-
 void cTelnet::gotPrompt(std::string& mud_data)
 {
     mpPostingTimer->stop();
+
     if (mpPostingTimer->interval() != mTimeOut) {
         mpPostingTimer->setInterval(mTimeOut);
     }
+
     mMudData += mud_data;
 
-    if (mUSE_IRE_DRIVER_BUGFIX && mGA_Driver) {
-        //////////////////////////////////////////////////////////////////////
-        //
-        // Patch for servers that need GA/EOR for prompt fixups
-        //
+    if (!mpHost->mPromptedForMXPProcessorOn && !mpHost->getForceMXPProcessorOn() && !isMXPEnabled()) {
+        trackMXPElementDetection(mud_data);
+    }
 
+    // Patch for servers that need GA/EOR for prompt fixups
+    if (mUSE_IRE_DRIVER_BUGFIX && mGA_Driver) {
         int j = 0;
         int s = mMudData.size();
+
         while (j < s) {
             // search for leading <LF> but skip leading ANSI control sequences
             if (mMudData[j] == 0x1B) {
@@ -3496,6 +3497,7 @@ void cTelnet::gotPrompt(std::string& mud_data)
                     ++j;
                 }
             }
+
             if (mMudData[j] == '\n') {
                 mMudData.erase(j, 1);
                 break;
@@ -3505,8 +3507,6 @@ void cTelnet::gotPrompt(std::string& mud_data)
         NEXT:
             ++j;
         }
-        //
-        ////////////////////////////
     }
 
     postData();
@@ -3522,7 +3522,9 @@ void cTelnet::trackMXPElementDetection(const std::string& line)
 
     // List of MXP startup indicators
     static const std::vector<std::string> mxpIndicators = {
-        "<version>", "<support>", "<!element", "<!entity", "<!attlist", "<!doctype>", "<reset>", "<send"
+        "<version>", "<support>",
+        "<!element", "<!entity", "<!attlist", "<!tag",
+        "<send ", "<a ", "<expire ", "<sound ", "<music ", "<var ", "<color "
     };
 
     // Convert line to lower-case for case-insensitive search
@@ -3603,7 +3605,13 @@ void cTelnet::slot_timerPosting()
     if (!mIsTimerPosting) {
         return;
     }
+
     mMudData += "\r";
+
+    if (!mpHost->mPromptedForMXPProcessorOn && !mpHost->getForceMXPProcessorOn() && !isMXPEnabled()) {
+        trackMXPElementDetection(mMudData);
+    }
+
     postData();
     mMudData = "";
     mIsTimerPosting = false;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1595,7 +1595,7 @@ void cTelnet::promptEnableTTYPEVersion()
     }
 }
 
-// Prompt user to enable MXP processor and reconnect
+// Prompt user to enable MXP processor
 void cTelnet::promptEnableMXPProcessor()
 {
     mpHost->mPromptedForMXPProcessorOn = true;
@@ -3540,6 +3540,7 @@ void cTelnet::trackMXPElementDetection(const std::string& line)
     static const std::vector<std::string> mxpEscapes = {
         "\x1B[0z", "\x1B[1z", "\x1B[2z", "\x1B[3z", "\x1B[4z"
     };
+
     for (const auto& esc : mxpEscapes) {
         if (line.find(esc) != std::string::npos) {
             promptEnableMXPProcessor();

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -328,7 +328,7 @@ private:
     static std::pair<bool, bool> testReadReplayFile();
 
     void trackKaVirNegotiation(unsigned char option);
-    void promptEnableMXPProcessor();
+    void autoEnableMXPProcessor();
     void promptEnableTTYPEVersion();
 
     QPointer<Host> mpHost;

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -223,6 +223,7 @@ public:
     bool isMSPEnabled() const { return enableMSP; }
     bool isMXPEnabled() const { return enableMXP; }
     bool isChannel102Enabled() const { return enableChannel102; }
+    void trackMXPElementDetection(const std::string&);
     void requestDiscordInfo();
     QString decodeOption(const unsigned char) const;
     QAbstractSocket::SocketState getConnectionState() const { return socket.state(); }
@@ -327,6 +328,7 @@ private:
     static std::pair<bool, bool> testReadReplayFile();
 
     void trackKaVirNegotiation(unsigned char option);
+    void promptEnableMXPProcessor();
     void promptEnableTTYPEVersion();
 
     QPointer<Host> mpHost;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -645,6 +645,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     mFORCE_CHARSET_NEGOTIATION_OFF->setChecked(pHost->mFORCE_CHARSET_NEGOTIATION_OFF);
     checkBox_mVersionInTTYPE->setChecked(pHost->mVersionInTTYPE);
+    checkBox_mForceMXPProcessorOn->setChecked(pHost->mForceMXPProcessorOn);
     mForceNewEnvironNegotiationOff->setChecked(pHost->mForceNewEnvironNegotiationOff);
     mMapperUseAntiAlias->setChecked(pHost->mMapperUseAntiAlias);
     checkbox_mMapperShowRoomBorders->setChecked(pHost->mMapperShowRoomBorders);
@@ -1384,6 +1385,7 @@ void dlgProfilePreferences::clearHostDetails()
 
     mFORCE_CHARSET_NEGOTIATION_OFF->setChecked(false);
     checkBox_mVersionInTTYPE->setChecked(false);
+    checkBox_mForceMXPProcessorOn->setChecked(false);
     mForceNewEnvironNegotiationOff->setChecked(false);
     mMapperUseAntiAlias->setChecked(false);
     checkbox_mMapperShowRoomBorders->setChecked(false);
@@ -2944,6 +2946,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         pHost->commandLineMinimumHeight = commandLineMinimumHeight->value();
         pHost->mFORCE_CHARSET_NEGOTIATION_OFF = mFORCE_CHARSET_NEGOTIATION_OFF->isChecked();
         pHost->mVersionInTTYPE = checkBox_mVersionInTTYPE->isChecked();
+        pHost->mForceMXPProcessorOn = checkBox_mForceMXPProcessorOn->isChecked();
         pHost->mForceNewEnvironNegotiationOff = mForceNewEnvironNegotiationOff->isChecked();
         pHost->mIsNextLogFileInHtmlFormat = mIsToLogInHtml->isChecked();
         pHost->mIsLoggingTimestamps = mIsLoggingTimestamps->isChecked();

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -645,7 +645,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     mFORCE_CHARSET_NEGOTIATION_OFF->setChecked(pHost->mFORCE_CHARSET_NEGOTIATION_OFF);
     checkBox_mVersionInTTYPE->setChecked(pHost->mVersionInTTYPE);
-    checkBox_mForceMXPProcessorOn->setChecked(pHost->mForceMXPProcessorOn);
+    checkBox_mForceMXPProcessorOn->setChecked(pHost->getForceMXPProcessorOn());
     mForceNewEnvironNegotiationOff->setChecked(pHost->mForceNewEnvironNegotiationOff);
     mMapperUseAntiAlias->setChecked(pHost->mMapperUseAntiAlias);
     checkbox_mMapperShowRoomBorders->setChecked(pHost->mMapperShowRoomBorders);
@@ -2946,7 +2946,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         pHost->commandLineMinimumHeight = commandLineMinimumHeight->value();
         pHost->mFORCE_CHARSET_NEGOTIATION_OFF = mFORCE_CHARSET_NEGOTIATION_OFF->isChecked();
         pHost->mVersionInTTYPE = checkBox_mVersionInTTYPE->isChecked();
-        pHost->mForceMXPProcessorOn = checkBox_mForceMXPProcessorOn->isChecked();
+        pHost->setForceMXPProcessorOn(checkBox_mForceMXPProcessorOn->isChecked());
         pHost->mForceNewEnvironNegotiationOff = mForceNewEnvironNegotiationOff->isChecked();
         pHost->mIsNextLogFileInHtmlFormat = mIsToLogInHtml->isChecked();
         pHost->mIsLoggingTimestamps = mIsLoggingTimestamps->isChecked();

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -4011,7 +4011,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item row="3" column="0">
            <widget class="QCheckBox" name="checkBox_mForceMXPProcessorOn">
             <property name="toolTip">
-             <string>&lt;p&gt;Some servers do not negotiate Mud eXtension Protocol (MXP). When checked, this preference forces the MXP processor to be enabled.&lt;/p&gt;</string>
+             <string>&lt;p&gt;Some servers do not negotiate Mud eXtension Protocol (MXP). When checked, this preference forces the MXP processor to be enabled. Note: To disable MXP entirely, leave this unchecked and also uncheck MXP in Choose protocols section of the General tab in Settings.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string>Force MXP processing on</string>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -4008,6 +4008,16 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="checkBox_mForceMXPProcessorOn">
+            <property name="toolTip">
+             <string>&lt;p&gt;Some servers do not negotiate Mud eXtension Protocol (MXP). When checked, this preference forces the MXP processor to be enabled.&lt;/p&gt;</string>
+            </property>
+            <property name="text">
+             <string>Force MXP processing on</string>
+            </property>
+           </widget>
+          </item>
           <item row="4" column="0" colspan="2">
            <widget class="QLabel" name="need_reconnect_for_specialoption">
             <property name="enabled">
@@ -4508,6 +4518,7 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>mFORCE_GA_OFF</tabstop>
   <tabstop>mFORCE_CHARSET_NEGOTIATION_OFF</tabstop>
   <tabstop>checkBox_mVersionInTTYPE</tabstop>
+  <tabstop>checkBox_mForceMXPProcessorOn</tabstop>
   <tabstop>checkBox_mUSE_FORCE_LF_AFTER_PROMPT</tabstop>
   <tabstop>mForceNewEnvironNegotiationOff</tabstop>
   <tabstop>buttonPurgeMediaCache</tabstop>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

This PR is a follow-up to #7862 and improves how Mudlet handles MXP support across old profiles, new profiles, and in-band detection scenarios:

1. Ensures the *Choose Protocols → MXP* preference is correctly defaulted to checked on first load of existing profiles that did not previously have it set (new profiles already worked).
2. Migrates the old "disable MXP" special option to uncheck the *Choose Protocols → MXP* setting for users who previously opted out.
3. Retains support for scripts using the deprecated `getConfig("specialForceMxpNegotiationOff")` and `setConfig(...)`.
4. Adds content-based MXP detection: if the MXP processor is off and tags like `<VERSION>`, `<SUPPORT>`, or `<!ELEMENT>` are detected, MXP is automatically enabled once per profile with a console notification.

#### Motivation for adding to Mudlet

MXP negotiation is not required by spec. Games fall into one of three categories:
1. Games that do not use MXP at all — enabling the processor may break gameplay.
2. Games that negotiate MXP — StickMUD and others using the KaVir protocol snippet work as expected.
3. Games like Lusternia — expect MXP to be processed based on user-side `CONFIG MXP ON` without negotiation.

This PR improves compatibility in all three cases:
- By default, MXP is off unless negotiated or enabled by the user.
- When tags indicating MXP use are detected without negotiation, MXP is automatically enabled once per profile with a console message explaining what happened and how to disable it.
- Prior profile settings and legacy script API usage are honored and migrated smoothly.

#### Other info (issues closed, discussion etc)

Fixes #7833  
Related to and builds on #7862

Future idea: migrate CHARSET and NEW-ENVIRON to the protocol dropdown to simplify the UI further.

---

https://github.com/user-attachments/assets/ec21db2d-89b1-404e-acff-3bae472a6e0c
