### PR TITLE
Add custom line draw handler for map interactions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,6 +108,7 @@ set(mudlet_SRCS
     ShortcutsManager.cpp
     SingleLineTextEdit.cpp
     T2DMap.cpp
+    map/handlers/CustomLineDrawHandler.cpp
     LabelInteractionHandler.cpp
     PanInteractionHandler.cpp
     SelectionRectangleHandler.cpp
@@ -293,6 +294,7 @@ set(mudlet_HDRS
     ShortcutsManager.h
     SingleLineTextEdit.h
     T2DMap.h
+    map/handlers/CustomLineDrawHandler.h
     LabelInteractionHandler.h
     PanInteractionHandler.h
     SelectionRectangleHandler.h

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -33,6 +33,7 @@
 #include "LabelInteractionHandler.h"
 #include "PanInteractionHandler.h"
 #include "SelectionRectangleHandler.h"
+#include "map/handlers/CustomLineDrawHandler.h"
 #include "TRoom.h" // For DIR_XXX defines
 #include "TRoomDB.h"
 #include "dlgMapper.h"
@@ -170,6 +171,9 @@ T2DMap::T2DMap(QWidget* parent)
     mMultiSelectionListWidget.move(0, 0);
     mMultiSelectionListWidget.hide();
     connect(&mMultiSelectionListWidget, &QTreeWidget::itemSelectionChanged, this, &T2DMap::slot_roomSelectionChanged);
+
+    mCustomLineDrawInteractionHandler = std::make_unique<CustomLineDrawHandler>(*this);
+    registerInteractionHandler(mCustomLineDrawInteractionHandler.get(), 400);
 
     mSelectionRectangleInteractionHandler = std::make_unique<SelectionRectangleHandler>(*this);
     registerInteractionHandler(mSelectionRectangleInteractionHandler.get(), 200);
@@ -3043,24 +3047,6 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
     mudlet::self()->activateProfile(mpHost);
     mNewMoveAction = true;
     if (context.buttons & Qt::LeftButton) {
-        // drawing new custom exit line
-        if (context.isCustomLineDrawing) {
-            if (context.isDialogLocked) {
-                return; // Prevent any line drawing until ready
-            }
-
-            TRoom* room = mpMap->mpRoomDB->getRoom(mCustomLinesRoomFrom);
-            if (room) {
-                const float mx = static_cast<float>(context.mapX);
-                const float my = static_cast<float>(context.mapY);
-                // might be useful to have a snap to grid type option
-                room->customLines[mCustomLinesRoomExit].push_back(QPointF(mx, my));
-                room->calcRoomDimensions();
-                repaint();
-                return;
-            }
-        }
-
         // check click on custom exit lines (not in viewOnly mode)
         if (!context.hasMultiSelection && !context.isMapViewOnly) {
             // But NOT if got one or more rooms already selected!
@@ -3176,6 +3162,8 @@ T2DMap::MapInteractionContext T2DMap::buildInteractionContext(QMouseEvent* event
     context.isMoveLabelActive = mMoveLabel;
     context.isCustomLineDrawing = mCustomLinesRoomFrom > 0;
     context.isDialogLocked = mDialogLock;
+    context.customLinesRoomFrom = mCustomLinesRoomFrom;
+    context.customLinesRoomExit = mCustomLinesRoomExit;
 
     if (!mpMap || !mpMap->mpRoomDB) {
         return context;

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -97,6 +97,8 @@ public:
         bool isMoveLabelActive = false;
         bool isCustomLineDrawing = false;
         bool isDialogLocked = false;
+        int customLinesRoomFrom = 0;
+        QString customLinesRoomExit;
     };
 
     class IInteractionHandler
@@ -299,6 +301,7 @@ private:
     };
 
     InteractionDispatcher mInteractionDispatcher;
+    std::unique_ptr<IInteractionHandler> mCustomLineDrawInteractionHandler;
     std::unique_ptr<IInteractionHandler> mSelectionRectangleInteractionHandler;
     std::unique_ptr<IInteractionHandler> mLabelInteractionHandler;
     std::unique_ptr<IInteractionHandler> mPanInteractionHandler;

--- a/src/map/handlers/CustomLineDrawHandler.cpp
+++ b/src/map/handlers/CustomLineDrawHandler.cpp
@@ -1,0 +1,67 @@
+#include "map/handlers/CustomLineDrawHandler.h"
+
+#include "TMap.h"
+#include "TRoom.h"
+#include "TRoomDB.h"
+
+#include "pre_guard.h"
+#include <QEvent>
+#include <QMouseEvent>
+#include <QPointF>
+#include "post_guard.h"
+
+CustomLineDrawHandler::CustomLineDrawHandler(T2DMap& mapWidget)
+: mMapWidget(mapWidget)
+{
+}
+
+bool CustomLineDrawHandler::matches(const T2DMap::MapInteractionContext& context) const
+{
+    if (!context.event || !mMapWidget.mpMap) {
+        return false;
+    }
+
+    if (context.event->type() != QEvent::MouseButtonPress) {
+        return false;
+    }
+
+    if (context.button != Qt::LeftButton) {
+        return false;
+    }
+
+    if (!context.isCustomLineDrawing) {
+        return false;
+    }
+
+    if (context.customLinesRoomFrom <= 0) {
+        return false;
+    }
+
+    return true;
+}
+
+bool CustomLineDrawHandler::handle(T2DMap::MapInteractionContext& context)
+{
+    if (!mMapWidget.mpMap || !mMapWidget.mpMap->mpRoomDB) {
+        return false;
+    }
+
+    if (context.isDialogLocked) {
+        return true;
+    }
+
+    TRoom* room = mMapWidget.mpMap->mpRoomDB->getRoom(context.customLinesRoomFrom);
+
+    if (!room) {
+        return false;
+    }
+
+    const float mapX = static_cast<float>(context.mapX);
+    const float mapY = static_cast<float>(context.mapY);
+
+    room->customLines[context.customLinesRoomExit].push_back(QPointF(mapX, mapY));
+    room->calcRoomDimensions();
+    mMapWidget.repaint();
+
+    return true;
+}

--- a/src/map/handlers/CustomLineDrawHandler.h
+++ b/src/map/handlers/CustomLineDrawHandler.h
@@ -1,0 +1,18 @@
+#ifndef MUDLET_CUSTOMLINEDRAWHANDLER_H
+#define MUDLET_CUSTOMLINEDRAWHANDLER_H
+
+#include "T2DMap.h"
+
+class CustomLineDrawHandler : public T2DMap::IInteractionHandler
+{
+public:
+    explicit CustomLineDrawHandler(T2DMap& mapWidget);
+
+    bool matches(const T2DMap::MapInteractionContext& context) const override;
+    bool handle(T2DMap::MapInteractionContext& context) override;
+
+private:
+    T2DMap& mMapWidget;
+};
+
+#endif // MUDLET_CUSTOMLINEDRAWHANDLER_H


### PR DESCRIPTION
## Summary
- add a dedicated custom line drawing interaction handler for the 2D map
- share the custom line drawing state through the interaction context and remove the inlined drawing branch
- register the handler with the dispatcher at high priority and build it with the rest of the map widget code

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f17f1406cc832ab250a240d1f512d2