### PR TITLE
Infrastructure: remove vcpkg references from CodeQL and clang-tidy workflows

### DIFF
--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -76,32 +76,18 @@ jobs:
         rm -rf boost-*/* download.7z
       shell: bash
 
-    # workaround a poor interaction between github actions/cmake/vcpkg, see https://github.com/lukka/run-vcpkg/issues/88#issuecomment-885758902
-    - name: Use CMake 3.20.1
-      uses: lukka/get-cmake@v3.20.1
+    - name: Use CMake 3.30.3
+      uses: lukka/get-cmake@v3.30.3
 
-    - name: (Linux) Install non-vcpkg dependencies (1/2)
+    - name: (Linux) Install dependencies
       if: runner.os == 'Linux'
       run: |
-        # gettext is needed for vcpkg
-        sudo apt-get install gettext -y
+        sudo apt-get update
 
-    # Restore from cache the previously built ports. If "cache miss", then provision vcpkg, install desired ports, finally cache everything for the next run.
-    - name: Restore from cache and run vcpkg
-      uses: lukka/run-vcpkg@v7
-      env:
-        vcpkgResponseFile: ${{github.workspace}}/3rdparty/our-vcpkg-dependencies/vcpkg-${{matrix.triplet}}-dependencies
-      with:
-        vcpkgArguments: '@${{env.vcpkgResponseFile}}'
-        vcpkgDirectory: '${{github.workspace}}/3rdparty/vcpkg'
-        appendedCacheKey: ${{hashFiles(env.vcpkgResponseFile)}}-cachekey
-
-    - name: (Linux) Install non-vcpkg dependencies (2/2)
-      if: runner.os == 'Linux'
-      run: |
-        # Install from vcpkg everything we can for cross-platform consistency
-        # If not available, use other methods
-        sudo apt-get install libsecret-1-dev pkg-config libzip-dev libglu1-mesa-dev libpulse-dev -y
+        # Install all required dependencies
+        # liblua5.1-0-dev is needed for CMake to find Lua headers/library
+        sudo apt-get install libsecret-1-dev ccache pkg-config libzip-dev libglu1-mesa-dev libpulse-dev \
+          libassimp-dev libpcre3-dev libpugixml-dev libsqlite3-dev libyajl-dev libhunspell-dev liblua5.1-0-dev libboost-dev -y
 
         echo "Skipping generation of translation stats, so not installing lua-yajl."
 
@@ -110,14 +96,12 @@ jobs:
       with:
         cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
         cmakeListsTxtPath: '${{github.workspace}}/CMakeLists.txt'
-        useVcpkgToolchainFile: true
         # has to be the github workspace, not the runner workspace, for the docker-based clang-tidy-review
         buildDirectory: '${{github.workspace}}/b/ninja'
         cmakeAppendedArgs: >-
           -DCMAKE_GLOBAL_AUTOGEN_TARGET=ON
           -G Ninja
           -DCMAKE_PREFIX_PATH=${{ env.QT_PREFIX != '' && env.QT_PREFIX || env.MINGW_BASE_DIR }}
-          -DVCPKG_APPLOCAL_DEPS=OFF
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
         buildWithCMakeArgs: >-
           --target autogen

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -100,39 +100,26 @@ jobs:
     - name: Use CMake 3.30.3
       uses: lukka/get-cmake@v3.30.3
 
-    - name: (Linux) Install non-vcpkg dependencies (1/2)
+    - name: (Linux) Install Lua via GitHub Actions
+      uses: leafo/gh-actions-lua@v12
       if: runner.os == 'Linux'
-      run: |
-        # dependencies needed for vcpkg specifically
-        sudo apt-get install gettext -y
-
-    - name: Restore from cache and run vcpkg
-      uses: lukka/run-vcpkg@v7
-      env:
-        vcpkgResponseFile: ${{github.workspace}}/3rdparty/our-vcpkg-dependencies/vcpkg-${{matrix.triplet}}-dependencies
       with:
-        vcpkgArguments: '@${{env.vcpkgResponseFile}}'
-        vcpkgDirectory: '${{github.workspace}}/3rdparty/vcpkg'
-        appendedCacheKey: ${{hashFiles(env.vcpkgResponseFile)}}-cachekey
+        luaVersion: "5.1.5"
+        buildCache: false
 
-    - name: (Linux) Install non-vcpkg dependencies (2/2)
+    - name: (Linux) Install Luarocks via GitHub Actions
+      uses: leafo/gh-actions-luarocks@v6
+      if: runner.os == 'Linux'
+
+    - name: (Linux) Install dependencies
       if: runner.os == 'Linux'
       run: |
-        # Install from vcpkg everything we can for cross-platform consistency
-        # If not available, use other methods
-        sudo apt-get install \
-        ccache \
-        expect \
-        g++-${{matrix.gcc_compiler_version}} \
-        libassimp-dev \
-        libglu1-mesa-dev \
-        libpulse-dev \
-        libsecret-1-dev \
-        libzip-dev \
-        luarocks \
-        pcregrep \
-        pkg-config \
-        -y
+        sudo apt-get update
+
+        # Install all required dependencies
+        # liblua5.1-0-dev is needed for CMake to find Lua headers/library
+        sudo apt-get install libsecret-1-dev ccache pkg-config pcregrep expect libzip-dev libglu1-mesa-dev libpulse-dev g++-${{matrix.gcc_compiler_version}} \
+          libassimp-dev libpcre3-dev libpugixml-dev libsqlite3-dev libyajl-dev libhunspell-dev liblua5.1-0-dev libboost-dev -y
 
         # switch to GCC that supports C++20 while retaining support for older OS's
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{matrix.gcc_compiler_version}} ${{matrix.gcc_compiler_version}}
@@ -143,14 +130,7 @@ jobs:
         echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
 
         # Install lua-yajl early to generate translation statistics
-        export PATH="${{env.VCPKG_ROOT}}/installed/${{matrix.triplet}}/tools/lua:$PATH"
-        # workaround https://github.com/lloyd/yajl/issues/209
-        mv ${{env.VCPKG_ROOT}}/installed/${{matrix.triplet}}/lib/libyajl_s.a ${{env.VCPKG_ROOT}}/installed/${{matrix.triplet}}/lib/libyajl.a
-        mv ${{env.VCPKG_ROOT}}/installed/${{matrix.triplet}}/debug/lib/libyajl_s.a ${{env.VCPKG_ROOT}}/installed/${{matrix.triplet}}/debug/lib/libyajl.a
-        # Rock locations search is hardcoded to -L/usr/local/lib and not adjustable
-        export LIBRARY_PATH="${{env.VCPKG_ROOT}}/installed/${{matrix.triplet}}/lib:$LIBRARY_PATH"
-        # LUA_INCDIR needs to be passed as well due to https://github.com/luarocks/luarocks/issues/1239
-        luarocks install YAJL_INCDIR="${{env.VCPKG_ROOT}}/installed/${{matrix.triplet}}/include" YAJL_LIBDIR="${{env.VCPKG_ROOT}}/installed/${{matrix.triplet}}/lib" LUA_INCDIR="${{env.VCPKG_ROOT}}/installed/${{matrix.triplet}}/include" --local lua-yajl
+        luarocks install --local lua-yajl
 
         # Allow stats generation script to see location of lua-yajl
         eval "$(luarocks path --local --lua-version "5.1")"
@@ -168,12 +148,10 @@ jobs:
       with:
         cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
         cmakeListsTxtPath: '${{github.workspace}}/CMakeLists.txt'
-        useVcpkgToolchainFile: true
         buildDirectory: '${{runner.workspace}}/b/ninja'
         cmakeAppendedArgs: >-
           -G Ninja
           -DCMAKE_PREFIX_PATH=${{ env.QT_PREFIX != '' && env.QT_PREFIX || env.MINGW_BASE_DIR }}
-          -DVCPKG_APPLOCAL_DEPS=OFF
       env:
         NINJA_STATUS: '[%f/%t %o/sec] '
 

--- a/.github/workflows/performance-analysis.yml
+++ b/.github/workflows/performance-analysis.yml
@@ -30,8 +30,6 @@ jobs:
     - name: Use CMake 3.30.3
       uses: lukka/get-cmake@v3.30.3
 
-      # run-vcpkg action does not run on arm64 (https://github.com/lukka/run-vcpkg/issues/152)
-      # so install dependencies manually
     - name: Install dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Removes leftover vcpkg references from workflows after the main vcpkg removal in #8493.
#### Motivation for adding to Mudlet
Fix codeql and clang-tidy analysis to work
#### Other info (issues closed, discussion etc)
