### PR TITLE
Refactor custom line editing into interaction handler

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,6 +109,7 @@ set(mudlet_SRCS
     SingleLineTextEdit.cpp
     T2DMap.cpp
     map/handlers/CustomLineDrawHandler.cpp
+    map/handlers/CustomLineEditHandler.cpp
     map/handlers/LabelInteractionHandler.cpp
     map/handlers/PanInteractionHandler.cpp
     map/handlers/SelectionRectangleHandler.cpp
@@ -295,6 +296,7 @@ set(mudlet_HDRS
     SingleLineTextEdit.h
     T2DMap.h
     map/handlers/CustomLineDrawHandler.h
+    map/handlers/CustomLineEditHandler.h
     map/handlers/LabelInteractionHandler.h
     map/handlers/PanInteractionHandler.h
     map/handlers/SelectionRectangleHandler.h

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -34,6 +34,7 @@
 #include "map/handlers/PanInteractionHandler.h"
 #include "map/handlers/SelectionRectangleHandler.h"
 #include "map/handlers/CustomLineDrawHandler.h"
+#include "map/handlers/CustomLineEditHandler.h"
 #include "TRoom.h" // For DIR_XXX defines
 #include "TRoomDB.h"
 #include "dlgMapper.h"
@@ -174,6 +175,9 @@ T2DMap::T2DMap(QWidget* parent)
 
     mCustomLineDrawInteractionHandler = std::make_unique<CustomLineDrawHandler>(*this);
     registerInteractionHandler(mCustomLineDrawInteractionHandler.get(), 400);
+
+    mCustomLineEditInteractionHandler = std::make_unique<CustomLineEditHandler>(*this);
+    registerInteractionHandler(mCustomLineEditInteractionHandler.get(), 350);
 
     mSelectionRectangleInteractionHandler = std::make_unique<SelectionRectangleHandler>(*this);
     registerInteractionHandler(mSelectionRectangleInteractionHandler.get(), 200);
@@ -3047,89 +3051,6 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
     mudlet::self()->activateProfile(mpHost);
     mNewMoveAction = true;
     if (context.buttons & Qt::LeftButton) {
-        // check click on custom exit lines (not in viewOnly mode)
-        if (!context.hasMultiSelection && !context.isMapViewOnly) {
-            // But NOT if got one or more rooms already selected!
-            TArea* pA = context.area;
-            if (pA) {
-                const qreal mx = context.mapX;
-                const qreal my = context.mapY;
-                const QPointF clickPoint = context.mapPoint;
-                QSetIterator<int> itRoom = pA->rooms;
-                while (itRoom.hasNext()) {
-                    const int currentRoomId = itRoom.next();
-                    TRoom* room = mpMap->mpRoomDB->getRoom(currentRoomId);
-                    if (!room) {
-                        continue;
-                    }
-                    QMapIterator<QString, QList<QPointF>> lineIterator(room->customLines);
-                    while (lineIterator.hasNext()) {
-                        lineIterator.next();
-                        const QList<QPointF>& linePoints = lineIterator.value();
-                        if (!linePoints.empty()) {
-                            // The way this code is structured means that EARLIER
-                            // points are selected in preference to later ones!
-                            // This might not be intuitive to the users...
-                            float oldX, oldY, newX, newY;
-                            for (int pointIndex = 0; pointIndex < linePoints.size(); pointIndex++) {
-                                if (pointIndex == 0) {
-                                    // First segment of a custom line
-                                    // start it at the centre of the room
-                                    oldX = room->x();
-                                    oldY = room->y();
-                                    //FIXME: use exit direction to calculate start of line
-                                    newX = linePoints[0].x();
-                                    newY = linePoints[0].y();
-                                } else {
-                                    // Not the first segment of a custom line
-                                    // so start it at the end of the previous one
-                                    oldX = newX;
-                                    oldY = newY;
-                                    newX = linePoints[pointIndex].x();
-                                    newY = linePoints[pointIndex].y();
-                                }
-                                // End of each custom line segment is given
-
-                                // click auf einen edit - punkt
-                                if (mCustomLineSelectedRoom != 0) {
-                                    // We have already chosen a line to edit
-                                    if (fabs(mx - newX) <= 0.25 && fabs(my - newY) <= 0.25) {
-                                        // And this looks close enough to a point that we should edit it
-                                        mCustomLineSelectedPoint = pointIndex;
-                                        return;
-                                    }
-                                }
-
-                                // We have not previously chosen a line to edit
-                                const QLineF lineSegment = QLineF(oldX, oldY, newX, newY);
-                                const QLineF normalVector = lineSegment.normalVector();
-                                QLineF testLine1;
-                                testLine1.setP1(clickPoint);
-                                testLine1.setAngle(normalVector.angle());
-                                testLine1.setLength(0.1);
-                                QLineF testLine2;
-                                testLine2.setP1(clickPoint);
-                                testLine2.setAngle(normalVector.angle());
-                                testLine2.setLength(-0.1);
-                                QPointF intersectionPoint;
-                                if ((lineSegment.intersects(testLine1, &intersectionPoint) == QLineF::BoundedIntersection)
-                                    || (lineSegment.intersects(testLine2, &intersectionPoint) == QLineF::BoundedIntersection)) {
-                                    // Choose THIS line to edit as we have
-                                    // clicked close enough to it...
-                                    mCustomLineSelectedRoom = room->getId();
-                                    mCustomLineSelectedExit = lineIterator.key();
-                                    repaint();
-                                    return;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            mCustomLineSelectedRoom = 0;
-            mCustomLineSelectedExit = "";
-        }
-
         if (context.isRoomBeingMoved) {
             // Moving rooms so end that
             mPick = true;
@@ -4273,23 +4194,6 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
     if (mInteractionDispatcher.dispatch(context)) {
         return;
     }
-
-    if (mCustomLineSelectedRoom != 0 && mCustomLineSelectedPoint >= 0) {
-        TRoom* room = mpMap->mpRoomDB->getRoom(mCustomLineSelectedRoom);
-        if (room) {
-            if (room->customLines.contains(mCustomLineSelectedExit)) {
-                if (room->customLines[mCustomLineSelectedExit].size() > mCustomLineSelectedPoint) {
-                    room->customLines[mCustomLineSelectedExit][mCustomLineSelectedPoint] = context.mapPoint;
-                    room->calcRoomDimensions();
-                    repaint();
-                    mpMap->setUnsaved(__func__);
-                    return;
-                }
-            }
-        }
-    }
-
-    mCustomLineSelectedPoint = -1;
 
     // Selection and label handling is delegated to interaction handlers.
 

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -49,6 +49,7 @@ class TArea;
 class TMap;
 class TRoom;
 struct MapInfoProperties;
+class CustomLineEditHandler;
 
 class QCheckBox;
 class QComboBox;
@@ -75,6 +76,8 @@ public:
     void wheelEvent(QWheelEvent*) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* e) override;
+
+    friend class CustomLineEditHandler;
 
     struct MapInteractionContext {
         QMouseEvent* event = nullptr;
@@ -302,6 +305,7 @@ private:
 
     InteractionDispatcher mInteractionDispatcher;
     std::unique_ptr<IInteractionHandler> mCustomLineDrawInteractionHandler;
+    std::unique_ptr<IInteractionHandler> mCustomLineEditInteractionHandler;
     std::unique_ptr<IInteractionHandler> mSelectionRectangleInteractionHandler;
     std::unique_ptr<IInteractionHandler> mLabelInteractionHandler;
     std::unique_ptr<IInteractionHandler> mPanInteractionHandler;

--- a/src/map/handlers/CustomLineEditHandler.cpp
+++ b/src/map/handlers/CustomLineEditHandler.cpp
@@ -1,0 +1,210 @@
+#include "map/handlers/CustomLineEditHandler.h"
+
+#include "TMap.h"
+#include "TRoom.h"
+#include "TRoomDB.h"
+
+#include "pre_guard.h"
+#include <QEvent>
+#include <QMouseEvent>
+#include <QPointF>
+#include <QLineF>
+#include <QMapIterator>
+#include <QSetIterator>
+#include "post_guard.h"
+
+#include <cmath>
+
+CustomLineEditHandler::CustomLineEditHandler(T2DMap& mapWidget)
+: mMapWidget(mapWidget)
+{
+}
+
+bool CustomLineEditHandler::matches(const T2DMap::MapInteractionContext& context) const
+{
+    if (!context.event || !mMapWidget.mpMap) {
+        return false;
+    }
+
+    const QEvent::Type eventType = context.event->type();
+
+    if (eventType == QEvent::MouseButtonPress) {
+        if (context.button != Qt::LeftButton) {
+            return false;
+        }
+
+        if (context.isMapViewOnly || context.hasMultiSelection || context.isCustomLineDrawing) {
+            return false;
+        }
+
+        return true;
+    }
+
+    if (eventType == QEvent::MouseMove) {
+        return mMapWidget.mCustomLineSelectedRoom != 0 && mMapWidget.mCustomLineSelectedPoint >= 0;
+    }
+
+    if (eventType == QEvent::MouseButtonRelease) {
+        if (context.button != Qt::LeftButton) {
+            return false;
+        }
+
+        return mMapWidget.mCustomLineSelectedPoint >= 0;
+    }
+
+    return false;
+}
+
+bool CustomLineEditHandler::handle(T2DMap::MapInteractionContext& context)
+{
+    if (!context.event) {
+        return false;
+    }
+
+    const QEvent::Type eventType = context.event->type();
+
+    if (eventType == QEvent::MouseButtonPress) {
+        return handleMousePress(context);
+    }
+
+    if (eventType == QEvent::MouseMove) {
+        return handleMouseMove(context);
+    }
+
+    if (eventType == QEvent::MouseButtonRelease) {
+        return handleMouseRelease();
+    }
+
+    return false;
+}
+
+bool CustomLineEditHandler::handleMousePress(T2DMap::MapInteractionContext& context)
+{
+    if (!mMapWidget.mpMap || !mMapWidget.mpMap->mpRoomDB || !context.area) {
+        resetSelection();
+        return false;
+    }
+
+    mMapWidget.mCustomLineSelectedPoint = -1;
+
+    const float mx = static_cast<float>(context.mapX);
+    const float my = static_cast<float>(context.mapY);
+    const QPointF& clickPoint = context.mapPoint;
+
+    QSetIterator<int> roomIterator(context.area->rooms);
+
+    while (roomIterator.hasNext()) {
+        const int currentRoomId = roomIterator.next();
+        TRoom* room = mMapWidget.mpMap->mpRoomDB->getRoom(currentRoomId);
+        if (!room) {
+            continue;
+        }
+
+        QMapIterator<QString, QList<QPointF>> lineIterator(room->customLines);
+        while (lineIterator.hasNext()) {
+            lineIterator.next();
+            const QList<QPointF>& linePoints = lineIterator.value();
+            if (linePoints.isEmpty()) {
+                continue;
+            }
+
+            float oldX = 0.0F;
+            float oldY = 0.0F;
+            float newX = 0.0F;
+            float newY = 0.0F;
+
+            for (int pointIndex = 0; pointIndex < linePoints.size(); ++pointIndex) {
+                if (pointIndex == 0) {
+                    oldX = room->x();
+                    oldY = room->y();
+                    newX = static_cast<float>(linePoints[0].x());
+                    newY = static_cast<float>(linePoints[0].y());
+                } else {
+                    oldX = newX;
+                    oldY = newY;
+                    newX = static_cast<float>(linePoints[pointIndex].x());
+                    newY = static_cast<float>(linePoints[pointIndex].y());
+                }
+
+                if (mMapWidget.mCustomLineSelectedRoom != 0) {
+                    if (std::fabs(mx - newX) <= 0.25F && std::fabs(my - newY) <= 0.25F) {
+                        mMapWidget.mCustomLineSelectedPoint = pointIndex;
+                        return true;
+                    }
+                }
+
+                const QLineF lineSegment(oldX, oldY, newX, newY);
+                const QLineF normalVector = lineSegment.normalVector();
+
+                QLineF testLine1;
+                testLine1.setP1(clickPoint);
+                testLine1.setAngle(normalVector.angle());
+                testLine1.setLength(0.1);
+
+                QLineF testLine2;
+                testLine2.setP1(clickPoint);
+                testLine2.setAngle(normalVector.angle());
+                testLine2.setLength(-0.1);
+
+                QPointF intersectionPoint;
+                const auto intersection1 = lineSegment.intersects(testLine1, &intersectionPoint);
+                const auto intersection2 = lineSegment.intersects(testLine2, &intersectionPoint);
+                if (intersection1 == QLineF::BoundedIntersection || intersection2 == QLineF::BoundedIntersection) {
+                    mMapWidget.mCustomLineSelectedRoom = room->getId();
+                    mMapWidget.mCustomLineSelectedExit = lineIterator.key();
+                    mMapWidget.mCustomLineSelectedPoint = -1;
+                    mMapWidget.repaint();
+                    return true;
+                }
+            }
+        }
+    }
+
+    resetSelection();
+    return false;
+}
+
+bool CustomLineEditHandler::handleMouseMove(T2DMap::MapInteractionContext& context)
+{
+    if (!mMapWidget.mpMap || !mMapWidget.mpMap->mpRoomDB) {
+        mMapWidget.mCustomLineSelectedPoint = -1;
+        return false;
+    }
+
+    TRoom* room = mMapWidget.mpMap->mpRoomDB->getRoom(mMapWidget.mCustomLineSelectedRoom);
+    if (!room) {
+        mMapWidget.mCustomLineSelectedPoint = -1;
+        return false;
+    }
+
+    if (!room->customLines.contains(mMapWidget.mCustomLineSelectedExit)) {
+        mMapWidget.mCustomLineSelectedPoint = -1;
+        return false;
+    }
+
+    QList<QPointF>& points = room->customLines[mMapWidget.mCustomLineSelectedExit];
+    if (mMapWidget.mCustomLineSelectedPoint < 0 || mMapWidget.mCustomLineSelectedPoint >= points.size()) {
+        mMapWidget.mCustomLineSelectedPoint = -1;
+        return false;
+    }
+
+    points[mMapWidget.mCustomLineSelectedPoint] = context.mapPoint;
+    room->calcRoomDimensions();
+    mMapWidget.repaint();
+    mMapWidget.mpMap->setUnsaved("CustomLineEditHandler::handleMouseMove");
+
+    return true;
+}
+
+bool CustomLineEditHandler::handleMouseRelease()
+{
+    mMapWidget.mCustomLineSelectedPoint = -1;
+    return false;
+}
+
+void CustomLineEditHandler::resetSelection()
+{
+    mMapWidget.mCustomLineSelectedRoom = 0;
+    mMapWidget.mCustomLineSelectedExit.clear();
+    mMapWidget.mCustomLineSelectedPoint = -1;
+}

--- a/src/map/handlers/CustomLineEditHandler.h
+++ b/src/map/handlers/CustomLineEditHandler.h
@@ -1,0 +1,23 @@
+#ifndef MUDLET_CUSTOMLINEEDITHANDLER_H
+#define MUDLET_CUSTOMLINEEDITHANDLER_H
+
+#include "T2DMap.h"
+
+class CustomLineEditHandler : public T2DMap::IInteractionHandler
+{
+public:
+    explicit CustomLineEditHandler(T2DMap& mapWidget);
+
+    bool matches(const T2DMap::MapInteractionContext& context) const override;
+    bool handle(T2DMap::MapInteractionContext& context) override;
+
+private:
+    bool handleMousePress(T2DMap::MapInteractionContext& context);
+    bool handleMouseMove(T2DMap::MapInteractionContext& context);
+    bool handleMouseRelease();
+    void resetSelection();
+
+    T2DMap& mMapWidget;
+};
+
+#endif // MUDLET_CUSTOMLINEEDITHANDLER_H


### PR DESCRIPTION
## Summary
- add a CustomLineEditHandler that encapsulates proximity checks and dragging updates for custom line editing
- register the handler with T2DMap and expose the state it needs to track selected rooms, exits, and points
- include the new handler sources in the build

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f1919f8204832a9f9ed798f612c9c9