### PR TITLE
Add handler for room move mode cleanup

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,6 +112,7 @@ set(mudlet_SRCS
     map/handlers/CustomLineDrawHandler.cpp
     map/handlers/CustomLineEditContextMenuHandler.cpp
     map/handlers/CustomLineEditHandler.cpp
+    map/handlers/RoomMoveActivationHandler.cpp
     map/handlers/LabelInteractionHandler.cpp
     map/handlers/PanInteractionHandler.cpp
     map/handlers/SelectionRectangleHandler.cpp
@@ -301,6 +302,7 @@ set(mudlet_HDRS
     map/handlers/CustomLineDrawHandler.h
     map/handlers/CustomLineEditContextMenuHandler.h
     map/handlers/CustomLineEditHandler.h
+    map/handlers/RoomMoveActivationHandler.h
     map/handlers/LabelInteractionHandler.h
     map/handlers/PanInteractionHandler.h
     map/handlers/SelectionRectangleHandler.h

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -34,6 +34,7 @@
 #include "map/handlers/CustomLineDrawHandler.h"
 #include "map/handlers/CustomLineEditContextMenuHandler.h"
 #include "map/handlers/CustomLineEditHandler.h"
+#include "map/handlers/RoomMoveActivationHandler.h"
 #include "map/handlers/LabelInteractionHandler.h"
 #include "map/handlers/PanInteractionHandler.h"
 #include "map/handlers/SelectionRectangleHandler.h"
@@ -186,6 +187,9 @@ T2DMap::T2DMap(QWidget* parent)
 
     mCustomLineEditInteractionHandler = std::make_unique<CustomLineEditHandler>(*this);
     registerInteractionHandler(mCustomLineEditInteractionHandler.get(), 350);
+
+    mRoomMoveActivationHandler = std::make_unique<RoomMoveActivationHandler>(*this);
+    registerInteractionHandler(mRoomMoveActivationHandler.get(), 300);
 
     mSelectionRectangleInteractionHandler = std::make_unique<SelectionRectangleHandler>(*this);
     registerInteractionHandler(mSelectionRectangleInteractionHandler.get(), 200);
@@ -2944,16 +2948,6 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
 
     mudlet::self()->activateProfile(mpHost);
     mNewMoveAction = true;
-    if (context.buttons & Qt::LeftButton) {
-        if (context.isRoomBeingMoved) {
-            // Moving rooms so end that
-            mPick = true;
-
-            setMouseTracking(false);
-            mRoomBeingMoved = false;
-        }
-    }
-
     TEvent sysMapWindowMousePressEvent{};
     sysMapWindowMousePressEvent.mArgumentList.append(QLatin1String("sysMapWindowMousePressEvent"));
     sysMapWindowMousePressEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -53,6 +53,7 @@ class CustomLineDrawContextMenuHandler;
 class CustomLineDrawHandler;
 class CustomLineEditContextMenuHandler;
 class CustomLineEditHandler;
+class RoomMoveActivationHandler;
 
 class QCheckBox;
 class QComboBox;
@@ -317,6 +318,7 @@ private:
     std::unique_ptr<IInteractionHandler> mCustomLineDrawInteractionHandler;
     std::unique_ptr<IInteractionHandler> mCustomLineEditContextMenuHandler;
     std::unique_ptr<IInteractionHandler> mCustomLineEditInteractionHandler;
+    std::unique_ptr<IInteractionHandler> mRoomMoveActivationHandler;
     std::unique_ptr<IInteractionHandler> mSelectionRectangleInteractionHandler;
     std::unique_ptr<IInteractionHandler> mLabelInteractionHandler;
     std::unique_ptr<IInteractionHandler> mPanInteractionHandler;

--- a/src/map/handlers/RoomMoveActivationHandler.cpp
+++ b/src/map/handlers/RoomMoveActivationHandler.cpp
@@ -1,0 +1,42 @@
+#include "map/handlers/RoomMoveActivationHandler.h"
+
+#include "pre_guard.h"
+#include <QMouseEvent>
+#include <QRect>
+#include "post_guard.h"
+
+RoomMoveActivationHandler::RoomMoveActivationHandler(T2DMap& mapWidget)
+: mMapWidget(mapWidget)
+{
+}
+
+bool RoomMoveActivationHandler::matches(const T2DMap::MapInteractionContext& context) const
+{
+    if (!context.event) {
+        return false;
+    }
+
+    if (!context.isRoomBeingMoved) {
+        return false;
+    }
+
+    return context.event->type() == QEvent::MouseButtonPress
+        && context.button == Qt::LeftButton;
+}
+
+bool RoomMoveActivationHandler::handle(T2DMap::MapInteractionContext& context)
+{
+    if (!context.event || !context.isRoomBeingMoved) {
+        return false;
+    }
+
+    mMapWidget.mPopupMenu = false;
+    mMapWidget.mPick = true;
+    mMapWidget.setMouseTracking(false);
+    mMapWidget.mRoomBeingMoved = false;
+    mMapWidget.mMultiRect = QRect(0, 0, 0, 0);
+
+    context.isRoomBeingMoved = false;
+
+    return false;
+}

--- a/src/map/handlers/RoomMoveActivationHandler.h
+++ b/src/map/handlers/RoomMoveActivationHandler.h
@@ -1,0 +1,18 @@
+#ifndef MUDLET_ROOMMOVEACTIVATIONHANDLER_H
+#define MUDLET_ROOMMOVEACTIVATIONHANDLER_H
+
+#include "T2DMap.h"
+
+class RoomMoveActivationHandler : public T2DMap::IInteractionHandler
+{
+public:
+    explicit RoomMoveActivationHandler(T2DMap& mapWidget);
+
+    bool matches(const T2DMap::MapInteractionContext& context) const override;
+    bool handle(T2DMap::MapInteractionContext& context) override;
+
+private:
+    T2DMap& mMapWidget;
+};
+
+#endif // MUDLET_ROOMMOVEACTIVATIONHANDLER_H


### PR DESCRIPTION
## Summary
- add a RoomMoveActivationHandler to clean up move mode state when the left mouse button is pressed
- ensure the handler clears popup state, resets move rectangles, and hands control back to selection logic
- register the new handler and include it in the build system

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f1977c26e4832a9fafa40a11df9cf4