### PR TITLE
Fix: getPlayingMusic() returns wrong value when filtering

### DIFF
--- a/src/TLuaInterpreterMedia.cpp
+++ b/src/TLuaInterpreterMedia.cpp
@@ -959,7 +959,6 @@ int TLuaInterpreter::getPlayingMusicAsTableArgument(lua_State* L, const char* fu
     mediaData.setMediaType(TMediaData::MediaTypeMusic);
 
     processPlayingMediaTable(L, mediaData);
-    lua_pushboolean(L, true);
     return 1;
 }
 
@@ -1069,15 +1068,13 @@ int TLuaInterpreter::getPlayingSoundsAsTableArgument(lua_State* L, const char* f
         } else if (key == QLatin1String("priority")) {
             int value = getVerifiedInt(L, func, -1, "value for priority must be integer");
 
-            if (key == QLatin1String("priority")) {
-                if (value > TMediaData::MediaPriorityMax) {
-                    value = TMediaData::MediaPriorityMax;
-                } else if (value < TMediaData::MediaPriorityMin) {
-                    value = TMediaData::MediaPriorityMin;
-                }
-
-                mediaData.setMediaPriority(value);
+            if (value > TMediaData::MediaPriorityMax) {
+                value = TMediaData::MediaPriorityMax;
+            } else if (value < TMediaData::MediaPriorityMin) {
+                value = TMediaData::MediaPriorityMin;
             }
+
+            mediaData.setMediaPriority(value);
         }
 
         // removes value, but keeps key for next iteration


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixed two bugs in media playback query functions:
- `getPlayingMusic()` now correctly returns a table of results when filtering by parameters (was returning `true` instead)
- Removed redundant code in `getPlayingSounds()` that checked the same condition twice

#### Motivation for adding to Mudlet

When users call `getPlayingMusic({tag = "ambience"})` or similar filtered queries, they expect to receive a table of matching music files as documented. Previously, it incorrectly returned `true`, breaking scripts that rely on this functionality.

#### Other info (issues closed, discussion etc)

Changes are in `src/TLuaInterpreterMedia.cpp`:
- Line ~962: Removed erroneous `lua_pushboolean(L, true)` from `getPlayingMusicAsTableArgument()`
- Line ~1070: Removed redundant nested condition check in `getPlayingSoundsAsTableArgument()`

These align with the documented behavior at https://wiki.mudlet.org/w/Manual:Miscellaneous_Functions#getPlayingMusic