### PR TITLE
fix assert in setGauge

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -563,8 +563,8 @@ end
 ---   </pre>
 function setGauge(gaugeName, currentValue, maxValue, gaugeText)
   assert(gaugesTable[gaugeName], "setGauge: no such gauge exists.")
-  assert(tonumber(currentValue) ~= nil, 'setGauge: bad argument #2 type (unable to convert to a number!)')
-  assert(tonumber(maxValue) ~= nil, 'setGauge: bad argument #3 type (unable to convert to a number!)')
+  assert(tonumber(currentValue) ~= nil, 'setGauge: bad argument #2 type (unable to convert '..type(currentValue)..' to a number!)')
+  assert(tonumber(maxValue) ~= nil, 'setGauge: bad argument #3 type (unable to convert '..type(maxValue)..' to a number!)')
   local value = currentValue / maxValue
   -- save new values in table
   gaugesTable[gaugeName].value = value

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -563,8 +563,8 @@ end
 ---   </pre>
 function setGauge(gaugeName, currentValue, maxValue, gaugeText)
   assert(gaugesTable[gaugeName], "setGauge: no such gauge exists.")
-  assert(type(currentValue) == 'number', 'setGauge: bad argument #2 type (expected number, got '..type(currentValue)..'!)')
-  assert(type(maxValue) == 'number', 'setGauge: bad argument #3 type (expected number, got '..type(maxValue)..'!)')
+  assert(tonumber(currentValue) ~= nil, 'setGauge: bad argument #2 type (unable to convert to a number!)')
+  assert(tonumber(maxValue) ~= nil, 'setGauge: bad argument #3 type (unable to convert to a number!)')
   local value = currentValue / maxValue
   -- save new values in table
   gaugesTable[gaugeName].value = value


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix overly strong assert on `setGauge()` which was breaking old scripts.
Accept anything number or string which converts successfully to a number.

#### Motivation for adding to Mudlet
Regression fix.

#### Other info (issues closed, discussion etc)
Checked other functions and this is the only problem one I could pick up.

<img width="1238" height="279" alt="image" src="https://github.com/user-attachments/assets/efdddb36-d047-4d07-8cce-9c1d6e9e4318" />


closes #8077