### PR TITLE
Fix: Update connection error messages/checking for multilingual Mudlet

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -593,7 +593,7 @@ void cTelnet::slot_socketDisconnected()
             } else {
                 reason = socket.errorString();
             }
-            QString err = tr("[ ALERT ] - Socket got disconnected.\nReason: ") % reason;
+            QString err = tr("[ ALERT ] - Socket got disconnected.\nReason: %1.").arg(reason);
             postMessage(err);
         }
         postMessage(msg);

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -583,15 +583,15 @@ void cTelnet::slot_socketDisconnected()
         } else {
 #endif
             if (mDontReconnect) {
-                reason = qsl("User Disconnected");
+                reason = tr("User Disconnected");
             // successful connection duration under 5s == rejected by server
             } else if (mConnectionTimer.elapsed() > 0 && mConnectionTimer.elapsed() < 5000) {
-                reason = qsl("Connection/login attempt rejected by server");
+                reason = tr("Connection/login attempt rejected by server");
+            // SocketError(13) == SslHandshakeFailedError (https://doc.qt.io/qt-6/qabstractsocket.html#SocketError-enum)
+            } else if (socket.error() == QAbstractSocket::SocketError(13)) {
+                reason = tr("Secure connections aren't supported by this game on this port - try turning the option off.");
             } else {
                 reason = socket.errorString();
-            }
-            if (reason == qsl("Error during SSL handshake: error:140770FC:SSL routines:SSL23_GET_SERVER_HELLO:unknown protocol")) {
-                reason = tr("Secure connections aren't supported by this game on this port - try turning the option off.");
             }
             QString err = tr("[ ALERT ] - Socket got disconnected.\nReason: ") % reason;
             postMessage(err);

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -589,7 +589,7 @@ void cTelnet::slot_socketDisconnected()
                 reason = tr("Connection/login attempt rejected by server");
             // SocketError(13) == SslHandshakeFailedError (https://doc.qt.io/qt-6/qabstractsocket.html#SocketError-enum)
             } else if (socket.error() == QAbstractSocket::SocketError(13)) {
-                reason = tr("Secure connections aren't supported by this game on this port - try turning the option off.");
+                reason = tr("Secure connections aren't supported by this game on this port - try turning the option off");
             } else {
                 reason = socket.errorString();
             }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Change the qsl("connection failure messages") that we stumbled upon in PR #7952 to tr("connection failure messages").

Additionally, replace the string matching for a failed secure connection (which didn't seem to work) with a check against the SSL handshake fail error enum (QAbstractSocket::SocketError(13))

#### Motivation for adding to Mudlet
Tidying up this little bit of code to the more modern internationalized Mudlet standard.

#### Other info (issues closed, discussion etc)
@SlySven, if you could test this I would appreciate it. The SSL handshake error catching has worked in all failure modes I've managed to test, but I haven't managed to duplicate the errors I saw you produce on Discord.