### PR TITLE
Fix: Prevent duplicate profile loading in autologin

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4301,7 +4301,6 @@ void mudlet::doAutoLogin(const QString& profile_name)
         return;
     }
 
-    // Guard against loading the same profile multiple times (fixes #1195)
     if (mHostManager.hostLoaded(profile_name)) {
         qDebug() << "Profile" << profile_name << "already loaded, skipping duplicate autologin";
         return;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4301,6 +4301,12 @@ void mudlet::doAutoLogin(const QString& profile_name)
         return;
     }
 
+    // Guard against loading the same profile multiple times (fixes #1195)
+    if (mHostManager.hostLoaded(profile_name)) {
+        qDebug() << "Profile" << profile_name << "already loaded, skipping duplicate autologin";
+        return;
+    }
+
     loadProfile(profile_name, true);
 
     slot_connectionDialogueFinished(profile_name, true);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix: Prevent duplicate profile loading in autologin, which could happen if you duplicated a default game
#### Motivation for adding to Mudlet
Fix #1195
#### Other info (issues closed, discussion etc)
