### PR TITLE
Fix: Command line text cleared during echo suppression

### DIFF
--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -143,6 +143,9 @@ private:
 
     // Track echo suppression state
     bool mIsEchoSuppressed = false;
+    // Store text that was in the command line before echo suppression started
+    // This allows us to restore user input after password prompts complete
+    QString mPreEchoText;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(TCommandLine::CommandLineType)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Preserve command line text during password masking/echo suppression mode. When the server requests password input and activates echo suppression, any text previously typed in the command line is now saved and automatically restored after password entry is complete, rather than being permanently cleared.

#### Motivation for adding to Mudlet

Fixes a workflow disruption where users preparing commands during automated login sequences would lose their typed text when the password prompt appeared. This is particularly problematic for MUD players who frequently switch characters and use automated login scripts - they often type their next command while waiting for login to complete, only to have it unexpectedly cleared when echo suppression activates.

The current behavior in PR #7882, while providing excellent security for password input, had the unintended side effect of clearing any preparatory text users had typed, forcing them to retype their commands after login.

#### Other info (issues closed, discussion etc)

Closes #7921. Improves upon PR #7882 by maintaining the security benefits of password masking while preserving user workflow. The implementation adds a new member variable `mPreEchoText` to `TCommandLine` that temporarily stores the command line content when echo suppression begins, then restores it when echo suppression ends. This ensures no user input is lost while maintaining all the accessibility and security features introduced in the original password masking implementation.

---

https://github.com/user-attachments/assets/600b2ba1-6921-4154-9722-583b2fc8c6c0