### PR TITLE
Improve: ensure at least one tab is present before detaching in the main window

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -6440,7 +6440,8 @@ void mudlet::slot_aiError(const QString& error)
 
 void mudlet::slot_tabDetachRequested(int index, const QPoint& globalPos)
 {
-    if (index < 0 || index >= mpTabBar->count()) {
+    // ensure at least one tab is present in the main window
+    if (index < 1 || index >= mpTabBar->count()) {
         return;
     }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Ensure at least one tab is present before detaching in the main window, so you can't leave an empty main window behind. In the future we should look at giving the technically-oriented folks the [ability to customise](https://github.com/Mudlet/Mudlet/issues/7984#issuecomment-3162184475) the main window.
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/7984
#### Other info (issues closed, discussion etc)
