### PR TITLE
Fix: anti-alias text for errors view and debug view

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -60,7 +60,7 @@ const QString TConsole::cmLuaLineVariable("line");
 TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidget* parent)
 : QWidget(parent)
 , mpHost(pH)
-, mDisplayFontDetails((type == MainConsole) && pH->fontsAntiAlias())
+, mDisplayFontDetails(pH->fontsAntiAlias())
 , buffer(pH, this)
 , emergencyStop(new QToolButton)
 , mConsoleName(name)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Anti-alias text for errors view and debug view when built with recent Qt versions
#### Motivation for adding to Mudlet
Bugfix
#### Other info (issues closed, discussion etc)
Before (no AA):
<img width="796" height="229" alt="image" src="https://github.com/user-attachments/assets/055b6301-f242-409b-bff5-65916c7fe475" />


After (with AA):
<img width="796" height="229" alt="image" src="https://github.com/user-attachments/assets/2f3a6b59-a569-490d-bcb9-b45222ff7d1f" />
