### PR TITLE
Fix: Restore correct bold handling for ANSI colors 8-15

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -582,7 +582,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                     const int spacesNeeded = temp.toInt(&isOk);
                     if (isOk && spacesNeeded > 0) {
                         const TChar::AttributeFlags attributeFlags =
-                                ((mBold || mpHost->mMxpClient.bold()) ? TChar::Bold : TChar::None)
+                                ((mIsDefaultColor ? mBold || mpHost->mMxpClient.bold() : false) ? TChar::Bold : TChar::None)
                                 | (mItalics || mpHost->mMxpClient.italic() ? TChar::Italic : TChar::None)
                                 | (mOverline ? TChar::Overline : TChar::None)
                                 | (mReverse ? TChar::Reverse : TChar::None)
@@ -751,7 +751,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                         // There is no further MXP or Codeset evaluation
 
                         const TChar::AttributeFlags attributeFlags =
-                                ((mBold || mpHost->mMxpClient.bold()) ? TChar::Bold : TChar::None)
+                                ((mIsDefaultColor ? mBold || mpHost->mMxpClient.bold() : false) ? TChar::Bold : TChar::None)
                                 | (mItalics || mpHost->mMxpClient.italic() ? TChar::Italic : TChar::None)
                                 | (mOverline ? TChar::Overline : TChar::None)
                                 | (mReverse ? TChar::Reverse : TChar::None)
@@ -807,7 +807,7 @@ COMMIT_LINE:
                     continue;
                 } else if (mpHost->mBlankLineBehaviour == Host::BlankLineBehaviour::ReplaceWithSpace) {
                     const TChar::AttributeFlags attributeFlags =
-                            ((mBold || mpHost->mMxpClient.bold()) ? TChar::Bold : TChar::None)
+                            ((mIsDefaultColor ? mBold || mpHost->mMxpClient.bold() : false) ? TChar::Bold : TChar::None)
                             | (mItalics || mpHost->mMxpClient.italic() ? TChar::Italic : TChar::None)
                             | (mOverline ? TChar::Overline : TChar::None)
                             | (mReverse ? TChar::Reverse : TChar::None)
@@ -961,7 +961,7 @@ COMMIT_LINE:
         }
 
         const TChar::AttributeFlags attributeFlags =
-                ((mBold || mpHost->mMxpClient.bold()) ? TChar::Bold : TChar::None)
+                ((mIsDefaultColor ? mBold || mpHost->mMxpClient.bold() : false) ? TChar::Bold : TChar::None)
                 | (mItalics || mpHost->mMxpClient.italic() ? TChar::Italic : TChar::None)
                 | (mOverline ? TChar::Overline : TChar::None)
                 | (mReverse ? TChar::Reverse : TChar::None)


### PR DESCRIPTION
## Brief overview of PR changes/additions

This PR fixes a regression introduced in PR #8262 where the `mIsDefaultColor` conditional was inadvertently removed from the Bold attribute flag logic in `TBuffer::translateToPlainText()`.

## Motivation for adding to Mudlet

A bug was reported in Discord where Achaea game channels were displaying text with unwanted bold styling for ANSI colors 8-15. Investigation revealed that PR #8262's changes to enhance OSC 8 hyperlink styling had unintentionally broken standard ANSI terminal behavior.

## Other info (issues, special instructions, etc.)

**Root Cause:**
In standard ANSI terminal emulation:
- For **default colors** (`mIsDefaultColor=true`): the bold flag should set both the Bold attribute AND use the bright color variant
- For **specific colors 8-15** (`mIsDefaultColor=false`): the bold flag should ONLY use the bright color, NOT set the Bold attribute

PR #8262 simplified the conditional logic by removing the `mIsDefaultColor` check, which caused colors 8-15 to incorrectly receive both the bright color AND bold font weight.

**Fix:**
This PR restores the `mIsDefaultColor` check in all 4 locations where `attributeFlags` is constructed in `translateToPlainText()`, returning ANSI color handling to its correct behavior.

**Changed Lines:**
- Line 585: CUF (Cursor Forward) handling
- Line 754: Literal entity processing
- Line 810: Blank line handling  
- Line 964: Main character processing

**Testing:**
- Built successfully on macOS
- Tested with Mudlet running - application launches correctly
- Code review confirms the fix matches the original logic before PR #8262

Fixes issue reported in Discord.