### PR TITLE
Add: openMudletHomeDir()

### DIFF
--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -1285,3 +1285,7 @@ function getConfig(...)
 
   return oldgetConfig(args[1])
 end
+
+function openMudletHomeDir()
+  openUrl("file:" .. getMudletHomeDir())
+end


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add `openMudletHomeDir()` to open profile folder in player's system's file browser

#### Motivation for adding to Mudlet
Remove some steps necessary from current `getMudletHomeDir()` implementation

#### Other info (issues closed, discussion etc)
Solved in Lua with existing c++ functionality