### PR TITLE
Fix: 64 byte shortcuts memory leak

### DIFF
--- a/src/ShortcutsManager.cpp
+++ b/src/ShortcutsManager.cpp
@@ -22,13 +22,8 @@
 
 ShortcutsManager::~ShortcutsManager()
 {
-    QMutableMapIterator<QString, QKeySequence*> itShortcut(shortcuts);
-    while (itShortcut.hasNext()) {
-        itShortcut.next();
-        auto pKeySequence = itShortcut.value();
-        delete pKeySequence;
-        itShortcut.remove();
-    }
+    // Only delete the defaults map - these are heap-allocated copies we own.
+    // Do NOT delete the shortcuts map - those are pointers to mudlet's member variables.
     QMutableMapIterator<QString, QKeySequence*> itDefault(defaults);
     while (itDefault.hasNext()) {
         itDefault.next();

--- a/src/ShortcutsManager.h
+++ b/src/ShortcutsManager.h
@@ -34,7 +34,7 @@ class ShortcutsManager : public QObject
     Q_OBJECT
 
 public:
-    ShortcutsManager() = default;
+    explicit ShortcutsManager(QObject* parent = nullptr) : QObject(parent) {}
     ShortcutsManager(ShortcutsManager const&) = delete;
     ShortcutsManager& operator=(ShortcutsManager const&) = delete;
     ShortcutsManager(ShortcutsManager&&) = delete;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -678,7 +678,7 @@ void mudlet::init()
     connect(this, &mudlet::signal_hostCreated, this, &mudlet::slot_assignShortcutsFromProfile);
     connect(this, &mudlet::signal_profileActivated, this, &mudlet::slot_assignShortcutsFromProfile);
 
-    mpShortcutsManager = new ShortcutsManager();
+    mpShortcutsManager = new ShortcutsManager(this);
     mpShortcutsManager->registerShortcut(qsl("Script editor"), tr("Script editor"), &mKeySequenceTriggers);
     mpShortcutsManager->registerShortcut(qsl("Show Map"), tr("Show Map"), &mKeySequenceShowMap);
     mpShortcutsManager->registerShortcut(qsl("Compact input line"), tr("Compact input line"), &mKeySequenceInputLine);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix 64 byte shortcuts memory leak
#### Motivation for adding to Mudlet
Fix small memory leak, should not have any.
#### Other info (issues closed, discussion etc)
