### PR TITLE
Add room context menu interaction handler

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,6 +112,7 @@ set(mudlet_SRCS
     map/handlers/CustomLineDrawHandler.cpp
     map/handlers/CustomLineEditContextMenuHandler.cpp
     map/handlers/CustomLineEditHandler.cpp
+    map/handlers/RoomContextMenuHandler.cpp
     map/handlers/RoomMoveActivationHandler.cpp
     map/handlers/RoomMoveDragHandler.cpp
     map/handlers/LabelInteractionHandler.cpp

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -34,6 +34,7 @@
 #include "map/handlers/CustomLineDrawHandler.h"
 #include "map/handlers/CustomLineEditContextMenuHandler.h"
 #include "map/handlers/CustomLineEditHandler.h"
+#include "map/handlers/RoomContextMenuHandler.h"
 #include "map/handlers/RoomMoveActivationHandler.h"
 #include "map/handlers/RoomMoveDragHandler.h"
 #include "map/handlers/LabelInteractionHandler.h"
@@ -55,6 +56,8 @@
 #include <QtEvents>
 #include <QtUiTools>
 #include <QStandardPaths>
+#include <QAction>
+#include <QMenu>
 #include "post_guard.h"
 
 #include "mapInfoContributorManager.h"
@@ -251,6 +254,9 @@ T2DMap::T2DMap(QWidget* parent)
 
     mCustomLineEditInteractionHandler = std::make_unique<CustomLineEditHandler>(*this);
     registerInteractionHandler(mCustomLineEditInteractionHandler.get(), 350);
+
+    mRoomContextMenuHandler = std::make_unique<RoomContextMenuHandler>(*this);
+    registerInteractionHandler(mRoomContextMenuHandler.get(), 340);
 
     mRoomMoveActivationHandler = std::make_unique<RoomMoveActivationHandler>(*this);
     registerInteractionHandler(mRoomMoveActivationHandler.get(), 300);
@@ -2703,230 +2709,31 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
 
     // Left button release and label move clean-up are handled by interaction handlers.
 
-    if (context.button == Qt::RightButton) {
+    if (context.button == Qt::RightButton && mLabelHighlighted) {
         auto popup = new QMenu(this);
         popup->setToolTipsVisible(true);
         popup->setAttribute(Qt::WA_DeleteOnClose);
 
-        auto* pArea = context.area;
-        if (!context.isLabelHighlighted && mCustomLineSelectedRoom == 0) {
-            prepareSingleClickSelection(context);
+        //: 2D Mapper context menu (label) item
+        auto moveLabel = new QAction(tr("Move"), this);
+        //: 2D Mapper context menu item (label) tooltip
+        moveLabel->setToolTip(tr("Move label"));
+        connect(moveLabel, &QAction::triggered, this, &T2DMap::slot_moveLabel);
+        //: 2D Mapper context menu (label) item
+        auto deleteLabel = new QAction(tr("Delete"), this);
+        //: 2D Mapper context menu (label) item tooltip
+        deleteLabel->setToolTip(tr("Delete label"));
+        connect(deleteLabel, &QAction::triggered, this, &T2DMap::slot_deleteLabel);
+        popup->addAction(moveLabel);
+        popup->addAction(deleteLabel);
 
-            const int selectionSize = mMultiSelectionSet.size();
-
-            if (!mpMap->mpRoomDB || mpMap->mpRoomDB->isEmpty()) {
-                // No map loaded
-                //: 2D Mapper context menu (no map found) item
-                auto createMap = new QAction(tr("Create new map"), this);
-                connect(createMap, &QAction::triggered, this, &T2DMap::slot_newMap);
-                //: 2D Mapper context menu (no map found) item
-                auto loadMap = new QAction(tr("Load map"), this);
-                connect(loadMap, &QAction::triggered, this, &T2DMap::slot_loadMap);
-
-                popup->addAction(createMap);
-                popup->addAction(loadMap);
-
-                mPopupMenu = true;
-                popup->popup(mapToGlobal(context.widgetPosition));
-                return;
-            }
-            // Else there is a map - though it might not have ANY rooms!
-
-            if (!mMapViewOnly) {
-                if (selectionSize == 0) {
-                    auto [x, y] = getMousePosition();
-                    mContextMenuClickPosition = {x, y}; // Remember position of original right-click to create room there!
-                    //: Menu option to create a new room in the mapper
-                    mpCreateRoomAction = new QAction(tr("Create new room here"), this);
-                    connect(mpCreateRoomAction.data(), &QAction::triggered, this, &T2DMap::slot_createRoom);
-                    popup->addAction(mpCreateRoomAction);
-                }
-
-                if (selectionSize > 0) {
-                    //: 2D Mapper context menu (room) item
-                    auto moveRoom = new QAction(tr("Move"), this);
-                    connect(moveRoom, &QAction::triggered, this, &T2DMap::slot_moveRoom);
-                    popup->addAction(moveRoom);
-                }
-
-                if (selectionSize > 0) {
-                    //: 2D Mapper context menu (room) item
-                    auto roomProperties = new QAction(tr("Configure room..."), this);
-                    //: 2D Mapper context menu (room) item tooltip
-                    roomProperties->setToolTip(utils::richText(tr("Set room's name and color of icon, weight and lock for speed walks, and a symbol to mark special rooms")));
-                    connect(roomProperties, &QAction::triggered, this, &T2DMap::slot_showPropertiesDialog);
-                    popup->addAction(roomProperties);
-                }
-
-                if (selectionSize == 1) {
-                    //: 2D Mapper context menu (room) item
-                    auto roomExits = new QAction(tr("Set exits..."), this);
-                    connect(roomExits, &QAction::triggered, this, &T2DMap::slot_setExits);
-                    popup->addAction(roomExits);
-                }
-
-                if (selectionSize == 1) {
-                    //: 2D Mapper context menu (room) item
-                    auto customExitLine = new QAction(tr("Create exit line..."), this);
-                    if (pArea && !pArea->gridMode) {
-                        //: 2D Mapper context menu (room) item tooltip (enabled state)
-                        customExitLine->setToolTip(utils::richText(tr("Replace an exit line with a custom line")));
-                        connect(customExitLine, &QAction::triggered, this, &T2DMap::slot_setCustomLine);
-                    } else {
-                        // Disable custom exit lines in grid mode as they aren't visible anyway
-                        //: 2D Mapper context menu (room) item tooltip (disabled state)
-                        customExitLine->setToolTip(utils::richText(tr("Custom exit lines are not shown and are not editable in grid mode")));
-                        customExitLine->setEnabled(false);
-                    }
-                    popup->addAction(customExitLine);
-                }
-
-
-                if (selectionSize > 1) {
-                    //: 2D Mapper context menu (room) item
-                    auto spreadRooms = new QAction(tr("Spread..."), this);
-                    //: 2D Mapper context menu (room) item tooltip
-                    spreadRooms->setToolTip(utils::richText(tr("Increase map X-Y spacing for the selected group of rooms")));
-                    connect(spreadRooms, &QAction::triggered, this, &T2DMap::slot_spread);
-                    popup->addAction(spreadRooms);
-                }
-
-                if (selectionSize > 1) {
-                    //: 2D Mapper context menu (room) item
-                    auto shrinkRooms = new QAction(tr("Shrink..."), this);
-                    //: 2D Mapper context menu (room) item tooltip
-                    shrinkRooms->setToolTip(utils::richText(tr("Decrease map X-Y spacing for the selected group of rooms")));
-                    connect(shrinkRooms, &QAction::triggered, this, &T2DMap::slot_shrink);
-                    popup->addAction(shrinkRooms);
-                }
-
-                if (selectionSize > 0) {
-                    //: 2D Mapper context menu (room) item
-                    auto deleteRoom = new QAction(tr("Delete"), this);
-                    connect(deleteRoom, &QAction::triggered, this, &T2DMap::slot_deleteRoom);
-                    popup->addAction(deleteRoom);
-                }
-
-                if (selectionSize > 0) {
-                    //: 2D Mapper context menu (room) item
-                    auto moveRoomXY = new QAction(tr("Move to position..."), this);
-                    //: 2D Mapper context menu (room) item tooltip
-                    moveRoomXY->setToolTip(utils::richText(tr("Move selected room or group of rooms to the given coordinates in this area")));
-                    connect(moveRoomXY, &QAction::triggered, this, &T2DMap::slot_movePosition);
-                    popup->addAction(moveRoomXY);
-                }
-
-                if (selectionSize > 0) {
-                    //: 2D Mapper context menu (room) item
-                    auto roomArea = new QAction(tr("Move to area..."), this);
-                    connect(roomArea, &QAction::triggered, this, &T2DMap::slot_setArea);
-                    popup->addAction(roomArea);
-                }
-                //: 2D Mapper context menu (room) item
-                auto createLabel = new QAction(tr("Create label..."), this);
-                //: 2D Mapper context menu (room) item tooltip
-                createLabel->setToolTip(utils::richText(tr("Create label to show text or an image")));
-                connect(createLabel, &QAction::triggered, this, &T2DMap::slot_createLabel);
-                popup->addAction(createLabel);
-
-                //: 2D Mapper context menu (area) item
-                auto exportAreaImage = new QAction(tr("Export area to image..."), this);
-                //: 2D Mapper context menu (area) item tooltip
-                exportAreaImage->setToolTip(utils::richText(tr("Export the current area as an image file")));
-                connect(exportAreaImage, &QAction::triggered, this, &T2DMap::slot_exportAreaToImage);
-                popup->addAction(exportAreaImage);
-            }
-
-            if (selectionSize == 1) {
-                //: 2D Mapper context menu (room) item
-                auto setPlayerLocation = new QAction(tr("Set player location"), this);
-                //: 2D Mapper context menu (room) item tooltip (enabled state)
-                setPlayerLocation->setToolTip(utils::richText(tr("Set the player's current location to here")));
-                connect(setPlayerLocation, &QAction::triggered, this, &T2DMap::slot_setPlayerLocation);
-                popup->addAction(setPlayerLocation);
-            }
-
-            popup->addSeparator();
-
-            const QString viewModeItem = context.isMapViewOnly ?
-                //: 2D Mapper context menu (room) item
-                tr("Switch to editing mode") :
-                //: 2D Mapper context menu (room) item
-                tr("Switch to viewing mode");
-            auto setMapViewOnly = new QAction(viewModeItem, this);
-            connect(setMapViewOnly, &QAction::triggered, this, &T2DMap::slot_toggleMapViewOnly);
-            popup->addAction(setMapViewOnly);
-
-        } else if (mLabelHighlighted) {
-            //: 2D Mapper context menu (label) item
-            auto moveLabel = new QAction(tr("Move"), this);
-            //: 2D Mapper context menu item (label) tooltip
-            moveLabel->setToolTip(tr("Move label"));
-            connect(moveLabel, &QAction::triggered, this, &T2DMap::slot_moveLabel);
-            //: 2D Mapper context menu (label) item
-            auto deleteLabel = new QAction(tr("Delete"), this);
-            //: 2D Mapper context menu (label) item tooltip
-            deleteLabel->setToolTip(tr("Delete label"));
-            connect(deleteLabel, &QAction::triggered, this, &T2DMap::slot_deleteLabel);
-            popup->addAction(moveLabel);
-            popup->addAction(deleteLabel);
-        }
-        //this is placed at the end since it is likely someone will want to hook anywhere
-        QMap<QString, QMenu*> userMenus;
-        QMapIterator<QString, QStringList> it(mUserMenus);
-        while (it.hasNext()) {
-            it.next();
-            QStringList menuInfo = it.value();
-            const QString displayName = menuInfo[1];
-            // Need to give the top-level context menu as the parent so the
-            // sub-menus get destroyed at the right time:
-            auto userMenu = new QMenu(displayName, popup);
-            userMenus.insert(it.key(), userMenu);
-        }
-        it.toFront();
-        while (it.hasNext()) {
-            //take care of nested menus now since they're all made
-            it.next();
-            QStringList menuInfo = it.value();
-            const QString menuParent = menuInfo[0];
-            if (menuParent.isEmpty()) { //parentless
-                popup->addMenu(userMenus[it.key()]);
-            } else { //has a parent
-                userMenus[menuParent]->addMenu(userMenus[it.key()]);
-            }
-        }
-        //add our actions
-        QMapIterator<QString, QStringList> it2(mUserActions);
-        auto mapper = new QSignalMapper(popup);
-
-        while (it2.hasNext()) {
-            it2.next();
-            QStringList actionInfo = it2.value();
-            auto action = new QAction(actionInfo.at(2), this);
-            if (actionInfo.at(1).isEmpty()) { //no parent
-                popup->addAction(action);
-            } else if (userMenus.contains(actionInfo.at(1))) {
-                userMenus[actionInfo[1]]->addAction(action);
-            } else {
-                delete action;
-                continue;
-            }
-            mapper->setMapping(action, it2.key());
-            // TODO: QSignalMapper is not completely compatible with the functor
-            // style of QObject::connect(...) - it has been declared obsolete
-            // and should be replaced with lambda functions to perform what the
-            // slot method did...
-            connect(action, &QAction::triggered, mapper, qOverload<>(&QSignalMapper::map));
-        }
-        // In relation to above "TODO" in the meantime we can handle things
-        // by a change to one of a group of newer signals with a specific
-        // signature:
-        connect(mapper, &QSignalMapper::mappedString, this, &T2DMap::slot_userAction);
-
-        // After all has been added, finally have Qt display the context menu as a whole
         mPopupMenu = true;
         popup->popup(mapToGlobal(context.widgetPosition));
+        update();
+
+        return;
     }
+
 }
 
 bool T2DMap::event(QEvent* event)

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -55,6 +55,7 @@ class CustomLineEditContextMenuHandler;
 class CustomLineEditHandler;
 class RoomMoveActivationHandler;
 class RoomMoveDragHandler;
+class RoomContextMenuHandler;
 
 class QCheckBox;
 class QComboBox;
@@ -86,6 +87,7 @@ public:
     friend class CustomLineDrawHandler;
     friend class CustomLineEditContextMenuHandler;
     friend class CustomLineEditHandler;
+    friend class RoomContextMenuHandler;
     friend class RoomMoveDragHandler;
     friend class SelectionRectangleHandler;
 
@@ -322,6 +324,7 @@ private:
     std::unique_ptr<IInteractionHandler> mCustomLineDrawInteractionHandler;
     std::unique_ptr<IInteractionHandler> mCustomLineEditContextMenuHandler;
     std::unique_ptr<IInteractionHandler> mCustomLineEditInteractionHandler;
+    std::unique_ptr<IInteractionHandler> mRoomContextMenuHandler;
     std::unique_ptr<IInteractionHandler> mRoomMoveActivationHandler;
     std::unique_ptr<IInteractionHandler> mRoomMoveDragHandler;
     std::unique_ptr<IInteractionHandler> mSelectionRectangleInteractionHandler;

--- a/src/map/handlers/RoomContextMenuHandler.cpp
+++ b/src/map/handlers/RoomContextMenuHandler.cpp
@@ -1,0 +1,315 @@
+#include "map/handlers/RoomContextMenuHandler.h"
+
+#include "TArea.h"
+#include "TMap.h"
+#include "TRoomDB.h"
+#include "utils.h"
+
+#include "pre_guard.h"
+#include <QAction>
+#include <QEvent>
+#include <QMap>
+#include <QMenu>
+#include <QMouseEvent>
+#include <QObject>
+#include <QStringList>
+#include <QSignalMapper>
+#include "post_guard.h"
+
+RoomContextMenuHandler::RoomContextMenuHandler(T2DMap& mapWidget)
+: mMapWidget(mapWidget)
+{
+}
+
+bool RoomContextMenuHandler::matches(const T2DMap::MapInteractionContext& context) const
+{
+    if (!context.event || !mMapWidget.mpMap) {
+        return false;
+    }
+
+    if (context.event->type() != QEvent::MouseButtonRelease) {
+        return false;
+    }
+
+    if (context.button != Qt::RightButton) {
+        return false;
+    }
+
+    if (context.isLabelHighlighted || context.isCustomLineDrawing) {
+        return false;
+    }
+
+    if (hasCustomLineSelection(context)) {
+        return false;
+    }
+
+    return true;
+}
+
+bool RoomContextMenuHandler::handle(T2DMap::MapInteractionContext& context)
+{
+    if (!mMapWidget.mpMap) {
+        return false;
+    }
+
+    if (context.isDialogLocked) {
+        return true;
+    }
+
+    auto* popup = new QMenu(&mMapWidget);
+    popup->setToolTipsVisible(true);
+    popup->setAttribute(Qt::WA_DeleteOnClose);
+
+    auto* roomDatabase = mMapWidget.mpMap->mpRoomDB;
+    if (!roomDatabase || roomDatabase->isEmpty()) {
+        // No map loaded
+        //: 2D Mapper context menu (no map found) item
+        auto createMap = new QAction(T2DMap::tr("Create new map"), &mMapWidget);
+        QObject::connect(createMap, &QAction::triggered, &mMapWidget, &T2DMap::slot_newMap);
+        //: 2D Mapper context menu (no map found) item
+        auto loadMap = new QAction(T2DMap::tr("Load map"), &mMapWidget);
+        QObject::connect(loadMap, &QAction::triggered, &mMapWidget, &T2DMap::slot_loadMap);
+
+        popup->addAction(createMap);
+        popup->addAction(loadMap);
+
+        mMapWidget.mPopupMenu = true;
+        popup->popup(mMapWidget.mapToGlobal(context.widgetPosition));
+        mMapWidget.update();
+
+        return true;
+    }
+
+    mMapWidget.prepareSingleClickSelection(context);
+    const int selectionSize = context.multiSelectionSet ? context.multiSelectionSet->size() : 0;
+
+    if (!context.isMapViewOnly) {
+        populateEditModeActions(popup, selectionSize, context.area);
+    }
+
+    populateViewModeActions(popup, selectionSize);
+
+    popup->addSeparator();
+
+    const QString viewModeItem = context.isMapViewOnly ?
+        //: 2D Mapper context menu (room) item
+        T2DMap::tr("Switch to editing mode") :
+        //: 2D Mapper context menu (room) item
+        T2DMap::tr("Switch to viewing mode");
+    auto setMapViewOnly = new QAction(viewModeItem, &mMapWidget);
+    QObject::connect(setMapViewOnly, &QAction::triggered, &mMapWidget, &T2DMap::slot_toggleMapViewOnly);
+    popup->addAction(setMapViewOnly);
+
+    populateUserMenus(popup);
+
+    mMapWidget.mPopupMenu = true;
+    popup->popup(mMapWidget.mapToGlobal(context.widgetPosition));
+    mMapWidget.update();
+
+    return true;
+}
+
+void RoomContextMenuHandler::populateEditModeActions(QMenu* menu, int selectionSize, TArea* area) const
+{
+    if (!menu) {
+        return;
+    }
+
+    if (selectionSize == 0) {
+        const auto [x, y] = mMapWidget.getMousePosition();
+        mMapWidget.mContextMenuClickPosition = {x, y};
+        //: Menu option to create a new room in the mapper
+        mMapWidget.mpCreateRoomAction = new QAction(T2DMap::tr("Create new room here"), &mMapWidget);
+        QObject::connect(mMapWidget.mpCreateRoomAction.data(), &QAction::triggered, &mMapWidget, &T2DMap::slot_createRoom);
+        menu->addAction(mMapWidget.mpCreateRoomAction);
+    }
+
+    if (selectionSize > 0) {
+        //: 2D Mapper context menu (room) item
+        auto moveRoom = new QAction(T2DMap::tr("Move"), &mMapWidget);
+        QObject::connect(moveRoom, &QAction::triggered, &mMapWidget, &T2DMap::slot_moveRoom);
+        menu->addAction(moveRoom);
+    }
+
+    if (selectionSize > 0) {
+        //: 2D Mapper context menu (room) item
+        auto roomProperties = new QAction(T2DMap::tr("Configure room..."), &mMapWidget);
+        //: 2D Mapper context menu (room) item tooltip
+        roomProperties->setToolTip(utils::richText(T2DMap::tr("Set room's name and color of icon, weight and lock for speed walks, and a symbol to mark special rooms")));
+        QObject::connect(roomProperties, &QAction::triggered, &mMapWidget, &T2DMap::slot_showPropertiesDialog);
+        menu->addAction(roomProperties);
+    }
+
+    if (selectionSize == 1) {
+        //: 2D Mapper context menu (room) item
+        auto roomExits = new QAction(T2DMap::tr("Set exits..."), &mMapWidget);
+        QObject::connect(roomExits, &QAction::triggered, &mMapWidget, &T2DMap::slot_setExits);
+        menu->addAction(roomExits);
+    }
+
+    if (selectionSize == 1) {
+        //: 2D Mapper context menu (room) item
+        auto customExitLine = new QAction(T2DMap::tr("Create exit line..."), &mMapWidget);
+        if (area && !area->gridMode) {
+            //: 2D Mapper context menu (room) item tooltip (enabled state)
+            customExitLine->setToolTip(utils::richText(T2DMap::tr("Replace an exit line with a custom line")));
+            QObject::connect(customExitLine, &QAction::triggered, &mMapWidget, &T2DMap::slot_setCustomLine);
+        } else {
+            // Disable custom exit lines in grid mode as they aren't visible anyway
+            //: 2D Mapper context menu (room) item tooltip (disabled state)
+            customExitLine->setToolTip(utils::richText(T2DMap::tr("Custom exit lines are not shown and are not editable in grid mode")));
+            customExitLine->setEnabled(false);
+        }
+        menu->addAction(customExitLine);
+    }
+
+    if (selectionSize > 1) {
+        //: 2D Mapper context menu (room) item
+        auto spreadRooms = new QAction(T2DMap::tr("Spread..."), &mMapWidget);
+        //: 2D Mapper context menu (room) item tooltip
+        spreadRooms->setToolTip(utils::richText(T2DMap::tr("Increase map X-Y spacing for the selected group of rooms")));
+        QObject::connect(spreadRooms, &QAction::triggered, &mMapWidget, &T2DMap::slot_spread);
+        menu->addAction(spreadRooms);
+    }
+
+    if (selectionSize > 1) {
+        //: 2D Mapper context menu (room) item
+        auto shrinkRooms = new QAction(T2DMap::tr("Shrink..."), &mMapWidget);
+        //: 2D Mapper context menu (room) item tooltip
+        shrinkRooms->setToolTip(utils::richText(T2DMap::tr("Decrease map X-Y spacing for the selected group of rooms")));
+        QObject::connect(shrinkRooms, &QAction::triggered, &mMapWidget, &T2DMap::slot_shrink);
+        menu->addAction(shrinkRooms);
+    }
+
+    if (selectionSize > 0) {
+        //: 2D Mapper context menu (room) item
+        auto deleteRoom = new QAction(T2DMap::tr("Delete"), &mMapWidget);
+        QObject::connect(deleteRoom, &QAction::triggered, &mMapWidget, &T2DMap::slot_deleteRoom);
+        menu->addAction(deleteRoom);
+    }
+
+    if (selectionSize > 0) {
+        //: 2D Mapper context menu (room) item
+        auto moveRoomXY = new QAction(T2DMap::tr("Move to position..."), &mMapWidget);
+        //: 2D Mapper context menu (room) item tooltip
+        moveRoomXY->setToolTip(utils::richText(T2DMap::tr("Move selected room or group of rooms to the given coordinates in this area")));
+        QObject::connect(moveRoomXY, &QAction::triggered, &mMapWidget, &T2DMap::slot_movePosition);
+        menu->addAction(moveRoomXY);
+    }
+
+    if (selectionSize > 0) {
+        //: 2D Mapper context menu (room) item
+        auto roomArea = new QAction(T2DMap::tr("Move to area..."), &mMapWidget);
+        QObject::connect(roomArea, &QAction::triggered, &mMapWidget, &T2DMap::slot_setArea);
+        menu->addAction(roomArea);
+    }
+
+    //: 2D Mapper context menu (room) item
+    auto createLabel = new QAction(T2DMap::tr("Create label..."), &mMapWidget);
+    //: 2D Mapper context menu (room) item tooltip
+    createLabel->setToolTip(utils::richText(T2DMap::tr("Create label to show text or an image")));
+    QObject::connect(createLabel, &QAction::triggered, &mMapWidget, &T2DMap::slot_createLabel);
+    menu->addAction(createLabel);
+
+    //: 2D Mapper context menu (area) item
+    auto exportAreaImage = new QAction(T2DMap::tr("Export area to image..."), &mMapWidget);
+    //: 2D Mapper context menu (area) item tooltip
+    exportAreaImage->setToolTip(utils::richText(T2DMap::tr("Export the current area as an image file")));
+    QObject::connect(exportAreaImage, &QAction::triggered, &mMapWidget, &T2DMap::slot_exportAreaToImage);
+    menu->addAction(exportAreaImage);
+}
+
+void RoomContextMenuHandler::populateViewModeActions(QMenu* menu, int selectionSize) const
+{
+    if (!menu) {
+        return;
+    }
+
+    if (selectionSize == 1) {
+        //: 2D Mapper context menu (room) item
+        auto setPlayerLocation = new QAction(T2DMap::tr("Set player location"), &mMapWidget);
+        //: 2D Mapper context menu (room) item tooltip (enabled state)
+        setPlayerLocation->setToolTip(utils::richText(T2DMap::tr("Set the player's current location to here")));
+        QObject::connect(setPlayerLocation, &QAction::triggered, &mMapWidget, &T2DMap::slot_setPlayerLocation);
+        menu->addAction(setPlayerLocation);
+    }
+}
+
+void RoomContextMenuHandler::populateUserMenus(QMenu* menu) const
+{
+    if (!menu) {
+        return;
+    }
+
+    // this is placed at the end since it is likely someone will want to hook anywhere
+    QMap<QString, QMenu*> userMenus;
+    QMapIterator<QString, QStringList> it(mMapWidget.mUserMenus);
+    while (it.hasNext()) {
+        it.next();
+        QStringList menuInfo = it.value();
+        const QString displayName = menuInfo[1];
+        // Need to give the top-level context menu as the parent so the
+        // sub-menus get destroyed at the right time:
+        auto userMenu = new QMenu(displayName, menu);
+        userMenus.insert(it.key(), userMenu);
+    }
+
+    it.toFront();
+    while (it.hasNext()) {
+        //take care of nested menus now since they're all made
+        it.next();
+        QStringList menuInfo = it.value();
+        const QString menuParent = menuInfo[0];
+        if (menuParent.isEmpty()) { //parentless
+            menu->addMenu(userMenus[it.key()]);
+        } else if (userMenus.contains(menuParent)) { //has a parent
+            userMenus[menuParent]->addMenu(userMenus[it.key()]);
+        }
+    }
+
+    //add our actions
+    QMapIterator<QString, QStringList> it2(mMapWidget.mUserActions);
+    auto mapper = new QSignalMapper(menu);
+
+    while (it2.hasNext()) {
+        it2.next();
+        QStringList actionInfo = it2.value();
+        const QString menuParentKey = actionInfo.value(1);
+        auto action = new QAction(actionInfo.value(2), menu);
+        if (menuParentKey.isEmpty()) { //no parent
+            menu->addAction(action);
+        } else if (auto parentMenu = userMenus.value(menuParentKey, nullptr)) { //has a parent
+            parentMenu->addAction(action);
+        } else {
+            delete action;
+            continue;
+        }
+        mapper->setMapping(action, it2.key());
+        // TODO: QSignalMapper is not completely compatible with the functor
+        // style of QObject::connect(...) - it has been declared obsolete
+        // and should be replaced with lambda functions to perform what the
+        // slot method did...
+        QObject::connect(action, &QAction::triggered, mapper, qOverload<>(&QSignalMapper::map));
+    }
+    // In relation to above "TODO" in the meantime we can handle things
+    // by a change to one of a group of newer signals with a specific
+    // signature:
+    QObject::connect(mapper, &QSignalMapper::mappedString, &mMapWidget, &T2DMap::slot_userAction);
+}
+
+bool RoomContextMenuHandler::hasCustomLineSelection(const T2DMap::MapInteractionContext& context) const
+{
+    if (context.customLineSelectedRoom != 0) {
+        return true;
+    }
+
+    if (!context.customLineSelectedExit.isEmpty()) {
+        return true;
+    }
+
+    if (context.customLineSelectedPoint >= 0) {
+        return true;
+    }
+
+    return false;
+}

--- a/src/map/handlers/RoomContextMenuHandler.h
+++ b/src/map/handlers/RoomContextMenuHandler.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "T2DMap.h"
+
+class QMenu;
+class TArea;
+
+class RoomContextMenuHandler : public T2DMap::IInteractionHandler
+{
+public:
+    explicit RoomContextMenuHandler(T2DMap& mapWidget);
+
+    bool matches(const T2DMap::MapInteractionContext& context) const override;
+    bool handle(T2DMap::MapInteractionContext& context) override;
+
+private:
+    void populateEditModeActions(QMenu* menu, int selectionSize, TArea* area) const;
+    void populateViewModeActions(QMenu* menu, int selectionSize) const;
+    void populateUserMenus(QMenu* menu) const;
+    bool hasCustomLineSelection(const T2DMap::MapInteractionContext& context) const;
+
+    T2DMap& mMapWidget;
+};


### PR DESCRIPTION
## Summary
- add a RoomContextMenuHandler that assembles room and area context menu actions based on the current interaction mode
- register the handler with the map interaction dispatcher and reduce T2DMap::mouseReleaseEvent to label-specific menu handling
- include the new handler sources in the build

## Testing
- not run (UI smoke test requires interactive environment)


------
https://chatgpt.com/codex/tasks/task_e_68f1f1fbe9f0832a82caca33673ed882