### PR TITLE
Improve: instantly move camera between areas in 3d mapper

### DIFF
--- a/src/modern_glwidget.cpp
+++ b/src/modern_glwidget.cpp
@@ -246,15 +246,26 @@ void ModernGLWidget::paintGL()
             return;
         }
         
-        // Check if room ID changed and start smooth transition
+        // Check if room ID changed and determine transition type
         if (mRID != mPreviousRID) {
-            // Room changed - start smooth transition
+            // Room changed - check if area also changed
             int targetAID = pRID->getArea();
             int targetX = pRID->x();
             int targetY = pRID->y();
             int targetZ = pRID->z();
 
-            startSmoothTransition(targetAID, targetX, targetY, targetZ);
+            if (targetAID != mPreviousAID) {
+                // Area changed - instant transition
+                mCameraController.setTarget(static_cast<float>(targetX), static_cast<float>(targetY), static_cast<float>(targetZ));
+                // Stop any ongoing smooth animation
+                if (mCameraSmoothAnimating) {
+                    mCameraAnimationTimer->stop();
+                    mCameraSmoothAnimating = false;
+                }
+            } else {
+                // Same area - smooth transition
+                startSmoothTransition(targetAID, targetX, targetY, targetZ);
+            }
         }
         // Instant update map (smooth transition only impacts camera position)
         mAID = pRID->getArea();
@@ -265,6 +276,7 @@ void ModernGLWidget::paintGL()
         mMapCenterY = oy;
         mMapCenterZ = oz;
         mPreviousRID = mRID; // Update tracking
+        mPreviousAID = mAID; // Update area tracking
 
 
     } else {

--- a/src/modern_glwidget.h
+++ b/src/modern_glwidget.h
@@ -185,6 +185,7 @@ private:
     QEasingCurve mEasingCurve;
     bool mCameraSmoothAnimating = false; // Dedicated flag for smooth camera animation
     int mPreviousRID = 0; // Track previous room ID to detect changes
+    int mPreviousAID = 0; // Track previous area ID to detect area changes
 
     // Private methods for modern OpenGL
     void updateMatrices();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Instantly move camera between areas in 3d mapper, but still smooth it out between rooms
#### Motivation for adding to Mudlet
Better UX
#### Other info (issues closed, discussion etc)
[Screencast from 2025-09-16 08-14-53.webm](https://github.com/user-attachments/assets/31a4ff5b-d072-454e-99bd-efbe69985ec8)
