### PR TITLE
Add mapInfoColor support to setConfig/getConfig

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7334,14 +7334,14 @@ int TLuaInterpreter::setConfig(lua_State * L)
             if (!lua_istable(L, 2)) {
                 lua_pushfstring(L, "%s: bad argument #%d type (table expected for mapInfoColor, got %s!)",
                     __func__, 2, luaL_typename(L, 2));
-                return warnArgumentValue(L, __func__, qsl("mapInfoColor requires a table with {r, g, b, a} keys"));
+                return warnArgumentValue(L, __func__, qsl("mapInfoColor requires a table {r, g, b} or {r, g, b, a}"));
             }
 
-            // Get red component
-            lua_getfield(L, 2, "r");
+            // Get red component (index 1)
+            lua_rawgeti(L, 2, 1);
             if (!lua_isnumber(L, -1)) {
                 lua_pop(L, 1);
-                return warnArgumentValue(L, __func__, qsl("mapInfoColor table must have 'r' key with numeric value"));
+                return warnArgumentValue(L, __func__, qsl("mapInfoColor table must have red component at index 1"));
             }
             const int r = lua_tonumber(L, -1);
             lua_pop(L, 1);
@@ -7349,11 +7349,11 @@ int TLuaInterpreter::setConfig(lua_State * L)
                 return warnArgumentValue(L, __func__, csmInvalidRedValue.arg(r));
             }
 
-            // Get green component
-            lua_getfield(L, 2, "g");
+            // Get green component (index 2)
+            lua_rawgeti(L, 2, 2);
             if (!lua_isnumber(L, -1)) {
                 lua_pop(L, 1);
-                return warnArgumentValue(L, __func__, qsl("mapInfoColor table must have 'g' key with numeric value"));
+                return warnArgumentValue(L, __func__, qsl("mapInfoColor table must have green component at index 2"));
             }
             const int g = lua_tonumber(L, -1);
             lua_pop(L, 1);
@@ -7361,11 +7361,11 @@ int TLuaInterpreter::setConfig(lua_State * L)
                 return warnArgumentValue(L, __func__, csmInvalidGreenValue.arg(g));
             }
 
-            // Get blue component
-            lua_getfield(L, 2, "b");
+            // Get blue component (index 3)
+            lua_rawgeti(L, 2, 3);
             if (!lua_isnumber(L, -1)) {
                 lua_pop(L, 1);
-                return warnArgumentValue(L, __func__, qsl("mapInfoColor table must have 'b' key with numeric value"));
+                return warnArgumentValue(L, __func__, qsl("mapInfoColor table must have blue component at index 3"));
             }
             const int b = lua_tonumber(L, -1);
             lua_pop(L, 1);
@@ -7373,9 +7373,9 @@ int TLuaInterpreter::setConfig(lua_State * L)
                 return warnArgumentValue(L, __func__, csmInvalidBlueValue.arg(b));
             }
 
-            // Get alpha component (optional, defaults to 255)
+            // Get alpha component (index 4, optional, defaults to 255)
             int a = 255;
-            lua_getfield(L, 2, "a");
+            lua_rawgeti(L, 2, 4);
             if (lua_isnumber(L, -1)) {
                 a = lua_tonumber(L, -1);
                 if (a < 0 || a > 255) {
@@ -7699,18 +7699,14 @@ int TLuaInterpreter::getConfig(lua_State *L)
         { qsl("mapShowRoomBorders"), [&](){ lua_pushboolean(L, host.mMapperShowRoomBorders); } },
         { qsl("mapInfoColor"), [&](){
             lua_newtable(L);
-            lua_pushstring(L, "r");
             lua_pushnumber(L, host.mMapInfoBg.red());
-            lua_settable(L, -3);
-            lua_pushstring(L, "g");
+            lua_rawseti(L, -2, 1);
             lua_pushnumber(L, host.mMapInfoBg.green());
-            lua_settable(L, -3);
-            lua_pushstring(L, "b");
+            lua_rawseti(L, -2, 2);
             lua_pushnumber(L, host.mMapInfoBg.blue());
-            lua_settable(L, -3);
-            lua_pushstring(L, "a");
+            lua_rawseti(L, -2, 3);
             lua_pushnumber(L, host.mMapInfoBg.alpha());
-            lua_settable(L, -3);
+            lua_rawseti(L, -2, 4);
         } },
         { qsl("editorAutoComplete"), [&](){ lua_pushboolean(L, host.mEditorAutoComplete); } },
         { qsl("enableGMCP"), [&](){ lua_pushboolean(L, host.mEnableGMCP); } },

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7330,6 +7330,65 @@ int TLuaInterpreter::setConfig(lua_State * L)
 
             return success();
         }
+        if (key == qsl("mapInfoColor")) {
+            if (!lua_istable(L, 2)) {
+                lua_pushfstring(L, "%s: bad argument #%d type (table expected for mapInfoColor, got %s!)",
+                    __func__, 2, luaL_typename(L, 2));
+                return warnArgumentValue(L, __func__, qsl("mapInfoColor requires a table with {r, g, b, a} keys"));
+            }
+
+            // Get red component
+            lua_getfield(L, 2, "r");
+            if (!lua_isnumber(L, -1)) {
+                lua_pop(L, 1);
+                return warnArgumentValue(L, __func__, qsl("mapInfoColor table must have 'r' key with numeric value"));
+            }
+            const int r = lua_tonumber(L, -1);
+            lua_pop(L, 1);
+            if (r < 0 || r > 255) {
+                return warnArgumentValue(L, __func__, csmInvalidRedValue.arg(r));
+            }
+
+            // Get green component
+            lua_getfield(L, 2, "g");
+            if (!lua_isnumber(L, -1)) {
+                lua_pop(L, 1);
+                return warnArgumentValue(L, __func__, qsl("mapInfoColor table must have 'g' key with numeric value"));
+            }
+            const int g = lua_tonumber(L, -1);
+            lua_pop(L, 1);
+            if (g < 0 || g > 255) {
+                return warnArgumentValue(L, __func__, csmInvalidGreenValue.arg(g));
+            }
+
+            // Get blue component
+            lua_getfield(L, 2, "b");
+            if (!lua_isnumber(L, -1)) {
+                lua_pop(L, 1);
+                return warnArgumentValue(L, __func__, qsl("mapInfoColor table must have 'b' key with numeric value"));
+            }
+            const int b = lua_tonumber(L, -1);
+            lua_pop(L, 1);
+            if (b < 0 || b > 255) {
+                return warnArgumentValue(L, __func__, csmInvalidBlueValue.arg(b));
+            }
+
+            // Get alpha component (optional, defaults to 255)
+            int a = 255;
+            lua_getfield(L, 2, "a");
+            if (lua_isnumber(L, -1)) {
+                a = lua_tonumber(L, -1);
+                if (a < 0 || a > 255) {
+                    lua_pop(L, 1);
+                    return warnArgumentValue(L, __func__, csmInvalidAlphaValue.arg(a));
+                }
+            }
+            lua_pop(L, 1);
+
+            host.mMapInfoBg = QColor(r, g, b, a);
+            updateMap(L);
+            return success();
+        }
     }
 
     if (key == qsl("enableGMCP")) {
@@ -7638,6 +7697,21 @@ int TLuaInterpreter::getConfig(lua_State *L)
         }},
         { qsl("mapperPanelVisible"), [&](){ lua_pushboolean(L, host.mShowPanel); } },
         { qsl("mapShowRoomBorders"), [&](){ lua_pushboolean(L, host.mMapperShowRoomBorders); } },
+        { qsl("mapInfoColor"), [&](){
+            lua_newtable(L);
+            lua_pushstring(L, "r");
+            lua_pushnumber(L, host.mMapInfoBg.red());
+            lua_settable(L, -3);
+            lua_pushstring(L, "g");
+            lua_pushnumber(L, host.mMapInfoBg.green());
+            lua_settable(L, -3);
+            lua_pushstring(L, "b");
+            lua_pushnumber(L, host.mMapInfoBg.blue());
+            lua_settable(L, -3);
+            lua_pushstring(L, "a");
+            lua_pushnumber(L, host.mMapInfoBg.alpha());
+            lua_settable(L, -3);
+        } },
         { qsl("editorAutoComplete"), [&](){ lua_pushboolean(L, host.mEditorAutoComplete); } },
         { qsl("enableGMCP"), [&](){ lua_pushboolean(L, host.mEnableGMCP); } },
         { qsl("enableMSSP"), [&](){ lua_pushboolean(L, host.mEnableMSSP); } },

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -1267,6 +1267,7 @@ function getConfig(...)
       "logDirectory",                    -- read-only in getConfig
       "logInHTML",
       "mapExitSize",
+      "mapInfoColor",
       "mapperPanelVisible", 
       "mapRoomSize",
       "mapRoundRooms",


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
This adds the ability to programmatically configure the mapper's info box background color through Lua scripting using setConfig/getConfig.
#### Motivation for adding to Mudlet
Fix #6865
#### Other info (issues closed, discussion etc)
