### PR TITLE
Fix: Interim solution to remove search bar from miniconsoles

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -475,15 +475,15 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     }
 
     layoutLayer2->addWidget(mpButtonMainLayer);
-    layoutButtonLayer->addWidget(mpBufferSearchBox);
-    layoutButtonLayer->addWidget(mpBufferSearchUp);
-    layoutButtonLayer->addWidget(mpBufferSearchDown);
-    layoutButtonLayer->addWidget(timeStampButton);
-    layoutButtonLayer->addWidget(replayButton);
-    layoutButtonLayer->addWidget(logButton);
-    layoutButtonLayer->addWidget(emergencyStop);
     if (mType == MainConsole) {
-        // In fact a whole lot more could be inside this "if"!
+        // All console control buttons should only be on MainConsole
+        layoutButtonLayer->addWidget(mpBufferSearchBox);
+        layoutButtonLayer->addWidget(mpBufferSearchUp);
+        layoutButtonLayer->addWidget(mpBufferSearchDown);
+        layoutButtonLayer->addWidget(timeStampButton);
+        layoutButtonLayer->addWidget(replayButton);
+        layoutButtonLayer->addWidget(logButton);
+        layoutButtonLayer->addWidget(emergencyStop);
         layoutButtonLayer->addWidget(mpLineEdit_networkLatency);
     }
     layoutLayer2->setContentsMargins(0, 0, 0, 0);


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes miniconsoles unexpectedly showing search bars and control buttons. This interim solution restricts search bar, timestamp, replay, logging, and emergency stop buttons to only appear on the main console where they belong.

#### Motivation for adding to Mudlet

Miniconsoles should have a clean, minimal appearance without control buttons. The recent appearance of search bars and other controls on miniconsoles was a visual regression that cluttered the interface and confused users.

#### Other info (issues closed, discussion etc)

- Closes #8275 - MiniConsoles have a search bar suddenly
- This is an interim fix while a larger architectural refactor is being developed in a separate PR
- All console control buttons are now properly restricted to MainConsole only