### PR TITLE
Improve: Editor to display intro texts more cleverly

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -200,7 +200,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     connect(mpSystemMessageArea->messageAreaCloseButton, &QAbstractButton::clicked, this, &dlgTriggerEditor::hideSystemMessageArea);
     connect(mpSystemMessageArea->notificationAreaMessageBox, &QLabel::linkActivated, this, [=](const QString& URL) {
         mpSystemMessageArea->notificationAreaMessageBox->setText(createInfoText(URL));
-    })
+    });
 
     // main areas
     mpTriggersMainArea = new dlgTriggersMainArea(this);
@@ -8142,7 +8142,7 @@ void dlgTriggerEditor::showIntro()
         break;
     case EditorViewType::cmAliasView:
         // text = msgInfoAddAlias;
-        text = createInfoText(qsl("")) // TODO: How to tell it, there was no link clicked?
+        text = createInfoText(qsl("")); // TODO: How to tell it, there was no link clicked?
         break;
     case EditorViewType::cmScriptView:
         text = msgInfoAddScript;
@@ -8184,14 +8184,14 @@ QString dlgTriggerEditor::createInfoText(const QString& desiredContents)
     }
 
     return qsl("<p>%1</p><ol>%2</ol>")
-        .arg(infoTextSummary, infoTextOptions)
+        .arg(infoTextSummary, infoTextOptions);
 }
 
 
 QString dlgTriggerEditor::createInfoOptionText(const infoOption& option, const QString& desiredContents) const
 {
     if (!option.name == desiredContents) {
-        return qsl("<li><a href="%1">%2</a></li>").arg(option.name, option.headline);
+        return qsl("<li><a href='%1'>%2</a></li>").arg(option.name, option.headline);
     } else {
         return qsl("<li>%1%2</li>").arg(option.headline, option.contents); // %2 wrapped in <p></p> etc.
     }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6096,9 +6096,7 @@ void dlgTriggerEditor::slot_aliasSelected(QTreeWidgetItem* pItem)
     } else {
         // No details to show - as will be the case if the top item (ID = 0) is
         // selected - so show the help message:
-        mpAliasMainArea->hide();
-        mpSourceEditorArea->hide();
-        showInfo(msgInfoAddAlias);
+        clearAliasForm();
     }
 }
 
@@ -6145,9 +6143,7 @@ void dlgTriggerEditor::slot_keySelected(QTreeWidgetItem* pItem)
     } else {
         // No details to show - as will be the case if the top item (ID = 0) is
         // selected - so show the help message:
-        mpKeysMainArea->hide();
-        mpSourceEditorArea->hide();
-        showInfo(msgInfoAddKey);
+        clearKeyForm();
     }
 }
 
@@ -6444,9 +6440,7 @@ void dlgTriggerEditor::slot_actionSelected(QTreeWidgetItem* pItem)
 {
     if (!pItem) {
         // No details to show - so show the help message:
-        mpActionsMainArea->hide();
-        mpSourceEditorArea->hide();
-        showInfo(msgInfoAddButton);
+        clearActionForm();
         return;
     }
 
@@ -6557,9 +6551,7 @@ void dlgTriggerEditor::slot_actionSelected(QTreeWidgetItem* pItem)
         }
     } else {
         // On root of treewidget_actions: - show help message instead
-        mpActionsMainArea->hide();
-        mpSourceEditorArea->hide();
-        showInfo(msgInfoAddButton);
+        clearActionForm();
     }
 }
 
@@ -6594,9 +6586,7 @@ void dlgTriggerEditor::slot_scriptsSelected(QTreeWidgetItem* pItem)
 {
     if (!pItem) {
         // No details to show - so show the help message:
-        mpScriptsMainArea->hide();
-        mpSourceEditorArea->hide();
-        showInfo(msgInfoAddScript);
+        clearScriptForm();
         return;
     }
 
@@ -6639,9 +6629,7 @@ void dlgTriggerEditor::slot_scriptsSelected(QTreeWidgetItem* pItem)
     } else {
         // No details to show - as will be the case if the top item (ID = 0) is
         // selected - so show the help message:
-        mpScriptsMainArea->hide();
-        mpSourceEditorArea->hide();
-        showInfo(msgInfoAddScript);
+        clearScriptForm();
     }
 }
 
@@ -6694,9 +6682,7 @@ void dlgTriggerEditor::slot_timerSelected(QTreeWidgetItem* pItem)
     } else {
         // No details to show - as will be the case if the top item (ID = 0) is
         // selected - so show the help message:
-        mpTimersMainArea->hide();
-        mpSourceEditorArea->hide();
-        showInfo(msgInfoAddTimer);
+        clearTimerForm();
     }
 }
 
@@ -7919,9 +7905,7 @@ void dlgTriggerEditor::slot_showTimers()
     if (!pI || pI == treeWidget_timers->currentItem() || !pI->childCount()) {
         // There is no root item, we are on the root item or there are no other
         // items - so show the help message:
-        mpTimersMainArea->hide();
-        mpSourceEditorArea->hide();
-        showInfo(msgInfoAddTimer);
+        clearTimerForm();
     } else {
         mpTimersMainArea->show();
         mpSourceEditorArea->show();
@@ -7948,9 +7932,7 @@ void dlgTriggerEditor::showCurrentTriggerItem()
     if (!pI || pI == treeWidget_triggers->currentItem() || !pI->childCount()) {
         // There is no root item, we are on the root item or there are no other
         // items - so show the help message:
-        mpTriggersMainArea->hide();
-        mpSourceEditorArea->hide();
-        showInfo(msgInfoAddTrigger);
+        clearTriggerForm();
     } else {
         mpTriggersMainArea->show();
         mpSourceEditorArea->show();
@@ -7965,9 +7947,7 @@ void dlgTriggerEditor::slot_showTriggers()
     if (!pI || pI == treeWidget_triggers->currentItem() || !pI->childCount()) {
         // There is no root item, we are on the root item or there are no other
         // items - so show the help message:
-        mpTriggersMainArea->hide();
-        mpSourceEditorArea->hide();
-        showInfo(msgInfoAddTrigger);
+        clearTriggerForm();
     } else {
         mpTriggersMainArea->show();
         mpSourceEditorArea->show();
@@ -8013,9 +7993,7 @@ void dlgTriggerEditor::slot_showKeys()
     if (!pI || pI == treeWidget_keys->currentItem() || !pI->childCount()) {
         // There is no root item, we are on the root item or there are no other
         // items - so show the help message:
-        mpKeysMainArea->hide();
-        mpSourceEditorArea->hide();
-        showInfo(msgInfoAddKey);
+        clearKeyForm();
     } else {
         mpKeysMainArea->show();
         mpSourceEditorArea->show();
@@ -8074,8 +8052,7 @@ void dlgTriggerEditor::show_vars()
             mpVarsMainArea->show();
             slot_variableSelected(treeWidget_variables->currentItem());
         } else {
-            mpVarsMainArea->hide();
-            showInfo(msgInfoAddVar);
+            clearVarForm();
         }
     }
     treeWidget_variables->show();
@@ -8089,9 +8066,7 @@ void dlgTriggerEditor::slot_showAliases()
     if (!pI || pI == treeWidget_aliases->currentItem() || !pI->childCount()) {
         // There is no root item, we are on the root item or there are no other
         // items - so show the help message:
-        mpAliasMainArea->hide();
-        mpSourceEditorArea->hide();
-        showInfo(msgInfoAddAlias);
+        clearAliasForm();
     } else {
         mpAliasMainArea->show();
         mpSourceEditorArea->show();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1113,7 +1113,7 @@ void dlgTriggerEditor::slot_clickedMessageBox(const QString& URL)
     if (URL.startsWith("http")) {
         QDesktopServices::openUrl(URL);
     } else { // internal links used by expanding info text navigation
-        mpSystemMessageArea->notificationAreaMessageBox->setText(showIntro(URL));
+        showIntro(URL);
     }
 }
 
@@ -8280,7 +8280,7 @@ void dlgTriggerEditor::showIntro(const QString& desiredOption)
 {
     if (!infoAddItem.contains(mCurrentView)) {
         qWarning() << "ERROR: dlgTriggerEditor::showIntro() undefined view";
-        return(QString());
+        return;
     }
 
     infoTextParts infoAddCurrentItem = infoAddItem.value(mCurrentView);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4245,7 +4245,7 @@ void dlgTriggerEditor::addAlias(bool isFolder)
 
     mpCurrentAliasItem = pNewItem;
     treeWidget_aliases->setCurrentItem(pNewItem);
-    showIntro();
+    showInfo(msgInfoAddAlias);
     slot_aliasSelected(treeWidget_aliases->currentItem());
 }
 
@@ -10425,7 +10425,7 @@ void dlgTriggerEditor::clearTriggerForm()
 {
     mpTriggersMainArea->hide();
     mpSourceEditorArea->hide();
-    showInfo(msgInfoAddTrigger);
+    showIntro();
 }
 
 void dlgTriggerEditor::clearTimerForm()
@@ -10439,7 +10439,7 @@ void dlgTriggerEditor::clearAliasForm()
 {
     mpAliasMainArea->hide();
     mpSourceEditorArea->hide();
-    showInfo(msgInfoAddAlias);
+    showIntro();
 }
 
 void dlgTriggerEditor::clearScriptForm()

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -85,7 +85,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
             tr("<ol><li>Click on the 'Add Item' icon above.</li>"
                "<li>Define an input <strong>pattern</strong> either literally or with a Perl regular expression.</li>"
                "<li>Define a 'substitution' <strong>command</strong> to send to the game in clear text <strong>instead of the alias pattern</strong>, or write a script for more complicated needs.</li>"
-               "<li><strong>Activate</strong> the alias. That's it!</li></ol>")},
+               "<li><strong>Activate</strong> the alias.</li></ol>")},
         {qsl("alias2"), tr("How to add a new alias from the command line"),
             tr("<p>There are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you.</p>")},
         {qsl("alias3"), tr("Check the Mudlet manual for more information"),
@@ -102,16 +102,37 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                            "<p>That's it! If you'd like to be able to create triggers from the input line, there are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you."
                         "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Triggers'>more information</a>.</p>");
 
-    msgInfoAddScript = tr("<p>Scripts organize code and can react to events. To add a new script:"
-                          "<ol><li>Click on the 'Add Item' icon above.</li>"
-                          "<li>Enter a script in the box below. You can for example define <strong>functions</strong> to be called by other triggers, aliases, etc.</li>"
-                          "<li>If you write lua <strong>commands</strong> without defining a function, they will be run on Mudlet startup and each time you open the script for editing.</li>"
-                          "<li>If needed, you can register a list of <strong>events</strong> with the + and - symbols. If one of these events take place, the function with the same name as the script item itself will be called.</li>"
-                          "<li><strong>Activate</strong> the script.</li></ol></p>"
-                          "<p><strong>Note:</strong> Scripts are run automatically when viewed, even if they are deactivated.</p>"
-                          "<p><strong>Note:</strong> Events can also be added to a script from the command line in the main profile window like this:</p>"
-                          "<p><code>lua registerAnonymousEventHandler(&quot;nameOfTheMudletEvent&quot;, &quot;nameOfYourFunctionToBeCalled&quot;)</code></p>"
-                          "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Scripts'>more information</a>.</p>");
+    infoAddItem.insert(EditorViewType::cmTriggerView, {
+        tr("Triggers react on game output."), {
+        {qsl("trigger1"), tr("How to add a new trigger now"),
+            tr("<ol><li>Click on the 'Add Item' icon above.</li>"
+               "<li>Define a <strong>pattern</strong> that you want to trigger on.</li>"
+               "<li>Select the appropriate pattern <strong>type</strong>.</li>"
+               "<li>Define a clear text <strong>command</strong> that you want to send to the game if the trigger finds the pattern in the text from the game, or write a script for more complicated needs..</li>"
+               "<li><strong>Activate</strong> the trigger.</li></ol>")},
+        {qsl("trigger2"), tr("How to add a new trigger from the command line"),
+            tr("<p>There are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you.</p>")},
+        {qsl("trigger3"), tr("Check the Mudlet manual for more information"),
+            tr("<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Triggers'>Introduction to Triggers</a> for a detailed overview.</p>")}
+        }
+    });
+
+    infoAddItem.insert(EditorViewType::cmScriptView, {
+        tr("Scripts organize code and can react to events."), {
+        {qsl("script1"), tr("How to add a new script now"),
+            tr("<ol><li>Click on the 'Add Item' icon above.</li>"
+               "<li>Enter a script in the box below. You can for example define <strong>functions</strong> to be called by other triggers, aliases, etc.</li>"
+               "<li>If you write lua <strong>commands</strong> without defining a function, they will be run on Mudlet startup and each time you open the script for editing.</li>"
+               "<li><strong>Activate</strong> the script.</li></ol>"
+               "<p><strong>Note:</strong> Scripts are run automatically when viewed, even if they are deactivated.</p>")},
+        {qsl("script2"), tr("How to have a script react to events"),
+            tr("<p>You can register a list of <strong>events</strong> with the + and - symbols. If one of these events take place, the function with the same name as the script item itself will be called.</p>"
+               "<p><strong>Note:</strong> Events can also be added to a script from the command line in the main profile window like this:</p>"
+               "<p><code>lua registerAnonymousEventHandler(&quot;nameOfTheMudletEvent&quot;, &quot;nameOfYourFunctionToBeCalled&quot;)</code></p>")},
+        {qsl("script3"), tr("Check the Mudlet manual for more information"),
+            tr("<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Scripts'>Introduction to Scripts</a> for a detailed overview.</p>")}
+        }
+    });
 
     msgInfoAddTimer = tr("<p>Timers react after a timespan once or regularly. To add a new timer:"
                          "<ol><li>Click on the 'Add Item' icon above.</li>"
@@ -124,6 +145,23 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                          "<p>This will greet you exactly 3 seconds after it was made.</p>"
                          "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Timers'>more information</a>.</p>");
 
+    infoAddItem.insert(EditorViewType::cmTimerView, {
+        tr("Timers react after a timespan once or regularly."), {
+        {qsl("timer1"), tr("How to add a new timer now"),
+            tr("<ol><li>Click on the 'Add Item' icon above.</li>"
+               "<li>Define the <strong>timespan</strong> after which the timer should react in a this format: hours : minutes : seconds.</li>"
+               "<li>Define a clear text <strong>command</strong> that you want to send to the game when the time has passed, or write a script for more complicated needs.</li>"
+               "<li><strong>Activate</strong> the timer.</li></ol>"
+               "<p><strong>Note:</strong> If you want the trigger to react only once and not regularly, use the Lua tempTimer() function instead.</p>")},
+        {qsl("timer2"), tr("How to add a new timer from the command line"),
+            tr("<p>Timers can also be defined from the input line in the main profile window like this:</p>"
+               "<p><code>lua tempTimer(3, function() echo(&quot;hello!\n&quot;) end)</code></p>"
+               "<p>This will greet you exactly 3 seconds after it was made.</p>")},
+        {qsl("timer3"), tr("Check the Mudlet manual for more information"),
+            tr("<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Timers'>Introduction to Timers</a> for a detailed overview.</p>")}
+        }
+    });
+
     msgInfoAddButton = tr("<p>Buttons react on mouse clicks. To add a new button:"
                           "<ol><li>Add a new group to define a new <strong>button bar</strong> in case you don't have any.</li>"
                           "<li>Add new groups as <strong>menus</strong> to a button bar or sub-menus to menus.<li>"
@@ -134,6 +172,23 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                           "<p><strong>Note:</strong> If a button is made a <strong>click-down</strong> button then you may also define a clear text command that you want to send to the game when the button is pressed a second time to uncheck it or to write a script to run when it happens - within such a script the Lua 'getButtonState()' function reports whether the button is up or down.</p>"
                           "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Buttons'>more information</a>.</p>");
 
+    infoAddItem.insert(EditorViewType::cmActionView, {
+        tr("Buttons react on mouse clicks."), {
+        {qsl("button1"), tr("How to add a new button now"),
+            tr("<ol><li>Add a new group to define a new <strong>button bar</strong> in case you don't have any.</li>"
+               "<li>Add new groups as <strong>menus</strong> to a button bar or sub-menus to menus.<li>"
+               "<li>Add new items as <strong>buttons</strong> to a button bar or menu or sub-menu.</li>"
+               "<li>Define a clear text <strong>command</strong> that you want to send to the game if the button is pressed, or write a script for more complicated needs.</li>"
+               "<li><strong>Activate</strong> the toolbar, menu or button. </li></ol>"
+               "<p><strong>Note:</strong> Deactivated items will be hidden and if they are toolbars or menus then all the items they contain will be also be hidden.</p>"
+               "<p><strong>Note:</strong> If a button is made a <strong>click-down</strong> button then you may also define a clear text command that you want to send to the game when the button is pressed a second time to uncheck it or to write a script to run when it happens - within such a script the Lua 'getButtonState()' function reports whether the button is up or down.</p>")},
+//        {qsl("button2"), tr("How to add a new button from the command line"),
+//            tr("")},
+        {qsl("button3"), tr("Check the Mudlet manual for more information"),
+            tr("<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Buttons'>Introduction to Buttons</a> for a detailed overview.</p>")}
+        }
+    });
+
     msgInfoAddKey = tr("<p>Keys react on keyboard presses. To add a new key binding:"
                        "<ol><li>Click on the 'Add Item' icon above.</li>"
                        "<li>Click on <strong>'grab key'</strong> and then press your key combination, e.g. including modifier keys like Control, Shift, etc.</li>"
@@ -143,6 +198,22 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                        "<p><code>lua permKey(&quot;my jump key&quot;, &quot;&quot;, mudlet.key.F8, [[send(&quot;jump&quot;]]) end)</code></p>"
                        "<p>Pressing F8 will make you jump.</p>"
                        "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Keybindings'>more information</a>.</p>");
+
+    infoAddItem.insert(EditorViewType::cmKeysView, {
+        tr("Keys react on keyboard presses."), {
+        {qsl("key1"), tr("How to add a new keybinding now"),
+            tr("<ol><li>Click on the 'Add Item' icon above.</li>"
+               "<li>Click on <strong>'grab key'</strong> and then press your key combination, e.g. including modifier keys like Control, Shift, etc.</li>"
+               "<li>Define a clear text <strong>command</strong> that you want to send to the game if the button is pressed, or write a script for more complicated needs.</li>"
+               "<li><strong>Activate</strong> the new key binding.</li></ol>")},
+        {qsl("key2"), tr("How to add a new keybinding from the command line"),
+            tr("<p>Keys can be defined from the input line in the main profile window like this:</p>"
+               "<p><code>lua permKey(&quot;my jump key&quot;, &quot;&quot;, mudlet.key.F8, [[send(&quot;jump&quot;]]) end)</code></p>"
+               "<p>Pressing F8 will make you jump.</p>")},
+        {qsl("key3"), tr("Check the Mudlet manual for more information"),
+            tr("<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Keybindings'>Introduction to Keybindings</a> for a detailed overview.</p>")}
+        }
+    });
 
     msgInfoAddVar = tr("<p>Variables store information. To make a new variable:"
                        "<ol><li>Click on the 'Add Item' icon above. To add a table instead click 'Add Group'.</li>"
@@ -155,6 +226,24 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                        "<p><code>lua foo = &quot;bar&quot;</code></p>"
                        "<p>This will create a string called 'foo' with 'bar' as its value.</p>"
                        "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Variables'>more information</a>.</p>");
+
+    infoAddItem.insert(EditorViewType::cmVarsView, {
+        tr("Variables store information."), {
+        {qsl("variable1"), tr("How to add a new variable now"),
+            tr("<ol><li>Click on the 'Add Item' icon above. To add a table instead click 'Add Group'.</li>"
+               "<li>Select type of variable value (can be a string, integer, boolean)</li>"
+               "<li>Enter the value you want to store in this variable.</li>"
+               "<li>If you want to keep the variable in your next Mudlet sessions, check the checkbox in the list of variables to the left.</li>"
+               "<li>To remove a variable manually, set it to 'nil' or click on the 'Delete' icon above.</li></ol>"
+               "<p><strong>Note:</strong> Variables created here won't be saved when Mudlet shuts down unless you check their checkbox in the list of variables to the left. You could also create scripts with the variables instead.</p>")},
+        {qsl("variable2"), tr("How to add a new variable from the command line"),
+            tr("<p>Variables and tables can also be defined from the input line in the main profile window like this:</p>"
+               "<p><code>lua foo = &quot;bar&quot;</code></p>"
+               "<p>This will create a string called 'foo' with 'bar' as its value.</p>")},
+        {qsl("variable3"), tr("Check the Mudlet manual for more information"),
+            tr("<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Variables'>Introduction to Variables</a> for a detailed overview.</p>")}
+        }
+    });
 
     // Descriptions for screen readers, clarify to translators that the context of "activated" is current status and not confirmation of toggle.
     //: Item is currently on, short enough to be spoken
@@ -8142,34 +8231,7 @@ void dlgTriggerEditor::showInfo(const QString& error)
 
 void dlgTriggerEditor::showIntro()
 {
-    QString text;
-    switch (mCurrentView) {
-    case EditorViewType::cmTriggerView:
-        text = msgInfoAddTrigger;
-        break;
-    case EditorViewType::cmTimerView:
-        // text = msgInfoAddTimer;
-        text = createInfoText(mCurrentView);
-        break;
-    case EditorViewType::cmAliasView:
-        // text = msgInfoAddAlias;
-        text = createInfoText(mCurrentView);
-        break;
-    case EditorViewType::cmScriptView:
-        text = msgInfoAddScript;
-        break;
-    case EditorViewType::cmActionView:
-        text = msgInfoAddButton;
-        break;
-    case EditorViewType::cmKeysView:
-        text = msgInfoAddKey;
-        break;
-    case EditorViewType::cmVarsView:
-        text = msgInfoAddVar;
-        break;
-    default:
-        qWarning() << "ERROR: dlgTriggerEditor::showIntro() undefined view, not sure what to show";
-    }
+    QString text = createInfoText(mCurrentView);
 
     mpSystemMessageArea->notificationAreaIconLabelError->hide();
     mpSystemMessageArea->notificationAreaIconLabelWarning->hide();
@@ -8186,7 +8248,7 @@ QString dlgTriggerEditor::createInfoText(const EditorViewType viewType, const QS
 {
     // TODO: Prototype currently works for Alias only
     if (!infoAddItem.contains(viewType)) {
-        qWarning() << "ERROR: dlgTriggerEditor::createInfoText() undefined view, not implemented yet";
+        qWarning() << "ERROR: dlgTriggerEditor::createInfoText() undefined view";
         return(QString());
     }
 
@@ -10445,7 +10507,7 @@ void dlgTriggerEditor::clearTimerForm()
 {
     mpTimersMainArea->hide();
     mpTimersMainArea->hide();
-    showInfo(msgInfoAddTimer);
+    showIntro();
 }
 
 void dlgTriggerEditor::clearAliasForm()
@@ -10459,28 +10521,28 @@ void dlgTriggerEditor::clearScriptForm()
 {
     mpScriptsMainArea->hide();
     mpSourceEditorArea->hide();
-    showInfo(msgInfoAddScript);
+    showIntro();
 }
 
 void dlgTriggerEditor::clearActionForm()
 {
     mpActionsMainArea->hide();
     mpSourceEditorArea->hide();
-    showInfo(msgInfoAddButton);
+    showIntro();
 }
 
 void dlgTriggerEditor::clearKeyForm()
 {
     mpKeysMainArea->hide();
     mpSourceEditorArea->hide();
-    showInfo(msgInfoAddKey);
+    showIntro();
 }
 
 void dlgTriggerEditor::clearVarForm()
 {
     mpVarsMainArea->hide();
     mpSourceEditorArea->hide();
-    showInfo(msgInfoAddVar);
+    showIntro();
 }
 
 void dlgTriggerEditor::setEditorShowBidi(const bool state)

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -79,18 +79,19 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                          "<p>That's it! If you'd like to be able to create aliases from the input line, there are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you."
                          "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Aliases'>more information</a>.</p>");
 
-    infoAddAlias.summary = tr("Alias react on user input.");
-    infoAddAlias.options.append({qsl("alias1"), tr("How to add a new alias now"), 
-        tr("<ol><li>Click on the 'Add Item' icon above.</li>"
-           "<li>Define an input <strong>pattern</strong> either literally or with a Perl regular expression.</li>"
-           "<li>Define a 'substitution' <strong>command</strong> to send to the game in clear text <strong>instead of the alias pattern</strong>, or write a script for more complicated needs.</li>"
-           "<li><strong>Activate</strong> the alias.</li></ol>")});
-    infoAddAlias.options.append({qsl("alias2"), tr("How to add a new alias from the command line"), 
-        tr("<p>There are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you.</p>")});
-    infoAddAlias.options.append({qsl("alias3"), tr("Check the Mudlet manual for more information"), 
-        tr("<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Aliases'>Introduction to Aliases</a> for a detailed overview.</p>")});
-
-    infoAddItem.insert(EditorViewType::cmAliasView, {infoAddAlias.summary, infoAddAlias.options});
+    infoAddItem.insert(EditorViewType::cmAliasView, {
+        tr("Alias react on user input."), {
+        {qsl("alias1"), tr("How to add a new alias now"),
+            tr("<ol><li>Click on the 'Add Item' icon above.</li>"
+               "<li>Define an input <strong>pattern</strong> either literally or with a Perl regular expression.</li>"
+               "<li>Define a 'substitution' <strong>command</strong> to send to the game in clear text <strong>instead of the alias pattern</strong>, or write a script for more complicated needs.</li>"
+               "<li><strong>Activate</strong> the alias. That's it!</li></ol>")},
+        {qsl("alias2"), tr("How to add a new alias from the command line"),
+            tr("<p>There are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you.</p>")},
+        {qsl("alias3"), tr("Check the Mudlet manual for more information"),
+            tr("<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Aliases'>Introduction to Aliases</a> for a detailed overview.</p>")}
+        }
+    });
 
     msgInfoAddTrigger = tr("<p>Triggers react on game output. To add a new trigger:"
                            "<ol><li>Click on the 'Add Item' icon above.</li>"

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8020,9 +8020,7 @@ void dlgTriggerEditor::slot_showVariables()
     if (!pI || pI == treeWidget_variables->currentItem() || !pI->childCount()) {
         // There is no root item, we are on the root item or there are no other
         // items - so show the help message:
-        mpVarsMainArea->hide();
-        mpSourceEditorArea->hide();
-        showInfo(msgInfoAddVar);
+        clearVarForm();
     } else {
         mpVarsMainArea->show();
         mpSourceEditorArea->show();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -198,9 +198,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     // so our errors box doesn't stretch to produce a grey area
     layoutColumn->addWidget(mpSystemMessageArea, 0);
     connect(mpSystemMessageArea->messageAreaCloseButton, &QAbstractButton::clicked, this, &dlgTriggerEditor::hideSystemMessageArea);
-    connect(mpSystemMessageArea->notificationAreaMessageBox, &QLabel::linkActivated, this, [=](const QString& URL) {
-        mpSystemMessageArea->notificationAreaMessageBox->setText(createInfoText(URL));
-    });
+    connect(mpSystemMessageArea->notificationAreaMessageBox, &QLabel::linkActivated, this, &dlgTriggerEditor::slot_clickedMessageBox);
 
     // main areas
     mpTriggersMainArea = new dlgTriggersMainArea(this);
@@ -969,6 +967,18 @@ void dlgTriggerEditor::slot_searchSplitterMoved(const int pos, const int index)
     Q_UNUSED(pos)
     Q_UNUSED(index)
     mSearchSplitterState = searchSplitter->saveState();
+}
+
+void slot_clickedMessageBox(const QString& URL)
+{
+    //     mpSystemMessageArea->notificationAreaMessageBox->setText(createInfoText(URL));
+
+    QString infoText = createInfoText(URL);
+    mpSystemMessageArea->notificationAreaMessageBox->setText(infoText);
+    QApplication::beep();
+    mudlet::self()->mTrayIcon.showMessage("Debug click", 
+        qsl("URL: %1\ninfo text:%2".arg(URL, infoText)),
+        mudlet::self()->mTrayIcon.icon());
 }
 
 void dlgTriggerEditor::slot_editorThemeChanged()

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8246,7 +8246,6 @@ void dlgTriggerEditor::showIntro()
 
 QString dlgTriggerEditor::createInfoText(const EditorViewType viewType, const QString& desiredOption)
 {
-    // TODO: Prototype currently works for Alias only
     if (!infoAddItem.contains(viewType)) {
         qWarning() << "ERROR: dlgTriggerEditor::createInfoText() undefined view";
         return(QString());

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -198,9 +198,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     // so our errors box doesn't stretch to produce a grey area
     layoutColumn->addWidget(mpSystemMessageArea, 0);
     connect(mpSystemMessageArea->messageAreaCloseButton, &QAbstractButton::clicked, this, &dlgTriggerEditor::hideSystemMessageArea);
-    connect(mpSystemMessageArea->notificationAreaMessageBox, &QLabel::linkActivated, this, [=](const QString& URL) {
-        mpSystemMessageArea->notificationAreaMessageBox->setText(createInfoText(URL));
-    });
+    connect(mpSystemMessageArea->notificationAreaMessageBox, &QLabel::linkActivated, this, &dlgTriggerEditor::slot_clickedMessageBox);
 
     // main areas
     mpTriggersMainArea = new dlgTriggersMainArea(this);
@@ -971,7 +969,17 @@ void dlgTriggerEditor::slot_searchSplitterMoved(const int pos, const int index)
     mSearchSplitterState = searchSplitter->saveState();
 }
 
+void slot_clickedMessageBox(const QString& URL)
+{
+    //     mpSystemMessageArea->notificationAreaMessageBox->setText(createInfoText(URL));
 
+    QString infoText = createInfoText(URL);
+    mpSystemMessageArea->notificationAreaMessageBox->setText(infoText);
+    QApplication::beep();
+    mudlet::self()->mTrayIcon.showMessage("Debug click", 
+        qsl("URL: %1\ninfo text:%2").arg(URL, infoText),
+        mudlet::self()->mTrayIcon.icon());
+}
 
 void dlgTriggerEditor::slot_editorThemeChanged()
 {

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8166,7 +8166,7 @@ void dlgTriggerEditor::showIntro()
         text = msgInfoAddVar;
         break;
     default:
-        qWarning() << "ERROR: dlgTriggerEditor::showInfo() undefined view, not sure what to show";
+        qWarning() << "ERROR: dlgTriggerEditor::showIntro() undefined view, not sure what to show";
     }
 
     mpSystemMessageArea->notificationAreaIconLabelError->hide();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -198,7 +198,9 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     // so our errors box doesn't stretch to produce a grey area
     layoutColumn->addWidget(mpSystemMessageArea, 0);
     connect(mpSystemMessageArea->messageAreaCloseButton, &QAbstractButton::clicked, this, &dlgTriggerEditor::hideSystemMessageArea);
-    connect(mpSystemMessageArea->notificationAreaMessageBox, &QLabel::linkActivated, this, &dlgTriggerEditor::slot_clickedMessageBox);
+    connect(mpSystemMessageArea->notificationAreaMessageBox, &QLabel::linkActivated, this, [=](const QString& URL) {
+        mpSystemMessageArea->notificationAreaMessageBox->setText(createInfoText(URL));
+    });
 
     // main areas
     mpTriggersMainArea = new dlgTriggersMainArea(this);
@@ -969,17 +971,7 @@ void dlgTriggerEditor::slot_searchSplitterMoved(const int pos, const int index)
     mSearchSplitterState = searchSplitter->saveState();
 }
 
-void slot_clickedMessageBox(const QString& URL)
-{
-    //     mpSystemMessageArea->notificationAreaMessageBox->setText(createInfoText(URL));
 
-    QString infoText = createInfoText(URL);
-    mpSystemMessageArea->notificationAreaMessageBox->setText(infoText);
-    QApplication::beep();
-    mudlet::self()->mTrayIcon.showMessage("Debug click", 
-        qsl("URL: %1\ninfo text:%2").arg(URL, infoText),
-        mudlet::self()->mTrayIcon.icon());
-}
 
 void dlgTriggerEditor::slot_editorThemeChanged()
 {

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8283,7 +8283,7 @@ void dlgTriggerEditor::showIntro(const QString& desiredOption)
         return;
     }
 
-    infoTextParts introAddCurrentItem = introAddItem.value(mCurrentView);
+    introTextParts introAddCurrentItem = introAddItem.value(mCurrentView);
     QString introTextOptions;
     for (const auto &[name, headline, contents] : introAddCurrentItem.options) {
         introTextOptions.append(

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8191,8 +8191,7 @@ QString dlgTriggerEditor::createInfoText(const QString& desiredContents)
 QString dlgTriggerEditor::createInfoOptionText(const infoOption& option, const QString& desiredContents)
 {
     if (option.name != desiredContents) {
-        // TODO: DEBUG: return qsl("<li><a href='%1'>%2</a></li>").arg(option.name, option.headline);
-        return qsl("<li>%1 - %2</a></li>").arg(option.name, option.headline);
+        return qsl("<li><a href='%1'>%2</a></li>").arg(option.name, option.headline);
     } else {
         return qsl("<li>%1%2</li>").arg(option.headline, option.contents); // %2 wrapped in <p></p> etc.
     }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -198,7 +198,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     // so our errors box doesn't stretch to produce a grey area
     layoutColumn->addWidget(mpSystemMessageArea, 0);
     connect(mpSystemMessageArea->messageAreaCloseButton, &QAbstractButton::clicked, this, &dlgTriggerEditor::hideSystemMessageArea);
-    connect(mpSystemMessageArea->notificationAreaMessageBox, &QLabel::linkActivated, this [=](const QString& URL) {
+    connect(mpSystemMessageArea->notificationAreaMessageBox, &QLabel::linkActivated, this, [=](const QString& URL) {
         mpSystemMessageArea->notificationAreaMessageBox->setText(createInfoText(URL));
     })
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -79,7 +79,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                          "<p>That's it! If you'd like to be able to create aliases from the input line, there are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you."
                          "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Aliases'>more information</a>.</p>");
 
-    infoAddAlias.summary = tr("<p>Alias react on user input.</p>");
+    infoAddAlias.summary = tr("Alias react on user input.");
     infoAddAlias.options.append({qsl("alias1"), tr("How to add a new alias now"), 
         tr("<ol><li>Click on the 'Add Item' icon above.</li>"
            "<li>Define an input <strong>pattern</strong> either literally or with a Perl regular expression.</li>"
@@ -974,11 +974,12 @@ void dlgTriggerEditor::slot_clickedMessageBox(const QString& URL)
     //     mpSystemMessageArea->notificationAreaMessageBox->setText(createInfoText(URL));
 
     QString infoText = createInfoText(URL);
-    mpSystemMessageArea->notificationAreaMessageBox->setText(infoText);
     QApplication::beep();
     mudlet::self()->mTrayIcon.showMessage("Debug click", 
         qsl("URL: %1\ninfo text:%2").arg(URL, infoText),
         mudlet::self()->mTrayIcon.icon());
+
+    mpSystemMessageArea->notificationAreaMessageBox->setText(infoText);
 }
 
 void dlgTriggerEditor::slot_editorThemeChanged()

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8180,7 +8180,7 @@ void dlgTriggerEditor::showIntro()
     }
 }
 
-QString dlgTriggerEditor::createInfoText(const QString& desiredContents)
+QString dlgTriggerEditor::createInfoText(const QString& desiredOption)
 {
     QString infoTextOptions;
     QString infoTextSummary;
@@ -8189,7 +8189,7 @@ QString dlgTriggerEditor::createInfoText(const QString& desiredContents)
     infoTextSummary = infoAddAlias.summary;
     QVectorIterator<infoOption> iterateOptions(infoAddAlias.options);
     while (iterateOptions.hasNext()) {
-        infoTextOptions.append(createInfoOptionText(iterateOptions.next(), desiredContents));
+        infoTextOptions.append(createInfoOptionText(iterateOptions.next(), desiredOption));
     }
 
     return qsl("<p>%1</p><ul>%2</ul>")
@@ -8197,9 +8197,9 @@ QString dlgTriggerEditor::createInfoText(const QString& desiredContents)
 }
 
 
-QString dlgTriggerEditor::createInfoOptionText(const infoOption& option, const QString& desiredContents)
+QString dlgTriggerEditor::createInfoOptionText(const infoOption& option, const QString& desiredOption)
 {
-    if (option.name != desiredContents) {
+    if (option.name != desiredOption) {
         return qsl("<li><a href='%1'>%2</a></li>").arg(option.name, option.headline);
     } else {
         return qsl("<li><strong>%1</strong>%2</li>").arg(option.headline, option.contents); // contents are wrapped in <p></p> etc.

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -81,14 +81,14 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     infoAddAlias.summary = tr("<p>Alias react on user input.</p>");
     infoAddAlias.options.append({qsl("alias1"), tr("How to add a new alias now"), 
-        tr(	"<ol><li>Click on the 'Add Item' icon above.</li>"
-	        "<li>Define an input <strong>pattern</strong> either literally or with a Perl regular expression.</li>"
-	        "<li>Define a 'substitution' <strong>command</strong> to send to the game in clear text <strong>instead of the alias pattern</strong>, or write a script for more complicated needs.</li>"
-	        "<li><strong>Activate</strong> the alias.</li></ol>")});
+        tr("<ol><li>Click on the 'Add Item' icon above.</li>"
+           "<li>Define an input <strong>pattern</strong> either literally or with a Perl regular expression.</li>"
+           "<li>Define a 'substitution' <strong>command</strong> to send to the game in clear text <strong>instead of the alias pattern</strong>, or write a script for more complicated needs.</li>"
+           "<li><strong>Activate</strong> the alias.</li></ol>")});
     infoAddAlias.options.append({qsl("alias2"), tr("How to add a new alias from the command line"), 
-        tr( "<p>There are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you.</p>")});
+        tr("<p>There are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you.</p>")});
     infoAddAlias.options.append({qsl("alias3"), tr("Check the Mudlet manual for more information"), 
-        tr( "<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Aliases'>Introduction to Aliases</a> for a detailed overview.</p>")});
+        tr("<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Aliases'>Introduction to Aliases</a> for a detailed overview.</p>")});
 
     msgInfoAddTrigger = tr("<p>Triggers react on game output. To add a new trigger:"
                            "<ol><li>Click on the 'Add Item' icon above.</li>"

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8252,10 +8252,10 @@ QString dlgTriggerEditor::createInfoText(const EditorViewType viewType, const QS
     }
 
     infoTextParts infoAddCurrentItem = infoAddItem.value(viewType);
-    QVectorIterator<infoOption> iterateOptions(infoAddCurrentItem.options);
     QString infoTextOptions;
-    while (iterateOptions.hasNext()) {
-        infoTextOptions.append(createInfoOptionText(iterateOptions.next(), desiredOption));
+
+    for (const infoOption &currentOption : infoAddCurrentItem.options) {
+        infoTextOptions.append(createInfoOptionText(currentOption, desiredOption));
     }
 
     return qsl("<p>%1</p><ul>%2</ul>")

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1113,7 +1113,7 @@ void dlgTriggerEditor::slot_clickedMessageBox(const QString& URL)
     if (URL.startsWith("http")) {
         QDesktopServices::openUrl(URL);
     } else { // internal links used by expanding info text navigation
-        mpSystemMessageArea->notificationAreaMessageBox->setText(createInfoText(mCurrentView, URL));
+        mpSystemMessageArea->notificationAreaMessageBox->setText(showIntro(URL));
     }
 }
 
@@ -8276,29 +8276,14 @@ void dlgTriggerEditor::showInfo(const QString& error)
     }
 }
 
-void dlgTriggerEditor::showIntro()
+void dlgTriggerEditor::showIntro(const QString& desiredOption)
 {
-    QString text = createInfoText(mCurrentView);
-
-    mpSystemMessageArea->notificationAreaIconLabelError->hide();
-    mpSystemMessageArea->notificationAreaIconLabelWarning->hide();
-    mpSystemMessageArea->notificationAreaIconLabelInformation->show();
-    mpSystemMessageArea->notificationAreaMessageBox->setText(text);
-    mpSystemMessageArea->show();
-
-    if (!mpHost->mIsProfileLoadingSequence) {
-        mudlet::self()->announce(text);
-    }
-}
-
-QString dlgTriggerEditor::createInfoText(const EditorViewType viewType, const QString& desiredOption)
-{
-    if (!infoAddItem.contains(viewType)) {
-        qWarning() << "ERROR: dlgTriggerEditor::createInfoText() undefined view";
+    if (!infoAddItem.contains(mCurrentView)) {
+        qWarning() << "ERROR: dlgTriggerEditor::showIntro() undefined view";
         return(QString());
     }
 
-    infoTextParts infoAddCurrentItem = infoAddItem.value(viewType);
+    infoTextParts infoAddCurrentItem = infoAddItem.value(mCurrentView);
     QString infoTextOptions;
     for (const auto &[name, headline, contents] : infoAddCurrentItem.options) {
         infoTextOptions.append(
@@ -8306,8 +8291,9 @@ QString dlgTriggerEditor::createInfoText(const EditorViewType viewType, const QS
             ? qsl("<li><a href='%1'>%2</a></li>").arg(name, headline)
             : qsl("<li><strong>%1</strong>%2</li>").arg(headline, contents));
     }
-    return qsl("<p>%1</p><ul>%2</ul>")
-        .arg(infoAddCurrentItem.summary, infoTextOptions);
+
+    showInfo(qsl("<p>%1</p><ul>%2</ul>")
+        .arg(infoAddCurrentItem.summary, infoTextOptions));
 }
 
 void dlgTriggerEditor::slot_showActions()

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8142,7 +8142,7 @@ void dlgTriggerEditor::showIntro()
         break;
     case EditorViewType::cmAliasView:
         // text = msgInfoAddAlias;
-        text = createInfoText(qsl("")); // TODO: How to tell it, there was no link clicked?
+        text = createInfoText(qsl("")); // Got no better idea, how to tell it, there was no link clicked..
         break;
     case EditorViewType::cmScriptView:
         text = msgInfoAddScript;
@@ -8183,15 +8183,16 @@ QString dlgTriggerEditor::createInfoText(const QString& desiredContents)
         infoTextOptions.append(createInfoOptionText(iterateOptions.next(), desiredContents));
     }
 
-    return qsl("<p>%1</p><ol>%2</ol>")
-        .arg(infoTextSummary, infoTextOptions);
+    return qsl("<p>%1</p><ul>%2</ul>%3")
+        .arg(infoTextSummary, infoTextOptions, desiredContents); // TODO: DEBUG: remove %3 and desiredContents
 }
 
 
 QString dlgTriggerEditor::createInfoOptionText(const infoOption& option, const QString& desiredContents)
 {
     if (option.name != desiredContents) {
-        return qsl("<li><a href='%1'>%2</a></li>").arg(option.name, option.headline);
+        // TODO: DEBUG: return qsl("<li><a href='%1'>%2</a></li>").arg(option.name, option.headline);
+        return qsl("<li>%1 - %2</a></li>").arg(option.name, option.headline);
     } else {
         return qsl("<li>%1%2</li>").arg(option.headline, option.contents); // %2 wrapped in <p></p> etc.
     }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8186,10 +8186,10 @@ QString dlgTriggerEditor::createInfoText(const EditorViewType viewType, const QS
     // TODO: Prototype currently works for Alias only
     if (!infoAddItem.contains(viewType)) {
         qWarning() << "ERROR: dlgTriggerEditor::createInfoText() undefined view, not implemented yet";
-        return(QString);
+        return(QString());
     }
 
-    infoTextParts infoAddCurrentItem = infoAddItem.key(viewType);
+    infoTextParts infoAddCurrentItem = infoAddItem.value(viewType);
     QVectorIterator<infoOption> iterateOptions(infoAddCurrentItem.options);
     QString infoTextOptions;
     while (iterateOptions.hasNext()) {

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -80,15 +80,22 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                          "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Aliases'>more information</a>.</p>");
 
     infoAddItem.insert(EditorViewType::cmAliasView, {
+        //: Headline for the Messagebox in the Mudlet Alias Editor
         tr("Alias react on user input."), {
+        //: Name of a selectable option for the Messagebox in the Mudlet Alias Editor
         {qsl("alias1"), tr("How to add a new alias now"),
+        //: Help contents of a selectable option for the Messagebox in the Mudlet Alias Editor
             tr("<ol><li>Click on the 'Add Item' icon above.</li>"
                "<li>Define an input <strong>pattern</strong> either literally or with a Perl regular expression.</li>"
                "<li>Define a 'substitution' <strong>command</strong> to send to the game in clear text <strong>instead of the alias pattern</strong>, or write a script for more complicated needs.</li>"
                "<li><strong>Activate</strong> the alias.</li></ol>")},
+        //: Name of a selectable option for the Messagebox in the Mudlet Alias Editor
         {qsl("alias2"), tr("How to add a new alias from the command line"),
+        //: Help contents of a selectable option for the Messagebox in the Mudlet Alias Editor
             tr("<p>There are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you.</p>")},
+        //: Name of a selectable option for the Messagebox in the Mudlet Alias Editor
         {qsl("alias3"), tr("Check the Mudlet manual for more information"),
+        //: Help contents of a selectable option for the Messagebox in the Mudlet Alias Editor
             tr("<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Aliases'>Introduction to Aliases</a> for a detailed overview.</p>")}
         }
     });
@@ -103,33 +110,47 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                         "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Triggers'>more information</a>.</p>");
 
     infoAddItem.insert(EditorViewType::cmTriggerView, {
+        //: Headline for the Messagebox in the Mudlet Trigger Editor
         tr("Triggers react on game output."), {
+        //: Name of a selectable option for the Messagebox in the Mudlet Trigger Editor
         {qsl("trigger1"), tr("How to add a new trigger now"),
+        //: Help contents of a selectable option for the Messagebox in the Mudlet Trigger Editor
             tr("<ol><li>Click on the 'Add Item' icon above.</li>"
                "<li>Define a <strong>pattern</strong> that you want to trigger on.</li>"
                "<li>Select the appropriate pattern <strong>type</strong>.</li>"
                "<li>Define a clear text <strong>command</strong> that you want to send to the game if the trigger finds the pattern in the text from the game, or write a script for more complicated needs..</li>"
                "<li><strong>Activate</strong> the trigger.</li></ol>")},
+        //: Name of a selectable option for the Messagebox in the Mudlet Trigger Editor
         {qsl("trigger2"), tr("How to add a new trigger from the command line"),
+        //: Help contents of a selectable option for the Messagebox in the Mudlet Trigger Editor
             tr("<p>There are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you.</p>")},
+        //: Name of a selectable option for the Messagebox in the Mudlet Trigger Editor
         {qsl("trigger3"), tr("Check the Mudlet manual for more information"),
+        //: Help contents of a selectable option for the Messagebox in the Mudlet Trigger Editor
             tr("<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Triggers'>Introduction to Triggers</a> for a detailed overview.</p>")}
         }
     });
 
     infoAddItem.insert(EditorViewType::cmScriptView, {
+        //: Headline for the Messagebox in the Mudlet Script Editor
         tr("Scripts organize code and can react to events."), {
+        //: Name of a selectable option for the Messagebox in the Mudlet Script Editor
         {qsl("script1"), tr("How to add a new script now"),
+        //: Help contents of a selectable option for the Messagebox in the Mudlet Script Editor
             tr("<ol><li>Click on the 'Add Item' icon above.</li>"
                "<li>Enter a script in the box below. You can for example define <strong>functions</strong> to be called by other triggers, aliases, etc.</li>"
                "<li>If you write lua <strong>commands</strong> without defining a function, they will be run on Mudlet startup and each time you open the script for editing.</li>"
                "<li><strong>Activate</strong> the script.</li></ol>"
                "<p><strong>Note:</strong> Scripts are run automatically when viewed, even if they are deactivated.</p>")},
+        //: Name of a selectable option for the Messagebox in the Mudlet Script Editor
         {qsl("script2"), tr("How to have a script react to events"),
+        //: Help contents of a selectable option for the Messagebox in the Mudlet Script Editor
             tr("<p>You can register a list of <strong>events</strong> with the + and - symbols. If one of these events take place, the function with the same name as the script item itself will be called.</p>"
                "<p><strong>Note:</strong> Events can also be added to a script from the command line in the main profile window like this:</p>"
                "<p><code>lua registerAnonymousEventHandler(&quot;nameOfTheMudletEvent&quot;, &quot;nameOfYourFunctionToBeCalled&quot;)</code></p>")},
+        //: Name of a selectable option for the Messagebox in the Mudlet Script Editor
         {qsl("script3"), tr("Check the Mudlet manual for more information"),
+        //: Help contents of a selectable option for the Messagebox in the Mudlet Script Editor
             tr("<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Scripts'>Introduction to Scripts</a> for a detailed overview.</p>")}
         }
     });
@@ -146,18 +167,25 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                          "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Timers'>more information</a>.</p>");
 
     infoAddItem.insert(EditorViewType::cmTimerView, {
+        //: Headline for the Messagebox in the Mudlet Timer Editor
         tr("Timers react after a timespan once or regularly."), {
+        //: Name of a selectable option for the Messagebox in the Mudlet Timer Editor
         {qsl("timer1"), tr("How to add a new timer now"),
+        //: Help contents of a selectable option for the Messagebox in the Mudlet Timer Editor
             tr("<ol><li>Click on the 'Add Item' icon above.</li>"
                "<li>Define the <strong>timespan</strong> after which the timer should react in a this format: hours : minutes : seconds.</li>"
                "<li>Define a clear text <strong>command</strong> that you want to send to the game when the time has passed, or write a script for more complicated needs.</li>"
                "<li><strong>Activate</strong> the timer.</li></ol>"
                "<p><strong>Note:</strong> If you want the trigger to react only once and not regularly, use the Lua tempTimer() function instead.</p>")},
+        //: Name of a selectable option for the Messagebox in the Mudlet Timer Editor
         {qsl("timer2"), tr("How to add a new timer from the command line"),
+        //: Help contents of a selectable option for the Messagebox in the Mudlet Timer Editor
             tr("<p>Timers can also be defined from the input line in the main profile window like this:</p>"
                "<p><code>lua tempTimer(3, function() echo(&quot;hello!\n&quot;) end)</code></p>"
                "<p>This will greet you exactly 3 seconds after it was made.</p>")},
+        //: Name of a selectable option for the Messagebox in the Mudlet Timer Editor
         {qsl("timer3"), tr("Check the Mudlet manual for more information"),
+        //: Help contents of a selectable option for the Messagebox in the Mudlet Timer Editor
             tr("<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Timers'>Introduction to Timers</a> for a detailed overview.</p>")}
         }
     });
@@ -173,8 +201,11 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                           "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Buttons'>more information</a>.</p>");
 
     infoAddItem.insert(EditorViewType::cmActionView, {
+        //: Headline for the Messagebox in the Mudlet Button
         tr("Buttons react on mouse clicks."), {
+        //: Name of a selectable option for the Messagebox in the Mudlet Button Editor
         {qsl("button1"), tr("How to add a new button now"),
+        //: Help contents of a selectable option for the Messagebox in the Mudlet Button Editor
             tr("<ol><li>Add a new group to define a new <strong>button bar</strong> in case you don't have any.</li>"
                "<li>Add new groups as <strong>menus</strong> to a button bar or sub-menus to menus.<li>"
                "<li>Add new items as <strong>buttons</strong> to a button bar or menu or sub-menu.</li>"
@@ -184,7 +215,9 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                "<p><strong>Note:</strong> If a button is made a <strong>click-down</strong> button then you may also define a clear text command that you want to send to the game when the button is pressed a second time to uncheck it or to write a script to run when it happens - within such a script the Lua 'getButtonState()' function reports whether the button is up or down.</p>")},
 //        {qsl("button2"), tr("How to add a new button from the command line"),
 //            tr("")},
+        //: Name of a selectable option for the Messagebox in the Mudlet Button Editor
         {qsl("button3"), tr("Check the Mudlet manual for more information"),
+        //: Help contents of a selectable option for the Messagebox in the Mudlet Button Editor
             tr("<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Buttons'>Introduction to Buttons</a> for a detailed overview.</p>")}
         }
     });
@@ -200,17 +233,24 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                        "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Keybindings'>more information</a>.</p>");
 
     infoAddItem.insert(EditorViewType::cmKeysView, {
+        //: Headline for the Messagebox in the Mudlet Keys Editor
         tr("Keys react on keyboard presses."), {
+        //: Name of a selectable option for the Messagebox in the Mudlet Keys Editor
         {qsl("key1"), tr("How to add a new keybinding now"),
+        //: Help contents of a selectable option for the Messagebox in the Mudlet Keys Editor
             tr("<ol><li>Click on the 'Add Item' icon above.</li>"
                "<li>Click on <strong>'grab key'</strong> and then press your key combination, e.g. including modifier keys like Control, Shift, etc.</li>"
                "<li>Define a clear text <strong>command</strong> that you want to send to the game if the button is pressed, or write a script for more complicated needs.</li>"
                "<li><strong>Activate</strong> the new key binding.</li></ol>")},
+        //: Name of a selectable option for the Messagebox in the Mudlet Keys Editor
         {qsl("key2"), tr("How to add a new keybinding from the command line"),
+        //: Help contents of a selectable option for the Messagebox in the Mudlet Keys Editor
             tr("<p>Keys can be defined from the input line in the main profile window like this:</p>"
                "<p><code>lua permKey(&quot;my jump key&quot;, &quot;&quot;, mudlet.key.F8, [[send(&quot;jump&quot;]]) end)</code></p>"
                "<p>Pressing F8 will make you jump.</p>")},
+        //: Name of a selectable option for the Messagebox in the Mudlet Keys Editor
         {qsl("key3"), tr("Check the Mudlet manual for more information"),
+        //: Help contents of a selectable option for the Messagebox in the Mudlet Keys Editor
             tr("<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Keybindings'>Introduction to Keybindings</a> for a detailed overview.</p>")}
         }
     });
@@ -228,19 +268,26 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                        "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Variables'>more information</a>.</p>");
 
     infoAddItem.insert(EditorViewType::cmVarsView, {
+        //: Headline for the Messagebox in the Mudlet Variable Editor
         tr("Variables store information."), {
+        //: Name of a selectable option for the Messagebox in the Mudlet Variable Editor
         {qsl("variable1"), tr("How to add a new variable now"),
+        //: Help contents of a selectable option for the Messagebox in the Mudlet Variable Editor
             tr("<ol><li>Click on the 'Add Item' icon above. To add a table instead click 'Add Group'.</li>"
                "<li>Select type of variable value (can be a string, integer, boolean)</li>"
                "<li>Enter the value you want to store in this variable.</li>"
                "<li>If you want to keep the variable in your next Mudlet sessions, check the checkbox in the list of variables to the left.</li>"
                "<li>To remove a variable manually, set it to 'nil' or click on the 'Delete' icon above.</li></ol>"
                "<p><strong>Note:</strong> Variables created here won't be saved when Mudlet shuts down unless you check their checkbox in the list of variables to the left. You could also create scripts with the variables instead.</p>")},
+        //: Name of a selectable option for the Messagebox in the Mudlet Variable Editor
         {qsl("variable2"), tr("How to add a new variable from the command line"),
+        //: Help contents of a selectable option for the Messagebox in the Mudlet Variable Editor
             tr("<p>Variables and tables can also be defined from the input line in the main profile window like this:</p>"
                "<p><code>lua foo = &quot;bar&quot;</code></p>"
                "<p>This will create a string called 'foo' with 'bar' as its value.</p>")},
+        //: Name of a selectable option for the Messagebox in the Mudlet Variable Editor
         {qsl("variable3"), tr("Check the Mudlet manual for more information"),
+        //: Help contents of a selectable option for the Messagebox in the Mudlet Variable Editor
             tr("<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Variables'>Introduction to Variables</a> for a detailed overview.</p>")}
         }
     });

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8253,22 +8253,14 @@ QString dlgTriggerEditor::createInfoText(const EditorViewType viewType, const QS
 
     infoTextParts infoAddCurrentItem = infoAddItem.value(viewType);
     QString infoTextOptions;
-
-    for (const infoOption &currentOption : infoAddCurrentItem.options) {
-        infoTextOptions.append(createInfoOptionText(currentOption, desiredOption));
+    for (const auto &[name, headline, contents] : infoAddCurrentItem.options) {
+        infoTextOptions.append(
+            (name != desiredOption)
+            ? qsl("<li><a href='%1'>%2</a></li>").arg(name, headline)
+            : qsl("<li><strong>%1</strong>%2</li>").arg(headline, contents));
     }
-
     return qsl("<p>%1</p><ul>%2</ul>")
         .arg(infoAddCurrentItem.summary, infoTextOptions);
-}
-
-QString dlgTriggerEditor::createInfoOptionText(const infoOption& option, const QString& desiredOption)
-{
-    if (option.name != desiredOption) {
-        return qsl("<li><a href='%1'>%2</a></li>").arg(option.name, option.headline);
-    } else {
-        return qsl("<li><strong>%1</strong>%2</li>").arg(option.headline, option.contents); // contents are wrapped in <p></p> etc.
-    }
 }
 
 void dlgTriggerEditor::slot_showActions()

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -79,6 +79,17 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                          "<p>That's it! If you'd like to be able to create aliases from the input line, there are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you."
                          "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Aliases'>more information</a>.</p>");
 
+    infoAddAlias.summary = tr("<p>Alias react on user input.</p>");
+    infoAddAlias.options.append({qsl("alias1"), tr("How to add a new alias now"), 
+        tr(	"<ol><li>Click on the 'Add Item' icon above.</li>"
+	        "<li>Define an input <strong>pattern</strong> either literally or with a Perl regular expression.</li>"
+	        "<li>Define a 'substitution' <strong>command</strong> to send to the game in clear text <strong>instead of the alias pattern</strong>, or write a script for more complicated needs.</li>"
+	        "<li><strong>Activate</strong> the alias.</li></ol>")};
+    infoAddAlias.options.append({qsl("alias2"), tr("How to add a new alias from the command line"), 
+        tr( "<p>There are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you.</p>")};
+    infoAddAlias.options.append({qsl("alias3"), tr("Check the Mudlet manual for more information"), 
+        tr( "<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Aliases'>Introduction to Aliases</a> for a detailed overview.</p>")};
+
     msgInfoAddTrigger = tr("<p>Triggers react on game output. To add a new trigger:"
                            "<ol><li>Click on the 'Add Item' icon above.</li>"
                            "<li>Define a <strong>pattern</strong> that you want to trigger on.</li>"
@@ -187,6 +198,9 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     // so our errors box doesn't stretch to produce a grey area
     layoutColumn->addWidget(mpSystemMessageArea, 0);
     connect(mpSystemMessageArea->messageAreaCloseButton, &QAbstractButton::clicked, this, &dlgTriggerEditor::hideSystemMessageArea);
+    connect(mpSystemMessageArea->notificationAreaMessageBox, &QLabel::linkActivated, this [=](const QString& URL) {
+        mpSystemMessageArea->notificationAreaMessageBox->setText(createInfoText(URL));
+    })
 
     // main areas
     mpTriggersMainArea = new dlgTriggersMainArea(this);
@@ -4231,7 +4245,7 @@ void dlgTriggerEditor::addAlias(bool isFolder)
 
     mpCurrentAliasItem = pNewItem;
     treeWidget_aliases->setCurrentItem(pNewItem);
-    showInfo(msgInfoAddAlias);
+    showIntro();
     slot_aliasSelected(treeWidget_aliases->currentItem());
 }
 
@@ -8092,6 +8106,18 @@ void dlgTriggerEditor::showError(const QString& error)
     }
 }
 
+void dlgTriggerEditor::showWarning(const QString& error)
+{
+    mpSystemMessageArea->notificationAreaIconLabelInformation->hide();
+    mpSystemMessageArea->notificationAreaIconLabelError->hide();
+    mpSystemMessageArea->notificationAreaIconLabelWarning->show();
+    mpSystemMessageArea->notificationAreaMessageBox->setText(error);
+    mpSystemMessageArea->show();
+    if (!mpHost->mIsProfileLoadingSequence) {
+        mudlet::self()->announce(error);
+    }
+}
+
 void dlgTriggerEditor::showInfo(const QString& error)
 {
     mpSystemMessageArea->notificationAreaIconLabelError->hide();
@@ -8104,15 +8130,70 @@ void dlgTriggerEditor::showInfo(const QString& error)
     }
 }
 
-void dlgTriggerEditor::showWarning(const QString& error)
+void dlgTriggerEditor::showIntro()
 {
-    mpSystemMessageArea->notificationAreaIconLabelInformation->hide();
+    QString text;
+    switch (mCurrentView) {
+    case EditorViewType::cmTriggerView:
+        text = msgInfoAddTrigger;
+        break;
+    case EditorViewType::cmTimerView:
+        text = msgInfoAddTimer;
+        break;
+    case EditorViewType::cmAliasView:
+        // text = msgInfoAddAlias;
+        text = createInfoText(qsl("")) // TODO: How to tell it, there was no link clicked?
+        break;
+    case EditorViewType::cmScriptView:
+        text = msgInfoAddScript;
+        break;
+    case EditorViewType::cmActionView:
+        text = msgInfoAddButton;
+        break;
+    case EditorViewType::cmKeysView:
+        text = msgInfoAddKey;
+        break;
+    case EditorViewType::cmVarsView:
+        text = msgInfoAddVar;
+        break;
+    default:
+        qWarning() << "ERROR: dlgTriggerEditor::showInfo() undefined view, not sure what to show";
+    }
+
     mpSystemMessageArea->notificationAreaIconLabelError->hide();
-    mpSystemMessageArea->notificationAreaIconLabelWarning->show();
-    mpSystemMessageArea->notificationAreaMessageBox->setText(error);
+    mpSystemMessageArea->notificationAreaIconLabelWarning->hide();
+    mpSystemMessageArea->notificationAreaIconLabelInformation->show();
+    mpSystemMessageArea->notificationAreaMessageBox->setText(text);
     mpSystemMessageArea->show();
+
     if (!mpHost->mIsProfileLoadingSequence) {
-        mudlet::self()->announce(error);
+        mudlet::self()->announce(text);
+    }
+}
+
+QString dlgTriggerEditor::createInfoText(const QString& desiredContents)
+{
+    QString infoTextOptions;
+    QString infoTextSummary;
+
+    // TODO: Prototype currently works for Alias only
+    infoTextSummary = infoAddAlias.summary;
+    QVectorIterator<infoOption> iterateOptions(infoAddAlias.options);
+    while (iterateOptions.hasNext()) {
+        infoTextOptions.append(createInfoOptionText(iterateOptions.next(), desiredContents));
+    }
+
+    return qsl("<p>%1</p><ol>%2</ol>")
+        .arg(infoTextSummary, infoTextOptions)
+}
+
+
+QString dlgTriggerEditor::createInfoOptionText(const infoOption& option, const QString& desiredContents) const
+{
+    if (!option.name == desiredContents) {
+        return qsl("<li><a href="%1">%2</a></li>").arg(option.name, option.headline);
+    } else {
+        return qsl("<li>%1%2</li>").arg(option.headline, option.contents); // %2 wrapped in <p></p> etc.
     }
 }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -84,11 +84,11 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
         tr(	"<ol><li>Click on the 'Add Item' icon above.</li>"
 	        "<li>Define an input <strong>pattern</strong> either literally or with a Perl regular expression.</li>"
 	        "<li>Define a 'substitution' <strong>command</strong> to send to the game in clear text <strong>instead of the alias pattern</strong>, or write a script for more complicated needs.</li>"
-	        "<li><strong>Activate</strong> the alias.</li></ol>")};
+	        "<li><strong>Activate</strong> the alias.</li></ol>")});
     infoAddAlias.options.append({qsl("alias2"), tr("How to add a new alias from the command line"), 
-        tr( "<p>There are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you.</p>")};
+        tr( "<p>There are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you.</p>")});
     infoAddAlias.options.append({qsl("alias3"), tr("Check the Mudlet manual for more information"), 
-        tr( "<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Aliases'>Introduction to Aliases</a> for a detailed overview.</p>")};
+        tr( "<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Aliases'>Introduction to Aliases</a> for a detailed overview.</p>")});
 
     msgInfoAddTrigger = tr("<p>Triggers react on game output. To add a new trigger:"
                            "<ol><li>Click on the 'Add Item' icon above.</li>"

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -977,7 +977,7 @@ void slot_clickedMessageBox(const QString& URL)
     mpSystemMessageArea->notificationAreaMessageBox->setText(infoText);
     QApplication::beep();
     mudlet::self()->mTrayIcon.showMessage("Debug click", 
-        qsl("URL: %1\ninfo text:%2".arg(URL, infoText)),
+        qsl("URL: %1\ninfo text:%2").arg(URL, infoText),
         mudlet::self()->mTrayIcon.icon());
 }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -976,7 +976,7 @@ void dlgTriggerEditor::slot_clickedMessageBox(const QString& URL)
     if (URL.startsWith("http")) {
         QDesktopServices::openUrl(URL);
     } else { // internal links used by expanding info text navigation
-        mpSystemMessageArea->notificationAreaMessageBox->setText(createInfoText(URL));
+        mpSystemMessageArea->notificationAreaMessageBox->setText(createInfoText(mCurrentView, URL));
     }
 }
 
@@ -8147,11 +8147,12 @@ void dlgTriggerEditor::showIntro()
         text = msgInfoAddTrigger;
         break;
     case EditorViewType::cmTimerView:
-        text = msgInfoAddTimer;
+        // text = msgInfoAddTimer;
+        text = createInfoText(mCurrentView);
         break;
     case EditorViewType::cmAliasView:
         // text = msgInfoAddAlias;
-        text = createInfoText(qsl("")); // Got no better idea, how to tell it, there was no link clicked..
+        text = createInfoText(mCurrentView);
         break;
     case EditorViewType::cmScriptView:
         text = msgInfoAddScript;
@@ -8180,22 +8181,24 @@ void dlgTriggerEditor::showIntro()
     }
 }
 
-QString dlgTriggerEditor::createInfoText(const QString& desiredOption)
+QString dlgTriggerEditor::createInfoText(const EditorViewType viewType, const QString& desiredOption)
 {
-    QString infoTextOptions;
-    QString infoTextSummary;
-
     // TODO: Prototype currently works for Alias only
-    infoTextSummary = infoAddAlias.summary;
-    QVectorIterator<infoOption> iterateOptions(infoAddAlias.options);
+    if (!infoAddItem.contains(viewType)) {
+        qWarning() << "ERROR: dlgTriggerEditor::createInfoText() undefined view, not implemented yet";
+        return(QString);
+    }
+
+    infoTextParts infoAddCurrentItem = infoAddItem.key(viewType);
+    QVectorIterator<infoOption> iterateOptions(infoAddCurrentItem.options);
+    QString infoTextOptions;
     while (iterateOptions.hasNext()) {
         infoTextOptions.append(createInfoOptionText(iterateOptions.next(), desiredOption));
     }
 
     return qsl("<p>%1</p><ul>%2</ul>")
-        .arg(infoTextSummary, infoTextOptions);
+        .arg(infoAddCurrentItem.summary, infoTextOptions);
 }
-
 
 QString dlgTriggerEditor::createInfoOptionText(const infoOption& option, const QString& desiredOption)
 {

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -971,15 +971,11 @@ void dlgTriggerEditor::slot_searchSplitterMoved(const int pos, const int index)
 
 void dlgTriggerEditor::slot_clickedMessageBox(const QString& URL)
 {
-    //     mpSystemMessageArea->notificationAreaMessageBox->setText(createInfoText(URL));
-
-    QString infoText = createInfoText(URL);
-    QApplication::beep();
-    mudlet::self()->mTrayIcon.showMessage("Debug click", 
-        qsl("URL: %1\ninfo text:%2").arg(URL, infoText),
-        mudlet::self()->mTrayIcon.icon());
-
-    mpSystemMessageArea->notificationAreaMessageBox->setText(infoText);
+    if (URL.startsWith("http")) {
+        QDesktopServices::openUrl(URL);
+    } else { // internal links used by expanding info text navigation
+        mpSystemMessageArea->notificationAreaMessageBox->setText(createInfoText(URL));
+    }
 }
 
 void dlgTriggerEditor::slot_editorThemeChanged()
@@ -8194,8 +8190,8 @@ QString dlgTriggerEditor::createInfoText(const QString& desiredContents)
         infoTextOptions.append(createInfoOptionText(iterateOptions.next(), desiredContents));
     }
 
-    return qsl("<p>%1</p><ul>%2</ul>%3")
-        .arg(infoTextSummary, infoTextOptions, desiredContents); // TODO: DEBUG: remove %3 and desiredContents
+    return qsl("<p>%1</p><ul>%2</ul>")
+        .arg(infoTextSummary, infoTextOptions);
 }
 
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -79,7 +79,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                          "<p>That's it! If you'd like to be able to create aliases from the input line, there are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you."
                          "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Aliases'>more information</a>.</p>");
 
-    infoAddItem.insert(EditorViewType::cmAliasView, {
+    introAddItem.insert(EditorViewType::cmAliasView, {
         //: Headline for the Messagebox in the Mudlet Alias Editor
         tr("Alias react on user input."), {
         //: Name of a selectable option for the Messagebox in the Mudlet Alias Editor
@@ -109,7 +109,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                            "<p>That's it! If you'd like to be able to create triggers from the input line, there are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you."
                         "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Triggers'>more information</a>.</p>");
 
-    infoAddItem.insert(EditorViewType::cmTriggerView, {
+    introAddItem.insert(EditorViewType::cmTriggerView, {
         //: Headline for the Messagebox in the Mudlet Trigger Editor
         tr("Triggers react on game output."), {
         //: Name of a selectable option for the Messagebox in the Mudlet Trigger Editor
@@ -131,7 +131,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
         }
     });
 
-    infoAddItem.insert(EditorViewType::cmScriptView, {
+    introAddItem.insert(EditorViewType::cmScriptView, {
         //: Headline for the Messagebox in the Mudlet Script Editor
         tr("Scripts organize code and can react to events."), {
         //: Name of a selectable option for the Messagebox in the Mudlet Script Editor
@@ -166,7 +166,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                          "<p>This will greet you exactly 3 seconds after it was made.</p>"
                          "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Timers'>more information</a>.</p>");
 
-    infoAddItem.insert(EditorViewType::cmTimerView, {
+    introAddItem.insert(EditorViewType::cmTimerView, {
         //: Headline for the Messagebox in the Mudlet Timer Editor
         tr("Timers react after a timespan once or regularly."), {
         //: Name of a selectable option for the Messagebox in the Mudlet Timer Editor
@@ -200,7 +200,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                           "<p><strong>Note:</strong> If a button is made a <strong>click-down</strong> button then you may also define a clear text command that you want to send to the game when the button is pressed a second time to uncheck it or to write a script to run when it happens - within such a script the Lua 'getButtonState()' function reports whether the button is up or down.</p>"
                           "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Buttons'>more information</a>.</p>");
 
-    infoAddItem.insert(EditorViewType::cmActionView, {
+    introAddItem.insert(EditorViewType::cmActionView, {
         //: Headline for the Messagebox in the Mudlet Button
         tr("Buttons react on mouse clicks."), {
         //: Name of a selectable option for the Messagebox in the Mudlet Button Editor
@@ -232,7 +232,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                        "<p>Pressing F8 will make you jump.</p>"
                        "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Keybindings'>more information</a>.</p>");
 
-    infoAddItem.insert(EditorViewType::cmKeysView, {
+    introAddItem.insert(EditorViewType::cmKeysView, {
         //: Headline for the Messagebox in the Mudlet Keys Editor
         tr("Keys react on keyboard presses."), {
         //: Name of a selectable option for the Messagebox in the Mudlet Keys Editor
@@ -267,7 +267,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                        "<p>This will create a string called 'foo' with 'bar' as its value.</p>"
                        "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Variables'>more information</a>.</p>");
 
-    infoAddItem.insert(EditorViewType::cmVarsView, {
+    introAddItem.insert(EditorViewType::cmVarsView, {
         //: Headline for the Messagebox in the Mudlet Variable Editor
         tr("Variables store information."), {
         //: Name of a selectable option for the Messagebox in the Mudlet Variable Editor
@@ -8278,22 +8278,22 @@ void dlgTriggerEditor::showInfo(const QString& error)
 
 void dlgTriggerEditor::showIntro(const QString& desiredOption)
 {
-    if (!infoAddItem.contains(mCurrentView)) {
+    if (!introAddItem.contains(mCurrentView)) {
         qWarning() << "ERROR: dlgTriggerEditor::showIntro() undefined view";
         return;
     }
 
-    infoTextParts infoAddCurrentItem = infoAddItem.value(mCurrentView);
-    QString infoTextOptions;
-    for (const auto &[name, headline, contents] : infoAddCurrentItem.options) {
-        infoTextOptions.append(
+    infoTextParts introAddCurrentItem = introAddItem.value(mCurrentView);
+    QString introTextOptions;
+    for (const auto &[name, headline, contents] : introAddCurrentItem.options) {
+        introTextOptions.append(
             (name != desiredOption)
             ? qsl("<li><a href='%1'>%2</a></li>").arg(name, headline)
             : qsl("<li><strong>%1</strong>%2</li>").arg(headline, contents));
     }
 
     showInfo(qsl("<p>%1</p><ul>%2</ul>")
-        .arg(infoAddCurrentItem.summary, infoTextOptions));
+        .arg(introAddCurrentItem.summary, introTextOptions));
 }
 
 void dlgTriggerEditor::slot_showActions()

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8188,9 +8188,9 @@ QString dlgTriggerEditor::createInfoText(const QString& desiredContents)
 }
 
 
-QString dlgTriggerEditor::createInfoOptionText(const infoOption& option, const QString& desiredContents) const
+QString dlgTriggerEditor::createInfoOptionText(const infoOption& option, const QString& desiredContents)
 {
-    if (!option.name == desiredContents) {
+    if (option.name != desiredContents) {
         return qsl("<li><a href='%1'>%2</a></li>").arg(option.name, option.headline);
     } else {
         return qsl("<li>%1%2</li>").arg(option.headline, option.contents); // %2 wrapped in <p></p> etc.

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -90,6 +90,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     infoAddAlias.options.append({qsl("alias3"), tr("Check the Mudlet manual for more information"), 
         tr("<p>Start at the <a href='http://wiki.mudlet.org/w/Manual:Introduction#Aliases'>Introduction to Aliases</a> for a detailed overview.</p>")});
 
+    infoAddItem.insert(EditorViewType::cmAliasView, {infoAddAlias.summary, infoAddAlias.options});
+
     msgInfoAddTrigger = tr("<p>Triggers react on game output. To add a new trigger:"
                            "<ol><li>Click on the 'Add Item' icon above.</li>"
                            "<li>Define a <strong>pattern</strong> that you want to trigger on.</li>"
@@ -8200,7 +8202,7 @@ QString dlgTriggerEditor::createInfoOptionText(const infoOption& option, const Q
     if (option.name != desiredContents) {
         return qsl("<li><a href='%1'>%2</a></li>").arg(option.name, option.headline);
     } else {
-        return qsl("<li>%1%2</li>").arg(option.headline, option.contents); // %2 wrapped in <p></p> etc.
+        return qsl("<li><strong>%1</strong>%2</li>").arg(option.headline, option.contents); // contents are wrapped in <p></p> etc.
     }
 }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -969,7 +969,7 @@ void dlgTriggerEditor::slot_searchSplitterMoved(const int pos, const int index)
     mSearchSplitterState = searchSplitter->saveState();
 }
 
-void slot_clickedMessageBox(const QString& URL)
+void dlgTriggerEditor::slot_clickedMessageBox(const QString& URL)
 {
     //     mpSystemMessageArea->notificationAreaMessageBox->setText(createInfoText(URL));
 

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -315,6 +315,7 @@ private slots:
     void slot_restoreEditorItemsToolbar();
     void slot_itemEdited();
     void slot_searchSplitterMoved(const int pos, const int index);
+    void slot_clickedMessageBox(const QString&);
 
 public:
     TConsole* mpErrorConsole = nullptr;
@@ -620,7 +621,6 @@ private:
     void showIntro();
     QString createInfoText(const QString&);
     QString createInfoOptionText(const infoOption&, const QString&); 
-    
     QString descActive;
     QString descInactive;
     QString descActiveFolder;

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -615,7 +615,7 @@ private:
         QVector<infoOption> options;
     };
 
-    // QVector<infoTextParts> infoTextsForAllObjects;
+    QMap<EditorViewType, infoTextParts> infoAddItem;
     infoTextParts infoAddAlias;
 
     void showIntro();

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -617,7 +617,8 @@ private:
         QVector<infoOption> options;
     };
 
-    QVector<infoTextParts> infoAddAlias;
+    // QVector<infoTextParts> infoTextsForAllObjects;
+    infoTextParts infoAddAlias;
 
     QString descActive;
     QString descInactive;

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -617,8 +617,7 @@ private:
 
     QMap<EditorViewType, infoTextParts> infoAddItem;
 
-    void showIntro();
-    QString createInfoText(const EditorViewType, const QString& = QString());
+    void showIntro(const QString& = QString());
     QString descActive;
     QString descInactive;
     QString descActiveFolder;

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -188,7 +188,7 @@ public:
     void showInfo(const QString&);
     void showIntro();
     QString createInfoText(const QString&);
-    QString createInfoOptionText(const QString&, const QString&); 
+    QString createInfoOptionText(const infoOption&, const QString&); 
     void children_icon_triggers(QTreeWidgetItem* pWidgetItemParent);
     void children_icon_alias(QTreeWidgetItem* pWidgetItemParent);
     void children_icon_key(QTreeWidgetItem* pWidgetItemParent);

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -186,9 +186,6 @@ public:
     void showError(const QString&);
     void showWarning(const QString&);
     void showInfo(const QString&);
-    void showIntro();
-    QString createInfoText(const QString&);
-    QString createInfoOptionText(const infoOption&, const QString&); 
     void children_icon_triggers(QTreeWidgetItem* pWidgetItemParent);
     void children_icon_alias(QTreeWidgetItem* pWidgetItemParent);
     void children_icon_key(QTreeWidgetItem* pWidgetItemParent);
@@ -620,6 +617,10 @@ private:
     // QVector<infoTextParts> infoTextsForAllObjects;
     infoTextParts infoAddAlias;
 
+    void showIntro();
+    QString createInfoText(const QString&);
+    QString createInfoOptionText(const infoOption&, const QString&); 
+    
     QString descActive;
     QString descInactive;
     QString descActiveFolder;

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -619,7 +619,7 @@ private:
     infoTextParts infoAddAlias;
 
     void showIntro();
-    QString createInfoText(const QString&);
+    QString createInfoText(const EditorViewType, const QString& = QString());
     QString createInfoOptionText(const infoOption&, const QString&); 
     QString descActive;
     QString descInactive;

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -186,6 +186,9 @@ public:
     void showError(const QString&);
     void showWarning(const QString&);
     void showInfo(const QString&);
+    void showIntro();
+    QString createInfoText(const QString&);
+    QString createInfoOptionText(const QString&, const QString&); 
     void children_icon_triggers(QTreeWidgetItem* pWidgetItemParent);
     void children_icon_alias(QTreeWidgetItem* pWidgetItemParent);
     void children_icon_key(QTreeWidgetItem* pWidgetItemParent);
@@ -602,6 +605,20 @@ private:
     QString msgInfoAddButton;
     QString msgInfoAddVar;
     QString msgInfoAddKey;
+
+    struct infoOption {
+        QString name;
+        QString headline;
+        QString contents;  
+    };
+
+    struct infoTextParts {
+        QString summary;
+        QVector<infoOption> options;
+    }
+
+    QVector<infoTextParts> infoAddAlias;
+
     QString descActive;
     QString descInactive;
     QString descActiveFolder;

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -315,6 +315,7 @@ private slots:
     void slot_restoreEditorItemsToolbar();
     void slot_itemEdited();
     void slot_searchSplitterMoved(const int pos, const int index);
+    void slot_clickedMessageBox(const QString&);
 
 public:
     TConsole* mpErrorConsole = nullptr;

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -54,6 +54,7 @@
 #include <QListWidgetItem>
 #include <QScrollArea>
 #include <QTreeWidget>
+#include <QDesktopServices>
 #include "post_guard.h"
 
 // Edbee editor includes

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -616,7 +616,6 @@ private:
     };
 
     QMap<EditorViewType, infoTextParts> infoAddItem;
-    infoTextParts infoAddAlias;
 
     void showIntro();
     QString createInfoText(const EditorViewType, const QString& = QString());

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -315,7 +315,6 @@ private slots:
     void slot_restoreEditorItemsToolbar();
     void slot_itemEdited();
     void slot_searchSplitterMoved(const int pos, const int index);
-    void slot_clickedMessageBox(const QString&);
 
 public:
     TConsole* mpErrorConsole = nullptr;

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -619,7 +619,6 @@ private:
 
     void showIntro();
     QString createInfoText(const EditorViewType, const QString& = QString());
-    QString createInfoOptionText(const infoOption&, const QString&); 
     QString descActive;
     QString descInactive;
     QString descActiveFolder;

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -615,7 +615,7 @@ private:
     struct infoTextParts {
         QString summary;
         QVector<infoOption> options;
-    }
+    };
 
     QVector<infoTextParts> infoAddAlias;
 

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -604,18 +604,18 @@ private:
     QString msgInfoAddVar;
     QString msgInfoAddKey;
 
-    struct infoOption {
+    struct introOption {
         QString name;
         QString headline;
         QString contents;  
     };
 
-    struct infoTextParts {
+    struct introTextParts {
         QString summary;
-        QVector<infoOption> options;
+        QVector<introOption> options;
     };
 
-    QMap<EditorViewType, infoTextParts> infoAddItem;
+    QMap<EditorViewType, introTextParts> introAddItem;
 
     void showIntro(const QString& = QString());
     QString descActive;

--- a/src/ui/system_message_area.ui
+++ b/src/ui/system_message_area.ui
@@ -209,7 +209,7 @@ background-color: rgb(255, 254, 215);
          <bool>true</bool>
         </property>
         <property name="textInteractionFlags">
-         <set>Qt::LinksAccessibleByMouse|Qt::LinksAccessibleByKeyboard|Qt::TextSelectableByMouse|</set>
+         <set>Qt::LinksAccessibleByMouse|Qt::LinksAccessibleByKeyboard|Qt::TextSelectableByMouse</set>
         </property>
        </widget>
       </item>

--- a/src/ui/system_message_area.ui
+++ b/src/ui/system_message_area.ui
@@ -209,7 +209,7 @@ background-color: rgb(255, 254, 215);
          <bool>true</bool>
         </property>
         <property name="textInteractionFlags">
-         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+         <set>Qt::LinksAccessibleByMouse|Qt::LinksAccessibleByKeyboard|Qt::TextSelectableByMouse|</set>
         </property>
        </widget>
       </item>

--- a/src/ui/system_message_area.ui
+++ b/src/ui/system_message_area.ui
@@ -89,13 +89,13 @@ background-color: rgb(255, 254, 215);
          <bool>false</bool>
         </property>
         <property name="alignment">
-         <set>Qt::AlignCenter</set>
+         <set>Qt::AlignmentFlag::AlignCenter</set>
         </property>
         <property name="margin">
          <number>5</number>
         </property>
         <property name="textInteractionFlags">
-         <set>Qt::TextSelectableByMouse</set>
+         <set>Qt::TextInteractionFlag::TextSelectableByMouse</set>
         </property>
        </widget>
       </item>
@@ -123,13 +123,13 @@ background-color: rgb(255, 254, 215);
          <bool>false</bool>
         </property>
         <property name="alignment">
-         <set>Qt::AlignCenter</set>
+         <set>Qt::AlignmentFlag::AlignCenter</set>
         </property>
         <property name="margin">
          <number>5</number>
         </property>
         <property name="textInteractionFlags">
-         <set>Qt::TextSelectableByMouse</set>
+         <set>Qt::TextInteractionFlag::TextSelectableByMouse</set>
         </property>
        </widget>
       </item>
@@ -157,13 +157,13 @@ background-color: rgb(255, 254, 215);
          <bool>false</bool>
         </property>
         <property name="alignment">
-         <set>Qt::AlignCenter</set>
+         <set>Qt::AlignmentFlag::AlignCenter</set>
         </property>
         <property name="margin">
          <number>5</number>
         </property>
         <property name="textInteractionFlags">
-         <set>Qt::TextSelectableByMouse</set>
+         <set>Qt::TextInteractionFlag::TextSelectableByMouse</set>
         </property>
        </widget>
       </item>
@@ -191,13 +191,13 @@ background-color: rgb(255, 254, 215);
          <string/>
         </property>
         <property name="textFormat">
-         <enum>Qt::RichText</enum>
+         <enum>Qt::TextFormat::RichText</enum>
         </property>
         <property name="scaledContents">
          <bool>true</bool>
         </property>
         <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -206,10 +206,10 @@ background-color: rgb(255, 254, 215);
          <number>0</number>
         </property>
         <property name="openExternalLinks">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
         <property name="textInteractionFlags">
-         <set>Qt::LinksAccessibleByMouse|Qt::LinksAccessibleByKeyboard|Qt::TextSelectableByMouse</set>
+         <set>Qt::TextInteractionFlag::TextBrowserInteraction</set>
         </property>
        </widget>
       </item>
@@ -246,12 +246,11 @@ background-color: rgb(255, 254, 215);
             </size>
            </property>
            <property name="focusPolicy">
-            <enum>Qt::NoFocus</enum>
+            <enum>Qt::FocusPolicy::NoFocus</enum>
            </property>
            <property name="icon">
             <iconset resource="../mudlet.qrc">
-             <normaloff>:/icons/application-exit.png</normaloff>:/icons/application-exit.png
-            </iconset>
+             <normaloff>:/icons/application-exit.png</normaloff>:/icons/application-exit.png</iconset>
            </property>
            <property name="autoRaise">
             <bool>true</bool>
@@ -261,10 +260,10 @@ background-color: rgb(255, 254, 215);
          <item>
           <spacer name="verticalSpacer_closeButton">
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeType">
-            <enum>QSizePolicy::Minimum</enum>
+            <enum>QSizePolicy::Policy::Minimum</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -283,10 +282,10 @@ background-color: rgb(255, 254, 215);
    <item>
     <spacer name="verticalSpacer_system_message_area">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeType">
-      <enum>QSizePolicy::MinimumExpanding</enum>
+      <enum>QSizePolicy::Policy::MinimumExpanding</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
- Shrink the introductory information shown in yellow message box when no object is selected in Editor window

  See it in action: (within a very small window, so text is wrapped early, as was in the original issue)

https://github.com/user-attachments/assets/701c8e90-758d-4596-877c-bd0b164dc241



- Make links in said text also available via keyboard, not only via mouse
- Refactor: Use more clearXForm() from #5561 by @Delwing

#### Motivation for adding to Mudlet
Fix #4784

#### Other info (issues closed, discussion etc)
- Some inspriation for data structure gathered from #2913
- Tool: Try HTML interactively online here: https://www.w3schools.com/html/tryit.asp
- WARNING: Info Link URLs SHOULD be unique across all object so dynamic link handling functions alright. Using generic names like "alias1", "alias2" to ensure no overlap