### PR TITLE
Fix: partial revert of  change to link-ptbs-to-dblsqd GH Actions workflow

### DIFF
--- a/CI/register-windows-release.sh
+++ b/CI/register-windows-release.sh
@@ -60,11 +60,14 @@ FetchAndCheckURL() {
       return 1
     fi
 
-    SEARCH_PATTERN="windows-64.exe"
-    echo "Searching for ${SEARCH_PATTERN}"
+    # The processing of this variable by the jq tool means that converting this
+    # variable name to SCREAMING_SNAKE_CASE was too hard to do and get correct
+    # so leave it alone in a form that "works":
+    search_pattern="windows-64.exe"
+    echo "Searching for ${search_pattern}"
 
     # Use jq to filter the JSON data
-    matching_url=$(echo "$json_data" | jq -r --arg search_pattern "${SEARCH_PATTERN}" '.data[] | select(.platform == "windows" and (.url | test(${SEARCH_PATTERN}))) | .url')
+    matching_url=$(echo "$json_data" | jq -r --arg search_pattern "$search_pattern" '.data[] | select(.platform == "windows" and (.url | test($search_pattern))) | .url')
 
     # Check if the URL was found
     if [ -z "$matching_url" ]; then


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Revert a change I made in #8015 where I changed a `bash` variable name into a SCREAMING_SNAKE_CASE one - unfortunately I did not (and still don't) fully understand how it was processed by the `jq` (command line JSON query tool) and broke the processing of the DBLSQD feed data and thus stopped the script from working as intended.

#### Motivation for adding to Mudlet
Get Windows PTBs produced again.

#### Other info (issues closed, discussion etc)
This PR should put the affected bit of the script back to exactly how it was prior to the PR that broke things!