### PR TITLE
Fix: Replace deprecated Qt6 methods to resolve Codefactor warnings

### DIFF
--- a/3rdparty/communi/src/core/ircmessage.cpp
+++ b/3rdparty/communi/src/core/ircmessage.cpp
@@ -701,7 +701,7 @@ IrcMessage* IrcMessage::fromData(const QByteArray& data, IrcConnection* connecti
     if (!tag.isEmpty()) {
         QDateTime ts = QDateTime::fromString(QString::fromUtf8(tag), Qt::ISODate);
         if (ts.isValid())
-            message->d_ptr->timeStamp = ts.toTimeSpec(Qt::LocalTime);
+            message->d_ptr->timeStamp = ts.toLocalTime();
     }
     return message;
 }

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -272,7 +272,7 @@ void TTabBar::dropEvent(QDropEvent* event)
     const QMimeData* mimeData = event->mimeData();
     if (mimeData->hasFormat("application/x-mudlet-tab")) {
         const QString tabName = QString::fromUtf8(mimeData->data("application/x-mudlet-tab"));
-        const int dropIndex = tabAt(event->pos());
+        const int dropIndex = tabAt(event->position().toPoint());
         emit tabReattachRequested(tabName, dropIndex);
         event->acceptProposedAction();
     }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
This PR fixes deprecation warnings by replacing deprecated Qt6 methods with their modern equivalents:
- Replaced `QDateTime::toTimeSpec(Qt::LocalTime)` with `toLocalTime()` in communi IRC message handling
- Replaced `QDropEvent::pos()` with `position().toPoint()` in tab bar drag-and-drop functionality

#### Motivation for adding to Mudlet
These changes resolve Codefactor warnings that were appearing across all CI platforms (Ubuntu, macOS ARM64, macOS x86_64) with both clang and gcc compilers. The deprecated methods will eventually be removed from Qt, so updating to the modern API ensures future compatibility and cleaner builds.

#### Other info (issues closed, discussion etc)
- Fixes deprecation warnings on lines 704 in `3rdparty/communi/src/core/ircmessage.cpp` and 275 in `src/TTabBar.cpp`
- No functional changes - the replacement methods provide identical behavior
- Verified that the project builds successfully with these changes
- Compatible with the project's Qt6 6.4.0+ requirement