### PR TITLE
Add: Mudlet will ring normal OS alarm sound when receiving ASCII BELL character

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -571,19 +571,9 @@ int TTextEdit::drawGraphemeBackground(QPainter& painter, QVector<QColor>& fgColo
     switch (mpConsole->mControlCharacter) {
     default:
         // No special handling, except for these:
-        if (Q_UNLIKELY(unicode == '\a' || unicode == '\t')) {
-            if (unicode == '\t') {
-                charWidth = mTabStopwidth - (column % mTabStopwidth);
-                graphemes.append(QString(QChar::Tabulation));
-            } else {
-                // The alert character could make a sound when it is processed
-                // in cTelnet::proccessSocketData(...) but it does not have a
-                // visible representation - so lets give it one - a double
-                // note:
-                charWidth = 1;
-                graphemes.append(QChar(0x266B));
-            }
-
+        if (Q_UNLIKELY(unicode == '\t')) {
+            charWidth = mTabStopwidth - (column % mTabStopwidth);
+            graphemes.append(QString(QChar::Tabulation));
         } else {
             charWidth = graphemeInfo::getWidth(unicode, mWideAmbigousWidthGlyphs);
             graphemes.append((charWidth < 1) ? QChar() : grapheme);

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -4082,10 +4082,7 @@ Some data loss is likely - please mention this problem to the game admins.)", co
                     // it is not possible to fake/test it with a Lua
                     // feedTriggers(...) call - OTOH doing it there would make
                     // a beep every time the screen was refreshed!
-                    // TODO: https://github.com/Mudlet/Mudlet/issues/5836 - provide 
-                    // option to actually make a (void) QApplication::beep() or a 
-                    // user-selected sound (different for each profile) and/or 
-                    // instead of the visual alert
+                    // TODO: https://github.com/Mudlet/Mudlet/issues/5836 - provide option to actually make a (void) QApplication::beep() or a user-selected sound (different for each profile) and/or instead of the visual alert
                     QApplication::alert(mudlet::self(), 3000);
                     if (!mudlet::self()->muteGame()) {
                         QApplication::beep();

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -4082,9 +4082,14 @@ Some data loss is likely - please mention this problem to the game admins.)", co
                     // it is not possible to fake/test it with a Lua
                     // feedTriggers(...) call - OTOH doing it there would make
                     // a beep every time the screen was refreshed!
-                    // TODO: https://github.com/Mudlet/Mudlet/issues/5836 - provide option to actually make a (void) QApplication::beep() or a user-selected sound (different for each profile) and/or instead of the visual alert
+                    // TODO: https://github.com/Mudlet/Mudlet/issues/5836 - provide 
+                    // option to actually make a (void) QApplication::beep() or a 
+                    // user-selected sound (different for each profile) and/or 
+                    // instead of the visual alert
                     QApplication::alert(mudlet::self(), 3000);
-                    QApplication::beep();
+                    if (!mudlet::self()->muteGame()) {
+                        QApplication::beep();
+                    }
                 }
                 if (ch != '\r' && ch != '\0') {
                     cleandata += ch;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -4084,6 +4084,7 @@ Some data loss is likely - please mention this problem to the game admins.)", co
                     // a beep every time the screen was refreshed!
                     // TODO: https://github.com/Mudlet/Mudlet/issues/5836 - provide option to actually make a (void) QApplication::beep() or a user-selected sound (different for each profile) and/or instead of the visual alert
                     QApplication::alert(mudlet::self(), 3000);
+                    QApplication::beep();
                 }
                 if (ch != '\r' && ch != '\0') {
                     cleandata += ch;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Make Mudlet sound the bell, using the default volume and sound, when receiving an ASCII BELL character from the game
- Do not make Mudlet sound the bell, if the options to "mute all media" or at least "mute sounds from game" are activated
- Do not display ♫ symbol, when receiving ASCII BELL character, while setting "display control characters" is set to "nothing"

#### Motivation for adding to Mudlet
- Fix #7966

#### Other info (issues closed, discussion etc)
