### PR TITLE
Infrastructure: rationalise font handling

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -216,7 +216,6 @@ QString stopWatch::getElapsedDayTimeString() const
 
 Host::Host(int port, const QString& hostname, const QString& login, const QString& pass, int id)
 : mTelnet(this, hostname)
-, mpConsole(nullptr)
 , mLuaInterpreter(this, hostname, id)
 , commandLineMinimumHeight(30)
 , mAlertOnNewData(true)
@@ -226,7 +225,6 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mBlockScriptCompile(true)
 , mBlockStopWatchCreation(true)
 , mEchoLuaErrors(false)
-, mCommandLineFont(QFont(qsl("Bitstream Vera Sans Mono"), 14, QFont::Normal))
 , mCommandSeparator(qsl(";;"))
 , mMxpClient(this)
 , mMxpProcessor(&mMxpClient)
@@ -240,7 +238,6 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mUseProxy(false)
 , mProxyPort(0)
 , mIsProfileLoadingSequence(false)
-, mNoAntiAlias(false)
 , mpEditorDialog(nullptr)
 , mpMap(new TMap(this, hostname))
 , mpMedia(new TMedia(this, hostname))
@@ -293,7 +290,6 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mpDlgIRC(nullptr)
 , mpDlgProfilePreferences(nullptr)
 , mTutorialForCompactLineAlreadyShown(false)
-, mDisplayFont(QFont(qsl("Bitstream Vera Sans Mono"), 14, QFont::Normal))
 , mLuaInterface(nullptr)
 , mTriggerUnit(this)
 , mTimerUnit(this)
@@ -326,6 +322,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mCompactInputLine(false)
 {
     TDebug::addHost(this, mHostName);
+    setDisplayFont(QFont(qsl("Bitstream Vera Sans Mono"), 14, QFont::Normal));
 
     // The "autolog" sentinel file controls whether logging the game's text as
     // plain text or HTML is immediately resumed on profile loading. Do not
@@ -1026,33 +1023,34 @@ QString Host::getMmpMapLocation() const
 // error and debug consoles inherit font of the main console
 void Host::updateConsolesFont()
 {
-    if (mpConsole) {
-        mpConsole->refreshView();
-
-        TEvent event{};
-        event.mArgumentList.append(qsl("sysSettingChanged"));
-        event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-        event.mArgumentList.append(qsl("main window font"));
-        event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-        event.mArgumentList.append(mDisplayFont.family());
-        event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-        event.mArgumentList.append(QString::number(mDisplayFont.pointSize()));
-        event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-        raiseEvent(event);
+    if (!mpConsole) {
+        qWarning().nospace().noquote() << "Host::updateConsolesFont() WARNING - no TMainConsole to deal with font releated operatione.";
+        return;
     }
 
-    if (mpEditorDialog && mpEditorDialog->mpErrorConsole) {
-        mpEditorDialog->mpErrorConsole->setFontName(mDisplayFont.family());
-        mpEditorDialog->mpErrorConsole->setFontSize(mDisplayFont.pointSize());
+    mpConsole->refreshView();
+
+    TEvent event{};
+    event.mArgumentList.append(qsl("sysSettingChanged"));
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    event.mArgumentList.append(qsl("main window font"));
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    event.mArgumentList.append(mpConsole->font().family());
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    event.mArgumentList.append(QString::number(mpConsole->font().pointSize()));
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    raiseEvent(event);
+
+    if (mpEditorDialog) {
+        mpEditorDialog->setDisplayFont(mpConsole->font());
     }
 
     if (mudlet::self()->smpDebugArea) {
-        mudlet::self()->smpDebugConsole->setFontName(mDisplayFont.family());
-        mudlet::self()->smpDebugConsole->setFontSize(mDisplayFont.pointSize());
+        mudlet::self()->smpDebugConsole->setFont(mpConsole->font());
     }
 
     if (mpNotePad) {
-        mpNotePad->setFont(mDisplayFont);
+        mpNotePad->setFont(mpConsole->font());
     }
 }
 
@@ -1097,6 +1095,7 @@ QString Host::mediaLocationMSP() const
     return mMediaLocationMSP;
 }
 
+// Completely specifies the font for use in the main console and elsewhere:
 std::pair<bool, QString> Host::setDisplayFont(const QFont& font)
 {
     const QFontMetrics metrics(font);
@@ -1104,11 +1103,24 @@ std::pair<bool, QString> Host::setDisplayFont(const QFont& font)
         return {false, qsl("specified font is invalid (its letters have 0 width)")};
     }
 
-    mDisplayFont = font;
-    updateConsolesFont();
+    if (mpConsole) {
+        if (mpConsole->font() != font) {
+            mpConsole->setFont(font);
+
+            updateConsolesFont();
+        }
+        return {true, QString()};
+    }
+
+    qDebug().noquote().nospace() << "Host::setDisplayFont(...) INFO - No TMainConsole to set font for - faking it";
+
+    mTempDisplayFontAttributes = TFontAttributes(font);
+    mTempDisplayFont = mTempDisplayFontAttributes.value().makeFont();
+
     return {true, QString()};
 }
 
+// Also completely specifies the font for use in the main console and elsewhere:
 void Host::setDisplayFontFromString(const QString& fontData)
 {
     QFont font;
@@ -1118,8 +1130,22 @@ void Host::setDisplayFontFromString(const QString& fontData)
 
 void Host::setDisplayFontSize(int size)
 {
-    mDisplayFont.setPointSize(size);
-    updateConsolesFont();
+    if (mpConsole) {
+        if (mpConsole->font().pointSize() != size) {
+            mpConsole->setFontSize(size);
+            updateConsolesFont();
+        }
+
+        return;
+    }
+
+    qDebug().noquote().nospace() << "Host::setDisplayFontSize(...) INFO - No TMainConsole to set font for - faking it";
+    if (!mTempDisplayFontAttributes.has_value()) {
+        mTempDisplayFontAttributes = TFontAttributes(!mNoAntiAlias);
+    }
+
+    mTempDisplayFontAttributes.value().mPointSize = size;
+    mTempDisplayFont = mTempDisplayFontAttributes.value().makeFont();
 }
 
 // Now returns the total weight of the path
@@ -2948,21 +2974,6 @@ std::unique_ptr<QNetworkProxy>& Host::getConnectionProxy()
     return mpDownloaderProxy;
 }
 
-void Host::setDisplayFontSpacing(const qreal spacing)
-{
-    mDisplayFont.setLetterSpacing(QFont::AbsoluteSpacing, spacing);
-}
-
-void Host::setDisplayFontStyle(QFont::StyleStrategy s)
-{
-    mDisplayFont.setStyleStrategy(s);
-}
-
-void Host::setDisplayFontFixedPitch(bool enable)
-{
-    mDisplayFont.setFixedPitch(enable);
-}
-
 void Host::loadSecuredPassword()
 {
     auto *job = new QKeychain::ReadPasswordJob(qsl("Mudlet profile"));
@@ -3867,20 +3878,18 @@ QSize Host::calcFontSize(const QString& windowName)
         return QSize(-1, -1);
     }
 
-    QFont font;
     if (windowName.isEmpty() || windowName.compare(qsl("main"), Qt::CaseSensitive) == 0) {
-        font = mDisplayFont;
-    } else {
-        auto pC = mpConsole->mSubConsoleMap.value(windowName);
-        if (pC) {
-            Q_ASSERT_X(pC->mUpperPane, "calcFontSize", "located console does not have the upper pane available");
-            font = pC->mUpperPane->mDisplayFont;
-        } else {
-            return QSize(-1, -1);
-        }
+        QFontMetrics fontMetrics(mpConsole->mUpperPane->fontMetrics());
+        return QSize(fontMetrics.horizontalAdvance(QChar('W')), fontMetrics.height());
     }
 
-    auto fontMetrics = QFontMetrics(font);
+    auto pC = mpConsole->mSubConsoleMap.value(windowName);
+    if (!pC) {
+        return QSize(-1, -1);
+    }
+
+    Q_ASSERT_X(pC->mUpperPane, "calcFontSize", "located console does not have the upper pane available");
+    QFontMetrics fontMetrics(pC->mUpperPane->fontMetrics());
     return QSize(fontMetrics.horizontalAdvance(QChar('W')), fontMetrics.height());
 }
 
@@ -4413,4 +4422,28 @@ void Host::setRemoteEchoingActive(bool active)
         mIsRemoteEchoingActive = active;
         emit signal_remoteEchoChanged(active);
     }
+}
+
+QFont Host::getDisplayFont()
+{
+    if (mpConsole) {
+        return mpConsole->font();
+    }
+
+    qDebug().noquote().nospace() << "Host::getDisplayFont() INFO - No TMainConsole to get font from - faking it";
+
+    if (!mTempDisplayFontAttributes.has_value() || !mTempDisplayFont.has_value()) {
+        mTempDisplayFontAttributes = TFontAttributes(!mNoAntiAlias);
+        mTempDisplayFont = mTempDisplayFontAttributes.value().makeFont();
+    }
+
+    return mTempDisplayFont.value();
+}
+
+QFont Host::getAndClearTempDisplayFont()
+{
+    QFont tempFont = mTempDisplayFont.value();
+    mTempDisplayFont.reset();
+    mTempDisplayFontAttributes.reset();
+    return tempFont;
 }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1024,7 +1024,7 @@ QString Host::getMmpMapLocation() const
 void Host::updateConsolesFont()
 {
     if (!mpConsole) {
-        qWarning().nospace().noquote() << "Host::updateConsolesFont() WARNING - no TMainConsole to deal with font releated operatione.";
+        qWarning().nospace().noquote() << "Host::updateConsolesFont() WARNING - no TMainConsole to deal with font releated operations.";
         return;
     }
 

--- a/src/Host.h
+++ b/src/Host.h
@@ -339,13 +339,13 @@ public:
     QString mediaLocationGMCP() const;
     void setMediaLocationMSP(const QString& mediaUrl);
     QString mediaLocationMSP() const;
-    const QFont& getDisplayFont() const { return mDisplayFont; }
+    // Use this rather than accessng the TMainConsole::font() as the latter
+    // isn't always around during profile start-up:
+    QFont getDisplayFont();
+    QFont getAndClearTempDisplayFont();
     std::pair<bool, QString> setDisplayFont(const QFont&);
     void setDisplayFontFromString(const QString&);
     void setDisplayFontSize(int size);
-    void setDisplayFontSpacing(const qreal spacing);
-    void setDisplayFontStyle(QFont::StyleStrategy s);
-    void setDisplayFontFixedPitch(bool enable);
     void updateProxySettings(QNetworkAccessManager* manager);
     std::unique_ptr<QNetworkProxy>& getConnectionProxy();
     void updateAnsi16ColorsInTable();
@@ -434,9 +434,22 @@ public:
     }
 
     void sendCmdLine(const QString& cmd);
+    bool fontsAntiAlias() const { return !mNoAntiAlias; }
 
-    cTelnet mTelnet;
+private:
+    bool mNoAntiAlias = false;
+    // These are used only during profile initiation to provide faked details
+    // for things looking to the main console font before it gets instantiated:
+    std::optional<TFontAttributes> mTempDisplayFontAttributes;
+    std::optional<QFont> mTempDisplayFont;
+
+public:
+    // Make this the first public member instantiated so we can use ITS font
+    // as the "reference" or "master" font for whole profile - and so we don't
+    // have to maintain a separate one here in this class which does not, as
+    // something derived from a QOject, have one:
     QPointer<TMainConsole> mpConsole;
+    cTelnet mTelnet;
     QPointer<dlgPackageManager> mpPackageManager;
     QPointer<dlgModuleManager> mpModuleManager;
     TLuaInterpreter mLuaInterpreter;
@@ -453,7 +466,6 @@ public:
     bool mBlockScriptCompile;
     bool mBlockStopWatchCreation;
     bool mEchoLuaErrors;
-    QFont mCommandLineFont;
     QString mCommandSeparator;
     bool mEnableGMCP = true;
     bool mEnableMSSP = true;
@@ -495,7 +507,6 @@ public:
     // pushed down:
     bool mIsProfileLoadingSequence;
 
-    bool mNoAntiAlias;
 
     dlgTriggerEditor* mpEditorDialog;
     QScopedPointer<TMap> mpMap;
@@ -775,8 +786,6 @@ private:
     TCommandLine* activeCommandLine();
     void closeChildren();
 
-
-    QFont mDisplayFont;
     QStringList mModulesToSync;
     QScopedPointer<LuaInterface> mLuaInterface;
 

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2429,6 +2429,10 @@ void T2DMap::paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, c
         // Can't call pRoom->getArea() further down without a valid pRoom!
         return;
     }
+
+    painter.save();
+    painter.setFont(mpHost->getDisplayFont());
+
     int yOffset = 20;
     const int initialYOffset = yOffset;
     // Left margin for info widget:
@@ -2471,6 +2475,8 @@ void T2DMap::paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, c
     if (yOffset > initialYOffset) {
         painter.fillRect(xOffset, 10, width() - 10 - xOffset, 10, mpHost->mMapInfoBg);
     }
+
+    painter.restore();
 }
 
 int T2DMap::paintMapInfoContributor(QPainter& painter, int xOffset, int yOffset, const MapInfoProperties& properties)

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -52,7 +52,7 @@ TCommandLine::TCommandLine(Host* pHost, const QString& name, CommandLineType typ
     setAutoFillBackground(true);
     setFocusPolicy(Qt::StrongFocus);
 
-    setFont(mpHost->getDisplayFont());
+    setFont(mpConsole->font());
     document()->setDocumentMargin(2);
 
     if (mType & (MainCommandLine|ConsoleCommandLine)) {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1345,7 +1345,7 @@ void TConsole::setFontSize(int size)
 {
     if (mDisplayFontDetails.mPointSize != size) {
         mDisplayFontDetails.mPointSize = size;
-        setFont(mDisplayFontDetails.makeFont());
+        setFont(mDisplayFontDetails.makeFont(), true);
     }
 }
 
@@ -1461,10 +1461,10 @@ void TConsole::raiseFontChangeEvent()
     mpHost->raiseEvent(fontChangeEvent);
 }
 
-void TConsole::setFont(const QFont& newFont)
+void TConsole::setFont(const QFont& newFont, const bool forceChange)
 {
     TFontAttributes newFontDetails(newFont);
-    if (mDisplayFontDetails != newFontDetails) {
+    if (forceChange || (mDisplayFontDetails != newFontDetails)) {
         mDisplayFontDetails = newFontDetails;
         QWidget::setFont(newFont);
         // Update associated TCommandLine's:
@@ -1491,7 +1491,7 @@ void TConsole::setFont(const QFont& newFont)
 void TConsole::setFontName(const QString& fontName)
 {
     mDisplayFontDetails.mName = fontName;
-    setFont(mDisplayFontDetails.makeFont());
+    setFont(mDisplayFontDetails.makeFont(), true);
     refreshView();
 }
 

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -60,6 +60,7 @@ const QString TConsole::cmLuaLineVariable("line");
 TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidget* parent)
 : QWidget(parent)
 , mpHost(pH)
+, mDisplayFontDetails((type == MainConsole) && pH->fontsAntiAlias())
 , buffer(pH, this)
 , emergencyStop(new QToolButton)
 , mConsoleName(name)
@@ -94,6 +95,9 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
         mCommandBgColor = mpHost->mCommandBgColor;
         mCommandFgColor = mpHost->mCommandFgColor;
     }
+
+    QWidget::setFont(mDisplayFontDetails.makeFont());
+
     setContentsMargins(0, 0, 0, 0);
     setAttribute(Qt::WA_DeleteOnClose);
     setAttribute(Qt::WA_OpaquePaintEvent); //was disabled
@@ -198,6 +202,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
         mpCommandLine = new TCommandLine(pH, qsl("main"), TCommandLine::MainCommandLine, this, mpMainDisplay);
         mpCommandLine->setContentsMargins(0, 0, 0, 0);
         mpCommandLine->setSizePolicy(sizePolicy);
+        mpCommandLine->setFont(font());
         // Setting the focusProxy cannot be done here because things have not
         // been completed enough at this point - it has been defered to a
         // zero-timer at the end of this constructor
@@ -232,11 +237,13 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     mUpperPane->setContentsMargins(0, 0, 0, 0);
     mUpperPane->setSizePolicy(sizePolicy3);
     mUpperPane->setAccessibleName(tr("main window"));
+    mUpperPane->setFont(font());
 
     mLowerPane = new TTextEdit(this, splitter, &buffer, mpHost, true);
     mLowerPane->setObjectName(qsl("lowerPane_%1_%2").arg(mProfileName, mConsoleName));
     mLowerPane->setContentsMargins(0, 0, 0, 0);
     mLowerPane->setSizePolicy(sizePolicy3);
+    mLowerPane->setFont(font());
 
     if (mType == MainConsole) {
         setFocusProxy(mpCommandLine);
@@ -402,7 +409,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     mpBufferSearchBox->setMinimumSize(QSize(100, 30));
     mpBufferSearchBox->setMaximumSize(QSize(150, 30));
     mpBufferSearchBox->setSizePolicy(sizePolicy5);
-    mpBufferSearchBox->setFont(mpHost->mCommandLineFont);
+    mpBufferSearchBox->setFont(font());
     mpBufferSearchBox->setFocusPolicy(Qt::ClickFocus);
     mpBufferSearchBox->setPlaceholderText("Search ...");
     QPalette commandLinePalette;
@@ -500,6 +507,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
         mpMainFrame->move(0, 0);
         mpMainDisplay->move(0, 0);
     }
+
     if (mType & CentralDebugConsole) {
         layerCommandLine->hide();
     }
@@ -527,9 +535,6 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
 
     // error and debug consoles inherit font of the main console
     if (mType & (ErrorConsole | CentralDebugConsole)) {
-        mDisplayFont = mpHost->getDisplayFont();
-        mDisplayFontName = mDisplayFont.family();
-        mDisplayFontSize = mDisplayFont.pointSize();
 
         // They always use "Control Pictures" to show control characters:
         mControlCharacter = ControlCharacterMode::Picture;
@@ -543,12 +548,9 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
         setMouseTracking(true);
     }
 
-
     if (mType & MainConsole) {
         mpButtonMainLayer->setVisible(!mpHost->getCompactInputLine());
-    }
 
-    if (mType & MainConsole) {
         mpCommandLine->adjustHeight();
     }
 
@@ -709,7 +711,7 @@ void TConsole::refresh()
 
     mpMainDisplay->resize(x - mBorders.left() - mBorders.right(), y - mBorders.top() - mBorders.bottom() - mpCommandLine->height());
 
-    if (mType & MainConsole) {
+    if (!mpCommandLine.isNull()) {
         mpCommandLine->adjustHeight();
     }
 
@@ -872,17 +874,9 @@ QString getColorCode(QColor color)
 
 void TConsole::changeColors()
 {
-    mDisplayFont.setFixedPitch(true);
     if (mType == CentralDebugConsole) {
-        mDisplayFont.setStyleStrategy((QFont::StyleStrategy)(QFont::NoAntialias | QFont::PreferQuality));
-        mDisplayFont.setFixedPitch(true);
-        mUpperPane->setFont(mDisplayFont);
-        mLowerPane->setFont(mDisplayFont);
+        // No-op now?
     } else if (mType & (ErrorConsole|SubConsole|UserWindow|Buffer)) {
-        mDisplayFont.setStyleStrategy(QFont::StyleStrategy(QFont::NoAntialias | QFont::PreferQuality));
-        mDisplayFont.setFixedPitch(true);
-        mUpperPane->setFont(mDisplayFont);
-        mLowerPane->setFont(mDisplayFont);
         if (!mBgImageMode) {
             auto styleSheet = qsl("QWidget#MainDisplay{background-color: rgba(%1);}").arg(getColorCode(mBgColor));
             mpMainDisplay->setStyleSheet(styleSheet);
@@ -907,15 +901,6 @@ void TConsole::changeColors()
             mpCommandLine->mRegularPalette = commandLinePalette;
             mpCommandLine->setStyleSheet(styleSheet);
         }
-        if (mpHost->mNoAntiAlias) {
-            mpHost->setDisplayFontStyle(QFont::NoAntialias);
-        } else {
-            mpHost->setDisplayFontStyle(QFont::StyleStrategy(QFont::PreferAntialias | QFont::PreferQuality));
-        }
-        mpHost->setDisplayFontFixedPitch(true);
-        mDisplayFont.setFixedPitch(true);
-        mUpperPane->setFont(mpHost->getDisplayFont());
-        mLowerPane->setFont(mpHost->getDisplayFont());
         if (!mBgImageMode) {
             auto styleSheet = qsl("QWidget#MainDisplay{background-color: rgba(%1);}").arg(getColorCode(mpHost->mBgColor));
             mpMainDisplay->setStyleSheet(styleSheet);
@@ -926,9 +911,6 @@ void TConsole::changeColors()
         mFgColor = mpHost->mFgColor;
         mCommandFgColor = mpHost->mCommandFgColor;
         mCommandBgColor = mpHost->mCommandBgColor;
-        if (mpCommandLine) {
-            mpCommandLine->setFont(mpHost->getDisplayFont());
-        }
         mFormatCurrent.setColors(mpHost->mFgColor, mpHost->mBgColor);
     } else {
         Q_ASSERT_X(false, "TConsole::changeColors()", "invalid TConsole type detected");
@@ -1359,12 +1341,12 @@ void TConsole::luaWrapLine(int line)
     buffer.wrapLine(line, mWrapAt, mIndentCount, ch);
 }
 
-bool TConsole::setFontSize(int size)
+void TConsole::setFontSize(int size)
 {
-    mDisplayFontSize = size;
-
-    refreshView();
-    return true;
+    if (mDisplayFontDetails.mPointSize != size) {
+        mDisplayFontDetails.mPointSize = size;
+        setFont(mDisplayFontDetails.makeFont());
+    }
 }
 
 bool TConsole::setConsoleBackgroundImage(const QString& imgPath, int mode)
@@ -1418,6 +1400,7 @@ void TConsole::setCmdVisible(bool isVisible)
         mpCommandLine->setContentsMargins(0, 0, 0, 0);
         mpCommandLine->setSizePolicy(sizePolicy);
         mpCommandLine->setFocusPolicy(Qt::StrongFocus);
+        mpCommandLine->setFont(font());
         // put this CommandLine in the mainConsoles SubCommandLineMap
         // name is the console name
         mpHost->mpConsole->mSubCommandLineMap[mConsoleName] = mpCommandLine;
@@ -1449,22 +1432,67 @@ void TConsole::setCmdVisible(bool isVisible)
 
 void TConsole::refreshView() const
 {
-    mUpperPane->mDisplayFont = QFont(mDisplayFontName, mDisplayFontSize, QFont::Normal);
-    mUpperPane->setFont(mUpperPane->mDisplayFont);
+    mUpperPane->setFont(font());
     mUpperPane->updateScreenView();
     mUpperPane->forceUpdate();
-    mLowerPane->mDisplayFont = QFont(mDisplayFontName, mDisplayFontSize, QFont::Normal);
-    mLowerPane->setFont(mLowerPane->mDisplayFont);
+    mLowerPane->setFont(font());
     mLowerPane->updateScreenView();
     mLowerPane->forceUpdate();
 }
 
-bool TConsole::setFontName(const QString& fontName)
+void TConsole::raiseFontChangeEvent()
 {
-    mDisplayFontName = fontName;
+    if (!mpHost) {
+        return;
+    }
+    if (!(mType & (MainConsole|UserWindow|SubConsole))) {
+        return;
+    }
 
+    TEvent fontChangeEvent{};
+    fontChangeEvent.mArgumentList.append(QLatin1String("sysFontChangeEvent"));
+    fontChangeEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    fontChangeEvent.mArgumentList.append(mConsoleName);
+    fontChangeEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    fontChangeEvent.mArgumentList.append(font().family());
+    fontChangeEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    fontChangeEvent.mArgumentList.append(QString::number(font().pointSize()));
+    fontChangeEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    mpHost->raiseEvent(fontChangeEvent);
+}
+
+void TConsole::setFont(const QFont& newFont)
+{
+    TFontAttributes newFontDetails(newFont);
+    if (mDisplayFontDetails != newFontDetails) {
+        mDisplayFontDetails = newFontDetails;
+        QWidget::setFont(newFont);
+        // Update associated TCommandLine's:
+        if (mType & (MainConsole|SubConsole|UserWindow)) {
+            if (mpHost->mpConsole) {
+                for (auto& commandLine : mpHost->mpConsole->mSubCommandLineMap) {
+                    auto pConsole = commandLine->console();
+                    if (pConsole && (pConsole == this)) {
+                        commandLine->setFont(font());
+                        commandLine->adjustHeight();
+                    }
+                }
+            }
+            if (!mpCommandLine.isNull()) {
+                mpCommandLine->setFont(font());
+                mpCommandLine->adjustHeight();
+            }
+        }
+        refreshView();
+        raiseFontChangeEvent();
+    }
+}
+
+void TConsole::setFontName(const QString& fontName)
+{
+    mDisplayFontDetails.mName = fontName;
+    setFont(mDisplayFontDetails.makeFont());
     refreshView();
-    return true;
 }
 
 QString TConsole::getCurrentLine()

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -36,6 +36,7 @@
 #include <QDataStream>
 #include <QElapsedTimer>
 #include <QFile>
+#include <QFont>
 #include <QHBoxLayout>
 #include <QIcon>
 #include <QLabel>
@@ -50,6 +51,91 @@
 #include <list>
 #include <map>
 
+// This contains the details of a font that we might want to maintain a record
+// of, independently of a QFont instance:
+struct TFontAttributes
+{
+    explicit TFontAttributes(const bool isAntiAliased = false)
+    : mStyleStrategy(isAntiAliased
+                             ? static_cast<QFont::StyleStrategy>(QFont::PreferAntialias | QFont::PreferQuality)
+                             : static_cast<QFont::StyleStrategy>(QFont::NoAntialias | QFont::PreferQuality))
+    {}
+
+    explicit TFontAttributes(const QFont& font) {
+        mName = font.family();
+        mPointSize = font.pointSize();
+        mStyleHint = font.styleHint();
+        mStyleStrategy = font.styleStrategy();
+        mFixedPitch = font.fixedPitch();
+        mKerning = font.kerning();
+        mWeight = font.weight();
+        mUnderline = font.underline();
+        mOverline = font.overline();
+        mStrikeout = font.strikeOut();
+        mItalic = font.italic();
+        // Although we had a setter for this we never used it:
+        // mLetterSpacing = font.letterSpacing();
+        // mSpacingType = font.SpacingType();
+    }
+
+    // Since C++20 the comparison operators can also be default coded by the
+    // compiler:
+    bool operator==(const TFontAttributes& other) const = default;
+    bool operator!=(const TFontAttributes& other) const = default;
+
+    TFontAttributes& operator=(const TFontAttributes& other) = default;
+
+    QFont makeFont() const {
+        QFont font = QFont(mName, mPointSize, mWeight, mItalic);
+        font.setFixedPitch(mFixedPitch);
+        font.setStyleHint(mStyleHint, mStyleStrategy);
+        font.setKerning(mKerning);
+        font.setUnderline(mUnderline);
+        font.setOverline(mOverline);
+        font.setStrikeOut(mStrikeout);
+
+        return font;
+    }
+
+    void setAntiAliasOption(const bool isAntiAliased) {
+        mStyleStrategy = isAntiAliased
+                                 ? static_cast<QFont::StyleStrategy>(QFont::PreferAntialias | QFont::PreferQuality)
+                                 : static_cast<QFont::StyleStrategy>(QFont::NoAntialias | QFont::PreferQuality);
+    }
+
+    // enums to consider:
+    // Not used: QFont::Capitalization mCapitalization; // { MixedCase, AllUppercase, AllLowercase, SmallCaps, Capitalize }
+    // Not used: QFont::HintingPreference mHintingPreference; // { PreferDefaultHinting, PreferNoHinting, PreferVerticalHinting, PreferFullHinting }
+    // Not used: QFont::SpacingType mSpacingType; // { PercentageSpacing, AbsoluteSpacing }
+    // Not used: QFont::Stretch mStretch; // { AnyStretch, UltraCondensed, ExtraCondensed, Condensed, SemiCondensed, …, UltraExpanded }
+    // Not used: QFont::Style mStyle; // { StyleNormal, StyleItalic, StyleOblique }
+    // Combined and used with next: QFont::StyleHint mStyleHint; // { AnyStyle, SansSerif, Helvetica, Serif, Times, …, System }
+    // Combined and used with prior: QFont::StyleStrategy mStyleStrategy; // { PreferDefault, PreferBitmap, PreferDevice, PreferOutline, ForceOutline, …, PreferQuality }
+    // Used: QFont::Weight mWeight; // { Thin, ExtraLight, Light, Normal, Medium, …, Black }
+
+    QString mName = qsl("Bitstream Vera Sans Mono");
+    int mPointSize = 14;
+    // Actually this is combined with the next one - but doesn't work on X11
+    // anyway - and since we don't specify it in the TConsole case this means
+    // the QFont::AnyStyle is used for other Desktop environments:
+    QFont::StyleHint mStyleHint = QFont::AnyStyle;
+    // We use either: (QFont::NoAntialias | QFont::PreferQuality) for all
+    // TConsoles but the main one can be set to (QFont::PreferAntialias |
+    // QFont::PreferQuality) instead - see constuctor:
+    QFont::StyleStrategy mStyleStrategy;
+    // qreal mLetterSpacing = 0.0;
+    // QFont::SpacingType mSpacingType = QFont::AbsoluteSpacing;
+    // We use but don't set "Line Spacing" - so don't worry about it.
+    QFont::Weight mWeight = QFont::Normal;
+    bool mFixedPitch = true; // We always set this
+    bool mKerning = false; // We haven't been resetting this but we ought to
+    // we don't set these on "base" fonts for TConsole's but we can set them for
+    // bits of text:
+    bool mUnderline = false;
+    bool mOverline = false;
+    bool mStrikeout = false;
+    bool mItalic = false;
+};
 
 enum class ControlCharacterMode {
     AsIs = 0x0,
@@ -180,8 +266,8 @@ public:
     void refresh();
     void refreshView() const;
     void raiseMudletMousePressOrReleaseEvent(QMouseEvent*, const bool);
-    bool setFontSize(int);
-    bool setFontName(const QString& fontName);
+    void setFontSize(int);
+    void setFontName(const QString& fontName);
     bool setConsoleBackgroundImage(const QString&, int);
     bool resetConsoleBackgroundImage();
     void setLink(const QStringList& linkFunction, const QStringList& linkHint, const QVector<int> linkReference = QVector<int>());
@@ -219,9 +305,16 @@ public:
     void clearSplit();
     bool showTimeStamps() const { return mShowTimeStamps; }
     void raiseMudletResizeEvent();
+    // This *should* be overridding the (void) QWidget::setFont(const QFont&)
+    // method but doesn't seem to be...!
+    void setFont(const QFont&);
 
 
     QPointer<Host> mpHost;
+
+    // Initialised in the constructor:
+    TFontAttributes mDisplayFontDetails;
+
     // Only assigned a value for user windows:
     QPointer<TDockWidget> mpDockWidget;
     QPointer<TCommandLine> mpCommandLine;
@@ -248,9 +341,6 @@ public:
 
     QString mConsoleName;
     QString mCurrentLine;
-    QString mDisplayFontName = qsl("Bitstream Vera Sans Mono");
-    int mDisplayFontSize = 14;
-    QFont mDisplayFont = QFont(mDisplayFontName, mDisplayFontSize, QFont::Normal);
     int mEngineCursor = -1;
 
     int mIndentCount = 0;
@@ -341,6 +431,7 @@ private slots:
 
 private:
     void createSearchOptionIcon();
+    void raiseFontChangeEvent();
 
     ConsoleType mType = UnknownType;
     QSize mOldSize;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -307,7 +307,11 @@ public:
     void raiseMudletResizeEvent();
     // This *should* be overridding the (void) QWidget::setFont(const QFont&)
     // method but doesn't seem to be...!
-    void setFont(const QFont&);
+    // The forceChange option is required when using this method within
+    // setFontName(...) or setFontSize(...) so that the changes made
+    // on the TFontDetails class are forced into play, as otherwise
+    // it looks that they haven't inside this method:
+    void setFont(const QFont&, const bool forceChange = false);
 
 
     QPointer<Host> mpHost;

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -2480,7 +2480,7 @@ int TLuaInterpreter::setFont(lua_State* L)
         }
         console->refreshView();
     } else {
-        QFont(fontName, console->font().pointSize())
+        auto font = QFont(fontName, console->font().pointSize());
         console->setFont(font);
     }
     lua_pushboolean(L, true);

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -2454,32 +2454,33 @@ int TLuaInterpreter::setFont(lua_State* L)
         windowName = WINDOW_NAME(L, s++);
     }
 
-    const QString font = getVerifiedString(L, __func__, s, "name");
+    const QString fontName = getVerifiedString(L, __func__, s, "name");
 
-    if (font.trimmed().isEmpty()) {
+    if (fontName.trimmed().isEmpty()) {
         return warnArgumentValue(L, __func__, "font must not be empty");
     }
 
-    if (!mudlet::self()->getAvailableFonts().contains(font, Qt::CaseInsensitive)) {
-        return warnArgumentValue(L, __func__, qsl("font '%1' is not available").arg(font));
+    if (!mudlet::self()->getAvailableFonts().contains(fontName, Qt::CaseInsensitive)) {
+        return warnArgumentValue(L, __func__, qsl("font '%1' is not available").arg(fontName));
     }
 
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     // On GNU/Linux or FreeBSD ensure that emojis are displayed in colour even
     // if this font doesn't support it:
-    QFont::insertSubstitution(font, qsl("Noto Color Emoji"));
+    QFont::insertSubstitution(fontName, qsl("Noto Color Emoji"));
     // TODO issue #4159: a nonexisting font breaks the console
 #endif
 
     auto console = CONSOLE(L, windowName);
     if (console == host.mpConsole) {
         // apply changes to main console and its while-scrolling component too.
-        auto result = host.setDisplayFont(QFont(font, host.getDisplayFont().pointSize()));
+        auto result = host.setDisplayFont(QFont(fontName, host.getDisplayFont().pointSize()));
         if (!result.first) {
             return warnArgumentValue(L, __func__, result.second);
         }
         console->refreshView();
     } else {
+        QFont(fontName, console->font().pointSize())
         console->setFont(font);
     }
     lua_pushboolean(L, true);

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -940,32 +940,27 @@ int TLuaInterpreter::getFont(lua_State* L)
         return QFontInfo(font).family();
     };
 
-    QString font;
+    QString fontName;
 
     if (console == host.mpConsole) {
-        font = actualFontFamily(host.getDisplayFont());
+        fontName = actualFontFamily(host.getDisplayFont());
     } else if (console->mUpperPane) {
-        font = actualFontFamily(console->mUpperPane->font());
+        fontName = actualFontFamily(console->mUpperPane->font());
     } else {
-        font = actualFontFamily(console->font());
+        fontName = actualFontFamily(console->font());
     }
 
-    lua_pushstring(L, font.toUtf8().constData());
+    lua_pushstring(L, fontName.toUtf8().constData());
     return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getFontSize
 int TLuaInterpreter::getFontSize(lua_State* L)
 {
-    const Host& host = getHostFromLua(L);
     int rval = -1;
     const QString windowName {WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
-    if (console == host.mpConsole) {
-        rval = host.getDisplayFont().pointSize();
-    } else {
-        rval = console->mUpperPane->mDisplayFont.pointSize();
-    }
+    rval = console->mUpperPane->font().pointSize();
 
     if (rval <= -1) {
         lua_pushnil(L);
@@ -1093,7 +1088,7 @@ int TLuaInterpreter::getLineNumber(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMainConsoleWidth
 int TLuaInterpreter::getMainConsoleWidth(lua_State* L)
 {
-    const Host& host = getHostFromLua(L);
+    Host& host = getHostFromLua(L);
     int fw = QFontMetrics(host.getDisplayFont()).averageCharWidth();
     fw *= host.mWrapAt + 1;
     lua_pushnumber(L, fw);
@@ -2709,12 +2704,12 @@ int TLuaInterpreter::setMiniConsoleFontSize(lua_State* L)
     const QString windowName = getVerifiedString(L, __func__, 1, "miniconsole name");
     const int size = getVerifiedInt(L, __func__, 2, "font size");
     auto console = CONSOLE(L, windowName);
-    if (console->setFontSize(size)) {
-        lua_pushboolean(L, true);
-    } else {
+    if (size < 1) {
         return warnArgumentValue(L, __func__, qsl("setting font size of '%1' failed").arg(windowName));
     }
-    return 0;
+    console->setFontSize(size);
+    lua_pushboolean(L, true);
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMovie

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -54,6 +54,8 @@ TMainConsole::TMainConsole(Host* pH, QWidget* parent)
 : TConsole(pH, qsl("main"), TConsole::MainConsole, parent)
 , mClipboard(pH)
 {
+    setFont(pH->getAndClearTempDisplayFont());
+
     // During first use where mIsDebugConsole IS true mudlet::self() is null
     // then - but we rely on that flag to avoid having to also test for a
     // non-null mudlet::self() - the connect(...) will produce a debug

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -84,14 +84,11 @@ TTextEdit::TTextEdit(TConsole* pC, QWidget* pW, TBuffer* pB, Host* pH, bool isLo
 , mMouseWheelRemainder()
 {
     mLastClickTimer.start();
+    Q_ASSERT_X(mpHost, "TTextEdit::TTextEdit(...)", "mpHost is a nullptr");
+    setFont(mpHost->getDisplayFont());
+    mFontHeight = fontMetrics().height();
+    mFontWidth = fontMetrics().averageCharWidth();
     if (pC->getType() != TConsole::CentralDebugConsole) {
-        const auto hostFont = mpHost->getDisplayFont();
-        mFontHeight = QFontMetrics(hostFont).height();
-        mFontWidth = QFontMetrics(hostFont).averageCharWidth();
-
-        mpHost->setDisplayFontFixedPitch(true);
-        setFont(hostFont);
-
 #if defined(DEBUG_CODEPOINT_PROBLEMS)
         // There is no point in setting this option on the Central Debug Console
         // as A) it is shared and B) any codepoints that it can't handle will
@@ -103,13 +100,8 @@ TTextEdit::TTextEdit(TConsole* pC, QWidget* pW, TBuffer* pB, Host* pH, bool isLo
 #endif
     } else {
         // This is part of the Central Debug Console
-        mFontHeight = QFontMetrics(mDisplayFont).height();
-        mFontWidth = QFontMetrics(mDisplayFont).averageCharWidth();
         mFgColor = QColor(192, 192, 192);
         mBgColor = Qt::black;
-        mDisplayFont = QFont(qsl("Bitstream Vera Sans Mono"), 14, QFont::Normal);
-        mDisplayFont.setFixedPitch(true);
-        setFont(mDisplayFont);
     }
     mScreenHeight = height() / mFontHeight;
 
@@ -258,27 +250,14 @@ void TTextEdit::updateHorizontalScrollBar()
 
 void TTextEdit::updateScreenView()
 {
+    mFontWidth = fontMetrics().averageCharWidth();
+    mFontHeight = fontMetrics().height();
     if (isHidden()) {
-        mFontWidth = QFontMetrics(mDisplayFont).averageCharWidth();
-        mFontDescent = QFontMetrics(mDisplayFont).descent();
-        mFontAscent = QFontMetrics(mDisplayFont).ascent();
-        mFontHeight = mFontAscent + mFontDescent;
         return; //NOTE: otherwise mScreenHeight==0 would cause a floating point exception
     }
-    // This was "if (pC->mType == TConsole::MainConsole) {"
-    // and mIsMiniConsole is true for user created Mini Consoles and User Windows
     if (mpConsole->getType() == TConsole::MainConsole) {
-        mFontWidth = QFontMetrics(mpHost->getDisplayFont()).averageCharWidth();
-        mFontDescent = QFontMetrics(mpHost->getDisplayFont()).descent();
-        mFontAscent = QFontMetrics(mpHost->getDisplayFont()).ascent();
-        mFontHeight = mFontAscent + mFontDescent;
         mBgColor = mpHost->mBgColor;
         mFgColor = mpHost->mFgColor;
-    } else {
-        mFontWidth = QFontMetrics(mDisplayFont).averageCharWidth();
-        mFontDescent = QFontMetrics(mDisplayFont).descent();
-        mFontAscent = QFontMetrics(mDisplayFont).ascent();
-        mFontHeight = mFontAscent + mFontDescent;
     }
     mScreenHeight = visibleRegion().boundingRect().height() / mFontHeight;
     if (!mIsLowerPane) {
@@ -847,30 +826,13 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
     pixmap.fill(Qt::transparent);
 
     QPainter p(&pixmap);
+    // Setting the font here isn't academic as the text IS drawn with THIS painter (p)
+    p.setFont(painter.font());
     p.setCompositionMode(QPainter::CompositionMode_SourceOver);
-    if (mpConsole->getType() == TConsole::MainConsole) {
-        p.setFont(mpHost->getDisplayFont());
-        p.setRenderHint(QPainter::TextAntialiasing, !mpHost->mNoAntiAlias);
-    } else {
-        p.setFont(mDisplayFont);
-        p.setRenderHint(QPainter::TextAntialiasing, false);
-    }
 
-    QPoint P_topLeft = r.topLeft();
-    QPoint P_bottomRight = r.bottomRight();
-
-    int y_topLeft = P_topLeft.y();
-    int x_bottomRight = P_bottomRight.x();
-    int y_bottomRight = P_bottomRight.y();
-
-    if (x_bottomRight > mScreenWidth * mFontWidth) {
-        x_bottomRight = mScreenWidth * mFontWidth;
-    }
-
-    //    int x1 = x_topLeft / mFontWidth;
-    int y1 = y_topLeft / mFontHeight;
-    int x2 = x_bottomRight / mFontWidth;
-    int y2 = y_bottomRight / mFontHeight;
+    int y_top = r.top() / mFontHeight;
+    int y_bottom = r.bottom()/ mFontHeight;
+    int x_right = std::min(r.right(), (mScreenWidth * mFontWidth)) / mFontWidth;
 
     int lineOffset = imageTopLine();
     int from = 0;
@@ -881,7 +843,7 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
         if (mLastRenderedOffset) {
             mScrollVector = lineOffset - mLastRenderedOffset;
         } else {
-            mScrollVector = y2 + lineOffset;
+            mScrollVector = y_bottom + lineOffset;
         }
     }
 
@@ -893,14 +855,12 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
     }
     if ((r.height() < rect().height()) && (lineOffset > 0)) {
         p.drawPixmap(0, 0, mScreenMap);
+        from = y_top;
+        noScroll = true;
         if (!mForceUpdate && !mMouseTracking) {
-            from = y1;
-            noScroll = true;
             noCopy = true;
         } else {
-            from = y1;
-            y2 = mScreenHeight;
-            noScroll = true;
+            y_bottom = mScreenHeight;
             mScrollVector = 0;
         }
     }
@@ -917,18 +877,18 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
             screenPixmap = mScreenMap.copy(0, 0, mScreenWidth * mFontWidth * dpr, (mScreenHeight - abs(mScrollVector)) * mFontHeight * dpr);
             p.drawPixmap(0, abs(mScrollVector) * mFontHeight, screenPixmap);
             from = 0;
-            y2 = abs(mScrollVector);
+            y_bottom = abs(mScrollVector);
         }
     }
 
     //delete non used characters.
     //needed for horizontal scrolling because there sometimes characters didn't get cleared
-    QRect deleteRect = QRect(0, from * mFontHeight, x2 * mFontHeight, (y2 + 1) * mFontHeight);
+    QRect deleteRect = QRect(0, from * mFontHeight, x_right * mFontHeight, (y_bottom + 1) * mFontHeight);
     p.setCompositionMode(QPainter::CompositionMode_Source);
     p.fillRect(deleteRect, Qt::transparent);
 
     p.setCompositionMode(QPainter::CompositionMode_SourceOver);
-    for (int i = from; i <= y2; ++i) {
+    for (int i = from; i <= y_bottom; ++i) {
         if (static_cast<int>(mpBuffer->buffer.size()) <= i + lineOffset) {
             break;
         }
@@ -973,6 +933,7 @@ void TTextEdit::paintEvent(QPaintEvent* e)
     if (!painter.isActive()) {
         return;
     }
+    painter.setFont(font());
     drawForeground(painter, rect);
 }
 
@@ -1741,13 +1702,7 @@ void TTextEdit::slot_copySelectionToClipboardImage()
 std::pair<bool, int> TTextEdit::drawTextForClipboard(QPainter& painter, QRect rectangle, int lineOffset) const
 {
     painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
-    if (mpConsole->getType() == TConsole::MainConsole) {
-        painter.setFont(mpHost->getDisplayFont());
-        painter.setRenderHint(QPainter::TextAntialiasing, !mpHost->mNoAntiAlias);
-    } else {
-        painter.setFont(mDisplayFont);
-        painter.setRenderHint(QPainter::TextAntialiasing, false);
-    }
+    painter.setFont(font());
 
     int lineCount = rectangle.height() / mFontHeight;
     int linesDrawn = 0;
@@ -2149,28 +2104,12 @@ int TTextEdit::bufferScrollDown(int lines)
 
 int TTextEdit::getColumnCount() const
 {
-    int charWidth;
-
-    if (mpConsole->getType() == TConsole::MainConsole) {
-        charWidth = qRound(QFontMetricsF(mpHost->getDisplayFont()).averageCharWidth());
-    } else {
-        charWidth = qRound(QFontMetricsF(mDisplayFont).averageCharWidth());
-    }
-
-    return width() / charWidth;
+    return qRound(width() / QFontMetricsF(font()).averageCharWidth());
 }
 
 int TTextEdit::getRowCount() const
 {
-    int rowHeight;
-
-    if (mpConsole->getType() == TConsole::MainConsole) {
-        rowHeight = qRound(QFontMetricsF(mpHost->getDisplayFont()).lineSpacing());
-    } else {
-        rowHeight = qRound(QFontMetricsF(mDisplayFont).lineSpacing());
-    }
-
-    return height() / rowHeight;
+    return qRound(height() / QFontMetricsF(font()).lineSpacing());
 }
 
 inline QString TTextEdit::htmlCenter(const QString& text)

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -116,10 +116,7 @@ public:
     // long enough again.
     int mOldCaretColumn;
 
-    QFont mDisplayFont;
     QColor mFgColor;
-    int mFontAscent;
-    int mFontDescent;
     bool mIsCommandPopup;
     // If true, this TTextEdit is to display the last lines in
     // mpConsole.mpBuffer. This is always true for the lower main window panel

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -386,7 +386,8 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("USE_IRE_DRIVER_BUGFIX") = pHost->mUSE_IRE_DRIVER_BUGFIX ? "yes" : "no";
     host.append_attribute("mUSE_FORCE_LF_AFTER_PROMPT") = pHost->mUSE_FORCE_LF_AFTER_PROMPT ? "yes" : "no";
     host.append_attribute("mUSE_UNIX_EOL") = pHost->mUSE_UNIX_EOL ? "yes" : "no";
-    host.append_attribute("mNoAntiAlias") = pHost->mNoAntiAlias ? "yes" : "no";
+    // THIS one is stored in a backwards manner - *sigh*:
+    host.append_attribute("mNoAntiAlias") = pHost->fontsAntiAlias() ? "no" : "yes";
     host.append_attribute("mEchoLuaErrors") = pHost->mEchoLuaErrors ? "yes" : "no";
     host.append_attribute("runAllKeyMatches") = pHost->getKeyUnit()->mRunAllKeyMatches ? "yes" : "no";
     host.append_attribute("AmbigousWidthGlyphsToBeWide") = pHost->mAutoAmbigousWidthGlyphsSetting ? "auto" : (pHost->mWideAmbigousWidthGlyphs ? "yes" : "no");
@@ -568,7 +569,8 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
         host.append_child("mWhite").text().set(pHost->mWhite.name().toUtf8().constData());
         host.append_child("mLightWhite").text().set(pHost->mLightWhite.name().toUtf8().constData());
         host.append_child("mDisplayFont").text().set(pHost->getDisplayFont().toString().toUtf8().constData());
-        host.append_child("mCommandLineFont").text().set(pHost->mCommandLineFont.toString().toUtf8().constData());
+        // We don't use this ourselves any more but still write it out for older versions:
+        host.append_child("mCommandLineFont").text().set(pHost->getDisplayFont().toString().toUtf8().constData());
         // There was a mis-spelt duplicate commandSeperator above but it is now gone
         host.append_child("mCommandSeparator").text().set(pHost->mCommandSeparator.toUtf8().constData());
         host.append_child("commandLineMinimumHeight").text().set(QString::number(pHost->commandLineMinimumHeight).toUtf8().constData());

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1168,7 +1168,7 @@ void XMLimport::readHost(Host* pHost)
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
                 // On GNU/Linux and FreeBSD ensure that emojis are displayed in
                 // colour even if this font doesn't support it:
-                QFont::insertSubstitution(pHost->mDisplayFont.family(), qsl("Noto Color Emoji"));
+                QFont::insertSubstitution(pHost->getDisplayFont().family(), qsl("Noto Color Emoji"));
 #endif
             } else if (name() == qsl("mCommandLineFont")) {
                 // We use the same font as the main console now so discard this

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1170,9 +1170,10 @@ void XMLimport::readHost(Host* pHost)
                 // colour even if this font doesn't support it:
                 QFont::insertSubstitution(pHost->mDisplayFont.family(), qsl("Noto Color Emoji"));
 #endif
-                pHost->setDisplayFontFixedPitch(true);
             } else if (name() == qsl("mCommandLineFont")) {
-                pHost->mCommandLineFont.fromString(readElementText());
+                // We use the same font as the main console now so discard this
+                // one silently:
+                Q_UNUSED(readElementText())
             } else if (name() == qsl("commandSeperator")) {
                 // Ignore this misspelled duplicate, it has been removed from
                 // the Xml format but will appear in older files and trip the

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -742,7 +742,7 @@ bool cTelnet::socketOutRaw(std::string& data)
 void cTelnet::checkNAWS()
 {
     Host* pHost = mpHost;
-    if (!pHost) {
+    if (!pHost ||!pHost->mpConsole) {
         return;
     }
     // Use the smaller of the screen width or the wrapAt, then subtract the

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -109,14 +109,14 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
 
     // Explicitly set the font otherwise it changes between the Application and
     // the default System one as the mapper is docked and undocked!
-    QFont mapperFont = QFont(mpHost->getDisplayFont().family());
-    if (mpHost->mNoAntiAlias) {
-        mapperFont.setStyleStrategy(QFont::NoAntialias);
-    } else {
-        mapperFont.setStyleStrategy(static_cast<QFont::StyleStrategy>(QFont::PreferAntialias | QFont::PreferQuality));
-    }
-    setFont(mapperFont);
-    mp2dMap->mFontHeight = QFontMetrics(mpHost->getDisplayFont()).height();
+    // Previous code set this to the main console one (before it was read from
+    // the game save file, apparently) so it was actually the initial value
+    // specified in the Host class. Revising the code to make it use the
+    // selected font for the main console meant that all the controls at the
+    // bottom took on that font which was glaringly inconsistant with the
+    // overall GUI appearance - instead now it adopts the "default" application
+    // font:
+    setFont(qApp->font());
     mpMap->restore16ColorSet();
     auto menu = new QMenu(this);
     pushButton_info->setMenu(menu);
@@ -407,4 +407,11 @@ bool dlgMapper::isFloatAndDockable() const
         return true;
     }
     return false;
+}
+
+void dlgMapper::setFont(const QFont& newFont)
+{
+    QWidget::setFont(newFont);
+    mp2dMap->setFont(newFont);
+    mp2dMap->mFontHeight = mp2dMap->fontMetrics().height();
 }

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -54,6 +54,7 @@ public:
     bool isIn3DMode() const { return pushButton_3D->isDown(); }
     bool isFloatAndDockable() const;
     int getCurrentShownAreaIndex();
+    void setFont(const QFont&);
 
 public slots:
     void slot_toggleRoundRooms(const bool);

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -619,22 +619,16 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 {
     loadEditorTab();
 
-    mDisplayFont = pHost->getDisplayFont();
-    pushButton_fontDialog->setText(QString("%1, %2, %3pt").arg(mDisplayFont.family()).arg(mDisplayFont.styleName()).arg(mDisplayFont.pointSize()));
+    fontComboBox_displayFont->setCurrentFont(pHost->getDisplayFont());
+    // Accomodate an initial font size being larger than expected - and ensure
+    // it is a positive value:
+    spinBox_displayFontSize->setMaximum(std::max(pHost->getDisplayFont().pointSize(), 40));
+    spinBox_displayFontSize->setValue(std::max(1, pHost->getDisplayFont().pointSize()));
+    checkBox_antiAlias->setChecked(!pHost->mNoAntiAlias);
 
-    connect(pushButton_fontDialog, &QPushButton::clicked, this, [this, pHost](){
-        bool ok;
-        QFont font = QFontDialog::getFont(&ok, pHost->getDisplayFont(), this->window());
-        if (ok) {
-            qDebug() << "Font selected: " << font.toString();
-            qDebug() << "Font family: " << font.family();
-            qDebug() << "Font size: " << font.pointSize();
-            mDisplayFont = font;
-            mFontSize = font.pointSize();
-            slot_setFontSize();
-            pushButton_fontDialog->setText(QString("%1, %2, %3pt").arg(mDisplayFont.family()).arg(mDisplayFont.styleName()).arg(mDisplayFont.pointSize()));
-        }
-    });
+    connect(fontComboBox_displayFont, &QFontComboBox::currentFontChanged, this, &dlgProfilePreferences::slot_displayFontChanged);
+    connect(spinBox_displayFontSize, qOverload<int>(&QSpinBox::valueChanged), this, &dlgProfilePreferences::slot_displayFontSizeChanged);
+    connect(checkBox_antiAlias, &QCheckBox::clicked, this, &dlgProfilePreferences::slot_displayFontAliasingChanged);
 
     // search engine load
     search_engine_combobox->addItems(QStringList(mpHost->mSearchEngineData.keys()));
@@ -770,12 +764,6 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     // same with special connection warnings
     need_reconnect_for_specialoption->hide();
 
-    mDisplayFont = pHost->getDisplayFont();
-    mFontSize = pHost->getDisplayFont().pointSize();
-    if (mFontSize < 0) {
-        mFontSize = 10;
-    }
-
     wrap_at_spinBox->setValue(pHost->mWrapAt);
     indent_wrapped_spinBox->setValue(pHost->mWrapIndentCount);
     hanging_indent_wrapped_spinBox->setValue(pHost->mWrapHangingIndentCount);
@@ -861,7 +849,6 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
 
     commandLineMinimumHeight->setValue(pHost->commandLineMinimumHeight);
-    mNoAntiAlias->setChecked(!pHost->mNoAntiAlias);
     mFORCE_MCCP_OFF->setChecked(pHost->mFORCE_NO_COMPRESSION);
     mFORCE_GA_OFF->setChecked(pHost->mFORCE_GA_OFF);
     mAlertOnNewData->setChecked(pHost->mAlertOnNewData);
@@ -1290,7 +1277,10 @@ void dlgProfilePreferences::disconnectHostRelatedControls()
     // disconnect(...) counterparts - so we need to provide the "dummy"
     // arguments to get the wanted wild-card behaviour for them:
 
-    disconnect(pushButton_fontDialog, &QAbstractButton::clicked, nullptr, nullptr);
+    disconnect(fontComboBox_displayFont, &QFontComboBox::currentFontChanged, nullptr, nullptr);
+    disconnect(spinBox_displayFontSize, qOverload<int>(&QSpinBox::valueChanged), nullptr, nullptr);
+    disconnect(checkBox_antiAlias, &QCheckBox::clicked, nullptr, nullptr);
+
     disconnect(buttonDownloadMap, &QAbstractButton::clicked, nullptr, nullptr);
 
     disconnect(pushButton_foreground_color, &QAbstractButton::clicked, nullptr, nullptr);
@@ -1429,7 +1419,9 @@ void dlgProfilePreferences::clearHostDetails()
     mIsToLogInHtml->setChecked(false);
     mIsLoggingTimestamps->setChecked(false);
     commandLineMinimumHeight->clear();
-    mNoAntiAlias->setChecked(false);
+    fontComboBox_displayFont->clear();
+    spinBox_displayFontSize->setValue(14);
+    checkBox_antiAlias->setChecked(false);
     mFORCE_MCCP_OFF->setChecked(false);
     mFORCE_GA_OFF->setChecked(false);
     mAlertOnNewData->setChecked(false);
@@ -1885,81 +1877,6 @@ void dlgProfilePreferences::slot_setCommandBgColor()
         setButtonAndProfileColor(pushButton_command_background_color, pHost->mCommandBgColor);
     }
 }
-
-void dlgProfilePreferences::slot_setFontSize()
-{
-    slot_setDisplayFont();
-
-    Host* pHost = mpHost;
-
-    if (!pHost) {
-        return;
-    }
-
-    pHost->mTelnet.sendInfoNewEnvironValue(qsl("FONT_SIZE"));
-}
-
-void dlgProfilePreferences::slot_setDisplayFont()
-{
-    Host* pHost = mpHost;
-    if (!pHost) {
-        return;
-    }
-
-    if (pHost->getDisplayFont() == mDisplayFont) {
-        return;
-    }
-
-    label_invalidFontError->hide();
-    label_variableWidthFontWarning->hide();
-    if (auto [validFont, errorMessage] = pHost->setDisplayFont(mDisplayFont); !validFont) {
-        label_invalidFontError->show();
-        return;
-    } else if (!QFontInfo(mDisplayFont).fixedPitch()) {
-        label_variableWidthFontWarning->show();
-    }
-
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    // On GNU/Linux or FreeBSD ensure that emojis are displayed in colour even
-    // if this font doesn't support it:
-    QFont::insertSubstitution(pHost->mDisplayFont.family(), qsl("Noto Color Emoji"));
-#endif
-
-    auto mainConsole = pHost->mpConsole;
-    if (!mainConsole) {
-        return;
-    }
-
-    // update the display properly when font or size selections change.
-    mainConsole->changeColors();
-    mainConsole->mUpperPane->updateScreenView();
-    mainConsole->mUpperPane->forceUpdate();
-    mainConsole->mLowerPane->updateScreenView();
-    mainConsole->mLowerPane->forceUpdate();
-    mainConsole->refresh();
-
-    auto config = edbeePreviewWidget->config();
-    config->beginChanges();
-    config->setFont(mDisplayFont);
-    config->endChanges();
-
-    pHost->mTelnet.sendInfoNewEnvironValue(qsl("FONT"));
-}
-
-// Currently UNUSED!
-//void dlgProfilePreferences::slot_setCommandLineFont()
-//{
-//    Host* pHost = mpHost;
-//    if (!pHost) {
-//        return;
-//    }
-//    bool ok;
-//    QFont font = QFontDialog::getFont(&ok, pHost->mCommandLineFont, this);
-//    pHost->mCommandLineFont = font;
-//    if (pHost->mpConsole) {
-//        pHost->mpConsole->changeColors();
-//    }
-//}
 
 void dlgProfilePreferences::slot_setColorBlack()
 {
@@ -2950,7 +2867,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         pHost->mLogDir = mLogDirPath;
         pHost->mLogFileName = lineEdit_logFileName->text();
         pHost->mLogFileNameFormat = comboBox_logFileNameFormat->currentData().toString();
-        pHost->mNoAntiAlias = !mNoAntiAlias->isChecked();
+        pHost->mNoAntiAlias = !checkBox_antiAlias->isChecked();
         pHost->mAlertOnNewData = mAlertOnNewData->isChecked();
 
         pHost->mUseProxy = groupBox_proxy->isChecked();
@@ -4563,4 +4480,71 @@ void dlgProfilePreferences::slot_changeLargeAreaExitArrows(const bool state)
     }
 
     pHost->setLargeAreaExitArrows(state);
+}
+
+bool dlgProfilePreferences::updateDisplayFont()
+{
+    if (mpHost.isNull() || (mpHost.data()->mpConsole.isNull())) {
+        return false;
+    }
+
+    QFont displayFont = fontComboBox_displayFont->currentFont();
+    displayFont.setPointSize(spinBox_displayFontSize->value());
+    displayFont.setStyleHint(QFont::AnyStyle, checkBox_antiAlias->isChecked()
+                              ? static_cast<QFont::StyleStrategy>(QFont::PreferAntialias | QFont::PreferQuality)
+                              : static_cast<QFont::StyleStrategy>(QFont::NoAntialias | QFont::PreferQuality));
+
+    if (TFontAttributes(mpHost->getDisplayFont()) == TFontAttributes(displayFont)) {
+        // No change!
+        return false;
+    }
+
+    const QFontMetrics metrics(displayFont);
+    if (metrics.averageCharWidth() == 0) {
+        label_invalidFontError->show();
+        return false;
+    }
+    label_invalidFontError->hide();
+
+    if (!QFontInfo(displayFont).fixedPitch()) {
+        label_variableWidthFontWarning->show();
+    } else {
+        label_variableWidthFontWarning->hide();
+    }
+
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    // On GNU/Linux or FreeBSD ensure that emojis are displayed in colour even
+    // if this font doesn't support it:
+    QFont::insertSubstitution(mpHost->displayFont.family(), qsl("Noto Color Emoji"));
+#endif
+
+    // update the display properly when font or size or antiAliasing selections
+    // change.
+    mpHost->setDisplayFont(displayFont);
+
+    auto config = edbeePreviewWidget->config();
+    config->beginChanges();
+    config->setFont(displayFont);
+    config->endChanges();
+
+    return true;
+}
+
+void dlgProfilePreferences::slot_displayFontChanged()
+{
+    if (!mpHost.isNull() && updateDisplayFont()) {
+        mpHost->mTelnet.sendInfoNewEnvironValue(qsl("FONT"));
+    }
+}
+
+void dlgProfilePreferences::slot_displayFontSizeChanged()
+{
+    if (!mpHost.isNull() && updateDisplayFont()) {
+        mpHost->mTelnet.sendInfoNewEnvironValue(qsl("FONT_SIZE"));
+    }
+}
+
+void dlgProfilePreferences::slot_displayFontAliasingChanged()
+{
+    updateDisplayFont();
 }

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -4515,7 +4515,7 @@ bool dlgProfilePreferences::updateDisplayFont()
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     // On GNU/Linux or FreeBSD ensure that emojis are displayed in colour even
     // if this font doesn't support it:
-    QFont::insertSubstitution(mpHost->displayFont.family(), qsl("Noto Color Emoji"));
+    QFont::insertSubstitution(mpHost->getDisplayFont().family(), qsl("Noto Color Emoji"));
 #endif
 
     // update the display properly when font or size or antiAliasing selections

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -56,11 +56,6 @@ public:
     void setTab(QString tab);
 
 public slots:
-    // Fonts.
-    void slot_setFontSize();
-    void slot_setDisplayFont();
-// Not used: slot_setCommandLineFont();
-
     // Terminal colors.
     void slot_setColorBlack();
     void slot_setColorLightBlack();
@@ -176,6 +171,9 @@ private slots:
     void slot_changeLargeAreaExitArrows(const bool);
     void slot_hidePasswordMigrationLabel();
     void slot_loadHistoryMap();
+    void slot_displayFontChanged();
+    void slot_displayFontSizeChanged();
+    void slot_displayFontAliasingChanged();
 
 signals:
     void signal_themeUpdateCompleted();
@@ -208,9 +206,9 @@ private:
     QString mapSaveLoadDirectory(Host* pHost);
     void loadMap(const QString&);
     void fillOutMapHistory();
+    bool updateDisplayFont();
 
-    int mFontSize = 10;
-    QFont mDisplayFont;
+
     QPointer<Host> mpHost;
     QPointer<QTemporaryFile> tempThemesArchive;
     QMap<QString, QString> mSearchEngineMap;

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -10503,3 +10503,15 @@ void dlgTriggerEditor::checkForMoreThanOneTriggerItem()
 
     mpTriggersMainArea->groupBox_multiLineTrigger->setEnabled(activeItems > 1);
 }
+
+void dlgTriggerEditor::setDisplayFont(const QFont& newFont)
+{
+    if (mpErrorConsole) {
+        mpErrorConsole->setFont(newFont);
+    }
+
+    auto config = mpSourceEditorEdbee->config();
+    config->beginChanges();
+    config->setFont(newFont);
+    config->endChanges();
+}

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -228,6 +228,7 @@ public:
     void showCurrentTriggerItem();
     void hideSystemMessageArea();
     void showIDLabels(const bool);
+    void setDisplayFont(const QFont&);
 
 public slots:
     void slot_toggleHiddenVariables(bool);

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -728,31 +728,80 @@
         <widget class="QGroupBox" name="groupBox_font">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
+           <horstretch>1</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
          <property name="title">
           <string>Font</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_groupBox_font">
-          <item row="3" column="0" colspan="4">
-           <widget class="QLabel" name="label_variableWidthFontWarning">
-            <property name="font">
-             <font>
-              <pointsize>8</pointsize>
-             </font>
-            </property>
+         <layout class="QGridLayout" name="gridLayout_groupBox_font" columnstretch="0,1,0,0,0">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_displayFont">
             <property name="text">
-             <string comment="Note that this text is split into two lines so that the message is not too wide in English, please do the same for other locales where the text is the same or longer">This font is not monospace, which may not be ideal for playing some text games:
-you can use it but there could be issues with aligning columns of text</string>
+             <string>Font:</string>
             </property>
             <property name="buddy">
-             <cstring>fontSize</cstring>
+             <cstring>fontComboBox_displayFont</cstring>
             </property>
            </widget>
           </item>
-          <item row="2" column="0" colspan="4">
+          <item row="0" column="1">
+           <widget class="QFontComboBox" name="fontComboBox_displayFont">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>1</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="editable">
+             <bool>false</bool>
+            </property>
+            <property name="maxVisibleItems">
+             <number>20</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="label_displayFontSize">
+            <property name="text">
+             <string>Size:</string>
+            </property>
+            <property name="buddy">
+             <cstring>spinBox_displayFontSize</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QSpinBox" name="spinBox_displayFontSize">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>99</number>
+            </property>
+            <property name="value">
+             <number>14</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="5">
+           <widget class="QCheckBox" name="checkBox_antiAlias">
+            <property name="toolTip">
+             <string>&lt;p&gt;Use anti aliasing on fonts. Smoothes fonts if you have a high screen resolution and you can use larger fonts. Note that on low resolutions and small font sizes, the font gets blurry.&lt;/p&gt;</string>
+            </property>
+            <property name="text">
+             <string>Enable anti-aliasing</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="4">
            <widget class="QLabel" name="label_invalidFontError">
             <property name="font">
              <font>
@@ -764,39 +813,16 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="1" colspan="2">
-           <widget class="QPushButton" name="pushButton_fontDialog">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+          <item row="2" column="0" colspan="4">
+           <widget class="QLabel" name="label_variableWidthFontWarning">
+            <property name="font">
+             <font>
+              <pointsize>8</pointsize>
+             </font>
             </property>
             <property name="text">
-             <string>Select Font</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_30">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Font:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <widget class="QCheckBox" name="mNoAntiAlias">
-            <property name="toolTip">
-             <string>&lt;p&gt;Use anti aliasing on fonts. Smoothes fonts if you have a high screen resolution and you can use larger fonts. Note that on low resolutions and small font sizes, the font gets blurry.&lt;/p&gt;</string>
-            </property>
-            <property name="text">
-             <string>Enable anti-aliasing</string>
+             <string comment="Note that this text is split into two lines so that the message is not too wide in English, please do the same for other locales where the text is the same or longer">This font is not monospace, which may not be ideal for playing some text games:
+you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
@@ -4381,7 +4407,9 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>comboBox_dictionary</tabstop>
   <tabstop>radioButton_userDictionary_profile</tabstop>
   <tabstop>radioButton_userDictionary_common</tabstop>
-  <tabstop>mNoAntiAlias</tabstop>
+  <tabstop>fontComboBox_displayFont</tabstop>
+  <tabstop>spinBox_displayFontSize</tabstop>
+  <tabstop>checkBox_antiAlias</tabstop>
   <tabstop>topBorderHeight</tabstop>
   <tabstop>bottomBorderHeight</tabstop>
   <tabstop>leftBorderWidth</tabstop>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
* Revert redesign of main font selection in preferences.
* Restructure usage of fonts to remove the somewhat redundent `(QFont) mDisplayFont` for widgets that inherently have their own (QFont) which they use for painting operations.
* Provide a means to track only the details of `QFont`s that we care about which should be more lightweight than holding a complete copy of a font (in `TFontDetails`).
* Include the "antialisaing" detall for the main display font (only for the main console) in the active updates that changing the main font in the preferences produces.
* Apply changes to the font in a `TConsole` to **all** the `TCommandLine`s associated with it.

#### Brief overview of PR changes/additions
* The previously revised font settings in the preferences that used a native font selection was not as useful as it seemed - at least the Windows one offered controls that we did not need or use which meant they had not actual effects which would be confusing to the end user.
* Storing a separate copy of `QFont`s did not seem productive especially as it was easy to modify the intrinsic one and not the copy or vice-versa.
* Adding a separate class to track the font details we ARE interested in makes it easier to compare fonts and to tell whether two instances are the same as far as Mudlet is concerned
* It was not clear that the "anti-aliasing" setting was being correctly applied/used where it was intended - with this PR it is also updated as it is changed in the prefernces along with the other two settings: font "family" and "size".
* The font in command-lines now clearly follow the main console or a sub- console that they belong to.

#### Other info (issues closed, discussion etc)
Once this is done it is perhaps a bit clearer that the Lua API `setFont(["windowName", ] "fontName")` sets the font family to use for the main or (if given a name) a sub-console/user-window - and if it is the "Main console" that also carries through into:
* the Lua script window in the editor
* the error window in the editor
* the "notepad"
* the map info display in the 2D mapper

the font is also replicated in the corresponding "command-lines" for that "console".

The Lua API `setFontSize(["windowName", ]integer)` sets the font size for all the places where the correspond font had been set by the `setFont(...)` call. Setting the font name and size via the Lua API are two separate operations and they do act seemingly independently of each other.

Setting these things via the preferences take effect on the main console (and related things) immediately (except for the mapper - that only updates when the preferences dialogue is closed) - the anti-alias setting also acts on these things in the same manner (which it didn't before IIRC).

As a side effect of the reversion this will close #7907!

I have a separate commit that gives the option for sub-console/user-windows to track the main console font family (so that changing the font in there carries through into those other windows) - optionally they can *also* track the size of the main font (by a user/scriptable factor) so that as the main font is made smaller or larger so do the other consoles - however this can be switched off if not wanted. I've let that as a separate commit because it would just enlarge this already meaty PR and it can be safely left to be reviewed/done separately!