### PR TITLE
Fix: Package export to root directory on Windows creates double slashes

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -1973,7 +1973,10 @@ QString dlgPackageExporter::getActualPath() const
     QSettings& settings = *mudlet::getQSettings();
     QString lastDir = settings.value("lastFileDialogLocation", QDir::homePath()).toString();
 
-    return mPackagePath.isEmpty() ? lastDir : mPackagePath;
+    // Clean the path to remove trailing slashes and normalize separators
+    // This prevents double slashes when exporting to root directories (e.g., C:/ becomes C://package.mpackage)
+    QString path = mPackagePath.isEmpty() ? lastDir : mPackagePath;
+    return QDir::cleanPath(path);
 }
 
 void dlgPackageExporter::slot_cancelExport()

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -631,7 +631,7 @@ void dlgPackageExporter::slot_importIcon()
     }
     lastDir = QFileInfo(fileName).absolutePath();
     settings.setValue("lastFileDialogLocation", lastDir);
-    mPackagePath = lastDir;
+    mPackagePath = QDir::cleanPath(lastDir);
     emit signal_exportLocationChanged(mPackagePath);
     mPackageIconPath = fileName;
     const QIcon myIcon(mPackageIconPath);
@@ -1551,7 +1551,7 @@ void dlgPackageExporter::slot_addFiles()
 
         lastDir = fDialog->directory().absolutePath();
         settings.setValue("lastFileDialogLocation", lastDir);
-        mPackagePath = lastDir;
+        mPackagePath = QDir::cleanPath(lastDir);
         emit signal_exportLocationChanged(mPackagePath);
     }
     fDialog->deleteLater();
@@ -1569,6 +1569,8 @@ void dlgPackageExporter::slot_openPackageLocation()
         return;
     }
 
+    // Clean path to remove trailing slashes before saving and displaying
+    mPackagePath = QDir::cleanPath(mPackagePath);
     settings.setValue("lastFileDialogLocation", mPackagePath);
     emit signal_exportLocationChanged(mPackagePath);
 }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
When exporting a package to a root directory (e.g., C:/), code would create a malformed path like "C://package.mpackage" instead of "C:/package.mpackage" - this fixes it.
#### Motivation for adding to Mudlet
Fix #5281
#### Other info (issues closed, discussion etc)
