### PR TITLE
Extract pan interaction into dedicated handler

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,6 +108,7 @@ set(mudlet_SRCS
     ShortcutsManager.cpp
     SingleLineTextEdit.cpp
     T2DMap.cpp
+    PanInteractionHandler.cpp
     TAccessibleTextEdit.cpp
     TAction.cpp
     TAlias.cpp
@@ -290,6 +291,7 @@ set(mudlet_HDRS
     ShortcutsManager.h
     SingleLineTextEdit.h
     T2DMap.h
+    PanInteractionHandler.h
     TAccessibleConsole.h
     TAccessibleTextEdit.h
     TAction.h

--- a/src/PanInteractionHandler.cpp
+++ b/src/PanInteractionHandler.cpp
@@ -1,0 +1,145 @@
+#include "PanInteractionHandler.h"
+
+#include "TMap.h"
+
+#include "pre_guard.h"
+#include <QMouseEvent>
+#include <QtGlobal>
+#include "post_guard.h"
+
+PanInteractionHandler::PanInteractionHandler(T2DMap& mapWidget)
+: mMapWidget(mapWidget)
+{
+}
+
+bool PanInteractionHandler::matches(const T2DMap::MapInteractionContext& context) const
+{
+    if (!context.event || !mMapWidget.mpMap) {
+        return false;
+    }
+
+    switch (context.event->type()) {
+    case QEvent::MouseButtonPress:
+        return context.button == Qt::LeftButton
+            && (context.modifiers.testFlag(Qt::AltModifier) || context.isMapViewOnly);
+    case QEvent::MouseMove:
+        return mMapWidget.mpMap->mLeftDown || mMapWidget.mpMap->m2DPanMode;
+    case QEvent::MouseButtonRelease:
+        return context.button == Qt::LeftButton
+            && (mMapWidget.mpMap->mLeftDown || mMapWidget.mpMap->m2DPanMode);
+    default:
+        return false;
+    }
+}
+
+bool PanInteractionHandler::handle(T2DMap::MapInteractionContext& context)
+{
+    if (!context.event) {
+        return false;
+    }
+
+    switch (context.event->type()) {
+    case QEvent::MouseButtonPress:
+        return handleMousePress(context);
+    case QEvent::MouseMove:
+        return handleMouseMove(context);
+    case QEvent::MouseButtonRelease:
+        return handleMouseRelease(context);
+    default:
+        return false;
+    }
+}
+
+bool PanInteractionHandler::handleMousePress(T2DMap::MapInteractionContext& context) const
+{
+    if (!mMapWidget.mpMap) {
+        return false;
+    }
+
+    if (context.button != Qt::LeftButton) {
+        return false;
+    }
+
+    if (!context.modifiers.testFlag(Qt::AltModifier) && !context.isMapViewOnly) {
+        return false;
+    }
+
+    mMapWidget.setCursor(Qt::ClosedHandCursor);
+    mMapWidget.mpMap->mLeftDown = true;
+
+    return false;
+}
+
+bool PanInteractionHandler::handleMouseMove(T2DMap::MapInteractionContext& context) const
+{
+    if (!mMapWidget.mpMap) {
+        return false;
+    }
+
+    auto* map = mMapWidget.mpMap;
+
+    if (!map->mLeftDown && !map->m2DPanMode) {
+        return false;
+    }
+
+    const bool hasPanModifier = context.modifiers.testFlag(Qt::AltModifier) || context.isMapViewOnly;
+
+    if (!map->m2DPanMode) {
+        if (!hasPanModifier) {
+            return false;
+        }
+
+        map->m2DPanStart = context.widgetPositionF;
+        map->m2DPanMode = true;
+    }
+
+    if (!hasPanModifier) {
+        map->m2DPanMode = false;
+        map->mLeftDown = false;
+        return true;
+    }
+
+    const QPointF panNewPosition = context.widgetPositionF;
+    const QPointF movement = map->m2DPanStart - panNewPosition;
+
+    const qreal roomWidth = static_cast<qreal>(mMapWidget.mRoomWidth);
+    const qreal roomHeight = static_cast<qreal>(mMapWidget.mRoomHeight);
+
+    if (!qFuzzyIsNull(roomWidth)) {
+        mMapWidget.mMapCenterX += movement.x() / roomWidth;
+    }
+
+    if (!qFuzzyIsNull(roomHeight)) {
+        mMapWidget.mMapCenterY += movement.y() / roomHeight;
+    }
+
+    map->m2DPanStart = panNewPosition;
+    mMapWidget.mShiftMode = true;
+    mMapWidget.update();
+
+    return true;
+}
+
+bool PanInteractionHandler::handleMouseRelease(T2DMap::MapInteractionContext& context) const
+{
+    if (!mMapWidget.mpMap) {
+        return false;
+    }
+
+    auto* map = mMapWidget.mpMap;
+
+    if (context.button != Qt::LeftButton) {
+        return false;
+    }
+
+    if (!map->mLeftDown && !map->m2DPanMode) {
+        return false;
+    }
+
+    map->mLeftDown = false;
+    map->m2DPanMode = false;
+    mMapWidget.unsetCursor();
+
+    return false;
+}
+

--- a/src/PanInteractionHandler.h
+++ b/src/PanInteractionHandler.h
@@ -1,0 +1,23 @@
+#ifndef MUDLET_PANINTERACTIONHANDLER_H
+#define MUDLET_PANINTERACTIONHANDLER_H
+
+#include "T2DMap.h"
+
+class PanInteractionHandler : public T2DMap::IInteractionHandler
+{
+public:
+    explicit PanInteractionHandler(T2DMap& mapWidget);
+
+    bool matches(const T2DMap::MapInteractionContext& context) const override;
+    bool handle(T2DMap::MapInteractionContext& context) override;
+
+private:
+    bool handleMousePress(T2DMap::MapInteractionContext& context) const;
+    bool handleMouseMove(T2DMap::MapInteractionContext& context) const;
+    bool handleMouseRelease(T2DMap::MapInteractionContext& context) const;
+
+    T2DMap& mMapWidget;
+};
+
+#endif // MUDLET_PANINTERACTIONHANDLER_H
+

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -30,6 +30,7 @@
 #include "TArea.h"
 #include "TConsole.h"
 #include "TEvent.h"
+#include "PanInteractionHandler.h"
 #include "TRoom.h" // For DIR_XXX defines
 #include "TRoomDB.h"
 #include "dlgMapper.h"
@@ -167,6 +168,9 @@ T2DMap::T2DMap(QWidget* parent)
     mMultiSelectionListWidget.move(0, 0);
     mMultiSelectionListWidget.hide();
     connect(&mMultiSelectionListWidget, &QTreeWidget::itemSelectionChanged, this, &T2DMap::slot_roomSelectionChanged);
+
+    mPanInteractionHandler = std::make_unique<PanInteractionHandler>(*this);
+    registerInteractionHandler(mPanInteractionHandler.get(), 100);
 }
 
 void T2DMap::init()
@@ -2606,13 +2610,6 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
         mMoveLabel = false;
     }
 
-    //move map with left mouse button + ALT (->
-    if (mpMap->mLeftDown) {
-        mpMap->mLeftDown = false;
-        mpMap->m2DPanMode = false;
-        unsetCursor();
-    }
-
     if (context.button == Qt::LeftButton) {
         mMultiSelection = false; // End drag-to-select rectangle resizing
         mHelpMsg.clear();
@@ -3053,12 +3050,6 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
     mudlet::self()->activateProfile(mpHost);
     mNewMoveAction = true;
     if (context.buttons & Qt::LeftButton) {
-        // move map with left mouse button + ALT, or just a left mouse button in viewOnly mode
-        if (context.modifiers.testFlag(Qt::AltModifier) || context.isMapViewOnly) {
-            setCursor(Qt::ClosedHandCursor);
-            mpMap->mLeftDown = true;
-        }
-
         // drawing new custom exit line
         if (context.isCustomLineDrawing) {
             if (context.isDialogLocked) {
@@ -4404,25 +4395,6 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
     auto context = buildInteractionContext(event);
 
     if (mInteractionDispatcher.dispatch(context)) {
-        return;
-    }
-
-    if (mpMap->mLeftDown && !mpMap->m2DPanMode && (context.modifiers.testFlag(Qt::AltModifier) || context.isMapViewOnly)) {
-        mpMap->m2DPanStart = context.widgetPositionF;
-        mpMap->m2DPanMode = true;
-    }
-    if (mpMap->m2DPanMode && (!context.modifiers.testFlag(Qt::AltModifier) && !context.isMapViewOnly)) {
-        mpMap->m2DPanMode = false;
-        mpMap->mLeftDown = false;
-    }
-    if (mpMap->m2DPanMode) {
-        const QPointF panNewPosition = context.widgetPositionF;
-        mShiftMode = true;
-        const QPointF movement = mpMap->m2DPanStart - panNewPosition;
-        mMapCenterX += movement.x() / mRoomWidth;
-        mMapCenterY += movement.y() / mRoomHeight;
-        mpMap->m2DPanStart = panNewPosition;
-        update();
         return;
     }
 

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -42,6 +42,7 @@
 #include "post_guard.h"
 
 #include <QList>
+#include <memory>
 
 class Host;
 class TArea;
@@ -298,6 +299,7 @@ private:
     };
 
     InteractionDispatcher mInteractionDispatcher;
+    std::unique_ptr<IInteractionHandler> mPanInteractionHandler;
 
     MapInteractionContext buildInteractionContext(QMouseEvent* event);
 

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -664,6 +664,7 @@ SOURCES += \
     ShortcutsManager.cpp \
     SingleLineTextEdit.cpp \
     T2DMap.cpp \
+    PanInteractionHandler.cpp \
     TAccessibleTextEdit.cpp \
     TAction.cpp \
     TAlias.cpp \
@@ -799,6 +800,7 @@ HEADERS += \
     ShortcutsManager.h \
     SingleLineTextEdit.h \
     T2DMap.h \
+    PanInteractionHandler.h \
     TAccessibleConsole.h \
     TAccessibleTextEdit.h \
     TAction.h \


### PR DESCRIPTION
## Summary
- add a PanInteractionHandler that manages the 2D map panning state through the interaction dispatcher
- register the handler on construction and remove duplicated pan code from the legacy mouse event methods
- include the new handler files in the build system definitions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f16dd9da24832a9c208f03e9244e98