### PR TITLE
Refactor map user context menu population

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -55,6 +55,10 @@
 #include "pre_guard.h"
 #include <QtEvents>
 #include <QtUiTools>
+#include <QAction>
+#include <QMap>
+#include <QMapIterator>
+#include <QMenu>
 #include <QStandardPaths>
 #include "post_guard.h"
 
@@ -3228,6 +3232,58 @@ void T2DMap::slot_toggleMapViewOnly()
         mpHost->raiseEvent(mapModeEvent);
 
         update();
+    }
+}
+
+void T2DMap::populateUserContextMenus(QMenu& menu)
+{
+    QMap<QString, QMenu*> userMenus;
+    QMapIterator<QString, QStringList> menuIterator(mUserMenus);
+
+    while (menuIterator.hasNext()) {
+        menuIterator.next();
+        const QStringList menuInfo = menuIterator.value();
+        const QString displayName = menuInfo.value(1);
+        auto* userMenu = new QMenu(displayName, &menu);
+        userMenus.insert(menuIterator.key(), userMenu);
+    }
+
+    menuIterator.toFront();
+    while (menuIterator.hasNext()) {
+        menuIterator.next();
+        const QStringList menuInfo = menuIterator.value();
+        const QString menuParent = menuInfo.value(0);
+
+        if (auto* childMenu = userMenus.value(menuIterator.key(), nullptr)) {
+            if (menuParent.isEmpty()) {
+                menu.addMenu(childMenu);
+            } else if (auto* parentMenu = userMenus.value(menuParent, nullptr)) {
+                parentMenu->addMenu(childMenu);
+            }
+        }
+    }
+
+    QMapIterator<QString, QStringList> actionIterator(mUserActions);
+    while (actionIterator.hasNext()) {
+        actionIterator.next();
+        const QString uniqueName = actionIterator.key();
+        const QStringList actionInfo = actionIterator.value();
+        const QString menuParentKey = actionInfo.value(1);
+        const QString displayText = actionInfo.value(2);
+
+        auto* action = new QAction(displayText, &menu);
+        if (menuParentKey.isEmpty()) {
+            menu.addAction(action);
+        } else if (auto* parentMenu = userMenus.value(menuParentKey, nullptr)) {
+            parentMenu->addAction(action);
+        } else {
+            delete action;
+            continue;
+        }
+
+        QObject::connect(action, &QAction::triggered, this, [this, uniqueName](bool) {
+            slot_userAction(uniqueName);
+        });
     }
 }
 

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -64,6 +64,7 @@ class QListWidgetItem;
 class QPushButton;
 class QTreeWidgetItem;
 class QMouseEvent;
+class QMenu;
 
 
 class T2DMap : public QWidget
@@ -129,6 +130,7 @@ public:
 
     void registerInteractionHandler(IInteractionHandler* handler, int priority);
     void prepareSingleClickSelection(MapInteractionContext& context);
+    void populateUserContextMenus(QMenu& menu);
 
     // Was getTopLeft() which returned an index into mMultiSelectionList but that
     // has been been changed to mMultiSelectionSet which cannot be accessed via

--- a/src/map/handlers/RoomContextMenuHandler.cpp
+++ b/src/map/handlers/RoomContextMenuHandler.cpp
@@ -8,12 +8,9 @@
 #include "pre_guard.h"
 #include <QAction>
 #include <QEvent>
-#include <QMap>
 #include <QMenu>
 #include <QMouseEvent>
 #include <QObject>
-#include <QStringList>
-#include <QSignalMapper>
 #include "post_guard.h"
 
 RoomContextMenuHandler::RoomContextMenuHandler(T2DMap& mapWidget)
@@ -100,7 +97,7 @@ bool RoomContextMenuHandler::handle(T2DMap::MapInteractionContext& context)
     QObject::connect(setMapViewOnly, &QAction::triggered, &mMapWidget, &T2DMap::slot_toggleMapViewOnly);
     popup->addAction(setMapViewOnly);
 
-    populateUserMenus(popup);
+    mMapWidget.populateUserContextMenus(*popup);
 
     mMapWidget.mPopupMenu = true;
     popup->popup(mMapWidget.mapToGlobal(context.widgetPosition));
@@ -233,68 +230,6 @@ void RoomContextMenuHandler::populateViewModeActions(QMenu* menu, int selectionS
         QObject::connect(setPlayerLocation, &QAction::triggered, &mMapWidget, &T2DMap::slot_setPlayerLocation);
         menu->addAction(setPlayerLocation);
     }
-}
-
-void RoomContextMenuHandler::populateUserMenus(QMenu* menu) const
-{
-    if (!menu) {
-        return;
-    }
-
-    // this is placed at the end since it is likely someone will want to hook anywhere
-    QMap<QString, QMenu*> userMenus;
-    QMapIterator<QString, QStringList> it(mMapWidget.mUserMenus);
-    while (it.hasNext()) {
-        it.next();
-        QStringList menuInfo = it.value();
-        const QString displayName = menuInfo[1];
-        // Need to give the top-level context menu as the parent so the
-        // sub-menus get destroyed at the right time:
-        auto userMenu = new QMenu(displayName, menu);
-        userMenus.insert(it.key(), userMenu);
-    }
-
-    it.toFront();
-    while (it.hasNext()) {
-        //take care of nested menus now since they're all made
-        it.next();
-        QStringList menuInfo = it.value();
-        const QString menuParent = menuInfo[0];
-        if (menuParent.isEmpty()) { //parentless
-            menu->addMenu(userMenus[it.key()]);
-        } else if (userMenus.contains(menuParent)) { //has a parent
-            userMenus[menuParent]->addMenu(userMenus[it.key()]);
-        }
-    }
-
-    //add our actions
-    QMapIterator<QString, QStringList> it2(mMapWidget.mUserActions);
-    auto mapper = new QSignalMapper(menu);
-
-    while (it2.hasNext()) {
-        it2.next();
-        QStringList actionInfo = it2.value();
-        const QString menuParentKey = actionInfo.value(1);
-        auto action = new QAction(actionInfo.value(2), menu);
-        if (menuParentKey.isEmpty()) { //no parent
-            menu->addAction(action);
-        } else if (auto parentMenu = userMenus.value(menuParentKey, nullptr)) { //has a parent
-            parentMenu->addAction(action);
-        } else {
-            delete action;
-            continue;
-        }
-        mapper->setMapping(action, it2.key());
-        // TODO: QSignalMapper is not completely compatible with the functor
-        // style of QObject::connect(...) - it has been declared obsolete
-        // and should be replaced with lambda functions to perform what the
-        // slot method did...
-        QObject::connect(action, &QAction::triggered, mapper, qOverload<>(&QSignalMapper::map));
-    }
-    // In relation to above "TODO" in the meantime we can handle things
-    // by a change to one of a group of newer signals with a specific
-    // signature:
-    QObject::connect(mapper, &QSignalMapper::mappedString, &mMapWidget, &T2DMap::slot_userAction);
 }
 
 bool RoomContextMenuHandler::hasCustomLineSelection(const T2DMap::MapInteractionContext& context) const

--- a/src/map/handlers/RoomContextMenuHandler.h
+++ b/src/map/handlers/RoomContextMenuHandler.h
@@ -16,7 +16,6 @@ public:
 private:
     void populateEditModeActions(QMenu* menu, int selectionSize, TArea* area) const;
     void populateViewModeActions(QMenu* menu, int selectionSize) const;
-    void populateUserMenus(QMenu* menu) const;
     bool hasCustomLineSelection(const T2DMap::MapInteractionContext& context) const;
 
     T2DMap& mMapWidget;


### PR DESCRIPTION
## Summary
- add a T2DMap helper that populates map user context menus with lambda-based triggers
- reuse the new helper from the room context menu handler to remove duplicated menu wiring

## Testing
- not run (UI feature)


------
https://chatgpt.com/codex/tasks/task_e_68f1f93e6e90832abbac4527992ede12