### PR TITLE
Fix: Password not persisting in connection dialog

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -446,7 +446,7 @@ void dlgConnectionProfiles::writeSecurePassword(const QString& profile, const QS
     // Use async API for QtKeychain integration with file fallback
     auto* credManager = new CredentialManager();
 
-    credManager->storeCredential(profile, "character", pass,
+    credManager->storePassword(profile, "character", pass,
         [credManager, profile](bool success, const QString& errorMessage) {
             if (success) {
                 qDebug() << "dlgConnectionProfiles: Successfully stored password for profile" << profile;
@@ -464,7 +464,7 @@ void dlgConnectionProfiles::deleteSecurePassword(const QString& profile) const
     // Use async API for QtKeychain integration with file fallback
     auto* credManager = new CredentialManager();
 
-    credManager->removeCredential(profile, "character",
+    credManager->removePassword(profile, "character",
         [credManager, profile](bool success, const QString& errorMessage) {
             if (success) {
                 qDebug() << "dlgConnectionProfiles: Successfully removed password for profile" << profile;


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixed a bug where passwords entered in the Options tab of the connection dialog were not being saved correctly to the system keychain. The issue was caused by a service name mismatch - passwords were stored with one identifier but retrieved using a different one, causing them to never be found.

Changed `writeSecurePassword()` and `deleteSecurePassword()` in `dlgConnectionProfiles.cpp` to use the correct wrapper methods (`storePassword()` and `removePassword()`) instead of calling low-level credential functions directly.

#### Motivation for adding to Mudlet

Users were experiencing frustration with having to re-enter their passwords every time they opened a profile or restarted Mudlet. This fix ensures passwords persist correctly across sessions when secure storage is enabled, improving the user experience.

#### Other info (issues closed, discussion etc)

The bug only affected the version 4.20+ password storage scheme. The fix ensures consistent service name formatting (`Mudlet-{ProfileName}-character`) for both storage and retrieval operations.