### PR TITLE
Improve: Allow users to set map background alpha

### DIFF
--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -578,7 +578,9 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
         host.append_child("commandLineMinimumHeight").text().set(QString::number(pHost->commandLineMinimumHeight).toUtf8().constData());
 
         host.append_child("mFgColor2").text().set(pHost->mFgColor_2.name().toUtf8().constData());
-        host.append_child("mBgColor2").text().set(pHost->mBgColor_2.name().toUtf8().constData());
+        auto mapBgColorNode = host.append_child("mBgColor2");
+        mapBgColorNode.text().set(pHost->mBgColor_2.name().toUtf8().constData());
+        mapBgColorNode.append_attribute("alpha").set_value(pHost->mBgColor_2.alpha());
         host.append_child("mLowerLevelColor").text().set(pHost->mLowerLevelColor.name().toUtf8().constData());
         host.append_child("mUpperLevelColor").text().set(pHost->mUpperLevelColor.name().toUtf8().constData());
         host.append_child("mRoomBorderColor").text().set(pHost->mRoomBorderColor.name().toUtf8().constData());

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1199,7 +1199,9 @@ void XMLimport::readHost(Host* pHost)
 #if QT_VERSION < QT_VERSION_CHECK(6, 6, 0)
                 pHost->mFgColor_2.setNamedColor(readElementText());
             } else if (name() == qsl("mBgColor2")) {
+                auto alpha = (attributes().hasAttribute(qsl("alpha"))) ? attributes().value(qsl("alpha")).toInt() : 255;
                 pHost->mBgColor_2.setNamedColor(readElementText());
+                pHost->mBgColor_2.setAlpha(alpha);
             } else if (name() == qsl("mLowerLevelColor")) {
                 pHost->mLowerLevelColor.setNamedColor(readElementText());
             } else if (name() == qsl("mUpperLevelColor")) {
@@ -1247,7 +1249,9 @@ void XMLimport::readHost(Host* pHost)
 #else
                 pHost->mFgColor_2 = QColor::fromString(readElementText());
             } else if (name() == qsl("mBgColor2")) {
+                auto alpha = (attributes().hasAttribute(qsl("alpha"))) ? attributes().value(qsl("alpha")).toInt() : 255;
                 pHost->mBgColor_2 = QColor::fromString(readElementText());
+                pHost->mBgColor_2.setAlpha(alpha);
             } else if (name() == qsl("mLowerLevelColor")) {
                 pHost->mLowerLevelColor = QColor::fromString(readElementText());
             } else if (name() == qsl("mUpperLevelColor")) {

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2042,7 +2042,7 @@ void dlgProfilePreferences::slot_setMapBgColor()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_background_color_2, pHost->mBgColor_2);
+        setButtonAndProfileColor(pushButton_background_color_2, pHost->mBgColor_2, true);
     }
 }
 

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2043,6 +2043,18 @@ void dlgProfilePreferences::slot_setMapBgColor()
     Host* pHost = mpHost;
     if (pHost) {
         setButtonAndProfileColor(pushButton_background_color_2, pHost->mBgColor_2, true);
+        // if 3D map, update transparency flags
+        if (pHost->mpMap->mpMapper->glWidget) {
+            GLWidget* map = pHost->mpMap->mpMapper->glWidget;
+            if (pHost->mBgColor_2.alpha() < 255) {
+            map->setAttribute(Qt::WA_OpaquePaintEvent, false);
+            map->setAttribute(Qt::WA_AlwaysStackOnTop, true);
+            } else {
+            map->setAttribute(Qt::WA_OpaquePaintEvent, true);
+            map->setAttribute(Qt::WA_AlwaysStackOnTop, false);
+            }
+        }
+
     }
 }
 

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2043,7 +2043,8 @@ void dlgProfilePreferences::slot_setMapBgColor()
     Host* pHost = mpHost;
     if (pHost) {
         setButtonAndProfileColor(pushButton_background_color_2, pHost->mBgColor_2, true);
-        // if 3D map, update transparency flags
+// if 3D map, update transparency flags
+#if defined(INCLUDE_3DMAPPER)
         if (pHost->mpMap->mpMapper->glWidget) {
             GLWidget* map = pHost->mpMap->mpMapper->glWidget;
             if (pHost->mBgColor_2.alpha() < 255) {
@@ -2054,7 +2055,7 @@ void dlgProfilePreferences::slot_setMapBgColor()
             map->setAttribute(Qt::WA_AlwaysStackOnTop, false);
             }
         }
-
+#endif
     }
 }
 

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -50,8 +50,12 @@ GLWidget::GLWidget(TMap* pMap, Host* pHost, QWidget *parent)
 , mpMap(pMap)
 , mpHost(pHost)
 {
+    if (mpHost->mBgColor_2.alpha() < 255) {
     setAttribute(Qt::WA_OpaquePaintEvent, false);
     setAttribute(Qt::WA_AlwaysStackOnTop);
+    } else {
+    setAttribute(Qt::WA_OpaquePaintEvent);
+    }
 }
 
 QSize GLWidget::minimumSizeHint() const

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -50,7 +50,8 @@ GLWidget::GLWidget(TMap* pMap, Host* pHost, QWidget *parent)
 , mpMap(pMap)
 , mpHost(pHost)
 {
-    setAttribute(Qt::WA_OpaquePaintEvent);
+    setAttribute(Qt::WA_OpaquePaintEvent, false);
+    setAttribute(Qt::WA_AlwaysStackOnTop);
 }
 
 QSize GLWidget::minimumSizeHint() const
@@ -223,7 +224,7 @@ void GLWidget::slot_setCameraPositionZ(int angle)
 
 void GLWidget::initializeGL()
 {
-    const QColor color(QColorConstants::Black);
+    const QColor color(mpHost->mBgColor_2);
     glClearColor(color.redF(), color.greenF(), color.blueF(), color.alphaF());
     xRot = 1;
     yRot = 5;
@@ -323,7 +324,8 @@ void GLWidget::paintGL()
     glClearDepth(1.0);
     glDepthFunc(GL_LESS);
 
-    glClearColor(0.0, 0.0, 0.0, 1.0);
+    const QColor color(mpHost->mBgColor_2);
+    glClearColor(color.redF(), color.greenF(), color.blueF(), color.alphaF());
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     glLoadIdentity();
     GLfloat diffuseLight[] = {0.507, 0.507, 0.507, 1.0};


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Enable users to set an alpha value for the mapper background in: Preferences > Mapper colors > Background color
- Make transparent/translucent backgrounds actually work (e.g. 0 for a fully transparent map background).
- Make the 3D mapper use the color set in Preferences > Mapper colors > Background color (previously it was permanently black no matter what).
- Properly save map background alpha across sessions.

#### Motivation for adding to Mudlet
This unlocks some really neat GUI options as I personally love having a map overlay on top of the main console.

#### Other info (issues closed, discussion etc)
The 3D mapper is a bit funky since it is based on QOpenGLWidget which has some limitations:

> [Limitations and Other Considerations](https://doc.qt.io/qt-6/qopenglwidget.html#limitations-and-other-considerations)

>Putting other widgets underneath and making the QOpenGLWidget transparent will not lead to the expected results: The widgets underneath will not be visible. This is because in practice the QOpenGLWidget is drawn before all other regular, non-OpenGL widgets, and so see-through type of solutions are not feasible. Other type of layouts, like having widgets on top of the QOpenGLWidget, will function as expected.

>When absolutely necessary, this limitation can be overcome by setting the [Qt::WA_AlwaysStackOnTop](https://doc.qt.io/qt-6/qt.html#WidgetAttribute-enum) attribute on the QOpenGLWidget. Be aware however that this breaks stacking order, for example it will not be possible to have other widgets on top of the QOpenGLWidget, so it should only be used in situations where a semi-transparent QOpenGLWidget with other widgets visible underneath is required.

So I've gone ahead and made it so setting the alpha value of the map under 255 toggles transparency on AND the 3D map will always stack on top. The unfortunate side effect is that everything then gets stuck behind the 3D mapper. Hopefully this is niche enough to not cause issues. If it is problematic, users are still free to set the alpha back to 255 and AlwaysStackOnTop will be disabled.

Pardon the light mode!
https://github.com/user-attachments/assets/0c501008-974b-41bd-b1be-ecba288f4c71

To make background transparent as in the video set the alpha to `0` in: Preferences > Mapper colors > Background color