### PR TITLE
Fix: re-enable custom dark theme for Linux and Windows 10

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,7 @@ set(mudlet_SRCS
     AliasUnit.cpp
     AltFocusMenuBarDisable.cpp
     ctelnet.cpp
+    DarkTheme.cpp
     discord.cpp
     dlgAboutDialog.cpp
     dlgActionMainArea.cpp
@@ -238,6 +239,7 @@ set(mudlet_HDRS
     AliasUnit.h
     AltFocusMenuBarDisable.h
     ctelnet.h
+    DarkTheme.h
     discord.h
     dlgAboutDialog.h
     dlgActionMainArea.h

--- a/src/DarkTheme.cpp
+++ b/src/DarkTheme.cpp
@@ -1,0 +1,55 @@
+/***************************************************************************
+ *   Copyright (C) 2021 by Manuel Wegmann - wegmann.manuel@yahoo.com       *
+ *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "DarkTheme.h"
+#include "AltFocusMenuBarDisable.h"
+
+//DarkTheme only works with Fusion style
+DarkTheme::DarkTheme()
+: DarkTheme(new AltFocusMenuBarDisable(qsl("Fusion")))
+{}
+
+DarkTheme::DarkTheme(QStyle* style) : QProxyStyle(style) {}
+
+void DarkTheme::polish(QPalette& palette)
+{
+    // modify palette to dark
+    palette.setColor(QPalette::Window, QColor(53, 53, 53));
+    palette.setColor(QPalette::WindowText, Qt::white);
+    palette.setColor(QPalette::Base, QColor(42, 42, 42));
+    palette.setColor(QPalette::AlternateBase, QColor(66, 66, 66));
+    palette.setColor(QPalette::ToolTipBase, QColor(53, 53, 53));
+    palette.setColor(QPalette::ToolTipText, Qt::white);
+    palette.setColor(QPalette::Text, Qt::white);
+    palette.setColor(QPalette::Dark, QColor(35, 35, 35));
+    palette.setColor(QPalette::Shadow, QColor(20, 20, 20));
+    palette.setColor(QPalette::Button, QColor(53, 53, 53));
+    palette.setColor(QPalette::ButtonText, Qt::white);
+    palette.setColor(QPalette::BrightText, Qt::red);
+    palette.setColor(QPalette::Link, QColor(42, 130, 218));
+    palette.setColor(QPalette::Highlight, QColor(42, 130, 218));
+    palette.setColor(QPalette::HighlightedText, Qt::white);
+    palette.setColor(QPalette::Disabled, QPalette::WindowText, QColor(127, 127, 127));
+    palette.setColor(QPalette::Disabled, QPalette::Text, QColor(127, 127, 127));
+    palette.setColor(QPalette::Disabled, QPalette::Light, QColor(53, 53, 53));
+    palette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(127, 127, 127));
+    palette.setColor(QPalette::Disabled, QPalette::HighlightedText, QColor(127, 127, 127));
+    palette.setColor(QPalette::Disabled, QPalette::Highlight, QColor(80, 80, 80));
+}

--- a/src/DarkTheme.h
+++ b/src/DarkTheme.h
@@ -1,0 +1,38 @@
+/***************************************************************************
+ *   Copyright (C) 2021 by Manuel Wegmann - wegmann.manuel@yahoo.com       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#ifndef MUDLET_DARKTHEME_H
+#define MUDLET_DARKTHEME_H
+
+#include <QProxyStyle>
+#include <QStyleFactory>
+
+#include "utils.h"
+
+class DarkTheme : public QProxyStyle
+{
+    Q_OBJECT
+
+public:
+    DarkTheme();
+    explicit DarkTheme(QStyle* style);
+    void polish(QPalette& palette) override;
+};
+
+#endif // end MUDLET_DARKTHEME_H

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -30,6 +30,7 @@
 
 #include "AltFocusMenuBarDisable.h"
 #include "CredentialManager.h"
+#include "DarkTheme.h"
 #include "EAction.h"
 #include "LuaInterface.h"
 #include "TCommandLine.h"
@@ -5418,30 +5419,53 @@ void mudlet::setShowIconsOnMenu(const Qt::CheckState state)
     }
 }
 
+bool mudlet::needsCustomDarkTheme()
+{
+#if defined(Q_OS_WINDOWS)
+    return QSysInfo::productVersion() == qsl("10");
+#elif defined(Q_OS_LINUX)
+    return true;
+#else
+    return false;
+#endif
+}
+
 void mudlet::setAppearance(const enums::Appearance state, const bool& loading)
 {
     if (state == mAppearance && !loading) {
         return;
     }
 
-    switch (state) {
-    case enums::Appearance::dark:
-        QGuiApplication::styleHints()->setColorScheme(Qt::ColorScheme::Dark);
+    mDarkMode = false;
+    if (state == enums::Appearance::dark || (state == enums::Appearance::systemSetting && QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark)) {
         mDarkMode = true;
-        break;
-    case enums::Appearance::light:
-        QGuiApplication::styleHints()->setColorScheme(Qt::ColorScheme::Light);
-        mDarkMode = false;
-        break;
-    case enums::Appearance::systemSetting:
-        QGuiApplication::styleHints()->setColorScheme(Qt::ColorScheme::Unknown);
-        mDarkMode = (QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark);
-        break;
     }
 
-    // Apply the AltFocusMenuBarDisable wrapper for both themes
-    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
-    qApp->setStyle(new AltFocusMenuBarDisable(mDefaultStyle));
+    if (needsCustomDarkTheme()) {
+        if (mDarkMode) {
+            // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
+            qApp->setStyle(new DarkTheme);
+        } else {
+            // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
+            qApp->setStyle(new AltFocusMenuBarDisable(mDefaultStyle));
+        }
+    } else {
+        switch (state) {
+        case enums::Appearance::dark:
+            QGuiApplication::styleHints()->setColorScheme(Qt::ColorScheme::Dark);
+            break;
+        case enums::Appearance::light:
+            QGuiApplication::styleHints()->setColorScheme(Qt::ColorScheme::Light);
+            break;
+        case enums::Appearance::systemSetting:
+            QGuiApplication::styleHints()->setColorScheme(Qt::ColorScheme::Unknown);
+            break;
+        }
+        // Apply the AltFocusMenuBarDisable wrapper for Qt native themes
+        // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
+        qApp->setStyle(new AltFocusMenuBarDisable(mDefaultStyle));
+    }
+
     getHostManager().changeAllHostColour(getActiveHost());
     mAppearance = state;
     emit signal_appearanceChanged(state);

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -572,6 +572,7 @@ private:
 
     void assignKeySequences();
     QString autodetectPreferredLanguage();
+    static bool needsCustomDarkTheme();
     void closeHost(const QString&);
     int getDictionaryWordCount(const QString &dictionaryPath);
     void goingDown() { mIsGoingDown = true; }

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -612,6 +612,7 @@ SOURCES += \
     AliasUnit.cpp \
     AltFocusMenuBarDisable.cpp \
     ctelnet.cpp \
+    DarkTheme.cpp \
     discord.cpp \
     dlgAboutDialog.cpp \
     dlgActionMainArea.cpp \
@@ -746,6 +747,7 @@ HEADERS += \
     AliasUnit.h \
     AltFocusMenuBarDisable.h \
     ctelnet.h \
+    DarkTheme.h \
     discord.h \
     dlgAboutDialog.h \
     dlgActionMainArea.h \


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Re-enable custom dark theme for Linux and Windows 10
#### Motivation for adding to Mudlet
https://discord.com/channels/283581582550237184/427919962561052673/1413002622100574359, the default Qt one didn't work for Linux (packaging issue?) and Windows 10 (only 11 is supported)
#### Other info (issues closed, discussion etc)
