### PR TITLE
Improve: remove Lua API loaded and Map loaded messages

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3672,30 +3672,30 @@ void TLuaInterpreter::parseJSON(QString& key, const QString& string_data, const 
 void TLuaInterpreter::handleIreComposerEdit(const QString& jsonData)
 {
     Host& host = getHostFromLua(pGlobalLua);
-    
+
     QJsonParseError parseError;
     QJsonDocument jsonDoc = QJsonDocument::fromJson(jsonData.toUtf8(), &parseError);
-    
+
     if (parseError.error != QJsonParseError::NoError) {
         qDebug() << "IRE Composer: JSON parse error:" << parseError.errorString();
         return;
     }
-    
+
     if (!jsonDoc.isObject()) {
         qDebug() << "IRE Composer: JSON is not an object";
         return;
     }
-    
+
     QJsonObject jsonObj = jsonDoc.object();
-    
+
     if (!jsonObj.contains("title") || !jsonObj.contains("text")) {
         qDebug() << "IRE Composer: Missing required 'title' or 'text' fields";
         return;
     }
-    
+
     const QString title = jsonObj["title"].toString();
     const QString initialText = jsonObj["text"].toString();
-    
+
     if (host.mTelnet.mpComposer) {
         return;
     }
@@ -5988,7 +5988,6 @@ void TLuaInterpreter::loadGlobal()
 
         error = luaL_dostring(pGlobalLua, luaGlobal.toUtf8().constData());
         if (!error) {
-            mpHost->postMessage(tr("[  OK  ]  - Mudlet-lua API & Geyser Layout manager loaded."));
             return;
         }
         qWarning() << "TLuaInterpreter::loadGlobal() loading " << pathFileName << " failed: " << lua_tostring(pGlobalLua, -1);
@@ -7558,14 +7557,14 @@ int TLuaInterpreter::setConfig(lua_State * L)
         }
         return success();
     }
-    
+
     // Handle experiment keys
     if (key.startsWith(qsl("experiment."))) {
         auto [result, errorMessage] = host.setExperimentEnabled(key, getVerifiedBool(L, __func__, 2, "value"));
         if (!result) {
             return warnArgumentValue(L, __func__, errorMessage);
         }
-        
+
         // Special handling for 3D mapper experiment
         if (key == qsl("experiment.3dmap.modernmapper")) {
 #if defined(INCLUDE_3DMAPPER)
@@ -7576,7 +7575,7 @@ int TLuaInterpreter::setConfig(lua_State * L)
         }
         return success();
     }
-    
+
     return warnArgumentValue(L, __func__, qsl("'%1' isn't a valid configuration option").arg(key));
 }
 
@@ -7764,7 +7763,7 @@ int TLuaInterpreter::getConfig(lua_State *L)
         it->second();
         return 1;
     }
-    
+
     // Handle experiment keys
     if (key.startsWith(qsl("experiment."))) {
         if (key == qsl("experiment.list")) {

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -595,11 +595,7 @@ void TMap::audit()
         appendErrorMsg(infoMsg);
     }
 
-    auto loadTime = mpHost->getLuaInterpreter()->condenseMapLoad();
-    if (loadTime != -1.0) {
-        const QString msg = tr("[  OK  ]  - Map loaded successfully (%1s).").arg(loadTime);
-        postMessage(msg);
-    }
+    mpHost->getLuaInterpreter()->condenseMapLoad();
 }
 
 // This may be duplicating TArea class functionality:


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove two messages.  Lua API and map loaded messages.

<img width="2213" height="369" alt="Screenshot_20250907_123044" src="https://github.com/user-attachments/assets/fa60e291-4a66-48ae-a112-dc7689a85f35" />
(first two lines)

#### Motivation for adding to Mudlet
Mudlet should just work, showing that it's working seems redundant.  Better user experience.
Excess messages are confusing for [brand new players](https://wiki.mudlet.org/w/Mudlet:February_2021_Userstudy).

#### Other info (issues closed, discussion etc)
Mudlet will fail spectacularly with plenty of error messages if the Lua API isn't present.
A corrupted map will also present a helpful message to the user.