### PR TITLE
Infrastructure: fix clangtidy workflow to use Qt 6

### DIFF
--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -19,7 +19,7 @@ jobs:
             buildname: 'clang-tidy'
             triplet: x64-linux
             compiler: clang_64
-            qt: '5.14.1'
+            qt: '6.9.0'
 
     env:
       BOOST_ROOT: ${{github.workspace}}/3rdparty/boost
@@ -44,6 +44,7 @@ jobs:
         dir: ${{github.workspace}}
         arch: win64_mingw73
         cache: true
+        modules: qt5compat qtmultimedia
 
     - name: (Linux/macOS) Install Qt
       uses: jurplel/install-qt-action@v4
@@ -52,6 +53,7 @@ jobs:
         version: ${{matrix.qt}}
         dir: ${{github.workspace}}
         cache: true
+        modules: qt5compat qtmultimedia
 
     - name: Restore Boost cache
       uses: actions/cache@v4
@@ -115,7 +117,7 @@ jobs:
         cmakeAppendedArgs: >-
           -DCMAKE_GLOBAL_AUTOGEN_TARGET=ON
           -G Ninja
-          -DCMAKE_PREFIX_PATH=${{env.MINGW_BASE_DIR}}
+          -DCMAKE_PREFIX_PATH=${{ env.QT_PREFIX != '' && env.QT_PREFIX || env.MINGW_BASE_DIR }}
           -DVCPKG_APPLOCAL_DEPS=OFF
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
         buildWithCMakeArgs: >-


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
fix clangtidy workflow to use Qt 6
#### Motivation for adding to Mudlet
so we can get clangtidy feedback once again
#### Other info (issues closed, discussion etc)
