### PR TITLE
Reset label highlight after deletion

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3158,6 +3158,7 @@ void T2DMap::slot_deleteLabel()
 
     bool updateNeeded = false;
     bool saveNeeded = false;
+    bool highlightRemoved = false;
     QMutableMapIterator<int, TMapLabel> itMapLabel(pA->mMapLabels);
     while (itMapLabel.hasNext()) {
         itMapLabel.next();
@@ -3171,6 +3172,7 @@ void T2DMap::slot_deleteLabel()
             if (!label.temporary) {
                 saveNeeded = true;
             }
+            highlightRemoved = true;
         }
     }
 
@@ -3179,6 +3181,10 @@ void T2DMap::slot_deleteLabel()
         if (saveNeeded) {
             mpMap->setUnsaved(__func__);
         }
+    }
+
+    if (highlightRemoved) {
+        mLabelHighlighted = false;
     }
 }
 


### PR DESCRIPTION
## Summary
- reset the map label highlight flag when a highlighted label is deleted so the label context menu no longer appears

## Testing
- not run (not set up)


------
https://chatgpt.com/codex/tasks/task_e_68f2354cf580832abb293bb2e420a500