### PR TITLE
Add: options to permanently hide banner items

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8278,6 +8278,16 @@ void dlgTriggerEditor::changeView(EditorViewType view)
     }
     mCurrentView = view;
 
+    if (mpBannerUndoTimer && mpBannerUndoTimer->isActive()) {
+        mpBannerUndoTimer->stop();
+        mpBannerUndoTimer->deleteLater();
+        mpBannerUndoTimer = nullptr;
+    }
+
+    if (bannerPermanentlyHidden(mCurrentView)) {
+        hideSystemMessageArea();
+    }
+
     mpActionsMainArea->setVisible(view == EditorViewType::cmActionView);
     treeWidget_actions->setVisible(view == EditorViewType::cmActionView);
 
@@ -8605,6 +8615,10 @@ void dlgTriggerEditor::showIntro(const QString& desiredOption)
         return;
     }
 
+    if (bannerPermanentlyHidden(mCurrentView)) {
+        return;
+    }
+
     introTextParts introAddCurrentItem = introAddItem.value(mCurrentView);
     QString introTextOptions;
     for (const auto &[name, headline, contents] : introAddCurrentItem.options) {
@@ -8614,8 +8628,16 @@ void dlgTriggerEditor::showIntro(const QString& desiredOption)
             : qsl("<li><strong>%1</strong>%2</li>").arg(headline, contents));
     }
 
-    showInfo(qsl("<p>%1</p><ul>%2</ul>")
-        .arg(introAddCurrentItem.summary, introTextOptions));
+    QString content = qsl("<p>%1</p><ul>%2</ul>")
+        .arg(introAddCurrentItem.summary, introTextOptions);
+
+    mLastDismissedBannerContent = content;
+    mLastDismissedBannerView = mCurrentView;
+
+    disconnect(mpSystemMessageArea->messageAreaCloseButton, &QAbstractButton::clicked, this, &dlgTriggerEditor::hideSystemMessageArea);
+    connect(mpSystemMessageArea->messageAreaCloseButton, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_bannerDismissClicked);
+
+    showInfo(content);
 }
 
 void dlgTriggerEditor::slot_showActions()
@@ -11433,4 +11455,103 @@ void dlgTriggerEditor::setDisplayFont(const QFont& newFont)
     config->beginChanges();
     config->setFont(newFont);
     config->endChanges();
+}
+
+void dlgTriggerEditor::slot_bannerDismissClicked()
+{
+    handleBannerDismiss();
+}
+
+void dlgTriggerEditor::handleBannerDismiss()
+{
+    hideSystemMessageArea();
+    showBannerUndoToast();
+}
+
+void dlgTriggerEditor::showBannerUndoToast()
+{
+    if (mpBannerUndoTimer) {
+        mpBannerUndoTimer->stop();
+        mpBannerUndoTimer->deleteLater();
+    }
+
+    mpBannerUndoTimer = new QTimer(this);
+    mpBannerUndoTimer->setSingleShot(true);
+    mpBannerUndoTimer->setInterval(std::chrono::seconds(5));
+
+    QString toastMessage = tr("Banner hidden. <a href='undo' style='color: inherit; text-decoration: underline;'>Undo</a> | <a href='hide-permanently' style='color: inherit; text-decoration: underline;'>Hide permanently</a>");
+
+    mpSystemMessageArea->notificationAreaIconLabelError->hide();
+    mpSystemMessageArea->notificationAreaIconLabelWarning->hide();
+    mpSystemMessageArea->notificationAreaIconLabelInformation->show();
+    mpSystemMessageArea->notificationAreaMessageBox->setText(toastMessage);
+    mpSystemMessageArea->show();
+
+    connect(mpBannerUndoTimer, &QTimer::timeout, this, &dlgTriggerEditor::hideSystemMessageArea);
+    mpBannerUndoTimer->start();
+
+    disconnect(mpSystemMessageArea->notificationAreaMessageBox, &QLabel::linkActivated, this, &dlgTriggerEditor::slot_clickedMessageBox);
+    connect(mpSystemMessageArea->notificationAreaMessageBox, &QLabel::linkActivated, this, [this](const QString& link) {
+        if (link == "undo") {
+            undoBannerDismiss();
+        } else if (link == "hide-permanently") {
+            handlePermanentBannerDismiss();
+        } else {
+            slot_clickedMessageBox(link);
+        }
+    });
+}
+
+void dlgTriggerEditor::undoBannerDismiss()
+{
+    if (mpBannerUndoTimer) {
+        mpBannerUndoTimer->stop();
+        mpBannerUndoTimer->deleteLater();
+        mpBannerUndoTimer = nullptr;
+    }
+
+    if (mLastDismissedBannerView == mCurrentView && !mLastDismissedBannerContent.isEmpty()) {
+        mpSystemMessageArea->notificationAreaIconLabelError->hide();
+        mpSystemMessageArea->notificationAreaIconLabelWarning->hide();
+        mpSystemMessageArea->notificationAreaIconLabelInformation->show();
+        mpSystemMessageArea->notificationAreaMessageBox->setText(mLastDismissedBannerContent);
+        mpSystemMessageArea->show();
+
+        connect(mpSystemMessageArea->notificationAreaMessageBox, &QLabel::linkActivated, this, &dlgTriggerEditor::slot_clickedMessageBox);
+    }
+}
+
+
+void dlgTriggerEditor::handlePermanentBannerDismiss()
+{
+    setBannerPermanentlyHidden(mCurrentView, true);
+    hideSystemMessageArea();
+}
+
+bool dlgTriggerEditor::bannerPermanentlyHidden(EditorViewType viewType)
+{
+    const QMetaEnum metaEnum = QMetaEnum::fromType<EditorViewType>();
+    const char* enumName = metaEnum.valueToKey(static_cast<int>(viewType));
+
+    if (!enumName) {
+        return false;
+    }
+
+    QSettings* settings = mudlet::getQSettings();
+    const QString key = qsl("Editor/banner_permanently_hidden/%1").arg(QString::fromLatin1(enumName).toLower());
+    return settings->value(key, false).toBool();
+}
+
+void dlgTriggerEditor::setBannerPermanentlyHidden(EditorViewType viewType, bool hidden)
+{
+    const QMetaEnum metaEnum = QMetaEnum::fromType<EditorViewType>();
+    const char* enumName = metaEnum.valueToKey(static_cast<int>(viewType));
+
+    if (!enumName) {
+        return;
+    }
+
+    QSettings* settings = mudlet::getQSettings();
+    const QString key = qsl("Editor/banner_permanently_hidden/%1").arg(QString::fromLatin1(enumName).toLower());
+    settings->setValue(key, hidden);
 }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -11479,6 +11479,7 @@ void dlgTriggerEditor::showBannerUndoToast()
     mpBannerUndoTimer->setSingleShot(true);
     mpBannerUndoTimer->setInterval(std::chrono::seconds(5));
 
+    //: Toast notification shown when user dismisses an editor tip banner. Allows them to undo or permanently hide the tips for this editor view type.
     QString toastMessage = tr("Banner hidden. <a href='undo' style='color: inherit; text-decoration: underline;'>Undo</a> | <a href='hide-permanently' style='color: inherit; text-decoration: underline;'>Hide permanently</a>");
 
     mpSystemMessageArea->notificationAreaIconLabelError->hide();

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -174,6 +174,7 @@ public:
         cmKeysView = 0x06,
         cmVarsView = 0x07
     };
+    Q_ENUM(EditorViewType)
 
     void closeEvent(QCloseEvent* event) override;
     void focusInEvent(QFocusEvent*) override;
@@ -322,6 +323,7 @@ private slots:
     void slot_itemEdited();
     void slot_searchSplitterMoved(const int pos, const int index);
     void slot_clickedMessageBox(const QString&);
+    void slot_bannerDismissClicked();
 
 public:
     TConsole* mpErrorConsole = nullptr;
@@ -626,6 +628,20 @@ private:
     QMap<EditorViewType, introTextParts> introAddItem;
 
     void showIntro(const QString& = QString());
+
+    // Banner state tracking
+    QTimer* mpBannerUndoTimer = nullptr;
+    EditorViewType mLastDismissedBannerView = EditorViewType::cmUnknownView;
+    QString mLastDismissedBannerContent;
+
+    // Banner methods
+    void handleBannerDismiss();
+    void showBannerUndoToast();
+    void undoBannerDismiss();
+    void handlePermanentBannerDismiss();
+    bool bannerPermanentlyHidden(EditorViewType viewType);
+    void setBannerPermanentlyHidden(EditorViewType viewType, bool hidden);
+
     QString descActive;
     QString descInactive;
     QString descActiveFolder;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add: options to permanently hide banner items

The mouse didn't get captured here, so you'll need to imagine where it goes unfortunately:
[Screencast from 2025-09-19 08-54-18.webm](https://github.com/user-attachments/assets/7b626573-275d-4592-ab33-ca1af30571cc)

#### Motivation for adding to Mudlet
Player demand in https://github.com/Mudlet/Mudlet/pull/8224#issuecomment-3296586944
#### Other info (issues closed, discussion etc)
