### PR TITLE
Fix: restore upper and lower room 2D mapper colours for Qt >= 6.6.0

### DIFF
--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1232,6 +1232,10 @@ void XMLimport::readHost(Host* pHost)
                 pHost->mFgColor_2 = QColor::fromString(readElementText());
             } else if (name() == qsl("mBgColor2")) {
                 pHost->mBgColor_2 = QColor::fromString(readElementText());
+            } else if (name() == qsl("mLowerLevelColor")) {
+                pHost->mLowerLevelColor = QColor::fromString(readElementText());
+            } else if (name() == qsl("mUpperLevelColor")) {
+                pHost->mUpperLevelColor = QColor::fromString(readElementText());
             } else if (name() == qsl("mRoomBorderColor")) {
                 pHost->mRoomBorderColor = QColor::fromString(readElementText());
             } else if (name() == qsl("mRoomCollisionBorderColor")) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Provides code compatible with later Qt versions when reading the colours used to show rooms above and below the current z-coordinate in the 2D map. The original PR that introduced this detail #7654 only included code for Qt < 6.6.0 - using `(void) QColor::setNamedColor(const QString&)` but this has been deprecated since Qt 6.6 and has been replaced by `(Qcolor) QColor::fromString(QAnyStringView)` - the original will now produce build warnings in the current 6.9 versions.

#### Motivation for adding to Mudlet
Make the settings for these colours be preserved between sessions and stop the generation of (OS command-line) warnings of the form: `XMLimport::readUnknownElement("Host") ERROR - UNKNOWN Package Element name:` for `mLowerLevelColor` and `mUpperLevelColor`.

#### Other info (issues closed, discussion etc)
This was brought to my attention by **termie** in the Discord **#help** channel at 2025/07/01 20:12 UTC, though it also tickled a memory I had of seeing the same warnings about these (but I had thought it was just a problem in my own setup).