### PR TITLE
Improve: automatically select ctrl+f search box

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -183,6 +183,7 @@ bool TCommandLine::event(QEvent* event)
                 mudlet::self()->mpCurrentActiveHost->setCompactInputLine(false);
             }
             mpConsole->mpBufferSearchBox->setFocus();
+            mpConsole->mpBufferSearchBox->selectAll();
             ke->accept();
             return true;
         }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Automatically select existing text in search box when pressing Ctrl+F:
<img width="668" height="307" alt="image" src="https://github.com/user-attachments/assets/64d8cd3d-1b9e-44ed-a0ef-e85dc81ea5f8" />

#### Motivation for adding to Mudlet
Player feedback from survey
#### Other info (issues closed, discussion etc)
