### PR TITLE
fix: update export directory in package exporter

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -623,6 +623,8 @@ void dlgPackageExporter::slot_importIcon()
     }
     lastDir = QFileInfo(fileName).absolutePath();
     settings.setValue("lastFileDialogLocation", lastDir);
+    mPackagePath = lastDir;
+    emit signal_exportLocationChanged(mPackagePath);
     mPackageIconPath = fileName;
     const QIcon myIcon(mPackageIconPath);
     ui->Icon->clear();
@@ -1541,6 +1543,8 @@ void dlgPackageExporter::slot_addFiles()
 
         lastDir = fDialog->directory().absolutePath();
         settings.setValue("lastFileDialogLocation", lastDir);
+        mPackagePath = lastDir;
+        emit signal_exportLocationChanged(mPackagePath);
     }
     fDialog->deleteLater();
 }
@@ -1556,8 +1560,8 @@ void dlgPackageExporter::slot_openPackageLocation()
     if (mPackagePath.isEmpty()) {
         return;
     }
-    lastDir = QFileInfo(mPackagePath).absolutePath();
-    settings.setValue("lastFileDialogLocation", lastDir);
+
+    settings.setValue("lastFileDialogLocation", mPackagePath);
     emit signal_exportLocationChanged(mPackagePath);
 }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Update export directory placeholder to reflect last chosen directory.

#### Motivation for adding to Mudlet
Mudlet remembers last directory accessed across entire profile, but export directory placeholder wasn't reflecting changes.

#### Other info (issues closed, discussion etc)
closes #8164