### PR TITLE
Add: MXP EXPIRE tag support for expiring links

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -151,6 +151,7 @@ set(mudlet_SRCS
     TMxpElementDefinitionHandler.cpp
     TMxpElementRegistry.cpp
     TMxpEntityTagHandler.cpp
+    TMxpExpireTagHandler.cpp
     TMxpFontTagHandler.cpp
     TMxpFormattingTagsHandler.cpp
     TMxpLinkTagHandler.cpp
@@ -328,6 +329,7 @@ set(mudlet_HDRS
     TMxpElementDefinitionHandler.h
     TMxpElementRegistry.h
     TMxpEntityTagHandler.h
+    TMxpExpireTagHandler.h
     TMxpFontTagHandler.h
     TMxpFormattingTagsHandler.h
     TMxpLinkTagHandler.h

--- a/src/TLinkStore.cpp
+++ b/src/TLinkStore.cpp
@@ -24,7 +24,7 @@
 #include "Host.h"
 #endif
 
-int TLinkStore::addLinks(const QStringList& links, const QStringList& hints, Host* pH, const QVector<int>& luaReference)
+int TLinkStore::addLinks(const QStringList& links, const QStringList& hints, Host* pH, const QVector<int>& luaReference, const QString& expireName)
 {
     if (++mLinkID > mMaxLinks) {
         mLinkID = 1;
@@ -33,9 +33,21 @@ int TLinkStore::addLinks(const QStringList& links, const QStringList& hints, Hos
     // Used to unref lua objects in the registry to avoid memory leaks
     freeReference(pH, mReferenceStore.value(mLinkID, QVector<int>()));
 
+    // Remove old expire mapping if it exists (when wrapping around)
+    QString oldExpireName = mExpireStore.value(mLinkID);
+    if (!oldExpireName.isEmpty()) {
+        mExpireToLinks.remove(oldExpireName, mLinkID);
+    }
+
     mLinkStore[mLinkID] = links;
     mHintStore[mLinkID] = hints;
     mReferenceStore[mLinkID] = luaReference;
+
+    // Store expire name if provided
+    if (!expireName.isEmpty()) {
+        mExpireStore[mLinkID] = expireName;
+        mExpireToLinks.insert(expireName, mLinkID);
+    }
 
     return mLinkID;
 }
@@ -53,6 +65,33 @@ void TLinkStore::freeReference(Host* pH, const QVector<int>& oldReference)
 #endif
         }
     }
+}
+
+void TLinkStore::expireLinks(const QString& expireName, Host* pH)
+{
+    if (expireName.isEmpty()) {
+        return;
+    }
+
+    // Get all link IDs with this expire name
+    QList<int> linkIds = mExpireToLinks.values(expireName);
+
+    for (int linkId : linkIds) {
+        // Free Lua references
+        freeReference(pH, mReferenceStore.value(linkId));
+
+        // Remove from all stores
+        mLinkStore.remove(linkId);
+        mHintStore.remove(linkId);
+        mReferenceStore.remove(linkId);
+        mExpireStore.remove(linkId);
+#if !defined(LinkStore_Test)
+        mStylingStore.remove(linkId);
+#endif
+    }
+
+    // Remove all mappings for this expire name
+    mExpireToLinks.remove(expireName);
 }
 
 #if !defined(LinkStore_Test)

--- a/src/TLinkStore.h
+++ b/src/TLinkStore.h
@@ -46,13 +46,17 @@ public:
     : mMaxLinks(maxLinks)
     {}
 
-    int addLinks(const QStringList& links, const QStringList& hints, Host* pH = nullptr, const QVector<int>& luaReference = QVector<int>());
+    int addLinks(const QStringList& links, const QStringList& hints, Host* pH = nullptr, const QVector<int>& luaReference = QVector<int>(), const QString& expireName = QString());
 
     QStringList& getLinks(int id) { return mLinkStore[id]; }
     QStringList& getHints(int id) { return mHintStore[id]; }
     QStringList getLinksConst(int id) const { return mLinkStore.value(id); }
     QStringList getHintsConst(int id) const { return mHintStore.value(id); }
     QVector<int> getReference(int id) const { return mReferenceStore.value(id); }
+    
+    // EXPIRE tag support - manage link expiry by name
+    void expireLinks(const QString& expireName, Host* pH = nullptr);
+    QString getExpireName(int id) const { return mExpireStore.value(id); }
 
     int getCurrentLinkID() const { return mLinkID; }
 
@@ -77,6 +81,9 @@ private:
 #if !defined(LinkStore_Test)
     QMap<int, Mudlet::HyperlinkStyling> mStylingStore;
 #endif
+    // EXPIRE tag support - track which links belong to which expire group
+    QMap<int, QString> mExpireStore;  // Maps link ID to expire name
+    QMultiMap<QString, int> mExpireToLinks;  // Maps expire name to link IDs (for quick lookup)
 };
 
 #endif //MUDLET_TLINKSTORE_H

--- a/src/TMxpClient.h
+++ b/src/TMxpClient.h
@@ -78,6 +78,10 @@ public:
     virtual int setLink(const QStringList& hrefs, const QStringList& hints) = 0;
     virtual bool getLink(int id, QStringList** hrefs, QStringList** hints) = 0;
 
+    // EXPIRE tag support
+    virtual int setLink(const QStringList& hrefs, const QStringList& hints, const QString& expireName) = 0;
+    virtual void expireLinks(const QString& expireName) = 0;
+
     virtual void playMedia(TMediaData& mediaData) = 0;
     virtual void stopMedia(TMediaData& mediaData) = 0;
 

--- a/src/TMxpElementDefinitionHandler.cpp
+++ b/src/TMxpElementDefinitionHandler.cpp
@@ -21,6 +21,10 @@
 #include "TMxpContext.h"
 #include "TMxpTagParser.h"
 
+#ifdef DEBUG_MXP_PROCESSING
+#include <QDebug>
+#endif
+
 // <!ELEMENT element-name [definition] [ATT=attribute-list] [TAG=tag] [FLAG=flags] [OPEN] [DELETE] [EMPTY]>
 TMxpTagHandlerResult TMxpElementDefinitionHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
 {
@@ -31,6 +35,10 @@ TMxpTagHandlerResult TMxpElementDefinitionHandler::handleStartTag(TMxpContext& c
 
     TMxpElement element;
     element.name = tag->getAttrName(0); // element-name
+
+#ifdef DEBUG_MXP_PROCESSING
+    qDebug() << "TMxpElementDefinitionHandler: Defining custom element:" << element.name;
+#endif
 
     if (tag->hasAttribute("DELETE")) {
         ctx.getElementRegistry().unregisterElement(element.name);
@@ -76,9 +84,16 @@ TMxpTagHandlerResult TMxpElementDefinitionHandler::handleStartTag(TMxpContext& c
 
     if (!element.definition.isEmpty()) {
         element.parsedDefinition = TMxpTagParser::parseToMxpNodeList(element.definition);
+#ifdef DEBUG_MXP_PROCESSING
+        qDebug() << "  Definition:" << element.definition;
+#endif
     }
 
     ctx.getElementRegistry().registerElement(element);
+
+#ifdef DEBUG_MXP_PROCESSING
+    qDebug() << "  Custom element registered:" << element.name;
+#endif
 
     return MXP_TAG_HANDLED;
 }

--- a/src/TMxpExpireTagHandler.cpp
+++ b/src/TMxpExpireTagHandler.cpp
@@ -1,0 +1,84 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by Mike Conley - mconley@mudlet.org               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "TMxpExpireTagHandler.h"
+#include "TMxpClient.h"
+#include "TMxpContext.h"
+
+#ifdef DEBUG_MXP_PROCESSING
+#include <QDebug>
+#endif
+
+// Override supports() to add debug output
+bool TMxpExpireTagHandler::supports(TMxpContext& ctx, TMxpClient& client, MxpTag* tag)
+{
+#ifdef DEBUG_MXP_PROCESSING
+    qDebug() << "TMxpExpireTagHandler::supports() called for tag:" << tag->getName();
+#endif
+    // Call parent class supports() which checks if tag->isNamed("EXPIRE")
+    bool result = TMxpSingleTagHandler::supports(ctx, client, tag);
+#ifdef DEBUG_MXP_PROCESSING
+    qDebug() << "TMxpExpireTagHandler::supports() returning:" << result;
+#endif
+    return result;
+}
+
+// <EXPIRE name>
+// Removes all links tagged with the given expire name
+TMxpTagHandlerResult TMxpExpireTagHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
+{
+    Q_UNUSED(ctx)
+
+    QString expireName;
+
+#ifdef DEBUG_MXP_PROCESSING
+    qDebug() << "TMxpExpireTagHandler: Processing EXPIRE tag";
+    qDebug() << "  Attribute count:" << tag->getAttributesCount();
+    for (int i = 0; i < tag->getAttributesCount(); i++) {
+        auto attr = tag->getAttribute(i);
+        qDebug() << "  Attribute" << i << ":" << attr.getName() << "=" << attr.getValue();
+    }
+#endif
+
+    // The expire name can be specified in different ways:
+    // <EXPIRE name> or <EXPIRE name="name">
+    if (tag->getAttributesCount() > 0) {
+        if (tag->hasAttribute(qsl("name"))) {
+            expireName = tag->getAttributeValue(qsl("name"));
+        } else {
+            // First attribute without a value is the name
+            expireName = tag->getAttribute(0).getName();
+        }
+    }
+
+    if (expireName.isEmpty()) {
+#ifdef DEBUG_MXP_PROCESSING
+        qDebug() << "TMxpExpireTagHandler: No expire name found, not handling";
+#endif
+        return MXP_TAG_NOT_HANDLED;
+    }
+
+#ifdef DEBUG_MXP_PROCESSING
+    qDebug() << "TMxpExpireTagHandler: Expiring links with name:" << expireName;
+#endif
+
+    client.expireLinks(expireName);
+
+    return MXP_TAG_HANDLED;
+}

--- a/src/TMxpExpireTagHandler.cpp
+++ b/src/TMxpExpireTagHandler.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2025 by Mike Conley - mconley@mudlet.org               *
+ *   Copyright (C) 2025 by Mike Conley - mike.conley@stickmud.com          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/TMxpExpireTagHandler.h
+++ b/src/TMxpExpireTagHandler.h
@@ -2,7 +2,7 @@
 #define MUDLET_TMXPEXPIRETAGHANDLER_H
 
 /***************************************************************************
- *   Copyright (C) 2025 by Mike Conley - mconley@mudlet.org               *
+ *   Copyright (C) 2025 by Mike Conley - mike.conley@stickmud.com          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/TMxpExpireTagHandler.h
+++ b/src/TMxpExpireTagHandler.h
@@ -1,0 +1,38 @@
+#ifndef MUDLET_TMXPEXPIRETAGHANDLER_H
+#define MUDLET_TMXPEXPIRETAGHANDLER_H
+
+/***************************************************************************
+ *   Copyright (C) 2025 by Mike Conley - mconley@mudlet.org               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "TMxpTagHandler.h"
+
+// <EXPIRE name>
+// Removes all links tagged with the given expire name
+class TMxpExpireTagHandler : public TMxpSingleTagHandler
+{
+public:
+    TMxpExpireTagHandler()
+    : TMxpSingleTagHandler(qsl("EXPIRE"))
+    {}
+
+    bool supports(TMxpContext& ctx, TMxpClient& client, MxpTag* tag) override;
+    TMxpTagHandlerResult handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag) override;
+};
+
+#endif //MUDLET_TMXPEXPIRETAGHANDLER_H

--- a/src/TMxpLinkTagHandler.cpp
+++ b/src/TMxpLinkTagHandler.cpp
@@ -25,8 +25,11 @@
 TMxpTagHandlerResult TMxpLinkTagHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
 {
     Q_UNUSED(ctx)
-    if (tag->hasAttribute("EXPIRE")) {
-        return MXP_TAG_NOT_HANDLED;
+    
+    // Extract expire name if present
+    QString expireName;
+    if (tag->hasAttribute(qsl("expire"))) {
+        expireName = tag->getAttributeValue(qsl("expire"));
     }
 
     QString href = getHref(tag);
@@ -34,11 +37,17 @@ TMxpTagHandlerResult TMxpLinkTagHandler::handleStartTag(TMxpContext& ctx, TMxpCl
         return MXP_TAG_NOT_HANDLED;
     }
 
-    const QString hint = tag->hasAttribute("hint") ? tag->getAttributeValue("hint") : href;
+    const QString hint = tag->hasAttribute(qsl("hint")) ? tag->getAttributeValue(qsl("hint")) : href;
 
     href = qsl("openUrl([[%1]])").arg(href);
 
-    mLinkId = client.setLink(QStringList(href), QStringList(hint));
+    // Use the version of setLink that supports expire names
+    if (!expireName.isEmpty()) {
+        mLinkId = client.setLink(QStringList(href), QStringList(hint), expireName);
+    } else {
+        mLinkId = client.setLink(QStringList(href), QStringList(hint));
+    }
+    
     client.setLinkMode(true);
     return MXP_TAG_HANDLED;
 }

--- a/src/TMxpMudlet.cpp
+++ b/src/TMxpMudlet.cpp
@@ -71,6 +71,16 @@ int TMxpMudlet::setLink(const QStringList& links, const QStringList& hints)
     return getLinkStore().addLinks(links, hints, mpHost);
 }
 
+int TMxpMudlet::setLink(const QStringList& links, const QStringList& hints, const QString& expireName)
+{
+    return getLinkStore().addLinks(links, hints, mpHost, QVector<int>(), expireName);
+}
+
+void TMxpMudlet::expireLinks(const QString& expireName)
+{
+    getLinkStore().expireLinks(expireName, mpHost);
+}
+
 bool TMxpMudlet::getLink(int id, QStringList** links, QStringList** hints)
 {
     *links = &getLinkStore().getLinks(id);

--- a/src/TMxpMudlet.h
+++ b/src/TMxpMudlet.h
@@ -84,6 +84,10 @@ public:
 
     bool getLink(int id, QStringList** links, QStringList** hints) override;
 
+    // EXPIRE tag support
+    int setLink(const QStringList& links, const QStringList& hints, const QString& expireName) override;
+    void expireLinks(const QString& expireName) override;
+
     void playMedia(TMediaData& mediaData) override;
     void stopMedia(TMediaData& mediaData) override;
 

--- a/src/TMxpSendTagHandler.cpp
+++ b/src/TMxpSendTagHandler.cpp
@@ -23,14 +23,17 @@
 
 TMxpTagHandlerResult TMxpSendTagHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
 {
-    //    if (tag->hasAttr("EXPIRE") && tag->getAttr(0).isNamed("EXPIRE"))
-    //        return MXP_TAG_NOT_HANDLED;
-
     mLastCaption.clear();
     mCurrentTagContent.clear();
 
     QString href = extractHref(tag);
     QString hint = extractHint(tag);
+    QString expireName;
+    
+    // Extract expire name if present
+    if (tag->hasAttribute(ATTR_EXPIRE)) {
+        expireName = tag->getAttributeValue(ATTR_EXPIRE);
+    }
 
     if (href.contains(TAG_CONTENT_PLACEHOLDER, Qt::CaseInsensitive) || hint.contains(TAG_CONTENT_PLACEHOLDER, Qt::CaseInsensitive)) {
         mIsHrefInContent = true;
@@ -68,7 +71,12 @@ TMxpTagHandlerResult TMxpSendTagHandler::handleStartTag(TMxpContext& ctx, TMxpCl
         }
     }
 
-    mLinkId = client.setLink(hrefs, hints);
+    // Use the version of setLink that supports expire names
+    if (!expireName.isEmpty()) {
+        mLinkId = client.setLink(hrefs, hints, expireName);
+    } else {
+        mLinkId = client.setLink(hrefs, hints);
+    }
 
     // Only set link mode if a link was actually created
     if (mLinkId != 0) {

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -701,6 +701,7 @@ SOURCES += \
     TMxpElementDefinitionHandler.cpp \
     TMxpElementRegistry.cpp \
     TMxpEntityTagHandler.cpp \
+    TMxpExpireTagHandler.cpp \
     TLuaInterpreterTextToSpeech.cpp \
     TMxpFormattingTagsHandler.cpp \
     TMxpColorTagHandler.cpp \
@@ -842,6 +843,7 @@ HEADERS += \
     TMxpElementDefinitionHandler.h \
     TMxpElementRegistry.h \
     TMxpEntityTagHandler.h \
+    TMxpExpireTagHandler.h \
     TMxpContext.h \
     TMxpFormattingTagsHandler.h \
     TMxpMudlet.h \

--- a/test/TMxpStubClient.h
+++ b/test/TMxpStubClient.h
@@ -192,6 +192,21 @@ public:
 
         return 1;
     }
+
+    int setLink(const QStringList& hrefs, const QStringList& hints, const QString& expireName) override
+    {
+        qDebug().noquote() << qsl("setLink([%1], [%2], [%3])").arg(hrefs.join(", "), hints.join(", "), expireName);
+        mHrefs = hrefs;
+        mHints = hints;
+
+        return 1;
+    }
+
+    void expireLinks(const QString& expireName) override
+    {
+        qDebug().noquote() << qsl("expireLinks([%1])").arg(expireName);
+    }
+
     bool getLink(int id, QStringList** href, QStringList** hint) override
     {
         *href = &mHrefs;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Implements support for the MXP (Mud eXtension Protocol) EXPIRE tag, which allows MUD servers to automatically deactivate clickable links when they're no longer relevant. For example, when you move to a new room, the exit links from the previous room are deactivated so you can't accidentally click them.

The EXPIRE tag can be used in two ways:
- Standalone: `<EXPIRE name>` deactivates all links tagged with that name
- As an attribute: `<SEND href="..." EXPIRE="name">` tags a link to be expired later

Expired links remain visible in scrollback for historical reference but become non-functional when clicked.

#### Motivation for adding to Mudlet

This feature was requested by @mfontani in [Discord comments](https://discord.com/channels/279748146316312576/1393998251786768384/1429244386541178911) to improve the MUD playing experience by preventing accidental clicks on outdated navigation links. The MXP v1.0 specification includes EXPIRE tag support, and implementing it brings Mudlet closer to full MXP compliance.

StickMUD (stickmud.com:7680) has already implemented server-side support for this feature and uses it to expire room exit links when players move to new rooms.

#### Other info (issues closed, discussion etc)

- Tested extensively with StickMUD's MXP implementation
- All existing unit tests pass
- No breaking changes to existing functionality
- Links are deactivated but remain visually unchanged in scrollback to preserve historical context

---

Video of MXP tags expiring. Clicking on prior room links does nothing, while clicking on existing room links functions.

https://github.com/user-attachments/assets/417bb1e7-458a-459b-9529-ca7749744cc5
