### PR TITLE
Move label context menu handling into interaction handler

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -56,8 +56,6 @@
 #include <QtEvents>
 #include <QtUiTools>
 #include <QStandardPaths>
-#include <QAction>
-#include <QMenu>
 #include "post_guard.h"
 
 #include "mapInfoContributorManager.h"
@@ -2706,34 +2704,6 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
     if (mInteractionDispatcher.dispatch(context)) {
         return;
     }
-
-    // Left button release and label move clean-up are handled by interaction handlers.
-
-    if (context.button == Qt::RightButton && mLabelHighlighted) {
-        auto popup = new QMenu(this);
-        popup->setToolTipsVisible(true);
-        popup->setAttribute(Qt::WA_DeleteOnClose);
-
-        //: 2D Mapper context menu (label) item
-        auto moveLabel = new QAction(tr("Move"), this);
-        //: 2D Mapper context menu item (label) tooltip
-        moveLabel->setToolTip(tr("Move label"));
-        connect(moveLabel, &QAction::triggered, this, &T2DMap::slot_moveLabel);
-        //: 2D Mapper context menu (label) item
-        auto deleteLabel = new QAction(tr("Delete"), this);
-        //: 2D Mapper context menu (label) item tooltip
-        deleteLabel->setToolTip(tr("Delete label"));
-        connect(deleteLabel, &QAction::triggered, this, &T2DMap::slot_deleteLabel);
-        popup->addAction(moveLabel);
-        popup->addAction(deleteLabel);
-
-        mPopupMenu = true;
-        popup->popup(mapToGlobal(context.widgetPosition));
-        update();
-
-        return;
-    }
-
 }
 
 bool T2DMap::event(QEvent* event)

--- a/src/map/handlers/LabelInteractionHandler.cpp
+++ b/src/map/handlers/LabelInteractionHandler.cpp
@@ -7,6 +7,8 @@
 
 #include "pre_guard.h"
 #include <QMap>
+#include <QAction>
+#include <QMenu>
 #include <QMouseEvent>
 #include <QMutableMapIterator>
 #include <QRectF>
@@ -33,7 +35,8 @@ bool LabelInteractionHandler::matches(const T2DMap::MapInteractionContext& conte
     case QEvent::MouseMove:
         return context.isLabelHighlighted || context.isMoveLabelActive;
     case QEvent::MouseButtonRelease:
-        return context.button == Qt::LeftButton && context.isMoveLabelActive;
+        return (context.button == Qt::LeftButton && context.isMoveLabelActive)
+            || (context.button == Qt::RightButton && context.isLabelHighlighted && context.area);
     default:
         return false;
     }
@@ -146,13 +149,42 @@ bool LabelInteractionHandler::handleMouseMove(T2DMap::MapInteractionContext& con
 
 bool LabelInteractionHandler::handleMouseRelease(T2DMap::MapInteractionContext& context) const
 {
-    if (context.button != Qt::LeftButton) {
+    switch (context.button) {
+    case Qt::LeftButton:
+        if (mMapWidget.mMoveLabel) {
+            mMapWidget.mMoveLabel = false;
+        }
+        return false;
+    case Qt::RightButton:
+        if (!context.area || !context.isLabelHighlighted) {
+            return false;
+        }
+
+        auto* popup = new QMenu(&mMapWidget);
+        popup->setToolTipsVisible(true);
+        popup->setAttribute(Qt::WA_DeleteOnClose);
+
+        //: 2D Mapper context menu (label) item
+        auto* moveLabel = new QAction(mMapWidget.tr("Move"), popup);
+        //: 2D Mapper context menu item (label) tooltip
+        moveLabel->setToolTip(mMapWidget.tr("Move label"));
+        QObject::connect(moveLabel, &QAction::triggered, &mMapWidget, &T2DMap::slot_moveLabel);
+
+        //: 2D Mapper context menu (label) item
+        auto* deleteLabel = new QAction(mMapWidget.tr("Delete"), popup);
+        //: 2D Mapper context menu (label) item tooltip
+        deleteLabel->setToolTip(mMapWidget.tr("Delete label"));
+        QObject::connect(deleteLabel, &QAction::triggered, &mMapWidget, &T2DMap::slot_deleteLabel);
+
+        popup->addAction(moveLabel);
+        popup->addAction(deleteLabel);
+
+        mMapWidget.mPopupMenu = true;
+        popup->popup(mMapWidget.mapToGlobal(context.widgetPosition));
+        mMapWidget.update();
+
+        return true;
+    default:
         return false;
     }
-
-    if (mMapWidget.mMoveLabel) {
-        mMapWidget.mMoveLabel = false;
-    }
-
-    return false;
 }


### PR DESCRIPTION
## Summary
- extend the label interaction handler to react to right-button releases and show the move/delete menu
- remove the label-specific branch from `T2DMap::mouseReleaseEvent` now that the handler owns the behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f1f540796c832a8aa00b1e2819ef77