### PR TITLE
Add: snapping controls to custom line editing

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,6 +112,7 @@ set(mudlet_SRCS
     CustomLineDrawHandler.cpp
     CustomLineEditContextMenuHandler.cpp
     CustomLineEditHandler.cpp
+    CustomLineSession.cpp
     LabelInteractionHandler.cpp
     PanInteractionHandler.cpp
     RoomContextMenuHandler.cpp
@@ -305,6 +306,7 @@ set(mudlet_HDRS
     CustomLineDrawHandler.h
     CustomLineEditContextMenuHandler.h
     CustomLineEditHandler.h
+    CustomLineSession.h
     LabelInteractionHandler.h
     PanInteractionHandler.h
     RoomMoveActivationHandler.h

--- a/src/CustomLineDrawContextMenuHandler.cpp
+++ b/src/CustomLineDrawContextMenuHandler.cpp
@@ -87,6 +87,26 @@ bool CustomLineDrawContextMenuHandler::handle(T2DMap::MapInteractionContext& con
         customLineUndoLastPoint->setEnabled(false);
     }
 
+    //: 2D Mapper context menu (drawing custom exit line) item
+    auto snapToGrid = new QAction(T2DMap::tr("Snap points to grid"), &mMapWidget);
+    snapToGrid->setCheckable(true);
+    snapToGrid->setChecked(mMapWidget.isSnapCustomLinePointsToGridEnabled());
+    QObject::connect(snapToGrid, &QAction::toggled, &mMapWidget, &T2DMap::slot_setSnapCustomLinePointsToGrid);
+    //: 2D Mapper context menu (drawing custom exit line) item tooltip
+    snapToGrid->setToolTip(utils::richText(T2DMap::tr("Snap current points and keep custom line edits aligned to the map grid")));
+
+    //: 2D Mapper context menu (drawing custom exit line) item
+    auto moveLastPoint = new QAction(T2DMap::tr("Move last point to target room"), &mMapWidget);
+    if (mMapWidget.canMoveCustomLineLastPointToTargetRoom(*room, context.customLinesRoomExit)) {
+        QObject::connect(moveLastPoint, &QAction::triggered, &mMapWidget, &T2DMap::slot_moveCustomLineLastPointToTargetRoom);
+        //: 2D Mapper context menu (drawing custom exit line) item tooltip (enabled state)
+        moveLastPoint->setToolTip(utils::richText(T2DMap::tr("Snap the final point to the destination room")));
+    } else {
+        moveLastPoint->setEnabled(false);
+        //: 2D Mapper context menu (drawing custom exit line) item tooltip (disabled state)
+        moveLastPoint->setToolTip(utils::richText(T2DMap::tr("Select a line with a valid target room and at least one adjustable point")));
+    }
+
     //: 2D Mapper context menu (drawing custom exit line) item name (but not used as display text as that is set separately)
     auto customLineProperties = new QAction(T2DMap::tr("Properties"), &mMapWidget);
     //: 2D Mapper context menu (drawing custom exit line) item display text (has to be entered separately as the ... would get stripped off otherwise)
@@ -104,6 +124,8 @@ bool CustomLineDrawContextMenuHandler::handle(T2DMap::MapInteractionContext& con
     room->calcRoomDimensions();
 
     popup->addAction(customLineUndoLastPoint);
+    popup->addAction(snapToGrid);
+    popup->addAction(moveLastPoint);
     popup->addAction(customLineProperties);
     popup->addAction(customLineFinish);
 

--- a/src/CustomLineDrawHandler.cpp
+++ b/src/CustomLineDrawHandler.cpp
@@ -78,7 +78,12 @@ bool CustomLineDrawHandler::handle(T2DMap::MapInteractionContext& context)
     const float mapX = static_cast<float>(context.mapX);
     const float mapY = static_cast<float>(context.mapY);
 
-    room->customLines[context.customLinesRoomExit].push_back(QPointF(mapX, mapY));
+    QPointF newPoint(mapX, mapY);
+    if (mMapWidget.isSnapCustomLinePointsToGridEnabled()) {
+        newPoint = mMapWidget.snapPointToGrid(newPoint);
+    }
+
+    room->customLines[context.customLinesRoomExit].push_back(newPoint);
     room->calcRoomDimensions();
     mMapWidget.repaint();
 

--- a/src/CustomLineEditContextMenuHandler.cpp
+++ b/src/CustomLineEditContextMenuHandler.cpp
@@ -108,6 +108,26 @@ bool CustomLineEditContextMenuHandler::handle(T2DMap::MapInteractionContext& con
         removePoint->setToolTip(utils::richText(T2DMap::tr("Select a point first, then remove it")));
     }
 
+    //: 2D Mapper context menu (custom line editing) item
+    auto snapToGrid = new QAction(T2DMap::tr("Snap points to grid"), &mMapWidget);
+    snapToGrid->setCheckable(true);
+    snapToGrid->setChecked(mMapWidget.isSnapCustomLinePointsToGridEnabled());
+    QObject::connect(snapToGrid, &QAction::toggled, &mMapWidget, &T2DMap::slot_setSnapCustomLinePointsToGrid);
+    //: 2D Mapper context menu (custom line editing) item tooltip
+    snapToGrid->setToolTip(utils::richText(T2DMap::tr("Snap current points and keep custom line edits aligned to the map grid")));
+
+    //: 2D Mapper context menu (custom line editing) item
+    auto moveLastPoint = new QAction(T2DMap::tr("Move last point to target room"), &mMapWidget);
+    if (mMapWidget.canMoveSelectedCustomLineLastPointToTargetRoom()) {
+        QObject::connect(moveLastPoint, &QAction::triggered, &mMapWidget, &T2DMap::slot_moveCustomLineLastPointToTargetRoom);
+        //: 2D Mapper context menu (custom line editing) item tooltip (enabled state)
+        moveLastPoint->setToolTip(utils::richText(T2DMap::tr("Snap the final point to the destination room")));
+    } else {
+        moveLastPoint->setEnabled(false);
+        //: 2D Mapper context menu (custom line editing) item tooltip (disabled state)
+        moveLastPoint->setToolTip(utils::richText(T2DMap::tr("Select a line with a valid target room and at least one adjustable point")));
+    }
+
     //: 2D Mapper context menu (custom line editing) item name (but not used as display text as that is set separately)
     auto lineProperties = new QAction(T2DMap::tr("Properties"), &mMapWidget);
     //: 2D Mapper context menu (custom line editing) item display text (has to be entered separately as the ... would get stripped off otherwise
@@ -123,6 +143,8 @@ bool CustomLineEditContextMenuHandler::handle(T2DMap::MapInteractionContext& con
 
     popup->addAction(addPoint);
     popup->addAction(removePoint);
+    popup->addAction(snapToGrid);
+    popup->addAction(moveLastPoint);
     popup->addAction(lineProperties);
     popup->addAction(deleteLine);
 

--- a/src/CustomLineEditHandler.cpp
+++ b/src/CustomLineEditHandler.cpp
@@ -208,7 +208,12 @@ bool CustomLineEditHandler::handleMouseMove(T2DMap::MapInteractionContext& conte
         return false;
     }
 
-    points[mMapWidget.mCustomLineSelectedPoint] = context.mapPoint;
+    QPointF newPoint = context.mapPoint;
+    if (mMapWidget.isSnapCustomLinePointsToGridEnabled()) {
+        newPoint = mMapWidget.snapPointToGrid(newPoint);
+    }
+
+    points[mMapWidget.mCustomLineSelectedPoint] = newPoint;
     room->calcRoomDimensions();
     mMapWidget.repaint();
     mMapWidget.mpMap->setUnsaved("CustomLineEditHandler::handleMouseMove");

--- a/src/CustomLineSession.cpp
+++ b/src/CustomLineSession.cpp
@@ -1,0 +1,322 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by Piotr Wilczynski - delwing@gmail.com            *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "CustomLineSession.h"
+
+#include "T2DMap.h"
+#include "TMap.h"
+#include "TRoom.h"
+#include "TRoomDB.h"
+
+#include <cmath>
+
+CustomLineSession::CustomLineSession(T2DMap& mapWidget)
+: mMapWidget(mapWidget)
+{
+}
+
+bool CustomLineSession::isSnapToGridEnabled() const
+{
+    return mSnapToGridEnabled;
+}
+
+void CustomLineSession::setSnapToGridEnabled(bool enabled)
+{
+    if (mSnapToGridEnabled == enabled) {
+        return;
+    }
+
+    if (enabled) {
+        restoreOriginalLineIfNeeded();
+        const auto key = currentLineKey();
+        if (!key) {
+            mSnapToGridEnabled = enabled;
+            return;
+        }
+
+        TRoom* room = nullptr;
+        QList<QPointF>* points = resolveLinePoints(*key, room);
+        if (!points || !room) {
+            mSnapToGridEnabled = enabled;
+            return;
+        }
+
+        rememberOriginalLine(*key, *points);
+        snapLineToGrid(*key, *points, *room);
+    } else {
+        restoreOriginalLineIfNeeded();
+        mSnapToGridEnabled = enabled;
+        if (mMapWidget.mpMap) {
+            mMapWidget.repaint();
+        }
+        mOriginalLine.reset();
+        return;
+    }
+
+    mSnapToGridEnabled = enabled;
+}
+
+QPointF CustomLineSession::snapPointToGrid(const QPointF& point) const
+{
+    constexpr qreal snapIncrement = 0.5;
+    const qreal snappedX = std::round(point.x() / snapIncrement) * snapIncrement;
+    const qreal snappedY = std::round(point.y() / snapIncrement) * snapIncrement;
+    return QPointF(snappedX, snappedY);
+}
+
+bool CustomLineSession::canMoveSelectedCustomLineLastPointToTargetRoom() const
+{
+    if (!mMapWidget.mpMap || !mMapWidget.mpMap->mpRoomDB) {
+        return false;
+    }
+
+    if (mMapWidget.mCustomLineSelectedRoom <= 0 || mMapWidget.mCustomLineSelectedExit.isEmpty()) {
+        return false;
+    }
+
+    TRoom* room = mMapWidget.mpMap->mpRoomDB->getRoom(mMapWidget.mCustomLineSelectedRoom);
+    if (!room) {
+        return false;
+    }
+
+    return canMoveCustomLineLastPointToTargetRoom(*room, mMapWidget.mCustomLineSelectedExit);
+}
+
+bool CustomLineSession::canMoveCustomLineLastPointToTargetRoom(const TRoom& room, const QString& exitKey) const
+{
+    if (!mMapWidget.mpMap || !mMapWidget.mpMap->mpRoomDB) {
+        return false;
+    }
+
+    const auto itLine = room.customLines.constFind(exitKey);
+    if (itLine == room.customLines.constEnd()) {
+        return false;
+    }
+
+    const QList<QPointF>& points = itLine.value();
+    if (points.isEmpty()) {
+        return false;
+    }
+
+    const auto targetRoomId = resolveCustomLineTargetRoomId(room, exitKey);
+    if (!targetRoomId || *targetRoomId <= 0) {
+        return false;
+    }
+
+    return mMapWidget.mpMap->mpRoomDB->getRoom(*targetRoomId) != nullptr;
+}
+
+void CustomLineSession::moveCustomLineLastPointToTargetRoom()
+{
+    if (!mMapWidget.mpMap || !mMapWidget.mpMap->mpRoomDB) {
+        return;
+    }
+
+    const auto key = currentLineKey();
+    if (!key) {
+        return;
+    }
+
+    TRoom* room = nullptr;
+    QList<QPointF>* points = resolveLinePoints(*key, room);
+    if (!points || !room || points->isEmpty()) {
+        return;
+    }
+
+    const auto targetRoomId = resolveCustomLineTargetRoomId(*room, key->exitKey);
+    if (!targetRoomId || *targetRoomId <= 0) {
+        return;
+    }
+
+    TRoom* targetRoom = mMapWidget.mpMap->mpRoomDB->getRoom(*targetRoomId);
+    if (!targetRoom) {
+        return;
+    }
+
+    QPointF newPoint(targetRoom->x(), targetRoom->y());
+    if (mSnapToGridEnabled) {
+        newPoint = snapPointToGrid(newPoint);
+    }
+
+    QPointF& lastPoint = points->last();
+    if (qFuzzyIsNull(lastPoint.x() - newPoint.x()) && qFuzzyIsNull(lastPoint.y() - newPoint.y())) {
+        return;
+    }
+
+    lastPoint = newPoint;
+    room->calcRoomDimensions();
+    mMapWidget.repaint();
+    if (mMapWidget.mpMap) {
+        mMapWidget.mpMap->setUnsaved(__func__);
+    }
+}
+
+void CustomLineSession::clearOriginalPoints()
+{
+    mOriginalLine.reset();
+}
+
+std::optional<CustomLineSession::LineKey> CustomLineSession::currentLineKey() const
+{
+    if (mMapWidget.mCustomLineSelectedRoom > 0 && !mMapWidget.mCustomLineSelectedExit.isEmpty()) {
+        return LineKey { mMapWidget.mCustomLineSelectedRoom, mMapWidget.mCustomLineSelectedExit };
+    }
+
+    if (mMapWidget.mCustomLinesRoomFrom > 0 && !mMapWidget.mCustomLinesRoomExit.isEmpty()) {
+        return LineKey { mMapWidget.mCustomLinesRoomFrom, mMapWidget.mCustomLinesRoomExit };
+    }
+
+    return std::nullopt;
+}
+
+QList<QPointF>* CustomLineSession::resolveLinePoints(const LineKey& key, TRoom*& room) const
+{
+    if (!key.isValid() || !mMapWidget.mpMap || !mMapWidget.mpMap->mpRoomDB) {
+        return nullptr;
+    }
+
+    room = mMapWidget.mpMap->mpRoomDB->getRoom(key.roomId);
+    if (!room) {
+        return nullptr;
+    }
+
+    auto itLine = room->customLines.find(key.exitKey);
+    if (itLine == room->customLines.end()) {
+        return nullptr;
+    }
+
+    return &itLine.value();
+}
+
+void CustomLineSession::rememberOriginalLine(const LineKey& key, const QList<QPointF>& points)
+{
+    if (!key.isValid()) {
+        mOriginalLine.reset();
+        return;
+    }
+
+    mOriginalLine = OriginalLine { key, points };
+}
+
+void CustomLineSession::snapLineToGrid(LineKey key, QList<QPointF>& points, TRoom& room)
+{
+    if (!key.isValid()) {
+        return;
+    }
+
+    bool changed = false;
+    for (QPointF& point : points) {
+        const QPointF snapped = snapPointToGrid(point);
+        if (!qFuzzyIsNull(point.x() - snapped.x()) || !qFuzzyIsNull(point.y() - snapped.y())) {
+            point = snapped;
+            changed = true;
+        }
+    }
+
+    if (changed) {
+        room.calcRoomDimensions();
+        mMapWidget.repaint();
+        if (mMapWidget.mpMap) {
+            mMapWidget.mpMap->setUnsaved(__func__);
+        }
+    }
+}
+
+void CustomLineSession::restoreOriginalLineIfNeeded()
+{
+    if (!mOriginalLine) {
+        return;
+    }
+
+    const auto key = currentLineKey();
+    if (!key || !(mOriginalLine->key == *key)) {
+        mOriginalLine.reset();
+        return;
+    }
+
+    TRoom* room = nullptr;
+    QList<QPointF>* points = resolveLinePoints(mOriginalLine->key, room);
+    if (!points || !room) {
+        mOriginalLine.reset();
+        return;
+    }
+
+    if (*points == mOriginalLine->points) {
+        mOriginalLine.reset();
+        return;
+    }
+
+    *points = mOriginalLine->points;
+    room->calcRoomDimensions();
+    mMapWidget.repaint();
+    if (mMapWidget.mpMap) {
+        mMapWidget.mpMap->setUnsaved(__func__);
+    }
+
+    mOriginalLine.reset();
+}
+
+std::optional<int> CustomLineSession::resolveCustomLineTargetRoomId(const TRoom& room, const QString& exitKey) const
+{
+    if (exitKey == QLatin1String("nw")) {
+        return room.getNorthwest();
+    }
+    if (exitKey == QLatin1String("n")) {
+        return room.getNorth();
+    }
+    if (exitKey == QLatin1String("ne")) {
+        return room.getNortheast();
+    }
+    if (exitKey == QLatin1String("up")) {
+        return room.getUp();
+    }
+    if (exitKey == QLatin1String("w")) {
+        return room.getWest();
+    }
+    if (exitKey == QLatin1String("e")) {
+        return room.getEast();
+    }
+    if (exitKey == QLatin1String("down")) {
+        return room.getDown();
+    }
+    if (exitKey == QLatin1String("sw")) {
+        return room.getSouthwest();
+    }
+    if (exitKey == QLatin1String("s")) {
+        return room.getSouth();
+    }
+    if (exitKey == QLatin1String("se")) {
+        return room.getSoutheast();
+    }
+    if (exitKey == QLatin1String("in")) {
+        return room.getIn();
+    }
+    if (exitKey == QLatin1String("out")) {
+        return room.getOut();
+    }
+
+    const auto& specialExits = room.getSpecialExits();
+    const auto itSpecial = specialExits.constFind(exitKey);
+    if (itSpecial != specialExits.constEnd()) {
+        return itSpecial.value();
+    }
+
+    return std::nullopt;
+}
+

--- a/src/CustomLineSession.h
+++ b/src/CustomLineSession.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <optional>
+
+#include "pre_guard.h"
+#include <QList>
+#include <QPointF>
+#include <QString>
+#include "post_guard.h"
+
+class T2DMap;
+class TRoom;
+
+class CustomLineSession
+{
+public:
+    explicit CustomLineSession(T2DMap& mapWidget);
+
+    bool isSnapToGridEnabled() const;
+    void setSnapToGridEnabled(bool enabled);
+
+    QPointF snapPointToGrid(const QPointF& point) const;
+
+    bool canMoveSelectedCustomLineLastPointToTargetRoom() const;
+    bool canMoveCustomLineLastPointToTargetRoom(const TRoom& room, const QString& exitKey) const;
+    void moveCustomLineLastPointToTargetRoom();
+
+    void clearOriginalPoints();
+
+private:
+    struct LineKey
+    {
+        int roomId = 0;
+        QString exitKey;
+
+        bool isValid() const { return roomId > 0 && !exitKey.isEmpty(); }
+        bool operator==(const LineKey& other) const { return roomId == other.roomId && exitKey == other.exitKey; }
+    };
+
+    struct OriginalLine
+    {
+        LineKey key;
+        QList<QPointF> points;
+    };
+
+    std::optional<LineKey> currentLineKey() const;
+    QList<QPointF>* resolveLinePoints(const LineKey& key, TRoom*& room) const;
+
+    void rememberOriginalLine(const LineKey& key, const QList<QPointF>& points);
+    void snapLineToGrid(LineKey key, QList<QPointF>& points, TRoom& room);
+    void restoreOriginalLineIfNeeded();
+
+    std::optional<int> resolveCustomLineTargetRoomId(const TRoom& room, const QString& exitKey) const;
+
+    T2DMap& mMapWidget;
+    bool mSnapToGridEnabled = false;
+    std::optional<OriginalLine> mOriginalLine;
+};
+

--- a/src/CustomLineSession.h
+++ b/src/CustomLineSession.h
@@ -1,12 +1,29 @@
+/***************************************************************************
+*   Copyright (C) 2025 by Piotr Wilczynski - delwing@gmail.com            *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
 #pragma once
 
 #include <optional>
 
-#include "pre_guard.h"
 #include <QList>
 #include <QPointF>
 #include <QString>
-#include "post_guard.h"
 
 class T2DMap;
 class TRoom;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -34,6 +34,7 @@
 #include "CustomLineDrawHandler.h"
 #include "CustomLineEditContextMenuHandler.h"
 #include "CustomLineEditHandler.h"
+#include "CustomLineSession.h"
 #include "LabelInteractionHandler.h"
 #include "PanInteractionHandler.h"
 #include "RoomContextMenuHandler.h"
@@ -354,6 +355,8 @@ T2DMap::T2DMap(QWidget* parent)
     mMultiSelectionListWidget.move(0, 0);
     mMultiSelectionListWidget.hide();
     connect(&mMultiSelectionListWidget, &QTreeWidget::itemSelectionChanged, this, &T2DMap::slot_roomSelectionChanged);
+
+    mCustomLineSession = std::make_unique<CustomLineSession>(*this);
 
     mCustomLineDrawContextMenuHandler = std::make_unique<CustomLineDrawContextMenuHandler>(*this);
     registerInteractionHandler(mCustomLineDrawContextMenuHandler.get(), 450);
@@ -3173,7 +3176,7 @@ void T2DMap::slot_customLineAddPoint()
     }
     segment.setLength(segment.length() / 2.0);
     QPointF newPoint = segment.p2();
-    if (mSnapCustomLinePointsToGridEnabled) {
+    if (isSnapCustomLinePointsToGridEnabled()) {
         newPoint = snapPointToGrid(newPoint);
     }
     room->customLines[mCustomLineSelectedExit].insert(mCustomLineSelectedPoint, newPoint);
@@ -3188,13 +3191,8 @@ void T2DMap::slot_customLineAddPoint()
 
 void T2DMap::slot_setSnapCustomLinePointsToGrid(bool enabled)
 {
-    const bool wasEnabled = mSnapCustomLinePointsToGridEnabled;
-    mSnapCustomLinePointsToGridEnabled = enabled;
-
-    if (enabled) {
-        snapSelectedCustomLineToGrid();
-    } else if (wasEnabled != enabled) {
-        repaint();
+    if (mCustomLineSession) {
+        mCustomLineSession->setSnapToGridEnabled(enabled);
     }
 }
 
@@ -3224,216 +3222,45 @@ void T2DMap::slot_customLineRemovePoint()
 }
 
 
-void T2DMap::snapSelectedCustomLineToGrid()
+bool T2DMap::isSnapCustomLinePointsToGridEnabled() const
 {
-    if (!mpMap || !mpMap->mpRoomDB) {
-        return;
-    }
-
-    int roomId = mCustomLineSelectedRoom;
-    QString exitKey = mCustomLineSelectedExit;
-
-    if (roomId <= 0 || exitKey.isEmpty()) {
-        roomId = mCustomLinesRoomFrom;
-        exitKey = mCustomLinesRoomExit;
-    }
-
-    if (roomId <= 0 || exitKey.isEmpty()) {
-        return;
-    }
-
-    TRoom* room = mpMap->mpRoomDB->getRoom(roomId);
-    if (!room) {
-        return;
-    }
-
-    auto itLine = room->customLines.find(exitKey);
-    if (itLine == room->customLines.end()) {
-        return;
-    }
-
-    QList<QPointF>& points = itLine.value();
-    if (points.isEmpty()) {
-        return;
-    }
-
-    bool changed = false;
-    for (QPointF& point : points) {
-        const QPointF snapped = snapPointToGrid(point);
-        if (!qFuzzyIsNull(point.x() - snapped.x()) || !qFuzzyIsNull(point.y() - snapped.y())) {
-            point = snapped;
-            changed = true;
-        }
-    }
-
-    if (changed) {
-        room->calcRoomDimensions();
-        repaint();
-        mpMap->setUnsaved(__func__);
-    }
+    return mCustomLineSession && mCustomLineSession->isSnapToGridEnabled();
 }
+
 
 
 QPointF T2DMap::snapPointToGrid(const QPointF& point) const
 {
-    constexpr qreal snapIncrement = 0.5;
-    const qreal snappedX = std::round(point.x() / snapIncrement) * snapIncrement;
-    const qreal snappedY = std::round(point.y() / snapIncrement) * snapIncrement;
-    return QPointF(snappedX, snappedY);
+    if (mCustomLineSession) {
+        return mCustomLineSession->snapPointToGrid(point);
+    }
+
+    return point;
 }
 
-
-std::optional<int> T2DMap::resolveCustomLineTargetRoomId(const TRoom& room, const QString& exitKey) const
-{
-    if (exitKey == key_nw) {
-        return room.getNorthwest();
-    }
-    if (exitKey == key_n) {
-        return room.getNorth();
-    }
-    if (exitKey == key_ne) {
-        return room.getNortheast();
-    }
-    if (exitKey == key_up) {
-        return room.getUp();
-    }
-    if (exitKey == key_w) {
-        return room.getWest();
-    }
-    if (exitKey == key_e) {
-        return room.getEast();
-    }
-    if (exitKey == key_down) {
-        return room.getDown();
-    }
-    if (exitKey == key_sw) {
-        return room.getSouthwest();
-    }
-    if (exitKey == key_s) {
-        return room.getSouth();
-    }
-    if (exitKey == key_se) {
-        return room.getSoutheast();
-    }
-    if (exitKey == key_in) {
-        return room.getIn();
-    }
-    if (exitKey == key_out) {
-        return room.getOut();
-    }
-
-    const auto& specialExits = room.getSpecialExits();
-    const auto itSpecial = specialExits.constFind(exitKey);
-    if (itSpecial != specialExits.constEnd()) {
-        return itSpecial.value();
-    }
-
-    return std::nullopt;
-}
 
 
 bool T2DMap::canMoveSelectedCustomLineLastPointToTargetRoom() const
 {
-    if (!mpMap || !mpMap->mpRoomDB) {
-        return false;
-    }
-
-    if (mCustomLineSelectedRoom <= 0 || mCustomLineSelectedExit.isEmpty()) {
-        return false;
-    }
-
-    TRoom* room = mpMap->mpRoomDB->getRoom(mCustomLineSelectedRoom);
-    if (!room) {
-        return false;
-    }
-
-    return canMoveCustomLineLastPointToTargetRoom(*room, mCustomLineSelectedExit);
+    return mCustomLineSession && mCustomLineSession->canMoveSelectedCustomLineLastPointToTargetRoom();
 }
+
 
 
 bool T2DMap::canMoveCustomLineLastPointToTargetRoom(const TRoom& room, const QString& exitKey) const
 {
-    if (!mpMap || !mpMap->mpRoomDB) {
-        return false;
-    }
-
-    const auto itLine = room.customLines.constFind(exitKey);
-    if (itLine == room.customLines.constEnd()) {
-        return false;
-    }
-
-    const QList<QPointF>& points = itLine.value();
-    if (points.isEmpty()) {
-        return false;
-    }
-
-    const auto targetRoomId = resolveCustomLineTargetRoomId(room, exitKey);
-    if (!targetRoomId || *targetRoomId <= 0) {
-        return false;
-    }
-
-    return mpMap->mpRoomDB->getRoom(*targetRoomId) != nullptr;
+    return mCustomLineSession && mCustomLineSession->canMoveCustomLineLastPointToTargetRoom(room, exitKey);
 }
+
 
 
 void T2DMap::slot_moveCustomLineLastPointToTargetRoom()
 {
-    if (!mpMap || !mpMap->mpRoomDB) {
-        return;
+    if (mCustomLineSession) {
+        mCustomLineSession->moveCustomLineLastPointToTargetRoom();
     }
-
-    int roomId = mCustomLineSelectedRoom;
-    QString exitKey = mCustomLineSelectedExit;
-
-    if (roomId <= 0 || exitKey.isEmpty()) {
-        roomId = mCustomLinesRoomFrom;
-        exitKey = mCustomLinesRoomExit;
-    }
-
-    if (roomId <= 0 || exitKey.isEmpty()) {
-        return;
-    }
-
-    TRoom* room = mpMap->mpRoomDB->getRoom(roomId);
-    if (!room) {
-        return;
-    }
-
-    auto itLine = room->customLines.find(exitKey);
-    if (itLine == room->customLines.end()) {
-        return;
-    }
-
-    QList<QPointF>& points = itLine.value();
-    if (points.isEmpty()) {
-        return;
-    }
-
-    const auto targetRoomId = resolveCustomLineTargetRoomId(*room, exitKey);
-    if (!targetRoomId || *targetRoomId <= 0) {
-        return;
-    }
-
-    TRoom* targetRoom = mpMap->mpRoomDB->getRoom(*targetRoomId);
-    if (!targetRoom) {
-        return;
-    }
-
-    QPointF newPoint(targetRoom->x(), targetRoom->y());
-    if (mSnapCustomLinePointsToGridEnabled) {
-        newPoint = snapPointToGrid(newPoint);
-    }
-
-    QPointF& lastPoint = points.last();
-    if (qFuzzyIsNull(lastPoint.x() - newPoint.x()) && qFuzzyIsNull(lastPoint.y() - newPoint.y())) {
-        return;
-    }
-
-    lastPoint = newPoint;
-    room->calcRoomDimensions();
-    repaint();
-    mpMap->setUnsaved(__func__);
 }
+
 
 
 void T2DMap::slot_undoCustomLineLastPoint()
@@ -3453,6 +3280,10 @@ void T2DMap::slot_undoCustomLineLastPoint()
 
 void T2DMap::slot_doneCustomLine()
 {
+    if (mCustomLineSession) {
+        mCustomLineSession->clearOriginalPoints();
+    }
+
     if (mpCustomLinesDialog) {
         mpCustomLinesDialog->accept();
         mpCustomLinesDialog = nullptr;
@@ -3476,6 +3307,10 @@ void T2DMap::slot_deleteCustomExitLine()
     if (mCustomLineSelectedRoom > 0) {
         TRoom* room = mpMap->mpRoomDB->getRoom(mCustomLineSelectedRoom);
         if (room) {
+            if (mCustomLineSession) {
+                mCustomLineSession->clearOriginalPoints();
+            }
+
             room->customLinesArrow.remove(mCustomLineSelectedExit);
             room->customLinesColor.remove(mCustomLineSelectedExit);
             room->customLinesStyle.remove(mCustomLineSelectedExit);
@@ -4740,6 +4575,10 @@ void T2DMap::slot_customLineColor()
 // title bar and by ESC keypress...
 void T2DMap::slot_cancelCustomLineDialog()
 {
+    if (mCustomLineSession) {
+        mCustomLineSession->clearOriginalPoints();
+    }
+
     mpCustomLinesDialog->deleteLater();
     mpCustomLinesDialog = nullptr;
     mCustomLinesRoomFrom = 0;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -64,6 +64,8 @@
 #include <QtUiTools>
 #include "post_guard.h"
 
+#include <cmath>
+
 #include "mapInfoContributorManager.h"
 
 
@@ -3170,7 +3172,11 @@ void T2DMap::slot_customLineAddPoint()
         segment = QLineF(customLineStartPoint, room->customLines.value(mCustomLineSelectedExit).at(0));
     }
     segment.setLength(segment.length() / 2.0);
-    room->customLines[mCustomLineSelectedExit].insert(mCustomLineSelectedPoint, segment.p2());
+    QPointF newPoint = segment.p2();
+    if (mSnapCustomLinePointsToGridEnabled) {
+        newPoint = snapPointToGrid(newPoint);
+    }
+    room->customLines[mCustomLineSelectedExit].insert(mCustomLineSelectedPoint, newPoint);
     mCustomLineSelectedPoint++;
     // Need to update the TRoom {min|max}_{x|y} settings as they are used during
     // the painting process:
@@ -3178,6 +3184,20 @@ void T2DMap::slot_customLineAddPoint()
     repaint();
     mpMap->setUnsaved(__func__);
 }
+
+
+void T2DMap::slot_setSnapCustomLinePointsToGrid(bool enabled)
+{
+    const bool wasEnabled = mSnapCustomLinePointsToGridEnabled;
+    mSnapCustomLinePointsToGridEnabled = enabled;
+
+    if (enabled) {
+        snapSelectedCustomLineToGrid();
+    } else if (wasEnabled != enabled) {
+        repaint();
+    }
+}
+
 
 
 void T2DMap::slot_customLineRemovePoint()
@@ -3198,6 +3218,193 @@ void T2DMap::slot_customLineRemovePoint()
     }
     // Need to update the TRoom {min|max}_{x|y} settings as they are used during
     // the painting process:
+    room->calcRoomDimensions();
+    repaint();
+    mpMap->setUnsaved(__func__);
+}
+
+
+void T2DMap::snapSelectedCustomLineToGrid()
+{
+    if (!mpMap || !mpMap->mpRoomDB) {
+        return;
+    }
+
+    if (mCustomLineSelectedRoom <= 0 || mCustomLineSelectedExit.isEmpty()) {
+        return;
+    }
+
+    TRoom* room = mpMap->mpRoomDB->getRoom(mCustomLineSelectedRoom);
+    if (!room) {
+        return;
+    }
+
+    if (!room->customLines.contains(mCustomLineSelectedExit)) {
+        return;
+    }
+
+    QList<QPointF>& points = room->customLines[mCustomLineSelectedExit];
+    if (points.isEmpty()) {
+        return;
+    }
+
+    bool changed = false;
+    for (QPointF& point : points) {
+        const QPointF snapped = snapPointToGrid(point);
+        if (!qFuzzyIsNull(point.x() - snapped.x()) || !qFuzzyIsNull(point.y() - snapped.y())) {
+            point = snapped;
+            changed = true;
+        }
+    }
+
+    if (changed) {
+        room->calcRoomDimensions();
+        repaint();
+        mpMap->setUnsaved(__func__);
+    }
+}
+
+
+QPointF T2DMap::snapPointToGrid(const QPointF& point) const
+{
+    constexpr qreal snapIncrement = 0.5;
+    const qreal snappedX = std::round(point.x() / snapIncrement) * snapIncrement;
+    const qreal snappedY = std::round(point.y() / snapIncrement) * snapIncrement;
+    return QPointF(snappedX, snappedY);
+}
+
+
+std::optional<int> T2DMap::resolveCustomLineTargetRoomId(const TRoom& room, const QString& exitKey) const
+{
+    if (exitKey == key_nw) {
+        return room.getNorthwest();
+    }
+    if (exitKey == key_n) {
+        return room.getNorth();
+    }
+    if (exitKey == key_ne) {
+        return room.getNortheast();
+    }
+    if (exitKey == key_up) {
+        return room.getUp();
+    }
+    if (exitKey == key_w) {
+        return room.getWest();
+    }
+    if (exitKey == key_e) {
+        return room.getEast();
+    }
+    if (exitKey == key_down) {
+        return room.getDown();
+    }
+    if (exitKey == key_sw) {
+        return room.getSouthwest();
+    }
+    if (exitKey == key_s) {
+        return room.getSouth();
+    }
+    if (exitKey == key_se) {
+        return room.getSoutheast();
+    }
+    if (exitKey == key_in) {
+        return room.getIn();
+    }
+    if (exitKey == key_out) {
+        return room.getOut();
+    }
+
+    const auto& specialExits = room.getSpecialExits();
+    const auto itSpecial = specialExits.constFind(exitKey);
+    if (itSpecial != specialExits.constEnd()) {
+        return itSpecial.value();
+    }
+
+    return std::nullopt;
+}
+
+
+bool T2DMap::canMoveSelectedCustomLineLastPointToTargetRoom() const
+{
+    if (!mpMap || !mpMap->mpRoomDB) {
+        return false;
+    }
+
+    if (mCustomLineSelectedRoom <= 0 || mCustomLineSelectedExit.isEmpty()) {
+        return false;
+    }
+
+    TRoom* room = mpMap->mpRoomDB->getRoom(mCustomLineSelectedRoom);
+    if (!room) {
+        return false;
+    }
+
+    if (!room->customLines.contains(mCustomLineSelectedExit)) {
+        return false;
+    }
+
+    const auto& customLinePoints = room->customLines.value(mCustomLineSelectedExit);
+    if (customLinePoints.isEmpty()) {
+        return false;
+    }
+
+    const auto targetRoomId = resolveCustomLineTargetRoomId(*room, mCustomLineSelectedExit);
+    if (!targetRoomId || *targetRoomId <= 0) {
+        return false;
+    }
+
+    if (!mpMap->mpRoomDB->getRoom(*targetRoomId)) {
+        return false;
+    }
+
+    return true;
+}
+
+
+void T2DMap::slot_moveCustomLineLastPointToTargetRoom()
+{
+    if (!mpMap || !mpMap->mpRoomDB) {
+        return;
+    }
+
+    if (mCustomLineSelectedRoom <= 0 || mCustomLineSelectedExit.isEmpty()) {
+        return;
+    }
+
+    TRoom* room = mpMap->mpRoomDB->getRoom(mCustomLineSelectedRoom);
+    if (!room) {
+        return;
+    }
+
+    if (!room->customLines.contains(mCustomLineSelectedExit)) {
+        return;
+    }
+
+    QList<QPointF>& points = room->customLines[mCustomLineSelectedExit];
+    if (points.isEmpty()) {
+        return;
+    }
+
+    const auto targetRoomId = resolveCustomLineTargetRoomId(*room, mCustomLineSelectedExit);
+    if (!targetRoomId || *targetRoomId <= 0) {
+        return;
+    }
+
+    TRoom* targetRoom = mpMap->mpRoomDB->getRoom(*targetRoomId);
+    if (!targetRoom) {
+        return;
+    }
+
+    QPointF newPoint(targetRoom->x(), targetRoom->y());
+    if (mSnapCustomLinePointsToGridEnabled) {
+        newPoint = snapPointToGrid(newPoint);
+    }
+
+    QPointF& lastPoint = points.last();
+    if (qFuzzyIsNull(lastPoint.x() - newPoint.x()) && qFuzzyIsNull(lastPoint.y() - newPoint.y())) {
+        return;
+    }
+
+    lastPoint = newPoint;
     room->calcRoomDimensions();
     repaint();
     mpMap->setUnsaved(__func__);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3230,20 +3230,29 @@ void T2DMap::snapSelectedCustomLineToGrid()
         return;
     }
 
-    if (mCustomLineSelectedRoom <= 0 || mCustomLineSelectedExit.isEmpty()) {
+    int roomId = mCustomLineSelectedRoom;
+    QString exitKey = mCustomLineSelectedExit;
+
+    if (roomId <= 0 || exitKey.isEmpty()) {
+        roomId = mCustomLinesRoomFrom;
+        exitKey = mCustomLinesRoomExit;
+    }
+
+    if (roomId <= 0 || exitKey.isEmpty()) {
         return;
     }
 
-    TRoom* room = mpMap->mpRoomDB->getRoom(mCustomLineSelectedRoom);
+    TRoom* room = mpMap->mpRoomDB->getRoom(roomId);
     if (!room) {
         return;
     }
 
-    if (!room->customLines.contains(mCustomLineSelectedExit)) {
+    auto itLine = room->customLines.find(exitKey);
+    if (itLine == room->customLines.end()) {
         return;
     }
 
-    QList<QPointF>& points = room->customLines[mCustomLineSelectedExit];
+    QList<QPointF>& points = itLine.value();
     if (points.isEmpty()) {
         return;
     }
@@ -3338,25 +3347,32 @@ bool T2DMap::canMoveSelectedCustomLineLastPointToTargetRoom() const
         return false;
     }
 
-    if (!room->customLines.contains(mCustomLineSelectedExit)) {
+    return canMoveCustomLineLastPointToTargetRoom(*room, mCustomLineSelectedExit);
+}
+
+
+bool T2DMap::canMoveCustomLineLastPointToTargetRoom(const TRoom& room, const QString& exitKey) const
+{
+    if (!mpMap || !mpMap->mpRoomDB) {
         return false;
     }
 
-    const auto& customLinePoints = room->customLines.value(mCustomLineSelectedExit);
-    if (customLinePoints.isEmpty()) {
+    const auto itLine = room.customLines.constFind(exitKey);
+    if (itLine == room.customLines.constEnd()) {
         return false;
     }
 
-    const auto targetRoomId = resolveCustomLineTargetRoomId(*room, mCustomLineSelectedExit);
+    const QList<QPointF>& points = itLine.value();
+    if (points.isEmpty()) {
+        return false;
+    }
+
+    const auto targetRoomId = resolveCustomLineTargetRoomId(room, exitKey);
     if (!targetRoomId || *targetRoomId <= 0) {
         return false;
     }
 
-    if (!mpMap->mpRoomDB->getRoom(*targetRoomId)) {
-        return false;
-    }
-
-    return true;
+    return mpMap->mpRoomDB->getRoom(*targetRoomId) != nullptr;
 }
 
 
@@ -3366,25 +3382,34 @@ void T2DMap::slot_moveCustomLineLastPointToTargetRoom()
         return;
     }
 
-    if (mCustomLineSelectedRoom <= 0 || mCustomLineSelectedExit.isEmpty()) {
+    int roomId = mCustomLineSelectedRoom;
+    QString exitKey = mCustomLineSelectedExit;
+
+    if (roomId <= 0 || exitKey.isEmpty()) {
+        roomId = mCustomLinesRoomFrom;
+        exitKey = mCustomLinesRoomExit;
+    }
+
+    if (roomId <= 0 || exitKey.isEmpty()) {
         return;
     }
 
-    TRoom* room = mpMap->mpRoomDB->getRoom(mCustomLineSelectedRoom);
+    TRoom* room = mpMap->mpRoomDB->getRoom(roomId);
     if (!room) {
         return;
     }
 
-    if (!room->customLines.contains(mCustomLineSelectedExit)) {
+    auto itLine = room->customLines.find(exitKey);
+    if (itLine == room->customLines.end()) {
         return;
     }
 
-    QList<QPointF>& points = room->customLines[mCustomLineSelectedExit];
+    QList<QPointF>& points = itLine.value();
     if (points.isEmpty()) {
         return;
     }
 
-    const auto targetRoomId = resolveCustomLineTargetRoomId(*room, mCustomLineSelectedExit);
+    const auto targetRoomId = resolveCustomLineTargetRoomId(*room, exitKey);
     if (!targetRoomId || *targetRoomId <= 0) {
         return;
     }

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -73,6 +73,8 @@
 // qsls cannot be shared so define a common instance to use when
 // there are multiple places where they are used within this file:
 
+T2DMap::~T2DMap() = default;
+
 // replacement parameter supplied at point of use:
 const QString& key_plain = qsl("%1");
 

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -323,6 +323,7 @@ public slots:
     void slot_setSnapCustomLinePointsToGrid(bool enabled);
     void slot_moveCustomLineLastPointToTargetRoom();
     bool canMoveSelectedCustomLineLastPointToTargetRoom() const;
+    bool canMoveCustomLineLastPointToTargetRoom(const TRoom& room, const QString& exitKey) const;
     void slot_cancelCustomLineDialog();
     void slot_loadMap();
     void slot_newMap();

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -54,6 +54,7 @@ class CustomLineDrawContextMenuHandler;
 class CustomLineDrawHandler;
 class CustomLineEditContextMenuHandler;
 class CustomLineEditHandler;
+class CustomLineSession;
 class RoomMoveActivationHandler;
 class RoomMoveDragHandler;
 class RoomContextMenuHandler;
@@ -89,6 +90,7 @@ public:
     friend class CustomLineDrawHandler;
     friend class CustomLineEditContextMenuHandler;
     friend class CustomLineEditHandler;
+    friend class CustomLineSession;
     friend class LabelInteractionHandler;
     friend class RoomContextMenuHandler;
     friend class RoomMoveDragHandler;
@@ -184,7 +186,6 @@ public:
     QPoint mPHighlight;
     bool mPick = false;
     int mTargetRoomId = 0;
-    bool mSnapCustomLinePointsToGridEnabled = false;
     bool mStartSpeedWalk = false;
 
 
@@ -345,6 +346,7 @@ private:
         QList<HandlerEntry> mHandlers;
     };
 
+    std::unique_ptr<CustomLineSession> mCustomLineSession;
     InteractionDispatcher mInteractionDispatcher;
     std::unique_ptr<IInteractionHandler> mCustomLineDrawContextMenuHandler;
     std::unique_ptr<IInteractionHandler> mCustomLineDrawInteractionHandler;
@@ -363,10 +365,8 @@ private:
     void resizeMultiSelectionWidget();
     std::pair<int, int> getMousePosition();
     std::pair<bool, QString> performImageSave(const QPixmap& pixmap, const QString& filePath, const QString& format);
-    bool isSnapCustomLinePointsToGridEnabled() const { return mSnapCustomLinePointsToGridEnabled; }
-    void snapSelectedCustomLineToGrid();
+    bool isSnapCustomLinePointsToGridEnabled() const;
     QPointF snapPointToGrid(const QPointF& point) const;
-    std::optional<int> resolveCustomLineTargetRoomId(const TRoom& room, const QString& exitKey) const;
     bool checkButtonIsForGivenDirection(const QPushButton*, const QString&, const int&);
     bool sizeFontToFitTextInRect(QFont&, const QRectF&, const QString&, const quint8 percentageMargin = 10, const qreal minFontSize = 7.0);
     inline void drawRoom(QPainter&, QFont&, QFont&, QPen&, TRoom*, const bool isGridMode, const bool areRoomIdsLegible, const bool showRoomNames, const int, const float, const float, const QMap<int, QPointF>&, const bool showRoomCollision);

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -184,6 +184,7 @@ public:
     QPoint mPHighlight;
     bool mPick = false;
     int mTargetRoomId = 0;
+    bool mSnapCustomLinePointsToGridEnabled = false;
     bool mStartSpeedWalk = false;
 
 
@@ -319,6 +320,9 @@ public slots:
     void slot_customLineProperties();
     void slot_customLineAddPoint();
     void slot_customLineRemovePoint();
+    void slot_setSnapCustomLinePointsToGrid(bool enabled);
+    void slot_moveCustomLineLastPointToTargetRoom();
+    bool canMoveSelectedCustomLineLastPointToTargetRoom() const;
     void slot_cancelCustomLineDialog();
     void slot_loadMap();
     void slot_newMap();
@@ -358,6 +362,10 @@ private:
     void resizeMultiSelectionWidget();
     std::pair<int, int> getMousePosition();
     std::pair<bool, QString> performImageSave(const QPixmap& pixmap, const QString& filePath, const QString& format);
+    bool isSnapCustomLinePointsToGridEnabled() const { return mSnapCustomLinePointsToGridEnabled; }
+    void snapSelectedCustomLineToGrid();
+    QPointF snapPointToGrid(const QPointF& point) const;
+    std::optional<int> resolveCustomLineTargetRoomId(const TRoom& room, const QString& exitKey) const;
     bool checkButtonIsForGivenDirection(const QPushButton*, const QString&, const int&);
     bool sizeFontToFitTextInRect(QFont&, const QRectF&, const QString&, const quint8 percentageMargin = 10, const qreal minFontSize = 7.0);
     inline void drawRoom(QPainter&, QFont&, QFont&, QPen&, TRoom*, const bool isGridMode, const bool areRoomIdsLegible, const bool showRoomNames, const int, const float, const float, const QMap<int, QPointF>&, const bool showRoomCollision);

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -76,6 +76,7 @@ class T2DMap : public QWidget
 public:
     Q_DISABLE_COPY(T2DMap)
     explicit T2DMap(QWidget* parent = nullptr);
+    ~T2DMap();
     std::pair<bool, QString> setMapZoom(const qreal zoom, const int areaId = 0);
     void init();
     void paintEvent(QPaintEvent*) override;

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -668,6 +668,7 @@ SOURCES += \
     CustomLineDrawHandler.cpp \
     CustomLineEditContextMenuHandler.cpp \
     CustomLineEditHandler.cpp \
+    CustomLineSession.cpp \
     LabelInteractionHandler.cpp \
     PanInteractionHandler.cpp \
     RoomContextMenuHandler.cpp \
@@ -814,6 +815,7 @@ HEADERS += \
     CustomLineDrawHandler.h \
     CustomLineEditContextMenuHandler.h \
     CustomLineEditHandler.h \
+    CustomLineSession.h \
     LabelInteractionHandler.h \
     PanInteractionHandler.h \
     RoomContextMenuHandler.h \


### PR DESCRIPTION
#### Brief overview of PR changes/additions
For drawing custom lines you can snap to grid all it's points + you can move last point directly onto target room

#### Motivation for adding to Mudlet

I always found not perfectly angled lines to be bothersome, now it's possible to easily achieve perfect lines between rooms.

#### Other info (issues closed, discussion etc)
