### PR TITLE
Add remainingNamedTimer function to support named timers

### DIFF
--- a/src/mudlet-lua/lua/IDManager.lua
+++ b/src/mudlet-lua/lua/IDManager.lua
@@ -198,6 +198,17 @@ function IDMgr:getTriggers()
   return triggerNames
 end
 
+function IDMgr:remainingTime(name)
+  local object = self.timers[name]
+  if not object then
+    return nil, "timer not found"
+  end
+  if object.handlerID == -1 then
+    return nil, "timer is inactive"
+  end
+  return remainingTime(object.handlerID)
+end
+
 function IDMgr:new()
   local mgr = {
     events = {},
@@ -450,6 +461,21 @@ function deleteAllNamedTimers(user)
   end
   local mgr = getManager(user)
   return mgr:deleteAllTimers()
+end
+
+-- Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#remainingNamedTimer
+function remainingNamedTimer(user, name)
+  local funcName = "remainingNamedTimer"
+  local userType = type(user)
+  if userType ~= "string" then
+    printError(userErrorMsg(funcName, userType), true, true)
+  end
+  local nameType = type(name)
+  if nameType ~= "string" then
+    printError(nameErrorMsg(funcName, nameType), true, true)
+  end
+  local mgr = getManager(user)
+  return mgr:remainingTime(name)
 end
 
 -- Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#registerNamedTrigger

--- a/src/mudlet-lua/tests/IDManager_spec.lua
+++ b/src/mudlet-lua/tests/IDManager_spec.lua
@@ -197,6 +197,52 @@ describe("Tests the functionality of IDMgr", function()
     pending("Should allow you to delete a named timer")
     pending("Should allow you to delete all named timers")
 
+    describe("Tests the functionality of remainingNamedTimer", function()
+      local tempTimerSpy
+      local remainingTimeSpy
+      before_each(function()
+        tempTimerSpy = spy.on(_G, "tempTimer")
+        remainingTimeSpy = spy.on(_G, "remainingTime")
+      end)
+      after_each(function()
+        tempTimer:revert()
+        remainingTime:revert()
+        deleteAllNamedTimers(user)
+      end)
+
+      it("Should return remaining time for an active named timer", function()
+        local handlerFunc = function() end
+        registerNamedTimer(user, timerName, time, handlerFunc)
+        -- Mock remainingTime to return a value
+        remainingTime:clear()
+        remainingTimeSpy = spy.on(_G, "remainingTime")
+        remainingTimeSpy.callback = function() return 50 end
+        local result = remainingNamedTimer(user, timerName)
+        assert.is_equal(50, result)
+        assert.spy(remainingTimeSpy).was_called(1)
+      end)
+
+      it("Should return nil and error message for non-existent timer", function()
+        local result, err = remainingNamedTimer(user, "nonexistent")
+        assert.is_nil(result)
+        assert.is_equal("timer not found", err)
+      end)
+
+      it("Should raise an error if user parameter is missing or wrong type", function()
+        local exec = function()
+          remainingNamedTimer()
+        end
+        assert.error_matches(exec, "bad argument #1 type")
+      end)
+
+      it("Should raise an error if name parameter is missing or wrong type", function()
+        local exec = function()
+          remainingNamedTimer(user)
+        end
+        assert.error_matches(exec, "bad argument #2 type")
+      end)
+    end)
+
     it("Should raise an error if the handlerName is missing or wrong type", function()
       local reg = function()
         registerNamedTimer(user)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Implements support for getting the remaining time of named timers created via the IDManager. Previously, the remainingTime() function only worked with timer IDs or timer names registered directly in TimerUnit, not with named timers created through registerNamedTimer().
#### Motivation for adding to Mudlet
Fixes #6005
#### Other info (issues closed, discussion etc)
