### PR TITLE
Fix modifier drag selection activation

### DIFF
--- a/src/map/handlers/SelectionRectangleHandler.cpp
+++ b/src/map/handlers/SelectionRectangleHandler.cpp
@@ -119,6 +119,10 @@ bool SelectionRectangleHandler::handleMousePress(T2DMap::MapInteractionContext& 
         mMapWidget.mMultiSelectionAnchorSet.clear();
     }
 
+    if (!mMapWidget.mMapViewOnly && (hasShift || hasCtrl)) {
+        mMapWidget.mMultiSelection = true;
+    }
+
     return false;
 }
 


### PR DESCRIPTION
## Summary
- ensure the map selection handler keeps multi-selection active when dragging with Ctrl or Shift
- allow the rectangle selection to start when extending selections with modifier keys

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f2511439bc832a8d6dd5d74bb55100