### PR TITLE
Fix: MXP menu tooltips now display correctly

### DIFF
--- a/src/TMxpSendTagHandler.cpp
+++ b/src/TMxpSendTagHandler.cpp
@@ -47,7 +47,7 @@ TMxpTagHandlerResult TMxpSendTagHandler::handleStartTag(TMxpContext& ctx, TMxpCl
 
     // remove excess hints, but allow for a custom tooltip
     while (hints.size() > hrefs.size() + 1) {
-        hints.removeFirst();
+        hints.removeLast();
     }
 
     // <SEND HREF="PROBE SUSPENDERS30901|BUY SUSPENDERS30901" hint="Click to see command menu">30901</SEND>


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes MXP SEND tag menus to show the correct tooltip text when multiple hints are provided.

#### Motivation for adding to Mudlet

The MXP standard says that when you have more labels than commands in a SEND tag, the first label should be used as the menu's tooltip. The code was removing labels from the beginning instead of the end, which meant the tooltip was always wrong.

#### Other info (issues closed, discussion etc)

Closes #5394

**Technical details:** Changed `hints.removeFirst()` to `hints.removeLast()` in `TMxpSendTagHandler.cpp` to preserve the first hint as the tooltip while removing excess hints from the end.