### PR TITLE
Implement OS-style room selection modifiers

### DIFF
--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -203,6 +203,7 @@ public:
     bool mPopupMenu = false;
     QPointer<QMenu> mActiveContextMenu;
     QSet<int> mMultiSelectionSet;
+    QSet<int> mMultiSelectionBaseSet;
     QSet<int> mMultiSelectionAnchorSet;
     bool mNewMoveAction = false;
     QRect mMapInfoRect;

--- a/src/map/handlers/SelectionRectangleHandler.cpp
+++ b/src/map/handlers/SelectionRectangleHandler.cpp
@@ -86,6 +86,8 @@ bool SelectionRectangleHandler::handleMousePress(T2DMap::MapInteractionContext& 
     const bool hasShift = context.modifiers.testFlag(Qt::ShiftModifier);
     const bool hasCtrl = context.modifiers.testFlag(Qt::ControlModifier);
 
+    mMapWidget.mMultiSelectionBaseSet = mMapWidget.mMultiSelectionSet;
+
     if (!hasCtrl) {
         if (!mMapWidget.mMapViewOnly) {
             mMapWidget.mHelpMsg = T2DMap::tr("Drag to select multiple rooms or labels, release to finish...");
@@ -177,9 +179,19 @@ bool SelectionRectangleHandler::handleMouseMove(T2DMap::MapInteractionContext& c
             }
         }
 
-        if (hasShift && !hasCtrl) {
+        if (hasShift) {
             mMapWidget.mMultiSelectionSet = mMapWidget.mMultiSelectionAnchorSet;
             mMapWidget.mMultiSelectionSet.unite(rectangleSelection);
+        } else if (hasCtrl) {
+            QSet<int> toggledSelection = mMapWidget.mMultiSelectionBaseSet;
+            for (int roomId : rectangleSelection) {
+                if (toggledSelection.contains(roomId)) {
+                    toggledSelection.remove(roomId);
+                } else {
+                    toggledSelection.insert(roomId);
+                }
+            }
+            mMapWidget.mMultiSelectionSet = toggledSelection;
         } else {
             mMapWidget.mMultiSelectionSet = rectangleSelection;
         }
@@ -217,6 +229,7 @@ bool SelectionRectangleHandler::handleMouseRelease(T2DMap::MapInteractionContext
     mMapWidget.mMultiSelection = false;
     mMapWidget.mHelpMsg.clear();
     mMapWidget.mMultiSelectionAnchorSet.clear();
+    mMapWidget.mMultiSelectionBaseSet.clear();
 
     if (mMapWidget.mSizeLabel) {
         mMapWidget.mSizeLabel = false;


### PR DESCRIPTION
## Summary
- snapshot the current selection state when starting a rectangle drag
- treat Ctrl drags as toggling rooms inside the rectangle and Shift drags as additive
- clear stored selection state when finishing the drag

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68f24b1b3dd4832ab0ca194e22b08933