### PR TITLE
Fix: remove many compilation warnings

### DIFF
--- a/src/CameraController.cpp
+++ b/src/CameraController.cpp
@@ -144,9 +144,6 @@ QVector3D CameraController::getPosition()
     }
 
     const float toDegrees = 180.0f / pi;
-    const float x = mPositionVector.x();
-    const float y = mPositionVector.y();
-    const float z = mPositionVector.z();
     const float theta = toDegrees * std::acos(mPositionVector.z());
     const float phi = toDegrees * std::atan2(mPositionVector.y(), mPositionVector.x());
     return QVector3D(mDistance, theta, phi);

--- a/src/CameraController.h
+++ b/src/CameraController.h
@@ -62,7 +62,7 @@ public:
     // Camera state
     QVector3D getPosition();
     QVector3D getTarget() const { return mTarget; }
-    QVector3D getUp() const { return mUpVector; }
+    // QVector3D getUp() const { return mUpVector; }
     float getScale() const { return mDistance; }
 
     // View center (for external API compatibility)

--- a/src/LlamaFileManager.cpp
+++ b/src/LlamaFileManager.cpp
@@ -282,6 +282,8 @@ void LlamafileManager::onProcessStarted() {
 }
 
 void LlamafileManager::onProcessFinished(int exitCode, QProcess::ExitStatus exitStatus) {
+    Q_UNUSED(exitStatus)
+
     // Capture any remaining output from the process
     QString stdoutOutput = QString::fromUtf8(process->readAllStandardOutput()).trimmed();
     QString stderrOutput = QString::fromUtf8(process->readAllStandardError()).trimmed();

--- a/src/RenderCommand.cpp
+++ b/src/RenderCommand.cpp
@@ -39,6 +39,9 @@ void RenderCubeCommand::execute(QOpenGLFunctions* gl,
                                QOpenGLBuffer& indexBuffer,
                                QOpenGLBuffer& texCoordBuffer)
 {
+    Q_UNUSED(gl)
+    Q_UNUSED(texCoordBuffer)
+
     GeometryData cubeGeometry = geometryManager->generateCubeGeometry(mX, mY, mZ, mSize, mR, mG, mB, mA);
 
     // Set uniforms
@@ -74,6 +77,9 @@ void RenderLinesCommand::execute(QOpenGLFunctions* gl,
                                 QOpenGLBuffer& indexBuffer,
                                 QOpenGLBuffer& texCoordBuffer)
 {
+    Q_UNUSED(gl)
+    Q_UNUSED(texCoordBuffer)
+
     GeometryData lineGeometry = geometryManager->generateLineGeometry(mVertices, mColors);
 
     if (lineGeometry.isEmpty()) {
@@ -112,6 +118,9 @@ void RenderTrianglesCommand::execute(QOpenGLFunctions* gl,
                                     QOpenGLBuffer& indexBuffer,
                                     QOpenGLBuffer& texCoordBuffer)
 {
+    Q_UNUSED(gl)
+    Q_UNUSED(texCoordBuffer)
+
     GeometryData triangleGeometry = geometryManager->generateTriangleGeometry(mVertices, mColors);
 
     if (triangleGeometry.isEmpty()) {
@@ -149,6 +158,8 @@ void RenderTexturedTrianglesCommand::execute(QOpenGLFunctions* gl,
                                            QOpenGLBuffer& indexBuffer,
                                            QOpenGLBuffer& texCoordBuffer)
 {
+    Q_UNUSED(gl)
+
     if (mGeometry.isEmpty()) {
         return;
     }
@@ -202,6 +213,9 @@ void RenderInstancedCubesCommand::execute(QOpenGLFunctions* gl,
                                          QOpenGLBuffer& indexBuffer,
                                          QOpenGLBuffer& texCoordBuffer)
 {
+    Q_UNUSED(gl)
+    Q_UNUSED(texCoordBuffer)
+
     if (mInstances.isEmpty()) {
         return;
     }
@@ -243,6 +257,16 @@ void GLStateCommand::execute(QOpenGLFunctions* gl,
                             QOpenGLBuffer& indexBuffer,
                             QOpenGLBuffer& texCoordBuffer)
 {
+    Q_UNUSED(shader)
+    Q_UNUSED(geometryManager)
+    Q_UNUSED(resourceManager)
+    Q_UNUSED(vao)
+    Q_UNUSED(vertexBuffer)
+    Q_UNUSED(colorBuffer)
+    Q_UNUSED(normalBuffer)
+    Q_UNUSED(indexBuffer)
+    Q_UNUSED(texCoordBuffer)
+
     switch (mStateType) {
         case ENABLE_DEPTH_TEST:
             gl->glEnable(GL_DEPTH_TEST);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4984,9 +4984,6 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
         return {false, qsl("Area %1 has invalid dimensions").arg(areaId)};
     }
 
-    // Use zoom level to determine appropriate scale - similar to paintEvent
-    const float xyzoom = pArea->get2DMapZoom();
-
     // Calculate room size based on area dimensions - auto-sizing approach
     // Aim for reasonable room sizes that fit well regardless of area size
     const int targetImageDimension = 1024; // Target around 1024 pixels for the larger dimension
@@ -4995,11 +4992,6 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
     const int minRoomSize = 8;
     const int maxRoomSize = 50; // Prevent rooms from being too large
     const int finalRoomSize = qBound(minRoomSize, roomSize, maxRoomSize);
-
-    // Store room-based dimensions for export
-    const float exportRoomWidth = finalRoomSize;
-    const float exportRoomHeight = finalRoomSize;
-
 
     // Calculate image size based on actual area content
     const int padding = finalRoomSize * 2;
@@ -5073,17 +5065,6 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
     const float exitWidth = 1 / eSize * finalRoomSize * rSize;
     pen.setWidthF(exitWidth);
 
-    // Use the same Z-level filtering and drawing approach as paintEvent
-
-    // Get the current Z level from the area center
-    TRoom* centerRoom = nullptr;
-    for (int roomId : pArea->rooms) {
-        TRoom* pRoom = mpMap->mpRoomDB->getRoom(roomId);
-        if (pRoom) {
-            centerRoom = pRoom;
-            break;
-        }
-    }
     // Use the same Z-level filtering and drawing approach as paintEvent
     const int exportZLevel = zLevel.has_value() ? zLevel.value() : mMapCenterZ;
 
@@ -5337,8 +5318,6 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
                         if (room->customLinesArrow.value(exitKey, false)) {
                             QLineF arrowLine = QLineF(polyLinePoints.last(), polyLinePoints.at(polyLinePoints.size() - 2));
                             arrowLine.setLength(exitWidth * 5.0);
-                            const QPointF arrowTip = arrowLine.p1();
-                            const QPointF arrowBase = arrowLine.p2();
 
                             QLineF arrowHead1 = arrowLine;
                             arrowHead1.setLength(exitWidth * 3.0);

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1070,7 +1070,7 @@ void TBuffer::processMxpWatchdogCallback()
                 size_t      unusedBufferPosition = 0;
 
                 mMudLine.append(lastEntityValue);
-                for (size_t i = 0; i < lastEntityValue.size(); ++i) {
+                for (qsizetype i = 0; i < lastEntityValue.size(); ++i) {
                     mMudBuffer.push_back(style);
                 }
                 commitLine('\r', unusedBufferPosition);
@@ -2475,7 +2475,6 @@ void TBuffer::decodeOSC(const QString& sequence)
                 // Add menu items in pairs (label, command)
                 // The first menu item becomes the primary left-click action (index 0)
                 // All items (including first) appear in the right-click menu (index 1+)
-                bool isFirstItem = true;
                 for (int i = 0; i < mCurrentHyperlinkMenu.size() - 1; i += 2) {
                     QString menuLabel = mCurrentHyperlinkMenu[i];
                     QString menuCommand = mCurrentHyperlinkMenu[i + 1];
@@ -2498,7 +2497,6 @@ void TBuffer::decodeOSC(const QString& sequence)
                         menuCommands.append(qsl("send([[%1]])").arg(menuCommand));
                         menuHints.append(menuLabel);
                     }
-                    isFirstItem = false;
                 }
 
                 // Set the tooltip for the link (what shows on hover)
@@ -5813,8 +5811,6 @@ void TBuffer::setActiveLink(int linkIndex)
 
     // Reset previous active link
     if (previousActiveLink > 0 && previousActiveLink != linkIndex) {
-        // Check current state to preserve visited links
-        Mudlet::HyperlinkStyling::LinkState currentState = getLinkState(previousActiveLink);
 
         // Return to hover if it's still hovered
         if (previousActiveLink == mCurrentHoveredLinkIndex) {
@@ -5888,7 +5884,7 @@ int TBuffer::getLinkIndexAt(int line, int column) const
     const auto& bufferLine = buffer.at(line);
 
     // Validate column bounds
-    if (column < 0 || column >= bufferLine.size()) {
+    if (column < 0 || column >= static_cast<int>(bufferLine.size())) {
         return 0;
     }
 

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -36,8 +36,8 @@ TKey::TKey(TKey* parent, Host* pHost)
 
 TKey::TKey(QString name, Host* pHost)
 : Tree<TKey>( nullptr )
-, mName(name)
 , mpHost(pHost)
+, mName(name)
 {
 }
 

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -636,7 +636,6 @@ void TTextEdit::drawGraphemeForeground(QPainter& painter, const QColor& fgColor,
     const bool isUnderlineDotted = attributes & TChar::UnderlineDotted;
     const bool isUnderlineDashed = attributes & TChar::UnderlineDashed;
     const bool hasAdvancedUnderline = isUnderlineWavy || isUnderlineDotted || isUnderlineDashed;
-    const bool hasCustomDecorationColors = charStyle.hasCustomUnderlineColor() || charStyle.hasCustomOverlineColor() || charStyle.hasCustomStrikeoutColor();
 
     // If we have advanced underline styles or custom decoration colors, disable Qt's built-in decorations
     // and draw them manually later

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1371,7 +1371,6 @@ void dlgTriggerEditor::readSettings()
 {
     QSettings& settings = *mudlet::getQSettings();
 
-    const QPoint savedPos = settings.value("script_editor_pos", QPoint(10, 10)).toPoint();
     const QSize size = settings.value("script_editor_size", QSize(600, 400)).toSize();
     resize(size);
 
@@ -9097,7 +9096,7 @@ void dlgTriggerEditor::slot_sourceReplace()
 {
     auto controller = mpSourceEditorEdbee->controller();
     auto replaceText = mpSourceEditorFindArea->lineEdit_replaceText->text();
-    for (int i = 0; i < controller->textSelection()->rangeCount(); i++) {
+    for (size_t i = 0; i < controller->textSelection()->rangeCount(); i++) {
         auto &range = controller->textSelection()->range(i);
         if (mpSourceEditorEdbee->textDocument()->text().mid(range.anchor(), range.length()) == replaceText) {
             slot_sourceFindNext();

--- a/src/modern_glwidget.cpp
+++ b/src/modern_glwidget.cpp
@@ -38,7 +38,15 @@
 
 
 ModernGLWidget::ModernGLWidget(TMap* pMap, Host* pHost, QWidget* parent)
-: QOpenGLWidget(parent), mShaderManager(&mResourceManager, this), mVertexBuffer(QOpenGLBuffer::VertexBuffer), mColorBuffer(QOpenGLBuffer::VertexBuffer), mNormalBuffer(QOpenGLBuffer::VertexBuffer), mIndexBuffer(QOpenGLBuffer::IndexBuffer), mInstanceBuffer(QOpenGLBuffer::VertexBuffer), mpMap(pMap), mpHost(pHost)
+: QOpenGLWidget(parent)
+, mpMap(pMap)
+, mShaderManager(&mResourceManager, this)
+, mVertexBuffer(QOpenGLBuffer::VertexBuffer)
+, mColorBuffer(QOpenGLBuffer::VertexBuffer)
+, mNormalBuffer(QOpenGLBuffer::VertexBuffer)
+, mIndexBuffer(QOpenGLBuffer::IndexBuffer)
+, mInstanceBuffer(QOpenGLBuffer::VertexBuffer)
+, mpHost(pHost)
 {
     if (mpHost->mBgColor_2.alpha() < 255) {
         setAttribute(Qt::WA_OpaquePaintEvent, false);
@@ -217,7 +225,6 @@ void ModernGLWidget::paintGL()
 
     glEnable(GL_MULTISAMPLE);
 
-    float px, py, pz;
     if (mRID != mpMap->mRoomIdHash.value(mpMap->mProfileName) && mShiftMode) {
         mShiftMode = false;
     }
@@ -285,16 +292,11 @@ void ModernGLWidget::paintGL()
         mPreviousRID = mRID; // Update tracking
         mPreviousAID = mAID; // Update area tracking
 
-
     } else {
         ox = mMapCenterX;
         oy = mMapCenterY;
         oz = mMapCenterZ;
     }
-
-    px = static_cast<float>(ox);
-    py = static_cast<float>(oy);
-    pz = static_cast<float>(oz);
 
     TArea* pArea = mpMap->mpRoomDB->getArea(mAID);
     if (!pArea) {
@@ -405,8 +407,6 @@ void ModernGLWidget::renderRooms()
         bool isCurrentRoom = (rz == pz) && (rx == px) && (ry == py);
         bool isTargetRoom = (currentRoomId == mTargetRoomId);
         bool belowOrAtLevel = (rz <= pz);
-        float roomAlpha = 1.0f;
-        const float defaultSize = 1.0f / scale;
 
         // 1. Collect main room cube data
         if (isCurrentRoom) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -5655,8 +5655,6 @@ bool mudlet::migratePasswordsToProfileStorage()
 
     const QStringList profiles = QDir(mudlet::getMudletPath(enums::profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
 
-    bool anyMigrationNeeded = false;
-
     for (const auto& profile : profiles) {
         // Try to retrieve password from CredentialManager
         QString password = CredentialManager::retrieveCredential(profile, "character");
@@ -5673,7 +5671,6 @@ bool mudlet::migratePasswordsToProfileStorage()
             } else {
                 qDebug().nospace().noquote() << "mudlet::migratePasswordsToProfileStorage() INFO - migrated password for profile \"" << profile << "\" to profile storage (secure storage preserved for compatibility).";
             }
-            anyMigrationNeeded = true;
         }
 
         // Also check for old-format keychain entries (service: "Mudlet profile", key: profile name)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Removes unused variables or code and eliminates warnings about unused arguments to functions/methods. Changes types or adds `static_cast`s to avoid mismatched numerical comparisons. Reorders constructor initialisation lists so they are performed in the correct sequence.

#### Motivation for adding to Mudlet
Removal of various compilation warnings.

#### Other info (issues closed, discussion etc)
There is also the (merged upstream) https://github.com/edbee/edbee-lib/pull/168 which addresses one other warning left in the edbee-lib editor (3rd party) library.