### PR TITLE
Fix: memory leak in async XML export functions

### DIFF
--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -153,7 +153,7 @@ void XMLexport::writeModuleXML(const QString& moduleName, const QString& fileNam
         helpPackage.append_child("helpURL").text().set("");
     }
     if (async) {
-        auto future = QtConcurrent::run([&, fileName]() { return saveXml(fileName); });
+        auto future = QtConcurrent::run([this, fileName]() { return saveXml(fileName); });
         auto watcher = new QFutureWatcher<bool>;
         connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=, this]() {
             if (!mpHost) {
@@ -173,7 +173,7 @@ void XMLexport::exportHost(const QString& filename_pugi_xml)
 {
     auto mudletPackage = writeXmlHeader();
     writeHost(mpHost, mudletPackage);
-    auto future = QtConcurrent::run([&, filename_pugi_xml]() { return saveXml(filename_pugi_xml); });
+    auto future = QtConcurrent::run([this, filename_pugi_xml]() { return saveXml(filename_pugi_xml); });
 
     auto watcher = new QFutureWatcher<bool>;
     connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=, this]() {
@@ -787,7 +787,7 @@ bool XMLexport::exportProfile(const QString& exportFileName)
     auto mudletPackage = writeXmlHeader();
 
     if (writeGenericPackage(mpHost, mudletPackage)) {
-        auto future = QtConcurrent::run([&, exportFileName]() { return saveXml(exportFileName); });
+        auto future = QtConcurrent::run([this, exportFileName]() { return saveXml(exportFileName); });
         auto watcher = new QFutureWatcher<bool>;
         QObject::connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=, this]() {
             if (!mpHost) {


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fixed dangling reference issue in XMLexport async operations where
lambda captures were using [&, ...] instead of [this, ...]. This
caused the lambda to hold a reference to the XMLexport object which
could be destroyed before the async task completed, leading to
memory leaks in pugixml allocations.
#### Motivation for adding to Mudlet
Better app quality
#### Other info (issues closed, discussion etc)
