### PR TITLE
Improve mapper context menu right-click handling

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -98,9 +98,47 @@ void T2DMap::registerInteractionHandler(IInteractionHandler* handler, int priori
     mInteractionDispatcher.registerHandler(handler, priority);
 }
 
+std::optional<int> T2DMap::roomIdAtWidgetPosition(const QPoint& widgetPosition, const TArea* area) const
+{
+    if (!mpMap || !mpMap->mpRoomDB || !area) {
+        return std::nullopt;
+    }
+
+    const float fx = ((xspan / 2.0f) - mMapCenterX) * mRoomWidth;
+    const float fy = ((yspan / 2.0f) - mMapCenterY) * mRoomHeight;
+
+    const int mx = widgetPosition.x();
+    const int my = widgetPosition.y();
+    const int mz = mMapCenterZ;
+
+    QSetIterator<int> roomIterator(area->getAreaRooms());
+    while (roomIterator.hasNext()) {
+        const int roomId = roomIterator.next();
+        TRoom* room = mpMap->mpRoomDB->getRoom(roomId);
+        if (!room) {
+            continue;
+        }
+
+        const int rx = room->x() * mRoomWidth + fx;
+        const int ry = room->y() * -1 * mRoomHeight + fy;
+        const int rz = room->z();
+
+        if ((qAbs(mx - rx) < qRound(mRoomWidth * rSize / 2.0))
+            && (qAbs(my - ry) < qRound(mRoomHeight * rSize / 2.0))
+            && (mz == rz)) {
+            return roomId;
+        }
+    }
+
+    return std::nullopt;
+}
+
 void T2DMap::prepareSingleClickSelection(MapInteractionContext& context)
 {
     mMultiRect = QRect(context.widgetPosition, context.widgetPosition);
+
+    context.hasClickedRoom = false;
+    context.clickedRoomId = 0;
 
     if (!mpMap || !mpMap->mpRoomDB) {
         return;
@@ -108,6 +146,14 @@ void T2DMap::prepareSingleClickSelection(MapInteractionContext& context)
 
     auto* area = context.area;
     if (!area) {
+        return;
+    }
+
+    const auto clickedRoomId = roomIdAtWidgetPosition(context.widgetPosition, area);
+    context.hasClickedRoom = clickedRoomId.has_value();
+    context.clickedRoomId = clickedRoomId.value_or(0);
+
+    if (context.button == Qt::RightButton) {
         return;
     }
 
@@ -2776,6 +2822,8 @@ T2DMap::MapInteractionContext T2DMap::buildInteractionContext(QMouseEvent* event
     context.customLineSelectedRoom = mCustomLineSelectedRoom;
     context.customLineSelectedExit = mCustomLineSelectedExit;
     context.customLineSelectedPoint = mCustomLineSelectedPoint;
+    context.hasClickedRoom = false;
+    context.clickedRoomId = 0;
 
     if (!mpMap || !mpMap->mpRoomDB) {
         return context;

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -43,6 +43,7 @@
 
 #include <QList>
 #include <memory>
+#include <optional>
 
 class Host;
 class TArea;
@@ -118,6 +119,8 @@ public:
         int customLineSelectedRoom = 0;
         QString customLineSelectedExit;
         int customLineSelectedPoint = -1;
+        bool hasClickedRoom = false;
+        int clickedRoomId = 0;
     };
 
     class IInteractionHandler
@@ -130,6 +133,7 @@ public:
 
     void registerInteractionHandler(IInteractionHandler* handler, int priority);
     void prepareSingleClickSelection(MapInteractionContext& context);
+    std::optional<int> roomIdAtWidgetPosition(const QPoint& widgetPosition, const TArea* area) const;
     void populateUserContextMenus(QMenu& menu);
 
     // Was getTopLeft() which returned an index into mMultiSelectionList but that

--- a/src/map/handlers/LabelInteractionHandler.cpp
+++ b/src/map/handlers/LabelInteractionHandler.cpp
@@ -28,15 +28,23 @@ bool LabelInteractionHandler::matches(const T2DMap::MapInteractionContext& conte
 
     switch (context.event->type()) {
     case QEvent::MouseButtonPress:
-        return context.button == Qt::LeftButton
-            && !context.isMapViewOnly
-            && context.area
-            && !context.isCustomLineDrawing;
+        if (!context.area || context.isCustomLineDrawing) {
+            return false;
+        }
+
+        if (context.button == Qt::LeftButton) {
+            return !context.isMapViewOnly;
+        }
+
+        if (context.button == Qt::RightButton) {
+            return true;
+        }
+
+        return false;
     case QEvent::MouseMove:
         return context.isLabelHighlighted || context.isMoveLabelActive;
     case QEvent::MouseButtonRelease:
-        return (context.button == Qt::LeftButton && context.isMoveLabelActive)
-            || (context.button == Qt::RightButton && context.isLabelHighlighted && context.area);
+        return context.button == Qt::LeftButton && context.isMoveLabelActive;
     default:
         return false;
     }
@@ -62,38 +70,115 @@ bool LabelInteractionHandler::handle(T2DMap::MapInteractionContext& context)
 
 bool LabelInteractionHandler::handleMousePress(T2DMap::MapInteractionContext& context) const
 {
-    if (context.button != Qt::LeftButton) {
-        return false;
-    }
-
     auto* area = context.area;
-    if (!area || area->mMapLabels.isEmpty()) {
+    if (!area) {
+        if (context.button == Qt::RightButton) {
+            mMapWidget.mLabelHighlighted = false;
+            mMapWidget.update();
+        }
+        context.isLabelHighlighted = false;
         return false;
     }
 
-    QMutableMapIterator<int, TMapLabel> iterator(area->mMapLabels);
-    while (iterator.hasNext()) {
-        iterator.next();
-        auto mapLabel = iterator.value();
-        if (mapLabel.pos.z() != mMapWidget.mMapCenterZ) {
-            continue;
+    if (context.button == Qt::LeftButton) {
+        if (area->mMapLabels.isEmpty()) {
+            return false;
         }
 
-        const float labelX = mapLabel.pos.x() * mMapWidget.mRoomWidth + mMapWidget.mRX;
-        const float labelY = mapLabel.pos.y() * mMapWidget.mRoomHeight * -1 + mMapWidget.mRY;
-        const QPoint click = context.widgetPosition;
-        const QRectF boundingRect(labelX, labelY, mapLabel.clickSize.width(), mapLabel.clickSize.height());
-        if (boundingRect.contains(click)) {
-            mapLabel.highlight = !mapLabel.highlight;
-            mMapWidget.mLabelHighlighted = mapLabel.highlight;
-            iterator.setValue(mapLabel);
-            mMapWidget.update();
-            return true;
+        QMutableMapIterator<int, TMapLabel> iterator(area->mMapLabels);
+        while (iterator.hasNext()) {
+            iterator.next();
+            auto mapLabel = iterator.value();
+            if (mapLabel.pos.z() != mMapWidget.mMapCenterZ) {
+                continue;
+            }
+
+            const float labelX = mapLabel.pos.x() * mMapWidget.mRoomWidth + mMapWidget.mRX;
+            const float labelY = mapLabel.pos.y() * mMapWidget.mRoomHeight * -1 + mMapWidget.mRY;
+            const QPoint click = context.widgetPosition;
+            const QRectF boundingRect(labelX, labelY, mapLabel.clickSize.width(), mapLabel.clickSize.height());
+            if (boundingRect.contains(click)) {
+                mapLabel.highlight = !mapLabel.highlight;
+                mMapWidget.mLabelHighlighted = mapLabel.highlight;
+                context.isLabelHighlighted = mMapWidget.mLabelHighlighted;
+                iterator.setValue(mapLabel);
+                mMapWidget.update();
+                return true;
+            }
         }
+
+        mMapWidget.mLabelHighlighted = false;
+        context.isLabelHighlighted = false;
+        mMapWidget.update();
+
+        return false;
     }
 
-    mMapWidget.mLabelHighlighted = false;
-    mMapWidget.update();
+    if (context.button == Qt::RightButton) {
+        bool highlightChanged = false;
+        bool labelFound = false;
+
+        QMutableMapIterator<int, TMapLabel> iterator(area->mMapLabels);
+        while (iterator.hasNext()) {
+            iterator.next();
+            auto mapLabel = iterator.value();
+
+            const bool isSameZLevel = qRound(mapLabel.pos.z()) == mMapWidget.mMapCenterZ;
+            bool shouldHighlight = false;
+            if (isSameZLevel) {
+                const float labelX = mapLabel.pos.x() * mMapWidget.mRoomWidth + mMapWidget.mRX;
+                const float labelY = mapLabel.pos.y() * mMapWidget.mRoomHeight * -1 + mMapWidget.mRY;
+                const QRectF boundingRect(labelX, labelY, mapLabel.clickSize.width(), mapLabel.clickSize.height());
+                shouldHighlight = boundingRect.contains(context.widgetPosition);
+            }
+
+            if (mapLabel.highlight != shouldHighlight) {
+                mapLabel.highlight = shouldHighlight;
+                iterator.setValue(mapLabel);
+                highlightChanged = true;
+            }
+
+            if (shouldHighlight) {
+                labelFound = true;
+            }
+        }
+
+        mMapWidget.mLabelHighlighted = labelFound;
+        context.isLabelHighlighted = labelFound;
+
+        if (highlightChanged || !labelFound) {
+            mMapWidget.update();
+        }
+
+        if (!labelFound) {
+            return false;
+        }
+
+        auto* popup = new QMenu(&mMapWidget);
+        popup->setToolTipsVisible(true);
+        popup->setAttribute(Qt::WA_DeleteOnClose);
+
+        //: 2D Mapper context menu (label) item
+        auto* moveLabel = new QAction(mMapWidget.tr("Move"), popup);
+        //: 2D Mapper context menu item (label) tooltip
+        moveLabel->setToolTip(mMapWidget.tr("Move label"));
+        QObject::connect(moveLabel, &QAction::triggered, &mMapWidget, &T2DMap::slot_moveLabel);
+
+        //: 2D Mapper context menu (label) item
+        auto* deleteLabel = new QAction(mMapWidget.tr("Delete"), popup);
+        //: 2D Mapper context menu (label) item tooltip
+        deleteLabel->setToolTip(mMapWidget.tr("Delete label"));
+        QObject::connect(deleteLabel, &QAction::triggered, &mMapWidget, &T2DMap::slot_deleteLabel);
+
+        popup->addAction(moveLabel);
+        popup->addAction(deleteLabel);
+
+        mMapWidget.mPopupMenu = true;
+        popup->popup(mMapWidget.mapToGlobal(context.widgetPosition));
+        mMapWidget.update();
+
+        return true;
+    }
 
     return false;
 }
@@ -147,45 +232,13 @@ bool LabelInteractionHandler::handleMouseMove(T2DMap::MapInteractionContext& con
     return false;
 }
 
-bool LabelInteractionHandler::handleMouseRelease(T2DMap::MapInteractionContext &context) const {
-    switch (context.button) {
-        case Qt::LeftButton: {
-            if (mMapWidget.mMoveLabel) {
-                mMapWidget.mMoveLabel = false;
-            }
-            return false;
+bool LabelInteractionHandler::handleMouseRelease(T2DMap::MapInteractionContext& context) const
+{
+    if (context.button == Qt::LeftButton) {
+        if (mMapWidget.mMoveLabel) {
+            mMapWidget.mMoveLabel = false;
         }
-        case Qt::RightButton: {
-            if (!context.area || !context.isLabelHighlighted) {
-                return false;
-            }
-
-            auto *popup = new QMenu(&mMapWidget);
-            popup->setToolTipsVisible(true);
-            popup->setAttribute(Qt::WA_DeleteOnClose);
-
-            //: 2D Mapper context menu (label) item
-            auto *moveLabel = new QAction(mMapWidget.tr("Move"), popup);
-            //: 2D Mapper context menu item (label) tooltip
-            moveLabel->setToolTip(mMapWidget.tr("Move label"));
-            QObject::connect(moveLabel, &QAction::triggered, &mMapWidget, &T2DMap::slot_moveLabel);
-
-            //: 2D Mapper context menu (label) item
-            auto *deleteLabel = new QAction(mMapWidget.tr("Delete"), popup);
-            //: 2D Mapper context menu (label) item tooltip
-            deleteLabel->setToolTip(mMapWidget.tr("Delete label"));
-            QObject::connect(deleteLabel, &QAction::triggered, &mMapWidget, &T2DMap::slot_deleteLabel);
-
-            popup->addAction(moveLabel);
-            popup->addAction(deleteLabel);
-
-            mMapWidget.mPopupMenu = true;
-            popup->popup(mMapWidget.mapToGlobal(context.widgetPosition));
-            mMapWidget.update();
-
-            return true;
-        }
-        default:
-            return false;
     }
+
+    return false;
 }

--- a/src/map/handlers/RoomContextMenuHandler.cpp
+++ b/src/map/handlers/RoomContextMenuHandler.cpp
@@ -78,7 +78,36 @@ bool RoomContextMenuHandler::handle(T2DMap::MapInteractionContext& context)
     }
 
     mMapWidget.prepareSingleClickSelection(context);
-    const int selectionSize = context.multiSelectionSet ? context.multiSelectionSet->size() : 0;
+
+    bool selectionChanged = false;
+
+    if (context.hasClickedRoom) {
+        const bool preserveSelection = context.modifiers.testFlag(Qt::ControlModifier)
+            && mMapWidget.mMultiSelectionSet.contains(context.clickedRoomId)
+            && mMapWidget.mMultiSelectionSet.size() > 1;
+
+        if (!preserveSelection) {
+            mMapWidget.clearSelection();
+            mMapWidget.mMultiSelectionSet.clear();
+            mMapWidget.mMultiSelectionSet.insert(context.clickedRoomId);
+            mMapWidget.mMultiSelectionHighlightRoomId = context.clickedRoomId;
+            selectionChanged = true;
+        }
+    } else if (!mMapWidget.mMultiSelectionSet.isEmpty()) {
+        mMapWidget.clearSelection();
+        mMapWidget.mMultiSelectionSet.clear();
+        mMapWidget.mMultiSelectionHighlightRoomId = 0;
+        selectionChanged = true;
+    }
+
+    context.multiSelectionSet = &mMapWidget.mMultiSelectionSet;
+    context.hasMultiSelection = !mMapWidget.mMultiSelectionSet.isEmpty();
+
+    if (selectionChanged) {
+        mMapWidget.updateSelectionWidget();
+    }
+
+    const int selectionSize = mMapWidget.mMultiSelectionSet.size();
 
     if (!context.isMapViewOnly) {
         populateEditModeActions(popup, selectionSize, context.area);


### PR DESCRIPTION
## Summary
- add a T2DMap helper to find the room under the cursor without mutating selection and propagate the clicked room id into interaction contexts
- update the room context menu to reset or preserve selections based on the clicked room and modifiers before showing the appropriate menu
- extend the label interaction handler so right-clicks highlight the hovered label, open the menu immediately, and clear highlights when empty space is clicked

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68f21d57ad88832abaef7468b2979f86