### PR TITLE
Fix: Prevent heap-use-after-free crash during Mudlet shutdown

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -957,7 +957,12 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
     // this needs to run after `writers` and `mWritingHostAndModules` have been set
     // so that the currentlySavingProfile() check can run properly
     emit profileSaveStarted();
-    qApp->processEvents();
+    
+    // Only process events if we're not in the middle of closing down
+    // This prevents recursive closure scenarios that can lead to heap-use-after-free
+    if (!mIsClosingDown) {
+        qApp->processEvents();
+    }
 
     auto watcher = new QFutureWatcher<void>;
     mModuleFuture = QtConcurrent::run([=, this]() {


### PR DESCRIPTION
Fix: Prevent heap-use-after-free crash during Mudlet shutdown

#### Brief overview of PR changes/additions

This PR fixes a critical heap-use-after-free crash that occurs during Mudlet shutdown when multiple profiles or detached windows are open. The fix prevents recursive event processing during profile saves by guarding the `qApp->processEvents()` call with a check for the shutdown state.

**Key changes:**
- Added `mIsClosingDown` check before calling `qApp->processEvents()` in `Host::saveProfile()`
- Prevents recursive profile closure scenarios while maintaining normal save functionality
- Profiles still save properly during shutdown, but without the dangerous event loop recursion

#### Motivation for adding to Mudlet

This addresses a serious crash bug that occurs during normal Mudlet usage when users have multiple profiles or detached windows open. The crash happens due to recursive event processing during shutdown:

1. Main console close event triggers profile save
2. `qApp->processEvents()` processes pending close events for detached windows
3. Detached window close triggers second profile save while first is still running
4. Host object gets deleted while original save is accessing it
5. Results in heap-use-after-free crash

The fix ensures stable shutdown behavior while preserving all intended functionality.

#### Other info (issues closed, discussion etc)

Closes #7985

**Root cause analysis:**
The crash stack trace shows recursive calls to `Host::saveProfile()` and `Host::requestClose()`, indicating that `qApp->processEvents()` at line 960 in `Host::saveProfile()` was processing close events for other windows while a profile save was already in progress. This led to nested closures and the Host object being freed while still in use.

**Testing scenario to reproduce:**
1. Open Mudlet with multiple profiles
2. Detach a console window from one profile
3. Close Mudlet (main window or detached window)
4. Crash occurs during shutdown sequence

**Impact:** 
- Fixes critical shutdown crash
- No impact on save functionality - profiles still save during shutdown
- Minimal change with targeted fix scope
- Only affects event processing during shutdown, not normal operation