### PR TITLE
Fix: Spell checking not screen reader accesible #7609

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -125,6 +125,18 @@ TCommandLine::TCommandLine(Host* pHost, const QString& name, CommandLineType typ
 
 void TCommandLine::processNormalKey(QEvent* event)
 {
+    auto* ke = dynamic_cast<QKeyEvent*>(event);
+    if (!ke) {
+        QPlainTextEdit::event(event);
+        adjustHeight();
+        return;
+    }
+
+    QTextCursor oldCursor = textCursor();
+    oldCursor.select(QTextCursor::WordUnderCursor);
+    const int wordStart = oldCursor.selectionStart();
+    const int wordEnd = oldCursor.selectionEnd();
+
     QPlainTextEdit::event(event);
     adjustHeight();
 
@@ -135,7 +147,23 @@ void TCommandLine::processNormalKey(QEvent* event)
     } else {
         mUserKeptOnTyping = false;
     }
-    spellCheck();
+
+    bool isDelimiter = false;
+    const QString text = ke->text();
+    if (!text.isEmpty()) {
+        const QChar ch = text.at(0);
+        isDelimiter = ch.isSpace() || ch.isPunct();
+    }
+
+    bool leftWord = false;
+    if (text.isEmpty() && !isDelimiter) {
+        const int pos = this->textCursor().position();
+        leftWord = pos < wordStart || pos > wordEnd;
+    }
+
+    if (isDelimiter || leftWord) {
+        spellCheck();
+    }
 }
 
 bool TCommandLine::keybindingMatched(QKeyEvent* keyEvent)

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -38,6 +38,7 @@
 #include <QRegularExpression>
 #include <QScrollBar>
 #include <QSaveFile>
+#include <QAccessible>
 #include <QToolButton>
 #include <QIcon>
 #include "post_guard.h"
@@ -1267,6 +1268,10 @@ void TCommandLine::spellCheckWord(QTextCursor& c)
     }
     c.setCharFormat(f);
     setTextCursor(c);
+    if (QAccessible::isActive()) {
+        QAccessibleEvent event(this, QAccessible::TextAttributeChanged);
+        QAccessible::updateAccessibility(&event);
+    }
     mSpellChecking = false;
 }
 

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -155,14 +155,20 @@ void TCommandLine::processNormalKey(QEvent* event)
         isDelimiter = ch.isSpace() || ch.isPunct();
     }
 
+    const bool isDeletionKey = ke->key() == Qt::Key_Backspace || ke->key() == Qt::Key_Delete;
     bool leftWord = false;
-    if (text.isEmpty() && !isDelimiter) {
+    if (isDeletionKey) {
         const int pos = this->textCursor().position();
         leftWord = pos < wordStart || pos > wordEnd;
     }
 
     if (isDelimiter || leftWord) {
-        spellCheck();
+        QTextCursor currentCursor = textCursor();
+        spellCheckWord(oldCursor);
+        QTextCharFormat f;
+        f.setFontUnderline(false);
+        currentCursor.setCharFormat(f);
+        setTextCursor(currentCursor);
     }
 }
 

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -39,6 +39,7 @@
 #include <QScrollBar>
 #include <QSaveFile>
 #include <QAccessible>
+#include <QAccessibleAnnouncementEvent>
 #include <QToolButton>
 #include <QIcon>
 #include "post_guard.h"
@@ -1235,6 +1236,7 @@ void TCommandLine::spellCheckWord(QTextCursor& c)
         return;
     }
 
+    bool misspelled = false;
     // The dictionary used from "the system" may not be UTF-8 encoded so we
     // will need to transform the UTF-16BE "QString" to the appropriate encoding
     // using the correct "codec":
@@ -1255,11 +1257,13 @@ void TCommandLine::spellCheckWord(QTextCursor& c)
                 // The word is not in it either:
                 f.setUnderlineStyle(QTextCharFormat::SpellCheckUnderline);
                 f.setUnderlineColor(Qt::red);
+                misspelled = true;
             }
         } else {
             // The word is not in the main dictionary and that is all we are using:
             f.setUnderlineStyle(QTextCharFormat::SpellCheckUnderline);
             f.setUnderlineColor(Qt::red);
+            misspelled = true;
         }
 
     } else {
@@ -1269,6 +1273,11 @@ void TCommandLine::spellCheckWord(QTextCursor& c)
     c.setCharFormat(f);
     setTextCursor(c);
     if (QAccessible::isActive()) {
+        if (misspelled) {
+            QAccessibleAnnouncementEvent announce(this, tr("Spelling mistake"));
+            announce.setPoliteness(QAccessible::AnnouncementPoliteness::Assertive);
+            QAccessible::updateAccessibility(&announce);
+        }
         QAccessibleEvent event(this, QAccessible::TextAttributeChanged);
         QAccessible::updateAccessibility(&event);
     }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix spell cheking not screen reader accesible issue #7609

Identifty the spell cheking event and calls for a "spelling mistake" from the screan reader

#### Motivation for adding to Mudlet
improve screen reader users experiencie 
#### Other info (issues closed, discussion etc)
