### PR TITLE
Fix: Prevent password loss and improve credential debug messages

### DIFF
--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -488,7 +488,7 @@ void CredentialManager::storeCredential(const QString& service, const QString& a
                 errorMessage = qsl("Both keychain and encrypted file storage failed. Keychain error: %1").arg(errorMessage);
             }
         } else {
-            qDebug() << "CredentialManager: Password stored to keychain";
+            qDebug() << "CredentialManager: Password stored to keychain service:" << service;
         }
         
         // Final validity check before calling callback
@@ -560,7 +560,7 @@ void CredentialManager::retrieveCredential(const QString& service, const QString
             // Get password directly from keychain (keychain handles decryption)
             password = readJob->textData();
             // No additional decryption needed for keychain passwords
-            qDebug() << "CredentialManager: Retrieved password from keychain";
+            qDebug() << "CredentialManager: Retrieved password from keychain service:" << service;
         } else {
             // Keychain failed, try file storage fallback with specific error context
             QString errorContext;

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -279,7 +279,7 @@ void CredentialManager::retrievePassword(const QString& profileName, const QStri
                             
                             // Only clean up legacy entry if this version is >= 4.20.0
                             // This prevents breaking compatibility with older Mudlet versions
-                            #ifdef APP_VERSION
+#ifdef APP_VERSION
                             const QString currentVersion = QString(APP_VERSION);
                             const QVersionNumber appVersion = QVersionNumber::fromString(currentVersion);
                             const QVersionNumber secureStorageVersion = QVersionNumber(4, 20, 0);
@@ -291,10 +291,10 @@ void CredentialManager::retrievePassword(const QString& profileName, const QStri
                             } else {
                                 qDebug() << "CredentialManager: Legacy cleanup skipped for version" << currentVersion;
                             }
-                            #else
+#else
                             // In test environment, preserve legacy entries for safety
                             qDebug() << "CredentialManager: Legacy cleanup skipped (test mode)";
-                            #endif
+#endif
                         } else {
                             // No legacy password found, try encrypted file storage
                             qDebug() << "CredentialManager: No legacy password found, using encrypted file storage for profile" << profileName;

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -48,11 +48,15 @@ CredentialManager::CredentialManager(QObject* parent)
     : QObject(parent)
     , mCurrentJob(nullptr)
     , mTimeoutTimer(nullptr)
+    , mIsDestroying(false)
 {
 }
 
 CredentialManager::~CredentialManager()
 {
+    // Set destruction flag to prevent any new operations or callbacks
+    mIsDestroying = true;
+    
     // During destruction, we should NOT call callbacks as they may reference
     // objects that are being destroyed. Instead, just clean up without callbacks.
     
@@ -61,6 +65,7 @@ CredentialManager::~CredentialManager()
     mCurrentRetrievalCallback = nullptr;
     mCurrentAvailabilityCallback = nullptr;
     
+    // Clean up operations - this is safe even during application shutdown
     cleanupCurrentOperation();
 }
 
@@ -79,7 +84,18 @@ void CredentialManager::setupTimeout()
 void CredentialManager::cleanupTimeout()
 {
     if (mTimeoutTimer) {
+        // Safely stop and disconnect the timer
         mTimeoutTimer->stop();
+        
+        // If we're destroying or shutting down, avoid disconnect calls that might crash
+        if (!mIsDestroying && !QCoreApplication::closingDown()) {
+            // Safe to disconnect during normal operation
+            mTimeoutTimer->disconnect();
+        } else {
+            // During shutdown/destruction, just null the pointer and let Qt handle cleanup
+            // Note: we don't call disconnect() as the object graph may be partially destroyed
+        }
+        
         mTimeoutTimer->deleteLater();
         mTimeoutTimer = nullptr;
     }
@@ -106,8 +122,16 @@ void CredentialManager::cleanupCurrentOperation()
     cleanupTimeout();
     
     if (mCurrentJob) {
-        // Disconnect all signals to prevent callbacks after cleanup
-        mCurrentJob->disconnect();
+        // If we're destroying or shutting down, avoid disconnect calls that might crash
+        if (!mIsDestroying && !QCoreApplication::closingDown()) {
+            // Safe to disconnect during normal operation
+            mCurrentJob->disconnect();
+        } else {
+            // During shutdown/destruction, just null the pointer and let Qt handle cleanup
+            // Note: we don't call disconnect() as the object graph may be partially destroyed
+        }
+        
+        // Always safe to delete later, Qt handles this properly during shutdown
         mCurrentJob->deleteLater();
         mCurrentJob = nullptr;
     }
@@ -121,6 +145,12 @@ void CredentialManager::cleanupCurrentOperation()
 // Safety method to check if we should proceed with keychain operations
 bool CredentialManager::isOperationValid() const
 {
+    // Check if we're being destroyed
+    if (mIsDestroying) {
+        qDebug() << "CredentialManager: Operation invalid - object being destroyed";
+        return false;
+    }
+    
     // Check if application is shutting down
     if (QCoreApplication::closingDown()) {
         qDebug() << "CredentialManager: Operation invalid - application shutting down";
@@ -252,6 +282,8 @@ void CredentialManager::retrievePassword(const QString& profileName, const QStri
         
         // First try keychain
         auto fallbackCallback = [this, profileName, key, callback](bool keychainSuccess, const QString& keychainPassword, const QString& keychainError) {
+            qDebug() << "CredentialManager: Keychain result for profile" << profileName << "- success:" << keychainSuccess << "password empty:" << keychainPassword.isEmpty();
+            
             if (keychainSuccess && !keychainPassword.isEmpty()) {
                 // Keychain succeeded
                 if (callback) {
@@ -259,7 +291,7 @@ void CredentialManager::retrievePassword(const QString& profileName, const QStri
                 }
             } else {
                 // Keychain failed, try legacy keychain format if this is a password request
-                if (key == "password") {
+                if (key == "password" || key == "character") {
                     qDebug() << "CredentialManager: Checking for legacy keychain format for profile" << profileName;
                     checkLegacyKeychainFormat(profileName, [this, profileName, key, callback, keychainError](bool legacySuccess, const QString& legacyPassword) {
                         if (legacySuccess && !legacyPassword.isEmpty()) {
@@ -586,6 +618,101 @@ void CredentialManager::retrieveCredential(const QString& service, const QString
             }
             qDebug() << "CredentialManager:" << errorContext << ", trying fallback storage";
             
+            // Try legacy keychain format if this is a character password and service follows new format
+            if (account == "character" && service.startsWith("Mudlet-") && service.endsWith("-character")) {
+                // Extract profile name from service (format: "Mudlet-ProfileName-character")
+                QString profileName = service.mid(7); // Remove "Mudlet-" prefix
+                profileName.chop(10); // Remove "-character" suffix
+                
+                qDebug() << "CredentialManager: Checking for legacy keychain format for profile" << profileName;
+                
+                // Check legacy keychain format asynchronously
+                auto* legacyReadJob = new QKeychain::ReadPasswordJob("Mudlet profile", this);
+                legacyReadJob->setKey(profileName);
+                legacyReadJob->setAutoDelete(false);
+                
+                // Store the current callback and clear it to prevent double-calling
+                auto originalCallback = mCurrentRetrievalCallback;
+                mCurrentRetrievalCallback = nullptr;
+                
+                connect(legacyReadJob, &QKeychain::ReadPasswordJob::finished, this, [this, legacyReadJob, profileName, service, account, originalCallback, readJob]() {
+                    bool legacyFound = (legacyReadJob->error() == QKeychain::NoError);
+                    QString legacyPassword = legacyFound ? legacyReadJob->textData() : QString();
+                    
+                    if (legacyFound && !legacyPassword.isEmpty()) {
+                        qDebug() << "CredentialManager: Found legacy password for profile" << profileName;
+                        
+                        // Migrate to new format asynchronously
+                        qDebug() << "CredentialManager: Migrating legacy password to new format for profile" << profileName;
+                        
+                        // Extract original profile name and key from service name for migration
+                        QString originalProfileName = service.mid(7); // Remove "Mudlet-" prefix
+                        originalProfileName.chop(10); // Remove "-character" suffix
+                        
+                        // Store in new format
+                        auto* migrationManager = new CredentialManager();
+                        migrationManager->storePassword(originalProfileName, account, legacyPassword, 
+                            [migrationManager, profileName, originalCallback, legacyPassword](bool migrationSuccess, const QString& migrationError) {
+                                if (migrationSuccess) {
+                                    qDebug() << "CredentialManager: Legacy migration successful for profile" << profileName;
+                                    
+                                    // Clean up legacy entry if migration succeeded
+#ifdef APP_VERSION
+                                    const QString currentVersion = QString(APP_VERSION);
+                                    const QVersionNumber appVersion = QVersionNumber::fromString(currentVersion);
+                                    const QVersionNumber secureStorageVersion = QVersionNumber(4, 20, 0);
+                                    
+                                    if (appVersion >= secureStorageVersion) {
+                                        // Clean up legacy entry asynchronously
+                                        auto* cleanupManager = new CredentialManager();
+                                        cleanupManager->deleteLegacyKeychainEntry(profileName);
+                                        cleanupManager->deleteLater();
+                                        qDebug() << "CredentialManager: Legacy cleanup initiated for version" << currentVersion;
+                                    } else {
+                                        qDebug() << "CredentialManager: Legacy cleanup skipped for version" << currentVersion;
+                                    }
+#else
+                                    qDebug() << "CredentialManager: Legacy cleanup skipped (test mode)";
+#endif
+                                } else {
+                                    qWarning() << "CredentialManager: Legacy migration failed for profile" << profileName << ":" << migrationError;
+                                }
+                                
+                                // Return the legacy password regardless of migration result
+                                if (originalCallback) {
+                                    originalCallback(true, legacyPassword, QString());
+                                }
+                                
+                                migrationManager->deleteLater();
+                            });
+                    } else {
+                        qDebug() << "CredentialManager: No legacy password found for profile" << profileName;
+                        
+                        // No legacy password, try file storage
+                        QString filePassword = retrieveCredentialFromFile(service, account);
+                        bool fileSuccess = !filePassword.isNull();
+                        QString finalError = fileSuccess ? QString() : qsl("Both keychain and encrypted file storage failed for credentials. Keychain: %1").arg(readJob->errorString());
+                        
+                        if (fileSuccess) {
+                            qDebug() << "CredentialManager: Retrieved password from encrypted file storage";
+                        }
+                        
+                        if (originalCallback && isOperationValid()) {
+                            originalCallback(fileSuccess, filePassword, finalError);
+                        }
+                    }
+                    
+                    legacyReadJob->deleteLater();
+                });
+                
+                legacyReadJob->start();
+                
+                // Early return to avoid the file storage check below
+                readJob->deleteLater();
+                return;
+            }
+            
+            // Not a character password or not new format, try file storage directly
             password = retrieveCredentialFromFile(service, account);
 
             if (!password.isNull()) {

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -33,6 +33,7 @@
 #include <QRegularExpression>
 #include <QStandardPaths>
 #include <QTimer>
+#include <QVersionNumber>
 #if defined(INCLUDE_OWN_QT6_KEYCHAIN)
 #include "../3rdparty/qtkeychain/keychain.h"
 #else
@@ -172,18 +173,18 @@ bool CredentialManager::shouldUseKeychain(const QString& profileName) const
     
     // If portable mode is active, prefer SecureStringUtils for portability
     if (isPortableModeActive()) {
-        qDebug() << "CredentialManager: Using SecureStringUtils due to portable mode";
+        qDebug() << "CredentialManager: Using encrypted storage (portable mode)";
         return false;
     }
     
     // If in test environment, use SecureStringUtils to avoid keychain access
     if (SecureStringUtils::isTestEnvironment()) {
-        qDebug() << "CredentialManager: Using SecureStringUtils due to test environment";
+        qDebug() << "CredentialManager: Using encrypted storage (test mode)";
         return false;
     }
     
     // Otherwise, prefer keychain for better security
-    qDebug() << "CredentialManager: Using keychain for better security";
+    qDebug() << "CredentialManager: Using keychain storage";
     return true;
 }
 
@@ -259,56 +260,73 @@ void CredentialManager::retrievePassword(const QString& profileName, const QStri
             } else {
                 // Keychain failed, try legacy keychain format if this is a password request
                 if (key == "password") {
-                    qDebug() << "CredentialManager: Keychain failed, checking legacy format for profile:" << profileName;
+                    qDebug() << "CredentialManager: Checking for legacy keychain format for profile" << profileName;
                     checkLegacyKeychainFormat(profileName, [this, profileName, key, callback, keychainError](bool legacySuccess, const QString& legacyPassword) {
                         if (legacySuccess && !legacyPassword.isEmpty()) {
-                            qDebug() << "CredentialManager: Found password in legacy keychain format, migrating to new format";
+                            qDebug() << "CredentialManager: Migrating legacy password for profile" << profileName;
                             // Store in new format and remove from legacy
                             storePassword(profileName, key, legacyPassword, [callback, legacyPassword](bool migrationSuccess, const QString& migrationError) {
                                 if (migrationSuccess) {
-                                    qDebug() << "CredentialManager: Successfully migrated legacy password to new format";
+                                    qDebug() << "CredentialManager: Legacy migration successful";
                                 } else {
-                                    qWarning() << "CredentialManager: Failed to migrate legacy password:" << migrationError;
+                                    qWarning() << "CredentialManager: Legacy migration failed:" << migrationError;
                                 }
                                 // Return the password regardless of migration result
                                 if (callback) {
                                     callback(true, legacyPassword, QString());
                                 }
                             });
-                            // Clean up legacy entry asynchronously (don't wait for result)
-                            deleteLegacyKeychainEntry(profileName);
+                            
+                            // Only clean up legacy entry if this version is >= 4.20.0
+                            // This prevents breaking compatibility with older Mudlet versions
+                            #ifdef APP_VERSION
+                            const QString currentVersion = QString(APP_VERSION);
+                            const QVersionNumber appVersion = QVersionNumber::fromString(currentVersion);
+                            const QVersionNumber secureStorageVersion = QVersionNumber(4, 20, 0);
+                            
+                            if (appVersion >= secureStorageVersion) {
+                                // Clean up legacy entry asynchronously (don't wait for result)
+                                deleteLegacyKeychainEntry(profileName);
+                                qDebug() << "CredentialManager: Legacy cleanup enabled for version" << currentVersion;
+                            } else {
+                                qDebug() << "CredentialManager: Legacy cleanup skipped for version" << currentVersion;
+                            }
+                            #else
+                            // In test environment, preserve legacy entries for safety
+                            qDebug() << "CredentialManager: Legacy cleanup skipped (test mode)";
+                            #endif
                         } else {
-                            // No legacy password found, try SecureStringUtils fallback
-                            qDebug() << "CredentialManager: No legacy password found, trying SecureStringUtils fallback:" << keychainError;
+                            // No legacy password found, try encrypted file storage
+                            qDebug() << "CredentialManager: No legacy password found, using encrypted file storage for profile" << profileName;
                             QString fallbackPassword = retrieveCredentialFromFile(profileName, key);
 
                             if (!fallbackPassword.isEmpty()) {
-                                qDebug() << "CredentialManager: Retrieved password from SecureStringUtils fallback";
+                                qDebug() << "CredentialManager: Password retrieved from encrypted file storage";
 
                                 if (callback) {
                                     callback(true, fallbackPassword, QString());
                                 }
                             } else {
                                 if (callback) {
-                                    callback(false, QString(), qsl("Keychain, legacy keychain, and SecureStringUtils all failed. Keychain error: %1").arg(keychainError));
+                                    callback(false, QString(), qsl("No stored credentials found for profile %1 (keychain, legacy, and encrypted file storage all empty)").arg(profileName));
                                 }
                             }
                         }
                     });
                 } else {
-                    // Not a password request, try SecureStringUtils fallback directly
-                    qDebug() << "CredentialManager: Keychain failed, trying SecureStringUtils fallback:" << keychainError;
+                    // Not a password request, use encrypted file storage directly
+                    qDebug() << "CredentialManager: Using encrypted file storage for credential" << key << "for profile" << profileName;
                     QString fallbackPassword = retrieveCredentialFromFile(profileName, key);
 
                     if (!fallbackPassword.isEmpty()) {
-                        qDebug() << "CredentialManager: Retrieved password from SecureStringUtils fallback";
+                        qDebug() << "CredentialManager: Retrieved credential from encrypted file storage";
 
                         if (callback) {
                             callback(true, fallbackPassword, QString());
                         }
                     } else {
                         if (callback) {
-                            callback(false, QString(), qsl("Both keychain and SecureStringUtils failed. Keychain error: %1").arg(keychainError));
+                            callback(false, QString(), qsl("No stored credentials found for profile %1 (keychain and encrypted file storage both empty)").arg(profileName));
                         }
                     }
                 }
@@ -457,7 +475,7 @@ void CredentialManager::storeCredential(const QString& service, const QString& a
         
         // If keychain failed, try file storage fallback
         if (!success) {
-            qDebug() << "QtKeychain storage failed, attempting file fallback:" << errorMessage;
+            qDebug() << "CredentialManager: Keychain storage failed, using encrypted file storage:" << errorMessage;
             
             // Use service as profile name and account as key for file storage
             bool fileSuccess = storeCredentialToFile(service, account, password);
@@ -465,10 +483,12 @@ void CredentialManager::storeCredential(const QString& service, const QString& a
             if (fileSuccess) {
                 success = true;
                 errorMessage = QString(); // Clear error message on successful fallback
-                qDebug() << "File storage fallback succeeded";
+                qDebug() << "CredentialManager: Password stored to encrypted file storage";
             } else {
-                errorMessage = qsl("Both keychain and file storage failed. Keychain error: %1").arg(errorMessage);
+                errorMessage = qsl("Both keychain and encrypted file storage failed. Keychain error: %1").arg(errorMessage);
             }
+        } else {
+            qDebug() << "CredentialManager: Password stored to keychain";
         }
         
         // Final validity check before calling callback
@@ -540,18 +560,40 @@ void CredentialManager::retrieveCredential(const QString& service, const QString
             // Get password directly from keychain (keychain handles decryption)
             password = readJob->textData();
             // No additional decryption needed for keychain passwords
+            qDebug() << "CredentialManager: Retrieved password from keychain";
         } else {
-            // Keychain failed, try file storage fallback
-            qDebug() << "QtKeychain retrieval failed, attempting file fallback:" << readJob->errorString();
+            // Keychain failed, try file storage fallback with specific error context
+            QString errorContext;
+            switch (readJob->error()) {
+                case QKeychain::EntryNotFound:
+                    errorContext = "No password stored in keychain";
+                    break;
+                case QKeychain::AccessDeniedByUser:
+                    errorContext = "User denied keychain access";
+                    break;
+                case QKeychain::AccessDenied:
+                    errorContext = "Keychain access denied by system";
+                    break;
+                case QKeychain::NoBackendAvailable:
+                    errorContext = "No keychain service available";
+                    break;
+                case QKeychain::NotImplemented:
+                    errorContext = "Keychain not supported on this platform";
+                    break;
+                default:
+                    errorContext = qsl("Keychain error: %1").arg(readJob->errorString());
+                    break;
+            }
+            qDebug() << "CredentialManager:" << errorContext << ", trying fallback storage";
             
             password = retrieveCredentialFromFile(service, account);
 
             if (!password.isNull()) {
                 success = true;
                 errorMessage = QString(); // Clear error message on successful fallback
-                qDebug() << "File storage fallback succeeded";
+                qDebug() << "CredentialManager: Retrieved password from encrypted file storage";
             } else {
-                errorMessage = qsl("Both keychain and file storage failed. Keychain error: %1").arg(readJob->errorString());
+                errorMessage = qsl("Both keychain and encrypted file storage failed for credentials. Keychain: %1").arg(readJob->errorString());
             }
         }
         
@@ -990,14 +1032,14 @@ void CredentialManager::checkLegacyKeychainFormat(const QString& profileName,
     readJob->setKey(profileName);
     readJob->setAutoDelete(false);
     
-    connect(readJob, &QKeychain::ReadPasswordJob::finished, this, [readJob, callback]() {
+    connect(readJob, &QKeychain::ReadPasswordJob::finished, this, [readJob, callback, profileName]() {
         bool success = (readJob->error() == QKeychain::NoError);
         QString password = success ? readJob->textData() : QString();
         
         if (success) {
-            qDebug() << "CredentialManager: Found password in legacy keychain format";
+            qDebug() << "CredentialManager: Found legacy password for profile" << profileName;
         } else {
-            qDebug() << "CredentialManager: No password found in legacy keychain format:" << readJob->errorString();
+            qDebug() << "CredentialManager: No legacy password found for profile" << profileName;
         }
         
         callback(success, password);
@@ -1022,9 +1064,9 @@ void CredentialManager::deleteLegacyKeychainEntry(const QString& profileName)
     
     connect(deleteJob, &QKeychain::DeletePasswordJob::finished, this, [deleteJob, profileName]() {
         if (deleteJob->error() == QKeychain::NoError) {
-            qDebug() << "CredentialManager: Successfully deleted legacy keychain entry for profile:" << profileName;
+            qDebug() << "CredentialManager: Deleted legacy entry for profile" << profileName;
         } else {
-            qDebug() << "CredentialManager: Failed to delete legacy keychain entry for profile:" << profileName << "Error:" << deleteJob->errorString();
+            qDebug() << "CredentialManager: Failed to delete legacy entry for profile" << profileName << ":" << deleteJob->errorString();
         }
 
         deleteJob->deleteLater();

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -54,7 +54,7 @@ CredentialManager::CredentialManager(QObject* parent)
 CredentialManager::~CredentialManager()
 {
     // Set destruction flag to prevent any new operations or callbacks
-    mIsDestroying = true;
+    mShuttingDown = true;
     
     // During destruction, we should NOT call callbacks as they may reference
     // objects that are being destroyed. Instead, just clean up without callbacks.
@@ -87,7 +87,7 @@ void CredentialManager::cleanupTimeout()
         mTimeoutTimer->stop();
         
         // If we're destroying or shutting down, avoid disconnect calls that might crash
-        if (!mIsDestroying && !QCoreApplication::closingDown()) {
+        if (!mShuttingDown && !QCoreApplication::closingDown()) {
             // Safe to disconnect during normal operation
             mTimeoutTimer->disconnect();
         }
@@ -119,7 +119,7 @@ void CredentialManager::cleanupCurrentOperation()
     
     if (mCurrentJob) {
         // If we're destroying or shutting down, avoid disconnect calls that might crash
-        if (!mIsDestroying && !QCoreApplication::closingDown()) {
+        if (!mShuttingDown && !QCoreApplication::closingDown()) {
             // Safe to disconnect during normal operation
             mCurrentJob->disconnect();
         }
@@ -142,7 +142,7 @@ void CredentialManager::cleanupCurrentOperation()
 bool CredentialManager::isOperationValid() const
 {
     // Check if we're being destroyed
-    if (mIsDestroying) {
+    if (mShuttingDown) {
         qDebug() << "CredentialManager: Operation invalid - object being destroyed";
         return false;
     }

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -124,8 +124,11 @@ void CredentialManager::cleanupCurrentOperation()
             mCurrentJob->disconnect();
         }
         
-        // Always safe to delete later, Qt handles this properly during shutdown
-        mCurrentJob->deleteLater();
+        // Check if the job is still valid before calling deleteLater
+        if (mCurrentJob->thread() != nullptr) {
+            // Only call deleteLater if the object is still valid
+            mCurrentJob->deleteLater();
+        }
         mCurrentJob = nullptr;
     }
     
@@ -619,6 +622,9 @@ void CredentialManager::retrieveCredential(const QString& service, const QString
                 
                 qDebug() << "CredentialManager: Checking for legacy keychain format for profile" << profileName;
                 
+                // Capture the error string now while readJob is still valid
+                QString keychainError = readJob->errorString();
+                
                 // Check legacy keychain format asynchronously
                 auto* legacyReadJob = new QKeychain::ReadPasswordJob("Mudlet profile", this);
                 legacyReadJob->setKey(profileName);
@@ -628,7 +634,7 @@ void CredentialManager::retrieveCredential(const QString& service, const QString
                 auto originalCallback = mCurrentRetrievalCallback;
                 mCurrentRetrievalCallback = nullptr;
                 
-                connect(legacyReadJob, &QKeychain::ReadPasswordJob::finished, this, [this, legacyReadJob, profileName, service, account, originalCallback, readJob]() {
+                connect(legacyReadJob, &QKeychain::ReadPasswordJob::finished, this, [this, legacyReadJob, profileName, service, account, originalCallback, keychainError]() {
                     bool legacyFound = (legacyReadJob->error() == QKeychain::NoError);
                     QString legacyPassword = legacyFound ? legacyReadJob->textData() : QString();
                     
@@ -684,13 +690,13 @@ void CredentialManager::retrieveCredential(const QString& service, const QString
                         // No legacy password, try file storage
                         QString filePassword = retrieveCredentialFromFile(service, account);
                         bool fileSuccess = !filePassword.isNull();
-                        QString finalError = fileSuccess ? QString() : qsl("Both keychain and encrypted file storage failed for credentials. Keychain: %1").arg(readJob->errorString());
+                        QString finalError = fileSuccess ? QString() : qsl("Both keychain and encrypted file storage failed for credentials. Keychain: %1").arg(keychainError);
                         
                         if (fileSuccess) {
                             qDebug() << "CredentialManager: Retrieved password from encrypted file storage";
                         }
                         
-                        if (originalCallback && isOperationValid()) {
+                        if (originalCallback) {
                             originalCallback(fileSuccess, filePassword, finalError);
                         }
                     }

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -116,19 +116,15 @@ void CredentialManager::handleTimeout()
 void CredentialManager::cleanupCurrentOperation()
 {
     cleanupTimeout();
-    
+
     if (mCurrentJob) {
         // If we're destroying or shutting down, avoid disconnect calls that might crash
         if (!mShuttingDown && !QCoreApplication::closingDown()) {
             // Safe to disconnect during normal operation
             mCurrentJob->disconnect();
         }
-        
-        // Check if the job is still valid before calling deleteLater
-        if (mCurrentJob->thread() != nullptr) {
-            // Only call deleteLater if the object is still valid
-            mCurrentJob->deleteLater();
-        }
+
+        mCurrentJob->deleteLater();
         mCurrentJob = nullptr;
     }
     

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -48,7 +48,6 @@ CredentialManager::CredentialManager(QObject* parent)
     : QObject(parent)
     , mCurrentJob(nullptr)
     , mTimeoutTimer(nullptr)
-    , mIsDestroying(false)
 {
 }
 

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -90,9 +90,6 @@ void CredentialManager::cleanupTimeout()
         if (!mIsDestroying && !QCoreApplication::closingDown()) {
             // Safe to disconnect during normal operation
             mTimeoutTimer->disconnect();
-        } else {
-            // During shutdown/destruction, just null the pointer and let Qt handle cleanup
-            // Note: we don't call disconnect() as the object graph may be partially destroyed
         }
         
         mTimeoutTimer->deleteLater();
@@ -125,9 +122,6 @@ void CredentialManager::cleanupCurrentOperation()
         if (!mIsDestroying && !QCoreApplication::closingDown()) {
             // Safe to disconnect during normal operation
             mCurrentJob->disconnect();
-        } else {
-            // During shutdown/destruction, just null the pointer and let Qt handle cleanup
-            // Note: we don't call disconnect() as the object graph may be partially destroyed
         }
         
         // Always safe to delete later, Qt handles this properly during shutdown

--- a/src/CredentialManager.h
+++ b/src/CredentialManager.h
@@ -131,7 +131,7 @@ private:
     AvailabilityCallback mCurrentAvailabilityCallback;
     
     // Destruction flag to prevent operations during cleanup
-    bool mIsDestroying = false;
+    bool mShuttingDown = false;
 };
 
 #endif // MUDLET_CREDENTIALMANAGER_H

--- a/src/CredentialManager.h
+++ b/src/CredentialManager.h
@@ -124,7 +124,7 @@ private:
     void deleteLegacyKeychainEntry(const QString& profileName);
     
     // Current operation state
-    QKeychain::Job* mCurrentJob;
+    QPointer<QKeychain::Job> mCurrentJob;
     QTimer* mTimeoutTimer;
     CredentialCallback mCurrentCallback;
     CredentialRetrievalCallback mCurrentRetrievalCallback;

--- a/src/CredentialManager.h
+++ b/src/CredentialManager.h
@@ -131,7 +131,7 @@ private:
     AvailabilityCallback mCurrentAvailabilityCallback;
     
     // Destruction flag to prevent operations during cleanup
-    bool mIsDestroying;
+    bool mIsDestroying = false;
 };
 
 #endif // MUDLET_CREDENTIALMANAGER_H

--- a/src/CredentialManager.h
+++ b/src/CredentialManager.h
@@ -129,6 +129,9 @@ private:
     CredentialCallback mCurrentCallback;
     CredentialRetrievalCallback mCurrentRetrievalCallback;
     AvailabilityCallback mCurrentAvailabilityCallback;
+    
+    // Destruction flag to prevent operations during cleanup
+    bool mIsDestroying;
 };
 
 #endif // MUDLET_CREDENTIALMANAGER_H

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -624,13 +624,13 @@ void dlgConnectionProfiles::slot_saveName()
 
         // Check if there are orphaned keychain entries for this profile name
         auto* credManager = new CredentialManager(this);
-        credManager->retrieveCredential(newProfileName, "character",
+        credManager->retrievePassword(newProfileName, "character",
             [this, credManager, newProfileName, pItem, newProfileHost, newProfilePort, newProfileSslTsl]
             (bool foundCharacterEntry, const QString& characterPassword, const QString& errorMessage) {
                 Q_UNUSED(characterPassword)
                 Q_UNUSED(errorMessage)
 
-                credManager->retrieveCredential(newProfileName, "proxy",
+                credManager->retrievePassword(newProfileName, "proxy",
                     [this, credManager, newProfileName, pItem, newProfileHost, newProfilePort, newProfileSslTsl, foundCharacterEntry]
                     (bool foundProxyEntry, const QString& proxyPassword, const QString& errorMessage) {
                         Q_UNUSED(proxyPassword)
@@ -1372,7 +1372,7 @@ void dlgConnectionProfiles::loadSecuredPassword(const QString& profile, L callba
     // Use async API for QtKeychain integration with file fallback
     auto* credManager = new CredentialManager();
 
-    credManager->retrieveCredential(profile, "character",
+    credManager->retrievePassword(profile, "character",
         [credManager, callback = std::move(callback)](bool success, const QString& password, const QString& errorMessage) {
             if (success) {
                 callback(password);
@@ -2278,7 +2278,7 @@ void dlgConnectionProfiles::slot_loadPasswordAsync()
     if (mudlet::self()->storingPasswordsSecurely()) {
         mKeychainOperationInProgress = true;
         auto* credManager = new CredentialManager(this);
-        credManager->retrieveCredential(profile_name, "character",
+        credManager->retrievePassword(profile_name, "character",
             [this, credManager, profile_name](bool success, const QString& retrievedPassword, const QString& errorMessage) {
                 // Clear the operation flag first
                 mKeychainOperationInProgress = false;

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -41,6 +41,7 @@
 #include <QDir>
 #include <QRandomGenerator>
 #include <QSettings>
+#include <QSignalBlocker>
 #include <QTime>
 #include "post_guard.h"
 #include <chrono>
@@ -1541,10 +1542,11 @@ void dlgConnectionProfiles::slot_copyProfile()
         discord_optin_checkBox->setChecked(false);
 
         // restore the password, which won't be copied by the disk copy if stored in the credential manager
-        // Temporarily disconnect textChanged to avoid triggering save on programmatic setText
-        disconnect(character_password_entry, &QLineEdit::textChanged, this, &dlgConnectionProfiles::slot_passwordTextChanged);
-        character_password_entry->setText(oldPassword);
-        connect(character_password_entry, &QLineEdit::textChanged, this, &dlgConnectionProfiles::slot_passwordTextChanged);
+        // Temporarily block textChanged signal to avoid triggering save on programmatic setText
+        {
+            const QSignalBlocker blocker(character_password_entry);
+            character_password_entry->setText(oldPassword);
+        }
         
         if (mudlet::self()->storingPasswordsSecurely() && !oldPassword.trimmed().isEmpty()) {
             writeSecurePassword(profile_name, oldPassword);
@@ -2289,10 +2291,11 @@ void dlgConnectionProfiles::slot_loadPasswordAsync()
 
                     if (success) {
                         // Keychain operation succeeded - set the password (even if empty)
-                        // Temporarily disconnect textChanged to avoid triggering save on programmatic setText
-                        disconnect(character_password_entry, &QLineEdit::textChanged, this, &dlgConnectionProfiles::slot_passwordTextChanged);
-                        character_password_entry->setText(retrievedPassword);
-                        connect(character_password_entry, &QLineEdit::textChanged, this, &dlgConnectionProfiles::slot_passwordTextChanged);
+                        // Temporarily block textChanged signal to avoid triggering save on programmatic setText
+                        {
+                            const QSignalBlocker blocker(character_password_entry);
+                            character_password_entry->setText(retrievedPassword);
+                        }
                         
                         if (retrievedPassword.isEmpty()) {
                             qDebug() << "dlgConnectionProfiles: Keychain returned empty password for" << profile_name;
@@ -2352,22 +2355,21 @@ void dlgConnectionProfiles::loadPasswordFromSettings(const QString& profile_name
     const QString password = settings.value(qsl("password"), QString()).toString();
     const QString oldPassword = settings.value(qsl("login"), QString()).toString();
 
-    // Temporarily disconnect textChanged to avoid triggering save on programmatic setText
-    disconnect(character_password_entry, &QLineEdit::textChanged, this, &dlgConnectionProfiles::slot_passwordTextChanged);
-    
-    if (!password.isEmpty()) {
-        character_password_entry->setText(password);
-    } else if (!oldPassword.isEmpty()) {
-        // Migrate old password
-        character_password_entry->setText(oldPassword);
-        settings.setValue(qsl("password"), oldPassword);
-        settings.remove(qsl("login"));
-    } else {
-        character_password_entry->setText(QString());
+    // Temporarily block textChanged signal to avoid triggering save on programmatic setText
+    {
+        const QSignalBlocker blocker(character_password_entry);
+        
+        if (!password.isEmpty()) {
+            character_password_entry->setText(password);
+        } else if (!oldPassword.isEmpty()) {
+            // Migrate old password
+            character_password_entry->setText(oldPassword);
+            settings.setValue(qsl("password"), oldPassword);
+            settings.remove(qsl("login"));
+        } else {
+            character_password_entry->setText(QString());
+        }
     }
-    
-    // Reconnect the signal
-    connect(character_password_entry, &QLineEdit::textChanged, this, &dlgConnectionProfiles::slot_passwordTextChanged);
 
     settings.endGroup();
 }

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -41,6 +41,7 @@
 #include <QDir>
 #include <QRandomGenerator>
 #include <QSettings>
+#include <QTime>
 #include "post_guard.h"
 #include <chrono>
 #include <sstream>
@@ -955,12 +956,24 @@ QString dlgConnectionProfiles::getDescription(const QString& profile_name) const
 void dlgConnectionProfiles::slot_itemClicked(QListWidgetItem* pItem)
 {
     if (!pItem) {
+        qDebug() << "dlgConnectionProfiles::slot_itemClicked() called with null item";
         return;
     }
 
-    slot_togglePasswordVisibility(false);
-
     const QString profile_name = pItem->data(csmNameRole).toString();
+
+    // Prevent rapid duplicate clicks on the same profile
+    static QString lastProfileClicked;
+    static QTime lastClickTime;
+    
+    if (profile_name == lastProfileClicked && lastClickTime.isValid() && lastClickTime.msecsTo(QTime::currentTime()) < 100) {
+        return;
+    }
+    
+    lastProfileClicked = profile_name;
+    lastClickTime = QTime::currentTime();
+
+    slot_togglePasswordVisibility(false);
 
     profile_name_entry->setText(profile_name);
 
@@ -1528,7 +1541,11 @@ void dlgConnectionProfiles::slot_copyProfile()
         discord_optin_checkBox->setChecked(false);
 
         // restore the password, which won't be copied by the disk copy if stored in the credential manager
+        // Temporarily disconnect textChanged to avoid triggering save on programmatic setText
+        disconnect(character_password_entry, &QLineEdit::textChanged, this, &dlgConnectionProfiles::slot_passwordTextChanged);
         character_password_entry->setText(oldPassword);
+        connect(character_password_entry, &QLineEdit::textChanged, this, &dlgConnectionProfiles::slot_passwordTextChanged);
+        
         if (mudlet::self()->storingPasswordsSecurely() && !oldPassword.trimmed().isEmpty()) {
             writeSecurePassword(profile_name, oldPassword);
         }
@@ -2233,6 +2250,11 @@ void dlgConnectionProfiles::slot_loadPasswordAsync()
 
     const QString profile_name = timer->property("profileName").toString();
 
+    // Prevent duplicate password loading operations for the same profile
+    if (mKeychainOperationInProgress) {
+        return;
+    }
+
     if (profile_name.isEmpty()) {
         return;
     }
@@ -2267,9 +2289,15 @@ void dlgConnectionProfiles::slot_loadPasswordAsync()
 
                     if (success) {
                         // Keychain operation succeeded - set the password (even if empty)
+                        // Temporarily disconnect textChanged to avoid triggering save on programmatic setText
+                        disconnect(character_password_entry, &QLineEdit::textChanged, this, &dlgConnectionProfiles::slot_passwordTextChanged);
                         character_password_entry->setText(retrievedPassword);
+                        connect(character_password_entry, &QLineEdit::textChanged, this, &dlgConnectionProfiles::slot_passwordTextChanged);
+                        
                         if (retrievedPassword.isEmpty()) {
                             qDebug() << "dlgConnectionProfiles: Keychain returned empty password for" << profile_name;
+                        } else {
+                            qDebug() << "dlgConnectionProfiles: Successfully loaded password from keychain for" << profile_name;
                         }
                     } else {
                         // Fallback to QSettings only if keychain operation failed
@@ -2324,6 +2352,9 @@ void dlgConnectionProfiles::loadPasswordFromSettings(const QString& profile_name
     const QString password = settings.value(qsl("password"), QString()).toString();
     const QString oldPassword = settings.value(qsl("login"), QString()).toString();
 
+    // Temporarily disconnect textChanged to avoid triggering save on programmatic setText
+    disconnect(character_password_entry, &QLineEdit::textChanged, this, &dlgConnectionProfiles::slot_passwordTextChanged);
+    
     if (!password.isEmpty()) {
         character_password_entry->setText(password);
     } else if (!oldPassword.isEmpty()) {
@@ -2334,6 +2365,9 @@ void dlgConnectionProfiles::loadPasswordFromSettings(const QString& profile_name
     } else {
         character_password_entry->setText(QString());
     }
+    
+    // Reconnect the signal
+    connect(character_password_entry, &QLineEdit::textChanged, this, &dlgConnectionProfiles::slot_passwordTextChanged);
 
     settings.endGroup();
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -5623,7 +5623,7 @@ bool mudlet::migratePasswordsToSecureStorage()
     }
 
     if (!anyMigrationNeeded) {
-        qDebug() << "mudlet::migratePasswordsToSecureStorage() INFO - no migration needed.";
+        qDebug() << "mudlet::migratePasswordsToSecureStorage() INFO - no passwords found in profile data files to migrate.";
     }
 
     // Always emit the signal (either immediately or after migrations complete)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Fixed a bug where users lost their saved passwords when switching between different Mudlet versions
- Added safety checks to prevent password deletion unless you're using a newer version (4.20.0+)
- Made error messages clearer and more helpful when password loading fails
- Improved the system's ability to find passwords stored in different locations
- Added better logging to help diagnose password-related issues

#### Motivation for adding to Mudlet

Users reported that their saved passwords disappeared after trying development versions of Mudlet. This happened because the system was automatically cleaning up old password storage without considering that users might switch back to older versions. The unclear error messages also made it difficult to understand what was happening when passwords couldn't be loaded.

#### Other info (issues closed, discussion etc)

This fix ensures users can safely test different Mudlet versions without losing their saved passwords. It also makes password-related problems easier to understand and troubleshoot, while maintaining compatibility with all existing Mudlet installations.