### PR TITLE
Add: newtry Auto-redirect keyboard focus from output to command line

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2873,15 +2873,19 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
         QWidget::keyPressEvent(event);
         return;
     }
-
+    
+    // #7933 Auto-reditect focus to command line from output window when press alpha-numeric characters 
+    // skips ctrl,alt, etc. This improves experiencie and makes fast switch to screenreader users focusing on output
     if (!(event->modifiers() & (Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier)) && !event->text().isEmpty() && event->text().front().isPrint()) {
-        mpHost->setCaretEnabled(false);
-        mpHost->setFocusOnHostActiveCommandLine();
-        QKeyEvent newEvent(
-    event->type(), event->key(), event->modifiers(), event->text(), event->isAutoRepeat(), event->count());
-        qApp->sendEvent(mpConsole->mpCommandLine, &newEvent);
-        return;
-    }
+        if (mpHost && mpConsole && mpConsole->mpCommandLine) {
+            mpHost->setCaretEnabled(false);
+            mpHost->setFocusOnHostActiveCommandLine();
+            QKeyEvent newEvent(event->type(), event->key(), event->modifiers(), event->text(), event->isAutoRepeat(), event->count());
+            qApp->sendEvent(mpConsole->mpCommandLine, &newEvent);
+            return;
+        }
+        // if not command line ignore
+    }        
 
     qsizetype newCaretLine = -1;
     qsizetype newCaretColumn = -1;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2874,6 +2874,15 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
         return;
     }
 
+    if (!(event->modifiers() & (Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier)) && !event->text().isEmpty() && event->text().front().isPrint()) {
+        mpHost->setCaretEnabled(false);
+        mpHost->setFocusOnHostActiveCommandLine();
+        QKeyEvent newEvent(
+    event->type(), event->key(), event->modifiers(), event->text(), event->isAutoRepeat(), event->count());
+        qApp->sendEvent(mpConsole->mpCommandLine, &newEvent);
+        return;
+    }
+
     qsizetype newCaretLine = -1;
     qsizetype newCaretColumn = -1;
 


### PR DESCRIPTION
[Add: new attemp Auto-redirect keyboard focus from output to command line](https://github.com/sammerpetria/Mudlet/commit/4a8cc80a41f5f3504c5833e95415bbd8ae0a032b)

#### Brief overview of PR changes/additions

Automatically redirects keyboard focus from the output window to the command line when users type alpha-numeric characters. This eliminates the need for screen reader users to manually press shortcut keys to switch focus when they want to type commands.


#### Motivation for adding to Mudlet

This change addresses GitHub issue https://github.com/Mudlet/Mudlet/issues/7926, which requested an accessibility improvement for screen reader users. Currently, when focus is in the output window (TTextEdit), typing alpha-numeric characters is ignored, forcing users to press a configured shortcut key to return focus to the command line. This extra step slows down the workflow for screen reader users who frequently switch between reviewing text output and entering commands.

Improve the experiencie for not only screen readers user the option to use the accesibility  special key feature to switch between output/input (tab, ctrl+tab, f6), navigate with keyboard the output (for selecction for example), dont rely on mouse, and go fast to input line.

#### Other info (issues closed, discussion etc)
Its another try of #7927

tested in ubuntu compile and windows via qtcreator. win11.
works ok tested with NVDA, tested used de ctrl+tab, and f6 keys to focus on output and then go back with anykey.
test multiple profiles and doesnt seem to be a problem. Dont know other concerns, internals things but seems to work.
(noob right here xD)
First try to contribute.