### PR TITLE
fix: configure room font size and wording

### DIFF
--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -201,15 +201,17 @@ void dlgRoomProperties::initSymbolInstructions()
 
     QString instructions;
     if (mpSymbols.size() == 1) {
-        instructions = tr("Type one or more graphemes (\"visible characters\") to use as a symbol "
-                          "for all of the %n selected room(s):",
+        //: room properties dialog, setting symbols
+        instructions = tr("Enter one or more characters to set a new symbol for %n room(s).  Clear to unset.",
                           // Intentional comment to separate arguments!
                           "%n is the total number of rooms involved.",
                           mpRooms.size());
     } else {
-        instructions = tr("To change the symbol for all of the %n selected room(s), please choose:\n"
-                          " • an existing symbol from the list below (sorted by most commonly used first)\n"
-                          " • enter one or more graphemes (\"visible characters\") as a new symbol\n",
+        //: room properties dialog, setting symbols
+        instructions = tr("To set the symbol for all %n room(s), please choose:\n"
+                          " • an existing symbol from the list,\n"
+                          " • enter one or more characters to set a new symbol,\n"
+                          " • clear to unset.",
                           // Intentional comment to separate arguments!
                           "This is for when applying a new room symbol to one or more rooms "
                           "and some have different symbols or no symbol at present. "

--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -92,11 +92,13 @@ void dlgRoomProperties::init(
             comboBox_roomSymbol->lineEdit()->selectAll();
         }
     }
+    auto mapSymbolFont = mpHost->mpMap->mMapSymbolFont;
+    mapSymbolFont.setPointSize(qApp->font().pointSize());
     if (!lineEdit_roomSymbol->isHidden()) {
-        lineEdit_roomSymbol->setFont(mpHost->mpMap->mMapSymbolFont);
+        lineEdit_roomSymbol->setFont(mapSymbolFont);
     }
     if (!comboBox_roomSymbol->isHidden()) {
-        comboBox_roomSymbol->setFont(mpHost->mpMap->mMapSymbolFont);
+        comboBox_roomSymbol->setFont(mapSymbolFont);
     }
     initSymbolInstructions();
 
@@ -200,15 +202,14 @@ void dlgRoomProperties::initSymbolInstructions()
     QString instructions;
     if (mpSymbols.size() == 1) {
         instructions = tr("Type one or more graphemes (\"visible characters\") to use as a symbol "
-                          "for all of the %n selected room(s), or enter a space to clear the symbol:",
+                          "for all of the %n selected room(s):",
                           // Intentional comment to separate arguments!
                           "%n is the total number of rooms involved.",
                           mpRooms.size());
     } else {
         instructions = tr("To change the symbol for all of the %n selected room(s), please choose:\n"
                           " • an existing symbol from the list below (sorted by most commonly used first)\n"
-                          " • enter one or more graphemes (\"visible characters\") as a new symbol\n"
-                          " • enter a space to clear any existing symbols",
+                          " • enter one or more graphemes (\"visible characters\") as a new symbol\n",
                           // Intentional comment to separate arguments!
                           "This is for when applying a new room symbol to one or more rooms "
                           "and some have different symbols or no symbol at present. "


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Adjust font size for symbol preview text in configure room window.  Modify wording to remove spaces to clear symbols as backspace works and it more intuitive.

#### Motivation for adding to Mudlet
More intuitive interface.

<img width="388" height="487" alt="image" src="https://github.com/user-attachments/assets/2d408e52-837b-4aab-bfce-5a060aab9d94" />

#### Other info (issues closed, discussion etc)
closes #8218 
closes #8255 
supersedes #8232 