### PR TITLE
Fix room size to be correct when set from Preferences

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -4735,7 +4735,7 @@ void dlgProfilePreferences::slot_roomSizeChanged(int size)
     if (mpHost) {
         mpHost->mRoomSize = static_cast<float>(size) / 10.0f;
         if (mpHost->mpMap && mpHost->mpMap->mpMapper && mpHost->mpMap->mpMapper->mp2dMap) {
-            mpHost->mpMap->mpMapper->mp2dMap->setRoomSize(size);
+            mpHost->mpMap->mpMapper->mp2dMap->setRoomSize(static_cast<float>(size) / 10.0f);
             mpHost->mpMap->mpMapper->mp2dMap->update();
         }
     }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix room size to be correct when set from Preferences - previous commit made them be off.
#### Motivation for adding to Mudlet
Bugfix for https://github.com/Mudlet/Mudlet/commit/36cab5e2dc5165b540e6f995d1f3aef0f31b32b8
#### Other info (issues closed, discussion etc)
