### PR TITLE
Fix: Prevent duplicate connection attempts after disconnect-reconnect sequence

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1562,16 +1562,31 @@ void dlgConnectionProfiles::loadProfile(bool alsoConnect)
         return;
     }
 
+    // Check if the host already exists before calling mudlet::loadProfile()
+    Host* pHostBeforeLoad = mudlet::self()->getHostManager().getHost(profile_name);
+    bool hostExistedBefore = (pHostBeforeLoad != nullptr);
+
     Host *pHost = mudlet::self()->loadProfile(profile_name, alsoConnect, profile_history->currentData().toString());
 
     // overwrite the generic profile with user supplied name, url and login information
     if (pHost) {
 
         Host* pActiveHost = mudlet::self()->getActiveHost();
+        
         if (pActiveHost && pActiveHost->getName() == profile_name) {
-            // The intention here is to do as little as possible if the same profile is chosen again
-            // this replicates function of mudlet::slot_reconnect to avoid #7395
+            // Skip reconnect if mudlet::loadProfile already connected for existing hosts
+            if (alsoConnect && hostExistedBefore) {
+                QDialog::accept();
+                return;
+            }
+            // Reconnect to the active profile
             pActiveHost->mTelnet.reconnect();
+            QDialog::accept();
+            return;
+        }
+        
+        // Skip signal emission if mudlet::loadProfile already handled the connection
+        if (alsoConnect && hostExistedBefore) {
             QDialog::accept();
             return;
         }


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes duplicate connection attempts that occurred when performing a Reconnect → Disconnect → Connect sequence. The issue caused duplicate DNS lookups and connection attempts, resulting in unnecessary network overhead and confusing connection logs.

#### Motivation for adding to Mudlet

Users experienced duplicate connection attempts after disconnecting and reconnecting to the same profile, which created:
- Unnecessary network traffic from duplicate DNS lookups
- Confusing duplicate connection messages in logs
- Potential timing issues with connection establishment

#### Other info (issues closed, discussion etc)

**Root Cause:** Two separate code paths were both attempting to connect:
1. `mudlet::loadProfile()` called `connectIt()` for existing hosts
2. The reconnect path in `dlgConnectionProfiles::loadProfile()` called `reconnect()`

**Solution:** Added logic to detect when `mudlet::loadProfile()` has already handled the connection for existing hosts and skip the duplicate reconnect call.

**Files Modified:**
- `src/dlgConnectionProfiles.cpp` - Added duplicate connection prevention logic
- `src/mudlet.cpp` - Minor cleanup of related code

---

**Before (Problem)**

https://github.com/user-attachments/assets/1a71067f-f21d-4eaf-a6b3-728589f97bfa

---

**After (Fixed)**

https://github.com/user-attachments/assets/4b28a51d-7c24-4703-8aab-86ec6209c557
