### PR TITLE
Fix 'unknown view' texts in command-line output

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -11311,49 +11311,63 @@ void dlgTriggerEditor::clearTriggerForm()
 {
     mpTriggersMainArea->hide();
     mpSourceEditorArea->hide();
-    showIntro();
+    if (mCurrentView != EditorViewType::cmUnknownView) {
+        showIntro();
+    }
 }
 
 void dlgTriggerEditor::clearTimerForm()
 {
     mpTimersMainArea->hide();
     mpTimersMainArea->hide();
-    showIntro();
+    if (mCurrentView != EditorViewType::cmUnknownView) {
+        showIntro();
+    }
 }
 
 void dlgTriggerEditor::clearAliasForm()
 {
     mpAliasMainArea->hide();
     mpSourceEditorArea->hide();
-    showIntro();
+    if (mCurrentView != EditorViewType::cmUnknownView) {
+        showIntro();
+    }
 }
 
 void dlgTriggerEditor::clearScriptForm()
 {
     mpScriptsMainArea->hide();
     mpSourceEditorArea->hide();
-    showIntro();
+    if (mCurrentView != EditorViewType::cmUnknownView) {
+        showIntro();
+    }
 }
 
 void dlgTriggerEditor::clearActionForm()
 {
     mpActionsMainArea->hide();
     mpSourceEditorArea->hide();
-    showIntro();
+    if (mCurrentView != EditorViewType::cmUnknownView) {
+        showIntro();
+    }
 }
 
 void dlgTriggerEditor::clearKeyForm()
 {
     mpKeysMainArea->hide();
     mpSourceEditorArea->hide();
-    showIntro();
+    if (mCurrentView != EditorViewType::cmUnknownView) {
+        showIntro();
+    }
 }
 
 void dlgTriggerEditor::clearVarForm()
 {
     mpVarsMainArea->hide();
     mpSourceEditorArea->hide();
-    showIntro();
+    if (mCurrentView != EditorViewType::cmUnknownView) {
+        showIntro();
+    }
 }
 
 void dlgTriggerEditor::setEditorShowBidi(const bool state)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix 'unknown view' texts in command-line output
#### Motivation for adding to Mudlet
Fixing:

```
ERROR: dlgTriggerEditor::showIntro() undefined view
ERROR: dlgTriggerEditor::showIntro() undefined view
ERROR: dlgTriggerEditor::showIntro() undefined view
ERROR: dlgTriggerEditor::showIntro() undefined view
ERROR: dlgTriggerEditor::showIntro() undefined view
ERROR: dlgTriggerEditor::showIntro() undefined view
```
#### Other info (issues closed, discussion etc)
