### PR TITLE
Fix Alt-drag panning in map edit mode

### DIFF
--- a/src/map/handlers/SelectionRectangleHandler.cpp
+++ b/src/map/handlers/SelectionRectangleHandler.cpp
@@ -30,7 +30,8 @@ bool SelectionRectangleHandler::matches(const T2DMap::MapInteractionContext& con
     case QEvent::MouseButtonPress:
         return context.button == Qt::LeftButton
             && !context.isCustomLineDrawing
-            && !context.isRoomBeingMoved;
+            && !context.isRoomBeingMoved
+            && !context.modifiers.testFlag(Qt::AltModifier);
     case QEvent::MouseMove:
         return context.isMultiSelectionActive || context.isSizingLabel;
     case QEvent::MouseButtonRelease:


### PR DESCRIPTION
## Summary
- prevent the selection rectangle handler from activating when Alt is held
- allow Alt+drag to fall through to the pan handler in map edit mode

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f24978b264832aab48d7b2f22d75b0