### PR TITLE
Improve: make the text for adding a new trigger/alias/etc less visually 'loud'

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8594,7 +8594,7 @@ void dlgTriggerEditor::showIntro(const QString& desiredOption)
     for (const auto &[name, headline, contents] : introAddCurrentItem.options) {
         introTextOptions.append(
             (name != desiredOption)
-            ? qsl("<li><a href='%1'>%2</a></li>").arg(name, headline)
+            ? qsl("<li><a href='%1' style='color: inherit; text-decoration: underline;'>%2</a></li>").arg(name, headline)
             : qsl("<li><strong>%1</strong>%2</li>").arg(headline, contents));
     }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
I felt like the new links in the intro section were a bit too 'loud', that is, visually asking for too much attention. This is a try to make that better. Interested in hearing input @Kebap @ZookaOnGit:

Before:
<img width="1370" height="592" alt="image" src="https://github.com/user-attachments/assets/3da97735-bc51-4e1f-add3-e258856d7c15" />

After: 
<img width="1370" height="592" alt="image" src="https://github.com/user-attachments/assets/5bbf4e63-c1e1-495e-8941-36e11df60ee1" />

#### Motivation for adding to Mudlet
Making the UI a bit less visually noisy.
#### Other info (issues closed, discussion etc)
The blue links work great the first 10 times you see them, but not so well after that.