### PR TITLE
Infrastructure: clean up code base - remove warnings

### DIFF
--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -32,7 +32,6 @@
 TAlias::TAlias(TAlias* parent, Host* pHost)
 : Tree<TAlias>( parent )
 , mpHost(pHost)
-, isNew(true)
 {
 }
 
@@ -40,7 +39,6 @@ TAlias::TAlias(const QString& name, Host* pHost)
 : Tree<TAlias>(nullptr)
 , mName(name)
 , mpHost(pHost)
-, isNew(true)
 {
 }
 
@@ -404,10 +402,10 @@ QString TAlias::moduleName(TAlias* pAlias)
 
 bool TAlias::checkIfNew()
 {
-    return isNew;
+    return mIsNew;
 }
 
 void TAlias::unmarkAsNew()
 {
-    isNew = false;
+    mIsNew = false;
 }

--- a/src/TAlias.h
+++ b/src/TAlias.h
@@ -87,7 +87,7 @@ public:
     bool exportItem = true;
     bool mRegisteredAnonymousLuaFunction = false;
     QVector<NameGroupMatches> nameCaptures;
-    bool isNew;
+    bool mIsNew = true;
 
 private:
     bool mNeedsToBeCompiled = true;

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -872,9 +872,6 @@ void TDetachedWindow::updateToolBarActions()
 
     // Connection-related actions
     if (hasActiveProfile) {
-        bool isConnected = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectedState);
-        bool isConnecting = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectingState);
-
         // Enable/disable individual actions based on connection state
         // All actions should always be enabled to match main window behavior
         mpActionConnect->setEnabled(true);
@@ -942,6 +939,7 @@ void TDetachedWindow::updateDiscordNamedIcon()
 
 void TDetachedWindow::updateToolbarForProfile(Host* pHost)
 {
+    Q_UNUSED(pHost)
     // Update toolbar actions based on the provided host/profile
     // This method is called from mudlet's updateDetachedWindowToolbars()
     updateToolBarActions();
@@ -1065,6 +1063,9 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
 #if defined(DEBUG_WINDOW_HANDLING)
     qDebug() << "TDetachedWindow::updateDockWidgetVisibilityForProfile: Starting for profile" << profileName
              << "- mDockWidgetMap.size():" << mDockWidgetMap.size();
+
+    // Track if we found and showed a dock widget for the current profile
+    bool currentProfileHasVisibleDockWidget = false;
 #endif
     
     // Collect dock widgets to process to avoid iterator invalidation
@@ -1082,10 +1083,7 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
 #endif
         }
     }
-    
-    // Track if we found and showed a dock widget for the current profile
-    bool currentProfileHasVisibleDockWidget = false;
-    
+
     // Process dock widgets without iterating over the map directly
     for (const auto& dockPair : dockWidgetsToProcess) {
         const QString& dockKey = dockPair.first;
@@ -1124,9 +1122,8 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
                     
                     // Set this as the global map dock widget reference
                     mpMapDockWidget = dockWidget;
-                    currentProfileHasVisibleDockWidget = true;
-                    
 #if defined(DEBUG_WINDOW_HANDLING)
+                    currentProfileHasVisibleDockWidget = true;
                     qDebug() << "TDetachedWindow: Dock widget should be visible - showing and setting as active";
 #endif
                 } else {
@@ -2093,6 +2090,7 @@ void TDetachedWindow::performWindowMerge(TDetachedWindow* otherWindow)
 
 void TDetachedWindow::logWindowState(const QString& context)
 {
+    Q_UNUSED(context)
     // Simplified debug output for critical state information only
     if (mShouldStayVisible && mpTabBar && mpTabBar->count() > 0 && !isVisible()) {
 #if defined(DEBUG_WINDOW_HANDLING)
@@ -2538,8 +2536,6 @@ void TDetachedWindow::changeEvent(QEvent* event)
     }
     
     if (event->type() == QEvent::WindowStateChange) {
-        auto stateChangeEvent = static_cast<QWindowStateChangeEvent*>(event);
-
         // Check if window is being minimized
         if (windowState() & Qt::WindowMinimized) {
             mIsBeingMinimized = true;

--- a/src/TLuaInterpreterAI.cpp
+++ b/src/TLuaInterpreterAI.cpp
@@ -36,6 +36,7 @@
 // No documentation available in wiki - internal function
 std::pair<bool, QString> TLuaInterpreter::aiEnabled(lua_State* L)
 {
+    Q_UNUSED(L)
     mudlet* pMudlet = mudlet::self();
 
     if (!pMudlet->aiModelAvailable()) {

--- a/src/TScript.cpp
+++ b/src/TScript.cpp
@@ -34,7 +34,6 @@ TScript::TScript( TScript * parent, Host * pHost )
 , mpHost(pHost)
 , mNeedsToBeCompiled(true)
 , mModuleMember(false)
-, isNew(true)
 {
 }
 
@@ -46,7 +45,6 @@ TScript::TScript(const QString& name, Host * pHost )
 , mpHost(pHost)
 , mNeedsToBeCompiled(true)
 , mModuleMember(false)
-, isNew(true)
 {
 }
 
@@ -222,10 +220,10 @@ QString TScript::moduleName(TScript* pScript)
 
 bool TScript::checkIfNew()
 {
-    return isNew;
+    return mIsNew;
 }
 
 void TScript::unmarkAsNew()
 {
-    isNew = false;
+    mIsNew = false;
 }

--- a/src/TScript.h
+++ b/src/TScript.h
@@ -67,7 +67,7 @@ public:
 
     bool exportItem;
     bool mModuleMasterFolder;
-    bool isNew;
+    bool mIsNew = true;
 
 private:
     TScript() = default;

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -71,7 +71,6 @@ TTrigger::TTrigger( TTrigger * parent, Host * pHost )
 , mBgColor(QColor(Qt::yellow))
 , mIsColorizerTrigger(false)
 , mModuleMember(false)
-, isNew(true)
 , mExpiryCount(-1)
 {
 }
@@ -106,7 +105,6 @@ TTrigger::TTrigger(const QString& name, const QStringList& patterns, const QList
 , mBgColor(QColor(Qt::yellow))
 , mIsColorizerTrigger(false)
 , mModuleMember(false)
-, isNew(true)
 , mExpiryCount(-1)
 {
     setRegexCodeList(patterns, patternKinds);
@@ -1180,12 +1178,12 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
 
 bool TTrigger::checkIfNew()
 {
-    return isNew;
+    return mIsNew;
 }
 
 void TTrigger::unmarkAsNew()
 {
-    isNew = false;
+    mIsNew = false;
 }
 
 

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -168,7 +168,7 @@ public:
     // specifies whenever the payload is Lua code as a string
     // or a function
     bool mRegisteredAnonymousLuaFunction;
-    bool isNew;
+    bool mIsNew = true;
 
     int getExpiryCount() const;
     void setExpiryCount(int expiryCount);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Removes dead code and puts other fragments behind appropriate `#if defined` to remove unused code warnings.

Refactor some new-ish constant class initialisations to the header file, to remove warnings about them not being initialised in the correct order (and also add a `m` prefix).

#### Motivation for adding to Mudlet
To eliminate build warnings.

#### Other info (issues closed, discussion etc)