### PR TITLE
Fix: correct missing library required by non-Windows/MacOS qmake builds

### DIFF
--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -402,7 +402,9 @@ unix:!macx {
         -lpugixml
 
     isEmpty( 3DMAPPER_TEST ) | !equals(3DMAPPER_TEST, "NO" ) {
-       LIBS += -lGLU
+       LIBS += \
+         -lGLU \
+         -lassimp
     }
 
     LUA_DEFAULT_DIR = $${DATADIR}/lua


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a missing LIBS entry to the non-Windows/non-MacOS part so that other OSes can use it at the link stage.

#### Motivation for adding to Mudlet
Allow those of us who still prefer `qmake` to build Mudlet again!

#### Other info (issues closed, discussion etc)
This was missing from PR #8185.