### PR TITLE
Add: Auto-redirect keyboard focus from output to command line [failed attempt]

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -54,6 +54,7 @@
 #include <QScrollBar>
 #include <QStringRef>
 #include <QTextBoundaryFinder>
+#include <QTimer>
 #include <QToolTip>
 #include <QVersionNumber>
 #include "post_guard.h"
@@ -2876,31 +2877,25 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
         const QString text = event->text();
 
         if (!text.isEmpty() && text.at(0).isLetterOrNumber()) {
-            // Find the appropriate command line to redirect to
-            TCommandLine* targetCommandLine = nullptr;
+            // Use the Host's public method to set focus to the active command line
+            mpHost->setFocusOnHostActiveCommandLine();
             
-            // First, try to get the command line associated with this console
-            if (mpConsole && mpConsole->mpCommandLine && mpConsole->mpCommandLine->isVisible()) {
-                targetCommandLine = mpConsole->mpCommandLine;
-            } else if (mpHost && mpHost->mpConsole && mpHost->mpConsole->mpCommandLine && mpHost->mpConsole->mpCommandLine->isVisible()) {
-                // If this console doesn't have a command line, fall back to the main console
-                targetCommandLine = mpHost->mpConsole->mpCommandLine;
-            }
+            // Forward the key event to the command line that now has focus
+            // We need to use QTimer::singleShot to ensure the focus change happens first
+            QTimer::singleShot(0, [this, event]() {
+                if (auto* focusedWidget = QApplication::focusWidget()) {
+                    if (qobject_cast<TCommandLine*>(focusedWidget)) {
+                        QApplication::sendEvent(focusedWidget, event);
+                    }
+                }
+            });
             
-            if (targetCommandLine) {
-                // Set focus to the command line
-                targetCommandLine->setFocus(Qt::ShortcutFocusReason);
-                
-                // Forward the key event to the command line so the typed character appears
-                QApplication::sendEvent(targetCommandLine, event);
-                
-                // Mark the event as handled
-                event->accept();
-                return;
-            }
+            // Mark the event as handled
+            event->accept();
+            return;
         }
         
-        // For non-alpha-numeric keys or if no command line found, use default behavior
+        // For non-alpha-numeric keys or if no active command line found, use default behavior
         QWidget::keyPressEvent(event);
         return;
     }

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2870,6 +2870,37 @@ void TTextEdit::updateCaret()
 void TTextEdit::keyPressEvent(QKeyEvent* event)
 {
     if (!mpHost->caretEnabled()) {
+        // Feature #7926: Auto-redirect focus to command line for alpha-numeric characters
+        // This improves accessibility for screen reader users by automatically redirecting
+        // typing focus from the output window to the command line
+        const QString text = event->text();
+        if (!text.isEmpty() && text.at(0).isLetterOrNumber()) {
+            // Find the appropriate command line to redirect to
+            TCommandLine* targetCommandLine = nullptr;
+            
+            // First, try to get the command line associated with this console
+            if (mpConsole && mpConsole->mpCommandLine && mpConsole->mpCommandLine->isVisible()) {
+                targetCommandLine = mpConsole->mpCommandLine;
+            }
+            // If this console doesn't have a command line, fall back to the main console
+            else if (mpHost && mpHost->mpConsole && mpHost->mpConsole->mpCommandLine && mpHost->mpConsole->mpCommandLine->isVisible()) {
+                targetCommandLine = mpHost->mpConsole->mpCommandLine;
+            }
+            
+            if (targetCommandLine) {
+                // Set focus to the command line
+                targetCommandLine->setFocus(Qt::ShortcutFocusReason);
+                
+                // Forward the key event to the command line so the typed character appears
+                QApplication::sendEvent(targetCommandLine, event);
+                
+                // Mark the event as handled
+                event->accept();
+                return;
+            }
+        }
+        
+        // For non-alpha-numeric keys or if no command line found, use default behavior
         QWidget::keyPressEvent(event);
         return;
     }

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2871,35 +2871,34 @@ void TTextEdit::updateCaret()
 void TTextEdit::keyPressEvent(QKeyEvent* event)
 {
     if (!mpHost->caretEnabled()) {
-        // Auto-redirect focus to command line for alpha-numeric characters
-        // This improves accessibility for screen reader users by automatically redirecting
-        // typing focus from the output window to the command line
-        const QString text = event->text();
-
-        if (!text.isEmpty() && text.at(0).isLetterOrNumber()) {
-            // Use the Host's public method to set focus to the active command line
-            mpHost->setFocusOnHostActiveCommandLine();
-            
-            // Forward the key event to the command line that now has focus
-            // Use a 1ms timer to ensure it runs after the Host's 0ms focus timer
-            QTimer::singleShot(1, [this, event]() {
-                if (auto* focusedWidget = QApplication::focusWidget()) {
-                    if (qobject_cast<TCommandLine*>(focusedWidget)) {
-                        QApplication::sendEvent(focusedWidget, event);
-                    }
-                }
-            });
-            
-            // Mark the event as handled
-            event->accept();
-            return;
-        }
-        
-        // For non-alpha-numeric keys or if no active command line found, use default behavior
         QWidget::keyPressEvent(event);
         return;
     }
 
+    // Auto-redirect focus to command line for alpha-numeric characters
+    // This improves accessibility for screen reader users by automatically redirecting
+    // typing focus from the output window to the command line
+    const QString text = event->text();
+
+    if (!text.isEmpty() && text.at(0).isLetterOrNumber()) {
+        // Use the Host's public method to set focus to the active command line
+        mpHost->setFocusOnHostActiveCommandLine();
+        
+        // Forward the key event to the command line that now has focus
+        // Use a 1ms timer to ensure it runs after the Host's 0ms focus timer
+        QTimer::singleShot(1, [this, event]() {
+            if (auto* focusedWidget = QApplication::focusWidget()) {
+                if (qobject_cast<TCommandLine*>(focusedWidget)) {
+                    QApplication::sendEvent(focusedWidget, event);
+                }
+            }
+        });
+        
+        // Mark the event as handled
+        event->accept();
+        return;
+    }
+        
     qsizetype newCaretLine = -1;
     qsizetype newCaretColumn = -1;
 

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2884,14 +2884,38 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
         // Use the Host's public method to set focus to the active command line
         mpHost->setFocusOnHostActiveCommandLine();
         
+        // Create a heap-allocated copy of the key event for safe forwarding
+        // This prevents use-after-free when the timer fires after the original event is destroyed
+        auto* eventCopy = new QKeyEvent(event->type(), event->key(), event->modifiers(),
+                                        event->nativeScanCode(), event->nativeVirtualKey(),
+                                        event->nativeModifiers(), event->text(),
+                                        event->isAutoRepeat(), event->count());
+        
+        // Use QPointer for safe widget access in the timer callback
+        QPointer<TTextEdit> safeThis(this);
+        
         // Forward the key event to the command line that now has focus
         // Use a 1ms timer to ensure it runs after the Host's 0ms focus timer
-        QTimer::singleShot(1, [this, event]() {
+        QTimer::singleShot(1, [safeThis, eventCopy]() {
+            // Safety check: ensure the widget still exists
+            if (!safeThis) {
+                qDebug() << "TTextEdit::keyPressEvent timer - Widget was destroyed before timer fired";
+                delete eventCopy;
+                return;
+            }
+            
             if (auto* focusedWidget = QApplication::focusWidget()) {
                 if (qobject_cast<TCommandLine*>(focusedWidget)) {
-                    QApplication::sendEvent(focusedWidget, event);
+                    qDebug() << "TTextEdit::keyPressEvent timer - Forwarding event to command line";
+                    QApplication::sendEvent(focusedWidget, eventCopy);
+                } else {
+                    qDebug() << "TTextEdit::keyPressEvent timer - Focus not on command line, focused widget:" << focusedWidget->metaObject()->className();
                 }
+            } else {
+                qDebug() << "TTextEdit::keyPressEvent timer - No focused widget found";
             }
+            // Clean up the copied event
+            delete eventCopy;
         });
         
         // Mark the event as handled

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2881,8 +2881,8 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
             mpHost->setFocusOnHostActiveCommandLine();
             
             // Forward the key event to the command line that now has focus
-            // We need to use QTimer::singleShot to ensure the focus change happens first
-            QTimer::singleShot(0, [this, event]() {
+            // Use a 1ms timer to ensure it runs after the Host's 0ms focus timer
+            QTimer::singleShot(1, [this, event]() {
                 if (auto* focusedWidget = QApplication::focusWidget()) {
                     if (qobject_cast<TCommandLine*>(focusedWidget)) {
                         QApplication::sendEvent(focusedWidget, event);

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2870,10 +2870,11 @@ void TTextEdit::updateCaret()
 void TTextEdit::keyPressEvent(QKeyEvent* event)
 {
     if (!mpHost->caretEnabled()) {
-        // Feature #7926: Auto-redirect focus to command line for alpha-numeric characters
+        // Auto-redirect focus to command line for alpha-numeric characters
         // This improves accessibility for screen reader users by automatically redirecting
         // typing focus from the output window to the command line
         const QString text = event->text();
+
         if (!text.isEmpty() && text.at(0).isLetterOrNumber()) {
             // Find the appropriate command line to redirect to
             TCommandLine* targetCommandLine = nullptr;
@@ -2881,9 +2882,8 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
             // First, try to get the command line associated with this console
             if (mpConsole && mpConsole->mpCommandLine && mpConsole->mpCommandLine->isVisible()) {
                 targetCommandLine = mpConsole->mpCommandLine;
-            }
-            // If this console doesn't have a command line, fall back to the main console
-            else if (mpHost && mpHost->mpConsole && mpHost->mpConsole->mpCommandLine && mpHost->mpConsole->mpCommandLine->isVisible()) {
+            } else if (mpHost && mpHost->mpConsole && mpHost->mpConsole->mpCommandLine && mpHost->mpConsole->mpCommandLine->isVisible()) {
+                // If this console doesn't have a command line, fall back to the main console
                 targetCommandLine = mpHost->mpConsole->mpCommandLine;
             }
             


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Automatically redirects keyboard focus from the output window to the command line when users type alpha-numeric characters. This eliminates the need for screen reader users to manually press shortcut keys to switch focus when they want to type commands.

#### Motivation for adding to Mudlet

This change addresses GitHub issue #7926, which requested an accessibility improvement for screen reader users. Currently, when focus is in the output window (TTextEdit), typing alpha-numeric characters is ignored, forcing users to press a configured shortcut key to return focus to the command line. This extra step slows down the workflow for screen reader users who frequently switch between reviewing text output and entering commands.

The implementation:
- Detects alpha-numeric key presses when caret mode is enabled in TTextEdit
- Uses the Host's public API to set focus to the last-used (active) command line
- Forwards the typed character to the command line using a memory-safe timer-based approach with heap-allocated event copies
- Maintains existing behavior for all other keys and scenarios
- Does not affect users who don't rely on screen readers

#### Other info (issues closed, discussion etc)

Closes #7926

This is a targeted accessibility enhancement that improves the user experience for screen reader users without affecting the existing functionality for other users. The change follows the principle of progressive enhancement - adding functionality that benefits those who need it while maintaining the status quo for everyone else.

Technical details:
- Modified `TTextEdit::keyPressEvent()` in `/src/TTextEdit.cpp`
- Added `#include <QTimer>` for timer functionality
- Added logic to detect alpha-numeric characters when `mpHost->caretEnabled()`
- Uses `mpHost->setFocusOnHostActiveCommandLine()` to leverage existing focus tracking
- Creates heap-allocated QKeyEvent copies to prevent use-after-free issues
- Uses `QPointer<TTextEdit>` for safe widget access in timer callbacks
- Uses `QTimer::singleShot(1, ...)` with 1ms delay to ensure focus change completes before forwarding the key event
- Dynamically checks `QApplication::focusWidget()` to verify the target is a command line
- Includes comprehensive debug logging for troubleshooting
- Proper memory cleanup with explicit event deletion
- Relies on Host's robust focus tracking rather than manual console/command line lookups

---

https://github.com/user-attachments/assets/d9a21aa3-adf8-4e45-90e6-fcb8d8638292
