### PR TITLE
Fix: Block auto reconnect if connection duration less than 5 seconds.

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -588,7 +588,7 @@ void cTelnet::slot_socketDisconnected()
             if (mDontReconnect) {
                 reason = qsl("User Disconnected");
             // successful connection duration under 5s == rejected by server
-            } else if (mConnectionTimer.elapsed() > 0 && mConnectionTimer.elapsed() < 5000) { 
+            } else if (mConnectionTimer.elapsed() > 0 && mConnectionTimer.elapsed() < 5000) {
                 reason = qsl("Connection/login attempt rejected by server");
             } else {
                 reason = socket.errorString();

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -587,6 +587,9 @@ void cTelnet::slot_socketDisconnected()
 #endif
             if (mDontReconnect) {
                 reason = qsl("User Disconnected");
+            // successful connection duration under 5s == rejected by server
+            } else if (mConnectionTimer.elapsed() > 0 && mConnectionTimer.elapsed() < 5000) { 
+                reason = qsl("Connection/login attempt rejected by server");
             } else {
                 reason = socket.errorString();
             }
@@ -605,7 +608,7 @@ void cTelnet::slot_socketDisconnected()
     }
 #endif
 
-    if (mAutoReconnect && !mDontReconnect) {
+    if (mAutoReconnect && !mDontReconnect && mConnectionTimer.elapsed() >= 5000) {
         connectIt(hostName, hostPort);
     }
     mDontReconnect = false;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Use cTelnet's mConnectionTimer to track whether the client was connected to the server for under 5 seconds. If so, auto-reconnect is blocked.

Also the disconnect message is modified to clarify that the disconnection reason was for "Connection/login attempt rejected by server".

#### Motivation for adding to Mudlet
Hopefully an approximate fix for the issues surrounding failed auto-logins / Mudlet spamming servers with automatic reconnects.

#### Other info (issues closed, discussion etc)
Tested to prevent login-loops for mistaken passwords, but succeeds in reconnecting for disconnection events during a normal playing session. Also this doesn't prevent echoing connection errors via e.g. failed SSL authentication.

I consider this an elegant solution for differentiating between servers rejecting a client's connection attempt and disconnecting while playing, but I would understand if Mudlet would prefer to more explicitly track whether a login attempt failed etc.

(Potentially) Fixes: #7584