### PR TITLE
Fix: Add StartupWMClass and .DirIcon for AppImage icon recognition

### DIFF
--- a/.DirIcon
+++ b/.DirIcon
@@ -1,0 +1,1 @@
+mudlet.png

--- a/mudlet.desktop
+++ b/mudlet.desktop
@@ -8,4 +8,5 @@ Terminal=false
 Type=Application
 MimeType=application/zip;
 Icon=mudlet
+StartupWMClass=Mudlet
 Categories=Game;AdventureGame;RolePlaying;ActionGame;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -782,10 +782,6 @@ if(UNIX AND NOT APPLE)
     DESTINATION "share/mudlet/lua"
     PATTERN ".git" EXCLUDE PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ
                                        WORLD_READ)
-   install(
-    FILES "../mudlet.desktop"
-    DESTINATION "share/applications" PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ
-      WORLD_READ)
 
   install(
     FILES "../mudlet.desktop"
@@ -797,7 +793,7 @@ if(UNIX AND NOT APPLE)
     WORLD_READ)
   install(
     FILES "../mudlet.png"
-    DESTINATION "share/icons/hicolor/256x256/apps" PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ
+    DESTINATION "share/icons/hicolor/512x512/apps" PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ
     WORLD_READ)
 
   install(


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Ubuntu's dock/sidebar currently shows a generic icon when running Mudlet from AppImage instead of the Mudlet icon.  This PR was an attempt to make it show the Mudlet icon - but it didn't actually fix the problem. That said, it didn't make things work either, so perhaps we can give it a go anyway.

#### Motivation for adding to Mudlet

Better UX.

#### Other info (issues closed, discussion etc)

Also corrected the icon install path to match the actual 512x512 size and removed a duplicate desktop file install.
