### PR TITLE
Improve: sendGMCP and sendATCP error messages

### DIFF
--- a/src/TLuaInterpreterNetworking.cpp
+++ b/src/TLuaInterpreterNetworking.cpp
@@ -323,13 +323,18 @@ int TLuaInterpreter::sendATCP(lua_State* L)
     output += TN_IAC;
     output += TN_SE;
 
+    // Check connection status first (most common issue)
+    if (host.mTelnet.getConnectionState() != QAbstractSocket::ConnectedState) {
+        return warnArgumentValue(L, __func__, qsl("not connected to game server - connect first before sending ATCP"));
+    }
+
     if (!host.mTelnet.isATCPEnabled()) {
-        return warnArgumentValue(L, __func__, "ATCP is not currently enabled");
+        return warnArgumentValue(L, __func__, qsl("ATCP is not currently enabled"));
     }
 
     // output is in Mud Server Encoding form here:
     if (!host.mTelnet.socketOutRaw(output)) {
-        return warnArgumentValue(L, __func__, "unable to send all of the ATCP message");
+        return warnArgumentValue(L, __func__, qsl("failed to send ATCP message - connection may have been lost or a socket write error occurred"));
     }
 
     lua_pushboolean(L, true);
@@ -367,13 +372,18 @@ int TLuaInterpreter::sendGMCP(lua_State* L)
     output += TN_IAC;
     output += TN_SE;
 
+    // Check connection status first (most common issue)
+    if (host.mTelnet.getConnectionState() != QAbstractSocket::ConnectedState) {
+        return warnArgumentValue(L, __func__, qsl("not connected to game server - connect first before sending GMCP"));
+    }
+
     if (!host.mTelnet.isGMCPEnabled()) {
-        return warnArgumentValue(L, __func__, "GMCP is not currently enabled");
+        return warnArgumentValue(L, __func__, qsl("GMCP is not currently enabled"));
     }
 
     // output is in Mud Server Encoding form here:
     if (!host.mTelnet.socketOutRaw(output)) {
-        return warnArgumentValue(L, __func__, "unable to send all of the GMCP message");
+        return warnArgumentValue(L, __func__, qsl("failed to send GMCP message - connection may have been lost or a socket write error occurred"));
     }
 
     lua_pushboolean(L, true);


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Improved error messages for `sendGMCP()` and `sendATCP()` functions to provide clearer guidance when commands fail. The functions now check if you're connected to the game server first and provide specific error messages explaining what went wrong.

**Changes:**
- Added connection check before attempting to send GMCP/ATCP messages
- Replaced vague "unable to send all of the GMCP message" with specific error messages:
  - "not connected to game server - connect first before sending GMCP/ATCP"
  - "failed to send GMCP/ATCP message - connection may have been lost or a socket write error occurred"
- Applied `qsl()` macro to all string literals per coding standards

#### Motivation for adding to Mudlet

The original error messages were too generic and didn't help users diagnose problems. When `sendGMCP()` failed, users received "unable to send all of the GMCP message" which provided no context about the actual cause - whether they weren't connected, the protocol wasn't enabled, or a socket error occurred. This made troubleshooting difficult for script developers.

#### Other info (issues closed, discussion etc)

Closes #4924