### PR TITLE
Fix map room list still showing after deleteMap

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -97,6 +97,7 @@ void TMap::mapClear()
     mNewMove = true;
     mVersion = mDefaultVersion;
     mUserData.clear();
+
     // mSaveVersion is not reset - so that any new Mudlet map file saves are to
     // whatever version was previously set/deduced
 
@@ -104,6 +105,12 @@ void TMap::mapClear()
     // only has the "Default Area" after TRoomDB::clearMapDB() has been run.
     if (mpMapper) {
         mpMapper->updateAreaComboBox();
+
+        auto map = mpMapper->mp2dMap;
+        if (map) {
+            map->mMultiSelectionListWidget.clear();
+            map->mMultiSelectionListWidget.hide();
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Clear and hide room list combo box after deleteMap()

#### Motivation for adding to Mudlet
Clears and hides incorrect information. Better user experience.  

#### Other info (issues closed, discussion etc)
closes #6860 

https://github.com/user-attachments/assets/f71700b7-f526-4158-b78f-7c786b740ea2

