### PR TITLE
Add: map info to the 3D mapper as well

### DIFF
--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -247,8 +247,6 @@ private:
     bool checkButtonIsForGivenDirection(const QPushButton*, const QString&, const int&);
     bool sizeFontToFitTextInRect(QFont&, const QRectF&, const QString&, const quint8 percentageMargin = 10, const qreal minFontSize = 7.0);
     inline void drawRoom(QPainter&, QFont&, QFont&, QPen&, TRoom*, const bool isGridMode, const bool areRoomIdsLegible, const bool showRoomNames, const int, const float, const float, const QMap<int, QPointF>&, const bool showRoomCollision);
-    void paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, const int displayAreaId, QColor& infoColor);
-    int paintMapInfoContributor(QPainter&, int xOffset, int yOffset, const MapInfoProperties& properties);
     void paintRoomExits(QPainter&, QPen&, QList<int>& exitList, QList<int>& oneWayExits, const TArea*, int, float, QMap<int, QPointF>&);
     void initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWalkTargetRoomId);
     inline void drawDoor(QPainter&, const TRoom&, const QString&, const QLineF&);

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -530,7 +530,7 @@ void dlgMapper::paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter
     painter.restore();
 
     if (yOffset > initialYOffset) {
-        painter.fillRect(xOffset, 10, widgetWidth - 10 - xOffset, 10, pHost->mMapInfoBg);
+        painter.fillRect(xOffset, initialYOffset - 10, widgetWidth - 10 - xOffset, 10, pHost->mMapInfoBg);
     }
 }
 

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -30,9 +30,11 @@
 #include "mapInfoContributorManager.h"
 
 #include "pre_guard.h"
+#include <QElapsedTimer>
 #include <QListWidget>
 #include <QMenu>
 #include <QMessageBox>
+#include <QPainter>
 #include <QProgressDialog>
 #include "post_guard.h"
 
@@ -473,4 +475,91 @@ void dlgMapper::recreate3DWidget()
     
     glWidget->setVisible(was3DMode);
 #endif
+}
+
+void dlgMapper::paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, Host* pHost, TMap* pMap,
+                            int roomID, int displayAreaId, int selectionSize, QColor& infoColor,
+                            int xOffset, int yOffset, int widgetWidth, int fontHeight)
+{
+    if (!pMap || !pMap->mMapInfoContributorManager || !pHost) {
+        return;
+    }
+
+    QList<QString> contributorList = pMap->mMapInfoContributorManager->getContributorKeys();
+    QSet<QString> const contributorKeys{contributorList.begin(), contributorList.end()};
+    if (!contributorKeys.intersects(pHost->mMapInfoContributors)) {
+        return;
+    }
+
+    TRoom* pRoom = pMap->mpRoomDB->getRoom(roomID);
+    if (!pRoom) {
+        return;
+    }
+
+    const int initialYOffset = yOffset;
+
+    painter.save();
+    painter.setFont(pHost->getDisplayFont());
+
+    for (const auto& key : pMap->mMapInfoContributorManager->getContributorKeys()) {
+        if (pHost->mMapInfoContributors.contains(key)) {
+            auto properties = pMap->mMapInfoContributorManager->getContributor(key)(roomID, selectionSize, pRoom->getArea(), displayAreaId, infoColor);
+            if (!properties.color.isValid()) {
+                properties.color = infoColor;
+            }
+            yOffset += paintMapInfoContributor(painter, xOffset, yOffset, properties, pHost->mMapInfoBg, fontHeight, widgetWidth);
+        }
+    }
+
+#ifdef QT_DEBUG
+    yOffset += paintMapInfoContributor(painter,
+                         xOffset,
+                         yOffset,
+                         {false,
+                          false,
+                          QObject::tr("render time: %1S")
+                                  .arg(renderTimer.nsecsElapsed() * 1.0e-9, 0, 'f', 3),
+                          infoColor},
+                         pHost->mMapInfoBg,
+                         fontHeight,
+                         widgetWidth);
+#else
+    Q_UNUSED(renderTimer)
+#endif
+
+    painter.restore();
+
+    if (yOffset > initialYOffset) {
+        painter.fillRect(xOffset, 10, widgetWidth - 10 - xOffset, 10, pHost->mMapInfoBg);
+    }
+}
+
+int dlgMapper::paintMapInfoContributor(QPainter& painter, int xOffset, int yOffset,
+                                      const MapInfoProperties& properties, QColor bgColor, int fontHeight,
+                                      int widgetWidth)
+{
+    if (properties.text.isEmpty()) {
+        return 0;
+    }
+
+    painter.save();
+    auto infoText = properties.text.trimmed();
+    auto font = painter.font();
+    font.setBold(properties.isBold);
+    font.setItalic(properties.isItalic);
+    painter.setFont(font);
+    const int infoHeight = fontHeight;
+    QRect testRect;
+    QRect mapInfoRect = QRect(xOffset, yOffset, widgetWidth - 10 - xOffset, infoHeight);
+    testRect = painter.boundingRect(mapInfoRect.left() + 10, mapInfoRect.top(), mapInfoRect.width() - 20, mapInfoRect.height() - 20,
+                                   Qt::Alignment(Qt::AlignTop | Qt::AlignLeft) | Qt::TextFlag(Qt::TextWordWrap | Qt::TextIncludeTrailingSpaces),
+                                   infoText);
+    mapInfoRect.setHeight(testRect.height() + 10);
+    painter.fillRect(mapInfoRect, bgColor);
+    painter.setPen(properties.color);
+    painter.drawText(mapInfoRect.left() + 10, mapInfoRect.top(), mapInfoRect.width() - 20, mapInfoRect.height() - 10,
+                    Qt::Alignment(Qt::AlignTop | Qt::AlignLeft) | Qt::TextFlag(Qt::TextWordWrap | Qt::TextIncludeTrailingSpaces),
+                    infoText);
+    painter.restore();
+    return mapInfoRect.height();
 }

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -33,6 +33,7 @@
 
 class Host;
 class TMap;
+struct MapInfoProperties;
 #if defined(INCLUDE_3DMAPPER)
 #include "glwidget_integration.h"
 class QOpenGLWidget;
@@ -73,6 +74,13 @@ public slots:
     void slot_setShowRoomIds(bool showRoomIds);
     void slot_updateInfoContributors();
     void slot_switchArea(const int);
+    
+    static void paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, Host* pHost, TMap* pMap,
+                            int roomID, int displayAreaId, int selectionSize, QColor& infoColor,
+                            int xOffset, int yOffset, int widgetWidth, int fontHeight);
+    static int paintMapInfoContributor(QPainter& painter, int xOffset, int yOffset,
+                                      const MapInfoProperties& properties, QColor bgColor, int fontHeight,
+                                      int widgetWidth);
 
 private:
     TMap* mpMap = nullptr;

--- a/src/modern_glwidget.cpp
+++ b/src/modern_glwidget.cpp
@@ -29,6 +29,7 @@
 #include "TRoomDB.h"
 #include "dlgMapper.h"
 #include "mudlet.h"
+#include "mapInfoContributorManager.h"
 
 #include "pre_guard.h"
 #include <QtEvents>
@@ -320,6 +321,11 @@ void ModernGLWidget::paintGL()
     painter.setPen(QPen(QColor(255, 255, 255, 200))); // Semi-transparent white
     painter.setFont(QFont("Arial", 12, QFont::Bold));
     painter.drawText(10, height() - 20, "Modern OpenGL Mapper");
+    
+    // Draw map info using contributor manager
+    QColor infoColor = mpHost->mMapInfoBg.isValid() ? mpHost->mMapInfoBg : QColor(0, 0, 0, 200);
+    paintMapInfo(mFrameTimer, painter, mAID, infoColor);
+    
     painter.end();
     
     // Display instant frame time
@@ -1243,4 +1249,89 @@ void ModernGLWidget::onCameraAnimationTick()
     
     // Trigger a repaint
     update();
+}
+
+void ModernGLWidget::paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, const int displayAreaId, QColor& infoColor)
+{
+    if (!mpMap || !mpMap->mMapInfoContributorManager || !mpHost) {
+        return;
+    }
+
+    QList<QString> contributorList = mpMap->mMapInfoContributorManager->getContributorKeys();
+    QSet<QString> const contributorKeys{contributorList.begin(), contributorList.end()};
+    if (!contributorKeys.intersects(mpHost->mMapInfoContributors)) {
+        return;
+    }
+
+    TRoom* pRoom = mpMap->mpRoomDB->getRoom(mRID);
+    if (!pRoom) {
+        return;
+    }
+
+    int roomID = mRID;
+    int xOffset = 10;
+    int yOffset = 10;
+    const int initialYOffset = yOffset;
+
+    for (const auto& key : mpMap->mMapInfoContributorManager->getContributorKeys()) {
+        if (mpHost->mMapInfoContributors.contains(key)) {
+            auto properties = mpMap->mMapInfoContributorManager->getContributor(key)(roomID, 0, pRoom->getArea(), displayAreaId, infoColor);
+            if (!properties.color.isValid()) {
+                properties.color = infoColor;
+            }
+            yOffset += paintMapInfoContributor(painter, xOffset, yOffset, properties);
+        }
+    }
+
+#ifdef QT_DEBUG
+    yOffset += paintMapInfoContributor(painter,
+                         xOffset,
+                         yOffset,
+                         {false,
+                          false,
+                          tr("render time: %1S mO: (%2,%3,%4)")
+                                  .arg(renderTimer.nsecsElapsed() * 1.0e-9, 0, 'f', 3)
+                                  .arg(QString::number(mMapCenterX), QString::number(mMapCenterY), QString::number(mMapCenterZ)),
+                          infoColor});
+#else
+    Q_UNUSED(renderTimer)
+#endif
+
+    if (yOffset > initialYOffset) {
+        painter.fillRect(xOffset, 10, width() - 10 - xOffset, 10, mpHost->mMapInfoBg);
+    }
+}
+
+int ModernGLWidget::paintMapInfoContributor(QPainter& painter, int xOffset, int yOffset, const MapInfoProperties& properties)
+{
+    if (properties.text.isEmpty()) {
+        return 0;
+    }
+
+    painter.save();
+    auto infoText = properties.text.trimmed();
+    auto font = painter.font();
+    font.setBold(properties.isBold);
+    font.setItalic(properties.isItalic);
+    painter.setFont(font);
+
+    const int lineHeight = QFontMetrics(font).height();
+    QRect testRect;
+    QRect infoRect = QRect(xOffset, yOffset, width() - 10 - xOffset, lineHeight);
+    testRect = painter.boundingRect(infoRect.left() + 10, infoRect.top(), infoRect.width() - 20, infoRect.height() - 20, 
+                                   Qt::Alignment(Qt::AlignTop | Qt::AlignLeft) | Qt::TextFlag(Qt::TextWordWrap | Qt::TextIncludeTrailingSpaces), 
+                                   infoText);
+
+    if (testRect.height() > infoRect.height()) {
+        infoRect.setHeight(testRect.height() + 20);
+    }
+
+    painter.fillRect(infoRect, properties.color);
+    painter.setPen(QPen(mpHost->mMapInfoText));
+    painter.drawText(infoRect.left() + 10, infoRect.top(), infoRect.width() - 20, infoRect.height() - 20, 
+                    Qt::Alignment(Qt::AlignTop | Qt::AlignLeft) | Qt::TextFlag(Qt::TextWordWrap | Qt::TextIncludeTrailingSpaces), 
+                    infoText);
+
+    painter.restore();
+    return infoRect.height();
 }

--- a/src/modern_glwidget.cpp
+++ b/src/modern_glwidget.cpp
@@ -323,7 +323,12 @@ void ModernGLWidget::paintGL()
     painter.drawText(10, height() - 20, "Modern OpenGL Mapper");
     
     // Draw map info using contributor manager
-    QColor infoColor = mpHost->mMapInfoBg.isValid() ? mpHost->mMapInfoBg : QColor(0, 0, 0, 200);
+    QColor infoColor;
+    if (mpHost->mBgColor_2.lightness() > 127) {
+        infoColor = QColor(Qt::black);
+    } else {
+        infoColor = QColor(Qt::white);
+    }
     paintMapInfo(mFrameTimer, painter, mAID, infoColor);
     
     painter.end();
@@ -1273,6 +1278,9 @@ void ModernGLWidget::paintMapInfo(const QElapsedTimer& renderTimer, QPainter& pa
     int yOffset = 10;
     const int initialYOffset = yOffset;
 
+    painter.save();
+    painter.setFont(mpHost->getDisplayFont());
+    
     for (const auto& key : mpMap->mMapInfoContributorManager->getContributorKeys()) {
         if (mpHost->mMapInfoContributors.contains(key)) {
             auto properties = mpMap->mMapInfoContributorManager->getContributor(key)(roomID, 0, pRoom->getArea(), displayAreaId, infoColor);
@@ -1282,7 +1290,7 @@ void ModernGLWidget::paintMapInfo(const QElapsedTimer& renderTimer, QPainter& pa
             yOffset += paintMapInfoContributor(painter, xOffset, yOffset, properties);
         }
     }
-
+    
 #ifdef QT_DEBUG
     yOffset += paintMapInfoContributor(painter,
                          xOffset,
@@ -1297,6 +1305,8 @@ void ModernGLWidget::paintMapInfo(const QElapsedTimer& renderTimer, QPainter& pa
     Q_UNUSED(renderTimer)
 #endif
 
+    painter.restore();
+
     if (yOffset > initialYOffset) {
         painter.fillRect(xOffset, 10, width() - 10 - xOffset, 10, mpHost->mMapInfoBg);
     }
@@ -1307,31 +1317,25 @@ int ModernGLWidget::paintMapInfoContributor(QPainter& painter, int xOffset, int 
     if (properties.text.isEmpty()) {
         return 0;
     }
-
+    
     painter.save();
     auto infoText = properties.text.trimmed();
     auto font = painter.font();
     font.setBold(properties.isBold);
     font.setItalic(properties.isItalic);
     painter.setFont(font);
-
-    const int lineHeight = QFontMetrics(font).height();
+    const int infoHeight = mFontHeight;
     QRect testRect;
-    QRect infoRect = QRect(xOffset, yOffset, width() - 10 - xOffset, lineHeight);
-    testRect = painter.boundingRect(infoRect.left() + 10, infoRect.top(), infoRect.width() - 20, infoRect.height() - 20, 
+    QRect mMapInfoRect = QRect(xOffset, yOffset, width() - 10 - xOffset, infoHeight);
+    testRect = painter.boundingRect(mMapInfoRect.left() + 10, mMapInfoRect.top(), mMapInfoRect.width() - 20, mMapInfoRect.height() - 20, 
                                    Qt::Alignment(Qt::AlignTop | Qt::AlignLeft) | Qt::TextFlag(Qt::TextWordWrap | Qt::TextIncludeTrailingSpaces), 
                                    infoText);
-
-    if (testRect.height() > infoRect.height()) {
-        infoRect.setHeight(testRect.height() + 20);
-    }
-
-    painter.fillRect(infoRect, properties.color);
-    painter.setPen(QPen(mpHost->mMapInfoText));
-    painter.drawText(infoRect.left() + 10, infoRect.top(), infoRect.width() - 20, infoRect.height() - 20, 
+    mMapInfoRect.setHeight(testRect.height() + 10);
+    painter.fillRect(mMapInfoRect, mpHost->mMapInfoBg);
+    painter.setPen(properties.color);
+    painter.drawText(mMapInfoRect.left() + 10, mMapInfoRect.top(), mMapInfoRect.width() - 20, mMapInfoRect.height() - 10, 
                     Qt::Alignment(Qt::AlignTop | Qt::AlignLeft) | Qt::TextFlag(Qt::TextWordWrap | Qt::TextIncludeTrailingSpaces), 
                     infoText);
-
     painter.restore();
-    return infoRect.height();
+    return mMapInfoRect.height();
 }

--- a/src/modern_glwidget.cpp
+++ b/src/modern_glwidget.cpp
@@ -29,7 +29,6 @@
 #include "TRoomDB.h"
 #include "dlgMapper.h"
 #include "mudlet.h"
-#include "mapInfoContributorManager.h"
 
 #include "pre_guard.h"
 #include <QtEvents>
@@ -329,7 +328,8 @@ void ModernGLWidget::paintGL()
     } else {
         infoColor = QColor(Qt::white);
     }
-    paintMapInfo(mFrameTimer, painter, mAID, infoColor);
+    dlgMapper::paintMapInfo(mFrameTimer, painter, mpHost, mpMap, 
+                           mRID, mAID, 0, infoColor, 10, 10, width(), mFontHeight);
     
     painter.end();
     
@@ -1256,86 +1256,3 @@ void ModernGLWidget::onCameraAnimationTick()
     update();
 }
 
-void ModernGLWidget::paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, const int displayAreaId, QColor& infoColor)
-{
-    if (!mpMap || !mpMap->mMapInfoContributorManager || !mpHost) {
-        return;
-    }
-
-    QList<QString> contributorList = mpMap->mMapInfoContributorManager->getContributorKeys();
-    QSet<QString> const contributorKeys{contributorList.begin(), contributorList.end()};
-    if (!contributorKeys.intersects(mpHost->mMapInfoContributors)) {
-        return;
-    }
-
-    TRoom* pRoom = mpMap->mpRoomDB->getRoom(mRID);
-    if (!pRoom) {
-        return;
-    }
-
-    int roomID = mRID;
-    int xOffset = 10;
-    int yOffset = 10;
-    const int initialYOffset = yOffset;
-
-    painter.save();
-    painter.setFont(mpHost->getDisplayFont());
-    
-    for (const auto& key : mpMap->mMapInfoContributorManager->getContributorKeys()) {
-        if (mpHost->mMapInfoContributors.contains(key)) {
-            auto properties = mpMap->mMapInfoContributorManager->getContributor(key)(roomID, 0, pRoom->getArea(), displayAreaId, infoColor);
-            if (!properties.color.isValid()) {
-                properties.color = infoColor;
-            }
-            yOffset += paintMapInfoContributor(painter, xOffset, yOffset, properties);
-        }
-    }
-    
-#ifdef QT_DEBUG
-    yOffset += paintMapInfoContributor(painter,
-                         xOffset,
-                         yOffset,
-                         {false,
-                          false,
-                          tr("render time: %1S mO: (%2,%3,%4)")
-                                  .arg(renderTimer.nsecsElapsed() * 1.0e-9, 0, 'f', 3)
-                                  .arg(QString::number(mMapCenterX), QString::number(mMapCenterY), QString::number(mMapCenterZ)),
-                          infoColor});
-#else
-    Q_UNUSED(renderTimer)
-#endif
-
-    painter.restore();
-
-    if (yOffset > initialYOffset) {
-        painter.fillRect(xOffset, 10, width() - 10 - xOffset, 10, mpHost->mMapInfoBg);
-    }
-}
-
-int ModernGLWidget::paintMapInfoContributor(QPainter& painter, int xOffset, int yOffset, const MapInfoProperties& properties)
-{
-    if (properties.text.isEmpty()) {
-        return 0;
-    }
-    
-    painter.save();
-    auto infoText = properties.text.trimmed();
-    auto font = painter.font();
-    font.setBold(properties.isBold);
-    font.setItalic(properties.isItalic);
-    painter.setFont(font);
-    const int infoHeight = mFontHeight;
-    QRect testRect;
-    QRect mMapInfoRect = QRect(xOffset, yOffset, width() - 10 - xOffset, infoHeight);
-    testRect = painter.boundingRect(mMapInfoRect.left() + 10, mMapInfoRect.top(), mMapInfoRect.width() - 20, mMapInfoRect.height() - 20, 
-                                   Qt::Alignment(Qt::AlignTop | Qt::AlignLeft) | Qt::TextFlag(Qt::TextWordWrap | Qt::TextIncludeTrailingSpaces), 
-                                   infoText);
-    mMapInfoRect.setHeight(testRect.height() + 10);
-    painter.fillRect(mMapInfoRect, mpHost->mMapInfoBg);
-    painter.setPen(properties.color);
-    painter.drawText(mMapInfoRect.left() + 10, mMapInfoRect.top(), mMapInfoRect.width() - 20, mMapInfoRect.height() - 10, 
-                    Qt::Alignment(Qt::AlignTop | Qt::AlignLeft) | Qt::TextFlag(Qt::TextWordWrap | Qt::TextIncludeTrailingSpaces), 
-                    infoText);
-    painter.restore();
-    return mMapInfoRect.height();
-}

--- a/src/modern_glwidget.h
+++ b/src/modern_glwidget.h
@@ -189,8 +189,6 @@ private:
     QColor getPlaneColor(int zLevel, bool belowOrAtLevel);
     QColor getEnvironmentColor(TRoom* pRoom);
     void startSmoothTransition(int targetAID, int targetX, int targetY, int targetZ);
-    void paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, const int displayAreaId, QColor& infoColor);
-    int paintMapInfoContributor(QPainter& painter, int xOffset, int yOffset, const MapInfoProperties& properties);
 };
 
 #endif // MUDLET_MODERN_GLWIDGET_H

--- a/src/modern_glwidget.h
+++ b/src/modern_glwidget.h
@@ -53,6 +53,7 @@
 class Host;
 class TMap;
 class TRoom;
+struct MapInfoProperties;
 
 class ModernGLWidget : public QOpenGLWidget, protected QOpenGLFunctions
 {
@@ -187,6 +188,8 @@ private:
     QColor getPlaneColor(int zLevel, bool belowOrAtLevel);
     QColor getEnvironmentColor(TRoom* pRoom);
     void startSmoothTransition(int targetAID, int targetX, int targetY, int targetZ);
+    void paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, const int displayAreaId, QColor& infoColor);
+    int paintMapInfoContributor(QPainter& painter, int xOffset, int yOffset, const MapInfoProperties& properties);
 };
 
 #endif // MUDLET_MODERN_GLWIDGET_H

--- a/src/modern_glwidget.h
+++ b/src/modern_glwidget.h
@@ -144,6 +144,7 @@ private:
     int mMapCenterY = 0;
     int mMapCenterZ = 0;
     bool mShiftMode = false;
+    int mFontHeight = 20;
 
     // Scales the size of rooms compared to the space between them - currently
     // hard coded to be a quarter (would be equivalent to a 2D room size setting


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Previously the map info was only shown in the 2D mapper - now it is shown in the 3D mapper as well
#### Motivation for adding to Mudlet
Feature parity
#### Other info (issues closed, discussion etc)
Controls for setting it aren't there yet in the 3D mode, only 2D mode. They will be added later when we revamp the 3D controls.

3D:
<img width="927" height="587" alt="image" src="https://github.com/user-attachments/assets/73639a94-b235-4fee-ad14-9f096ac7e3ff" />

2D:
<img width="927" height="587" alt="image" src="https://github.com/user-attachments/assets/f4e905ff-ca0a-41b7-b1c5-1c52d011377f" />
