### PR TITLE
Fix: Improve tab indicators and detached window UX

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -555,6 +555,10 @@ target_compile_definitions(mudlet PRIVATE DEBUG_TELNET=1)
 # * Enable the features associated with reporting problems in processing Unicode
 #   codepoints that cannot be displayed on screen in a `TConsole`:
 # target_compile_definitions(mudlet PRIVATE DEBUG_CODEPOINT_PROBLEMS)
+#
+# * Produce qDebug() messages about window handling operations like dock widget
+#   transfers, profile switching, and detached window management:
+# target_compile_definitions(mudlet PRIVATE DEBUG_WINDOW_HANDLING)
 
 target_sources(mudlet PRIVATE "${mudlet_BINARY_DIR}/translations/translated/qm.qrc")
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -462,7 +462,8 @@ Host::~Host()
     // directly as a member variable. This ensures the destructor doesn't depend on the
     // object's state being valid.
 
-    TDebug::removeHost(this, mHostName);
+    // Don't pass 'this' pointer during destruction - it's unsafe as the Host is being destroyed
+    TDebug::removeHost(nullptr, mHostName);
 }
 
 void Host::forceClose()
@@ -1069,7 +1070,7 @@ void Host::updateConsolesFont()
         mpEditorDialog->setDisplayFont(mpConsole->font());
     }
 
-    if (mudlet::self()->smpDebugArea) {
+    if (mudlet::self()->smpDebugArea && mudlet::self()->smpDebugConsole) {
         mudlet::self()->smpDebugConsole->setFont(mpConsole->font());
     }
 

--- a/src/TDebug.cpp
+++ b/src/TDebug.cpp
@@ -52,14 +52,40 @@ TDebug& TDebug::operator>>(Host* pHost)
         if (Q_UNLIKELY(!smMessageQueue.isEmpty())) {
             // The smpDebugConsole must have just come on-line - so unload all
             // the stacked up messages:
-            while (!smMessageQueue.isEmpty()) {
+            QPointer<TConsole> debugConsole = mudlet::smpDebugConsole;
+            while (!smMessageQueue.isEmpty() && debugConsole) {
                 const auto& message = smMessageQueue.dequeue();
-                if (message.mTag.isNull()) {
-                    mudlet::smpDebugConsole->print(message.mMessage, message.mForeground, message.mBackground);
+                // Create local copy for each print call to ensure thread safety
+                QPointer<TConsole> localDebugConsole = debugConsole;
+                if (localDebugConsole) {
+                    if (message.mTag.isNull()) {
+                        localDebugConsole->print(message.mMessage, message.mForeground, message.mBackground);
+                    } else {
+                        localDebugConsole->print(message.mTag % message.mMessage, message.mForeground, message.mBackground);
+                    }
                 } else {
-                    mudlet::smpDebugConsole->print(message.mTag % message.mMessage, message.mForeground, message.mBackground);
+                    // Console became invalid, break out of the loop
+                    break;
                 }
+                // Update the loop condition variable
+                debugConsole = mudlet::smpDebugConsole;
             }
+        }
+
+        // Check if debug console is still valid before using it
+        QPointer<TConsole> debugConsole = mudlet::smpDebugConsole;
+        if (!debugConsole) {
+            return *this;
+        }
+
+        // Safety check: if pHost is not null but not in smIdentifierMap, 
+        // the Host is probably being destroyed, so treat as system message
+        if (pHost && !smIdentifierMap.contains(pHost)) {
+            QPointer<TConsole> localDebugConsole = debugConsole;
+            if (localDebugConsole) {
+                localDebugConsole->print(csmTagSystemMessage % msg, fgColor, bgColor);
+            }
+            return *this;
         }
 
         auto tag = deduceProfileTag(msg, pHost);
@@ -69,14 +95,25 @@ TDebug& TDebug::operator>>(Host* pHost)
             // case we will already done everything needed in previous chunk
             // of code. Otherwise just print the message without a tag marking:
             if (!msg.isEmpty()) {
-                mudlet::smpDebugConsole->print(msg, fgColor, bgColor);
+                QPointer<TConsole> localDebugConsole = debugConsole;
+                if (localDebugConsole) {
+                    localDebugConsole->print(msg, fgColor, bgColor);
+                }
             }
         } else if (tag == csmTagSystemMessage || Q_UNLIKELY(tag == csmTagFault) || TDebug::smIdentifierMap.count() > 1) {
             // This is a system message or something went wrong in identifying the profile or more than one profile is active
-            mudlet::smpDebugConsole->print(tag % msg, fgColor, bgColor);
+            // Create local copy and re-check debugConsole validity before printing
+            QPointer<TConsole> localDebugConsole = debugConsole;
+            if (localDebugConsole) {
+                localDebugConsole->print(tag % msg, fgColor, bgColor);
+            }
         } else {
             // Only one profile active - so don't print the tag:
-            mudlet::smpDebugConsole->print(msg, fgColor, bgColor);
+            // Create local copy and re-check debugConsole validity before printing
+            QPointer<TConsole> localDebugConsole = debugConsole;
+            if (localDebugConsole) {
+                localDebugConsole->print(msg, fgColor, bgColor);
+            }
         }
     }
     return *this;
@@ -205,7 +242,26 @@ void TDebug::changeHostName(const Host* pHost, const QString& newName)
 
 /* static */ void TDebug::removeHost(Host* pHost, const QString hostName)
 {
-    auto identifier = TDebug::smIdentifierMap.take(pHost);
+    QPair<QString, QString> identifier;
+    
+    if (pHost) {
+        // Normal case: remove by Host pointer
+        identifier = TDebug::smIdentifierMap.take(pHost);
+    } else {
+        // Host is being destroyed: find by hostName and remove
+        const Host* foundHost = nullptr;
+        for (auto it = smIdentifierMap.begin(); it != smIdentifierMap.end(); ++it) {
+            if (it.value().first == hostName) {
+                foundHost = it.key();
+                identifier = it.value();
+                break;
+            }
+        }
+        if (foundHost) {
+            smIdentifierMap.remove(foundHost);
+        }
+    }
+    
     // Check for the use of non-profile specific tags:
     if (identifier.second != csmTagOverflow && identifier.second != csmTagSystemMessage && identifier.second != csmTagFault) {
         // is a normal identifier so push it in at the back of the queue for reuse:

--- a/src/TDebug.cpp
+++ b/src/TDebug.cpp
@@ -53,10 +53,12 @@ TDebug& TDebug::operator>>(Host* pHost)
             // The smpDebugConsole must have just come on-line - so unload all
             // the stacked up messages:
             QPointer<TConsole> debugConsole = mudlet::smpDebugConsole;
+
             while (!smMessageQueue.isEmpty() && debugConsole) {
                 const auto& message = smMessageQueue.dequeue();
                 // Create local copy for each print call to ensure thread safety
                 QPointer<TConsole> localDebugConsole = debugConsole;
+
                 if (localDebugConsole) {
                     if (message.mTag.isNull()) {
                         localDebugConsole->print(message.mMessage, message.mForeground, message.mBackground);
@@ -74,6 +76,7 @@ TDebug& TDebug::operator>>(Host* pHost)
 
         // Check if debug console is still valid before using it
         QPointer<TConsole> debugConsole = mudlet::smpDebugConsole;
+
         if (!debugConsole) {
             return *this;
         }
@@ -82,13 +85,16 @@ TDebug& TDebug::operator>>(Host* pHost)
         // the Host is probably being destroyed, so treat as system message
         if (pHost && !smIdentifierMap.contains(pHost)) {
             QPointer<TConsole> localDebugConsole = debugConsole;
+
             if (localDebugConsole) {
                 localDebugConsole->print(csmTagSystemMessage % msg, fgColor, bgColor);
             }
+
             return *this;
         }
 
         auto tag = deduceProfileTag(msg, pHost);
+
         if (tag.isNull()) {
             // We use an empty message with no host pointer to flush out the
             // enqueued messages the first time the CDC is shown - so in that
@@ -104,6 +110,7 @@ TDebug& TDebug::operator>>(Host* pHost)
             // This is a system message or something went wrong in identifying the profile or more than one profile is active
             // Create local copy and re-check debugConsole validity before printing
             QPointer<TConsole> localDebugConsole = debugConsole;
+
             if (localDebugConsole) {
                 localDebugConsole->print(tag % msg, fgColor, bgColor);
             }
@@ -116,6 +123,7 @@ TDebug& TDebug::operator>>(Host* pHost)
             }
         }
     }
+
     return *this;
 }
 
@@ -250,6 +258,7 @@ void TDebug::changeHostName(const Host* pHost, const QString& newName)
     } else {
         // Host is being destroyed: find by hostName and remove
         const Host* foundHost = nullptr;
+
         for (auto it = smIdentifierMap.begin(); it != smIdentifierMap.end(); ++it) {
             if (it.value().first == hostName) {
                 foundHost = it.key();
@@ -257,6 +266,7 @@ void TDebug::changeHostName(const Host* pHost, const QString& newName)
                 break;
             }
         }
+
         if (foundHost) {
             smIdentifierMap.remove(foundHost);
         }
@@ -267,6 +277,7 @@ void TDebug::changeHostName(const Host* pHost, const QString& newName)
         // is a normal identifier so push it in at the back of the queue for reuse:
         smAvailableIdentifiers.enqueue(identifier.second);
     }
+
     TDebug localMessage(Qt::darkGray, Qt::white);
     localMessage << qsl("Profile '%1' ended.\n").arg(hostName) >> nullptr;
     TDebug tableMessage(Qt::white, Qt::black);

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -50,7 +50,7 @@
 #include <QWidget>
 #include <QWindowStateChangeEvent>
 
-TDetachedWindow::TDetachedWindow(const QString& profileName, TMainConsole* console, QWidget* parent)
+TDetachedWindow::TDetachedWindow(const QString& profileName, TMainConsole* console, QWidget* parent, bool toolbarVisible)
     : QMainWindow(parent)
     , mCurrentProfileName(profileName)
 {
@@ -62,6 +62,11 @@ TDetachedWindow::TDetachedWindow(const QString& profileName, TMainConsole* conso
     createMenus();
     createStatusBar();
     restoreWindowGeometry();
+
+    // Set initial toolbar visibility based on main window state
+    if (mpToolBar) {
+        mpToolBar->setVisible(toolbarVisible);
+    }
 
     // Set window properties
     setWindowTitle(tr("Mudlet - %1 (Detached)").arg(profileName));
@@ -212,6 +217,14 @@ void TDetachedWindow::createMenus()
     mpWindowMenu->addAction(closeAction);
 
     mpWindowMenu->addSeparator();
+
+    // Toolbar visibility toggle
+    mpActionToggleToolBar = new QAction(tr("Show &Toolbar"), this);
+    mpActionToggleToolBar->setCheckable(true);
+    mpActionToggleToolBar->setChecked(mpToolBar ? mpToolBar->isVisible() : true);
+    mpActionToggleToolBar->setStatusTip(tr("Show or hide the toolbar"));
+    connect(mpActionToggleToolBar, &QAction::triggered, this, &TDetachedWindow::slot_toggleToolBarVisibility);
+    mpWindowMenu->addAction(mpActionToggleToolBar);
 
     // Always on top toggle
     auto alwaysOnTopAction = new QAction(tr("Always on &Top"), this);
@@ -409,6 +422,14 @@ void TDetachedWindow::showTabContextMenu(const QPoint& position)
         connect(closeWindowAction, &QAction::triggered, this, &QWidget::close);
     }
 
+    contextMenu.addSeparator();
+
+    // Add toolbar visibility toggle to the context menu
+    auto toolbarToggleAction = contextMenu.addAction(tr("Show Toolbar"));
+    toolbarToggleAction->setCheckable(true);
+    toolbarToggleAction->setChecked(mpToolBar && mpToolBar->isVisible());
+    connect(toolbarToggleAction, &QAction::triggered, this, &TDetachedWindow::slot_toggleToolBarVisibility);
+
     contextMenu.exec(mpTabBar->mapToGlobal(position));
 }
 
@@ -459,6 +480,15 @@ void TDetachedWindow::createToolBar()
     addToolBar(mpToolBar);
     mpToolBar->setMovable(false);
     mpToolBar->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+
+    // Reattach action - placed first in the toolbar for prominence
+    mpActionReattach = new QAction(QIcon(qsl(":/icons/view-restore.png")), tr("Reattach"), this);
+    mpActionReattach->setToolTip(utils::richText(tr("Reattach this profile window to the main Mudlet window")));
+    mpActionReattach->setObjectName(qsl("reattach_action"));
+    mpToolBar->addAction(mpActionReattach);
+
+    // Add separator after reattach button to make it distinct
+    mpToolBar->addSeparator();
 
     // Connect button with dropdown actions
     mpButtonConnect = new QToolButton(this);
@@ -655,6 +685,9 @@ void TDetachedWindow::connectToolBarActions()
     connect(mpActionCloseProfile, &QAction::triggered, this, &TDetachedWindow::slot_closeCurrentProfile);
     connect(mpActionCloseApplication, &QAction::triggered, this, &TDetachedWindow::slot_closeApplication);
 
+    // Reattach action
+    connect(mpActionReattach, &QAction::triggered, this, &TDetachedWindow::onReattachAction);
+
     // Script editor actions - use our custom slots to ensure correct profile context
     connect(mpActionTriggers, &QAction::triggered, this, &TDetachedWindow::slot_showTriggerDialog);
     connect(mpActionAliases, &QAction::triggered, this, &TDetachedWindow::slot_showAliasDialog);
@@ -765,6 +798,9 @@ void TDetachedWindow::updateToolBarActions()
     // Help and About are always enabled
     mpActionHelp->setEnabled(true);
     mpActionAbout->setEnabled(true);
+
+    // Reattach is always enabled when the window exists
+    mpActionReattach->setEnabled(true);
 
     // Full screen toggle is always enabled
     mpActionFullScreenView->setEnabled(true);
@@ -928,6 +964,21 @@ void TDetachedWindow::slot_toggleAlwaysOnTop()
     QTimer::singleShot(100, this, [this]() {
         mIsChangingWindowFlags = false;
     });
+}
+
+void TDetachedWindow::slot_toggleToolBarVisibility()
+{
+    if (!mpToolBar) {
+        return;
+    }
+
+    bool isCurrentlyVisible = mpToolBar->isVisible();
+    mpToolBar->setVisible(!isCurrentlyVisible);
+    
+    // Update the action to reflect the new state
+    if (mpActionToggleToolBar) {
+        mpActionToggleToolBar->setChecked(!isCurrentlyVisible);
+    }
 }
 
 void TDetachedWindow::slot_saveProfile()

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -279,7 +279,6 @@ void TDetachedWindow::createMenus()
     mpActionToggleToolBar->setChecked(mpToolBar ? mpToolBar->isVisible() : true);
     mpActionToggleToolBar->setStatusTip(tr("Show or hide the toolbar"));
     connect(mpActionToggleToolBar, &QAction::triggered, this, &TDetachedWindow::slot_toggleToolBarVisibility);
-    mpWindowMenu->addAction(mpActionToggleToolBar);
 
     // Always on top toggle
     auto alwaysOnTopAction = new QAction(tr("Always on &Top"), this);
@@ -480,7 +479,7 @@ void TDetachedWindow::showTabContextMenu(const QPoint& position)
     contextMenu.addSeparator();
 
     // Add toolbar visibility toggle to the context menu
-    auto toolbarToggleAction = contextMenu.addAction(tr("Show Toolbar"));
+    auto toolbarToggleAction = contextMenu.addAction(tr("Profile Toolbar"));
     toolbarToggleAction->setCheckable(true);
     toolbarToggleAction->setChecked(mpToolBar && mpToolBar->isVisible());
     connect(toolbarToggleAction, &QAction::triggered, this, &TDetachedWindow::slot_toggleToolBarVisibility);
@@ -730,6 +729,10 @@ void TDetachedWindow::createToolBar()
     mpActionFullScreenView->setCheckable(true);
     mpActionFullScreenView->setObjectName(qsl("fullscreen_action"));
     mpToolBar->addAction(mpActionFullScreenView);
+
+    // Setup context menu for the toolbar
+    mpToolBar->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(mpToolBar, &QToolBar::customContextMenuRequested, this, &TDetachedWindow::slot_showDetachedToolBarContextMenu);
 
     // Connect all actions to their respective slots in the main mudlet instance
     connectToolBarActions();
@@ -1014,7 +1017,10 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
                     
                     qDebug() << "TDetachedWindow: Dock widget should be visible - showing and setting as active";
                 } else {
+                    // Block signals to prevent user preference from being updated by system-initiated change
+                    dockWidget->blockSignals(true);
                     dockWidget->setVisible(false);
+                    dockWidget->blockSignals(false);
                     qDebug() << "TDetachedWindow: Dock widget should be hidden - respecting user preference";
                 }
                 
@@ -1034,7 +1040,10 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
             } else {
                 // This dock widget belongs to a different profile - hide it
                 qDebug() << "TDetachedWindow: Hiding dock widget for different profile" << dockProfileName;
+                // Block signals to prevent user preference from being updated by system-initiated change
+                dockWidget->blockSignals(true);
                 dockWidget->setVisible(false);
+                dockWidget->blockSignals(false);
                 
                 // Restore main mapper for the other profile
                 if (auto pHost = mudlet::self()->getHostManager().getHost(dockProfileName)) {
@@ -1098,13 +1107,46 @@ void TDetachedWindow::slot_toggleToolBarVisibility()
         return;
     }
 
-    bool isCurrentlyVisible = mpToolBar->isVisible();
-    mpToolBar->setVisible(!isCurrentlyVisible);
+    bool newVisibility = !isToolBarVisible();
     
-    // Update the action to reflect the new state
-    if (mpActionToggleToolBar) {
-        mpActionToggleToolBar->setChecked(!isCurrentlyVisible);
+    // Synchronize toolbar visibility across all windows
+    auto mudletInstance = mudlet::self();
+    if (mudletInstance) {
+        mudletInstance->synchronizeToolBarVisibility(newVisibility);
     }
+}
+
+void TDetachedWindow::slot_showDetachedToolBarContextMenu(const QPoint& position)
+{
+    if (!mpToolBar) {
+        return;
+    }
+
+    QMenu menu(this);
+    
+    // Create "Profile Toolbar" toggle action
+    QAction* toolbarToggleAction = menu.addAction(tr("Profile Toolbar"));
+    toolbarToggleAction->setCheckable(true);
+    toolbarToggleAction->setChecked(mpToolBar->isVisible());
+    connect(toolbarToggleAction, &QAction::triggered, this, &TDetachedWindow::slot_toggleToolBarVisibility);
+    
+    // Show the context menu at the clicked position
+    menu.exec(mpToolBar->mapToGlobal(position));
+}
+
+void TDetachedWindow::setToolBarVisibility(bool visible)
+{
+    if (mpToolBar) {
+        mpToolBar->setVisible(visible);
+    }
+    if (mpActionToggleToolBar) {
+        mpActionToggleToolBar->setChecked(visible);
+    }
+}
+
+bool TDetachedWindow::isToolBarVisible() const
+{
+    return mpToolBar ? mpToolBar->isVisible() : false;
 }
 
 void TDetachedWindow::slot_saveProfile()
@@ -2009,8 +2051,41 @@ void TDetachedWindow::slot_showMapperDialog()
         return;
     }
 
-    // Check if we already have a mapper dock widget for this profile
+    // Close any existing map for this profile in other windows first
+    auto mudletInstance = mudlet::self();
     QString mapKey = qsl("map_%1").arg(mCurrentProfileName);
+    
+    // Check if main window has a map for this profile and close it
+    auto mainMapDock = mudletInstance->getMainWindowDockWidget(mapKey);
+
+    if (mainMapDock && mainMapDock->isVisible()) {
+        qDebug() << "TDetachedWindow: Closing main window map for profile" << mCurrentProfileName << "to prevent conflicts";
+        // Block signals to prevent user preference from being updated by system-initiated change
+        mainMapDock->blockSignals(true);
+        mainMapDock->setVisible(false);
+        mainMapDock->blockSignals(false);
+    }
+    
+    // Check other detached windows for conflicting maps
+    const auto& detachedWindows = mudletInstance->getDetachedWindows();
+
+    for (auto it = detachedWindows.begin(); it != detachedWindows.end(); ++it) {
+        TDetachedWindow* otherWindow = it.value();
+
+        if (otherWindow && otherWindow != this) {
+            auto otherMapDock = otherWindow->getDockWidget(mapKey);
+
+            if (otherMapDock && otherMapDock->isVisible()) {
+                qDebug() << "TDetachedWindow: Closing map in other detached window for profile" << mCurrentProfileName;
+                // Block signals to prevent user preference from being updated by system-initiated change
+                otherMapDock->blockSignals(true);
+                otherMapDock->setVisible(false);
+                otherMapDock->blockSignals(false);
+            }
+        }
+    }
+
+    // Check if we already have a mapper dock widget for this profile
     QPointer<QDockWidget> existingMapDock = mDockWidgetMap.value(mapKey);
     
     if (existingMapDock) {
@@ -2094,13 +2169,10 @@ void TDetachedWindow::slot_showMapperDialog()
             return;
         }
         
-        // Track user-initiated visibility changes (not system-initiated profile switches)
-        // Only update user preference if this is likely a user action
-        if (!mCurrentProfileName.isEmpty() && mCurrentProfileName == mapKey.mid(4)) {
-            // Current profile's dock widget visibility changed - likely user action
-            mDockWidgetUserPreference[mapKey] = visible;
-            qDebug() << "TDetachedWindow: User changed dock widget visibility for" << mapKey << "to" << visible;
-        }
+        // Track user-initiated visibility changes - always update user preference
+        // to ensure dock widget state is properly tracked regardless of which profile is active
+        mDockWidgetUserPreference[mapKey] = visible;
+        qDebug() << "TDetachedWindow: User changed dock widget visibility for" << mapKey << "to" << visible;
         
         // Extract profile name from mapKey to safely look up objects
         QString profileName = mapKey;
@@ -2301,4 +2373,72 @@ void TDetachedWindow::slot_closeAllProfiles()
     // The profiles should already be removed from mProfileConsoleMap by now,
     // but closeEvent() will handle any remaining cleanup
     close();
+}
+
+void TDetachedWindow::addTransferredDockWidget(const QString& mapKey, QDockWidget* dockWidget)
+{
+    // Add to the map
+    mDockWidgetMap[mapKey] = dockWidget;
+    
+    // Set up signal connection for visibility changes - similar to what's done for new dock widgets
+    connect(dockWidget, &QDockWidget::visibilityChanged, this, [this, mapKey](bool visible) {
+        auto mapDockWidget = mDockWidgetMap.value(mapKey);
+        if (!mapDockWidget) {
+            return;
+        }
+        
+        // Track user-initiated visibility changes - always update user preference
+        // to ensure dock widget state is properly tracked regardless of which profile is active
+        mDockWidgetUserPreference[mapKey] = visible;
+        qDebug() << "TDetachedWindow: User changed dock widget visibility for" << mapKey << "to" << visible;
+        
+        // Extract profile name from mapKey to safely look up objects
+        QString profileName = mapKey;
+        if (profileName.startsWith("map_")) {
+            profileName = profileName.mid(4); // Remove "map_" prefix
+        }
+        
+        // Safely get the host and map - they might be null during shutdown
+        auto mudletInstance = mudlet::self();
+        if (!mudletInstance) {
+            return;
+        }
+        
+        Host* pHost = mudletInstance->getHostManager().getHost(profileName);
+        if (!pHost) {
+            return;
+        }
+        
+        auto pMap = pHost->mpMap.data();
+        if (!pMap) {
+            return;
+        }
+        
+        if (!visible) {
+            // If this is the currently active map dock, clear the global reference
+            if (mpMapDockWidget == mapDockWidget) {
+                mpMapDockWidget = nullptr;
+            }
+            
+            // Restore the main window's mapper as the active one when hiding
+            if (pHost->mpDockableMapWidget) {
+                auto mainMapWidget = pHost->mpDockableMapWidget->widget();
+                if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
+                    pMap->mpMapper = mainMapper;
+                }
+            }
+        } else {
+            // When showing, set this as the active mapper
+            mpMapDockWidget = mapDockWidget;
+            
+            // Ensure the map's active mapper points to our detached instance
+            auto mapWidget = mapDockWidget->widget();
+            if (auto detachedMapper = qobject_cast<dlgMapper*>(mapWidget)) {
+                pMap->mpMapper = detachedMapper;
+            }
+        }
+        
+        // Update visibility for the current profile
+        updateDockWidgetVisibilityForProfile(profileName);
+    });
 }

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -164,6 +164,13 @@ void TDetachedWindow::setupUI()
     mpTabBar->setTabsClosable(true);
     mpTabBar->setMovable(true);
 
+    // Inherit font from main window's tab bar to ensure consistency
+    if (auto mudletInstance = mudlet::self()) {
+        if (mudletInstance->mpTabBar) {
+            mpTabBar->setFont(mudletInstance->mpTabBar->font());
+        }
+    }
+
     // Add initial tab for the first profile
     if (!mCurrentProfileName.isEmpty()) {
         QString displayText = mCurrentProfileName;

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -997,8 +997,8 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
             
             if (dockProfileName == profileName) {
                 // This dock widget belongs to the current profile
-                // Check the intended visibility state, not the current visibility
-                bool shouldBeVisible = mDockWidgetIntendedVisibility.value(dockKey, false);
+                // Check the user's preference for dock widget visibility
+                bool shouldBeVisible = mDockWidgetUserPreference.value(dockKey, false);
                 qDebug() << "TDetachedWindow: Found dock widget for current profile" << profileName 
                          << "currently visible:" << dockWidget->isVisible() 
                          << "should be visible:" << shouldBeVisible;
@@ -1436,7 +1436,7 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
         
         // Remove from our tracking maps
         mDockWidgetMap.remove(mapKey);
-        mDockWidgetIntendedVisibility.remove(mapKey);
+        mDockWidgetUserPreference.remove(mapKey);
     }
 
     // Find the tab index
@@ -2081,8 +2081,8 @@ void TDetachedWindow::slot_showMapperDialog()
     // Store reference in our map for cleanup and profile-specific access
     mDockWidgetMap[mapKey] = newMapDockWidget;
     
-    // Set intended visibility to true since we're initially showing this dock widget
-    mDockWidgetIntendedVisibility[mapKey] = true;
+    // Set user preference to true since we're initially showing this dock widget
+    mDockWidgetUserPreference[mapKey] = true;
     
     // Set global reference to the currently active map
     mpMapDockWidget = newMapDockWidget;
@@ -2095,10 +2095,10 @@ void TDetachedWindow::slot_showMapperDialog()
         }
         
         // Track user-initiated visibility changes (not system-initiated profile switches)
-        // Only update intended visibility if this is likely a user action
+        // Only update user preference if this is likely a user action
         if (!mCurrentProfileName.isEmpty() && mCurrentProfileName == mapKey.mid(4)) {
             // Current profile's dock widget visibility changed - likely user action
-            mDockWidgetIntendedVisibility[mapKey] = visible;
+            mDockWidgetUserPreference[mapKey] = visible;
             qDebug() << "TDetachedWindow: User changed dock widget visibility for" << mapKey << "to" << visible;
         }
         

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -20,6 +20,7 @@
 #include "TDetachedWindow.h"
 #include "TMainConsole.h"
 #include "TTabBar.h"
+#include "TDebug.h"
 #include "Host.h"
 #include "HostManager.h"
 #include "mudlet.h"
@@ -107,7 +108,20 @@ void TDetachedWindow::setupUI()
 
     // Add initial tab for the first profile
     if (!mCurrentProfileName.isEmpty()) {
-        mpTabBar->addTab(mCurrentProfileName);
+        QString displayText = mCurrentProfileName;
+        
+        // Apply CDC identifier prefix if debug mode is active
+        if (mudlet::smDebugMode) {
+            Host* pHost = mudlet::self()->getHostManager().getHost(mCurrentProfileName);
+            if (pHost) {
+                QString debugTag = TDebug::getTag(pHost);
+                if (!debugTag.isEmpty()) {
+                    displayText = debugTag + mCurrentProfileName;
+                }
+            }
+        }
+        
+        mpTabBar->addTab(displayText);
         mpTabBar->setTabData(0, mCurrentProfileName);
     }
 
@@ -446,19 +460,20 @@ void TDetachedWindow::createToolBar()
     mpActionDisconnect = new QAction(tr("Disconnect"), this);
     mpActionDisconnect->setObjectName(qsl("disconnect"));
 
-    mpActionReconnect = new QAction(tr("Reconnect"), this);
-    mpActionReconnect->setIcon(QIcon(qsl(":/icons/system-restart.png")));
-    mpActionReconnect->setObjectName(qsl("reconnect"));
-
     mpActionCloseProfile = new QAction(tr("Close profile"), this);
     mpActionCloseProfile->setIcon(QIcon(qsl(":/icons/profile-close.png")));
     mpActionCloseProfile->setIconText(tr("Close profile"));
     mpActionCloseProfile->setObjectName(qsl("close_profile"));
 
+    mpActionCloseApplication = new QAction(tr("Close Mudlet"), this);
+    mpActionCloseApplication->setIcon(QIcon::fromTheme(qsl("application-exit"), QIcon(qsl(":/icons/application-exit.png"))));
+    mpActionCloseApplication->setIconText(tr("Close Mudlet"));
+    mpActionCloseApplication->setObjectName(qsl("close_application"));
+
     mpButtonConnect->addAction(mpActionConnect);
     mpButtonConnect->addAction(mpActionDisconnect);
-    mpButtonConnect->addAction(mpActionReconnect);
     mpButtonConnect->addAction(mpActionCloseProfile);
+    mpButtonConnect->addAction(mpActionCloseApplication);
     mpButtonConnect->setDefaultAction(mpActionConnect);
 
     // Script Editor Actions
@@ -583,6 +598,18 @@ void TDetachedWindow::createToolBar()
     mpActionReplay->setObjectName(qsl("replay_action"));
     mpToolBar->addAction(mpActionReplay);
 
+    // Standalone Reconnect action (like main window)
+    mpActionReconnectStandalone = new QAction(QIcon(qsl(":/icons/system-restart.png")), tr("Reconnect"), this);
+    mpActionReconnectStandalone->setToolTip(utils::richText(tr("Disconnects you from the game and connects once again")));
+    mpActionReconnectStandalone->setObjectName(qsl("reconnect_standalone"));
+    mpToolBar->addAction(mpActionReconnectStandalone);
+
+    // About action (like main window)
+    mpActionAbout = new QAction(QIcon(qsl(":/icons/mudlet_information.png")), tr("About"), this);
+    mpActionAbout->setToolTip(utils::richText(tr("Inform yourself about this version of Mudlet, the people who made it and the licence under which you can share it.")));
+    mpActionAbout->setObjectName(qsl("about_action"));
+    mpToolBar->addAction(mpActionAbout);
+
     // Full screen toggle
     QIcon fullScreenIcon;
     fullScreenIcon.addPixmap(qsl(":/icons/view-fullscreen.png"), QIcon::Normal, QIcon::Off);
@@ -607,8 +634,8 @@ void TDetachedWindow::connectToolBarActions()
     // Connection actions - use our custom slots to ensure correct profile context
     connect(mpActionConnect, &QAction::triggered, this, &TDetachedWindow::slot_connectProfile);
     connect(mpActionDisconnect, &QAction::triggered, this, &TDetachedWindow::slot_disconnectProfile);
-    connect(mpActionReconnect, &QAction::triggered, this, &TDetachedWindow::slot_reconnectProfile);
     connect(mpActionCloseProfile, &QAction::triggered, this, &TDetachedWindow::slot_closeCurrentProfile);
+    connect(mpActionCloseApplication, &QAction::triggered, this, &TDetachedWindow::slot_closeApplication);
 
     // Script editor actions - use our custom slots to ensure correct profile context
     connect(mpActionTriggers, &QAction::triggered, this, &TDetachedWindow::slot_showTriggerDialog);
@@ -636,6 +663,8 @@ void TDetachedWindow::connectToolBarActions()
     connect(mpActionPackageExporter, &QAction::triggered, this, &TDetachedWindow::slot_showPackageExporterDialog);
 
     connect(mpActionReplay, &QAction::triggered, this, &TDetachedWindow::slot_showReplayDialog);
+    connect(mpActionReconnectStandalone, &QAction::triggered, this, &TDetachedWindow::slot_reconnectProfile);
+    connect(mpActionAbout, &QAction::triggered, this, &TDetachedWindow::slot_showAboutDialog);
     connect(mpActionFullScreenView, &QAction::triggered, this, &TDetachedWindow::slot_toggleFullScreenView);
 }
 
@@ -695,8 +724,9 @@ void TDetachedWindow::updateToolBarActions()
         // All actions should always be enabled to match main window behavior
         mpActionConnect->setEnabled(true);
         mpActionDisconnect->setEnabled(true);
-        mpActionReconnect->setEnabled(true);
+        mpActionReconnectStandalone->setEnabled(true);
         mpActionCloseProfile->setEnabled(true);
+        mpActionCloseApplication->setEnabled(true);
     } else {
         // Update status bar
         updateStatusBar(nullptr, false, false);
@@ -704,8 +734,9 @@ void TDetachedWindow::updateToolBarActions()
         // Even when no profile is active, keep all actions enabled to match main window
         mpActionConnect->setEnabled(true);
         mpActionDisconnect->setEnabled(true);
-        mpActionReconnect->setEnabled(true);
+        mpActionReconnectStandalone->setEnabled(true);
         mpActionCloseProfile->setEnabled(true);
+        mpActionCloseApplication->setEnabled(true);
     }
 
     // Mute actions are always enabled
@@ -713,8 +744,9 @@ void TDetachedWindow::updateToolBarActions()
     mpActionMuteAPI->setEnabled(true);
     mpActionMuteGame->setEnabled(true);
 
-    // Help is always enabled
+    // Help and About are always enabled
     mpActionHelp->setEnabled(true);
+    mpActionAbout->setEnabled(true);
 
     // Full screen toggle is always enabled
     mpActionFullScreenView->setEnabled(true);
@@ -828,20 +860,23 @@ void TDetachedWindow::updateTabIndicator(int tabIndex)
     if (pHost) {
         bool isConnected = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectedState);
         bool isConnecting = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectingState);
-
-        if (isConnected) {
-            tabIcon = QIcon(qsl(":/icons/dialog-ok-apply.png"));
-        } else if (isConnecting) {
-            tabIcon = QIcon(qsl(":/icons/dialog-information.png"));
-        } else {
-            tabIcon = QIcon(qsl(":/icons/dialog-close.png"));
-        }
+        tabIcon = mudlet::createConnectionStatusIcon(isConnected, isConnecting, false);
     } else {
-        tabIcon = QIcon(qsl(":/icons/dialog-error.png"));
+        tabIcon = mudlet::createConnectionStatusIcon(false, false, true);
     }
 
-    // Set the tab text and icon
-    mpTabBar->setTabText(tabIndex, profileName);
+    // Set the tab text and icon, accounting for CDC identifiers
+    QString displayText = profileName;
+    
+    // Apply CDC identifier prefix if debug mode is active (like main window does)
+    if (mudlet::smDebugMode && pHost) {
+        QString debugTag = TDebug::getTag(pHost);
+        if (!debugTag.isEmpty()) {
+            displayText = debugTag + profileName;
+        }
+    }
+    
+    mpTabBar->setTabText(tabIndex, displayText);
     mpTabBar->setTabIcon(tabIndex, tabIcon);
 }
 
@@ -1425,6 +1460,13 @@ void TDetachedWindow::slot_closeCurrentProfile()
     });
 }
 
+void TDetachedWindow::slot_closeApplication()
+{
+    withCurrentProfileActive([this]() {
+        mudlet::self()->close();
+    });
+}
+
 void TDetachedWindow::slot_showTriggerDialog()
 {
     withCurrentProfileActive([this]() {
@@ -1530,6 +1572,13 @@ void TDetachedWindow::slot_showPackageExporterDialog()
     });
 }
 
+void TDetachedWindow::slot_showAboutDialog()
+{
+    withCurrentProfileActive([this]() {
+        mudlet::self()->slot_showAboutDialog();
+    });
+}
+
 void TDetachedWindow::slot_muteMedia()
 {
     withCurrentProfileActive([this]() {
@@ -1574,4 +1623,28 @@ void TDetachedWindow::changeEvent(QEvent* event)
     }
 
     QMainWindow::changeEvent(event);
+}
+
+void TDetachedWindow::refreshTabBar()
+{
+    // Update all tab texts to account for CDC identifiers (like main window does)
+    for (int i = 0; i < mpTabBar->count(); ++i) {
+        QString profileName = mpTabBar->tabData(i).toString();
+        if (!profileName.isEmpty()) {
+            QString displayText = profileName;
+            
+            // Apply CDC identifier prefix if debug mode is active
+            if (mudlet::smDebugMode) {
+                Host* pHost = mudlet::self()->getHostManager().getHost(profileName);
+                if (pHost) {
+                    QString debugTag = TDebug::getTag(pHost);
+                    if (!debugTag.isEmpty()) {
+                        displayText = debugTag + profileName;
+                    }
+                }
+            }
+            
+            mpTabBar->setTabText(i, displayText);
+        }
+    }
 }

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -2246,7 +2246,9 @@ void TDetachedWindow::slot_showMapperDialog()
             }
         }
         
+#if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "TDetachedWindow: Map dock visibility changed for" << mapKey << "visible:" << visible;
+#endif
     });
 
     // Show the dock widget

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -111,9 +111,11 @@ TDetachedWindow::~TDetachedWindow()
                 if (auto mudletInstance = mudlet::self()) {
                     if (auto pHost = mudletInstance->getHostManager().getHost(profileName)) {
                         auto pMap = pHost->mpMap.data();
+
                         if (pMap && pHost->mpDockableMapWidget) {
                             // Find the main window's mapper
                             auto mainMapWidget = pHost->mpDockableMapWidget->widget();
+
                             if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
                                 pMap->mpMapper = mainMapper;
                             }
@@ -121,9 +123,11 @@ TDetachedWindow::~TDetachedWindow()
                     }
                 }
             }
+
             it.value()->deleteLater();
         }
     }
+
     mDockWidgetMap.clear();
     
     if (mpMapDockWidget) {
@@ -132,9 +136,11 @@ TDetachedWindow::~TDetachedWindow()
             if (auto mudletInstance = mudlet::self()) {
                 if (auto pHost = mudletInstance->getHostManager().getHost(mCurrentProfileName)) {
                     auto pMap = pHost->mpMap.data();
+
                     if (pMap && pHost->mpDockableMapWidget) {
                         // Find the main window's mapper
                         auto mainMapWidget = pHost->mpDockableMapWidget->widget();
+
                         if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
                             pMap->mpMapper = mainMapper;
                         }
@@ -142,6 +148,7 @@ TDetachedWindow::~TDetachedWindow()
                 }
             }
         }
+
         mpMapDockWidget->deleteLater();
         mpMapDockWidget = nullptr;
     }
@@ -178,8 +185,10 @@ void TDetachedWindow::setupUI()
         // Apply CDC identifier prefix if debug mode is active
         if (mudlet::smDebugMode) {
             Host* pHost = mudlet::self()->getHostManager().getHost(mCurrentProfileName);
+
             if (pHost) {
                 QString debugTag = TDebug::getTag(pHost);
+
                 if (!debugTag.isEmpty()) {
                     displayText = debugTag + mCurrentProfileName;
                 }
@@ -199,6 +208,7 @@ void TDetachedWindow::setupUI()
     // Add the initial console
     if (!mCurrentProfileName.isEmpty() && mProfileConsoleMap.contains(mCurrentProfileName)) {
         auto console = mProfileConsoleMap[mCurrentProfileName];
+
         if (console) {
             mpConsoleContainer->addWidget(console);
             mpConsoleContainer->setCurrentWidget(console);
@@ -335,6 +345,7 @@ void TDetachedWindow::closeEvent(QCloseEvent* event)
 void TDetachedWindow::dragEnterEvent(QDragEnterEvent* event)
 {
     const QMimeData* mimeData = event->mimeData();
+
     if (mimeData->hasFormat("application/x-mudlet-tab")) {
         event->acceptProposedAction();
     } else {
@@ -345,6 +356,7 @@ void TDetachedWindow::dragEnterEvent(QDragEnterEvent* event)
 void TDetachedWindow::dragMoveEvent(QDragMoveEvent* event)
 {
     const QMimeData* mimeData = event->mimeData();
+
     if (mimeData->hasFormat("application/x-mudlet-tab")) {
         event->acceptProposedAction();
     } else {
@@ -355,6 +367,7 @@ void TDetachedWindow::dragMoveEvent(QDragMoveEvent* event)
 void TDetachedWindow::dropEvent(QDropEvent* event)
 {
     const QMimeData* mimeData = event->mimeData();
+
     if (mimeData->hasFormat("application/x-mudlet-tab")) {
         const QString profileName = QString::fromUtf8(mimeData->data("application/x-mudlet-tab"));
 
@@ -363,6 +376,7 @@ void TDetachedWindow::dropEvent(QDropEvent* event)
             // Request main window to detach this tab to this detached window
             emit profileDetachToWindowRequested(profileName, this);
         }
+
         event->acceptProposedAction();
     }
 }
@@ -448,6 +462,7 @@ void TDetachedWindow::showTabContextMenu(const QPoint& position)
 {
     // Only show context menu if click was on a tab
     int tabIndex = mpTabBar->tabAt(position);
+
     if (tabIndex == -1) {
         return;
     }
@@ -526,6 +541,7 @@ void TDetachedWindow::restoreWindowGeometry()
         // Center on screen containing the main window
         if (parentWidget()) {
             const QScreen* screen = QApplication::screenAt(parentWidget()->pos());
+
             if (screen) {
                 const QRect screenGeometry = screen->availableGeometry();
                 move(screenGeometry.center() - rect().center());
@@ -745,6 +761,7 @@ void TDetachedWindow::createToolBar()
 void TDetachedWindow::connectToolBarActions()
 {
     auto mudletInstance = mudlet::self();
+
     if (!mudletInstance) {
         return;
     }
@@ -792,9 +809,11 @@ void TDetachedWindow::connectToolBarActions()
 void TDetachedWindow::updateToolBarActions()
 {
     Host* pHost = nullptr;
+
     if (!mCurrentProfileName.isEmpty()) {
         pHost = mudlet::self()->getHostManager().getHost(mCurrentProfileName);
     }
+
     bool hasActiveProfile = (pHost != nullptr);
 
     // Enable/disable actions based on profile state
@@ -866,6 +885,7 @@ void TDetachedWindow::updateWindowTitle()
     if (mProfileConsoleMap.size() == 1) {
         // Single profile - use the simple format
         Host* pHost = nullptr;
+
         if (!mCurrentProfileName.isEmpty()) {
             pHost = mudlet::self()->getHostManager().getHost(mCurrentProfileName);
             title = tr("Mudlet - %1 (Detached)").arg(mCurrentProfileName);
@@ -879,6 +899,7 @@ void TDetachedWindow::updateWindowTitle()
 
             if (isConnected) {
                 title += tr(" - Connected");
+
                 if (!pHost->getUrl().isEmpty()) {
                     title += tr(" to %1").arg(pHost->getUrl());
                 }
@@ -914,6 +935,7 @@ void TDetachedWindow::updateTabIndicator(int tabIndex)
     }
 
     QString profileName = mpTabBar->tabData(tabIndex).toString();
+
     if (profileName.isEmpty()) {
         return;
     }
@@ -942,6 +964,7 @@ void TDetachedWindow::updateTabIndicator(int tabIndex)
     // Apply CDC identifier prefix if debug mode is active (like main window does)
     if (mudlet::smDebugMode && pHost) {
         QString debugTag = TDebug::getTag(pHost);
+
         if (!debugTag.isEmpty()) {
             displayText = debugTag + profileName;
         }
@@ -975,6 +998,7 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
     
     // Collect dock widgets to process to avoid iterator invalidation
     QList<QPair<QString, QPointer<QDockWidget>>> dockWidgetsToProcess;
+
     for (auto it = mDockWidgetMap.begin(); it != mDockWidgetMap.end(); ++it) {
         if (it.value()) {
             dockWidgetsToProcess.append(qMakePair(it.key(), it.value()));
@@ -1048,6 +1072,7 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
                 if (auto pHost = mudlet::self()->getHostManager().getHost(profileName)) {
                     if (auto pMap = pHost->mpMap.data()) {
                         auto mapWidget = dockWidget->widget();
+
                         if (auto detachedMapper = qobject_cast<dlgMapper*>(mapWidget)) {
                             // Only set as active mapper if the dock widget should be visible
                             if (shouldBeVisible) {
@@ -1074,6 +1099,7 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
                     if (auto pMap = pHost->mpMap.data()) {
                         if (pHost->mpDockableMapWidget) {
                             auto mainMapWidget = pHost->mpDockableMapWidget->widget();
+
                             if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
                                 pMap->mpMapper = mainMapper;
 #if defined(DEBUG_WINDOW_HANDLING)
@@ -1114,6 +1140,7 @@ void TDetachedWindow::slot_toggleAlwaysOnTop()
     mIsChangingWindowFlags = true;
 
     Qt::WindowFlags flags = windowFlags();
+
     if (flags & Qt::WindowStaysOnTopHint) {
         // Remove always on top flag
         setWindowFlags(flags & ~Qt::WindowStaysOnTopHint);
@@ -1121,6 +1148,7 @@ void TDetachedWindow::slot_toggleAlwaysOnTop()
         // Add always on top flag
         setWindowFlags(flags | Qt::WindowStaysOnTopHint);
     }
+
     show();  // Required after changing window flags
 
     // Reset flag after a short delay to allow the window operations to complete
@@ -1139,6 +1167,7 @@ void TDetachedWindow::slot_toggleToolBarVisibility()
     
     // Synchronize toolbar visibility across all windows
     auto mudletInstance = mudlet::self();
+
     if (mudletInstance) {
         mudletInstance->synchronizeToolBarVisibility(newVisibility);
     }
@@ -1167,6 +1196,7 @@ void TDetachedWindow::setToolBarVisibility(bool visible)
     if (mpToolBar) {
         mpToolBar->setVisible(visible);
     }
+
     if (mpActionToggleToolBar) {
         mpActionToggleToolBar->setChecked(visible);
     }
@@ -1184,6 +1214,7 @@ void TDetachedWindow::slot_saveProfile()
     }
 
     Host* pHost = mudlet::self()->getHostManager().getHost(mCurrentProfileName);
+
     if (pHost) {
         pHost->saveProfile();
     }
@@ -1202,6 +1233,7 @@ void TDetachedWindow::updateWindowMenu()
         mpWindowMenu->removeAction(action);
         action->deleteLater();
     }
+
     mWindowListActions.clear();
 
     // Remove separator if it exists
@@ -1220,12 +1252,14 @@ void TDetachedWindow::updateWindowMenu()
 
     // Only show window list if there are multiple windows OR if there are multiple profiles
     bool hasMultipleProfiles = mudlet::self()->getHostManager().getHostCount() > 1;
+
     if (totalWindows > 1 || hasMultipleProfiles) {
         // Add separator before window list
         mWindowListSeparator = mpWindowMenu->addSeparator();
 
         // Add main window profiles
         QStringList mainWindowProfiles;
+
         for (const auto& host : mudlet::self()->getHostManager()) {
             if (host && host->mpConsole) {
                 const QString profileName = host->getName();
@@ -1255,8 +1289,10 @@ void TDetachedWindow::updateWindowMenu()
         // Add detached window profiles
         // Collect unique detached windows to avoid duplicates
         QSet<TDetachedWindow*> uniqueDetachedWindows;
+
         for (auto it = detachedWindows.begin(); it != detachedWindows.end(); ++it) {
             TDetachedWindow* detachedWindow = it.value();
+
             if (detachedWindow) {
                 uniqueDetachedWindows.insert(detachedWindow);
             }
@@ -1266,6 +1302,7 @@ void TDetachedWindow::updateWindowMenu()
         for (TDetachedWindow* detachedWindow : uniqueDetachedWindows) {
             // Get all profiles in this detached window
             QStringList profilesInWindow = detachedWindow->getProfileNames();
+
             for (const QString& windowProfileName : profilesInWindow) {
                 QString actionText = tr("%1 (Detached)").arg(windowProfileName);
                 QAction* profileAction = new QAction(actionText, this);
@@ -1283,6 +1320,7 @@ void TDetachedWindow::updateWindowMenu()
 void TDetachedWindow::slot_activateMainWindow()
 {
     mudlet* mainWindow = mudlet::self();
+
     if (mainWindow) {
         mainWindow->raise();
         mainWindow->activateWindow();
@@ -1294,6 +1332,7 @@ void TDetachedWindow::slot_activateMainWindow()
 void TDetachedWindow::slot_activateDetachedWindow()
 {
     QAction* action = qobject_cast<QAction*>(sender());
+
     if (!action) {
         return;
     }
@@ -1303,6 +1342,7 @@ void TDetachedWindow::slot_activateDetachedWindow()
     
     if (detachedWindows.contains(profileName)) {
         TDetachedWindow* detachedWindow = detachedWindows[profileName];
+
         if (detachedWindow) {
             detachedWindow->raise();
             detachedWindow->activateWindow();
@@ -1315,6 +1355,7 @@ void TDetachedWindow::slot_activateDetachedWindow()
 void TDetachedWindow::slot_activateMainWindowProfile()
 {
     QAction* action = qobject_cast<QAction*>(sender());
+
     if (!action) {
         return;
     }
@@ -1323,9 +1364,11 @@ void TDetachedWindow::slot_activateMainWindowProfile()
     
     // Delegate to mudlet's main window profile activation
     mudlet* mainWindow = mudlet::self();
+
     if (mainWindow) {
         // Find the tab index for this profile in the main window
         int tabIndex = -1;
+
         for (int i = 0; i < mainWindow->mpTabBar->count(); ++i) {
             if (mainWindow->mpTabBar->tabData(i).toString() == profileName) {
                 tabIndex = i;
@@ -1353,6 +1396,7 @@ void TDetachedWindow::slot_activateMainWindowProfile()
 void TDetachedWindow::slot_activateDetachedWindowProfile()
 {
     QAction* action = qobject_cast<QAction*>(sender());
+
     if (!action) {
         return;
     }
@@ -1361,8 +1405,10 @@ void TDetachedWindow::slot_activateDetachedWindowProfile()
     
     // Find which detached window contains this profile
     const auto& detachedWindows = mudlet::self()->getDetachedWindows();
+
     for (auto it = detachedWindows.begin(); it != detachedWindows.end(); ++it) {
         TDetachedWindow* detachedWindow = it.value();
+
         if (detachedWindow && detachedWindow->getProfileNames().contains(profileName)) {
             // Activate the detached window
             detachedWindow->raise();
@@ -1455,6 +1501,7 @@ bool TDetachedWindow::addProfile(const QString& profileName, TMainConsole* conso
     // Schedule a delayed update to handle any Qt layout timing issues
     QTimer::singleShot(10, this, [this, profileName]() {
         auto console = mProfileConsoleMap.value(profileName);
+
         if (console) {
             console->updateGeometry();
             console->adjustSize();
@@ -1474,8 +1521,10 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
 
     // Clean up any dock widgets for this profile before removing it
     QString mapKey = qsl("map_%1").arg(profileName);
+
     if (mDockWidgetMap.contains(mapKey)) {
         QPointer<QDockWidget> mapDockWidget = mDockWidgetMap.value(mapKey);
+
         if (mapDockWidget) {
 #if defined(DEBUG_WINDOW_HANDLING)
             qDebug() << "TDetachedWindow::removeProfile: Cleaning up dock widget for profile" << profileName;
@@ -1494,6 +1543,7 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
                 if (auto pMap = pHost->mpMap.data()) {
                     if (pHost->mpDockableMapWidget) {
                         auto mainMapWidget = pHost->mpDockableMapWidget->widget();
+
                         if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
                             pMap->mpMapper = mainMapper;
 #if defined(DEBUG_WINDOW_HANDLING)
@@ -1515,6 +1565,7 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
 
     // Find the tab index
     int tabIndex = -1;
+
     for (int i = 0; i < mpTabBar->count(); ++i) {
         if (mpTabBar->tabData(i).toString() == profileName) {
             tabIndex = i;
@@ -1528,6 +1579,7 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
 
     // Remove console from stacked widget
     auto console = mProfileConsoleMap[profileName];
+
     if (console) {
         mpConsoleContainer->removeWidget(console);
         // DON'T set parent to nullptr here - let the receiving window handle reparenting
@@ -1578,6 +1630,7 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
         if (mpTabBar->count() > 0) {
             // Switch to the first remaining tab
             const QString newProfileName = mpTabBar->tabData(mpTabBar->currentIndex()).toString();
+
             if (!newProfileName.isEmpty()) {
                 switchToProfile(newProfileName);
             }
@@ -1594,6 +1647,7 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
     if (mpTabBar->count() > 0) {
         // Force layout update
         mpConsoleContainer->update();
+
         if (layout()) {
             layout()->update();
         }
@@ -1610,9 +1664,9 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
         activateWindow();
 
         // Force window to front on macOS
-        #ifdef Q_OS_MACOS
+#ifdef Q_OS_MACOS
         setAttribute(Qt::WA_ShowWithoutActivating, false);
-        #endif
+#endif
 
         // Force repaint to ensure visibility
         repaint();
@@ -1651,6 +1705,7 @@ TMainConsole* TDetachedWindow::getCurrentConsole() const
     if (mCurrentProfileName.isEmpty()) {
         return nullptr;
     }
+
     return mProfileConsoleMap.value(mCurrentProfileName);
 }
 
@@ -1668,6 +1723,7 @@ void TDetachedWindow::switchToProfile(const QString& profileName)
     mCurrentProfileName = profileName;
 
     auto console = mProfileConsoleMap[profileName];
+
     if (console && mpConsoleContainer) {
         // Set the current widget in the stacked container
         mpConsoleContainer->setCurrentWidget(console);
@@ -1709,6 +1765,7 @@ void TDetachedWindow::switchToProfile(const QString& profileName)
             if (mpTabBar->currentIndex() != i) {
                 mpTabBar->setCurrentIndex(i);
             }
+
             break;
         }
     }
@@ -1733,6 +1790,7 @@ void TDetachedWindow::switchToProfile(const QString& profileName)
     // Schedule a delayed update to handle any Qt layout timing issues
     QTimer::singleShot(10, this, [this, profileName]() {
         auto console = mProfileConsoleMap.value(profileName);
+
         if (console) {
             console->updateGeometry();
             console->adjustSize();
@@ -1749,6 +1807,7 @@ void TDetachedWindow::slot_tabChanged(int index)
     }
 
     QString profileName = mpTabBar->tabData(index).toString();
+
     if (!profileName.isEmpty() && profileName != mCurrentProfileName) {
         switchToProfile(profileName);
     }
@@ -1770,6 +1829,7 @@ void TDetachedWindow::slot_tabMoved(int oldPos, int newPos)
 
     // Create a map of profile names to console widgets
     QMap<QString, TMainConsole*> consoleWidgetMap;
+
     for (auto it = mProfileConsoleMap.begin(); it != mProfileConsoleMap.end(); ++it) {
         if (it.value()) {
             consoleWidgetMap.insert(it.key(), it.value());
@@ -1785,8 +1845,10 @@ void TDetachedWindow::slot_tabMoved(int oldPos, int newPos)
     // Reorder the console widgets in the stacked widget to match the new tab order
     // Remove all widgets from the stacked widget and re-add them in the new order
     QList<TMainConsole*> widgetsToReAdd;
+
     for (const QString& profileName : profileNamesInOrder) {
         TMainConsole* console = consoleWidgetMap.value(profileName);
+
         if (console) {
             mpConsoleContainer->removeWidget(console);
             widgetsToReAdd.append(console);
@@ -1804,6 +1866,7 @@ void TDetachedWindow::slot_tabMoved(int oldPos, int newPos)
     } else if (!mCurrentProfileName.isEmpty()) {
         // Fallback: use the current profile name to find the correct console
         TMainConsole* currentConsole = mProfileConsoleMap.value(mCurrentProfileName);
+
         if (currentConsole) {
             mpConsoleContainer->setCurrentWidget(currentConsole);
         }
@@ -1817,6 +1880,7 @@ void TDetachedWindow::closeProfileByIndex(int index)
     }
 
     QString profileName = mpTabBar->tabData(index).toString();
+
     if (profileName.isEmpty()) {
         return;
     }
@@ -1857,12 +1921,14 @@ void TDetachedWindow::checkForWindowMergeOpportunity()
 
     // Get list of all detached windows from mudlet
     auto mudletInstance = mudlet::self();
+
     if (!mudletInstance) {
         return;
     }
 
     // Look for overlapping detached windows
     const auto& detachedWindows = mudletInstance->getDetachedWindows();
+
     for (auto it = detachedWindows.begin(); it != detachedWindows.end(); ++it) {
         TDetachedWindow* otherWindow = it.value();
 
@@ -1875,6 +1941,7 @@ void TDetachedWindow::checkForWindowMergeOpportunity()
 
         // Check if windows significantly overlap (more than 50% of smaller window)
         const QRect intersection = ourRect.intersected(otherRect);
+
         if (intersection.isEmpty()) {
             continue;
         }
@@ -1962,11 +2029,13 @@ void TDetachedWindow::logWindowState(const QString& context)
 void TDetachedWindow::withCurrentProfileActive(const std::function<void()>& action)
 {
     auto mudletInstance = mudlet::self();
+
     if (!mudletInstance || mCurrentProfileName.isEmpty()) {
         return;
     }
 
     Host* pHost = mudletInstance->getHostManager().getHost(mCurrentProfileName);
+
     if (!pHost) {
         return;
     }
@@ -2432,26 +2501,32 @@ void TDetachedWindow::addTransferredDockWidget(const QString& mapKey, QDockWidge
         // Track user-initiated visibility changes - always update user preference
         // to ensure dock widget state is properly tracked regardless of which profile is active
         mDockWidgetUserPreference[mapKey] = visible;
+#if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "TDetachedWindow: User changed dock widget visibility for" << mapKey << "to" << visible;
+#endif
         
         // Extract profile name from mapKey to safely look up objects
         QString profileName = mapKey;
+
         if (profileName.startsWith("map_")) {
             profileName = profileName.mid(4); // Remove "map_" prefix
         }
         
         // Safely get the host and map - they might be null during shutdown
         auto mudletInstance = mudlet::self();
+
         if (!mudletInstance) {
             return;
         }
         
         Host* pHost = mudletInstance->getHostManager().getHost(profileName);
+
         if (!pHost) {
             return;
         }
         
         auto pMap = pHost->mpMap.data();
+
         if (!pMap) {
             return;
         }
@@ -2465,6 +2540,7 @@ void TDetachedWindow::addTransferredDockWidget(const QString& mapKey, QDockWidge
             // Restore the main window's mapper as the active one when hiding
             if (pHost->mpDockableMapWidget) {
                 auto mainMapWidget = pHost->mpDockableMapWidget->widget();
+
                 if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
                     pMap->mpMapper = mainMapper;
                 }
@@ -2475,6 +2551,7 @@ void TDetachedWindow::addTransferredDockWidget(const QString& mapKey, QDockWidge
             
             // Ensure the map's active mapper points to our detached instance
             auto mapWidget = mapDockWidget->widget();
+
             if (auto detachedMapper = qobject_cast<dlgMapper*>(mapWidget)) {
                 pMap->mpMapper = detachedMapper;
             }

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -87,6 +87,9 @@ TDetachedWindow::~TDetachedWindow()
                 ++it;
             }
         }
+        
+        // Update multi-view controls since detached windows changed
+        mudletInstance->updateMultiViewControls();
     }
 
     saveWindowGeometry();
@@ -201,7 +204,8 @@ void TDetachedWindow::createMenus()
 
     auto closeAction = new QAction(tr("&Close"), this);
     closeAction->setShortcut(QKeySequence::Close);
-    connect(closeAction, &QAction::triggered, this, &QWidget::close);
+    closeAction->setStatusTip(tr("Close this window and all profiles in it"));
+    connect(closeAction, &QAction::triggered, this, &TDetachedWindow::slot_closeAllProfiles);
     windowMenu->addAction(closeAction);
 
     windowMenu->addSeparator();
@@ -223,8 +227,18 @@ void TDetachedWindow::createMenus()
 
 void TDetachedWindow::closeEvent(QCloseEvent* event)
 {
-    // Only remove consoles if this is not a reattachment
+    // Ensure profiles are properly closed when window is closed
+    // This prevents orphaned profiles that remain loaded but invisible
     if (!mIsReattaching) {
+        // Get a copy of profile names before we start closing them
+        QStringList profilesToClose = mProfileConsoleMap.keys();
+        
+        // Properly close each profile - this ensures proper cleanup and save prompts
+        for (const QString& profileName : profilesToClose) {
+            qDebug() << "TDetachedWindow::closeEvent() - Properly closing profile:" << profileName;
+            mudlet::self()->slot_closeProfileByName(profileName);
+        }
+        
         // Remove all consoles from the stacked widget and reset their parents
         for (auto console : mProfileConsoleMap) {
             if (console) {
@@ -232,13 +246,11 @@ void TDetachedWindow::closeEvent(QCloseEvent* event)
                 console->setParent(nullptr);
             }
         }
-        mProfileConsoleMap.clear();
-    }
 
-    // Emit signal to notify main window only if not reattaching
-    if (!mIsReattaching) {
-        // Emit for each profile being closed
-        for (const QString& profileName : mProfileConsoleMap.keys()) {
+        mProfileConsoleMap.clear();
+        
+        // Emit signal to notify main window for any remaining cleanup
+        for (const QString& profileName : profilesToClose) {
             emit windowClosed(profileName);
         }
     }
@@ -1283,6 +1295,11 @@ void TDetachedWindow::closeProfileByIndex(int index)
 
     // If this was the last profile, close the detached window
     if (mProfileConsoleMap.isEmpty()) {
+        // Signal that this window is closing to update multi-view controls
+        // Since the profile map is now empty, closeEvent() won't emit windowClosed signals
+        // so we need to notify the main window about the window closure here
+        emit windowClosed(profileName);
+        
         QTimer::singleShot(0, this, [this] {
             close();
         });
@@ -1647,4 +1664,23 @@ void TDetachedWindow::refreshTabBar()
             mpTabBar->setTabText(i, displayText);
         }
     }
+}
+
+void TDetachedWindow::slot_closeAllProfiles()
+{
+    // Properly close all profiles before closing the window
+    // This ensures save prompts and proper cleanup
+    QStringList profilesToClose = mProfileConsoleMap.keys();
+    
+    qDebug() << "TDetachedWindow::slot_closeAllProfiles() - Closing" << profilesToClose.size() << "profiles";
+    
+    for (const QString& profileName : profilesToClose) {
+        qDebug() << "TDetachedWindow::slot_closeAllProfiles() - Closing profile:" << profileName;
+        mudlet::self()->slot_closeProfileByName(profileName);
+    }
+    
+    // After all profiles are closed, close the window
+    // The profiles should already be removed from mProfileConsoleMap by now,
+    // but closeEvent() will handle any remaining cleanup
+    close();
 }

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -964,17 +964,23 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
     // Clear the global map dock widget reference first
     mpMapDockWidget = nullptr;
     
+#if defined(DEBUG_WINDOW_HANDLING)
     qDebug() << "TDetachedWindow::updateDockWidgetVisibilityForProfile: Starting for profile" << profileName
              << "- mDockWidgetMap.size():" << mDockWidgetMap.size();
+#endif
     
     // Collect dock widgets to process to avoid iterator invalidation
     QList<QPair<QString, QPointer<QDockWidget>>> dockWidgetsToProcess;
     for (auto it = mDockWidgetMap.begin(); it != mDockWidgetMap.end(); ++it) {
         if (it.value()) {
             dockWidgetsToProcess.append(qMakePair(it.key(), it.value()));
+#if defined(DEBUG_WINDOW_HANDLING)
             qDebug() << "TDetachedWindow: Found dock widget in map:" << it.key() << "isVisible:" << it.value()->isVisible();
+#endif
         } else {
+#if defined(DEBUG_WINDOW_HANDLING)
             qDebug() << "TDetachedWindow: Found null dock widget in map for key:" << it.key();
+#endif
         }
     }
     
@@ -988,23 +994,29 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
         
         // Check if the dock widget still exists and is in our map
         if (!dockWidget || !mDockWidgetMap.contains(dockKey)) {
+#if defined(DEBUG_WINDOW_HANDLING)
             qDebug() << "TDetachedWindow: Skipping dock widget" << dockKey << "- widget exists:" << (dockWidget != nullptr) 
                      << "in map:" << mDockWidgetMap.contains(dockKey);
+#endif
             continue;
         }
         
         // Check if this docked widget belongs to the current profile
         if (dockKey.startsWith("map_")) {
             QString dockProfileName = dockKey.mid(4); // Remove "map_" prefix
+#if defined(DEBUG_WINDOW_HANDLING)
             qDebug() << "TDetachedWindow: Processing map dock" << dockKey << "profile:" << dockProfileName << "current:" << profileName;
+#endif
             
             if (dockProfileName == profileName) {
                 // This dock widget belongs to the current profile
                 // Check the user's preference for dock widget visibility
                 bool shouldBeVisible = mDockWidgetUserPreference.value(dockKey, false);
+#if defined(DEBUG_WINDOW_HANDLING)
                 qDebug() << "TDetachedWindow: Found dock widget for current profile" << profileName 
                          << "currently visible:" << dockWidget->isVisible() 
                          << "should be visible:" << shouldBeVisible;
+#endif
                 
                 // Show or hide based on intended visibility
                 if (shouldBeVisible) {
@@ -1015,13 +1027,17 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
                     mpMapDockWidget = dockWidget;
                     currentProfileHasVisibleDockWidget = true;
                     
+#if defined(DEBUG_WINDOW_HANDLING)
                     qDebug() << "TDetachedWindow: Dock widget should be visible - showing and setting as active";
+#endif
                 } else {
                     // Block signals to prevent user preference from being updated by system-initiated change
                     dockWidget->blockSignals(true);
                     dockWidget->setVisible(false);
                     dockWidget->blockSignals(false);
+#if defined(DEBUG_WINDOW_HANDLING)
                     qDebug() << "TDetachedWindow: Dock widget should be hidden - respecting user preference";
+#endif
                 }
                 
                 // Ensure the map's active mapper points to our detached instance (if visible)
@@ -1032,14 +1048,18 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
                             // Only set as active mapper if the dock widget should be visible
                             if (shouldBeVisible) {
                                 pMap->mpMapper = detachedMapper;
+#if defined(DEBUG_WINDOW_HANDLING)
                                 qDebug() << "TDetachedWindow: Set active mapper for profile" << profileName;
+#endif
                             }
                         }
                     }
                 }
             } else {
                 // This dock widget belongs to a different profile - hide it
+#if defined(DEBUG_WINDOW_HANDLING)
                 qDebug() << "TDetachedWindow: Hiding dock widget for different profile" << dockProfileName;
+#endif
                 // Block signals to prevent user preference from being updated by system-initiated change
                 dockWidget->blockSignals(true);
                 dockWidget->setVisible(false);
@@ -1052,7 +1072,9 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
                             auto mainMapWidget = pHost->mpDockableMapWidget->widget();
                             if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
                                 pMap->mpMapper = mainMapper;
+#if defined(DEBUG_WINDOW_HANDLING)
                                 qDebug() << "TDetachedWindow: Restored main mapper for profile" << dockProfileName;
+#endif
                             }
                         }
                     }
@@ -1063,10 +1085,12 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
     }
     
     // Debug output to help track dock widget visibility changes
+#if defined(DEBUG_WINDOW_HANDLING)
     qDebug() << "TDetachedWindow::updateDockWidgetVisibilityForProfile:" << profileName 
              << "- Found visible dock widget:" << currentProfileHasVisibleDockWidget
              << "- Total dock widgets:" << dockWidgetsToProcess.size()
              << "- mpMapDockWidget set:" << (mpMapDockWidget != nullptr);
+#endif
 }
 
 void TDetachedWindow::slot_toggleFullScreenView()
@@ -2172,7 +2196,9 @@ void TDetachedWindow::slot_showMapperDialog()
         // Track user-initiated visibility changes - always update user preference
         // to ensure dock widget state is properly tracked regardless of which profile is active
         mDockWidgetUserPreference[mapKey] = visible;
+#if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "TDetachedWindow: User changed dock widget visibility for" << mapKey << "to" << visible;
+#endif
         
         // Extract profile name from mapKey to safely look up objects
         QString profileName = mapKey;

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -72,6 +72,9 @@ TDetachedWindow::TDetachedWindow(const QString& profileName, TMainConsole* conso
     // Update toolbar state and window title for this profile
     updateToolBarActions();
     updateWindowTitle();
+
+    // Initialize the window menu
+    updateWindowMenu();
 }
 
 TDetachedWindow::~TDetachedWindow()
@@ -192,23 +195,23 @@ void TDetachedWindow::createMenus()
     connect(closeProfileAction, &QAction::triggered, mudlet::self(), &mudlet::slot_closeCurrentProfile);
     profileMenu->addAction(closeProfileAction);
 
-    auto windowMenu = menuBar()->addMenu(tr("&Window"));
+    mpWindowMenu = menuBar()->addMenu(tr("&Window"));
 
     auto reattachAction = new QAction(tr("&Reattach to Main Window"), this);
     reattachAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_R));
     reattachAction->setStatusTip(tr("Reattach this profile window to the main Mudlet window"));
     connect(reattachAction, &QAction::triggered, this, &TDetachedWindow::onReattachAction);
-    windowMenu->addAction(reattachAction);
+    mpWindowMenu->addAction(reattachAction);
 
-    windowMenu->addSeparator();
+    mpWindowMenu->addSeparator();
 
     auto closeAction = new QAction(tr("&Close"), this);
     closeAction->setShortcut(QKeySequence::Close);
     closeAction->setStatusTip(tr("Close this window and all profiles in it"));
     connect(closeAction, &QAction::triggered, this, &TDetachedWindow::slot_closeAllProfiles);
-    windowMenu->addAction(closeAction);
+    mpWindowMenu->addAction(closeAction);
 
-    windowMenu->addSeparator();
+    mpWindowMenu->addSeparator();
 
     // Always on top toggle
     auto alwaysOnTopAction = new QAction(tr("Always on &Top"), this);
@@ -216,13 +219,16 @@ void TDetachedWindow::createMenus()
     alwaysOnTopAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_T));
     alwaysOnTopAction->setStatusTip(tr("Keep this window always on top of other windows"));
     connect(alwaysOnTopAction, &QAction::triggered, this, &TDetachedWindow::slot_toggleAlwaysOnTop);
-    windowMenu->addAction(alwaysOnTopAction);
+    mpWindowMenu->addAction(alwaysOnTopAction);
+
+    // Connect the Window menu's aboutToShow signal to update the window list
+    connect(mpWindowMenu, &QMenu::aboutToShow, this, &TDetachedWindow::updateWindowMenu);
 
     // Minimize action
     auto minimizeAction = new QAction(tr("&Minimize"), this);
     minimizeAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_M));
     connect(minimizeAction, &QAction::triggered, this, &QWidget::showMinimized);
-    windowMenu->addAction(minimizeAction);
+    mpWindowMenu->addAction(minimizeAction);
 }
 
 void TDetachedWindow::closeEvent(QCloseEvent* event)
@@ -943,6 +949,189 @@ void TDetachedWindow::slot_exportProfile()
     mudlet::self()->slot_packageExporter();
 }
 
+void TDetachedWindow::updateWindowMenu()
+{
+    // Clean up existing window list actions
+    for (QAction* action : mWindowListActions) {
+        mpWindowMenu->removeAction(action);
+        action->deleteLater();
+    }
+    mWindowListActions.clear();
+
+    // Remove separator if it exists
+    if (mWindowListSeparator) {
+        mpWindowMenu->removeAction(mWindowListSeparator);
+        mWindowListSeparator->deleteLater();
+        mWindowListSeparator = nullptr;
+    }
+
+    // Get the detached windows from mudlet
+    const auto& detachedWindows = mudlet::self()->getDetachedWindows();
+    
+    // Count total windows (main + detached)
+    int totalWindows = 1; // Main window
+    totalWindows += detachedWindows.size();
+
+    // Only show window list if there are multiple windows OR if there are multiple profiles
+    bool hasMultipleProfiles = mudlet::self()->getHostManager().getHostCount() > 1;
+    if (totalWindows > 1 || hasMultipleProfiles) {
+        // Add separator before window list
+        mWindowListSeparator = mpWindowMenu->addSeparator();
+
+        // Add main window profiles
+        QStringList mainWindowProfiles;
+        for (const auto& host : mudlet::self()->getHostManager()) {
+            if (host && host->mpConsole) {
+                const QString profileName = host->getName();
+                // Only include profiles that are in the main window (not detached)
+                if (!detachedWindows.contains(profileName)) {
+                    mainWindowProfiles.append(profileName);
+                }
+            }
+        }
+
+        // Add main window profiles
+        if (!mainWindowProfiles.isEmpty()) {
+            for (const QString& profileName : mainWindowProfiles) {
+                QString actionText = tr("%1 (Main Window)").arg(profileName);
+                QAction* profileAction = new QAction(actionText, this);
+                profileAction->setCheckable(true);
+                profileAction->setChecked(mudlet::self()->isActiveWindow() && 
+                    mudlet::self()->getActiveHost() && 
+                    mudlet::self()->getActiveHost()->getName() == profileName);
+                profileAction->setData(profileName); // Store profile name for identification
+                connect(profileAction, &QAction::triggered, this, &TDetachedWindow::slot_activateMainWindowProfile);
+                mpWindowMenu->addAction(profileAction);
+                mWindowListActions.append(profileAction);
+            }
+        }
+
+        // Add detached window profiles
+        // Collect unique detached windows to avoid duplicates
+        QSet<TDetachedWindow*> uniqueDetachedWindows;
+        for (auto it = detachedWindows.begin(); it != detachedWindows.end(); ++it) {
+            TDetachedWindow* detachedWindow = it.value();
+            if (detachedWindow) {
+                uniqueDetachedWindows.insert(detachedWindow);
+            }
+        }
+        
+        // Process each unique detached window
+        for (TDetachedWindow* detachedWindow : uniqueDetachedWindows) {
+            // Get all profiles in this detached window
+            QStringList profilesInWindow = detachedWindow->getProfileNames();
+            for (const QString& windowProfileName : profilesInWindow) {
+                QString actionText = tr("%1 (Detached)").arg(windowProfileName);
+                QAction* profileAction = new QAction(actionText, this);
+                profileAction->setCheckable(true);
+                profileAction->setChecked(detachedWindow == this && detachedWindow->getCurrentProfileName() == windowProfileName);
+                profileAction->setData(windowProfileName); // Store profile name for identification
+                connect(profileAction, &QAction::triggered, this, &TDetachedWindow::slot_activateDetachedWindowProfile);
+                mpWindowMenu->addAction(profileAction);
+                mWindowListActions.append(profileAction);
+            }
+        }
+    }
+}
+
+void TDetachedWindow::slot_activateMainWindow()
+{
+    mudlet* mainWindow = mudlet::self();
+    if (mainWindow) {
+        mainWindow->raise();
+        mainWindow->activateWindow();
+        mainWindow->show(); // Ensure it's not minimized
+        updateWindowMenu(); // Refresh checkmarks
+    }
+}
+
+void TDetachedWindow::slot_activateDetachedWindow()
+{
+    QAction* action = qobject_cast<QAction*>(sender());
+    if (!action) {
+        return;
+    }
+
+    QString profileName = action->data().toString();
+    const auto& detachedWindows = mudlet::self()->getDetachedWindows();
+    
+    if (detachedWindows.contains(profileName)) {
+        TDetachedWindow* detachedWindow = detachedWindows[profileName];
+        if (detachedWindow) {
+            detachedWindow->raise();
+            detachedWindow->activateWindow();
+            detachedWindow->show(); // Ensure it's not minimized
+            updateWindowMenu(); // Refresh checkmarks
+        }
+    }
+}
+
+void TDetachedWindow::slot_activateMainWindowProfile()
+{
+    QAction* action = qobject_cast<QAction*>(sender());
+    if (!action) {
+        return;
+    }
+
+    QString profileName = action->data().toString();
+    
+    // Delegate to mudlet's main window profile activation
+    mudlet* mainWindow = mudlet::self();
+    if (mainWindow) {
+        // Find the tab index for this profile in the main window
+        int tabIndex = -1;
+        for (int i = 0; i < mainWindow->mpTabBar->count(); ++i) {
+            if (mainWindow->mpTabBar->tabData(i).toString() == profileName) {
+                tabIndex = i;
+                break;
+            }
+        }
+
+        if (tabIndex >= 0) {
+            // Activate the main window first
+            mainWindow->raise();
+            mainWindow->activateWindow();
+            mainWindow->show(); // Ensure it's not minimized
+            
+            // Switch to the specific tab
+            mainWindow->mpTabBar->setCurrentIndex(tabIndex);
+            
+            // Trigger the tab change logic to ensure the profile is properly activated
+            mainWindow->slot_tabChanged(tabIndex);
+            
+            updateWindowMenu(); // Refresh checkmarks
+        }
+    }
+}
+
+void TDetachedWindow::slot_activateDetachedWindowProfile()
+{
+    QAction* action = qobject_cast<QAction*>(sender());
+    if (!action) {
+        return;
+    }
+
+    QString profileName = action->data().toString();
+    
+    // Find which detached window contains this profile
+    const auto& detachedWindows = mudlet::self()->getDetachedWindows();
+    for (auto it = detachedWindows.begin(); it != detachedWindows.end(); ++it) {
+        TDetachedWindow* detachedWindow = it.value();
+        if (detachedWindow && detachedWindow->getProfileNames().contains(profileName)) {
+            // Activate the detached window
+            detachedWindow->raise();
+            detachedWindow->activateWindow();
+            detachedWindow->show(); // Ensure it's not minimized
+            
+            // Switch to the specific profile tab in the detached window
+            detachedWindow->switchToProfile(profileName);
+            
+            updateWindowMenu(); // Refresh checkmarks
+            break;
+        }
+    }
+}
+
 void TDetachedWindow::closeProfile()
 {
     if (mCurrentProfileName.isEmpty()) {
@@ -1637,6 +1826,9 @@ void TDetachedWindow::changeEvent(QEvent* event)
                 qDebug() << "TDetachedWindow::changeEvent: Window is no longer minimized";
             }
         }
+    } else if (event->type() == QEvent::ActivationChange) {
+        // Update window menu when window activation changes
+        updateWindowMenu();
     }
 
     QMainWindow::changeEvent(event);

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -308,7 +308,9 @@ void TDetachedWindow::closeEvent(QCloseEvent* event)
         
         // Properly close each profile - this ensures proper cleanup and save prompts
         for (const QString& profileName : profilesToClose) {
+#if defined(DEBUG_WINDOW_HANDLING)
             qDebug() << "TDetachedWindow::closeEvent() - Properly closing profile:" << profileName;
+#endif
             mudlet::self()->slot_closeProfileByName(profileName);
         }
         
@@ -398,7 +400,9 @@ void TDetachedWindow::hideEvent(QHideEvent* event)
     // Prevent the window from being hidden if it should stay visible (has profiles)
     // IMPORTANT: Only allow hiding if there are NO profiles remaining, regardless of mIsReattaching
     if (mShouldStayVisible && mpTabBar && mpTabBar->count() > 0) {
+#if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "TDetachedWindow::hideEvent: Preventing window hide - has" << mpTabBar->count() << "profiles";
+#endif
         // Force the window to stay visible - but only if not minimized
         QTimer::singleShot(0, this, [this]() {
             if (mpTabBar && mpTabBar->count() > 0 && !mIsBeingMinimized) {
@@ -1473,7 +1477,9 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
     if (mDockWidgetMap.contains(mapKey)) {
         QPointer<QDockWidget> mapDockWidget = mDockWidgetMap.value(mapKey);
         if (mapDockWidget) {
+#if defined(DEBUG_WINDOW_HANDLING)
             qDebug() << "TDetachedWindow::removeProfile: Cleaning up dock widget for profile" << profileName;
+#endif
             
             // If this is the currently active map dock, clear the global reference
             if (mpMapDockWidget == mapDockWidget) {
@@ -1490,7 +1496,9 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
                         auto mainMapWidget = pHost->mpDockableMapWidget->widget();
                         if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
                             pMap->mpMapper = mainMapper;
+#if defined(DEBUG_WINDOW_HANDLING)
                             qDebug() << "TDetachedWindow::removeProfile: Restored main mapper for profile" << profileName;
+#endif
                         }
                     }
                 }
@@ -1944,7 +1952,9 @@ void TDetachedWindow::logWindowState(const QString& context)
 {
     // Simplified debug output for critical state information only
     if (mShouldStayVisible && mpTabBar && mpTabBar->count() > 0 && !isVisible()) {
+#if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "TDetachedWindow [" << context << "] WARNING: Window should stay visible but is hidden - profiles:" << getProfileCount();
+#endif
     }
 }
 
@@ -2083,7 +2093,9 @@ void TDetachedWindow::slot_showMapperDialog()
     auto mainMapDock = mudletInstance->getMainWindowDockWidget(mapKey);
 
     if (mainMapDock && mainMapDock->isVisible()) {
+#if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "TDetachedWindow: Closing main window map for profile" << mCurrentProfileName << "to prevent conflicts";
+#endif
         // Block signals to prevent user preference from being updated by system-initiated change
         mainMapDock->blockSignals(true);
         mainMapDock->setVisible(false);
@@ -2100,7 +2112,9 @@ void TDetachedWindow::slot_showMapperDialog()
             auto otherMapDock = otherWindow->getDockWidget(mapKey);
 
             if (otherMapDock && otherMapDock->isVisible()) {
+#if defined(DEBUG_WINDOW_HANDLING)
                 qDebug() << "TDetachedWindow: Closing map in other detached window for profile" << mCurrentProfileName;
+#endif
                 // Block signals to prevent user preference from being updated by system-initiated change
                 otherMapDock->blockSignals(true);
                 otherMapDock->setVisible(false);

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -25,6 +25,9 @@
 #include "HostManager.h"
 #include "mudlet.h"
 #include "utils.h"
+#include "dlgMapper.h"
+#include "TRoomDB.h"
+#include "TMap.h"
 #include <QVBoxLayout>
 #include <QMenuBar>
 #include <QAction>
@@ -49,6 +52,7 @@
 #include <QSizePolicy>
 #include <QWidget>
 #include <QWindowStateChangeEvent>
+#include <QDockWidget>
 
 TDetachedWindow::TDetachedWindow(const QString& profileName, TMainConsole* console, QWidget* parent, bool toolbarVisible)
     : QMainWindow(parent)
@@ -100,6 +104,50 @@ TDetachedWindow::~TDetachedWindow()
         mudletInstance->updateMultiViewControls();
     }
 
+    // Clean up any docked widgets and restore main mappers
+    for (auto it = mDockWidgetMap.begin(); it != mDockWidgetMap.end(); ++it) {
+        if (it.value()) {
+            // If this is a map dock widget, restore the main mapper
+            if (it.key().startsWith("map_")) {
+                QString profileName = it.key().mid(4); // Remove "map_" prefix
+                if (auto mudletInstance = mudlet::self()) {
+                    if (auto pHost = mudletInstance->getHostManager().getHost(profileName)) {
+                        auto pMap = pHost->mpMap.data();
+                        if (pMap && pHost->mpDockableMapWidget) {
+                            // Find the main window's mapper
+                            auto mainMapWidget = pHost->mpDockableMapWidget->widget();
+                            if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
+                                pMap->mpMapper = mainMapper;
+                            }
+                        }
+                    }
+                }
+            }
+            it.value()->deleteLater();
+        }
+    }
+    mDockWidgetMap.clear();
+    
+    if (mpMapDockWidget) {
+        // Restore main mapper if this detached window had an active map
+        if (!mCurrentProfileName.isEmpty()) {
+            if (auto mudletInstance = mudlet::self()) {
+                if (auto pHost = mudletInstance->getHostManager().getHost(mCurrentProfileName)) {
+                    auto pMap = pHost->mpMap.data();
+                    if (pMap && pHost->mpDockableMapWidget) {
+                        // Find the main window's mapper
+                        auto mainMapWidget = pHost->mpDockableMapWidget->widget();
+                        if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
+                            pMap->mpMapper = mainMapper;
+                        }
+                    }
+                }
+            }
+        }
+        mpMapDockWidget->deleteLater();
+        mpMapDockWidget = nullptr;
+    }
+
     saveWindowGeometry();
 }
 
@@ -116,6 +164,7 @@ void TDetachedWindow::setupUI()
     mpTabBar = new TTabBar(centralWidget);
     mpTabBar->setMaximumHeight(30);
     mpTabBar->setTabsClosable(true);
+    mpTabBar->setMovable(true);
 
     // Add initial tab for the first profile
     if (!mCurrentProfileName.isEmpty()) {
@@ -158,6 +207,7 @@ void TDetachedWindow::setupUI()
     connect(mpTabBar, &TTabBar::tabDetachRequested, this, &TDetachedWindow::onReattachAction);
     connect(mpTabBar, &QTabBar::tabCloseRequested, this, &TDetachedWindow::closeProfileByIndex);
     connect(mpTabBar, &QTabBar::currentChanged, this, &TDetachedWindow::slot_tabChanged);
+    connect(mpTabBar, &QTabBar::tabMoved, this, &TDetachedWindow::slot_tabMoved);
 
     // Connect double-click to reattach
     connect(mpTabBar, &QTabBar::tabBarDoubleClicked, this, &TDetachedWindow::onReattachAction);
@@ -934,6 +984,110 @@ void TDetachedWindow::updateTabIndicator(int tabIndex)
     mpTabBar->setTabIcon(tabIndex, tabIcon);
 }
 
+void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profileName)
+{
+    // Clear the global map dock widget reference first
+    mpMapDockWidget = nullptr;
+    
+    qDebug() << "TDetachedWindow::updateDockWidgetVisibilityForProfile: Starting for profile" << profileName
+             << "- mDockWidgetMap.size():" << mDockWidgetMap.size();
+    
+    // Collect dock widgets to process to avoid iterator invalidation
+    QList<QPair<QString, QPointer<QDockWidget>>> dockWidgetsToProcess;
+    for (auto it = mDockWidgetMap.begin(); it != mDockWidgetMap.end(); ++it) {
+        if (it.value()) {
+            dockWidgetsToProcess.append(qMakePair(it.key(), it.value()));
+            qDebug() << "TDetachedWindow: Found dock widget in map:" << it.key() << "isVisible:" << it.value()->isVisible();
+        } else {
+            qDebug() << "TDetachedWindow: Found null dock widget in map for key:" << it.key();
+        }
+    }
+    
+    // Track if we found and showed a dock widget for the current profile
+    bool currentProfileHasVisibleDockWidget = false;
+    
+    // Process dock widgets without iterating over the map directly
+    for (const auto& dockPair : dockWidgetsToProcess) {
+        const QString& dockKey = dockPair.first;
+        QPointer<QDockWidget> dockWidget = dockPair.second;
+        
+        // Check if the dock widget still exists and is in our map
+        if (!dockWidget || !mDockWidgetMap.contains(dockKey)) {
+            qDebug() << "TDetachedWindow: Skipping dock widget" << dockKey << "- widget exists:" << (dockWidget != nullptr) 
+                     << "in map:" << mDockWidgetMap.contains(dockKey);
+            continue;
+        }
+        
+        // Check if this docked widget belongs to the current profile
+        if (dockKey.startsWith("map_")) {
+            QString dockProfileName = dockKey.mid(4); // Remove "map_" prefix
+            qDebug() << "TDetachedWindow: Processing map dock" << dockKey << "profile:" << dockProfileName << "current:" << profileName;
+            
+            if (dockProfileName == profileName) {
+                // This dock widget belongs to the current profile
+                // Check the intended visibility state, not the current visibility
+                bool shouldBeVisible = mDockWidgetIntendedVisibility.value(dockKey, false);
+                qDebug() << "TDetachedWindow: Found dock widget for current profile" << profileName 
+                         << "currently visible:" << dockWidget->isVisible() 
+                         << "should be visible:" << shouldBeVisible;
+                
+                // Show or hide based on intended visibility
+                if (shouldBeVisible) {
+                    dockWidget->show();
+                    dockWidget->raise();
+                    
+                    // Set this as the global map dock widget reference
+                    mpMapDockWidget = dockWidget;
+                    currentProfileHasVisibleDockWidget = true;
+                    
+                    qDebug() << "TDetachedWindow: Dock widget should be visible - showing and setting as active";
+                } else {
+                    dockWidget->setVisible(false);
+                    qDebug() << "TDetachedWindow: Dock widget should be hidden - respecting user preference";
+                }
+                
+                // Ensure the map's active mapper points to our detached instance (if visible)
+                if (auto pHost = mudlet::self()->getHostManager().getHost(profileName)) {
+                    if (auto pMap = pHost->mpMap.data()) {
+                        auto mapWidget = dockWidget->widget();
+                        if (auto detachedMapper = qobject_cast<dlgMapper*>(mapWidget)) {
+                            // Only set as active mapper if the dock widget should be visible
+                            if (shouldBeVisible) {
+                                pMap->mpMapper = detachedMapper;
+                                qDebug() << "TDetachedWindow: Set active mapper for profile" << profileName;
+                            }
+                        }
+                    }
+                }
+            } else {
+                // This dock widget belongs to a different profile - hide it
+                qDebug() << "TDetachedWindow: Hiding dock widget for different profile" << dockProfileName;
+                dockWidget->setVisible(false);
+                
+                // Restore main mapper for the other profile
+                if (auto pHost = mudlet::self()->getHostManager().getHost(dockProfileName)) {
+                    if (auto pMap = pHost->mpMap.data()) {
+                        if (pHost->mpDockableMapWidget) {
+                            auto mainMapWidget = pHost->mpDockableMapWidget->widget();
+                            if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
+                                pMap->mpMapper = mainMapper;
+                                qDebug() << "TDetachedWindow: Restored main mapper for profile" << dockProfileName;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // Add other dock widget types here as they are implemented
+    }
+    
+    // Debug output to help track dock widget visibility changes
+    qDebug() << "TDetachedWindow::updateDockWidgetVisibilityForProfile:" << profileName 
+             << "- Found visible dock widget:" << currentProfileHasVisibleDockWidget
+             << "- Total dock widgets:" << dockWidgetsToProcess.size()
+             << "- mpMapDockWidget set:" << (mpMapDockWidget != nullptr);
+}
+
 void TDetachedWindow::slot_toggleFullScreenView()
 {
     if (isFullScreen()) {
@@ -1277,6 +1431,43 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
         return false;
     }
 
+    // Clean up any dock widgets for this profile before removing it
+    QString mapKey = qsl("map_%1").arg(profileName);
+    if (mDockWidgetMap.contains(mapKey)) {
+        QPointer<QDockWidget> mapDockWidget = mDockWidgetMap.value(mapKey);
+        if (mapDockWidget) {
+            qDebug() << "TDetachedWindow::removeProfile: Cleaning up dock widget for profile" << profileName;
+            
+            // If this is the currently active map dock, clear the global reference
+            if (mpMapDockWidget == mapDockWidget) {
+                mpMapDockWidget = nullptr;
+            }
+            
+            // Remove the dock widget from Qt's dock widget management
+            QMainWindow::removeDockWidget(mapDockWidget);
+            
+            // Restore the main window's mapper before deleting our dock widget
+            if (auto pHost = mudlet::self()->getHostManager().getHost(profileName)) {
+                if (auto pMap = pHost->mpMap.data()) {
+                    if (pHost->mpDockableMapWidget) {
+                        auto mainMapWidget = pHost->mpDockableMapWidget->widget();
+                        if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
+                            pMap->mpMapper = mainMapper;
+                            qDebug() << "TDetachedWindow::removeProfile: Restored main mapper for profile" << profileName;
+                        }
+                    }
+                }
+            }
+            
+            // Clean up the dock widget
+            mapDockWidget->deleteLater();
+        }
+        
+        // Remove from our tracking maps
+        mDockWidgetMap.remove(mapKey);
+        mDockWidgetIntendedVisibility.remove(mapKey);
+    }
+
     // Find the tab index
     int tabIndex = -1;
     for (int i = 0; i < mpTabBar->count(); ++i) {
@@ -1486,6 +1677,9 @@ void TDetachedWindow::switchToProfile(const QString& profileName)
     updateToolBarActions();
     updateWindowTitle();
     updateTabIndicator();
+    
+    // Update docked window visibility based on the new active profile
+    updateDockWidgetVisibilityForProfile(profileName);
 
     // Force window repainting and layout update
     updateGeometry();
@@ -1513,6 +1707,62 @@ void TDetachedWindow::slot_tabChanged(int index)
     QString profileName = mpTabBar->tabData(index).toString();
     if (!profileName.isEmpty() && profileName != mCurrentProfileName) {
         switchToProfile(profileName);
+    }
+}
+
+void TDetachedWindow::slot_tabMoved(int oldPos, int newPos)
+{
+    // Get the current order of profile names from the tab bar
+    const QStringList& profileNamesInOrder = mpTabBar->tabNames();
+    const int itemsCount = mpConsoleContainer->count();
+    
+    // Validate that tab count matches console count
+    if (itemsCount != profileNamesInOrder.count()) {
+        qWarning().nospace().noquote() << "TDetachedWindow::slot_tabMoved(" << oldPos << ", " << newPos 
+                                       << ") WARNING - mismatch in count of tabs (" << profileNamesInOrder.count() 
+                                       << ") and TMainConsoles (" << itemsCount << ")";
+        return;
+    }
+
+    // Create a map of profile names to console widgets
+    QMap<QString, TMainConsole*> consoleWidgetMap;
+    for (auto it = mProfileConsoleMap.begin(); it != mProfileConsoleMap.end(); ++it) {
+        if (it.value()) {
+            consoleWidgetMap.insert(it.key(), it.value());
+        } else {
+            qWarning().nospace().noquote() << "TDetachedWindow::slot_tabMoved(" << oldPos << ", " << newPos 
+                                           << ") WARNING - nullptr for TMainConsole for profile: " << it.key();
+        }
+    }
+
+    // Remember the currently active widget before reordering
+    TMainConsole* currentActiveConsole = qobject_cast<TMainConsole*>(mpConsoleContainer->currentWidget());
+
+    // Reorder the console widgets in the stacked widget to match the new tab order
+    // Remove all widgets from the stacked widget and re-add them in the new order
+    QList<TMainConsole*> widgetsToReAdd;
+    for (const QString& profileName : profileNamesInOrder) {
+        TMainConsole* console = consoleWidgetMap.value(profileName);
+        if (console) {
+            mpConsoleContainer->removeWidget(console);
+            widgetsToReAdd.append(console);
+        }
+    }
+
+    // Re-add the widgets in the new order
+    for (TMainConsole* console : widgetsToReAdd) {
+        mpConsoleContainer->addWidget(console);
+    }
+
+    // Restore the currently active widget
+    if (currentActiveConsole && mpConsoleContainer->indexOf(currentActiveConsole) >= 0) {
+        mpConsoleContainer->setCurrentWidget(currentActiveConsole);
+    } else if (!mCurrentProfileName.isEmpty()) {
+        // Fallback: use the current profile name to find the correct console
+        TMainConsole* currentConsole = mProfileConsoleMap.value(mCurrentProfileName);
+        if (currentConsole) {
+            mpConsoleContainer->setCurrentWidget(currentConsole);
+        }
     }
 }
 
@@ -1775,9 +2025,164 @@ void TDetachedWindow::slot_showVariableDialog()
 
 void TDetachedWindow::slot_showMapperDialog()
 {
-    withCurrentProfileActive([this]() {
-        mudlet::self()->slot_mapper();
+    if (mCurrentProfileName.isEmpty()) {
+        return;
+    }
+
+    Host* pHost = mudlet::self()->getHostManager().getHost(mCurrentProfileName);
+    if (!pHost) {
+        return;
+    }
+
+    auto pMap = pHost->mpMap.data();
+    if (!pMap) {
+        return;
+    }
+
+    // Check if we already have a mapper dock widget for this profile
+    QString mapKey = qsl("map_%1").arg(mCurrentProfileName);
+    QPointer<QDockWidget> existingMapDock = mDockWidgetMap.value(mapKey);
+    
+    if (existingMapDock) {
+        // Toggle visibility of existing mapper and update global reference
+        bool newVisibility = !existingMapDock->isVisible();
+        existingMapDock->setVisible(newVisibility);
+        
+        // Update mpMapDockWidget to point to the current profile's map if it's being shown
+        if (newVisibility) {
+            mpMapDockWidget = existingMapDock;
+            
+            // Ensure the map's active mapper points to our detached instance
+            auto mapWidget = existingMapDock->widget();
+            if (auto detachedMapper = qobject_cast<dlgMapper*>(mapWidget)) {
+                pMap->mpMapper = detachedMapper;
+            }
+        } else if (mpMapDockWidget == existingMapDock) {
+            // If we're hiding the current map, clear the global reference and restore main mapper
+            mpMapDockWidget = nullptr;
+            
+            // Restore the main window's mapper as the active one
+            if (pHost->mpDockableMapWidget) {
+                auto mainMapWidget = pHost->mpDockableMapWidget->widget();
+                if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
+                    pMap->mpMapper = mainMapper;
+                }
+            }
+        }
+        return;
+    }
+
+    // Create a new docked mapper widget for this profile
+    auto newMapDockWidget = new QDockWidget(tr("Map - %1").arg(mCurrentProfileName), this);
+    newMapDockWidget->setObjectName(qsl("dockMap_%1_detached").arg(mCurrentProfileName));
+    
+    // Store the main window's mapper temporarily so we can restore it later
+    QPointer<dlgMapper> mainMapper = pMap->mpMapper;
+    QPointer<QDockWidget> mainDockWidget = pHost->mpDockableMapWidget;
+    
+    // Create a new mapper instance for the detached window
+    // We need to copy player room style details first
+    pHost->getPlayerRoomStyleDetails(pMap->mPlayerRoomStyle,
+                                   pMap->mPlayerRoomOuterDiameterPercentage,
+                                   pMap->mPlayerRoomInnerDiameterPercentage,
+                                   pMap->mPlayerRoomOuterColor,
+                                   pMap->mPlayerRoomInnerColor);
+
+    // Create the mapper dialog
+    auto detachedMapper = new dlgMapper(newMapDockWidget, pHost, pMap);
+    detachedMapper->setStyleSheet(pHost->mProfileStyleSheet);
+    newMapDockWidget->setWidget(detachedMapper);
+
+    // CRITICAL: Set the map's active mapper to our detached instance
+    // This ensures map updates go to our detached window instead of the main window
+    pMap->mpMapper = detachedMapper;
+
+    // Initialize the mapper
+    if (pMap->mpRoomDB && !pMap->mpRoomDB->isEmpty()) {
+        detachedMapper->mp2dMap->init();
+        detachedMapper->updateAreaComboBox();
+        detachedMapper->resetAreaComboBoxToPlayerRoomArea();
+        detachedMapper->show();
+    }
+
+    // Add the dock widget to this detached window
+    QMainWindow::addDockWidget(Qt::RightDockWidgetArea, newMapDockWidget);
+    
+    // Store reference in our map for cleanup and profile-specific access
+    mDockWidgetMap[mapKey] = newMapDockWidget;
+    
+    // Set intended visibility to true since we're initially showing this dock widget
+    mDockWidgetIntendedVisibility[mapKey] = true;
+    
+    // Set global reference to the currently active map
+    mpMapDockWidget = newMapDockWidget;
+
+    // Connect to handle dock widget visibility changes
+    connect(newMapDockWidget, &QDockWidget::visibilityChanged, this, [this, mapKey](bool visible) {
+        auto mapDockWidget = mDockWidgetMap.value(mapKey);
+        if (!mapDockWidget) {
+            return;
+        }
+        
+        // Track user-initiated visibility changes (not system-initiated profile switches)
+        // Only update intended visibility if this is likely a user action
+        if (!mCurrentProfileName.isEmpty() && mCurrentProfileName == mapKey.mid(4)) {
+            // Current profile's dock widget visibility changed - likely user action
+            mDockWidgetIntendedVisibility[mapKey] = visible;
+            qDebug() << "TDetachedWindow: User changed dock widget visibility for" << mapKey << "to" << visible;
+        }
+        
+        // Extract profile name from mapKey to safely look up objects
+        QString profileName = mapKey;
+        if (profileName.startsWith("map_")) {
+            profileName = profileName.mid(4); // Remove "map_" prefix
+        }
+        
+        // Safely get the host and map - they might be null during shutdown
+        auto mudletInstance = mudlet::self();
+        if (!mudletInstance) {
+            return;
+        }
+        
+        Host* pHost = mudletInstance->getHostManager().getHost(profileName);
+        if (!pHost) {
+            return;
+        }
+        
+        auto pMap = pHost->mpMap.data();
+        if (!pMap) {
+            return;
+        }
+        
+        if (!visible) {
+            // If this is the currently active map dock, clear the global reference
+            if (mpMapDockWidget == mapDockWidget) {
+                mpMapDockWidget = nullptr;
+            }
+            
+            // Restore the main window's mapper as the active one when hiding
+            if (pHost->mpDockableMapWidget) {
+                auto mainMapWidget = pHost->mpDockableMapWidget->widget();
+                if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
+                    pMap->mpMapper = mainMapper;
+                }
+            }
+        } else {
+            // When showing, set this as the active mapper
+            mpMapDockWidget = mapDockWidget;
+            
+            // Ensure the map's active mapper points to our detached instance
+            auto mapWidget = mapDockWidget->widget();
+            if (auto detachedMapper = qobject_cast<dlgMapper*>(mapWidget)) {
+                pMap->mpMapper = detachedMapper;
+            }
+        }
+        
+        qDebug() << "TDetachedWindow: Map dock visibility changed for" << mapKey << "visible:" << visible;
     });
+
+    // Show the dock widget
+    newMapDockWidget->show();
 }
 
 void TDetachedWindow::slot_showHelpDialog()

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -545,7 +545,7 @@ void TDetachedWindow::createToolBar()
     mpToolBar->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
 
     // Reattach action - placed first in the toolbar for prominence
-    mpActionReattach = new QAction(QIcon(qsl(":/icons/view-restore.png")), tr("Reattach"), this);
+    mpActionReattach = new QAction(QIcon(qsl(":/icons/mudlet_main_48px.png")), tr("Reattach"), this);
     mpActionReattach->setToolTip(utils::richText(tr("Reattach this profile window to the main Mudlet window")));
     mpActionReattach->setObjectName(qsl("reattach_action"));
     mpToolBar->addAction(mpActionReattach);

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -47,7 +47,6 @@
 #include <QAbstractSocket>
 #include <QLabel>
 #include <QSet>
-#include <QStatusBar>
 #include <QStackedWidget>
 #include <QSizePolicy>
 #include <QWidget>
@@ -64,7 +63,6 @@ TDetachedWindow::TDetachedWindow(const QString& profileName, TMainConsole* conso
     setupUI();
     createToolBar();
     createMenus();
-    createStatusBar();
     restoreWindowGeometry();
 
     // Set initial toolbar visibility based on main window state
@@ -769,26 +767,6 @@ void TDetachedWindow::connectToolBarActions()
     connect(mpActionFullScreenView, &QAction::triggered, this, &TDetachedWindow::slot_toggleFullScreenView);
 }
 
-void TDetachedWindow::createStatusBar()
-{
-    // Create status bar with connection and profile information
-    auto statusBar = this->statusBar();
-    statusBar->showMessage(tr("Ready"));
-
-    // Profile information (left side)
-    mpStatusBarProfileLabel = new QLabel(tr("Profile: %1").arg(mCurrentProfileName.isEmpty() ? tr("None") : mCurrentProfileName));
-    mpStatusBarProfileLabel->setStyleSheet(qsl("QLabel { padding: 2px 8px; }"));
-    statusBar->addWidget(mpStatusBarProfileLabel);
-
-    // Add stretcher to push connection info to the right
-    statusBar->addWidget(new QWidget(), 1);
-
-    // Connection information (right side)
-    mpStatusBarConnectionLabel = new QLabel(tr("Disconnected"));
-    mpStatusBarConnectionLabel->setStyleSheet(qsl("QLabel { padding: 2px 8px; }"));
-    statusBar->addPermanentWidget(mpStatusBarConnectionLabel);
-}
-
 void TDetachedWindow::updateToolBarActions()
 {
     Host* pHost = nullptr;
@@ -818,9 +796,6 @@ void TDetachedWindow::updateToolBarActions()
         bool isConnected = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectedState);
         bool isConnecting = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectingState);
 
-        // Update status bar
-        updateStatusBar(pHost, isConnected, isConnecting);
-
         // Enable/disable individual actions based on connection state
         // All actions should always be enabled to match main window behavior
         mpActionConnect->setEnabled(true);
@@ -829,9 +804,6 @@ void TDetachedWindow::updateToolBarActions()
         mpActionCloseProfile->setEnabled(true);
         mpActionCloseApplication->setEnabled(true);
     } else {
-        // Update status bar
-        updateStatusBar(nullptr, false, false);
-
         // Even when no profile is active, keep all actions enabled to match main window
         mpActionConnect->setEnabled(true);
         mpActionDisconnect->setEnabled(true);
@@ -902,39 +874,6 @@ void TDetachedWindow::updateWindowTitle()
     }
 
     setWindowTitle(title);
-}
-
-void TDetachedWindow::updateStatusBar(Host* pHost, bool isConnected, bool isConnecting)
-{
-    if (!mpStatusBarConnectionLabel || !mpStatusBarProfileLabel) {
-        return;
-    }
-
-    // Update profile label
-    if (mProfileConsoleMap.size() == 1) {
-        mpStatusBarProfileLabel->setText(tr("Profile: %1").arg(mCurrentProfileName));
-    } else {
-        mpStatusBarProfileLabel->setText(tr("Profiles: %1 | Active: %2")
-                                       .arg(mProfileConsoleMap.size())
-                                       .arg(mCurrentProfileName.isEmpty() ? tr("None") : mCurrentProfileName));
-    }
-
-    // Update connection label
-    if (pHost) {
-        if (isConnected) {
-            mpStatusBarConnectionLabel->setText(tr("Connected to %1").arg(pHost->getUrl()));
-            mpStatusBarConnectionLabel->setStyleSheet(qsl("QLabel { color: green; padding: 2px 8px; }"));
-        } else if (isConnecting) {
-            mpStatusBarConnectionLabel->setText(tr("Connecting to %1...").arg(pHost->getUrl()));
-            mpStatusBarConnectionLabel->setStyleSheet(qsl("QLabel { color: orange; padding: 2px 8px; }"));
-        } else {
-            mpStatusBarConnectionLabel->setText(tr("Disconnected from %1").arg(pHost->getUrl()));
-            mpStatusBarConnectionLabel->setStyleSheet(qsl("QLabel { color: red; padding: 2px 8px; }"));
-        }
-    } else {
-        mpStatusBarConnectionLabel->setText(tr("No Profile"));
-        mpStatusBarConnectionLabel->setStyleSheet(qsl("QLabel { color: gray; padding: 2px 8px; }"));
-    }
 }
 
 void TDetachedWindow::updateTabIndicator(int tabIndex)
@@ -1144,7 +1083,6 @@ void TDetachedWindow::slot_saveProfile()
     Host* pHost = mudlet::self()->getHostManager().getHost(mCurrentProfileName);
     if (pHost) {
         pHost->saveProfile();
-        statusBar()->showMessage(tr("Profile '%1' saved").arg(mCurrentProfileName), 2000);
     }
 }
 
@@ -1538,9 +1476,8 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
             }
         } else {
             mCurrentProfileName.clear();
-            // Update window title and status bar when no profiles remain
+            // Update window title when no profiles remain
             updateWindowTitle();
-            updateStatusBar(nullptr, false, false);
             // Allow window to be hidden since no profiles remain
             mShouldStayVisible = false;
         }

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -478,6 +478,14 @@ void TDetachedWindow::showTabContextMenu(const QPoint& position)
     toolbarToggleAction->setChecked(mpToolBar && mpToolBar->isVisible());
     connect(toolbarToggleAction, &QAction::triggered, this, &TDetachedWindow::slot_toggleToolBarVisibility);
 
+    // Add connection indicator toggle
+    auto connectionIndicatorToggleAction = contextMenu.addAction(tr("Show Connection Indicators on Tabs"));
+    connectionIndicatorToggleAction->setCheckable(true);
+    connectionIndicatorToggleAction->setChecked(mudlet::self()->showTabConnectionIndicators());
+    connect(connectionIndicatorToggleAction, &QAction::triggered, this, [this](bool checked) {
+        mudlet::self()->setShowTabConnectionIndicators(checked);
+    });
+
     contextMenu.exec(mpTabBar->mapToGlobal(position));
 }
 
@@ -900,12 +908,18 @@ void TDetachedWindow::updateTabIndicator(int tabIndex)
     Host* pHost = mudlet::self()->getHostManager().getHost(profileName);
     QIcon tabIcon;
 
-    if (pHost) {
-        bool isConnected = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectedState);
-        bool isConnecting = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectingState);
-        tabIcon = mudlet::createConnectionStatusIcon(isConnected, isConnecting, false);
+    // Only show connection indicators if the global setting is enabled
+    if (mudlet::self()->showTabConnectionIndicators()) {
+        if (pHost) {
+            bool isConnected = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectedState);
+            bool isConnecting = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectingState);
+            tabIcon = mudlet::createConnectionStatusIcon(isConnected, isConnecting, false);
+        } else {
+            tabIcon = mudlet::createConnectionStatusIcon(false, false, true);
+        }
     } else {
-        tabIcon = mudlet::createConnectionStatusIcon(false, false, true);
+        // No icon when indicators are disabled
+        tabIcon = QIcon();
     }
 
     // Set the tab text and icon, accounting for CDC identifiers
@@ -921,6 +935,18 @@ void TDetachedWindow::updateTabIndicator(int tabIndex)
     
     mpTabBar->setTabText(tabIndex, displayText);
     mpTabBar->setTabIcon(tabIndex, tabIcon);
+}
+
+void TDetachedWindow::updateAllTabIndicators()
+{
+    if (!mpTabBar) {
+        return;
+    }
+
+    // Update all tabs in this detached window
+    for (int i = 0; i < mpTabBar->count(); ++i) {
+        updateTabIndicator(i);
+    }
 }
 
 void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profileName)

--- a/src/TDetachedWindow.h
+++ b/src/TDetachedWindow.h
@@ -81,6 +81,7 @@ private slots:
     void slot_toggleAlwaysOnTop();
     void slot_saveProfile();
     void slot_exportProfile();
+    void slot_closeAllProfiles(); // Close all profiles properly before closing window
 
     // Detached window specific toolbar action slots
     void slot_connectProfile();

--- a/src/TDetachedWindow.h
+++ b/src/TDetachedWindow.h
@@ -40,7 +40,7 @@ class TDetachedWindow : public QMainWindow
     Q_OBJECT
 
 public:
-    explicit TDetachedWindow(const QString& profileName, TMainConsole* console, QWidget* parent = nullptr);
+    explicit TDetachedWindow(const QString& profileName, TMainConsole* console, QWidget* parent = nullptr, bool toolbarVisible = true);
     ~TDetachedWindow();
 
     // Multiple profile support
@@ -81,6 +81,7 @@ private slots:
     void slot_tabChanged(int index);
     void slot_toggleFullScreenView();
     void slot_toggleAlwaysOnTop();
+    void slot_toggleToolBarVisibility();
     void slot_saveProfile();
     void slot_exportProfile();
     void slot_closeAllProfiles(); // Close all profiles properly before closing window
@@ -168,8 +169,10 @@ private:
     QAction* mpActionMuteAPI{nullptr};
     QAction* mpActionMuteGame{nullptr};
     QAction* mpActionFullScreenView{nullptr};
+    QAction* mpActionToggleToolBar{nullptr};
     QAction* mpActionAbout{nullptr};
     QAction* mpActionReconnectStandalone{nullptr};
+    QAction* mpActionReattach{nullptr};
 
     // Toolbar buttons
     QToolButton* mpButtonConnect{nullptr};

--- a/src/TDetachedWindow.h
+++ b/src/TDetachedWindow.h
@@ -54,6 +54,7 @@ public:
 
     void updateToolbarForProfile(Host* pHost);
     void setReattaching(bool reattaching) { mIsReattaching = reattaching; }
+    void refreshTabBar();  // Update tab text to account for CDC identifiers
 
 protected:
     void closeEvent(QCloseEvent* event) override;
@@ -86,6 +87,7 @@ private slots:
     void slot_disconnectProfile();
     void slot_reconnectProfile();
     void slot_closeCurrentProfile();
+    void slot_closeApplication();
     void slot_showTriggerDialog();
     void slot_showAliasDialog();
     void slot_showTimerDialog();
@@ -104,6 +106,7 @@ private slots:
     void slot_muteMedia();
     void slot_muteAPI();
     void slot_muteGame();
+    void slot_showAboutDialog();
 
 private:
     void setupUI();
@@ -136,8 +139,8 @@ private:
     // Toolbar actions - mirroring main window
     QAction* mpActionConnect{nullptr};
     QAction* mpActionDisconnect{nullptr};
-    QAction* mpActionReconnect{nullptr};
     QAction* mpActionCloseProfile{nullptr};
+    QAction* mpActionCloseApplication{nullptr};
     QAction* mpActionTriggers{nullptr};
     QAction* mpActionAliases{nullptr};
     QAction* mpActionTimers{nullptr};
@@ -157,6 +160,8 @@ private:
     QAction* mpActionMuteAPI{nullptr};
     QAction* mpActionMuteGame{nullptr};
     QAction* mpActionFullScreenView{nullptr};
+    QAction* mpActionAbout{nullptr};
+    QAction* mpActionReconnectStandalone{nullptr};
 
     // Toolbar buttons
     QToolButton* mpButtonConnect{nullptr};

--- a/src/TDetachedWindow.h
+++ b/src/TDetachedWindow.h
@@ -29,6 +29,7 @@
 #include <QLabel>
 #include <QMap>
 #include <QStackedWidget>
+#include <QDockWidget>
 #include <functional>
 
 class TMainConsole;
@@ -58,6 +59,22 @@ public:
     void updateWindowMenu();  // Update the window menu with current window list
     void switchToProfile(const QString& profileName);  // Switch to a specific profile tab
 
+    // Dock widget management methods
+    QDockWidget* getDockWidget(const QString& mapKey) const { return mDockWidgetMap.value(mapKey); }
+    void addDockWidget(const QString& mapKey, QDockWidget* dockWidget) { mDockWidgetMap[mapKey] = dockWidget; }
+    void removeDockWidget(const QString& mapKey) { 
+        mDockWidgetMap.remove(mapKey); 
+        mDockWidgetIntendedVisibility.remove(mapKey);
+    }
+    
+    // Intended visibility management
+    void setDockWidgetIntendedVisibility(const QString& mapKey, bool visible) { mDockWidgetIntendedVisibility[mapKey] = visible; }
+    bool getDockWidgetIntendedVisibility(const QString& mapKey) const { return mDockWidgetIntendedVisibility.value(mapKey, false); }
+    
+    // Map dock widget access methods
+    QDockWidget* getMapDockWidget() const { return mpMapDockWidget; }
+    void setMapDockWidget(QDockWidget* dockWidget) { mpMapDockWidget = dockWidget; }
+
 protected:
     void closeEvent(QCloseEvent* event) override;
     void dragEnterEvent(QDragEnterEvent* event) override;
@@ -79,6 +96,7 @@ private slots:
     void closeProfile();
     void closeProfileByIndex(int index);
     void slot_tabChanged(int index);
+    void slot_tabMoved(int oldPos, int newPos);
     void slot_toggleFullScreenView();
     void slot_toggleAlwaysOnTop();
     void slot_toggleToolBarVisibility();
@@ -128,6 +146,7 @@ private:
     void updateWindowTitle();
     void updateStatusBar(Host* pHost, bool isConnected, bool isConnecting);
     void updateTabIndicator(int tabIndex = -1);  // -1 means current tab
+    void updateDockWidgetVisibilityForProfile(const QString& profileName);  // Show/hide docked widgets based on active profile
     void saveWindowGeometry();
     void restoreWindowGeometry();
     void checkForWindowMergeOpportunity();  // Check if this window overlaps with another detached window
@@ -206,6 +225,11 @@ private:
     QList<QAction*> mWindowListActions;
     QAction* mWindowListSeparator{nullptr};
     QMenu* mpWindowMenu{nullptr};
+
+    // Docked widgets management
+    QMap<QString, QPointer<QDockWidget>> mDockWidgetMap;
+    QMap<QString, bool> mDockWidgetIntendedVisibility; // Track intended visibility for each dock widget
+    QDockWidget* mpMapDockWidget{nullptr};
 };
 
 #endif // TDETACHEDWINDOW_H

--- a/src/TDetachedWindow.h
+++ b/src/TDetachedWindow.h
@@ -140,11 +140,9 @@ private:
     void setupUI();
     void createMenus();
     void createToolBar();
-    void createStatusBar();
     void connectToolBarActions();
     void updateToolBarActions();
     void updateWindowTitle();
-    void updateStatusBar(Host* pHost, bool isConnected, bool isConnecting);
     void updateTabIndicator(int tabIndex = -1);  // -1 means current tab
     void updateDockWidgetVisibilityForProfile(const QString& profileName);  // Show/hide docked widgets based on active profile
     void saveWindowGeometry();
@@ -197,10 +195,6 @@ private:
     QToolButton* mpButtonConnect{nullptr};
     QToolButton* mpButtonMute{nullptr};
     QToolButton* mpButtonPackageManagers{nullptr};
-
-    // Status bar
-    QLabel* mpStatusBarConnectionLabel{nullptr};
-    QLabel* mpStatusBarProfileLabel{nullptr};
 
     // Store window state
     QPoint mLastPosition;

--- a/src/TDetachedWindow.h
+++ b/src/TDetachedWindow.h
@@ -3,10 +3,7 @@
 
 /***************************************************************************
  *   Copyright (C) 2025 by Mike Conley - mike.conley@stickmud.com          *
- *                    // Docked widgets management
-    QMap<QString, QPointer<QDockWidget>> mDockWidgetMap;
-    QMap<QString, bool> mDockWidgetUserPreference;  // User's show/hide preference for dock widgets
-    QDockWidget* mpMapDockWidget{nullptr};                                                     *
+ *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
  *   the Free Software Foundation; either version 2 of the License, or     *

--- a/src/TDetachedWindow.h
+++ b/src/TDetachedWindow.h
@@ -55,6 +55,8 @@ public:
     void updateToolbarForProfile(Host* pHost);
     void setReattaching(bool reattaching) { mIsReattaching = reattaching; }
     void refreshTabBar();  // Update tab text to account for CDC identifiers
+    void updateWindowMenu();  // Update the window menu with current window list
+    void switchToProfile(const QString& profileName);  // Switch to a specific profile tab
 
 protected:
     void closeEvent(QCloseEvent* event) override;
@@ -109,6 +111,12 @@ private slots:
     void slot_muteGame();
     void slot_showAboutDialog();
 
+    // Window menu activation slots
+    void slot_activateMainWindow();
+    void slot_activateDetachedWindow();
+    void slot_activateMainWindowProfile();
+    void slot_activateDetachedWindowProfile();
+
 private:
     void setupUI();
     void createMenus();
@@ -121,7 +129,6 @@ private:
     void updateTabIndicator(int tabIndex = -1);  // -1 means current tab
     void saveWindowGeometry();
     void restoreWindowGeometry();
-    void switchToProfile(const QString& profileName);
     void checkForWindowMergeOpportunity();  // Check if this window overlaps with another detached window
     void performWindowMerge(TDetachedWindow* otherWindow);  // Automatically merge with another window
     void logWindowState(const QString& context);  // Debug method to track window state
@@ -191,6 +198,11 @@ private:
 
     // Flag to prevent duplicate reattach operations on this window
     bool mReattachInProgress{false};
+
+    // Window menu management for multiple windows
+    QList<QAction*> mWindowListActions;
+    QAction* mWindowListSeparator{nullptr};
+    QMenu* mpWindowMenu{nullptr};
 };
 
 #endif // TDETACHEDWINDOW_H

--- a/src/TDetachedWindow.h
+++ b/src/TDetachedWindow.h
@@ -3,7 +3,10 @@
 
 /***************************************************************************
  *   Copyright (C) 2025 by Mike Conley - mike.conley@stickmud.com          *
- *                                                                         *
+ *                    // Docked widgets management
+    QMap<QString, QPointer<QDockWidget>> mDockWidgetMap;
+    QMap<QString, bool> mDockWidgetUserPreference;  // User's show/hide preference for dock widgets
+    QDockWidget* mpMapDockWidget{nullptr};                                                     *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
  *   the Free Software Foundation; either version 2 of the License, or     *
@@ -64,12 +67,12 @@ public:
     void addDockWidget(const QString& mapKey, QDockWidget* dockWidget) { mDockWidgetMap[mapKey] = dockWidget; }
     void removeDockWidget(const QString& mapKey) { 
         mDockWidgetMap.remove(mapKey); 
-        mDockWidgetIntendedVisibility.remove(mapKey);
+        mDockWidgetUserPreference.remove(mapKey);
     }
     
-    // Intended visibility management
-    void setDockWidgetIntendedVisibility(const QString& mapKey, bool visible) { mDockWidgetIntendedVisibility[mapKey] = visible; }
-    bool getDockWidgetIntendedVisibility(const QString& mapKey) const { return mDockWidgetIntendedVisibility.value(mapKey, false); }
+    // User preference management for dock widget visibility
+    void setDockWidgetUserPreference(const QString& mapKey, bool visible) { mDockWidgetUserPreference[mapKey] = visible; }
+    bool getDockWidgetUserPreference(const QString& mapKey) const { return mDockWidgetUserPreference.value(mapKey, false); }
     
     // Map dock widget access methods
     QDockWidget* getMapDockWidget() const { return mpMapDockWidget; }
@@ -225,7 +228,7 @@ private:
 
     // Docked widgets management
     QMap<QString, QPointer<QDockWidget>> mDockWidgetMap;
-    QMap<QString, bool> mDockWidgetIntendedVisibility; // Track intended visibility for each dock widget
+    QMap<QString, bool> mDockWidgetUserPreference;  // User's show/hide preference for dock widgets
     QDockWidget* mpMapDockWidget{nullptr};
 };
 

--- a/src/TDetachedWindow.h
+++ b/src/TDetachedWindow.h
@@ -74,6 +74,9 @@ public:
     // Map dock widget access methods
     QDockWidget* getMapDockWidget() const { return mpMapDockWidget; }
     void setMapDockWidget(QDockWidget* dockWidget) { mpMapDockWidget = dockWidget; }
+    
+    // Tab indicator methods
+    void updateAllTabIndicators();  // Update all tab indicators in this window
 
 protected:
     void closeEvent(QCloseEvent* event) override;

--- a/src/TDetachedWindow.h
+++ b/src/TDetachedWindow.h
@@ -65,6 +65,7 @@ public:
     // Dock widget management methods
     QDockWidget* getDockWidget(const QString& mapKey) const { return mDockWidgetMap.value(mapKey); }
     void addDockWidget(const QString& mapKey, QDockWidget* dockWidget) { mDockWidgetMap[mapKey] = dockWidget; }
+    void addTransferredDockWidget(const QString& mapKey, QDockWidget* dockWidget); // Sets up signal connections for transferred dock widgets
     void removeDockWidget(const QString& mapKey) { 
         mDockWidgetMap.remove(mapKey); 
         mDockWidgetUserPreference.remove(mapKey);
@@ -77,6 +78,10 @@ public:
     // Map dock widget access methods
     QDockWidget* getMapDockWidget() const { return mpMapDockWidget; }
     void setMapDockWidget(QDockWidget* dockWidget) { mpMapDockWidget = dockWidget; }
+    
+    // Toolbar synchronization methods
+    void setToolBarVisibility(bool visible);
+    bool isToolBarVisible() const;
     
     // Tab indicator methods
     void updateAllTabIndicators();  // Update all tab indicators in this window
@@ -118,6 +123,7 @@ private slots:
     void slot_closeApplication();
     void slot_showTriggerDialog();
     void slot_showAliasDialog();
+    void slot_showDetachedToolBarContextMenu(const QPoint& position);
     void slot_showTimerDialog();
     void slot_showActionDialog();
     void slot_showScriptDialog();

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -253,6 +253,7 @@ void TTabBar::mouseMoveEvent(QMouseEvent* event)
             // Improved directional detection: require predominantly vertical movement
             // and sufficient distance from the tab bar
             bool isVerticalMovement = false;
+
             if (verticalDistance > 0) {
                 const int verticalPercentage = (verticalDistance * 100) / (horizontalDistance + verticalDistance);
                 isVerticalMovement = verticalPercentage >= VERTICAL_MOVEMENT_RATIO_THRESHOLD;
@@ -284,6 +285,7 @@ void TTabBar::mouseMoveEvent(QMouseEvent* event)
 void TTabBar::dragEnterEvent(QDragEnterEvent* event)
 {
     const QMimeData* mimeData = event->mimeData();
+
     if (mimeData->hasFormat("application/x-mudlet-tab")) {
         event->acceptProposedAction();
     } else {
@@ -294,6 +296,7 @@ void TTabBar::dragEnterEvent(QDragEnterEvent* event)
 void TTabBar::dragMoveEvent(QDragMoveEvent* event)
 {
     const QMimeData* mimeData = event->mimeData();
+
     if (mimeData->hasFormat("application/x-mudlet-tab")) {
         event->acceptProposedAction();
     } else {
@@ -304,6 +307,7 @@ void TTabBar::dragMoveEvent(QDragMoveEvent* event)
 void TTabBar::dropEvent(QDropEvent* event)
 {
     const QMimeData* mimeData = event->mimeData();
+
     if (mimeData->hasFormat("application/x-mudlet-tab")) {
         const QString tabName = QString::fromUtf8(mimeData->data("application/x-mudlet-tab"));
         const int dropIndex = tabAt(event->position().toPoint());

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -33,7 +33,13 @@
 #include <QMimeData>
 #include <QApplication>
 #include <QScreen>
+#include <QDateTime>
 #include "post_guard.h"
+
+// Constants for improved drag detection
+static const int DETACH_DISTANCE_THRESHOLD = 80;  // Increased from 50
+static const int VERTICAL_MOVEMENT_RATIO_THRESHOLD = 60;  // Percentage: vertical movement must be 60% of total
+static const int TAB_REORDER_DELAY_MS = 150;  // Allow Qt tab reordering to process first
 
 
 void TTabBar::setNamedTabState(const QString& tabName, const bool state, QSet<QString>& effect)
@@ -213,6 +219,8 @@ void TTabBar::mousePressEvent(QMouseEvent* event)
     if (event->button() == Qt::LeftButton) {
         mDragStartPos = event->pos();
         mDragIndex = tabAt(event->pos());
+        mDragStartTime = QDateTime::currentMSecsSinceEpoch();
+        mPendingDetach = false;
     }
     QTabBar::mousePressEvent(event);
 }
@@ -225,25 +233,50 @@ void TTabBar::mouseMoveEvent(QMouseEvent* event)
         return;
     }
 
-    // Calculate distance moved
-    const int distance = (event->pos() - mDragStartPos).manhattanLength();
-
-    if (distance >= QApplication::startDragDistance()) {
-        // Check if drag is moving outside the tab bar area
-        const QPoint globalPos = mapToGlobal(event->pos());
-        const QRect tabBarGlobalRect = QRect(mapToGlobal(rect().topLeft()), rect().size());
-
-        // If dragged outside tab bar and beyond threshold, initiate detach
-        if (!tabBarGlobalRect.contains(globalPos)) {
-            const QPoint distanceFromBar = globalPos - tabBarGlobalRect.center();
-            if (distanceFromBar.manhattanLength() > DETACH_DISTANCE_THRESHOLD) {
-                emit tabDetachRequested(mDragIndex, globalPos);
-                mDragIndex = -1; // Reset drag state
-                return;
+    // Calculate movement vectors
+    const QPoint movement = event->pos() - mDragStartPos;
+    const int totalDistance = movement.manhattanLength();
+    
+    // Only proceed if we've moved enough to start considering detachment
+    if (totalDistance >= QApplication::startDragDistance()) {
+        // Calculate directional components
+        const int horizontalDistance = qAbs(movement.x());
+        const int verticalDistance = qAbs(movement.y());
+        
+        // Ensure we have enough time for Qt's tab reordering to be attempted first
+        const qint64 currentTime = QDateTime::currentMSecsSinceEpoch();
+        const qint64 timeSincePress = currentTime - mDragStartTime;
+        
+        // Only consider detachment after the reorder delay has passed
+        if (timeSincePress >= TAB_REORDER_DELAY_MS) {
+            // Improved directional detection: require predominantly vertical movement
+            // and sufficient distance from the tab bar
+            bool isVerticalMovement = false;
+            if (verticalDistance > 0) {
+                const int verticalPercentage = (verticalDistance * 100) / (horizontalDistance + verticalDistance);
+                isVerticalMovement = verticalPercentage >= VERTICAL_MOVEMENT_RATIO_THRESHOLD;
+            }
+            
+            // Check if we're significantly outside the tab bar area
+            const QPoint globalPos = mapToGlobal(event->pos());
+            const QRect tabBarGlobalRect = QRect(mapToGlobal(rect().topLeft()), rect().size());
+            
+            // Calculate distance from tab bar with enhanced threshold
+            if (!tabBarGlobalRect.contains(globalPos) && isVerticalMovement) {
+                const QPoint distanceFromBar = globalPos - tabBarGlobalRect.center();
+                const int distanceFromBarManhattan = distanceFromBar.manhattanLength();
+                
+                // Use the improved threshold and ensure it's primarily vertical movement
+                if (distanceFromBarManhattan > DETACH_DISTANCE_THRESHOLD) {
+                    emit tabDetachRequested(mDragIndex, globalPos);
+                    mDragIndex = -1; // Reset drag state
+                    return;
+                }
             }
         }
     }
 
+    // Always call the parent implementation to allow normal tab reordering
     QTabBar::mouseMoveEvent(event);
 }
 

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -37,9 +37,10 @@
 #include "post_guard.h"
 
 // Constants for improved drag detection
-static const int DETACH_DISTANCE_THRESHOLD = 80;  // Increased from 50
-static const int VERTICAL_MOVEMENT_RATIO_THRESHOLD = 60;  // Percentage: vertical movement must be 60% of total
-static const int TAB_REORDER_DELAY_MS = 150;  // Allow Qt tab reordering to process first
+static const int DETACH_DISTANCE_THRESHOLD = 80;  // Pixels to drag before tab detaches
+static const int DETACH_PIXEL_BUFFER = 20;        // Drag tolerance buffer
+static const int VERTICAL_MOVEMENT_RATIO_THRESHOLD = 60;  // Percentage of movement that must be vertical
+static const int TAB_REORDER_DELAY_MS = 150;  // Delay before allowing tab detachment
 
 
 void TTabBar::setNamedTabState(const QString& tabName, const bool state, QSet<QString>& effect)

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -92,6 +92,8 @@ private:
     int mDragIndex = -1;
     bool mDetachEnabled = true;
     static const int DETACH_DISTANCE_THRESHOLD = 50;
+    qint64 mDragStartTime = 0;
+    bool mPendingDetach = false;
 
 private slots:
     void onDetachedTabReattach(const QString& tabName);

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -156,7 +156,8 @@ void TTextEdit::focusInEvent(QFocusEvent* event)
 
 void TTextEdit::focusOutEvent(QFocusEvent* event)
 {
-    if (mpHost->caretEnabled()) {
+    // Safety check: during destruction, mpHost might be null
+    if (mpHost && mpHost->caretEnabled()) {
         mpHost->setCaretEnabled(false);
     }
 
@@ -251,6 +252,11 @@ void TTextEdit::updateHorizontalScrollBar()
 
 void TTextEdit::updateScreenView()
 {
+    // Safety check: during destruction, mpHost or mpConsole might be null
+    if (!mpHost || !mpConsole) {
+        return;
+    }
+    
     mFontWidth = fontMetrics().averageCharWidth();
     mFontHeight = fontMetrics().height();
     if (isHidden()) {
@@ -1937,12 +1943,17 @@ void TTextEdit::showEvent(QShowEvent* event)
 void TTextEdit::resizeEvent(QResizeEvent* event)
 {
     updateScreenView();
-    if (!mIsLowerPane && mpConsole->getType() == TConsole::MainConsole) {
-        mpHost->updateDisplayDimensions();
+    
+    // Safety check: during destruction, mpHost or mpConsole might be null
+    if (mpHost && mpConsole) {
+        if (!mIsLowerPane && mpConsole->getType() == TConsole::MainConsole) {
+            mpHost->updateDisplayDimensions();
+        }
     }
 
     QWidget::resizeEvent(event);
-    if (!mIsLowerPane
+    
+    if (mpConsole && !mIsLowerPane
         && (mpConsole->getType() & (TConsole::MainConsole | TConsole::UserWindow | TConsole::SubConsole))) {
 
         mpConsole->raiseMudletResizeEvent();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2543,6 +2543,7 @@ void mudlet::readLateSettings(const QSettings& settings)
 
     mShowMapAuditErrors = settings.value("reportMapIssuesToConsole", QVariant(false)).toBool();
     mStorePasswordsSecurely = settings.value("storePasswordsSecurely", QVariant(true)).toBool();
+    mShowTabConnectionIndicators = settings.value("showTabConnectionIndicators", QVariant(true)).toBool();
 
 
     resize(size);
@@ -2715,6 +2716,7 @@ void mudlet::writeSettings()
     settings.setValue("editorTextOptions", static_cast<int>(mEditorTextOptions));
     settings.setValue("reportMapIssuesToConsole", mShowMapAuditErrors);
     settings.setValue("storePasswordsSecurely", mStorePasswordsSecurely);
+    settings.setValue("showTabConnectionIndicators", mShowTabConnectionIndicators);
     settings.setValue("showIconsInMenus", mShowIconsOnMenuCheckedState);
     settings.setValue("copyAsImageTimeout", mCopyAsImageTimeout);
     settings.setValue("interfaceLanguage", mInterfaceLanguage);
@@ -4089,6 +4091,18 @@ void mudlet::slot_showTabContextMenu(const QPoint& position)
     
     contextMenu.addAction(toggleToolbarAction);
     
+    contextMenu.addSeparator();
+    
+    // Add connection indicator toggle
+    QAction* toggleConnectionIndicatorsAction = new QAction(tr("Show Connection Indicators on Tabs"), &contextMenu);
+    toggleConnectionIndicatorsAction->setCheckable(true);
+    toggleConnectionIndicatorsAction->setChecked(mShowTabConnectionIndicators);
+    connect(toggleConnectionIndicatorsAction, &QAction::triggered, this, [this](bool checked) {
+        setShowTabConnectionIndicators(checked);
+    });
+    
+    contextMenu.addAction(toggleConnectionIndicatorsAction);
+    
     // Show the context menu at the global position
     contextMenu.exec(mpTabBar->mapToGlobal(position));
 }
@@ -5001,6 +5015,19 @@ void mudlet::setShowMapAuditErrors(const bool state)
         mShowMapAuditErrors = state;
 
         emit signal_showMapAuditErrorsChanged(state);
+    }
+}
+
+void mudlet::setShowTabConnectionIndicators(const bool state)
+{
+    if (mShowTabConnectionIndicators != state) {
+        mShowTabConnectionIndicators = state;
+        
+        // Update all tab indicators immediately
+        updateTabIndicators();
+        
+        // Update detached window tab indicators
+        updateDetachedWindowTabIndicators();
     }
 }
 
@@ -6707,16 +6734,39 @@ void mudlet::updateMainWindowTabIndicators()
         Host* pHost = mHostManager.getHost(profileName);
         QIcon tabIcon;
 
-        if (pHost) {
+        // Only show connection indicators if the setting is enabled
+        if (mShowTabConnectionIndicators && pHost) {
             bool isConnected = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectedState);
             bool isConnecting = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectingState);
             tabIcon = createConnectionStatusIcon(isConnected, isConnecting, false);
-        } else {
+        } else if (mShowTabConnectionIndicators && !pHost) {
             tabIcon = createConnectionStatusIcon(false, false, true);
+        } else {
+            // No icon when indicators are disabled
+            tabIcon = QIcon();
         }
 
         // Only set the tab icon, keep the original tab text as just the profile name
         mpTabBar->setTabIcon(i, tabIcon);
+    }
+}
+
+void mudlet::updateTabIndicators()
+{
+    // For main window, just call the existing method
+    updateMainWindowTabIndicators();
+}
+
+void mudlet::updateDetachedWindowTabIndicators()
+{
+    // Update tab indicators for all detached windows
+    const auto& detachedWindows = getDetachedWindows();
+    for (auto it = detachedWindows.begin(); it != detachedWindows.end(); ++it) {
+        TDetachedWindow* detachedWindow = it.value();
+        if (detachedWindow) {
+            // Update all tabs in this detached window
+            detachedWindow->updateAllTabIndicators();
+        }
     }
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1715,6 +1715,15 @@ void mudlet::slot_tabChanged(int tabID)
     updateMainWindowTabIndicators();
 }
 
+void mudlet::slot_refreshTabIndicatorsDelayed()
+{
+    // This slot is called by a timer to refresh tab indicators a few seconds
+    // after profile creation to catch connection status changes that typically
+    // happen within the first few seconds of opening a profile
+    updateMainWindowTabIndicators();
+    updateDetachedWindowToolbars();
+}
+
 void mudlet::addConsoleForNewHost(Host* pH)
 {
     if (pH->mpConsole) {
@@ -1816,6 +1825,10 @@ void mudlet::addConsoleForNewHost(Host* pH)
     // profiles get shown across a split screen - even though mMultiView is NOT
     // set)!
     qApp->processEvents();
+    
+    // Set up a timer to refresh tab indicators after a few seconds
+    // This catches connection status changes that typically happen shortly after profile creation
+    QTimer::singleShot(3000, this, &mudlet::slot_refreshTabIndicatorsDelayed);
 }
 
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2487,8 +2487,12 @@ void mudlet::writeSettings()
 void mudlet::slot_showConnectionDialog()
 {
     if (mpConnectionDialog) {
+        // If dialog already exists, bring it to the front of the main window
+        mpConnectionDialog->raise();
+        mpConnectionDialog->activateWindow();
         return;
     }
+
     mpConnectionDialog = new dlgConnectionProfiles(this);
     connect(mpConnectionDialog, &dlgConnectionProfiles::signal_load_profile, this, &mudlet::slot_connectionDialogueFinished);
     mpConnectionDialog->fillout_form();
@@ -2498,7 +2502,24 @@ void mudlet::slot_showConnectionDialog()
 
     connect(mpConnectionDialog, &QDialog::accepted, this, [=, this]() { enableToolbarButtons(); });
     mpConnectionDialog->setAttribute(Qt::WA_DeleteOnClose);
-    mpConnectionDialog->show();
+    
+    // Use a timer to ensure the main window is ready before showing the dialog
+    // This is especially important at startup when the main window might not be fully initialized
+    QTimer::singleShot(0, this, [this]() {
+        // Ensure the main window is visible and ready
+        if (!isVisible()) {
+            show();
+        }
+        
+        // Bring the main window to the front first
+        raise();
+        activateWindow();
+        
+        // Then show and bring the dialog to the front
+        mpConnectionDialog->show();
+        mpConnectionDialog->raise();
+        mpConnectionDialog->activateWindow();
+    });
 }
 
 void mudlet::slot_showEditorDialog()
@@ -5884,8 +5905,9 @@ void mudlet::detachTab(int tabIndex, const QPoint& position)
     // Update tab bar auto-hide behavior since we now have detached windows
     updateMainWindowTabBarAutoHide();
 
-    // If no tabs remain, show connection dialog
-    if (mpTabBar->count() == 0 && !mIsGoingDown) {
+    // Only show connection dialog if there are no profiles loaded anywhere,
+    // not just when the main window is empty (profiles might be in detached windows)
+    if (mpTabBar->count() == 0 && mHostManager.getHostCount() == 0 && !mIsGoingDown) {
         disableToolbarButtons();
         slot_showConnectionDialog();
         setWindowTitle(scmVersion);
@@ -6300,8 +6322,9 @@ void mudlet::moveProfileFromMainToDetachedWindow(const QString& profileName, int
     // Update tab bar auto-hide behavior
     updateMainWindowTabBarAutoHide();
 
-    // If no tabs remain in main window, show connection dialog
-    if (mpTabBar->count() == 0 && !mIsGoingDown) {
+    // Only show connection dialog if there are no profiles loaded anywhere,
+    // not just when the main window is empty (profiles might be in detached windows)
+    if (mpTabBar->count() == 0 && mHostManager.getHostCount() == 0 && !mIsGoingDown) {
         disableToolbarButtons();
         slot_showConnectionDialog();
         setWindowTitle(scmVersion);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -5979,6 +5979,9 @@ void mudlet::reattachTab(const QString& profileName, int insertIndex)
     // Update tab bar auto-hide behavior since detached windows may have changed
     updateMainWindowTabBarAutoHide();
 
+    // Refresh tab bar to ensure CDC identifiers are displayed after reattachment
+    refreshTabBar();
+
     enableToolbarButtons();
 
     if (pHost) {
@@ -6606,4 +6609,7 @@ void mudlet::moveProfileFromDetachedToMainWindow(const QString& profileName, TDe
 
     // Update tab bar auto-hide behavior since detached windows may have changed
     updateMainWindowTabBarAutoHide();
+    
+    // Refresh tab bar to ensure CDC identifiers are displayed after reattachment
+    refreshTabBar();
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1630,18 +1630,24 @@ void mudlet::slot_reattachAllDetachedWindows()
     auto detachedWindowsCopy = mDetachedWindows;
 
     if (detachedWindowsCopy.isEmpty()) {
+#if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "slot_reattachAllDetachedWindows: No detached windows to reattach";
+#endif
         return;
     }
     
+#if defined(DEBUG_WINDOW_HANDLING)
     qDebug() << "slot_reattachAllDetachedWindows: Reattaching" << detachedWindowsCopy.size() << "detached windows";
+#endif
 
     for (auto it = detachedWindowsCopy.begin(); it != detachedWindowsCopy.end(); ++it) {
         const QString& profileName = it.key();
         TDetachedWindow* detachedWindow = it.value();
 
         if (detachedWindow) {
+#if defined(DEBUG_WINDOW_HANDLING)
             qDebug() << "slot_reattachAllDetachedWindows: Reattaching profile" << profileName;
+#endif
             // Use the existing reattach mechanism
             reattachTab(profileName, -1); // Use default insert index
         }
@@ -1873,7 +1879,9 @@ void mudlet::closeHost(const QString& name)
     if (mMainWindowDockWidgetMap.contains(mapKey)) {
         QPointer<QDockWidget> mapDockWidget = mMainWindowDockWidgetMap.value(mapKey);
         if (mapDockWidget) {
+#if defined(DEBUG_WINDOW_HANDLING)
             qDebug() << "mudlet::closeHost: Cleaning up main window dock widget for profile" << name;
+#endif
             
             // If this is the currently active map dock, clear the global reference
             if (mpCurrentMapDockWidget == mapDockWidget) {
@@ -2337,7 +2345,9 @@ void mudlet::showEvent(QShowEvent* event)
                 qWarning() << "Startup validation: Found orphaned profiles from previous session:" << orphanedProfiles;
                 
                 // Automatically reattach orphaned profiles without user prompt
+#if defined(DEBUG_WINDOW_HANDLING)
                 qDebug() << "Automatically reattaching" << orphanedProfiles.size() << "orphaned profiles:" << orphanedProfiles.join(", ");
+#endif
                 reattachOrphanedProfiles();
             }
         });
@@ -3190,7 +3200,9 @@ void mudlet::slot_showMapperDialog()
             auto detachedMapDock = detachedWindow->getDockWidget(mapKey);
 
             if (detachedMapDock && detachedMapDock->isVisible()) {
+#if defined(DEBUG_WINDOW_HANDLING)
                 qDebug() << "mudlet: Closing map in detached window for profile" << profileName << "to prevent conflicts";
+#endif
                 // Block signals to prevent user preference from being updated by system-initiated change
                 detachedMapDock->blockSignals(true);
                 detachedMapDock->setVisible(false);
@@ -3292,7 +3304,9 @@ void mudlet::slot_showMapperDialog()
         // Track user-initiated visibility changes - always update user preference
         // to ensure dock widget state is properly tracked regardless of which profile is active
         mMainWindowDockWidgetUserPreference[mapKey] = visible;
+#if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "mudlet: User changed dock widget visibility for" << mapKey << "to" << visible;
+#endif
         
         // Extract profile name from mapKey to safely look up objects
         QString profileName = mapKey;
@@ -3339,7 +3353,9 @@ void mudlet::slot_showMapperDialog()
             }
         }
         
+#if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "mudlet: Main window map dock visibility changed for" << mapKey << "visible:" << visible;
+#endif
     });
 
     // Show the dock widget

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -628,12 +628,6 @@ void mudlet::init()
     connect(dactionToggleLogging, &QAction::triggered, this, &mudlet::slot_toggleLogging);
     connect(dactionToggleEmergencyStop, &QAction::triggered, this, &mudlet::slot_toggleEmergencyStop);
 
-    // Add toolbar toggle action to Options menu
-    if (menuOptions && mpActionToggleMainToolBar) {
-        menuOptions->addSeparator();
-        menuOptions->addAction(mpActionToggleMainToolBar);
-    }
-
     // we historically use Alt on Windows and Linux, but that is uncomfortable on macOS
 #if defined(Q_OS_MACOS)
     mKeySequenceTriggers = QKeySequence(Qt::CTRL | Qt::Key_E);
@@ -3186,6 +3180,25 @@ void mudlet::slot_showMapperDialog()
     const QString profileName = pHost->getName();
     const QString mapKey = qsl("map_%1").arg(profileName);
     
+    // Close any existing map for this profile in detached windows first
+    const auto& detachedWindows = getDetachedWindows();
+
+    for (auto it = detachedWindows.begin(); it != detachedWindows.end(); ++it) {
+        TDetachedWindow* detachedWindow = it.value();
+
+        if (detachedWindow) {
+            auto detachedMapDock = detachedWindow->getDockWidget(mapKey);
+
+            if (detachedMapDock && detachedMapDock->isVisible()) {
+                qDebug() << "mudlet: Closing map in detached window for profile" << profileName << "to prevent conflicts";
+                // Block signals to prevent user preference from being updated by system-initiated change
+                detachedMapDock->blockSignals(true);
+                detachedMapDock->setVisible(false);
+                detachedMapDock->blockSignals(false);
+            }
+        }
+    }
+    
     // Check if we already have a main window dock widget for this profile
     QPointer<QDockWidget> existingMapDock = mMainWindowDockWidgetMap.value(mapKey);
     
@@ -3200,6 +3213,7 @@ void mudlet::slot_showMapperDialog()
             
             // Ensure the map's active mapper points to our main window instance
             auto mapWidget = existingMapDock->widget();
+
             if (auto mainMapper = qobject_cast<dlgMapper*>(mapWidget)) {
                 pMap->mpMapper = mainMapper;
             }
@@ -3215,6 +3229,7 @@ void mudlet::slot_showMapperDialog()
                 }
             }
         }
+
         return;
     }
 
@@ -3274,13 +3289,10 @@ void mudlet::slot_showMapperDialog()
             return;
         }
         
-        // Track user-initiated visibility changes (not system-initiated profile switches)
-        // Only update user preference if this is likely a user action
-        if (getActiveHost() && getActiveHost()->getName() == mapKey.mid(4)) {
-            // Current profile's dock widget visibility changed - likely user action
-            mMainWindowDockWidgetUserPreference[mapKey] = visible;
-            qDebug() << "mudlet: User changed dock widget visibility for" << mapKey << "to" << visible;
-        }
+        // Track user-initiated visibility changes - always update user preference
+        // to ensure dock widget state is properly tracked regardless of which profile is active
+        mMainWindowDockWidgetUserPreference[mapKey] = visible;
+        qDebug() << "mudlet: User changed dock widget visibility for" << mapKey << "to" << visible;
         
         // Extract profile name from mapKey to safely look up objects
         QString profileName = mapKey;
@@ -4054,13 +4066,10 @@ void mudlet::slot_toggleMainToolBar()
 {
     // Toggle the toolbar visibility
     enums::controlsVisibility currentState = toolBarVisibility();
-    if (currentState == enums::visibleNever) {
-        setToolBarVisibility(enums::visibleAlways);
-        mpActionToggleMainToolBar->setChecked(true);
-    } else {
-        setToolBarVisibility(enums::visibleNever);
-        mpActionToggleMainToolBar->setChecked(false);
-    }
+    bool newVisibility = (currentState == enums::visibleNever);
+    
+    // Synchronize toolbar visibility across all windows
+    synchronizeToolBarVisibility(newVisibility);
 }
 
 void mudlet::slot_showMainToolBarContextMenu(const QPoint& position)
@@ -4068,7 +4077,7 @@ void mudlet::slot_showMainToolBarContextMenu(const QPoint& position)
     QMenu contextMenu(this);
     
     // Create a copy of the toggle action for the context menu
-    QAction* toggleAction = new QAction(tr("Show Main Toolbar"), &contextMenu);
+    QAction* toggleAction = new QAction(tr("Profile Toolbar"), &contextMenu);
     toggleAction->setCheckable(true);
     toggleAction->setChecked(mpMainToolBar->isVisible());
     connect(toggleAction, &QAction::triggered, this, &mudlet::slot_toggleMainToolBar);
@@ -4079,12 +4088,58 @@ void mudlet::slot_showMainToolBarContextMenu(const QPoint& position)
     contextMenu.exec(mpMainToolBar->mapToGlobal(position));
 }
 
+void mudlet::synchronizeToolBarVisibility(bool visible)
+{
+    // Update main window toolbar
+    if (mpMainToolBar) {
+        if (visible) {
+            setToolBarVisibility(enums::visibleAlways);
+        } else {
+            setToolBarVisibility(enums::visibleNever);
+        }
+        if (mpActionToggleMainToolBar) {
+            mpActionToggleMainToolBar->setChecked(visible);
+        }
+    }
+    
+    // Update all detached windows
+    for (auto& detachedWindow : mDetachedWindows) {
+        if (detachedWindow) {
+            detachedWindow->setToolBarVisibility(visible);
+        }
+    }
+}
+
 void mudlet::slot_showTabContextMenu(const QPoint& position)
 {
     QMenu contextMenu(this);
     
+    // Find which tab was right-clicked
+    int tabIndex = -1;
+    for (int i = 0; i < mpTabBar->count(); ++i) {
+        if (mpTabBar->tabRect(i).contains(position)) {
+            tabIndex = i;
+            break;
+        }
+    }
+    
+    // If we right-clicked on a specific tab, add tab-specific actions
+    if (tabIndex >= 0) {
+        const QString profileName = mpTabBar->tabData(tabIndex).toString();
+        
+        // Add "Detach Tab" option
+        QAction* detachTabAction = new QAction(tr("Detach Tab \"%1\"").arg(profileName), &contextMenu);
+        detachTabAction->setIcon(QIcon(":/icons/window-new.png"));
+        connect(detachTabAction, &QAction::triggered, this, [this, tabIndex]() {
+            detachTab(tabIndex, QPoint()); // Position doesn't matter for manual detach
+        });
+        
+        contextMenu.addAction(detachTabAction);
+        contextMenu.addSeparator();
+    }
+    
     // Add toolbar visibility toggle
-    QAction* toggleToolbarAction = new QAction(tr("Show Main Toolbar"), &contextMenu);
+    QAction* toggleToolbarAction = new QAction(tr("Profile Toolbar"), &contextMenu);
     toggleToolbarAction->setCheckable(true);
     toggleToolbarAction->setChecked(mpMainToolBar->isVisible());
     connect(toggleToolbarAction, &QAction::triggered, this, &mudlet::slot_toggleMainToolBar);
@@ -7274,7 +7329,10 @@ void mudlet::updateMainWindowDockWidgetVisibilityForProfile(const QString& profi
                     
                     qDebug() << "mudlet: Main window dock widget should be visible - showing and setting as active";
                 } else {
+                    // Block signals to prevent user preference from being updated by system-initiated change
+                    dockWidget->blockSignals(true);
                     dockWidget->setVisible(false);
+                    dockWidget->blockSignals(false);
                     qDebug() << "mudlet: Main window dock widget should be hidden - respecting user preference";
                 }
                 
@@ -7294,7 +7352,10 @@ void mudlet::updateMainWindowDockWidgetVisibilityForProfile(const QString& profi
             } else {
                 // This dock widget belongs to a different profile - hide it
                 qDebug() << "mudlet: Hiding main window dock widget for different profile" << dockProfileName;
+                // Block signals to prevent user preference from being updated by system-initiated change
+                dockWidget->blockSignals(true);
                 dockWidget->setVisible(false);
+                dockWidget->blockSignals(false);
                 
                 // Restore host's default mapper for the other profile
                 if (auto pHost = mHostManager.getHost(dockProfileName)) {
@@ -7338,9 +7399,9 @@ void mudlet::transferDockWidgetToDetachedWindow(const QString& profileName, TDet
     
     // Store the current visibility state and determine user preference
     bool wasVisible = mainDockWidget->isVisible();
-    // If the dock widget is currently visible, the user clearly wants it visible
-    // If it's not visible, respect the stored user preference (defaulting to false for new profiles)
-    bool intendedVisible = wasVisible || mMainWindowDockWidgetUserPreference.value(mapKey, false);
+    // Use the stored user preference directly - current visibility may be misleading
+    // due to profile switching or other system reasons
+    bool intendedVisible = mMainWindowDockWidgetUserPreference.value(mapKey, false);
     
     // Get the mapper widget from the main window dock widget
     auto mapperWidget = qobject_cast<dlgMapper*>(mainDockWidget->widget());
@@ -7351,6 +7412,9 @@ void mudlet::transferDockWidgetToDetachedWindow(const QString& profileName, TDet
     
     // Remove the dock widget from the main window
     removeDockWidget(mainDockWidget);
+    
+    // Disconnect existing signal connections to avoid conflicts
+    mainDockWidget->disconnect();
     
     // Clear from main window tracking
     mMainWindowDockWidgetMap.remove(mapKey);
@@ -7363,17 +7427,19 @@ void mudlet::transferDockWidgetToDetachedWindow(const QString& profileName, TDet
     mainDockWidget->setParent(detachedWindow);
     mainDockWidget->setObjectName(qsl("dockMap_%1_detached").arg(profileName));
     
+    // Transfer the user preference state first, before adding to tracking
+    detachedWindow->setDockWidgetUserPreference(mapKey, intendedVisible);
+    
     // Add the dock widget to the detached window
     detachedWindow->QMainWindow::addDockWidget(Qt::RightDockWidgetArea, mainDockWidget);
     
-    // Transfer to detached window's tracking map
-    detachedWindow->addDockWidget(mapKey, mainDockWidget);
+    // Transfer to detached window's tracking map with signal connections
+    detachedWindow->addTransferredDockWidget(mapKey, mainDockWidget);
     
-    // Transfer the user preference state as well
-    detachedWindow->setDockWidgetUserPreference(mapKey, intendedVisible);
-    
-    // Set the visibility to match the intended state
+    // Set the visibility to match the intended state - block signals to prevent overwriting user preference
+    mainDockWidget->blockSignals(true);
     mainDockWidget->setVisible(intendedVisible);
+    mainDockWidget->blockSignals(false);
     if (intendedVisible) {
         // Update detached window's global reference if it's now visible
         detachedWindow->setMapDockWidget(mainDockWidget);
@@ -7403,9 +7469,9 @@ void mudlet::transferDockWidgetFromDetachedWindow(const QString& profileName, TD
     
     // Store the current visibility state and determine user preference
     bool wasVisible = detachedDockWidget->isVisible();
-    // If the dock widget is currently visible, the user clearly wants it visible
-    // If it's not visible, respect the stored user preference
-    bool intendedVisible = wasVisible || detachedWindow->getDockWidgetUserPreference(mapKey);
+    // Use the stored user preference directly - current visibility may be misleading
+    // due to profile switching or other system reasons
+    bool intendedVisible = detachedWindow->getDockWidgetUserPreference(mapKey);
     
     // Get the mapper widget from the detached window dock widget
     auto mapperWidget = qobject_cast<dlgMapper*>(detachedDockWidget->widget());
@@ -7421,6 +7487,9 @@ void mudlet::transferDockWidgetFromDetachedWindow(const QString& profileName, TD
     
     // Remove the dock widget from the detached window
     detachedWindow->QMainWindow::removeDockWidget(detachedDockWidget);
+    
+    // Disconnect existing signal connections to avoid conflicts
+    detachedDockWidget->disconnect();
     
     // Clear from detached window tracking using the public API
     detachedWindow->removeDockWidget(mapKey);
@@ -7438,8 +7507,61 @@ void mudlet::transferDockWidgetFromDetachedWindow(const QString& profileName, TD
     // Transfer the user preference state as well
     mMainWindowDockWidgetUserPreference[mapKey] = intendedVisible;
     
-    // Set the visibility to match the intended state
+    // Reconnect signal for main window visibility tracking
+    connect(detachedDockWidget, &QDockWidget::visibilityChanged, this, [this, mapKey](bool visible) {
+        auto mapDockWidget = mMainWindowDockWidgetMap.value(mapKey);
+        if (!mapDockWidget) {
+            return;
+        }
+        
+        // Track user-initiated visibility changes - always update user preference
+        // to ensure dock widget state is properly tracked regardless of which profile is active
+        mMainWindowDockWidgetUserPreference[mapKey] = visible;
+        qDebug() << "mudlet: User changed dock widget visibility for" << mapKey << "to" << visible;
+        
+        // Extract profile name from mapKey to safely look up objects
+        QString profileName = mapKey;
+        if (profileName.startsWith("map_")) {
+            profileName = profileName.mid(4); // Remove "map_" prefix
+        }
+        
+        // Safely get the host - it might be null during shutdown
+        Host* pHost = mHostManager.getHost(profileName);
+        if (!pHost) {
+            return;
+        }
+        
+        auto pMap = pHost->mpMap.data();
+        if (!pMap) {
+            return;
+        }
+        
+        if (!visible) {
+            // If this is the currently active map dock, clear the global reference
+            if (mpCurrentMapDockWidget == mapDockWidget) {
+                mpCurrentMapDockWidget = nullptr;
+            }
+        } else {
+            // When showing, set this as the active mapper for the main window
+            mpCurrentMapDockWidget = mapDockWidget;
+            
+            // Ensure the map's active mapper points to our main window instance
+            auto mapWidget = mapDockWidget->widget();
+            if (auto mainMapper = qobject_cast<dlgMapper*>(mapWidget)) {
+                pMap->mpMapper = mainMapper;
+            }
+        }
+        
+        // Trigger dock widget visibility update for the current profile
+        if (mpCurrentActiveHost && mpCurrentActiveHost->getName() == profileName) {
+            updateMainWindowDockWidgetVisibilityForProfile(profileName);
+        }
+    });
+    
+    // Set the visibility to match the intended state - block signals to prevent overwriting user preference
+    detachedDockWidget->blockSignals(true);
     detachedDockWidget->setVisible(intendedVisible);
+    detachedDockWidget->blockSignals(false);
     if (intendedVisible) {
         // Update main window's global reference if it's now visible
         mpCurrentMapDockWidget = detachedDockWidget;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -536,7 +536,7 @@ void mudlet::init()
     connect(mpActionCloseProfile.data(), &QAction::triggered, this, &mudlet::slot_closeCurrentProfile);
     connect(mpActionReplay.data(), &QAction::triggered, this, &mudlet::slot_replay);
     connect(mpActionNotes.data(), &QAction::triggered, this, &mudlet::slot_notes);
-    connect(mpActionMapper.data(), &QAction::triggered, this, &mudlet::slot_mapper);
+    connect(mpActionMapper.data(), &QAction::triggered, this, &mudlet::slot_showMapperDialog);
     connect(mpActionIRC.data(), &QAction::triggered, this, &mudlet::slot_irc);
     connect(mpActionDiscord.data(), &QAction::triggered, this, &mudlet::slot_profileDiscord);
     connect(mpActionMudletDiscord.data(), &QAction::triggered, this, &mudlet::slot_mudletDiscord);
@@ -1874,6 +1874,28 @@ void mudlet::closeHost(const QString& name)
     }
     migrateDebugConsole(pH);
 
+    // Clean up any main window dock widgets for this profile
+    const QString mapKey = qsl("map_%1").arg(name);
+    if (mMainWindowDockWidgetMap.contains(mapKey)) {
+        QPointer<QDockWidget> mapDockWidget = mMainWindowDockWidgetMap.value(mapKey);
+        if (mapDockWidget) {
+            qDebug() << "mudlet::closeHost: Cleaning up main window dock widget for profile" << name;
+            
+            // If this is the currently active map dock, clear the global reference
+            if (mpCurrentMapDockWidget == mapDockWidget) {
+                mpCurrentMapDockWidget = nullptr;
+            }
+            
+            // Remove the dock widget
+            removeDockWidget(mapDockWidget);
+            mapDockWidget->deleteLater();
+        }
+        
+        // Remove from our tracking map
+        mMainWindowDockWidgetMap.remove(mapKey);
+        mMainWindowDockWidgetIntendedVisibility.remove(mapKey);
+    }
+
     mpTabBar->removeTab(name);
     // PLACEMARKER: Host destruction (1) - from all sources
     int hostCount = mHostManager.getHostCount();
@@ -1923,6 +1945,9 @@ void mudlet::slot_tabChanged(int tabID)
     activateProfile(mHostManager.getHost(hostName));
     updateDetachedWindowToolbars();
     updateMainWindowTabIndicators();
+    
+    // Update main window dock widget visibility for the new active profile
+    updateMainWindowDockWidgetVisibilityForProfile(hostName);
 }
 
 void mudlet::slot_refreshTabIndicatorsDelayed()
@@ -3142,6 +3167,169 @@ void mudlet::slot_mapper()
         return;
     }
     pHost->showHideOrCreateMapper(true);
+}
+
+void mudlet::slot_showMapperDialog()
+{
+    Host* pHost = getActiveHost();
+    if (!pHost) {
+        return;
+    }
+
+    auto pMap = pHost->mpMap.data();
+    if (!pMap) {
+        return;
+    }
+
+    const QString profileName = pHost->getName();
+    const QString mapKey = qsl("map_%1").arg(profileName);
+    
+    // Check if we already have a main window dock widget for this profile
+    QPointer<QDockWidget> existingMapDock = mMainWindowDockWidgetMap.value(mapKey);
+    
+    if (existingMapDock) {
+        // Toggle visibility of existing mapper and update global reference
+        bool newVisibility = !existingMapDock->isVisible();
+        existingMapDock->setVisible(newVisibility);
+        
+        // Update mpCurrentMapDockWidget to point to the current profile's map if it's being shown
+        if (newVisibility) {
+            mpCurrentMapDockWidget = existingMapDock;
+            
+            // Ensure the map's active mapper points to our main window instance
+            auto mapWidget = existingMapDock->widget();
+            if (auto mainMapper = qobject_cast<dlgMapper*>(mapWidget)) {
+                pMap->mpMapper = mainMapper;
+            }
+        } else if (mpCurrentMapDockWidget == existingMapDock) {
+            // If we're hiding the current map, clear the global reference and restore host's default mapper
+            mpCurrentMapDockWidget = nullptr;
+            
+            // Restore the host's default mapper if it exists
+            if (pHost->mpDockableMapWidget) {
+                auto hostMapWidget = pHost->mpDockableMapWidget->widget();
+                if (auto hostMapper = qobject_cast<dlgMapper*>(hostMapWidget)) {
+                    pMap->mpMapper = hostMapper;
+                }
+            }
+        }
+        return;
+    }
+
+    // If the host already has its default dock widget, hide it to avoid conflicts
+    if (pHost->mpDockableMapWidget) {
+        pHost->mpDockableMapWidget->setVisible(false);
+    }
+
+    // Create a new docked mapper widget for this profile in the main window
+    auto newMapDockWidget = new QDockWidget(tr("Map - %1").arg(profileName), this);
+    newMapDockWidget->setObjectName(qsl("dockMap_%1_main").arg(profileName));
+    
+    // Store the host's default mapper temporarily so we can restore it later
+    QPointer<dlgMapper> hostMapper = pMap->mpMapper;
+    
+    // Create a new mapper instance for the main window's per-profile dock widget
+    // We need to copy player room style details first
+    pHost->getPlayerRoomStyleDetails(pMap->mPlayerRoomStyle,
+                                   pMap->mPlayerRoomOuterDiameterPercentage,
+                                   pMap->mPlayerRoomInnerDiameterPercentage,
+                                   pMap->mPlayerRoomOuterColor,
+                                   pMap->mPlayerRoomInnerColor);
+
+    // Create the mapper dialog
+    auto mainMapper = new dlgMapper(newMapDockWidget, pHost, pMap);
+    mainMapper->setStyleSheet(pHost->mProfileStyleSheet);
+    newMapDockWidget->setWidget(mainMapper);
+
+    // CRITICAL: Set the map's active mapper to our main window instance
+    // This ensures map updates go to our main window dock widget instead of the host's default
+    pMap->mpMapper = mainMapper;
+
+    // Initialize the mapper
+    if (pMap->mpRoomDB && !pMap->mpRoomDB->isEmpty()) {
+        mainMapper->mp2dMap->init();
+        mainMapper->updateAreaComboBox();
+        mainMapper->resetAreaComboBoxToPlayerRoomArea();
+        mainMapper->show();
+    }
+
+    // Add the dock widget to the main window
+    addDockWidget(Qt::RightDockWidgetArea, newMapDockWidget);
+    
+    // Store reference in our map for cleanup and profile-specific access
+    mMainWindowDockWidgetMap[mapKey] = newMapDockWidget;
+    
+    // Set intended visibility to true since we're initially showing this dock widget
+    mMainWindowDockWidgetIntendedVisibility[mapKey] = true;
+    
+    // Set global reference to the currently active map
+    mpCurrentMapDockWidget = newMapDockWidget;
+
+    // Connect to handle dock widget visibility changes
+    connect(newMapDockWidget, &QDockWidget::visibilityChanged, this, [this, mapKey](bool visible) {
+        auto mapDockWidget = mMainWindowDockWidgetMap.value(mapKey);
+        if (!mapDockWidget) {
+            return;
+        }
+        
+        // Track user-initiated visibility changes (not system-initiated profile switches)
+        // Only update intended visibility if this is likely a user action
+        if (getActiveHost() && getActiveHost()->getName() == mapKey.mid(4)) {
+            // Current profile's dock widget visibility changed - likely user action
+            mMainWindowDockWidgetIntendedVisibility[mapKey] = visible;
+            qDebug() << "mudlet: User changed dock widget visibility for" << mapKey << "to" << visible;
+        }
+        
+        // Extract profile name from mapKey to safely look up objects
+        QString profileName = mapKey;
+        if (profileName.startsWith("map_")) {
+            profileName = profileName.mid(4); // Remove "map_" prefix
+        }
+        
+        // Safely get the host and map - they might be null during shutdown
+        Host* pHost = getActiveHost();
+        if (!pHost || pHost->getName() != profileName) {
+            // Try to get the specific host for this profile
+            pHost = mHostManager.getHost(profileName);
+            if (!pHost) {
+                return;
+            }
+        }
+        
+        auto pMap = pHost->mpMap.data();
+        if (!pMap) {
+            return;
+        }
+        
+        if (!visible) {
+            // If this is the currently active map dock, clear the global reference
+            if (mpCurrentMapDockWidget == mapDockWidget) {
+                mpCurrentMapDockWidget = nullptr;
+            }
+            
+            // Restore the host's default mapper when hiding
+            if (pHost->mpDockableMapWidget) {
+                auto hostMapWidget = pHost->mpDockableMapWidget->widget();
+                if (auto hostMapper = qobject_cast<dlgMapper*>(hostMapWidget)) {
+                    pMap->mpMapper = hostMapper;
+                }
+            }
+        } else {
+            // When showing, set this as the active mapper
+            mpCurrentMapDockWidget = mapDockWidget;
+            
+            // Ensure the map's active mapper points to our main window instance
+            auto mapWidget = mapDockWidget->widget();
+            if (auto mainMapper = qobject_cast<dlgMapper*>(mapWidget)) {
+                pMap->mpMapper = mainMapper;
+            }
+        }
+        
+        qDebug() << "mudlet: Main window map dock visibility changed for" << mapKey << "visible:" << visible;
+    });
+
+    // Show the dock widget
+    newMapDockWidget->show();
 }
 
 void mudlet::slot_openMappingScriptsPage()
@@ -6126,6 +6314,9 @@ void mudlet::detachTab(int tabIndex, const QPoint& position)
     auto detachedWindow = new TDetachedWindow(profileName, console, this, toolbarVisible);
     mDetachedWindows.insert(profileName, detachedWindow);
 
+    // Transfer any dock widgets from the main window to the detached window
+    transferDockWidgetToDetachedWindow(profileName, detachedWindow);
+
     // Connect signals
     connect(detachedWindow, &TDetachedWindow::reattachRequested,
             this, [this](const QString& profileName) {
@@ -6231,6 +6422,9 @@ void mudlet::reattachTab(const QString& profileName, int insertIndex)
             }
         }
     }
+
+    // Transfer any dock widgets from the detached window to the main window BEFORE removing the profile
+    transferDockWidgetFromDetachedWindow(safeProfileName, detachedWindow);
 
     // CRITICAL: Remove the profile from the detached window properly
     bool removalSuccess = detachedWindow->removeProfile(safeProfileName);
@@ -6640,6 +6834,9 @@ void mudlet::moveProfileBetweenDetachedWindows(const QString& profileName, TDeta
     const QSize oldSize = console->size();
     const bool wasVisible = console->isVisible();
 
+    // Transfer any dock widgets from source to target window
+    transferDockWidgetBetweenDetachedWindows(profileName, sourceWindow, targetWindow);
+
     // Remove profile from source window
     sourceWindow->removeProfile(profileName);
 
@@ -6967,30 +7164,312 @@ void mudlet::moveProfileFromDetachedToMainWindow(const QString& profileName, TDe
     if (pHost) {
         setWindowTitle(QString("%1 - %2").arg(profileName, scmVersion));
     }
+}
 
-    // Force repaint/refresh of main window after profile move
-    repaint();
-    update();
-    if (pHost && pHost->mpConsole) {
-        pHost->mpConsole->repaint();
-        pHost->mpConsole->update();
-        pHost->mpConsole->refresh();
+void mudlet::updateMainWindowDockWidgetVisibilityForProfile(const QString& profileName)
+{
+    // Clear the current map dock widget reference first
+    mpCurrentMapDockWidget = nullptr;
+    
+    qDebug() << "mudlet::updateMainWindowDockWidgetVisibilityForProfile: Starting for profile" << profileName
+             << "- mMainWindowDockWidgetMap.size():" << mMainWindowDockWidgetMap.size();
+    
+    // Collect dock widgets to process to avoid iterator invalidation
+    QList<QPair<QString, QPointer<QDockWidget>>> dockWidgetsToProcess;
+    for (auto it = mMainWindowDockWidgetMap.begin(); it != mMainWindowDockWidgetMap.end(); ++it) {
+        if (it.value()) {
+            dockWidgetsToProcess.append(qMakePair(it.key(), it.value()));
+            qDebug() << "mudlet: Found main window dock widget in map:" << it.key() << "isVisible:" << it.value()->isVisible();
+        } else {
+            qDebug() << "mudlet: Found null main window dock widget in map for key:" << it.key();
+        }
     }
-    qDebug() << "moveProfileFromDetachedToMainWindow: Forced main window repaint after profile move";
+    
+    // Track if we found and showed a dock widget for the current profile
+    bool currentProfileHasVisibleDockWidget = false;
+    
+    // Process dock widgets without iterating over the map directly
+    for (const auto& dockPair : dockWidgetsToProcess) {
+        const QString& dockKey = dockPair.first;
+        QPointer<QDockWidget> dockWidget = dockPair.second;
+        
+        // Check if the dock widget still exists and is in our map
+        if (!dockWidget || !mMainWindowDockWidgetMap.contains(dockKey)) {
+            qDebug() << "mudlet: Skipping main window dock widget" << dockKey << "- widget exists:" << (dockWidget != nullptr) 
+                     << "in map:" << mMainWindowDockWidgetMap.contains(dockKey);
+            continue;
+        }
+        
+        // Check if this docked widget belongs to the current profile
+        if (dockKey.startsWith("map_")) {
+            QString dockProfileName = dockKey.mid(4); // Remove "map_" prefix
+            qDebug() << "mudlet: Processing main window map dock" << dockKey << "profile:" << dockProfileName << "current:" << profileName;
+            
+            if (dockProfileName == profileName) {
+                // This dock widget belongs to the current profile
+                // Check the intended visibility state, not the current visibility
+                bool shouldBeVisible = mMainWindowDockWidgetIntendedVisibility.value(dockKey, false);
+                qDebug() << "mudlet: Found main window dock widget for current profile" << profileName 
+                         << "currently visible:" << dockWidget->isVisible() 
+                         << "should be visible:" << shouldBeVisible;
+                
+                // Show or hide based on intended visibility
+                if (shouldBeVisible) {
+                    dockWidget->show();
+                    dockWidget->raise();
+                    
+                    // Set this as the current map dock widget reference
+                    mpCurrentMapDockWidget = dockWidget;
+                    currentProfileHasVisibleDockWidget = true;
+                    
+                    qDebug() << "mudlet: Main window dock widget should be visible - showing and setting as active";
+                } else {
+                    dockWidget->setVisible(false);
+                    qDebug() << "mudlet: Main window dock widget should be hidden - respecting user preference";
+                }
+                
+                // Ensure the map's active mapper points to our main window instance (if visible)
+                if (auto pHost = mHostManager.getHost(profileName)) {
+                    if (auto pMap = pHost->mpMap.data()) {
+                        auto mapWidget = dockWidget->widget();
+                        if (auto mainMapper = qobject_cast<dlgMapper*>(mapWidget)) {
+                            // Only set as active mapper if the dock widget should be visible
+                            if (shouldBeVisible) {
+                                pMap->mpMapper = mainMapper;
+                                qDebug() << "mudlet: Set active mapper for main window profile" << profileName;
+                            }
+                        }
+                    }
+                }
+            } else {
+                // This dock widget belongs to a different profile - hide it
+                qDebug() << "mudlet: Hiding main window dock widget for different profile" << dockProfileName;
+                dockWidget->setVisible(false);
+                
+                // Restore host's default mapper for the other profile
+                if (auto pHost = mHostManager.getHost(dockProfileName)) {
+                    if (auto pMap = pHost->mpMap.data()) {
+                        if (pHost->mpDockableMapWidget) {
+                            auto hostMapWidget = pHost->mpDockableMapWidget->widget();
+                            if (auto hostMapper = qobject_cast<dlgMapper*>(hostMapWidget)) {
+                                pMap->mpMapper = hostMapper;
+                                qDebug() << "mudlet: Restored host mapper for main window profile" << dockProfileName;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // Add other dock widget types here as they are implemented
+    }
+    
+    // Debug output to help track dock widget visibility changes
+    qDebug() << "mudlet::updateMainWindowDockWidgetVisibilityForProfile:" << profileName 
+             << "- Found visible dock widget:" << currentProfileHasVisibleDockWidget
+             << "- Total dock widgets:" << dockWidgetsToProcess.size()
+             << "- mpCurrentMapDockWidget set:" << (mpCurrentMapDockWidget != nullptr);
+}
 
-    // Update tab bar auto-hide behavior since detached windows may have changed
-    updateMainWindowTabBarAutoHide();
+void mudlet::transferDockWidgetToDetachedWindow(const QString& profileName, TDetachedWindow* detachedWindow)
+{
+    if (!detachedWindow) {
+        return;
+    }
     
-    // Update the window menu to reflect the window changes
-    updateWindowMenu();
+    const QString mapKey = qsl("map_%1").arg(profileName);
+    QPointer<QDockWidget> mainDockWidget = mMainWindowDockWidgetMap.value(mapKey);
     
-    // Refresh tab bar to ensure CDC identifiers are displayed after reattachment
-    refreshTabBar();
+    if (!mainDockWidget) {
+        qDebug() << "mudlet::transferDockWidgetToDetachedWindow: No main window dock widget found for profile" << profileName;
+        return;
+    }
+    
+    qDebug() << "mudlet::transferDockWidgetToDetachedWindow: Transferring dock widget for profile" << profileName;
+    
+    // Store the current visibility state and determine intended visibility
+    bool wasVisible = mainDockWidget->isVisible();
+    // If the dock widget is currently visible, the user clearly wants it visible
+    // If it's not visible, respect the stored intended visibility (defaulting to false for new profiles)
+    bool intendedVisible = wasVisible || mMainWindowDockWidgetIntendedVisibility.value(mapKey, false);
+    
+    // Get the mapper widget from the main window dock widget
+    auto mapperWidget = qobject_cast<dlgMapper*>(mainDockWidget->widget());
+    if (!mapperWidget) {
+        qDebug() << "mudlet::transferDockWidgetToDetachedWindow: No mapper widget found in dock widget";
+        return;
+    }
+    
+    // Remove the dock widget from the main window
+    removeDockWidget(mainDockWidget);
+    
+    // Clear from main window tracking
+    mMainWindowDockWidgetMap.remove(mapKey);
+    mMainWindowDockWidgetIntendedVisibility.remove(mapKey);
+    if (mpCurrentMapDockWidget == mainDockWidget) {
+        mpCurrentMapDockWidget = nullptr;
+    }
+    
+    // Reparent the dock widget to the detached window
+    mainDockWidget->setParent(detachedWindow);
+    mainDockWidget->setObjectName(qsl("dockMap_%1_detached").arg(profileName));
+    
+    // Add the dock widget to the detached window
+    detachedWindow->QMainWindow::addDockWidget(Qt::RightDockWidgetArea, mainDockWidget);
+    
+    // Transfer to detached window's tracking map
+    detachedWindow->addDockWidget(mapKey, mainDockWidget);
+    
+    // Transfer the intended visibility state as well
+    detachedWindow->setDockWidgetIntendedVisibility(mapKey, intendedVisible);
+    
+    // Set the visibility to match the intended state
+    mainDockWidget->setVisible(intendedVisible);
+    if (intendedVisible) {
+        // Update detached window's global reference if it's now visible
+        detachedWindow->setMapDockWidget(mainDockWidget);
+    }
+    
+    // Update the mapper's parent
+    mapperWidget->setParent(mainDockWidget);
+    
+    qDebug() << "mudlet::transferDockWidgetToDetachedWindow: Transfer completed for profile" << profileName << "wasVisible:" << wasVisible << "intendedVisible:" << intendedVisible;
+}
+
+void mudlet::transferDockWidgetFromDetachedWindow(const QString& profileName, TDetachedWindow* detachedWindow)
+{
+    if (!detachedWindow) {
+        return;
+    }
+    
+    const QString mapKey = qsl("map_%1").arg(profileName);
+    QPointer<QDockWidget> detachedDockWidget = detachedWindow->getDockWidget(mapKey);
+    
+    if (!detachedDockWidget) {
+        qDebug() << "mudlet::transferDockWidgetFromDetachedWindow: No detached window dock widget found for profile" << profileName;
+        return;
+    }
+    
+    qDebug() << "mudlet::transferDockWidgetFromDetachedWindow: Transferring dock widget for profile" << profileName;
+    
+    // Store the current visibility state and determine intended visibility
+    bool wasVisible = detachedDockWidget->isVisible();
+    // If the dock widget is currently visible, the user clearly wants it visible
+    // If it's not visible, respect the stored intended visibility
+    bool intendedVisible = wasVisible || detachedWindow->getDockWidgetIntendedVisibility(mapKey);
+    
+    // Get the mapper widget from the detached window dock widget
+    auto mapperWidget = qobject_cast<dlgMapper*>(detachedDockWidget->widget());
+    if (!mapperWidget) {
+        qDebug() << "mudlet::transferDockWidgetFromDetachedWindow: No mapper widget found in dock widget";
+        return;
+    }
+    
+    // Clear detached window's global reference if this was the active dock
+    if (detachedWindow->getMapDockWidget() == detachedDockWidget) {
+        detachedWindow->setMapDockWidget(nullptr);
+    }
+    
+    // Remove the dock widget from the detached window
+    detachedWindow->QMainWindow::removeDockWidget(detachedDockWidget);
+    
+    // Clear from detached window tracking using the public API
+    detachedWindow->removeDockWidget(mapKey);
+    
+    // Reparent the dock widget to the main window
+    detachedDockWidget->setParent(this);
+    detachedDockWidget->setObjectName(qsl("dockMap_%1_main").arg(profileName));
+    
+    // Add the dock widget to the main window
+    addDockWidget(Qt::RightDockWidgetArea, detachedDockWidget);
+    
+    // Transfer to main window's tracking map
+    mMainWindowDockWidgetMap[mapKey] = detachedDockWidget;
+    
+    // Transfer the intended visibility state as well
+    mMainWindowDockWidgetIntendedVisibility[mapKey] = intendedVisible;
+    
+    // Set the visibility to match the intended state
+    detachedDockWidget->setVisible(intendedVisible);
+    if (intendedVisible) {
+        // Update main window's global reference if it's now visible
+        mpCurrentMapDockWidget = detachedDockWidget;
+    }
+    
+    // Update the mapper's parent
+    mapperWidget->setParent(detachedDockWidget);
+    
+    qDebug() << "mudlet::transferDockWidgetFromDetachedWindow: Transfer completed for profile" << profileName << "wasVisible:" << wasVisible << "intendedVisible:" << intendedVisible;
+}
+
+void mudlet::transferDockWidgetBetweenDetachedWindows(const QString& profileName, TDetachedWindow* sourceWindow, TDetachedWindow* targetWindow)
+{
+    if (!sourceWindow || !targetWindow) {
+        return;
+    }
+    
+    const QString mapKey = qsl("map_%1").arg(profileName);
+    QPointer<QDockWidget> sourceDockWidget = sourceWindow->getDockWidget(mapKey);
+    
+    if (!sourceDockWidget) {
+        qDebug() << "mudlet::transferDockWidgetBetweenDetachedWindows: No dock widget found in source window for profile" << profileName;
+        return;
+    }
+    
+    qDebug() << "mudlet::transferDockWidgetBetweenDetachedWindows: Transferring dock widget for profile" << profileName;
+    
+    // Store the current visibility state and determine intended visibility
+    bool wasVisible = sourceDockWidget->isVisible();
+    // If the dock widget is currently visible, the user clearly wants it visible
+    // If it's not visible, respect the stored intended visibility
+    bool intendedVisible = wasVisible || sourceWindow->getDockWidgetIntendedVisibility(mapKey);
+    
+    // Get the mapper widget from the source dock widget
+    auto mapperWidget = qobject_cast<dlgMapper*>(sourceDockWidget->widget());
+    if (!mapperWidget) {
+        qDebug() << "mudlet::transferDockWidgetBetweenDetachedWindows: No mapper widget found in dock widget";
+        return;
+    }
+    
+    // Clear source window's global reference if this was the active dock
+    if (sourceWindow->getMapDockWidget() == sourceDockWidget) {
+        sourceWindow->setMapDockWidget(nullptr);
+    }
+    
+    // Remove the dock widget from the source window
+    sourceWindow->QMainWindow::removeDockWidget(sourceDockWidget);
+    
+    // Clear from source window tracking using the public API
+    sourceWindow->removeDockWidget(mapKey);
+    
+    // Reparent the dock widget to the target window
+    sourceDockWidget->setParent(targetWindow);
+    sourceDockWidget->setObjectName(qsl("dockMap_%1_detached").arg(profileName));
+    
+    // Add the dock widget to the target window
+    targetWindow->QMainWindow::addDockWidget(Qt::RightDockWidgetArea, sourceDockWidget);
+    
+    // Transfer to target window's tracking map
+    targetWindow->addDockWidget(mapKey, sourceDockWidget);
+    
+    // Transfer the intended visibility state as well
+    targetWindow->setDockWidgetIntendedVisibility(mapKey, intendedVisible);
+    
+    // Set the visibility to match the intended state
+    sourceDockWidget->setVisible(intendedVisible);
+    if (intendedVisible) {
+        // Update target window's global reference if it's now visible
+        targetWindow->setMapDockWidget(sourceDockWidget);
+    }
+    
+    // Update the mapper's parent
+    mapperWidget->setParent(sourceDockWidget);
+    
+    qDebug() << "mudlet::transferDockWidgetBetweenDetachedWindows: Transfer completed for profile" << profileName << "wasVisible:" << wasVisible << "intendedVisible:" << intendedVisible;
 }
 
 bool mudlet::hasOrphanedProfiles()
 {
-    // Check if any loaded profiles don't have visible windows
+    // Check all loaded profiles to see if any are orphaned
     for (const auto& pHost : mHostManager) {
         if (!pHost || !pHost->mpConsole) {
             continue;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3246,6 +3246,10 @@ void mudlet::slot_reconnect()
     pHost->mTelnet.reconnect();
     updateDetachedWindowToolbars();
     updateMainWindowTabIndicators();
+    
+    // Set up a timer to refresh tab indicators after a few seconds
+    // This catches connection status changes that typically happen shortly after reconnection
+    QTimer::singleShot(3000, this, &mudlet::slot_refreshTabIndicatorsDelayed);
 }
 
 void mudlet::slot_disconnect()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1692,6 +1692,7 @@ void mudlet::updateWindowMenu()
         menuWindow->removeAction(action);
         action->deleteLater();
     }
+
     mWindowListActions.clear();
 
     // Remove separator if it exists
@@ -1707,12 +1708,14 @@ void mudlet::updateWindowMenu()
 
     // Only show window list if there are multiple windows OR if there are multiple profiles
     bool hasMultipleProfiles = mHostManager.getHostCount() > 1;
+
     if (totalWindows > 1 || hasMultipleProfiles) {
         // Add separator before window list
         mWindowListSeparator = menuWindow->addSeparator();
 
         // Add main window profiles
         QStringList mainWindowProfiles;
+
         for (const auto& host : mHostManager) {
             if (host && host->mpConsole) {
                 const QString profileName = host->getName();
@@ -1742,8 +1745,10 @@ void mudlet::updateWindowMenu()
         // Add detached window profiles
         // Collect unique detached windows to avoid duplicates
         QSet<TDetachedWindow*> uniqueDetachedWindows;
+
         for (auto it = mDetachedWindows.begin(); it != mDetachedWindows.end(); ++it) {
             TDetachedWindow* detachedWindow = it.value();
+
             if (detachedWindow) {
                 uniqueDetachedWindows.insert(detachedWindow);
             }
@@ -1753,6 +1758,7 @@ void mudlet::updateWindowMenu()
         for (TDetachedWindow* detachedWindow : uniqueDetachedWindows) {
             // Get all profiles in this detached window
             QStringList profilesInWindow = detachedWindow->getProfileNames();
+
             for (const QString& windowProfileName : profilesInWindow) {
                 QString actionText = tr("%1 (Detached)").arg(windowProfileName);
                 QAction* profileAction = new QAction(actionText, this);
@@ -1769,6 +1775,7 @@ void mudlet::updateWindowMenu()
     // Also update window menus on all detached windows
     for (auto it = mDetachedWindows.begin(); it != mDetachedWindows.end(); ++it) {
         TDetachedWindow* detachedWindow = it.value();
+
         if (detachedWindow) {
             detachedWindow->updateWindowMenu();
         }
@@ -1791,8 +1798,10 @@ void mudlet::slot_activateDetachedWindow()
     }
 
     QString profileName = action->data().toString();
+
     if (mDetachedWindows.contains(profileName)) {
         TDetachedWindow* detachedWindow = mDetachedWindows[profileName];
+
         if (detachedWindow) {
             detachedWindow->raise();
             detachedWindow->activateWindow();
@@ -1805,6 +1814,7 @@ void mudlet::slot_activateDetachedWindow()
 void mudlet::slot_activateMainWindowProfile()
 {
     QAction* action = qobject_cast<QAction*>(sender());
+
     if (!action) {
         return;
     }
@@ -1813,6 +1823,7 @@ void mudlet::slot_activateMainWindowProfile()
     
     // Find the tab index for this profile in the main window
     int tabIndex = -1;
+
     for (int i = 0; i < mpTabBar->count(); ++i) {
         if (mpTabBar->tabData(i).toString() == profileName) {
             tabIndex = i;
@@ -1839,6 +1850,7 @@ void mudlet::slot_activateMainWindowProfile()
 void mudlet::slot_activateDetachedWindowProfile()
 {
     QAction* action = qobject_cast<QAction*>(sender());
+
     if (!action) {
         return;
     }
@@ -1848,6 +1860,7 @@ void mudlet::slot_activateDetachedWindowProfile()
     // Find which detached window contains this profile
     for (auto it = mDetachedWindows.begin(); it != mDetachedWindows.end(); ++it) {
         TDetachedWindow* detachedWindow = it.value();
+
         if (detachedWindow && detachedWindow->getProfileNames().contains(profileName)) {
             // Activate the detached window
             detachedWindow->raise();
@@ -1868,16 +1881,20 @@ void mudlet::slot_activateDetachedWindowProfile()
 void mudlet::closeHost(const QString& name)
 {
     Host* pH = mHostManager.getHost(name);
+
     if (!pH) {
         // Don't try and close a non-existant profile:
         return;
     }
+
     migrateDebugConsole(pH);
 
     // Clean up any main window dock widgets for this profile
     const QString mapKey = qsl("map_%1").arg(name);
+
     if (mMainWindowDockWidgetMap.contains(mapKey)) {
         QPointer<QDockWidget> mapDockWidget = mMainWindowDockWidgetMap.value(mapKey);
+
         if (mapDockWidget) {
 #if defined(DEBUG_WINDOW_HANDLING)
             qDebug() << "mudlet::closeHost: Cleaning up main window dock widget for profile" << name;
@@ -1911,15 +1928,18 @@ void mudlet::closeHost(const QString& name)
 void mudlet::updateMultiViewControls()
 {
     const bool isEnabled = (mHostManager.getHostCount() > 1);
+
     if (mpActionMultiView->isEnabled() != isEnabled){
         mpActionMultiView->setEnabled(isEnabled);
     }
+
     if (dactionMultiView->isEnabled() != isEnabled) {
         dactionMultiView->setEnabled(isEnabled);
     }
     
     // Update reattach detached windows menu visibility
     const bool hasDetachedWindows = !mDetachedWindows.isEmpty();
+
     if (dactionReattachDetachedWindows->isVisible() != hasDetachedWindows) {
         dactionReattachDetachedWindows->setVisible(hasDetachedWindows);
     }
@@ -1932,6 +1952,7 @@ void mudlet::reshowRequiredMainConsoles()
             if (host->mpConsole) {
                 // Only show consoles that are in the main window, not detached ones
                 const QString profileName = host->getName();
+
                 if (!mDetachedWindows.contains(profileName)) {
                     host->mpConsole->show();
                 }
@@ -3169,20 +3190,24 @@ void mudlet::slot_showHelpDialogIrc()
 void mudlet::slot_mapper()
 {
     Host* pHost = getActiveHost();
+
     if (!pHost) {
         return;
     }
+
     pHost->showHideOrCreateMapper(true);
 }
 
 void mudlet::slot_showMapperDialog()
 {
     Host* pHost = getActiveHost();
+
     if (!pHost) {
         return;
     }
 
     auto pMap = pHost->mpMap.data();
+
     if (!pMap) {
         return;
     }
@@ -3236,6 +3261,7 @@ void mudlet::slot_showMapperDialog()
             // Restore the host's default mapper if it exists
             if (pHost->mpDockableMapWidget) {
                 auto hostMapWidget = pHost->mpDockableMapWidget->widget();
+
                 if (auto hostMapper = qobject_cast<dlgMapper*>(hostMapWidget)) {
                     pMap->mpMapper = hostMapper;
                 }
@@ -3297,6 +3323,7 @@ void mudlet::slot_showMapperDialog()
     // Connect to handle dock widget visibility changes
     connect(newMapDockWidget, &QDockWidget::visibilityChanged, this, [this, mapKey](bool visible) {
         auto mapDockWidget = mMainWindowDockWidgetMap.value(mapKey);
+
         if (!mapDockWidget) {
             return;
         }
@@ -3310,21 +3337,25 @@ void mudlet::slot_showMapperDialog()
         
         // Extract profile name from mapKey to safely look up objects
         QString profileName = mapKey;
+
         if (profileName.startsWith("map_")) {
             profileName = profileName.mid(4); // Remove "map_" prefix
         }
         
         // Safely get the host and map - they might be null during shutdown
         Host* pHost = getActiveHost();
+
         if (!pHost || pHost->getName() != profileName) {
             // Try to get the specific host for this profile
             pHost = mHostManager.getHost(profileName);
+
             if (!pHost) {
                 return;
             }
         }
         
         auto pMap = pHost->mpMap.data();
+
         if (!pMap) {
             return;
         }
@@ -3338,6 +3369,7 @@ void mudlet::slot_showMapperDialog()
             // Restore the host's default mapper when hiding
             if (pHost->mpDockableMapWidget) {
                 auto hostMapWidget = pHost->mpDockableMapWidget->widget();
+
                 if (auto hostMapper = qobject_cast<dlgMapper*>(hostMapWidget)) {
                     pMap->mpMapper = hostMapper;
                 }
@@ -3348,6 +3380,7 @@ void mudlet::slot_showMapperDialog()
             
             // Ensure the map's active mapper points to our main window instance
             auto mapWidget = mapDockWidget->widget();
+
             if (auto mainMapper = qobject_cast<dlgMapper*>(mapWidget)) {
                 pMap->mpMapper = mainMapper;
             }
@@ -3405,10 +3438,13 @@ void mudlet::slot_toggleEmergencyStop()
 void mudlet::slot_notes()
 {
     Host* pHost = getActiveHost();
+
     if (!pHost) {
         return;
     }
+
     dlgNotepad* pNotes = pHost->mpNotePad;
+
     if (!pNotes) {
         pHost->mpNotePad = new dlgNotepad(pHost);
         pNotes = pHost->mpNotePad;
@@ -3421,6 +3457,7 @@ void mudlet::slot_notes()
         pHost->mpNotePad->setStyleSheet(pHost->mProfileStyleSheet);
         pHost->mpNotePad->notesEdit->setStyleSheet(pHost->mProfileStyleSheet);
     }
+
     pNotes->raise();
     pNotes->show();
 }
@@ -4113,6 +4150,7 @@ void mudlet::synchronizeToolBarVisibility(bool visible)
         } else {
             setToolBarVisibility(enums::visibleNever);
         }
+
         if (mpActionToggleMainToolBar) {
             mpActionToggleMainToolBar->setChecked(visible);
         }
@@ -4132,6 +4170,7 @@ void mudlet::slot_showTabContextMenu(const QPoint& position)
     
     // Find which tab was right-clicked
     int tabIndex = -1;
+
     for (int i = 0; i < mpTabBar->count(); ++i) {
         if (mpTabBar->tabRect(i).contains(position)) {
             tabIndex = i;
@@ -5886,6 +5925,7 @@ void mudlet::refreshTabBar()
 {
     for (const auto& pHost : mHostManager) {
         const QString hostName = pHost->getName();
+
         if (smDebugMode) {
             mpTabBar->applyPrefixToDisplayedText(hostName, TDebug::getTag(pHost.data()));
         } else {
@@ -5896,6 +5936,7 @@ void mudlet::refreshTabBar()
     // Also refresh all detached windows to ensure they show CDC identifiers
     for (auto it = mDetachedWindows.begin(); it != mDetachedWindows.end(); ++it) {
         TDetachedWindow* detachedWindow = it.value();
+
         if (detachedWindow) {
             detachedWindow->refreshTabBar();
         }
@@ -6506,9 +6547,10 @@ void mudlet::reattachTab(const QString& profileName, int insertIndex)
         detachedWindow->setReattaching(true);
     }
 
-    // CRITICAL DEBUG: Check if main window splitter already contains a console for this profile
+    // heck if main window splitter already contains a console for this profile
     for (int i = 0; i < mpSplitter_profileContainer->count(); ++i) {
         QWidget* widget = mpSplitter_profileContainer->widget(i);
+
         if (auto* existingConsole = qobject_cast<TMainConsole*>(widget)) {
             if (existingConsole->objectName() == safeProfileName) {
                 qWarning() << "reattachTab: CONFLICT! Main window already has console for" << safeProfileName
@@ -6524,8 +6566,9 @@ void mudlet::reattachTab(const QString& profileName, int insertIndex)
     // Transfer any dock widgets from the detached window to the main window BEFORE removing the profile
     transferDockWidgetFromDetachedWindow(safeProfileName, detachedWindow);
 
-    // CRITICAL: Remove the profile from the detached window properly
+    // Remove the profile from the detached window properly
     bool removalSuccess = detachedWindow->removeProfile(safeProfileName);
+
     if (!removalSuccess) {
         qWarning() << "reattachTab: Failed to remove profile" << safeProfileName << "from detached window";
         return;
@@ -6547,13 +6590,15 @@ void mudlet::reattachTab(const QString& profileName, int insertIndex)
     const int newTabIndex = mpTabBar->insertTab(insertIndex, safeProfileName);
     mpTabBar->setTabData(newTabIndex, safeProfileName);
 
-    // CRITICAL DEBUG: Check for duplicate tabs
+    // Check for duplicate tabs
     int tabCount = 0;
+
     for (int i = 0; i < mpTabBar->count(); ++i) {
         if (mpTabBar->tabData(i).toString() == safeProfileName) {
             tabCount++;
         }
     }
+
     if (tabCount > 1) {
         qWarning() << "reattachTab: DUPLICATE TABS! Found" << tabCount << "tabs for" << safeProfileName;
     }
@@ -6561,13 +6606,14 @@ void mudlet::reattachTab(const QString& profileName, int insertIndex)
     // Set as current tab
     mpTabBar->setCurrentIndex(newTabIndex);
 
-    // CRITICAL: Remove from detached windows map BEFORE activating profile
+    // Remove from detached windows map BEFORE activating profile
     // This is essential because activateProfile checks mDetachedWindows to decide
     // whether to show the console, and we need it to see this profile as being in main window
     mDetachedWindows.remove(safeProfileName);
 
-    // CRITICAL: Force activation of the profile to ensure it's properly shown
+    // Force activation of the profile to ensure it's properly shown
     Host* pHost = mHostManager.getHost(safeProfileName);
+
     if (pHost) {
         activateProfile(pHost);
 
@@ -6648,6 +6694,7 @@ void mudlet::reattachTab(const QString& profileName, int insertIndex)
 TMainConsole* mudlet::removeConsoleFromSplitter(const QString& profileName)
 {
     Host* pHost = mHostManager.getHost(profileName);
+
     if (!pHost || !pHost->mpConsole) {
         return nullptr;
     }
@@ -6832,8 +6879,10 @@ void mudlet::updateDetachedWindowTabIndicators()
 {
     // Update tab indicators for all detached windows
     const auto& detachedWindows = getDetachedWindows();
+
     for (auto it = detachedWindows.begin(); it != detachedWindows.end(); ++it) {
         TDetachedWindow* detachedWindow = it.value();
+
         if (detachedWindow) {
             // Update all tabs in this detached window
             detachedWindow->updateAllTabIndicators();
@@ -7315,6 +7364,7 @@ void mudlet::updateMainWindowDockWidgetVisibilityForProfile(const QString& profi
     
     // Collect dock widgets to process to avoid iterator invalidation
     QList<QPair<QString, QPointer<QDockWidget>>> dockWidgetsToProcess;
+
     for (auto it = mMainWindowDockWidgetMap.begin(); it != mMainWindowDockWidgetMap.end(); ++it) {
         if (it.value()) {
             dockWidgetsToProcess.append(qMakePair(it.key(), it.value()));
@@ -7338,24 +7388,30 @@ void mudlet::updateMainWindowDockWidgetVisibilityForProfile(const QString& profi
         
         // Check if the dock widget still exists and is in our map
         if (!dockWidget || !mMainWindowDockWidgetMap.contains(dockKey)) {
+#if defined(DEBUG_WINDOW_HANDLING)
             qDebug() << "mudlet: Skipping main window dock widget" << dockKey << "- widget exists:" << (dockWidget != nullptr) 
                      << "in map:" << mMainWindowDockWidgetMap.contains(dockKey);
+#endif
             continue;
         }
         
         // Check if this docked widget belongs to the current profile
         if (dockKey.startsWith("map_")) {
             QString dockProfileName = dockKey.mid(4); // Remove "map_" prefix
+#if defined(DEBUG_WINDOW_HANDLING)
             qDebug() << "mudlet: Processing main window map dock" << dockKey << "profile:" << dockProfileName << "current:" << profileName;
-            
+#endif
+
             if (dockProfileName == profileName) {
                 // This dock widget belongs to the current profile
                 // Check the user's preference for dock widget visibility
                 bool shouldBeVisible = mMainWindowDockWidgetUserPreference.value(dockKey, false);
+#if defined(DEBUG_WINDOW_HANDLING)
                 qDebug() << "mudlet: Found main window dock widget for current profile" << profileName 
                          << "currently visible:" << dockWidget->isVisible() 
                          << "should be visible:" << shouldBeVisible;
-                
+#endif
+
                 // Show or hide based on user preference
                 if (shouldBeVisible) {
                     dockWidget->show();
@@ -7364,32 +7420,41 @@ void mudlet::updateMainWindowDockWidgetVisibilityForProfile(const QString& profi
                     // Set this as the current map dock widget reference
                     mpCurrentMapDockWidget = dockWidget;
                     currentProfileHasVisibleDockWidget = true;
-                    
+
+#if defined(DEBUG_WINDOW_HANDLING)
                     qDebug() << "mudlet: Main window dock widget should be visible - showing and setting as active";
+#endif
                 } else {
                     // Block signals to prevent user preference from being updated by system-initiated change
                     dockWidget->blockSignals(true);
                     dockWidget->setVisible(false);
                     dockWidget->blockSignals(false);
+#if defined(DEBUG_WINDOW_HANDLING)
                     qDebug() << "mudlet: Main window dock widget should be hidden - respecting user preference";
+#endif
                 }
                 
                 // Ensure the map's active mapper points to our main window instance (if visible)
                 if (auto pHost = mHostManager.getHost(profileName)) {
                     if (auto pMap = pHost->mpMap.data()) {
                         auto mapWidget = dockWidget->widget();
+
                         if (auto mainMapper = qobject_cast<dlgMapper*>(mapWidget)) {
                             // Only set as active mapper if the dock widget should be visible
                             if (shouldBeVisible) {
                                 pMap->mpMapper = mainMapper;
+#if defined(DEBUG_WINDOW_HANDLING)
                                 qDebug() << "mudlet: Set active mapper for main window profile" << profileName;
+#endif
                             }
                         }
                     }
                 }
             } else {
                 // This dock widget belongs to a different profile - hide it
+#if defined(DEBUG_WINDOW_HANDLING)
                 qDebug() << "mudlet: Hiding main window dock widget for different profile" << dockProfileName;
+#endif
                 // Block signals to prevent user preference from being updated by system-initiated change
                 dockWidget->blockSignals(true);
                 dockWidget->setVisible(false);
@@ -7400,9 +7465,12 @@ void mudlet::updateMainWindowDockWidgetVisibilityForProfile(const QString& profi
                     if (auto pMap = pHost->mpMap.data()) {
                         if (pHost->mpDockableMapWidget) {
                             auto hostMapWidget = pHost->mpDockableMapWidget->widget();
+
                             if (auto hostMapper = qobject_cast<dlgMapper*>(hostMapWidget)) {
                                 pMap->mpMapper = hostMapper;
+#if defined(DEBUG_WINDOW_HANDLING)
                                 qDebug() << "mudlet: Restored host mapper for main window profile" << dockProfileName;
+#endif
                             }
                         }
                     }
@@ -7411,12 +7479,14 @@ void mudlet::updateMainWindowDockWidgetVisibilityForProfile(const QString& profi
         }
         // Add other dock widget types here as they are implemented
     }
-    
+
+#if defined(DEBUG_WINDOW_HANDLING)
     // Debug output to help track dock widget visibility changes
     qDebug() << "mudlet::updateMainWindowDockWidgetVisibilityForProfile:" << profileName 
              << "- Found visible dock widget:" << currentProfileHasVisibleDockWidget
              << "- Total dock widgets:" << dockWidgetsToProcess.size()
              << "- mpCurrentMapDockWidget set:" << (mpCurrentMapDockWidget != nullptr);
+#endif
 }
 
 void mudlet::transferDockWidgetToDetachedWindow(const QString& profileName, TDetachedWindow* detachedWindow)
@@ -7447,6 +7517,7 @@ void mudlet::transferDockWidgetToDetachedWindow(const QString& profileName, TDet
     
     // Get the mapper widget from the main window dock widget
     auto mapperWidget = qobject_cast<dlgMapper*>(mainDockWidget->widget());
+
     if (!mapperWidget) {
 #if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "mudlet::transferDockWidgetToDetachedWindow: No mapper widget found in dock widget";
@@ -7484,6 +7555,7 @@ void mudlet::transferDockWidgetToDetachedWindow(const QString& profileName, TDet
     mainDockWidget->blockSignals(true);
     mainDockWidget->setVisible(intendedVisible);
     mainDockWidget->blockSignals(false);
+
     if (intendedVisible) {
         // Update detached window's global reference if it's now visible
         detachedWindow->setMapDockWidget(mainDockWidget);
@@ -7491,8 +7563,10 @@ void mudlet::transferDockWidgetToDetachedWindow(const QString& profileName, TDet
     
     // Update the mapper's parent
     mapperWidget->setParent(mainDockWidget);
-    
+
+#if defined(DEBUG_WINDOW_HANDLING)
     qDebug() << "mudlet::transferDockWidgetToDetachedWindow: Transfer completed for profile" << profileName << "wasVisible:" << wasVisible << "intendedVisible:" << intendedVisible;
+#endif
 }
 
 void mudlet::transferDockWidgetFromDetachedWindow(const QString& profileName, TDetachedWindow* detachedWindow)
@@ -7523,6 +7597,7 @@ void mudlet::transferDockWidgetFromDetachedWindow(const QString& profileName, TD
     
     // Get the mapper widget from the detached window dock widget
     auto mapperWidget = qobject_cast<dlgMapper*>(detachedDockWidget->widget());
+
     if (!mapperWidget) {
 #if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "mudlet::transferDockWidgetFromDetachedWindow: No mapper widget found in dock widget";
@@ -7571,17 +7646,20 @@ void mudlet::transferDockWidgetFromDetachedWindow(const QString& profileName, TD
         
         // Extract profile name from mapKey to safely look up objects
         QString profileName = mapKey;
+
         if (profileName.startsWith("map_")) {
             profileName = profileName.mid(4); // Remove "map_" prefix
         }
         
         // Safely get the host - it might be null during shutdown
         Host* pHost = mHostManager.getHost(profileName);
+
         if (!pHost) {
             return;
         }
         
         auto pMap = pHost->mpMap.data();
+
         if (!pMap) {
             return;
         }
@@ -7612,6 +7690,7 @@ void mudlet::transferDockWidgetFromDetachedWindow(const QString& profileName, TD
     detachedDockWidget->blockSignals(true);
     detachedDockWidget->setVisible(intendedVisible);
     detachedDockWidget->blockSignals(false);
+
     if (intendedVisible) {
         // Update main window's global reference if it's now visible
         mpCurrentMapDockWidget = detachedDockWidget;
@@ -7619,8 +7698,9 @@ void mudlet::transferDockWidgetFromDetachedWindow(const QString& profileName, TD
     
     // Update the mapper's parent
     mapperWidget->setParent(detachedDockWidget);
-    
+#if defined(DEBUG_WINDOW_HANDLING)    
     qDebug() << "mudlet::transferDockWidgetFromDetachedWindow: Transfer completed for profile" << profileName << "wasVisible:" << wasVisible << "intendedVisible:" << intendedVisible;
+#endif
 }
 
 void mudlet::transferDockWidgetBetweenDetachedWindows(const QString& profileName, TDetachedWindow* sourceWindow, TDetachedWindow* targetWindow)
@@ -7633,11 +7713,15 @@ void mudlet::transferDockWidgetBetweenDetachedWindows(const QString& profileName
     QPointer<QDockWidget> sourceDockWidget = sourceWindow->getDockWidget(mapKey);
     
     if (!sourceDockWidget) {
+#if defined(DEBUG_WINDOW_HANDLING)  
         qDebug() << "mudlet::transferDockWidgetBetweenDetachedWindows: No dock widget found in source window for profile" << profileName;
+#endif
         return;
     }
-    
+
+#if defined(DEBUG_WINDOW_HANDLING)  
     qDebug() << "mudlet::transferDockWidgetBetweenDetachedWindows: Transferring dock widget for profile" << profileName;
+#endif
     
     // Store the current visibility state and determine user preference
     bool wasVisible = sourceDockWidget->isVisible();
@@ -7647,8 +7731,11 @@ void mudlet::transferDockWidgetBetweenDetachedWindows(const QString& profileName
     
     // Get the mapper widget from the source dock widget
     auto mapperWidget = qobject_cast<dlgMapper*>(sourceDockWidget->widget());
+
     if (!mapperWidget) {
+#if defined(DEBUG_WINDOW_HANDLING)  
         qDebug() << "mudlet::transferDockWidgetBetweenDetachedWindows: No mapper widget found in dock widget";
+#endif
         return;
     }
     
@@ -7678,6 +7765,7 @@ void mudlet::transferDockWidgetBetweenDetachedWindows(const QString& profileName
     
     // Set the visibility to match the intended state
     sourceDockWidget->setVisible(intendedVisible);
+
     if (intendedVisible) {
         // Update target window's global reference if it's now visible
         targetWindow->setMapDockWidget(sourceDockWidget);
@@ -7685,8 +7773,10 @@ void mudlet::transferDockWidgetBetweenDetachedWindows(const QString& profileName
     
     // Update the mapper's parent
     mapperWidget->setParent(sourceDockWidget);
-    
+
+#if defined(DEBUG_WINDOW_HANDLING)
     qDebug() << "mudlet::transferDockWidgetBetweenDetachedWindows: Transfer completed for profile" << profileName << "wasVisible:" << wasVisible << "intendedVisible:" << intendedVisible;
+#endif
 }
 
 bool mudlet::hasOrphanedProfiles()
@@ -7736,6 +7826,7 @@ QStringList mudlet::getOrphanedProfiles()
         
         // Check if profile is in main window (has a tab)
         bool inMainWindow = false;
+
         for (int i = 0; i < mpTabBar->count(); ++i) {
             if (mpTabBar->tabData(i).toString() == profileName) {
                 inMainWindow = true;
@@ -7772,6 +7863,7 @@ void mudlet::reattachOrphanedProfiles()
     // Reattach each orphaned profile to the main window
     for (const QString& profileName : orphanedProfiles) {
         Host* pHost = mHostManager.getHost(profileName);
+
         if (!pHost || !pHost->mpConsole) {
             qWarning() << "reattachOrphanedProfiles: Invalid host for profile:" << profileName;
             continue;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1595,17 +1595,41 @@ void mudlet::slot_closeProfileByName(const QString& profileName)
 // Window menu slot implementations
 void mudlet::slot_reattachAllDetachedWindows()
 {
+    // First, check for and reattach any orphaned profiles
+    QStringList orphanedProfiles = getOrphanedProfiles();
+
+    if (!orphanedProfiles.isEmpty()) {
+        qWarning() << "slot_reattachAllDetachedWindows: Found orphaned profiles:" << orphanedProfiles;
+        reattachOrphanedProfiles();
+    }
+    
     // Get a copy of the detached windows map since reattaching will modify it
     auto detachedWindowsCopy = mDetachedWindows;
+
+    if (detachedWindowsCopy.isEmpty()) {
+        qDebug() << "slot_reattachAllDetachedWindows: No detached windows to reattach";
+        return;
+    }
+    
+    qDebug() << "slot_reattachAllDetachedWindows: Reattaching" << detachedWindowsCopy.size() << "detached windows";
 
     for (auto it = detachedWindowsCopy.begin(); it != detachedWindowsCopy.end(); ++it) {
         const QString& profileName = it.key();
         TDetachedWindow* detachedWindow = it.value();
 
         if (detachedWindow) {
+            qDebug() << "slot_reattachAllDetachedWindows: Reattaching profile" << profileName;
             // Use the existing reattach mechanism
             reattachTab(profileName, -1); // Use default insert index
         }
+    }
+    
+    // Final validation to ensure no profiles are left orphaned
+    QStringList remainingOrphans = getOrphanedProfiles();
+
+    if (!remainingOrphans.isEmpty()) {
+        qWarning() << "slot_reattachAllDetachedWindows: Still have orphaned profiles after reattachment:" << remainingOrphans;
+        reattachOrphanedProfiles();
     }
 }
 
@@ -1658,6 +1682,12 @@ void mudlet::updateMultiViewControls()
     }
     if (dactionMultiView->isEnabled() != isEnabled) {
         dactionMultiView->setEnabled(isEnabled);
+    }
+    
+    // Update reattach detached windows menu visibility
+    const bool hasDetachedWindows = !mDetachedWindows.isEmpty();
+    if (dactionReattachDetachedWindows->isVisible() != hasDetachedWindows) {
+        dactionReattachDetachedWindows->setVisible(hasDetachedWindows);
     }
 }
 
@@ -2049,6 +2079,34 @@ void mudlet::showEvent(QShowEvent* event)
 {
     mWindowMinimized = false;
     QMainWindow::showEvent(event);
+    
+    // Validate profiles on startup - check for orphaned profiles that might 
+    // have been left invisible due to improper detached window closure
+    static bool startupValidationDone = false;
+
+    if (!startupValidationDone) {
+        startupValidationDone = true;
+        
+        // Use a timer to defer this check until after full initialization
+        QTimer::singleShot(1000, this, [this]() {
+            QStringList orphanedProfiles = getOrphanedProfiles();
+
+            if (!orphanedProfiles.isEmpty()) {
+                qWarning() << "Startup validation: Found orphaned profiles from previous session:" << orphanedProfiles;
+                
+                // Ask user if they want to reattach the orphaned profiles
+                QString message = tr("Found %1 profile(s) that were left in an invisible state from a previous session:\n\n%2\n\nWould you like to reattach them to the main window?")
+                                 .arg(orphanedProfiles.size())
+                                 .arg(orphanedProfiles.join(", "));
+                                 
+                auto reply = QMessageBox::question(this, tr("Orphaned Profiles Detected"), message,
+                                                 QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+                if (reply == QMessageBox::Yes) {
+                    reattachOrphanedProfiles();
+                }
+            }
+        });
+    }
 }
 
 void mudlet::hideEvent(QHideEvent* event)
@@ -5684,6 +5742,9 @@ void mudlet::slot_detachedWindowClosed(const QString& profileName)
 
         // Update tab bar auto-hide behavior since detached windows changed
         updateMainWindowTabBarAutoHide();
+        
+        // Update multi-view controls including "Reattach detached windows" menu visibility
+        updateMultiViewControls();
 
         // Properly close the host to avoid dangling connections
         Host* pHost = mHostManager.getHost(profileName);
@@ -6333,6 +6394,9 @@ void mudlet::moveProfileBetweenDetachedWindows(const QString& profileName, TDeta
         targetWindow->updateToolbarForProfile(pHost);
     }
 
+    // Always update multi-view controls after moving profiles between windows
+    updateMultiViewControls();
+
     // Check if source window should be closed (no profiles left)
     if (sourceWindow->getProfileCount() == 0) {
         // Remove all entries for this window from detached windows map before closing
@@ -6351,6 +6415,9 @@ void mudlet::moveProfileBetweenDetachedWindows(const QString& profileName, TDeta
 
         // Update tab bar auto-hide behavior since detached windows changed
         updateMainWindowTabBarAutoHide();
+        
+        // Update multi-view controls including "Reattach detached windows" menu visibility
+        updateMultiViewControls();
     }
 }
 
@@ -6612,4 +6679,112 @@ void mudlet::moveProfileFromDetachedToMainWindow(const QString& profileName, TDe
     
     // Refresh tab bar to ensure CDC identifiers are displayed after reattachment
     refreshTabBar();
+}
+
+bool mudlet::hasOrphanedProfiles()
+{
+    // Check if any loaded profiles don't have visible windows
+    for (const auto& pHost : mHostManager) {
+        if (!pHost || !pHost->mpConsole) {
+            continue;
+        }
+        
+        const QString profileName = pHost->getName();
+        
+        // Check if profile is in main window (has a tab)
+        bool inMainWindow = false;
+
+        for (int i = 0; i < mpTabBar->count(); ++i) {
+            if (mpTabBar->tabData(i).toString() == profileName) {
+                inMainWindow = true;
+                break;
+            }
+        }
+        
+        // Check if profile is in a detached window
+        bool inDetachedWindow = mDetachedWindows.contains(profileName);
+        
+        // If profile is not visible in either location, it's orphaned
+        if (!inMainWindow && !inDetachedWindow) {
+            qWarning() << "hasOrphanedProfiles: Found orphaned profile:" << profileName;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+QStringList mudlet::getOrphanedProfiles()
+{
+    QStringList orphanedProfiles;
+    
+    // Find all loaded profiles that don't have visible windows
+    for (const auto& pHost : mHostManager) {
+        if (!pHost || !pHost->mpConsole) {
+            continue;
+        }
+        
+        const QString profileName = pHost->getName();
+        
+        // Check if profile is in main window (has a tab)
+        bool inMainWindow = false;
+        for (int i = 0; i < mpTabBar->count(); ++i) {
+            if (mpTabBar->tabData(i).toString() == profileName) {
+                inMainWindow = true;
+                break;
+            }
+        }
+        
+        // Check if profile is in a detached window
+        bool inDetachedWindow = mDetachedWindows.contains(profileName);
+        
+        // If profile is not visible in either location, it's orphaned
+        if (!inMainWindow && !inDetachedWindow) {
+            qWarning() << "getOrphanedProfiles: Found orphaned profile:" << profileName;
+            orphanedProfiles << profileName;
+        }
+    }
+
+    return orphanedProfiles;
+}
+
+void mudlet::reattachOrphanedProfiles()
+{
+    QStringList orphanedProfiles = getOrphanedProfiles();
+    
+    if (orphanedProfiles.isEmpty()) {
+        qDebug() << "reattachOrphanedProfiles: No orphaned profiles found";
+        return;
+    }
+    
+    qWarning() << "reattachOrphanedProfiles: Reattaching" << orphanedProfiles.size() << "orphaned profiles:" << orphanedProfiles;
+    
+    // Reattach each orphaned profile to the main window
+    for (const QString& profileName : orphanedProfiles) {
+        Host* pHost = mHostManager.getHost(profileName);
+        if (!pHost || !pHost->mpConsole) {
+            qWarning() << "reattachOrphanedProfiles: Invalid host for profile:" << profileName;
+            continue;
+        }
+        
+        qDebug() << "reattachOrphanedProfiles: Reattaching orphaned profile:" << profileName;
+        
+        // Add console back to main window
+        const int insertIndex = mpTabBar->count(); // Insert at end
+        addConsoleToSplitter(pHost->mpConsole, insertIndex);
+        
+        // Add tab back to tab bar
+        const int newTabIndex = mpTabBar->insertTab(insertIndex, profileName);
+        mpTabBar->setTabData(newTabIndex, profileName);
+        
+        // Make it the current tab
+        mpTabBar->setCurrentIndex(newTabIndex);
+        activateProfile(pHost);
+    }
+    
+    // Update UI after reattachment
+    updateMultiViewControls();
+    updateMainWindowTabBarAutoHide();
+    refreshTabBar();
+    enableToolbarButtons();
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2294,16 +2294,9 @@ void mudlet::showEvent(QShowEvent* event)
             if (!orphanedProfiles.isEmpty()) {
                 qWarning() << "Startup validation: Found orphaned profiles from previous session:" << orphanedProfiles;
                 
-                // Ask user if they want to reattach the orphaned profiles
-                QString message = tr("Found %1 profile(s) that were left in an invisible state from a previous session:\n\n%2\n\nWould you like to reattach them to the main window?")
-                                 .arg(orphanedProfiles.size())
-                                 .arg(orphanedProfiles.join(", "));
-                                 
-                auto reply = QMessageBox::question(this, tr("Orphaned Profiles Detected"), message,
-                                                 QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
-                if (reply == QMessageBox::Yes) {
-                    reattachOrphanedProfiles();
-                }
+                // Automatically reattach orphaned profiles without user prompt
+                qDebug() << "Automatically reattaching" << orphanedProfiles.size() << "orphaned profiles:" << orphanedProfiles.join(", ");
+                reattachOrphanedProfiles();
             }
         });
     }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -6949,7 +6949,9 @@ void mudlet::moveProfileBetweenDetachedWindows(const QString& profileName, TDeta
         return;
     }
 
+#if defined(DEBUG_WINDOW_HANDLING)
     qDebug() << "mudlet: Moving profile" << profileName << "between detached windows";
+#endif
 
     // Store console state before move
     const QSize oldSize = console->size();
@@ -7205,12 +7207,16 @@ void mudlet::moveProfileFromDetachedToMainWindow(const QString& profileName, TDe
 
     // EXPERIMENTAL: Force a complete refresh of the main window state
     // This ensures that all UI elements are properly synchronized after the profile move
+#if defined(DEBUG_WINDOW_HANDLING)
     qDebug() << "moveProfileFromDetachedToMainWindow: Forcing complete main window refresh";
+#endif
 
     // Make sure the moved profile becomes the current active one
     if (pHost && mpCurrentActiveHost != pHost) {
+#if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "moveProfileFromDetachedToMainWindow: Current active host is" << (mpCurrentActiveHost ? mpCurrentActiveHost->getName() : "null")
                  << ", forcing switch to" << pHost->getName();
+#endif
         mpCurrentActiveHost = pHost;
     }
 
@@ -7232,16 +7238,22 @@ void mudlet::moveProfileFromDetachedToMainWindow(const QString& profileName, TDe
     // Process any remaining events
     QCoreApplication::processEvents();
 
+#if defined(DEBUG_WINDOW_HANDLING)
     qDebug() << "moveProfileFromDetachedToMainWindow: Completed main window refresh";
+#endif
 
     // IMPORTANT: Only close window if it's now empty
     if (sourceWindow->getProfileCount() == 0) {
+#if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "moveProfileFromDetachedToMainWindow: Source window is now empty, closing it";
+#endif
         // Window is now empty, remove all entries for this window from detached windows map
         auto it = mDetachedWindows.begin();
         while (it != mDetachedWindows.end()) {
             if (it.value() == sourceWindow) {
+#if defined(DEBUG_WINDOW_HANDLING)
                 qDebug() << "moveProfileFromDetachedToMainWindow: Removing" << it.key() << "from detached windows map";
+#endif
                 it = mDetachedWindows.erase(it);
             } else {
                 ++it;
@@ -7252,10 +7264,14 @@ void mudlet::moveProfileFromDetachedToMainWindow(const QString& profileName, TDe
         sourceWindow->close();
         sourceWindow->deleteLater();
 
+#if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "moveProfileFromDetachedToMainWindow: Closed empty detached window";
+#endif
     } else {
         // Window still has other profiles
+#if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "moveProfileFromDetachedToMainWindow: Window still has" << sourceWindow->getProfileCount() << "profiles";
+#endif
     }
 
     // Verify Host->Console relationship is still intact
@@ -7292,17 +7308,23 @@ void mudlet::updateMainWindowDockWidgetVisibilityForProfile(const QString& profi
     // Clear the current map dock widget reference first
     mpCurrentMapDockWidget = nullptr;
     
+#if defined(DEBUG_WINDOW_HANDLING)
     qDebug() << "mudlet::updateMainWindowDockWidgetVisibilityForProfile: Starting for profile" << profileName
              << "- mMainWindowDockWidgetMap.size():" << mMainWindowDockWidgetMap.size();
+#endif
     
     // Collect dock widgets to process to avoid iterator invalidation
     QList<QPair<QString, QPointer<QDockWidget>>> dockWidgetsToProcess;
     for (auto it = mMainWindowDockWidgetMap.begin(); it != mMainWindowDockWidgetMap.end(); ++it) {
         if (it.value()) {
             dockWidgetsToProcess.append(qMakePair(it.key(), it.value()));
+#if defined(DEBUG_WINDOW_HANDLING)
             qDebug() << "mudlet: Found main window dock widget in map:" << it.key() << "isVisible:" << it.value()->isVisible();
+#endif
         } else {
+#if defined(DEBUG_WINDOW_HANDLING)
             qDebug() << "mudlet: Found null main window dock widget in map for key:" << it.key();
+#endif
         }
     }
     

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1284,7 +1284,7 @@ void mudlet::loadMaps()
 // migrates the Central Debug Console to the next available host, if any
 void mudlet::migrateDebugConsole(Host* currentHost)
 {
-    if (!smpDebugArea) {
+    if (!smpDebugArea || !smpDebugConsole) {
         return;
     }
 
@@ -5256,6 +5256,14 @@ void mudlet::refreshTabBar()
             mpTabBar->applyPrefixToDisplayedText(hostName);
         }
     }
+    
+    // Also refresh all detached windows to ensure they show CDC identifiers
+    for (auto it = mDetachedWindows.begin(); it != mDetachedWindows.end(); ++it) {
+        TDetachedWindow* detachedWindow = it.value();
+        if (detachedWindow) {
+            detachedWindow->refreshTabBar();
+        }
+    }
 }
 
 //NOLINT(readability-convert-member-functions-to-static)
@@ -6079,6 +6087,49 @@ void mudlet::updateDetachedWindowToolbars()
     }
 }
 
+QIcon mudlet::createConnectionStatusIcon(bool isConnected, bool isConnecting, bool hasError)
+{
+    // Create a 16x16 pixmap for the icon
+    QPixmap pixmap(16, 16);
+    pixmap.fill(Qt::transparent);
+    
+    QPainter painter(&pixmap);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    
+    // Set up the dot properties
+    const int centerX = 8;
+    const int centerY = 8;
+    const int radius = 4;
+    
+    if (hasError) {
+        // Red filled triangle for error
+        painter.setBrush(QColor(220, 50, 50));
+        painter.setPen(QPen(QColor(180, 40, 40), 1));
+        QPolygon triangle;
+        triangle << QPoint(centerX, centerY - 4) 
+                 << QPoint(centerX - 4, centerY + 3)
+                 << QPoint(centerX + 4, centerY + 3);
+        painter.drawPolygon(triangle);
+    } else if (isConnected) {
+        // Green filled circle for connected
+        painter.setBrush(QColor(50, 180, 50));
+        painter.setPen(QPen(QColor(40, 150, 40), 1));
+        painter.drawEllipse(centerX - radius, centerY - radius, radius * 2, radius * 2);
+    } else if (isConnecting) {
+        // Yellow filled circle for connecting
+        painter.setBrush(QColor(220, 180, 50));
+        painter.setPen(QPen(QColor(180, 150, 40), 1));
+        painter.drawEllipse(centerX - radius, centerY - radius, radius * 2, radius * 2);
+    } else {
+        // Empty circle (just outline) for disconnected
+        painter.setBrush(Qt::transparent);
+        painter.setPen(QPen(QColor(120, 120, 120), 2));
+        painter.drawEllipse(centerX - radius, centerY - radius, radius * 2, radius * 2);
+    }
+    
+    return QIcon(pixmap);
+}
+
 void mudlet::updateMainWindowTabIndicators()
 {
     if (!mpTabBar) {
@@ -6098,16 +6149,9 @@ void mudlet::updateMainWindowTabIndicators()
         if (pHost) {
             bool isConnected = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectedState);
             bool isConnecting = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectingState);
-
-            if (isConnected) {
-                tabIcon = QIcon(qsl(":/icons/dialog-ok-apply.png"));
-            } else if (isConnecting) {
-                tabIcon = QIcon(qsl(":/icons/dialog-information.png"));
-            } else {
-                tabIcon = QIcon(qsl(":/icons/dialog-close.png"));
-            }
+            tabIcon = createConnectionStatusIcon(isConnected, isConnecting, false);
         } else {
-            tabIcon = QIcon(qsl(":/icons/dialog-error.png"));
+            tabIcon = createConnectionStatusIcon(false, false, true);
         }
 
         // Only set the tab icon, keep the original tab text as just the profile name

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1893,7 +1893,7 @@ void mudlet::closeHost(const QString& name)
         
         // Remove from our tracking map
         mMainWindowDockWidgetMap.remove(mapKey);
-        mMainWindowDockWidgetIntendedVisibility.remove(mapKey);
+        mMainWindowDockWidgetUserPreference.remove(mapKey);
     }
 
     mpTabBar->removeTab(name);
@@ -3261,8 +3261,8 @@ void mudlet::slot_showMapperDialog()
     // Store reference in our map for cleanup and profile-specific access
     mMainWindowDockWidgetMap[mapKey] = newMapDockWidget;
     
-    // Set intended visibility to true since we're initially showing this dock widget
-    mMainWindowDockWidgetIntendedVisibility[mapKey] = true;
+    // Set user preference to true since we're initially showing this dock widget
+    mMainWindowDockWidgetUserPreference[mapKey] = true;
     
     // Set global reference to the currently active map
     mpCurrentMapDockWidget = newMapDockWidget;
@@ -3275,10 +3275,10 @@ void mudlet::slot_showMapperDialog()
         }
         
         // Track user-initiated visibility changes (not system-initiated profile switches)
-        // Only update intended visibility if this is likely a user action
+        // Only update user preference if this is likely a user action
         if (getActiveHost() && getActiveHost()->getName() == mapKey.mid(4)) {
             // Current profile's dock widget visibility changed - likely user action
-            mMainWindowDockWidgetIntendedVisibility[mapKey] = visible;
+            mMainWindowDockWidgetUserPreference[mapKey] = visible;
             qDebug() << "mudlet: User changed dock widget visibility for" << mapKey << "to" << visible;
         }
         
@@ -7257,13 +7257,13 @@ void mudlet::updateMainWindowDockWidgetVisibilityForProfile(const QString& profi
             
             if (dockProfileName == profileName) {
                 // This dock widget belongs to the current profile
-                // Check the intended visibility state, not the current visibility
-                bool shouldBeVisible = mMainWindowDockWidgetIntendedVisibility.value(dockKey, false);
+                // Check the user's preference for dock widget visibility
+                bool shouldBeVisible = mMainWindowDockWidgetUserPreference.value(dockKey, false);
                 qDebug() << "mudlet: Found main window dock widget for current profile" << profileName 
                          << "currently visible:" << dockWidget->isVisible() 
                          << "should be visible:" << shouldBeVisible;
                 
-                // Show or hide based on intended visibility
+                // Show or hide based on user preference
                 if (shouldBeVisible) {
                     dockWidget->show();
                     dockWidget->raise();
@@ -7336,11 +7336,11 @@ void mudlet::transferDockWidgetToDetachedWindow(const QString& profileName, TDet
     
     qDebug() << "mudlet::transferDockWidgetToDetachedWindow: Transferring dock widget for profile" << profileName;
     
-    // Store the current visibility state and determine intended visibility
+    // Store the current visibility state and determine user preference
     bool wasVisible = mainDockWidget->isVisible();
     // If the dock widget is currently visible, the user clearly wants it visible
-    // If it's not visible, respect the stored intended visibility (defaulting to false for new profiles)
-    bool intendedVisible = wasVisible || mMainWindowDockWidgetIntendedVisibility.value(mapKey, false);
+    // If it's not visible, respect the stored user preference (defaulting to false for new profiles)
+    bool intendedVisible = wasVisible || mMainWindowDockWidgetUserPreference.value(mapKey, false);
     
     // Get the mapper widget from the main window dock widget
     auto mapperWidget = qobject_cast<dlgMapper*>(mainDockWidget->widget());
@@ -7354,7 +7354,7 @@ void mudlet::transferDockWidgetToDetachedWindow(const QString& profileName, TDet
     
     // Clear from main window tracking
     mMainWindowDockWidgetMap.remove(mapKey);
-    mMainWindowDockWidgetIntendedVisibility.remove(mapKey);
+    mMainWindowDockWidgetUserPreference.remove(mapKey);
     if (mpCurrentMapDockWidget == mainDockWidget) {
         mpCurrentMapDockWidget = nullptr;
     }
@@ -7369,8 +7369,8 @@ void mudlet::transferDockWidgetToDetachedWindow(const QString& profileName, TDet
     // Transfer to detached window's tracking map
     detachedWindow->addDockWidget(mapKey, mainDockWidget);
     
-    // Transfer the intended visibility state as well
-    detachedWindow->setDockWidgetIntendedVisibility(mapKey, intendedVisible);
+    // Transfer the user preference state as well
+    detachedWindow->setDockWidgetUserPreference(mapKey, intendedVisible);
     
     // Set the visibility to match the intended state
     mainDockWidget->setVisible(intendedVisible);
@@ -7401,11 +7401,11 @@ void mudlet::transferDockWidgetFromDetachedWindow(const QString& profileName, TD
     
     qDebug() << "mudlet::transferDockWidgetFromDetachedWindow: Transferring dock widget for profile" << profileName;
     
-    // Store the current visibility state and determine intended visibility
+    // Store the current visibility state and determine user preference
     bool wasVisible = detachedDockWidget->isVisible();
     // If the dock widget is currently visible, the user clearly wants it visible
-    // If it's not visible, respect the stored intended visibility
-    bool intendedVisible = wasVisible || detachedWindow->getDockWidgetIntendedVisibility(mapKey);
+    // If it's not visible, respect the stored user preference
+    bool intendedVisible = wasVisible || detachedWindow->getDockWidgetUserPreference(mapKey);
     
     // Get the mapper widget from the detached window dock widget
     auto mapperWidget = qobject_cast<dlgMapper*>(detachedDockWidget->widget());
@@ -7435,8 +7435,8 @@ void mudlet::transferDockWidgetFromDetachedWindow(const QString& profileName, TD
     // Transfer to main window's tracking map
     mMainWindowDockWidgetMap[mapKey] = detachedDockWidget;
     
-    // Transfer the intended visibility state as well
-    mMainWindowDockWidgetIntendedVisibility[mapKey] = intendedVisible;
+    // Transfer the user preference state as well
+    mMainWindowDockWidgetUserPreference[mapKey] = intendedVisible;
     
     // Set the visibility to match the intended state
     detachedDockWidget->setVisible(intendedVisible);
@@ -7467,11 +7467,11 @@ void mudlet::transferDockWidgetBetweenDetachedWindows(const QString& profileName
     
     qDebug() << "mudlet::transferDockWidgetBetweenDetachedWindows: Transferring dock widget for profile" << profileName;
     
-    // Store the current visibility state and determine intended visibility
+    // Store the current visibility state and determine user preference
     bool wasVisible = sourceDockWidget->isVisible();
     // If the dock widget is currently visible, the user clearly wants it visible
-    // If it's not visible, respect the stored intended visibility
-    bool intendedVisible = wasVisible || sourceWindow->getDockWidgetIntendedVisibility(mapKey);
+    // If it's not visible, respect the stored user preference
+    bool intendedVisible = wasVisible || sourceWindow->getDockWidgetUserPreference(mapKey);
     
     // Get the mapper widget from the source dock widget
     auto mapperWidget = qobject_cast<dlgMapper*>(sourceDockWidget->widget());
@@ -7501,8 +7501,8 @@ void mudlet::transferDockWidgetBetweenDetachedWindows(const QString& profileName
     // Transfer to target window's tracking map
     targetWindow->addDockWidget(mapKey, sourceDockWidget);
     
-    // Transfer the intended visibility state as well
-    targetWindow->setDockWidgetIntendedVisibility(mapKey, intendedVisible);
+    // Transfer the user preference state as well
+    targetWindow->setDockWidgetUserPreference(mapKey, intendedVisible);
     
     // Set the visibility to match the intended state
     sourceDockWidget->setVisible(intendedVisible);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -7429,11 +7429,15 @@ void mudlet::transferDockWidgetToDetachedWindow(const QString& profileName, TDet
     QPointer<QDockWidget> mainDockWidget = mMainWindowDockWidgetMap.value(mapKey);
     
     if (!mainDockWidget) {
+#if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "mudlet::transferDockWidgetToDetachedWindow: No main window dock widget found for profile" << profileName;
+#endif
         return;
     }
     
+#if defined(DEBUG_WINDOW_HANDLING)
     qDebug() << "mudlet::transferDockWidgetToDetachedWindow: Transferring dock widget for profile" << profileName;
+#endif
     
     // Store the current visibility state and determine user preference
     bool wasVisible = mainDockWidget->isVisible();
@@ -7444,7 +7448,9 @@ void mudlet::transferDockWidgetToDetachedWindow(const QString& profileName, TDet
     // Get the mapper widget from the main window dock widget
     auto mapperWidget = qobject_cast<dlgMapper*>(mainDockWidget->widget());
     if (!mapperWidget) {
+#if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "mudlet::transferDockWidgetToDetachedWindow: No mapper widget found in dock widget";
+#endif
         return;
     }
     
@@ -7499,11 +7505,15 @@ void mudlet::transferDockWidgetFromDetachedWindow(const QString& profileName, TD
     QPointer<QDockWidget> detachedDockWidget = detachedWindow->getDockWidget(mapKey);
     
     if (!detachedDockWidget) {
+#if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "mudlet::transferDockWidgetFromDetachedWindow: No detached window dock widget found for profile" << profileName;
+#endif
         return;
     }
     
+#if defined(DEBUG_WINDOW_HANDLING)
     qDebug() << "mudlet::transferDockWidgetFromDetachedWindow: Transferring dock widget for profile" << profileName;
+#endif
     
     // Store the current visibility state and determine user preference
     bool wasVisible = detachedDockWidget->isVisible();
@@ -7514,7 +7524,9 @@ void mudlet::transferDockWidgetFromDetachedWindow(const QString& profileName, TD
     // Get the mapper widget from the detached window dock widget
     auto mapperWidget = qobject_cast<dlgMapper*>(detachedDockWidget->widget());
     if (!mapperWidget) {
+#if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "mudlet::transferDockWidgetFromDetachedWindow: No mapper widget found in dock widget";
+#endif
         return;
     }
     
@@ -7749,7 +7761,9 @@ void mudlet::reattachOrphanedProfiles()
     QStringList orphanedProfiles = getOrphanedProfiles();
     
     if (orphanedProfiles.isEmpty()) {
+#if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "reattachOrphanedProfiles: No orphaned profiles found";
+#endif
         return;
     }
     
@@ -7763,7 +7777,9 @@ void mudlet::reattachOrphanedProfiles()
             continue;
         }
         
+#if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "reattachOrphanedProfiles: Reattaching orphaned profile:" << profileName;
+#endif
         
         // Add console back to main window
         const int insertIndex = mpTabBar->count(); // Insert at end

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -740,6 +740,12 @@ void mudlet::init()
 
     initializeAI();
 
+    // Initialize the window menu on startup
+    updateWindowMenu();
+
+    // Connect the Window menu's aboutToShow signal to update the window list
+    connect(menuWindow, &QMenu::aboutToShow, this, &mudlet::updateWindowMenu);
+
     // PLACEMARKER: sample benchmarking code
     // looking to benchmark old/new code? Use this example
     // full docs at https://nanobench.ankerl.com
@@ -1631,6 +1637,9 @@ void mudlet::slot_reattachAllDetachedWindows()
         qWarning() << "slot_reattachAllDetachedWindows: Still have orphaned profiles after reattachment:" << remainingOrphans;
         reattachOrphanedProfiles();
     }
+
+    // Update the window menu to reflect all windows being reattached
+    updateWindowMenu();
 }
 
 void mudlet::slot_toggleAlwaysOnTop()
@@ -1651,6 +1660,184 @@ void mudlet::slot_toggleAlwaysOnTop()
 void mudlet::slot_minimize()
 {
     showMinimized();
+}
+
+void mudlet::updateWindowMenu()
+{
+    // Clean up existing window list actions
+    for (QAction* action : mWindowListActions) {
+        menuWindow->removeAction(action);
+        action->deleteLater();
+    }
+    mWindowListActions.clear();
+
+    // Remove separator if it exists
+    if (mWindowListSeparator) {
+        menuWindow->removeAction(mWindowListSeparator);
+        mWindowListSeparator->deleteLater();
+        mWindowListSeparator = nullptr;
+    }
+
+    // Count total windows (main + detached)
+    int totalWindows = 1; // Main window
+    totalWindows += mDetachedWindows.size();
+
+    // Only show window list if there are multiple windows OR if there are multiple profiles
+    bool hasMultipleProfiles = mHostManager.getHostCount() > 1;
+    if (totalWindows > 1 || hasMultipleProfiles) {
+        // Add separator before window list
+        mWindowListSeparator = menuWindow->addSeparator();
+
+        // Add main window profiles
+        QStringList mainWindowProfiles;
+        for (const auto& host : mHostManager) {
+            if (host && host->mpConsole) {
+                const QString profileName = host->getName();
+                // Only include profiles that are in the main window (not detached)
+                if (!mDetachedWindows.contains(profileName)) {
+                    mainWindowProfiles.append(profileName);
+                }
+            }
+        }
+
+        // Add main window header if it has profiles
+        if (!mainWindowProfiles.isEmpty()) {
+            // Add main window section
+            for (const QString& profileName : mainWindowProfiles) {
+                Host* host = mHostManager.getHost(profileName);
+                QString actionText = tr("%1 (Main Window)").arg(profileName);
+                QAction* profileAction = new QAction(actionText, this);
+                profileAction->setCheckable(true);
+                profileAction->setChecked(isActiveWindow() && mpCurrentActiveHost && mpCurrentActiveHost->getName() == profileName);
+                profileAction->setData(profileName); // Store profile name for identification
+                connect(profileAction, &QAction::triggered, this, &mudlet::slot_activateMainWindowProfile);
+                menuWindow->addAction(profileAction);
+                mWindowListActions.append(profileAction);
+            }
+        }
+
+        // Add detached window profiles
+        // Collect unique detached windows to avoid duplicates
+        QSet<TDetachedWindow*> uniqueDetachedWindows;
+        for (auto it = mDetachedWindows.begin(); it != mDetachedWindows.end(); ++it) {
+            TDetachedWindow* detachedWindow = it.value();
+            if (detachedWindow) {
+                uniqueDetachedWindows.insert(detachedWindow);
+            }
+        }
+        
+        // Process each unique detached window
+        for (TDetachedWindow* detachedWindow : uniqueDetachedWindows) {
+            // Get all profiles in this detached window
+            QStringList profilesInWindow = detachedWindow->getProfileNames();
+            for (const QString& windowProfileName : profilesInWindow) {
+                QString actionText = tr("%1 (Detached)").arg(windowProfileName);
+                QAction* profileAction = new QAction(actionText, this);
+                profileAction->setCheckable(true);
+                profileAction->setChecked(detachedWindow->isActiveWindow() && detachedWindow->getCurrentProfileName() == windowProfileName);
+                profileAction->setData(windowProfileName); // Store profile name for identification
+                connect(profileAction, &QAction::triggered, this, &mudlet::slot_activateDetachedWindowProfile);
+                menuWindow->addAction(profileAction);
+                mWindowListActions.append(profileAction);
+            }
+        }
+    }
+
+    // Also update window menus on all detached windows
+    for (auto it = mDetachedWindows.begin(); it != mDetachedWindows.end(); ++it) {
+        TDetachedWindow* detachedWindow = it.value();
+        if (detachedWindow) {
+            detachedWindow->updateWindowMenu();
+        }
+    }
+}
+
+void mudlet::slot_activateMainWindow()
+{
+    raise();
+    activateWindow();
+    show(); // Ensure it's not minimized
+    updateWindowMenu(); // Refresh checkmarks
+}
+
+void mudlet::slot_activateDetachedWindow()
+{
+    QAction* action = qobject_cast<QAction*>(sender());
+    if (!action) {
+        return;
+    }
+
+    QString profileName = action->data().toString();
+    if (mDetachedWindows.contains(profileName)) {
+        TDetachedWindow* detachedWindow = mDetachedWindows[profileName];
+        if (detachedWindow) {
+            detachedWindow->raise();
+            detachedWindow->activateWindow();
+            detachedWindow->show(); // Ensure it's not minimized
+            updateWindowMenu(); // Refresh checkmarks
+        }
+    }
+}
+
+void mudlet::slot_activateMainWindowProfile()
+{
+    QAction* action = qobject_cast<QAction*>(sender());
+    if (!action) {
+        return;
+    }
+
+    QString profileName = action->data().toString();
+    
+    // Find the tab index for this profile in the main window
+    int tabIndex = -1;
+    for (int i = 0; i < mpTabBar->count(); ++i) {
+        if (mpTabBar->tabData(i).toString() == profileName) {
+            tabIndex = i;
+            break;
+        }
+    }
+
+    if (tabIndex >= 0) {
+        // Activate the main window first
+        raise();
+        activateWindow();
+        show(); // Ensure it's not minimized
+        
+        // Switch to the specific tab
+        mpTabBar->setCurrentIndex(tabIndex);
+        
+        // Trigger the tab change logic to ensure the profile is properly activated
+        slot_tabChanged(tabIndex);
+        
+        updateWindowMenu(); // Refresh checkmarks
+    }
+}
+
+void mudlet::slot_activateDetachedWindowProfile()
+{
+    QAction* action = qobject_cast<QAction*>(sender());
+    if (!action) {
+        return;
+    }
+
+    QString profileName = action->data().toString();
+    
+    // Find which detached window contains this profile
+    for (auto it = mDetachedWindows.begin(); it != mDetachedWindows.end(); ++it) {
+        TDetachedWindow* detachedWindow = it.value();
+        if (detachedWindow && detachedWindow->getProfileNames().contains(profileName)) {
+            // Activate the detached window
+            detachedWindow->raise();
+            detachedWindow->activateWindow();
+            detachedWindow->show(); // Ensure it's not minimized
+            
+            // Switch to the specific profile tab in the detached window
+            detachedWindow->switchToProfile(profileName);
+            
+            updateWindowMenu(); // Refresh checkmarks
+            break;
+        }
+    }
 }
 
 // This removes the Host (profile) from this class's QMainWindow and related
@@ -5580,6 +5767,9 @@ void mudlet::changeEvent(QEvent* event)
 {
     if (event->type() == QEvent::WindowStateChange) {
         emit signal_windowStateChanged(windowState());
+    } else if (event->type() == QEvent::ActivationChange) {
+        // Update window menu when window activation changes
+        updateWindowMenu();
     }
     QWidget::changeEvent(event);
 }
@@ -5780,6 +5970,9 @@ void mudlet::slot_detachedWindowClosed(const QString& profileName)
         // Update multi-view controls including "Reattach detached windows" menu visibility
         updateMultiViewControls();
 
+        // Update the window menu to reflect the removed window
+        updateWindowMenu();
+
         // Properly close the host to avoid dangling connections
         Host* pHost = mHostManager.getHost(profileName);
         if (pHost) {
@@ -5917,6 +6110,9 @@ void mudlet::detachTab(int tabIndex, const QPoint& position)
 
     // Update tab bar auto-hide behavior since we now have detached windows
     updateMainWindowTabBarAutoHide();
+
+    // Update the window menu to reflect the new detached window
+    updateWindowMenu();
 
     // Only show connection dialog if there are no profiles loaded anywhere,
     // not just when the main window is empty (profiles might be in detached windows)
@@ -6712,6 +6908,9 @@ void mudlet::moveProfileFromDetachedToMainWindow(const QString& profileName, TDe
 
     // Update tab bar auto-hide behavior since detached windows may have changed
     updateMainWindowTabBarAutoHide();
+    
+    // Update the window menu to reflect the window changes
+    updateWindowMenu();
     
     // Refresh tab bar to ensure CDC identifiers are displayed after reattachment
     refreshTabBar();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -217,6 +217,11 @@ void mudlet::init()
     mpMainToolBar->setWindowTitle(tr("Main Toolbar"));
     addToolBar(mpMainToolBar);
     mpMainToolBar->setMovable(false);
+    
+    // Add context menu to toolbar for show/hide functionality
+    mpMainToolBar->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(mpMainToolBar, &QWidget::customContextMenuRequested,
+            this, &mudlet::slot_showMainToolBarContextMenu);
     addToolBarBreak();
     auto frame = new QWidget(this);
     setCentralWidget(frame);
@@ -236,6 +241,11 @@ void mudlet::init()
     // Connect the tab bar's reattach signal (for drag and drop reattachment)
     connect(mpTabBar, &TTabBar::tabReattachRequested,
             this, &mudlet::slot_tabReattachRequested);
+    
+    // Add context menu to tab bar for toolbar visibility options
+    mpTabBar->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(mpTabBar, &QWidget::customContextMenuRequested,
+            this, &mudlet::slot_showTabContextMenu);
     auto layoutTopLevel = new QVBoxLayout(frame);
     layoutTopLevel->setContentsMargins(0, 0, 0, 0);
     layoutTopLevel->addWidget(mpTabBar);
@@ -418,6 +428,12 @@ void mudlet::init()
     mpActionNotes->setObjectName(qsl("notepad_action"));
     mpMainToolBar->widgetForAction(mpActionNotes)->setObjectName(mpActionNotes->objectName());
 
+    // Create toolbar toggle action
+    mpActionToggleMainToolBar = new QAction(tr("Show Main Toolbar"), this);
+    mpActionToggleMainToolBar->setCheckable(true);
+    mpActionToggleMainToolBar->setChecked(true); // Initially checked
+    mpActionToggleMainToolBar->setObjectName(qsl("toggle_main_toolbar_action"));
+
     mpButtonPackageManagers = new QToolButton(this);
     mpButtonPackageManagers->setText(tr("Packages"));
     mpButtonPackageManagers->setObjectName(qsl("package_manager"));
@@ -512,6 +528,7 @@ void mudlet::init()
     connect(mpActionVariables.data(), &QAction::triggered, this, &mudlet::slot_showVariableDialog);
     connect(mpActionButtons.data(), &QAction::triggered, this, &mudlet::slot_showActionDialog);
     connect(mpActionOptions.data(), &QAction::triggered, this, &mudlet::slot_showPreferencesDialog);
+    connect(mpActionToggleMainToolBar.data(), &QAction::triggered, this, &mudlet::slot_toggleMainToolBar);
     connect(mpActionAbout.data(), &QAction::triggered, this, &mudlet::slot_showAboutDialog);
     connect(mpActionMultiView.data(), &QAction::triggered, this, &mudlet::slot_multiView);
     connect(mpActionReconnect.data(), &QAction::triggered, this, &mudlet::slot_reconnect);
@@ -610,6 +627,12 @@ void mudlet::init()
     connect(dactionToggleReplay, &QAction::triggered, this, &mudlet::slot_toggleReplay);
     connect(dactionToggleLogging, &QAction::triggered, this, &mudlet::slot_toggleLogging);
     connect(dactionToggleEmergencyStop, &QAction::triggered, this, &mudlet::slot_toggleEmergencyStop);
+
+    // Add toolbar toggle action to Options menu
+    if (menuOptions && mpActionToggleMainToolBar) {
+        menuOptions->addSeparator();
+        menuOptions->addAction(mpActionToggleMainToolBar);
+    }
 
     // we historically use Alt on Windows and Linux, but that is uncomfortable on macOS
 #if defined(Q_OS_MACOS)
@@ -2605,6 +2628,12 @@ void mudlet::setToolBarVisibility(const enums::controlsVisibility state)
     mToolbarVisibility = state;
 
     adjustToolBarVisibility();
+    
+    // Update the toggle action to match the current state
+    if (mpActionToggleMainToolBar) {
+        mpActionToggleMainToolBar->setChecked(state != enums::visibleNever);
+    }
+    
     emit signal_toolBarVisibilityChanged(state);
 }
 
@@ -3829,6 +3858,51 @@ void mudlet::slot_windowStateChanged(const Qt::WindowStates newState)
     if (dactionToggleFullScreen->isChecked() != (newState & Qt::WindowFullScreen)) {
         dactionToggleFullScreen->setChecked(newState & Qt::WindowFullScreen);
     }
+}
+
+void mudlet::slot_toggleMainToolBar()
+{
+    // Toggle the toolbar visibility
+    enums::controlsVisibility currentState = toolBarVisibility();
+    if (currentState == enums::visibleNever) {
+        setToolBarVisibility(enums::visibleAlways);
+        mpActionToggleMainToolBar->setChecked(true);
+    } else {
+        setToolBarVisibility(enums::visibleNever);
+        mpActionToggleMainToolBar->setChecked(false);
+    }
+}
+
+void mudlet::slot_showMainToolBarContextMenu(const QPoint& position)
+{
+    QMenu contextMenu(this);
+    
+    // Create a copy of the toggle action for the context menu
+    QAction* toggleAction = new QAction(tr("Show Main Toolbar"), &contextMenu);
+    toggleAction->setCheckable(true);
+    toggleAction->setChecked(mpMainToolBar->isVisible());
+    connect(toggleAction, &QAction::triggered, this, &mudlet::slot_toggleMainToolBar);
+    
+    contextMenu.addAction(toggleAction);
+    
+    // Show the context menu at the global position
+    contextMenu.exec(mpMainToolBar->mapToGlobal(position));
+}
+
+void mudlet::slot_showTabContextMenu(const QPoint& position)
+{
+    QMenu contextMenu(this);
+    
+    // Add toolbar visibility toggle
+    QAction* toggleToolbarAction = new QAction(tr("Show Main Toolbar"), &contextMenu);
+    toggleToolbarAction->setCheckable(true);
+    toggleToolbarAction->setChecked(mpMainToolBar->isVisible());
+    connect(toggleToolbarAction, &QAction::triggered, this, &mudlet::slot_toggleMainToolBar);
+    
+    contextMenu.addAction(toggleToolbarAction);
+    
+    // Show the context menu at the global position
+    contextMenu.exec(mpTabBar->mapToGlobal(position));
 }
 
 // Called from the ctelnet instance for the host concerned:
@@ -6047,8 +6121,9 @@ void mudlet::detachTab(int tabIndex, const QPoint& position)
         mpTabBar->repaint();
     }
 
-    // Create detached window
-    auto detachedWindow = new TDetachedWindow(profileName, console, this);
+    // Create detached window with toolbar state inherited from main window
+    bool toolbarVisible = (mpMainToolBar && mpMainToolBar->isVisible());
+    auto detachedWindow = new TDetachedWindow(profileName, console, this, toolbarVisible);
     mDetachedWindows.insert(profileName, detachedWindow);
 
     // Connect signals

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -749,7 +749,7 @@ private:
 
     // Dock widget management for main window per-profile widgets
     QMap<QString, QPointer<QDockWidget>> mMainWindowDockWidgetMap;
-    QMap<QString, bool> mMainWindowDockWidgetIntendedVisibility; // Track intended visibility for each dock widget
+    QMap<QString, bool> mMainWindowDockWidgetUserPreference; // User's show/hide preference for dock widgets
     QPointer<QDockWidget> mpCurrentMapDockWidget;
 
     // Helper methods for detached windows

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -470,6 +470,7 @@ public slots:
     void slot_detachedWindowClosed(const QString& profileName);
     void slot_profileDetachToWindow(const QString& profileName, TDetachedWindow* targetWindow);
     void updateDetachedWindowToolbars();
+    static QIcon createConnectionStatusIcon(bool isConnected, bool isConnecting, bool hasError);
     void updateMainWindowTabIndicators();
     void updateMainWindowTabBarAutoHide();
     void slot_showActionDialog();

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -309,12 +309,14 @@ public:
     std::pair<bool, QString> setProfileIcon(const QString& profile, const QString& newIconPath);
     void setShowIconsOnMenu(const Qt::CheckState);
     void setShowMapAuditErrors(const bool);
+    void setShowTabConnectionIndicators(const bool);
     void setupPreInstallPackages(const QString&);
     void setToolBarIconSize(int);
     void setToolBarVisibility(enums::controlsVisibility);
     void showChangelogIfUpdated();
     void slot_showConnectionDialog();
     bool showMapAuditErrors() const { return mShowMapAuditErrors; }
+    bool showTabConnectionIndicators() const { return mShowTabConnectionIndicators; }
     // Brings up the preferences dialog and selects the tab whos objectName is
     // supplied:
     void showOptionsDialog(const QString&);
@@ -406,6 +408,7 @@ public:
     // How many graphemes do we need before we run the spell checker on a "word" in the command line:
     int mMinLengthForSpellCheck = 3;
     bool mDrawUpperLowerLevels = true;
+    bool mShowTabConnectionIndicators = true; // Global preference for showing connection status indicators on tabs
 
     // AI integration methods
     LlamafileManager* getAIManager() const { return mpLlamafileManager.get(); }
@@ -484,6 +487,8 @@ public slots:
     static QIcon createConnectionStatusIcon(bool isConnected, bool isConnecting, bool hasError);
     void updateMainWindowTabIndicators();
     void updateMainWindowTabBarAutoHide();
+    void updateTabIndicators(); // Update all tab indicators (main window)
+    void updateDetachedWindowTabIndicators(); // Update all detached window tab indicators
     void slot_showActionDialog();
     void slot_showAliasDialog();
     void slot_showEditorDialog();

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -452,6 +452,11 @@ public slots:
     void slot_reattachAllDetachedWindows();
     void slot_toggleAlwaysOnTop();
     void slot_minimize();
+    void updateWindowMenu();
+    void slot_activateMainWindow();
+    void slot_activateDetachedWindow();
+    void slot_activateMainWindowProfile();
+    void slot_activateDetachedWindowProfile();
     void slot_replay();
     void slot_replaySpeedUp();
     void slot_replaySpeedDown();
@@ -706,6 +711,10 @@ private:
     QMap<Host*, QToolBar*> mUserToolbarMap;
     // The collection of words in what mpHunspell_sharedDictionary points to:
     QSet<QString> mWordSet_shared;
+
+    // Window menu management for multiple windows
+    QList<QAction*> mWindowListActions;
+    QAction* mWindowListSeparator = nullptr;
 
     // amount of times the shortcut has been shown help educate new users
     int mScrollbackTutorialsShown = 0; // Cancel split screen

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -246,6 +246,7 @@ public:
     const QMap<QByteArray, QString>& getEncodingNamesMap() const { return mEncodingNameMap; }
     HostManager& getHostManager() { return mHostManager; }
     const QMap<QString, QPointer<TDetachedWindow>>& getDetachedWindows() const { return mDetachedWindows; }
+    QDockWidget* getMainWindowDockWidget(const QString& mapKey) const { return mMainWindowDockWidgetMap.value(mapKey); }
     std::optional<QSize> getImageSize(const QString&);
     const QString& getInterfaceLanguage() const { return mInterfaceLanguage; }
     int64_t getPhysicalMemoryTotal();
@@ -500,6 +501,7 @@ public slots:
     void slot_showTabContextMenu(const QPoint& position);
     void slot_toggleMainToolBar();
     void slot_showMainToolBarContextMenu(const QPoint& position);
+    void synchronizeToolBarVisibility(bool visible);
     void slot_showTriggerDialog();
     void slot_showVariableDialog();
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -435,6 +435,7 @@ public slots:
     void slot_showFullChangelog();
 #endif
     void slot_mapper();
+    void slot_showMapperDialog(); // Enhanced mapper dialog with per-profile dock widgets
     void slot_moduleManager();
     void slot_mudletDiscord();
     void slot_multiView(const bool);
@@ -741,11 +742,22 @@ private:
     // Detached windows for profiles
     QMap<QString, QPointer<TDetachedWindow>> mDetachedWindows;
 
+    // Dock widget management for main window per-profile widgets
+    QMap<QString, QPointer<QDockWidget>> mMainWindowDockWidgetMap;
+    QMap<QString, bool> mMainWindowDockWidgetIntendedVisibility; // Track intended visibility for each dock widget
+    QPointer<QDockWidget> mpCurrentMapDockWidget;
+
     // Helper methods for detached windows
     void detachTab(int tabIndex, const QPoint& position);
     void reattachTab(const QString& profileName, int insertIndex = -1);
     TMainConsole* removeConsoleFromSplitter(const QString& profileName);
     void addConsoleToSplitter(TMainConsole* console, int index = -1);
+
+    // Helper methods for main window dock widget management
+    void updateMainWindowDockWidgetVisibilityForProfile(const QString& profileName);
+    void transferDockWidgetToDetachedWindow(const QString& profileName, TDetachedWindow* detachedWindow);
+    void transferDockWidgetFromDetachedWindow(const QString& profileName, TDetachedWindow* detachedWindow);
+    void transferDockWidgetBetweenDetachedWindows(const QString& profileName, TDetachedWindow* sourceWindow, TDetachedWindow* targetWindow);
 };
 
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -541,6 +541,7 @@ private slots:
     void slot_windowStateChanged(const Qt::WindowStates);
     void slot_aiStatusChanged(LlamafileManager::Status newStatus, LlamafileManager::Status oldStatus);
     void slot_aiError(const QString& error);
+    void slot_refreshTabIndicatorsDelayed();
 
 
 private:

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -264,6 +264,11 @@ public:
     bool migratePasswordsToSecureStorage();
     void onlyShowProfiles(const QStringList&);
     bool openWebPage(const QString&);
+    
+    // Profile validation and orphan detection
+    bool hasOrphanedProfiles();
+    QStringList getOrphanedProfiles();
+    void reattachOrphanedProfiles();
     // Both of these revises the contents of the .aff file and handle a .dic
     // file that has been updated externally/manually (to add or remove words)
     // - the first also puts the contents of the .dic file into the

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -491,6 +491,9 @@ public slots:
     void slot_showPreferencesDialog();
     void slot_showScriptDialog();
     void slot_showTimerDialog();
+    void slot_showTabContextMenu(const QPoint& position);
+    void slot_toggleMainToolBar();
+    void slot_showMainToolBarContextMenu(const QPoint& position);
     void slot_showTriggerDialog();
     void slot_showVariableDialog();
 
@@ -657,6 +660,7 @@ private:
     QPointer<QAction> mpActionScripts;
     QPointer<QAction> mpActionSpeedDisplay;
     QPointer<QAction> mpActionTimers;
+    QPointer<QAction> mpActionToggleMainToolBar;
     QPointer<QAction> mpActionTriggers;
     QPointer<QAction> mpActionVariables;
     Announcer* mpAnnouncer = nullptr;

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -321,6 +321,10 @@ DEFINES+=DEBUG_TELNET=1
 # * Enable the features associated with reporting problems in processing Unicode
 # codepoints that cannot be displayed on screen in a `TConsole`:
 # DEFINES+=DEBUG_CODEPOINT_PROBLEMS
+#
+# * Produce qDebug() messages about window handling operations like dock widget
+# transfers, profile switching, and detached window management:
+# DEFINES+=DEBUG_WINDOW_HANDLING
 
 unix:!macx {
 # Distribution packagers would be using PREFIX = /usr but this is accepted


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This PR comprehensively improves Mudlet's user experience by:

* **Intuitive tab indicators**: Replaces confusing connection status icons with clear dot-style indicators (green filled circle for connected, yellow for connecting, empty circle for disconnected, red triangle for errors)
* **Global indicator toggle**: Adds user-controllable visibility of connection indicators via right-click context menu on any tab
* **Enhanced detached windows**: Provides full feature parity with main window including:
  - Tab reordering support (drag tabs to reorder within detached windows)
  - Seamless docked map widget transfers between windows
  - Toolbar visibility inheritance and independent control
  - Dynamic Window menu listing all profiles across all windows for easy navigation
* **Improved stability**: Ensures CDC identifier consistency during tab transfers and adds robust window lifecycle management

#### Motivation for adding to Mudlet

**Primary Issue**: Users were confused by connection status indicators - the disconnected state used a close/X icon nearly identical to the close tab button, causing accidental tab closures when checking connection status.

**Secondary Improvements**: 
* Users requested ability to hide connection indicators to reduce interface clutter
* Detached windows lacked essential features, making them feel like second-class citizens  
* Multi-window workflows needed better navigation between profiles
* Map transfers between windows required seamless docked widget support

#### Other info (issues closed, discussion etc)

* Implements traffic light color scheme (green/yellow/red) with intuitive filled vs empty states
* Provides VS Code-style navigation between multiple windows and profiles
* Maintains CDC identifiers when tabs are detached/reattached to/from main window
* Gates debug output behind `DEBUG_WINDOW_HANDLING` compile-time flag
* **Fixes** #6495 (Menu Mudlet->Preferences->show main toolbar 'Always' for hidden toolbar)
* **Fixes** #7651 (Opening a second profile unhides the mapper on the first profile)

The new dot-style indicators eliminate confusion with UI controls while the global toggle gives users complete interface control. Enhanced detached windows now provide seamless multi-window experience similar to