### PR TITLE
Fix: getConfig Lua wrapper now passes all arguments to enable enhanced API

### DIFF
--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -1298,7 +1298,8 @@ function getConfig(...)
     return result
   end
 
-  return oldgetConfig(args[1])
+  -- Pass all arguments to the C++ function to support enhanced API
+  return oldgetConfig(unpack(args))
 end
 
 function openMudletHomeDir()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes the `getConfig` Lua wrapper in `Other.lua` to properly pass all arguments to the underlying C++ implementation. The wrapper was only passing the first argument, preventing the enhanced API from working.

#### Motivation for adding to Mudlet

This resolves issue #8160 where `getConfig("showSentText", true)` was not returning string values as expected. The enhanced API allows new scripts to access more detailed tri-state configuration information while maintaining backward compatibility for existing scripts.

#### Other info (issues closed, discussion etc)

**Closes #8160**

**Technical Details:**
- Changed: `return oldgetConfig(args[1])` 
- To: `return oldgetConfig(unpack(args))`
- This brings `getConfig` in line with `setConfig` which already correctly passes all arguments

**Test the fix:**
```lua
-- Legacy API (backward compatible)
print("Legacy:", getConfig("showSentText"))  -- Returns: boolean

-- Enhanced API (now working)
print("Enhanced:", getConfig("showSentText", true))  -- Returns: "never"/"script"/"always"