### PR TITLE
add getPID() to return process id

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3182,6 +3182,14 @@ int TLuaInterpreter::getOS(lua_State* L)
 #endif
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getPID
+int TLuaInterpreter::getPID(lua_State* L)
+{
+    int pid = QApplication::applicationPid();
+    lua_pushinteger(L, pid);
+    return 1;
+}
+
 // No documentation available in wiki - internal function
 bool TLuaInterpreter::compileAndExecuteScript(const QString& code)
 {
@@ -5475,6 +5483,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getColumnCount", TLuaInterpreter::getColumnCount);
     lua_register(pGlobalLua, "getRowCount", TLuaInterpreter::getRowCount);
     lua_register(pGlobalLua, "getOS", TLuaInterpreter::getOS);
+    lua_register(pGlobalLua, "getPID", TLuaInterpreter::getPID);
     lua_register(pGlobalLua, "getClipboardText", TLuaInterpreter::getClipboardText);
     lua_register(pGlobalLua, "setClipboardText", TLuaInterpreter::setClipboardText);
     lua_register(pGlobalLua, "getAvailableFonts", TLuaInterpreter::getAvailableFonts);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3182,8 +3182,8 @@ int TLuaInterpreter::getOS(lua_State* L)
 #endif
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getPID
-int TLuaInterpreter::getPID(lua_State* L)
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getProcessID
+int TLuaInterpreter::getProcessID(lua_State* L)
 {
     int pid = QApplication::applicationPid();
     lua_pushinteger(L, pid);
@@ -5483,7 +5483,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getColumnCount", TLuaInterpreter::getColumnCount);
     lua_register(pGlobalLua, "getRowCount", TLuaInterpreter::getRowCount);
     lua_register(pGlobalLua, "getOS", TLuaInterpreter::getOS);
-    lua_register(pGlobalLua, "getPID", TLuaInterpreter::getPID);
+    lua_register(pGlobalLua, "getProcessID", TLuaInterpreter::getProcessID);
     lua_register(pGlobalLua, "getClipboardText", TLuaInterpreter::getClipboardText);
     lua_register(pGlobalLua, "setClipboardText", TLuaInterpreter::setClipboardText);
     lua_register(pGlobalLua, "getAvailableFonts", TLuaInterpreter::getAvailableFonts);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -604,6 +604,7 @@ public:
     static int getColumnCount(lua_State*);
     static int getRowCount(lua_State*);
     static int getOS(lua_State*);
+    static int getPID(lua_State*);
     static int getClipboardText(lua_State*);
     static int setClipboardText(lua_State*);
     static int getAvailableFonts(lua_State*);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -604,7 +604,7 @@ public:
     static int getColumnCount(lua_State*);
     static int getRowCount(lua_State*);
     static int getOS(lua_State*);
-    static int getPID(lua_State*);
+    static int getProcessID(lua_State*);
     static int getClipboardText(lua_State*);
     static int setClipboardText(lua_State*);
     static int getAvailableFonts(lua_State*);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
adds a global lua function, getPID()

#### Motivation for adding to Mudlet
the process id provides a stable identifier when running multiple instances of mudlet from the same base profile

#### Other info (issues closed, discussion etc)
I added the documentation line, but clearly no docs there yet
