### PR TITLE
Fix: save any pending edits before saving profile to disk to prevent data loss

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -9491,6 +9491,8 @@ void dlgTriggerEditor::runScheduledCleanReset()
 
 void dlgTriggerEditor::slot_profileSaveAction()
 {
+    slot_saveEdits();
+    
     auto [ok, filename, error] = mpHost->saveProfile(nullptr, nullptr, true);
 
     if (!ok) {
@@ -9517,7 +9519,8 @@ void dlgTriggerEditor::slot_profileSaveAsAction()
     if (!fileName.endsWith(qsl(".xml"), Qt::CaseInsensitive) && !fileName.endsWith(qsl(".trigger"), Qt::CaseInsensitive)) {
         fileName.append(qsl(".xml"));
     }
-
+    slot_saveEdits();
+    
     mpHost->saveProfileAs(fileName);
     mSavingAs = false;
 }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Save any pending edits before saving profile to disk to prevent data loss
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/8014
#### Other info (issues closed, discussion etc)
