### PR TITLE
Infrastructure: modernize font fallback on Linux/BSDs for Qt 6.9.0

### DIFF
--- a/src/FontManager.cpp
+++ b/src/FontManager.cpp
@@ -27,6 +27,7 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QDesktopServices>
+#include <QFontDatabase>
 #include "post_guard.h"
 
 void FontManager::addFonts()
@@ -108,4 +109,17 @@ void FontManager::unloadFonts(const QString& belongsTo)
         QFontDatabase::removeApplicationFont(id);
     }
     loadedFontAffiliation.remove(belongsTo);
+}
+
+void FontManager::addEmojiFont()
+{
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+    // Use the new Qt 6.9 function for emoji fonts
+    QFontDatabase::addApplicationEmojiFontFamily(qsl("Noto Color Emoji"));
+#else
+    // Fallback for older Qt versions - this will be handled by individual components
+    // using QFont::insertSubstitution as before
+#endif
+#endif // defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
 }

--- a/src/FontManager.h
+++ b/src/FontManager.h
@@ -36,6 +36,7 @@ public:
     void loadFont(const QString& filePath, const QString& belongsTo = "main");
     bool fontAlreadyLoaded(const QString& filePath);
     void unloadFonts(const QString& belongsTo);
+    void addEmojiFont();
 
 private:
     void loadFonts(const QString& folder);

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -2501,10 +2501,13 @@ int TLuaInterpreter::setFont(lua_State* L)
     }
 
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+#if QT_VERSION < QT_VERSION_CHECK(6, 9, 0)
     // On GNU/Linux or FreeBSD ensure that emojis are displayed in colour even
     // if this font doesn't support it:
     QFont::insertSubstitution(fontName, qsl("Noto Color Emoji"));
     // TODO issue #4159: a nonexisting font breaks the console
+#endif
+    // For Qt 6.9+, emoji font support is handled globally in FontManager::addEmojiFont()
 #endif
 
     auto console = CONSOLE(L, windowName);

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1223,9 +1223,12 @@ void XMLimport::readHost(Host* pHost)
             } else if (name() == qsl("mDisplayFont")) {
                 pHost->setDisplayFontFromString(readElementText());
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+#if QT_VERSION < QT_VERSION_CHECK(6, 9, 0)
                 // On GNU/Linux and FreeBSD ensure that emojis are displayed in
                 // colour even if this font doesn't support it:
                 QFont::insertSubstitution(pHost->getDisplayFont().family(), qsl("Noto Color Emoji"));
+#endif
+                // For Qt 6.9+, emoji font support is handled globally in FontManager::addEmojiFont()
 #endif
             } else if (name() == qsl("mCommandLineFont")) {
                 // We use the same font as the main console now so discard this

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -4544,9 +4544,12 @@ bool dlgProfilePreferences::updateDisplayFont()
     }
 
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+#if QT_VERSION < QT_VERSION_CHECK(6, 9, 0)
     // On GNU/Linux or FreeBSD ensure that emojis are displayed in colour even
     // if this font doesn't support it:
     QFont::insertSubstitution(mpHost->getDisplayFont().family(), qsl("Noto Color Emoji"));
+#endif
+    // For Qt 6.9+, emoji font support is handled globally in FontManager::addEmojiFont()
 #endif
 
     // update the display properly when font or size or antiAliasing selections

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -743,6 +743,8 @@ void mudlet::init()
 
     // load bundled fonts
     mFontManager.addFonts();
+    // Configure emoji font support
+    mFontManager.addEmojiFont();
 
     // Initialise a couple of QMaps and some other elements that must be
     // translated into the current GUI Language


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Modernize font fallback on Linux to use [a new function](https://doc.qt.io/qt-6/qfontdatabase.html#addApplicationEmojiFontFamily) introduced in Qt 6.9.
#### Motivation for adding to Mudlet
Very often do [people in Discord](https://discord.com/channels/283581582550237184/283582068334526464/1404150768977842219) get issues where the only available font is the emoji one so they get 1 character displayed per one line:

I'm hoping this will fix such cases.
#### Other info (issues closed, discussion etc)
