### PR TITLE
Fix: Prevent duplicate close events when closing profile tabs

### DIFF
--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -1636,6 +1636,15 @@ void TMainConsole::showStatistics()
 
 void TMainConsole::closeEvent(QCloseEvent* event)
 {
+    // Guard against duplicate close events during widget destruction.
+    // The first close comes from explicit close(), the second can come
+    // from Qt during widget deletion. Processing the event twice can
+    // cause crashes in TBuffer destruction.
+    if (mEnableClose) {
+        event->accept();
+        return;
+    }
+
     qDebug().nospace().noquote() << "TMainConsole::closeEvent(...) INFO - received by \"" << mpHost->getName() << "\".";
     TEvent conCloseEvent{};
     conCloseEvent.mArgumentList.append(qsl("sysExitEvent"));
@@ -1670,6 +1679,7 @@ void TMainConsole::closeEvent(QCloseEvent* event)
             }
         }
         mpHost->waitForProfileSave();
+        mEnableClose = true;
         event->accept();
         return;
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixed an issue where closing a profile tab would trigger the close event handler twice, causing duplicate debug messages and potentially leading to crashes during profile shutdown.

The fix adds a guard at the beginning of `TMainConsole::closeEvent()` to prevent re-entry during widget destruction, and ensures the `mEnableClose` flag is properly set in all close paths.

#### Motivation for adding to Mudlet

When closing a profile tab, users would see duplicate debug output:
- `TMainConsole::closeEvent(...) INFO - received by "ProfileName".` (appears twice)
- `mudlet::saveWindowLayout() - Already-Saved: true` (appears twice)

More critically, this duplicate event processing was linked to a reported segmentation fault in `TBuffer::~TBuffer()` where the destructor would crash with a null pointer dereference. The double close event was interfering with proper widget destruction order.

#### Other info (issues closed, discussion etc)

Related to [Discord chat conversation](https://discord.com/channels/283581582550237184/427919962561052673/1435409031748653188) where a crash was reported during profile closure.

Changes made:
- Added early return guard in `TMainConsole::closeEvent()` when `mEnableClose` is already true
- Set `mEnableClose = true` in the forced close path (before return at line 1682) to ensure the flag is set in all code paths
- Added detailed comment explaining the guard's purpose