### PR TITLE
Improve: move Ambiguous East Asian Width option control from preferences to setConfig()

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -213,18 +213,6 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
                                               "will be run.</p>"
                                               "<p><i>It is recommended to not enable this option if you need to maintain compatibility "
                                               "with scripts or packages for Mudlet versions prior to <b>3.9.0</b>.</i></p>"));
-    checkBox_useWideAmbiguousEastAsianGlyphs->setToolTip(tr("<p>Some East Asian MUDs may use glyphs (characters) that Unicode classifies as being "
-                                                            "of <i>Ambiguous</i> width when drawn in a font with a so-called <i>fixed</i> pitch; in "
-                                                            "fact such text is <i>duo-spaced</i> when not using a proportional font. These symbols can be "
-                                                            "drawn using either a half or the whole space of a full character. By default Mudlet tries to "
-                                                            "chose the right width automatically but you can override the setting for each profile.</p>"
-                                                            "<p>This control has three settings:"
-                                                            "<ul><li><b>Unchecked</b> '<i>narrow</i>' = Draw ambiguous width characters in a single 'space'.</li>"
-                                                            "<li><b>Checked</b> '<i>wide</i>' = Draw ambiguous width characters two 'spaces' wide.</li>"
-                                                            "<li><b>Partly checked</b> <i>(Default) 'auto'</i> = Use 'wide' setting for MUD Server "
-                                                            "encodings of <b>Big5</b>/<b>Big5-HKSCS</b>, <b>GBK</b>, <b>GBK18030</b> or <b>EUC-KR</b> and 'narrow' for all others.</li></ul></p>"
-                                                            "<p><i>This is a temporary arrangement and will probably change when Mudlet gains "
-                                                            "full support for languages other than English.</i></p>"));
     checkBox_enableTextAnalyzer->setToolTip(tr("<p>Enable a context (right click) menu action on any console/user window that, "
                                                "when the mouse cursor is hovered over it, will display the UTF-16 and UTF-8 items "
                                                "that make up each Unicode codepoint on the <b>first</b> line of any selection.</p>"
@@ -425,7 +413,6 @@ void dlgProfilePreferences::disableHostDetails()
     checkBox_USE_IRE_DRIVER_BUGFIX->setEnabled(false);
     checkBox_enableTextAnalyzer->setEnabled(false);
     checkBox_echoLuaErrors->setEnabled(false);
-    checkBox_useWideAmbiguousEastAsianGlyphs->setEnabled(false);
     label_controlCharacterHandling->setEnabled(false);
     comboBox_controlCharacterHandling->setEnabled(false);
 
@@ -550,7 +537,6 @@ void dlgProfilePreferences::enableHostDetails()
     checkBox_USE_IRE_DRIVER_BUGFIX->setEnabled(true);
     checkBox_enableTextAnalyzer->setEnabled(true);
     checkBox_echoLuaErrors->setEnabled(true);
-    checkBox_useWideAmbiguousEastAsianGlyphs->setEnabled(true);
     label_controlCharacterHandling->setEnabled(true);
     comboBox_controlCharacterHandling->setEnabled(true);
 
@@ -673,7 +659,6 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         radioButton_userDictionary_common->setChecked(false);
     }
     checkBox_echoLuaErrors->setChecked(pHost->mEchoLuaErrors);
-    checkBox_useWideAmbiguousEastAsianGlyphs->setCheckState(pHost->getWideAmbiguousEAsianGlyphsControlState());
 
     // On the first run for a profile this will be the "English (American)"
     // dictionary "en_US".
@@ -3018,7 +3003,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         }
 
         pHost->mEchoLuaErrors = checkBox_echoLuaErrors->isChecked();
-        pHost->setWideAmbiguousEAsianGlyphs(checkBox_useWideAmbiguousEastAsianGlyphs->checkState());
+        pHost->setWideAmbiguousEAsianGlyphs(pHost->getWideAmbiguousEAsianGlyphsControlState());
         pHost->mEditorTheme = code_editor_theme_selection_combobox->currentText();
         pHost->mEditorThemeFile = code_editor_theme_selection_combobox->currentData().toString();
         pHost->mEditorAutoComplete = checkBox_autocompleteLuaCode->isChecked();
@@ -3199,12 +3184,17 @@ void dlgProfilePreferences::slot_setEncoding(const int newEncodingIndex)
     if (pHost) {
         pHost->mTelnet.setEncoding(comboBox_encoding->itemData(newEncodingIndex).toByteArray());
 
-        if (checkBox_useWideAmbiguousEastAsianGlyphs->checkState() == Qt::PartiallyChecked) {
-            // We are linking the Server encoding to this setting currently
-            // - eventually it would move to the locale/language control when it
-            // goes in, but we only need to change the setting for this if it is
-            // set to be automatic changed as necessary:
-
+        // When this was a tri-state checkbox setting we would store the
+        // partially checked setting (only, not the checked or unchecked values)
+        // into the Host class in order to cause the encoding to be checked so
+        // that it would determine what the (bool) Host::mWideAmbigousWidthGlyphs
+        // value should be.
+        // Since the control has been removed we now need to examine the value
+        // stored and if THAT equates to "Qt::PartiallyChecked" then do the same:
+        if (pHost->getWideAmbiguousEAsianGlyphsControlState()  == Qt::PartiallyChecked) {
+            // We are linking the Server encoding to this setting but we only
+            // need to refresh the setting for this if it is set to be automatic
+            // changed as necessary:
             pHost->setWideAmbiguousEAsianGlyphs(Qt::PartiallyChecked);
         }
     }

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -1238,6 +1238,7 @@ function getConfig(...)
   if #args == 0 then
     -- Please sort this list alphabetically (case insensitive) as it helps to follow changes:
     local list = {
+      "ambiguousEAsianWidthCharacters",
       "announceIncomingText",
       "askTlsAvailable",
       "autoClearInputLine",
@@ -1254,21 +1255,28 @@ function getConfig(...)
       "enableMSSP",
       "enableMTTS",
       "enableMXP",
+      "f3SearchEnabled",
       "fixUnnecessaryLinebreaks",
       "forceNewEnvironNegotiationOff",
       "inputLineStrictUnixEndings",
+      "logDirectory",
       "logInHTML",
       "mapExitSize",
       "mapperPanelVisible",
       "mapRoomSize",
       "mapRoundRooms",
       "mapShowRoomBorders",
+      "promptForMXPProcessorOn",
+      "promptForVersionInTTYPE",
       "show3dMapView",
       "showRoomIdsOnMap",
       "showSentText",
+      "showTabConnectionIndicators",
       "specialForceCompressionOff",
       "specialForceCharsetNegotiationOff",
       "specialForceGAOff",
+      "specialForceMXPProcessorOn",
+      "versionInTTYPE",
     }
     for _,v in ipairs(list) do
       result[v] = oldgetConfig(v)

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -1291,16 +1291,6 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="checkBox_useWideAmbiguousEastAsianGlyphs">
-            <property name="text">
-             <string>Make 'Ambiguous' E. Asian width characters wide</string>
-            </property>
-            <property name="tristate">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0">
            <widget class="QCheckBox" name="checkBox_USE_IRE_DRIVER_BUGFIX">
             <property name="toolTip">
@@ -4467,7 +4457,6 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>hanging_indent_wrapped_spinBox</tabstop>
   <tabstop>doubleclick_ignore_lineedit</tabstop>
   <tabstop>checkBox_USE_IRE_DRIVER_BUGFIX</tabstop>
-  <tabstop>checkBox_useWideAmbiguousEastAsianGlyphs</tabstop>
   <tabstop>checkBox_enableTextAnalyzer</tabstop>
   <tabstop>checkBox_echoLuaErrors</tabstop>
   <tabstop>comboBox_controlCharacterHandling</tabstop>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
A replacement for #8020 that actually works - rather than removing the ability to control the "Ambiguous East Asian Width Characters" completely it just removes the control from the preferences and, unlike that failed PR, moves it to something that the Lua API (and thus the end-user) can examine and control via the `getConfig(...)` and `setConfig(...)` interface. The setting is called `ambiguousEAsianWidthCharacters` and the three values it can have are:
* `"narrow"` (with the same effect as the removed checkbox being "unchecked")
* `"wide"` (same effect as "checked")
* `"auto"` (same effect as "partially-checked")

It also synchronises the `getConfig()` function (which takes no arguments and returns all the settings it knows about in a table) in the `Other.lua` external file. There were several settings that had been added to the internal C core code but which hadn't been added to the external Lua function that supplements it to handle a "no-arguments" usage. Whilst those two are now in step this PR does not make any guarantees about synchronicity with the C core code `setConfig(...)` function!

#### Motivation for adding to Mudlet
To remove a not often needed control from the preferences to simplify them.

#### Other info (issues closed, discussion etc)
Whilst correctly updating the "bulk" `getConfig(...)` in the `Other.lua` file to support this new (there) setting I found a number of others that had been added to the C++ core `getConfig(...)` function but which had not been added in that external Lua file so which would be missed if the user tried to get ALL the settings available.

This replaces/supplants PR #8058 which can be closed as not required.