### PR TITLE
fix: remove icon button when package is changed

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -535,7 +535,7 @@ void dlgPackageExporter::slot_packageChanged(int index)
         ui->pushButton_removeIcon->show();
     } else {
         ui->Icon->hide();
-        ui->pushButton_removeIcon->show();
+        ui->pushButton_removeIcon->hide();
     }
     const QIcon myIcon(mPackageIconPath);
     ui->Icon->clear();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove icon button was showing when a package was changed, but no icon was set.

#### Motivation for adding to Mudlet
UI fix.

#### Other info (issues closed, discussion etc)
