### PR TITLE
Fix: Don't drop editor items too far to the left anymore

### DIFF
--- a/src/TTreeWidget.cpp
+++ b/src/TTreeWidget.cpp
@@ -332,12 +332,7 @@ void TTreeWidget::dropEvent(QDropEvent* event)
 {
     QTreeWidgetItem* pItem = itemAt(event->position().toPoint());
 
-    if (!pItem) {
-        event->setDropAction(Qt::IgnoreAction);
-        event->ignore();
-    }
-
-    if (pItem == topLevelItem(0)) {
+    if (!pItem || pItem == topLevelItem(0)) {
         event->setDropAction(Qt::IgnoreAction);
         event->ignore();
     }

--- a/src/TTreeWidget.cpp
+++ b/src/TTreeWidget.cpp
@@ -338,10 +338,8 @@ void TTreeWidget::dropEvent(QDropEvent* event)
     }
 
     if (pItem == topLevelItem(0)) {
-        if ((dropIndicatorPosition() == QAbstractItemView::AboveItem) || (dropIndicatorPosition() == QAbstractItemView::BelowItem)) {
-            event->setDropAction(Qt::IgnoreAction);
-            event->ignore();
-        }
+        event->setDropAction(Qt::IgnoreAction);
+        event->ignore();
     }
 
     if (mIsVarTree) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Slightly adjust drop logic for editor items.

#### Motivation for adding to Mudlet
Fix #6507

#### Other info (issues closed, discussion etc)
Testing LLM to solve issues