### PR TITLE
Infrastructure: fix clangtidy-analysis to run on ubuntu latest runner

### DIFF
--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             buildname: 'clang-tidy'
             triplet: x64-linux
             compiler: clang_64


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
fix clangtidy-analysis to run on ubuntu latest runner, as ubuntu 20.04 isn't available anymore
#### Motivation for adding to Mudlet
getting clang-tidy working once again
#### Other info (issues closed, discussion etc)
