### PR TITLE
Fix: leak in setting edbee theme in trigger highlighter

### DIFF
--- a/src/TriggerHighlighter.cpp
+++ b/src/TriggerHighlighter.cpp
@@ -58,12 +58,12 @@ void TriggerHighlighter::setTheme(const QString& themeName)
     edbee::TextTheme* theme = themeManager->theme(themeName);
 
     // set defaults from chosen theme
-    edbee::TextThemeRule* defaultRule = new edbee::TextThemeRule("default", "selector", theme->foregroundColor(), theme->backgroundColor(), false, false, false);
-    applyFormatting(anchorFormat, defaultRule);
-    applyFormatting(charClassFormat, defaultRule);
-    applyFormatting(escapeCharFormat, defaultRule);
-    applyFormatting(groupFormat, defaultRule);
-    applyFormatting(quantifierFormat, defaultRule);
+    edbee::TextThemeRule defaultRule("default", "selector", theme->foregroundColor(), theme->backgroundColor(), false, false, false);
+    applyFormatting(anchorFormat, &defaultRule);
+    applyFormatting(charClassFormat, &defaultRule);
+    applyFormatting(escapeCharFormat, &defaultRule);
+    applyFormatting(groupFormat, &defaultRule);
+    applyFormatting(quantifierFormat, &defaultRule);
 
     QList<edbee::TextThemeRule*> rules = theme->rules();
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix

```
Direct leak of 4000 byte(s) in 50 object(s) allocated from:
    #0 0x7f21286b61e7 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x5652d10ed62c in TriggerHighlighter::setTheme(QString const&) (/home/runner/work/Mudlet/Mudlet/src/mudlet+0x202562c)
    #2 0x5652d10ecba7 in TriggerHighlighter::TriggerHighlighter(QTextDocument*) (/home/runner/work/Mudlet/Mudlet/src/mudlet+0x2024ba7)
    #3 0x5652d0998ef2 in SingleLineTextEdit::SingleLineTextEdit(QWidget*) (/home/runner/work/Mudlet/Mudlet/src/mudlet+0x18d0ef2)
    #4 0x5652d05f581a in Ui_trigger_pattern_edit::setupUi(QWidget*) (/home/runner/work/Mudlet/Mudlet/src/mudlet+0x152d81a)
    #5 0x5652d05f2792 in dlgTriggerPatternEdit::dlgTriggerPatternEdit(QWidget*) (/home/runner/work/Mudlet/Mudlet/src/mudlet+0x152a792)
    #6 0x5652d044b2a2 in dlgTriggerEditor::dlgTriggerEditor(Host*) (/home/runner/work/Mudlet/Mudlet/src/mudlet+0x13832a2)
    #7 0x5652d08479a9 in mudlet::addConsoleForNewHost(Host*) (/home/runner/work/Mudlet/Mudlet/src/mudlet+0x177f9a9)
    #8 0x5652d086efcb in mudlet::slot_connectionDialogueFinished(QString const&, bool) (/home/runner/work/Mudlet/Mudlet/src/mudlet+0x17a6fcb)
```
#### Motivation for adding to Mudlet
Better app quality
#### Other info (issues closed, discussion etc)
Discovered when running Mudlet with cmake.