### PR TITLE
Infrastructure: Switch macOS 14 and 15 in build workflows

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -47,7 +47,7 @@ jobs:
             compiler: clang_64
             gcc_compiler_version: 10
             qt: '6.9.0'
-          - os: macos-14
+          - os: macos-14-large
             buildname: 'macos (x86_64) / c++, lua tests'
             triplet: x64-osx
             compiler: clang_64

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -54,7 +54,7 @@ jobs:
             qt: '6.9.0'
             deploy: 'deploy'
             run_tests: 'true'
-          - os: macos-14-arm64
+          - os: macos-14
             buildname: 'macos (arm64) / c++, lua tests'
             triplet: arm64-osx
             compiler: clang_64

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -47,14 +47,14 @@ jobs:
             compiler: clang_64
             gcc_compiler_version: 10
             qt: '6.9.0'
-          - os: macos-14-large
+          - os: macos-15-intel
             buildname: 'macos (x86_64) / c++, lua tests'
             triplet: x64-osx
             compiler: clang_64
             qt: '6.9.0'
             deploy: 'deploy'
             run_tests: 'true'
-          - os: macos-14
+          - os: macos-14-arm64
             buildname: 'macos (arm64) / c++, lua tests'
             triplet: arm64-osx
             compiler: clang_64

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -47,7 +47,7 @@ jobs:
             compiler: clang_64
             gcc_compiler_version: 10
             qt: '6.9.0'
-          - os: macos-13
+          - os: macos-14
             buildname: 'macos (x86_64) / c++, lua tests'
             triplet: x64-osx
             compiler: clang_64


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Switch macOS 14 for arm builds, and macOS 15 for intel builds (15 is the earliest we have access to for free) in build workflows
#### Motivation for adding to Mudlet
https://github.com/actions/runner-images/issues/13046 - macOS 13 is depricated by github actions
#### Other info (issues closed, discussion etc)
