### PR TITLE
Infrastructure: purge trailing whitespace

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -426,7 +426,7 @@ public:
     bool showIdsInEditor() const { return mShowIDsInEditor; }
     void setShowIdsInEditor(const bool isShown) { mShowIDsInEditor = isShown; if (mpEditorDialog) {mpEditorDialog->showIDLabels(isShown);} }
     bool getF3SearchEnabled() const { return mF3SearchEnabled; }
-    void setF3SearchEnabled(const bool enabled) { 
+    void setF3SearchEnabled(const bool enabled) {
         mF3SearchEnabled = enabled;
         if (mpConsole) {
             mpConsole->setF3SearchEnabled(enabled);

--- a/src/LlamaFileManager.h
+++ b/src/LlamaFileManager.h
@@ -103,22 +103,22 @@ public:
     Status status() const noexcept { return currentStatus; }
     bool isRunning() const noexcept { return currentStatus == Status::Running; }
     std::optional<qint64> processId() const noexcept;
-    
+
     // Configuration
     void setConfig(const Config& config) { this->config = config; }
     const Config& getConfig() const noexcept { return config; }
-    
+
     // API calls
     void chatCompletion(const ApiRequest& request, ApiCallback callback);
     void textCompletion(const ApiRequest& request, ApiCallback callback);
     void embeddings(const ApiRequest& request, ApiCallback callback);
     void getModels(ApiCallback callback);
     void textCompletionStream(const ApiRequest& request, StreamChunkCallback chunkCallback, StreamErrorCallback errorCallback);
-    
+
     // Health monitoring
     void enableHealthCheck(bool enable = true);
     bool isHealthy() const noexcept { return healthy; }
-    
+
     // Utility functions
     static bool isLlamafileExecutable(const QString& path);
     static QString findLlamafileExecutable(const QStringList& searchPaths = {});
@@ -146,14 +146,14 @@ private:
     std::unique_ptr<QProcess> process;
     std::unique_ptr<QTimer> healthCheckTimer;
     std::unique_ptr<QNetworkAccessManager> networkManager;
-    
+
     // State
     Config config;
     Status currentStatus = Status::Stopped;
     bool healthy = false;
     int restartAttempts = 0;
     QString lastError;
-    
+
     // Helper methods
     void setStatus(Status newStatus);
     void makeApiRequest(const QString& endpoint, const QJsonObject& requestData, ApiCallback callback);
@@ -163,7 +163,7 @@ private:
     QStringList buildProcessArguments() const;
     void attemptRestart();
     void resetRestartAttempts() { restartAttempts = 0; }
-    
+
     // Validation
     bool validateConfig();
     bool isPortAvailable(int port) const;

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2561,7 +2561,7 @@ inline int TBuffer::skipSpacesAtBeginOfLine(const int row, const int column)
 }
 
 // find lindbreaks and indents (if not necessary, return empty list)
-inline QList<WrapInfo> TBuffer::getWrapInfo(const QString& lineText, bool isNewline, 
+inline QList<WrapInfo> TBuffer::getWrapInfo(const QString& lineText, bool isNewline,
     const int maxWidth, const int indent, const int hangingIndent)
 {
     QList<WrapInfo> output;
@@ -2605,7 +2605,7 @@ inline QList<WrapInfo> TBuffer::getWrapInfo(const QString& lineText, bool isNewl
                 needsIndent = true;
             }
             lineBreakFinder.setPosition(indexOfChar);
-            // we check c == QChar::Space since we are happy to break at -any- space, 
+            // we check c == QChar::Space since we are happy to break at -any- space,
             // unlike the indirect-linebreak permission of QTextBoundaryFinder::Line
             // (see: https://www.unicode.org/reports/tr14/#LD9) which will only break at
             // at the first char after 1+ space(s)
@@ -2740,7 +2740,7 @@ int TBuffer::wrapLine(int startLine, int maxWidth, int indentSize, int hangingIn
         const QString lineText = lineBuffer[i];
         // a blank timestamp indicates a wrapped line
         const bool isNewline = (time != mudlet::smBlankTimeStamp);
-        QList<WrapInfo> lineBreaks = getWrapInfo(lineText, isNewline, maxWidth, indent, hangingIndent); 
+        QList<WrapInfo> lineBreaks = getWrapInfo(lineText, isNewline, maxWidth, indent, hangingIndent);
         if (lineBreaks.isEmpty()) {
             tempList.append(lineText);
             queue.push(buffer[i]);

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1600,7 +1600,7 @@ void TCommandLine::setEchoSuppression(bool suppress)
         // This preserves any command the user may have typed while waiting for login
         mPreEchoText = toPlainText();
         clear();  // Clear for password input
-        
+
         // Show password toggle button and reset visibility state
         if (mpPasswordToggleButton) {
             mPasswordVisible = false; // Start with password hidden
@@ -1611,12 +1611,12 @@ void TCommandLine::setEchoSuppression(bool suppress)
     } else {
         // Clear the password field first
         clear();
-        
+
         // Hide password toggle button
         if (mpPasswordToggleButton) {
             mpPasswordToggleButton->setVisible(false);
         }
-        
+
         // Restore the previously typed text if any
         // This allows users to continue with commands they typed during login sequences
         if (!mPreEchoText.isEmpty()) {
@@ -1660,7 +1660,7 @@ void TCommandLine::slot_togglePasswordVisibility()
     if (!mIsEchoSuppressed || mType != MainCommandLine) {
         return;
     }
-    
+
     mPasswordVisible = !mPasswordVisible;
     updatePasswordToggleButton();
     viewport()->update(); // triggers paintEvent to mask/unmask
@@ -1671,7 +1671,7 @@ void TCommandLine::updatePasswordToggleButton()
     if (!mpPasswordToggleButton) {
         return;
     }
-    
+
     if (mPasswordVisible) {
         // Password is visible, show "hide" icon (eye with slash)
         mpPasswordToggleButton->setIcon(QIcon(qsl(":/icons/password-show-off.png")));
@@ -1688,24 +1688,24 @@ void TCommandLine::positionPasswordToggleButton()
     if (!mpPasswordToggleButton) {
         return;
     }
-    
+
     // Position the button at the right side of the text edit
     const QRect viewportRect = viewport()->geometry();
     const int buttonWidth = mpPasswordToggleButton->width();
     const int buttonHeight = mpPasswordToggleButton->height();
     const int margin = 5;
-    
+
     // Position at the right edge, vertically centered
     const int x = viewportRect.width() - buttonWidth - margin;
     const int y = (viewportRect.height() - buttonHeight) / 2;
-    
+
     mpPasswordToggleButton->move(x, y);
 }
 
 void TCommandLine::resizeEvent(QResizeEvent* event)
 {
     QPlainTextEdit::resizeEvent(event);
-    
+
     // Reposition the password toggle button when the widget is resized
     if (mpPasswordToggleButton && mpPasswordToggleButton->isVisible()) {
         positionPasswordToggleButton();

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1342,7 +1342,7 @@ QPair<quint8, TChar> TConsole::getTextAttributes() const
     const QPoint beginPoint = P_begin;
     const QPoint endPoint = P_end;
     const QPoint userCursorPoint = mUserCursor;
-    
+
     int x = beginPoint.x();
     int y = beginPoint.y();
 
@@ -1354,7 +1354,7 @@ QPair<quint8, TChar> TConsole::getTextAttributes() const
 
     // Take a snapshot of buffer size to avoid TOCTOU issues
     const int bufferSize = static_cast<int>(buffer.buffer.size());
-    
+
     // Early bounds check
     if (y < 0 || x < 0 || y >= bufferSize) {
         return qMakePair(2, TChar());
@@ -1363,7 +1363,7 @@ QPair<quint8, TChar> TConsole::getTextAttributes() const
     // Get line reference and check its bounds safely
     const auto& line = buffer.buffer.at(y);
     const int lineSize = static_cast<int>(line.size());
-    
+
     if (x >= lineSize) {
         return qMakePair(2, TChar());
     }

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -55,19 +55,19 @@ TDetachedWindow::TDetachedWindow(const QString& profileName, TMainConsole* conso
 {
     // Add the initial profile
     mProfileConsoleMap[profileName] = console;
-    
+
     setupUI();
     createToolBar();
     createMenus();
     createStatusBar();
     restoreWindowGeometry();
-    
+
     // Set window properties
     setWindowTitle(tr("Mudlet - %1 (Detached)").arg(profileName));
     setWindowIcon(parent ? parent->windowIcon() : QIcon());
     setAttribute(Qt::WA_DeleteOnClose);
     setAcceptDrops(true);
-    
+
     // Update toolbar state and window title for this profile
     updateToolBarActions();
     updateWindowTitle();
@@ -87,7 +87,7 @@ TDetachedWindow::~TDetachedWindow()
             }
         }
     }
-    
+
     saveWindowGeometry();
 }
 
@@ -95,28 +95,28 @@ void TDetachedWindow::setupUI()
 {
     auto centralWidget = new QWidget(this);
     setCentralWidget(centralWidget);
-    
+
     mpMainLayout = new QVBoxLayout(centralWidget);
     mpMainLayout->setContentsMargins(0, 0, 0, 0);
     mpMainLayout->setSpacing(0);
-    
+
     // Create a tab bar to show the profile names and allow reattachment
     mpTabBar = new TTabBar(centralWidget);
     mpTabBar->setMaximumHeight(30);
     mpTabBar->setTabsClosable(true);
-    
+
     // Add initial tab for the first profile
     if (!mCurrentProfileName.isEmpty()) {
         mpTabBar->addTab(mCurrentProfileName);
         mpTabBar->setTabData(0, mCurrentProfileName);
     }
-    
+
     mpMainLayout->addWidget(mpTabBar);
-    
+
     // Create a stacked widget to hold multiple consoles
     mpConsoleContainer = new QStackedWidget(centralWidget);
     mpMainLayout->addWidget(mpConsoleContainer);
-    
+
     // Add the initial console
     if (!mCurrentProfileName.isEmpty() && mProfileConsoleMap.contains(mCurrentProfileName)) {
         auto console = mProfileConsoleMap[mCurrentProfileName];
@@ -126,20 +126,20 @@ void TDetachedWindow::setupUI()
             console->show();
         }
     }
-    
+
     updateTabIndicator(0);  // Set initial connection status
-    
+
     // Connect signals
     connect(mpTabBar, &TTabBar::tabDetachRequested, this, &TDetachedWindow::onReattachAction);
     connect(mpTabBar, &QTabBar::tabCloseRequested, this, &TDetachedWindow::closeProfileByIndex);
     connect(mpTabBar, &QTabBar::currentChanged, this, &TDetachedWindow::slot_tabChanged);
-    
+
     // Connect double-click to reattach
     connect(mpTabBar, &QTabBar::tabBarDoubleClicked, this, &TDetachedWindow::onReattachAction);
-    
+
     // Connect context menu for right-click reattach
     mpTabBar->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(mpTabBar, &QWidget::customContextMenuRequested, 
+    connect(mpTabBar, &QWidget::customContextMenuRequested,
             this, &TDetachedWindow::showTabContextMenu);
 }
 
@@ -147,28 +147,28 @@ void TDetachedWindow::createMenus()
 {
     // Profile menu with quick actions
     auto profileMenu = menuBar()->addMenu(tr("&Profile"));
-    
+
     auto saveProfileAction = new QAction(QIcon(qsl(":/icons/document-save.png")), tr("&Save Profile"), this);
     saveProfileAction->setShortcut(QKeySequence::Save);
     saveProfileAction->setStatusTip(tr("Save the current profile"));
     connect(saveProfileAction, &QAction::triggered, this, &TDetachedWindow::slot_saveProfile);
     profileMenu->addAction(saveProfileAction);
-    
+
     profileMenu->addSeparator();
-    
+
     auto exportProfileAction = new QAction(QIcon(qsl(":/icons/document-export.png")), tr("&Export Profile"), this);
     exportProfileAction->setStatusTip(tr("Export profile as package"));
     connect(exportProfileAction, &QAction::triggered, this, &TDetachedWindow::slot_exportProfile);
     profileMenu->addAction(exportProfileAction);
-    
+
     auto profileSettingsAction = new QAction(QIcon(qsl(":/icons/configure.png")), tr("Profile &Settings"), this);
     profileSettingsAction->setShortcut(QKeySequence::Preferences);
     profileSettingsAction->setStatusTip(tr("Open profile settings"));
     connect(profileSettingsAction, &QAction::triggered, mudlet::self(), &mudlet::slot_showPreferencesDialog);
     profileMenu->addAction(profileSettingsAction);
-    
+
     profileMenu->addSeparator();
-    
+
     auto closeProfileAction = new QAction(QIcon(qsl(":/icons/profile-close.png")), tr("&Close Profile"), this);
     closeProfileAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_W));
     closeProfileAction->setStatusTip(tr("Close the current profile"));
@@ -176,22 +176,22 @@ void TDetachedWindow::createMenus()
     profileMenu->addAction(closeProfileAction);
 
     auto windowMenu = menuBar()->addMenu(tr("&Window"));
-    
+
     auto reattachAction = new QAction(tr("&Reattach to Main Window"), this);
     reattachAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_R));
     reattachAction->setStatusTip(tr("Reattach this profile window to the main Mudlet window"));
     connect(reattachAction, &QAction::triggered, this, &TDetachedWindow::onReattachAction);
     windowMenu->addAction(reattachAction);
-    
+
     windowMenu->addSeparator();
-    
+
     auto closeAction = new QAction(tr("&Close"), this);
     closeAction->setShortcut(QKeySequence::Close);
     connect(closeAction, &QAction::triggered, this, &QWidget::close);
     windowMenu->addAction(closeAction);
-    
+
     windowMenu->addSeparator();
-    
+
     // Always on top toggle
     auto alwaysOnTopAction = new QAction(tr("Always on &Top"), this);
     alwaysOnTopAction->setCheckable(true);
@@ -199,7 +199,7 @@ void TDetachedWindow::createMenus()
     alwaysOnTopAction->setStatusTip(tr("Keep this window always on top of other windows"));
     connect(alwaysOnTopAction, &QAction::triggered, this, &TDetachedWindow::slot_toggleAlwaysOnTop);
     windowMenu->addAction(alwaysOnTopAction);
-    
+
     // Minimize action
     auto minimizeAction = new QAction(tr("&Minimize"), this);
     minimizeAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_M));
@@ -220,7 +220,7 @@ void TDetachedWindow::closeEvent(QCloseEvent* event)
         }
         mProfileConsoleMap.clear();
     }
-    
+
     // Emit signal to notify main window only if not reattaching
     if (!mIsReattaching) {
         // Emit for each profile being closed
@@ -256,7 +256,7 @@ void TDetachedWindow::dropEvent(QDropEvent* event)
     const QMimeData* mimeData = event->mimeData();
     if (mimeData->hasFormat("application/x-mudlet-tab")) {
         const QString profileName = QString::fromUtf8(mimeData->data("application/x-mudlet-tab"));
-        
+
         // Don't allow dropping a tab that's already in this window
         if (!mProfileConsoleMap.contains(profileName)) {
             // Request main window to detach this tab to this detached window
@@ -270,7 +270,7 @@ void TDetachedWindow::moveEvent(QMoveEvent* event)
 {
     mLastPosition = event->pos();
     QMainWindow::moveEvent(event);
-    
+
     // Check if we should offer to merge with another detached window
     QTimer::singleShot(100, this, &TDetachedWindow::checkForWindowMergeOpportunity);
 }
@@ -289,13 +289,13 @@ void TDetachedWindow::hideEvent(QHideEvent* event)
         QMainWindow::hideEvent(event);
         return;
     }
-    
+
     // Allow hiding if we're changing window flags (e.g., always on top)
     if (mIsChangingWindowFlags) {
         QMainWindow::hideEvent(event);
         return;
     }
-             
+
     // Prevent the window from being hidden if it should stay visible (has profiles)
     // IMPORTANT: Only allow hiding if there are NO profiles remaining, regardless of mIsReattaching
     if (mShouldStayVisible && mpTabBar && mpTabBar->count() > 0) {
@@ -312,7 +312,7 @@ void TDetachedWindow::hideEvent(QHideEvent* event)
         event->ignore();
         return;
     }
-    
+
     QMainWindow::hideEvent(event);
 }
 
@@ -322,18 +322,18 @@ void TDetachedWindow::onReattachAction()
     if (mReattachInProgress) {
         return;
     }
-    
+
     // Only set mIsReattaching if this is the last profile (which will close the window)
     if (getProfileCount() <= 1) {
         mIsReattaching = true;
     }
-    
+
     // Reattach the currently active profile
     if (!mCurrentProfileName.isEmpty()) {
         mReattachInProgress = true;
-        
+
         emit reattachRequested(mCurrentProfileName);
-        
+
         // Reset the flag after a short delay to allow for the operation to complete
         QTimer::singleShot(500, this, [this]() {
             mReattachInProgress = false;
@@ -348,35 +348,35 @@ void TDetachedWindow::showTabContextMenu(const QPoint& position)
     if (tabIndex == -1) {
         return;
     }
-    
+
     QString profileName = mpTabBar->tabData(tabIndex).toString();
-    
+
     QMenu contextMenu(this);
-    
-    auto reattachAction = contextMenu.addAction(QIcon(qsl(":/icons/view-restore.png")), 
+
+    auto reattachAction = contextMenu.addAction(QIcon(qsl(":/icons/view-restore.png")),
                                                tr("Reattach '%1' to Main Window").arg(profileName));
     connect(reattachAction, &QAction::triggered, [this, profileName] {
         // Switch to this profile first, then reattach
         switchToProfile(profileName);
         onReattachAction();
     });
-    
+
     contextMenu.addSeparator();
-    
-    auto closeTabAction = contextMenu.addAction(QIcon(qsl(":/icons/profile-close.png")), 
+
+    auto closeTabAction = contextMenu.addAction(QIcon(qsl(":/icons/profile-close.png")),
                                                tr("Close Profile '%1'").arg(profileName));
     connect(closeTabAction, &QAction::triggered, [this, tabIndex] {
         closeProfileByIndex(tabIndex);
     });
-    
+
     if (mProfileConsoleMap.size() > 1) {
         contextMenu.addSeparator();
-        
-        auto closeWindowAction = contextMenu.addAction(QIcon(qsl(":/icons/dialog-close.png")), 
+
+        auto closeWindowAction = contextMenu.addAction(QIcon(qsl(":/icons/dialog-close.png")),
                                                       tr("Close Window (All Profiles)"));
         connect(closeWindowAction, &QAction::triggered, this, &QWidget::close);
     }
-    
+
     contextMenu.exec(mpTabBar->mapToGlobal(position));
 }
 
@@ -394,16 +394,16 @@ void TDetachedWindow::restoreWindowGeometry()
     QSettings settings;
     // Use current profile name for settings key
     const QString key = QString("DetachedWindow/%1").arg(mCurrentProfileName.isEmpty() ? "Unknown" : mCurrentProfileName);
-    
+
     const QByteArray geometry = settings.value(key + "/geometry").toByteArray();
     const QByteArray windowState = settings.value(key + "/windowState").toByteArray();
-    
+
     if (!geometry.isEmpty()) {
         restoreGeometry(geometry);
     } else {
         // Default size and position
         resize(800, 600);
-        
+
         // Center on screen containing the main window
         if (parentWidget()) {
             const QScreen* screen = QApplication::screenAt(parentWidget()->pos());
@@ -413,7 +413,7 @@ void TDetachedWindow::restoreWindowGeometry()
             }
         }
     }
-    
+
     if (!windowState.isEmpty()) {
         restoreState(windowState);
     }
@@ -644,15 +644,15 @@ void TDetachedWindow::createStatusBar()
     // Create status bar with connection and profile information
     auto statusBar = this->statusBar();
     statusBar->showMessage(tr("Ready"));
-    
+
     // Profile information (left side)
     mpStatusBarProfileLabel = new QLabel(tr("Profile: %1").arg(mCurrentProfileName.isEmpty() ? tr("None") : mCurrentProfileName));
     mpStatusBarProfileLabel->setStyleSheet(qsl("QLabel { padding: 2px 8px; }"));
     statusBar->addWidget(mpStatusBarProfileLabel);
-    
+
     // Add stretcher to push connection info to the right
     statusBar->addWidget(new QWidget(), 1);
-    
+
     // Connection information (right side)
     mpStatusBarConnectionLabel = new QLabel(tr("Disconnected"));
     mpStatusBarConnectionLabel->setStyleSheet(qsl("QLabel { padding: 2px 8px; }"));
@@ -687,10 +687,10 @@ void TDetachedWindow::updateToolBarActions()
     if (hasActiveProfile) {
         bool isConnected = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectedState);
         bool isConnecting = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectingState);
-        
+
         // Update status bar
         updateStatusBar(pHost, isConnected, isConnecting);
-        
+
         // Enable/disable individual actions based on connection state
         // All actions should always be enabled to match main window behavior
         mpActionConnect->setEnabled(true);
@@ -700,7 +700,7 @@ void TDetachedWindow::updateToolBarActions()
     } else {
         // Update status bar
         updateStatusBar(nullptr, false, false);
-        
+
         // Even when no profile is active, keep all actions enabled to match main window
         mpActionConnect->setEnabled(true);
         mpActionDisconnect->setEnabled(true);
@@ -732,7 +732,7 @@ void TDetachedWindow::updateToolbarForProfile(Host* pHost)
 void TDetachedWindow::updateWindowTitle()
 {
     QString title;
-    
+
     if (mProfileConsoleMap.size() == 1) {
         // Single profile - use the simple format
         Host* pHost = nullptr;
@@ -742,11 +742,11 @@ void TDetachedWindow::updateWindowTitle()
         } else {
             title = tr("Mudlet (Detached)");
         }
-        
+
         if (pHost) {
             bool isConnected = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectedState);
             bool isConnecting = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectingState);
-            
+
             if (isConnected) {
                 title += tr(" - Connected");
                 if (!pHost->getUrl().isEmpty()) {
@@ -764,7 +764,7 @@ void TDetachedWindow::updateWindowTitle()
                 .arg(mProfileConsoleMap.size())
                 .arg(mCurrentProfileName.isEmpty() ? tr("None") : mCurrentProfileName);
     }
-    
+
     setWindowTitle(title);
 }
 
@@ -773,7 +773,7 @@ void TDetachedWindow::updateStatusBar(Host* pHost, bool isConnected, bool isConn
     if (!mpStatusBarConnectionLabel || !mpStatusBarProfileLabel) {
         return;
     }
-    
+
     // Update profile label
     if (mProfileConsoleMap.size() == 1) {
         mpStatusBarProfileLabel->setText(tr("Profile: %1").arg(mCurrentProfileName));
@@ -782,7 +782,7 @@ void TDetachedWindow::updateStatusBar(Host* pHost, bool isConnected, bool isConn
                                        .arg(mProfileConsoleMap.size())
                                        .arg(mCurrentProfileName.isEmpty() ? tr("None") : mCurrentProfileName));
     }
-    
+
     // Update connection label
     if (pHost) {
         if (isConnected) {
@@ -806,29 +806,29 @@ void TDetachedWindow::updateTabIndicator(int tabIndex)
     if (!mpTabBar || mpTabBar->count() == 0) {
         return;
     }
-    
+
     // If no tab index specified, update current tab
     if (tabIndex == -1) {
         tabIndex = mpTabBar->currentIndex();
     }
-    
+
     if (tabIndex < 0 || tabIndex >= mpTabBar->count()) {
         return;
     }
-    
+
     QString profileName = mpTabBar->tabData(tabIndex).toString();
     if (profileName.isEmpty()) {
         return;
     }
-    
+
     // Get the host and determine connection status
     Host* pHost = mudlet::self()->getHostManager().getHost(profileName);
     QIcon tabIcon;
-    
+
     if (pHost) {
         bool isConnected = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectedState);
         bool isConnecting = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectingState);
-        
+
         if (isConnected) {
             tabIcon = QIcon(qsl(":/icons/dialog-ok-apply.png"));
         } else if (isConnecting) {
@@ -839,7 +839,7 @@ void TDetachedWindow::updateTabIndicator(int tabIndex)
     } else {
         tabIcon = QIcon(qsl(":/icons/dialog-error.png"));
     }
-    
+
     // Set the tab text and icon
     mpTabBar->setTabText(tabIndex, profileName);
     mpTabBar->setTabIcon(tabIndex, tabIcon);
@@ -860,7 +860,7 @@ void TDetachedWindow::slot_toggleAlwaysOnTop()
 {
     // Set flag to allow hiding during window flag changes
     mIsChangingWindowFlags = true;
-    
+
     Qt::WindowFlags flags = windowFlags();
     if (flags & Qt::WindowStaysOnTopHint) {
         // Remove always on top flag
@@ -870,7 +870,7 @@ void TDetachedWindow::slot_toggleAlwaysOnTop()
         setWindowFlags(flags | Qt::WindowStaysOnTopHint);
     }
     show();  // Required after changing window flags
-    
+
     // Reset flag after a short delay to allow the window operations to complete
     QTimer::singleShot(100, this, [this]() {
         mIsChangingWindowFlags = false;
@@ -882,7 +882,7 @@ void TDetachedWindow::slot_saveProfile()
     if (mCurrentProfileName.isEmpty()) {
         return;
     }
-    
+
     Host* pHost = mudlet::self()->getHostManager().getHost(mCurrentProfileName);
     if (pHost) {
         pHost->saveProfile();
@@ -901,7 +901,7 @@ void TDetachedWindow::closeProfile()
     if (mCurrentProfileName.isEmpty()) {
         return;
     }
-    
+
     // Close the current profile
     closeProfileByIndex(mpTabBar->currentIndex());
 }
@@ -911,65 +911,65 @@ bool TDetachedWindow::addProfile(const QString& profileName, TMainConsole* conso
     if (mProfileConsoleMap.contains(profileName) || !console) {
         return false;
     }
-    
+
     // Add to our map
     mProfileConsoleMap[profileName] = console;
-    
+
     // Ensure window should stay visible when it has profiles
     mShouldStayVisible = true;
-    
+
     // Add tab
     int tabIndex = mpTabBar->addTab(profileName);
     mpTabBar->setTabData(tabIndex, profileName);
-    
+
     // Add console to stacked widget
     mpConsoleContainer->addWidget(console);
-    
+
     // Force console to properly resize and fill the available space
     console->setParent(mpConsoleContainer);
     console->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    
+
     // Clear any size constraints that might have been set in the previous window
     console->setMinimumSize(0, 0);
     console->setMaximumSize(16777215, 16777215);  // Qt's maximum size
-    
+
     // Force immediate visibility and geometry updates
     console->setVisible(true);
     console->show();
     console->raise();
-    
+
     // Multiple rounds of geometry updates to ensure proper sizing
     console->updateGeometry();
     console->adjustSize();
-    
+
     // Force immediate redraw
     console->update();
     console->repaint();
-    
+
     // Update the container to ensure proper layout
     mpConsoleContainer->updateGeometry();
     mpConsoleContainer->update();
     mpConsoleContainer->repaint();
-    
+
     // Update tab indicator for the new tab
     updateTabIndicator(tabIndex);
-    
+
     // Switch to the new profile
     mpTabBar->setCurrentIndex(tabIndex);
-    
+
     // Explicitly switch to the new profile to ensure toolbar actions are updated
     switchToProfile(profileName);
-    
+
     // Additional forced updates after switching to the profile
     console->updateGeometry();
     console->update();
     console->repaint();
-    
+
     // Update the entire window layout
     updateGeometry();
     update();
     repaint();
-    
+
     // Schedule a delayed update to handle any Qt layout timing issues
     QTimer::singleShot(10, this, [this, profileName]() {
         auto console = mProfileConsoleMap.value(profileName);
@@ -980,7 +980,7 @@ bool TDetachedWindow::addProfile(const QString& profileName, TMainConsole* conso
             console->repaint();
         }
     });
-    
+
     return true;
 }
 
@@ -989,7 +989,7 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
     if (!mProfileConsoleMap.contains(profileName)) {
         return false;
     }
-    
+
     // Find the tab index
     int tabIndex = -1;
     for (int i = 0; i < mpTabBar->count(); ++i) {
@@ -998,11 +998,11 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
             break;
         }
     }
-    
+
     if (tabIndex == -1) {
         return false;
     }
-    
+
     // Remove console from stacked widget
     auto console = mProfileConsoleMap[profileName];
     if (console) {
@@ -1010,15 +1010,15 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
         // DON'T set parent to nullptr here - let the receiving window handle reparenting
         // console->setParent(nullptr);
     }
-    
+
     // Remove from map
     mProfileConsoleMap.remove(profileName);
-    
+
     // Remember which tab was currently selected and adjust selection intelligently
     const int currentTabIndex = mpTabBar->currentIndex();
     const int tabCount = mpTabBar->count();
     int newSelectedIndex = -1;
-    
+
     // Determine what tab should be selected after removal
     if (tabCount > 1) { // There will be tabs remaining after removal
         if (tabIndex == currentTabIndex) {
@@ -1038,18 +1038,18 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
             newSelectedIndex = currentTabIndex;
         }
     }
-    
+
     mpTabBar->removeTab(tabIndex);
-    
+
     // Set the new selected tab if there are remaining tabs
     if (newSelectedIndex >= 0 && newSelectedIndex < mpTabBar->count()) {
         mpTabBar->setCurrentIndex(newSelectedIndex);
     }
-    
+
     // Force tab bar to update and repaint
     mpTabBar->update();
     mpTabBar->repaint();
-    
+
     // Update current profile if necessary
     if (mCurrentProfileName == profileName) {
         if (mpTabBar->count() > 0) {
@@ -1067,7 +1067,7 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
             mShouldStayVisible = false;
         }
     }
-    
+
     // Ensure the window remains visible if it still has profiles
     if (mpTabBar->count() > 0) {
         // Force layout update
@@ -1075,29 +1075,29 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
         if (layout()) {
             layout()->update();
         }
-        
+
         // Ensure window is not minimized
         if (isMinimized()) {
             showNormal();
         }
-        
+
         // Make sure the window is visible and on top
         setVisible(true);
         show();
         raise();
         activateWindow();
-        
+
         // Force window to front on macOS
         #ifdef Q_OS_MACOS
         setAttribute(Qt::WA_ShowWithoutActivating, false);
         #endif
-        
+
         // Force repaint to ensure visibility
         repaint();
-        
+
         // Additional forced update after event processing
         update();
-        
+
         // Also schedule a delayed visibility restoration in case the drag operation
         // affects window state after this method returns
         QTimer::singleShot(100, this, [this, profileName]() {
@@ -1110,7 +1110,7 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
             }
         });
     }
-    
+
     return true;
 }
 
@@ -1142,37 +1142,37 @@ void TDetachedWindow::switchToProfile(const QString& profileName)
     if (!mProfileConsoleMap.contains(profileName)) {
         return;
     }
-    
+
     mCurrentProfileName = profileName;
-    
+
     auto console = mProfileConsoleMap[profileName];
     if (console && mpConsoleContainer) {
         // Set the current widget in the stacked container
         mpConsoleContainer->setCurrentWidget(console);
-        
+
         // Ensure console has proper size policy and constraints for the container
         console->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
         console->setMinimumSize(0, 0);
         console->setMaximumSize(16777215, 16777215);  // Qt's maximum size
-        
+
         // Force console visibility and proper sizing
         console->setVisible(true);
         console->show();
         console->raise();
-        
+
         // Multiple rounds of geometry updates
         console->updateGeometry();
         console->adjustSize();
-        
+
         // Force immediate redraw
         console->update();
         console->repaint();
-        
+
         // Update container to ensure proper layout
         mpConsoleContainer->updateGeometry();
         mpConsoleContainer->update();
         mpConsoleContainer->repaint();
-        
+
         // Force parent widget updates
         if (console->parentWidget()) {
             console->parentWidget()->updateGeometry();
@@ -1180,7 +1180,7 @@ void TDetachedWindow::switchToProfile(const QString& profileName)
             console->parentWidget()->repaint();
         }
     }
-    
+
     // Update tab selection to match the profile switch
     for (int i = 0; i < mpTabBar->count(); ++i) {
         if (mpTabBar->tabData(i).toString() == profileName) {
@@ -1190,21 +1190,21 @@ void TDetachedWindow::switchToProfile(const QString& profileName)
             break;
         }
     }
-    
+
     // Force tab bar repainting
     mpTabBar->update();
     mpTabBar->repaint();
-    
+
     // Update UI for the new active profile
     updateToolBarActions();
     updateWindowTitle();
     updateTabIndicator();
-    
+
     // Force window repainting and layout update
     updateGeometry();
     update();
     repaint();
-    
+
     // Schedule a delayed update to handle any Qt layout timing issues
     QTimer::singleShot(10, this, [this, profileName]() {
         auto console = mProfileConsoleMap.value(profileName);
@@ -1222,7 +1222,7 @@ void TDetachedWindow::slot_tabChanged(int index)
     if (index < 0 || index >= mpTabBar->count()) {
         return;
     }
-    
+
     QString profileName = mpTabBar->tabData(index).toString();
     if (!profileName.isEmpty() && profileName != mCurrentProfileName) {
         switchToProfile(profileName);
@@ -1234,18 +1234,18 @@ void TDetachedWindow::closeProfileByIndex(int index)
     if (index < 0 || index >= mpTabBar->count()) {
         return;
     }
-    
+
     QString profileName = mpTabBar->tabData(index).toString();
     if (profileName.isEmpty()) {
         return;
     }
-    
+
     // Close the specific profile
     mudlet::self()->slot_closeProfileByName(profileName);
-    
+
     // Remove the profile from this detached window
     removeProfile(profileName);
-    
+
     // If this was the last profile, close the detached window
     if (mProfileConsoleMap.isEmpty()) {
         QTimer::singleShot(0, this, [this] {
@@ -1260,44 +1260,44 @@ void TDetachedWindow::checkForWindowMergeOpportunity()
     if (mIsReattaching || !isVisible() || !isActiveWindow()) {
         return;
     }
-    
+
     // Don't check if we have no profiles
     if (mProfileConsoleMap.isEmpty()) {
         return;
     }
-    
+
     // Get our window geometry
     const QRect ourRect = geometry();
-    
+
     // Get list of all detached windows from mudlet
     auto mudletInstance = mudlet::self();
     if (!mudletInstance) {
         return;
     }
-    
+
     // Look for overlapping detached windows
     const auto& detachedWindows = mudletInstance->getDetachedWindows();
     for (auto it = detachedWindows.begin(); it != detachedWindows.end(); ++it) {
         TDetachedWindow* otherWindow = it.value();
-        
+
         // Skip ourselves
         if (otherWindow == this || !otherWindow || !otherWindow->isVisible()) {
             continue;
         }
-        
+
         const QRect otherRect = otherWindow->geometry();
-        
+
         // Check if windows significantly overlap (more than 50% of smaller window)
         const QRect intersection = ourRect.intersected(otherRect);
         if (intersection.isEmpty()) {
             continue;
         }
-        
+
         const int ourArea = ourRect.width() * ourRect.height();
         const int otherArea = otherRect.width() * otherRect.height();
         const int intersectionArea = intersection.width() * intersection.height();
         const int smallerArea = qMin(ourArea, otherArea);
-        
+
         // If overlap is significant (more than 60% of the smaller window)
         if (intersectionArea > (smallerArea * 0.6)) {
             // Automatically merge windows
@@ -1312,41 +1312,41 @@ void TDetachedWindow::performWindowMerge(TDetachedWindow* otherWindow)
     if (!otherWindow || otherWindow == this || mIsReattaching) {
         return;
     }
-    
+
     // Additional safety checks
     if (!isVisible() || !otherWindow->isVisible()) {
         return;
     }
-    
+
     // Prevent multiple merge operations for the same windows
     static QSet<QPair<TDetachedWindow*, TDetachedWindow*>> activeMergeOperations;
     const auto mergePair = qMakePair(this, otherWindow);
     const auto reverseMergePair = qMakePair(otherWindow, this);
-    
+
     if (activeMergeOperations.contains(mergePair) || activeMergeOperations.contains(reverseMergePair)) {
         return;
     }
-    
+
     activeMergeOperations.insert(mergePair);
-    
+
     // Get profile names for the merge
     const QStringList ourProfiles = getProfileNames();
-    
+
     if (ourProfiles.isEmpty()) {
         activeMergeOperations.remove(mergePair);
         return;
     }
-    
+
     // Automatically merge without prompting - defer the operation to avoid timing issues
     QTimer::singleShot(0, this, [this, otherWindow, ourProfiles, mergePair]() {
         // Check if the other window is still valid
         if (!otherWindow) {
             return;
         }
-        
+
         // Set flag to prevent cleanup during merge
         mIsReattaching = true;
-        
+
         // Merge all our profiles into the other window
         for (const QString& profileName : ourProfiles) {
             // Double-check the profile still exists in this window
@@ -1355,7 +1355,7 @@ void TDetachedWindow::performWindowMerge(TDetachedWindow* otherWindow)
             }
         }
     });
-    
+
     // Clean up the active merge tracking after a delay
     QTimer::singleShot(100, [mergePair]() {
         activeMergeOperations.remove(mergePair);
@@ -1377,21 +1377,21 @@ void TDetachedWindow::withCurrentProfileActive(const std::function<void()>& acti
     if (!mudletInstance || mCurrentProfileName.isEmpty()) {
         return;
     }
-    
+
     Host* pHost = mudletInstance->getHostManager().getHost(mCurrentProfileName);
     if (!pHost) {
         return;
     }
-    
+
     // Store the current active host
     Host* previousActiveHost = mudletInstance->mpCurrentActiveHost;
-    
+
     // Temporarily set our profile's host as active
     mudletInstance->mpCurrentActiveHost = pHost;
-    
+
     // Execute the action
     action();
-    
+
     // Restore the previous active host
     mudletInstance->mpCurrentActiveHost = previousActiveHost;
 }
@@ -1559,7 +1559,7 @@ void TDetachedWindow::changeEvent(QEvent* event)
 {
     if (event->type() == QEvent::WindowStateChange) {
         auto stateChangeEvent = static_cast<QWindowStateChangeEvent*>(event);
-        
+
         // Check if window is being minimized
         if (windowState() & Qt::WindowMinimized) {
             mIsBeingMinimized = true;
@@ -1572,6 +1572,6 @@ void TDetachedWindow::changeEvent(QEvent* event)
             }
         }
     }
-    
+
     QMainWindow::changeEvent(event);
 }

--- a/src/TDetachedWindow.h
+++ b/src/TDetachedWindow.h
@@ -51,7 +51,7 @@ public:
     TMainConsole* getCurrentConsole() const;
     TMainConsole* getConsole(const QString& profileName) const;
     int getProfileCount() const { return mProfileConsoleMap.size(); }
-    
+
     void updateToolbarForProfile(Host* pHost);
     void setReattaching(bool reattaching) { mIsReattaching = reattaching; }
 
@@ -80,7 +80,7 @@ private slots:
     void slot_toggleAlwaysOnTop();
     void slot_saveProfile();
     void slot_exportProfile();
-    
+
     // Detached window specific toolbar action slots
     void slot_connectProfile();
     void slot_disconnectProfile();
@@ -121,7 +121,7 @@ private:
     void checkForWindowMergeOpportunity();  // Check if this window overlaps with another detached window
     void performWindowMerge(TDetachedWindow* otherWindow);  // Automatically merge with another window
     void logWindowState(const QString& context);  // Debug method to track window state
-    
+
     // Helper method to temporarily set the active host for actions
     void withCurrentProfileActive(const std::function<void()>& action);
 
@@ -132,7 +132,7 @@ private:
     QVBoxLayout* mpMainLayout{nullptr};
     TTabBar* mpTabBar{nullptr};
     QToolBar* mpToolBar{nullptr};
-    
+
     // Toolbar actions - mirroring main window
     QAction* mpActionConnect{nullptr};
     QAction* mpActionDisconnect{nullptr};
@@ -157,32 +157,32 @@ private:
     QAction* mpActionMuteAPI{nullptr};
     QAction* mpActionMuteGame{nullptr};
     QAction* mpActionFullScreenView{nullptr};
-    
+
     // Toolbar buttons
     QToolButton* mpButtonConnect{nullptr};
     QToolButton* mpButtonMute{nullptr};
     QToolButton* mpButtonPackageManagers{nullptr};
-    
+
     // Status bar
     QLabel* mpStatusBarConnectionLabel{nullptr};
     QLabel* mpStatusBarProfileLabel{nullptr};
-    
+
     // Store window state
     QPoint mLastPosition;
     QSize mLastSize;
-    
+
     // Flag to indicate if window is being closed due to reattachment
     bool mIsReattaching{false};
-    
+
     // Flag to force window to stay visible when it has profiles
     bool mShouldStayVisible{true};
-    
+
     // Flag to track if window is being minimized (to allow hiding during minimize)
     bool mIsBeingMinimized{false};
-    
+
     // Flag to allow hiding during window flag changes (always on top, etc.)
     bool mIsChangingWindowFlags{false};
-    
+
     // Flag to prevent duplicate reattach operations on this window
     bool mReattachInProgress{false};
 };

--- a/src/TGameDetails.h
+++ b/src/TGameDetails.h
@@ -647,7 +647,7 @@ qsl("<a href='https://abandonedrealms.com'>Website</a><br>"
                  "venue of original ideas, mind boggling quests, and bloodcurdling "
                  "beasts, spinning into realms of power, magic, and technology, "
                  "and many players with which to share your adventures.")},
-                 
+
             {qsl("Medievia"),
              qsl("medievia.com"),
              4000,

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -139,7 +139,7 @@ QList<TMediaData> TMedia::playingMedia(TMediaData& mediaData)
     if (!mediaData.mediaFileName().isEmpty()) {
         const bool fileRelative = TMedia::isFileRelative(mediaData);
 
-        if (!fileRelative && (mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP || 
+        if (!fileRelative && (mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP ||
                               mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP)) {
             return mMatchingTMediaDataList; // MSP and GMCP files should not have absolute paths.
         }
@@ -155,7 +155,7 @@ QList<TMediaData> TMedia::playingMedia(TMediaData& mediaData)
             continue;
         }
 
-        if (pPlayer->getPlaybackState() != QMediaPlayer::PlayingState && 
+        if (pPlayer->getPlaybackState() != QMediaPlayer::PlayingState &&
             pPlayer->mediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
             continue;
         }
@@ -164,7 +164,7 @@ QList<TMediaData> TMedia::playingMedia(TMediaData& mediaData)
             continue;
         }
 
-        if (mediaData.mediaPriority() != TMediaData::MediaPriorityNotSet && 
+        if (mediaData.mediaPriority() != TMediaData::MediaPriorityNotSet &&
             pPlayer->mediaData().mediaPriority() != TMediaData::MediaPriorityNotSet &&
             pPlayer->mediaData().mediaPriority() > mediaData.mediaPriority()) {
             continue;
@@ -244,7 +244,7 @@ void TMedia::pauseMedia(TMediaData& mediaData)
     if (!mediaData.mediaFileName().isEmpty() && mediaData.mediaInput() == TMediaData::MediaInputFile) {
         const bool fileRelative = TMedia::isFileRelative(mediaData);
 
-        if (!fileRelative && (mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP || 
+        if (!fileRelative && (mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP ||
                               mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP)) {
             return; // MSP and GMCP files should not have absolute paths.
         }
@@ -293,7 +293,7 @@ void TMedia::stopMedia(TMediaData& mediaData)
     if (!mediaData.mediaFileName().isEmpty() && mediaData.mediaInput() == TMediaData::MediaInputFile) {
         const bool fileRelative = TMedia::isFileRelative(mediaData);
 
-        if (!fileRelative && (mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP || 
+        if (!fileRelative && (mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP ||
                               mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP)) {
             return; // MSP and GMCP files should not have absolute paths.
         }
@@ -990,7 +990,7 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
 
     // Playback state changed connection
     disconnect(player->mediaPlayer(), &QMediaPlayer::playbackStateChanged, nullptr, nullptr);
-    connect(player->mediaPlayer(), &QMediaPlayer::playbackStateChanged, this, 
+    connect(player->mediaPlayer(), &QMediaPlayer::playbackStateChanged, this,
             [this, weakPlayer](QMediaPlayerPlaybackState playbackState) {
                 if (auto lockedPlayer = weakPlayer.lock()) {
                     handlePlayerPlaybackStateChanged(playbackState, lockedPlayer);
@@ -1022,7 +1022,7 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
             } else {
                 if (fadeInUsed) {
                     if (progress < relativeFadeInPosition) {
-                        const double fadeInVolume = static_cast<double>(volume * (progress - startPosition)) / 
+                        const double fadeInVolume = static_cast<double>(volume * (progress - startPosition)) /
                                                     static_cast<double>(relativeFadeInPosition - startPosition);
                         lockedPlayer->setVolume(qRound(fadeInVolume));
                         actionTaken = true;
@@ -1034,7 +1034,7 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
 
                 if (!actionTaken && fadeOutUsed && progress > 0) {
                     if (progress > relativeFadeOutPosition) {
-                        const double fadeOutVolume = static_cast<double>(volume * (relativeDuration - progress)) / 
+                        const double fadeOutVolume = static_cast<double>(volume * (relativeDuration - progress)) /
                                                      static_cast<double>(fadeOutDuration);
                         lockedPlayer->setVolume(qRound(fadeOutVolume));
                         actionTaken = true;
@@ -1308,9 +1308,9 @@ std::shared_ptr<TMediaPlayer> TMedia::matchMediaPlayer(TMediaData& mediaData)
             continue;
         }
 
-        if (pTestPlayer->getPlaybackState() == QMediaPlayer::PlayingState && 
+        if (pTestPlayer->getPlaybackState() == QMediaPlayer::PlayingState &&
             pTestPlayer->mediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
-            if (pTestPlayer->mediaData().mediaAbsolutePathFileName().endsWith(mediaData.mediaAbsolutePathFileName())) { 
+            if (pTestPlayer->mediaData().mediaAbsolutePathFileName().endsWith(mediaData.mediaAbsolutePathFileName())) {
                 // Is the same sound or music playing?
                 pTestPlayer->setMediaData(mediaData);
                 pTestPlayer->setVolume(mediaData.mediaFadeIn() != TMediaData::MediaFadeNotSet ? 1 : mediaData.mediaVolume());
@@ -1338,9 +1338,9 @@ bool TMedia::doesMediaHavePriorityToPlay(TMediaData& mediaData, const QString& a
             continue;
         }
 
-        if (pTestPlayer->getPlaybackState() == QMediaPlayer::PlayingState && 
+        if (pTestPlayer->getPlaybackState() == QMediaPlayer::PlayingState &&
             pTestPlayer->mediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
-            if (!pTestPlayer->mediaData().mediaAbsolutePathFileName().endsWith(absolutePathFileName)) { 
+            if (!pTestPlayer->mediaData().mediaAbsolutePathFileName().endsWith(absolutePathFileName)) {
                 // Is it a different sound or music than specified?
                 if (pTestPlayer->mediaData().mediaPriority() != TMediaData::MediaPriorityNotSet &&
                     pTestPlayer->mediaData().mediaPriority() > maxMediaPriority) {
@@ -1378,11 +1378,11 @@ void TMedia::matchMediaKeyAndStopMediaVariants(TMediaData& mediaData, const QStr
             pTestPlayer->mediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
 
             if (!mediaData.mediaKey().isEmpty() && !pTestPlayer->mediaData().mediaKey().isEmpty()
-                && mediaData.mediaKey() == pTestPlayer->mediaData().mediaKey()) { 
+                && mediaData.mediaKey() == pTestPlayer->mediaData().mediaKey()) {
                 // Does it have the same key?
                 if (!pTestPlayer->mediaData().mediaAbsolutePathFileName().endsWith(absolutePathFileName)
                     || (!mediaData.mediaUrl().isEmpty() && !pTestPlayer->mediaData().mediaUrl().isEmpty()
-                        && mediaData.mediaUrl() != pTestPlayer->mediaData().mediaUrl())) { 
+                        && mediaData.mediaUrl() != pTestPlayer->mediaData().mediaUrl())) {
                     // Is it a different sound or music than specified?
                     TMediaData stopMediaData = pTestPlayer->mediaData();
                     mpHost->mpMedia->stopMedia(stopMediaData); // Stop it!
@@ -1439,7 +1439,7 @@ bool TMedia::setupVideo(const std::shared_ptr<TMediaPlayer>& player)
     } else if (widgetType == TMediaData::MediaWidgetWindow) {
         myVideoWidget = qobject_cast<TConsole*>(targetWidget)->mpVideoWidget;
     }
-    
+
     if (!myVideoWidget) {
         myVideoWidget = new QVideoWidget();
         myVideoWidget->setParent(targetWidget);

--- a/src/TMxpTagProcessor.cpp
+++ b/src/TMxpTagProcessor.cpp
@@ -52,7 +52,7 @@ TMxpTagHandlerResult TMxpTagProcessor::handleTag(TMxpContext& ctx, TMxpClient& c
             result = client.tagHandled(tag, result);
             if (result != MXP_TAG_NOT_HANDLED) {
                 return result;
-            }                
+            }
         }
     }
 

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -227,12 +227,12 @@ void TTabBar::mouseMoveEvent(QMouseEvent* event)
 
     // Calculate distance moved
     const int distance = (event->pos() - mDragStartPos).manhattanLength();
-    
+
     if (distance >= QApplication::startDragDistance()) {
         // Check if drag is moving outside the tab bar area
         const QPoint globalPos = mapToGlobal(event->pos());
         const QRect tabBarGlobalRect = QRect(mapToGlobal(rect().topLeft()), rect().size());
-        
+
         // If dragged outside tab bar and beyond threshold, initiate detach
         if (!tabBarGlobalRect.contains(globalPos)) {
             const QPoint distanceFromBar = globalPos - tabBarGlobalRect.center();
@@ -243,7 +243,7 @@ void TTabBar::mouseMoveEvent(QMouseEvent* event)
             }
         }
     }
-    
+
     QTabBar::mouseMoveEvent(event);
 }
 

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2812,8 +2812,8 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
         QWidget::keyPressEvent(event);
         return;
     }
-    
-    // #7933 Auto-reditect focus to command line from output window when press alpha-numeric characters 
+
+    // #7933 Auto-reditect focus to command line from output window when press alpha-numeric characters
     // skips ctrl,alt, etc. This improves experiencie and makes fast switch to screenreader users focusing on output
     if (!(event->modifiers() & (Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier)) && !event->text().isEmpty() && event->text().front().isPrint()) {
         if (mpHost && mpConsole && mpConsole->mpCommandLine) {
@@ -2824,7 +2824,7 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
             return;
         }
         // if not command line ignore
-    }        
+    }
 
     qsizetype newCaretLine = -1;
     qsizetype newCaretColumn = -1;

--- a/src/TVar.h
+++ b/src/TVar.h
@@ -106,7 +106,7 @@ inline QDebug& operator<<(QDebug& debug, const TVar* var)
     case LUA_TNONE: debug.nospace() << ", valueType=none"; break;
     case LUA_TNIL: debug.nospace() << ", valueType=nil"; break;
     case LUA_TBOOLEAN: debug.nospace() << ", valueType=boolean"; break;
-    case LUA_TLIGHTUSERDATA: debug.nospace() << ", valueType=lightuserdata"; break;  
+    case LUA_TLIGHTUSERDATA: debug.nospace() << ", valueType=lightuserdata"; break;
     case LUA_TNUMBER: debug.nospace() << ", valueType=number"; break;
     case LUA_TSTRING: debug.nospace() << ", valueType=string"; break;
     case LUA_TTABLE: debug.nospace() << ", valueType=table"; break;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -167,7 +167,7 @@ cTelnet::~cTelnet()
 {
     // Set flag to prevent any further access to Host/Console during destruction
     mIsBeingDestroyed = true;
-    
+
     // Stop all timers immediately
     if (mTimerLogin) {
         mTimerLogin->stop();
@@ -178,7 +178,7 @@ cTelnet::~cTelnet()
     if (mpPostingTimer) {
         mpPostingTimer->stop();
     }
-    
+
     // Aggressively disconnect the socket to prevent signals during destruction
     if (socket.state() != QAbstractSocket::UnconnectedState) {
         // Block all signals from the socket first
@@ -187,10 +187,10 @@ cTelnet::~cTelnet()
         // Force immediate closure without waiting
         socket.abort();
     }
-    
+
     // Disconnect all signal connections to prevent callbacks during destruction
     disconnect();
-    
+
     if (loadingReplay) {
         // If we are doing a replay we had better abort it so that if we are
         // NOT the "last profile standing" the replay system gets reset for

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -434,7 +434,7 @@ private:
 
     // KaVir protocol negotiation tracking
     QVector<unsigned char> mNegotiationOrder;
-    
+
     // Flag to track if this cTelnet instance is being destroyed
     // Used to prevent access to Host/Console during destruction
     bool mIsBeingDestroyed = false;

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1575,7 +1575,7 @@ void dlgConnectionProfiles::loadProfile(bool alsoConnect)
             QDialog::accept();
             return;
         }
-        
+
         pHost->setName(profile_name);
 
         if (!host_name_entry->text().trimmed().isEmpty()) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -231,7 +231,7 @@ void mudlet::init()
     connect(mpTabBar, &QTabBar::currentChanged, this, &mudlet::slot_tabChanged);
     connect(mpTabBar, &QTabBar::tabMoved, this, &mudlet::slot_tabMoved);
     // Connect the tab bar's detach signal
-    connect(mpTabBar, &TTabBar::tabDetachRequested, 
+    connect(mpTabBar, &TTabBar::tabDetachRequested,
             this, &mudlet::slot_tabDetachRequested);
     // Connect the tab bar's reattach signal (for drag and drop reattachment)
     connect(mpTabBar, &TTabBar::tabReattachRequested,
@@ -1591,11 +1591,11 @@ void mudlet::slot_reattachAllDetachedWindows()
 {
     // Get a copy of the detached windows map since reattaching will modify it
     auto detachedWindowsCopy = mDetachedWindows;
-    
+
     for (auto it = detachedWindowsCopy.begin(); it != detachedWindowsCopy.end(); ++it) {
         const QString& profileName = it.key();
         TDetachedWindow* detachedWindow = it.value();
-        
+
         if (detachedWindow) {
             // Use the existing reattach mechanism
             reattachTab(profileName, -1); // Use default insert index
@@ -1692,7 +1692,7 @@ void mudlet::addConsoleForNewHost(Host* pH)
     pConsole->setWindowTitle(pH->getName());
     pConsole->setObjectName(pH->getName());
     const QString profileName = pH->getName();
-    
+
     // Check if this profile should be in a detached window
     if (mDetachedWindows.contains(profileName)) {
         TDetachedWindow* detachedWindow = mDetachedWindows[profileName];
@@ -1704,7 +1704,7 @@ void mudlet::addConsoleForNewHost(Host* pH)
             mDetachedWindows.remove(profileName);
         }
     }
-    
+
     // Add to main window (original behavior)
     const QString tabName = profileName;
     const int newTabID = mpTabBar->addTab(tabName);
@@ -2165,14 +2165,14 @@ void mudlet::dropEvent(QDropEvent* event)
     const QMimeData* mimeData = event->mimeData();
     if (mimeData->hasFormat("application/x-mudlet-tab")) {
         const QString profileName = QString::fromUtf8(mimeData->data("application/x-mudlet-tab"));
-        
+
         // Check if this profile is currently in a detached window
         if (mDetachedWindows.contains(profileName)) {
             TDetachedWindow* sourceWindow = mDetachedWindows.value(profileName);
             if (sourceWindow) {
                 // Move profile from detached window back to main window
                 moveProfileFromDetachedToMainWindow(profileName, sourceWindow);
-                
+
                 // Force tab bar repaint after drop operation
                 mpTabBar->repaint();
                 mpTabBar->update();
@@ -3328,7 +3328,7 @@ void mudlet::slot_multiView(const bool state)
         if (!console) {
             continue;
         }
-        
+
         // IMPORTANT: Only manage visibility for consoles in the main window
         // Consoles in detached windows should not be affected by main window multi-view logic
         const QString profileName = pHost->getName();
@@ -3336,7 +3336,7 @@ void mudlet::slot_multiView(const bool state)
             // This console is in a detached window, skip it
             continue;
         }
-        
+
         if (mpCurrentActiveHost && (&*mpCurrentActiveHost == &*pHost)) {
             // After switching the option off need to redraw the, now only, main
             // TConsole to be displayed for the currently active profile:
@@ -5082,11 +5082,11 @@ void mudlet::activateProfile(Host* pHost)
             // Only hide the previous console if both profiles are in the same window context
             const QString oldProfileName = mpCurrentActiveHost->getName();
             const QString newProfileName = pHost->getName();
-            
+
             // Check if both profiles are in main window (not detached)
             const bool oldInMainWindow = !mDetachedWindows.contains(oldProfileName);
             const bool newInMainWindow = !mDetachedWindows.contains(newProfileName);
-            
+
             // Only hide the previous console if both are in the main window
             if (oldInMainWindow && newInMainWindow) {
                 mpCurrentActiveHost->mpConsole->hide();
@@ -5109,18 +5109,18 @@ void mudlet::activateProfile(Host* pHost)
     mpTabBar->setTabUnderline(newActiveTabIndex, false);
 
     mpCurrentActiveHost = pHost;
-    
+
     // CRITICAL FIX: Handle console visibility properly for both multiview and single-view modes
     const QString currentProfileName = mpCurrentActiveHost->getName();
     const bool currentInMainWindow = !mDetachedWindows.contains(currentProfileName);
-    
+
     if (currentInMainWindow) {
         // Show the current console
         mpCurrentActiveHost->mpConsole->show();
         mpCurrentActiveHost->mpConsole->repaint();
         mpCurrentActiveHost->mpConsole->refresh();
         mpCurrentActiveHost->mpConsole->mpCommandLine->repaint();
-        
+
         // If NOT in multiview mode, hide all other consoles in the main window
         if (!mMultiView) {
             for (const auto& host : mHostManager) {
@@ -5495,18 +5495,18 @@ void mudlet::initializeAI()
 {
     // Create the LlamafileManager
     mpLlamafileManager = std::make_unique<LlamafileManager>(this);
-    
+
     // Connect signals
     connect(mpLlamafileManager.get(), &LlamafileManager::statusChanged,
             this, &mudlet::slot_aiStatusChanged);
     connect(mpLlamafileManager.get(), &LlamafileManager::processError,
             this, &mudlet::slot_aiError);
-    
+
     // Try to find and configure AI model
     if (findAIModel()) {
         qDebug() << "mudlet::initializeAI() INFO: AI model found at:" << mAIModelPath;
         setupAIConfig();
-        
+
         // Auto-start if enabled and model is available
         if (mAIAutoStart) {
             qDebug() << "mudlet::initializeAI() INFO: Auto-starting AI service...";
@@ -5518,7 +5518,7 @@ void mudlet::initializeAI()
                     config.port = 8080;
                     config.autoRestart = true;
                     config.enableGpu = true;
-                    
+
                     mpLlamafileManager->start(config);
                 }
             });
@@ -5533,16 +5533,16 @@ void mudlet::shutdownAI()
     if (mpLlamafileManager && mpLlamafileManager->isRunning()) {
         qDebug() << "mudlet::shutdownAI() - Stopping AI service...";
         mpLlamafileManager->stop();
-        
+
         // Wait a bit for graceful shutdown
         QEventLoop loop;
         QTimer timer;
         timer.setSingleShot(true);
         timer.setInterval(3000); // 3 second timeout
-        
+
         connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
         connect(mpLlamafileManager.get(), &LlamafileManager::processStopped, &loop, &QEventLoop::quit);
-        
+
         timer.start();
         loop.exec();
     }
@@ -5553,7 +5553,7 @@ bool mudlet::findAIModel()
     // Check if model path is already set in settings
     if (mpSettings->contains("AI/modelPath")) {
         QString savedPath = mpSettings->value("AI/modelPath").toString();
-        
+
 #ifdef Q_OS_WIN
         // On Windows, ensure .exe extension exists
         if (!savedPath.endsWith(".exe", Qt::CaseInsensitive)) {
@@ -5569,13 +5569,13 @@ bool mudlet::findAIModel()
             }
         }
 #endif
-        
+
         if (LlamafileManager::isLlamafileExecutable(savedPath)) {
             mAIModelPath = savedPath;
             return true;
         }
     }
-    
+
     // Search for llamafile executables in common locations
     QStringList searchPaths;
     searchPaths << QCoreApplication::applicationDirPath()
@@ -5585,14 +5585,14 @@ bool mudlet::findAIModel()
                 << (getMudletPath(enums::profilesPath) + "/ai")
                 << "/usr/local/bin"
                 << "/opt/llamafile";
-    
+
     QString foundPath = LlamafileManager::findLlamafileExecutable(searchPaths);
     if (!foundPath.isEmpty()) {
         mAIModelPath = foundPath;
         mpSettings->setValue("AI/modelPath", mAIModelPath);
         return true;
     }
-    
+
     return false;
 }
 
@@ -5632,10 +5632,10 @@ void mudlet::setAIAutoStart(bool autoStart)
 void mudlet::slot_aiStatusChanged(LlamafileManager::Status newStatus, LlamafileManager::Status oldStatus)
 {
     Q_UNUSED(oldStatus)
-    
+
     bool running = (newStatus == LlamafileManager::Status::Running);
     emit signal_aiStatusChanged(running);
-    
+
     if (running) {
         qDebug() << "mudlet::slot_aiStatusChanged() - AI service is now running";
     } else if (newStatus == LlamafileManager::Status::Error) {
@@ -5653,7 +5653,7 @@ void mudlet::slot_tabDetachRequested(int index, const QPoint& globalPos)
     if (index < 0 || index >= mpTabBar->count()) {
         return;
     }
-    
+
     detachTab(index, globalPos);
 }
 
@@ -5690,29 +5690,29 @@ void mudlet::slot_detachedWindowClosed(const QString& profileName)
 }
 
 void mudlet::detachTab(int tabIndex, const QPoint& position)
-{    
+{
     if (tabIndex < 0 || tabIndex >= mpTabBar->count()) {
         return;
     }
-    
+
     const QString profileName = mpTabBar->tabData(tabIndex).toString();
     Host* pHost = mHostManager.getHost(profileName);
-    
+
     if (!pHost || !pHost->mpConsole) {
         return;
     }
-    
+
     // Remove console from the main window
     TMainConsole* console = removeConsoleFromSplitter(profileName);
     if (!console) {
         return;
     }
-    
+
     // Handle main window tab selection before removing the tab
     const int currentTabIndex = mpTabBar->currentIndex();
     const int tabCount = mpTabBar->count();
     int newSelectedIndex = -1;
-    
+
     // Determine what tab should be selected after removal
     if (tabCount > 1) { // There will be tabs remaining after removal
         if (tabIndex == currentTabIndex) {
@@ -5732,28 +5732,28 @@ void mudlet::detachTab(int tabIndex, const QPoint& position)
             newSelectedIndex = currentTabIndex;
         }
     }
-    
+
     // Remove tab from main window tab bar since it will be in the detached window
     mpTabBar->removeTab(tabIndex);
-    
+
     // Set the new selected tab if there are remaining tabs
     if (newSelectedIndex >= 0 && newSelectedIndex < mpTabBar->count()) {
         mpTabBar->setCurrentIndex(newSelectedIndex);
-        
+
         // Force tab change logic to run for the newly selected tab
         slot_tabChanged(newSelectedIndex);
-        
+
         // Force tab bar repaint
         mpTabBar->update();
         mpTabBar->repaint();
     }
-    
+
     // Create detached window
     auto detachedWindow = new TDetachedWindow(profileName, console, this);
     mDetachedWindows.insert(profileName, detachedWindow);
-    
+
     // Connect signals
-    connect(detachedWindow, &TDetachedWindow::reattachRequested, 
+    connect(detachedWindow, &TDetachedWindow::reattachRequested,
             this, [this](const QString& profileName) {
                 slot_tabReattachRequested(profileName, -1); // Use default insert index
             });
@@ -5772,12 +5772,12 @@ void mudlet::detachTab(int tabIndex, const QPoint& position)
     detachedWindow->show();
     detachedWindow->raise();
     detachedWindow->activateWindow();
-    
+
     // Update multi-view controls
     updateMultiViewControls();
 
     // Update tab bar auto-hide behavior since we now have detached windows
-    updateMainWindowTabBarAutoHide();    
+    updateMainWindowTabBarAutoHide();
 
     // If no tabs remain, show connection dialog
     if (mpTabBar->count() == 0 && !mIsGoingDown) {
@@ -5791,30 +5791,30 @@ void mudlet::reattachTab(const QString& profileName, int insertIndex)
 {
     // Make a copy of the profile name to avoid use-after-free if the window gets deleted
     const QString safeProfileName = profileName;
-    
+
     if (!mDetachedWindows.contains(safeProfileName)) {
         return;
     }
-    
+
     TDetachedWindow* detachedWindow = mDetachedWindows.value(safeProfileName);
     TMainConsole* console = detachedWindow->getConsole(safeProfileName);
-    
+
     if (!console) {
         return;
     }
-    
+
     // Only set the reattaching flag if this is the last profile in the window
     // (which means the window will be closed after this reattachment)
     if (detachedWindow->getProfileCount() <= 1) {
         detachedWindow->setReattaching(true);
     }
-    
+
     // CRITICAL DEBUG: Check if main window splitter already contains a console for this profile
     for (int i = 0; i < mpSplitter_profileContainer->count(); ++i) {
         QWidget* widget = mpSplitter_profileContainer->widget(i);
         if (auto* existingConsole = qobject_cast<TMainConsole*>(widget)) {
             if (existingConsole->objectName() == safeProfileName) {
-                qWarning() << "reattachTab: CONFLICT! Main window already has console for" << safeProfileName 
+                qWarning() << "reattachTab: CONFLICT! Main window already has console for" << safeProfileName
                           << "existing:" << existingConsole << "moving:" << console;
                 // Remove the conflicting console
                 existingConsole->setParent(nullptr);
@@ -5823,30 +5823,30 @@ void mudlet::reattachTab(const QString& profileName, int insertIndex)
             }
         }
     }
-    
+
     // CRITICAL: Remove the profile from the detached window properly
     bool removalSuccess = detachedWindow->removeProfile(safeProfileName);
     if (!removalSuccess) {
         qWarning() << "reattachTab: Failed to remove profile" << safeProfileName << "from detached window";
         return;
     }
-    
+
     // Ensure the console is properly prepared for transfer
     if (console->parentWidget()) {
         console->setParent(nullptr);
     }
-    
+
     // Add console back to main window
     if (insertIndex < 0 || insertIndex >= mpTabBar->count()) {
         insertIndex = mpTabBar->count(); // Insert at end
     }
-    
+
     addConsoleToSplitter(console, insertIndex);
-    
+
     // Add tab back to tab bar
     const int newTabIndex = mpTabBar->insertTab(insertIndex, safeProfileName);
     mpTabBar->setTabData(newTabIndex, safeProfileName);
-    
+
     // CRITICAL DEBUG: Check for duplicate tabs
     int tabCount = 0;
     for (int i = 0; i < mpTabBar->count(); ++i) {
@@ -5857,30 +5857,30 @@ void mudlet::reattachTab(const QString& profileName, int insertIndex)
     if (tabCount > 1) {
         qWarning() << "reattachTab: DUPLICATE TABS! Found" << tabCount << "tabs for" << safeProfileName;
     }
-    
+
     // Set as current tab
     mpTabBar->setCurrentIndex(newTabIndex);
-    
+
     // CRITICAL: Remove from detached windows map BEFORE activating profile
     // This is essential because activateProfile checks mDetachedWindows to decide
     // whether to show the console, and we need it to see this profile as being in main window
     mDetachedWindows.remove(safeProfileName);
-    
+
     // CRITICAL: Force activation of the profile to ensure it's properly shown
     Host* pHost = mHostManager.getHost(safeProfileName);
     if (pHost) {
         activateProfile(pHost);
-        
+
         // Set the current tab to the newly added one and force tab selection logic
         mpTabBar->setCurrentIndex(newTabIndex);
-        
+
         // Force the tab change logic to run to ensure proper activation and repainting
         slot_tabChanged(newTabIndex);
-        
+
         // Force repainting of the tab bar to ensure visual updates
         mpTabBar->update();
         mpTabBar->repaint();
-        
+
         // Check if console is visible after activation
         if (pHost->mpConsole) {
             // Force visibility and repainting if needed
@@ -5888,35 +5888,35 @@ void mudlet::reattachTab(const QString& profileName, int insertIndex)
                 pHost->mpConsole->setVisible(true);
                 pHost->mpConsole->show();
             }
-            
+
             // Always force console update and repaint to ensure it's properly displayed
             pHost->mpConsole->update();
             pHost->mpConsole->repaint();
         }
-        
+
         // Force main window updates
         update();
         repaint();
     }
-    
+
     // Close the detached window if it's now empty or if it was the last profile
     if (detachedWindow->getProfileCount() == 0) {
         detachedWindow->close();
         detachedWindow->deleteLater(); // Ensure proper cleanup
     }
-    
+
     // Force main window refresh
     update();
     repaint();
-    
+
     // Update controls and window title
     updateMultiViewControls();
-    
+
     // Update tab bar auto-hide behavior since detached windows may have changed
     updateMainWindowTabBarAutoHide();
 
     enableToolbarButtons();
-    
+
     if (pHost) {
         setWindowTitle(QString("%1 - %2").arg(safeProfileName, scmVersion));
     }
@@ -5928,9 +5928,9 @@ TMainConsole* mudlet::removeConsoleFromSplitter(const QString& profileName)
     if (!pHost || !pHost->mpConsole) {
         return nullptr;
     }
-    
+
     TMainConsole* console = pHost->mpConsole;
-    
+
     // Find the console in the splitter and remove it
     for (int i = 0; i < mpSplitter_profileContainer->count(); ++i) {
         if (mpSplitter_profileContainer->widget(i) == console) {
@@ -5939,7 +5939,7 @@ TMainConsole* mudlet::removeConsoleFromSplitter(const QString& profileName)
             break;
         }
     }
-    
+
     return console;
 }
 
@@ -5948,10 +5948,10 @@ void mudlet::addConsoleToSplitter(TMainConsole* console, int index)
     if (!console) {
         return;
     }
-    
+
     // Safety check: make sure console doesn't have a conflicting parent
     if (console->parentWidget() && console->parentWidget() != mpSplitter_profileContainer) {
-        qWarning() << "addConsoleToSplitter: Console has unexpected parent" << console->parentWidget() 
+        qWarning() << "addConsoleToSplitter: Console has unexpected parent" << console->parentWidget()
                    << ", removing from current parent first";
         // Remove from current parent without setting to nullptr
         if (auto* layout = console->parentWidget()->layout()) {
@@ -5959,25 +5959,25 @@ void mudlet::addConsoleToSplitter(TMainConsole* console, int index)
         }
         console->setParent(nullptr);
     }
-    
+
     if (index < 0 || index >= mpSplitter_profileContainer->count()) {
         mpSplitter_profileContainer->addWidget(console);
     } else {
         mpSplitter_profileContainer->insertWidget(index, console);
     }
-    
+
     // Always show the console initially when adding to main window
     // The proper hide/show logic will be handled by activateProfile() later
     console->show();
-    
+
     // Force a layout update on the splitter
     mpSplitter_profileContainer->update();
-    
+
     // CRITICAL FIX: Ensure the splitter allocates proper space to all widgets
     // This fixes the issue where newly added consoles get zero width
     QList<int> sizes = mpSplitter_profileContainer->sizes();
     bool needsResize = false;
-    
+
     // Check if any widget has zero or very small size
     for (int size : sizes) {
         if (size < 10) { // Less than 10 pixels is effectively invisible
@@ -5985,12 +5985,12 @@ void mudlet::addConsoleToSplitter(TMainConsole* console, int index)
             break;
         }
     }
-    
+
     if (needsResize || sizes.isEmpty()) {
         // Redistribute space equally among all widgets
         int totalWidth = mpSplitter_profileContainer->width();
         int widgetCount = mpSplitter_profileContainer->count();
-        
+
         if (totalWidth > 0 && widgetCount > 0) {
             int sizePerWidget = totalWidth / widgetCount;
             QList<int> newSizes;
@@ -5998,7 +5998,7 @@ void mudlet::addConsoleToSplitter(TMainConsole* console, int index)
                 newSizes.append(sizePerWidget);
             }
             mpSplitter_profileContainer->setSizes(newSizes);
-            
+
             // Force immediate update
             mpSplitter_profileContainer->update();
             console->update();
@@ -6011,7 +6011,7 @@ void mudlet::updateDetachedWindowToolbars()
 {
     // Clean up any null pointers first
     cleanupDetachedWindowsMap();
-    
+
     // Update toolbars in all detached windows
     for (auto it = mDetachedWindows.begin(); it != mDetachedWindows.end(); ++it) {
         QPointer<TDetachedWindow> detachedWindow = it.value();
@@ -6028,21 +6028,21 @@ void mudlet::updateMainWindowTabIndicators()
     if (!mpTabBar) {
         return;
     }
-    
+
     // Update connection status indicators for all tabs
     for (int i = 0; i < mpTabBar->count(); ++i) {
         const QString profileName = mpTabBar->tabData(i).toString();
         if (profileName.isEmpty()) {
             continue;
         }
-        
+
         Host* pHost = mHostManager.getHost(profileName);
         QIcon tabIcon;
-        
+
         if (pHost) {
             bool isConnected = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectedState);
             bool isConnecting = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectingState);
-            
+
             if (isConnected) {
                 tabIcon = QIcon(qsl(":/icons/dialog-ok-apply.png"));
             } else if (isConnecting) {
@@ -6053,7 +6053,7 @@ void mudlet::updateMainWindowTabIndicators()
         } else {
             tabIcon = QIcon(qsl(":/icons/dialog-error.png"));
         }
-        
+
         // Only set the tab icon, keep the original tab text as just the profile name
         mpTabBar->setTabIcon(i, tabIcon);
     }
@@ -6064,7 +6064,7 @@ void mudlet::updateMainWindowTabBarAutoHide()
     if (!mpTabBar) {
         return;
     }
-    
+
     // If there are detached windows in use, always show tabs for profiles
     // in the main window (disable auto-hide). Otherwise, use the normal
     // auto-hide behavior.
@@ -6118,7 +6118,7 @@ void mudlet::moveProfileFromMainToDetachedWindow(const QString& profileName, int
 
     // Remove tab from main window tab bar
     mpTabBar->removeTab(tabIndex);
-    
+
     // Force tab bar repaint after removing tab
     mpTabBar->repaint();
     mpTabBar->update();
@@ -6126,7 +6126,7 @@ void mudlet::moveProfileFromMainToDetachedWindow(const QString& profileName, int
 
     // Add profile to target detached window
     targetWindow->addProfile(profileName, console);
-    
+
     // Add profile to the detached windows map
     mDetachedWindows[profileName] = targetWindow;
 
@@ -6167,61 +6167,61 @@ void mudlet::moveProfileBetweenDetachedWindows(const QString& profileName, TDeta
     }
 
     qDebug() << "mudlet: Moving profile" << profileName << "between detached windows";
-    
+
     // Store console state before move
     const QSize oldSize = console->size();
     const bool wasVisible = console->isVisible();
-    
+
     // Remove profile from source window
     sourceWindow->removeProfile(profileName);
-    
+
     // Important: Reset console properties before moving to ensure proper sizing
     console->setParent(nullptr);  // Temporarily unparent
     console->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     console->setMinimumSize(0, 0);
     console->setMaximumSize(16777215, 16777215);  // Qt's maximum size
-    
+
     // Ensure console is in a clean state before adding to new window
     console->hide();
 
     // Add profile to target window
     targetWindow->addProfile(profileName, console);
-    
+
     // Force immediate layout and visibility updates for both windows
     sourceWindow->update();
     sourceWindow->repaint();
-    
+
     targetWindow->update();
     targetWindow->repaint();
-    
+
     // Comprehensive console redrawing and resizing
     if (console) {
         // Force console to be visible and properly sized
         console->show();
         console->setVisible(true);
         console->raise();
-        
+
         // Multiple rounds of geometry and layout updates to ensure proper sizing
         console->updateGeometry();
         console->adjustSize();
-        
+
         // Force immediate repaint
         console->update();
         console->repaint();
-        
+
         // Update the parent container as well
         if (console->parentWidget()) {
             console->parentWidget()->updateGeometry();
             console->parentWidget()->update();
             console->parentWidget()->repaint();
         }
-        
+
         // Final geometry and visibility updates
         console->updateGeometry();
         console->update();
         console->repaint();
     }
-    
+
     // Update the detached windows map to point to the new window
     mDetachedWindows[profileName] = targetWindow;
 
@@ -6241,11 +6241,11 @@ void mudlet::moveProfileBetweenDetachedWindows(const QString& profileName, TDeta
                 ++it;
             }
         }
-        
+
         // Use deleteLater to prevent race conditions
         sourceWindow->close();
         sourceWindow->deleteLater();
-        
+
         // Update tab bar auto-hide behavior since detached windows changed
         updateMainWindowTabBarAutoHide();
     }
@@ -6292,7 +6292,7 @@ void mudlet::moveProfileFromDetachedToMainWindow(const QString& profileName, TDe
     // while we're moving it between windows
     auto* telnet = &pHost->mTelnet;
     bool wasProcessingEnabled = true; // We'll assume it was enabled
-    
+
     // Block the socket from processing new data temporarily
     if (telnet->getConnectionState() == QAbstractSocket::ConnectedState) {
         // We can't easily access the socket member directly, so let's use a different approach
@@ -6306,14 +6306,14 @@ void mudlet::moveProfileFromDetachedToMainWindow(const QString& profileName, TDe
         qWarning() << "moveProfileFromDetachedToMainWindow: Console not found in source window for profile" << profileName;
         return;
     }
-    
+
     if (console != pHost->mpConsole) {
         qWarning() << "moveProfileFromDetachedToMainWindow: Console mismatch! Host console:" << pHost->mpConsole.data() << "Window console:" << console;
     }
-    
+
     // CRITICAL: Remove profile from source window FIRST to avoid widget hierarchy conflicts
     sourceWindow->removeProfile(profileName);
-    
+
     // Verify console is still valid
     if (!pHost->mpConsole) {
         qCritical() << "moveProfileFromDetachedToMainWindow: Host console became null after removeProfile!";
@@ -6324,22 +6324,22 @@ void mudlet::moveProfileFromDetachedToMainWindow(const QString& profileName, TDe
             return;
         }
     }
-    
+
     // Double-check that we have the right console
     if (pHost->mpConsole != console) {
         qWarning() << "moveProfileFromDetachedToMainWindow: Host console changed! Fixing...";
         pHost->mpConsole = console;
     }
-    
+
     // Now add console to main window - it should have parent=nullptr now
     const int insertIndex = mpTabBar->count(); // Insert at end
-    
+
     // CRITICAL DEBUG: Check if main window splitter already contains a console for this profile
     for (int i = 0; i < mpSplitter_profileContainer->count(); ++i) {
         QWidget* widget = mpSplitter_profileContainer->widget(i);
         if (auto* existingConsole = qobject_cast<TMainConsole*>(widget)) {
             if (existingConsole->objectName() == profileName) {
-                qWarning() << "moveProfileFromDetachedToMainWindow: CONFLICT! Main window already has console for" << profileName 
+                qWarning() << "moveProfileFromDetachedToMainWindow: CONFLICT! Main window already has console for" << profileName
                           << "existing:" << existingConsole << "moving:" << console;
                 // Remove the conflicting console - need to use setParent for splitter widgets
                 existingConsole->setParent(nullptr);
@@ -6348,13 +6348,13 @@ void mudlet::moveProfileFromDetachedToMainWindow(const QString& profileName, TDe
             }
         }
     }
-    
+
     addConsoleToSplitter(console, insertIndex);
-    
+
     // Add tab to tab bar
     const int newTabIndex = mpTabBar->insertTab(insertIndex, profileName);
     mpTabBar->setTabData(newTabIndex, profileName);
-    
+
     // CRITICAL DEBUG: Check for duplicate tabs
     int tabCount = 0;
     for (int i = 0; i < mpTabBar->count(); ++i) {
@@ -6365,20 +6365,20 @@ void mudlet::moveProfileFromDetachedToMainWindow(const QString& profileName, TDe
     if (tabCount > 1) {
         qWarning() << "moveProfileFromDetachedToMainWindow: DUPLICATE TABS! Found" << tabCount << "tabs for" << profileName;
     }
-    
+
     // Set as current tab
     mpTabBar->setCurrentIndex(newTabIndex);
-    
+
     // CRITICAL: Remove from detached windows map BEFORE activating profile
     // This is essential because activateProfile checks mDetachedWindows to decide
     // whether to show the console, and we need it to see this profile as being in main window
     mDetachedWindows.remove(profileName);
-    
+
     // Force activation of the profile to ensure it's properly shown
     // This is important because the timing of events during tab moves can be tricky
     if (pHost) {
         activateProfile(pHost);
-        
+
         // Additional debugging - check if console is actually visible
         if (pHost->mpConsole) {
             // AGGRESSIVE FIX: Force console visibility in the splitter
@@ -6390,13 +6390,13 @@ void mudlet::moveProfileFromDetachedToMainWindow(const QString& profileName, TDe
                 pHost->mpConsole->update();
                 pHost->mpConsole->repaint();
             }
-            
+
             // Also ensure the splitter itself is visible
             if (!mpSplitter_profileContainer->isVisible()) {
                 mpSplitter_profileContainer->setVisible(true);
                 mpSplitter_profileContainer->show();
             }
-            
+
             // Force updates on the main window components
             centralWidget()->update();
             update();
@@ -6404,24 +6404,24 @@ void mudlet::moveProfileFromDetachedToMainWindow(const QString& profileName, TDe
             QCoreApplication::processEvents();
         }
     }
-    
+
     // Force main window refresh to ensure proper display
     mpTabBar->repaint();
     update();
     repaint();
     QCoreApplication::processEvents();
-    
+
     // EXPERIMENTAL: Force a complete refresh of the main window state
     // This ensures that all UI elements are properly synchronized after the profile move
     qDebug() << "moveProfileFromDetachedToMainWindow: Forcing complete main window refresh";
-    
+
     // Make sure the moved profile becomes the current active one
     if (pHost && mpCurrentActiveHost != pHost) {
-        qDebug() << "moveProfileFromDetachedToMainWindow: Current active host is" << (mpCurrentActiveHost ? mpCurrentActiveHost->getName() : "null") 
+        qDebug() << "moveProfileFromDetachedToMainWindow: Current active host is" << (mpCurrentActiveHost ? mpCurrentActiveHost->getName() : "null")
                  << ", forcing switch to" << pHost->getName();
         mpCurrentActiveHost = pHost;
     }
-    
+
     // Force the tab to be current and ensure all associated UI updates
     for (int i = 0; i < mpTabBar->count(); ++i) {
         if (mpTabBar->tabData(i).toString() == profileName) {
@@ -6430,18 +6430,18 @@ void mudlet::moveProfileFromDetachedToMainWindow(const QString& profileName, TDe
             break;
         }
     }
-    
+
     // Force all main window components to update
     if (centralWidget()) {
         centralWidget()->update();
         centralWidget()->repaint();
     }
-    
+
     // Process any remaining events
     QCoreApplication::processEvents();
-    
+
     qDebug() << "moveProfileFromDetachedToMainWindow: Completed main window refresh";
-    
+
     // IMPORTANT: Only close window if it's now empty
     if (sourceWindow->getProfileCount() == 0) {
         qDebug() << "moveProfileFromDetachedToMainWindow: Source window is now empty, closing it";
@@ -6455,45 +6455,45 @@ void mudlet::moveProfileFromDetachedToMainWindow(const QString& profileName, TDe
                 ++it;
             }
         }
-        
+
         // Use deleteLater to prevent race conditions
         sourceWindow->close();
         sourceWindow->deleteLater();
-        
+
         qDebug() << "moveProfileFromDetachedToMainWindow: Closed empty detached window";
     } else {
         // Window still has other profiles
         qDebug() << "moveProfileFromDetachedToMainWindow: Window still has" << sourceWindow->getProfileCount() << "profiles";
     }
-    
+
     // Verify Host->Console relationship is still intact
     if (pHost && pHost->mpConsole != console) {
         qWarning() << "moveProfileFromDetachedToMainWindow: Host->Console relationship broken, fixing...";
         pHost->mpConsole = console;
     }
-    
+
     // Final verification
     if (!pHost || !pHost->mpConsole) {
         qCritical() << "moveProfileFromDetachedToMainWindow: Final verification failed - Host or Console is invalid!";
     } else {
         qDebug() << "moveProfileFromDetachedToMainWindow: Move completed successfully for profile" << profileName;
     }
-    
+
     // Restore normal socket processing
     if (telnet->getConnectionState() == QAbstractSocket::ConnectedState) {
         QCoreApplication::processEvents(); // Process any events that accumulated during transfer
         qDebug() << "moveProfileFromDetachedToMainWindow: Restored normal socket processing";
     }
-    
+
     // Update controls and window title
     updateMultiViewControls();
     updateMainWindowTabBarAutoHide();
     enableToolbarButtons();
-    
+
     if (pHost) {
         setWindowTitle(QString("%1 - %2").arg(profileName, scmVersion));
     }
-    
+
     // Force repaint/refresh of main window after profile move
     repaint();
     update();

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -711,7 +711,7 @@ private:
     std::unique_ptr<LlamafileManager> mpLlamafileManager;
     QString mAIModelPath;
     bool mAIAutoStart = true;
-    
+
     // Helper methods for AI integration
     void initializeAI();
     void shutdownAI();

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -496,7 +496,7 @@ QString Updater::getPreviousVersion() const
 
 #if defined(Q_OS_WINDOWS)
 // we are trying to detect machines running a 32-Bit build of Mudlet on a 64-Bit Intel/AMD processor
-bool Updater::is64BitCompatible() const 
+bool Updater::is64BitCompatible() const
 {
 #if defined(Q_OS_WIN64)
     return true;

--- a/test/TMxpCustomElementTagHandlerTest.cpp
+++ b/test/TMxpCustomElementTagHandlerTest.cpp
@@ -229,7 +229,7 @@ private slots:
         // Real life example from Aldebaran: (there are more sensible ones with EXPIRE which Mudlet does not yet support)
         //
         // <!EL WH '<SEND "whisper &NAME; |finger &NAME; |tell &NAME; " HINT="whisper &NAME;|finger &NAME;|tell &NAME;" PROMPT>' ATT='NAME=someone'>
-        // 
+        //
         // Used like <WH playerid>Player</WH> says: Hello!
         // However, if player is invisible, playerid is empty, like <WH >Someone</WH> says: Hello!
         //

--- a/test/TMxpFormattingTagsTest.cpp
+++ b/test/TMxpFormattingTagsTest.cpp
@@ -18,7 +18,7 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
- 
+
 #include <QTest>
 #include "TMxpFormattingTagsHandler.h"
 #include "TMxpStubClient.h"
@@ -47,7 +47,7 @@ private slots:
     {
 
         TMxpStubContext ctx;
-        TMxpStubClient stub;      
+        TMxpStubClient stub;
         TMxpFormattingTagsHandler formattingTagsHandler;
         TMxpTagHandler& tagHandler = formattingTagsHandler;
 

--- a/test/TMxpVersionTagTest.cpp
+++ b/test/TMxpVersionTagTest.cpp
@@ -18,7 +18,7 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
- 
+
 #include <QTest>
 #include "TMxpVersionTagHandler.h"
 #include "TMxpStubClient.h"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Use a ` +$` search-and-replace to remove trailing spaces in `.cpp` and `.h` source code files to remove unwanted trailing whitespace that has crept into a number of files.

#### Motivation for adding to Mudlet
To clean up files as `git` notices such white-space and objects in some circumstances - and such spaces are redundant in the source code.

#### Other info (issues closed, discussion etc)