### PR TITLE
Fix: Return focus to main window when closing window with commandline

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -633,6 +633,11 @@ void TCommandLine::focusOutEvent(QFocusEvent* event)
 
 void TCommandLine::hideEvent(QHideEvent* event)
 {
+    // Redirect focus to main commandline when hiding a SubCommandLine to prevent keyboard input being trapped
+    if (mType == SubCommandLine && hasFocus() && mpHost && mpHost->mpConsole && mpHost->mpConsole->mpCommandLine) {
+        mpHost->mpConsole->mpCommandLine->setFocus();
+    }
+
     QPlainTextEdit::hideEvent(event);
 }
 


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
When a window containing a commandline is closed, redirect focus back to the main commandline so keyboard input continues working.
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/8498
#### Other info (issues closed, discussion etc)
