### PR TITLE
Infrastructure: remove qDebug()s for loading profiles via CLI

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -475,17 +475,12 @@ int main(int argc, char* argv[])
 #endif
 
     QStringList cliProfiles = parser.values(profileToOpen);
-    qDebug() << "Got CLI profiles:" << cliProfiles;
 
     if (cliProfiles.isEmpty()) {
-        qDebug() << "No CLI profiles specified, checking environment variable";
         const QString envProfiles = QString::fromLocal8Bit(qgetenv("MUDLET_PROFILES"));
-        qDebug() << "Environment MUDLET_PROFILES value:" << envProfiles;
         if (!envProfiles.isEmpty()) {
-            qDebug() << "Found environment profiles, splitting on ':'";
             // : is not an allowed character in a profile name, so we can use it to split the list
             cliProfiles = envProfiles.split(':');
-            qDebug() << "Final profile list from environment:" << cliProfiles;
         }
     }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove qDebug()s for loading profiles via CLI
#### Motivation for adding to Mudlet
Accidentally left in debug prints
#### Other info (issues closed, discussion etc)
