### PR TITLE
fix: Modified DB.lua assertion to allow for default false fields

### DIFF
--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -1643,7 +1643,7 @@ db.__SheetMT = {
     local field = db.__schema[db_name][sht_name]['columns'][f_name]
     local field_type = ""
     local rt
-    if assert(field, errormsg:format(k, sht_name, db_name)) then
+    if assert(field ~= nil, errormsg:format(k, sht_name, db_name)) then
       field_type = type(field)
       if field_type == "table" and field._timestamp ~= nil then
         field_type = "datetime"


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Allow db functions to work with a field that defaults to `false`
#### Motivation for adding to Mudlet
False is a reasonable default for a database field, and others will undoubtedly encounter this issue in the future.
#### Other info (issues closed, discussion etc)
Discussion occurred on Discord. Testing live on my own system, should be safe to merge within a few days.