### PR TITLE
Refactor map interaction handling into dedicated handlers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,7 +108,9 @@ set(mudlet_SRCS
     ShortcutsManager.cpp
     SingleLineTextEdit.cpp
     T2DMap.cpp
+    LabelInteractionHandler.cpp
     PanInteractionHandler.cpp
+    SelectionRectangleHandler.cpp
     TAccessibleTextEdit.cpp
     TAction.cpp
     TAlias.cpp
@@ -291,7 +293,9 @@ set(mudlet_HDRS
     ShortcutsManager.h
     SingleLineTextEdit.h
     T2DMap.h
+    LabelInteractionHandler.h
     PanInteractionHandler.h
+    SelectionRectangleHandler.h
     TAccessibleConsole.h
     TAccessibleTextEdit.h
     TAction.h

--- a/src/LabelInteractionHandler.cpp
+++ b/src/LabelInteractionHandler.cpp
@@ -1,0 +1,158 @@
+#include "LabelInteractionHandler.h"
+
+#include "TArea.h"
+#include "TMap.h"
+#include "TMapLabel.h"
+#include "TRoomDB.h"
+
+#include "pre_guard.h"
+#include <QMap>
+#include <QMouseEvent>
+#include <QMutableMapIterator>
+#include <QRectF>
+#include <QtGlobal>
+#include "post_guard.h"
+
+LabelInteractionHandler::LabelInteractionHandler(T2DMap& mapWidget)
+: mMapWidget(mapWidget)
+{
+}
+
+bool LabelInteractionHandler::matches(const T2DMap::MapInteractionContext& context) const
+{
+    if (!context.event || !mMapWidget.mpMap) {
+        return false;
+    }
+
+    switch (context.event->type()) {
+    case QEvent::MouseButtonPress:
+        return context.button == Qt::LeftButton
+            && !context.isMapViewOnly
+            && context.area
+            && !context.isCustomLineDrawing;
+    case QEvent::MouseMove:
+        return context.isLabelHighlighted || context.isMoveLabelActive;
+    case QEvent::MouseButtonRelease:
+        return context.button == Qt::LeftButton && context.isMoveLabelActive;
+    default:
+        return false;
+    }
+}
+
+bool LabelInteractionHandler::handle(T2DMap::MapInteractionContext& context)
+{
+    if (!context.event) {
+        return false;
+    }
+
+    switch (context.event->type()) {
+    case QEvent::MouseButtonPress:
+        return handleMousePress(context);
+    case QEvent::MouseMove:
+        return handleMouseMove(context);
+    case QEvent::MouseButtonRelease:
+        return handleMouseRelease(context);
+    default:
+        return false;
+    }
+}
+
+bool LabelInteractionHandler::handleMousePress(T2DMap::MapInteractionContext& context) const
+{
+    if (context.button != Qt::LeftButton) {
+        return false;
+    }
+
+    auto* area = context.area;
+    if (!area || area->mMapLabels.isEmpty()) {
+        return false;
+    }
+
+    QMutableMapIterator<int, TMapLabel> iterator(area->mMapLabels);
+    while (iterator.hasNext()) {
+        iterator.next();
+        auto mapLabel = iterator.value();
+        if (mapLabel.pos.z() != mMapWidget.mMapCenterZ) {
+            continue;
+        }
+
+        const float labelX = mapLabel.pos.x() * mMapWidget.mRoomWidth + mMapWidget.mRX;
+        const float labelY = mapLabel.pos.y() * mMapWidget.mRoomHeight * -1 + mMapWidget.mRY;
+        const QPoint click = context.widgetPosition;
+        const QRectF boundingRect(labelX, labelY, mapLabel.clickSize.width(), mapLabel.clickSize.height());
+        if (boundingRect.contains(click)) {
+            mapLabel.highlight = !mapLabel.highlight;
+            mMapWidget.mLabelHighlighted = mapLabel.highlight;
+            iterator.setValue(mapLabel);
+            mMapWidget.update();
+            return true;
+        }
+    }
+
+    mMapWidget.mLabelHighlighted = false;
+    mMapWidget.update();
+
+    return false;
+}
+
+bool LabelInteractionHandler::handleMouseMove(T2DMap::MapInteractionContext& context) const
+{
+    if (!mMapWidget.mpMap || !mMapWidget.mpMap->mpRoomDB) {
+        return false;
+    }
+
+    if (mMapWidget.mLabelHighlighted) {
+        auto* area = mMapWidget.mpMap->mpRoomDB->getArea(mMapWidget.mAreaID);
+        if (!area || area->mMapLabels.isEmpty()) {
+            return false;
+        }
+
+        bool needUpdate = false;
+        bool needToSave = false;
+        QMapIterator<int, TMapLabel> iterator(area->mMapLabels);
+        while (iterator.hasNext()) {
+            iterator.next();
+            auto mapLabel = iterator.value();
+            if (qRound(mapLabel.pos.z()) != mMapWidget.mMapCenterZ) {
+                continue;
+            }
+            if (!mapLabel.highlight) {
+                continue;
+            }
+
+            mapLabel.pos = QVector3D(static_cast<float>(context.mapX), static_cast<float>(context.mapY), static_cast<float>(mMapWidget.mMapCenterZ));
+            area->mMapLabels[iterator.key()] = mapLabel;
+            needUpdate = true;
+            if (!mapLabel.temporary) {
+                needToSave = true;
+            }
+        }
+        if (needUpdate) {
+            mMapWidget.update();
+            if (needToSave) {
+                mMapWidget.mpMap->setUnsaved(__func__);
+            }
+        }
+        return true;
+    }
+
+    if (mMapWidget.mMoveLabel) {
+        mMapWidget.mMoveLabel = false;
+        return false;
+    }
+
+    return false;
+}
+
+bool LabelInteractionHandler::handleMouseRelease(T2DMap::MapInteractionContext& context) const
+{
+    if (context.button != Qt::LeftButton) {
+        return false;
+    }
+
+    if (mMapWidget.mMoveLabel) {
+        mMapWidget.mMoveLabel = false;
+    }
+
+    return false;
+}

--- a/src/LabelInteractionHandler.h
+++ b/src/LabelInteractionHandler.h
@@ -1,0 +1,22 @@
+#ifndef MUDLET_LABELINTERACTIONHANDLER_H
+#define MUDLET_LABELINTERACTIONHANDLER_H
+
+#include "T2DMap.h"
+
+class LabelInteractionHandler : public T2DMap::IInteractionHandler
+{
+public:
+    explicit LabelInteractionHandler(T2DMap& mapWidget);
+
+    bool matches(const T2DMap::MapInteractionContext& context) const override;
+    bool handle(T2DMap::MapInteractionContext& context) override;
+
+private:
+    bool handleMousePress(T2DMap::MapInteractionContext& context) const;
+    bool handleMouseMove(T2DMap::MapInteractionContext& context) const;
+    bool handleMouseRelease(T2DMap::MapInteractionContext& context) const;
+
+    T2DMap& mMapWidget;
+};
+
+#endif // MUDLET_LABELINTERACTIONHANDLER_H

--- a/src/SelectionRectangleHandler.cpp
+++ b/src/SelectionRectangleHandler.cpp
@@ -1,0 +1,286 @@
+#include "SelectionRectangleHandler.h"
+
+#include "TArea.h"
+#include "TMap.h"
+#include "TRoom.h"
+#include "TRoomDB.h"
+#include "utils.h"
+
+#include "pre_guard.h"
+#include <QMouseEvent>
+#include <QRect>
+#include <QRectF>
+#include <QSet>
+#include <QtGlobal>
+#include <QTreeWidgetItem>
+#include "post_guard.h"
+
+SelectionRectangleHandler::SelectionRectangleHandler(T2DMap& mapWidget)
+: mMapWidget(mapWidget)
+{
+}
+
+bool SelectionRectangleHandler::matches(const T2DMap::MapInteractionContext& context) const
+{
+    if (!context.event || !mMapWidget.mpMap) {
+        return false;
+    }
+
+    switch (context.event->type()) {
+    case QEvent::MouseButtonPress:
+        return context.button == Qt::LeftButton
+            && !context.isCustomLineDrawing
+            && !context.isRoomBeingMoved;
+    case QEvent::MouseMove:
+        return context.isMultiSelectionActive || context.isSizingLabel;
+    case QEvent::MouseButtonRelease:
+        return context.button == Qt::LeftButton
+            && (context.isMultiSelectionActive || context.isSizingLabel);
+    default:
+        return false;
+    }
+}
+
+bool SelectionRectangleHandler::handle(T2DMap::MapInteractionContext& context)
+{
+    if (!context.event) {
+        return false;
+    }
+
+    switch (context.event->type()) {
+    case QEvent::MouseButtonPress:
+        return handleMousePress(context);
+    case QEvent::MouseMove:
+        return handleMouseMove(context);
+    case QEvent::MouseButtonRelease:
+        return handleMouseRelease(context);
+    default:
+        return false;
+    }
+}
+
+bool SelectionRectangleHandler::handleMousePress(T2DMap::MapInteractionContext& context) const
+{
+    if (context.button != Qt::LeftButton) {
+        return false;
+    }
+
+    if (!mMapWidget.mpMap || !mMapWidget.mpMap->mpRoomDB) {
+        return false;
+    }
+
+    mMapWidget.mPopupMenu = false;
+    mMapWidget.mMultiSelection = !mMapWidget.mMapViewOnly;
+    mMapWidget.mMultiRect = QRect(context.widgetPosition, context.widgetPosition);
+
+    if (!mMapWidget.mpMap->mpRoomDB->getRoom(mMapWidget.mRoomID)) {
+        return true;
+    }
+
+    auto* area = context.area;
+    if (!area) {
+        return true;
+    }
+
+    const float fx = (static_cast<float>(mMapWidget.xspan) / 2.0f - static_cast<float>(mMapWidget.mMapCenterX)) * mMapWidget.mRoomWidth;
+    const float fy = (static_cast<float>(mMapWidget.yspan) / 2.0f - static_cast<float>(mMapWidget.mMapCenterY)) * mMapWidget.mRoomHeight;
+
+    if (!context.modifiers.testFlag(Qt::ControlModifier)) {
+        if (!mMapWidget.mMapViewOnly) {
+            mMapWidget.mHelpMsg = T2DMap::tr("Drag to select multiple rooms or labels, release to finish...");
+        }
+        mMapWidget.mMultiSelectionSet.clear();
+    }
+
+    QSetIterator<int> itRoom(area->getAreaRooms());
+    while (itRoom.hasNext()) {
+        const int currentAreaRoom = itRoom.next();
+        TRoom* room = mMapWidget.mpMap->mpRoomDB->getRoom(currentAreaRoom);
+        if (!room) {
+            continue;
+        }
+
+        const int rx = room->x() * mMapWidget.mRoomWidth + fx;
+        const int ry = room->y() * -1 * mMapWidget.mRoomHeight + fy;
+        const int rz = room->z();
+
+        const int mx = context.widgetPosition.x();
+        const int my = context.widgetPosition.y();
+        const int mz = mMapWidget.mMapCenterZ;
+
+        if ((qAbs(mx - rx) < qRound(mMapWidget.mRoomWidth * mMapWidget.rSize / 2.0))
+            && (qAbs(my - ry) < qRound(mMapWidget.mRoomHeight * mMapWidget.rSize / 2.0))
+            && (mz == rz)) {
+            if (mMapWidget.mMultiSelectionSet.contains(currentAreaRoom) && context.modifiers.testFlag(Qt::ControlModifier)) {
+                mMapWidget.mMultiSelectionSet.remove(currentAreaRoom);
+            } else {
+                mMapWidget.mMultiSelectionSet.insert(currentAreaRoom);
+            }
+
+            if (!mMapWidget.mMultiSelectionSet.empty()) {
+                mMapWidget.mMultiSelection = false;
+            }
+        }
+    }
+
+    switch (mMapWidget.mMultiSelectionSet.size()) {
+    case 0:
+        mMapWidget.mMultiSelectionHighlightRoomId = 0;
+        break;
+    case 1:
+        mMapWidget.mMultiSelection = false;
+        mMapWidget.mMultiSelectionHighlightRoomId = *(mMapWidget.mMultiSelectionSet.begin());
+        mMapWidget.mHelpMsg.clear();
+        break;
+    default:
+        mMapWidget.mMultiSelection = false;
+        mMapWidget.mHelpMsg.clear();
+        mMapWidget.getCenterSelection();
+        break;
+    }
+
+    if (mMapWidget.mMultiSelection && !mMapWidget.mMultiSelectionSet.empty() && context.modifiers.testFlag(Qt::ControlModifier)) {
+        mMapWidget.mMultiSelection = false;
+        mMapWidget.mHelpMsg.clear();
+    }
+
+    return false;
+}
+
+bool SelectionRectangleHandler::handleMouseMove(T2DMap::MapInteractionContext& context) const
+{
+    if (!mMapWidget.mpMap || !mMapWidget.mpMap->mpRoomDB) {
+        return false;
+    }
+
+    if (!(mMapWidget.mMultiSelection && !mMapWidget.mRoomBeingMoved) && !mMapWidget.mSizeLabel) {
+        return false;
+    }
+
+    if (mMapWidget.mNewMoveAction) {
+        mMapWidget.mMultiRect = QRect(context.widgetPosition, context.widgetPosition);
+        mMapWidget.mNewMoveAction = false;
+    } else {
+        mMapWidget.mMultiRect.setBottomLeft(context.widgetPosition);
+    }
+
+    if (!mMapWidget.mpMap->mpRoomDB->getRoom(mMapWidget.mRoomID)) {
+        return true;
+    }
+
+    auto* area = mMapWidget.mpMap->mpRoomDB->getArea(mMapWidget.mAreaID);
+    if (!area) {
+        return true;
+    }
+
+    if (!mMapWidget.mSizeLabel) {
+        mMapWidget.mMultiSelectionSet.clear();
+        const float fx = mMapWidget.xspan / 2.0f * mMapWidget.mRoomWidth - mMapWidget.mRoomWidth * static_cast<float>(mMapWidget.mMapCenterX);
+        const float fy = mMapWidget.yspan / 2.0f * mMapWidget.mRoomHeight - mMapWidget.mRoomHeight * static_cast<float>(mMapWidget.mMapCenterY);
+        QSetIterator<int> itSelectedRoom(area->getAreaRooms());
+        while (itSelectedRoom.hasNext()) {
+            const int currentRoomId = itSelectedRoom.next();
+            TRoom* room = mMapWidget.mpMap->mpRoomDB->getRoom(currentRoomId);
+            if (!room) {
+                continue;
+            }
+
+            if ((room->z() != mMapWidget.mMapCenterZ) && !context.modifiers.testFlag(Qt::ShiftModifier)) {
+                continue;
+            }
+
+            const float rx = static_cast<float>(room->x()) * mMapWidget.mRoomWidth + fx;
+            const float ry = static_cast<float>(room->y() * -1) * mMapWidget.mRoomHeight + fy;
+            QRectF dr;
+            if (area->gridMode) {
+                dr = QRectF(static_cast<qreal>(rx - (mMapWidget.mRoomWidth / 2.0f)), static_cast<qreal>(ry - (mMapWidget.mRoomHeight / 2.0f)), static_cast<qreal>(mMapWidget.mRoomWidth), static_cast<qreal>(mMapWidget.mRoomHeight));
+            } else {
+                dr = QRectF(static_cast<qreal>(rx - mMapWidget.mRoomWidth * static_cast<float>(mMapWidget.rSize / 2.0)), static_cast<qreal>(ry - mMapWidget.mRoomHeight * static_cast<float>(mMapWidget.rSize / 2.0)), static_cast<qreal>(mMapWidget.mRoomWidth) * mMapWidget.rSize, static_cast<qreal>(mMapWidget.mRoomHeight) * mMapWidget.rSize);
+            }
+            if (mMapWidget.mMultiRect.contains(dr)) {
+                mMapWidget.mMultiSelectionSet.insert(currentRoomId);
+            }
+        }
+        switch (mMapWidget.mMultiSelectionSet.size()) {
+        case 0:
+            mMapWidget.mMultiSelectionHighlightRoomId = 0;
+            break;
+        case 1:
+            mMapWidget.mMultiSelectionHighlightRoomId = *(mMapWidget.mMultiSelectionSet.begin());
+            break;
+        default:
+            mMapWidget.getCenterSelection();
+            break;
+        }
+
+        if (mMapWidget.mMultiSelectionSet.size() > 1) {
+            populateMultiSelectionWidget();
+        } else {
+            mMapWidget.mMultiSelectionListWidget.hide();
+        }
+    }
+
+    mMapWidget.update();
+
+    return true;
+}
+
+bool SelectionRectangleHandler::handleMouseRelease(T2DMap::MapInteractionContext& context) const
+{
+    if (context.button != Qt::LeftButton) {
+        return false;
+    }
+
+    mMapWidget.mMultiSelection = false;
+    mMapWidget.mHelpMsg.clear();
+
+    if (mMapWidget.mSizeLabel) {
+        mMapWidget.mSizeLabel = false;
+        const QRectF labelRect = mMapWidget.mMultiRect;
+        mMapWidget.createLabel(labelRect);
+    }
+
+    mMapWidget.mMultiRect = QRect(0, 0, 0, 0);
+    mMapWidget.updateSelectionWidget();
+    mMapWidget.update();
+
+    return true;
+}
+
+void SelectionRectangleHandler::populateMultiSelectionWidget() const
+{
+    mMapWidget.mMultiSelectionListWidget.blockSignals(true);
+    mMapWidget.mIsSelectionSorting = mMapWidget.mMultiSelectionListWidget.isSortingEnabled();
+    mMapWidget.mIsSelectionSortByNames = (mMapWidget.mMultiSelectionListWidget.sortColumn() == 1);
+    mMapWidget.mMultiSelectionListWidget.clear();
+    mMapWidget.mMultiSelectionListWidget.setSortingEnabled(false);
+    QSetIterator<int> itRoom = mMapWidget.mMultiSelectionSet;
+    mMapWidget.mIsSelectionUsingNames = false;
+    while (itRoom.hasNext()) {
+        auto item = new QTreeWidgetItem;
+        const int multiSelectionRoomId = itRoom.next();
+        item->setText(0, qsl("%1").arg(multiSelectionRoomId, mMapWidget.mMaxRoomIdDigits));
+        item->setTextAlignment(0, Qt::AlignRight);
+        TRoom* room = mMapWidget.mpMap->mpRoomDB->getRoom(multiSelectionRoomId);
+        if (room) {
+            const QString roomName = room->name;
+            if (!roomName.isEmpty()) {
+                item->setText(1, roomName);
+                item->setTextAlignment(1, Qt::AlignLeft);
+                mMapWidget.mIsSelectionUsingNames = true;
+            }
+        }
+        mMapWidget.mMultiSelectionListWidget.addTopLevelItem(item);
+    }
+
+    mMapWidget.mMultiSelectionListWidget.setColumnHidden(1, !mMapWidget.mIsSelectionUsingNames);
+    if ((!mMapWidget.mIsSelectionUsingNames) && mMapWidget.mIsSelectionSortByNames && mMapWidget.mIsSelectionSorting) {
+        mMapWidget.mIsSelectionSortByNames = false;
+    }
+    mMapWidget.mMultiSelectionListWidget.sortByColumn(mMapWidget.mIsSelectionSortByNames ? 1 : 0, Qt::AscendingOrder);
+    mMapWidget.mMultiSelectionListWidget.setSortingEnabled(mMapWidget.mIsSelectionSorting);
+    mMapWidget.resizeMultiSelectionWidget();
+    mMapWidget.mMultiSelectionListWidget.selectAll();
+    mMapWidget.mMultiSelectionListWidget.blockSignals(false);
+    mMapWidget.mMultiSelectionListWidget.show();
+}

--- a/src/SelectionRectangleHandler.h
+++ b/src/SelectionRectangleHandler.h
@@ -1,0 +1,24 @@
+#ifndef MUDLET_SELECTIONRECTANGLEHANDLER_H
+#define MUDLET_SELECTIONRECTANGLEHANDLER_H
+
+#include "T2DMap.h"
+
+class SelectionRectangleHandler : public T2DMap::IInteractionHandler
+{
+public:
+    explicit SelectionRectangleHandler(T2DMap& mapWidget);
+
+    bool matches(const T2DMap::MapInteractionContext& context) const override;
+    bool handle(T2DMap::MapInteractionContext& context) override;
+
+private:
+    bool handleMousePress(T2DMap::MapInteractionContext& context) const;
+    bool handleMouseMove(T2DMap::MapInteractionContext& context) const;
+    bool handleMouseRelease(T2DMap::MapInteractionContext& context) const;
+
+    void populateMultiSelectionWidget() const;
+
+    T2DMap& mMapWidget;
+};
+
+#endif // MUDLET_SELECTIONRECTANGLEHANDLER_H

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -30,7 +30,9 @@
 #include "TArea.h"
 #include "TConsole.h"
 #include "TEvent.h"
+#include "LabelInteractionHandler.h"
 #include "PanInteractionHandler.h"
+#include "SelectionRectangleHandler.h"
 #include "TRoom.h" // For DIR_XXX defines
 #include "TRoomDB.h"
 #include "dlgMapper.h"
@@ -168,6 +170,12 @@ T2DMap::T2DMap(QWidget* parent)
     mMultiSelectionListWidget.move(0, 0);
     mMultiSelectionListWidget.hide();
     connect(&mMultiSelectionListWidget, &QTreeWidget::itemSelectionChanged, this, &T2DMap::slot_roomSelectionChanged);
+
+    mSelectionRectangleInteractionHandler = std::make_unique<SelectionRectangleHandler>(*this);
+    registerInteractionHandler(mSelectionRectangleInteractionHandler.get(), 200);
+
+    mLabelInteractionHandler = std::make_unique<LabelInteractionHandler>(*this);
+    registerInteractionHandler(mLabelInteractionHandler.get(), 150);
 
     mPanInteractionHandler = std::make_unique<PanInteractionHandler>(*this);
     registerInteractionHandler(mPanInteractionHandler.get(), 100);
@@ -2606,22 +2614,7 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
         return;
     }
 
-    if (context.isMoveLabelActive) {
-        mMoveLabel = false;
-    }
-
-    if (context.button == Qt::LeftButton) {
-        mMultiSelection = false; // End drag-to-select rectangle resizing
-        mHelpMsg.clear();
-        if (mSizeLabel) {
-            mSizeLabel = false;
-            const QRectF labelRect = mMultiRect;
-            createLabel(labelRect);
-        }
-        mMultiRect = QRect(0, 0, 0, 0);
-        update();
-        return;
-    }
+    // Left button release and label move clean-up are handled by interaction handlers.
 
     if (context.button == Qt::RightButton) {
         auto popup = new QMenu(this);
@@ -3157,111 +3150,6 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
 
             setMouseTracking(false);
             mRoomBeingMoved = false;
-        } else {
-            mPopupMenu = false;
-            // Not in a context menu, so start selection mode - including drag to select if not in viewOnly mode
-            mMultiSelection = !mMapViewOnly;
-            mMultiRect = QRect(context.widgetPosition, context.widgetPosition);
-            if (!mpMap->mpRoomDB->getRoom(mRoomID)) {
-                return;
-            }
-            TArea* pArea = mpMap->mpRoomDB->getArea(mAreaID);
-            if (!pArea) {
-                return;
-            }
-            const float fx = ((xspan / 2.0) - mMapCenterX) * mRoomWidth;
-            const float fy = ((yspan / 2.0) - mMapCenterY) * mRoomHeight;
-
-            if (!context.modifiers.testFlag(Qt::ControlModifier)) {
-                if (!mMapViewOnly) {
-                    // If control key NOT down then clear selection, and put up helpful text
-                    //: 2D Mapper big, bottom of screen help message
-                    mHelpMsg = tr("Drag to select multiple rooms or labels, release to finish...");
-                }
-                mMultiSelectionSet.clear();
-            }
-
-            QSetIterator<int> itRoom(pArea->getAreaRooms());
-            while (itRoom.hasNext()) { // Scan to find rooms in selection
-                const int currentAreaRoom = itRoom.next();
-                TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
-                if (!room) {
-                    continue;
-                }
-                const int rx = room->x() * mRoomWidth + fx;
-                const int ry = room->y() * -1 * mRoomHeight + fy;
-                const int rz = room->z();
-
-                    const int mx = context.widgetPosition.x();
-                    const int my = context.widgetPosition.y();
-                    const int mz = mMapCenterZ;
-                    if ((abs(mx - rx) < qRound(mRoomWidth * rSize / 2.0)) && (abs(my - ry) < qRound(mRoomHeight * rSize / 2.0)) && (mz == rz)) {
-                        if (mMultiSelectionSet.contains(currentAreaRoom) && context.modifiers.testFlag(Qt::ControlModifier)) {
-                        mMultiSelectionSet.remove(currentAreaRoom);
-                    } else {
-                        mMultiSelectionSet.insert(currentAreaRoom);
-                    }
-
-                    if (!mMultiSelectionSet.empty()) {
-                        mMultiSelection = false;
-                    }
-                }
-            }
-            switch (mMultiSelectionSet.size()) {
-            case 0:
-                mMultiSelectionHighlightRoomId = 0;
-                break;
-            case 1:
-                mMultiSelection = false; // OK, found one room so stop
-                mMultiSelectionHighlightRoomId = *(mMultiSelectionSet.begin());
-                mHelpMsg.clear();
-                break;
-            default:
-                mMultiSelection = false; // OK, found more than one room so stop
-                mHelpMsg.clear();
-                getCenterSelection();
-            }
-
-            // select labels (not in viewOnly mode)
-            if (!pArea->mMapLabels.isEmpty() && !mMapViewOnly) {
-                QMutableMapIterator<int, TMapLabel> itMapLabel(pArea->mMapLabels);
-                while (itMapLabel.hasNext()) {
-                    itMapLabel.next();
-                    auto mapLabel = itMapLabel.value();
-                    if (mapLabel.pos.z() != mMapCenterZ) {
-                        continue;
-                    }
-
-                    QPointF labelPosition;
-                    const float labelX = mapLabel.pos.x() * mRoomWidth + mRX;
-                    const float labelY = mapLabel.pos.y() * mRoomHeight * -1 + mRY;
-
-                    labelPosition.setX(labelX);
-                    labelPosition.setY(labelY);
-                    const int mx = context.widgetPosition.x();
-                    const int my = context.widgetPosition.y();
-                    const QPoint click = QPoint(mx, my);
-                    const QRectF br = QRect(labelX, labelY, mapLabel.clickSize.width(), mapLabel.clickSize.height());
-                    if (br.contains(click)) {
-                        mapLabel.highlight = !mapLabel.highlight;
-                        mLabelHighlighted = mapLabel.highlight;
-                        pArea->mMapLabels[itMapLabel.key()] = mapLabel;
-                        update();
-                        return;
-                    }
-                }
-            }
-
-            mLabelHighlighted = false;
-            update();
-
-            if (mMultiSelection && !mMultiSelectionSet.empty() && context.modifiers.testFlag(Qt::ControlModifier)) {
-                // We were dragging multi-selection rectangle, we had selected at
-                // least one room and the user has <CTRL>-clicked with the mouse
-                // so switch off the dragging
-                mMultiSelection = false;
-                mHelpMsg.clear();
-            }
         }
     }
 
@@ -4415,146 +4303,7 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
 
     mCustomLineSelectedPoint = -1;
 
-    //FIXME:
-    if (mLabelHighlighted) {
-        auto pA = mpMap->mpRoomDB->getArea(mAreaID);
-        if (pA && !pA->mMapLabels.isEmpty()) {
-            bool needUpdate = false;
-            bool needToSave = false;
-            QMapIterator<int, TMapLabel> itMapLabel(pA->mMapLabels);
-            while (itMapLabel.hasNext()) {
-                itMapLabel.next();
-                auto mapLabel = itMapLabel.value();
-
-                if (qRound(mapLabel.pos.z()) != mMapCenterZ) {
-                    continue;
-                }
-                if (!mapLabel.highlight) {
-                    continue;
-                }
-                mapLabel.pos = QVector3D(static_cast<float>(context.mapX), static_cast<float>(context.mapY), static_cast<float>(mMapCenterZ));
-                pA->mMapLabels[itMapLabel.key()] = mapLabel;
-                needUpdate = true;
-                if (!mapLabel.temporary) {
-                    needToSave = true;
-                }
-            }
-            if (needUpdate) {
-                update();
-                if (needToSave) {
-                    mpMap->setUnsaved(__func__);
-                }
-            }
-        }
-    } else {
-        mMoveLabel = false;
-    }
-
-    if ((mMultiSelection && !mRoomBeingMoved) || mSizeLabel) {
-        //    (The drag to select (or size) rectangle is being actively resized and rooms are not being moved)
-        // OR (We are sizing up a label)
-        if (mNewMoveAction) {
-            mMultiRect = QRect(context.widgetPosition, context.widgetPosition);
-            mNewMoveAction = false;
-        } else {
-            mMultiRect.setBottomLeft(context.widgetPosition);
-        }
-
-        if (!mpMap->mpRoomDB->getRoom(mRoomID)) {
-            return;
-        }
-        TArea* pArea = mpMap->mpRoomDB->getArea(mAreaID);
-        if (!pArea) {
-            return;
-        }
-
-        if (!mSizeLabel) { // NOT sizing a label
-            mMultiSelectionSet.clear();
-            const float fx = xspan / 2.0f * mRoomWidth - mRoomWidth * static_cast<float>(mMapCenterX);
-            const float fy = yspan / 2.0f * mRoomHeight - mRoomHeight * static_cast<float>(mMapCenterY);
-            QSetIterator<int> itSelectedRoom(pArea->getAreaRooms());
-            while (itSelectedRoom.hasNext()) {
-                const int currentRoomId = itSelectedRoom.next();
-                TRoom* room = mpMap->mpRoomDB->getRoom(currentRoomId);
-                if (!room) {
-                    continue;
-                }
-
-                // copy rooms on all z-levels if the shift key is being pressed
-                // CHECK: Consider adding z-level to multi-selection Widget?
-                if ((room->z() != mMapCenterZ) && !context.modifiers.testFlag(Qt::ShiftModifier)) {
-                    continue;
-                }
-
-                const float rx = static_cast<float>(room->x()) * mRoomWidth  + fx;
-                const float ry = static_cast<float>(room->y() * -1) * mRoomHeight + fy;
-                QRectF dr;
-                if (pArea->gridMode) {
-                    dr = QRectF(static_cast<qreal>(rx - (mRoomWidth / 2.0f)), static_cast<qreal>(ry - (mRoomHeight / 2.0f)), static_cast<qreal>(mRoomWidth), static_cast<qreal>(mRoomHeight));
-                } else {
-                    dr = QRectF(static_cast<qreal>(rx - mRoomWidth * static_cast<float>(rSize / 2.0)), static_cast<qreal>(ry - mRoomHeight * static_cast<float>(rSize / 2.0)), static_cast<qreal>(mRoomWidth) * rSize, static_cast<qreal>(mRoomHeight) * rSize);
-                }
-                if (mMultiRect.contains(dr)) {
-                    mMultiSelectionSet.insert(currentRoomId);
-                }
-            }
-            switch (mMultiSelectionSet.size()) {
-            case 0:
-                mMultiSelectionHighlightRoomId = 0;
-                break;
-            case 1:
-                mMultiSelectionHighlightRoomId = *(mMultiSelectionSet.begin());
-                break;
-            default:
-                getCenterSelection(); // Sets mMultiSelectionHighlightRoomId to (a) central room
-            }
-
-            if (mMultiSelectionSet.size() > 1) {
-                // We don't want to cause calls to slot_roomSelectionChanged() here!
-                mMultiSelectionListWidget.blockSignals(true);
-                // Save sorting state before we switch it off
-                mIsSelectionSorting = mMultiSelectionListWidget.isSortingEnabled();
-                mIsSelectionSortByNames = (mMultiSelectionListWidget.sortColumn() == 1);
-                mMultiSelectionListWidget.clear();
-                // Do NOT sort while inserting items!
-                mMultiSelectionListWidget.setSortingEnabled(false);
-                QSetIterator<int> itRoom = mMultiSelectionSet;
-                mIsSelectionUsingNames = false;
-                while (itRoom.hasNext()) {
-                    auto item = new QTreeWidgetItem;
-                    const int multiSelectionRoomId = itRoom.next();
-                    item->setText(0, qsl("%1").arg(multiSelectionRoomId, mMaxRoomIdDigits));
-                    item->setTextAlignment(0, Qt::AlignRight);
-                    TRoom* pR_multiSelection = mpMap->mpRoomDB->getRoom(multiSelectionRoomId);
-                    if (pR_multiSelection) {
-                        const QString multiSelectionRoomName = pR_multiSelection->name;
-                        if (!multiSelectionRoomName.isEmpty()) {
-                            item->setText(1, multiSelectionRoomName);
-                            item->setTextAlignment(1, Qt::AlignLeft);
-                            mIsSelectionUsingNames = true;
-                        }
-                    }
-                    mMultiSelectionListWidget.addTopLevelItem(item);
-                }
-                mMultiSelectionListWidget.setColumnHidden(1, !mIsSelectionUsingNames);
-                // Can't sort if nothing to sort on, switch to sorting by room number
-                if ((!mIsSelectionUsingNames) && mIsSelectionSortByNames && mIsSelectionSorting) {
-                    mIsSelectionSortByNames = false;
-                }
-                mMultiSelectionListWidget.sortByColumn(mIsSelectionSortByNames ? 1 : 0, Qt::AscendingOrder);
-                mMultiSelectionListWidget.setSortingEnabled(mIsSelectionSorting);
-                resizeMultiSelectionWidget();
-                mMultiSelectionListWidget.selectAll();
-                mMultiSelectionListWidget.blockSignals(false);
-                mMultiSelectionListWidget.show();
-            } else {
-                mMultiSelectionListWidget.hide();
-            }
-        }
-
-        update();
-        return;
-    }
+    // Selection and label handling is delegated to interaction handlers.
 
     if (mRoomBeingMoved && !mSizeLabel && !mMultiSelectionSet.isEmpty()) {
         mMultiRect = QRect(0, 0, 0, 0);

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -299,6 +299,8 @@ private:
     };
 
     InteractionDispatcher mInteractionDispatcher;
+    std::unique_ptr<IInteractionHandler> mSelectionRectangleInteractionHandler;
+    std::unique_ptr<IInteractionHandler> mLabelInteractionHandler;
     std::unique_ptr<IInteractionHandler> mPanInteractionHandler;
 
     MapInteractionContext buildInteractionContext(QMouseEvent* event);

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -664,7 +664,9 @@ SOURCES += \
     ShortcutsManager.cpp \
     SingleLineTextEdit.cpp \
     T2DMap.cpp \
+    LabelInteractionHandler.cpp \
     PanInteractionHandler.cpp \
+    SelectionRectangleHandler.cpp \
     TAccessibleTextEdit.cpp \
     TAction.cpp \
     TAlias.cpp \
@@ -800,7 +802,9 @@ HEADERS += \
     ShortcutsManager.h \
     SingleLineTextEdit.h \
     T2DMap.h \
+    LabelInteractionHandler.h \
     PanInteractionHandler.h \
+    SelectionRectangleHandler.h \
     TAccessibleConsole.h \
     TAccessibleTextEdit.h \
     TAction.h \


### PR DESCRIPTION
## Summary
- add SelectionRectangleHandler and LabelInteractionHandler to manage mapper multi-selection and label interactions
- register the new handlers with T2DMap and remove legacy mouse event branches
- update build system entries to compile the new handlers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f17bc5046c832aa7b86be0712d7850