### PR TITLE
Fix: MXP parser blocked on non-escaped '&' and '<' characters

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -152,7 +152,11 @@ TBuffer::TBuffer(Host* pH, TConsole* pConsole)
 , mForeGroundColorLight(pH->mFgColor)
 , mBackGroundColor(pH->mBgColor)
 , mpHost(pH)
+, mTagWatchdog(nullptr)
 {
+    mTagWatchdog = new QTimer();
+    mTagWatchdog->setSingleShot(true);
+    QObject::connect(mTagWatchdog, &QTimer::timeout, [this]() { processMxpWatchdogCallback(); });
     // All additions to the buffer must use append()/appendLine() to preserve formatting via TChar.
     // Direct modification of the `buffer` vector may bypass formatting and should be avoided.
     clear();
@@ -164,6 +168,11 @@ TBuffer::TBuffer(Host* pH, TConsole* pConsole)
         Q_ASSERT_X(table.size() == 128, "TBuffer", "Mis-sized encoding look-up table.");
     }
 #endif
+}
+
+TBuffer::~TBuffer()
+{
+    delete mTagWatchdog;
 }
 
 // user-defined literal to represent megabytes
@@ -581,23 +590,9 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                     bool isOk = false;
                     const int spacesNeeded = temp.toInt(&isOk);
                     if (isOk && spacesNeeded > 0) {
-                        const TChar::AttributeFlags attributeFlags =
-                                ((mBold || mpHost->mMxpClient.bold()) ? TChar::Bold : TChar::None)
-                                | (mItalics || mpHost->mMxpClient.italic() ? TChar::Italic : TChar::None)
-                                | (mOverline ? TChar::Overline : TChar::None)
-                                | (mReverse ? TChar::Reverse : TChar::None)
-                                | (mStrikeOut || mpHost->mMxpClient.strikeOut() ? TChar::StrikeOut : TChar::None)
-                                | (mUnderline || mpHost->mMxpClient.underline() ? TChar::Underline : TChar::None)
-                                | (mUnderlineWavy ? TChar::UnderlineWavy : TChar::None)
-                                | (mUnderlineDotted ? TChar::UnderlineDotted : TChar::None)
-                                | (mUnderlineDashed ? TChar::UnderlineDashed : TChar::None)
-                                | (mFastBlink ? TChar::FastBlink : (mBlink ? TChar::Blink :TChar::None))
-                                | (TChar::alternateFontFlag(mAltFont))
-                                | (mConcealed ? TChar::Concealed : TChar::None);
-
                         // Note: we are using the background color for the
                         // foreground color as well so that we are transparent:
-                        const TChar c(mBackGroundColor, mBackGroundColor, attributeFlags);
+                        const TChar c(mBackGroundColor, mBackGroundColor, computeCurrentAttributeFlags());
                         for (int spaceCount = 0; spaceCount < spacesNeeded; ++spaceCount) {
                             mMudLine.append(QChar::Space);
                             mMudBuffer.push_back(c);
@@ -703,6 +698,12 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                     // (countermeasure against infinite recursion)
                     TMxpProcessingResult const result =
                             mpHost->mMxpProcessor.processMxpInput(ch, localBufferPosition >= endOfMXPEntity);
+                    if (!mTagWatchdog->isActive()
+                    && mpHost->mMxpProcessor.getMxpTagBuilder().isInsideTag()
+                    && !mpHost->mMxpProcessor.getMxpTagBuilder().getRawTagContent().empty()) {
+                        mWatchdogPhase = WatchdogPhase::Phase1_Snapshot;
+                        mTagWatchdog->start(MAX_TAG_TIMEOUT_MS);
+                    }
 
                     switch (result) {
                     case HANDLER_NEXT_CHAR:
@@ -777,6 +778,9 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                         //HANDLER_FALL_THROUGH -> do nothing
                         assert(localBuffer[localBufferPosition] == ch);
                     }
+                } else if (mpHost->mMxpProcessor.getMxpTagBuilder().isInsideTag()) {
+                    localBufferPosition++;
+                    continue;
                 } else {
                     mpHost->mMxpProcessor.processRawInput(ch);
                 }
@@ -789,118 +793,9 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
         }
 
 COMMIT_LINE:
-        if (CHAR_IS_COMMIT_CHAR(ch)) {
-            // DE: MUD Zeilen werden immer am Zeilenanfang geschrieben
-            // EN: MUD lines are always written at the beginning of the line
-
-            // FIXME: This is the point where we should renormalise the new text
-            // data - of course there is the theoretical chance that the new
-            // text would alter the prior contents but as that is on a separate
-            // line there should not be any changes to text before a line feed
-            // which sort of seems to be implied by the current value of ch:
-
-            // Qt struggles to report blank lines on Windows to screen readers, this is a workaround
-            // https://bugreports.qt.io/browse/QTBUG-105035
-            if (Q_UNLIKELY(mMudLine.isEmpty())) {
-                if (mpHost->mBlankLineBehaviour == Host::BlankLineBehaviour::Hide) {
-                    localBufferPosition++;
-                    continue;
-                } else if (mpHost->mBlankLineBehaviour == Host::BlankLineBehaviour::ReplaceWithSpace) {
-                    const TChar::AttributeFlags attributeFlags =
-                            ((mBold || mpHost->mMxpClient.bold()) ? TChar::Bold : TChar::None)
-                            | (mItalics || mpHost->mMxpClient.italic() ? TChar::Italic : TChar::None)
-                            | (mOverline ? TChar::Overline : TChar::None)
-                            | (mReverse ? TChar::Reverse : TChar::None)
-                            | (mStrikeOut || mpHost->mMxpClient.strikeOut() ? TChar::StrikeOut : TChar::None)
-                            | (mUnderline || mpHost->mMxpClient.underline() ? TChar::Underline : TChar::None)
-                            | (mUnderlineWavy ? TChar::UnderlineWavy : TChar::None)
-                            | (mUnderlineDotted ? TChar::UnderlineDotted : TChar::None)
-                            | (mUnderlineDashed ? TChar::UnderlineDashed : TChar::None)
-                            | (mFastBlink ? TChar::FastBlink : (mBlink ? TChar::Blink :TChar::None))
-                            | (TChar::alternateFontFlag(mAltFont))
-                            | (mConcealed ? TChar::Concealed : TChar::None);
-
-                    // Note: we are using the background color for the
-                    // foreground color as well so that we are transparent:
-                    const TChar c(mBackGroundColor, mBackGroundColor, attributeFlags);
-                    mMudLine.append(QChar::Space);
-                    mMudBuffer.push_back(c);
-                }
-            }
-
-            if (static_cast<size_t>(mMudLine.size()) != mMudBuffer.size()) {
-                qWarning() << "TBuffer::translateToPlainText(...) WARNING: mismatch in new text "
-                              "data character and attribute data items!";
-            }
-
-            if (!lineBuffer.back().isEmpty()) {
-                if (!mMudLine.isEmpty()) {
-                    lineBuffer << mMudLine;
-                } else {
-                    if (ch == '\r') {
-                        ++localBufferPosition;
-                        continue; //empty timer posting
-                    }
-                    lineBuffer << QString();
-                }
-                buffer.push_back(mMudBuffer);
-                timeBuffer << QTime::currentTime().toString(mudlet::smTimeStampFormat);
-                if (ch == '\xff') {
-                    promptBuffer.append(true);
-                } else {
-                    promptBuffer.append(false);
-                }
-            } else {
-                if (!mMudLine.isEmpty()) {
-                    lineBuffer.back().append(mMudLine);
-                } else {
-                    if (ch == '\r') {
-                        ++localBufferPosition;
-                        continue; //empty timer posting
-                    }
-                    lineBuffer.back().append(QString());
-                }
-                buffer.back() = mMudBuffer;
-                timeBuffer.back() = QTime::currentTime().toString(mudlet::smTimeStampFormat);
-                if (ch == '\xff') {
-                    promptBuffer.back() = true;
-                } else {
-                    promptBuffer.back() = false;
-                }
-            }
-
-            mMudLine.clear();
-            mMudBuffer.clear();
-            const int line = lineBuffer.size() - 1;
-            mpHost->mpConsole->runTriggers(line);
-            // Only use of TBuffer::wrap(), breaks up new text
-            // NOTE: it MAY have been clobbered by the trigger engine!
-            const int addedLines = wrapLine(line, mWrapAt, mWrapIndent, mWrapHangingIndent);
-
-            // Start a new, but empty line in the various buffers
-            log(lineBuffer.size() - 1, lineBuffer.size() - 1);
-            ++localBufferPosition;
-            // Suppress new empty line IFF echoes already created a new empty line
-            // i.e. add newline if no added lines or the lastline isn't empty
-            if (addedLines == 0 || !lineBuffer.back().isEmpty()) {
-                std::deque<TChar> const newLine;
-                buffer.push_back(newLine);
-                lineBuffer.push_back(QString());
-                timeBuffer.push_back(QString());
-                promptBuffer << false;
-            }
-            if (static_cast<int>(buffer.size()) > mLinesLimit) {
-                // Whilst we also include a call to TConsole::handleLinesOverflowEvent(...)
-                // in all other methods where the following is used (because
-                // both need to monitor the number of lines of text in the
-                // buffer) the event that the former may be required to
-                // generate is NOT used for the TMainConsole case whereas this
-                // (translateToPlainText(...)) method is ONLY for that one:
-                shrinkBuffer();
-            }
+        if (commitLine(ch, localBufferPosition)) {
             continue;
         }
-
         // PLACEMARKER: Incoming text decoding
         // Used to double up the TChars for Utf-8 byte sequences that produce
         // a surrogate pair (non-BMP):
@@ -960,37 +855,23 @@ COMMIT_LINE:
             }
         }
 
-        const TChar::AttributeFlags attributeFlags =
-                ((mBold || mpHost->mMxpClient.bold()) ? TChar::Bold : TChar::None)
-                | (mItalics || mpHost->mMxpClient.italic() ? TChar::Italic : TChar::None)
-                | (mOverline ? TChar::Overline : TChar::None)
-                | (mReverse ? TChar::Reverse : TChar::None)
-                | (mStrikeOut || mpHost->mMxpClient.strikeOut() ? TChar::StrikeOut : TChar::None)
-                | (mUnderline || mpHost->mMxpClient.underline() ? TChar::Underline : TChar::None)
-                | (mUnderlineWavy ? TChar::UnderlineWavy : TChar::None)
-                | (mUnderlineDotted ? TChar::UnderlineDotted : TChar::None)
-                | (mUnderlineDashed ? TChar::UnderlineDashed : TChar::None)
-                | (mFastBlink ? TChar::FastBlink : (mBlink ? TChar::Blink :TChar::None))
-                | (TChar::alternateFontFlag(mAltFont))
-                | (mConcealed ? TChar::Concealed : TChar::None);
-
-        TChar c((!mIsDefaultColor && mBold) ? mForeGroundColorLight : mForeGroundColor, mBackGroundColor, attributeFlags);
+        TChar c((!mIsDefaultColor && mBold) ? mForeGroundColorLight : mForeGroundColor, mBackGroundColor, computeCurrentAttributeFlags());
 
         if (mHyperlinkActive) {
             c.mLinkIndex = mCurrentHyperlinkLinkId;
-            
+
             // Store the original ANSI-formatted character before applying CSS styling
             // This is needed for ANSI base restoration when pseudo-classes are inactive
             if (!mLinkOriginalCharacters.contains(mCurrentHyperlinkLinkId)) {
                 mLinkOriginalCharacters[mCurrentHyperlinkLinkId] = c;
 #if defined(DEBUG_OSC_PROCESSING)
-                qDebug().nospace().noquote() << "TBuffer::translateToPlainText(): Stored original character for link " << mCurrentHyperlinkLinkId 
-                                              << " with ANSI colors: fg=" << c.mFgColor.name() 
+                qDebug().nospace().noquote() << "TBuffer::translateToPlainText(): Stored original character for link " << mCurrentHyperlinkLinkId
+                                              << " with ANSI colors: fg=" << c.mFgColor.name()
                                               << " bg=" << c.mBgColor.name()
                                               << " flags=" << c.mFlags;
 #endif
             }
-            
+
             // Apply enhanced hyperlink styling
             if (mCurrentHyperlinkStyling.hasForegroundColor) {
                 c.mFgColor = mCurrentHyperlinkStyling.foregroundColor;
@@ -998,11 +879,11 @@ COMMIT_LINE:
             if (mCurrentHyperlinkStyling.hasBackgroundColor) {
                 c.mBgColor = mCurrentHyperlinkStyling.backgroundColor;
             }
-            
+
             // Apply text decorations
             if (mCurrentHyperlinkStyling.isUnderlined) {
                 c.mFlags |= TChar::Underline;
-                
+
                 // Apply specific underline style based on underlineStyle enum
                 switch (mCurrentHyperlinkStyling.underlineStyle) {
                     case Mudlet::HyperlinkStyling::UnderlineWavy:
@@ -1027,7 +908,7 @@ COMMIT_LINE:
             if (mCurrentHyperlinkStyling.isStrikeOut) {
                 c.mFlags |= TChar::StrikeOut;
             }
-            
+
             // Apply decoration colors - only for active decorations
             if (mCurrentHyperlinkStyling.hasUnderlineColor && mCurrentHyperlinkStyling.isUnderlined) {
                 c.setUnderlineColor(mCurrentHyperlinkStyling.underlineColor);
@@ -1038,14 +919,14 @@ COMMIT_LINE:
             if (mCurrentHyperlinkStyling.hasStrikeoutColor && mCurrentHyperlinkStyling.isStrikeOut) {
                 c.setStrikeoutColor(mCurrentHyperlinkStyling.strikeoutColor);
             }
-            
+
             if (mCurrentHyperlinkStyling.isBold) {
                 c.mFlags |= TChar::Bold;
             }
             if (mCurrentHyperlinkStyling.isItalic) {
                 c.mFlags |= TChar::Italic;
             }
-            
+
             // Only apply underline if explicitly set in styling (respects OSC 8 default of no underline)
             // Note: This differs from other Mudlet hyperlinks which default to underlined
         }
@@ -1073,6 +954,158 @@ COMMIT_LINE:
 
         ++localBufferPosition;
     }
+}
+
+
+bool TBuffer::commitLine(char ch, size_t& localBufferPosition)
+{
+    if (CHAR_IS_COMMIT_CHAR(ch)) {
+        // DE: MUD Zeilen werden immer am Zeilenanfang geschrieben
+        // EN: MUD lines are always written at the beginning of the line
+
+        // FIXME: This is the point where we should renormalise the new text
+        // data - of course there is the theoretical chance that the new
+        // text would alter the prior contents but as that is on a separate
+        // line there should not be any changes to text before a line feed
+        // which sort of seems to be implied by the current value of ch:
+
+        // Qt struggles to report blank lines on Windows to screen readers, this is a workaround
+        // https://bugreports.qt.io/browse/QTBUG-105035
+        if (Q_UNLIKELY(mMudLine.isEmpty())) {
+            if (mpHost->mBlankLineBehaviour == Host::BlankLineBehaviour::Hide) {
+                localBufferPosition++;
+                return true;
+            } else if (mpHost->mBlankLineBehaviour == Host::BlankLineBehaviour::ReplaceWithSpace) {
+                // Note: we are using the background color for the
+                // foreground color as well so that we are transparent:
+                const TChar c(mBackGroundColor, mBackGroundColor, computeCurrentAttributeFlags());
+                mMudLine.append(QChar::Space);
+                mMudBuffer.push_back(c);
+            }
+        }
+
+        if (static_cast<size_t>(mMudLine.size()) != mMudBuffer.size()) {
+            qWarning() << "TBuffer::translateToPlainText(...) WARNING: mismatch in new text "
+                        "data character and attribute data items!";
+        }
+        if (!lineBuffer.back().isEmpty()) {
+            if (!mMudLine.isEmpty()) {
+                lineBuffer << mMudLine;
+            } else {
+                if (ch == '\r') {
+                    ++localBufferPosition;
+                    return true; //empty timer posting
+                }
+                lineBuffer << QString();
+            }
+            buffer.push_back(mMudBuffer);
+            timeBuffer << QTime::currentTime().toString(mudlet::smTimeStampFormat);
+            if (ch == '\xff') {
+                promptBuffer.append(true);
+            } else {
+                promptBuffer.append(false);
+            }
+        } else {
+            if (!mMudLine.isEmpty()) {
+                lineBuffer.back().append(mMudLine);
+            } else {
+                if (ch == '\r') {
+                    ++localBufferPosition;
+                    return true; //empty timer posting
+                }
+                lineBuffer.back().append(QString());
+            }
+            buffer.back() = mMudBuffer;
+            timeBuffer.back() = QTime::currentTime().toString(mudlet::smTimeStampFormat);
+            if (ch == '\xff') {
+                promptBuffer.back() = true;
+            } else {
+                promptBuffer.back() = false;
+            }
+        }
+        mMudLine.clear();
+        mMudBuffer.clear();
+        const int line = lineBuffer.size() - 1;
+        mpHost->mpConsole->runTriggers(line);
+
+        // Only use of TBuffer::wrap(), breaks up new text
+        // NOTE: it MAY have been clobbered by the trigger engine!
+        const int addedLines = wrapLine(line, mWrapAt, mWrapIndent, mWrapHangingIndent);
+
+        // Start a new, but empty line in the various buffers
+        log(lineBuffer.size() - 1, lineBuffer.size() - 1);
+
+        ++localBufferPosition;
+        // Suppress new empty line IFF echoes already created a new empty line
+        // i.e. add newline if no added lines or the lastline isn't empty
+        if (addedLines == 0 || !lineBuffer.back().isEmpty()) {
+            std::deque<TChar> const newLine;
+            buffer.push_back(newLine);
+            lineBuffer.push_back(QString());
+            timeBuffer.push_back(QString());
+            promptBuffer << false;
+        }
+
+        if (static_cast<int>(buffer.size()) > mLinesLimit) {
+            // Whilst we also include a call to TConsole::handleLinesOverflowEvent(...)
+            // in all other methods where the following is used (because
+            // both need to monitor the number of lines of text in the
+            // buffer) the event that the former may be required to
+            // generate is NOT used for the TMainConsole case whereas this
+            // (translateToPlainText(...)) method is ONLY for that one:
+            shrinkBuffer();
+        }
+        return true;
+    }
+    return false;
+}
+
+void TBuffer::processMxpWatchdogCallback()
+{
+    TMxpNodeBuilder&    tagBuilder = mpHost->mMxpProcessor.getMxpTagBuilder();
+    std::string         currentTagContent = tagBuilder.getRawTagContent();
+    bool                isMxpParserFrozen = !currentTagContent.empty()
+                                            && currentTagContent.starts_with(mWatchdogTagSnapshot)
+                                            && tagBuilder.isInsideTag();
+
+    if (mWatchdogPhase == WatchdogPhase::Phase1_Snapshot) {
+        mWatchdogTagSnapshot = currentTagContent;
+        mWatchdogPhase = WatchdogPhase::Phase2_Unfreeze;
+        mTagWatchdog->start(MAX_TAG_TIMEOUT_MS);
+    } else if (mWatchdogPhase == WatchdogPhase::Phase2_Unfreeze) {
+        if (isMxpParserFrozen) {
+            mpHost->mMxpProcessor.setLastEntityValue(QString::fromStdString('<' + currentTagContent));
+            QTimer::singleShot(0, [this] () {
+                const TChar style(mForeGroundColor, mBackGroundColor, computeCurrentAttributeFlags());
+                QString     lastEntityValue = mpHost->mMxpProcessor.getEntityValue();
+                size_t      unusedBufferPosition = 0;
+
+                mMudLine.append(lastEntityValue);
+                for (size_t i = 0; i < lastEntityValue.size(); ++i) {
+                    mMudBuffer.push_back(style);
+                }
+                commitLine('\r', unusedBufferPosition);
+                mpHost->mMxpProcessor.getMxpTagBuilder().reset();
+                mpHost->mpConsole->finalize();
+            });
+        }
+        mWatchdogPhase = WatchdogPhase::None;
+    }
+}
+
+TChar::AttributeFlags TBuffer::computeCurrentAttributeFlags() const {
+    return ((mBold || mpHost->mMxpClient.bold()) ? TChar::Bold : TChar::None)
+            | (mItalics || mpHost->mMxpClient.italic() ? TChar::Italic : TChar::None)
+            | (mOverline ? TChar::Overline : TChar::None)
+            | (mReverse ? TChar::Reverse : TChar::None)
+            | (mStrikeOut || mpHost->mMxpClient.strikeOut() ? TChar::StrikeOut : TChar::None)
+            | (mUnderline || mpHost->mMxpClient.underline() ? TChar::Underline : TChar::None)
+            | (mUnderlineWavy ? TChar::UnderlineWavy : TChar::None)
+            | (mUnderlineDotted ? TChar::UnderlineDotted : TChar::None)
+            | (mUnderlineDashed ? TChar::UnderlineDashed : TChar::None)
+            | (mFastBlink ? TChar::FastBlink : (mBlink ? TChar::Blink :TChar::None))
+            | (TChar::alternateFontFlag(mAltFont))
+            | (mConcealed ? TChar::Concealed : TChar::None);
 }
 
 void TBuffer::decodeSGR38(const QStringList& parameters, bool isColonSeparated)
@@ -2292,7 +2325,7 @@ void TBuffer::decodeOSC(const QString& sequence)
         break;
     case static_cast<quint8>('8'): {
         // Handle OSC 8 hyperlinks in the form: "8;params;URI"
-        
+
         QStringView rest = QStringView(sequence).mid(1);  // skip selector "8;"
         int firstSemi = rest.indexOf(';');
 
@@ -2343,7 +2376,7 @@ void TBuffer::decodeOSC(const QString& sequence)
             qDebug() << "[OSC8] Raw URL for parameter parsing:" << rawUrl;
 #endif
             QMap<QString, QString> queryParams = parseUriQueryParameters(rawUrl);
-            
+
             // Extract styling parameters
             if (queryParams.contains(qsl("style"))) {
 #if defined(DEBUG_OSC_PROCESSING)
@@ -2356,7 +2389,7 @@ void TBuffer::decodeOSC(const QString& sequence)
                 qDebug() << "[OSC8] No style parameter provided, using defaults (isUnderlined=" << mCurrentHyperlinkStyling.isUnderlined << ")";
 #endif
             }
-            
+
             // Extract menu parameters
             if (queryParams.contains(qsl("menu"))) {
                 QString menuString = queryParams.value(qsl("menu"));
@@ -2372,18 +2405,18 @@ void TBuffer::decodeOSC(const QString& sequence)
                 qDebug() << "[OSC8] No menu parameter found";
 #endif
             }
-            
+
             // Extract custom tooltip parameter
             QString customTooltip;
 
             if (queryParams.contains(qsl("tooltip"))) {
                 customTooltip = queryParams.value(qsl("tooltip"));
             }
-            
+
             // Remove styling/menu/tooltip query parameters from URL for command processing
             QString baseUrl = rawUrl;
             QMap<QString, QString> allParams = parseUriQueryParameters(rawUrl);
-            
+
             // For web URLs, preserve original parameters except our special ones
             if (rawUrl.startsWith(qsl("http://")) || rawUrl.startsWith(qsl("https://")) || rawUrl.startsWith(qsl("ftp://"))) {
                 // Remove our special parameters
@@ -2396,7 +2429,7 @@ void TBuffer::decodeOSC(const QString& sequence)
                 if (queryStart != -1) {
                     baseUrl = baseUrl.left(queryStart);
                 }
-                
+
                 // Only append parameters if there are any left
                 if (!allParams.isEmpty()) {
                     baseUrl = appendQueryParameters(baseUrl, allParams);
@@ -2449,7 +2482,7 @@ void TBuffer::decodeOSC(const QString& sequence)
 #endif
                 QStringList menuCommands;
                 QStringList menuHints;
-                
+
                 // Add menu items in pairs (label, command)
                 // The first menu item becomes the primary left-click action (index 0)
                 // All items (including first) appear in the right-click menu (index 1+)
@@ -2457,7 +2490,7 @@ void TBuffer::decodeOSC(const QString& sequence)
                 for (int i = 0; i < mCurrentHyperlinkMenu.size() - 1; i += 2) {
                     QString menuLabel = mCurrentHyperlinkMenu[i];
                     QString menuCommand = mCurrentHyperlinkMenu[i + 1];
-                    
+
                     // Determine command type based on prefix
                     if (menuCommand.startsWith(qsl("send:"))) {
                         QString innerCommand = QUrl::fromPercentEncoding(menuCommand.mid(5).toUtf8());
@@ -2478,7 +2511,7 @@ void TBuffer::decodeOSC(const QString& sequence)
                     }
                     isFirstItem = false;
                 }
-                
+
                 // Set the tooltip for the link (what shows on hover)
                 // Use custom tooltip if provided, otherwise show "Right-click for menu" message
                 QString linkTooltip;
@@ -2489,14 +2522,14 @@ void TBuffer::decodeOSC(const QString& sequence)
                     // Default tooltip for menu links
                     linkTooltip = QObject::tr("Right-click for menu");
                 }
-                
+
                 // For menus, we need tooltip as first hint, then menu labels
                 // This ensures tooltip.size() > commands.size() so only first hint shows in tooltip
                 // But menu labels are available for right-click menu display
                 QStringList finalHints;
                 finalHints.append(linkTooltip); // First: tooltip for hover
                 finalHints.append(menuHints);   // Rest: menu labels for right-click menu
-                
+
                 command = menuCommands;
                 hint = finalHints;
 #if defined(DEBUG_OSC_PROCESSING)
@@ -2508,14 +2541,14 @@ void TBuffer::decodeOSC(const QString& sequence)
             mCurrentHyperlinkCommand = command;
             mCurrentHyperlinkHint = hint;
             mCurrentHyperlinkLinkId = mLinkStore.addLinks(command, hint, mpHost, QVector<int>());
-            
+
             // Store the styling for this link so it can be retrieved later
             mLinkStore.setStyling(mCurrentHyperlinkLinkId, mCurrentHyperlinkStyling);
-            
+
             // Store the original background color for this link so we can restore it later
             // when the link styling doesn't specify a background
             mLinkOriginalBackgrounds[mCurrentHyperlinkLinkId] = mBackGroundColor;
-            
+
 #if defined(DEBUG_OSC_PROCESSING)
             qDebug().noquote() << "[OSC8] Hyperlink activated:" << rawUrl.left(50) + (rawUrl.length() > 50 ? "..." : "");
 #endif
@@ -2533,33 +2566,33 @@ QString TBuffer::appendQueryParameters(const QString& uri, const QMap<QString, Q
     if (parameters.isEmpty()) {
         return uri;
     }
-    
+
     QString result = uri;
     bool hasExistingParams = uri.contains(qsl("?"));
     QString separator = hasExistingParams ? qsl("&") : qsl("?");
-    
+
     QStringList paramStrings;
     for (auto it = parameters.constBegin(); it != parameters.constEnd(); ++it) {
         QString key = QUrl::toPercentEncoding(it.key());
         QString value = QUrl::toPercentEncoding(it.value());
         paramStrings.append(qsl("%1=%2").arg(key, value));
     }
-    
+
     if (!paramStrings.isEmpty()) {
         result += separator + paramStrings.join(qsl("&"));
     }
-    
+
     return result;
 }
 
 QMap<QString, QString> TBuffer::parseUriQueryParameters(const QString& uri)
 {
     QMap<QString, QString> parameters;
-    
+
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC8] parseUriQueryParameters called with uri:" << uri;
 #endif
-    
+
     // Find the query string part after '?'
     int queryStart = uri.indexOf('?');
     if (queryStart == -1) {
@@ -2568,28 +2601,28 @@ QMap<QString, QString> TBuffer::parseUriQueryParameters(const QString& uri)
 #endif
         return parameters; // No query parameters
     }
-    
+
     QString queryString = uri.mid(queryStart + 1);
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC8] Query string:" << queryString;
 #endif
-    
+
     // Decode the query string first, since the server percent-encodes the entire URL
     QString decodedQueryString = QUrl::fromPercentEncoding(queryString.toUtf8());
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC8] Decoded query string:" << decodedQueryString;
 #endif
-    
+
     // Only process JSON config parameters - no legacy CSS support
     if (decodedQueryString.startsWith(qsl("config={"))) {
         QString jsonString = decodedQueryString.mid(7); // Remove "config="
         parseJsonHyperlinkConfig(jsonString, parameters);
     }
-    
+
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC8] Parsed JSON parameters:" << parameters;
 #endif
-    
+
     return parameters;
 }
 
@@ -2601,23 +2634,23 @@ bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, 
 
     QJsonParseError parseError;
     QJsonDocument doc = QJsonDocument::fromJson(jsonString.toUtf8(), &parseError);
-    
+
     if (parseError.error != QJsonParseError::NoError) {
 #if defined(DEBUG_OSC_PROCESSING)
         qDebug() << "[OSC8] JSON parse error:" << parseError.errorString();
 #endif
         return false;
     }
-    
+
     if (!doc.isObject()) {
 #if defined(DEBUG_OSC_PROCESSING)
         qDebug() << "[OSC8] JSON root is not an object";
 #endif
         return false;
     }
-    
+
     QJsonObject root = doc.object();
-    
+
     // Parse style object
     if (root.contains(qsl("style")) && root[qsl("style")].isObject()) {
         QJsonObject styleObj = root[qsl("style")].toObject();
@@ -2626,7 +2659,7 @@ bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, 
             parameters.insert(qsl("style"), cssStyleString);
         }
     }
-    
+
     // Parse menu array
     if (root.contains(qsl("menu")) && root[qsl("menu")].isArray()) {
         QJsonArray menuArray = root[qsl("menu")].toArray();
@@ -2635,44 +2668,44 @@ bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, 
             parameters.insert(qsl("menu"), menuString);
         }
     }
-    
+
     // Parse tooltip string
     if (root.contains(qsl("tooltip")) && root[qsl("tooltip")].isString()) {
         parameters.insert(qsl("tooltip"), root[qsl("tooltip")].toString());
     }
-    
+
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC8] JSON converted to parameters:" << parameters;
 #endif
-    
+
     return true;
 }
 
 QString TBuffer::jsonStyleObjectToCss(const QJsonObject& styleObj)
 {
     QStringList cssProperties;
-    
+
     // Basic style properties
     if (styleObj.contains(qsl("color")) && styleObj[qsl("color")].isString()) {
         cssProperties << qsl("color:") + styleObj[qsl("color")].toString();
     }
-    
+
     if (styleObj.contains(qsl("bg")) && styleObj[qsl("bg")].isString()) {
         cssProperties << qsl("background-color:") + styleObj[qsl("bg")].toString();
     }
-    
+
     if (styleObj.contains(qsl("bold")) && styleObj[qsl("bold")].isBool() && styleObj[qsl("bold")].toBool()) {
         cssProperties << qsl("font-weight:bold");
     }
-    
+
     if (styleObj.contains(qsl("italic")) && styleObj[qsl("italic")].isBool() && styleObj[qsl("italic")].toBool()) {
         cssProperties << qsl("font-style:italic");
     }
-    
+
     // Text decorations - combine multiple decorations into single CSS property
     QStringList decorationParts;
     QString underlineStyle = qsl("solid"); // Default underline style
-    
+
     // Process underline
     if (styleObj.contains(qsl("underline"))) {
         QJsonValue underlineVal = styleObj[qsl("underline")];
@@ -2683,7 +2716,7 @@ QString TBuffer::jsonStyleObjectToCss(const QJsonObject& styleObj)
             underlineStyle = underlineVal.toString(); // Store style for later
         }
     }
-    
+
     // Process overline
     if (styleObj.contains(qsl("overline"))) {
         QJsonValue overlineVal = styleObj[qsl("overline")];
@@ -2694,7 +2727,7 @@ QString TBuffer::jsonStyleObjectToCss(const QJsonObject& styleObj)
             // Note: overline styles are currently limited to solid in the parser
         }
     }
-    
+
     // Process strikethrough
     if (styleObj.contains(qsl("strikethrough"))) {
         QJsonValue strikeVal = styleObj[qsl("strikethrough")];
@@ -2705,7 +2738,7 @@ QString TBuffer::jsonStyleObjectToCss(const QJsonObject& styleObj)
             // Note: strikethrough styles are currently limited to solid in the parser
         }
     }
-    
+
     // Combine all decorations into a single CSS property
     if (!decorationParts.isEmpty()) {
         QString decorationValue = decorationParts.join(qsl(" "));
@@ -2715,15 +2748,15 @@ QString TBuffer::jsonStyleObjectToCss(const QJsonObject& styleObj)
         }
         cssProperties << qsl("text-decoration:") + decorationValue;
     }
-    
+
     // Text decoration color
     if (styleObj.contains(qsl("text-decoration-color")) && styleObj[qsl("text-decoration-color")].isString()) {
         cssProperties << qsl("text-decoration-color:") + styleObj[qsl("text-decoration-color")].toString();
     }
-    
+
     // Pseudo-class states
     QStringList pseudoClasses = {qsl("hover"), qsl("active"), qsl("visited"), qsl("link"), qsl("focus"), qsl("focus-visible"), qsl("any-link")};
-    
+
     for (const QString& pseudoClass : pseudoClasses) {
         if (styleObj.contains(pseudoClass) && styleObj[pseudoClass].isObject()) {
             QJsonObject pseudoObj = styleObj[pseudoClass].toObject();
@@ -2733,14 +2766,14 @@ QString TBuffer::jsonStyleObjectToCss(const QJsonObject& styleObj)
             }
         }
     }
-    
+
     return cssProperties.join(qsl(";"));
 }
 
 QString TBuffer::jsonMenuArrayToString(const QJsonArray& menuArray)
 {
     QStringList menuItems;
-    
+
     for (const QJsonValue& item : menuArray) {
         if (item.isString() && item.toString() == qsl("-")) {
             // Separator
@@ -2755,7 +2788,7 @@ QString TBuffer::jsonMenuArrayToString(const QJsonArray& menuArray)
             }
         }
     }
-    
+
     return menuItems.join(qsl("|"));
 }
 
@@ -2764,10 +2797,10 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC8] parseHyperlinkStyling called with styleString:" << styleString;
 #endif
-    
+
     // Reset styling to defaults
     styling = Mudlet::HyperlinkStyling();
-    
+
     // Check if this is a CSS selector with pseudo-classes
     // Format: "property:value;:pseudo-class{property:value;property:value}:pseudo-class{...}"
     // or just: ":pseudo-class{property:value;property:value}:pseudo-class{...}"
@@ -2776,23 +2809,23 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
         // These are properties that come before any pseudo-class or between pseudo-classes
         QString baseProperties;
         QRegularExpression pseudoClassRegex(R"(:([\w-]+)\s*\{([^}]*)\})");
-        
+
         // Extract base properties by removing all pseudo-class blocks
         QString remainingStyle = styleString;
         QRegularExpressionMatchIterator matches = pseudoClassRegex.globalMatch(styleString);
-        
+
         // Remove pseudo-class blocks to get base properties
         while (matches.hasNext()) {
             QRegularExpressionMatch match = matches.next();
             remainingStyle.replace(match.captured(0), "");
         }
-        
+
         // Parse base properties if any exist
         // Filter out strings that are only semicolons and whitespace
         QString filteredBase = remainingStyle;
         filteredBase.remove(';');
         filteredBase = filteredBase.trimmed();
-        
+
         if (!filteredBase.isEmpty()) {
             baseProperties = remainingStyle.trimmed();
 #if defined(DEBUG_OSC_PROCESSING)
@@ -2800,7 +2833,7 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
 #endif
             // Mark that we have base styling (not just pseudo-class styling)
             styling.hasBaseCustomStyling = true;
-            
+
             // Parse base properties as simple CSS
             QStringList basePairs = baseProperties.split(';', Qt::SkipEmptyParts);
 
@@ -2813,7 +2846,7 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
 
                 QString property = propertyValue[0].trimmed().toLower();
                 QString value = propertyValue[1].trimmed();
-                
+
                 // Apply base properties to the default state
                 if (property == qsl("color")) {
                     QColor color = parseColorValue(value);
@@ -2838,7 +2871,7 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
                 }
             }
         }
-        
+
         // Now parse pseudo-class specific styles
         matches = pseudoClassRegex.globalMatch(styleString);
 
@@ -2846,14 +2879,14 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
             QRegularExpressionMatch match = matches.next();
             QString pseudoClass = ":" + match.captured(1);
             QString properties = match.captured(2);
-            
+
 #if defined(DEBUG_OSC_PROCESSING)
             qDebug() << "[OSC8] Found pseudo-class:" << pseudoClass << "with properties:" << properties;
 #endif
-            
+
             parseHyperlinkStateStyle(pseudoClass, properties, styling);
         }
-        
+
         // If no base styling was provided, but we have :link or :any-link styles,
         // use them as the default/base state since links need a default appearance
         if (!styling.hasCustomStyling) {
@@ -2903,28 +2936,28 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
                 styling.hasCustomStyling = true;
             }
         }
-        
+
         // Apply accessibility enhancements
         applyAccessibilityEnhancements(styling);
         return;
     }
-    
+
     // Fallback: Parse as simple CSS-like style string: "property:value;property:value"
     QStringList stylePairs = styleString.split(';', Qt::SkipEmptyParts);
-    
+
     bool hasAnyCustomStyling = false;
     bool textDecorationExplicitlySet = false;
-    
+
     for (const QString& pair : stylePairs) {
         QStringList propertyValue = pair.split(':', Qt::KeepEmptyParts);
 
         if (propertyValue.size() != 2) {
             continue; // Skip malformed property
         }
-        
+
         QString property = propertyValue[0].trimmed().toLower();
         QString value = propertyValue[1].trimmed();
-        
+
         if (property == "color") {
             QColor color = parseColorValue(value);
 
@@ -2951,13 +2984,13 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
             // Handle text-decoration with optional style: "underline", "underline wavy", "overline", "line-through", "none"
             // Can also handle multiple values: "underline overline", "underline wavy red"
             QStringList decorationParts = value.toLower().split(' ', Qt::SkipEmptyParts);
-            
+
             // Reset decoration flags when text-decoration is explicitly set
             styling.isUnderlined = false;
             styling.isOverlined = false;
             styling.isStrikeOut = false;
             styling.underlineStyle = Mudlet::HyperlinkStyling::UnderlineNone;
-            
+
             for (const QString& part : decorationParts) {
                 if (part == "underline") {
                     styling.isUnderlined = true;
@@ -3015,7 +3048,7 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
             styling.isUnderlined = false;
             styling.isOverlined = false;
             styling.isStrikeOut = false;
-            
+
             QStringList decorations = value.toLower().split(' ', Qt::SkipEmptyParts);
 
             for (const QString& decoration : decorations) {
@@ -3065,7 +3098,7 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
             hasAnyCustomStyling = true;
         }
     }
-    
+
     // If custom styling was provided, mark it and disable default underline if text-decoration wasn't explicitly set
     if (hasAnyCustomStyling) {
         styling.hasCustomStyling = true;
@@ -3080,7 +3113,7 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
 QColor TBuffer::parseColorValue(const QString& value)
 {
     QString cleanValue = value.trimmed().toLower();
-    
+
     // Handle hex colors: #rrggbb (6-digit) or #rgb (3-digit shorthand)
     // Qt's QColor constructor automatically expands 3-digit format (e.g., #f00 -> #ff0000)
     if (cleanValue.startsWith('#')) {
@@ -3090,14 +3123,14 @@ QColor TBuffer::parseColorValue(const QString& value)
             return color;
         }
     }
-    
+
     // Handle named colors
     QColor namedColor(cleanValue);
 
     if (namedColor.isValid()) {
         return namedColor;
     }
-    
+
     // Handle rgb() format: rgb(255, 0, 0) or rgb(100%, 0%, 0%)
     // Supports both integer (0-255) and percentage (0%-100%) values
     // Spaces after commas are optional: rgb(255,0,0) works too
@@ -3129,18 +3162,18 @@ QColor TBuffer::parseColorValue(const QString& value)
                     return -1;
                 }
             };
-            
+
             bool ok1, ok2, ok3;
             int r = parseComponent(components[0], ok1);
             int g = parseComponent(components[1], ok2);
             int b = parseComponent(components[2], ok3);
-            
+
             if (ok1 && ok2 && ok3 && r >= 0 && g >= 0 && b >= 0) {
                 return QColor(r, g, b);
             }
         }
     }
-    
+
     return QColor(); // Invalid color
 }
 
@@ -3225,7 +3258,7 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
     if (sub_end < 0) {
         return;
     }
-        
+
     // Check for OSC 8 documentation examples trigger phrase
     if (text.contains("!osc8-docs")) {
 #if defined(DEBUG_OSC_PROCESSING)
@@ -3234,7 +3267,7 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
         injectOSC8DocumentationExamples();
         return; // Don't display the trigger phrase itself
     }
-    
+
     int lastLine = buffer.size() - 1;
     if (Q_UNLIKELY(lastLine < 0)) {
         // There are NO lines in the buffer - so initialize with a new empty line
@@ -3267,11 +3300,11 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
         lineBuffer.back().append(thisChar);
         const TChar styling(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags), linkID);
         buffer.back().push_back(styling);
-        
-        // Note: Original character storage for ANSI-styled OSC 8 links happens in 
-        // translateToPlainText() where the TChar is created with ANSI formatting 
+
+        // Note: Original character storage for ANSI-styled OSC 8 links happens in
+        // translateToPlainText() where the TChar is created with ANSI formatting
         // before CSS styling is applied
-        
+
         if (firstChar) {
             timeBuffer.back() = QTime::currentTime().toString(mudlet::smTimeStampFormat);
             firstChar = false;
@@ -5240,170 +5273,170 @@ void TBuffer::injectOSC8DocumentationExamples()
     QString output = "\n╔════════════════════════════════════════════════════════════════════╗\n";
     output += "║         OSC 8 Hyperlink Documentation Examples                     ║\n";
     output += "╚════════════════════════════════════════════════════════════════════╝\n\n";
-    
+
     // ═══════════════════════════════════════════════════════════════════
     // Getting Started: Simple Links
     // ═══════════════════════════════════════════════════════════════════
     output += "══════════════════════════════════════════════════════════════════════\n";
     output += "GETTING STARTED: SIMPLE LINKS\n";
     output += "══════════════════════════════════════════════════════════════════════\n\n";
-    
+
     output += "1. Sending Commands:\n";
     output += "   \x1b]8;;send:look\x1b\\Look\x1b]8;;\x1b\\\n\n";
-    
+
     output += "2. Pre-filling Commands:\n";
     output += "   \x1b]8;;prompt:cast%20fireball\x1b\\Cast Fireball\x1b]8;;\x1b\\\n\n";
-    
+
     output += "3. Opening Web Pages:\n";
     output += "   \x1b]8;;https://www.mudlet.org\x1b\\Visit Mudlet\x1b]8;;\x1b\\\n\n";
-    
+
     // ═══════════════════════════════════════════════════════════════════
     // Adding Custom Styling
     // ═══════════════════════════════════════════════════════════════════
     output += "══════════════════════════════════════════════════════════════════════\n";
     output += "ADDING CUSTOM STYLING\n";
     output += "══════════════════════════════════════════════════════════════════════\n\n";
-    
+
     output += "Basic Styling:\n";
     output += "• Red text: \x1b]8;;send:attack?config={\"style\":{\"color\":\"red\"}}\x1b\\Attack\x1b]8;;\x1b\\\n";
     output += "• Bold red: \x1b]8;;send:attack?config={\"style\":{\"color\":\"red\",\"bold\":true}}\x1b\\Attack\x1b]8;;\x1b\\\n";
     output += "• Blue background: \x1b]8;;send:action?config={\"style\":{\"color\":\"white\",\"bg\":\"blue\"}}\x1b\\Action\x1b]8;;\x1b\\\n\n";
-    
+
     output += "Text Decorations:\n";
     output += "• Underlined: \x1b]8;;send:cast?config={\"style\":{\"underline\":true}}\x1b\\Underlined\x1b]8;;\x1b\\\n";
     output += "• Overlined: \x1b]8;;send:heal?config={\"style\":{\"overline\":true}}\x1b\\Overlined\x1b]8;;\x1b\\\n";
     output += "• Strikethrough: \x1b]8;;send:flee?config={\"style\":{\"strikethrough\":true}}\x1b\\Strikethrough\x1b]8;;\x1b\\\n";
     output += "• Wavy underline: \x1b]8;;send:spell?config={\"style\":{\"underline\":\"wavy\"}}\x1b\\Wavy Underline\x1b]8;;\x1b\\\n";
     output += "• Dotted overline: \x1b]8;;send:magic?config={\"style\":{\"overline\":\"dotted\"}}\x1b\\Dotted Overline\x1b]8;;\x1b\\\n\n";
-    
+
     output += "Decoration Colors:\n";
     output += "• Red underline: \x1b]8;;send:redline?config={\"style\":{\"underline\":true,\"text-decoration-color\":\"red\"}}\x1b\\Red Underline\x1b]8;;\x1b\\\n";
     output += "• Blue overline: \x1b]8;;send:blueover?config={\"style\":{\"overline\":true,\"text-decoration-color\":\"#0066ff\"}}\x1b\\Blue Overline\x1b]8;;\x1b\\\n";
     output += "• Green wavy: \x1b]8;;send:greenwave?config={\"style\":{\"underline\":\"wavy\",\"text-decoration-color\":\"green\"}}\x1b\\Green Wavy\x1b]8;;\x1b\\\n";
     output += "• Purple strike: \x1b]8;;send:purplestrike?config={\"style\":{\"strikethrough\":true,\"text-decoration-color\":\"purple\"}}\x1b\\Purple Strike\x1b]8;;\x1b\\\n\n";
-    
+
     // ═══════════════════════════════════════════════════════════════════
     // Interactive States
     // ═══════════════════════════════════════════════════════════════════
     output += "══════════════════════════════════════════════════════════════════════\n";
     output += "INTERACTIVE STATES\n";
     output += "══════════════════════════════════════════════════════════════════════\n\n";
-    
+
     output += "Hover Effects:\n";
     output += "• Hover color change: \x1b]8;;send:look?config={\"style\":{\"color\":\"blue\",\"hover\":{\"color\":\"red\"}}}\x1b\\Hover Me\x1b]8;;\x1b\\\n";
     output += "• Hover bold: \x1b]8;;send:defend?config={\"style\":{\"color\":\"blue\",\"bold\":true,\"hover\":{\"color\":\"yellow\"}}}\x1b\\Defend\x1b]8;;\x1b\\\n\n";
-    
+
     output += "Link vs Visited States:\n";
     output += "• \x1b]8;;send:explore?config={\"style\":{\"link\":{\"color\":\"blue\",\"underline\":true},\"visited\":{\"color\":\"purple\",\"strikethrough\":true}}}\x1b\\Visit Me\x1b]8;;\x1b\\\n\n";
-    
+
     output += "Button-Style Link:\n";
     output += "• \x1b]8;;send:attack?config={\"style\":{\"bg\":\"green\",\"color\":\"white\",\"bold\":true,\"hover\":{\"bg\":\"lightgreen\"},\"active\":{\"bg\":\"darkgreen\"}}}\x1b\\Attack\x1b]8;;\x1b\\\n\n";
-    
+
     output += "Multi-State Button:\n";
     output += "• \x1b]8;;send:action?config={\"style\":{\"bg\":\"green\",\"hover\":{\"bg\":\"lightgreen\"},\"active\":{\"bg\":\"darkgreen\"},\"focus-visible\":{\"bg\":\"lightblue\"}}}\x1b\\Multi-State\x1b]8;;\x1b\\\n\n";
-    
+
     output += "Any-Link Styling:\n";
     output += "• \x1b]8;;send:universal?config={\"style\":{\"any-link\":{\"bold\":true},\"hover\":{\"color\":\"orange\"}}}\x1b\\Universal Link\x1b]8;;\x1b\\\n\n";
-    
+
     // ═══════════════════════════════════════════════════════════════════
     // Context Menus and Tooltips
     // ═══════════════════════════════════════════════════════════════════
     output += "══════════════════════════════════════════════════════════════════════\n";
     output += "CONTEXT MENUS AND TOOLTIPS\n";
     output += "══════════════════════════════════════════════════════════════════════\n\n";
-    
+
     output += "Basic Menu:\n";
     output += "• \x1b]8;;send:combat?config={\"menu\":[{\"Attack\":\"send:attack\"},{\"Defend\":\"send:defend\"}]}\x1b\\Combat Menu\x1b]8;;\x1b\\ (right-click for menu)\n\n";
-    
+
     output += "Menu with Tooltip:\n";
     output += "• \x1b]8;;send:magic?config={\"menu\":[{\"Cast\":\"send:cast fireball\"},{\"Heal\":\"send:heal\"}],\"tooltip\":\"Magic actions\"}\x1b\\Magic Menu\x1b]8;;\x1b\\\n\n";
-    
+
     output += "Menu with Separators:\n";
     output += "• \x1b]8;;send:spells?config={\"menu\":[{\"Fireball\":\"send:cast fireball\"},{\"Ice Bolt\":\"send:cast ice bolt\"},\"-\",{\"Heal\":\"send:cast heal\"}]}\x1b\\Spell Menu\x1b]8;;\x1b\\\n\n";
-    
+
     output += "Primary vs Secondary Actions:\n";
     output += "• \x1b]8;;send:look?config={\"menu\":[{\"Look\":\"send:look\"},{\"Examine\":\"send:examine\"},\"-\",{\"Go North\":\"send:north\"}]}\x1b\\Look Around\x1b]8;;\x1b\\\n";
     output += "  (Left-click executes 'look', right-click shows menu)\n\n";
-    
+
     output += "Combined Styling and Menus:\n";
     output += "• \x1b]8;;send:attack?config={\"style\":{\"color\":\"red\",\"bold\":true},\"menu\":[{\"Attack\":\"send:attack\"},{\"Defend\":\"send:defend\"},{\"Heal\":\"send:heal\"}],\"tooltip\":\"Combat Actions\"}\x1b\\Combat Menu\x1b]8;;\x1b\\\n\n";
-    
+
     // ═══════════════════════════════════════════════════════════════════
     // Practical Examples
     // ═══════════════════════════════════════════════════════════════════
     output += "══════════════════════════════════════════════════════════════════════\n";
     output += "PRACTICAL EXAMPLES\n";
     output += "══════════════════════════════════════════════════════════════════════\n\n";
-    
+
     output += "Simple Styled Links:\n";
     output += "• Red attack link: \x1b]8;;send:attack?config={\"style\":{\"color\":\"red\"}}\x1b\\Attack\x1b]8;;\x1b\\\n";
     output += "• Bold blue with hover: \x1b]8;;send:defend?config={\"style\":{\"color\":\"blue\",\"bold\":true,\"hover\":{\"color\":\"yellow\"}}}\x1b\\Defend\x1b]8;;\x1b\\\n";
     output += "• Green wavy underline: \x1b]8;;send:spell?config={\"style\":{\"underline\":\"wavy\",\"text-decoration-color\":\"green\"}}\x1b\\Spell Link\x1b]8;;\x1b\\\n\n";
-    
+
     output += "Interactive Menu Examples:\n";
     output += "• Basic combat menu: \x1b]8;;send:combat?config={\"menu\":[{\"Attack\":\"send:attack\"},{\"Defend\":\"send:defend\"}]}\x1b\\Combat\x1b]8;;\x1b\\\n";
     output += "• Menu with separators: \x1b]8;;send:spells?config={\"menu\":[{\"Fireball\":\"send:cast fireball\"},{\"Ice Bolt\":\"send:cast ice bolt\"},\"-\",{\"Heal\":\"send:cast heal\"}]}\x1b\\Spells\x1b]8;;\x1b\\\n";
     output += "• Menu with tooltip: \x1b]8;;send:magic?config={\"menu\":[{\"Cast\":\"send:cast fireball\"},{\"Heal\":\"send:heal\"}],\"tooltip\":\"Magic actions\"}\x1b\\Magic\x1b]8;;\x1b\\\n\n";
-    
+
     output += "Button-Style Links:\n";
     output += "• \x1b]8;;send:attack?config={\"style\":{\"bg\":\"green\",\"color\":\"white\",\"bold\":true,\"hover\":{\"bg\":\"lightgreen\"},\"active\":{\"bg\":\"darkgreen\"}}}\x1b\\Attack Button\x1b]8;;\x1b\\\n\n";
-    
+
     // ═══════════════════════════════════════════════════════════════════
     // Advanced Features
     // ═══════════════════════════════════════════════════════════════════
     output += "══════════════════════════════════════════════════════════════════════\n";
     output += "ADVANCED FEATURES\n";
     output += "══════════════════════════════════════════════════════════════════════\n\n";
-    
+
     output += "ANSI + JSON Hybrid Styling:\n";
     output += "• \x1b[1m\x1b]8;;send:attack?config={\"style\":{\"color\":\"red\",\"hover\":{\"color\":\"yellow\",\"underline\":true}}}\x1b\\Bold Red Attack\x1b]8;;\x1b\\\x1b[0m\n";
     output += "• \x1b[38;5;196m\x1b]8;;send:fire?config={\"style\":{\"hover\":{\"bg\":\"black\"},\"active\":{\"color\":\"orange\"}}}\x1b\\Fire Magic\x1b]8;;\x1b\\\x1b[0m\n\n";
-    
+
     output += "Comprehensive Multi-State Example:\n";
     output += "• \x1b]8;;send:comprehensive?config={\"style\":{\"any-link\":{\"underline\":true},\"link\":{\"color\":\"blue\"},\"visited\":{\"color\":\"purple\"},\"hover\":{\"color\":\"red\"},\"active\":{\"color\":\"darkred\"},\"focus-visible\":{\"bg\":\"orange\",\"color\":\"white\"}}}\x1b\\Comprehensive Link\x1b]8;;\x1b\\\n\n";
-    
+
     output += "Color Format Examples:\n";
     output += "• Hex: \x1b]8;;send:hex?config={\"style\":{\"color\":\"#ff0000\"}}\x1b\\Red (#ff0000)\x1b]8;;\x1b\\\n";
     output += "• Shorthand: \x1b]8;;send:short?config={\"style\":{\"color\":\"#f00\"}}\x1b\\Red (#f00)\x1b]8;;\x1b\\\n";
     output += "• Named: \x1b]8;;send:named?config={\"style\":{\"color\":\"red\"}}\x1b\\Red (named)\x1b]8;;\x1b\\\n";
     output += "• RGB: \x1b]8;;send:rgb?config={\"style\":{\"color\":\"rgb(255,0,0)\"}}\x1b\\Red (RGB)\x1b]8;;\x1b\\\n\n";
-    
+
     // ═══════════════════════════════════════════════════════════════════
     // Real World Examples
     // ═══════════════════════════════════════════════════════════════════
     output += "══════════════════════════════════════════════════════════════════════\n";
     output += "REAL WORLD EXAMPLES\n";
     output += "══════════════════════════════════════════════════════════════════════\n\n";
-    
+
     output += "Navigation:\n";
     output += "  \x1b]8;;send:north?config={\"style\":{\"color\":\"#0066cc\",\"bold\":true,\"hover\":{\"color\":\"#3399ff\",\"underline\":true}}}\x1b\\North\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:south?config={\"style\":{\"color\":\"#0066cc\",\"bold\":true,\"hover\":{\"color\":\"#3399ff\",\"underline\":true}}}\x1b\\South\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:east?config={\"style\":{\"color\":\"#0066cc\",\"bold\":true,\"hover\":{\"color\":\"#3399ff\",\"underline\":true}}}\x1b\\East\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:west?config={\"style\":{\"color\":\"#0066cc\",\"bold\":true,\"hover\":{\"color\":\"#3399ff\",\"underline\":true}}}\x1b\\West\x1b]8;;\x1b\\\n\n";
-    
+
     output += "Combat:\n";
     output += "  \x1b]8;;send:attack?config={\"style\":{\"color\":\"#cc0000\",\"bold\":true,\"hover\":{\"bg\":\"#ffcccc\",\"color\":\"#000000\"}},\"menu\":[{\"Quick Strike\":\"send:quick\"},{\"Power Attack\":\"send:power\"},\"-\",{\"Feint\":\"send:feint\"}]}\x1b\\⚔️ Attack\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:defend?config={\"style\":{\"color\":\"#006600\",\"bold\":true,\"hover\":{\"bg\":\"#ccffcc\",\"color\":\"#000000\"}},\"tooltip\":\"Defensive stance - reduces damage by 50%\"}\x1b\\🛡️ Defend\x1b]8;;\x1b\\\n\n";
-    
+
     output += "RPG Items:\n";
     output += "  \x1b]8;;send:examine?config={\"style\":{\"color\":\"#cc6600\",\"italic\":true,\"hover\":{\"bg\":\"#ffe6cc\",\"color\":\"#000000\"}},\"tooltip\":\"Magic sword with fire enchantment\"}\x1b\\🗡️ Flaming Blade\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:bag?config={\"style\":{\"color\":\"#6600cc\",\"hover\":{\"color\":\"#9933ff\",\"underline\":true}},\"menu\":[{\"Open\":\"send:open\"},{\"Sort\":\"send:sort\"},\"-\",{\"Drop\":\"send:drop\"}]}\x1b\\🎒 Backpack\x1b]8;;\x1b\\\n\n";
-    
+
     output += "Status Indicators:\n";
     output += "  \x1b]8;;send:warning?config={\"style\":{\"bg\":\"#ffcc00\",\"color\":\"#000000\",\"bold\":true}}\x1b\\⚠️ Warning\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:error?config={\"style\":{\"bg\":\"#cc0000\",\"color\":\"#ffffff\",\"bold\":true}}\x1b\\❌ Error\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:success?config={\"style\":{\"bg\":\"#006600\",\"color\":\"#ffffff\",\"bold\":true}}\x1b\\✅ Success\x1b]8;;\x1b\\\n\n";
-    
+
     output += "Complete Example (All Features):\n";
     output += "  \x1b]8;;send:sword?config={\"style\":{\"color\":\"#cc6600\",\"bold\":true,\"hover\":{\"bg\":\"#ffcc99\",\"color\":\"#000000\"}},\"menu\":[{\"Equip\":\"send:equip\"},{\"Examine\":\"send:examine\"},\"-\",{\"Drop\":\"send:drop\"}],\"tooltip\":\"Flaming Sword: +5 damage, fire enchantment\"}\x1b\\🗡️ Flaming Sword\x1b]8;;\x1b\\\n\n";
-    
+
     // ═══════════════════════════════════════════════════════════════════
     // Summary
     // ═══════════════════════════════════════════════════════════════════
     output += "══════════════════════════════════════════════════════════════════════\n\n";
     output += "Documentation: https://wiki.mudlet.org/w/Manual:Supported_Protocols#OSC_8\n";
     output += "All examples above are clickable - try them!\n\n";
-    
+
     // Process the output through the normal text processing pipeline
     std::string outputBytes = output.toStdString();
 #if defined(DEBUG_OSC_PROCESSING)
@@ -5419,7 +5452,7 @@ void TBuffer::injectOSC8DocumentationExamples()
 Mudlet::HyperlinkStyling::StateStyle Mudlet::HyperlinkStyling::getEffectiveStyle() const
 {
     Mudlet::HyperlinkStyling::StateStyle effective;
-    
+
     // Start with base/default styling
     effective.foregroundColor = foregroundColor;
     effective.backgroundColor = backgroundColor;
@@ -5437,7 +5470,7 @@ Mudlet::HyperlinkStyling::StateStyle Mudlet::HyperlinkStyling::getEffectiveStyle
     effective.isStrikeOut = isStrikeOut;
     effective.isOverlined = isOverlined;
     effective.underlineStyle = underlineStyle;
-    
+
     // Apply :any-link styles (applies to both :link and :visited)
     if (anyLinkStyle.hasCustomStyling) {
         if (anyLinkStyle.hasForegroundColor) effective.foregroundColor = anyLinkStyle.foregroundColor;
@@ -5452,10 +5485,10 @@ Mudlet::HyperlinkStyling::StateStyle Mudlet::HyperlinkStyling::getEffectiveStyle
         effective.isOverlined = anyLinkStyle.isOverlined;
         effective.underlineStyle = anyLinkStyle.underlineStyle;
     }
-    
+
     // Apply state-specific styles with proper cascade order
     const StateStyle* stateStyle = nullptr;
-    
+
     switch (currentState) {
         case StateVisited:
             if (visitedStyle.hasCustomStyling) stateStyle = &visitedStyle;
@@ -5477,7 +5510,7 @@ Mudlet::HyperlinkStyling::StateStyle Mudlet::HyperlinkStyling::getEffectiveStyle
             if (linkStyle.hasCustomStyling) stateStyle = &linkStyle;
             break;
     }
-    
+
     // Apply the selected state style
     if (stateStyle) {
         if (stateStyle->hasForegroundColor) {
@@ -5508,33 +5541,33 @@ Mudlet::HyperlinkStyling::StateStyle Mudlet::HyperlinkStyling::getEffectiveStyle
         effective.underlineStyle = stateStyle->underlineStyle;
         effective.hasCustomStyling = true;
     }
-    
+
     // Even if the current state doesn't have custom styling, we need to mark that
     // the link has SOME pseudo-class styling so updateLinkCharacters() processes it.
     // This ensures ANSI base links with only :hover (but no :link) styling get updated.
     if (!effective.hasCustomStyling) {
         // Check if ANY pseudo-class state has custom styling
-        if (linkStyle.hasCustomStyling || visitedStyle.hasCustomStyling || 
+        if (linkStyle.hasCustomStyling || visitedStyle.hasCustomStyling ||
             hoverStyle.hasCustomStyling || activeStyle.hasCustomStyling ||
             focusStyle.hasCustomStyling || focusVisibleStyle.hasCustomStyling ||
             anyLinkStyle.hasCustomStyling) {
             effective.hasCustomStyling = true;
         }
     }
-    
+
     return effective;
 }
 
 void TBuffer::parseHyperlinkStateStyle(const QString& pseudoClass, const QString& styleString, Mudlet::HyperlinkStyling& styling)
 {
 #if defined(DEBUG_OSC_PROCESSING)
-    qDebug() << "[OSC8] parseHyperlinkStateStyle called with pseudoClass:" << pseudoClass 
+    qDebug() << "[OSC8] parseHyperlinkStateStyle called with pseudoClass:" << pseudoClass
              << "styleString:" << styleString;
 #endif
-    
+
     QString cleanPseudoClass = pseudoClass.trimmed().toLower();
     Mudlet::HyperlinkStyling::StateStyle* targetStyle = nullptr;
-    
+
     // Map pseudo-class selectors to appropriate state styles
     if (cleanPseudoClass == qsl(":link")) {
         targetStyle = &styling.linkStyle;
@@ -5556,7 +5589,7 @@ void TBuffer::parseHyperlinkStateStyle(const QString& pseudoClass, const QString
 #endif
         return;
     }
-    
+
     if (targetStyle) {
         parseStateStyleProperties(styleString, *targetStyle);
         applyAccessibilityEnhancements(styling);
@@ -5567,15 +5600,15 @@ void TBuffer::parseStateStyleProperties(const QString& styleString, Mudlet::Hype
 {
     // Parse CSS-like style string: "property:value;property:value"
     QStringList stylePairs = styleString.split(';', Qt::SkipEmptyParts);
-    
+
     bool hasAnyCustomStyling = false;
-    
+
     for (const QString& pair : stylePairs) {
         QStringList propertyValue = pair.split(':', Qt::KeepEmptyParts);
         if (propertyValue.size() != 2) {
             continue; // Skip malformed property
         }
-        
+
         QString property = propertyValue[0].trimmed().toLower();
         QString value = propertyValue[1].trimmed();
 
@@ -5603,13 +5636,13 @@ void TBuffer::parseStateStyleProperties(const QString& styleString, Mudlet::Hype
         } else if (property == qsl("text-decoration")) {
             // Handle text-decoration with optional style
             QStringList decorationParts = value.toLower().split(' ', Qt::SkipEmptyParts);
-            
+
             // Reset decoration flags
             stateStyle.isUnderlined = false;
             stateStyle.isOverlined = false;
             stateStyle.isStrikeOut = false;
             stateStyle.underlineStyle = Mudlet::HyperlinkStyling::UnderlineNone;
-            
+
             for (const QString& part : decorationParts) {
                 if (part == qsl("underline")) {
                     stateStyle.isUnderlined = true;
@@ -5659,7 +5692,7 @@ void TBuffer::parseStateStyleProperties(const QString& styleString, Mudlet::Hype
             }
         }
     }
-    
+
     stateStyle.hasCustomStyling = hasAnyCustomStyling;
 }
 
@@ -5673,7 +5706,7 @@ void TBuffer::applyAccessibilityEnhancements(Mudlet::HyperlinkStyling& styling)
         styling.focusStyle.underlineStyle = Mudlet::HyperlinkStyling::UnderlineSolid;
         styling.focusStyle.hasUnderlineColor = true;
         styling.focusStyle.underlineColor = QColor(0, 120, 215); // Windows accent blue
-        
+
         styling.focusVisibleStyle = styling.focusStyle; // Copy focus style to focus-visible
     }
 }
@@ -5684,9 +5717,9 @@ void TBuffer::setLinkState(int linkIndex, Mudlet::HyperlinkStyling::LinkState st
     if (linkIndex <= 0) {
         return; // Invalid link index
     }
-    
+
     mLinkStates[linkIndex] = state;
-    
+
 #if defined(DEBUG_OSC_PROCESSING)
     QString stateName;
     switch (state) {
@@ -5717,17 +5750,17 @@ Mudlet::HyperlinkStyling TBuffer::getEffectiveHyperlinkStyling(int linkIndex) co
     } else {
         // Get the stored styling for this link from mLinkStore
         Mudlet::HyperlinkStyling styling = mLinkStore.getStyling(linkIndex);
-        
+
         // Update the current state based on tracked state
         styling.currentState = getLinkState(linkIndex);
-        
-        // The HyperlinkStyling::getEffectiveStyle() method will compute the 
+
+        // The HyperlinkStyling::getEffectiveStyle() method will compute the
         // effective styling based on currentState, cascading from base -> :any-link -> state-specific
         // However, for rendering we need to apply it to the base styling properties
         // so the rendering code can use it directly
-        
+
         auto effective = styling.getEffectiveStyle();
-        
+
         // Copy effective state back to base properties for rendering
         styling.foregroundColor = effective.foregroundColor;
         styling.backgroundColor = effective.backgroundColor;
@@ -5746,7 +5779,7 @@ Mudlet::HyperlinkStyling TBuffer::getEffectiveHyperlinkStyling(int linkIndex) co
         styling.isOverlined = effective.isOverlined;
         styling.underlineStyle = effective.underlineStyle;
         styling.hasCustomStyling = effective.hasCustomStyling; // CRITICAL: Copy hasCustomStyling flag
-        
+
         return styling;
     }
 }
@@ -5755,7 +5788,7 @@ void TBuffer::setHoveredLink(int linkIndex)
 {
     int previousHoveredLink = mCurrentHoveredLinkIndex;
     mCurrentHoveredLinkIndex = linkIndex;
-    
+
     // Reset previous hovered link to its base state (default or visited)
     if (previousHoveredLink > 0 && previousHoveredLink != linkIndex) {
         auto currentState = getLinkState(previousHoveredLink);
@@ -5771,7 +5804,7 @@ void TBuffer::setHoveredLink(int linkIndex)
             updateLinkCharacters(previousHoveredLink); // Update displayed characters
         }
     }
-    
+
     // Set new link to hover state
     if (linkIndex > 0) {
         auto currentState = getLinkState(linkIndex);
@@ -5788,12 +5821,12 @@ void TBuffer::setActiveLink(int linkIndex)
 {
     int previousActiveLink = mCurrentActiveLinkIndex;
     mCurrentActiveLinkIndex = linkIndex;
-    
+
     // Reset previous active link
     if (previousActiveLink > 0 && previousActiveLink != linkIndex) {
         // Check current state to preserve visited links
         Mudlet::HyperlinkStyling::LinkState currentState = getLinkState(previousActiveLink);
-        
+
         // Return to hover if it's still hovered
         if (previousActiveLink == mCurrentHoveredLinkIndex) {
             setLinkState(previousActiveLink, Mudlet::HyperlinkStyling::StateHover);
@@ -5805,7 +5838,7 @@ void TBuffer::setActiveLink(int linkIndex)
 
         updateLinkCharacters(previousActiveLink); // Update displayed characters
     }
-    
+
     // Set new link to active state
     if (linkIndex > 0) {
         setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateActive);
@@ -5817,12 +5850,12 @@ void TBuffer::setFocusedLink(int linkIndex)
 {
     int previousFocusedLink = mCurrentFocusedLinkIndex;
     mCurrentFocusedLinkIndex = linkIndex;
-    
+
     // Reset previous focused link
     if (previousFocusedLink > 0 && previousFocusedLink != linkIndex) {
         setLinkState(previousFocusedLink, Mudlet::HyperlinkStyling::StateDefault);
     }
-    
+
     // Set new link to focus state
     if (linkIndex > 0) {
         // Determine if focus came from keyboard (would use StateFocusVisible)
@@ -5835,8 +5868,8 @@ void TBuffer::markLinkAsVisited(int linkIndex)
 {
     if (linkIndex > 0) {
         mVisitedLinks[linkIndex] = true;
-        
-        // If the link is not in an interactive state (hover/active/focus), 
+
+        // If the link is not in an interactive state (hover/active/focus),
         // update it to visited state immediately
         auto currentState = getLinkState(linkIndex);
 
@@ -5844,7 +5877,7 @@ void TBuffer::markLinkAsVisited(int linkIndex)
             setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateVisited);
             updateLinkCharacters(linkIndex);
         }
-        
+
 #if defined(DEBUG_OSC_PROCESSING)
         qDebug() << "[OSC8] Link" << linkIndex << "marked as visited";
 #endif
@@ -5862,14 +5895,14 @@ int TBuffer::getLinkIndexAt(int line, int column) const
     if (line < 0 || line >= lineBuffer.size()) {
         return 0;
     }
-    
+
     const auto& bufferLine = buffer.at(line);
-    
+
     // Validate column bounds
     if (column < 0 || column >= bufferLine.size()) {
         return 0;
     }
-    
+
     // Return the link index at this position
     return bufferLine.at(column).linkIndex();
 }
@@ -5881,10 +5914,10 @@ void TBuffer::updateLinkCharacters(int linkIndex)
     if (linkIndex <= 0) {
         return;
     }
-    
+
     // Get the effective styling for this link's current state
     Mudlet::HyperlinkStyling effectiveStyling = getEffectiveHyperlinkStyling(linkIndex);
-    
+
     // IMPORTANT: If this link has no custom CSS styling at all (neither base nor pseudo-class),
     // don't modify the characters. This preserves ANSI formatting for links without any CSS.
     if (!effectiveStyling.hasCustomStyling) {
@@ -5893,20 +5926,20 @@ void TBuffer::updateLinkCharacters(int linkIndex)
 #endif
         return; // Don't modify characters - preserve original ANSI formatting
     }
-    
+
     // Check if we should use ANSI base with pseudo-class overlays:
     // - Has pseudo-class styling (hasCustomStyling = true)
     // - But NO base CSS styling (hasBaseCustomStyling = false)
     // - And we're in default/visited state (not hover/active/focus)
-    bool useAnsiBase = !effectiveStyling.hasBaseCustomStyling && 
+    bool useAnsiBase = !effectiveStyling.hasBaseCustomStyling &&
                        (effectiveStyling.currentState == Mudlet::HyperlinkStyling::StateDefault ||
                         effectiveStyling.currentState == Mudlet::HyperlinkStyling::StateVisited);
-    
+
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC8] Updating link" << linkIndex << "- hasBaseCustomStyling:" << effectiveStyling.hasBaseCustomStyling
              << "currentState:" << effectiveStyling.currentState << "useAnsiBase:" << useAnsiBase;
 #endif
-    
+
     // Iterate through all lines in the buffer
     for (auto& line : buffer) {
         // Iterate through all characters in the line
@@ -5914,7 +5947,7 @@ void TBuffer::updateLinkCharacters(int linkIndex)
             // Check if this character belongs to the link we're updating
             if (tchar.linkIndex() == linkIndex) {
                 // Apply the effective styling to this character
-                
+
                 // If we should use ANSI base (no base CSS but in default/visited state),
                 // restore the original ANSI colors and formatting as a BASE,
                 // then let pseudo-class CSS styling override it
@@ -5932,24 +5965,24 @@ void TBuffer::updateLinkCharacters(int linkIndex)
                     tchar.mFgColor = originalChar.mFgColor;
                     tchar.mBgColor = originalChar.mBgColor;
                     tchar.mFlags = originalChar.mFlags; // Restore ALL ANSI formatting flags including decorations
-                    
+
                     // Clear any custom decoration colors that were applied by CSS pseudo-classes
                     // ANSI doesn't support custom decoration colors, so we clear them when restoring ANSI base
                     tchar.clearCustomUnderlineColor();
                     tchar.clearCustomOverlineColor();
                     tchar.clearCustomStrikeoutColor();
-                    
+
                     // DON'T continue here - let the CSS pseudo-class styling below override the ANSI base
                     // This allows e.g. :visited{color:#bb66dd} to work with ANSI base formatting
                 }
-                
+
                 // Apply CSS styling
-                
+
                 // Update foreground color
                 if (effectiveStyling.hasForegroundColor) {
                     tchar.mFgColor = effectiveStyling.foregroundColor;
                 }
-                
+
                 // Update background color - restore original if not specified in styling
                 if (effectiveStyling.hasBackgroundColor) {
                     tchar.mBgColor = effectiveStyling.backgroundColor;
@@ -5957,15 +5990,15 @@ void TBuffer::updateLinkCharacters(int linkIndex)
                     // Restore the original background color from when the link was created
                     tchar.mBgColor = mLinkOriginalBackgrounds.value(linkIndex, mBackGroundColor);
                 }
-                
+
                 // Update text decorations (only for CSS styling, not ANSI-base)
                 if (effectiveStyling.isUnderlined) {
                     tchar.mFlags |= TChar::Underline;
-                    
+
                     // Apply underline style
                     // First clear any existing underline style flags
                     tchar.mFlags &= ~(TChar::UnderlineWavy | TChar::UnderlineDotted | TChar::UnderlineDashed);
-                    
+
                     switch (effectiveStyling.underlineStyle) {
                         case Mudlet::HyperlinkStyling::UnderlineWavy:
                             tchar.mFlags |= TChar::UnderlineWavy;
@@ -5983,19 +6016,19 @@ void TBuffer::updateLinkCharacters(int linkIndex)
                     tchar.mFlags &= ~TChar::Underline;
                     tchar.mFlags &= ~(TChar::UnderlineWavy | TChar::UnderlineDotted | TChar::UnderlineDashed);
                 }
-                
+
                 if (effectiveStyling.isOverlined) {
                     tchar.mFlags |= TChar::Overline;
                 } else {
                     tchar.mFlags &= ~TChar::Overline;
                 }
-                
+
                 if (effectiveStyling.isStrikeOut) {
                     tchar.mFlags |= TChar::StrikeOut;
                 } else {
                     tchar.mFlags &= ~TChar::StrikeOut;
                 }
-                
+
                 // Apply decoration colors
                 if (effectiveStyling.hasUnderlineColor && effectiveStyling.isUnderlined) {
                     tchar.setUnderlineColor(effectiveStyling.underlineColor);
@@ -6006,14 +6039,14 @@ void TBuffer::updateLinkCharacters(int linkIndex)
                 if (effectiveStyling.hasStrikeoutColor && effectiveStyling.isStrikeOut) {
                     tchar.setStrikeoutColor(effectiveStyling.strikeoutColor);
                 }
-                
+
                 // Update bold and italic
                 if (effectiveStyling.isBold) {
                     tchar.mFlags |= TChar::Bold;
                 } else {
                     tchar.mFlags &= ~TChar::Bold;
                 }
-                
+
                 if (effectiveStyling.isItalic) {
                     tchar.mFlags |= TChar::Italic;
                 } else {

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -859,19 +859,19 @@ COMMIT_LINE:
 
         if (mHyperlinkActive) {
             c.mLinkIndex = mCurrentHyperlinkLinkId;
-
+            
             // Store the original ANSI-formatted character before applying CSS styling
             // This is needed for ANSI base restoration when pseudo-classes are inactive
             if (!mLinkOriginalCharacters.contains(mCurrentHyperlinkLinkId)) {
                 mLinkOriginalCharacters[mCurrentHyperlinkLinkId] = c;
 #if defined(DEBUG_OSC_PROCESSING)
-                qDebug().nospace().noquote() << "TBuffer::translateToPlainText(): Stored original character for link " << mCurrentHyperlinkLinkId
-                                              << " with ANSI colors: fg=" << c.mFgColor.name()
+                qDebug().nospace().noquote() << "TBuffer::translateToPlainText(): Stored original character for link " << mCurrentHyperlinkLinkId 
+                                              << " with ANSI colors: fg=" << c.mFgColor.name() 
                                               << " bg=" << c.mBgColor.name()
                                               << " flags=" << c.mFlags;
 #endif
             }
-
+            
             // Apply enhanced hyperlink styling
             if (mCurrentHyperlinkStyling.hasForegroundColor) {
                 c.mFgColor = mCurrentHyperlinkStyling.foregroundColor;
@@ -879,11 +879,11 @@ COMMIT_LINE:
             if (mCurrentHyperlinkStyling.hasBackgroundColor) {
                 c.mBgColor = mCurrentHyperlinkStyling.backgroundColor;
             }
-
+            
             // Apply text decorations
             if (mCurrentHyperlinkStyling.isUnderlined) {
                 c.mFlags |= TChar::Underline;
-
+                
                 // Apply specific underline style based on underlineStyle enum
                 switch (mCurrentHyperlinkStyling.underlineStyle) {
                     case Mudlet::HyperlinkStyling::UnderlineWavy:
@@ -908,7 +908,7 @@ COMMIT_LINE:
             if (mCurrentHyperlinkStyling.isStrikeOut) {
                 c.mFlags |= TChar::StrikeOut;
             }
-
+            
             // Apply decoration colors - only for active decorations
             if (mCurrentHyperlinkStyling.hasUnderlineColor && mCurrentHyperlinkStyling.isUnderlined) {
                 c.setUnderlineColor(mCurrentHyperlinkStyling.underlineColor);
@@ -919,14 +919,14 @@ COMMIT_LINE:
             if (mCurrentHyperlinkStyling.hasStrikeoutColor && mCurrentHyperlinkStyling.isStrikeOut) {
                 c.setStrikeoutColor(mCurrentHyperlinkStyling.strikeoutColor);
             }
-
+            
             if (mCurrentHyperlinkStyling.isBold) {
                 c.mFlags |= TChar::Bold;
             }
             if (mCurrentHyperlinkStyling.isItalic) {
                 c.mFlags |= TChar::Italic;
             }
-
+            
             // Only apply underline if explicitly set in styling (respects OSC 8 default of no underline)
             // Note: This differs from other Mudlet hyperlinks which default to underlined
         }
@@ -2325,7 +2325,7 @@ void TBuffer::decodeOSC(const QString& sequence)
         break;
     case static_cast<quint8>('8'): {
         // Handle OSC 8 hyperlinks in the form: "8;params;URI"
-
+        
         QStringView rest = QStringView(sequence).mid(1);  // skip selector "8;"
         int firstSemi = rest.indexOf(';');
 
@@ -2376,7 +2376,7 @@ void TBuffer::decodeOSC(const QString& sequence)
             qDebug() << "[OSC8] Raw URL for parameter parsing:" << rawUrl;
 #endif
             QMap<QString, QString> queryParams = parseUriQueryParameters(rawUrl);
-
+            
             // Extract styling parameters
             if (queryParams.contains(qsl("style"))) {
 #if defined(DEBUG_OSC_PROCESSING)
@@ -2389,7 +2389,7 @@ void TBuffer::decodeOSC(const QString& sequence)
                 qDebug() << "[OSC8] No style parameter provided, using defaults (isUnderlined=" << mCurrentHyperlinkStyling.isUnderlined << ")";
 #endif
             }
-
+            
             // Extract menu parameters
             if (queryParams.contains(qsl("menu"))) {
                 QString menuString = queryParams.value(qsl("menu"));
@@ -2405,18 +2405,18 @@ void TBuffer::decodeOSC(const QString& sequence)
                 qDebug() << "[OSC8] No menu parameter found";
 #endif
             }
-
+            
             // Extract custom tooltip parameter
             QString customTooltip;
 
             if (queryParams.contains(qsl("tooltip"))) {
                 customTooltip = queryParams.value(qsl("tooltip"));
             }
-
+            
             // Remove styling/menu/tooltip query parameters from URL for command processing
             QString baseUrl = rawUrl;
             QMap<QString, QString> allParams = parseUriQueryParameters(rawUrl);
-
+            
             // For web URLs, preserve original parameters except our special ones
             if (rawUrl.startsWith(qsl("http://")) || rawUrl.startsWith(qsl("https://")) || rawUrl.startsWith(qsl("ftp://"))) {
                 // Remove our special parameters
@@ -2429,7 +2429,7 @@ void TBuffer::decodeOSC(const QString& sequence)
                 if (queryStart != -1) {
                     baseUrl = baseUrl.left(queryStart);
                 }
-
+                
                 // Only append parameters if there are any left
                 if (!allParams.isEmpty()) {
                     baseUrl = appendQueryParameters(baseUrl, allParams);
@@ -2482,7 +2482,7 @@ void TBuffer::decodeOSC(const QString& sequence)
 #endif
                 QStringList menuCommands;
                 QStringList menuHints;
-
+                
                 // Add menu items in pairs (label, command)
                 // The first menu item becomes the primary left-click action (index 0)
                 // All items (including first) appear in the right-click menu (index 1+)
@@ -2490,7 +2490,7 @@ void TBuffer::decodeOSC(const QString& sequence)
                 for (int i = 0; i < mCurrentHyperlinkMenu.size() - 1; i += 2) {
                     QString menuLabel = mCurrentHyperlinkMenu[i];
                     QString menuCommand = mCurrentHyperlinkMenu[i + 1];
-
+                    
                     // Determine command type based on prefix
                     if (menuCommand.startsWith(qsl("send:"))) {
                         QString innerCommand = QUrl::fromPercentEncoding(menuCommand.mid(5).toUtf8());
@@ -2511,7 +2511,7 @@ void TBuffer::decodeOSC(const QString& sequence)
                     }
                     isFirstItem = false;
                 }
-
+                
                 // Set the tooltip for the link (what shows on hover)
                 // Use custom tooltip if provided, otherwise show "Right-click for menu" message
                 QString linkTooltip;
@@ -2522,14 +2522,14 @@ void TBuffer::decodeOSC(const QString& sequence)
                     // Default tooltip for menu links
                     linkTooltip = QObject::tr("Right-click for menu");
                 }
-
+                
                 // For menus, we need tooltip as first hint, then menu labels
                 // This ensures tooltip.size() > commands.size() so only first hint shows in tooltip
                 // But menu labels are available for right-click menu display
                 QStringList finalHints;
                 finalHints.append(linkTooltip); // First: tooltip for hover
                 finalHints.append(menuHints);   // Rest: menu labels for right-click menu
-
+                
                 command = menuCommands;
                 hint = finalHints;
 #if defined(DEBUG_OSC_PROCESSING)
@@ -2541,14 +2541,14 @@ void TBuffer::decodeOSC(const QString& sequence)
             mCurrentHyperlinkCommand = command;
             mCurrentHyperlinkHint = hint;
             mCurrentHyperlinkLinkId = mLinkStore.addLinks(command, hint, mpHost, QVector<int>());
-
+            
             // Store the styling for this link so it can be retrieved later
             mLinkStore.setStyling(mCurrentHyperlinkLinkId, mCurrentHyperlinkStyling);
-
+            
             // Store the original background color for this link so we can restore it later
             // when the link styling doesn't specify a background
             mLinkOriginalBackgrounds[mCurrentHyperlinkLinkId] = mBackGroundColor;
-
+            
 #if defined(DEBUG_OSC_PROCESSING)
             qDebug().noquote() << "[OSC8] Hyperlink activated:" << rawUrl.left(50) + (rawUrl.length() > 50 ? "..." : "");
 #endif
@@ -2566,33 +2566,33 @@ QString TBuffer::appendQueryParameters(const QString& uri, const QMap<QString, Q
     if (parameters.isEmpty()) {
         return uri;
     }
-
+    
     QString result = uri;
     bool hasExistingParams = uri.contains(qsl("?"));
     QString separator = hasExistingParams ? qsl("&") : qsl("?");
-
+    
     QStringList paramStrings;
     for (auto it = parameters.constBegin(); it != parameters.constEnd(); ++it) {
         QString key = QUrl::toPercentEncoding(it.key());
         QString value = QUrl::toPercentEncoding(it.value());
         paramStrings.append(qsl("%1=%2").arg(key, value));
     }
-
+    
     if (!paramStrings.isEmpty()) {
         result += separator + paramStrings.join(qsl("&"));
     }
-
+    
     return result;
 }
 
 QMap<QString, QString> TBuffer::parseUriQueryParameters(const QString& uri)
 {
     QMap<QString, QString> parameters;
-
+    
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC8] parseUriQueryParameters called with uri:" << uri;
 #endif
-
+    
     // Find the query string part after '?'
     int queryStart = uri.indexOf('?');
     if (queryStart == -1) {
@@ -2601,28 +2601,28 @@ QMap<QString, QString> TBuffer::parseUriQueryParameters(const QString& uri)
 #endif
         return parameters; // No query parameters
     }
-
+    
     QString queryString = uri.mid(queryStart + 1);
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC8] Query string:" << queryString;
 #endif
-
+    
     // Decode the query string first, since the server percent-encodes the entire URL
     QString decodedQueryString = QUrl::fromPercentEncoding(queryString.toUtf8());
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC8] Decoded query string:" << decodedQueryString;
 #endif
-
+    
     // Only process JSON config parameters - no legacy CSS support
     if (decodedQueryString.startsWith(qsl("config={"))) {
         QString jsonString = decodedQueryString.mid(7); // Remove "config="
         parseJsonHyperlinkConfig(jsonString, parameters);
     }
-
+    
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC8] Parsed JSON parameters:" << parameters;
 #endif
-
+    
     return parameters;
 }
 
@@ -2634,23 +2634,23 @@ bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, 
 
     QJsonParseError parseError;
     QJsonDocument doc = QJsonDocument::fromJson(jsonString.toUtf8(), &parseError);
-
+    
     if (parseError.error != QJsonParseError::NoError) {
 #if defined(DEBUG_OSC_PROCESSING)
         qDebug() << "[OSC8] JSON parse error:" << parseError.errorString();
 #endif
         return false;
     }
-
+    
     if (!doc.isObject()) {
 #if defined(DEBUG_OSC_PROCESSING)
         qDebug() << "[OSC8] JSON root is not an object";
 #endif
         return false;
     }
-
+    
     QJsonObject root = doc.object();
-
+    
     // Parse style object
     if (root.contains(qsl("style")) && root[qsl("style")].isObject()) {
         QJsonObject styleObj = root[qsl("style")].toObject();
@@ -2659,7 +2659,7 @@ bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, 
             parameters.insert(qsl("style"), cssStyleString);
         }
     }
-
+    
     // Parse menu array
     if (root.contains(qsl("menu")) && root[qsl("menu")].isArray()) {
         QJsonArray menuArray = root[qsl("menu")].toArray();
@@ -2668,44 +2668,44 @@ bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, 
             parameters.insert(qsl("menu"), menuString);
         }
     }
-
+    
     // Parse tooltip string
     if (root.contains(qsl("tooltip")) && root[qsl("tooltip")].isString()) {
         parameters.insert(qsl("tooltip"), root[qsl("tooltip")].toString());
     }
-
+    
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC8] JSON converted to parameters:" << parameters;
 #endif
-
+    
     return true;
 }
 
 QString TBuffer::jsonStyleObjectToCss(const QJsonObject& styleObj)
 {
     QStringList cssProperties;
-
+    
     // Basic style properties
     if (styleObj.contains(qsl("color")) && styleObj[qsl("color")].isString()) {
         cssProperties << qsl("color:") + styleObj[qsl("color")].toString();
     }
-
+    
     if (styleObj.contains(qsl("bg")) && styleObj[qsl("bg")].isString()) {
         cssProperties << qsl("background-color:") + styleObj[qsl("bg")].toString();
     }
-
+    
     if (styleObj.contains(qsl("bold")) && styleObj[qsl("bold")].isBool() && styleObj[qsl("bold")].toBool()) {
         cssProperties << qsl("font-weight:bold");
     }
-
+    
     if (styleObj.contains(qsl("italic")) && styleObj[qsl("italic")].isBool() && styleObj[qsl("italic")].toBool()) {
         cssProperties << qsl("font-style:italic");
     }
-
+    
     // Text decorations - combine multiple decorations into single CSS property
     QStringList decorationParts;
     QString underlineStyle = qsl("solid"); // Default underline style
-
+    
     // Process underline
     if (styleObj.contains(qsl("underline"))) {
         QJsonValue underlineVal = styleObj[qsl("underline")];
@@ -2716,7 +2716,7 @@ QString TBuffer::jsonStyleObjectToCss(const QJsonObject& styleObj)
             underlineStyle = underlineVal.toString(); // Store style for later
         }
     }
-
+    
     // Process overline
     if (styleObj.contains(qsl("overline"))) {
         QJsonValue overlineVal = styleObj[qsl("overline")];
@@ -2727,7 +2727,7 @@ QString TBuffer::jsonStyleObjectToCss(const QJsonObject& styleObj)
             // Note: overline styles are currently limited to solid in the parser
         }
     }
-
+    
     // Process strikethrough
     if (styleObj.contains(qsl("strikethrough"))) {
         QJsonValue strikeVal = styleObj[qsl("strikethrough")];
@@ -2738,7 +2738,7 @@ QString TBuffer::jsonStyleObjectToCss(const QJsonObject& styleObj)
             // Note: strikethrough styles are currently limited to solid in the parser
         }
     }
-
+    
     // Combine all decorations into a single CSS property
     if (!decorationParts.isEmpty()) {
         QString decorationValue = decorationParts.join(qsl(" "));
@@ -2748,15 +2748,15 @@ QString TBuffer::jsonStyleObjectToCss(const QJsonObject& styleObj)
         }
         cssProperties << qsl("text-decoration:") + decorationValue;
     }
-
+    
     // Text decoration color
     if (styleObj.contains(qsl("text-decoration-color")) && styleObj[qsl("text-decoration-color")].isString()) {
         cssProperties << qsl("text-decoration-color:") + styleObj[qsl("text-decoration-color")].toString();
     }
-
+    
     // Pseudo-class states
     QStringList pseudoClasses = {qsl("hover"), qsl("active"), qsl("visited"), qsl("link"), qsl("focus"), qsl("focus-visible"), qsl("any-link")};
-
+    
     for (const QString& pseudoClass : pseudoClasses) {
         if (styleObj.contains(pseudoClass) && styleObj[pseudoClass].isObject()) {
             QJsonObject pseudoObj = styleObj[pseudoClass].toObject();
@@ -2766,14 +2766,14 @@ QString TBuffer::jsonStyleObjectToCss(const QJsonObject& styleObj)
             }
         }
     }
-
+    
     return cssProperties.join(qsl(";"));
 }
 
 QString TBuffer::jsonMenuArrayToString(const QJsonArray& menuArray)
 {
     QStringList menuItems;
-
+    
     for (const QJsonValue& item : menuArray) {
         if (item.isString() && item.toString() == qsl("-")) {
             // Separator
@@ -2788,7 +2788,7 @@ QString TBuffer::jsonMenuArrayToString(const QJsonArray& menuArray)
             }
         }
     }
-
+    
     return menuItems.join(qsl("|"));
 }
 
@@ -2797,10 +2797,10 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC8] parseHyperlinkStyling called with styleString:" << styleString;
 #endif
-
+    
     // Reset styling to defaults
     styling = Mudlet::HyperlinkStyling();
-
+    
     // Check if this is a CSS selector with pseudo-classes
     // Format: "property:value;:pseudo-class{property:value;property:value}:pseudo-class{...}"
     // or just: ":pseudo-class{property:value;property:value}:pseudo-class{...}"
@@ -2809,23 +2809,23 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
         // These are properties that come before any pseudo-class or between pseudo-classes
         QString baseProperties;
         QRegularExpression pseudoClassRegex(R"(:([\w-]+)\s*\{([^}]*)\})");
-
+        
         // Extract base properties by removing all pseudo-class blocks
         QString remainingStyle = styleString;
         QRegularExpressionMatchIterator matches = pseudoClassRegex.globalMatch(styleString);
-
+        
         // Remove pseudo-class blocks to get base properties
         while (matches.hasNext()) {
             QRegularExpressionMatch match = matches.next();
             remainingStyle.replace(match.captured(0), "");
         }
-
+        
         // Parse base properties if any exist
         // Filter out strings that are only semicolons and whitespace
         QString filteredBase = remainingStyle;
         filteredBase.remove(';');
         filteredBase = filteredBase.trimmed();
-
+        
         if (!filteredBase.isEmpty()) {
             baseProperties = remainingStyle.trimmed();
 #if defined(DEBUG_OSC_PROCESSING)
@@ -2833,7 +2833,7 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
 #endif
             // Mark that we have base styling (not just pseudo-class styling)
             styling.hasBaseCustomStyling = true;
-
+            
             // Parse base properties as simple CSS
             QStringList basePairs = baseProperties.split(';', Qt::SkipEmptyParts);
 
@@ -2846,7 +2846,7 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
 
                 QString property = propertyValue[0].trimmed().toLower();
                 QString value = propertyValue[1].trimmed();
-
+                
                 // Apply base properties to the default state
                 if (property == qsl("color")) {
                     QColor color = parseColorValue(value);
@@ -2871,7 +2871,7 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
                 }
             }
         }
-
+        
         // Now parse pseudo-class specific styles
         matches = pseudoClassRegex.globalMatch(styleString);
 
@@ -2879,14 +2879,14 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
             QRegularExpressionMatch match = matches.next();
             QString pseudoClass = ":" + match.captured(1);
             QString properties = match.captured(2);
-
+            
 #if defined(DEBUG_OSC_PROCESSING)
             qDebug() << "[OSC8] Found pseudo-class:" << pseudoClass << "with properties:" << properties;
 #endif
-
+            
             parseHyperlinkStateStyle(pseudoClass, properties, styling);
         }
-
+        
         // If no base styling was provided, but we have :link or :any-link styles,
         // use them as the default/base state since links need a default appearance
         if (!styling.hasCustomStyling) {
@@ -2936,28 +2936,28 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
                 styling.hasCustomStyling = true;
             }
         }
-
+        
         // Apply accessibility enhancements
         applyAccessibilityEnhancements(styling);
         return;
     }
-
+    
     // Fallback: Parse as simple CSS-like style string: "property:value;property:value"
     QStringList stylePairs = styleString.split(';', Qt::SkipEmptyParts);
-
+    
     bool hasAnyCustomStyling = false;
     bool textDecorationExplicitlySet = false;
-
+    
     for (const QString& pair : stylePairs) {
         QStringList propertyValue = pair.split(':', Qt::KeepEmptyParts);
 
         if (propertyValue.size() != 2) {
             continue; // Skip malformed property
         }
-
+        
         QString property = propertyValue[0].trimmed().toLower();
         QString value = propertyValue[1].trimmed();
-
+        
         if (property == "color") {
             QColor color = parseColorValue(value);
 
@@ -2984,13 +2984,13 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
             // Handle text-decoration with optional style: "underline", "underline wavy", "overline", "line-through", "none"
             // Can also handle multiple values: "underline overline", "underline wavy red"
             QStringList decorationParts = value.toLower().split(' ', Qt::SkipEmptyParts);
-
+            
             // Reset decoration flags when text-decoration is explicitly set
             styling.isUnderlined = false;
             styling.isOverlined = false;
             styling.isStrikeOut = false;
             styling.underlineStyle = Mudlet::HyperlinkStyling::UnderlineNone;
-
+            
             for (const QString& part : decorationParts) {
                 if (part == "underline") {
                     styling.isUnderlined = true;
@@ -3048,7 +3048,7 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
             styling.isUnderlined = false;
             styling.isOverlined = false;
             styling.isStrikeOut = false;
-
+            
             QStringList decorations = value.toLower().split(' ', Qt::SkipEmptyParts);
 
             for (const QString& decoration : decorations) {
@@ -3098,7 +3098,7 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
             hasAnyCustomStyling = true;
         }
     }
-
+    
     // If custom styling was provided, mark it and disable default underline if text-decoration wasn't explicitly set
     if (hasAnyCustomStyling) {
         styling.hasCustomStyling = true;
@@ -3113,7 +3113,7 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
 QColor TBuffer::parseColorValue(const QString& value)
 {
     QString cleanValue = value.trimmed().toLower();
-
+    
     // Handle hex colors: #rrggbb (6-digit) or #rgb (3-digit shorthand)
     // Qt's QColor constructor automatically expands 3-digit format (e.g., #f00 -> #ff0000)
     if (cleanValue.startsWith('#')) {
@@ -3123,14 +3123,14 @@ QColor TBuffer::parseColorValue(const QString& value)
             return color;
         }
     }
-
+    
     // Handle named colors
     QColor namedColor(cleanValue);
 
     if (namedColor.isValid()) {
         return namedColor;
     }
-
+    
     // Handle rgb() format: rgb(255, 0, 0) or rgb(100%, 0%, 0%)
     // Supports both integer (0-255) and percentage (0%-100%) values
     // Spaces after commas are optional: rgb(255,0,0) works too
@@ -3162,18 +3162,18 @@ QColor TBuffer::parseColorValue(const QString& value)
                     return -1;
                 }
             };
-
+            
             bool ok1, ok2, ok3;
             int r = parseComponent(components[0], ok1);
             int g = parseComponent(components[1], ok2);
             int b = parseComponent(components[2], ok3);
-
+            
             if (ok1 && ok2 && ok3 && r >= 0 && g >= 0 && b >= 0) {
                 return QColor(r, g, b);
             }
         }
     }
-
+    
     return QColor(); // Invalid color
 }
 
@@ -3258,7 +3258,7 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
     if (sub_end < 0) {
         return;
     }
-
+        
     // Check for OSC 8 documentation examples trigger phrase
     if (text.contains("!osc8-docs")) {
 #if defined(DEBUG_OSC_PROCESSING)
@@ -3267,7 +3267,7 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
         injectOSC8DocumentationExamples();
         return; // Don't display the trigger phrase itself
     }
-
+    
     int lastLine = buffer.size() - 1;
     if (Q_UNLIKELY(lastLine < 0)) {
         // There are NO lines in the buffer - so initialize with a new empty line
@@ -3300,11 +3300,11 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
         lineBuffer.back().append(thisChar);
         const TChar styling(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags), linkID);
         buffer.back().push_back(styling);
-
-        // Note: Original character storage for ANSI-styled OSC 8 links happens in
-        // translateToPlainText() where the TChar is created with ANSI formatting
+        
+        // Note: Original character storage for ANSI-styled OSC 8 links happens in 
+        // translateToPlainText() where the TChar is created with ANSI formatting 
         // before CSS styling is applied
-
+        
         if (firstChar) {
             timeBuffer.back() = QTime::currentTime().toString(mudlet::smTimeStampFormat);
             firstChar = false;
@@ -5273,170 +5273,170 @@ void TBuffer::injectOSC8DocumentationExamples()
     QString output = "\n╔════════════════════════════════════════════════════════════════════╗\n";
     output += "║         OSC 8 Hyperlink Documentation Examples                     ║\n";
     output += "╚════════════════════════════════════════════════════════════════════╝\n\n";
-
+    
     // ═══════════════════════════════════════════════════════════════════
     // Getting Started: Simple Links
     // ═══════════════════════════════════════════════════════════════════
     output += "══════════════════════════════════════════════════════════════════════\n";
     output += "GETTING STARTED: SIMPLE LINKS\n";
     output += "══════════════════════════════════════════════════════════════════════\n\n";
-
+    
     output += "1. Sending Commands:\n";
     output += "   \x1b]8;;send:look\x1b\\Look\x1b]8;;\x1b\\\n\n";
-
+    
     output += "2. Pre-filling Commands:\n";
     output += "   \x1b]8;;prompt:cast%20fireball\x1b\\Cast Fireball\x1b]8;;\x1b\\\n\n";
-
+    
     output += "3. Opening Web Pages:\n";
     output += "   \x1b]8;;https://www.mudlet.org\x1b\\Visit Mudlet\x1b]8;;\x1b\\\n\n";
-
+    
     // ═══════════════════════════════════════════════════════════════════
     // Adding Custom Styling
     // ═══════════════════════════════════════════════════════════════════
     output += "══════════════════════════════════════════════════════════════════════\n";
     output += "ADDING CUSTOM STYLING\n";
     output += "══════════════════════════════════════════════════════════════════════\n\n";
-
+    
     output += "Basic Styling:\n";
     output += "• Red text: \x1b]8;;send:attack?config={\"style\":{\"color\":\"red\"}}\x1b\\Attack\x1b]8;;\x1b\\\n";
     output += "• Bold red: \x1b]8;;send:attack?config={\"style\":{\"color\":\"red\",\"bold\":true}}\x1b\\Attack\x1b]8;;\x1b\\\n";
     output += "• Blue background: \x1b]8;;send:action?config={\"style\":{\"color\":\"white\",\"bg\":\"blue\"}}\x1b\\Action\x1b]8;;\x1b\\\n\n";
-
+    
     output += "Text Decorations:\n";
     output += "• Underlined: \x1b]8;;send:cast?config={\"style\":{\"underline\":true}}\x1b\\Underlined\x1b]8;;\x1b\\\n";
     output += "• Overlined: \x1b]8;;send:heal?config={\"style\":{\"overline\":true}}\x1b\\Overlined\x1b]8;;\x1b\\\n";
     output += "• Strikethrough: \x1b]8;;send:flee?config={\"style\":{\"strikethrough\":true}}\x1b\\Strikethrough\x1b]8;;\x1b\\\n";
     output += "• Wavy underline: \x1b]8;;send:spell?config={\"style\":{\"underline\":\"wavy\"}}\x1b\\Wavy Underline\x1b]8;;\x1b\\\n";
     output += "• Dotted overline: \x1b]8;;send:magic?config={\"style\":{\"overline\":\"dotted\"}}\x1b\\Dotted Overline\x1b]8;;\x1b\\\n\n";
-
+    
     output += "Decoration Colors:\n";
     output += "• Red underline: \x1b]8;;send:redline?config={\"style\":{\"underline\":true,\"text-decoration-color\":\"red\"}}\x1b\\Red Underline\x1b]8;;\x1b\\\n";
     output += "• Blue overline: \x1b]8;;send:blueover?config={\"style\":{\"overline\":true,\"text-decoration-color\":\"#0066ff\"}}\x1b\\Blue Overline\x1b]8;;\x1b\\\n";
     output += "• Green wavy: \x1b]8;;send:greenwave?config={\"style\":{\"underline\":\"wavy\",\"text-decoration-color\":\"green\"}}\x1b\\Green Wavy\x1b]8;;\x1b\\\n";
     output += "• Purple strike: \x1b]8;;send:purplestrike?config={\"style\":{\"strikethrough\":true,\"text-decoration-color\":\"purple\"}}\x1b\\Purple Strike\x1b]8;;\x1b\\\n\n";
-
+    
     // ═══════════════════════════════════════════════════════════════════
     // Interactive States
     // ═══════════════════════════════════════════════════════════════════
     output += "══════════════════════════════════════════════════════════════════════\n";
     output += "INTERACTIVE STATES\n";
     output += "══════════════════════════════════════════════════════════════════════\n\n";
-
+    
     output += "Hover Effects:\n";
     output += "• Hover color change: \x1b]8;;send:look?config={\"style\":{\"color\":\"blue\",\"hover\":{\"color\":\"red\"}}}\x1b\\Hover Me\x1b]8;;\x1b\\\n";
     output += "• Hover bold: \x1b]8;;send:defend?config={\"style\":{\"color\":\"blue\",\"bold\":true,\"hover\":{\"color\":\"yellow\"}}}\x1b\\Defend\x1b]8;;\x1b\\\n\n";
-
+    
     output += "Link vs Visited States:\n";
     output += "• \x1b]8;;send:explore?config={\"style\":{\"link\":{\"color\":\"blue\",\"underline\":true},\"visited\":{\"color\":\"purple\",\"strikethrough\":true}}}\x1b\\Visit Me\x1b]8;;\x1b\\\n\n";
-
+    
     output += "Button-Style Link:\n";
     output += "• \x1b]8;;send:attack?config={\"style\":{\"bg\":\"green\",\"color\":\"white\",\"bold\":true,\"hover\":{\"bg\":\"lightgreen\"},\"active\":{\"bg\":\"darkgreen\"}}}\x1b\\Attack\x1b]8;;\x1b\\\n\n";
-
+    
     output += "Multi-State Button:\n";
     output += "• \x1b]8;;send:action?config={\"style\":{\"bg\":\"green\",\"hover\":{\"bg\":\"lightgreen\"},\"active\":{\"bg\":\"darkgreen\"},\"focus-visible\":{\"bg\":\"lightblue\"}}}\x1b\\Multi-State\x1b]8;;\x1b\\\n\n";
-
+    
     output += "Any-Link Styling:\n";
     output += "• \x1b]8;;send:universal?config={\"style\":{\"any-link\":{\"bold\":true},\"hover\":{\"color\":\"orange\"}}}\x1b\\Universal Link\x1b]8;;\x1b\\\n\n";
-
+    
     // ═══════════════════════════════════════════════════════════════════
     // Context Menus and Tooltips
     // ═══════════════════════════════════════════════════════════════════
     output += "══════════════════════════════════════════════════════════════════════\n";
     output += "CONTEXT MENUS AND TOOLTIPS\n";
     output += "══════════════════════════════════════════════════════════════════════\n\n";
-
+    
     output += "Basic Menu:\n";
     output += "• \x1b]8;;send:combat?config={\"menu\":[{\"Attack\":\"send:attack\"},{\"Defend\":\"send:defend\"}]}\x1b\\Combat Menu\x1b]8;;\x1b\\ (right-click for menu)\n\n";
-
+    
     output += "Menu with Tooltip:\n";
     output += "• \x1b]8;;send:magic?config={\"menu\":[{\"Cast\":\"send:cast fireball\"},{\"Heal\":\"send:heal\"}],\"tooltip\":\"Magic actions\"}\x1b\\Magic Menu\x1b]8;;\x1b\\\n\n";
-
+    
     output += "Menu with Separators:\n";
     output += "• \x1b]8;;send:spells?config={\"menu\":[{\"Fireball\":\"send:cast fireball\"},{\"Ice Bolt\":\"send:cast ice bolt\"},\"-\",{\"Heal\":\"send:cast heal\"}]}\x1b\\Spell Menu\x1b]8;;\x1b\\\n\n";
-
+    
     output += "Primary vs Secondary Actions:\n";
     output += "• \x1b]8;;send:look?config={\"menu\":[{\"Look\":\"send:look\"},{\"Examine\":\"send:examine\"},\"-\",{\"Go North\":\"send:north\"}]}\x1b\\Look Around\x1b]8;;\x1b\\\n";
     output += "  (Left-click executes 'look', right-click shows menu)\n\n";
-
+    
     output += "Combined Styling and Menus:\n";
     output += "• \x1b]8;;send:attack?config={\"style\":{\"color\":\"red\",\"bold\":true},\"menu\":[{\"Attack\":\"send:attack\"},{\"Defend\":\"send:defend\"},{\"Heal\":\"send:heal\"}],\"tooltip\":\"Combat Actions\"}\x1b\\Combat Menu\x1b]8;;\x1b\\\n\n";
-
+    
     // ═══════════════════════════════════════════════════════════════════
     // Practical Examples
     // ═══════════════════════════════════════════════════════════════════
     output += "══════════════════════════════════════════════════════════════════════\n";
     output += "PRACTICAL EXAMPLES\n";
     output += "══════════════════════════════════════════════════════════════════════\n\n";
-
+    
     output += "Simple Styled Links:\n";
     output += "• Red attack link: \x1b]8;;send:attack?config={\"style\":{\"color\":\"red\"}}\x1b\\Attack\x1b]8;;\x1b\\\n";
     output += "• Bold blue with hover: \x1b]8;;send:defend?config={\"style\":{\"color\":\"blue\",\"bold\":true,\"hover\":{\"color\":\"yellow\"}}}\x1b\\Defend\x1b]8;;\x1b\\\n";
     output += "• Green wavy underline: \x1b]8;;send:spell?config={\"style\":{\"underline\":\"wavy\",\"text-decoration-color\":\"green\"}}\x1b\\Spell Link\x1b]8;;\x1b\\\n\n";
-
+    
     output += "Interactive Menu Examples:\n";
     output += "• Basic combat menu: \x1b]8;;send:combat?config={\"menu\":[{\"Attack\":\"send:attack\"},{\"Defend\":\"send:defend\"}]}\x1b\\Combat\x1b]8;;\x1b\\\n";
     output += "• Menu with separators: \x1b]8;;send:spells?config={\"menu\":[{\"Fireball\":\"send:cast fireball\"},{\"Ice Bolt\":\"send:cast ice bolt\"},\"-\",{\"Heal\":\"send:cast heal\"}]}\x1b\\Spells\x1b]8;;\x1b\\\n";
     output += "• Menu with tooltip: \x1b]8;;send:magic?config={\"menu\":[{\"Cast\":\"send:cast fireball\"},{\"Heal\":\"send:heal\"}],\"tooltip\":\"Magic actions\"}\x1b\\Magic\x1b]8;;\x1b\\\n\n";
-
+    
     output += "Button-Style Links:\n";
     output += "• \x1b]8;;send:attack?config={\"style\":{\"bg\":\"green\",\"color\":\"white\",\"bold\":true,\"hover\":{\"bg\":\"lightgreen\"},\"active\":{\"bg\":\"darkgreen\"}}}\x1b\\Attack Button\x1b]8;;\x1b\\\n\n";
-
+    
     // ═══════════════════════════════════════════════════════════════════
     // Advanced Features
     // ═══════════════════════════════════════════════════════════════════
     output += "══════════════════════════════════════════════════════════════════════\n";
     output += "ADVANCED FEATURES\n";
     output += "══════════════════════════════════════════════════════════════════════\n\n";
-
+    
     output += "ANSI + JSON Hybrid Styling:\n";
     output += "• \x1b[1m\x1b]8;;send:attack?config={\"style\":{\"color\":\"red\",\"hover\":{\"color\":\"yellow\",\"underline\":true}}}\x1b\\Bold Red Attack\x1b]8;;\x1b\\\x1b[0m\n";
     output += "• \x1b[38;5;196m\x1b]8;;send:fire?config={\"style\":{\"hover\":{\"bg\":\"black\"},\"active\":{\"color\":\"orange\"}}}\x1b\\Fire Magic\x1b]8;;\x1b\\\x1b[0m\n\n";
-
+    
     output += "Comprehensive Multi-State Example:\n";
     output += "• \x1b]8;;send:comprehensive?config={\"style\":{\"any-link\":{\"underline\":true},\"link\":{\"color\":\"blue\"},\"visited\":{\"color\":\"purple\"},\"hover\":{\"color\":\"red\"},\"active\":{\"color\":\"darkred\"},\"focus-visible\":{\"bg\":\"orange\",\"color\":\"white\"}}}\x1b\\Comprehensive Link\x1b]8;;\x1b\\\n\n";
-
+    
     output += "Color Format Examples:\n";
     output += "• Hex: \x1b]8;;send:hex?config={\"style\":{\"color\":\"#ff0000\"}}\x1b\\Red (#ff0000)\x1b]8;;\x1b\\\n";
     output += "• Shorthand: \x1b]8;;send:short?config={\"style\":{\"color\":\"#f00\"}}\x1b\\Red (#f00)\x1b]8;;\x1b\\\n";
     output += "• Named: \x1b]8;;send:named?config={\"style\":{\"color\":\"red\"}}\x1b\\Red (named)\x1b]8;;\x1b\\\n";
     output += "• RGB: \x1b]8;;send:rgb?config={\"style\":{\"color\":\"rgb(255,0,0)\"}}\x1b\\Red (RGB)\x1b]8;;\x1b\\\n\n";
-
+    
     // ═══════════════════════════════════════════════════════════════════
     // Real World Examples
     // ═══════════════════════════════════════════════════════════════════
     output += "══════════════════════════════════════════════════════════════════════\n";
     output += "REAL WORLD EXAMPLES\n";
     output += "══════════════════════════════════════════════════════════════════════\n\n";
-
+    
     output += "Navigation:\n";
     output += "  \x1b]8;;send:north?config={\"style\":{\"color\":\"#0066cc\",\"bold\":true,\"hover\":{\"color\":\"#3399ff\",\"underline\":true}}}\x1b\\North\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:south?config={\"style\":{\"color\":\"#0066cc\",\"bold\":true,\"hover\":{\"color\":\"#3399ff\",\"underline\":true}}}\x1b\\South\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:east?config={\"style\":{\"color\":\"#0066cc\",\"bold\":true,\"hover\":{\"color\":\"#3399ff\",\"underline\":true}}}\x1b\\East\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:west?config={\"style\":{\"color\":\"#0066cc\",\"bold\":true,\"hover\":{\"color\":\"#3399ff\",\"underline\":true}}}\x1b\\West\x1b]8;;\x1b\\\n\n";
-
+    
     output += "Combat:\n";
     output += "  \x1b]8;;send:attack?config={\"style\":{\"color\":\"#cc0000\",\"bold\":true,\"hover\":{\"bg\":\"#ffcccc\",\"color\":\"#000000\"}},\"menu\":[{\"Quick Strike\":\"send:quick\"},{\"Power Attack\":\"send:power\"},\"-\",{\"Feint\":\"send:feint\"}]}\x1b\\⚔️ Attack\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:defend?config={\"style\":{\"color\":\"#006600\",\"bold\":true,\"hover\":{\"bg\":\"#ccffcc\",\"color\":\"#000000\"}},\"tooltip\":\"Defensive stance - reduces damage by 50%\"}\x1b\\🛡️ Defend\x1b]8;;\x1b\\\n\n";
-
+    
     output += "RPG Items:\n";
     output += "  \x1b]8;;send:examine?config={\"style\":{\"color\":\"#cc6600\",\"italic\":true,\"hover\":{\"bg\":\"#ffe6cc\",\"color\":\"#000000\"}},\"tooltip\":\"Magic sword with fire enchantment\"}\x1b\\🗡️ Flaming Blade\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:bag?config={\"style\":{\"color\":\"#6600cc\",\"hover\":{\"color\":\"#9933ff\",\"underline\":true}},\"menu\":[{\"Open\":\"send:open\"},{\"Sort\":\"send:sort\"},\"-\",{\"Drop\":\"send:drop\"}]}\x1b\\🎒 Backpack\x1b]8;;\x1b\\\n\n";
-
+    
     output += "Status Indicators:\n";
     output += "  \x1b]8;;send:warning?config={\"style\":{\"bg\":\"#ffcc00\",\"color\":\"#000000\",\"bold\":true}}\x1b\\⚠️ Warning\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:error?config={\"style\":{\"bg\":\"#cc0000\",\"color\":\"#ffffff\",\"bold\":true}}\x1b\\❌ Error\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:success?config={\"style\":{\"bg\":\"#006600\",\"color\":\"#ffffff\",\"bold\":true}}\x1b\\✅ Success\x1b]8;;\x1b\\\n\n";
-
+    
     output += "Complete Example (All Features):\n";
     output += "  \x1b]8;;send:sword?config={\"style\":{\"color\":\"#cc6600\",\"bold\":true,\"hover\":{\"bg\":\"#ffcc99\",\"color\":\"#000000\"}},\"menu\":[{\"Equip\":\"send:equip\"},{\"Examine\":\"send:examine\"},\"-\",{\"Drop\":\"send:drop\"}],\"tooltip\":\"Flaming Sword: +5 damage, fire enchantment\"}\x1b\\🗡️ Flaming Sword\x1b]8;;\x1b\\\n\n";
-
+    
     // ═══════════════════════════════════════════════════════════════════
     // Summary
     // ═══════════════════════════════════════════════════════════════════
     output += "══════════════════════════════════════════════════════════════════════\n\n";
     output += "Documentation: https://wiki.mudlet.org/w/Manual:Supported_Protocols#OSC_8\n";
     output += "All examples above are clickable - try them!\n\n";
-
+    
     // Process the output through the normal text processing pipeline
     std::string outputBytes = output.toStdString();
 #if defined(DEBUG_OSC_PROCESSING)
@@ -5452,7 +5452,7 @@ void TBuffer::injectOSC8DocumentationExamples()
 Mudlet::HyperlinkStyling::StateStyle Mudlet::HyperlinkStyling::getEffectiveStyle() const
 {
     Mudlet::HyperlinkStyling::StateStyle effective;
-
+    
     // Start with base/default styling
     effective.foregroundColor = foregroundColor;
     effective.backgroundColor = backgroundColor;
@@ -5470,7 +5470,7 @@ Mudlet::HyperlinkStyling::StateStyle Mudlet::HyperlinkStyling::getEffectiveStyle
     effective.isStrikeOut = isStrikeOut;
     effective.isOverlined = isOverlined;
     effective.underlineStyle = underlineStyle;
-
+    
     // Apply :any-link styles (applies to both :link and :visited)
     if (anyLinkStyle.hasCustomStyling) {
         if (anyLinkStyle.hasForegroundColor) effective.foregroundColor = anyLinkStyle.foregroundColor;
@@ -5485,10 +5485,10 @@ Mudlet::HyperlinkStyling::StateStyle Mudlet::HyperlinkStyling::getEffectiveStyle
         effective.isOverlined = anyLinkStyle.isOverlined;
         effective.underlineStyle = anyLinkStyle.underlineStyle;
     }
-
+    
     // Apply state-specific styles with proper cascade order
     const StateStyle* stateStyle = nullptr;
-
+    
     switch (currentState) {
         case StateVisited:
             if (visitedStyle.hasCustomStyling) stateStyle = &visitedStyle;
@@ -5510,7 +5510,7 @@ Mudlet::HyperlinkStyling::StateStyle Mudlet::HyperlinkStyling::getEffectiveStyle
             if (linkStyle.hasCustomStyling) stateStyle = &linkStyle;
             break;
     }
-
+    
     // Apply the selected state style
     if (stateStyle) {
         if (stateStyle->hasForegroundColor) {
@@ -5541,33 +5541,33 @@ Mudlet::HyperlinkStyling::StateStyle Mudlet::HyperlinkStyling::getEffectiveStyle
         effective.underlineStyle = stateStyle->underlineStyle;
         effective.hasCustomStyling = true;
     }
-
+    
     // Even if the current state doesn't have custom styling, we need to mark that
     // the link has SOME pseudo-class styling so updateLinkCharacters() processes it.
     // This ensures ANSI base links with only :hover (but no :link) styling get updated.
     if (!effective.hasCustomStyling) {
         // Check if ANY pseudo-class state has custom styling
-        if (linkStyle.hasCustomStyling || visitedStyle.hasCustomStyling ||
+        if (linkStyle.hasCustomStyling || visitedStyle.hasCustomStyling || 
             hoverStyle.hasCustomStyling || activeStyle.hasCustomStyling ||
             focusStyle.hasCustomStyling || focusVisibleStyle.hasCustomStyling ||
             anyLinkStyle.hasCustomStyling) {
             effective.hasCustomStyling = true;
         }
     }
-
+    
     return effective;
 }
 
 void TBuffer::parseHyperlinkStateStyle(const QString& pseudoClass, const QString& styleString, Mudlet::HyperlinkStyling& styling)
 {
 #if defined(DEBUG_OSC_PROCESSING)
-    qDebug() << "[OSC8] parseHyperlinkStateStyle called with pseudoClass:" << pseudoClass
+    qDebug() << "[OSC8] parseHyperlinkStateStyle called with pseudoClass:" << pseudoClass 
              << "styleString:" << styleString;
 #endif
-
+    
     QString cleanPseudoClass = pseudoClass.trimmed().toLower();
     Mudlet::HyperlinkStyling::StateStyle* targetStyle = nullptr;
-
+    
     // Map pseudo-class selectors to appropriate state styles
     if (cleanPseudoClass == qsl(":link")) {
         targetStyle = &styling.linkStyle;
@@ -5589,7 +5589,7 @@ void TBuffer::parseHyperlinkStateStyle(const QString& pseudoClass, const QString
 #endif
         return;
     }
-
+    
     if (targetStyle) {
         parseStateStyleProperties(styleString, *targetStyle);
         applyAccessibilityEnhancements(styling);
@@ -5600,15 +5600,15 @@ void TBuffer::parseStateStyleProperties(const QString& styleString, Mudlet::Hype
 {
     // Parse CSS-like style string: "property:value;property:value"
     QStringList stylePairs = styleString.split(';', Qt::SkipEmptyParts);
-
+    
     bool hasAnyCustomStyling = false;
-
+    
     for (const QString& pair : stylePairs) {
         QStringList propertyValue = pair.split(':', Qt::KeepEmptyParts);
         if (propertyValue.size() != 2) {
             continue; // Skip malformed property
         }
-
+        
         QString property = propertyValue[0].trimmed().toLower();
         QString value = propertyValue[1].trimmed();
 
@@ -5636,13 +5636,13 @@ void TBuffer::parseStateStyleProperties(const QString& styleString, Mudlet::Hype
         } else if (property == qsl("text-decoration")) {
             // Handle text-decoration with optional style
             QStringList decorationParts = value.toLower().split(' ', Qt::SkipEmptyParts);
-
+            
             // Reset decoration flags
             stateStyle.isUnderlined = false;
             stateStyle.isOverlined = false;
             stateStyle.isStrikeOut = false;
             stateStyle.underlineStyle = Mudlet::HyperlinkStyling::UnderlineNone;
-
+            
             for (const QString& part : decorationParts) {
                 if (part == qsl("underline")) {
                     stateStyle.isUnderlined = true;
@@ -5692,7 +5692,7 @@ void TBuffer::parseStateStyleProperties(const QString& styleString, Mudlet::Hype
             }
         }
     }
-
+    
     stateStyle.hasCustomStyling = hasAnyCustomStyling;
 }
 
@@ -5706,7 +5706,7 @@ void TBuffer::applyAccessibilityEnhancements(Mudlet::HyperlinkStyling& styling)
         styling.focusStyle.underlineStyle = Mudlet::HyperlinkStyling::UnderlineSolid;
         styling.focusStyle.hasUnderlineColor = true;
         styling.focusStyle.underlineColor = QColor(0, 120, 215); // Windows accent blue
-
+        
         styling.focusVisibleStyle = styling.focusStyle; // Copy focus style to focus-visible
     }
 }
@@ -5717,9 +5717,9 @@ void TBuffer::setLinkState(int linkIndex, Mudlet::HyperlinkStyling::LinkState st
     if (linkIndex <= 0) {
         return; // Invalid link index
     }
-
+    
     mLinkStates[linkIndex] = state;
-
+    
 #if defined(DEBUG_OSC_PROCESSING)
     QString stateName;
     switch (state) {
@@ -5750,17 +5750,17 @@ Mudlet::HyperlinkStyling TBuffer::getEffectiveHyperlinkStyling(int linkIndex) co
     } else {
         // Get the stored styling for this link from mLinkStore
         Mudlet::HyperlinkStyling styling = mLinkStore.getStyling(linkIndex);
-
+        
         // Update the current state based on tracked state
         styling.currentState = getLinkState(linkIndex);
-
-        // The HyperlinkStyling::getEffectiveStyle() method will compute the
+        
+        // The HyperlinkStyling::getEffectiveStyle() method will compute the 
         // effective styling based on currentState, cascading from base -> :any-link -> state-specific
         // However, for rendering we need to apply it to the base styling properties
         // so the rendering code can use it directly
-
+        
         auto effective = styling.getEffectiveStyle();
-
+        
         // Copy effective state back to base properties for rendering
         styling.foregroundColor = effective.foregroundColor;
         styling.backgroundColor = effective.backgroundColor;
@@ -5779,7 +5779,7 @@ Mudlet::HyperlinkStyling TBuffer::getEffectiveHyperlinkStyling(int linkIndex) co
         styling.isOverlined = effective.isOverlined;
         styling.underlineStyle = effective.underlineStyle;
         styling.hasCustomStyling = effective.hasCustomStyling; // CRITICAL: Copy hasCustomStyling flag
-
+        
         return styling;
     }
 }
@@ -5788,7 +5788,7 @@ void TBuffer::setHoveredLink(int linkIndex)
 {
     int previousHoveredLink = mCurrentHoveredLinkIndex;
     mCurrentHoveredLinkIndex = linkIndex;
-
+    
     // Reset previous hovered link to its base state (default or visited)
     if (previousHoveredLink > 0 && previousHoveredLink != linkIndex) {
         auto currentState = getLinkState(previousHoveredLink);
@@ -5804,7 +5804,7 @@ void TBuffer::setHoveredLink(int linkIndex)
             updateLinkCharacters(previousHoveredLink); // Update displayed characters
         }
     }
-
+    
     // Set new link to hover state
     if (linkIndex > 0) {
         auto currentState = getLinkState(linkIndex);
@@ -5821,12 +5821,12 @@ void TBuffer::setActiveLink(int linkIndex)
 {
     int previousActiveLink = mCurrentActiveLinkIndex;
     mCurrentActiveLinkIndex = linkIndex;
-
+    
     // Reset previous active link
     if (previousActiveLink > 0 && previousActiveLink != linkIndex) {
         // Check current state to preserve visited links
         Mudlet::HyperlinkStyling::LinkState currentState = getLinkState(previousActiveLink);
-
+        
         // Return to hover if it's still hovered
         if (previousActiveLink == mCurrentHoveredLinkIndex) {
             setLinkState(previousActiveLink, Mudlet::HyperlinkStyling::StateHover);
@@ -5838,7 +5838,7 @@ void TBuffer::setActiveLink(int linkIndex)
 
         updateLinkCharacters(previousActiveLink); // Update displayed characters
     }
-
+    
     // Set new link to active state
     if (linkIndex > 0) {
         setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateActive);
@@ -5850,12 +5850,12 @@ void TBuffer::setFocusedLink(int linkIndex)
 {
     int previousFocusedLink = mCurrentFocusedLinkIndex;
     mCurrentFocusedLinkIndex = linkIndex;
-
+    
     // Reset previous focused link
     if (previousFocusedLink > 0 && previousFocusedLink != linkIndex) {
         setLinkState(previousFocusedLink, Mudlet::HyperlinkStyling::StateDefault);
     }
-
+    
     // Set new link to focus state
     if (linkIndex > 0) {
         // Determine if focus came from keyboard (would use StateFocusVisible)
@@ -5868,8 +5868,8 @@ void TBuffer::markLinkAsVisited(int linkIndex)
 {
     if (linkIndex > 0) {
         mVisitedLinks[linkIndex] = true;
-
-        // If the link is not in an interactive state (hover/active/focus),
+        
+        // If the link is not in an interactive state (hover/active/focus), 
         // update it to visited state immediately
         auto currentState = getLinkState(linkIndex);
 
@@ -5877,7 +5877,7 @@ void TBuffer::markLinkAsVisited(int linkIndex)
             setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateVisited);
             updateLinkCharacters(linkIndex);
         }
-
+        
 #if defined(DEBUG_OSC_PROCESSING)
         qDebug() << "[OSC8] Link" << linkIndex << "marked as visited";
 #endif
@@ -5895,14 +5895,14 @@ int TBuffer::getLinkIndexAt(int line, int column) const
     if (line < 0 || line >= lineBuffer.size()) {
         return 0;
     }
-
+    
     const auto& bufferLine = buffer.at(line);
-
+    
     // Validate column bounds
     if (column < 0 || column >= bufferLine.size()) {
         return 0;
     }
-
+    
     // Return the link index at this position
     return bufferLine.at(column).linkIndex();
 }
@@ -5914,10 +5914,10 @@ void TBuffer::updateLinkCharacters(int linkIndex)
     if (linkIndex <= 0) {
         return;
     }
-
+    
     // Get the effective styling for this link's current state
     Mudlet::HyperlinkStyling effectiveStyling = getEffectiveHyperlinkStyling(linkIndex);
-
+    
     // IMPORTANT: If this link has no custom CSS styling at all (neither base nor pseudo-class),
     // don't modify the characters. This preserves ANSI formatting for links without any CSS.
     if (!effectiveStyling.hasCustomStyling) {
@@ -5926,20 +5926,20 @@ void TBuffer::updateLinkCharacters(int linkIndex)
 #endif
         return; // Don't modify characters - preserve original ANSI formatting
     }
-
+    
     // Check if we should use ANSI base with pseudo-class overlays:
     // - Has pseudo-class styling (hasCustomStyling = true)
     // - But NO base CSS styling (hasBaseCustomStyling = false)
     // - And we're in default/visited state (not hover/active/focus)
-    bool useAnsiBase = !effectiveStyling.hasBaseCustomStyling &&
+    bool useAnsiBase = !effectiveStyling.hasBaseCustomStyling && 
                        (effectiveStyling.currentState == Mudlet::HyperlinkStyling::StateDefault ||
                         effectiveStyling.currentState == Mudlet::HyperlinkStyling::StateVisited);
-
+    
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC8] Updating link" << linkIndex << "- hasBaseCustomStyling:" << effectiveStyling.hasBaseCustomStyling
              << "currentState:" << effectiveStyling.currentState << "useAnsiBase:" << useAnsiBase;
 #endif
-
+    
     // Iterate through all lines in the buffer
     for (auto& line : buffer) {
         // Iterate through all characters in the line
@@ -5947,7 +5947,7 @@ void TBuffer::updateLinkCharacters(int linkIndex)
             // Check if this character belongs to the link we're updating
             if (tchar.linkIndex() == linkIndex) {
                 // Apply the effective styling to this character
-
+                
                 // If we should use ANSI base (no base CSS but in default/visited state),
                 // restore the original ANSI colors and formatting as a BASE,
                 // then let pseudo-class CSS styling override it
@@ -5965,24 +5965,24 @@ void TBuffer::updateLinkCharacters(int linkIndex)
                     tchar.mFgColor = originalChar.mFgColor;
                     tchar.mBgColor = originalChar.mBgColor;
                     tchar.mFlags = originalChar.mFlags; // Restore ALL ANSI formatting flags including decorations
-
+                    
                     // Clear any custom decoration colors that were applied by CSS pseudo-classes
                     // ANSI doesn't support custom decoration colors, so we clear them when restoring ANSI base
                     tchar.clearCustomUnderlineColor();
                     tchar.clearCustomOverlineColor();
                     tchar.clearCustomStrikeoutColor();
-
+                    
                     // DON'T continue here - let the CSS pseudo-class styling below override the ANSI base
                     // This allows e.g. :visited{color:#bb66dd} to work with ANSI base formatting
                 }
-
+                
                 // Apply CSS styling
-
+                
                 // Update foreground color
                 if (effectiveStyling.hasForegroundColor) {
                     tchar.mFgColor = effectiveStyling.foregroundColor;
                 }
-
+                
                 // Update background color - restore original if not specified in styling
                 if (effectiveStyling.hasBackgroundColor) {
                     tchar.mBgColor = effectiveStyling.backgroundColor;
@@ -5990,15 +5990,15 @@ void TBuffer::updateLinkCharacters(int linkIndex)
                     // Restore the original background color from when the link was created
                     tchar.mBgColor = mLinkOriginalBackgrounds.value(linkIndex, mBackGroundColor);
                 }
-
+                
                 // Update text decorations (only for CSS styling, not ANSI-base)
                 if (effectiveStyling.isUnderlined) {
                     tchar.mFlags |= TChar::Underline;
-
+                    
                     // Apply underline style
                     // First clear any existing underline style flags
                     tchar.mFlags &= ~(TChar::UnderlineWavy | TChar::UnderlineDotted | TChar::UnderlineDashed);
-
+                    
                     switch (effectiveStyling.underlineStyle) {
                         case Mudlet::HyperlinkStyling::UnderlineWavy:
                             tchar.mFlags |= TChar::UnderlineWavy;
@@ -6016,19 +6016,19 @@ void TBuffer::updateLinkCharacters(int linkIndex)
                     tchar.mFlags &= ~TChar::Underline;
                     tchar.mFlags &= ~(TChar::UnderlineWavy | TChar::UnderlineDotted | TChar::UnderlineDashed);
                 }
-
+                
                 if (effectiveStyling.isOverlined) {
                     tchar.mFlags |= TChar::Overline;
                 } else {
                     tchar.mFlags &= ~TChar::Overline;
                 }
-
+                
                 if (effectiveStyling.isStrikeOut) {
                     tchar.mFlags |= TChar::StrikeOut;
                 } else {
                     tchar.mFlags &= ~TChar::StrikeOut;
                 }
-
+                
                 // Apply decoration colors
                 if (effectiveStyling.hasUnderlineColor && effectiveStyling.isUnderlined) {
                     tchar.setUnderlineColor(effectiveStyling.underlineColor);
@@ -6039,14 +6039,14 @@ void TBuffer::updateLinkCharacters(int linkIndex)
                 if (effectiveStyling.hasStrikeoutColor && effectiveStyling.isStrikeOut) {
                     tchar.setStrikeoutColor(effectiveStyling.strikeoutColor);
                 }
-
+                
                 // Update bold and italic
                 if (effectiveStyling.isBold) {
                     tchar.mFlags |= TChar::Bold;
                 } else {
                     tchar.mFlags &= ~TChar::Bold;
                 }
-
+                
                 if (effectiveStyling.isItalic) {
                     tchar.mFlags |= TChar::Italic;
                 } else {

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -751,17 +751,8 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                         // System entities are literal QString / UTF values which we just 'print'
                         // There is no further MXP or Codeset evaluation
 
-                        const TChar::AttributeFlags attributeFlags =
-                                ((mBold || mpHost->mMxpClient.bold()) ? TChar::Bold : TChar::None)
-                                | (mItalics || mpHost->mMxpClient.italic() ? TChar::Italic : TChar::None)
-                                | (mOverline ? TChar::Overline : TChar::None)
-                                | (mReverse ? TChar::Reverse : TChar::None)
-                                | (mStrikeOut || mpHost->mMxpClient.strikeOut() ? TChar::StrikeOut : TChar::None)
-                                | (mUnderline || mpHost->mMxpClient.underline() ? TChar::Underline : TChar::None)
-                                | (mUnderlineWavy ? TChar::UnderlineWavy : TChar::None)
-                                | (mUnderlineDotted ? TChar::UnderlineDotted : TChar::None)
-                                | (mUnderlineDashed ? TChar::UnderlineDashed : TChar::None);
-
+                        TChar::AttributeFlags attributeFlags = computeCurrentAttributeFlags();
+                        attributeFlags &= ~(TChar::FastBlink | TChar::Concealed | TChar::AltFontMask);
                         TChar c((!mIsDefaultColor && mBold) ? mForeGroundColorLight : mForeGroundColor, mBackGroundColor, attributeFlags);
 
                         size_t valueLength = mpHost->mMxpProcessor.getEntityValue().length();
@@ -1094,7 +1085,7 @@ void TBuffer::processMxpWatchdogCallback()
 }
 
 TChar::AttributeFlags TBuffer::computeCurrentAttributeFlags() const {
-    return ((mBold || mpHost->mMxpClient.bold()) ? TChar::Bold : TChar::None)
+    return ((mIsDefaultColor ? mBold || mpHost->mMxpClient.bold() : false) ? TChar::Bold : TChar::None)
             | (mItalics || mpHost->mMxpClient.italic() ? TChar::Italic : TChar::None)
             | (mOverline ? TChar::Overline : TChar::None)
             | (mReverse ? TChar::Reverse : TChar::None)

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -70,13 +70,13 @@ struct HyperlinkStyling {
     bool isOverlined = false;
     bool hasCustomStyling = false; // Tracks if any custom styling was provided
     bool hasBaseCustomStyling = false; // Tracks if base (non-pseudo-class) styling was provided
-    
+
     // Extended text decoration support
     enum UnderlineStyle {
         UnderlineNone,
         UnderlineSolid,     // Standard underline
         UnderlineWavy,      // Squiggly/wavy underline
-        UnderlineDotted,    // Dotted underline  
+        UnderlineDotted,    // Dotted underline
         UnderlineDashed     // Dashed underline
     };
     UnderlineStyle underlineStyle = UnderlineSolid;
@@ -86,7 +86,7 @@ struct HyperlinkStyling {
     bool hasUnderlineColor = false;
     bool hasOverlineColor = false;
     bool hasStrikeoutColor = false;
-    
+
     // CSS Link State Support with Accessibility
     enum LinkState {
         StateDefault,       // Default/unvisited (:link)
@@ -96,7 +96,7 @@ struct HyperlinkStyling {
         StateFocus,         // Keyboard focus (:focus)
         StateFocusVisible   // Visible keyboard focus (:focus-visible)
     };
-    
+
     // State-specific styling containers
     struct StateStyle {
         QColor foregroundColor;
@@ -117,19 +117,19 @@ struct HyperlinkStyling {
         UnderlineStyle underlineStyle = UnderlineSolid;
         bool hasCustomStyling = false;
     };
-    
+
     // State-specific styles
     StateStyle linkStyle;           // :link (unvisited)
-    StateStyle visitedStyle;        // :visited 
+    StateStyle visitedStyle;        // :visited
     StateStyle hoverStyle;          // :hover
     StateStyle activeStyle;         // :active
     StateStyle focusStyle;          // :focus
     StateStyle focusVisibleStyle;   // :focus-visible
     StateStyle anyLinkStyle;        // :any-link (applies to both :link and :visited)
-    
+
     // State tracking
     LinkState currentState = StateDefault;
-    
+
     // Methods to get effective styling for current state
     StateStyle getEffectiveStyle() const;
 };
@@ -263,7 +263,7 @@ public:
     bool isUnderlineWavy() const { return mFlags & UnderlineWavy; }
     bool isUnderlineDotted() const { return mFlags & UnderlineDotted; }
     bool isUnderlineDashed() const { return mFlags & UnderlineDashed; }
-    
+
     // Decoration color accessors
     const QColor& underlineColor() const { return mUnderlineColor; }
     const QColor& overlineColor() const { return mOverlineColor; }
@@ -271,7 +271,7 @@ public:
     bool hasCustomUnderlineColor() const { return mHasCustomUnderlineColor; }
     bool hasCustomOverlineColor() const { return mHasCustomOverlineColor; }
     bool hasCustomStrikeoutColor() const { return mHasCustomStrikeoutColor; }
-    
+
     // Decoration color setters
     void setUnderlineColor(const QColor& color) { mUnderlineColor = color; mHasCustomUnderlineColor = true; }
     void setOverlineColor(const QColor& color) { mOverlineColor = color; mHasCustomOverlineColor = true; }
@@ -358,7 +358,7 @@ private:
     // Kept as a separate flag because it must often be handled separately
     bool mIsSelected = false;
     int mLinkIndex = 0;
-    
+
     // Enhanced decoration color support for OSC 8 hyperlinks
     QColor mUnderlineColor;
     QColor mOverlineColor;
@@ -383,6 +383,7 @@ class TBuffer
 
 public:
     explicit TBuffer(Host* pH, TConsole* pConsole = nullptr);
+    ~TBuffer();
     QPoint insert(QPoint&, const QString& text, int, int, int, int, int, int, bool bold, bool italics, bool underline, bool strikeout);
     bool insertInLine(QPoint& cursor, const QString& what, const TChar& format);
     void expandLine(int y, int count, TChar&);
@@ -428,7 +429,7 @@ public:
     static const QList<QByteArray> getEncodingNames();
     void logRemainingOutput();
     void appendLog(const QString &text);
-    
+
     // OSC 8 hyperlink documentation examples - triggered by secret phrase
     void injectOSC8DocumentationExamples();
 
@@ -472,7 +473,10 @@ private:
     void decodeSGR48(const QStringList&, bool isColonSeparated = true);
     void decodeOSC(const QString&);
     void resetColors();
-    
+    bool commitLine(char ch, size_t& localBufferPosition);
+    void processMxpWatchdogCallback();
+    TChar::AttributeFlags computeCurrentAttributeFlags() const;
+
     // Helper function for parsing URI query parameters in OSC 8 hyperlinks
     QMap<QString, QString> parseUriQueryParameters(const QString& uri);
     // Helper function for parsing JSON format hyperlink configuration
@@ -573,11 +577,21 @@ private:
     QStringList mCurrentHyperlinkHint;
     int mCurrentHyperlinkLinkId = 0;
     bool mHyperlinkActive = false;
-    
+
+    enum class WatchdogPhase {
+        Phase1_Snapshot,
+        Phase2_Unfreeze,
+        None
+    };
+    static constexpr int    MAX_TAG_TIMEOUT_MS = 1300;
+    WatchdogPhase           mWatchdogPhase = WatchdogPhase::None;
+    QTimer*                 mTagWatchdog;
+    std::string             mWatchdogTagSnapshot;
+
     // Enhanced OSC 8 hyperlink styling and menu support
     Mudlet::HyperlinkStyling mCurrentHyperlinkStyling;
     QStringList mCurrentHyperlinkMenu; // Format: "Label|Command|Label|Command..."
-    
+
     // Link state tracking for interactive pseudo-classes
     QMap<int, Mudlet::HyperlinkStyling::LinkState> mLinkStates; // Track current state per linkIndex
     QMap<int, bool> mVisitedLinks; // Track which links have been visited (base state)
@@ -586,7 +600,7 @@ private:
     int mCurrentHoveredLinkIndex = 0;  // Which link is currently hovered (0 = none)
     int mCurrentActiveLinkIndex = 0;   // Which link is currently being clicked (0 = none)
     int mCurrentFocusedLinkIndex = 0;  // Which link has keyboard focus (0 = none)
-    
+
 public:
     // Methods for link state management (used by TTextEdit event handlers)
     void setLinkState(int linkIndex, Mudlet::HyperlinkStyling::LinkState state);
@@ -601,7 +615,7 @@ public:
     int getActiveLink() const { return mCurrentActiveLinkIndex; }
     int getFocusedLink() const { return mCurrentFocusedLinkIndex; }
     int getLinkIndexAt(int line, int column) const; // Get link index at specific position
-    
+
 private:
     // Update all TChar objects that belong to a specific link with effective styling
     void updateLinkCharacters(int linkIndex);

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -70,13 +70,13 @@ struct HyperlinkStyling {
     bool isOverlined = false;
     bool hasCustomStyling = false; // Tracks if any custom styling was provided
     bool hasBaseCustomStyling = false; // Tracks if base (non-pseudo-class) styling was provided
-
+    
     // Extended text decoration support
     enum UnderlineStyle {
         UnderlineNone,
         UnderlineSolid,     // Standard underline
         UnderlineWavy,      // Squiggly/wavy underline
-        UnderlineDotted,    // Dotted underline
+        UnderlineDotted,    // Dotted underline  
         UnderlineDashed     // Dashed underline
     };
     UnderlineStyle underlineStyle = UnderlineSolid;
@@ -86,7 +86,7 @@ struct HyperlinkStyling {
     bool hasUnderlineColor = false;
     bool hasOverlineColor = false;
     bool hasStrikeoutColor = false;
-
+    
     // CSS Link State Support with Accessibility
     enum LinkState {
         StateDefault,       // Default/unvisited (:link)
@@ -96,7 +96,7 @@ struct HyperlinkStyling {
         StateFocus,         // Keyboard focus (:focus)
         StateFocusVisible   // Visible keyboard focus (:focus-visible)
     };
-
+    
     // State-specific styling containers
     struct StateStyle {
         QColor foregroundColor;
@@ -117,19 +117,19 @@ struct HyperlinkStyling {
         UnderlineStyle underlineStyle = UnderlineSolid;
         bool hasCustomStyling = false;
     };
-
+    
     // State-specific styles
     StateStyle linkStyle;           // :link (unvisited)
-    StateStyle visitedStyle;        // :visited
+    StateStyle visitedStyle;        // :visited 
     StateStyle hoverStyle;          // :hover
     StateStyle activeStyle;         // :active
     StateStyle focusStyle;          // :focus
     StateStyle focusVisibleStyle;   // :focus-visible
     StateStyle anyLinkStyle;        // :any-link (applies to both :link and :visited)
-
+    
     // State tracking
     LinkState currentState = StateDefault;
-
+    
     // Methods to get effective styling for current state
     StateStyle getEffectiveStyle() const;
 };
@@ -263,7 +263,7 @@ public:
     bool isUnderlineWavy() const { return mFlags & UnderlineWavy; }
     bool isUnderlineDotted() const { return mFlags & UnderlineDotted; }
     bool isUnderlineDashed() const { return mFlags & UnderlineDashed; }
-
+    
     // Decoration color accessors
     const QColor& underlineColor() const { return mUnderlineColor; }
     const QColor& overlineColor() const { return mOverlineColor; }
@@ -271,7 +271,7 @@ public:
     bool hasCustomUnderlineColor() const { return mHasCustomUnderlineColor; }
     bool hasCustomOverlineColor() const { return mHasCustomOverlineColor; }
     bool hasCustomStrikeoutColor() const { return mHasCustomStrikeoutColor; }
-
+    
     // Decoration color setters
     void setUnderlineColor(const QColor& color) { mUnderlineColor = color; mHasCustomUnderlineColor = true; }
     void setOverlineColor(const QColor& color) { mOverlineColor = color; mHasCustomOverlineColor = true; }
@@ -358,7 +358,7 @@ private:
     // Kept as a separate flag because it must often be handled separately
     bool mIsSelected = false;
     int mLinkIndex = 0;
-
+    
     // Enhanced decoration color support for OSC 8 hyperlinks
     QColor mUnderlineColor;
     QColor mOverlineColor;
@@ -429,7 +429,7 @@ public:
     static const QList<QByteArray> getEncodingNames();
     void logRemainingOutput();
     void appendLog(const QString &text);
-
+    
     // OSC 8 hyperlink documentation examples - triggered by secret phrase
     void injectOSC8DocumentationExamples();
 
@@ -591,7 +591,7 @@ private:
     // Enhanced OSC 8 hyperlink styling and menu support
     Mudlet::HyperlinkStyling mCurrentHyperlinkStyling;
     QStringList mCurrentHyperlinkMenu; // Format: "Label|Command|Label|Command..."
-
+    
     // Link state tracking for interactive pseudo-classes
     QMap<int, Mudlet::HyperlinkStyling::LinkState> mLinkStates; // Track current state per linkIndex
     QMap<int, bool> mVisitedLinks; // Track which links have been visited (base state)
@@ -600,7 +600,7 @@ private:
     int mCurrentHoveredLinkIndex = 0;  // Which link is currently hovered (0 = none)
     int mCurrentActiveLinkIndex = 0;   // Which link is currently being clicked (0 = none)
     int mCurrentFocusedLinkIndex = 0;  // Which link has keyboard focus (0 = none)
-
+    
 public:
     // Methods for link state management (used by TTextEdit event handlers)
     void setLinkState(int linkIndex, Mudlet::HyperlinkStyling::LinkState state);
@@ -615,7 +615,7 @@ public:
     int getActiveLink() const { return mCurrentActiveLinkIndex; }
     int getFocusedLink() const { return mCurrentFocusedLinkIndex; }
     int getLinkIndexAt(int line, int column) const; // Get link index at specific position
-
+    
 private:
     // Update all TChar objects that belong to a specific link with effective styling
     void updateLinkCharacters(int linkIndex);

--- a/src/TEntityHandler.cpp
+++ b/src/TEntityHandler.cpp
@@ -23,27 +23,34 @@
 #include "TEntityHandler.h"
 
 // returns true if the char is handled by the EntityHandler (i.e. it is part of an entity)
-bool TEntityHandler::handle(char character, bool resolveCustomEntities)
+bool TEntityHandler::handle(char c, bool resolveCustomEntities)
 {
-    if (character == ';' && !mCurrentEntity.isEmpty()) { // END OF ENTITY
-        mCurrentEntity.append(character);
-        mResult = mpEntityResolver.getResolution(mCurrentEntity, resolveCustomEntities, &entityType);
-        mIsResolved = true;
-        mCurrentEntity.clear();
+    const bool isLegalNamedEntityChar = isalnum(c) ||
+                                        c == '#' || c == '.' || c == '-' ||
+                                        c == '_' || c == '&' || c == ';';
+    
+    if (!mCurrentEntity.isEmpty() || c == '&') {
+        mCurrentEntity.append(c);
+        if (c == ';') {
+            mResult = mpEntityResolver.getResolution(mCurrentEntity, resolveCustomEntities, &entityType);
+            mIsResolved = true;
+            mCurrentEntity.clear();
+        }
+        else if (!isLegalNamedEntityChar) {
+            mResult = mCurrentEntity;
+            mIsResolved = true;
+            entityType = ENTITY_TYPE_UNKNOWN;
+            mCurrentEntity.clear();
+        }
+        else {
+            mIsResolved = false;
+            entityType = ENTITY_TYPE_UNKNOWN;
+        }
         return true;
-    } else if (character == '&' || !mCurrentEntity.isEmpty()) { // START OR MIDDLE OF ENTITY
-        mIsResolved = false;
-        entityType = ENTITY_TYPE_UNKNOWN;
-        mCurrentEntity.append(character);
-        return true;
-    } else if (mCurrentEntity.length() > 7) { // LONG ENTITY? MAYBE INVALID... IGNORE IT
-        reset();
-        entityType = ENTITY_TYPE_UNKNOWN;
-        return false;
-    } else {
-        return false;
     }
+    return false;
 }
+
 bool TEntityHandler::isEntityResolved() const
 {
     return mIsResolved;

--- a/src/TEntityHandler.cpp
+++ b/src/TEntityHandler.cpp
@@ -35,14 +35,12 @@ bool TEntityHandler::handle(char c, bool resolveCustomEntities)
             mResult = mpEntityResolver.getResolution(mCurrentEntity, resolveCustomEntities, &entityType);
             mIsResolved = true;
             mCurrentEntity.clear();
-        }
-        else if (!isLegalNamedEntityChar) {
+        } else if (!isLegalNamedEntityChar) {
             mResult = mCurrentEntity;
             mIsResolved = true;
             entityType = ENTITY_TYPE_UNKNOWN;
             mCurrentEntity.clear();
-        }
-        else {
+        } else {
             mIsResolved = false;
             entityType = ENTITY_TYPE_UNKNOWN;
         }

--- a/src/TMxpNodeBuilder.cpp
+++ b/src/TMxpNodeBuilder.cpp
@@ -31,11 +31,12 @@ bool TMxpNodeBuilder::accept(char ch)
     if (mIsInsideTag) { // inside tag
         mCurrentText.clear();
         mIsText = false;
-
+        mRawTagContent += ch;
         if (!acceptTag(ch)) {
             return false;
         } else {
             mIsInsideTag = false;
+            mRawTagContent.clear();
             return true;
         }
     } else if (ch == '<') { // start tag
@@ -46,6 +47,7 @@ bool TMxpNodeBuilder::accept(char ch)
             return true;
         } else {              // second call
             mHasNode = false; //mIsText = false
+            mRawTagContent.clear();
             return acceptTag(ch);
         }
     } else if (!mOptionIgnoreText) { // text
@@ -79,7 +81,12 @@ bool TMxpNodeBuilder::acceptTag(char ch)
     }
 
     if (ch == '<') { // reset
+        if (!mIsInsideTag) {
         resetCurrentTag();
+        }
+        if (!mRawTagContent.empty() && mRawTagContent.back() == '<') {
+            mRawTagContent.pop_back();
+        }
         mIsInsideTag = true;
         return false;
     }
@@ -118,7 +125,7 @@ void TMxpNodeBuilder::resetCurrentTag()
     mIsInsideTag = false;
     mCurrentTagName.clear();
     mCurrentTagAttrs.clear();
-
+    mRawTagContent.clear();
     resetCurrentAttribute();
 }
 bool TMxpNodeBuilder::acceptAttribute(char ch)
@@ -217,4 +224,11 @@ void TMxpNodeBuilder::reset()
 {
     resetCurrentTag();
     mCurrentText.clear();
+}
+
+void TMxpNodeBuilder::resetForNewTag()
+{
+    reset();
+    mOptionIgnoreText = true;
+    mIsInsideTag = true;
 }

--- a/src/TMxpNodeBuilder.h
+++ b/src/TMxpNodeBuilder.h
@@ -89,6 +89,8 @@ public:
 
     inline bool isInsideTag() const { return mIsInsideTag; }
 
+    inline bool isQuotedSequence() const { return mIsQuotedSequence; }
+
     inline bool isTag() const { return !mIsText; }
 
     inline bool isText() const { return mIsText; }

--- a/src/TMxpNodeBuilder.h
+++ b/src/TMxpNodeBuilder.h
@@ -89,6 +89,8 @@ public:
 
     inline bool isInsideTag() const { return mIsInsideTag; }
 
+    inline bool isInsideComment() const { return mCurrentTagName == "!--"; }
+
     inline bool isQuotedSequence() const { return mIsQuotedSequence; }
 
     inline bool isTag() const { return !mIsText; }

--- a/src/TMxpNodeBuilder.h
+++ b/src/TMxpNodeBuilder.h
@@ -50,6 +50,7 @@ class TMxpNodeBuilder
 
     // current text node
     std::string mCurrentText;
+    std::string mRawTagContent;
 
     // text node parsing state
     bool mIsInsideText = false;
@@ -80,6 +81,7 @@ public:
     MxpTag* buildTag();
 
     void reset();
+    void resetForNewTag();
 
     inline bool hasTag() const { return isTag() && hasNode(); }
 
@@ -90,5 +92,8 @@ public:
     inline bool isTag() const { return !mIsText; }
 
     inline bool isText() const { return mIsText; }
+
+    const std::string& getRawTagContent() const { return mRawTagContent; }
+    void setRawTagContent(const std::string& content) { mRawTagContent = content; }
 };
 #endif //MUDLET_TMXPNODEBUILDER_H

--- a/src/TMxpProcessor.cpp
+++ b/src/TMxpProcessor.cpp
@@ -152,14 +152,17 @@ void TMxpProcessor::disable()
 
 TMxpProcessingResult TMxpProcessor::processMxpInput(char& ch, bool resolveCustomEntities)
 {
-    if (ch == '<' && mMxpTagBuilder.isInsideTag() && !mMxpTagBuilder.isQuotedSequence()) {
-            lastEntityValue = QStringLiteral("<") + QString::fromStdString(mMxpTagBuilder.getRawTagContent());
-            mMxpTagBuilder.resetForNewTag();
-            return HANDLER_INSERT_ENTITY_LIT;
+    if (ch == '<'
+    && mMxpTagBuilder.isInsideTag()
+    && !mMxpTagBuilder.isQuotedSequence()
+    && !mMxpTagBuilder.isInsideComment()) {
+        lastEntityValue = QStringLiteral("<") + QString::fromStdString(mMxpTagBuilder.getRawTagContent());
+        mMxpTagBuilder.resetForNewTag();
+        return HANDLER_INSERT_ENTITY_LIT;
     }
 
     if (!mMxpTagBuilder.accept(ch) && mMxpTagBuilder.isInsideTag() && !mMxpTagBuilder.hasTag()) {
-            return HANDLER_NEXT_CHAR;
+        return HANDLER_NEXT_CHAR;
     }
     
     if (mMxpTagBuilder.hasTag()) {

--- a/src/TMxpProcessor.cpp
+++ b/src/TMxpProcessor.cpp
@@ -152,10 +152,16 @@ void TMxpProcessor::disable()
 
 TMxpProcessingResult TMxpProcessor::processMxpInput(char& ch, bool resolveCustomEntities)
 {
-    if (!mMxpTagBuilder.accept(ch) && mMxpTagBuilder.isInsideTag() && !mMxpTagBuilder.hasTag()) {
-        return HANDLER_NEXT_CHAR;
+    if (ch == '<' && mMxpTagBuilder.isInsideTag()) {
+            lastEntityValue = QStringLiteral("<") + QString::fromStdString(mMxpTagBuilder.getRawTagContent());
+            mMxpTagBuilder.resetForNewTag();
+            return HANDLER_INSERT_ENTITY_LIT;
     }
 
+    if (!mMxpTagBuilder.accept(ch) && mMxpTagBuilder.isInsideTag() && !mMxpTagBuilder.hasTag()) {
+            return HANDLER_NEXT_CHAR;
+    }
+    
     if (mMxpTagBuilder.hasTag()) {
         QScopedPointer<MxpTag> const tag(mMxpTagBuilder.buildTag());
 

--- a/src/TMxpProcessor.cpp
+++ b/src/TMxpProcessor.cpp
@@ -152,7 +152,7 @@ void TMxpProcessor::disable()
 
 TMxpProcessingResult TMxpProcessor::processMxpInput(char& ch, bool resolveCustomEntities)
 {
-    if (ch == '<' && mMxpTagBuilder.isInsideTag()) {
+    if (ch == '<' && mMxpTagBuilder.isInsideTag() && !mMxpTagBuilder.isQuotedSequence()) {
             lastEntityValue = QStringLiteral("<") + QString::fromStdString(mMxpTagBuilder.getRawTagContent());
             mMxpTagBuilder.resetForNewTag();
             return HANDLER_INSERT_ENTITY_LIT;

--- a/src/TMxpProcessor.h
+++ b/src/TMxpProcessor.h
@@ -56,7 +56,10 @@ public:
 
     TMxpProcessingResult processMxpInput(char& ch, bool resolveCustomEntities);
     void processRawInput(char ch);
-    inline QString getEntityValue() { return lastEntityValue;}
+    inline QString getEntityValue() { return lastEntityValue;};
+    void setLastEntityValue(const QString& value) { lastEntityValue = value; }
+    TMxpTagProcessor& getMxpTagProcessor() { return mMxpTagProcessor; };
+    TMxpNodeBuilder& getMxpTagBuilder() { return mMxpTagBuilder; };
 
 private:
     // State of MXP system:

--- a/src/TMxpProcessor.h
+++ b/src/TMxpProcessor.h
@@ -56,10 +56,10 @@ public:
 
     TMxpProcessingResult processMxpInput(char& ch, bool resolveCustomEntities);
     void processRawInput(char ch);
-    inline QString getEntityValue() { return lastEntityValue;};
+    QString getEntityValue() { return lastEntityValue; }
     void setLastEntityValue(const QString& value) { lastEntityValue = value; }
-    TMxpTagProcessor& getMxpTagProcessor() { return mMxpTagProcessor; };
-    TMxpNodeBuilder& getMxpTagBuilder() { return mMxpTagBuilder; };
+    TMxpTagProcessor& getMxpTagProcessor() { return mMxpTagProcessor; }
+    TMxpNodeBuilder& getMxpTagBuilder() { return mMxpTagBuilder; }
 
 private:
     // State of MXP system:

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -1737,6 +1737,7 @@ OTHER_FILES += \
     ../test/TMxpStubClient.h \
     ../test/TMxpTagParserTest.cpp \
     ../test/TMxpVersionTagTest.cpp \
+    ../test/TMxpElementDefinitionHandlerTest.cpp \
     mac-deploy.sh \
     mudlet-lua/genDoc.sh \
     mudlet-lua/lua/ldoc.css

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -92,6 +92,9 @@ add_test(NAME TMxpFormattingTagsTest COMMAND TMxpFormattingTagsTest)
 add_executable(TMxpCustomElementTagHandlerTest TMxpCustomElementTagHandlerTest.cpp ${MXP_SOURCE} ../src/TMxpSendTagHandler.cpp ../src/TMxpTagParser.cpp ../src/TMxpNodeBuilder.cpp )
 add_test(NAME TMxpCustomElementTagHandlerTest COMMAND TMxpCustomElementTagHandlerTest)
 
+add_executable(TMxpElementDefinitionHandlerTest TMxpElementDefinitionHandlerTest.cpp ${MXP_SOURCE})
+add_test(NAME TMxpElementDefinitionHandlerTest COMMAND TMxpElementDefinitionHandlerTest)
+
 add_executable(TLuaInterfaceTest TLuaInterfaceTest.cpp ../src/LuaInterface.cpp ../src/TVar.cpp ../src/VarUnit.cpp)
 add_test(NAME TLuaInterfaceTest COMMAND TLuaInterfaceTest)
 

--- a/test/TMxpElementDefinitionHandlerTest.cpp
+++ b/test/TMxpElementDefinitionHandlerTest.cpp
@@ -1,0 +1,149 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by Nicolas Keita - nicolaskeita2@@gmail.com        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QtTest/QtTest>
+#include <QString>
+#include <QStringList>
+#include "TMxpStubClient.h"
+#include "TMxpProcessor.h"
+#include "TMxpElementRegistry.h"
+
+class TmxpElementDefinitionHandlerTest : public QObject {
+    Q_OBJECT
+
+private slots:
+    void testMxpElementRegistration_data()
+    {
+        QTest::addColumn<QString>("name");
+        QTest::addColumn<QString>("inputString");
+        QTest::addColumn<QStringList>("expectedAttrs");
+        QTest::addColumn<QString>("expectedFlags");
+        QTest::addColumn<bool>("expectedOpen");
+        QTest::addColumn<bool>("expectedEmpty");
+        QTest::addColumn<int>("expectedParsedDefinitionCount");
+
+        QStringList attrs1;
+        QTest::newRow("Test1")
+            << "Test1"
+            << R"(<!ELEMENT Test1 FLAG='Weird & Co'>)"
+            << attrs1
+            << QString("Weird & Co")
+            << false
+            << false
+            << 0;
+
+        QStringList attrs2 = {"name", "type"};
+        QTest::newRow("Test2")
+            << "Test2"
+            << R"(<!ELEMENT Test2 ATT="NAME=John TYPE=Admin" FLAG='SpecialFlag' OPEN EMPTY>)"
+            << attrs2
+            << QString("SpecialFlag")
+            << true
+            << true
+            << 0;
+
+        QStringList attrs3;
+        QTest::newRow("Test3")
+            << "Test3"
+            << R"(<!ELEMENT Test3 '<tag1 attr="val1"><tag2 attr="val2"><tag3 attr="val3">'>)"
+            << attrs3
+            << QString()
+            << false
+            << false
+            << 3;
+    }
+
+    void testMxpElementRegistration()
+    {
+        QFETCH(QString, name);
+        QFETCH(QString, inputString);
+        QFETCH(QStringList, expectedAttrs);
+        QFETCH(bool, expectedOpen);
+        QFETCH(bool, expectedEmpty);
+        QFETCH(int, expectedParsedDefinitionCount);
+        TMxpStubClient client;
+        TMxpProcessor mxpProcessor(&client);
+
+        for (QChar c : inputString) {
+            char ch = c.toLatin1();
+            mxpProcessor.processMxpInput(ch, true);
+        }
+
+        const TMxpElementRegistry &registry = mxpProcessor.getMxpTagProcessor().getElementRegistry();
+        QVERIFY(registry.containsElement(name));
+        const TMxpElement &element = registry.getElement(name);
+        QCOMPARE(element.attrs, expectedAttrs);
+        QCOMPARE(element.open, expectedOpen);
+        QCOMPARE(element.empty, expectedEmpty);
+        QCOMPARE(element.parsedDefinition.size(), expectedParsedDefinitionCount);
+    }
+
+    void testParserDoesNotFreezeOnAmpersand_data() {
+        QTest::addColumn<QString>("messageWithAmpersand");
+
+        QTest::newRow("no amp") << "abc";
+        QTest::newRow("solo amp") << "&\n";
+        QTest::newRow("amp followed by space") << "& followed by space\n";
+        QTest::newRow("amp at start no semicolon") << "&start\n";
+        QTest::newRow("amp + newline") << "line with &\nnext line\n";
+        QTest::newRow("amp + numbers") << "version &123;\n";
+        QTest::newRow("amp + special chars") << "weird &entity-._#;\n";
+        QTest::newRow("multiple consecutive amps") << "text &&&& more text\n";
+        QTest::newRow("only amps") << "&&&&\n";
+        QTest::newRow("amp + emoji") << "smile &😊;\n";
+    }
+
+    void testParserDoesNotFreezeOnAmpersand()
+    {
+        TMxpStubClient          stub;
+        TMxpProcessor           mxpProcessor(&stub);
+        TMxpProcessingResult    lastResult = HANDLER_FALL_THROUGH;
+        QFETCH(QString, messageWithAmpersand);
+
+        for (char c : messageWithAmpersand.toStdString()) {
+            lastResult = mxpProcessor.processMxpInput(c, true);
+        }
+
+        QVERIFY(lastResult != HANDLER_NEXT_CHAR);
+    }
+
+    void testParserDoesNotFreezeOnUnescapedTagStart_data()
+    {
+        QTest::addColumn<QString>("input_string");
+
+        QTest::newRow("starts_with_less_than") << "<test<!EN ob \"lamp\">";
+        QTest::newRow("less_than_second_char") << "a<test<!EN ob \"lamp\">";
+        QTest::newRow("multiple_less_than_before_valid_tag") << "<<<randomtext<!EN ob \"lamp\">";
+    }
+
+    void testParserDoesNotFreezeOnUnescapedTagStart() {
+
+        TMxpStubClient  stub;
+        TMxpProcessor   mxpProcessor(&stub);
+        QFETCH(QString, input_string);
+
+        for (char c : input_string.toStdString()) {
+            mxpProcessor.processMxpInput(c, true);
+        }
+        QCOMPARE(mxpProcessor.getMxpTagProcessor().getEntityResolver().getResolution("&ob;"), "lamp");
+    }
+};
+
+#include "TMxpElementDefinitionHandlerTest.moc"
+QTEST_MAIN(TmxpElementDefinitionHandlerTest)

--- a/test/TMxpElementDefinitionHandlerTest.cpp
+++ b/test/TMxpElementDefinitionHandlerTest.cpp
@@ -67,6 +67,56 @@ private slots:
             << false
             << false
             << 3;
+
+        QStringList attrs4 = {"class", "level", "race"};
+        QTest::newRow("Test4_MultipleAttrsAndFlag")
+            << "Player"
+            << R"(<!ELEMENT Player FLAG="Hero" ATT="CLASS=Warrior LEVEL=42 RACE=Elf">)"
+            << attrs4
+            << QString("Hero")
+            << false
+            << false
+            << 0;
+
+        QStringList attrs5;
+        QTest::newRow("Test5_EmptyFlag")
+            << "EmptyFlag"
+            << R"(<!ELEMENT EmptyFlag FLAG="">)"
+            << attrs5
+            << QString("")
+            << false
+            << false
+            << 0;
+
+        QStringList attrs6;
+        QTest::newRow("Test6_AutoClosingTag")
+            << "AutoClose"
+            << R"(<!ELEMENT AutoClose '<br/>' EMPTY>)"
+            << attrs6
+            << QString()
+            << false
+            << true
+            << 1;
+
+        QStringList attrs7;
+        QTest::newRow("Test7_NameWithDigitsAndUnderscore")
+            << "Enemy_123"
+            << R"(<!ELEMENT Enemy_123 FLAG="Dangerous">)"
+            << attrs7
+            << QString("Dangerous")
+            << false
+            << false
+            << 0;
+        
+        QStringList attrs8;
+        QTest::newRow("Test8_FlagWithChevronsAndAmpersand")
+            << "Weird"
+            << R"(<!ELEMENT Weird FLAG="Use <this> & that">)"
+            << attrs8
+            << QString("Use <this> & that")
+            << false
+            << false
+            << 0;
     }
 
     void testMxpElementRegistration()
@@ -107,6 +157,11 @@ private slots:
         QTest::newRow("multiple consecutive amps") << "text &&&& more text\n";
         QTest::newRow("only amps") << "&&&&\n";
         QTest::newRow("amp + emoji") << "smile &😊;\n";
+        QTest::newRow("html_entity") << "Hello &lt;World&gt;\r";
+        QTest::newRow("known_custom_entity") << "Use &custom;\r";
+        QTest::newRow("incomplete_entity") << "Broken &ent\r";
+        QTest::newRow("empty_entity") << "Edge case &;\r";
+        QTest::newRow("long_entity") << "&thisisaverylongentitynamethatmightbreak;\r";
     }
 
     void testParserDoesNotFreezeOnAmpersand()
@@ -130,6 +185,12 @@ private slots:
         QTest::newRow("starts_with_less_than") << "<test<!EN ob \"lamp\">";
         QTest::newRow("less_than_second_char") << "a<test<!EN ob \"lamp\">";
         QTest::newRow("multiple_less_than_before_valid_tag") << "<<<randomtext<!EN ob \"lamp\">";
+        QTest::newRow("unclosed_tag") << "<unclosed<!EN ob \"lamp\">";
+        QTest::newRow("closed_without_open") << "</ghost><!EN ob \"lamp\">";
+        QTest::newRow("mixed_with_text") << "foo<bar>baz<!EN ob \"lamp\">";
+        QTest::newRow("doctype_like") << "<!DOCTYPE fake><!EN ob \"lamp\">";
+        QTest::newRow("comment_tag") << "<!-- comment --><!EN ob \"lamp\">";
+        QTest::newRow("comment_with_less_than") << "<!-- this is a < comment -->\r<!EN ob \"lamp\">";
     }
 
     void testParserDoesNotFreezeOnUnescapedTagStart() {

--- a/test/TMxpEntityTagHandlerTest.cpp
+++ b/test/TMxpEntityTagHandlerTest.cpp
@@ -196,6 +196,56 @@ private slots:
         QCOMPARE(stub.mHints.size(), 1);
         QCOMPARE(stub.mHints[0], "examine");
     }
+    void testParserDoesNotFreezeOnAmpersand_data() {
+        QTest::addColumn<QString>("messageWithAmpersand");
+
+        QTest::newRow("no amp") << "abc";
+        QTest::newRow("solo amp") << "&\n";
+        QTest::newRow("amp followed by space") << "& followed by space\n";
+        QTest::newRow("amp at start no semicolon") << "&start\n";
+        QTest::newRow("amp + newline") << "line with &\nnext line\n";
+        QTest::newRow("amp + numbers") << "version &123;\n";
+        QTest::newRow("amp + special chars") << "weird &entity-._#;\n";
+        QTest::newRow("multiple consecutive amps") << "text &&&& more text\n";
+        QTest::newRow("only amps") << "&&&&\n";
+        QTest::newRow("amp + emoji") << "smile &😊;\n";
+    }
+
+    void testParserDoesNotFreezeOnAmpersand() {
+
+        TMxpStubClient          stub;
+        TMxpProcessor           mxpProcessor(&stub);
+        TMxpProcessingResult    lastResult = HANDLER_FALL_THROUGH;
+        QFETCH(QString, messageWithAmpersand);
+
+        for (char c : messageWithAmpersand.toStdString()) {
+            lastResult = mxpProcessor.processMxpInput(c, true);
+        }
+
+        QVERIFY(lastResult != HANDLER_NEXT_CHAR);
+    }
+
+    void testParserDoesNotFreezeOnUnescapedTagStart_data()
+    {
+        QTest::addColumn<QString>("input_string");
+
+        QTest::newRow("starts_with_less_than") << "<test<!EN ob \"lamp\">";
+        QTest::newRow("less_than_second_char") << "a<test<!EN ob \"lamp\">";
+        QTest::newRow("multiple_less_than_before_valid_tag") << "<<<randomtext<!EN ob \"lamp\">";
+    }
+
+    void testParserDoesNotFreezeOnUnescapedTagStart() {
+
+        TMxpStubClient  stub;
+        TMxpProcessor   mxpProcessor(&stub);
+        QFETCH(QString, input_string);
+
+        for (char c : input_string.toStdString()) {
+            mxpProcessor.processMxpInput(c, true);
+        }
+        QCOMPARE(mxpProcessor.getMxpTagProcessor().getEntityResolver().getResolution("&ob;"), "lamp");
+    }
+
 };
 
 #include "TMxpEntityTagHandlerTest.moc"

--- a/test/TMxpEntityTagHandlerTest.cpp
+++ b/test/TMxpEntityTagHandlerTest.cpp
@@ -196,56 +196,6 @@ private slots:
         QCOMPARE(stub.mHints.size(), 1);
         QCOMPARE(stub.mHints[0], "examine");
     }
-    void testParserDoesNotFreezeOnAmpersand_data() {
-        QTest::addColumn<QString>("messageWithAmpersand");
-
-        QTest::newRow("no amp") << "abc";
-        QTest::newRow("solo amp") << "&\n";
-        QTest::newRow("amp followed by space") << "& followed by space\n";
-        QTest::newRow("amp at start no semicolon") << "&start\n";
-        QTest::newRow("amp + newline") << "line with &\nnext line\n";
-        QTest::newRow("amp + numbers") << "version &123;\n";
-        QTest::newRow("amp + special chars") << "weird &entity-._#;\n";
-        QTest::newRow("multiple consecutive amps") << "text &&&& more text\n";
-        QTest::newRow("only amps") << "&&&&\n";
-        QTest::newRow("amp + emoji") << "smile &😊;\n";
-    }
-
-    void testParserDoesNotFreezeOnAmpersand() {
-
-        TMxpStubClient          stub;
-        TMxpProcessor           mxpProcessor(&stub);
-        TMxpProcessingResult    lastResult = HANDLER_FALL_THROUGH;
-        QFETCH(QString, messageWithAmpersand);
-
-        for (char c : messageWithAmpersand.toStdString()) {
-            lastResult = mxpProcessor.processMxpInput(c, true);
-        }
-
-        QVERIFY(lastResult != HANDLER_NEXT_CHAR);
-    }
-
-    void testParserDoesNotFreezeOnUnescapedTagStart_data()
-    {
-        QTest::addColumn<QString>("input_string");
-
-        QTest::newRow("starts_with_less_than") << "<test<!EN ob \"lamp\">";
-        QTest::newRow("less_than_second_char") << "a<test<!EN ob \"lamp\">";
-        QTest::newRow("multiple_less_than_before_valid_tag") << "<<<randomtext<!EN ob \"lamp\">";
-    }
-
-    void testParserDoesNotFreezeOnUnescapedTagStart() {
-
-        TMxpStubClient  stub;
-        TMxpProcessor   mxpProcessor(&stub);
-        QFETCH(QString, input_string);
-
-        for (char c : input_string.toStdString()) {
-            mxpProcessor.processMxpInput(c, true);
-        }
-        QCOMPARE(mxpProcessor.getMxpTagProcessor().getEntityResolver().getResolution("&ob;"), "lamp");
-    }
-
 };
 
 #include "TMxpEntityTagHandlerTest.moc"


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->

### Motivation for adding to Mudlet

This pull request addresses issue #7896.

#### Problem re-explained

Currently if the MUD game sends a non-escaped "&" or "<" the MXP parser will consider what follows as a "tag" or an "entity" and therefore will not display it on the screen.

```
MUD sends ->        "Greetings heroes & villains\n"
Mudlet displays ->  "Greetings heroes"
```

Sometimes it would even freeze.

This behavior usually results from the MUD game not escaping characters properly.

### Brief overview of PR changes/additions

1) If an entity (something that starts with '&') has non legal characters (spaces or newline for example), immediately display the text as raw text.
```
"Heroes & Villains\n" (a space is following the '&' -> malformed entity detected)
```

2) If a tag (something that starts with '<') is never closed after 3seconds, display the text that follows as raw text.

3) While looking for a closing '>' if the parser encounters another '<', consider the first '<' as malformed and immediately display the text as raw text.
```
MUD sends ->        "Enemies < Your hero <!EN validTag \"sword\">\n"
Mudlet displays ->  "Enemies < Your hero"
```


#### Tests

Additions 1. and 3. have unit tests.

Addition 2 (the change in TBuffer::translateToPlainText()) currently requires one of the following :

either a manual test :
```
void TMainConsole::printOnDisplay(std::string& incomingSocketData, const bool isFromServer)
{
    Q_ASSERT_X(mpLineEdit_networkLatency, "TMainConsole::printOnDisplay(...)", "mpLineEdit_networkLatency does not point to a valid QLineEdit");
    mProcessingTimer.restart();

      // Add this snippet
    static bool mxpPrefixAlreadySent = false;

    if (mpHost->mTelnet.isMXPEnabled() && !mxpPrefixAlreadySent) {
        mxpPrefixAlreadySent = true;
        incomingSocketData = "heroes < villains" + incomingSocketData;
    }  
```
 
 or 

a test that would use a newly created stub of the class TBuffer
(which is currently too dependent on Host* and TConsole*)

or 

a functional test (would need to modify the CMakeLists to create a big static lib and link it to the test)


#### Contact

@SpyNight on discord or 
nicolaskeita2@gmail.com


/claim #7896
Fixes #7896 