### PR TITLE
Add: support for starting Mudlet in fullscreen mode via command line

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -295,6 +295,9 @@ int main(int argc, char* argv[])
     const QCommandLineOption showSplashscreen(QStringList() << qsl("s") << qsl("splashscreen"), qsl("Show the splash screen when starting"));
     parser.addOption(showSplashscreen);
 
+    const QCommandLineOption startFullscreen(QStringList() << qsl("f") << qsl("fullscreen"), qsl("Start Mudlet in fullscreen mode"));
+    parser.addOption(startFullscreen);
+
     const QCommandLineOption mirrorToStdout(QStringList() << qsl("m") << qsl("mirror"), qsl("Mirror output of all consoles to STDOUT"));
     parser.addOption(mirrorToStdout);
 
@@ -344,6 +347,7 @@ int main(int argc, char* argv[])
                                                                   "                                    repeated."));
         texts << appendLF.arg(QCoreApplication::translate("main", "       -o, --only=<predefined>      make Mudlet only show the specific\n"
                                                                   "                                    predefined game, may be repeated."));
+        texts << appendLF.arg(QCoreApplication::translate("main", "       -f, --fullscreen             start Mudlet in fullscreen mode."));                                                                  
         texts << appendLF.arg(QCoreApplication::translate("main", "       --steammode                  adjusts Mudlet settings to match\n"
                                                                   "                                    Steam's requirements."));
         texts << appendLF.arg(QCoreApplication::translate("main", "There are other inherited options that arise from the Qt Libraries which are\n"
@@ -717,7 +721,13 @@ int main(int argc, char* argv[])
     if (!onlyProfiles.isEmpty()) {
         mudlet::self()->onlyShowProfiles(onlyProfiles);
     }
+
     mudlet::self()->show();
+    if (parser.isSet(startFullscreen)) {
+        QTimer::singleShot(0, [=]() {
+            mudlet::self()->showFullScreen();
+        });
+    }
 
     QTimer::singleShot(0, qApp, [cliProfiles]() {
         // ensure Mudlet singleton is initialised before calling profile loading


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add `-f` or `--fullscreen` to launch Mudlet in CLI
#### Motivation for adding to Mudlet
This is useful for Steam Deck.
#### Other info (issues closed, discussion etc)
Fixes https://github.com/Mudlet/Mudlet/issues/7906