### PR TITLE
fix: refresh dependencies when switching packages in package exporter

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -122,14 +122,8 @@ dlgPackageExporter::dlgPackageExporter(QWidget *parent, Host* pHost)
     te_parent->mPlainDescription = ui->textEdit_description->toPlainText();
 
     ui->packageList->addItem(tr("update installed package"));
-    ui->DependencyList->addItem(tr("add dependencies"));
-    ui->packageList->addItems(mpHost->mInstalledPackages);
-    ui->DependencyList->addItems(mpHost->mInstalledPackages);
-    auto modules = mpHost->mInstalledModules;
-    for (const auto& [moduleName, moduleData] : modules.asKeyValueRange()) {
-        ui->packageList->addItem(moduleName);
-        ui->DependencyList->addItem(moduleName);
-    }
+
+    populateDependencies();
 
     listTriggers();
     listAliases();
@@ -431,6 +425,19 @@ std::pair<bool, QString> dlgPackageExporter::writeFileToZip(const QString& archi
     return {true, QString()};
 }
 
+void dlgPackageExporter::populateDependencies()
+{
+    ui->DependencyList->clear();
+    ui->DependencyList->addItem(tr("add dependencies"));
+    ui->packageList->addItems(mpHost->mInstalledPackages);
+    ui->DependencyList->addItems(mpHost->mInstalledPackages);
+    auto modules = mpHost->mInstalledModules;
+    for (const auto& [moduleName, moduleData] : modules.asKeyValueRange()) {
+        ui->packageList->addItem(moduleName);
+        ui->DependencyList->addItem(moduleName);
+    }
+}
+
 void dlgPackageExporter::slot_addDependency()
 {
     auto text = ui->DependencyList->currentText();
@@ -539,12 +546,12 @@ void dlgPackageExporter::slot_packageChanged(int index)
     ui->textEdit_description->setMarkdown(description);
     const QString version = packageInfo.value(qsl("version"));
     ui->lineEdit_version->setText(version);
+    populateDependencies(); // available dependencies, as opposed to required ones which is next
     const QStringList dependencies = packageInfo.value(qsl("dependencies")).split(QLatin1Char(','));
     ui->comboBox_dependencies->clear();
     if (!dependencies.at(0).isEmpty()) {
         ui->comboBox_dependencies->addItems(dependencies);
     }
-
     //get files and folders from package
     ui->listWidget_addedFiles->clear();
     const QFileInfo info(qsl("%1/%2/").arg(packagePath, packageName));

--- a/src/dlgPackageExporter.h
+++ b/src/dlgPackageExporter.h
@@ -151,6 +151,7 @@ private:
     QString copyNewImagesToTmp(const QString& tempPath) const;
     static void cleanupUnusedImages(const QString& tempPath, const QString& plainDescription);
     void checkToEnableExportButton();
+    void populateDependencies();
 
     Ui::dlgPackageExporter* ui = nullptr;
     QPointer<Host> mpHost;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Master dependency list was not getting refreshed when switching between packages in package exporter.  Refresh the list every time the combo box is changed.
#### Motivation for adding to Mudlet
Better UI.

#### Other info (issues closed, discussion etc)
closes #7975

[Screencast_20251008_140041.webm](https://github.com/user-attachments/assets/6b1f8c04-d33a-4b3d-a4f2-7615ae01739b)
