### PR TITLE
Add: Multiple file selection in import dialogs

### DIFF
--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -131,21 +131,40 @@ void dlgModuleManager::slot_installModule()
     QSettings& settings = *mudlet::getQSettings();
     QString lastDir = settings.value("lastFileDialogLocation", QDir::homePath()).toString();
 
-    const QString fileName = QFileDialog::getOpenFileName(this, tr("Load Mudlet Module"), lastDir);
-    if (fileName.isEmpty()) {
+    const QStringList fileNames = QFileDialog::getOpenFileNames(this, tr("Load Mudlet Module"), lastDir);
+    if (fileNames.isEmpty()) {
         return;
     }
 
-    lastDir = QFileInfo(fileName).absolutePath();
+    lastDir = QFileInfo(fileNames.first()).absolutePath();
     settings.setValue("lastFileDialogLocation", lastDir);
 
-    QFile file(fileName);
-    if (!file.open(QFile::ReadOnly | QFile::Text)) {
-        QMessageBox::warning(this, tr("Load Mudlet Module:"), tr("Cannot read file %1:\n%2.").arg(fileName.toHtmlEscaped(), file.errorString()));
-        return;
+    QStringList unreadableFiles;
+    QStringList failedModules;
+
+    for (const QString& fileName : fileNames) {
+        QFile file(fileName);
+        if (!file.open(QFile::ReadOnly | QFile::Text)) {
+            unreadableFiles << QFileInfo(fileName).fileName();
+            continue;
+        }
+        file.close();
+
+        auto result = mpHost->installPackage(fileName, enums::PackageModuleType::ModuleFromUI);
+        if (!result.first) {
+            failedModules << QFileInfo(fileName).fileName();
+        }
     }
 
-    mpHost->installPackage(fileName, enums::PackageModuleType::ModuleFromUI);
+    if (!unreadableFiles.isEmpty()) {
+        QMessageBox::warning(this, tr("Load Mudlet Module:"), tr("Cannot read the following files:\n%1").arg(unreadableFiles.join(qsl("\n"))));
+    }
+
+    if (!failedModules.isEmpty()) {
+        QMessageBox::warning(this, tr("Load Mudlet Module"),
+            tr("The following modules failed to install:\n%1").arg(failedModules.join(qsl("\n"))));
+    }
+
     for (int i = moduleTable->rowCount() - 1; i >= 0; --i) {
         moduleTable->removeRow(i);
     }

--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -153,6 +153,9 @@ void dlgModuleManager::slot_installModule()
         auto result = mpHost->installPackage(fileName, enums::PackageModuleType::ModuleFromUI);
         if (!result.first) {
             failedModules << QFileInfo(fileName).fileName();
+        } else {
+            // Wait for this module's save to complete before installing the next one
+            mpHost->waitForProfileSave();
         }
     }
 

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -122,6 +122,9 @@ void dlgPackageManager::slot_installPackage()
         auto result = mpHost->installPackage(fileName, enums::PackageModuleType::Package);
         if (!result.first) {
             failedPackages << QFileInfo(fileName).fileName();
+        } else {
+            // Wait for this package's save to complete before installing the next one
+            mpHost->waitForProfileSave();
         }
     }
 

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -100,21 +100,39 @@ void dlgPackageManager::slot_installPackage()
     QSettings& settings = *mudlet::getQSettings();
     QString lastDir = settings.value("lastFileDialogLocation", QDir::homePath()).toString();
 
-    const QString fileName = QFileDialog::getOpenFileName(this, tr("Import Mudlet Package"), lastDir);
-    if (fileName.isEmpty()) {
+    const QStringList fileNames = QFileDialog::getOpenFileNames(this, tr("Import Mudlet Package"), lastDir);
+    if (fileNames.isEmpty()) {
         return;
     }
 
-    lastDir = QFileInfo(fileName).absolutePath();
+    lastDir = QFileInfo(fileNames.first()).absolutePath();
     settings.setValue("lastFileDialogLocation", lastDir);
 
-    QFile file(fileName);
-    if (!file.open(QFile::ReadOnly | QFile::Text)) {
-        QMessageBox::warning(this, tr("Import Mudlet Package:"), tr("Cannot read file %1:\n%2.").arg(fileName.toHtmlEscaped(), file.errorString()));
-        return;
+    QStringList unreadableFiles;
+    QStringList failedPackages;
+
+    for (const QString& fileName : fileNames) {
+        QFile file(fileName);
+        if (!file.open(QFile::ReadOnly | QFile::Text)) {
+            unreadableFiles << QFileInfo(fileName).fileName();
+            continue;
+        }
+        file.close();
+
+        auto result = mpHost->installPackage(fileName, enums::PackageModuleType::Package);
+        if (!result.first) {
+            failedPackages << QFileInfo(fileName).fileName();
+        }
     }
 
-    mpHost->installPackage(fileName, enums::PackageModuleType::Package);
+    if (!unreadableFiles.isEmpty()) {
+        QMessageBox::warning(this, tr("Import Mudlet Package:"), tr("Cannot read the following files:\n%1").arg(unreadableFiles.join(qsl("\n"))));
+    }
+
+    if (!failedPackages.isEmpty()) {
+        QMessageBox::warning(this, tr("Import Mudlet Package"),
+            tr("The following packages failed to install:\n%1").arg(failedPackages.join(qsl("\n"))));
+    }
 }
 
 void dlgPackageManager::slot_removePackages()

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -10425,6 +10425,9 @@ void dlgTriggerEditor::slot_import()
         auto result = mpHost->installPackage(fileName, enums::PackageModuleType::Package);
         if (!result.first) {
             failedPackages << QFileInfo(fileName).fileName();
+        } else {
+            // Wait for this package's save to complete before installing the next one
+            mpHost->waitForProfileSave();
         }
     }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -10413,14 +10413,25 @@ void dlgTriggerEditor::slot_import()
 
     QSettings& settings = *mudlet::getQSettings();
     QString lastDir = settings.value("lastFileDialogLocation", QDir::homePath()).toString();
-    const QString fileName = QFileDialog::getOpenFileName(this, tr("Import Mudlet Package"), lastDir);
-    if (fileName.isEmpty()) {
+    const QStringList fileNames = QFileDialog::getOpenFileNames(this, tr("Import Mudlet Package"), lastDir);
+    if (fileNames.isEmpty()) {
         return;
     }
-    lastDir = QFileInfo(fileName).absolutePath();
+    lastDir = QFileInfo(fileNames.first()).absolutePath();
     settings.setValue("lastFileDialogLocation", lastDir);
 
-    mpHost->installPackage(fileName, enums::PackageModuleType::Package);
+    QStringList failedPackages;
+    for (const QString& fileName : fileNames) {
+        auto result = mpHost->installPackage(fileName, enums::PackageModuleType::Package);
+        if (!result.first) {
+            failedPackages << QFileInfo(fileName).fileName();
+        }
+    }
+
+    if (!failedPackages.isEmpty()) {
+        QMessageBox::warning(this, tr("Import Mudlet Package"),
+            tr("The following packages failed to install:\n%1").arg(failedPackages.join(qsl("\n"))));
+    }
 
     treeWidget_triggers->clear();
     treeWidget_aliases->clear();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Implement multiple file selection for package and module import dialogs, allowing players to select and import multiple XML files simultaneously using standard keyboard shortcuts (Ctrl/Shift+click).
#### Motivation for adding to Mudlet
Fixes #607
#### Other info (issues closed, discussion etc)
