### PR TITLE
Infrastructure: get link-ptbs-to-dblsqd workflow working again

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -159,7 +159,6 @@ jobs:
       shell: msys2 {0}
       if: ${{ github.event_name == 'schedule' || github.event.inputs.scheduled == 'true' }}
       env:
-        ARCH: ${{env.ARCH}}
         VERSION_STRING: ${{env.VERSION_STRING}}
         BUILD_COMMIT: ${{env.BUILD_COMMIT}}
       run: $GITHUB_WORKSPACE/CI/register-windows-release.sh

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -20,8 +20,11 @@ jobs:
 
     - name: Retrieve latest PTB version
       run: |
-        # Get the latest Windows version, because that one runs first and will be registered in dblsqd. Linux/macOS won't exist yet
-        export PTB_VERSION=$(curl --silent https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/win/x86 | jq --raw-output ".releases[0].version")
+        # Get the latest Windows version, because that one runs first and will
+        # be registered in dblsqd. Linux/macOS won't exist yet. Note that we
+        # had to switch to the "x86_64" arch in 2025 as we stopped producing
+        # 32 bit Windows builds "x86" arch earlier in that year
+        export PTB_VERSION=$(curl --silent https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/win/x86_64 | jq --raw-output ".releases[0].version")
         export PTB_COMMIT=$(lua -e "print(os.getenv('PTB_VERSION'):match('.+\-(.+)$'))")
 
         echo "Latest PTB version is: $PTB_VERSION"

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -38,7 +38,8 @@ if [ "${MSYSTEM}" = "MSYS" ]; then
   exit 2
 elif [ "${MSYSTEM}" = "MINGW64" ]; then
   export BUILDCOMPONENT="x86_64"
-  export ARCH="x86_64"
+  # We only support "x86_64" architecture now but we used to do "x86" (32-bit)
+  # as well and exported this value as ARCH for use here and in other scripts
 else
   echo "This script is not set up to handle systems of type ${MSYSTEM}, only"
   echo "MINGW64 is currently supported. Please rerun this in a bash terminal of"
@@ -474,8 +475,7 @@ EOF
 
   echo "=== Downloading release feed ==="
   DOWNLOADED_FEED=$(mktemp)
-  # We used to support both "x86" and "x86_64" and stored the current one in ARCH
-  curl "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/${DBLSQD_CHANNEL}/win/${ARCH}" -o "${DOWNLOADED_FEED}"
+  curl "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/${DBLSQD_CHANNEL}/win/x86_64" -o "${DOWNLOADED_FEED}"
 
   echo "=== Generating a changelog ==="
   cd "${GITHUB_WORKSPACE}/CI" || exit 1
@@ -501,17 +501,16 @@ EOF
   # PTB's are handled by the register script, release builds are just pushed here
   if [[ "${DBLSQD_CHANNEL}" == "release" ]]; then
     echo "=== Registering release with Dblsqd ==="
-    echo "dblsqd push -a mudlet -c \"${DBLSQD_CHANNEL}\" -r \"${DBLSQD_VERSION_STRING}\" -s mudlet --type 'standalone' --attach win:${ARCH} \"${DEPLOY_URL}\""
-    dblsqd push -a mudlet -c "${DBLSQD_CHANNEL}" -r "${DBLSQD_VERSION_STRING}" -s mudlet --type 'standalone' --attach win:"${ARCH}" "${DEPLOY_URL}"
+    echo "dblsqd push -a mudlet -c \"${DBLSQD_CHANNEL}\" -r \"${DBLSQD_VERSION_STRING}\" -s mudlet --type 'standalone' --attach win:x86_64 \"${DEPLOY_URL}\""
+    dblsqd push -a mudlet -c "${DBLSQD_CHANNEL}" -r "${DBLSQD_VERSION_STRING}" -s mudlet --type 'standalone' --attach win:x86_64 "${DEPLOY_URL}"
   fi
 
 fi
 
-# Make ARCH, VERSION_STRING and BUILD_COMMIT available to the
+# Make VERSION_STRING and BUILD_COMMIT available to the
 # GHA "build-mudlet-win.yml" workflow so they can be passed to the
 # "Register Release" step:
 {
-  echo "ARCH=${ARCH}"
   echo "VERSION_STRING=${DBLSQD_VERSION_STRING}"
   echo "BUILD_COMMIT=${BUILD_COMMIT}"
 } >> "${GITHUB_ENV}"

--- a/CI/register-windows-release.sh
+++ b/CI/register-windows-release.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 ###########################################################################
-#   Copyright (C) 2024-2024  by John McKisson - john.mckisson@gmail.com   #
+#   Copyright (C) 2024 by John McKisson - john.mckisson@gmail.com         #
+#   Copyright (C) 2025 by Stephen Lyons - slysven@virginmedia.com         #
 #                                                                         #
 #   This program is free software; you can redistribute it and/or modify  #
 #   it under the terms of the GNU General Public License as published by  #
@@ -22,17 +23,16 @@
 # BUILD_COMMIT and registers it with dblsqd. It will attempt this for up to
 # an hour, every minute until success.
 # GHA Env vars needed:
-#    ARCH - For registering wither 64 bit build with dblsqd
 #    BUILD_COMMIT - For listing the json feed
 #    PATH - For path of dblsqd
 #    VERSION_STRING - The version of Mudlet being released
 
 # Version: 1.0.0    Initial Release
+# Version: 1.1.0    Hard-code only for x86_64 architecture
 
 # Exit codes:
 # 0 - Everything is fine. 8-)
 # 1 - Timeout exceeded, failure
-# 2 - ARCH not properly set
 
 echo "=== Downloading JSON feed ==="
 json_url="https://make.mudlet.org/snapshots/json.php?commitid=${BUILD_COMMIT}"
@@ -60,13 +60,7 @@ FetchAndCheckURL() {
       return 1
     fi
 
-    if [ "${ARCH}" == "x86_64" ]; then
-      SEARCH_PATTERN="windows-64.exe"
-    else
-      echo "ARCH environment variable is not set to x86_64 as expected."
-      exit 2
-    fi
-
+    SEARCH_PATTERN="windows-64.exe"
     echo "Searching for ${SEARCH_PATTERN}"
 
     # Use jq to filter the JSON data
@@ -105,8 +99,8 @@ done
 
 
 echo "=== Registering release with Dblsqd ==="
-echo "dblsqd push -a mudlet -c public-test-build -r \"${VERSION_STRING}\" -s mudlet --type 'standalone' --attach win:${ARCH} \"${matching_url}\""
+echo "dblsqd push -a mudlet -c public-test-build -r \"${VERSION_STRING}\" -s mudlet --type 'standalone' --attach win:x86_64} \"${matching_url}\""
 
 PATH="/c/Program Files/nodejs/:/c/npm/prefix/:${PATH}"
 export PATH
-dblsqd push -a mudlet -c public-test-build -r "${VERSION_STRING}" -s mudlet --type 'standalone' --attach win:"${ARCH}" "${matching_url}"
+dblsqd push -a mudlet -c public-test-build -r "${VERSION_STRING}" -s mudlet --type 'standalone' --attach win:x86_64 "${matching_url}"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Remove use of `ARCH` (enviromental) variable from Windows CI/CB system and hard code the use of `x86_64` everywhere it was used as we not longer produce 32-Bit Windows builds. This change had previously impacted the named workflow as that was looking for the 32-bit Windows releases that we were no longer reporting to DBLSQD.

#### Motivation for adding to Mudlet
Get PTBs produced properly again.

#### Other info (issues closed, discussion etc)
After #8015 this should finally fix and so /claim #7970.