### PR TITLE
Fix: New buttons at top level incorrectly named "new toolbar"

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4732,7 +4732,7 @@ void dlgTriggerEditor::addAction(bool isFolder)
     }
     // Otherwise: insert a new root item
     if (!pNewAction) {
-        name = tr("New toolbar");
+        name = isFolder ? tr("New toolbar") : tr("New button");
         pNewAction = new TAction(name, mpHost);
         pNewAction->setCommandButtonUp(cmdButtonUp);
         QStringList nl;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Top-level buttons in the button editor were being named "new toolbar" instead of "new button". The addAction() function now correctly uses "New toolbar" for folders (button bars) and "New button" for buttons at the top level, matching the behavior for nested items.
#### Motivation for adding to Mudlet
Fix #4857
#### Other info (issues closed, discussion etc)
