### PR TITLE
Fix: clearCmdLine() not clearing sub-command lines

### DIFF
--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -233,7 +233,7 @@ int TLuaInterpreter::clearCmdLine(lua_State* L)
 {
     const int n = lua_gettop(L);
     QString name = "main";
-    if (n > 1) {
+    if (n >= 1) {
         name = CMDLINE_NAME(L, 1);
     }
     auto pN = COMMANDLINE(L, name);


### PR DESCRIPTION
### Brief overview of PR changes/additions

Fixed a bug in `clearCmdLine()` where calling the function with a sub-command line name would incorrectly clear the main command line instead of the specified sub-command line. Changed the argument check from `if (n > 1)` to `if (n >= 1)` to properly detect when a command line name is provided.

Bug found by Discord user Xavious in [this thread](https://discord.com/channels/283581582550237184/283582068334526464/1429146839864840202).

#### Motivation for adding to Mudlet

Users creating custom command lines with `Geyser.CommandLine:new()` could not clear them using the documented `clearCmdLine(name)` function or `commandLine:clear()` method. This broke user interfaces that rely on clearing custom command lines, forcing users to work around the issue by using `printCmdLine(name, "")` instead.

#### Other info (issues closed, discussion etc)

The bug was caused by using the wrong argument count check - the function was checking for "more than 1 argument" when it should check for "at least 1 argument". This follows the same pattern correctly used by similar functions like `getCmdLine()` and `clearCmdLineSuggestions()`.
