### PR TITLE
Improve: update keyboard shortcut in editor and close button icon in trigger editor

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1216,6 +1216,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mPatternNavigationHintCloseButton = new QToolButton(mPatternNavigationHintBanner);
     mPatternNavigationHintCloseButton->setObjectName(qsl("patternNavigationHintCloseButton"));
     mPatternNavigationHintCloseButton->setAutoRaise(true);
+    mPatternNavigationHintCloseButton->setFixedSize(16, 16);
     mPatternNavigationHintCloseButton->setIcon(QIcon::fromTheme(qsl("dialog-close"), QIcon(qsl(":/icons/dialog-close.png"))));
     //: Tooltip for the button that hides the pattern navigation hint banner.
     mPatternNavigationHintCloseButton->setToolTip(tr("Hide this hint"));

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1216,7 +1216,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mPatternNavigationHintCloseButton = new QToolButton(mPatternNavigationHintBanner);
     mPatternNavigationHintCloseButton->setObjectName(qsl("patternNavigationHintCloseButton"));
     mPatternNavigationHintCloseButton->setAutoRaise(true);
-    mPatternNavigationHintCloseButton->setIcon(QIcon::fromTheme(qsl("application-exit"), QIcon(qsl(":/icons/application-exit.png"))));
+    mPatternNavigationHintCloseButton->setIcon(QIcon::fromTheme(qsl("dialog-close"), QIcon(qsl(":/icons/dialog-close.png"))));
     //: Tooltip for the button that hides the pattern navigation hint banner.
     mPatternNavigationHintCloseButton->setToolTip(tr("Hide this hint"));
     patternNavigationHintLayout->addWidget(mPatternNavigationHintCloseButton);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1508,7 +1508,7 @@ void dlgTriggerEditor::setupPatternNavigationShortcuts()
         return;
     }
 
-    mFirstPatternShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_K), mpTriggersMainArea);
+    mFirstPatternShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Up), mpTriggersMainArea);
     mFirstPatternShortcut->setContext(Qt::WidgetWithChildrenShortcut);
     connect(mFirstPatternShortcut, &QShortcut::activated, this, [this]() {
         if (mVisiblePatternCount < 1) {
@@ -1518,7 +1518,7 @@ void dlgTriggerEditor::setupPatternNavigationShortcuts()
     });
 
 
-    mLastPatternShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_L), mpTriggersMainArea);
+    mLastPatternShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Down), mpTriggersMainArea);
     mLastPatternShortcut->setContext(Qt::WidgetWithChildrenShortcut);
     connect(mLastPatternShortcut, &QShortcut::activated, this, [this]() {
         if (mVisiblePatternCount < 1) {
@@ -1583,8 +1583,8 @@ void dlgTriggerEditor::updatePatternNavigationHint()
     mPatternNavigationHintLabel->setText(tr(
         "<p><strong>Navigation shortcuts</strong></p>"
         "<ul>"
-        "<li>Press <strong>Ctrl+K</strong> to focus the first pattern field.</li>"
-        "<li>Press <strong>Ctrl+L</strong> to jump to the last visible pattern field.</li>"
+        "<li>Press <strong>Ctrl+Shift+Up</strong> to focus the first pattern field.</li>"
+        "<li>Press <strong>Ctrl+Shift+Down</strong> to jump to the last visible pattern field.</li>"
         "<li>Press <strong>Ctrl+Up</strong> or <strong>Ctrl+Down</strong> to move between pattern fields.</li>"
         "<li>Press <strong>Ctrl+Tab</strong> to toggle the Lua code editor.</li>"
         "</ul>"

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1216,7 +1216,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mPatternNavigationHintCloseButton = new QToolButton(mPatternNavigationHintBanner);
     mPatternNavigationHintCloseButton->setObjectName(qsl("patternNavigationHintCloseButton"));
     mPatternNavigationHintCloseButton->setAutoRaise(true);
-    mPatternNavigationHintCloseButton->setIcon(style()->standardIcon(QStyle::SP_TitleBarCloseButton));
+    mPatternNavigationHintCloseButton->setIcon(QIcon::fromTheme(qsl("application-exit"), QIcon(qsl(":/icons/application-exit.png"))));
     //: Tooltip for the button that hides the pattern navigation hint banner.
     mPatternNavigationHintCloseButton->setToolTip(tr("Hide this hint"));
     patternNavigationHintLayout->addWidget(mPatternNavigationHintCloseButton);
@@ -1507,7 +1507,7 @@ void dlgTriggerEditor::setupPatternNavigationShortcuts()
         return;
     }
 
-    mFirstPatternShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_F), mpTriggersMainArea);
+    mFirstPatternShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_K), mpTriggersMainArea);
     mFirstPatternShortcut->setContext(Qt::WidgetWithChildrenShortcut);
     connect(mFirstPatternShortcut, &QShortcut::activated, this, [this]() {
         if (mVisiblePatternCount < 1) {
@@ -1582,7 +1582,7 @@ void dlgTriggerEditor::updatePatternNavigationHint()
     mPatternNavigationHintLabel->setText(tr(
         "<p><strong>Navigation shortcuts</strong></p>"
         "<ul>"
-        "<li>Press <strong>Ctrl+F</strong> to focus the first pattern field.</li>"
+        "<li>Press <strong>Ctrl+K</strong> to focus the first pattern field.</li>"
         "<li>Press <strong>Ctrl+L</strong> to jump to the last visible pattern field.</li>"
         "<li>Press <strong>Ctrl+Up</strong> or <strong>Ctrl+Down</strong> to move between pattern fields.</li>"
         "<li>Press <strong>Ctrl+Tab</strong> to toggle the Lua code editor.</li>"


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
- Changed shortcut to focus first pattern field from Ctrl+F to Ctrl+Shift+Up
-  Changed shortcut to focus last pattern field from Ctrl+L to Ctrl+Shift+Down
- Changed pattern navigation hint close button to use standard application-exit icon instead of platform-specific title bar icon for consistency
#### Motivation for adding to Mudlet
Better UX
#### Other info (issues closed, discussion etc)
