### PR TITLE
improve: set a random player location on new map load

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1209,8 +1209,16 @@ void T2DMap::paintEvent(QPaintEvent* e)
 
     QList<int> exitList;
     QList<int> oneWayExits;
-    const int playerRoomId = mpMap->mRoomIdHash.value(mpMap->mProfileName);
+    int playerRoomId = mpMap->mRoomIdHash.value(mpMap->mProfileName);
     TRoom* pPlayerRoom = mpMap->mpRoomDB->getRoom(playerRoomId);
+
+    // try and set the player to a room if we don't have a known location
+    if (!pPlayerRoom && !mpMap->mpRoomDB->isEmpty()) {
+        int randomRoom = mpMap->mpRoomDB->getRoomIDList().first();
+        pPlayerRoom = mpMap->mpRoomDB->getRoom(randomRoom);
+        playerRoomId = pPlayerRoom->getId();
+    }
+    // no rooms at all, let's show an information message instead
     if (!pPlayerRoom) {
         painter.save();
         painter.fillRect(0, 0, width(), height(), Qt::transparent);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Set the current player location to a random room when Mudlet loads in a new map without a known player location.

#### Motivation for adding to Mudlet
Brings the user straight into the map where they can manipulate it further with the mouse instead of having to guess a location with `lua centerview()`.

#### Other info (issues closed, discussion etc)
closes #724 