### PR TITLE
Improve: IRE composer edit handling to use modern code

### DIFF
--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -95,6 +95,7 @@ public:
     void setMSDPTable(QString& key, const QString& string_data);
     void parseJSON(QString& key, const QString& string_data, const QString& protocol);
     void parseMSSP(const QString& string_data);
+    void handleIreComposerEdit(const QString& jsonData);
     void msdp2Lua(const char*);
     void initLuaGlobals();
     void initIndenterGlobals();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Improve: IRE composer edit handling to use Qt's JSON. 
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/7922
#### Other info (issues closed, discussion etc)
Qt's JSON handles escapes for us, so we shouldn't need the big regex anymore - but ideally #815 and #523 won't come back due it being removed.