### PR TITLE
Infrastructure: disable sanitizers on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,9 +39,9 @@ endif()
 if(WIN32)
   # APP_BUILD should now be be available
 
-  if(APP_BUILD matches "-ptb.+")
+  if(APP_BUILD MATCHES "-ptb.+")
     list(APPEND mudlet_RCCS icons/mudlet_ptb.ico)
-  elseif((APP_BUILD matches "-dev.+") or (APP_BUILD matches "-test.+"))
+  elseif((APP_BUILD MATCHES "-dev.+" OR APP_BUILD MATCHES "-test.+"))
     # The above test may not be correct as it won't pick up builds where
     # MUDLET_VERSION_BUILD has been set in the environment - OTOH for
     # "Packagers" they will likely want the original icon anyhow for their
@@ -439,19 +439,11 @@ if(NOT "${USE_ALTERNATE_LINKER}" STREQUAL "")
   set_alternate_linker(${USE_ALTERNATE_LINKER})
 endif()
 
-# Enable sanitizers support
-include(../3rdparty/cmake-scripts/sanitizers.cmake)
-
-set_sanitizer_options(address DEFAULT -fno-omit-frame-pointer)
-set_sanitizer_options(thread DEFAULT -fno-omit-frame-pointer)
-
-set(USE_SANITIZER
-      "address"
-      CACHE STRING
-      "Compile with sanitizers. Available sanitizers are: Address, Memory, MemoryWithOrigins, Undefined, Thread, or Leak")
-
-add_sanitizer_support(${USE_SANITIZER})
-message(STATUS "Compiling with the following sanitizer(s) enabled: ${USE_SANITIZER}")
+if(NOT WIN32)
+  include(cmake/EnableSanitizers.cmake)
+else()
+  message(STATUS "Sanitizers disabled on Windows")
+endif()
 
 find_package(Qt6 6.4.0 REQUIRED
     COMPONENTS Core

--- a/src/cmake/EnableSanitizers.cmake
+++ b/src/cmake/EnableSanitizers.cmake
@@ -1,0 +1,14 @@
+include(${CMAKE_SOURCE_DIR}/3rdparty/cmake-scripts/sanitizers.cmake)
+
+set_sanitizer_options(address DEFAULT -fno-omit-frame-pointer)
+set_sanitizer_options(thread DEFAULT -fno-omit-frame-pointer)
+
+set(USE_SANITIZER
+    "address"
+    CACHE STRING
+    "Compile with sanitizers. Available sanitizers are: \
+    Address, Memory, MemoryWithOrigins, Undefined, Thread, or Leak"
+)
+
+add_sanitizer_support(${USE_SANITIZER})
+message(STATUS "Compiling with the following sanitizer(s) enabled: ${USE_SANITIZER}")


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Disable sanitizers on Windows
Fixes the cmake build on Windows.
#### Motivation for adding to Mudlet
Sanitizers with Qt are not fully supported on Windows by GCC, Clang, or MSVC.