### PR TITLE
Fix: deprecation warnings not to appear in Qt 6.8.3

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -82,7 +82,7 @@ stopWatch::stopWatch()
 , mEffectiveStartDateTime()
 , mElapsedTime()
 {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
     mEffectiveStartDateTime.setTimeZone(QTimeZone::UTC);
 #else
     mEffectiveStartDateTime.setTimeSpec(Qt::UTC);

--- a/src/utils.h
+++ b/src/utils.h
@@ -47,7 +47,7 @@ public:
     // Qt 6.9 deprecated QDateTime::setOffsetFromUtc(int) and made it hard to
     // replicate the exact strings that we had before:
     static QString dateStamp() {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
         auto localNow = QDateTime::currentDateTime();
         const int offset = localNow.offsetFromUtc();
         if (offset) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix deprecation warnings not to appear in Qt 6.8.3 as well as 6.9. While these functions got properly depricated in 6.9 per Qt documentation, it seems the warnings for them started to appear in 6.8.3 as well.
#### Motivation for adding to Mudlet
Less noise when compiling.
#### Other info (issues closed, discussion etc)
