### PR TITLE
Fix: Prevent crash when importing XML via Script Editor

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -11500,16 +11500,17 @@ void dlgTriggerEditor::slot_import()
     treeWidget_keys->clear();
     treeWidget_scripts->clear();
 
-    slot_profileSaveAction();
-
-    fillout_form();
-
+    // Nullify current item pointers before saving to prevent use-after-free
     mpCurrentTriggerItem = nullptr;
     mpCurrentTimerItem = nullptr;
     mpCurrentAliasItem = nullptr;
     mpCurrentScriptItem = nullptr;
     mpCurrentActionItem = nullptr;
     mpCurrentKeyItem = nullptr;
+
+    slot_profileSaveAction();
+
+    fillout_form();
 
     slot_showTriggers();
 }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix crash on import via XML editor
#### Motivation for adding to Mudlet
Fix #8470 
#### Other info (issues closed, discussion etc)
