### PR TITLE
improve: add a remove dependency push button to package exporter

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -108,7 +108,8 @@ dlgPackageExporter::dlgPackageExporter(QWidget *parent, Host* pHost)
     connect(this, &dlgPackageExporter::signal_exportLocationChanged, this, &dlgPackageExporter::slot_updateLocationPlaceholder);
     slot_updateLocationPlaceholder();
     connect(ui->packageList, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &dlgPackageExporter::slot_packageChanged);
-    connect(ui->addDependency, &QPushButton::clicked, this, &dlgPackageExporter::slot_addDependency);
+    connect(ui->pushButton_addDependency, &QPushButton::clicked, this, &dlgPackageExporter::slot_addDependency);
+    connect(ui->pushButton_removeDependency, &QPushButton::clicked, this, &dlgPackageExporter::slot_removeDependency);
     connect(ui->pushButton_addIcon, &QPushButton::clicked, this, &dlgPackageExporter::slot_importIcon);
     connect(ui->pushButton_removeIcon, &QPushButton::clicked, this, &dlgPackageExporter::slot_removeIcon);
     connect(mCancelButton, &QPushButton::clicked, this, &dlgPackageExporter::slot_cancelExport);

--- a/src/ui/dlgPackageExporter.ui
+++ b/src/ui/dlgPackageExporter.ui
@@ -380,7 +380,7 @@ Further reading material. e.g. a link to the Mudlet wiki, forums, Github package
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <layout class="QHBoxLayout" name="horizontalLayout_dependencies" stretch="1,0,1">
+             <layout class="QHBoxLayout" name="horizontalLayout_dependencies" stretch="1,0,0,1">
               <property name="leftMargin">
                <number>0</number>
               </property>
@@ -404,12 +404,55 @@ Further reading material. e.g. a link to the Mudlet wiki, forums, Github package
                </widget>
               </item>
               <item alignment="Qt::AlignmentFlag::AlignHCenter">
-               <widget class="QPushButton" name="addDependency">
+               <widget class="QPushButton" name="pushButton_addDependency">
                 <property name="enabled">
                  <bool>true</bool>
                 </property>
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>34</width>
+                  <height>34</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>34</width>
+                  <height>34</height>
+                 </size>
+                </property>
                 <property name="text">
                  <string notr="true">+</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="pushButton_removeDependency">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>34</width>
+                  <height>34</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>34</width>
+                  <height>34</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string>-</string>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add a remove dependency push button to the package exporter window.  Also rename addDependency push button to pushButton_addDependency as per Mudlet coding standards.

#### Motivation for adding to Mudlet
While you can use the delete key, it's not very intuitive and users could not find how to remove dependencies (#7975)

#### Other info (issues closed, discussion etc)

[Screencast_20251008_131749.webm](https://github.com/user-attachments/assets/600b6476-32e6-4a25-9e99-7363d693b976)
