### PR TITLE
Infrastructure: raise minimum Qt to 6.8.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ include_optional_module(ENVIRONMENT_VARIABLE WITH_OWN_QTKEYCHAIN
                         OPTION_VARIABLE USE_OWN_QTKEYCHAIN
                         READABLE_NAME "own QtKeychain library")
 
-find_package(Qt6 6.4.0 REQUIRED)
+find_package(Qt6 6.8.2 REQUIRED)
 
 find_package(Lua 5.1 EXACT)
 

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -37,7 +37,13 @@
 ############################################################################
 
 if(lessThan(QT_MAJOR_VERSION,6)) {
-    error("Mudlet requires Qt 6.0 or later")
+    error("Mudlet requires Qt 6.8.2 or later")
+}
+if(equals(QT_MAJOR_VERSION,6):lessThan(QT_MINOR_VERSION,8)) {
+    error("Mudlet requires Qt 6.8.2 or later")
+}
+if(equals(QT_MAJOR_VERSION,6):equals(QT_MINOR_VERSION,8):lessThan(QT_PATCH_VERSION,2)) {
+    error("Mudlet requires Qt 6.8.2 or later")
 }
 
 # Including IRC Library

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,7 +11,7 @@ PROJECT(mudlet-tests
 
 ENABLE_TESTING()
 
-find_package(Qt6 6.4.0 REQUIRED
+find_package(Qt6 6.8.2 REQUIRED
     COMPONENTS Core
     Multimedia
     MultimediaWidgets

--- a/translations/translated/CMakeLists.txt
+++ b/translations/translated/CMakeLists.txt
@@ -23,7 +23,7 @@
 
 message(STATUS "Building translations")
 
-find_package(Qt6LinguistTools 6.4.0 REQUIRED)
+find_package(Qt6LinguistTools 6.8.2 REQUIRED)
 get_target_property(LRELEASE_LOCATION Qt6::lrelease LOCATION)
 
 file(GLOB TS_FILES *.ts)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Raise minimum Qt to 6.8.2
#### Motivation for adding to Mudlet
Debian Stable [ships with 6.8.2](https://packages.debian.org/trixie/qt6-base-dev), and using a more recent Qt allows us to take advantage of newer features.
#### Other info (issues closed, discussion etc)
New features available:
https://doc.qt.io/qt-6/whatsnew65.html
https://doc.qt.io/qt-6/whatsnew66.html
https://doc.qt.io/archives/qt-6.7/whatsnew67.html
https://doc.qt.io/qt-6.8/whatsnew68.html