### PR TITLE
Fix: Preserve font size and formatting in Geyser.Label decho/hecho/cecho

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -74,8 +74,11 @@ function Geyser.Label:decho(message)
   message = message or self.message
   self.message = message
 
-  -- Convert decho formatted text to HTML, preserving colors
-  local htmlContent = decho2html(message)
+  -- Get label's default format to preserve its colors
+  local labelFormat = getLabelFormat(self.name)
+
+  -- Convert decho formatted text to HTML, preserving label's default colors
+  local htmlContent = decho2html(message, labelFormat)
 
   -- Apply label's formatting settings
   local ft = self.formatTable
@@ -115,8 +118,11 @@ function Geyser.Label:hecho(message)
   message = message or self.message
   self.message = message
 
-  -- Convert hecho formatted text to HTML, preserving colors
-  local htmlContent = hecho2html(message)
+  -- Get label's default format to preserve its colors
+  local labelFormat = getLabelFormat(self.name)
+
+  -- Convert hecho formatted text to HTML, preserving label's default colors
+  local htmlContent = hecho2html(message, labelFormat)
 
   -- Apply label's formatting settings
   local ft = self.formatTable
@@ -156,8 +162,11 @@ function Geyser.Label:cecho(message)
   message = message or self.message
   self.message = message
 
-  -- Convert cecho formatted text to HTML, preserving colors
-  local htmlContent = cecho2html(message)
+  -- Get label's default format to preserve its colors
+  local labelFormat = getLabelFormat(self.name)
+
+  -- Convert cecho formatted text to HTML, preserving label's default colors
+  local htmlContent = cecho2html(message, labelFormat)
 
   -- Apply label's formatting settings
   local ft = self.formatTable

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -68,6 +68,129 @@ function Geyser.Label:rawEcho(message)
   self:autoAdjustSize()
 end
 
+--- Prints a message to the label with decho color formatting, preserving label's font size and formatting.
+-- @param message The message to print. Uses decho color codes like "<255,0,0>text" for colors.
+function Geyser.Label:decho(message)
+  message = message or self.message
+  self.message = message
+
+  -- Convert decho formatted text to HTML, preserving colors
+  local htmlContent = decho2html(message)
+
+  -- Apply label's formatting settings
+  local ft = self.formatTable
+  local fs = ft.fontSize
+  local alignment = ft.alignment
+  if alignment ~= "" then
+    alignment = string.format([[align="%s" ]], alignment)
+  end
+  if ft.bold then
+    htmlContent = "<b>" .. htmlContent .. "</b>"
+  end
+  if ft.italics then
+    htmlContent = "<i>" .. htmlContent .. "</i>"
+  end
+  if ft.underline then
+    htmlContent = "<u>" .. htmlContent .. "</u>"
+  end
+  if ft.strikethrough then
+    htmlContent = "<s>" .. htmlContent .. "</s>"
+  end
+  if self.font and self.font ~= "" then
+    htmlContent = string.format('<font face="%s">%s</font>', self.font, htmlContent)
+  end
+  if not fs then
+    fs = tostring(self.fontSize)
+  end
+  fs = "font-size: " .. fs .. "pt; "
+  htmlContent = [[<div ]] .. alignment .. [[style="]] .. fs ..
+  [[">]] .. htmlContent .. [[</div>]]
+  echo(self.name, htmlContent)
+  self:autoAdjustSize()
+end
+
+--- Prints a message to the label with hecho color formatting, preserving label's font size and formatting.
+-- @param message The message to print. Uses hecho color codes like "|cff0000text" for colors.
+function Geyser.Label:hecho(message)
+  message = message or self.message
+  self.message = message
+
+  -- Convert hecho formatted text to HTML, preserving colors
+  local htmlContent = hecho2html(message)
+
+  -- Apply label's formatting settings
+  local ft = self.formatTable
+  local fs = ft.fontSize
+  local alignment = ft.alignment
+  if alignment ~= "" then
+    alignment = string.format([[align="%s" ]], alignment)
+  end
+  if ft.bold then
+    htmlContent = "<b>" .. htmlContent .. "</b>"
+  end
+  if ft.italics then
+    htmlContent = "<i>" .. htmlContent .. "</i>"
+  end
+  if ft.underline then
+    htmlContent = "<u>" .. htmlContent .. "</u>"
+  end
+  if ft.strikethrough then
+    htmlContent = "<s>" .. htmlContent .. "</s>"
+  end
+  if self.font and self.font ~= "" then
+    htmlContent = string.format('<font face="%s">%s</font>', self.font, htmlContent)
+  end
+  if not fs then
+    fs = tostring(self.fontSize)
+  end
+  fs = "font-size: " .. fs .. "pt; "
+  htmlContent = [[<div ]] .. alignment .. [[style="]] .. fs ..
+  [[">]] .. htmlContent .. [[</div>]]
+  echo(self.name, htmlContent)
+  self:autoAdjustSize()
+end
+
+--- Prints a message to the label with cecho color formatting, preserving label's font size and formatting.
+-- @param message The message to print. Uses cecho color codes like "<red>text" for colors.
+function Geyser.Label:cecho(message)
+  message = message or self.message
+  self.message = message
+
+  -- Convert cecho formatted text to HTML, preserving colors
+  local htmlContent = cecho2html(message)
+
+  -- Apply label's formatting settings
+  local ft = self.formatTable
+  local fs = ft.fontSize
+  local alignment = ft.alignment
+  if alignment ~= "" then
+    alignment = string.format([[align="%s" ]], alignment)
+  end
+  if ft.bold then
+    htmlContent = "<b>" .. htmlContent .. "</b>"
+  end
+  if ft.italics then
+    htmlContent = "<i>" .. htmlContent .. "</i>"
+  end
+  if ft.underline then
+    htmlContent = "<u>" .. htmlContent .. "</u>"
+  end
+  if ft.strikethrough then
+    htmlContent = "<s>" .. htmlContent .. "</s>"
+  end
+  if self.font and self.font ~= "" then
+    htmlContent = string.format('<font face="%s">%s</font>', self.font, htmlContent)
+  end
+  if not fs then
+    fs = tostring(self.fontSize)
+  end
+  fs = "font-size: " .. fs .. "pt; "
+  htmlContent = [[<div ]] .. alignment .. [[style="]] .. fs ..
+  [[">]] .. htmlContent .. [[</div>]]
+  echo(self.name, htmlContent)
+  self:autoAdjustSize()
+end
+
 --- sets the color of the text on the label
 -- @param color the color you want the text to be. Can use color names such as "red", decho codes such as "<255,0,0>" and hex codes such as "#ff0000"
 function Geyser.Label:setFgColor(color)

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -74,11 +74,15 @@ function Geyser.Label:decho(message)
   message = message or self.message
   self.message = message
 
-  -- Get label's default format to preserve its colors
-  local labelFormat = getLabelFormat(self.name)
+  -- Build resetFormat table using label's actual fgColor, not just stylesheet
+  local resetFormat = getLabelFormat(self.name)
+  -- Override foreground with label's fgColor property if set
+  if self.fgColor and self.fgColor ~= "" then
+    resetFormat.foreground = Geyser.Color.hex(self.fgColor)
+  end
 
-  -- Convert decho formatted text to HTML, preserving label's default colors
-  local htmlContent = decho2html(message, labelFormat)
+  -- Convert decho formatted text to HTML, preserving label's colors
+  local htmlContent = decho2html(message, resetFormat)
 
   -- Apply label's formatting settings
   local ft = self.formatTable
@@ -118,11 +122,15 @@ function Geyser.Label:hecho(message)
   message = message or self.message
   self.message = message
 
-  -- Get label's default format to preserve its colors
-  local labelFormat = getLabelFormat(self.name)
+  -- Build resetFormat table using label's actual fgColor, not just stylesheet
+  local resetFormat = getLabelFormat(self.name)
+  -- Override foreground with label's fgColor property if set
+  if self.fgColor and self.fgColor ~= "" then
+    resetFormat.foreground = Geyser.Color.hex(self.fgColor)
+  end
 
-  -- Convert hecho formatted text to HTML, preserving label's default colors
-  local htmlContent = hecho2html(message, labelFormat)
+  -- Convert hecho formatted text to HTML, preserving label's colors
+  local htmlContent = hecho2html(message, resetFormat)
 
   -- Apply label's formatting settings
   local ft = self.formatTable
@@ -162,11 +170,15 @@ function Geyser.Label:cecho(message)
   message = message or self.message
   self.message = message
 
-  -- Get label's default format to preserve its colors
-  local labelFormat = getLabelFormat(self.name)
+  -- Build resetFormat table using label's actual fgColor, not just stylesheet
+  local resetFormat = getLabelFormat(self.name)
+  -- Override foreground with label's fgColor property if set
+  if self.fgColor and self.fgColor ~= "" then
+    resetFormat.foreground = Geyser.Color.hex(self.fgColor)
+  end
 
-  -- Convert cecho formatted text to HTML, preserving label's default colors
-  local htmlContent = cecho2html(message, labelFormat)
+  -- Convert cecho formatted text to HTML, preserving label's colors
+  local htmlContent = cecho2html(message, resetFormat)
 
   -- Apply label's formatting settings
   local ft = self.formatTable

--- a/src/mudlet-lua/tests/GeyserLabel_spec.lua
+++ b/src/mudlet-lua/tests/GeyserLabel_spec.lua
@@ -1,0 +1,108 @@
+describe("Tests functionality of Geyser.Label", function()
+  describe('Tests that decho/hecho/cecho preserve font size', function()
+    local label
+    local globalEchoSpy
+
+    before_each(function()
+      -- Spy on the global echo function to inspect what HTML is generated
+      globalEchoSpy = spy.on(_G, "echo")
+
+      -- Create a label with a specific font size
+      label = Geyser.Label:new({
+        name = "testLabel",
+        x = 0, y = 0,
+        width = 100, height = 100,
+      })
+
+      -- Set font size to 50
+      label:setFontSize(50)
+    end)
+
+    after_each(function()
+      _G.echo:revert()
+      if label then
+        label:hide()
+      end
+    end)
+
+    it('preserves font size when using echo()', function()
+      label:echo("test message")
+
+      -- Verify echo was called
+      assert.spy(globalEchoSpy).was.called()
+
+      -- Get the HTML that was passed to echo
+      local callArgs = globalEchoSpy.calls[#globalEchoSpy.calls]
+      local html = callArgs.vals[2] -- second argument is the message
+
+      -- Verify the HTML contains font-size: 50pt
+      assert.is_truthy(html:find("font%-size: 50pt"))
+    end)
+
+    it('preserves font size when using decho()', function()
+      label:decho("<255,0,0>red text")
+
+      -- Verify echo was called (decho ultimately calls echo)
+      assert.spy(globalEchoSpy).was.called()
+
+      -- Get the HTML that was passed to echo
+      local callArgs = globalEchoSpy.calls[#globalEchoSpy.calls]
+      local html = callArgs.vals[2]
+
+      -- Verify the HTML contains font-size: 50pt
+      assert.is_truthy(html:find("font%-size: 50pt"), "decho did not preserve font size")
+    end)
+
+    it('preserves font size when using hecho()', function()
+      label:hecho("|cff0000red text")
+
+      -- Verify echo was called (hecho ultimately calls echo)
+      assert.spy(globalEchoSpy).was.called()
+
+      -- Get the HTML that was passed to echo
+      local callArgs = globalEchoSpy.calls[#globalEchoSpy.calls]
+      local html = callArgs.vals[2]
+
+      -- Verify the HTML contains font-size: 50pt
+      assert.is_truthy(html:find("font%-size: 50pt"), "hecho did not preserve font size")
+    end)
+
+    it('preserves font size when using cecho()', function()
+      label:cecho("<red>red text")
+
+      -- Verify echo was called (cecho ultimately calls echo)
+      assert.spy(globalEchoSpy).was.called()
+
+      -- Get the HTML that was passed to echo
+      local callArgs = globalEchoSpy.calls[#globalEchoSpy.calls]
+      local html = callArgs.vals[2]
+
+      -- Verify the HTML contains font-size: 50pt
+      assert.is_truthy(html:find("font%-size: 50pt"), "cecho did not preserve font size")
+    end)
+
+    it('preserves bold formatting when using decho()', function()
+      label:setBold(true)
+      label:decho("<255,0,0>bold red text")
+
+      local callArgs = globalEchoSpy.calls[#globalEchoSpy.calls]
+      local html = callArgs.vals[2]
+
+      -- Verify the HTML contains both font-size and bold tags
+      assert.is_truthy(html:find("font%-size: 50pt"))
+      assert.is_truthy(html:find("<b>"))
+    end)
+
+    it('preserves alignment when using hecho()', function()
+      label:setAlignment("center")
+      label:hecho("|cff0000centered text")
+
+      local callArgs = globalEchoSpy.calls[#globalEchoSpy.calls]
+      local html = callArgs.vals[2]
+
+      -- Verify the HTML contains alignment
+      assert.is_truthy(html:find('align="center"'))
+      assert.is_truthy(html:find("font%-size: 50pt"))
+    end)
+  end)
+end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Geyser.Label now preserves font size and formatting when using `decho()`, `hecho()`, and `cecho()` methods. Previously, only `echo()` preserved these settings.

#### Motivation for adding to Mudlet

Fixes unexpected behavior where calling `testlabel:hecho("text")` would change the font size even after `testlabel:setFontSize(50)`. This makes all echo variants behave consistently, preserving user-defined formatting.

#### Other info (issues closed, discussion etc)

Closes #8389

Added unit tests in `GeyserLabel_spec.lua` to verify font size and formatting preservation across all echo methods.