### PR TITLE
Fix: Make hidden text (fg == bg) readable when highlighted

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -587,15 +587,8 @@ int TTextEdit::drawGraphemeBackground(QPainter& painter, QVector<QColor>& fgColo
     bool caretIsHere = mpHost->caretEnabled() && mCaretLine == line && mCaretColumn == column;
     if (Q_UNLIKELY(charStyle.isFound())) {
         if (Q_UNLIKELY(charStyle.isReversed() != (charStyle.isSelected() != caretIsHere))) {
-            // When colors would be swapped and the search highlight colors match,
-            // only reverse one color to make the text readable
-            if (mSearchHighlightFgColor == mSearchHighlightBgColor) {
-                fgColors.append(mSearchHighlightFgColor);
-                bgColor = (mSearchHighlightBgColor.lightness() < 128) ? Qt::white : Qt::black;
-            } else {
-                fgColors.append(mSearchHighlightBgColor);
-                bgColor = mSearchHighlightFgColor;
-            }
+            fgColors.append(mSearchHighlightBgColor);
+            bgColor = mSearchHighlightFgColor;
         } else {
             fgColors.append(mSearchHighlightFgColor);
             bgColor = mSearchHighlightBgColor;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -586,16 +586,32 @@ int TTextEdit::drawGraphemeBackground(QPainter& painter, QVector<QColor>& fgColo
     bool caretIsHere = mpHost->caretEnabled() && mCaretLine == line && mCaretColumn == column;
     if (Q_UNLIKELY(charStyle.isFound())) {
         if (Q_UNLIKELY(charStyle.isReversed() != (charStyle.isSelected() != caretIsHere))) {
-            fgColors.append(mSearchHighlightBgColor);
-            bgColor = mSearchHighlightFgColor;
+            // When colors would be swapped and the search highlight colors match,
+            // only reverse one color to make the text readable
+            if (mSearchHighlightFgColor == mSearchHighlightBgColor) {
+                fgColors.append(mSearchHighlightFgColor);
+                bgColor = (mSearchHighlightBgColor.lightness() < 128) ? Qt::white : Qt::black;
+            } else {
+                fgColors.append(mSearchHighlightBgColor);
+                bgColor = mSearchHighlightFgColor;
+            }
         } else {
             fgColors.append(mSearchHighlightFgColor);
             bgColor = mSearchHighlightBgColor;
         }
     } else {
         if (Q_UNLIKELY(charStyle.isReversed() != (charStyle.isSelected() != caretIsHere))) {
-            fgColors.append(charStyle.background());
-            bgColor = charStyle.foreground();
+            // When colors would be swapped (e.g., during selection)
+            // and foreground equals background (hidden text),
+            // only reverse one color to make the text readable
+            if (charStyle.foreground() == charStyle.background()) {
+                fgColors.append(charStyle.foreground());
+                // Invert background: use white for dark colors, black for light colors
+                bgColor = (charStyle.background().lightness() < 128) ? Qt::white : Qt::black;
+            } else {
+                fgColors.append(charStyle.background());
+                bgColor = charStyle.foreground();
+            }
         } else {
             fgColors.append(charStyle.foreground());
             bgColor = charStyle.background();

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -69,6 +69,7 @@ TTextEdit::TTextEdit(TConsole* pC, QWidget* pW, TBuffer* pB, Host* pH, bool isLo
 {
     mLastClickTimer.start();
     Q_ASSERT_X(mpHost, "TTextEdit::TTextEdit(...)", "mpHost is a nullptr");
+    Q_ASSERT_X(mSearchHighlightFgColor != mSearchHighlightBgColor, "TTextEdit::TTextEdit(...)", "search highlight foreground and background colors must not be the same");
     setFont(mpHost->getDisplayFont());
     mFontHeight = fontMetrics().height();
     mFontWidth = fontMetrics().averageCharWidth();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Some MUD games use identical foreground and background colors to hide 'secret' text. When such text is selected/highlighted, it should become readable by inverting only one color instead of swapping both.

Implementation: When foreground equals background and colors would be swapped during selection/highlighting, keep the foreground color and set background to white (for dark colors) or black (for light colors).
#### Motivation for adding to Mudlet
Fixes #3961
#### Other info (issues closed, discussion etc)
Testable with:

```lua
feedTriggers("\n\027[30;40mThis is hidden black text on black background\027[0m\n")
feedTriggers("\027[37;47mThis is hidden white text on white background\027[0m\n")
feedTriggers("\027[31;41mThis is hidden red text on red background\027[0m\n")
feedTriggers("\027[32;42mThis is hidden green text on green background\027[0m\n")
feedTriggers("\027[34;44mThis is hidden blue text on blue background\027[0m\n")
feedTriggers("Normal visible text for comparison\n")
feedTriggers("\027[30;40mSecret: \027[0m\027[30;40mthe password is hunter2\027[0m\027[30;40m!\027[0m\n")
```