### PR TITLE
Improve: always enable smooth movement in modern 3d mapper

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -4594,7 +4594,6 @@ QFont Host::getAndClearTempDisplayFont()
 const QSet<QString> Host::mValidExperiments = {
     qsl("experiment.rendering.originalish"),
     qsl("experiment.rendering.more-transparent"),
-    qsl("experiment.rendering-movement.smooth"),
     qsl("experiment.3dmap.modernmapper"),
 };
 

--- a/src/modern_glwidget.cpp
+++ b/src/modern_glwidget.cpp
@@ -253,11 +253,7 @@ void ModernGLWidget::paintGL()
             int targetX = pRID->x();
             int targetY = pRID->y();
             int targetZ = pRID->z();
-            
-            qDebug() << "[Smooth Camera] Room ID changed from" << mPreviousRID << "to" << mRID 
-                     << "- starting smooth transition from (" << mMapCenterX << "," << mMapCenterY << "," << mMapCenterZ << ")"
-                     << "to (" << targetX << "," << targetY << "," << targetZ << ")";
-            
+
             startSmoothTransition(targetAID, targetX, targetY, targetZ);
         }
         // Instant update map (smooth transition only impacts camera position)
@@ -1374,7 +1370,6 @@ void ModernGLWidget::startSmoothTransition(int targetAID, int targetX, int targe
     
     // Start animation timer
     mCameraAnimationTimer->start();
-    qDebug() << "[Smooth Camera] Timer started, animating flag set to true";
 }
 
 void ModernGLWidget::onCameraAnimationTick()

--- a/src/modern_glwidget.cpp
+++ b/src/modern_glwidget.cpp
@@ -246,8 +246,8 @@ void ModernGLWidget::paintGL()
             return;
         }
         
-        // Check if room ID changed and smooth camera experiment is enabled
-        if (mRID != mPreviousRID && mpHost && mpHost->experimentEnabled("experiment.rendering-movement.smooth")) {
+        // Check if room ID changed and start smooth transition
+        if (mRID != mPreviousRID) {
             // Room changed - start smooth transition
             int targetAID = pRID->getArea();
             int targetX = pRID->x();
@@ -270,9 +270,6 @@ void ModernGLWidget::paintGL()
         mMapCenterZ = oz;
         mPreviousRID = mRID; // Update tracking
 
-        if (mRID != mPreviousRID) {
-            qDebug() << "[Smooth Camera] Room ID changed but experiment disabled or not available";
-        }
 
     } else {
         ox = mMapCenterX;
@@ -1002,18 +999,8 @@ void ModernGLWidget::setViewCenter(int areaId, int xPos, int yPos, int zPos)
 {
     mShiftMode = true;
     
-    if (mpHost && mpHost->experimentEnabled("experiment.rendering-movement.smooth")) {
-        // Use smooth transition
-        startSmoothTransition(areaId, xPos, yPos, zPos);
-    } else {
-        // Original instant movement
-        mAID = areaId;
-        mMapCenterX = xPos;
-        mMapCenterY = yPos;
-        mMapCenterZ = zPos;
-        mCameraController.setTarget(xPos, yPos, zPos);
-        update();
-    }
+    // Use smooth transition
+    startSmoothTransition(areaId, xPos, yPos, zPos);
 }
 
 void ModernGLWidget::wheelEvent(QWheelEvent* e)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Always enable smooth movement in modern 3d mapper instead of being an opt-in experimental toggle
#### Motivation for adding to Mudlet
The idea works well and there's no reason not to turn it off
#### Other info (issues closed, discussion etc)
