### PR TITLE
Fix: Correct typo in special exits deletion tooltip

### DIFF
--- a/src/ui/room_exits.ui
+++ b/src/ui/room_exits.ui
@@ -1927,7 +1927,7 @@
          <enum>Qt::StrongFocus</enum>
         </property>
         <property name="toolTip">
-         <string>&lt;p&gt;Click on an item to edit/change it. To delete a Special Exit, ether: select it and press the keyboard Delete key; or set its Exit roomID to less than one; or clear the name/command entry.&lt;/p&gt;</string>
+         <string>&lt;p&gt;Click on an item to edit/change it. To delete a Special Exit, either: select it and press the keyboard Delete key; or set its Exit roomID to less than one; or clear the name/command entry.&lt;/p&gt;</string>
         </property>
         <property name="frameShadow">
          <enum>QFrame::Raised</enum>


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fixed spelling error in the room exits dialog tooltip: "ether" → "either"
#### Motivation for adding to Mudlet
Typo fix
#### Other info (issues closed, discussion etc)
