### PR TITLE
Fix: crash on exit in development with CredentialManager

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2863,7 +2863,6 @@ void mudlet::slot_showConnectionDialog()
     mpConnectionDialog->indicatePackagesInstallOnConnect(packagesToInstall);
 
     connect(mpConnectionDialog, &QDialog::accepted, this, [=, this]() { enableToolbarButtons(); });
-    connect(mpConnectionDialog, &QObject::destroyed, this, [=, this]() { mpConnectionDialog = nullptr; });
     mpConnectionDialog->setAttribute(Qt::WA_DeleteOnClose);
     
     // Use a timer to ensure the main window is ready before showing the dialog


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix crash
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/8119
#### Other info (issues closed, discussion etc)
I missed this in code review, but typically you do not need to delete Qt dialogs yourself. `mpConnectionDialog->setAttribute(Qt::WA_DeleteOnClose);` is enough, and Qt will delete it when it's gone.