### PR TITLE
Fix: Timer groups display correct icons when drag-dropped

### DIFF
--- a/src/TTreeWidget.cpp
+++ b/src/TTreeWidget.cpp
@@ -266,19 +266,59 @@ void TTreeWidget::rowsInserted(const QModelIndex& parent, int start, int end)
             TTimer* pTChild = mpHost->getTimerUnit()->getTimer(mChildID);
             if (pTChild) {
                 QIcon icon;
-                if (pTChild->isOffsetTimer()) {
-                    if (pTChild->shouldBeActive()) {
-                        icon.addPixmap(QPixmap(qsl(":/icons/offsettimer-on.png")), QIcon::Normal, QIcon::Off);
+                const bool itemActive = (pTChild->isActive() || pTChild->shouldBeActive());
+
+                if (pTChild->isFolder()) {
+                    // Timer folder
+                    if (itemActive) {
+                        if (pTChild->ancestorsActive()) {
+                            if (!pTChild->mPackageName.isEmpty()) {
+                                icon.addPixmap(QPixmap(qsl(":/icons/folder-brown.png")), QIcon::Normal, QIcon::Off);
+                            } else {
+                                icon.addPixmap(QPixmap(qsl(":/icons/folder-green.png")), QIcon::Normal, QIcon::Off);
+                            }
+                        } else {
+                            icon.addPixmap(QPixmap(qsl(":/icons/folder-grey.png")), QIcon::Normal, QIcon::Off);
+                        }
                     } else {
-                        icon.addPixmap(QPixmap(qsl(":/icons/offsettimer-off.png")), QIcon::Normal, QIcon::Off);
+                        if (pTChild->ancestorsActive()) {
+                            if (!pTChild->mPackageName.isEmpty()) {
+                                icon.addPixmap(QPixmap(qsl(":/icons/folder-brown-locked.png")), QIcon::Normal, QIcon::Off);
+                            } else {
+                                icon.addPixmap(QPixmap(qsl(":/icons/folder-green-locked.png")), QIcon::Normal, QIcon::Off);
+                            }
+                        } else {
+                            icon.addPixmap(QPixmap(qsl(":/icons/folder-grey-locked.png")), QIcon::Normal, QIcon::Off);
+                        }
+                    }
+                } else if (pTChild->isOffsetTimer()) {
+                    // Offset timer
+                    if (pTChild->shouldBeActive()) {
+                        if (pTChild->ancestorsActive()) {
+                            icon.addPixmap(QPixmap(qsl(":/icons/offsettimer-on.png")), QIcon::Normal, QIcon::Off);
+                        } else {
+                            icon.addPixmap(QPixmap(qsl(":/icons/offsettimer-on-grey.png")), QIcon::Normal, QIcon::Off);
+                        }
+                    } else {
+                        if (pTChild->ancestorsActive()) {
+                            icon.addPixmap(QPixmap(qsl(":/icons/offsettimer-off.png")), QIcon::Normal, QIcon::Off);
+                        } else {
+                            icon.addPixmap(QPixmap(qsl(":/icons/offsettimer-off-grey.png")), QIcon::Normal, QIcon::Off);
+                        }
                     }
                 } else {
+                    // Regular timer
                     if (pTChild->shouldBeActive()) {
-                        icon.addPixmap(QPixmap(qsl(":/icons/tag_checkbox_checked.png")), QIcon::Normal, QIcon::Off);
+                        if (pTChild->ancestorsActive()) {
+                            icon.addPixmap(QPixmap(qsl(":/icons/tag_checkbox_checked.png")), QIcon::Normal, QIcon::Off);
+                        } else {
+                            icon.addPixmap(QPixmap(qsl(":/icons/tag_checkbox_checked_grey.png")), QIcon::Normal, QIcon::Off);
+                        }
                     } else {
                         icon.addPixmap(QPixmap(qsl(":/icons/tag_checkbox.png")), QIcon::Normal, QIcon::Off);
                     }
                 }
+
                 QTreeWidgetItem* pParent = itemFromIndex(parent);
                 if (!pParent) {
                     QTreeWidget::rowsInserted(parent, start, end);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
When timer groups (folders) were moved via drag-and-drop, they temporarily displayed with incorrect icons (showing as timer items instead of folder icons) until the UI was refreshed - this fixes it.
#### Motivation for adding to Mudlet
Fix #2763
#### Other info (issues closed, discussion etc)
