### PR TITLE
Add: load profiles from command line in offline mode

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -519,7 +519,7 @@ int main(int argc, char* argv[])
 
     if (!envConnectProfilesText.isEmpty()) {
         // ':' is not an allowed character in a profile name, so we can use it to split the list
-        connectProfiles = envConnectProfilesText.split(QLatin1Char(':'),Qt::SkipEmptyParts);
+        connectProfiles = envConnectProfilesText.split(QLatin1Char(':'), Qt::SkipEmptyParts);
         for (auto& connectProfile : connectProfiles) {
             const auto thisOne = qMakePair(connectProfile.trimmed(), true);
             if (Q_LIKELY(!(connectOrLoadProfiles.contains(thisOne)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -283,8 +283,11 @@ int main(int argc, char* argv[])
     // other than that a non-null fourth argument maybe responsible for
     // making the option take a value that follows it - as such they do not
     // need to be passed to the translation system.
-    const QCommandLineOption profileToOpen(QStringList() << qsl("p") << qsl("profile"), qsl("Profile to open automatically"), qsl("profile"));
+    const QCommandLineOption profileToOpen(QStringList() << qsl("p") << qsl("profile"), qsl("Profile to connect automatically"), qsl("profile"));
     parser.addOption(profileToOpen);
+
+    const QCommandLineOption profileToLoad(QStringList() << qsl("l") << qsl("load"), qsl("Profile to load automatically"), qsl("profile"));
+    parser.addOption(profileToLoad);
 
     const QCommandLineOption showHelp(QStringList() << qsl("h") << qsl("help"), qsl("Display help and exit"));
     parser.addOption(showHelp);
@@ -339,11 +342,13 @@ int main(int argc, char* argv[])
         texts << appendLF.arg(QCoreApplication::translate("main", "Options:"));
         texts << appendLF.arg(QCoreApplication::translate("main", "       -h, --help                   displays this message."));
         texts << appendLF.arg(QCoreApplication::translate("main", "       -v, --version                displays version information."));
-        texts << appendLF.arg(QCoreApplication::translate("main", "       -s, --splashscreen           show splashscreen on startup."));
-        texts << appendLF.arg(QCoreApplication::translate("main", "       -p, --profile=<profile>      additional profile to open, may be\n"
-                                                                  "                                    repeated."));
+        texts << appendLF.arg(QCoreApplication::translate("main", "       -l, --load=<profile>         additional profile to load but not"
+                                                                  "                                    connect, may be repeated."));
         texts << appendLF.arg(QCoreApplication::translate("main", "       -o, --only=<predefined>      make Mudlet only show the specific\n"
                                                                   "                                    predefined game, may be repeated."));
+        texts << appendLF.arg(QCoreApplication::translate("main", "       -p, --profile=<profile>      additional profile to open and\n"
+                                                                  "                                    connect, may be repeated."));
+        texts << appendLF.arg(QCoreApplication::translate("main", "       -s, --splashscreen           show splashscreen on startup."));
         texts << appendLF.arg(QCoreApplication::translate("main", "       --steammode                  adjusts Mudlet settings to match\n"
                                                                   "                                    Steam's requirements."));
         texts << appendLF.arg(QCoreApplication::translate("main", "There are other inherited options that arise from the Qt Libraries which are\n"
@@ -473,18 +478,93 @@ int main(int argc, char* argv[])
 #endif
 #endif
 
-    QStringList cliProfiles = parser.values(profileToOpen);
-    qDebug() << "Got CLI profiles:" << cliProfiles;
+    // Check for profiles specified on the command line:
+    QList<QPair<QString, bool>> connectOrLoadProfiles;
+    auto connectProfiles = parser.values(profileToOpen);
+    auto loadProfiles = parser.values(profileToLoad);
+    for (auto& connectProfile : connectProfiles) {
+        if (Q_LIKELY(!(connectOrLoadProfiles.contains(qMakePair(connectProfile, true))))) {
+            connectOrLoadProfiles.append(qMakePair(connectProfile, true));
+        }
+    }
+    for (auto& loadProfile : loadProfiles) {
+        // If the same profile is also specified to be connected THAT takes
+        // priority:
+        if (Q_LIKELY(!(connectOrLoadProfiles.contains(qMakePair(loadProfile, false))
+                       ||connectOrLoadProfiles.contains(qMakePair(loadProfile, true))))) {
+            connectOrLoadProfiles.append(qMakePair(loadProfile, false));
+        }
+    }
 
-    if (cliProfiles.isEmpty()) {
-        qDebug() << "No CLI profiles specified, checking environment variable";
-        const QString envProfiles = QString::fromLocal8Bit(qgetenv("MUDLET_PROFILES"));
-        qDebug() << "Environment MUDLET_PROFILES value:" << envProfiles;
-        if (!envProfiles.isEmpty()) {
-            qDebug() << "Found environment profiles, splitting on ':'";
-            // : is not an allowed character in a profile name, so we can use it to split the list
-            cliProfiles = envProfiles.split(':');
-            qDebug() << "Final profile list from environment:" << cliProfiles;
+    if (connectOrLoadProfiles.isEmpty()) {
+        qDebug().noquote().nospace() << "No profiles to connect or load given on the command line.";
+    } else {
+        qDebug().noquote().nospace() << "Following profiles to connect or load given on the command line:";
+        for (auto& connectOrLoadProfile : connectOrLoadProfiles) {
+            if (connectOrLoadProfile.second) {
+                qDebug().noquote().nospace() << "    " << connectOrLoadProfile.first << " (connect)";
+            } else {
+                qDebug().noquote().nospace() << "    " << connectOrLoadProfile.first << " (load)";
+            }
+        }
+    }
+
+    // Check for profiles specified by environmental variables:
+    QList<QPair<QString, bool>> connectOrLoadEnvProfiles;
+    QString envConnectProfilesText = qEnvironmentVariable("MUDLET_PROFILES");
+    if (envConnectProfilesText.isEmpty()) {
+        envConnectProfilesText = qEnvironmentVariable("MUDLET_CONNECT_PROFILES");
+    }
+    QString envLoadProfilesText = qEnvironmentVariable("MUDLET_LOAD_PROFILES");
+
+    if (!envConnectProfilesText.isEmpty()) {
+        // ':' is not an allowed character in a profile name, so we can use it to split the list
+        connectProfiles = envConnectProfilesText.split(QLatin1Char(':'),Qt::SkipEmptyParts);
+        for (auto& connectProfile : connectProfiles) {
+            const auto thisOne = qMakePair(connectProfile.trimmed(), true);
+            if (Q_LIKELY(!(connectOrLoadProfiles.contains(thisOne)
+                           ||connectOrLoadEnvProfiles.contains(thisOne)))) {
+                connectOrLoadEnvProfiles.append(thisOne);
+            }
+            // If the environment specifies a profile to connect to AND the
+            // command line specifies the SAME one to only load - then remove
+            // the load one and insert the connect one:
+            if (Q_UNLIKELY(connectOrLoadProfiles.contains(qMakePair(connectProfile.trimmed(), false)))) {
+                qDebug().noquote().nospace() << "    Amending the above, an environment variable is requesting that: \"" << connectProfile << "\" is connected rather than just loaded!";
+                // Theoretically we should use QList<T>::removeAll(const T&) but
+                // since we know there can be only one entry we don't need to:
+                connectOrLoadProfiles.removeOne(qMakePair(connectProfile.trimmed(), false));
+            }
+        }
+    }
+
+    if (!envLoadProfilesText.isEmpty()) {
+        loadProfiles = envLoadProfilesText.split(QLatin1Char(':'), Qt::SkipEmptyParts);
+        for (auto& loadProfile : loadProfiles) {
+            if (Q_LIKELY(!(connectOrLoadProfiles.contains(qMakePair(loadProfile.trimmed(), false))
+                           ||connectOrLoadProfiles.contains(qMakePair(loadProfile.trimmed(), true))
+                           ||connectOrLoadEnvProfiles.contains(qMakePair(loadProfile.trimmed(), false))
+                           ||connectOrLoadEnvProfiles.contains(qMakePair(loadProfile.trimmed(), true))))) {
+
+                connectOrLoadEnvProfiles.append(qMakePair(loadProfile.trimmed(), false));
+            }
+        }
+    }
+
+    if (connectOrLoadEnvProfiles.isEmpty()) {
+        qDebug().noquote().nospace() << "No profiles to connect or load given by environment variables.";
+    } else {
+        qDebug().noquote().nospace() << "Following profiles to connect or load given by environment variables:";
+        for (auto& connectOrLoadProfile : connectOrLoadEnvProfiles) {
+            if (connectOrLoadProfile.second) {
+                qDebug().noquote().nospace() << "    " << connectOrLoadProfile.first << " (connect)";
+            } else {
+                qDebug().noquote().nospace() << "    " << connectOrLoadProfile.first << " (load)";
+            }
+
+            // Append them to the other QList so we just have one to work on
+            // afterwards:
+            connectOrLoadProfiles.append(connectOrLoadProfile);
         }
     }
 
@@ -719,9 +799,9 @@ int main(int argc, char* argv[])
     }
     mudlet::self()->show();
 
-    QTimer::singleShot(0, qApp, [cliProfiles]() {
+    QTimer::singleShot(0, qApp, [connectOrLoadProfiles]() {
         // ensure Mudlet singleton is initialised before calling profile loading
-        mudlet::self()->startAutoLogin(cliProfiles);
+        mudlet::self()->startAutoLoadOrConnect(connectOrLoadProfiles);
     });
 
 #if defined(INCLUDE_UPDATER)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3049,43 +3049,49 @@ void mudlet::deleteProfileData(const QString& profile, const QString& item)
     }
 }
 
-void mudlet::startAutoLogin(const QStringList& cliProfiles)
+void mudlet::startAutoLoadOrConnect(const QList<QPair<QString, bool>>& profilesToConnectOrLoad)
 {
-    QElapsedTimer timer;
-    timer.start();
+    QElapsedTimer allAutoLoadingTimer;
+    allAutoLoadingTimer.start();
 
-    QStringList hostList = QDir(getMudletPath(enums::profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+    QStringList hostList = QDir(getMudletPath(enums::profilesPath))
+            .entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
     hostList += TGameDetails::keys();
     hostList << qsl("Mudlet self-test");
     hostList.removeDuplicates();
     int loadedProfiles = 0;
 
-    for (auto& hostName : cliProfiles){
-        if (hostList.contains(hostName)) {
+    for (auto& profile : profilesToConnectOrLoad) {
+        if (hostList.contains(profile.first)) {
             QElapsedTimer timer;
             timer.start();
-            doAutoLogin(hostName);
-            hostList.removeOne(hostName);
+            doAutoConnectOrLoad(profile.first, profile.second);
+            hostList.removeOne(profile.first);
             loadedProfiles++;
-            qDebug() << "Profile" << hostName << "loaded in" << timer.elapsed()/1000.0 << "seconds";
+            qDebug().nospace().noquote() << "Profile: \"" << profile.first << "\" " << (profile.second ? "connected" : "loaded") << " in " << timer.elapsed()/1000.0 << " seconds.";
+        } else {
+            qWarning().nospace().noquote() << "Profile: \"" << profile.first << "\" cannot be found!";
         }
     }
 
-    for (auto& hostName : hostList) {
+    for (const auto& hostName : hostList) {
         const QString val = readProfileData(hostName, qsl("autologin"));
         if (val.toInt() == Qt::Checked) {
             QElapsedTimer timer;
             timer.start();
-            doAutoLogin(hostName);
+            // We do not currently provide a means to load but not connect a
+            // profile automatically on start up from the "Select a profile"
+            // dialogue - that is a task for another PR - Slysven 2025/08
+            doAutoConnectOrLoad(hostName, true);
             loadedProfiles++;
-            qDebug() << "Profile" << hostName << "loaded in" << timer.elapsed()/1000.0 << "seconds";
+            qDebug().nospace().noquote() << "Profile: \"" << hostName << "\" connected in " << timer.elapsed()/1000.0 << " seconds.";
         }
     }
 
     if (loadedProfiles == 0) {
         slot_showConnectionDialog();
     } else {
-        qDebug() << "All" << loadedProfiles << "profiles loaded in" << timer.elapsed()/1000.0 << "seconds";
+        qDebug().nospace().noquote() << "All " << loadedProfiles << " profiles connected or loaded in " << allAutoLoadingTimer.elapsed()/1000.0 << " seconds";
     }
 }
 
@@ -3184,15 +3190,15 @@ void mudlet::attachDebugArea(const QString& hostname)
     smpDebugArea->hide();
 }
 
-void mudlet::doAutoLogin(const QString& profile_name)
+void mudlet::doAutoConnectOrLoad(const QString& profile_name, const bool alsoConnect)
 {
     if (profile_name.isEmpty()) {
         return;
     }
 
-    loadProfile(profile_name, true);
+    loadProfile(profile_name, alsoConnect);
 
-    slot_connectionDialogueFinished(profile_name, true);
+    slot_connectionDialogueFinished(profile_name, alsoConnect);
     enableToolbarButtons();
 }
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -236,7 +236,7 @@ public:
     void commitLayoutUpdates(bool flush = false);
     void deleteProfileData(const QString &profile, const QString &item);
     void disableToolbarButtons();
-    void doAutoLogin(const QString&);
+    void doAutoConnectOrLoad(const QString&, const bool);
     void enableToolbarButtons();
     void forceClose();
     void armForceClose();
@@ -313,7 +313,7 @@ public:
     // Brings up the preferences dialog and selects the tab whos objectName is
     // supplied:
     void showOptionsDialog(const QString&);
-    void startAutoLogin(const QStringList&);
+    void startAutoLoadOrConnect(const QList<QPair<QString, bool>>&);
     bool storingPasswordsSecurely() const { return mStorePasswordsSecurely; }
     enums::controlsVisibility toolBarVisibility() const { return mToolbarVisibility; }
     void updateDiscordNamedIcon();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a command line `-l` / `--load` option to go alongside the `-p` / `--profile` option to specify profiles to be loaded but NOT connected on startup. Similarlarly add handling for a colon delimited list as `MUDLET_LOAD_PROFILES` to do the same thing via environmental variables. Modify existing handling of `MUDLET_PROFILES` to also consider `MUDLET_CONNECT_PROFILES` as a (recommended) alternative to give profiles to connect on start-up.

#### Motivation for adding to Mudlet
A recent discussion on Discord (between myself, **bazzarranti** and **atari2600tim**) in the **Help** channel pointed out that it was not possible to "load" profiles from the "commnadline" although it was possible to "connect" them.

> bazarranti — 01/08/2025 21:37 UTC
> I would like to be able to use "open profile on mudlet start" or open a
> profile from the command line, but open it in offline mode. I can't seem
> to figure out how to make that happen though. Can anyone help?

#### Other info (issues closed, discussion etc)
This maintains the order of profiles given, handling command-line options before environmental ones - and not ignoring the latter if the former is used. It also handles the same profile being requested twice and also conflicting requests to both load and connect a profile (the connect option will always win) - it also reportes (to the OS command line) a profile that is not recognised.