### PR TITLE
Add: Password visibility toggle for command line during echo suppression

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -37,6 +37,9 @@
 #include <QRegularExpression>
 #include <QScrollBar>
 #include <QSaveFile>
+#include <QToolButton>
+#include <QHBoxLayout>
+#include <QIcon>
 #include "post_guard.h"
 
 TCommandLine::TCommandLine(Host* pHost, const QString& name, CommandLineType type, TConsole* pConsole, QWidget* parent)
@@ -54,6 +57,19 @@ TCommandLine::TCommandLine(Host* pHost, const QString& name, CommandLineType typ
 
     setFont(mpHost->getDisplayFont());
     document()->setDocumentMargin(2);
+
+    // Create password toggle button for MainCommandLine only
+    if (mType == MainCommandLine) {
+        mpPasswordToggleButton = new QToolButton(this);
+        mpPasswordToggleButton->setMinimumSize(QSize(20, 20));
+        mpPasswordToggleButton->setMaximumSize(QSize(20, 20));
+        mpPasswordToggleButton->setFocusPolicy(Qt::NoFocus);
+        mpPasswordToggleButton->setCursor(Qt::PointingHandCursor);
+        mpPasswordToggleButton->setIcon(QIcon(qsl(":/icons/password-show-on.png"))); // Default to "show" icon
+        mpPasswordToggleButton->setToolTip(tr("Show password"));
+        mpPasswordToggleButton->setVisible(false); // Hidden by default
+        connect(mpPasswordToggleButton, &QToolButton::clicked, this, &TCommandLine::slot_togglePasswordVisibility);
+    }
 
     if (mType & (MainCommandLine|ConsoleCommandLine)) {
         // put an outline around the command line when it is integrated into
@@ -1585,9 +1601,22 @@ void TCommandLine::setEchoSuppression(bool suppress)
         // This preserves any command the user may have typed while waiting for login
         mPreEchoText = toPlainText();
         clear();  // Clear for password input
+        
+        // Show password toggle button and reset visibility state
+        if (mpPasswordToggleButton) {
+            mPasswordVisible = false; // Start with password hidden
+            updatePasswordToggleButton();
+            mpPasswordToggleButton->setVisible(true);
+            positionPasswordToggleButton();
+        }
     } else {
         // Clear the password field first
         clear();
+        
+        // Hide password toggle button
+        if (mpPasswordToggleButton) {
+            mpPasswordToggleButton->setVisible(false);
+        }
         
         // Restore the previously typed text if any
         // This allows users to continue with commands they typed during login sequences
@@ -1607,8 +1636,8 @@ void TCommandLine::setEchoSuppression(bool suppress)
 
 void TCommandLine::paintEvent(QPaintEvent* event)
 {
-    // Only mask text for the main command line when echo is suppressed
-    if (mIsEchoSuppressed && mType == MainCommandLine) {
+    // Only mask text for the main command line when echo is suppressed and password is not visible
+    if (mIsEchoSuppressed && mType == MainCommandLine && !mPasswordVisible) {
         QPainter painter(viewport());
         QTextCursor cursor = textCursor();
         QTextBlock block = document()->firstBlock();
@@ -1625,4 +1654,61 @@ void TCommandLine::paintEvent(QPaintEvent* event)
     }
 
     QPlainTextEdit::paintEvent(event);
+}
+
+void TCommandLine::slot_togglePasswordVisibility()
+{
+    if (!mIsEchoSuppressed || mType != MainCommandLine) {
+        return;
+    }
+    
+    mPasswordVisible = !mPasswordVisible;
+    updatePasswordToggleButton();
+    viewport()->update(); // triggers paintEvent to mask/unmask
+}
+
+void TCommandLine::updatePasswordToggleButton()
+{
+    if (!mpPasswordToggleButton) {
+        return;
+    }
+    
+    if (mPasswordVisible) {
+        // Password is visible, show "hide" icon (eye with slash)
+        mpPasswordToggleButton->setIcon(QIcon(qsl(":/icons/password-show-off.png")));
+        mpPasswordToggleButton->setToolTip(tr("Hide password"));
+    } else {
+        // Password is hidden, show "show" icon (eye)
+        mpPasswordToggleButton->setIcon(QIcon(qsl(":/icons/password-show-on.png")));
+        mpPasswordToggleButton->setToolTip(tr("Show password"));
+    }
+}
+
+void TCommandLine::positionPasswordToggleButton()
+{
+    if (!mpPasswordToggleButton) {
+        return;
+    }
+    
+    // Position the button at the right side of the text edit
+    const QRect viewportRect = viewport()->geometry();
+    const int buttonWidth = mpPasswordToggleButton->width();
+    const int buttonHeight = mpPasswordToggleButton->height();
+    const int margin = 5;
+    
+    // Position at the right edge, vertically centered
+    const int x = viewportRect.width() - buttonWidth - margin;
+    const int y = (viewportRect.height() - buttonHeight) / 2;
+    
+    mpPasswordToggleButton->move(x, y);
+}
+
+void TCommandLine::resizeEvent(QResizeEvent* event)
+{
+    QPlainTextEdit::resizeEvent(event);
+    
+    // Reposition the password toggle button when the widget is resized
+    if (mpPasswordToggleButton && mpPasswordToggleButton->isVisible()) {
+        positionPasswordToggleButton();
+    }
 }

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -38,7 +38,6 @@
 #include <QScrollBar>
 #include <QSaveFile>
 #include <QToolButton>
-#include <QHBoxLayout>
 #include <QIcon>
 #include "post_guard.h"
 
@@ -65,7 +64,7 @@ TCommandLine::TCommandLine(Host* pHost, const QString& name, CommandLineType typ
         mpPasswordToggleButton->setMaximumSize(QSize(20, 20));
         mpPasswordToggleButton->setFocusPolicy(Qt::NoFocus);
         mpPasswordToggleButton->setCursor(Qt::PointingHandCursor);
-        mpPasswordToggleButton->setIcon(QIcon(qsl(":/icons/password-show-on.png"))); // Default to "show" icon
+        mpPasswordToggleButton->setIcon(QIcon(qsl(":/icons/password-show-on.png")));
         mpPasswordToggleButton->setToolTip(tr("Show password"));
         mpPasswordToggleButton->setVisible(false); // Hidden by default
         connect(mpPasswordToggleButton, &QToolButton::clicked, this, &TCommandLine::slot_togglePasswordVisibility);

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -33,6 +33,8 @@
 #include <QString>
 #include <QStringList>
 #include <QTextDecoder>
+#include <QToolButton>
+#include <QResizeEvent>
 #include "post_guard.h"
 
 
@@ -114,6 +116,9 @@ private:
     bool handleCtrlTabChange(QKeyEvent* key, int tabNumber);
     void restoreHistory();
     void paintEvent(QPaintEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
+    void updatePasswordToggleButton();
+    void positionPasswordToggleButton();
 
     QPointer<Host> mpHost;
     CommandLineType mType = UnknownType;
@@ -143,9 +148,16 @@ private:
 
     // Track echo suppression state
     bool mIsEchoSuppressed = false;
+    // Track password visibility state when echo is suppressed
+    bool mPasswordVisible = false;
+    // Button to toggle password visibility
+    QToolButton* mpPasswordToggleButton = nullptr;
     // Store text that was in the command line before echo suppression started
     // This allows us to restore user input after password prompts complete
     QString mPreEchoText;
+
+private slots:
+    void slot_togglePasswordVisibility();
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(TCommandLine::CommandLineType)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds a password visibility toggle button to the main command line that appears only during echo suppression (password entry mode). The button allows users to temporarily reveal their password text to verify correct entry, then hide it again for security.

Key features:
- Toggle button appears on the right side of the main command line only when echo is suppressed
- Uses dedicated eye icons (`password-show-on.png` and `password-show-off.png`) to indicate current state
- Button shows "eye" icon when password is hidden (click to reveal) and "eye-off" icon when visible (click to hide)
- Integrates seamlessly with existing password masking functionality from PR #7882
- Maintains all existing security features (no history saving, limited interactions during password mode)

#### Motivation for adding to Mudlet

Enhances accessibility and usability during password entry by allowing users to:
- Verify they've typed their password correctly before submitting
- Recover from typing errors without having to clear and retype the entire password
- Improve confidence during login sequences, especially for users with complex passwords
- Maintain security by keeping passwords hidden by default while providing optional visibility

This addresses common user experience issues where users are unsure if they've entered their password correctly due to the masking, particularly beneficial for users with accessibility needs or complex authentication requirements.

#### Other info (issues closed, discussion etc)

Builds upon the password masking functionality introduced in PR #7882. The toggle button:
- Only appears for MainCommandLine during echo suppression
- Uses existing password visibility icons already present in the codebase
- Follows standard UI patterns for password field toggles
- Respects the existing security model (passwords still cleared when echo suppression ends)

---

https://github.com/user-attachments/assets/61a20f87-d091-4f14-bc90-6559d6cf2886
