### PR TITLE
Improve: populate search bar from ctrl-f

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -182,8 +182,11 @@ bool TCommandLine::event(QEvent* event)
                 mudlet::self()->dactionInputLine->setChecked(false);
                 mudlet::self()->mpCurrentActiveHost->setCompactInputLine(false);
             }
+
+            mpConsole->mUpperPane->slot_copySelectionToSearchBar();
             mpConsole->mpBufferSearchBox->setFocus();
             mpConsole->mpBufferSearchBox->selectAll();
+
             ke->accept();
             return true;
         }

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1833,11 +1833,6 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
         action3->setToolTip(QString());
         connect(action3, &QAction::triggered, this, &TTextEdit::slot_selectAll);
 
-        //: Populate search bar from console right-click.
-        QAction* action_searchBuffer = new QAction(tr("Search buffer"));
-        action_searchBuffer->setToolTip(QString());
-        connect(action_searchBuffer, &QAction::triggered, this, &TTextEdit::slot_copySelectionToSearchBar);
-
         QString selectedEngine = mpHost->getSearchEngine().first;
         QAction* action4 = new QAction(tr("Search on %1").arg(selectedEngine), this);
         action4->setToolTip(QString());
@@ -1873,7 +1868,6 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
         }
 
         popup->addSeparator();
-        popup->addAction(action_searchBuffer);
         popup->addAction(action4);
 
         if (!mudlet::self()->isControlsVisible()) {

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1673,6 +1673,24 @@ void TTextEdit::searchSelectionOnline()
     QDesktopServices::openUrl(QUrl(url));
 }
 
+void TTextEdit::slot_copySelectionToSearchBar()
+{
+    if (!establishSelectedText()) {
+        return;
+    }
+
+    QString selectedText = getSelectedText(QChar::LineFeed).trimmed();
+
+    if (mudlet::self()->dactionInputLine->isChecked()) {
+        // If hidden then reveal as if pressed Alt-L
+        mudlet::self()->dactionInputLine->setChecked(false);
+        mudlet::self()->mpCurrentActiveHost->setCompactInputLine(false);
+    }
+    mpConsole->mpBufferSearchBox->setText(selectedText);
+    mpConsole->mpBufferSearchBox->setFocus();
+    mpConsole->mpBufferSearchBox->selectAll();
+}
+
 QString TTextEdit::getSelectedText(const QChar& newlineChar, const bool showTimestamps)
 {
     // mPA QPoint where selection started
@@ -1815,6 +1833,11 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
         action3->setToolTip(QString());
         connect(action3, &QAction::triggered, this, &TTextEdit::slot_selectAll);
 
+        //: Populate search bar from console right-click.
+        QAction* action_searchBuffer = new QAction(tr("Search Buffer"));
+        action_searchBuffer->setToolTip(QString());
+        connect(action_searchBuffer, &QAction::triggered, this, &TTextEdit::slot_copySelectionToSearchBar);
+
         QString selectedEngine = mpHost->getSearchEngine().first;
         QAction* action4 = new QAction(tr("Search on %1").arg(selectedEngine), this);
         action4->setToolTip(QString());
@@ -1832,6 +1855,7 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
         popup->addAction(action2);
         popup->addAction(actionCopyImage);
         popup->addSeparator();
+        popup->addAction(action_searchBuffer);
         popup->addAction(action3);
 
         if (mDragStart != mDragSelectionEnd && mpHost->mEnableTextAnalyzer) {

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1829,12 +1829,12 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
         auto* actionCopyImage = new QAction(tr("Copy as image"), this);
         connect(actionCopyImage, &QAction::triggered, this, &TTextEdit::slot_copySelectionToClipboardImage);
 
-        QAction* action3 = new QAction(tr("Select All"), this);
+        QAction* action3 = new QAction(tr("Select all"), this);
         action3->setToolTip(QString());
         connect(action3, &QAction::triggered, this, &TTextEdit::slot_selectAll);
 
         //: Populate search bar from console right-click.
-        QAction* action_searchBuffer = new QAction(tr("Search Buffer"));
+        QAction* action_searchBuffer = new QAction(tr("Search buffer"));
         action_searchBuffer->setToolTip(QString());
         connect(action_searchBuffer, &QAction::triggered, this, &TTextEdit::slot_copySelectionToSearchBar);
 
@@ -1855,7 +1855,6 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
         popup->addAction(action2);
         popup->addAction(actionCopyImage);
         popup->addSeparator();
-        popup->addAction(action_searchBuffer);
         popup->addAction(action3);
 
         if (mDragStart != mDragSelectionEnd && mpHost->mEnableTextAnalyzer) {
@@ -1874,6 +1873,7 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
         }
 
         popup->addSeparator();
+        popup->addAction(action_searchBuffer);
         popup->addAction(action4);
 
         if (!mudlet::self()->isControlsVisible()) {

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -136,6 +136,7 @@ public:
 
 public slots:
     void slot_copySelectionToClipboard();
+    void slot_copySelectionToSearchBar();
     void slot_selectAll();
     void slot_scrollBarMoved(int);
     void slot_hScrollBarMoved(int);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Improves ways to initiate searching the buffer.  Ctrl-F now copies selected text to search bar.

#### Motivation for adding to Mudlet
Reduces steps to start searching buffer.  Improves Mudlet's accessibility.

Old method (still works);
- select text
- ctrl+c (or right click copy)
- open search bar if closed
- click on search field
- ctrl-v (or right click paste)

Alternative method;
- select text
- ctrl-f

#### Other info (issues closed, discussion etc)
https://discord.com/channels/283581582550237184/283582439002210305/1416750015862411347
https://discord.com/channels/283581582550237184/283582439002210305/1416808028157644901

https://github.com/user-attachments/assets/4c9dc695-e922-49b5-bb02-98cb2ac106da

(in the above I also implemented right-click, we decided to remove that and focus on Ctrl-F)