### PR TITLE
Fix: memory leak that happened when running tests

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -564,7 +564,7 @@ void Host::writeModule(const QString &moduleName, const QString &filename)
     if (filename.endsWith(qsl("mpackage"), Qt::CaseInsensitive) || filename.endsWith(qsl("zip"), Qt::CaseInsensitive)) {
         xml_filename = mudlet::getMudletPath(enums::profilePackagePathFileName, mHostName, moduleName);
     }
-    auto writer = new XMLexport(this);
+    auto writer = std::make_shared<XMLexport>(this);
     writers.insert(xml_filename, writer);
     writer->writeModuleXML(moduleName, xml_filename);
     updateModuleZips(filename, moduleName);
@@ -874,7 +874,7 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
         emit signal_saveCommandLinesHistory();
     }
 
-    auto writer = new XMLexport(this);
+    auto writer = std::make_shared<XMLexport>(this);
     writers.insert(qsl("profile"), writer);
     writer->exportHost(filename_xml);
     mWritingHostAndModules = true;
@@ -917,7 +917,7 @@ std::tuple<bool, QString, QString> Host::saveProfileAs(const QString& file)
         return {false, QString(), qsl("a save is already in progress")};
     }
 
-    auto writer = new XMLexport(this);
+    auto writer = std::make_shared<XMLexport>(this);
     writers.insert(qsl("profile"), writer);
     writer->exportProfile(file);
     return {true, file, QString()};
@@ -926,8 +926,8 @@ std::tuple<bool, QString, QString> Host::saveProfileAs(const QString& file)
 void Host::xmlSaved(const QString& xmlName)
 {
     if (writers.contains(xmlName)) {
-        auto writer = writers.take(xmlName);
-        writer->deleteLater();
+        writers.remove(xmlName);
+        // shared_ptr automatically deletes XMLexport when last reference goes away
     }
 
     if (writers.empty()) {

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -883,7 +883,7 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
     // this needs to run after `writers` and `mWritingHostAndModules` have been set
     // so that the currentlySavingProfile() check can run properly
     emit profileSaveStarted();
-    
+
     // Only process events if we're not in the middle of closing down
     // This prevents recursive closure scenarios that can lead to heap-use-after-free
     if (!mIsClosingDown) {
@@ -927,7 +927,6 @@ void Host::xmlSaved(const QString& xmlName)
 {
     if (writers.contains(xmlName)) {
         writers.remove(xmlName);
-        // shared_ptr automatically deletes XMLexport when last reference goes away
     }
 
     if (writers.empty()) {
@@ -1829,7 +1828,7 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, enums::Pa
             // Check if this is just a stale reference by verifying if module files actually exist
             QString modulePath = mudlet::getMudletPath(enums::profilePackagePath, getName(), packageName);
             QString moduleFile = mInstalledModules.value(packageName).value(0); // Get the actual file path from stored reference
-            
+
             bool moduleExists = QDir(modulePath).exists() || QFile::exists(moduleFile);
             if (!moduleExists) {
                 // Module files don't exist, clean up stale references
@@ -1896,7 +1895,7 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, enums::Pa
         }
 
         auto unzipSuccessful = mudlet::unzip(actualFileName, _dest, _tmpDir);
-        
+
         if (pUnzipDialog) {
             pUnzipDialog->deleteLater();
             pUnzipDialog = nullptr;
@@ -2027,7 +2026,7 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, enums::Pa
     if (mpModuleManager) {
         mpModuleManager->layoutModules();
     }
-    
+
     // Save profile to ensure modules persist and appear in module manager
     if (thing != enums::PackageModuleType::Package) {
         // Use a timer to save profile after module installation completes
@@ -2233,13 +2232,13 @@ void Host::setupSandboxedLuaState(lua_State* L)
     luaopen_table(L);
     luaopen_string(L);
     luaopen_math(L);
-    
+
     // Remove dangerous functions
     const char* dangerousFunctions[] = {
         // File operations
-        "dofile", "loadfile", "load", "loadstring", 
+        "dofile", "loadfile", "load", "loadstring",
         // Module system
-        "require", "module", 
+        "require", "module",
         // Library access
         "io", "os", "debug",
         // Environment manipulation
@@ -2247,23 +2246,23 @@ void Host::setupSandboxedLuaState(lua_State* L)
         // Raw memory access
         "collectgarbage"
     };
-    
+
     for (const auto& function : dangerousFunctions) {
         lua_pushnil(L);
         lua_setglobal(L, function);
     }
-    
+
     // Remove package system entirely to prevent require() restoration
     lua_pushnil(L);
     lua_setglobal(L, "package");
-    
+
     // Remove potentially dangerous base functions
     lua_getglobal(L, "_G");
     if (lua_istable(L, -1)) {
         const char* removedBaseFunctions[] = {
             "rawget", "rawset", "rawequal", "rawlen"
         };
-        
+
         for (const auto& function : removedBaseFunctions) {
             lua_pushnil(L);
             lua_setfield(L, -2, function);
@@ -3042,8 +3041,8 @@ void Host::loadSecuredPassword()
 {
     // Use async API for QtKeychain integration with file fallback
     auto* credManager = new CredentialManager(this);
-    
-    credManager->retrieveCredential(getName(), "character", 
+
+    credManager->retrieveCredential(getName(), "character",
         [this, credManager](bool success, const QString& password, const QString& errorMessage) {
             if (success && !password.isEmpty()) {
                 setPass(password);
@@ -3052,7 +3051,7 @@ void Host::loadSecuredPassword()
             } else if (!success && !errorMessage.isEmpty()) {
                 qDebug() << "Host::loadSecuredPassword() - Failed to retrieve password:" << errorMessage;
             }
-            
+
             // Clean up the credential manager
             credManager->deleteLater();
         });
@@ -4363,12 +4362,12 @@ void Host::setFocusOnHostActiveCommandLine()
     }
 
     mFocusTimerRunning = true;
-    
+
     // Lambda to set focus on command line
     auto setCommandLineFocus = [this]() {
         auto pCommandLine = activeCommandLine();
         TCommandLine* targetCommandLine = nullptr;
-        
+
         if (pCommandLine) {
             pCommandLine->activateWindow();
             pCommandLine->console()->show();
@@ -4382,10 +4381,10 @@ void Host::setFocusOnHostActiveCommandLine()
             mpConsole->repaint();
             targetCommandLine = mpConsole->mpCommandLine;
         }
-        
+
         if (targetCommandLine) {
             targetCommandLine->setFocus(Qt::OtherFocusReason);
-            
+
             // For Steam Deck and other environments where focus might be unreliable,
             // add additional focus attempts with slight delays
             QTimer::singleShot(10, this, [targetCommandLine]() {
@@ -4393,17 +4392,17 @@ void Host::setFocusOnHostActiveCommandLine()
                     targetCommandLine->setFocus(Qt::OtherFocusReason);
                 }
             });
-            
+
             QTimer::singleShot(50, this, [targetCommandLine]() {
                 if (targetCommandLine && !targetCommandLine->hasFocus()) {
                     targetCommandLine->setFocus(Qt::OtherFocusReason);
                 }
             });
         }
-        
+
         mFocusTimerRunning = false;
     };
-    
+
     QTimer::singleShot(0, this, setCommandLineFocus);
 }
 
@@ -4550,13 +4549,13 @@ std::pair<bool, QString> Host::setExperimentEnabled(const QString& experimentKey
     if (!mValidExperiments.contains(experimentKey)) {
         return {false, qsl("Invalid experiment name: %1").arg(experimentKey)};
     }
-    
+
     if (enabled) {
         // Check if this is a grouped experiment (contains dots beyond "experiment.")
         if (experimentKey.count('.') >= 2) {
             // Extract group (e.g., "experiment.rendering" from "experiment.rendering.originalish")
             QString group = experimentKey.section('.', 0, 1);
-            
+
             // Disable all other experiments in the same group
             for (auto it = mExperiments.begin(); it != mExperiments.end(); ++it) {
                 if (it.key() != experimentKey && it.key().startsWith(group + ".")) {
@@ -4568,7 +4567,7 @@ std::pair<bool, QString> Host::setExperimentEnabled(const QString& experimentKey
     } else {
         mExperiments[experimentKey] = false;
     }
-    
+
 #if defined(INCLUDE_3DMAPPER)
     // Refresh maps if any experiments changed the 3D map
     if (mpMap && mpMap->mpMapper && mpMap->mpMapper->mp2dMap) {
@@ -4578,7 +4577,7 @@ std::pair<bool, QString> Host::setExperimentEnabled(const QString& experimentKey
         mpMap->mpM->update();
     }
 #endif
-    
+
     return {true, QString()};
 }
 

--- a/src/Host.h
+++ b/src/Host.h
@@ -888,7 +888,7 @@ private:
     bool mWideAmbigousWidthGlyphs = false;
 
     // keeps track of all of the array writers we're currently operating with
-    QHash<QString, XMLexport*> writers;
+    QHash<QString, std::shared_ptr<XMLexport>> writers;
 
     QFuture<void> mModuleFuture;
 

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -157,7 +157,7 @@ void XMLexport::writeModuleXML(const QString& moduleName, const QString& fileNam
         auto self = shared_from_this();
         auto future = QtConcurrent::run([self, fileName]() { return self->saveXml(fileName); });
         auto watcher = new QFutureWatcher<bool>;
-        connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=, self]() {
+        connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [self, this, fileName]() {
             if (!mpHost) {
                 return;
             }
@@ -182,7 +182,7 @@ void XMLexport::exportHost(const QString& filename_pugi_xml)
     auto future = QtConcurrent::run([self, filename_pugi_xml]() { return self->saveXml(filename_pugi_xml); });
 
     auto watcher = new QFutureWatcher<bool>;
-    connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=, self]() {
+    connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [self, this]() {
         if (!mpHost) {
             return;
         }
@@ -798,7 +798,7 @@ bool XMLexport::exportProfile(const QString& exportFileName)
         auto self = shared_from_this();
         auto future = QtConcurrent::run([self, exportFileName]() { return self->saveXml(exportFileName); });
         auto watcher = new QFutureWatcher<bool>;
-        QObject::connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=, self]() {
+        QObject::connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [self, this]() {
             if (!mpHost) {
                 return;
             }

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -163,7 +163,6 @@ void XMLexport::writeModuleXML(const QString& moduleName, const QString& fileNam
             }
             mpHost->xmlSaved(fileName);
         });
-        // Ensure watcher is deleted after completion
         connect(watcher, &QFutureWatcher<bool>::finished, watcher, &QObject::deleteLater);
         watcher->setFuture(future);
         saveFutures.append(future);
@@ -189,7 +188,6 @@ void XMLexport::exportHost(const QString& filename_pugi_xml)
         }
         mpHost->xmlSaved(qsl("profile"));
     });
-    // Ensure watcher is deleted after completion
     connect(watcher, &QFutureWatcher<bool>::finished, watcher, &QObject::deleteLater);
     watcher->setFuture(future);
     saveFutures.append(future);
@@ -423,14 +421,14 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mProxyAddress") = pHost->mProxyAddress.toUtf8().constData();
     host.append_attribute("mProxyPort") = QString::number(pHost->mProxyPort).toUtf8().constData();
     host.append_attribute("mProxyUsername") = pHost->mProxyUsername.toUtf8().constData();
-    
+
     // Handle proxy password based on application version for backward compatibility
     // For version 4.20.0+, use secure storage and clear XML; for older versions, maintain plaintext in XML
     const QString currentAppVersion = QString(APP_VERSION);
     const QVersionNumber appVersion = QVersionNumber::fromString(currentAppVersion);
     const QVersionNumber secureStorageVersion = QVersionNumber(4, 20, 0);
     const bool useSecureStorage = appVersion >= secureStorageVersion;
-    
+
     if (useSecureStorage) {
         // Modern versions: store in secure storage, clear from XML
         if (!pHost->mProxyPassword.isEmpty()) {
@@ -642,7 +640,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
             }
         }
     }
-    
+
     // Write experiments
     {
         QStringList allExperiments = pHost->getAllExperiments();
@@ -654,7 +652,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
             }
         }
     }
-    
+
     writeTriggerPackage(pHost, mudletPackage, true);
     writeTimerPackage(pHost, mudletPackage, true);
     writeAliasPackage(pHost, mudletPackage, true);
@@ -806,7 +804,6 @@ bool XMLexport::exportProfile(const QString& exportFileName)
             }
             mpHost->xmlSaved(qsl("profile"));
         });
-        // Ensure watcher is deleted after completion
         QObject::connect(watcher, &QFutureWatcher<bool>::finished, watcher, &QObject::deleteLater);
         watcher->setFuture(future);
         saveFutures.append(future);

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -153,14 +153,18 @@ void XMLexport::writeModuleXML(const QString& moduleName, const QString& fileNam
         helpPackage.append_child("helpURL").text().set("");
     }
     if (async) {
-        auto future = QtConcurrent::run([this, fileName]() { return saveXml(fileName); });
+        // Capture shared_ptr to keep XMLexport alive during async operation
+        auto self = shared_from_this();
+        auto future = QtConcurrent::run([self, fileName]() { return self->saveXml(fileName); });
         auto watcher = new QFutureWatcher<bool>;
-        connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=, this]() {
+        connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=, self]() {
             if (!mpHost) {
                 return;
             }
             mpHost->xmlSaved(fileName);
         });
+        // Ensure watcher is deleted after completion
+        connect(watcher, &QFutureWatcher<bool>::finished, watcher, &QObject::deleteLater);
         watcher->setFuture(future);
         saveFutures.append(future);
     } else {
@@ -173,15 +177,20 @@ void XMLexport::exportHost(const QString& filename_pugi_xml)
 {
     auto mudletPackage = writeXmlHeader();
     writeHost(mpHost, mudletPackage);
-    auto future = QtConcurrent::run([this, filename_pugi_xml]() { return saveXml(filename_pugi_xml); });
+
+    // Capture shared_ptr to keep XMLexport alive during async operation
+    auto self = shared_from_this();
+    auto future = QtConcurrent::run([self, filename_pugi_xml]() { return self->saveXml(filename_pugi_xml); });
 
     auto watcher = new QFutureWatcher<bool>;
-    connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=, this]() {
+    connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=, self]() {
         if (!mpHost) {
             return;
         }
         mpHost->xmlSaved(qsl("profile"));
     });
+    // Ensure watcher is deleted after completion
+    connect(watcher, &QFutureWatcher<bool>::finished, watcher, &QObject::deleteLater);
     watcher->setFuture(future);
     saveFutures.append(future);
 }
@@ -787,14 +796,18 @@ bool XMLexport::exportProfile(const QString& exportFileName)
     auto mudletPackage = writeXmlHeader();
 
     if (writeGenericPackage(mpHost, mudletPackage)) {
-        auto future = QtConcurrent::run([this, exportFileName]() { return saveXml(exportFileName); });
+        // Capture shared_ptr to keep XMLexport alive during async operation
+        auto self = shared_from_this();
+        auto future = QtConcurrent::run([self, exportFileName]() { return self->saveXml(exportFileName); });
         auto watcher = new QFutureWatcher<bool>;
-        QObject::connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=, this]() {
+        QObject::connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=, self]() {
             if (!mpHost) {
                 return;
             }
             mpHost->xmlSaved(qsl("profile"));
         });
+        // Ensure watcher is deleted after completion
+        QObject::connect(watcher, &QFutureWatcher<bool>::finished, watcher, &QObject::deleteLater);
         watcher->setFuture(future);
         saveFutures.append(future);
 

--- a/src/XMLexport.h
+++ b/src/XMLexport.h
@@ -33,6 +33,8 @@
 #include <pugixml.hpp>
 #include "post_guard.h"
 
+#include <memory>
+
 class QFile;
 class Host;
 class LuaInterface;
@@ -46,7 +48,7 @@ class TVar;
 class VarUnit;
 
 
-class XMLexport : public QObject
+class XMLexport : public QObject, public std::enable_shared_from_this<XMLexport>
 {
     Q_OBJECT
 

--- a/src/XMLexport.h
+++ b/src/XMLexport.h
@@ -31,9 +31,8 @@
 #include <QPointer>
 #include <QSaveFile>
 #include <pugixml.hpp>
-#include "post_guard.h"
-
 #include <memory>
+#include "post_guard.h"
 
 class QFile;
 class Host;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fixed a memory leak that happened when running tests. Qt's deleteLater() was not being called when the application was shut down, leading to a false positive to appear. This didn't happen during normal playtime with Mudlet, so it's not an issue that affected players.
#### Motivation for adding to Mudlet
No memory leaks at all, not even in tests, so our tests can see if new leaks appear in code or not.
#### Other info (issues closed, discussion etc)
