### PR TITLE
Fix: ignore non-xml files in profile history

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -929,7 +929,7 @@ void dlgConnectionProfiles::slot_itemClicked(QListWidgetItem* pItem)
             profile_history->addItem(QIcon::fromTheme(qsl("document-save"), QIcon(qsl(":/icons/document-save.png"))),
                                      mudlet::self()->getUserLocale().toString(lastModified, mDateTimeFormat),
                                      QVariant(entry));
-        } else {
+        } else if (entry.endsWith(QLatin1String(".xml"), Qt::CaseInsensitive)) {
             profile_history->addItem(entry, QVariant(entry)); // if it has a custom name, use it as it is
         }
     }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix: ignore non-xml files in profile history.
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/8034
#### Other info (issues closed, discussion etc)
