### PR TITLE
Infrastructure: use packaged QtKeychain on Windows

### DIFF
--- a/CI/build-mudlet-for-windows.sh
+++ b/CI/build-mudlet-for-windows.sh
@@ -131,6 +131,10 @@ else
     export WITH_UPDATER="YES"
 fi
 
+# Since we have this already installed as a package there is no need to build
+# it from a submodule:
+export WITH_OWN_QTKEYCHAIN=NO
+
 echo "Running qmake to make MAKEFILE ..."
 echo ""
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Switch to using the Mingw-w64 package version of `Qt6Keychain`.

#### Motivation for adding to Mudlet
Reduce build time by not compiling something already available to us.

#### Other info (issues closed, discussion etc)
IIRC This was not a package that was built by upstream for the MINGW32 case so it might have been necessary to build it back when we were still producing a 32-Bit Windows build.

Given that it now seems to be available for all the OSes we support it might be reasonable to remove the submodule from our project and treat it just as another dependency that the end-hacker will need to have available.