### PR TITLE
Fix: Command line text restoration after echo suppression

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1583,7 +1583,30 @@ void TCommandLine::setEchoSuppression(bool suppress)
     if (suppress) {
         // Save the current text before clearing for password input
         // This preserves any command the user may have typed while waiting for login
-        mPreEchoText = toPlainText();
+        const QString currentText = toPlainText();
+        // Only save text if it's not empty and not already sent as a command
+        // We check if it differs from the most recent actual command (skipping empty entries)
+        bool shouldSave = false;
+
+        if (!currentText.isEmpty()) {
+            // Look for the most recent non-empty history entry
+            for (const QString& historyEntry : mHistoryList) {
+                if (!historyEntry.isEmpty()) {
+                    // Only save if current text is different from the last actual command
+                    shouldSave = (currentText != historyEntry);
+                    break;
+                }
+            }
+            // If history is empty or all entries are empty, save the current text
+            if (mHistoryList.isEmpty()) {
+                shouldSave = true;
+            }
+        }
+        
+        if (shouldSave) {
+            mPreEchoText = currentText;
+        }
+
         clear();  // Clear for password input
     } else {
         // Clear the password field first

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1607,7 +1607,7 @@ void TCommandLine::setEchoSuppression(bool suppress)
             mPreEchoText = currentText;
         }
 
-        clear();  // Clear for password input
+        clear(); // Clear for password input
     } else {
         // Clear the password field first
         clear();


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Refines the command line text preservation logic during echo suppression to ensure only unsent text gets restored after password prompts, preventing sent commands from reappearing in the command line.

#### Motivation for adding to Mudlet

During login sequences, users would see their previously entered userid reappear in the command line after completing password entry. This happened because the system couldn't properly distinguish between empty command lines and lines with unsent text when deciding what to restore.

#### Other info (issues closed, discussion etc)

Builds upon PR #7924's text preservation feature by improving the history comparison logic. The fix replaces simple history checking with more precise logic that only preserves text that differs from recently sent commands, maintaining clean command line behavior during login workflows.

---

Problem to solve: for normal logons, it will present your username back to you after ending the password sequence, then you have to delete it.


https://github.com/user-attachments/assets/bd36246a-5964-40e1-a4b2-6a14a97dd0fc

---

Solved problem: for normal logons, it will not present the username back to you (or whatever was typed and hit return last)

https://github.com/user-attachments/assets/72ee59dd-6aac-4451-890b-26d822896048

---

Status quo: for automatic logons, it will still remember the text you had in the command line that you did not hit enter upon yet

https://github.com/user-attachments/assets/fcb32500-b80d-433a-b937-34de993c6181
