### PR TITLE
fix : Use default app font for Room Symbol textbox to fix oversized text

### DIFF
--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -93,7 +93,7 @@ void dlgRoomProperties::init(
         }
     }
     if (!lineEdit_roomSymbol->isHidden()) {
-        lineEdit_roomSymbol->setFont(mpHost->mpMap->mMapSymbolFont);
+        lineEdit_roomSymbol->setFont(QApplication::font());
     }
     if (!comboBox_roomSymbol->isHidden()) {
         comboBox_roomSymbol->setFont(mpHost->mpMap->mMapSymbolFont);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fixes #8218  - Wrong font size in "room symbol" entry box in "room configuration" popup. 
Changed the roomSymbol to use the default font instead of mMapSymbolFont since it was very different from the dialog font.

#### Motivation for adding to Mudlet
--

#### Other info (issues closed, discussion etc)
--