### PR TITLE
Fix: Button bar gets focus when starting a profile

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -220,6 +220,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     layer->setStyleSheet("QWidget#layer{background-color: rgba(0,0,0,0)}");
     layer->setContentsMargins(0, 0, 0, 0);
     layer->setSizePolicy(sizePolicy);
+    layer->setFocusPolicy(Qt::NoFocus);
 
     auto vLayoutLayer = new QVBoxLayout;
     auto layoutLayer = new QHBoxLayout;
@@ -235,6 +236,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     splitter->setContentsMargins(0, 0, 0, 0);
     splitter->setSizePolicy(sizePolicy);
     splitter->setHandleWidth(3);
+    splitter->setFocusPolicy(Qt::NoFocus);
     //QSplitter covers the background if not set to transparent and a new AppStyleSheet is set for example by DarkTheme
     auto styleSheet = qsl("QSplitter { background-color: rgba(0,0,0,0) }");
     splitter->setStyleSheet(styleSheet);
@@ -285,6 +287,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     layerCommandLine = new QWidget; //( mpMainFrame );//layer );
     layerCommandLine->setContentsMargins(0, 0, 0, 0);
     layerCommandLine->setSizePolicy(sizePolicy);
+    layerCommandLine->setFocusPolicy(Qt::NoFocus);
 
     layerCommandLine->setMaximumHeight(31);
     layerCommandLine->setMinimumHeight(31);
@@ -494,6 +497,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     layerCommandLine->setAutoFillBackground(true);
 
     commandSplitter = new QSplitter(Qt::Horizontal, this);
+    commandSplitter->setFocusPolicy(Qt::NoFocus);
     connect(commandSplitter, &QSplitter::splitterMoved, this, &TConsole::slot_saveCommandSearchSettings);
     commandSplitter->addWidget(layerCommandLine);
     commandSplitter->addWidget(mpButtonMainLayer);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -298,6 +298,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     mpButtonMainLayer->setObjectName(qsl("mpButtonMainLayer"));
     mpButtonMainLayer->setSizePolicy(sizePolicy);
     mpButtonMainLayer->setContentsMargins(0, 0, 0, 0);
+    mpButtonMainLayer->setFocusPolicy(Qt::NoFocus);
     auto layoutButtonMainLayer = new QVBoxLayout(mpButtonMainLayer);
     layoutButtonMainLayer->setObjectName(qsl("layoutButtonMainLayer"));
     layoutButtonMainLayer->setContentsMargins(0, 0, 0, 0);
@@ -307,6 +308,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
            mpButtonMainLayer->setMaximumHeight(31);*/
     auto buttonLayer = new QWidget;
     buttonLayer->setObjectName(qsl("buttonLayer"));
+    buttonLayer->setFocusPolicy(Qt::NoFocus);
     auto layoutButtonLayer = new QHBoxLayout(buttonLayer);
     layoutButtonLayer->setObjectName(qsl("layoutButtonLayer"));
     layoutButtonLayer->setContentsMargins(0, 0, 0, 0);
@@ -314,6 +316,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
 
     auto buttonLayerSpacer = new QWidget(buttonLayer);
     buttonLayerSpacer->setSizePolicy(sizePolicy4);
+    buttonLayerSpacer->setFocusPolicy(Qt::NoFocus);
     layoutButtonMainLayer->addWidget(buttonLayerSpacer);
     layoutButtonMainLayer->addWidget(buttonLayer);
 

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -301,7 +301,6 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     mpButtonMainLayer->setObjectName(qsl("mpButtonMainLayer"));
     mpButtonMainLayer->setSizePolicy(sizePolicy);
     mpButtonMainLayer->setContentsMargins(0, 0, 0, 0);
-    mpButtonMainLayer->setFocusPolicy(Qt::NoFocus);
     auto layoutButtonMainLayer = new QVBoxLayout(mpButtonMainLayer);
     layoutButtonMainLayer->setObjectName(qsl("layoutButtonMainLayer"));
     layoutButtonMainLayer->setContentsMargins(0, 0, 0, 0);
@@ -311,7 +310,6 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
            mpButtonMainLayer->setMaximumHeight(31);*/
     auto buttonLayer = new QWidget;
     buttonLayer->setObjectName(qsl("buttonLayer"));
-    buttonLayer->setFocusPolicy(Qt::NoFocus);
     auto layoutButtonLayer = new QHBoxLayout(buttonLayer);
     layoutButtonLayer->setObjectName(qsl("layoutButtonLayer"));
     layoutButtonLayer->setContentsMargins(0, 0, 0, 0);
@@ -319,7 +317,6 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
 
     auto buttonLayerSpacer = new QWidget(buttonLayer);
     buttonLayerSpacer->setSizePolicy(sizePolicy4);
-    buttonLayerSpacer->setFocusPolicy(Qt::NoFocus);
     layoutButtonMainLayer->addWidget(buttonLayerSpacer);
     layoutButtonMainLayer->addWidget(buttonLayer);
 
@@ -424,7 +421,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     mpBufferSearchBox->setMinimumSize(QSize(100, 30));
     mpBufferSearchBox->setSizePolicy(sizePolicy);
     mpBufferSearchBox->setFont(font());
-    mpBufferSearchBox->setFocusPolicy(Qt::NoFocus);
+    mpBufferSearchBox->setFocusPolicy(Qt::ClickFocus);
     //: search bar placeholder text
     mpBufferSearchBox->setPlaceholderText(tr("Search"));
     QPalette commandLinePalette;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -421,7 +421,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     mpBufferSearchBox->setMinimumSize(QSize(100, 30));
     mpBufferSearchBox->setSizePolicy(sizePolicy);
     mpBufferSearchBox->setFont(font());
-    mpBufferSearchBox->setFocusPolicy(Qt::ClickFocus);
+    mpBufferSearchBox->setFocusPolicy(Qt::NoFocus);
     //: search bar placeholder text
     mpBufferSearchBox->setPlaceholderText(tr("Search"));
     QPalette commandLinePalette;


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes an issue where the button bar (containing timestamp, replay, and logging buttons) would receive focus instead of the command line when starting a profile. Now focus properly goes to the command line as expected.

#### Motivation for adding to Mudlet

When users start a profile, they expect to be able to immediately type commands. The button bar incorrectly getting focus meant users had to click on the command line first, which was an unnecessary extra step that interrupted the workflow.

#### Other info (issues closed, discussion etc)

Closes #8265

The fix prevents button bar container widgets from accepting focus by setting their focus policy to `Qt::NoFocus`, ensuring focus flows correctly to the command line during profile startup.