### PR TITLE
Infra: Remove dead link to source

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -36,7 +36,7 @@ signals:
 * additionally, use [clazy]([url](https://github.com/KDE/clazy)) for linting as well
 * use braces {} around all statements (ie, `if`'s and so on), even if they are one line
 * use `qsl()` to wrap Qt strings, this ensures they're created at compile time
-* at the same time, don't use a blank `qsl("")` - use `QString()` in that case ([source](http://blog.qt.io/blog/2014/06/13/qt-weekly-13-qstringliteral/))
+* at the same time, don't use a blank `qsl("")` - use `QString()` in that case
 * escape dynamic label information with .toHtmlEscaped() to ensure safe display ([example](https://github.com/Mudlet/Mudlet/pull/6807/files)).
 
 # Internationalization do's and don'ts


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Remove a dead link

#### Motivation for adding to Mudlet

Less confusion

#### Other info (issues closed, discussion etc)

Link was http://blog.qt.io/blog/2014/06/13/qt-weekly-13-qstringliteral/

Searched through blog history of [2014-06](https://www.qt.io/blog/archive/2014/06) and [2014-05](https://www.qt.io/blog/archive/2014/05) alright
Found [QT Weekly Blog Post 11](https://www.qt.io/blog/2014/05/20/qt-weekly-11-getting-started-with-winrt-2) and [14](https://www.qt.io/blog/2014/06/20/qt-weekly-14-testing-accessibility-on-os-x) easily
However 12 + 13 seem depublished