### PR TITLE
Fix: Remove noisy CredentialManager debug messages

### DIFF
--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -54,7 +54,6 @@ CredentialManager::~CredentialManager()
 {
     // During destruction, we should NOT call callbacks as they may reference
     // objects that are being destroyed. Instead, just clean up without callbacks.
-    qDebug() << "CredentialManager: Destructor called, cleaning up without callbacks";
     
     // Clear callbacks before cleanup to prevent them from being called
     mCurrentCallback = nullptr;


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Removes unnecessary debug logging from CredentialManager destructor that was creating console spam during normal profile operations. The "CredentialManager: Destructor called, cleaning up without callbacks" message appeared multiple times during profile loading and provided no useful information to end users.

#### Motivation for adding to Mudlet

Users see cluttered console output with repetitive debug messages that don't provide any actionable information. This cleanup reduces noise in the console logs, making it easier to spot actual issues and improving the overall user experience during profile operations.

#### Other info (issues closed, discussion etc)

Part of ongoing effort to clean up verbose debug output. The CredentialManager still performs all the same cleanup operations, just without the unnecessary logging. No functional changes