### PR TITLE
Fix: make leak sanitizer happy in i18n

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,7 +141,7 @@ QTranslator* loadTranslationsForCommandLine()
     }
     // We only need the Mudlet translations for the Command Line texts, no need
     // for any Qt ones:
-    QTranslator* pMudletTranslator = new QTranslator;
+    QTranslator* pMudletTranslator = new QTranslator(qApp);
     // If we allow the translations to be outside of the resource file inside
     // the application executable then this will have to be revised to handle
     // it:

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1491,7 +1491,7 @@ void mudlet::loadTranslators(const QString& languageCode)
     }
 
     translation const currentTranslation = mTranslationsMap.value(languageCode);
-    QPointer<QTranslator> const pQtTranslator = new QTranslator;
+    QPointer<QTranslator> const pQtTranslator = new QTranslator(this);
     const QString qtTranslatorFileName = currentTranslation.getQtTranslationFileName();
     if (!qtTranslatorFileName.isEmpty()) {
         // Need to use load(fileName (e.g. {qt_xx_YY.qm"}, pathName) form - Qt
@@ -1506,7 +1506,7 @@ void mudlet::loadTranslators(const QString& languageCode)
         }
     }
 
-    QPointer<QTranslator> const pMudletTranslator = new QTranslator;
+    QPointer<QTranslator> const pMudletTranslator = new QTranslator(this);
     const QString mudletTranslatorFileName = currentTranslation.getMudletTranslationFileName();
     if (!mudletTranslatorFileName.isEmpty()) {
         const bool isOk = pMudletTranslator->load(mudletTranslatorFileName, mPathNameMudletTranslations);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Make leak sanitizer happy in i18n code by deleting the objects when Mudlet is quitting. It's not a leak in a true sense because Mudlet is shut down anyway, so all memory is freed anyhow, but it does make the sanitizer happier.
#### Motivation for adding to Mudlet
Cleaner leak sanitizer output.
#### Other info (issues closed, discussion etc)
As a best practice, Qt object should always [have a parent](https://doc.qt.io/qt-6/object.html). That way, when the parent is deleted, all the children are too - and thus, there is no memory leaks.