### PR TITLE
Add: VS Code file associations and C++ development settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,8 +26,17 @@
     "tuple": "cpp",
     "type_traits": "cpp",
     "utility": "cpp",
-    "variant": "cpp"
+    "variant": "cpp",
+    "*.h": "cpp",
+    "*.cpp": "cpp",
+    "*.c": "c",
+    "CMakeLists.txt": "cmake"
   },
+  "C_Cpp.default.cppStandard": "c++20",
+  "C_Cpp.default.includePath": [
+    "${workspaceFolder}/src",
+    "${workspaceFolder}/3rdparty"
+  ],
   "[lua]": {
     "editor.tabSize": 2
   }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Enhances the VS Code workspace settings to better support C++ development by adding explicit file associations for C/C++ files and headers, setting the C++ standard to C++20, and configuring include paths for IntelliSense.

#### Motivation for adding to Mudlet

For the author, this prompts VS Code to select the correct Language Model for the Mudlet project vs. game projects using the LPC programming language with similar file extensions. 

Provides a better development experience for contributors using VS Code by:
- Ensuring proper syntax highlighting and IntelliSense for all C++ files (`.h`, `.cpp`, `.c`)
- Setting modern C++20 standard for better language support
- Configuring include paths to help with code navigation and autocomplete
- Adding CMake file association for better CMakeLists.txt editing

#### Other info (issues closed, discussion etc)

This change improves developer productivity without affecting the build process or runtime behavior. The configuration only impacts the VS Code editor experience