### PR TITLE
Fix: Correct position calculation for regex capture groups with lookb…

### DIFF
--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -297,11 +297,12 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
     for (i = 0; i < rc; i++) {
         const char *substring_start = haystackC + ovector[2 * i];
         const int substring_length = ovector[2 * i + 1] - ovector[2 * i];
-        const int utf16_pos = haystack.indexOf(QString::fromUtf8(substring_start, substring_length));
+        // Convert byte offset to UTF-16 character position
+        const int utf16_pos = QString::fromUtf8(haystackC, ovector[2 * i]).length();
         std::string match;
         if (substring_length < 1) {
             captureList.push_back(match);
-            posList.push_back(-1);
+            posList.push_back(utf16_pos + posOffset);
             continue;
         }
 
@@ -330,7 +331,8 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
             auto name = QString::fromUtf8(&tabptr[2]).trimmed(); //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)
             auto* substring_start = haystackC + ovector[2*n]; //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)
             auto substring_length = ovector[2*n+1] - ovector[2*n]; //NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
-            auto utf16_pos = haystack.indexOf(QString::fromUtf8(substring_start, substring_length));
+            // Convert byte offset to UTF-16 character position
+            auto utf16_pos = QString::fromUtf8(haystackC, ovector[2*n]).length(); //NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
             auto capture = QString::fromUtf8(substring_start, substring_length);
             nameGroups << qMakePair(name, capture);
             tabptr += name_entry_size;
@@ -371,12 +373,13 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
         for (i = 0; i < rc; i++) {
             const char *substring_start = haystackC + ovector[2 * i];
             const int substring_length = ovector[2 * i + 1] - ovector[2 * i];
-            const int utf16_pos = haystack.indexOf(QString::fromUtf8(substring_start, substring_length));
+            // Convert byte offset to UTF-16 character position
+            const int utf16_pos = QString::fromUtf8(haystackC, ovector[2 * i]).length();
 
             std::string match;
             if (substring_length < 1) {
                 captureList.push_back(match);
-                posList.push_back(-1);
+                posList.push_back(utf16_pos + posOffset);
                 continue;
             }
             match.append(substring_start, substring_length);

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -411,7 +411,7 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
             for (int position = 1; iti != posList.end(); ++iti, ++its, position++) {
                 const int begin = *iti;
                 const std::string& s = *its;
-                const int length = QString::fromStdString(s).size();
+                const int length = QString::fromUtf8(s.c_str(), s.size()).length();
                 if (total > 1) {
                     // skip complete match in Perl /g option type of triggers
                     // to enable people to highlight capture groups if there are any

--- a/src/run-tests.xml
+++ b/src/run-tests.xml
@@ -78,6 +78,72 @@
 				</TriggerGroup>
 			</TriggerGroup>
 		</TriggerGroup>
+		<TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+			<name>Test lookbehind highlighting (issue #4070)</name>
+			<script></script>
+			<triggerType>0</triggerType>
+			<conditonLineDelta>0</conditonLineDelta>
+			<mStayOpen>0</mStayOpen>
+			<mCommand></mCommand>
+			<packageName></packageName>
+			<mFgColor>#ff0000</mFgColor>
+			<mBgColor>#ffff00</mBgColor>
+			<mSoundFile></mSoundFile>
+			<colorTriggerFgColor>#000000</colorTriggerFgColor>
+			<colorTriggerBgColor>#000000</colorTriggerBgColor>
+			<regexCodeList />
+			<regexCodePropertyList />
+			<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="yes" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+				<name>Lookbehind colorizer</name>
+				<script>-- Test that matches[2] contains the captured text
+if not matches[2] or matches[2] ~= "Fox Plaza" then
+  error("Expected matches[2] to be 'Fox Plaza', got: " .. tostring(matches[2]))
+end
+print("Lookbehind highlighting test passed!")</script>
+				<triggerType>0</triggerType>
+				<conditonLineDelta>0</conditonLineDelta>
+				<mStayOpen>0</mStayOpen>
+				<mCommand></mCommand>
+				<packageName></packageName>
+				<mFgColor>#00ff00</mFgColor>
+				<mBgColor>#0000ff</mBgColor>
+				<mSoundFile></mSoundFile>
+				<colorTriggerFgColor>#000000</colorTriggerFgColor>
+				<colorTriggerBgColor>#000000</colorTriggerBgColor>
+				<regexCodeList>
+					<string>(?&lt;=: )([\w\s']+)</string>
+				</regexCodeList>
+				<regexCodePropertyList>
+					<integer>1</integer>
+				</regexCodePropertyList>
+			</Trigger>
+			<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+				<name>Test duplicate substring highlighting</name>
+				<script>-- Test that selectCaptureGroup selects the correct occurrence
+-- when the captured text appears multiple times
+local pos = selectCaptureGroup(1)
+if pos ~= 10 then
+  error("Expected selectCaptureGroup(1) to return position 10, got: " .. tostring(pos))
+end
+print("Duplicate substring highlighting test passed!")</script>
+				<triggerType>0</triggerType>
+				<conditonLineDelta>0</conditonLineDelta>
+				<mStayOpen>0</mStayOpen>
+				<mCommand></mCommand>
+				<packageName></packageName>
+				<mFgColor>#ff0000</mFgColor>
+				<mBgColor>#ffff00</mBgColor>
+				<mSoundFile></mSoundFile>
+				<colorTriggerFgColor>#000000</colorTriggerFgColor>
+				<colorTriggerBgColor>#000000</colorTriggerBgColor>
+				<regexCodeList>
+					<string>^test (\w+) \1$</string>
+				</regexCodeList>
+				<regexCodePropertyList>
+					<integer>1</integer>
+				</regexCodePropertyList>
+			</Trigger>
+		</TriggerGroup>
 	</TriggerPackage>
 	<TimerPackage />
 	<AliasPackage>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
This fixes issue #4070 where regex highlighting wasn't working correctly for patterns with lookbehind assertions like `(?<=: )([\w\s']+)`.
#### Motivation for adding to Mudlet
Fix #4070
#### Other info (issues closed, discussion etc)
