### PR TITLE
Infra: Don't localize filename "area_%1.png"

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -6087,7 +6087,7 @@ void T2DMap::slot_exportAreaToImage()
         defaultFileName = qsl("%1.png").arg(utils::sanitizeForPath(areaName));
     } else {
         // Fall back to area ID if no area name
-        defaultFileName = tr("area_%1.png").arg(mAreaID);
+        defaultFileName = qsl("area_%1.png").arg(mAreaID);
     }
     
     QString fullPath = qsl("%1/%2").arg(lastDir, defaultFileName);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR changes the export file naming scheme to keep the technical prefix (e.g. `area_1.png`, `area_2.png`) stable and untranslated across all languages. The localized name remains visible in the UI, but is no longer applied to the file name itself.

#### Motivation for adding to Mudlet
When exporting maps or areas, users may:
- Share the resulting image files with others.
- Re-export the same area later to document changes.
- Compare files across different sessions.

If the file names vary depending on the app’s UI language (e.g. `area_1.png` vs. `zona_1.png`), this creates confusion:
- Files cannot be easily compared when the UI language changes.
- Collaborators may see different names for the same logical area.
- Documentation and support references become inconsistent.

By keeping the file name prefix untranslated, we ensure:
- **Stability:** File names stay the same regardless of locale.
- **Comparability:** Old and new exports line up clearly for versioning or diffing.
- **Shareability:** Users working in different languages can still identify the same file without mismatched naming.

The localized name is still presented in the UI, preserving clarity for end users, while the exported file name remains predictable and consistent.

#### Other info (issues closed, discussion etc)
- Follows up on the great work from PR #8156
- Decision was made after weighing pros (user-friendly localized names) vs. cons (cross-language inconsistency, harder comparisons).  
- Most translation team seem to agree, as they stayed with "area" text untranslated in their locale as well:
  - Italian: area_%1.png
  - Polish: obszar_%1.png
  - Russian: area_%1.png
  - German: area_%1.png
