### PR TITLE
Add: sandbox loading metadata from packages

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2232,6 +2232,58 @@ void Host::readPackageConfig(const QString& luaConfig, QString& packageName, boo
     }
 }
 
+void Host::setupSandboxedLuaState(lua_State* L)
+{
+    // Load only safe libraries
+    luaL_requiref(L, "_G", luaopen_base, 1);
+    lua_pop(L, 1);
+    luaL_requiref(L, "table", luaopen_table, 1);
+    lua_pop(L, 1);
+    luaL_requiref(L, "string", luaopen_string, 1);
+    lua_pop(L, 1);
+    luaL_requiref(L, "math", luaopen_math, 1);
+    lua_pop(L, 1);
+    
+    // Remove dangerous functions
+    const char* dangerousFunctions[] = {
+        // File operations
+        "dofile", "loadfile", "load", "loadstring", 
+        // Module system
+        "require", "module", 
+        // Library access
+        "io", "os", "debug",
+        // Environment manipulation
+        "getfenv", "setfenv",
+        // Raw memory access
+        "collectgarbage",
+        nullptr
+    };
+    
+    for (int i = 0; dangerousFunctions[i] != nullptr; ++i) {
+        lua_pushnil(L);
+        lua_setglobal(L, dangerousFunctions[i]);
+    }
+    
+    // Remove package system entirely to prevent require() restoration
+    lua_pushnil(L);
+    lua_setglobal(L, "package");
+    
+    // Remove potentially dangerous base functions
+    lua_getglobal(L, "_G");
+    if (lua_istable(L, -1)) {
+        const char* removedBaseFunctions[] = {
+            "rawget", "rawset", "rawequal", "rawlen",
+            nullptr
+        };
+        
+        for (int i = 0; removedBaseFunctions[i] != nullptr; ++i) {
+            lua_pushnil(L);
+            lua_setfield(L, -2, removedBaseFunctions[i]);
+        }
+    }
+    lua_pop(L, 1); // pop _G
+}
+
 QString Host::getPackageConfig(const QString& luaConfig, bool isModule)
 {
     QString packageName;
@@ -2249,7 +2301,7 @@ QString Host::getPackageConfig(const QString& luaConfig, bool isModule)
     }
 
     lua_State* L = luaL_newstate();
-    luaL_openlibs(L);
+    setupSandboxedLuaState(L);
 
     int error = luaL_loadstring(L, strings.join("\n").toUtf8().constData());
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2235,14 +2235,10 @@ void Host::readPackageConfig(const QString& luaConfig, QString& packageName, boo
 void Host::setupSandboxedLuaState(lua_State* L)
 {
     // Load only safe libraries
-    luaL_requiref(L, "_G", luaopen_base, 1);
-    lua_pop(L, 1);
-    luaL_requiref(L, "table", luaopen_table, 1);
-    lua_pop(L, 1);
-    luaL_requiref(L, "string", luaopen_string, 1);
-    lua_pop(L, 1);
-    luaL_requiref(L, "math", luaopen_math, 1);
-    lua_pop(L, 1);
+    luaopen_base(L);
+    luaopen_table(L);
+    luaopen_string(L);
+    luaopen_math(L);
     
     // Remove dangerous functions
     const char* dangerousFunctions[] = {

--- a/src/Host.h
+++ b/src/Host.h
@@ -793,6 +793,7 @@ private:
     QString sanitizePackageName(const QString packageName) const;
     TCommandLine* activeCommandLine();
     void closeChildren();
+    void setupSandboxedLuaState(lua_State* L);
 
     QStringList mModulesToSync;
     QScopedPointer<LuaInterface> mLuaInterface;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Sandboxes the Lua environment used when reading data from `config.lua` in Lua packages.
#### Motivation for adding to Mudlet
Better security.
#### Other info (issues closed, discussion etc)
Other environments (such as the lua formatter) could be applied to this sandbox as well. It can't be applied to player scripts just yet though as-is, because it is likely to break existing player-made scripts that use these functions while posing no security concerns.