### PR TITLE
Add: GStreamer support for Windows OGG playback

### DIFF
--- a/CI/build-mudlet-for-windows.sh
+++ b/CI/build-mudlet-for-windows.sh
@@ -186,7 +186,14 @@ if [ -d "${MINGW_INTERNAL_BASE_DIR}/lib/gstreamer-1.0" ]; then
 else
   echo "Warning: GStreamer plugins directory not found at ${MINGW_INTERNAL_BASE_DIR}/lib/gstreamer-1.0"
   echo "Available directories:"
-  ls -la "${MINGW_INTERNAL_BASE_DIR}/lib/" | grep -i gst || echo "No GStreamer directories found"
+  for dir in "${MINGW_INTERNAL_BASE_DIR}/lib/"*gst*; do
+    if [ -d "$dir" ]; then
+      echo "  $(basename "$dir")"
+    fi
+  done
+  if [ ! -d "${MINGW_INTERNAL_BASE_DIR}/lib/"*gst* ]; then
+    echo "  No GStreamer directories found"
+  fi
 fi
 echo ""
 

--- a/CI/build-mudlet-for-windows.sh
+++ b/CI/build-mudlet-for-windows.sh
@@ -123,6 +123,17 @@ echo "LUA_PATH is: ${LUA_PATH}"
 echo "LUA_CPATH is: ${LUA_CPATH}"
 echo ""
 
+# Configure GStreamer for Qt6 Multimedia to support OGG and other formats
+export GST_PLUGIN_PATH="${MINGW_INTERNAL_BASE_DIR}/lib/gstreamer-1.0"
+export GST_PLUGIN_SYSTEM_PATH="${MINGW_INTERNAL_BASE_DIR}/lib/gstreamer-1.0"
+export QT_MULTIMEDIA_PREFERRED_PLUGINS="gstreamer"
+
+echo "Setting up GStreamer for multimedia support:"
+echo "GST_PLUGIN_PATH is: ${GST_PLUGIN_PATH}"
+echo "GST_PLUGIN_SYSTEM_PATH is: ${GST_PLUGIN_SYSTEM_PATH}"
+echo "QT_MULTIMEDIA_PREFERRED_PLUGINS is: ${QT_MULTIMEDIA_PREFERRED_PLUGINS}"
+echo ""
+
 if [[ "${MUDLET_VERSION_BUILD,,}" == *"-testing"* ]]; then
     # The updater is not helpful in this environment (PR testing build)
     export WITH_UPDATER="NO"

--- a/CI/build-mudlet-for-windows.sh
+++ b/CI/build-mudlet-for-windows.sh
@@ -186,12 +186,14 @@ if [ -d "${MINGW_INTERNAL_BASE_DIR}/lib/gstreamer-1.0" ]; then
 else
   echo "Warning: GStreamer plugins directory not found at ${MINGW_INTERNAL_BASE_DIR}/lib/gstreamer-1.0"
   echo "Available directories:"
+  found_gst=false
   for dir in "${MINGW_INTERNAL_BASE_DIR}/lib/"*gst*; do
     if [ -d "$dir" ]; then
       echo "  $(basename "$dir")"
+      found_gst=true
     fi
   done
-  if [ ! -d "${MINGW_INTERNAL_BASE_DIR}/lib/"*gst* ]; then
+  if [ "$found_gst" = false ]; then
     echo "  No GStreamer directories found"
   fi
 fi

--- a/CI/build-mudlet-for-windows.sh
+++ b/CI/build-mudlet-for-windows.sh
@@ -176,5 +176,19 @@ fi
 echo " ... make finished"
 echo ""
 
+echo "Copying GStreamer plugins to build directory for runtime availability..."
+GSTREAMER_DEST_DIR="./${BUILD_CONFIG}/gstreamer-1.0"
+mkdir -p "${GSTREAMER_DEST_DIR}"
+if [ -d "${MINGW_INTERNAL_BASE_DIR}/lib/gstreamer-1.0" ]; then
+  find "${MINGW_INTERNAL_BASE_DIR}/lib/gstreamer-1.0" -name "*.dll" -exec cp -v {} "${GSTREAMER_DEST_DIR}/" \;
+  echo "GStreamer plugins copied successfully to ${GSTREAMER_DEST_DIR}"
+  ls -la "${GSTREAMER_DEST_DIR}/"
+else
+  echo "Warning: GStreamer plugins directory not found at ${MINGW_INTERNAL_BASE_DIR}/lib/gstreamer-1.0"
+  echo "Available directories:"
+  ls -la "${MINGW_INTERNAL_BASE_DIR}/lib/" | grep -i gst || echo "No GStreamer directories found"
+fi
+echo ""
+
 cd ~ || exit 1
 exit 0

--- a/CI/package-mudlet-for-windows.sh
+++ b/CI/package-mudlet-for-windows.sh
@@ -175,6 +175,27 @@ else
   echo "Warning: GStreamer plugins directory not found at ${MINGW_INTERNAL_BASE_DIR}/lib/gstreamer-1.0"
 fi
 
+echo ""
+echo "Copying GStreamer core libraries..."
+# Copy GStreamer core runtime libraries needed for Qt multimedia
+if [ -f "${MINGW_INTERNAL_BASE_DIR}/bin/libgstreamer-1.0-0.dll" ]; then
+  cp -v -p -t . \
+    "${MINGW_INTERNAL_BASE_DIR}/bin/libgstreamer-1.0-0.dll" \
+    "${MINGW_INTERNAL_BASE_DIR}/bin/libgstbase-1.0-0.dll" \
+    "${MINGW_INTERNAL_BASE_DIR}/bin/libgstpbutils-1.0-0.dll" \
+    "${MINGW_INTERNAL_BASE_DIR}/bin/libgstaudio-1.0-0.dll" \
+    "${MINGW_INTERNAL_BASE_DIR}/bin/libgstvideo-1.0-0.dll" \
+    "${MINGW_INTERNAL_BASE_DIR}/bin/libgstapp-1.0-0.dll" \
+    "${MINGW_INTERNAL_BASE_DIR}/bin/libglib-2.0-0.dll" \
+    "${MINGW_INTERNAL_BASE_DIR}/bin/libgobject-2.0-0.dll" \
+    "${MINGW_INTERNAL_BASE_DIR}/bin/libgio-2.0-0.dll" \
+    "${MINGW_INTERNAL_BASE_DIR}/bin/libgmodule-2.0-0.dll" \
+    "${MINGW_INTERNAL_BASE_DIR}/bin/libffi-8.dll" || echo "Some GStreamer libraries not found (this may be expected)"
+  echo "GStreamer core libraries copied"
+else
+  echo "Warning: GStreamer core libraries not found at ${MINGW_INTERNAL_BASE_DIR}/bin/"
+fi
+
 
 echo ""
 echo "Copying discord-rpc library in..."

--- a/CI/package-mudlet-for-windows.sh
+++ b/CI/package-mudlet-for-windows.sh
@@ -165,6 +165,16 @@ cp -v -p -t . \
     "${MINGW_INTERNAL_BASE_DIR}/bin/libcrypto-3-x64.dll" \
     "${MINGW_INTERNAL_BASE_DIR}/bin/libssl-3-x64.dll"
 
+echo ""
+echo "Copying GStreamer plugins for multimedia support..."
+mkdir -p ./gstreamer-1.0
+if [ -d "${MINGW_INTERNAL_BASE_DIR}/lib/gstreamer-1.0" ]; then
+  cp -v -p -t ./gstreamer-1.0 "${MINGW_INTERNAL_BASE_DIR}/lib/gstreamer-1.0"/*.dll
+  echo "GStreamer plugins copied successfully"
+else
+  echo "Warning: GStreamer plugins directory not found at ${MINGW_INTERNAL_BASE_DIR}/lib/gstreamer-1.0"
+fi
+
 
 echo ""
 echo "Copying discord-rpc library in..."

--- a/CI/package-mudlet-for-windows.sh
+++ b/CI/package-mudlet-for-windows.sh
@@ -196,6 +196,18 @@ else
   echo "Warning: GStreamer core libraries not found at ${MINGW_INTERNAL_BASE_DIR}/bin/"
 fi
 
+echo ""
+echo "Copying Qt GStreamer multimedia plugin..."
+# Ensure the Qt GStreamer multimedia plugin is available for backend detection
+if [ -f "${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/gstreamermediaplugin.dll" ]; then
+  cp -v -p "${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/gstreamermediaplugin.dll" ./multimedia/
+  echo "Qt GStreamer multimedia plugin copied successfully"
+else
+  echo "Warning: Qt GStreamer multimedia plugin not found at ${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/"
+  echo "Available Qt multimedia plugins:"
+  ls -la "${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/" || echo "Multimedia plugins directory not found"
+fi
+
 
 echo ""
 echo "Copying discord-rpc library in..."

--- a/CI/package-mudlet-for-windows.sh
+++ b/CI/package-mudlet-for-windows.sh
@@ -199,13 +199,35 @@ fi
 echo ""
 echo "Copying Qt GStreamer multimedia plugin..."
 # Ensure the Qt GStreamer multimedia plugin is available for backend detection
-if [ -f "${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/gstreamermediaplugin.dll" ]; then
-  cp -v -p "${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/gstreamermediaplugin.dll" ./multimedia/
-  echo "Qt GStreamer multimedia plugin copied successfully"
-else
-  echo "Warning: Qt GStreamer multimedia plugin not found at ${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/"
-  echo "Available Qt multimedia plugins:"
-  ls -la "${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/" || echo "Multimedia plugins directory not found"
+# Try multiple possible locations for the Qt GStreamer plugin
+GSTREAMER_PLUGIN_FOUND=false
+POSSIBLE_PATHS=(
+  "${MINGW_INTERNAL_BASE_DIR}/share/qt6/plugins/multimedia/gstreamermediaplugin.dll"
+  "${MINGW_INTERNAL_BASE_DIR}/lib/qt6/plugins/multimedia/gstreamermediaplugin.dll"
+  "${MINGW_INTERNAL_BASE_DIR}/plugins/multimedia/gstreamermediaplugin.dll"
+  "${MINGW_INTERNAL_BASE_DIR}/share/qt/plugins/multimedia/gstreamermediaplugin.dll"
+  "${MINGW_INTERNAL_BASE_DIR}/lib/qt/plugins/multimedia/gstreamermediaplugin.dll"
+)
+
+for PLUGIN_PATH in "${POSSIBLE_PATHS[@]}"; do
+  if [ -f "$PLUGIN_PATH" ]; then
+    cp -v -p "$PLUGIN_PATH" ./multimedia/
+    echo "Qt GStreamer multimedia plugin copied successfully from: $PLUGIN_PATH"
+    GSTREAMER_PLUGIN_FOUND=true
+    break
+  fi
+done
+
+if [ "$GSTREAMER_PLUGIN_FOUND" = false ]; then
+  echo "Warning: Qt GStreamer multimedia plugin not found in any expected locations"
+  echo "Searched locations:"
+  for PLUGIN_PATH in "${POSSIBLE_PATHS[@]}"; do
+    echo "  $PLUGIN_PATH"
+  done
+  echo "Available Qt plugin directories:"
+  find "${MINGW_INTERNAL_BASE_DIR}" -type d -name "*multimedia*" 2>/dev/null || echo "  No multimedia plugin directories found"
+  echo "Available multimedia plugin files:"
+  find "${MINGW_INTERNAL_BASE_DIR}" -name "*mediaplugin*" -type f 2>/dev/null || echo "  No multimedia plugin files found"
 fi
 
 

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -95,6 +95,11 @@ while true; do
     "mingw-w64-${BUILDCOMPONENT}-qt6-base" \
     "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia" \
     "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia-wmf" \
+    "mingw-w64-${BUILDCOMPONENT}-gstreamer" \
+    "mingw-w64-${BUILDCOMPONENT}-gst-plugins-base" \
+    "mingw-w64-${BUILDCOMPONENT}-gst-plugins-good" \
+    "mingw-w64-${BUILDCOMPONENT}-gst-plugins-bad" \
+    "mingw-w64-${BUILDCOMPONENT}-gst-libav" \
     "mingw-w64-${BUILDCOMPONENT}-qt6-svg" \
     "mingw-w64-${BUILDCOMPONENT}-qt6-speech" \
     "mingw-w64-${BUILDCOMPONENT}-qt6-imageformats" \

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -95,6 +95,7 @@ while true; do
     "mingw-w64-${BUILDCOMPONENT}-qt6-base" \
     "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia" \
     "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia-wmf" \
+    "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia-gstreamer" \
     "mingw-w64-${BUILDCOMPONENT}-gstreamer" \
     "mingw-w64-${BUILDCOMPONENT}-gst-plugins-base" \
     "mingw-w64-${BUILDCOMPONENT}-gst-plugins-good" \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -460,6 +460,26 @@ int main(int argc, char* argv[])
     // Needed for Qt6 on Windows (at least) - and does not work in mudlet class c'tor
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
 #if defined(Q_OS_WINDOWS)
+    // Configure GStreamer plugin paths for multimedia support (OGG, etc.)
+    const QString appDir = QCoreApplication::applicationDirPath();
+    const QString gstPluginPath = QDir(appDir).filePath("gstreamer-1.0");
+    if (QDir(gstPluginPath).exists()) {
+        if (qputenv("GST_PLUGIN_PATH", gstPluginPath.toLocal8Bit())) {
+            qDebug().noquote() << "main(...) INFO - setting GST_PLUGIN_PATH to:" << gstPluginPath;
+        }
+        if (qputenv("GST_PLUGIN_SYSTEM_PATH", gstPluginPath.toLocal8Bit())) {
+            qDebug().noquote() << "main(...) INFO - setting GST_PLUGIN_SYSTEM_PATH to:" << gstPluginPath;
+        }
+        // Prefer GStreamer backend for better codec support (OGG, etc.)
+        if (qEnvironmentVariableIsEmpty("QT_MULTIMEDIA_PREFERRED_PLUGINS")) {
+            if (qputenv("QT_MULTIMEDIA_PREFERRED_PLUGINS", QByteArray("gstreamer"))) {
+                qDebug().noquote() << "main(...) INFO - setting QT_MULTIMEDIA_PREFERRED_PLUGINS to: \"gstreamer\".";
+            }
+        }
+    } else {
+        qDebug().noquote() << "main(...) INFO - GStreamer plugins not found at:" << gstPluginPath << ", using default multimedia backend";
+    }
+    
     if (qEnvironmentVariableIsEmpty("QT_MEDIA_BACKEND")) {
         // This variable is not set - and later versions of Qt 6.x need it for
         // sound to work:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -463,7 +463,9 @@ int main(int argc, char* argv[])
     // Configure GStreamer plugin paths for multimedia support (OGG, etc.)
     const QString appDir = QCoreApplication::applicationDirPath();
     const QString gstPluginPath = QDir(appDir).filePath("gstreamer-1.0");
-    if (QDir(gstPluginPath).exists()) {
+    bool gstreamerAvailable = QDir(gstPluginPath).exists();
+    
+    if (gstreamerAvailable) {
         if (qputenv("GST_PLUGIN_PATH", gstPluginPath.toLocal8Bit())) {
             qDebug().noquote() << "main(...) INFO - setting GST_PLUGIN_PATH to:" << gstPluginPath;
         }
@@ -482,11 +484,12 @@ int main(int argc, char* argv[])
     
     if (qEnvironmentVariableIsEmpty("QT_MEDIA_BACKEND")) {
         // This variable is not set - and later versions of Qt 6.x need it for
-        // sound to work:
-        if (qputenv("QT_MEDIA_BACKEND", QByteArray("windows"))) {
-            qDebug().noquote() << "main(...) INFO - setting QT_MEDIA_BACKEND enviromental variable to: \"windows\".";
+        // sound to work. Use GStreamer if available, otherwise fall back to Windows backend
+        const char* backend = gstreamerAvailable ? "gstreamer" : "windows";
+        if (qputenv("QT_MEDIA_BACKEND", QByteArray(backend))) {
+            qDebug().noquote() << "main(...) INFO - setting QT_MEDIA_BACKEND enviromental variable to:" << backend << ".";
         } else {
-            qWarning().noquote() << "main(...) WARNING - failed to set QT_MEDIA_BACKEND enviromental variable to: \"windows\", sound may not work.";
+            qWarning().noquote() << "main(...) WARNING - failed to set QT_MEDIA_BACKEND enviromental variable to:" << backend << ", sound may not work.";
         }
     } else {
         qDebug().noquote().nospace() << "main(...) INFO - QT_MEDIA_BACKEND enviromental variable is set to: \"" << qgetenv("QT_MEDIA_BACKEND") << "\".";


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Implements GStreamer backend support for Qt6 Multimedia on Windows to enable OGG Vorbis playback. This replaces the Windows Media Foundation dependency that lacks native OGG codec support.

Changes include:
- Added GStreamer packages to Windows build dependencies
- Configured GStreamer environment variables during build and runtime
- Packaged GStreamer plugins with Windows distribution
- Added graceful fallback to WMF if GStreamer is unavailable

#### Motivation for adding to Mudlet

Resolves long-standing issue where OGG files would not play on Windows 64-bit builds, while maintaining backward compatibility and providing enhanced codec support for additional multimedia formats.

#### Other info (issues closed, discussion etc)

Closes #7804

This addresses the root cause identified in the issue analysis where Windows Media Foundation doesn't include native OGG/Vorbis support. The GStreamer backend provides comprehensive codec support while maintaining compatibility through fallback  mechanisms.