### PR TITLE
Add: Automate TTYPE Version Compatibility for KaVir Protocol Detection

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1567,32 +1567,20 @@ void cTelnet::trackKaVirNegotiation(unsigned char option)
 
     qDebug().nospace() << "Matched KaVir protocol handling negotiation order: [" << optList.join(", ") << "]";
 #endif
-        promptEnableTTYPEVersion();
+        autoEnableTTYPEVersion();
     }
 }
 
-// Prompt user to enable TTYPE version compatibility mode and reconnect
-void cTelnet::promptEnableTTYPEVersion()
+// Auto-enable TTYPE version compatibility mode when KaVir protocol is detected
+void cTelnet::autoEnableTTYPEVersion()
 {
     mpHost->mPromptedForVersionInTTYPE = true;
 
-    auto msgBox = new QMessageBox();
-    msgBox->setIcon(QMessageBox::Question);
-    msgBox->setText(tr("This game appears to use a protocol that works best if Mudlet reports its version number during connection.\n\nEnable this compatibility mode for improved color support and reconnect?"));
-    msgBox->setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-    msgBox->setDefaultButton(QMessageBox::Yes);
-
-    int ret = msgBox->exec();
-    delete msgBox;
-
-    if (ret == QMessageBox::Yes) {
-        disconnectIt();
-        mpHost->mVersionInTTYPE = true;
-        postMessage(tr("[ INFO ]  - Compatibility mode enabled: Mudlet will now send its version number in the terminal type for this profile. Reconnecting..."));
-        reconnect();
-    } else {
-        postMessage(tr("[ INFO ]  - Compatibility mode not enabled. You can enable version in the terminal type later in Special Options."));
-    }
+    // Automatically enable TTYPE version compatibility
+    disconnectIt();
+    mpHost->mVersionInTTYPE = true;
+    postMessage(tr("[ INFO ]  - This game appears to use KaVir's protocol handler, which works best when Mudlet reports its version number during connection. Version reporting in terminal type has been automatically enabled for improved color support. Reconnecting..."));
+    reconnect();
 }
 
 // Auto-enable MXP processor when indicators are detected

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -329,7 +329,7 @@ private:
 
     void trackKaVirNegotiation(unsigned char option);
     void autoEnableMXPProcessor();
-    void promptEnableTTYPEVersion();
+    void autoEnableTTYPEVersion();
 
     QPointer<Host> mpHost;
 #if defined(QT_NO_SSL)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This PR removes the user prompt dialog for TTYPE version compatibility and replaces it with automatic enablement when KaVir's protocol handler is detected. The system now automatically enables version reporting in terminal type and reconnects, providing a seamless user experience with an informative console message.

#### Motivation for adding to Mudlet

Eliminates user friction by removing an interrupting dialog prompt that most users would accept anyway. The KaVir protocol detection is reliable enough to warrant automatic enablement, and users benefit from improved color support (256 colors) without needing to understand the technical details. This follows the same automation pattern established for other protocol enhancements, providing a smoother connection experience while still informing users of the change through console messaging.

#### Other info (issues closed, discussion etc)

Builds upon the foundation established in PR #7888 which implemented KaVir protocol detection. This change transforms the user experience from "detect and prompt" to "detect and automatically optimize," reducing the number of steps users need to take while maintaining full transparency about what Mudlet is doing on their behalf.

---

Example from Realms of Despair where the automation triggers the first time, marks the special option, and then does not repeat thereafter.

https://github.com/user-attachments/assets/a26f504b-3325-469b-b75b-40c782fefdc2


