### PR TITLE
Fix: Suppress a blank line after triggered echo with newline suffix

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -859,7 +859,7 @@ COMMIT_LINE:
             // Start a new, but empty line in the various buffers
             log(lineBuffer.size() - 1, lineBuffer.size() - 1);
             ++localBufferPosition;
-            // Suppress new empty line IFF echoes alreadt created a new empty line
+            // Suppress new empty line IFF echoes already created a new empty line
             // i.e. add newline if no added lines or the lastline isn't empty
             if (addedLines == 0 || !lineBuffer.back().isEmpty()) {
                 std::deque<TChar> const newLine;

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -854,16 +854,20 @@ COMMIT_LINE:
             mpHost->mpConsole->runTriggers(line);
             // Only use of TBuffer::wrap(), breaks up new text
             // NOTE: it MAY have been clobbered by the trigger engine!
-            wrapLine(line, mWrapAt, mWrapIndent, mWrapHangingIndent);
+            const int addedLines = wrapLine(line, mWrapAt, mWrapIndent, mWrapHangingIndent);
 
             // Start a new, but empty line in the various buffers
             log(lineBuffer.size() - 1, lineBuffer.size() - 1);
             ++localBufferPosition;
-            std::deque<TChar> const newLine;
-            buffer.push_back(newLine);
-            lineBuffer.push_back(QString());
-            timeBuffer.push_back(QString());
-            promptBuffer << false;
+            // Suppress new empty line IFF echoes alreadt created a new empty line
+            // i.e. add newline if no added lines or the lastline isn't empty
+            if (addedLines == 0 || !lineBuffer.back().isEmpty()) {
+                std::deque<TChar> const newLine;
+                buffer.push_back(newLine);
+                lineBuffer.push_back(QString());
+                timeBuffer.push_back(QString());
+                promptBuffer << false;
+            }
             if (static_cast<int>(buffer.size()) > mLinesLimit) {
                 // Whilst we also include a call to TConsole::handleLinesOverflowEvent(...)
                 // in all other methods where the following is used (because


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Added a check for whether new lines were added from trigger processing/wrapping and if the last line in the buffer is blank. If new lines were added and the last line in the buffer is empty, TBuffer::translateToPlainText will skip appending an additional blank line.

#### Motivation for adding to Mudlet
A discord user mentioned the wrap-overhaul causing their echoes to behave differently.

#### Other info (issues closed, discussion etc)
4.19.1:
![image](https://github.com/user-attachments/assets/51be1432-b534-4f10-991c-1f57a89714a7)

After PR #7714:
![image](https://github.com/user-attachments/assets/27a74309-8d48-4933-8194-788b7ced77ac)

After this PR:
![image](https://github.com/user-attachments/assets/b36c8182-7267-414a-b396-e6e68fa71ff3)