### PR TITLE
Infrastructure: Consolidate QNetworkAccessManager instances to one per profile

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -218,7 +218,8 @@ QString stopWatch::getElapsedDayTimeString() const
 }
 
 Host::Host(int port, const QString& hostname, const QString& login, const QString& pass, int id)
-: mTelnet(this, hostname)
+: mpNetworkAccessManager(new QNetworkAccessManager(this))
+, mTelnet(this, hostname)
 , mLuaInterpreter(this, hostname, id)
 , mMxpClient(this)
 , mMxpProcessor(&mMxpClient)
@@ -227,7 +228,6 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mpAuth(new GMCPAuthenticator(this))
 , mpDockableMapWidget()
 , mTimerDebugOutputSuppressionInterval(QTime())
-, mpNetworkAccessManager(new QNetworkAccessManager(this))
 , mTriggerUnit(this)
 , mTimerUnit(this)
 , mScriptUnit(this)

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -59,6 +59,7 @@
 #include <QtConcurrent>
 #include <QDialog>
 #include <QtUiTools>
+#include <QNetworkAccessManager>
 #include <QNetworkProxy>
 #include <QSettings>
 #include <zip.h>
@@ -226,6 +227,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mpAuth(new GMCPAuthenticator(this))
 , mpDockableMapWidget()
 , mTimerDebugOutputSuppressionInterval(QTime())
+, mpNetworkAccessManager(new QNetworkAccessManager(this))
 , mTriggerUnit(this)
 , mTimerUnit(this)
 , mScriptUnit(this)

--- a/src/Host.h
+++ b/src/Host.h
@@ -59,6 +59,7 @@ class QDialog;
 class QDockWidget;
 class QPushButton;
 class QListWidget;
+class QNetworkAccessManager;
 
 class TEvent;
 class TArea;
@@ -438,6 +439,7 @@ public:
     void setCommandLineHistorySaveSize(const int lines);
     bool showIdsInEditor() const { return mShowIDsInEditor; }
     void setShowIdsInEditor(const bool isShown) { mShowIDsInEditor = isShown; if (mpEditorDialog) {mpEditorDialog->showIDLabels(isShown);} }
+    QNetworkAccessManager* getNetworkAccessManager() { return mpNetworkAccessManager; }
     bool getF3SearchEnabled() const { return mF3SearchEnabled; }
     void setF3SearchEnabled(const bool enabled) {
         mF3SearchEnabled = enabled;
@@ -742,6 +744,7 @@ public:
     // An invalid/null value is treated as the "show all"/inactive case:
     QTime mTimerDebugOutputSuppressionInterval;
     std::unique_ptr<QNetworkProxy> mpConnectionProxy;
+    QNetworkAccessManager* mpNetworkAccessManager = nullptr;
     QString mProfileStyleSheet;
     dlgTriggerEditor::SearchOptions mSearchOptions = dlgTriggerEditor::SearchOption::SearchOptionNone;
     TConsole::SearchOptions mBufferSearchOptions = TConsole::SearchOption::SearchOptionNone;

--- a/src/Host.h
+++ b/src/Host.h
@@ -439,7 +439,7 @@ public:
     void setCommandLineHistorySaveSize(const int lines);
     bool showIdsInEditor() const { return mShowIDsInEditor; }
     void setShowIdsInEditor(const bool isShown) { mShowIDsInEditor = isShown; if (mpEditorDialog) {mpEditorDialog->showIDLabels(isShown);} }
-    QNetworkAccessManager* getNetworkAccessManager() { return mpNetworkAccessManager; }
+    QNetworkAccessManager* getNetworkAccessManager() const { return mpNetworkAccessManager; }
     bool getF3SearchEnabled() const { return mF3SearchEnabled; }
     void setF3SearchEnabled(const bool enabled) {
         mF3SearchEnabled = enabled;

--- a/src/Host.h
+++ b/src/Host.h
@@ -465,6 +465,10 @@ private:
     std::optional<QFont> mTempDisplayFont;
 
 public:
+    // Shared QNetworkAccessManager for all network operations in this profile
+    // Must be initialized before components that use it (ctelnet, TMap, TLuaInterpreter, TMedia)
+    QNetworkAccessManager* mpNetworkAccessManager = nullptr;
+
     // Make this the first public member instantiated so we can use ITS font
     // as the "reference" or "master" font for whole profile - and so we don't
     // have to maintain a separate one here in this class which does not, as
@@ -744,7 +748,6 @@ public:
     // An invalid/null value is treated as the "show all"/inactive case:
     QTime mTimerDebugOutputSuppressionInterval;
     std::unique_ptr<QNetworkProxy> mpConnectionProxy;
-    QNetworkAccessManager* mpNetworkAccessManager = nullptr;
     QString mProfileStyleSheet;
     dlgTriggerEditor::SearchOptions mSearchOptions = dlgTriggerEditor::SearchOption::SearchOptionNone;
     TConsole::SearchOptions mBufferSearchOptions = TConsole::SearchOption::SearchOptionNone;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -136,11 +136,10 @@ TLuaInterpreter::TLuaInterpreter(Host* pH, const QString& hostName, int id)
 , hostName(hostName)
 , mHostID(id)
 , purgeTimer(this)
-, mpFileDownloader(new QNetworkAccessManager(this))
 , mpFileSystemWatcher(new QFileSystemWatcher(this))
 {
     connect(&purgeTimer, &QTimer::timeout, this, &TLuaInterpreter::slot_purge);
-    connect(mpFileDownloader, &QNetworkAccessManager::finished, this, &TLuaInterpreter::slot_httpRequestFinished);
+    connect(mpHost->getNetworkAccessManager(), &QNetworkAccessManager::finished, this, &TLuaInterpreter::slot_httpRequestFinished);
     connect(mpFileSystemWatcher, &QFileSystemWatcher::fileChanged, this, &TLuaInterpreter::slot_pathChanged);
     connect(mpFileSystemWatcher, &QFileSystemWatcher::directoryChanged, this, &TLuaInterpreter::slot_pathChanged);
 
@@ -4750,18 +4749,18 @@ int TLuaInterpreter::performHttpRequest(lua_State *L, const char* functionName, 
         file.close();
     }
 
-    host.updateProxySettings(host.mLuaInterpreter.mpFileDownloader);
+    host.updateProxySettings(host.getNetworkAccessManager());
 
     QNetworkReply* reply;
     switch (operation) {
         case QNetworkAccessManager::PostOperation:
-            reply = host.mLuaInterpreter.mpFileDownloader->post(request, fileToUpload.isEmpty() ?dataToPost.toUtf8() : fileToUpload);
+            reply = host.getNetworkAccessManager()->post(request, fileToUpload.isEmpty() ?dataToPost.toUtf8() : fileToUpload);
             break;
         case QNetworkAccessManager::PutOperation:
-            reply = host.mLuaInterpreter.mpFileDownloader->put(request, fileToUpload.isEmpty() ?dataToPost.toUtf8() : fileToUpload);
+            reply = host.getNetworkAccessManager()->put(request, fileToUpload.isEmpty() ?dataToPost.toUtf8() : fileToUpload);
             break;
         default:
-            reply = host.mLuaInterpreter.mpFileDownloader->sendCustomRequest(request, verb.toUtf8(), fileToUpload.isEmpty() ?dataToPost.toUtf8() : fileToUpload);
+            reply = host.getNetworkAccessManager()->sendCustomRequest(request, verb.toUtf8(), fileToUpload.isEmpty() ?dataToPost.toUtf8() : fileToUpload);
     };
 
     if (mudlet::smDebugMode) {
@@ -7112,7 +7111,7 @@ void TLuaInterpreter::createCookiesTable(lua_State* L, QNetworkReply* reply)
 
     // Parse cookies, add them as key-value pairs to the empty table
     const Host& host = getHostFromLua(L);
-    QNetworkCookieJar* cookieJar = host.mLuaInterpreter.mpFileDownloader->cookieJar();
+    QNetworkCookieJar* cookieJar = host.getNetworkAccessManager()->cookieJar();
     const QList<QNetworkCookie> cookies = cookieJar->cookiesForUrl(reply->url());
     for (const QNetworkCookie& cookie : cookies) {
         // Push cookie name onto stack

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -852,7 +852,6 @@ private:
     int mHostID = 0;
     QList<QObject*> objectsToDelete;
     QTimer purgeTimer;
-    QNetworkAccessManager* mpFileDownloader = nullptr;
     QFileSystemWatcher* mpFileSystemWatcher = nullptr;
 
     // Holds the list of places to look for the LuaGlobal.lua file:

--- a/src/TLuaInterpreterNetworking.cpp
+++ b/src/TLuaInterpreterNetworking.cpp
@@ -139,8 +139,8 @@ int TLuaInterpreter::downloadFile(lua_State* L)
     QNetworkRequest request = QNetworkRequest(url);
     mudlet::self()->setNetworkRequestDefaults(url, request);
 
-    host.updateProxySettings(host.mLuaInterpreter.mpFileDownloader);
-    QNetworkReply* reply = host.mLuaInterpreter.mpFileDownloader->get(request);
+    host.updateProxySettings(host.getNetworkAccessManager());
+    QNetworkReply* reply = host.getNetworkAccessManager()->get(request);
     host.mLuaInterpreter.downloadMap.insert(reply, localFile);
     connect(reply, &QNetworkReply::downloadProgress, reply, [=](qint64 bytesDownloaded, qint64 totalBytes) {
         raiseDownloadProgressEvent(L, urlString, bytesDownloaded, totalBytes);
@@ -625,8 +625,8 @@ int TLuaInterpreter::getHTTP(lua_State* L)
         }
     }
 
-    host.updateProxySettings(host.mLuaInterpreter.mpFileDownloader);
-    QNetworkReply* reply = host.mLuaInterpreter.mpFileDownloader->get(request);
+    host.updateProxySettings(host.getNetworkAccessManager());
+    QNetworkReply* reply = host.getNetworkAccessManager()->get(request);
 
     if (mudlet::smDebugMode) {
         TDebug(Qt::white, Qt::blue) << qsl("getHTTP: script is getting data from %1\n").arg(reply->url().toString()) >> &host;
@@ -685,8 +685,8 @@ int TLuaInterpreter::deleteHTTP(lua_State *L)
         }
     }
 
-    host.updateProxySettings(host.mLuaInterpreter.mpFileDownloader);
-    QNetworkReply* reply = host.mLuaInterpreter.mpFileDownloader->deleteResource(request);
+    host.updateProxySettings(host.getNetworkAccessManager());
+    QNetworkReply* reply = host.getNetworkAccessManager()->deleteResource(request);
 
     if (mudlet::smDebugMode) {
         TDebug(Qt::white, Qt::blue) << qsl("deleteHTTP: script is sending delete request for %1\n").arg(reply->url().toString()) >> &host;

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -53,16 +53,9 @@ TMap::TMap(Host* pH, const QString& profileName)
 {
     restore16ColorSet();
 
-    // TODO: https://github.com/Mudlet/Mudlet/issues/6436
-    // According to Qt Docs we should really only have one of these
-    // (QNetworkAccessManager) for the whole application, but: each profile's
-    // TLuaInterpreter; each profile's ctelnet and now each profile's TMap
-    // (was dlgMapper) instance has one...!
-    mpNetworkAccessManager = new QNetworkAccessManager(this);
-
     mMapInfoContributorManager = new MapInfoContributorManager(this, pH);
 
-    connect(mpNetworkAccessManager, &QNetworkAccessManager::finished, this, &TMap::slot_replyFinished);
+    connect(mpHost->getNetworkAccessManager(), &QNetworkAccessManager::finished, this, &TMap::slot_replyFinished);
 }
 
 TMap::~TMap()
@@ -2516,7 +2509,7 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     }
 
     QNetworkRequest request = QNetworkRequest(url);
-    pHost->updateProxySettings(mpNetworkAccessManager);
+    pHost->updateProxySettings(pHost->getNetworkAccessManager());
     mudlet::self()->setNetworkRequestDefaults(url, request);
 
     mExpectedFileSize = 4000000;
@@ -2526,7 +2519,7 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     qApp->processEvents();
     // Attempts to ensure INFO message gets shown before download is initiated!
 
-    mpNetworkReply = mpNetworkAccessManager->get(request);
+    mpNetworkReply = pHost->getNetworkAccessManager()->get(request);
     // Using zero for both min and max values should cause the bar to oscillate
     // until the first update
     //: %1 is the name of the current Mudlet profile

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -364,9 +364,6 @@ private:
     // Are things so bad the user needs to check the log (ignored if messages ARE already sent to screen)
     bool mIsFileViewingRecommended = false;
 
-    // Moved and revised from dlgMapper:
-    QNetworkAccessManager* mpNetworkAccessManager = nullptr;
-
     QNetworkReply* mpNetworkReply = nullptr;
     QString mLocalMapFileName;
     int mExpectedFileSize = 0;

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -42,8 +42,7 @@ TMedia::TMedia(Host* pHost, const QString& profileName)
     mpHost = pHost;
     mProfileName = profileName;
 
-    mpNetworkAccessManager = new QNetworkAccessManager(this);
-    connect(mpNetworkAccessManager, &QNetworkAccessManager::finished, this, &TMedia::slot_writeFile);
+    connect(mpHost->getNetworkAccessManager(), &QNetworkAccessManager::finished, this, &TMedia::slot_writeFile);
 }
 
 void TMedia::playMedia(TMediaData& mediaData)
@@ -924,8 +923,8 @@ void TMedia::downloadFile(TMediaData& mediaData)
             request.setSslConfiguration(config);
         }
 #endif
-        mpHost->updateProxySettings(mpNetworkAccessManager);
-        QNetworkReply* getReply = mpNetworkAccessManager->get(request);
+        mpHost->updateProxySettings(mpHost->getNetworkAccessManager());
+        QNetworkReply* getReply = mpHost->getNetworkAccessManager()->get(request);
         mMediaDownloads.insert(getReply, mediaData);
         connect(getReply, &QNetworkReply::errorOccurred, this, [=](QNetworkReply::NetworkError) {
             qWarning() << "TMedia::downloadFile() WARNING - couldn't download sound from " << fileUrl.url();

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -181,7 +181,6 @@ private:
     QList<std::shared_ptr<TMediaPlayer>> mAPIMusicList;
     QList<std::shared_ptr<TMediaPlayer>> mAPIVideoList;
 
-    QNetworkAccessManager* mpNetworkAccessManager = nullptr;
     QMap<QNetworkReply*, TMediaData> mMediaDownloads;
 };
 #endif // MUDLET_TMEDIA_H

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -136,8 +136,7 @@ cTelnet::cTelnet(Host* pH, const QString& profileName)
     mTimerPass->setSingleShot(true);
     connect(mTimerPass, &QTimer::timeout, this, &cTelnet::slot_send_pass);
 
-    mpDownloader = new QNetworkAccessManager(this);
-    connect(mpDownloader, &QNetworkAccessManager::finished, this, &cTelnet::slot_replyFinished);
+    connect(mpHost->getNetworkAccessManager(), &QNetworkAccessManager::finished, this, &cTelnet::slot_replyFinished);
 }
 
 void cTelnet::reset()
@@ -3032,11 +3031,11 @@ void cTelnet::downloadAndInstallGUIPackage(const QString& packageName, const QSt
     postMessage(tr("[ INFO ]  - Downloading and installing package '%1' (url='%2').").arg(packageName, url));
 
     mServerPackage = mudlet::getMudletPath(enums::profileDataItemPath, mProfileName, fileName);
-    mpHost->updateProxySettings(mpDownloader);
+    mpHost->updateProxySettings(mpHost->getNetworkAccessManager());
 
     auto request = QNetworkRequest(QUrl(url));
     mudlet::self()->setNetworkRequestDefaults(url, request);
-    mpPackageDownloadReply = mpDownloader->get(request);
+    mpPackageDownloadReply = mpHost->getNetworkAccessManager()->get(request);
 
     mpProgressDialog = new QProgressDialog(tr("Downloading game GUI from server..."), tr("Cancel"), 0, 4000000, mpHost && mpHost->mpConsole ? mpHost->mpConsole : nullptr);
     connect(mpPackageDownloadReply, &QNetworkReply::downloadProgress, this, &cTelnet::slot_setDownloadProgress);

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -242,7 +242,6 @@ public:
     bool mGA_Driver = false;
     bool mFORCE_GA_OFF = false;
     QPointer<dlgComposer> mpComposer;
-    QNetworkAccessManager* mpDownloader = nullptr;
     QProgressDialog* mpProgressDialog = nullptr;
     QString mServerPackage;
     QString mProfileName;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
This change addresses the issue where Mudlet was creating multiple QNetworkAccessManager instances per profile, violating Qt best practices. According to Qt documentation, applications should ideally maintain a single QNetworkAccessManager instance to efficiently manage network resources and connection pooling.

Implementation approach:
The compromise solution of "one QNetworkAccessManager per profile" was chosen (as suggested by SlySven in the issue discussion) rather than one global instance. This allows:
- Multiple profiles to make network requests in parallel
- Proper isolation of network state between different profiles
- Simpler design while still following Qt recommendations
#### Motivation for adding to Mudlet
Fixes #6436
#### Other info (issues closed, discussion etc)
