### PR TITLE
Fix: Close Profile menu closes wrong profile in detached windows

### DIFF
--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -265,7 +265,7 @@ void TDetachedWindow::createMenus()
     auto closeProfileAction = new QAction(QIcon(qsl(":/icons/profile-close.png")), tr("&Close Profile"), this);
     closeProfileAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_W));
     closeProfileAction->setStatusTip(tr("Close the current profile"));
-    connect(closeProfileAction, &QAction::triggered, mudlet::self(), &mudlet::slot_closeCurrentProfile);
+    connect(closeProfileAction, &QAction::triggered, this, &TDetachedWindow::slot_closeCurrentProfile);
     profileMenu->addAction(closeProfileAction);
 
     mpWindowMenu = menuBar()->addMenu(tr("&Window"));
@@ -2151,9 +2151,9 @@ void TDetachedWindow::slot_reconnectProfile()
 
 void TDetachedWindow::slot_closeCurrentProfile()
 {
-    withCurrentProfileActive([this]() {
-        mudlet::self()->slot_closeCurrentProfile();
-    });
+    // Use the detached window's own close profile logic instead of 
+    // delegating to the main window, which would use the wrong tab bar
+    closeProfile();
 }
 
 void TDetachedWindow::slot_closeApplication()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixed the "Close Profile" menu action in detached windows to close the correct profile by:
- Updated menu connection to use detached window's own close profile logic instead of main window's method
- Modified `slot_closeCurrentProfile()` to call `closeProfile()` directly rather than delegating to main window
- Ensures detached window closes automatically when closing the last remaining profile

#### Motivation for adding to Mudlet

Users reported that clicking "Close Profile" in a detached window was closing a profile in the main window instead of the profile in the detached window where the action was triggered. This created a confusing user experience where the wrong profile would be closed, leaving the detached window unchanged.

The fix ensures consistent behavior where "Close Profile" always closes the profile in the window where it was clicked.

#### Other info (issues closed, discussion etc)

Closes #8070

This fix is complementary to PR #7990 which handled toolbar button states - this addresses the menu action that was missed in that PR.

---

**Before**

https://github.com/user-attachments/assets/9959e325-18fc-4707-a7d8-b0ec900935c4

---

**After**

https://github.com/user-attachments/assets/8b1cae01-bd03-4a6c-9959-d62eb080fa0d
