### PR TITLE
Improve: remove ambiguous width East Asian option

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2548,59 +2548,6 @@ void Host::refreshPackageFonts()
     }
 }
 
-void Host::setWideAmbiguousEAsianGlyphs(const Qt::CheckState state)
-{
-    bool localState = false;
-    bool needToEmit = false;
-    const QByteArray encoding(mTelnet.getEncoding());
-
-    if (state == Qt::PartiallyChecked) {
-        // Set things automatically
-        mAutoAmbigousWidthGlyphsSetting = true;
-
-        if (encoding == "GBK"
-            || encoding == "GB18030"
-            || encoding == "BIG5"
-            || encoding == "BIG5-HKSCS"
-            || encoding == "EUC-KR") {
-
-            // Need to use wide width for ambiguous characters
-            if (!mWideAmbigousWidthGlyphs) {
-                // But the last setting was narrow - so we need to change
-                mWideAmbigousWidthGlyphs = true;
-                localState = true;
-                needToEmit = true;
-            }
-
-        } else {
-            // Need to use narrow width for ambiguous characters
-            if (mWideAmbigousWidthGlyphs) {
-                // But the last setting was wide - so we need to change
-                mWideAmbigousWidthGlyphs = false;
-                localState = false;
-                needToEmit = true;
-            }
-
-        }
-
-    } else {
-        // Set things manually:
-        mAutoAmbigousWidthGlyphsSetting = false;
-        if (mWideAmbigousWidthGlyphs != (state == Qt::Checked)) {
-            // The last setting is the opposite to what we want:
-
-            mWideAmbigousWidthGlyphs = (state == Qt::Checked);
-            localState = (state == Qt::Checked);
-            needToEmit = true;
-        }
-
-    }
-
-    if (needToEmit) {
-        emit signal_changeIsAmbigousWidthGlyphsToBeWide(localState);
-    }
-}
-
 QColor Host::getAnsiColor(const int ansiCode, const bool isBackground) const
 {
     // clang-format off

--- a/src/Host.h
+++ b/src/Host.h
@@ -188,14 +188,6 @@ public:
     void            setRetries(const int retries)    { mRetries = retries; }
     int             getTimeout()                     { return mTimeout; }
     void            setTimeout(const int seconds)    { mTimeout = seconds; }
-    bool            wideAmbiguousEAsianGlyphs() { return mWideAmbigousWidthGlyphs; }
-    // Uses PartiallyChecked to set the automatic mode, otherwise Checked/Unchecked means use wide/narrow ambiguous glyphs
-    void            setWideAmbiguousEAsianGlyphs(Qt::CheckState state);
-    // Is used to set preference dialog control directly:
-    Qt::CheckState  getWideAmbiguousEAsianGlyphsControlState() {
-                           return mAutoAmbigousWidthGlyphsSetting
-                                  ? Qt::PartiallyChecked
-                                  : (mWideAmbigousWidthGlyphs ? Qt::Checked : Qt::Unchecked); }
     void            setHaveColorSpaceId(const bool state) { mSGRCodeHasColSpaceId = state; }
     bool            getHaveColorSpaceId() { return mSGRCodeHasColSpaceId; }
     void            setMayRedefineColors(const bool state) { mServerMayRedefineColors = state; }

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2607,8 +2607,7 @@ inline QList<WrapInfo> TBuffer::getWrapInfo(const QString& lineText, bool isNewl
         const QString grapheme = lineText.mid(indexOfChar, nextBoundary - indexOfChar);
         const uint unicode = graphemeInfo::getBaseCharacter(grapheme);
         // Safety check: during destruction, mpHost might be null
-        const int charWidth = mpHost ? graphemeInfo::getWidth(unicode, mpHost->wideAmbiguousEAsianGlyphs()) 
-                                     : graphemeInfo::getWidth(unicode, false);
+        const int charWidth = graphemeInfo::getWidth(unicode, false);
         const int indentationHere = isNewline ? indent : hangingIndent;
         if (xPos + charWidth > maxWidth - (needsIndent ? indentationHere : 0)) {
             if (isNewline) {

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -80,7 +80,6 @@ TTextEdit::TTextEdit(TConsole* pC, QWidget* pW, TBuffer* pB, Host* pH, bool isLo
 , mpHost(pH)
 , mScreenOffset(0)
 , mMaxHRange(0)
-, mWideAmbigousWidthGlyphs(pH->wideAmbiguousEAsianGlyphs())
 , mTabStopwidth(8)
 , mMouseWheelRemainder()
 {

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -815,21 +815,8 @@ void XMLimport::readHost(Host* pHost)
     pHost->setMayRedefineColors(attributes().value(QLatin1String("mServerMayRedefineColors")).toString() == QLatin1String("yes"));
 
     if (attributes().hasAttribute("AmbigousWidthGlyphsToBeWide")) {
-        const QStringView ambiguousWidthSetting(attributes().value(qsl("AmbigousWidthGlyphsToBeWide")));
-
-        if (ambiguousWidthSetting == YES) {
-            pHost->setWideAmbiguousEAsianGlyphs(Qt::Checked);
-        } else if (ambiguousWidthSetting == qsl("auto")) {
-            pHost->setWideAmbiguousEAsianGlyphs(Qt::PartiallyChecked);
-        } else {
-            pHost->setWideAmbiguousEAsianGlyphs(Qt::Unchecked);
-        }
-    } else {
-        // The encoding setting is stored as part of the profile details and NOT
-        // in the save file - probably because it is needed before the
-        // connection to the Server is initiated so it will already be in place
-        // which is just as well as it is needed for the automatic case...
-        pHost->setWideAmbiguousEAsianGlyphs(Qt::PartiallyChecked);
+        // this value has been dropped in 4.20
+        Q_UNUSED(readElementText())
     }
 
     if (attributes().hasAttribute("logFileNameFormat")) {

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1607,8 +1607,6 @@ void dlgConnectionProfiles::loadProfile(bool alsoConnect)
         // This settings also need to be configured, note that the only time not to
         // save the setting is on profile loading:
         pHost->mTelnet.setEncoding(readProfileData(profile_name, qsl("encoding")).toUtf8(), false);
-        // Needed to ensure setting is correct on start-up:
-        pHost->setWideAmbiguousEAsianGlyphs(pHost->getWideAmbiguousEAsianGlyphsControlState());
         pHost->setAutoReconnect(auto_reconnect->isChecked());
 
         // This also writes the value out to the profile's base directory:

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -213,18 +213,6 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
                                               "will be run.</p>"
                                               "<p><i>It is recommended to not enable this option if you need to maintain compatibility "
                                               "with scripts or packages for Mudlet versions prior to <b>3.9.0</b>.</i></p>"));
-    checkBox_useWideAmbiguousEastAsianGlyphs->setToolTip(tr("<p>Some East Asian MUDs may use glyphs (characters) that Unicode classifies as being "
-                                                            "of <i>Ambiguous</i> width when drawn in a font with a so-called <i>fixed</i> pitch; in "
-                                                            "fact such text is <i>duo-spaced</i> when not using a proportional font. These symbols can be "
-                                                            "drawn using either a half or the whole space of a full character. By default Mudlet tries to "
-                                                            "chose the right width automatically but you can override the setting for each profile.</p>"
-                                                            "<p>This control has three settings:"
-                                                            "<ul><li><b>Unchecked</b> '<i>narrow</i>' = Draw ambiguous width characters in a single 'space'.</li>"
-                                                            "<li><b>Checked</b> '<i>wide</i>' = Draw ambiguous width characters two 'spaces' wide.</li>"
-                                                            "<li><b>Partly checked</b> <i>(Default) 'auto'</i> = Use 'wide' setting for MUD Server "
-                                                            "encodings of <b>Big5</b>/<b>Big5-HKSCS</b>, <b>GBK</b>, <b>GBK18030</b> or <b>EUC-KR</b> and 'narrow' for all others.</li></ul></p>"
-                                                            "<p><i>This is a temporary arrangement and will probably change when Mudlet gains "
-                                                            "full support for languages other than English.</i></p>"));
     checkBox_enableTextAnalyzer->setToolTip(tr("<p>Enable a context (right click) menu action on any console/user window that, "
                                                "when the mouse cursor is hovered over it, will display the UTF-16 and UTF-8 items "
                                                "that make up each Unicode codepoint on the <b>first</b> line of any selection.</p>"
@@ -425,7 +413,6 @@ void dlgProfilePreferences::disableHostDetails()
     checkBox_USE_IRE_DRIVER_BUGFIX->setEnabled(false);
     checkBox_enableTextAnalyzer->setEnabled(false);
     checkBox_echoLuaErrors->setEnabled(false);
-    checkBox_useWideAmbiguousEastAsianGlyphs->setEnabled(false);
     label_controlCharacterHandling->setEnabled(false);
     comboBox_controlCharacterHandling->setEnabled(false);
 
@@ -550,7 +537,6 @@ void dlgProfilePreferences::enableHostDetails()
     checkBox_USE_IRE_DRIVER_BUGFIX->setEnabled(true);
     checkBox_enableTextAnalyzer->setEnabled(true);
     checkBox_echoLuaErrors->setEnabled(true);
-    checkBox_useWideAmbiguousEastAsianGlyphs->setEnabled(true);
     label_controlCharacterHandling->setEnabled(true);
     comboBox_controlCharacterHandling->setEnabled(true);
 
@@ -673,7 +659,6 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         radioButton_userDictionary_common->setChecked(false);
     }
     checkBox_echoLuaErrors->setChecked(pHost->mEchoLuaErrors);
-    checkBox_useWideAmbiguousEastAsianGlyphs->setCheckState(pHost->getWideAmbiguousEAsianGlyphsControlState());
 
     // On the first run for a profile this will be the "English (American)"
     // dictionary "en_US".
@@ -3018,7 +3003,6 @@ void dlgProfilePreferences::slot_saveAndClose()
         }
 
         pHost->mEchoLuaErrors = checkBox_echoLuaErrors->isChecked();
-        pHost->setWideAmbiguousEAsianGlyphs(checkBox_useWideAmbiguousEastAsianGlyphs->checkState());
         pHost->mEditorTheme = code_editor_theme_selection_combobox->currentText();
         pHost->mEditorThemeFile = code_editor_theme_selection_combobox->currentData().toString();
         pHost->mEditorAutoComplete = checkBox_autocompleteLuaCode->isChecked();
@@ -3196,18 +3180,11 @@ void dlgProfilePreferences::slot_chosenProfilesChanged(QAction* _action)
 void dlgProfilePreferences::slot_setEncoding(const int newEncodingIndex)
 {
     Host* pHost = mpHost;
-    if (pHost) {
-        pHost->mTelnet.setEncoding(comboBox_encoding->itemData(newEncodingIndex).toByteArray());
-
-        if (checkBox_useWideAmbiguousEastAsianGlyphs->checkState() == Qt::PartiallyChecked) {
-            // We are linking the Server encoding to this setting currently
-            // - eventually it would move to the locale/language control when it
-            // goes in, but we only need to change the setting for this if it is
-            // set to be automatic changed as necessary:
-
-            pHost->setWideAmbiguousEAsianGlyphs(Qt::PartiallyChecked);
-        }
+    if (!pHost) {
+        return;
     }
+
+    pHost->mTelnet.setEncoding(comboBox_encoding->itemData(newEncodingIndex).toByteArray());
 }
 
 // loads available Lua scripts from triggers, aliases, scripts, etc into the

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>965</width>
-    <height>694</height>
+    <width>1050</width>
+    <height>776</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -39,7 +39,7 @@
       <string notr="true"/>
      </property>
      <property name="tabShape">
-      <enum>QTabWidget::TabShape::Rounded</enum>
+      <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
       <number>2</number>
@@ -61,7 +61,7 @@
           <string>Icon sizes</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_groupBox_iconsAndToolbars">
-          <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignRight">
+          <item row="0" column="0">
            <widget class="QLabel" name="label_mainIconSize">
             <property name="text">
              <string>Icon size toolbars:</string>
@@ -71,7 +71,7 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="1" alignment="Qt::AlignmentFlag::AlignLeft">
+          <item row="0" column="1">
            <widget class="QSpinBox" name="MainIconSize">
             <property name="specialValueText">
              <string/>
@@ -87,7 +87,7 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="2" alignment="Qt::AlignmentFlag::AlignRight">
+          <item row="0" column="2">
            <widget class="QLabel" name="label_33">
             <property name="text">
              <string>Icon size in tree views:</string>
@@ -97,7 +97,7 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="3" alignment="Qt::AlignmentFlag::AlignLeft">
+          <item row="0" column="3">
            <widget class="QSpinBox" name="TEFolderIconSize">
             <property name="minimum">
              <number>1</number>
@@ -110,7 +110,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0" alignment="Qt::AlignmentFlag::AlignRight">
+          <item row="1" column="0">
            <widget class="QLabel" name="label_menuBarVisiblity">
             <property name="text">
              <string>Show menu bar:</string>
@@ -120,7 +120,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1" alignment="Qt::AlignmentFlag::AlignLeft">
+          <item row="1" column="1">
            <widget class="QComboBox" name="comboBox_menuBarVisibility">
             <property name="currentIndex">
              <number>0</number>
@@ -142,7 +142,7 @@
             </item>
            </widget>
           </item>
-          <item row="1" column="2" alignment="Qt::AlignmentFlag::AlignRight">
+          <item row="1" column="2">
            <widget class="QLabel" name="label_toolBarVisibility">
             <property name="text">
              <string>Show main toolbar</string>
@@ -152,7 +152,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="3" alignment="Qt::AlignmentFlag::AlignLeft">
+          <item row="1" column="3">
            <widget class="QComboBox" name="comboBox_toolBarVisibility">
             <property name="currentIndex">
              <number>0</number>
@@ -275,7 +275,7 @@
              <string>Set dark theme in &lt;a href=&quot;dark-code-editor&quot;&gt;code editor&lt;/a&gt; as well?</string>
             </property>
             <property name="textFormat">
-             <enum>Qt::TextFormat::RichText</enum>
+             <enum>Qt::PlainText</enum>
             </property>
            </widget>
           </item>
@@ -329,7 +329,7 @@
              <string>Please reconnect to your game for the change to take effect</string>
             </property>
             <property name="textFormat">
-             <enum>Qt::TextFormat::AutoText</enum>
+             <enum>Qt::PlainText</enum>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -379,7 +379,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0" alignment="Qt::AlignmentFlag::AlignRight">
+          <item row="1" column="0">
            <widget class="QLabel" name="label_whereToLog">
             <property name="text">
              <string>Save log files in:</string>
@@ -410,7 +410,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0" alignment="Qt::AlignmentFlag::AlignRight">
+          <item row="2" column="0">
            <widget class="QLabel" name="label_logFileNameFormat">
             <property name="text">
              <string>Log format:</string>
@@ -423,7 +423,7 @@
           <item row="2" column="1" colspan="3">
            <widget class="QComboBox" name="comboBox_logFileNameFormat"/>
           </item>
-          <item row="3" column="0" alignment="Qt::AlignmentFlag::AlignRight">
+          <item row="3" column="0">
            <widget class="QLabel" name="label_logFileName">
             <property name="text">
              <string>Log name:</string>
@@ -434,11 +434,7 @@
            </widget>
           </item>
           <item row="3" column="1" colspan="2">
-           <widget class="QLineEdit" name="lineEdit_logFileName">
-            <property name="alignment">
-             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-            </property>
-           </widget>
+           <widget class="QLineEdit" name="lineEdit_logFileName"/>
           </item>
           <item row="3" column="3">
            <widget class="QLabel" name="label_logFileNameExtension">
@@ -458,9 +454,6 @@
        </item>
        <item>
         <spacer name="verticalSpacer_general">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
@@ -609,9 +602,6 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="alignment">
-             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-            </property>
             <property name="maximum">
              <number>300</number>
             </property>
@@ -684,9 +674,6 @@
           </item>
           <item row="2" column="4">
            <spacer name="horizontalSpacer_radioButtons_userDictionary">
-            <property name="orientation">
-             <enum>Qt::Orientation::Horizontal</enum>
-            </property>
             <property name="sizeHint" stdset="0">
              <size>
               <width>40</width>
@@ -700,9 +687,6 @@
        </item>
        <item>
         <spacer name="verticalSpacer_inputLine">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>0</width>
@@ -1041,7 +1025,7 @@ you can use it but there could be issues with aligning columns of text</string>
           </sizepolicy>
          </property>
          <property name="layoutDirection">
-          <enum>Qt::LayoutDirection::LeftToRight</enum>
+          <enum>Qt::LeftToRight</enum>
          </property>
          <property name="title">
           <string>Word wrapping</string>
@@ -1050,7 +1034,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item>
            <widget class="QFrame" name="frame_wrap_at">
             <property name="frameShape">
-             <enum>QFrame::Shape::NoFrame</enum>
+             <enum>QFrame::NoFrame</enum>
             </property>
             <layout class="QHBoxLayout" name="horizontalLayout_frame_wrap_at">
              <item>
@@ -1104,7 +1088,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item>
            <widget class="QFrame" name="frame_indent_wrapped">
             <property name="frameShape">
-             <enum>QFrame::Shape::NoFrame</enum>
+             <enum>QFrame::NoFrame</enum>
             </property>
             <layout class="QHBoxLayout" name="horizontalLayout_frame_indent_wrapped">
              <item>
@@ -1158,7 +1142,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item>
            <widget class="QFrame" name="frame_hanging_indent_wrapped">
             <property name="frameShape">
-             <enum>QFrame::Shape::NoFrame</enum>
+             <enum>QFrame::NoFrame</enum>
             </property>
             <layout class="QHBoxLayout" name="horizontalLayout_frame_hanging_indent_wrapped">
              <item>
@@ -1263,16 +1247,6 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="checkBox_useWideAmbiguousEastAsianGlyphs">
-            <property name="text">
-             <string>Make 'Ambiguous' E. Asian width characters wide</string>
-            </property>
-            <property name="tristate">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0">
            <widget class="QCheckBox" name="checkBox_USE_IRE_DRIVER_BUGFIX">
             <property name="toolTip">
@@ -1306,7 +1280,7 @@ you can use it but there could be issues with aligning columns of text</string>
              <number>0</number>
             </property>
             <property name="sizeAdjustPolicy">
-             <enum>QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon</enum>
+             <enum>QComboBox::AdjustToContents</enum>
             </property>
             <item>
              <property name="text">
@@ -1325,7 +1299,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </item>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="1" column="0">
            <widget class="QCheckBox" name="checkBox_showTabConnectionIndicators">
             <property name="toolTip">
              <string>Display whenever a tab is connected or a disconnected</string>
@@ -1340,9 +1314,6 @@ you can use it but there could be issues with aligning columns of text</string>
        </item>
        <item>
         <spacer name="verticalSpacer_mainDisplay">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
@@ -1373,10 +1344,7 @@ you can use it but there could be issues with aligning columns of text</string>
              </size>
             </property>
             <property name="frameShape">
-             <enum>QFrame::Shape::StyledPanel</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Shadow::Raised</enum>
+             <enum>QFrame::NoFrame</enum>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_frame_edbeePreviewWidget">
              <property name="spacing">
@@ -1417,7 +1385,7 @@ you can use it but there could be issues with aligning columns of text</string>
              <bool>true</bool>
             </property>
             <property name="sizeAdjustPolicy">
-             <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
+             <enum>QComboBox::AdjustToContents</enum>
             </property>
            </widget>
           </item>
@@ -1503,9 +1471,6 @@ you can use it but there could be issues with aligning columns of text</string>
        </item>
        <item>
         <spacer name="verticalSpacer_codeEditor">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
@@ -1665,7 +1630,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item row="3" column="0" colspan="4">
            <widget class="Line" name="line_colorsSeparator">
             <property name="orientation">
-             <enum>Qt::Orientation::Horizontal</enum>
+             <enum>Qt::Vertical</enum>
             </property>
            </widget>
           </item>
@@ -2075,9 +2040,6 @@ you can use it but there could be issues with aligning columns of text</string>
        </item>
        <item>
         <spacer name="verticalSpacer_displayColors">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>678</width>
@@ -2170,7 +2132,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item row="3" column="0" colspan="3">
            <widget class="Line" name="line">
             <property name="orientation">
-             <enum>Qt::Orientation::Horizontal</enum>
+             <enum>Qt::Vertical</enum>
             </property>
            </widget>
           </item>
@@ -2369,14 +2331,14 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="0" alignment="Qt::AlignmentFlag::AlignRight">
+          <item row="2" column="0">
            <widget class="QLabel" name="label_mapSymbolsFont">
             <property name="text">
              <string>2D Map Room Symbol Font</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1" alignment="Qt::AlignmentFlag::AlignLeft">
+          <item row="2" column="1">
            <widget class="QFontComboBox" name="fontComboBox_mapSymbols"/>
           </item>
           <item row="3" column="0">
@@ -2441,7 +2403,7 @@ you can use it but there could be issues with aligning columns of text</string>
                 <number>0</number>
                </property>
                <property name="sizeAdjustPolicy">
-                <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
+                <enum>QComboBox::AdjustToContents</enum>
                </property>
                <item>
                 <property name="text">
@@ -2470,9 +2432,6 @@ you can use it but there could be issues with aligning columns of text</string>
                <property name="toolTip">
                 <string>&lt;p&gt;Percentage ratio (&lt;i&gt;the default is 120%&lt;/i&gt;) of the marker symbol to the space available for the room.&lt;/p&gt;</string>
                </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignCenter</set>
-               </property>
                <property name="suffix">
                 <string>%</string>
                </property>
@@ -2498,9 +2457,6 @@ you can use it but there could be issues with aligning columns of text</string>
                <property name="toolTip">
                 <string>&lt;p&gt;Percentage ratio of the inner diameter of the marker symbol to the outer one (&lt;i&gt;the default is 70%&lt;/i&gt;).&lt;/p&gt;</string>
                </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignCenter</set>
-               </property>
                <property name="suffix">
                 <string>%</string>
                </property>
@@ -2523,9 +2479,6 @@ you can use it but there could be issues with aligning columns of text</string>
        </item>
        <item>
         <spacer name="verticalSpacer_mapper">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
@@ -2690,7 +2643,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item row="4" column="0" colspan="4">
            <widget class="Line" name="line_mapperColorsSeparator">
             <property name="orientation">
-             <enum>Qt::Orientation::Horizontal</enum>
+             <enum>Qt::Vertical</enum>
             </property>
            </widget>
           </item>
@@ -3026,9 +2979,6 @@ you can use it but there could be issues with aligning columns of text</string>
        </item>
        <item>
         <spacer name="verticalSpacer_mapperColors">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
@@ -3063,7 +3013,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item row="0" column="1">
            <widget class="QLineEdit" name="ircHostName">
             <property name="inputMethodHints">
-             <set>Qt::InputMethodHint::ImhUrlCharactersOnly</set>
+             <set>Qt::ImhNone</set>
             </property>
             <property name="placeholderText">
              <string>irc.example.net</string>
@@ -3083,7 +3033,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item row="0" column="3">
            <widget class="QLineEdit" name="ircHostPort">
             <property name="inputMethodHints">
-             <set>Qt::InputMethodHint::ImhDigitsOnly</set>
+             <set>Qt::ImhNone</set>
             </property>
             <property name="placeholderText">
              <string>6667</string>
@@ -3137,7 +3087,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item row="2" column="1">
            <widget class="QLineEdit" name="ircPassword">
             <property name="echoMode">
-             <enum>QLineEdit::EchoMode::Password</enum>
+             <enum>QLineEdit::Normal</enum>
             </property>
             <property name="placeholderText">
              <string>password (optional)</string>
@@ -3266,9 +3216,6 @@ you can use it but there could be issues with aligning columns of text</string>
                <property name="toolTip">
                 <string>&lt;p&gt;Mudlet will only show Rich Presence information while you use this Discord username (useful if you have multiple Discord accounts). Leave empty to show it for any Discord account you log in to.&lt;/p&gt;</string>
                </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-               </property>
                <property name="placeholderText">
                 <string>specific Discord username</string>
                </property>
@@ -3299,7 +3246,7 @@ you can use it but there could be issues with aligning columns of text</string>
                 <string>&lt;p&gt;Mudlet will only show Rich Presence information while you use this Discord username (useful if you have multiple Discord accounts). Leave empty to show it for any Discord account you log in to.&lt;/p&gt;</string>
                </property>
                <property name="inputMethodHints">
-                <set>Qt::InputMethodHint::ImhDigitsOnly</set>
+                <set>Qt::ImhNone</set>
                </property>
                <property name="inputMask">
                 <string notr="true">9999;#</string>
@@ -3320,11 +3267,8 @@ you can use it but there could be issues with aligning columns of text</string>
        </item>
        <item>
         <spacer name="verticalSpacer_connection">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Policy::Expanding</enum>
+          <enum>QSizePolicy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -3368,13 +3312,10 @@ you can use it but there could be issues with aligning columns of text</string>
              <item row="0" column="0">
               <widget class="QLabel" name="label">
                <property name="layoutDirection">
-                <enum>Qt::LayoutDirection::LeftToRight</enum>
+                <enum>Qt::LeftToRight</enum>
                </property>
                <property name="text">
                 <string>Issuer:</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -3390,9 +3331,6 @@ you can use it but there could be issues with aligning columns of text</string>
                <property name="text">
                 <string>Issued to:</string>
                </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-               </property>
               </widget>
              </item>
              <item row="1" column="1">
@@ -3407,9 +3345,6 @@ you can use it but there could be issues with aligning columns of text</string>
                <property name="text">
                 <string>Expires:</string>
                </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-               </property>
               </widget>
              </item>
              <item row="2" column="1">
@@ -3423,9 +3358,6 @@ you can use it but there could be issues with aligning columns of text</string>
               <widget class="QLabel" name="label_7">
                <property name="text">
                 <string>Serial:</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -3502,10 +3434,7 @@ you can use it but there could be issues with aligning columns of text</string>
              <bool>true</bool>
             </property>
             <property name="frameShape">
-             <enum>QFrame::Shape::Box</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Shadow::Plain</enum>
+             <enum>QFrame::NoFrame</enum>
             </property>
             <property name="lineWidth">
              <number>3</number>
@@ -3549,9 +3478,6 @@ you can use it but there could be issues with aligning columns of text</string>
                <property name="scaledContents">
                 <bool>false</bool>
                </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignCenter</set>
-               </property>
                <property name="wordWrap">
                 <bool>true</bool>
                </property>
@@ -3559,7 +3485,7 @@ you can use it but there could be issues with aligning columns of text</string>
                 <number>5</number>
                </property>
                <property name="textInteractionFlags">
-                <set>Qt::TextInteractionFlag::NoTextInteraction</set>
+                <set>Qt::NoTextInteraction</set>
                </property>
               </widget>
              </item>
@@ -3583,9 +3509,6 @@ you can use it but there could be issues with aligning columns of text</string>
                <property name="scaledContents">
                 <bool>false</bool>
                </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignCenter</set>
-               </property>
                <property name="wordWrap">
                 <bool>true</bool>
                </property>
@@ -3593,7 +3516,7 @@ you can use it but there could be issues with aligning columns of text</string>
                 <number>5</number>
                </property>
                <property name="textInteractionFlags">
-                <set>Qt::TextInteractionFlag::NoTextInteraction</set>
+                <set>Qt::NoTextInteraction</set>
                </property>
               </widget>
              </item>
@@ -3617,9 +3540,6 @@ you can use it but there could be issues with aligning columns of text</string>
                <property name="scaledContents">
                 <bool>false</bool>
                </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignCenter</set>
-               </property>
                <property name="wordWrap">
                 <bool>true</bool>
                </property>
@@ -3627,7 +3547,7 @@ you can use it but there could be issues with aligning columns of text</string>
                 <number>5</number>
                </property>
                <property name="textInteractionFlags">
-                <set>Qt::TextInteractionFlag::NoTextInteraction</set>
+                <set>Qt::NoTextInteraction</set>
                </property>
               </widget>
              </item>
@@ -3653,9 +3573,6 @@ you can use it but there could be issues with aligning columns of text</string>
                </property>
                <property name="scaledContents">
                 <bool>true</bool>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
                </property>
                <property name="wordWrap">
                 <bool>true</bool>
@@ -3757,7 +3674,7 @@ you can use it but there could be issues with aligning columns of text</string>
              <string>&lt;p&gt;Password for logging into the proxy if required.&lt;/p&gt;</string>
             </property>
             <property name="echoMode">
-             <enum>QLineEdit::EchoMode::Password</enum>
+             <enum>QLineEdit::Normal</enum>
             </property>
             <property name="placeholderText">
              <string>password (optional)</string>
@@ -3769,11 +3686,8 @@ you can use it but there could be issues with aligning columns of text</string>
        </item>
        <item>
         <spacer name="verticalSpacer_chat">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Policy::Expanding</enum>
+          <enum>QSizePolicy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -3799,25 +3713,19 @@ you can use it but there could be issues with aligning columns of text</string>
           </sizepolicy>
          </property>
          <property name="layoutDirection">
-          <enum>Qt::LayoutDirection::LeftToRight</enum>
+          <enum>Qt::LeftToRight</enum>
          </property>
          <property name="title">
           <string>Main window shortcuts</string>
          </property>
-         <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
-         </property>
          <layout class="QVBoxLayout" name="verticalLayout_groupBox_mainWindowShortcuts">
           <property name="sizeConstraint">
-           <enum>QLayout::SizeConstraint::SetMinimumSize</enum>
+           <enum>QLayout::SetDefaultConstraint</enum>
           </property>
           <item>
            <widget class="QLabel" name="label_shortcutsInstructions">
             <property name="text">
              <string>To disable shortcut input 'Esc' key.</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
             </property>
            </widget>
           </item>
@@ -3830,7 +3738,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </layout>
            </widget>
           </item>
-          <item alignment="Qt::AlignmentFlag::AlignRight">
+          <item>
            <widget class="QToolButton" name="toolButton_resetMainWindowShortcuts">
             <property name="text">
              <string>Reset to defaults</string>
@@ -3842,9 +3750,6 @@ you can use it but there could be issues with aligning columns of text</string>
        </item>
        <item>
         <spacer name="verticalSpacer_shortcuts">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
@@ -3968,11 +3873,8 @@ you can use it but there could be issues with aligning columns of text</string>
        </item>
        <item>
         <spacer name="verticalSpacer_accessibility">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Policy::Expanding</enum>
+          <enum>QSizePolicy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -4071,7 +3973,7 @@ you can use it but there could be issues with aligning columns of text</string>
              <string>Please reconnect to your game for the change to take effect</string>
             </property>
             <property name="textFormat">
-             <enum>Qt::TextFormat::AutoText</enum>
+             <enum>Qt::PlainText</enum>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -4254,11 +4156,8 @@ you can use it but there could be issues with aligning columns of text</string>
                <property name="wrapping">
                 <bool>true</bool>
                </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-               </property>
                <property name="buttonSymbols">
-                <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
+                <enum>QAbstractSpinBox::UpDownArrows</enum>
                </property>
                <property name="accelerated">
                 <bool>true</bool>
@@ -4267,7 +4166,7 @@ you can use it but there could be issues with aligning columns of text</string>
                 <bool>true</bool>
                </property>
                <property name="currentSection">
-                <enum>QDateTimeEdit::Section::HourSection</enum>
+                <enum>QDateTimeEdit::HourSection</enum>
                </property>
                <property name="displayFormat">
                 <string comment="Used to set a time interval only">h:mm:ss.zzz</string>
@@ -4327,9 +4226,6 @@ you can use it but there could be issues with aligning columns of text</string>
        </item>
        <item>
         <spacer name="verticalSpacer_specialOptions">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
@@ -4353,9 +4249,6 @@ you can use it but there could be issues with aligning columns of text</string>
      <layout class="QHBoxLayout" name="horizontalLayout_widget_bottom">
       <item>
        <spacer name="horizontalSpacer_bottom">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
-        </property>
         <property name="sizeHint" stdset="0">
          <size>
           <width>444</width>
@@ -4439,7 +4332,6 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>hanging_indent_wrapped_spinBox</tabstop>
   <tabstop>doubleclick_ignore_lineedit</tabstop>
   <tabstop>checkBox_USE_IRE_DRIVER_BUGFIX</tabstop>
-  <tabstop>checkBox_useWideAmbiguousEastAsianGlyphs</tabstop>
   <tabstop>checkBox_enableTextAnalyzer</tabstop>
   <tabstop>checkBox_echoLuaErrors</tabstop>
   <tabstop>comboBox_controlCharacterHandling</tabstop>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove ambiguous width East Asian option - while it made sense in theory, in practice we have not found need for it, and we haven't found anyone who uses it either - making it hard to justify to keep it.
#### Motivation for adding to Mudlet
Simplifying options by removing this one:

<img width="780" height="417" alt="image" src="https://github.com/user-attachments/assets/add59fd5-3c46-44a3-a3fb-fbb5414dfbf6" />
 
#### Other info (issues closed, discussion etc)
Should we find users who need this, we can revert this PR and do an update.
