### PR TITLE
Fix map handler build errors by adjusting includes and friends

### DIFF
--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -86,6 +86,8 @@ public:
     friend class CustomLineDrawHandler;
     friend class CustomLineEditContextMenuHandler;
     friend class CustomLineEditHandler;
+    friend class RoomMoveDragHandler;
+    friend class SelectionRectangleHandler;
 
     struct MapInteractionContext {
         QMouseEvent* event = nullptr;

--- a/src/map/handlers/CustomLineEditHandler.cpp
+++ b/src/map/handlers/CustomLineEditHandler.cpp
@@ -1,6 +1,7 @@
 #include "map/handlers/CustomLineEditHandler.h"
 
 #include "TMap.h"
+#include "TArea.h"
 #include "TRoom.h"
 #include "TRoomDB.h"
 


### PR DESCRIPTION
## Summary
- include the TArea definition in the custom line edit handler to allow room iteration
- grant the room move and selection handlers friend access to T2DMap internals so they can update selection state

## Testing
- not run (Qt 6.9 build dependencies unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68f1a3314ac4832a81bd90d7bc99a597