### PR TITLE
Add UI option for setting buffer size, increase default to 100,000

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -260,6 +260,8 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mWrapAt(100)
 , mWrapIndentCount(0)
 , mWrapHangingIndentCount(0)
+, mConsoleBufferSize(100000)
+, mUseMaxConsoleBufferSize(false)
 , mEditorAutoComplete(true)
 , mEditorTheme(QLatin1String("Mudlet"))
 , mEditorThemeFile(QLatin1String("Mudlet.tmTheme"))

--- a/src/Host.h
+++ b/src/Host.h
@@ -354,6 +354,10 @@ public:
     std::pair<bool, QString> setDisplayFont(const QFont&);
     void setDisplayFontFromString(const QString&);
     void setDisplayFontSize(int size);
+    int getConsoleBufferSize() const { return mConsoleBufferSize; }
+    void setConsoleBufferSize(int size) { mConsoleBufferSize = size; }
+    bool getUseMaxConsoleBufferSize() const { return mUseMaxConsoleBufferSize; }
+    void setUseMaxConsoleBufferSize(bool useMax) { mUseMaxConsoleBufferSize = useMax; }
     void updateProxySettings(QNetworkAccessManager* manager);
     std::unique_ptr<QNetworkProxy>& getConnectionProxy();
     void updateAnsi16ColorsInTable();
@@ -611,6 +615,9 @@ public:
     int mWrapAt;
     int mWrapIndentCount;
     int mWrapHangingIndentCount;
+
+    int mConsoleBufferSize;
+    bool mUseMaxConsoleBufferSize;
 
     bool mEditorAutoComplete;
 

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -1552,23 +1552,25 @@ int TLuaInterpreter::setConsoleBufferSize(lua_State* L)
     // The macro will have returned with a nil + error message if the windowName
     // was not found:
     auto console = CONSOLE(L, windowName);
-    
+    Host& host = getHostFromLua(L);
+
     if (useMaximum) {
+        // Maximum buffer size is only supported for the main console
+        if (console != host.mpConsole) {
+            return warnArgumentValue(L, __func__, "useMaximum parameter is only supported for the main console");
+        }
+
         // Use system maximum buffer size instead of the provided linesLimit
         const int maxBufferSize = console->buffer.getMaxBufferSize();
         console->buffer.setBufferSize(maxBufferSize, sizeOfBatchDeletion);
-        
-        // Update Host settings if this is the main console
-        Host& host = getHostFromLua(L);
-        if (console == host.mpConsole) {
-            host.setConsoleBufferSize(maxBufferSize);
-            host.setUseMaxConsoleBufferSize(true);
-        }
+
+        // Update Host settings
+        host.setConsoleBufferSize(maxBufferSize);
+        host.setUseMaxConsoleBufferSize(true);
     } else {
         console->buffer.setBufferSize(linesLimit, sizeOfBatchDeletion);
-        
+
         // Update Host settings if this is the main console
-        Host& host = getHostFromLua(L);
         if (console == host.mpConsole) {
             host.setConsoleBufferSize(linesLimit);
             host.setUseMaxConsoleBufferSize(false);

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -1541,12 +1541,40 @@ int TLuaInterpreter::setConsoleBufferSize(lua_State* L)
     }
 
     auto linesLimit = getVerifiedInt(L, __func__, s++, "linesLimit");
-    auto sizeOfBatchDeletion = getVerifiedInt(L, __func__, s, "sizeOfBatchDeletion");
+    auto sizeOfBatchDeletion = getVerifiedInt(L, __func__, s++, "sizeOfBatchDeletion");
+    
+    // Optional fourth parameter: useMaximum (boolean)
+    bool useMaximum = false;
+    if (s <= n) {
+        useMaximum = lua_toboolean(L, s);
+    }
 
     // The macro will have returned with a nil + error message if the windowName
     // was not found:
     auto console = CONSOLE(L, windowName);
-    console->buffer.setBufferSize(linesLimit, sizeOfBatchDeletion);
+    
+    if (useMaximum) {
+        // Use system maximum buffer size instead of the provided linesLimit
+        const int maxBufferSize = console->buffer.getMaxBufferSize();
+        console->buffer.setBufferSize(maxBufferSize, sizeOfBatchDeletion);
+        
+        // Update Host settings if this is the main console
+        Host& host = getHostFromLua(L);
+        if (console == host.mpConsole) {
+            host.setConsoleBufferSize(maxBufferSize);
+            host.setUseMaxConsoleBufferSize(true);
+        }
+    } else {
+        console->buffer.setBufferSize(linesLimit, sizeOfBatchDeletion);
+        
+        // Update Host settings if this is the main console
+        Host& host = getHostFromLua(L);
+        if (console == host.mpConsole) {
+            host.setConsoleBufferSize(linesLimit);
+            host.setUseMaxConsoleBufferSize(false);
+        }
+    }
+    
     // Indicate success with a true return value:
     lua_pushboolean(L, true);
     return 1;

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -570,6 +570,8 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
         host.append_child("wrapAt").text().set(QString::number(pHost->mWrapAt).toUtf8().constData());
         host.append_child("wrapIndentCount").text().set(QString::number(pHost->mWrapIndentCount).toUtf8().constData());
         host.append_child("wrapHangingIndentCount").text().set(QString::number(pHost->mWrapHangingIndentCount).toUtf8().constData());
+        host.append_child("consoleBufferSize").text().set(QString::number(pHost->mConsoleBufferSize).toUtf8().constData());
+        host.append_child("useMaxConsoleBufferSize").text().set(pHost->mUseMaxConsoleBufferSize ? "yes" : "no");
         host.append_child("mFgColor").text().set(pHost->mFgColor.name().toUtf8().constData());
         host.append_child("mBgColor").text().set(pHost->mBgColor.name().toUtf8().constData());
         host.append_child("mCommandFgColor").text().set(pHost->mCommandFgColor.name().toUtf8().constData());

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1129,6 +1129,10 @@ void XMLimport::readHost(Host* pHost)
                 pHost->mWrapIndentCount = readElementText().toInt();
             } else if (name() == qsl("wrapHangingIndentCount")) {
                 pHost->mWrapHangingIndentCount = readElementText().toInt();
+            } else if (name() == qsl("consoleBufferSize")) {
+                pHost->mConsoleBufferSize = readElementText().toInt();
+            } else if (name() == qsl("useMaxConsoleBufferSize")) {
+                pHost->mUseMaxConsoleBufferSize = (readElementText() == qsl("yes"));
             } else if (name() == qsl("mCommandSeparator")) {
                 pHost->mCommandSeparator = readElementText();
             } else if (name() == qsl("mCommandLineFgColor")) {

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -417,6 +417,8 @@ void dlgProfilePreferences::disableHostDetails()
 
     groupBox_wrapping->setEnabled(false);
 
+    groupBox_consoleBuffer->setEnabled(false);
+
     groupBox_doubleClick->setEnabled(false);
 
     // Some of groupBox_displayOptions are usable, so must pick out and
@@ -543,6 +545,8 @@ void dlgProfilePreferences::enableHostDetails()
     groupBox_borders->setEnabled(true);
 
     groupBox_wrapping->setEnabled(true);
+
+    groupBox_consoleBuffer->setEnabled(true);
 
     groupBox_doubleClick->setEnabled(true);
 
@@ -793,6 +797,22 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     wrap_at_spinBox->setValue(pHost->mWrapAt);
     indent_wrapped_spinBox->setValue(pHost->mWrapIndentCount);
     hanging_indent_wrapped_spinBox->setValue(pHost->mWrapHangingIndentCount);
+
+    console_buffer_size_spinBox->setValue(pHost->getConsoleBufferSize());
+    checkBox_useMaxBufferSize->setChecked(pHost->getUseMaxConsoleBufferSize());
+    
+    // Set maximum buffer size based on system capabilities and update tooltip
+    if (pHost->mpConsole) {
+        const int maxBufferSize = pHost->mpConsole->buffer.getMaxBufferSize();
+        console_buffer_size_spinBox->setMaximum(maxBufferSize);
+        checkBox_useMaxBufferSize->setToolTip(tr("<p>Use the maximum buffer size your system can handle (%1 lines). This will be calculated based on available memory.</p>").arg(maxBufferSize));
+        
+        // If using max buffer size, disable the spinbox and set it to max
+        if (pHost->getUseMaxConsoleBufferSize()) {
+            console_buffer_size_spinBox->setValue(maxBufferSize);
+            console_buffer_size_spinBox->setEnabled(false);
+        }
+    }
 
     show_sent_text_combobox->setCurrentIndex(static_cast<int>(pHost->mCommandEchoMode));
     auto_clear_input_line_checkbox->setChecked(pHost->mAutoClearCommandLineAfterSend);
@@ -1264,6 +1284,9 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     connect(doubleSpinBox_networkPacketTimeout, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &dlgProfilePreferences::slot_setPostingTimeout);
     connect(checkBox_largeAreaExitArrows, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_changeLargeAreaExitArrows);
     connect(checkBox_invertMapZoom, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_changeInvertMapZoom);
+    
+    // Console buffer settings
+    connect(checkBox_useMaxBufferSize, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_toggleUseMaxBufferSize);
 
     //Shortcuts tab
     auto shortcutKeys = mudlet::self()->mpShortcutsManager->iterator();
@@ -1393,6 +1416,9 @@ void dlgProfilePreferences::disconnectHostRelatedControls()
     disconnect(spinBox_playerRoomInnerDiameter, qOverload<int>(&QSpinBox::valueChanged), nullptr, nullptr);
     disconnect(checkBox_largeAreaExitArrows, &QCheckBox::toggled, nullptr, nullptr);
     disconnect(checkBox_invertMapZoom, &QCheckBox::toggled, nullptr, nullptr);
+    
+    // Console buffer settings
+    disconnect(checkBox_useMaxBufferSize, &QCheckBox::toggled, nullptr, nullptr);
 }
 
 void dlgProfilePreferences::clearHostDetails()
@@ -2852,6 +2878,30 @@ void dlgProfilePreferences::slot_saveAndClose()
         pHost->updateDisplayDimensions();
         pHost->mWrapIndentCount = indent_wrapped_spinBox->value();
         pHost->mWrapHangingIndentCount = hanging_indent_wrapped_spinBox->value();
+
+        // Save console buffer settings and apply them
+        const bool useMaxBuffer = checkBox_useMaxBufferSize->isChecked();
+        int newBufferSize;
+        
+        if (useMaxBuffer && pHost->mpConsole) {
+            newBufferSize = pHost->mpConsole->buffer.getMaxBufferSize();
+        } else {
+            newBufferSize = console_buffer_size_spinBox->value();
+        }
+        
+        // Calculate batch delete size as 5% of buffer size (minimum 100)
+        const int newBatchDeleteSize = std::max(100, newBufferSize / 5);
+        
+        if (pHost->getConsoleBufferSize() != newBufferSize || pHost->getUseMaxConsoleBufferSize() != useMaxBuffer) {
+            pHost->setConsoleBufferSize(newBufferSize);
+            pHost->setUseMaxConsoleBufferSize(useMaxBuffer);
+            
+            // Apply the new buffer size to the main console
+            if (pHost->mpConsole) {
+                pHost->mpConsole->buffer.setBufferSize(newBufferSize, newBatchDeleteSize);
+            }
+        }
+
         pHost->mCommandEchoMode = static_cast<Host::CommandEchoMode>(show_sent_text_combobox->currentIndex());
         pHost->mAutoClearCommandLineAfterSend = auto_clear_input_line_checkbox->isChecked();
         pHost->mHighlightHistory = checkBox_highlightHistory->isChecked();
@@ -4485,6 +4535,27 @@ void dlgProfilePreferences::slot_changeWrapAt()
     }
 
     pHost->mTelnet.sendInfoNewEnvironValue(qsl("WORD_WRAP"));
+}
+
+void dlgProfilePreferences::slot_toggleUseMaxBufferSize(bool checked)
+{
+    Host* pHost = mpHost;
+    if (!pHost) {
+        return;
+    }
+    
+    if (checked) {
+        // When max is enabled, set spinbox to max value and disable it
+        if (pHost->mpConsole) {
+            const int maxBufferSize = pHost->mpConsole->buffer.getMaxBufferSize();
+            console_buffer_size_spinBox->setValue(maxBufferSize);
+        }
+        console_buffer_size_spinBox->setEnabled(false);
+    } else {
+        // When max is disabled, enable the spinbox and set to stored value
+        console_buffer_size_spinBox->setEnabled(true);
+        console_buffer_size_spinBox->setValue(pHost->getConsoleBufferSize());
+    }
 }
 
 void dlgProfilePreferences::slot_deleteMap()

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -167,6 +167,7 @@ private slots:
     void slot_enableDarkEditor(const QString&);
     void slot_toggleAdvertiseScreenReader(const bool);
     void slot_changeWrapAt();
+    void slot_toggleUseMaxBufferSize(bool checked);
     void slot_deleteMap();
     void slot_changeLargeAreaExitArrows(const bool);
     void slot_changeInvertMapZoom(const bool);

--- a/src/lua-function-list.json
+++ b/src/lua-function-list.json
@@ -448,7 +448,7 @@
     "setCommandBackgroundColor": "setCommandBackgroundColor([windowName], r, g, b, [transparency])",
     "setCommandForegroundColor": "setCommandForegroundColor([windowName], r, g, b, [transparency])",
     "setConfig": "setConfig(option, value)",
-    "setConsoleBufferSize": "setConsoleBufferSize([consoleName], linesLimit, sizeOfBatchDeletion)",
+    "setConsoleBufferSize": "setConsoleBufferSize([consoleName], linesLimit, sizeOfBatchDeletion, [useMaximum])",
     "setCustomEnvColor": "setCustomEnvColor(environmentID, r,g,b,a)",
     "setDiscordApplicationID": "setDiscordApplicationID(id)",
     "setDiscordDetail": "setDiscordDetail(text)",

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2013,6 +2013,15 @@ void mudlet::addConsoleForNewHost(Host* pH)
     pH->mpConsole = pConsole;
     pConsole->setWindowTitle(pH->getName());
     pConsole->setObjectName(pH->getName());
+    
+    // Apply Host's console buffer size settings to the newly created console
+    int bufferSize = pH->getConsoleBufferSize();
+    if (pH->getUseMaxConsoleBufferSize()) {
+        bufferSize = pConsole->buffer.getMaxBufferSize();
+    }
+    // Calculate batch delete size as 5% of buffer size (minimum 100)
+    const int batchDeleteSize = std::max(100, bufferSize / 5);
+    pConsole->buffer.setBufferSize(bufferSize, batchDeleteSize);
     const QString profileName = pH->getName();
 
     // Check if this profile should be in a detached window

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -1244,6 +1244,85 @@ you can use it but there could be issues with aligning columns of text</string>
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="groupBox_consoleBuffer">
+         <property name="title">
+          <string>Scrollback</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_groupBox_consoleBuffer">
+          <item>
+           <widget class="QFrame" name="frame_console_buffer_size">
+            <property name="frameShape">
+             <enum>QFrame::Shape::NoFrame</enum>
+            </property>
+            <layout class="QHBoxLayout" name="horizontalLayout_frame_console_buffer_size">
+             <item>
+              <widget class="QLabel" name="label_console_buffer_size_spinBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>200</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="toolTip">
+                <string>&lt;p&gt;Maximum number of lines to keep in the console buffer. When exceeded, older lines are removed in batches.&lt;/p&gt;</string>
+               </property>
+               <property name="text">
+                <string>Main display size:</string>
+               </property>
+               <property name="buddy">
+                <cstring>console_buffer_size_spinBox</cstring>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="console_buffer_size_spinBox">
+               <property name="toolTip">
+                <string>&lt;p&gt;Maximum number of lines to keep in the console buffer. Minimum is 100 lines.&lt;/p&gt;</string>
+               </property>
+               <property name="minimum">
+                <number>100</number>
+               </property>
+               <property name="maximum">
+                <number>2147483647</number>
+               </property>
+               <property name="value">
+                <number>10000</number>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="label_console_buffer_lines">
+               <property name="text">
+                <string>lines</string>
+               </property>
+               <property name="buddy">
+                <cstring>console_buffer_size_spinBox</cstring>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="checkBox_useMaxBufferSize">
+            <property name="toolTip">
+             <string>&lt;p&gt;Use the maximum buffer size your system can handle. This will be calculated based on available memory.&lt;/p&gt;</string>
+            </property>
+            <property name="text">
+             <string>Use maximum lines possible</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QGroupBox" name="groupBox_doubleClick">
          <property name="title">
           <string>Double-click</string>
@@ -4478,6 +4557,8 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>wrap_at_spinBox</tabstop>
   <tabstop>indent_wrapped_spinBox</tabstop>
   <tabstop>hanging_indent_wrapped_spinBox</tabstop>
+  <tabstop>console_buffer_size_spinBox</tabstop>
+  <tabstop>checkBox_useMaxBufferSize</tabstop>
   <tabstop>doubleclick_ignore_lineedit</tabstop>
   <tabstop>checkBox_USE_IRE_DRIVER_BUGFIX</tabstop>
   <tabstop>checkBox_useWideAmbiguousEastAsianGlyphs</tabstop>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add UI option for setting buffer size:

[Screencast from 2025-09-15 08-10-18.webm](https://github.com/user-attachments/assets/e5c0ec57-d7e1-4014-95d5-f57403717489)

#### Motivation for adding to Mudlet
Requested by players in the [2025 player survey](https://www.mudlet.org/2025/09/mudlet-2025-survey-responses/). Closes https://github.com/Mudlet/Mudlet/issues/8145. The logic is straightforward: options players ask for should be added, options players aren't asking for should not be added.
#### Other info (issues closed, discussion etc)
The 'use maximum size possible' option, which sets the buffer to the maximum amount of lines RAM can handle, is something that has been in the code for a while. It isalso mirrored to the Lua script for consistency to UI. That does present a problem however - if you have more than 1 console set to maximum size, you will use more memory than your system can handle, which some folks have done in the past and complained about it. This could use solving - with a global maximum on the entire Mudlet instance, perhaps? Ideas welcome.