### PR TITLE
Fix: increase minimum width for search bar, buttons, latency

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -545,7 +545,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     buttonLayerSpacer->setMinimumWidth(100);
     buttonLayer->setMaximumHeight(31);
     buttonLayer->setMinimumWidth(400);
-    mpButtonMainLayer->setMinimumWidth(150);
+    mpButtonMainLayer->setMinimumWidth(400);
     mpButtonMainLayer->setAutoFillBackground(true);
     mpButtonMainLayer->setPalette(commandLinePalette);
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Increase the minimum width for search bar, buttons and latency fields so the splitter doesn't hide widgets.  The minimum width is now the total of all widgets minimum size in this area.

#### Motivation for adding to Mudlet
Better UI.

#### Other info (issues closed, discussion etc)
closes #8269