### PR TITLE
Fix: Improve translation-friendliness of UI strings

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -95,10 +95,11 @@ T2DMap::T2DMap(QWidget* parent)
         //: Room name in the mapper widget
         tr("Name");
     mMultiSelectionListWidget.setHeaderLabels(headerLabels);
-    mMultiSelectionListWidget.setToolTip(utils::richText(tr("Click on a line to select or deselect that room number (with the given name if the "
-                                                            "rooms are named) to add or remove the room from the selection.  Click on the "
-                                                            "relevant header to sort by that method.  Note that the name column will only "
-                                                            "show if at least one of the rooms has a name.")));
+    //: Tooltip for the room selection list. This text will be formatted with HTML line breaks between sentences.
+    mMultiSelectionListWidget.setToolTip(utils::richText(tr("Click on a line to select or deselect that room number "
+                                                            "(it will have a name if the room is named).<br><br>"
+                                                            "Click on a column header to sort by that column.<br><br>"
+                                                            "The name column only appears if at least one room has a name.")));
     mMultiSelectionListWidget.setUniformRowHeights(true);
     mMultiSelectionListWidget.setItemsExpandable(false);
     mMultiSelectionListWidget.setSelectionMode(QAbstractItemView::MultiSelection); // Was ExtendedSelection

--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -248,7 +248,7 @@ QStringList dlgRoomProperties::getComboBoxSymbolItems()
                 %2 is the number of rooms using this symbol. Example output: "★ (count: 5)" or "! (count: 12)".
                 The word "count" and the format can be translated, but ensure the numbers remain clearly associated.
                 */
-                displayStrings.append(tr("%1 (count: %2)", "Format for room symbol with usage count")
+                displayStrings.append(tr("%1 (count: %2)")
                     .arg(itSymbolUsed.key(), QString::number(itSymbolUsed.value())));
             }
         }

--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -243,15 +243,13 @@ QStringList dlgRoomProperties::getComboBoxSymbolItems()
         while (itSymbolUsed.hasNext()) {
             itSymbolUsed.next();
             if (itSymbolUsed.value() == symbolCountsList.at(i)) {
-                displayStrings.append(qsl("%1 {%2:%3}")
-                    .arg(itSymbolUsed.key())
-                    /*:
-                    This text will be part of a list of room values shown, which will show the value
-                    itself, followed by the counted number of rooms with this very value like:
-                    grey {count:2} - so please translate like counted ammount, number of, etc.
-                    */
-                    .arg(tr("count"))
-                    .arg(QString::number(itSymbolUsed.value())));
+                /*:
+                Format for showing a room symbol with its usage count. %1 is the symbol itself (e.g., "★" or "!"),
+                %2 is the number of rooms using this symbol. Example output: "★ (count: 5)" or "! (count: 12)".
+                The word "count" and the format can be translated, but ensure the numbers remain clearly associated.
+                */
+                displayStrings.append(tr("%1 (count: %2)", "Format for room symbol with usage count")
+                    .arg(itSymbolUsed.key(), QString::number(itSymbolUsed.value())));
             }
         }
     }
@@ -283,15 +281,13 @@ QStringList dlgRoomProperties::getComboBoxWeightItems()
         while (itWeightUsed.hasNext()) {
             itWeightUsed.next();
             if (itWeightUsed.value() == weightCountsList.at(i)) {
-                displayStrings.append(qsl("%1 {%2:%3}")
-                    .arg(QString::number(itWeightUsed.key()))
-                    /*:
-                    This text will be part of a list of room values shown, which will name the value
-                    itself, followed by the counted number of rooms with that very value like:
-                    grey {count: 2} - So please translate like counted amount, number of, etc.
-                    */
-                    .arg(tr("count"))
-                    .arg(QString::number(itWeightUsed.value())));
+                /*:
+                Format for showing a room weight with its usage count. %1 is the weight value (e.g., "1" or "50"),
+                %2 is the number of rooms with this weight. Example output: "5 (count: 3)" or "100 (count: 7)".
+                The word "count" and the format can be translated, but ensure the numbers remain clearly associated.
+                */
+                displayStrings.append(tr("%1 (count: %2)", "Format for room weight with usage count")
+                    .arg(QString::number(itWeightUsed.key()), QString::number(itWeightUsed.value())));
             }
         }
     }
@@ -368,8 +364,8 @@ QString dlgRoomProperties::getNewSymbol()
         return lineEdit_roomSymbol->text();
     }
     QString newSymbolText = comboBox_roomSymbol->currentText();
-    // Parse the initial text before the curly braces containing count
-    const QRegularExpression countStripper(qsl("^(.*) {.*}$"));
+    // Parse the initial text before the parentheses containing count
+    const QRegularExpression countStripper(qsl("^(.*) \\(.*\\)$"));
     const QRegularExpressionMatch match = countStripper.match(newSymbolText);
     if (match.hasMatch() && match.lastCapturedIndex() > 0) {
         return match.captured(1);

--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -286,7 +286,7 @@ QStringList dlgRoomProperties::getComboBoxWeightItems()
                 %2 is the number of rooms with this weight. Example output: "5 (count: 3)" or "100 (count: 7)".
                 The word "count" and the format can be translated, but ensure the numbers remain clearly associated.
                 */
-                displayStrings.append(tr("%1 (count: %2)", "Format for room weight with usage count")
+                displayStrings.append(tr("%1 (count: %2)")
                     .arg(QString::number(itWeightUsed.key()), QString::number(itWeightUsed.value())));
             }
         }

--- a/src/mapInfoContributorManager.cpp
+++ b/src/mapInfoContributorManager.cpp
@@ -119,17 +119,14 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
         if (area) {
             infoText = qsl("%1\n").arg(
                 /*:
-                This text uses non-breaking spaces (as '%1's, as Qt Creator cannot handle
-                them literally in raw strings) and non-breaking hyphens which are used to
-                prevent the line being split at some places it might otherwise be; when
-                translating please consider at which points the text may be divided to fit onto
-                more than one line.
-                %2 is the (text) name of the area, %3 is the number for it,
-                %4 to %9 are pairs (min <-> max) of extremes for each of x,y and z coordinates
+                This text uses non-breaking spaces (Unicode U+00A0) and non-breaking hyphens
+                which are used to prevent the line being split at some places it might otherwise be.
+                When translating, please consider at which points the text may be divided to fit
+                onto more than one line. %1 is the (text) name of the area, %2 is the area ID number,
+                %3 and %4 are the minimum and maximum x coordinates, %5 and %6 for y, and %7 and %8 for z.
                 */
-                           tr("Area:%1%2 ID:%1%3 x:%1%4%1<‑>%1%5 y:%1%6%1<‑>%1%7 z:%1%8%1<‑>%1%9")
-                               .arg(QChar(160),
-                                    areaName,
+                           tr("Area:\u00A0%1 ID:\u00A0%2 x:\u00A0%3\u00A0<‑>\u00A0%4 y:\u00A0%5\u00A0<‑>\u00A0%6 z:\u00A0%7\u00A0<‑>\u00A0%8")
+                               .arg(areaName,
                                     QString::number(areaId),
                                     QString::number(area->min_x),
                                     QString::number(area->max_x),
@@ -158,17 +155,14 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
         case 0:
             infoText.append(qsl("%1\n").arg(
                 /*:
-                This text uses non-breaking spaces (as '%1's, as Qt Creator cannot handle
-                them literally in raw strings) and a non-breaking hyphen which are used to
-                prevent the line being split at some places it might otherwise be; when
-                translating please consider at which points the text may be divided to fit onto
-                more than one line.
-                This text is for when NO rooms are selected, %3 is the room number
-                of, and %4-%6 are the x,y and z coordinates for, the current player's room.
+                This text uses non-breaking spaces (Unicode U+00A0) and a non-breaking hyphen which
+                are used to prevent the line being split at some places it might otherwise be.
+                When translating, please consider at which points the text may be divided to fit onto
+                more than one line. This text is for when NO rooms are selected: %1 is the room ID number,
+                and %2, %3, %4 are the x, y, and z coordinates for the current player's room.
                 */
-                               tr("Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1current player location")
-                                    .arg(QChar(160),
-                                        QString::number(roomID),
+                               tr("Room\u00A0ID:\u00A0%1 Position\u00A0on\u00A0Map: (%2,%3,%4) ‑\u00A0current player location")
+                                    .arg(QString::number(roomID),
                                         QString::number(room->x()),
                                         QString::number(room->y()),
                                         QString::number(room->z()))));
@@ -181,17 +175,14 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
         case 1:
             infoText.append(qsl("%1\n").arg(
                 /*:
-                This text uses non-breaking spaces (as '%1's, as Qt Creator cannot handle
-                them literally in raw strings) and a non-breaking hyphen which are used to
-                prevent the line being split at some places it might otherwise be; when
-                translating please consider at which points the text may be divided to fit onto
-                more than one line.
-                This text is for when ONE room is selected, %3 is the room number
-                of, and %4-%6 are the x,y and z coordinates for, the selected Room.
+                This text uses non-breaking spaces (Unicode U+00A0) and a non-breaking hyphen which
+                are used to prevent the line being split at some places it might otherwise be.
+                When translating, please consider at which points the text may be divided to fit onto
+                more than one line. This text is for when ONE room is selected: %1 is the room ID number,
+                and %2, %3, %4 are the x, y, and z coordinates for the selected room.
                 */
-                               tr("Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1selected room")
-                                    .arg(QChar(160),
-                                        QString::number(roomID),
+                               tr("Room\u00A0ID:\u00A0%1 Position\u00A0on\u00A0Map: (%2,%3,%4) ‑\u00A0selected room")
+                                    .arg(QString::number(roomID),
                                         QString::number(room->x()),
                                         QString::number(room->y()),
                                         QString::number(room->z()))));
@@ -205,21 +196,17 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
         default:
             infoText.append(qsl("%1\n").arg(
                 /*:
-                This text uses non-breaking spaces (as '%1's, as Qt Creator cannot handle
-                them literally in raw strings) and a non-breaking hyphen which are used to
-                prevent the line being split at some places it might otherwise be; when
-                translating please consider at which points the text may be divided to fit onto
-                more than one line.
-                This text is for when TWO or MORE rooms are selected; %1 is the room
-                number for which %2-%4 are the x,y and z coordinates of the room nearest the
-                middle of the selection. This room has the yellow cross-hairs. %n is the count
-                of rooms selected and will ALWAYS be greater than 1 in this situation. It is
-                provided so that non-English translations can select required plural forms as
-                needed.
+                This text uses non-breaking spaces (Unicode U+00A0) and a non-breaking hyphen which
+                are used to prevent the line being split at some places it might otherwise be.
+                When translating, please consider at which points the text may be divided to fit onto
+                more than one line. This text is for when TWO or MORE rooms are selected: %1 is the room
+                ID number for which %2, %3, %4 are the x, y, and z coordinates of the room nearest the
+                middle of the selection. This room has the yellow cross-hairs. %n is the count of rooms
+                selected and will ALWAYS be greater than 1 in this situation. It is provided so that
+                non-English translations can select required plural forms as needed.
                 */
-                               tr("Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1center of %n selected rooms", nullptr, selectionSize)
-                                    .arg(QChar(160),
-                                        QString::number(roomID),
+                               tr("Room\u00A0ID:\u00A0%1 Position\u00A0on\u00A0Map: (%2,%3,%4) ‑\u00A0center of %n selected rooms", nullptr, selectionSize)
+                                    .arg(QString::number(roomID),
                                         QString::number(room->x()),
                                         QString::number(room->y()),
                                         QString::number(room->z()))));


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
This commit addresses several translation issues reported in #1802:

High Priority Fixes:
- mapInfoContributorManager.cpp: Refactored position display strings to use unique placeholders (%1-%8) instead of reusing %1 for both non-breaking spaces and data values. This makes it possible for translators to reorder elements for different language grammars. Changed from "Area:%1%2 ID:%1%3..." to "Area:\u00A0%1 ID:\u00A0%2..." using Unicode escape sequences for non-breaking spaces.

Medium Priority Fixes:
- T2DMap.cpp: Simplified complex tooltip text by breaking it into shorter sentences with clear HTML line breaks, making it easier for translators to understand and translate.

- dlgRoomProperties.cpp: Made translatable content clearer in the room symbol/weight count display. Changed from confusing format "%1 {%2:%3}" to more translator-friendly "%1 (count: %2)" with comprehensive documentation. Updated parsing regex to match the new parentheses-based format.

These changes improve translator experience without affecting functionality. All format changes maintain backward compatibility with the parsing logic.
#### Motivation for adding to Mudlet
Implement #1802
#### Other info (issues closed, discussion etc)
