### PR TITLE
Improve: default to hidden toolbar (huge buttons) by default

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2648,7 +2648,7 @@ void mudlet::readLateSettings(const QSettings& settings)
     // of: (bool) showXXXXBar = (XXXXBarVisibilty != visibleNever) for, until,
     // it is suggested Mudlet 4.x:
     setMenuBarVisibility(static_cast<enums::controlsVisibilityFlag>(settings.value("menuBarVisibility", static_cast<int>(enums::visibleAlways)).toInt()));
-    setToolBarVisibility(static_cast<enums::controlsVisibilityFlag>(settings.value("toolBarVisibility", static_cast<int>(enums::visibleAlways)).toInt()));
+    setToolBarVisibility(static_cast<enums::controlsVisibilityFlag>(settings.value("toolBarVisibility", static_cast<int>(enums::visibleNever)).toInt()));
     mEditorTextOptions = static_cast<QTextOption::Flags>(settings.value("editorTextOptions", QVariant(0)).toInt());
 
     mShowMapAuditErrors = settings.value("reportMapIssuesToConsole", QVariant(false)).toBool();

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -716,7 +716,7 @@ private:
     // Argument to QDateTime::toString(...) to format the elapsed time display
     // on the mpToolBarReplay:
     QString mTimeFormat;
-    enums::controlsVisibility mToolbarVisibility = enums::visibleAlways;
+    enums::controlsVisibility mToolbarVisibility = enums::visibleNever;
     QList<QPointer<QTranslator>> mTranslatorsLoadedList;
     // An encapsulation of the mInterfaceLanguage in a form that Qt uses to
     // hold all the details:


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Default to hidden toolbar (huge buttons) by default:

<img width="1904" height="1245" alt="image" src="https://github.com/user-attachments/assets/5762e933-98c8-4636-a660-c03209b47c07" />

<img width="1904" height="1245" alt="image" src="https://github.com/user-attachments/assets/5762c933-9906-4075-93e7-4d3b53c37854" />

#### Motivation for adding to Mudlet
More modern look'n'feel for 2025. The majority of [existing power players](https://discord.com/channels/283581582550237184/643874345705275392/1342747918771290182) prefers to keep them and their profiles will be unaffected, but anyone getting Mudlet for the first time will be less overwhelmed by the amount of bright buttons without obvious meaning to them.
#### Other info (issues closed, discussion etc)
Existing profiles are unaffected, and if you'd like to enable large buttons on a new profile, you can do so here:

<img width="1369" height="401" alt="image" src="https://github.com/user-attachments/assets/cd78f569-6336-463e-a4eb-493f16eb7779" />
