### PR TITLE
fix crash in processRegexMatch

### DIFF
--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -167,7 +167,7 @@ bool TAlias::match(const QString& haystack)
             auto name = QString::fromUtf8(&tabptr[2]).trimmed();
             auto* substring_start = haystackC + ovector[2*n];
             auto substring_length = ovector[2*n+1] - ovector[2*n];
-            auto utf16_pos = haystack.indexOf(QString(substring_start));
+            auto utf16_pos = haystack.indexOf(QString::fromUtf8(substring_start, substring_length));
             auto capture = QString::fromUtf8(substring_start, substring_length);
             nameGroups << qMakePair(name, capture);
             tabptr += name_entry_size;

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -344,7 +344,7 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
     for (i = 0; i < rc; i++) {
         const char *substring_start = haystackC + ovector[2 * i];
         const int substring_length = ovector[2 * i + 1] - ovector[2 * i];
-        const int utf16_pos = haystack.indexOf(QString(substring_start));
+        const int utf16_pos = haystack.indexOf(QString::fromUtf8(substring_start, substring_length));
         std::string match;
         if (substring_length < 1) {
             captureList.push_back(match);
@@ -377,7 +377,7 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
             auto name = QString::fromUtf8(&tabptr[2]).trimmed(); //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)
             auto* substring_start = haystackC + ovector[2*n]; //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)
             auto substring_length = ovector[2*n+1] - ovector[2*n]; //NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
-            auto utf16_pos = haystack.indexOf(QString(substring_start));
+            auto utf16_pos = haystack.indexOf(QString::fromUtf8(substring_start, substring_length));
             auto capture = QString::fromUtf8(substring_start, substring_length);
             nameGroups << qMakePair(name, capture);
             tabptr += name_entry_size;
@@ -418,7 +418,7 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
         for (i = 0; i < rc; i++) {
             const char *substring_start = haystackC + ovector[2 * i];
             const int substring_length = ovector[2 * i + 1] - ovector[2 * i];
-            const int utf16_pos = haystack.indexOf(QString(substring_start));
+            const int utf16_pos = haystack.indexOf(QString::fromUtf8(substring_start, substring_length));
 
             std::string match;
             if (substring_length < 1) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
uses suggested code from https://github.com/Mudlet/Mudlet/issues/7937

replaces unbounded QString with a bounded QString::fromUtf8



#### Motivation for adding to Mudlet
see above issue, address sanitizer detected a problem

#### Other info (issues closed, discussion etc)
