### PR TITLE
Improve allow ip version selection for game server connection

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2982,10 +2982,10 @@ void Host::updateProxySettings(QNetworkAccessManager* manager)
 
 std::unique_ptr<QNetworkProxy>& Host::getConnectionProxy()
 {
-    if (!mpConnectionProxy) {
-        mpConnectionProxy = std::make_unique<QNetworkProxy>(QNetworkProxy::Socks5Proxy);
+    if (!mpDownloaderProxy) {
+        mpDownloaderProxy = std::make_unique<QNetworkProxy>(QNetworkProxy::Socks5Proxy);
     }
-    auto& proxy = mpConnectionProxy;
+    auto& proxy = mpDownloaderProxy;
     proxy->setHostName(mProxyAddress);
     proxy->setPort(mProxyPort);
     if (!mProxyUsername.isEmpty()) {
@@ -2995,7 +2995,7 @@ std::unique_ptr<QNetworkProxy>& Host::getConnectionProxy()
         proxy->setPassword(mProxyPassword);
     }
 
-    return mpConnectionProxy;
+    return mpDownloaderProxy;
 }
 
 void Host::loadSecuredPassword()

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2956,10 +2956,10 @@ void Host::updateProxySettings(QNetworkAccessManager* manager)
 
 std::unique_ptr<QNetworkProxy>& Host::getConnectionProxy()
 {
-    if (!mpDownloaderProxy) {
-        mpDownloaderProxy = std::make_unique<QNetworkProxy>(QNetworkProxy::Socks5Proxy);
+    if (!mpConnectionProxy) {
+        mpConnectionProxy = std::make_unique<QNetworkProxy>(QNetworkProxy::Socks5Proxy);
     }
-    auto& proxy = mpDownloaderProxy;
+    auto& proxy = mpConnectionProxy;
     proxy->setHostName(mProxyAddress);
     proxy->setPort(mProxyPort);
     if (!mProxyUsername.isEmpty()) {
@@ -2969,7 +2969,7 @@ std::unique_ptr<QNetworkProxy>& Host::getConnectionProxy()
         proxy->setPassword(mProxyPassword);
     }
 
-    return mpDownloaderProxy;
+    return mpConnectionProxy;
 }
 
 void Host::setDisplayFontSpacing(const qreal spacing)

--- a/src/Host.h
+++ b/src/Host.h
@@ -168,8 +168,6 @@ public:
     Q_DECLARE_FLAGS(DiscordOptionFlags, DiscordOptionFlag)
 
 
-
-
     QString         getName()                        { return mHostName; }
     QString         getCommandSeparator()            { return mCommandSeparator; }
     void            setName(const QString& name);
@@ -440,6 +438,8 @@ public:
         }
     }
     void sendCmdLine(const QString& cmd);
+    void setRemoteEchoingActive(bool active);
+    bool isRemoteEchoingActive() const { return mIsRemoteEchoingActive; }
 
     cTelnet mTelnet;
     QPointer<TMainConsole> mpConsole;
@@ -525,10 +525,6 @@ public:
      * of the above mPrintCommand being true...
      */
     bool mIsRemoteEchoingActive = false;
-
-public:
-    void setRemoteEchoingActive(bool active);
-    bool isRemoteEchoingActive() const { return mIsRemoteEchoingActive; }
 
     // To cover the corner case of the user changing the mode
     // while a log is being written, this stores the mode of
@@ -698,7 +694,7 @@ public:
     // suppressed.
     // An invalid/null value is treated as the "show all"/inactive case:
     QTime mTimerDebugOutputSuppressionInterval;
-    std::unique_ptr<QNetworkProxy> mpDownloaderProxy;
+    std::unique_ptr<QNetworkProxy> mpConnectionProxy;
     QString mProfileStyleSheet;
     dlgTriggerEditor::SearchOptions mSearchOptions;
     TConsole::SearchOptions mBufferSearchOptions;
@@ -736,6 +732,10 @@ public:
     Q_ENUM(CaretShortcut)
     // shortcut to switch between the input line and the main window
     CaretShortcut mCaretShortcut = CaretShortcut::None;
+    // Which IP version to use for the Game Server connection - this has to be
+    // stored as a per profile item and not something in the game save so it
+    // is available in the "Connect Profile" dialogue:
+    QAbstractSocket::NetworkLayerProtocol mIPVersion = QAbstractSocket::AnyIPProtocol;
 
 signals:
     // Tells TTextEdit instances for this profile how to draw the ambiguous

--- a/src/Host.h
+++ b/src/Host.h
@@ -168,6 +168,8 @@ public:
     Q_DECLARE_FLAGS(DiscordOptionFlags, DiscordOptionFlag)
 
 
+
+
     QString         getName()                        { return mHostName; }
     QString         getCommandSeparator()            { return mCommandSeparator; }
     void            setName(const QString& name);
@@ -439,8 +441,6 @@ public:
     }
     void sendCmdLine(const QString& cmd);
     bool fontsAntiAlias() const { return !mNoAntiAlias; }
-    void setRemoteEchoingActive(bool active);
-    bool isRemoteEchoingActive() const { return mIsRemoteEchoingActive; }
 
 private:
     bool mNoAntiAlias = false;
@@ -536,6 +536,10 @@ public:
      * of the above mPrintCommand being true...
      */
     bool mIsRemoteEchoingActive = false;
+
+public:
+    void setRemoteEchoingActive(bool active);
+    bool isRemoteEchoingActive() const { return mIsRemoteEchoingActive; }
 
     // To cover the corner case of the user changing the mode
     // while a log is being written, this stores the mode of
@@ -705,7 +709,7 @@ public:
     // suppressed.
     // An invalid/null value is treated as the "show all"/inactive case:
     QTime mTimerDebugOutputSuppressionInterval;
-    std::unique_ptr<QNetworkProxy> mpConnectionProxy;
+    std::unique_ptr<QNetworkProxy> mpDownloaderProxy;
     QString mProfileStyleSheet;
     dlgTriggerEditor::SearchOptions mSearchOptions;
     TConsole::SearchOptions mBufferSearchOptions;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -105,22 +105,14 @@ cTelnet::cTelnet(Host* pH, const QString& profileName)
         mAcceptableEncodings << TBuffer::getEncodingNames();
     }
 
-    // initialize the socket after the Host initialisation is complete so we can access mSslTsl
-    QTimer::singleShot(0, this, [this]() {
 #if !defined(QT_NO_SSL)
-        if (mpHost->mSslTsl) {
-            connect(&socket, &QSslSocket::encrypted, this, &cTelnet::slot_socketConnected);
-        } else {
-            connect(&socket, &QAbstractSocket::connected, this, &cTelnet::slot_socketConnected);
-        }
-        connect(&socket, qOverload<const QList<QSslError>&>(&QSslSocket::sslErrors), this, &cTelnet::slot_socketSslError);
-#else
-        connect(&socket, &QAbstractSocket::connected, this, &cTelnet::slot_socketConnected);
+    connect(&mpSocket, &QSslSocket::encrypted, this, &cTelnet::slot_socketEncrypted);
+    connect(&mpSocket, qOverload<const QList<QSslError>&>(&QSslSocket::sslErrors), this, &cTelnet::slot_socketSslError);
 #endif
-        connect(&socket, &QAbstractSocket::disconnected, this, &cTelnet::slot_socketDisconnected);
-        connect(&socket, &QIODevice::readyRead, this, &cTelnet::slot_socketReadyToBeRead);
-    });
-
+    connect(&mpSocket, &QAbstractSocket::connected, this, &cTelnet::slot_socketConnected);
+    connect(&mpSocket, &QAbstractSocket::disconnected, this, &cTelnet::slot_socketDisconnected);
+    connect(&mpSocket, &QIODevice::readyRead, this, &cTelnet::slot_socketReadyToBeRead);
+    connect(&mpSocket, &QAbstractSocket::errorOccurred, this, &cTelnet::slot_socketError);
 
     // initialize telnet session
     reset();
@@ -196,7 +188,7 @@ cTelnet::~cTelnet()
     if (mpComposer) {
         mpComposer->deleteLater();
     }
-    socket.deleteLater();
+    mpSocket.deleteLater();
 }
 
 void cTelnet::cancelLoginTimers()
@@ -276,23 +268,29 @@ void cTelnet::encodingChanged(const QByteArray& requestedEncoding)
 #if !defined(QT_NO_SSL)
 QSslCertificate cTelnet::getPeerCertificate()
 {
-    return socket.peerCertificate();
+    return mpSocket.peerCertificate();
 }
 
 QList<QSslError> cTelnet::getSslErrors()
 {
-    return socket.sslHandshakeErrors();
+    return mpSocket.sslHandshakeErrors();
+}
+
+void cTelnet::slot_socketEncrypted()
+{
+    postMessage(tr("[  OK  ]  - A secure connection has been established successfully."));
+    finalizeConnection();
 }
 #endif
 
 QAbstractSocket::SocketError cTelnet::error()
 {
-    return socket.error();
+    return mpSocket.error();
 }
 
 QString cTelnet::errorString()
 {
-    return socket.errorString();
+    return mpSocket.errorString();
 }
 
 // newEncoding must be EITHER: one of the FIXED non-translatable values in
@@ -391,59 +389,69 @@ void cTelnet::connectIt(const QString& address, int port)
 
         if (mpHost->mUseProxy && !mpHost->mProxyAddress.isEmpty() && mpHost->mProxyPort != 0) {
             auto& proxy = mpHost->getConnectionProxy();
-            socket.setProxy(*proxy);
+            mpSocket.setProxy(*proxy);
             mConnectViaProxy = true;
         } else {
-            socket.setProxy(QNetworkProxy::DefaultProxy);
+            // Since we do not actually specify an application wide proxy this
+            // becomes equivalent to QNetworkProxy::NoProxy:
+            mpSocket.setProxy(QNetworkProxy::DefaultProxy);
             mConnectViaProxy = false;
         }
     }
 
-    if (socket.state() != QAbstractSocket::UnconnectedState) {
-        socket.abort();
+    // FIXME: This should be more refined to consider the other states this could be in better:
+    if (mpSocket.state() != QAbstractSocket::UnconnectedState) {
+        mpSocket.abort();
         connectIt(address, port);
         return;
     }
 
     emit signal_connecting(mpHost);
 
-    hostName = address;
-    hostPort = port;
+    mHostName = address;
+    mHostPort = port;
     postMessage(tr("[ INFO ]  - Looking up the IP address of server: %1:%2 ...").arg(address, QString::number(port)));
-    // don't use a compile-time slot for this: https://bugreports.qt.io/browse/QTBUG-67646
-    QHostInfo::lookupHost(address, this, SLOT(slot_socketHostFound(QHostInfo)));
+    // We can now use a compile-time slot for this as:
+    // https://bugreports.qt.io/browse/QTBUG-67646 was fixed for Qt 5.12.5
+    // IMPROVE: We should revised this to include a timeout - both for lookup and the connection attempt to follow that
+    QHostInfo::lookupHost(address, this, &cTelnet::slot_socketHostFound);
 }
 
 void cTelnet::reconnect()
 {
     // if we've connected offline and wish to reconnect, the last
     // connection parameters aren't yet set
-    if (hostName.isEmpty() && hostPort == 0) {
+    if (mHostName.isEmpty() && mHostPort == 0) {
         connectIt(mpHost->getUrl(), mpHost->getPort());
     } else {
-        connectIt(hostName, hostPort);
+        connectIt(mHostName, mHostPort);
     }
 }
 
 void cTelnet::disconnectIt()
 {
     mDontReconnect = true;
-    socket.disconnectFromHost();
+    mpSocket.disconnectFromHost();
 
 }
 
 void cTelnet::abortConnection()
 {
     mDontReconnect = true;
-    socket.abort();
+    mpSocket.abort();
 }
 
-// Not used:
-//void cTelnet::slot_socketError()
-//{
-//    QString err = tr("[ ERROR ] - TCP/IP socket ERROR:") % socket.errorString();
-//    postMessage(err);
-//}
+void cTelnet::slot_socketError()
+{
+    if (mpSocket.error() != QAbstractSocket::RemoteHostClosedError) {
+        // We don't need to report this error as it is expected if the user
+        // quits from a MUD:
+        mDontReconnect = true;
+        postMessage(tr("[ ERROR ] - TCP/IP socket error message:\n"
+                                   "%1")
+                            .arg(mpSocket.errorString()));
+    }
+}
 
 void cTelnet::slot_send_login()
 {
@@ -461,22 +469,27 @@ void cTelnet::slot_send_pass()
 
 void cTelnet::slot_socketConnected()
 {
-    QString msg;
-
     reset();
-    setKeepAlive(socket.socketDescriptor());
+    setKeepAlive(mpSocket.socketDescriptor());
 
-    if (mpHost->mSslTsl)
-    {
-        msg = tr("[ INFO ]  - A secure connection has been established successfully.");
+#if !defined(QT_NO_SSL)
+    if (mpHost->mSslTsl) {
+        postMessage(tr("[ INFO ]  - A connection has been made; negotiating encryption to make it a\n"
+                                   "secure one..."));
+        // This will raise QSslSocket::encrypted() when done
+        mpSocket.startClientEncryption();
     } else {
-        msg = tr("[ INFO ]  - A connection has been established successfully.");
+#endif
+        postMessage(tr("[  OK  ]  - A connection has been established successfully."));
+        finalizeConnection();
+#if !defined(QT_NO_SSL)
     }
-    msg.append(qsl("\n    \n    "));
-    postMessage(msg);
-    QString func = "onConnect";
-    QString nothing = "";
-    mpHost->mLuaInterpreter.call(func, nothing);
+#endif
+}
+
+void cTelnet::finalizeConnection()
+{
+    mpHost->mLuaInterpreter.call(qsl("onConnect"), QString());
     mConnectionTimer.start();
     mTimerLogin->start(2s);
     mTimerPass->start(3s);
@@ -522,7 +535,7 @@ void cTelnet::slot_socketDisconnected()
 
 #if !defined(QT_NO_SSL)
         QList<QSslError> sslErrors = getSslErrors();
-        QSslCertificate cert = socket.peerCertificate();
+        QSslCertificate cert = mpSocket.peerCertificate();
 
         if (mpHost->mSslIgnoreExpired) {
             sslErrors.removeAll(QSslError(QSslError::CertificateExpired, cert));
@@ -547,7 +560,7 @@ void cTelnet::slot_socketDisconnected()
             if (mDontReconnect) {
                 reason = qsl("User Disconnected");
             } else {
-                reason = socket.errorString();
+                reason = mpSocket.errorString();
             }
             if (reason == qsl("Error during SSL handshake: error:140770FC:SSL routines:SSL23_GET_SERVER_HELLO:unknown protocol")) {
                 reason = tr("Secure connections aren't supported by this game on this port - try turning the option off.");
@@ -565,7 +578,7 @@ void cTelnet::slot_socketDisconnected()
 #endif
 
     if (mAutoReconnect && !mDontReconnect) {
-        connectIt(hostName, hostPort);
+        connectIt(mHostName, mHostPort);
     }
     mDontReconnect = false;
 }
@@ -573,7 +586,7 @@ void cTelnet::slot_socketDisconnected()
 #if !defined(QT_NO_SSL)
 void cTelnet::slot_socketSslError(const QList<QSslError>& errors)
 {
-    QSslCertificate cert = socket.peerCertificate();
+    QSslCertificate cert = mpSocket.peerCertificate();
     QList<QSslError> ignoreErrorList;
 
     if (mpHost->mSslIgnoreExpired) {
@@ -584,42 +597,154 @@ void cTelnet::slot_socketSslError(const QList<QSslError>& errors)
     }
 
     if (mpHost->mSslIgnoreAll) {
-        socket.ignoreSslErrors(errors);
+        mpSocket.ignoreSslErrors(errors);
     } else {
-        socket.ignoreSslErrors(ignoreErrorList);
+        mpSocket.ignoreSslErrors(ignoreErrorList);
     }
 }
 #endif
 
 void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
 {
-#if !defined(QT_NO_SSL)
-    if (mpHost->mSslTsl) {
-        postMessage(qsl("%1\n").arg(tr("[ INFO ]  - Trying secure connection to %1: %2 ...").arg(hostInfo.hostName(), QString::number(hostPort))));
-        socket.connectToHostEncrypted(hostInfo.hostName(), hostPort, QIODevice::ReadWrite);
-
-    } else {
-#endif
-        if (!hostInfo.addresses().isEmpty()) {
-            mHostAddress = hostInfo.addresses().constFirst();
-            postMessage(qsl("%1\n").arg(tr("[ INFO ]  - The IP address of %1 has been found. It is: %2").arg(hostName, mHostAddress.toString())));
-            if (!mConnectViaProxy) {
-                postMessage(qsl("%1\n").arg(tr("[ INFO ]  - Trying to connect to %1:%2 ...").arg(mHostAddress.toString(), QString::number(hostPort))));
-            } else {
-                postMessage(qsl("%1\n").arg(tr("[ INFO ]  - Trying to connect to %1:%2 via proxy...").arg(mHostAddress.toString(), QString::number(hostPort))));
-            }
-            socket.connectToHost(mHostAddress, hostPort);
-        } else {
-            socket.connectToHost(hostInfo.hostName(), hostPort);
-            postMessage(tr("[ ERROR ] - Host name lookup Failure!\n"
-                           "Connection cannot be established.\n"
-                           "The server name is not correct, not working properly,\n"
-                           "or your nameservers are not working properly."));
-            return;
+    // Using a colon to separate the IP address and the port number can be
+    // confusing for numeric IPv6 address - this'll ensure those get formatted
+    auto formatAddressCorrectly = [=](const QString& address, const int port) {
+        const static QRegularExpression anythingOtherThanDigitsOrColons(qsl("[^0123456789abcdefABCEDF:]"));
+        if (anythingOtherThanDigitsOrColons.match(address.trimmed()).hasMatch()) {
+            // address has other characters so is NOT a literal IPv6 address,
+            // so return it just separated from the port by a ':'
+            return qsl("%1:%2").arg(address.trimmed(), QString::number(port));
         }
-#if !defined(QT_NO_SSL)
+        // Else it IS a literal IPv6 address - so format it accordingly
+        return qsl("[%1]:%2").arg(address.trimmed(), QString::number(port));
+    };
+
+    QList<QHostAddress> usableAddresses;
+    QStringList usableAddressTexts;
+    QList<QHostAddress> unusableAddresses;
+    QStringList unusableAddressTexts;
+    const auto wantedIPVersion = mpHost->mIPVersion;
+    for (const auto& address : hostInfo.addresses()) {
+        switch (wantedIPVersion) {
+        case QAbstractSocket::AnyIPProtocol:
+            if (address.protocol() == QAbstractSocket::IPv4Protocol) {
+                usableAddresses.append(address);
+                //: %1 is (one of the) IPv4 address(es) for a game server:
+                usableAddressTexts.append(tr("%1 (IPv4)").arg(formatAddressCorrectly(address.toString(), mHostPort)));
+            } else {
+                if (address.protocol() == QAbstractSocket::IPv6Protocol) {
+                    usableAddresses.append(address);
+                    if (address.scopeId().isEmpty()) {
+                        //: %1 is (one of the) IPv6 address(es) for a game server, it has no scopeId:
+                        usableAddressTexts.append(tr("%1 (IPv6)").arg(formatAddressCorrectly(address.toString(), mHostPort)));
+                    } else {
+                        //: %1 is (one of the) IPv6 address(es) for a game server, it has a scopeId which is %2:
+                        usableAddressTexts.append(tr("%1 (IPv6, %2)").arg(formatAddressCorrectly(address.toString(), mHostPort), address.scopeId()));
+                    }
+                } else {
+                    unusableAddresses.append(address);
+                    //: %1 is an unusable, not IPv4 or 6 address for a game server:
+                    unusableAddressTexts.append(tr("%1 (Other)").arg(formatAddressCorrectly(address.toString(), mHostPort)));
+                }
+            }
+            break;
+        case QAbstractSocket::IPv4Protocol:
+            if (address.protocol() == QAbstractSocket::IPv4Protocol) {
+                usableAddresses.append(address);
+                //: %1 is (one of the) IPv4 address(es) for a game server:
+                usableAddressTexts.append(tr("%1 (IPv4)").arg(formatAddressCorrectly(address.toString(), mHostPort)));
+            } else {
+                unusableAddresses.append(address);
+                if (address.protocol() == QAbstractSocket::IPv6Protocol) {
+                    if (address.scopeId().isEmpty()) {
+                        //: %1 is (one of the) IPv6 address(es) for a game server, it has no scopeId:
+                        unusableAddressTexts.append(tr("%1 (IPv6)").arg(formatAddressCorrectly(address.toString(), mHostPort)));
+                    } else {
+                        //: %1 is (one of the) IPv6 address(es) for a game server, it has a scopeId which is %2:
+                        unusableAddressTexts.append(tr("%1 (IPv6, %2)").arg(formatAddressCorrectly(address.toString(), mHostPort), address.scopeId()));
+                    }
+                } else {
+                    //: %1 is an unusable, not IPv4 or 6 address for a game server:
+                    unusableAddressTexts.append(tr("%1 (Other)").arg(formatAddressCorrectly(address.toString(), mHostPort)));
+                }
+            }
+            break;
+        case QAbstractSocket::IPv6Protocol:
+            if (address.protocol() == QAbstractSocket::IPv6Protocol) {
+                usableAddresses.append(address);
+                if (address.scopeId().isEmpty()) {
+                    //: %1 is (one of the) IPv6 address(es) for a game server, it has no scopeId:
+                    usableAddressTexts.append(tr("%1 (IPv6)").arg(formatAddressCorrectly(address.toString(), mHostPort)));
+                } else {
+                    //: %1 is (one of the) IPv6 address(es) for a game server, it has a scopeId which is %2:
+                    usableAddressTexts.append(tr("%1 (IPv6, %2)").arg(formatAddressCorrectly(address.toString(), mHostPort), address.scopeId()));
+                }
+            } else {
+                unusableAddresses.append(address);
+                if (address.protocol() == QAbstractSocket::IPv4Protocol) {
+                    //: %1 is (one of the) IPv4 address(es) for a game server:
+                    unusableAddressTexts.append(tr("%1 (IPv4)").arg(formatAddressCorrectly(address.toString(), mHostPort)));
+                } else {
+                    //: %1 is an unusable, not IPv4 or 6 address for a game server:
+                    unusableAddressTexts.append(tr("%1 (Other)").arg(formatAddressCorrectly(address.toString(), mHostPort)));
+                }
+            }
+            break;
+        default:
+            Q_UNREACHABLE();
+        }
     }
-#endif
+
+    if (usableAddresses.isEmpty()) {
+        if ((wantedIPVersion != QAbstractSocket::AnyIPProtocol) && !unusableAddresses.isEmpty()) {
+            // There are addresses of the other IP version that could have been used
+            if (wantedIPVersion == QAbstractSocket::IPv4Protocol) {
+                postMessage(tr("[ ERROR ] - DNS lookup Failure - no IP address could be found for the URL:\n"
+                               "%1\n"
+                               "for the IP version 4 protocol. A connection cannot be established.\n"
+                               "There is/are however other %n address(es) that might be usable\n"
+                               "if you change the option controlling acceptable IP versions.",
+                               "",
+                               unusableAddresses.count())
+                                    .arg(mHostName));
+            } else {
+                postMessage(tr("[ ERROR ] - DNS lookup Failure - no IP address could be found for the URL:\n"
+                               "%1\n"
+                               "for the IP version 6 protocol. A connection cannot be established.\n"
+                               "There is/are however other %n address(es) that might be usable\n"
+                               "if you change the option controlling acceptable IP versions.",
+                               "",
+                               unusableAddresses.count())
+                                    .arg(mHostName));
+            }
+        } else {
+            // There are NO addresses that could be used
+            postMessage(tr("[ ERROR ] - DNS lookup Failure - no IP address could be found for the URL:\n"
+                                       "%1\n"
+                                       "A connection cannot be established.\n"
+                                       "The server name is not correct, or your DNS is not working properly.")
+                                .arg(mHostName));
+        }
+        return;
+    }
+
+    // If we get here then we have at least one usable address - and we are
+    // going to use the first one!
+    mHostAddress = usableAddresses.constFirst();
+    postMessage(tr("[ INFO ]  - %n usable IP address(es) of %1 has/have been found.\n"
+                               "It is/They are:\n"
+                               "%2",
+                   "",
+                   usableAddressTexts.count())
+                        .arg(mHostName, usableAddressTexts.join(QChar::LineFeed)));
+    if (!mConnectViaProxy) {
+        postMessage(tr("[ INFO ]  - Trying to connect to %1 ...")
+                            .arg(usableAddressTexts.constFirst()));
+    } else {
+        postMessage(tr("[ INFO ]  - Trying to connect to %1 via proxy...")
+                            .arg(usableAddressTexts.constFirst()));
+    }
+    mpSocket.connectToHost(mHostAddress, mHostPort);
 }
 
 // This uses UTF-16BE encoded data but needs to be converted to the selected
@@ -705,7 +830,7 @@ bool cTelnet::socketOutRaw(std::string& data)
     // We were using socket.iswritable() but it was not clear that that was a
     // suitable way to check for an open, usable connection - whereas isvalid()
     // is true if the socket is valid and ready for use:
-    if (!socket.isValid()) {
+    if (!mpSocket.isValid()) {
         return false;
     }
     std::size_t dataLength = data.length();
@@ -716,7 +841,7 @@ bool cTelnet::socketOutRaw(std::string& data)
         // may be ASCII NUL characters in data and the first of those will
         // terminate the writing of the bytes following it in the single
         // argument method call:
-        qint64 chunkWritten = socket.write(data.substr(written).data(), (dataLength - written));
+        qint64 chunkWritten = mpSocket.write(data.substr(written).data(), (dataLength - written));
 
         if (chunkWritten < 0) {
             // -1 is the sentinel (error) value but any other negative value
@@ -954,12 +1079,12 @@ QString cTelnet::decodeOption(const unsigned char ch) const
 std::tuple<QString, int, bool> cTelnet::getConnectionInfo() const
 {
     // intentionally simplify connection state to a boolean
-    const bool connected = socket.state() == QAbstractSocket::ConnectedState;
+    const bool connected = mpSocket.state() == QAbstractSocket::ConnectedState;
 
-    if (hostName.isEmpty() && hostPort == 0) {
+    if (mHostName.isEmpty() && mHostPort == 0) {
         return {mpHost->getUrl(), mpHost->getPort(), connected};
     } else {
-        return {hostName, hostPort, connected};
+        return {mHostName, mHostPort, connected};
     }
 }
 
@@ -3205,8 +3330,8 @@ bool cTelnet::isIPAddress(QString& arg)
 void cTelnet::promptTlsConnectionAvailable()
 {
     // If an SSL port is detected by MSSP and we're not using it, prompt to use on future connections
-    if (mpHost->mMSSPTlsPort && socket.mode() == QSslSocket::UnencryptedMode && mpHost->mAskTlsAvailable && !isIPAddress(hostName)
-        && (mpHost->mMSSPHostName.isEmpty() || QString::compare(hostName, mpHost->mMSSPHostName, Qt::CaseInsensitive) == 0)) {
+    if (mpHost->mMSSPTlsPort && mpSocket.mode() == QSslSocket::UnencryptedMode && mpHost->mAskTlsAvailable && !isIPAddress(mHostName)
+        && (mpHost->mMSSPHostName.isEmpty() || QString::compare(mHostName, mpHost->mMSSPHostName, Qt::CaseInsensitive) == 0)) {
         postMessage(tr("[ INFO ]  - A more secure connection on port %1 is available.").arg(QString::number(mpHost->mMSSPTlsPort)));
 
         auto msgBox = new QMessageBox();
@@ -3223,12 +3348,12 @@ void cTelnet::promptTlsConnectionAvailable()
         switch (ret) {
         case QMessageBox::Yes:
             cTelnet::disconnectIt();
-            hostPort = mpHost->mMSSPTlsPort;
-            mpHost->setPort(hostPort);
+            mHostPort = mpHost->mMSSPTlsPort;
+            mpHost->setPort(mHostPort);
             mpHost->mSslTsl = true;
-            mpHost->writeProfileData(QLatin1String("port"), QString::number(hostPort));
+            mpHost->writeProfileData(QLatin1String("port"), QString::number(mHostPort));
             mpHost->writeProfileData(QLatin1String("ssl_tsl"), QString::number(Qt::Checked));
-            cTelnet::connectIt(mpHost->getUrl(), hostPort);
+            cTelnet::connectIt(mpHost->getUrl(), mHostPort);
             break;
         case QMessageBox::No:
             cTelnet::disconnectIt();
@@ -3868,7 +3993,7 @@ void cTelnet::slot_socketReadyToBeRead()
     // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (2 of 7) - investigate switching from using `char[]` to `std::array<char>`
     char in_buffer[BUFFER_SIZE + 10];
 
-    int amount = socket.read(in_buffer, BUFFER_SIZE);
+    int amount = mpSocket.read(in_buffer, BUFFER_SIZE);
     processSocketData(in_buffer, amount);
 }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -106,13 +106,13 @@ cTelnet::cTelnet(Host* pH, const QString& profileName)
     }
 
 #if !defined(QT_NO_SSL)
-    connect(&mpSocket, &QSslSocket::encrypted, this, &cTelnet::slot_socketEncrypted);
-    connect(&mpSocket, qOverload<const QList<QSslError>&>(&QSslSocket::sslErrors), this, &cTelnet::slot_socketSslError);
+    connect(&socket, &QSslSocket::encrypted, this, &cTelnet::slot_socketEncrypted);
+    connect(&socket, qOverload<const QList<QSslError>&>(&QSslSocket::sslErrors), this, &cTelnet::slot_socketSslError);
 #endif
-    connect(&mpSocket, &QAbstractSocket::connected, this, &cTelnet::slot_socketConnected);
-    connect(&mpSocket, &QAbstractSocket::disconnected, this, &cTelnet::slot_socketDisconnected);
-    connect(&mpSocket, &QIODevice::readyRead, this, &cTelnet::slot_socketReadyToBeRead);
-    connect(&mpSocket, &QAbstractSocket::errorOccurred, this, &cTelnet::slot_socketError);
+    connect(&socket, &QAbstractSocket::connected, this, &cTelnet::slot_socketConnected);
+    connect(&socket, &QAbstractSocket::disconnected, this, &cTelnet::slot_socketDisconnected);
+    connect(&socket, &QIODevice::readyRead, this, &cTelnet::slot_socketReadyToBeRead);
+    connect(&socket, &QAbstractSocket::errorOccurred, this, &cTelnet::slot_socketError);
 
     // initialize telnet session
     reset();
@@ -188,7 +188,7 @@ cTelnet::~cTelnet()
     if (mpComposer) {
         mpComposer->deleteLater();
     }
-    mpSocket.deleteLater();
+    socket.deleteLater();
 }
 
 void cTelnet::cancelLoginTimers()
@@ -268,12 +268,12 @@ void cTelnet::encodingChanged(const QByteArray& requestedEncoding)
 #if !defined(QT_NO_SSL)
 QSslCertificate cTelnet::getPeerCertificate()
 {
-    return mpSocket.peerCertificate();
+    return socket.peerCertificate();
 }
 
 QList<QSslError> cTelnet::getSslErrors()
 {
-    return mpSocket.sslHandshakeErrors();
+    return socket.sslHandshakeErrors();
 }
 
 void cTelnet::slot_socketEncrypted()
@@ -285,12 +285,12 @@ void cTelnet::slot_socketEncrypted()
 
 QAbstractSocket::SocketError cTelnet::error()
 {
-    return mpSocket.error();
+    return socket.error();
 }
 
 QString cTelnet::errorString()
 {
-    return mpSocket.errorString();
+    return socket.errorString();
 }
 
 // newEncoding must be EITHER: one of the FIXED non-translatable values in
@@ -389,27 +389,27 @@ void cTelnet::connectIt(const QString& address, int port)
 
         if (mpHost->mUseProxy && !mpHost->mProxyAddress.isEmpty() && mpHost->mProxyPort != 0) {
             auto& proxy = mpHost->getConnectionProxy();
-            mpSocket.setProxy(*proxy);
+            socket.setProxy(*proxy);
             mConnectViaProxy = true;
         } else {
             // Since we do not actually specify an application wide proxy this
             // becomes equivalent to QNetworkProxy::NoProxy:
-            mpSocket.setProxy(QNetworkProxy::DefaultProxy);
+            socket.setProxy(QNetworkProxy::DefaultProxy);
             mConnectViaProxy = false;
         }
     }
 
     // FIXME: This should be more refined to consider the other states this could be in better:
-    if (mpSocket.state() != QAbstractSocket::UnconnectedState) {
-        mpSocket.abort();
+    if (socket.state() != QAbstractSocket::UnconnectedState) {
+        socket.abort();
         connectIt(address, port);
         return;
     }
 
     emit signal_connecting(mpHost);
 
-    mHostName = address;
-    mHostPort = port;
+    hostName = address;
+    hostPort = port;
     postMessage(tr("[ INFO ]  - Looking up the IP address of server: %1:%2 ...").arg(address, QString::number(port)));
     // We can now use a compile-time slot for this as:
     // https://bugreports.qt.io/browse/QTBUG-67646 was fixed for Qt 5.12.5
@@ -421,35 +421,35 @@ void cTelnet::reconnect()
 {
     // if we've connected offline and wish to reconnect, the last
     // connection parameters aren't yet set
-    if (mHostName.isEmpty() && mHostPort == 0) {
+    if (hostName.isEmpty() && hostPort == 0) {
         connectIt(mpHost->getUrl(), mpHost->getPort());
     } else {
-        connectIt(mHostName, mHostPort);
+        connectIt(hostName, hostPort);
     }
 }
 
 void cTelnet::disconnectIt()
 {
     mDontReconnect = true;
-    mpSocket.disconnectFromHost();
+    socket.disconnectFromHost();
 
 }
 
 void cTelnet::abortConnection()
 {
     mDontReconnect = true;
-    mpSocket.abort();
+    socket.abort();
 }
 
 void cTelnet::slot_socketError()
 {
-    if (mpSocket.error() != QAbstractSocket::RemoteHostClosedError) {
+    if (socket.error() != QAbstractSocket::RemoteHostClosedError) {
         // We don't need to report this error as it is expected if the user
         // quits from a MUD:
         mDontReconnect = true;
         postMessage(tr("[ ERROR ] - TCP/IP socket error message:\n"
                                    "%1")
-                            .arg(mpSocket.errorString()));
+                            .arg(socket.errorString()));
     }
 }
 
@@ -470,14 +470,14 @@ void cTelnet::slot_send_pass()
 void cTelnet::slot_socketConnected()
 {
     reset();
-    setKeepAlive(mpSocket.socketDescriptor());
+    setKeepAlive(socket.socketDescriptor());
 
 #if !defined(QT_NO_SSL)
     if (mpHost->mSslTsl) {
         postMessage(tr("[ INFO ]  - A connection has been made; negotiating encryption to make it a\n"
                                    "secure one..."));
         // This will raise QSslSocket::encrypted() when done
-        mpSocket.startClientEncryption();
+        socket.startClientEncryption();
     } else {
 #endif
         postMessage(tr("[  OK  ]  - A connection has been established successfully."));
@@ -535,7 +535,7 @@ void cTelnet::slot_socketDisconnected()
 
 #if !defined(QT_NO_SSL)
         QList<QSslError> sslErrors = getSslErrors();
-        QSslCertificate cert = mpSocket.peerCertificate();
+        QSslCertificate cert = socket.peerCertificate();
 
         if (mpHost->mSslIgnoreExpired) {
             sslErrors.removeAll(QSslError(QSslError::CertificateExpired, cert));
@@ -560,7 +560,7 @@ void cTelnet::slot_socketDisconnected()
             if (mDontReconnect) {
                 reason = qsl("User Disconnected");
             } else {
-                reason = mpSocket.errorString();
+                reason = socket.errorString();
             }
             if (reason == qsl("Error during SSL handshake: error:140770FC:SSL routines:SSL23_GET_SERVER_HELLO:unknown protocol")) {
                 reason = tr("Secure connections aren't supported by this game on this port - try turning the option off.");
@@ -578,7 +578,7 @@ void cTelnet::slot_socketDisconnected()
 #endif
 
     if (mAutoReconnect && !mDontReconnect) {
-        connectIt(mHostName, mHostPort);
+        connectIt(hostName, hostPort);
     }
     mDontReconnect = false;
 }
@@ -586,7 +586,7 @@ void cTelnet::slot_socketDisconnected()
 #if !defined(QT_NO_SSL)
 void cTelnet::slot_socketSslError(const QList<QSslError>& errors)
 {
-    QSslCertificate cert = mpSocket.peerCertificate();
+    QSslCertificate cert = socket.peerCertificate();
     QList<QSslError> ignoreErrorList;
 
     if (mpHost->mSslIgnoreExpired) {
@@ -597,9 +597,9 @@ void cTelnet::slot_socketSslError(const QList<QSslError>& errors)
     }
 
     if (mpHost->mSslIgnoreAll) {
-        mpSocket.ignoreSslErrors(errors);
+        socket.ignoreSslErrors(errors);
     } else {
-        mpSocket.ignoreSslErrors(ignoreErrorList);
+        socket.ignoreSslErrors(ignoreErrorList);
     }
 }
 #endif
@@ -630,21 +630,21 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
             if (address.protocol() == QAbstractSocket::IPv4Protocol) {
                 usableAddresses.append(address);
                 //: %1 is (one of the) IPv4 address(es) for a game server:
-                usableAddressTexts.append(tr("%1 (IPv4)").arg(formatAddressCorrectly(address.toString(), mHostPort)));
+                usableAddressTexts.append(tr("%1 (IPv4)").arg(formatAddressCorrectly(address.toString(), hostPort)));
             } else {
                 if (address.protocol() == QAbstractSocket::IPv6Protocol) {
                     usableAddresses.append(address);
                     if (address.scopeId().isEmpty()) {
                         //: %1 is (one of the) IPv6 address(es) for a game server, it has no scopeId:
-                        usableAddressTexts.append(tr("%1 (IPv6)").arg(formatAddressCorrectly(address.toString(), mHostPort)));
+                        usableAddressTexts.append(tr("%1 (IPv6)").arg(formatAddressCorrectly(address.toString(), hostPort)));
                     } else {
                         //: %1 is (one of the) IPv6 address(es) for a game server, it has a scopeId which is %2:
-                        usableAddressTexts.append(tr("%1 (IPv6, %2)").arg(formatAddressCorrectly(address.toString(), mHostPort), address.scopeId()));
+                        usableAddressTexts.append(tr("%1 (IPv6, %2)").arg(formatAddressCorrectly(address.toString(), hostPort), address.scopeId()));
                     }
                 } else {
                     unusableAddresses.append(address);
                     //: %1 is an unusable, not IPv4 or 6 address for a game server:
-                    unusableAddressTexts.append(tr("%1 (Other)").arg(formatAddressCorrectly(address.toString(), mHostPort)));
+                    unusableAddressTexts.append(tr("%1 (Other)").arg(formatAddressCorrectly(address.toString(), hostPort)));
                 }
             }
             break;
@@ -652,20 +652,20 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
             if (address.protocol() == QAbstractSocket::IPv4Protocol) {
                 usableAddresses.append(address);
                 //: %1 is (one of the) IPv4 address(es) for a game server:
-                usableAddressTexts.append(tr("%1 (IPv4)").arg(formatAddressCorrectly(address.toString(), mHostPort)));
+                usableAddressTexts.append(tr("%1 (IPv4)").arg(formatAddressCorrectly(address.toString(), hostPort)));
             } else {
                 unusableAddresses.append(address);
                 if (address.protocol() == QAbstractSocket::IPv6Protocol) {
                     if (address.scopeId().isEmpty()) {
                         //: %1 is (one of the) IPv6 address(es) for a game server, it has no scopeId:
-                        unusableAddressTexts.append(tr("%1 (IPv6)").arg(formatAddressCorrectly(address.toString(), mHostPort)));
+                        unusableAddressTexts.append(tr("%1 (IPv6)").arg(formatAddressCorrectly(address.toString(), hostPort)));
                     } else {
                         //: %1 is (one of the) IPv6 address(es) for a game server, it has a scopeId which is %2:
-                        unusableAddressTexts.append(tr("%1 (IPv6, %2)").arg(formatAddressCorrectly(address.toString(), mHostPort), address.scopeId()));
+                        unusableAddressTexts.append(tr("%1 (IPv6, %2)").arg(formatAddressCorrectly(address.toString(), hostPort), address.scopeId()));
                     }
                 } else {
                     //: %1 is an unusable, not IPv4 or 6 address for a game server:
-                    unusableAddressTexts.append(tr("%1 (Other)").arg(formatAddressCorrectly(address.toString(), mHostPort)));
+                    unusableAddressTexts.append(tr("%1 (Other)").arg(formatAddressCorrectly(address.toString(), hostPort)));
                 }
             }
             break;
@@ -674,19 +674,19 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
                 usableAddresses.append(address);
                 if (address.scopeId().isEmpty()) {
                     //: %1 is (one of the) IPv6 address(es) for a game server, it has no scopeId:
-                    usableAddressTexts.append(tr("%1 (IPv6)").arg(formatAddressCorrectly(address.toString(), mHostPort)));
+                    usableAddressTexts.append(tr("%1 (IPv6)").arg(formatAddressCorrectly(address.toString(), hostPort)));
                 } else {
                     //: %1 is (one of the) IPv6 address(es) for a game server, it has a scopeId which is %2:
-                    usableAddressTexts.append(tr("%1 (IPv6, %2)").arg(formatAddressCorrectly(address.toString(), mHostPort), address.scopeId()));
+                    usableAddressTexts.append(tr("%1 (IPv6, %2)").arg(formatAddressCorrectly(address.toString(), hostPort), address.scopeId()));
                 }
             } else {
                 unusableAddresses.append(address);
                 if (address.protocol() == QAbstractSocket::IPv4Protocol) {
                     //: %1 is (one of the) IPv4 address(es) for a game server:
-                    unusableAddressTexts.append(tr("%1 (IPv4)").arg(formatAddressCorrectly(address.toString(), mHostPort)));
+                    unusableAddressTexts.append(tr("%1 (IPv4)").arg(formatAddressCorrectly(address.toString(), hostPort)));
                 } else {
                     //: %1 is an unusable, not IPv4 or 6 address for a game server:
-                    unusableAddressTexts.append(tr("%1 (Other)").arg(formatAddressCorrectly(address.toString(), mHostPort)));
+                    unusableAddressTexts.append(tr("%1 (Other)").arg(formatAddressCorrectly(address.toString(), hostPort)));
                 }
             }
             break;
@@ -706,7 +706,7 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
                                "if you change the option controlling acceptable IP versions.",
                                "",
                                unusableAddresses.count())
-                                    .arg(mHostName));
+                                    .arg(hostName));
             } else {
                 postMessage(tr("[ ERROR ] - DNS lookup Failure - no IP address could be found for the URL:\n"
                                "%1\n"
@@ -715,7 +715,7 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
                                "if you change the option controlling acceptable IP versions.",
                                "",
                                unusableAddresses.count())
-                                    .arg(mHostName));
+                                    .arg(hostName));
             }
         } else {
             // There are NO addresses that could be used
@@ -723,7 +723,7 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
                                        "%1\n"
                                        "A connection cannot be established.\n"
                                        "The server name is not correct, or your DNS is not working properly.")
-                                .arg(mHostName));
+                                .arg(hostName));
         }
         return;
     }
@@ -736,7 +736,7 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
                                "%2",
                    "",
                    usableAddressTexts.count())
-                        .arg(mHostName, usableAddressTexts.join(QChar::LineFeed)));
+                        .arg(hostName, usableAddressTexts.join(QChar::LineFeed)));
     if (!mConnectViaProxy) {
         postMessage(tr("[ INFO ]  - Trying to connect to %1 ...")
                             .arg(usableAddressTexts.constFirst()));
@@ -744,7 +744,7 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
         postMessage(tr("[ INFO ]  - Trying to connect to %1 via proxy...")
                             .arg(usableAddressTexts.constFirst()));
     }
-    mpSocket.connectToHost(mHostAddress, mHostPort);
+    socket.connectToHost(mHostAddress, hostPort);
 }
 
 // This uses UTF-16BE encoded data but needs to be converted to the selected
@@ -830,7 +830,7 @@ bool cTelnet::socketOutRaw(std::string& data)
     // We were using socket.iswritable() but it was not clear that that was a
     // suitable way to check for an open, usable connection - whereas isvalid()
     // is true if the socket is valid and ready for use:
-    if (!mpSocket.isValid()) {
+    if (!socket.isValid()) {
         return false;
     }
     std::size_t dataLength = data.length();
@@ -841,7 +841,7 @@ bool cTelnet::socketOutRaw(std::string& data)
         // may be ASCII NUL characters in data and the first of those will
         // terminate the writing of the bytes following it in the single
         // argument method call:
-        qint64 chunkWritten = mpSocket.write(data.substr(written).data(), (dataLength - written));
+        qint64 chunkWritten = socket.write(data.substr(written).data(), (dataLength - written));
 
         if (chunkWritten < 0) {
             // -1 is the sentinel (error) value but any other negative value
@@ -1079,12 +1079,12 @@ QString cTelnet::decodeOption(const unsigned char ch) const
 std::tuple<QString, int, bool> cTelnet::getConnectionInfo() const
 {
     // intentionally simplify connection state to a boolean
-    const bool connected = mpSocket.state() == QAbstractSocket::ConnectedState;
+    const bool connected = socket.state() == QAbstractSocket::ConnectedState;
 
-    if (mHostName.isEmpty() && mHostPort == 0) {
+    if (hostName.isEmpty() && hostPort == 0) {
         return {mpHost->getUrl(), mpHost->getPort(), connected};
     } else {
-        return {mHostName, mHostPort, connected};
+        return {hostName, hostPort, connected};
     }
 }
 
@@ -3330,8 +3330,8 @@ bool cTelnet::isIPAddress(QString& arg)
 void cTelnet::promptTlsConnectionAvailable()
 {
     // If an SSL port is detected by MSSP and we're not using it, prompt to use on future connections
-    if (mpHost->mMSSPTlsPort && mpSocket.mode() == QSslSocket::UnencryptedMode && mpHost->mAskTlsAvailable && !isIPAddress(mHostName)
-        && (mpHost->mMSSPHostName.isEmpty() || QString::compare(mHostName, mpHost->mMSSPHostName, Qt::CaseInsensitive) == 0)) {
+    if (mpHost->mMSSPTlsPort && socket.mode() == QSslSocket::UnencryptedMode && mpHost->mAskTlsAvailable && !isIPAddress(hostName)
+        && (mpHost->mMSSPHostName.isEmpty() || QString::compare(hostName, mpHost->mMSSPHostName, Qt::CaseInsensitive) == 0)) {
         postMessage(tr("[ INFO ]  - A more secure connection on port %1 is available.").arg(QString::number(mpHost->mMSSPTlsPort)));
 
         auto msgBox = new QMessageBox();
@@ -3348,12 +3348,12 @@ void cTelnet::promptTlsConnectionAvailable()
         switch (ret) {
         case QMessageBox::Yes:
             cTelnet::disconnectIt();
-            mHostPort = mpHost->mMSSPTlsPort;
-            mpHost->setPort(mHostPort);
+            hostPort = mpHost->mMSSPTlsPort;
+            mpHost->setPort(hostPort);
             mpHost->mSslTsl = true;
-            mpHost->writeProfileData(QLatin1String("port"), QString::number(mHostPort));
+            mpHost->writeProfileData(QLatin1String("port"), QString::number(hostPort));
             mpHost->writeProfileData(QLatin1String("ssl_tsl"), QString::number(Qt::Checked));
-            cTelnet::connectIt(mpHost->getUrl(), mHostPort);
+            cTelnet::connectIt(mpHost->getUrl(), hostPort);
             break;
         case QMessageBox::No:
             cTelnet::disconnectIt();
@@ -3993,7 +3993,7 @@ void cTelnet::slot_socketReadyToBeRead()
     // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (2 of 7) - investigate switching from using `char[]` to `std::array<char>`
     char in_buffer[BUFFER_SIZE + 10];
 
-    int amount = mpSocket.read(in_buffer, BUFFER_SIZE);
+    int amount = socket.read(in_buffer, BUFFER_SIZE);
     processSocketData(in_buffer, amount);
 }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -702,7 +702,7 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
                 postMessage(tr("[ ERROR ] - DNS lookup Failure - no IP address could be found for the URL:\n"
                                "%1\n"
                                "for the IP version 4 protocol. A connection cannot be established.\n"
-                               "There is/are however other %n address(es) that might be usable\n"
+                               "There is/are however %n other address(es) that might be usable\n"
                                "if you change the option controlling acceptable IP versions.",
                                "",
                                unusableAddresses.count())
@@ -711,7 +711,7 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
                 postMessage(tr("[ ERROR ] - DNS lookup Failure - no IP address could be found for the URL:\n"
                                "%1\n"
                                "for the IP version 6 protocol. A connection cannot be established.\n"
-                               "There is/are however other %n address(es) that might be usable\n"
+                               "There is/are however %n other address(es) that might be usable\n"
                                "if you change the option controlling acceptable IP versions.",
                                "",
                                unusableAddresses.count())

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -609,7 +609,7 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
     // Using a colon to separate the IP address and the port number can be
     // confusing for numeric IPv6 address - this'll ensure those get formatted
     auto formatAddressCorrectly = [=](const QString& address, const int port) {
-        const static QRegularExpression anythingOtherThanDigitsOrColons(qsl("[^0123456789abcdefABCEDF:]"));
+        static const QRegularExpression anythingOtherThanDigitsOrColons(qsl("[^0123456789abcdefABCEDF:]"));
         if (anythingOtherThanDigitsOrColons.match(address.trimmed()).hasMatch()) {
             // address has other characters so is NOT a literal IPv6 address,
             // so return it just separated from the port by a ':'

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -226,7 +226,7 @@ public:
     void trackMXPElementDetection(const std::string&);
     void requestDiscordInfo();
     QString decodeOption(const unsigned char) const;
-    QAbstractSocket::SocketState getConnectionState() const { return mpSocket.state(); }
+    QAbstractSocket::SocketState getConnectionState() const { return socket.state(); }
     std::tuple<QString, int, bool> getConnectionInfo() const;
     void setPostingTimeout(const int);
     int getPostingTimeout() const { return mTimeOut; }
@@ -335,9 +335,9 @@ private:
 
     QPointer<Host> mpHost;
 #if defined(QT_NO_SSL)
-    QTcpSocket mpSocket;
+    QTcpSocket socket;
 #else
-    QSslSocket mpSocket;
+    QSslSocket socket;
 #endif
     QHostAddress mHostAddress;
 //    QTextCodec* incomingDataCodec;
@@ -345,8 +345,8 @@ private:
     QTextCodec* outgoingDataCodec = nullptr;
 //    QTextDecoder* incomingDataDecoder;
     QTextEncoder* outgoingDataEncoder = nullptr;
-    QString mHostName;
-    int mHostPort = 0;
+    QString hostName;
+    int hostPort = 0;
     bool mWaitingForResponse = false;
     std::queue<int> mCommandQueue;
 

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -226,7 +226,7 @@ public:
     void trackMXPElementDetection(const std::string&);
     void requestDiscordInfo();
     QString decodeOption(const unsigned char) const;
-    QAbstractSocket::SocketState getConnectionState() const { return socket.state(); }
+    QAbstractSocket::SocketState getConnectionState() const { return mpSocket.state(); }
     std::tuple<QString, int, bool> getConnectionInfo() const;
     void setPostingTimeout(const int);
     int getPostingTimeout() const { return mTimeOut; }
@@ -255,8 +255,9 @@ public slots:
     void slot_socketConnected();
     void slot_socketDisconnected();
     void slot_socketReadyToBeRead();
-// Not used    void slot_socketError();
+    void slot_socketError();
 #if !defined(QT_NO_SSL)
+    void slot_socketEncrypted();
     void slot_socketSslError(const QList<QSslError>&);
 #endif
     void slot_timerPosting();
@@ -330,12 +331,13 @@ private:
     void trackKaVirNegotiation(unsigned char option);
     void autoEnableMXPProcessor();
     void promptEnableTTYPEVersion();
+    void finalizeConnection();
 
     QPointer<Host> mpHost;
 #if defined(QT_NO_SSL)
-    QTcpSocket socket;
+    QTcpSocket mpSocket;
 #else
-    QSslSocket socket;
+    QSslSocket mpSocket;
 #endif
     QHostAddress mHostAddress;
 //    QTextCodec* incomingDataCodec;
@@ -343,8 +345,8 @@ private:
     QTextCodec* outgoingDataCodec = nullptr;
 //    QTextDecoder* incomingDataDecoder;
     QTextEncoder* outgoingDataEncoder = nullptr;
-    QString hostName;
-    int hostPort = 0;
+    QString mHostName;
+    int mHostPort = 0;
     bool mWaitingForResponse = false;
     std::queue<int> mCommandQueue;
 

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -212,8 +212,11 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
 
     // We actually need to store the integer equivalents to the enum values as
     // conveying the enum values directly is awkward/hard/impossible as QVariants:
+    //: Text to show in IP Version selection comboBox to allow BOTH IPv4 and IPv6 connections
     comboBox_IPVersion->addItem(tr("Either"), static_cast<int>(QAbstractSocket::AnyIPProtocol));
+    //: Text to show in IP Version selection comboBox to allow only IPv4 connections
     comboBox_IPVersion->addItem(tr("IPv4 only"), static_cast<int>(QAbstractSocket::IPv4Protocol));
+    //: Text to show in IP Version selection comboBox to allow only IPv6 connections
     comboBox_IPVersion->addItem(tr("IPv6 only"), static_cast<int>(QAbstractSocket::IPv6Protocol));
 
     connect(mpAction_revealPassword, &QAction::triggered, this, &dlgConnectionProfiles::slot_togglePasswordVisibility);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -210,6 +210,12 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
         character_password_entry->setToolTip(utils::richText(tr("Characters password. Note that the password is not encrypted in storage")));
     }
 
+    // We actually need to store the integer equivalents to the enum values as
+    // conveying the enum values directly is awkward/hard/impossible as QVariants:
+    comboBox_IPVersion->addItem(tr("Either"), static_cast<int>(QAbstractSocket::AnyIPProtocol));
+    comboBox_IPVersion->addItem(tr("IPv4 only"), static_cast<int>(QAbstractSocket::IPv4Protocol));
+    comboBox_IPVersion->addItem(tr("IPv6 only"), static_cast<int>(QAbstractSocket::IPv6Protocol));
+
     connect(mpAction_revealPassword, &QAction::triggered, this, &dlgConnectionProfiles::slot_togglePasswordVisibility);
     connect(offline_button, &QAbstractButton::clicked, this, &dlgConnectionProfiles::slot_load);
     connect(connect_button, &QAbstractButton::clicked, this, &dlgConnectionProfiles::accept);
@@ -242,6 +248,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
 #else
     connect(discord_optin_checkBox, &QCheckBox::stateChanged, this, &dlgConnectionProfiles::slot_updateDiscordOptIn);
 #endif
+    connect(comboBox_IPVersion, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgConnectionProfiles::slot_updateIPVersion);
 
     // website_entry atm is only a label
     //connect(website_entry, SIGNAL(textEdited(const QString)), this, SLOT(slot_updateWebsite(const QString)));
@@ -889,6 +896,13 @@ void dlgConnectionProfiles::slot_itemClicked(QListWidgetItem* pItem)
         website_entry->show();
     }
     website_entry->setText(val);
+
+    val = readProfileData(profile_name, qsl("ipversion"));
+    if (val.isEmpty()) {
+        comboBox_IPVersion->setCurrentIndex(comboBox_IPVersion->findData(QAbstractSocket::AnyIPProtocol));
+    } else {
+        comboBox_IPVersion->setCurrentIndex(comboBox_IPVersion->findData(static_cast<QAbstractSocket::NetworkLayerProtocol>(val.toInt())));
+    }
 
     profile_history->clear();
 
@@ -1575,7 +1589,7 @@ void dlgConnectionProfiles::loadProfile(bool alsoConnect)
             QDialog::accept();
             return;
         }
-        
+
         pHost->setName(profile_name);
 
         if (!host_name_entry->text().trimmed().isEmpty()) {
@@ -1610,6 +1624,8 @@ void dlgConnectionProfiles::loadProfile(bool alsoConnect)
         // Needed to ensure setting is correct on start-up:
         pHost->setWideAmbiguousEAsianGlyphs(pHost->getWideAmbiguousEAsianGlyphsControlState());
         pHost->setAutoReconnect(auto_reconnect->isChecked());
+
+        pHost->mIPVersion = static_cast<QAbstractSocket::NetworkLayerProtocol>(comboBox_IPVersion->currentData().value<int>());
 
         // This also writes the value out to the profile's base directory:
         mudlet::self()->mDiscord.setApplicationID(pHost, mDiscordApplicationId);
@@ -2067,4 +2083,14 @@ void dlgConnectionProfiles::addLetterToProfileSearch(const int key)
     }
 
     profiles_tree_widget->setCurrentRow(indexes.first());
+}
+
+void dlgConnectionProfiles::slot_updateIPVersion()
+{
+    QListWidgetItem* pItem = profiles_tree_widget->currentItem();
+    if (!pItem) {
+        return;
+    }
+
+    writeProfileData(pItem->data(csmNameRole).toString(), qsl("ipversion"), QString::number(comboBox_IPVersion->currentData().toInt()));
 }

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -160,6 +160,7 @@ private slots:
     void slot_passwordSaved(QKeychain::Job* job);
     void slot_passwordDeleted(QKeychain::Job* job);
     void slot_reenableAllProfileItems();
+    void slot_updateIPVersion();
 };
 
 

--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -24,7 +24,7 @@
   <property name="windowTitle">
    <string>Select a profile to connect with</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout_connection_profiles">
    <property name="spacing">
     <number>0</number>
    </property>
@@ -41,7 +41,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QWidget" name="widget_top" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
        <horstretch>0</horstretch>
@@ -54,7 +54,7 @@
        <height>0</height>
       </size>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
+     <layout class="QHBoxLayout" name="horizontalLayout_widget_top">
       <property name="spacing">
        <number>0</number>
       </property>
@@ -71,7 +71,7 @@
        <number>0</number>
       </property>
       <item>
-       <widget class="QWidget" name="widget_5" native="true">
+       <widget class="QWidget" name="widget_top_left" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
           <horstretch>0</horstretch>
@@ -84,7 +84,7 @@
           <height>0</height>
          </size>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_3">
+        <layout class="QVBoxLayout" name="verticalLayout_widget_top_left">
          <property name="spacing">
           <number>0</number>
          </property>
@@ -154,7 +154,7 @@
            <property name="midLineWidth">
             <number>3</number>
            </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <layout class="QHBoxLayout" name="horizontalLayout_notificationArea">
             <property name="spacing">
              <number>0</number>
             </property>
@@ -335,9 +335,9 @@
              <height>16777215</height>
             </size>
            </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <layout class="QHBoxLayout" name="horizontalLayout_profileAdminArea">
             <item>
-             <spacer name="horizontalSpacer_4">
+             <spacer name="horizontalSpacer_profileAdminArea">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -419,7 +419,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QWidget" name="widget_2" native="true">
+       <widget class="QWidget" name="widget_top_right" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
           <horstretch>0</horstretch>
@@ -438,7 +438,7 @@
           <height>16777215</height>
          </size>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
+        <layout class="QVBoxLayout" name="verticalLayout_widget_top_right">
          <item>
           <widget class="QTextBrowser" name="welcome_message">
            <property name="enabled">
@@ -485,7 +485,7 @@
             <attribute name="title">
              <string>Connect to</string>
             </attribute>
-            <layout class="QGridLayout" name="gridLayout">
+            <layout class="QGridLayout" name="gridLayout_tab_connection_info">
              <item row="0" column="0">
               <widget class="QLabel" name="label_profileName">
                <property name="text">
@@ -629,7 +629,7 @@
             <attribute name="title">
              <string>Options</string>
             </attribute>
-            <layout class="QGridLayout" name="gridLayout_2">
+            <layout class="QGridLayout" name="gridLayout_tab_options">
              <item row="0" column="0">
               <widget class="QLabel" name="label_characterName">
                <property name="text">
@@ -719,6 +719,23 @@
               </widget>
              </item>
              <item row="3" column="0">
+              <widget class="QLabel" name="label_IPVersion">
+               <property name="text">
+                <string>IP Version:</string>
+               </property>
+               <property name="buddy">
+                <cstring>comboBox_IPVersion</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QComboBox" name="comboBox_IPVersion">
+               <property name="maxVisibleItems">
+                <number>3</number>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="0">
               <widget class="QCheckBox" name="discord_optin_checkBox">
                <property name="enabled">
                 <bool>false</bool>
@@ -748,7 +765,7 @@
                </property>
               </widget>
              </item>
-             <item row="4" column="0" colspan="2">
+             <item row="5" column="0" colspan="2">
               <widget class="QCheckBox" name="autologin_checkBox">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -773,7 +790,7 @@
                </property>
               </widget>
              </item>
-             <item row="5" column="0" colspan="2">
+             <item row="6" column="0" colspan="2">
               <widget class="QCheckBox" name="auto_reconnect">
                <property name="accessibleName">
                 <string>Auto-reconnect</string>
@@ -810,7 +827,7 @@
            <property name="title">
             <string>Information</string>
            </property>
-           <layout class="QVBoxLayout" name="vBoxLayout_4">
+           <layout class="QVBoxLayout" name="vBoxLayout_informationArea">
             <property name="leftMargin">
              <number>0</number>
             </property>
@@ -889,7 +906,7 @@
    </item>
    <item>
     <widget class="QWidget" name="widget_bottom" native="true">
-     <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <layout class="QHBoxLayout" name="horizontalLayout_widget_bottom">
       <item>
        <spacer name="horizontalSpacer">
         <property name="orientation">
@@ -950,6 +967,7 @@
   <tabstop>login_entry</tabstop>
   <tabstop>character_password_entry</tabstop>
   <tabstop>profile_history</tabstop>
+  <tabstop>comboBox_IPVersion</tabstop>
   <tabstop>discord_optin_checkBox</tabstop>
   <tabstop>autologin_checkBox</tabstop>
   <tabstop>auto_reconnect</tabstop>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Revise the `QSslSocket` connection process in `cTelnet` class to split it up into "Host Lookup" + "Making Connection" + "Encryption negotiation" - this is so that the first two can be made common with the insecure connection process - and so that Mudlet can examine the Host lookup results in the same manner for both. The prior use of
`QSslSocket::connectToHostEncrypted(...)` combined all three of those steps but meant there was no ability to examine the results of the Host Lookup. As a result the messaging can be made more uniform for both cases and detail the lookup results better - as well as allowing for selection of IPv4 or 6 only as needed.

#### Motivation for adding to Mudlet
@Kebap has been having problems recently with a bogus IPv6 lookup result and this should help with that. This should help - but not solve - #3053 and #3791 - and hopefully it can allow me or someone else - to develop a "happy eye-balls" approach to try opening the first valid IPv4 and IPv6 addresses at the same time. However that will need further work as it will require the handling of multiple `QTcpSocket`/`QSslSocket`s simultaneously and the current `cTelnet` class will need some serious reorganising to do this.

#### Other info (issues closed, discussion etc)
* Reorders a couple of methods declared in the `Host.h` file - they were out of position.
* Renames:
  * `(std::unique_ptr<QNetworkProxy>) Host::mpDownloaderProxy` ==> `Host::mpConnectionProxy`
  * `(QSslSocket/QTcpSocket) cTelnet::socket` ==> `cTelnet::mpSocket`
  * `(QString) cTelnet::hostName` ==> `cTelnet::mHostName`
  * `(int) cTelnet::hostPort` ==> `cTelnet::mHostPort`
* Restores reporting of non-SSL related `QTcpSocket`/`QSslSocket` errors - except for the one associated with the Server disconnecting (usually by `quit`-ting from a MUD)!