### PR TITLE
Infra: Modernize MxpTag::asString() internally

### DIFF
--- a/src/MxpTag.cpp
+++ b/src/MxpTag.cpp
@@ -79,8 +79,7 @@ QString MxpEndTag::toString() const
 
 QString MxpStartTag::toString() const
 {
-    auto result;
-    result = '<' % name;
+    auto result = '<' % name;
 
     for (const auto& attrName : mAttrsNames) {
         result = result % ' ';

--- a/src/MxpTag.cpp
+++ b/src/MxpTag.cpp
@@ -74,44 +74,36 @@ bool MxpTag::isNamed(const QString& tagName) const
 
 QString MxpEndTag::toString() const
 {
-    QString result;
-    result.append("</");
-    result.append(name);
-    result.append(">");
-    return result;
+    return qsl("</%1>").arg(name);
 }
 
 QString MxpStartTag::toString() const
 {
     QString result;
-    result.append('<');
-    result.append(name);
+    result = '<' % name;
+
     for (const auto& attrName : mAttrsNames) {
-        result.append(' ');
-        if (attrName.contains(" ") || attrName.contains("<")) {
-            result.append('"');
-            result.append(attrName);
-            result.append('"');
+        result = result % ' ';
+
+        // Need to quote the attribute name if it contains space or '<'
+        if (attrName.contains(' ') || attrName.contains('<')) {
+            result = result % qsl("\"%1\"").arg(attrName);
         } else {
-            result.append(attrName);
+            result = result % attrName;
         }
 
         const auto& attr = getAttribute(attrName);
         if (attr.hasValue()) {
-            result.append('=');
-
             const auto& val = attr.getValue();
-            result.append('"');
-            result.append(val);
-            result.append('"');
+            result = result % '=' % qsl("\"%1\"").arg(val);
         }
     }
 
     if (mIsEmpty) {
-        result.append(" /");
+        result = result % " /";
     }
 
-    result.append('>');
+    result = result % '>';
 
     return result;
 }

--- a/src/MxpTag.cpp
+++ b/src/MxpTag.cpp
@@ -79,7 +79,7 @@ QString MxpEndTag::toString() const
 
 QString MxpStartTag::toString() const
 {
-    QString result;
+    auto result;
     result = '<' % name;
 
     for (const auto& attrName : mAttrsNames) {

--- a/src/MxpTag.cpp
+++ b/src/MxpTag.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
  *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2025 by Lecker Kebap - Leris@mudlet.org                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -79,30 +80,30 @@ QString MxpEndTag::toString() const
 
 QString MxpStartTag::toString() const
 {
-    auto result = '<' % name;
+    QString result = qsl("<") + name;
 
     for (const auto& attrName : mAttrsNames) {
-        result = result % ' ';
+        result += ' ';
 
         // Need to quote the attribute name if it contains space or '<'
         if (attrName.contains(' ') || attrName.contains('<')) {
-            result = result % qsl("\"%1\"").arg(attrName);
+            result += qsl("\"%1\"").arg(attrName);
         } else {
-            result = result % attrName;
+            result += attrName;
         }
 
         const auto& attr = getAttribute(attrName);
         if (attr.hasValue()) {
             const auto& val = attr.getValue();
-            result = result % '=' % qsl("\"%1\"").arg(val);
+            result += qsl("=\"%1\"").arg(val);
         }
     }
 
     if (mIsEmpty) {
-        result = result % " /";
+        result += qsl(" /");
     }
 
-    result = result % '>';
+    result += qsl(">");
 
     return result;
 }

--- a/src/MxpTag.h
+++ b/src/MxpTag.h
@@ -21,6 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "utils.h"
 
 #include "pre_guard.h"
 #include <QMap>

--- a/src/MxpTag.h
+++ b/src/MxpTag.h
@@ -27,6 +27,7 @@
 #include <QPair>
 #include <QString>
 #include <QStringList>
+#include <QStringBuilder>
 #include "post_guard.h"
 
 #include <functional>

--- a/src/MxpTag.h
+++ b/src/MxpTag.h
@@ -28,7 +28,6 @@
 #include <QPair>
 #include <QString>
 #include <QStringList>
-#include <QStringBuilder>
 #include "post_guard.h"
 
 #include <functional>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Internal refactoring, no functional changes.
- use `.arg()`
- ~~use `QStringBuilder` with % operator~~ didn't work as expected with multiple code lines

#### Motivation for adding to Mudlet
Fix #8306 
Enhance #3625 by @gcms 

#### Other info (issues closed, discussion etc)
Increasing readability, shorting code ~50%.