### PR TITLE
Refactor single-click map selection handling

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -93,6 +93,69 @@ void T2DMap::registerInteractionHandler(IInteractionHandler* handler, int priori
     mInteractionDispatcher.registerHandler(handler, priority);
 }
 
+void T2DMap::prepareSingleClickSelection(MapInteractionContext& context)
+{
+    mMultiRect = QRect(context.widgetPosition, context.widgetPosition);
+
+    if (!mpMap || !mpMap->mpRoomDB) {
+        return;
+    }
+
+    auto* area = context.area;
+    if (!area) {
+        return;
+    }
+
+    const float fx = ((xspan / 2.0f) - mMapCenterX) * mRoomWidth;
+    const float fy = ((yspan / 2.0f) - mMapCenterY) * mRoomHeight;
+
+    QSetIterator<int> roomIterator(area->getAreaRooms());
+    while (roomIterator.hasNext()) {
+        const int roomId = roomIterator.next();
+        TRoom* room = mpMap->mpRoomDB->getRoom(roomId);
+        if (!room) {
+            continue;
+        }
+
+        const int rx = room->x() * mRoomWidth + fx;
+        const int ry = room->y() * -1 * mRoomHeight + fy;
+        const int rz = room->z();
+
+        const int mx = context.widgetPosition.x();
+        const int my = context.widgetPosition.y();
+        const int mz = mMapCenterZ;
+
+        if ((qAbs(mx - rx) < qRound(mRoomWidth * rSize / 2.0))
+            && (qAbs(my - ry) < qRound(mRoomHeight * rSize / 2.0))
+            && (mz == rz)) {
+            if (mMultiSelectionSet.contains(roomId) && context.modifiers.testFlag(Qt::ControlModifier)) {
+                mMultiSelectionSet.remove(roomId);
+            } else {
+                mMultiSelectionSet.insert(roomId);
+            }
+
+            if (!mMultiSelectionSet.empty()) {
+                mMultiSelection = false;
+            }
+        }
+    }
+
+    const int selectionSize = mMultiSelectionSet.size();
+    switch (selectionSize) {
+    case 0:
+        mMultiSelectionHighlightRoomId = 0;
+        break;
+    case 1:
+        mMultiSelection = false;
+        mMultiSelectionHighlightRoomId = *(mMultiSelectionSet.begin());
+        break;
+    default:
+        mMultiSelection = false;
+        getCenterSelection();
+        break;
+    }
+}
+
 void T2DMap::InteractionDispatcher::registerHandler(IInteractionHandler* handler, int priority)
 {
     if (!handler) {
@@ -2647,52 +2710,9 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
 
         auto* pArea = context.area;
         if (!context.isLabelHighlighted && mCustomLineSelectedRoom == 0) {
-            mMultiRect = QRect(context.widgetPosition, context.widgetPosition);
-            const float fx = ((xspan / 2.0) - mMapCenterX) * mRoomWidth;
-            const float fy = ((yspan / 2.0) - mMapCenterY) * mRoomHeight;
-
-            if (pArea) {
-                QSetIterator<int> itRoom(pArea->getAreaRooms());
-                while (itRoom.hasNext()) { // Scan to find rooms in selection
-                    const int currentAreaRoom = itRoom.next();
-                    TRoom *room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
-                    if (!room) {
-                        continue;
-                    }
-                    const int rx = room->x() * mRoomWidth + fx;
-                    const int ry = room->y() * -1 * mRoomHeight + fy;
-                    const int rz = room->z();
-
-                    const int mx = context.widgetPosition.x();
-                    const int my = context.widgetPosition.y();
-                    const int mz = mMapCenterZ;
-                    if ((abs(mx - rx) < qRound(mRoomWidth * rSize / 2.0)) && (abs(my - ry) < qRound(mRoomHeight * rSize / 2.0)) && (mz == rz)) {
-                        if (mMultiSelectionSet.contains(currentAreaRoom) && context.modifiers.testFlag(Qt::ControlModifier)) {
-                            mMultiSelectionSet.remove(currentAreaRoom);
-                        } else {
-                            mMultiSelectionSet.insert(currentAreaRoom);
-                        }
-
-                        if (!mMultiSelectionSet.empty()) {
-                            mMultiSelection = false;
-                        }
-                    }
-                }
-            }
+            prepareSingleClickSelection(context);
 
             const int selectionSize = mMultiSelectionSet.size();
-            switch (selectionSize) {
-                case 0:
-                    mMultiSelectionHighlightRoomId = 0;
-                    break;
-                case 1:
-                    mMultiSelection = false; // OK, found one room so stop
-                    mMultiSelectionHighlightRoomId = *(mMultiSelectionSet.begin());
-                    break;
-                default:
-                    mMultiSelection = false; // OK, found more than one room so stop
-                    getCenterSelection();
-            }
 
             if (!mpMap->mpRoomDB || mpMap->mpRoomDB->isEmpty()) {
                 // No map loaded

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -126,6 +126,7 @@ public:
     };
 
     void registerInteractionHandler(IInteractionHandler* handler, int priority);
+    void prepareSingleClickSelection(MapInteractionContext& context);
 
     // Was getTopLeft() which returned an index into mMultiSelectionList but that
     // has been been changed to mMultiSelectionSet which cannot be accessed via

--- a/src/map/handlers/SelectionRectangleHandler.cpp
+++ b/src/map/handlers/SelectionRectangleHandler.cpp
@@ -82,9 +82,6 @@ bool SelectionRectangleHandler::handleMousePress(T2DMap::MapInteractionContext& 
         return true;
     }
 
-    const float fx = (static_cast<float>(mMapWidget.xspan) / 2.0f - static_cast<float>(mMapWidget.mMapCenterX)) * mMapWidget.mRoomWidth;
-    const float fy = (static_cast<float>(mMapWidget.yspan) / 2.0f - static_cast<float>(mMapWidget.mMapCenterY)) * mMapWidget.mRoomHeight;
-
     if (!context.modifiers.testFlag(Qt::ControlModifier)) {
         if (!mMapWidget.mMapViewOnly) {
             mMapWidget.mHelpMsg = T2DMap::tr("Drag to select multiple rooms or labels, release to finish...");
@@ -92,51 +89,10 @@ bool SelectionRectangleHandler::handleMousePress(T2DMap::MapInteractionContext& 
         mMapWidget.mMultiSelectionSet.clear();
     }
 
-    QSetIterator<int> itRoom(area->getAreaRooms());
-    while (itRoom.hasNext()) {
-        const int currentAreaRoom = itRoom.next();
-        TRoom* room = mMapWidget.mpMap->mpRoomDB->getRoom(currentAreaRoom);
-        if (!room) {
-            continue;
-        }
+    mMapWidget.prepareSingleClickSelection(context);
 
-        const int rx = room->x() * mMapWidget.mRoomWidth + fx;
-        const int ry = room->y() * -1 * mMapWidget.mRoomHeight + fy;
-        const int rz = room->z();
-
-        const int mx = context.widgetPosition.x();
-        const int my = context.widgetPosition.y();
-        const int mz = mMapWidget.mMapCenterZ;
-
-        if ((qAbs(mx - rx) < qRound(mMapWidget.mRoomWidth * mMapWidget.rSize / 2.0))
-            && (qAbs(my - ry) < qRound(mMapWidget.mRoomHeight * mMapWidget.rSize / 2.0))
-            && (mz == rz)) {
-            if (mMapWidget.mMultiSelectionSet.contains(currentAreaRoom) && context.modifiers.testFlag(Qt::ControlModifier)) {
-                mMapWidget.mMultiSelectionSet.remove(currentAreaRoom);
-            } else {
-                mMapWidget.mMultiSelectionSet.insert(currentAreaRoom);
-            }
-
-            if (!mMapWidget.mMultiSelectionSet.empty()) {
-                mMapWidget.mMultiSelection = false;
-            }
-        }
-    }
-
-    switch (mMapWidget.mMultiSelectionSet.size()) {
-    case 0:
-        mMapWidget.mMultiSelectionHighlightRoomId = 0;
-        break;
-    case 1:
-        mMapWidget.mMultiSelection = false;
-        mMapWidget.mMultiSelectionHighlightRoomId = *(mMapWidget.mMultiSelectionSet.begin());
+    if (!mMapWidget.mMultiSelectionSet.empty()) {
         mMapWidget.mHelpMsg.clear();
-        break;
-    default:
-        mMapWidget.mMultiSelection = false;
-        mMapWidget.mHelpMsg.clear();
-        mMapWidget.getCenterSelection();
-        break;
     }
 
     if (mMapWidget.mMultiSelection && !mMapWidget.mMultiSelectionSet.empty() && context.modifiers.testFlag(Qt::ControlModifier)) {


### PR DESCRIPTION
## Summary
- add a T2DMap helper that centralises single-click selection toggling and highlight bookkeeping
- reuse the helper from the map widget and the selection rectangle handler to remove duplicate logic

## Testing
- not run (GUI interaction requires manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68f1a4f81d38832a95785f6ffb3b5fa8