### PR TITLE
Allow mapper context menus to reopen immediately when another is visible

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -53,13 +53,15 @@
 
 
 #include "pre_guard.h"
-#include <QtEvents>
-#include <QtUiTools>
 #include <QAction>
+#include <QApplication>
+#include <QCoreApplication>
 #include <QMap>
 #include <QMapIterator>
 #include <QMenu>
 #include <QStandardPaths>
+#include <QtEvents>
+#include <QtUiTools>
 #include "post_guard.h"
 
 #include "mapInfoContributorManager.h"
@@ -232,6 +234,23 @@ void T2DMap::InteractionDispatcher::registerHandler(IInteractionHandler* handler
     mHandlers.insert(insertIterator, entry);
 }
 
+void T2DMap::registerContextMenu(QMenu* menu)
+{
+    if (!menu) {
+        return;
+    }
+
+    mActiveContextMenu = menu;
+
+    QObject::connect(menu, &QMenu::aboutToHide, this, [this]() {
+        mActiveContextMenu.clear();
+    });
+
+    QObject::connect(menu, &QObject::destroyed, this, [this]() {
+        mActiveContextMenu.clear();
+    });
+}
+
 bool T2DMap::InteractionDispatcher::dispatch(MapInteractionContext& context) const
 {
     for (const auto& entry : mHandlers) {
@@ -251,6 +270,41 @@ bool T2DMap::InteractionDispatcher::dispatch(MapInteractionContext& context) con
     return false;
 }
 
+bool T2DMap::eventFilter(QObject* watched, QEvent* event)
+{
+    if (mActiveContextMenu && event && event->type() == QEvent::MouseButtonPress) {
+        auto* mouseEvent = static_cast<QMouseEvent*>(event);
+        if (mouseEvent && mouseEvent->button() == Qt::RightButton) {
+            const QPoint globalPos = mouseEvent->globalPosition().toPoint();
+            const QPoint localPos = mapFromGlobal(globalPos);
+
+            if (rect().contains(localPos)) {
+                auto menu = mActiveContextMenu;
+                mActiveContextMenu.clear();
+
+                if (menu) {
+                    menu->close();
+                }
+
+                const QPointF localPosF(localPos);
+                const QPointF globalPosF(globalPos);
+
+                auto* pressEvent = new QMouseEvent(QEvent::MouseButtonPress, localPosF, localPosF, globalPosF,
+                    Qt::RightButton, Qt::RightButton, mouseEvent->modifiers());
+                auto* releaseEvent = new QMouseEvent(QEvent::MouseButtonRelease, localPosF, localPosF, globalPosF,
+                    Qt::RightButton, Qt::NoButton, mouseEvent->modifiers());
+
+                QCoreApplication::postEvent(this, pressEvent);
+                QCoreApplication::postEvent(this, releaseEvent);
+
+                return true;
+            }
+        }
+    }
+
+    return QObject::eventFilter(watched, event);
+}
+
 const QString& key_icon_dialog_ok_apply = qsl(":/icons/dialog-ok-apply.png");
 const QString& key_icon_dialog_cancel = qsl(":/icons/dialog-cancel.png");
 
@@ -258,6 +312,10 @@ const QString& key_icon_dialog_cancel = qsl(":/icons/dialog-cancel.png");
 T2DMap::T2DMap(QWidget* parent)
 : QWidget(parent)
 {
+    if (auto* app = qApp) {
+        app->installEventFilter(this);
+    }
+
     mMultiSelectionListWidget.setParent(this);
     mMultiSelectionListWidget.setColumnCount(2);
     mMultiSelectionListWidget.hideColumn(1);
@@ -320,6 +378,13 @@ T2DMap::T2DMap(QWidget* parent)
 
     mPanInteractionHandler = std::make_unique<PanInteractionHandler>(*this);
     registerInteractionHandler(mPanInteractionHandler.get(), 100);
+}
+
+T2DMap::~T2DMap()
+{
+    if (auto* app = qApp) {
+        app->removeEventFilter(this);
+    }
 }
 
 void T2DMap::init()

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -75,6 +75,7 @@ class T2DMap : public QWidget
 public:
     Q_DISABLE_COPY(T2DMap)
     explicit T2DMap(QWidget* parent = nullptr);
+    ~T2DMap() override;
     std::pair<bool, QString> setMapZoom(const qreal zoom, const int areaId = 0);
     void init();
     void paintEvent(QPaintEvent*) override;
@@ -132,6 +133,8 @@ public:
     };
 
     void registerInteractionHandler(IInteractionHandler* handler, int priority);
+    void registerContextMenu(QMenu* menu);
+    bool eventFilter(QObject* watched, QEvent* event) override;
     void prepareSingleClickSelection(MapInteractionContext& context);
     std::optional<int> roomIdAtWidgetPosition(const QPoint& widgetPosition, const TArea* area) const;
     void populateUserContextMenus(QMenu& menu);
@@ -198,6 +201,7 @@ public:
 
     QRectF mMultiRect;
     bool mPopupMenu = false;
+    QPointer<QMenu> mActiveContextMenu;
     QSet<int> mMultiSelectionSet;
     bool mNewMoveAction = false;
     QRect mMapInfoRect;

--- a/src/map/handlers/CustomLineDrawContextMenuHandler.cpp
+++ b/src/map/handlers/CustomLineDrawContextMenuHandler.cpp
@@ -56,6 +56,7 @@ bool CustomLineDrawContextMenuHandler::handle(T2DMap::MapInteractionContext& con
     auto popup = new QMenu(&mMapWidget);
     popup->setToolTipsVisible(true);
     popup->setAttribute(Qt::WA_DeleteOnClose);
+    mMapWidget.registerContextMenu(popup);
 
     //: 2D Mapper context menu (drawing custom exit line) item
     auto customLineUndoLastPoint = new QAction(T2DMap::tr("Undo"), &mMapWidget);

--- a/src/map/handlers/CustomLineEditContextMenuHandler.cpp
+++ b/src/map/handlers/CustomLineEditContextMenuHandler.cpp
@@ -52,6 +52,7 @@ bool CustomLineEditContextMenuHandler::handle(T2DMap::MapInteractionContext& con
     auto popup = new QMenu(&mMapWidget);
     popup->setToolTipsVisible(true);
     popup->setAttribute(Qt::WA_DeleteOnClose);
+    mMapWidget.registerContextMenu(popup);
 
     //: 2D Mapper context menu (custom line editing) item
     auto addPoint = new QAction(T2DMap::tr("Add point"), &mMapWidget);

--- a/src/map/handlers/LabelInteractionHandler.cpp
+++ b/src/map/handlers/LabelInteractionHandler.cpp
@@ -157,6 +157,7 @@ bool LabelInteractionHandler::handleMousePress(T2DMap::MapInteractionContext& co
         auto* popup = new QMenu(&mMapWidget);
         popup->setToolTipsVisible(true);
         popup->setAttribute(Qt::WA_DeleteOnClose);
+        mMapWidget.registerContextMenu(popup);
 
         //: 2D Mapper context menu (label) item
         auto* moveLabel = new QAction(mMapWidget.tr("Move"), popup);

--- a/src/map/handlers/RoomContextMenuHandler.cpp
+++ b/src/map/handlers/RoomContextMenuHandler.cpp
@@ -56,6 +56,7 @@ bool RoomContextMenuHandler::handle(T2DMap::MapInteractionContext& context)
     auto* popup = new QMenu(&mMapWidget);
     popup->setToolTipsVisible(true);
     popup->setAttribute(Qt::WA_DeleteOnClose);
+    mMapWidget.registerContextMenu(popup);
 
     auto* roomDatabase = mMapWidget.mpMap->mpRoomDB;
     if (!roomDatabase || roomDatabase->isEmpty()) {


### PR DESCRIPTION
## Summary
- track the active map context menu and replay right-clicks so a new menu opens without an extra click
- install an application-level event filter on the 2D map to close an open menu and forward the click position
- register all mapper context menus with the new helper so they participate in the improved behaviour

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68f224615128832a9d98473573f66902