### PR TITLE
Refactor room drag handling into interaction handler

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,6 +113,7 @@ set(mudlet_SRCS
     map/handlers/CustomLineEditContextMenuHandler.cpp
     map/handlers/CustomLineEditHandler.cpp
     map/handlers/RoomMoveActivationHandler.cpp
+    map/handlers/RoomMoveDragHandler.cpp
     map/handlers/LabelInteractionHandler.cpp
     map/handlers/PanInteractionHandler.cpp
     map/handlers/SelectionRectangleHandler.cpp
@@ -303,6 +304,7 @@ set(mudlet_HDRS
     map/handlers/CustomLineEditContextMenuHandler.h
     map/handlers/CustomLineEditHandler.h
     map/handlers/RoomMoveActivationHandler.h
+    map/handlers/RoomMoveDragHandler.h
     map/handlers/LabelInteractionHandler.h
     map/handlers/PanInteractionHandler.h
     map/handlers/SelectionRectangleHandler.h

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -35,6 +35,7 @@
 #include "map/handlers/CustomLineEditContextMenuHandler.h"
 #include "map/handlers/CustomLineEditHandler.h"
 #include "map/handlers/RoomMoveActivationHandler.h"
+#include "map/handlers/RoomMoveDragHandler.h"
 #include "map/handlers/LabelInteractionHandler.h"
 #include "map/handlers/PanInteractionHandler.h"
 #include "map/handlers/SelectionRectangleHandler.h"
@@ -190,6 +191,9 @@ T2DMap::T2DMap(QWidget* parent)
 
     mRoomMoveActivationHandler = std::make_unique<RoomMoveActivationHandler>(*this);
     registerInteractionHandler(mRoomMoveActivationHandler.get(), 300);
+
+    mRoomMoveDragHandler = std::make_unique<RoomMoveDragHandler>(*this);
+    registerInteractionHandler(mRoomMoveDragHandler.get(), 290);
 
     mSelectionRectangleInteractionHandler = std::make_unique<SelectionRectangleHandler>(*this);
     registerInteractionHandler(mSelectionRectangleInteractionHandler.get(), 200);
@@ -4087,56 +4091,6 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
     }
 
     // Selection and label handling is delegated to interaction handlers.
-
-    if (mRoomBeingMoved && !mSizeLabel && !mMultiSelectionSet.isEmpty()) {
-        mMultiRect = QRect(0, 0, 0, 0);
-        if (!mpMap->mpRoomDB->getRoom(mRoomID)) {
-            return;
-        }
-        TArea* pArea = mpMap->mpRoomDB->getArea(mAreaID);
-        if (!pArea) {
-            return;
-        }
-
-        if (!getCenterSelection()) {
-            return;
-        }
-
-        TRoom* room = mpMap->mpRoomDB->getRoom(mMultiSelectionHighlightRoomId);
-        if (!room) {
-            return;
-        }
-
-        const int dx = qRound(context.mapX) - room->x();
-        const int dy = qRound(context.mapY) - room->y();
-        QSetIterator<int> itRoom = mMultiSelectionSet;
-        while (itRoom.hasNext()) {
-            room = mpMap->mpRoomDB->getRoom(itRoom.next());
-            if (room) {
-                room->offset(dx, dy, 0);
-                // Previously we would move all the rooms to the same level as
-                // the center room but this is not really helpful as it
-                // squashes multiple levels of rooms all onto the same level!
-
-                QMapIterator<QString, QList<QPointF>> itk(room->customLines);
-                QMap<QString, QList<QPointF>> newMap;
-                while (itk.hasNext()) {
-                    itk.next();
-                    QList<QPointF> _pL = itk.value();
-                    for (auto& point : _pL) {
-                        const QPointF op = point;
-                        point.setX(static_cast<float>(op.x() + dx));
-                        point.setY(static_cast<float>(op.y() + dy));
-                    }
-                    newMap.insert(itk.key(), _pL);
-                }
-                room->customLines = newMap;
-                room->calcRoomDimensions();
-            }
-        }
-        repaint();
-        mpMap->setUnsaved(__func__);
-    }
 }
 
 // Replacement for getTopLeftCenter - determines a room closest to geometrical

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -54,6 +54,7 @@ class CustomLineDrawHandler;
 class CustomLineEditContextMenuHandler;
 class CustomLineEditHandler;
 class RoomMoveActivationHandler;
+class RoomMoveDragHandler;
 
 class QCheckBox;
 class QComboBox;
@@ -319,6 +320,7 @@ private:
     std::unique_ptr<IInteractionHandler> mCustomLineEditContextMenuHandler;
     std::unique_ptr<IInteractionHandler> mCustomLineEditInteractionHandler;
     std::unique_ptr<IInteractionHandler> mRoomMoveActivationHandler;
+    std::unique_ptr<IInteractionHandler> mRoomMoveDragHandler;
     std::unique_ptr<IInteractionHandler> mSelectionRectangleInteractionHandler;
     std::unique_ptr<IInteractionHandler> mLabelInteractionHandler;
     std::unique_ptr<IInteractionHandler> mPanInteractionHandler;

--- a/src/map/handlers/RoomMoveDragHandler.cpp
+++ b/src/map/handlers/RoomMoveDragHandler.cpp
@@ -1,0 +1,103 @@
+#include "map/handlers/RoomMoveDragHandler.h"
+
+#include "TArea.h"
+#include "TRoom.h"
+#include "TRoomDB.h"
+
+#include "pre_guard.h"
+#include <QMouseEvent>
+#include <QPointF>
+#include <QRect>
+#include <QSet>
+#include <QtGlobal>
+#include "post_guard.h"
+
+RoomMoveDragHandler::RoomMoveDragHandler(T2DMap& mapWidget)
+: mMapWidget(mapWidget)
+{
+}
+
+bool RoomMoveDragHandler::matches(const T2DMap::MapInteractionContext& context) const
+{
+    if (!context.event) {
+        return false;
+    }
+
+    if (!context.isRoomBeingMoved || context.isSizingLabel || !context.hasMultiSelection) {
+        return false;
+    }
+
+    if (!context.multiSelectionSet || context.multiSelectionSet->isEmpty()) {
+        return false;
+    }
+
+    return context.event->type() == QEvent::MouseMove;
+}
+
+bool RoomMoveDragHandler::handle(T2DMap::MapInteractionContext& context)
+{
+    if (!context.event || context.event->type() != QEvent::MouseMove) {
+        return false;
+    }
+
+    if (!context.isRoomBeingMoved || context.isSizingLabel || !context.multiSelectionSet || context.multiSelectionSet->isEmpty()) {
+        return false;
+    }
+
+    if (!mMapWidget.mpMap || !mMapWidget.mpMap->mpRoomDB) {
+        return false;
+    }
+
+    mMapWidget.mMultiRect = QRect(0, 0, 0, 0);
+
+    auto* roomDb = mMapWidget.mpMap->mpRoomDB;
+    if (!roomDb->getRoom(mMapWidget.mRoomID)) {
+        return false;
+    }
+
+    if (!roomDb->getArea(mMapWidget.mAreaID)) {
+        return false;
+    }
+
+    if (!mMapWidget.getCenterSelection()) {
+        return false;
+    }
+
+    TRoom* referenceRoom = roomDb->getRoom(mMapWidget.mMultiSelectionHighlightRoomId);
+    if (!referenceRoom) {
+        return false;
+    }
+
+    const int dx = qRound(context.mapX) - referenceRoom->x();
+    const int dy = qRound(context.mapY) - referenceRoom->y();
+
+    QSetIterator<int> roomIterator = mMapWidget.mMultiSelectionSet;
+    while (roomIterator.hasNext()) {
+        TRoom* room = roomDb->getRoom(roomIterator.next());
+        if (!room) {
+            continue;
+        }
+
+        room->offset(dx, dy, 0);
+
+        QMapIterator<QString, QList<QPointF>> customLineIterator(room->customLines);
+        QMap<QString, QList<QPointF>> updatedLines;
+        while (customLineIterator.hasNext()) {
+            customLineIterator.next();
+            QList<QPointF> points = customLineIterator.value();
+            for (auto& point : points) {
+                const QPointF originalPoint = point;
+                point.setX(static_cast<float>(originalPoint.x() + dx));
+                point.setY(static_cast<float>(originalPoint.y() + dy));
+            }
+            updatedLines.insert(customLineIterator.key(), points);
+        }
+        room->customLines = updatedLines;
+        room->calcRoomDimensions();
+    }
+
+    mMapWidget.repaint();
+    mMapWidget.mpMap->setUnsaved(__func__);
+
+    return true;
+}

--- a/src/map/handlers/RoomMoveDragHandler.h
+++ b/src/map/handlers/RoomMoveDragHandler.h
@@ -1,0 +1,18 @@
+#ifndef MUDLET_ROOMMOVEDRAGHANDLER_H
+#define MUDLET_ROOMMOVEDRAGHANDLER_H
+
+#include "T2DMap.h"
+
+class RoomMoveDragHandler : public T2DMap::IInteractionHandler
+{
+public:
+    explicit RoomMoveDragHandler(T2DMap& mapWidget);
+
+    bool matches(const T2DMap::MapInteractionContext& context) const override;
+    bool handle(T2DMap::MapInteractionContext& context) override;
+
+private:
+    T2DMap& mMapWidget;
+};
+
+#endif // MUDLET_ROOMMOVEDRAGHANDLER_H


### PR DESCRIPTION
## Summary
- add a RoomMoveDragHandler that handles multi-room drag updates during map movement
- register the new handler with the interaction dispatcher and remove the duplicated mouseMoveEvent logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f19d0ce0d0832aaf336f304869d5eb