### PR TITLE
Fix: Remove extra added linebreak for command echoes during trigger processing.

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -859,7 +859,7 @@ COMMIT_LINE:
             // Start a new, but empty line in the various buffers
             log(lineBuffer.size() - 1, lineBuffer.size() - 1);
             ++localBufferPosition;
-            // Suppress new empty line IFF echoes alreadt created a new empty line
+            // Suppress new empty line IFF echoes already created a new empty line
             // i.e. add newline if no added lines or the lastline isn't empty
             if (addedLines == 0 || !lineBuffer.back().isEmpty()) {
                 std::deque<TChar> const newLine;

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -854,16 +854,20 @@ COMMIT_LINE:
             mpHost->mpConsole->runTriggers(line);
             // Only use of TBuffer::wrap(), breaks up new text
             // NOTE: it MAY have been clobbered by the trigger engine!
-            wrapLine(line, mWrapAt, mWrapIndent, mWrapHangingIndent);
+            const int addedLines = wrapLine(line, mWrapAt, mWrapIndent, mWrapHangingIndent);
 
             // Start a new, but empty line in the various buffers
             log(lineBuffer.size() - 1, lineBuffer.size() - 1);
             ++localBufferPosition;
-            std::deque<TChar> const newLine;
-            buffer.push_back(newLine);
-            lineBuffer.push_back(QString());
-            timeBuffer.push_back(QString());
-            promptBuffer << false;
+            // Suppress new empty line IFF echoes alreadt created a new empty line
+            // i.e. add newline if no added lines or the lastline isn't empty
+            if (addedLines == 0 || !lineBuffer.back().isEmpty()) {
+                std::deque<TChar> const newLine;
+                buffer.push_back(newLine);
+                lineBuffer.push_back(QString());
+                timeBuffer.push_back(QString());
+                promptBuffer << false;
+            }
             if (static_cast<int>(buffer.size()) > mLinesLimit) {
                 // Whilst we also include a call to TConsole::handleLinesOverflowEvent(...)
                 // in all other methods where the following is used (because

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1713,11 +1713,10 @@ void TConsole::printCommand(QString& msg)
     }
 
     if (mTriggerEngineMode) {
+        msg.append(QChar::LineFeed);
         const int lineBeforeNewContent = buffer.getLastLineNumber();
-        if (lineBeforeNewContent >= 0) {
-            if (buffer.lineBuffer.at(lineBeforeNewContent).right(1) != QChar(QChar::LineFeed)) {
+        if (lineBeforeNewContent >= 0 && !buffer.lineBuffer.back().isEmpty()) {
                 msg.prepend(QChar::LineFeed);
-            }
         }
         buffer.appendLine(msg, 0, msg.size() - 1, mCommandFgColor, mCommandBgColor);
     } else {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1679,7 +1679,6 @@ void TConsole::printCommand(QString& msg)
     }
 
     if (mTriggerEngineMode) {
-        msg.append(QChar::LineFeed);
         const int lineBeforeNewContent = buffer.getLastLineNumber();
         if (lineBeforeNewContent >= 0) {
             if (buffer.lineBuffer.at(lineBeforeNewContent).right(1) != QChar(QChar::LineFeed)) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Removed the added linebreak append from command echoes IF the trigger engine is processing.

#### Motivation for adding to Mudlet
While this behavior was apparently necessary to keep command echoes from bunching in the past, with the new word-wrapping and append methods it was leading to an extra linebreak being inserted between command echoes:
![image](https://github.com/user-attachments/assets/876f2acf-8108-446c-870d-0ad6611de944)

Now fixed:
![image](https://github.com/user-attachments/assets/54b685d7-d29d-48a9-898d-a33665190ab8)


#### Other info (issues closed, discussion etc)
Steps to recreate issue:
Make a trigger which sends 2+ commands. Make sure the "Show the text you sent" preference in "Input" is enabled.

Thanks to @termie for noticing this and helping me chase it down!
