### PR TITLE
Fix: Restore Focus when return from alt+tab. Issue #6164

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -245,6 +245,11 @@ bool TCommandLine::event(QEvent* event)
             break;
 
         case Qt::Key_Tab:
+            if (ke->modifiers() & Qt::AltModifier) {
+                // prevents ALT+TAB system switching auto refocusing to command line
+                return false;
+            }
+
             if ((mpHost->mCaretShortcut == Host::CaretShortcut::Tab && !(ke->modifiers() & Qt::ControlModifier)) ||
                 (mpHost->mCaretShortcut == Host::CaretShortcut::CtrlTab && (ke->modifiers() & Qt::ControlModifier))) {
                 mpHost->setCaretEnabled(true);

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -153,7 +153,11 @@ void TTextEdit::focusInEvent(QFocusEvent* event)
 void TTextEdit::focusOutEvent(QFocusEvent* event)
 {
     // Safety check: during destruction, mpHost might be null
-    if (mpHost && mpHost->caretEnabled()) {
+    // Avoid disabling caret mode when the window is merely deactivated
+    // (e.g., user Alt+Tabs away). This preserves focus for screen reader
+    // users like NVDA so returning to Mudlet restores the original widget
+    // rather than forcing focus to the command line.
+    if (mpHost && mpHost->caretEnabled() && event->reason() != Qt::ActiveWindowFocusReason) {
         mpHost->setCaretEnabled(false);
     }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -6374,6 +6374,16 @@ void mudlet::changeEvent(QEvent* event)
     if (event->type() == QEvent::WindowStateChange) {
         emit signal_windowStateChanged(windowState());
     } else if (event->type() == QEvent::ActivationChange) {
+        // prevents ALT+TAB system switching auto refocusing to command line
+        // remember the widget that had focus before deactivation to resume later
+        if (isActiveWindow()) {
+            if (mpFocusWidgetBeforeDeactivate) {
+                mpFocusWidgetBeforeDeactivate->setFocus();
+                mpFocusWidgetBeforeDeactivate.clear();
+            }
+        } else {
+            mpFocusWidgetBeforeDeactivate = QApplication::focusWidget();
+        }
         // Update window menu when window activation changes
         updateWindowMenu();
     }

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -689,6 +689,7 @@ private:
     QHBoxLayout* mpHBoxLayout_profileContainer = nullptr;
     QPointer<QLabel> mpLabelReplaySpeedDisplay;
     QPointer<QLabel> mpLabelReplayTime;
+    QPointer<QWidget> mpFocusWidgetBeforeDeactivate;
     // a list of profiles currently being migrated to secure or profile storage
     QStringList mProfilePasswordsToMigrate;
     // a list of character passwords currently being migrated to secure storage


### PR DESCRIPTION
This PR addresses issue #6164 (Alt+Tab and NVDA screen reader focus loss):

Fixes focus loss after Alt+Tab:
When returning to Mudlet after Alt+Tab, the application now restores focus to the correct output window or widget. This ensures that screen reader users (e.g., NVDA) can continue reading or navigating from where they left off, without needing to manually press Ctrl+Tab twice to resume reading.
This is useful for overall users not only screenreaders for example if they keyboard selecting text.

adjusts auto-redirect focus from output to command line:
auto-redirecting focus to the command line (see #7933 PR) was acting when pressed the TAB key for alt tabbing forcing focus to command line. The fix -prevent the autoredirect when  ALT+TAB

 This PR ensures that focus is only redirected when appropriate, improving usability for both screen reader and overall keyboard users.

#### Motivation for adding to Mudlet
Fix #6164 issue, better accesibility and experience for screenreader users and overall.

#### Other info (issues closed, discussion etc)
tested on windows 11 with NVDA

