### PR TITLE
Add: show map grid option

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -728,6 +728,9 @@ public:
     QColor mCommandLineBgColor{Qt::black};
     bool mMapperUseAntiAlias = true;
     bool mMapperShowRoomBorders = true;
+    bool mMapperShowGrid = false;
+    bool mFORCE_CHARSET_NEGOTIATION_OFF = false;
+    bool mForceNewEnvironNegotiationOff = false;
     bool mVersionInTTYPE = false;
     QSet<QChar> mDoubleClickIgnore;
     QPointer<QDockWidget> mpDockableMapWidget;

--- a/src/Host.h
+++ b/src/Host.h
@@ -729,8 +729,6 @@ public:
     bool mMapperUseAntiAlias = true;
     bool mMapperShowRoomBorders = true;
     bool mMapperShowGrid = false;
-    bool mFORCE_CHARSET_NEGOTIATION_OFF = false;
-    bool mForceNewEnvironNegotiationOff = false;
     bool mVersionInTTYPE = false;
     QSet<QChar> mDoubleClickIgnore;
     QPointer<QDockWidget> mpDockableMapWidget;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -434,6 +434,7 @@ void T2DMap::init()
     eSize = mpHost->mLineSize;
     rSize = mpHost->mRoomSize;
     mMapperUseAntiAlias = mpHost->mMapperUseAntiAlias;
+    mShowGrid = mpHost->mMapperShowGrid;
     if (mMapViewOnly != mpHost->mMapViewOnly) {
         // If it was initialised in one state but the stored setting is the
         // opposite then we need to toggle the mode:
@@ -1667,6 +1668,40 @@ void T2DMap::paintEvent(QPaintEvent* e)
     pen.setWidthF(exitWidth);
     painter.setRenderHint(QPainter::Antialiasing, mMapperUseAntiAlias);
     painter.setPen(pen);
+
+    if (mShowGrid && mRoomWidth > 0.0f && mRoomHeight > 0.0f) {
+        painter.save();
+
+        QColor gridColor = mpHost->mFgColor_2;
+        gridColor.setAlpha(50);
+        gridColor = gridColor.lighter(120);
+
+        QPen gridPen(gridColor);
+        const qreal gridWidth = qMax<qreal>(static_cast<qreal>(exitWidth) * 0.5, 0.5);
+        gridPen.setWidthF(gridWidth);
+        painter.setPen(gridPen);
+
+        const qreal visibleMinX = mMapCenterX - xspan / 2.0;
+        const qreal visibleMaxX = mMapCenterX + xspan / 2.0;
+        const qreal visibleMinY = -((yspan / 2.0) + mMapCenterY);
+        const qreal visibleMaxY = (yspan / 2.0) - mMapCenterY;
+
+        const int startX = static_cast<int>(std::floor(visibleMinX));
+        const int endX = static_cast<int>(std::ceil(visibleMaxX));
+        for (int gridX = startX; gridX <= endX; ++gridX) {
+            const qreal widgetX = static_cast<qreal>(gridX) * static_cast<qreal>(mRoomWidth) + static_cast<qreal>(mRX);
+            painter.drawLine(QPointF(widgetX, 0.0), QPointF(widgetX, static_cast<qreal>(widgetHeight)));
+        }
+
+        const int startY = static_cast<int>(std::floor(visibleMinY));
+        const int endY = static_cast<int>(std::ceil(visibleMaxY));
+        for (int gridY = startY; gridY <= endY; ++gridY) {
+            const qreal widgetY = static_cast<qreal>(gridY) * -static_cast<qreal>(mRoomHeight) + static_cast<qreal>(mRY);
+            painter.drawLine(QPointF(0.0, widgetY), QPointF(static_cast<qreal>(widgetWidth), widgetY));
+        }
+
+        painter.restore();
+    }
 
     // Draw label sizing or group selection box
     if (mSizeLabel) {

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -224,6 +224,7 @@ public:
     QRect mMapInfoRect;
     int mFontHeight = 20;
     bool mShowRoomID = false;
+    bool mShowGrid = false;
     QMap<int, QPixmap> mPixMap;
     double rSize = 0.5;
     double eSize = 3.0;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7283,6 +7283,12 @@ int TLuaInterpreter::setConfig(lua_State * L)
             host.mMapperShowRoomBorders = getVerifiedBool(L, __func__, 2, "value");
             return success();
         }
+        if (key == qsl("mapShowGrid")) {
+            const bool showGrid = getVerifiedBool(L, __func__, 2, "value");
+            host.mMapperShowGrid = showGrid;
+            host.mpMap->mpMapper->slot_setShowGrid(showGrid);
+            return success();
+        }
         if (key == qsl("showUpperLowerLevels")) {
             mudlet::self()->mDrawUpperLowerLevels = getVerifiedBool(L, __func__, 2, "value");
 
@@ -7682,6 +7688,7 @@ int TLuaInterpreter::getConfig(lua_State *L)
             lua_pushnumber(L, host.mMapInfoBg.alpha());
             lua_rawseti(L, -2, 4);
         } },
+        { qsl("mapShowGrid"), [&](){ lua_pushboolean(L, host.mMapperShowGrid); } },
         { qsl("editorAutoComplete"), [&](){ lua_pushboolean(L, host.mEditorAutoComplete); } },
         { qsl("enableGMCP"), [&](){ lua_pushboolean(L, host.mEnableGMCP); } },
         { qsl("enableMSSP"), [&](){ lua_pushboolean(L, host.mEnableMSSP); } },

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -394,6 +394,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mAcceptServerGUI") = pHost->mAcceptServerGUI ? "yes" : "no";
     host.append_attribute("mAcceptServerMedia") = pHost->mAcceptServerMedia ? "yes" : "no";
     host.append_attribute("mMapperUseAntiAlias") = pHost->mMapperUseAntiAlias ? "yes" : "no";
+    host.append_attribute("mMapperShowGrid") = pHost->mMapperShowGrid ? "yes" : "no";
     host.append_attribute("mMapperShowRoomBorders") = pHost->mMapperShowRoomBorders ? "yes" : "no";
     host.append_attribute("mVersionInTTYPE") = pHost->mVersionInTTYPE ? "yes" : "no";
     host.append_attribute("mPromptedForVersionInTTYPE") = pHost->mPromptedForVersionInTTYPE ? "yes" : "no";

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -761,6 +761,7 @@ void XMLimport::readHost(Host* pHost)
     setBoolAttribute(qsl("mAcceptServerGUI"), pHost->mAcceptServerGUI);
     setBoolAttribute(qsl("mAcceptServerMedia"), pHost->mAcceptServerMedia);
     setBoolAttribute(qsl("mMapperUseAntiAlias"), pHost->mMapperUseAntiAlias);
+    setBoolAttribute(qsl("mMapperShowGrid"), pHost->mMapperShowGrid);
     setBoolAttribute(qsl("mEditorAutoComplete"), pHost->mEditorAutoComplete);
     setBoolAttribute(qsl("mVersionInTTYPE"), pHost->mVersionInTTYPE);
     setBoolAttribute(qsl("mPromptedForVersionInTTYPE"), pHost->mPromptedForVersionInTTYPE);

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -206,11 +206,6 @@ void dlgMapper::slot_toggleShowRoomNames(int toggle)
     mp2dMap->update();
 }
 
-void dlgMapper::slot_toggleShowGrid(int toggle)
-{
-    slot_toggleShowGridFromMenu(toggle == Qt::Checked);
-}
-
 void dlgMapper::slot_toggleStrongHighlight(int toggle)
 {
     mpHost->mMapStrongHighlight = (toggle == Qt::Checked);
@@ -334,7 +329,9 @@ void dlgMapper::slot_setShowRoomIds(bool showRoomIds)
 
 void dlgMapper::slot_setShowGrid(bool showGrid)
 {
-    slot_toggleShowGridFromMenu(showGrid);
+    mp2dMap->mShowGrid = showGrid;
+    mp2dMap->mpHost->mMapperShowGrid = showGrid;
+    mp2dMap->update();
 }
 
 void dlgMapper::slot_toggleRoundRooms(const bool state)
@@ -596,7 +593,7 @@ void dlgMapper::slot_setupMapperMenu()
     showMapGrid->setChecked(mpHost->mMapperShowGrid);
     showMapGrid->setToolTip(tr("When enabled, grid will be shown on mapper."));
 
-    connect(showMapGrid, &QAction::toggled, this, &dlgMapper::slot_toggleShowGridFromMenu);
+    connect(showMapGrid, &QAction::toggled, this, &dlgMapper::slot_setShowGrid);
     menu->addAction(showMapGrid);
 
 #if defined(INCLUDE_3DMAPPER)
@@ -628,13 +625,6 @@ void dlgMapper::slot_toggleShowRoomIDsFromMenu(bool enabled)
 {
     mp2dMap->mShowRoomID = enabled;
     mp2dMap->mpHost->mShowRoomID = enabled;
-    mp2dMap->update();
-}
-
-void dlgMapper::slot_toggleShowGridFromMenu(bool enabled)
-{
-    mp2dMap->mShowGrid = enabled;
-    mp2dMap->mpHost->mMapperShowGrid = enabled;
     mp2dMap->update();
 }
 

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -79,7 +79,6 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
     widget_playerIconControls->setVisible(false);
     mp2dMap->mShowRoomID = mpHost->mShowRoomID;
 
-
     widget_panel->setVisible(mpHost->mShowPanel);
     connect(toolButton_shiftZup, &QAbstractButton::clicked, mp2dMap, &T2DMap::slot_shiftZup);
     connect(toolButton_shiftZdown, &QAbstractButton::clicked, mp2dMap, &T2DMap::slot_shiftZdown);
@@ -207,6 +206,11 @@ void dlgMapper::slot_toggleShowRoomNames(int toggle)
     mp2dMap->update();
 }
 
+void dlgMapper::slot_toggleShowGrid(int toggle)
+{
+    slot_toggleShowGridFromMenu(toggle == Qt::Checked);
+}
+
 void dlgMapper::slot_toggleStrongHighlight(int toggle)
 {
     mpHost->mMapStrongHighlight = (toggle == Qt::Checked);
@@ -326,6 +330,11 @@ void dlgMapper::slot_exitSize(int size)
 void dlgMapper::slot_setShowRoomIds(bool showRoomIds)
 {
     dlgMapper::slot_toggleShowRoomIDs(showRoomIds ? Qt::Checked : Qt::Unchecked);
+}
+
+void dlgMapper::slot_setShowGrid(bool showGrid)
+{
+    slot_toggleShowGridFromMenu(showGrid);
 }
 
 void dlgMapper::slot_toggleRoundRooms(const bool state)
@@ -582,6 +591,14 @@ void dlgMapper::slot_setupMapperMenu()
     connect(showRoomIdsAction, &QAction::toggled, this, &dlgMapper::slot_toggleShowRoomIDsFromMenu);
     menu->addAction(showRoomIdsAction);
 
+    auto* showMapGrid = new QAction(tr("Show map grid"), this);
+    showMapGrid->setCheckable(true);
+    showMapGrid->setChecked(mpHost->mMapperShowGrid);
+    showMapGrid->setToolTip(tr("When enabled, grid will be shown on mapper."));
+
+    connect(showMapGrid, &QAction::toggled, this, &dlgMapper::slot_toggleShowGridFromMenu);
+    menu->addAction(showMapGrid);
+
 #if defined(INCLUDE_3DMAPPER)
     auto* show3DMapAction = new QAction(tr("Show map in 3D"), this);
     show3DMapAction->setCheckable(true);
@@ -611,6 +628,13 @@ void dlgMapper::slot_toggleShowRoomIDsFromMenu(bool enabled)
 {
     mp2dMap->mShowRoomID = enabled;
     mp2dMap->mpHost->mShowRoomID = enabled;
+    mp2dMap->update();
+}
+
+void dlgMapper::slot_toggleShowGridFromMenu(bool enabled)
+{
+    mp2dMap->mShowGrid = enabled;
+    mp2dMap->mpHost->mMapperShowGrid = enabled;
     mp2dMap->update();
 }
 

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -61,6 +61,7 @@ public slots:
     void slot_toggleRoundRooms(const bool);
     void slot_toggleShowRoomIDs(int toggle);
     void slot_toggleShowRoomNames(int toggle);
+    void slot_toggleShowGrid(int toggle);
     void slot_toggleStrongHighlight(int toggle);
     void slot_toggle3DView(const bool);
     void slot_togglePanel();
@@ -68,11 +69,13 @@ public slots:
     void slot_roomSize(int size);
     void slot_exitSize(int size);
     void slot_setShowRoomIds(bool showRoomIds);
+    void slot_setShowGrid(bool showGrid);
     void slot_updateInfoContributors();
     void slot_switchArea(const int);
     void slot_setupMapperMenu();
     void slot_toggleUpperLowerLevels(bool enabled);
     void slot_toggleShowRoomIDsFromMenu(bool enabled);
+    void slot_toggleShowGridFromMenu(bool enabled);
     void updateInfoMenu();
 
     static void paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, Host* pHost, TMap* pMap,

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -61,7 +61,6 @@ public slots:
     void slot_toggleRoundRooms(const bool);
     void slot_toggleShowRoomIDs(int toggle);
     void slot_toggleShowRoomNames(int toggle);
-    void slot_toggleShowGrid(int toggle);
     void slot_toggleStrongHighlight(int toggle);
     void slot_toggle3DView(const bool);
     void slot_togglePanel();
@@ -75,7 +74,6 @@ public slots:
     void slot_setupMapperMenu();
     void slot_toggleUpperLowerLevels(bool enabled);
     void slot_toggleShowRoomIDsFromMenu(bool enabled);
-    void slot_toggleShowGridFromMenu(bool enabled);
     void updateInfoMenu();
 
     static void paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, Host* pHost, TMap* pMap,

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -1271,6 +1271,7 @@ function getConfig(...)
       "mapperPanelVisible", 
       "mapRoomSize",
       "mapRoundRooms",
+      "mapShowGrid",
       "mapShowRoomBorders",
       "promptForMXPProcessorOn",
       "promptForVersionInTTYPE",


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add toggle for showing map grid
Added as well to setConfig, so it can be turned on and off via lua api

<img width="645" height="789" alt="image" src="https://github.com/user-attachments/assets/094f08b9-a938-466e-85cf-47ff5a7344a6" />


#### Motivation for adding to Mudlet
Especially when moving and creating rooms, it might be beneficial to see how grid looks like
Also some... like me, might like more "technical" look of mapper.

#### Other info (issues closed, discussion etc)
