### PR TITLE
Fix: remember 2D/3D map status for the mapper

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -275,6 +275,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mBubbleMode(false)
 , mShowRoomID(false)
 , mShowPanel(true)
+, mShow3DView(false)
 , mServerGUI_Package_version(QLatin1String("-1"))
 , mServerGUI_Package_name(QLatin1String("nothing"))
 , mAcceptServerGUI(true)

--- a/src/Host.h
+++ b/src/Host.h
@@ -701,6 +701,7 @@ public:
     bool mMapViewOnly = true;
     bool mShowRoomID;
     bool mShowPanel;
+    bool mShow3DView;
     QString mServerGUI_Package_version;
     QString mServerGUI_Package_name;
     bool mAcceptServerGUI;

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -441,6 +441,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mMapViewOnly") = pHost->mMapViewOnly ? "yes" : "no";
     host.append_attribute("mShowRoomIDs") = pHost->mShowRoomID ? "yes" : "no";
     host.append_attribute("mShowPanel") = pHost->mShowPanel ? "yes" : "no";
+    host.append_attribute("mShow3DView") = pHost->mShow3DView ? "yes" : "no";
     host.append_attribute("mHaveMapperScript") = pHost->mHaveMapperScript ? "yes" : "no";
     host.append_attribute("mEditorAutoComplete") = pHost->mEditorAutoComplete ? "yes" : "no";
     host.append_attribute("mEditorShowBidi") = pHost->getEditorShowBidi() ? "yes" : "no";

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -788,6 +788,7 @@ void XMLimport::readHost(Host* pHost)
     setBoolAttribute(qsl("mMapViewOnly"), pHost->mMapViewOnly);
     setBoolAttribute(qsl("mShowRoomIDs"), pHost->mShowRoomID);
     setBoolAttribute(qsl("mShowPanel"), pHost->mShowPanel);
+    setBoolAttribute(qsl("mShow3DView"), pHost->mShow3DView);
     setBoolAttribute(qsl("mHaveMapperScript"), pHost->mHaveMapperScript);
     setBoolAttribute(qsl("mSslTsl"), pHost->mSslTsl);
     setBoolAttribute(qsl("mSslIgnoreExpired"), pHost->mSslIgnoreExpired);

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -96,6 +96,9 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
     connect(comboBox_showArea, qOverload<int>(&QComboBox::activated), this, &dlgMapper::slot_switchArea);
 #if defined(INCLUDE_3DMAPPER)
     connect(pushButton_3D, &QAbstractButton::clicked, this, &dlgMapper::slot_toggle3DView);
+    if (mpHost->mShow3DView) {
+        slot_toggle3DView(true);
+    }
 #else
     pushButton_3D->hide();
 #endif
@@ -284,7 +287,7 @@ void dlgMapper::slot_toggle3DView(const bool is3DMode)
             widget_2DControls->setVisible(true);
         });
     }
-
+    mpHost->mShow3DView = is3DMode;
 #else
     Q_UNUSED(is3DMode)
     mp2dMap->setVisible(true);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remember 2D/3D map status for the mapper. If you closed the mapper with the 3D view, it should still be there when you open it.
#### Motivation for adding to Mudlet
Bugfix.
#### Other info (issues closed, discussion etc)
