### PR TITLE
Improvement: Support custom opacity miniconsole backgrounds

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -96,7 +96,11 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     }
     setContentsMargins(0, 0, 0, 0);
     setAttribute(Qt::WA_DeleteOnClose);
-    setAttribute(Qt::WA_OpaquePaintEvent); //was disabled
+    setAttribute(Qt::WA_OpaquePaintEvent, false);
+
+    QPalette transparentBgPalette;
+    transparentBgPalette.setColor(QPalette::Window, QColor(0, 0, 0, 0));
+    setPalette(transparentBgPalette);
 
     const QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     const QSizePolicy sizePolicy3(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -105,13 +109,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     const QSizePolicy sizePolicy5(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
     mpMainFrame->setContentsMargins(0, 0, 0, 0);
-
-    QPalette framePalette;
-    framePalette.setColor(QPalette::Text, QColor(Qt::black));
-    framePalette.setColor(QPalette::Highlight, QColor(55, 55, 255));
-    framePalette.setColor(QPalette::Window, QColor(0, 0, 0, 255));
-    mpMainFrame->setPalette(framePalette);
-    mpMainFrame->setAutoFillBackground(true);
+    mpMainFrame->setPalette(transparentBgPalette);
     mpMainFrame->setObjectName(qsl("MainFrame"));
 
     auto centralLayout = new QVBoxLayout;
@@ -886,6 +884,14 @@ void TConsole::changeColors()
         if (!mBgImageMode) {
             auto styleSheet = qsl("QWidget#MainDisplay{background-color: rgba(%1);}").arg(getColorCode(mBgColor));
             mpMainDisplay->setStyleSheet(styleSheet);
+
+            QPalette transparentBgPalette;
+            transparentBgPalette.setColor(QPalette::Window, QColor(0, 0, 0, 0));
+            mpBaseVFrame->setPalette(transparentBgPalette);
+            mpBaseHFrame->setPalette(transparentBgPalette);
+            mpMainFrame->setPalette(transparentBgPalette);
+            mpMainDisplay->setPalette(transparentBgPalette);
+            setPalette(transparentBgPalette);
         } else {
             setConsoleBackgroundImage(mBgImagePath, mBgImageMode);
         }

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -674,7 +674,7 @@ int TTextEdit::drawGraphemeBackground(QPainter& painter, QVector<QColor>& fgColo
     if (caretIsHere) {
         bgColor = mCaretColor;
     }
-    if (!textRect.isNull()) {
+    if (!textRect.isNull() && bgColor != mpConsole->getConsoleBgColor()) {
         painter.fillRect(textRect, bgColor);
     }
     return charWidth;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Make everything below the top-layer of TConsoles transparent, which enables transparent miniconsole backgrounds by setting alpha values via <miniconsole>:setcolor(R,G,B,alpha).

Make TTextEdit only draw text backgrounds if the background color != the background color of the miniconsole.

#### Motivation for adding to Mudlet
It could be nice for some UI effects to have miniconsoles with custom opacity.

#### Other info (issues closed, discussion etc)
From my understanding, QT transparency can vary between OSes, if anyone would be willing to test this PR on MacOS I'd appreciate it! It's working as is on Windows 11 (edit: and Linux (Fedora/GNOME)). I'd also be happy for anyone willing to double check that this doesn't mess with their UIs unintentionally! So far my testing suggest that it shouldn't be an issue.

Fixes #6472

E.g.
![image](https://github.com/user-attachments/assets/6ec978d6-52fb-49a5-ae62-265e30589c1b)

Test script:
```
miniwindow = Geyser.MiniConsole:new({name = "indent-test",autoWrap = true})
clearWindow("indent-test")
miniwindow:move(50,10)
miniwindow:setColor(0,0,255,50)
setWindowWrap("indent-test", 30)
cecho("indent-test",
"\n\t\tText with no colors\
\t\t<red>Fg color red\
\t\t<:orange>Bg color orange\
<reset>\t\taaand we're reset!")

clearWindow("main")
cecho("\n\n\nText behind!!! Sadly so hard to read behind other text :(")
cecho("\nText behind!!!")
cecho("\nText behind!!!")
cecho("\nText behind!!!")
cecho("\nText behind!!!")
```