### PR TITLE
Add: show map grid option

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -688,6 +688,7 @@ public:
     QColor mUpperLevelColor{QColorConstants::White};
     QColor mRoomBorderColor{QColorConstants::LightGray};
     QColor mRoomCollisionBorderColor{QColorConstants::Yellow};
+    QColor mMapGridColor{QColor(211, 211, 211, 64)};
 
     QColor mMapInfoBg = QColor(150, 150, 150, 120);
     bool mMapStrongHighlight = false;
@@ -714,6 +715,7 @@ public:
 
     double mLineSize = 10.0;
     double mRoomSize = 0.5;
+    double mMapGridLineSize = 0.5;
     QSet<QString> mMapInfoContributors{qsl("Short")};
     bool mBubbleMode = false;
     bool mMapViewOnly = true;

--- a/src/Host.h
+++ b/src/Host.h
@@ -728,6 +728,9 @@ public:
     QColor mCommandLineBgColor{Qt::black};
     bool mMapperUseAntiAlias = true;
     bool mMapperShowRoomBorders = true;
+    bool mMapperShowGrid = false;
+    bool mFORCE_CHARSET_NEGOTIATION_OFF = false;
+    bool mForceNewEnvironNegotiationOff = false;
     bool mVersionInTTYPE = false;
     QSet<QChar> mDoubleClickIgnore;
     QPointer<QDockWidget> mpDockableMapWidget;

--- a/src/Host.h
+++ b/src/Host.h
@@ -729,8 +729,6 @@ public:
     bool mMapperUseAntiAlias = true;
     bool mMapperShowRoomBorders = true;
     bool mMapperShowGrid = false;
-    bool mFORCE_CHARSET_NEGOTIATION_OFF = false;
-    bool mForceNewEnvironNegotiationOff = false;
     bool mVersionInTTYPE = false;
     QSet<QChar> mDoubleClickIgnore;
     QPointer<QDockWidget> mpDockableMapWidget;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1672,12 +1672,10 @@ void T2DMap::paintEvent(QPaintEvent* e)
     if (mShowGrid && mRoomWidth > 0.0f && mRoomHeight > 0.0f) {
         painter.save();
 
-        QColor gridColor = mpHost->mFgColor_2;
-        gridColor.setAlpha(50);
-        gridColor = gridColor.lighter(120);
+        QColor gridColor = mpHost->mMapGridColor;
 
         QPen gridPen(gridColor);
-        const qreal gridWidth = qMax<qreal>(static_cast<qreal>(exitWidth) * 0.5, 0.5);
+        const qreal gridWidth = static_cast<qreal>(mpHost->mMapGridLineSize);
         gridPen.setWidthF(gridWidth);
         painter.setPen(gridPen);
 

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -434,6 +434,7 @@ void T2DMap::init()
     eSize = mpHost->mLineSize;
     rSize = mpHost->mRoomSize;
     mMapperUseAntiAlias = mpHost->mMapperUseAntiAlias;
+    mShowGrid = mpHost->mMapperShowGrid;
     if (mMapViewOnly != mpHost->mMapViewOnly) {
         // If it was initialised in one state but the stored setting is the
         // opposite then we need to toggle the mode:
@@ -1667,6 +1668,40 @@ void T2DMap::paintEvent(QPaintEvent* e)
     pen.setWidthF(exitWidth);
     painter.setRenderHint(QPainter::Antialiasing, mMapperUseAntiAlias);
     painter.setPen(pen);
+
+    if (mShowGrid && mRoomWidth > 0.0f && mRoomHeight > 0.0f) {
+        painter.save();
+
+        QColor gridColor = mpHost->mFgColor_2;
+        gridColor.setAlpha(50);
+        gridColor = gridColor.lighter(120);
+
+        QPen gridPen(gridColor);
+        const qreal gridWidth = qMax<qreal>(static_cast<qreal>(exitWidth) * 0.5, 0.5);
+        gridPen.setWidthF(gridWidth);
+        painter.setPen(gridPen);
+
+        const qreal visibleMinX = mMapCenterX - xspan / 2.0;
+        const qreal visibleMaxX = mMapCenterX + xspan / 2.0;
+        const qreal visibleMinY = -((yspan / 2.0) + mMapCenterY);
+        const qreal visibleMaxY = (yspan / 2.0) - mMapCenterY;
+
+        const int startX = static_cast<int>(std::floor(visibleMinX));
+        const int endX = static_cast<int>(std::ceil(visibleMaxX));
+        for (int gridX = startX; gridX <= endX; ++gridX) {
+            const qreal widgetX = static_cast<qreal>(gridX) * static_cast<qreal>(mRoomWidth) + static_cast<qreal>(mRX);
+            painter.drawLine(QPointF(widgetX, 0.0), QPointF(widgetX, static_cast<qreal>(widgetHeight)));
+        }
+
+        const int startY = static_cast<int>(std::floor(visibleMinY));
+        const int endY = static_cast<int>(std::ceil(visibleMaxY));
+        for (int gridY = startY; gridY <= endY; ++gridY) {
+            const qreal widgetY = static_cast<qreal>(gridY) * -static_cast<qreal>(mRoomHeight) + static_cast<qreal>(mRY);
+            painter.drawLine(QPointF(0.0, widgetY), QPointF(static_cast<qreal>(widgetWidth), widgetY));
+        }
+
+        painter.restore();
+    }
 
     // Draw label sizing or group selection box
     if (mSizeLabel) {

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -224,6 +224,7 @@ public:
     QRect mMapInfoRect;
     int mFontHeight = 20;
     bool mShowRoomID = false;
+    bool mShowGrid = false;
     QMap<int, QPixmap> mPixMap;
     double rSize = 0.5;
     double eSize = 3.0;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7283,6 +7283,12 @@ int TLuaInterpreter::setConfig(lua_State * L)
             host.mMapperShowRoomBorders = getVerifiedBool(L, __func__, 2, "value");
             return success();
         }
+        if (key == qsl("mapShowGrid")) {
+            const bool showGrid = getVerifiedBool(L, __func__, 2, "value");
+            host.mMapperShowGrid = showGrid;
+            host.mpMap->mpMapper->slot_setShowGrid(showGrid);
+            return success();
+        }
         if (key == qsl("showUpperLowerLevels")) {
             mudlet::self()->mDrawUpperLowerLevels = getVerifiedBool(L, __func__, 2, "value");
 
@@ -7682,6 +7688,7 @@ int TLuaInterpreter::getConfig(lua_State *L)
             lua_pushnumber(L, host.mMapInfoBg.alpha());
             lua_rawseti(L, -2, 4);
         } },
+        { qsl("mapShowGrid"), [&](){ lua_pushboolean(L, host.mMapperShowGrid); } },
         { qsl("editorAutoComplete"), [&](){ lua_pushboolean(L, host.mEditorAutoComplete); } },
         { qsl("enableGMCP"), [&](){ lua_pushboolean(L, host.mEnableGMCP); } },
         { qsl("enableMSSP"), [&](){ lua_pushboolean(L, host.mEnableMSSP); } },

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -394,6 +394,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mAcceptServerGUI") = pHost->mAcceptServerGUI ? "yes" : "no";
     host.append_attribute("mAcceptServerMedia") = pHost->mAcceptServerMedia ? "yes" : "no";
     host.append_attribute("mMapperUseAntiAlias") = pHost->mMapperUseAntiAlias ? "yes" : "no";
+    host.append_attribute("mMapperShowGrid") = pHost->mMapperShowGrid ? "yes" : "no";
     host.append_attribute("mMapperShowRoomBorders") = pHost->mMapperShowRoomBorders ? "yes" : "no";
     host.append_attribute("mVersionInTTYPE") = pHost->mVersionInTTYPE ? "yes" : "no";
     host.append_attribute("mPromptedForVersionInTTYPE") = pHost->mPromptedForVersionInTTYPE ? "yes" : "no";

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -403,6 +403,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("enableTextAnalyzer") = pHost->mEnableTextAnalyzer ? "yes" : "no";
     host.append_attribute("mRoomSize") = QString::number(pHost->mRoomSize, 'f', 1).toUtf8().constData();
     host.append_attribute("mLineSize") = QString::number(pHost->mLineSize, 'f', 1).toUtf8().constData();
+    host.append_attribute("mMapGridLineSize") = QString::number(pHost->mMapGridLineSize, 'f', 1).toUtf8().constData();
     host.append_attribute("mBubbleMode") = pHost->mBubbleMode ? "yes" : "no";
     host.append_attribute("mMapViewOnly") = pHost->mMapViewOnly ? "yes" : "no";
     host.append_attribute("mShowRoomIDs") = pHost->mShowRoomID ? "yes" : "no";
@@ -575,6 +576,9 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
         host.append_child("mUpperLevelColor").text().set(pHost->mUpperLevelColor.name().toUtf8().constData());
         host.append_child("mRoomBorderColor").text().set(pHost->mRoomBorderColor.name().toUtf8().constData());
         host.append_child("mRoomCollisionBorderColor").text().set(pHost->mRoomCollisionBorderColor.name().toUtf8().constData());
+        auto mapGridColorNode = host.append_child("mMapGridColor");
+        mapGridColorNode.text().set(pHost->mMapGridColor.name().toUtf8().constData());
+        mapGridColorNode.append_attribute("alpha").set_value(pHost->mMapGridColor.alpha());
         auto mapInfoBgNode = host.append_child("mMapInfoBg");
         mapInfoBgNode.text().set(pHost->mMapInfoBg.name().toUtf8().constData());
         mapInfoBgNode.append_attribute("alpha").set_value(pHost->mMapInfoBg.alpha());

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -968,6 +968,12 @@ void XMLimport::readHost(Host* pHost)
         pHost->mLineSize = 10.0; // Same value as is in Host class initializer list
     }
 
+    pHost->mMapGridLineSize = attributes().value(qsl("mMapGridLineSize")).toString().toDouble();
+
+    if (qFuzzyCompare(1.0 + pHost->mMapGridLineSize, 1.0)) {
+        pHost->mMapGridLineSize = 0.5; // Same value as is in Host class initializer list
+    }
+
     const QStringView ignore(attributes().value(qsl("mDoubleClickIgnore")));
 
     for (auto character : ignore) {
@@ -1293,6 +1299,10 @@ void XMLimport::readHost(Host* pHost)
                 pHost->mRoomBorderColor = QColor::fromString(readElementText());
             } else if (name() == qsl("mRoomCollisionBorderColor")) {
                 pHost->mRoomCollisionBorderColor = QColor::fromString(readElementText());
+            } else if (name() == qsl("mMapGridColor")) {
+                auto alpha = (attributes().hasAttribute(qsl("alpha"))) ? attributes().value(qsl("alpha")).toInt() : 255;
+                pHost->mMapGridColor = QColor::fromString(readElementText());
+                pHost->mMapGridColor.setAlpha(alpha);
             } else if (name() == qsl("mMapInfoBg")) {
                 auto alpha = (attributes().hasAttribute(qsl("alpha"))) ? attributes().value(qsl("alpha")).toInt() : 255;
                 pHost->mMapInfoBg = QColor::fromString(readElementText());

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -761,6 +761,7 @@ void XMLimport::readHost(Host* pHost)
     setBoolAttribute(qsl("mAcceptServerGUI"), pHost->mAcceptServerGUI);
     setBoolAttribute(qsl("mAcceptServerMedia"), pHost->mAcceptServerMedia);
     setBoolAttribute(qsl("mMapperUseAntiAlias"), pHost->mMapperUseAntiAlias);
+    setBoolAttribute(qsl("mMapperShowGrid"), pHost->mMapperShowGrid);
     setBoolAttribute(qsl("mEditorAutoComplete"), pHost->mEditorAutoComplete);
     setBoolAttribute(qsl("mVersionInTTYPE"), pHost->mVersionInTTYPE);
     setBoolAttribute(qsl("mPromptedForVersionInTTYPE"), pHost->mPromptedForVersionInTTYPE);

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -206,11 +206,6 @@ void dlgMapper::slot_toggleShowRoomNames(int toggle)
     mp2dMap->update();
 }
 
-void dlgMapper::slot_toggleShowGrid(int toggle)
-{
-    slot_toggleShowGridFromMenu(toggle == Qt::Checked);
-}
-
 void dlgMapper::slot_toggleStrongHighlight(int toggle)
 {
     mpHost->mMapStrongHighlight = (toggle == Qt::Checked);
@@ -334,7 +329,9 @@ void dlgMapper::slot_setShowRoomIds(bool showRoomIds)
 
 void dlgMapper::slot_setShowGrid(bool showGrid)
 {
-    slot_toggleShowGridFromMenu(showGrid);
+    mp2dMap->mShowGrid = showGrid;
+    mp2dMap->mpHost->mMapperShowGrid = showGrid;
+    mp2dMap->update();
 }
 
 void dlgMapper::slot_toggleRoundRooms(const bool state)
@@ -596,7 +593,7 @@ void dlgMapper::slot_setupMapperMenu()
     showMapGrid->setChecked(mpHost->mMapperShowGrid);
     showMapGrid->setToolTip(tr("When enabled, grid will be shown on mapper."));
 
-    connect(showMapGrid, &QAction::toggled, this, &dlgMapper::slot_toggleShowGridFromMenu);
+    connect(showMapGrid, &QAction::toggled, this, &dlgMapper::slot_setShowGrid);
     menu->addAction(showMapGrid);
 
 #if defined(INCLUDE_3DMAPPER)
@@ -628,13 +625,6 @@ void dlgMapper::slot_toggleShowRoomIDsFromMenu(bool enabled)
 {
     mp2dMap->mShowRoomID = enabled;
     mp2dMap->mpHost->mShowRoomID = enabled;
-    mp2dMap->update();
-}
-
-void dlgMapper::slot_toggleShowGridFromMenu(bool enabled)
-{
-    mp2dMap->mShowGrid = enabled;
-    mp2dMap->mpHost->mMapperShowGrid = enabled;
     mp2dMap->update();
 }
 

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -79,7 +79,6 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
     widget_playerIconControls->setVisible(false);
     mp2dMap->mShowRoomID = mpHost->mShowRoomID;
 
-
     widget_panel->setVisible(mpHost->mShowPanel);
     connect(toolButton_shiftZup, &QAbstractButton::clicked, mp2dMap, &T2DMap::slot_shiftZup);
     connect(toolButton_shiftZdown, &QAbstractButton::clicked, mp2dMap, &T2DMap::slot_shiftZdown);
@@ -207,6 +206,11 @@ void dlgMapper::slot_toggleShowRoomNames(int toggle)
     mp2dMap->update();
 }
 
+void dlgMapper::slot_toggleShowGrid(int toggle)
+{
+    slot_toggleShowGridFromMenu(toggle == Qt::Checked);
+}
+
 void dlgMapper::slot_toggleStrongHighlight(int toggle)
 {
     mpHost->mMapStrongHighlight = (toggle == Qt::Checked);
@@ -326,6 +330,11 @@ void dlgMapper::slot_exitSize(int size)
 void dlgMapper::slot_setShowRoomIds(bool showRoomIds)
 {
     dlgMapper::slot_toggleShowRoomIDs(showRoomIds ? Qt::Checked : Qt::Unchecked);
+}
+
+void dlgMapper::slot_setShowGrid(bool showGrid)
+{
+    slot_toggleShowGridFromMenu(showGrid);
 }
 
 void dlgMapper::slot_toggleRoundRooms(const bool state)
@@ -582,6 +591,14 @@ void dlgMapper::slot_setupMapperMenu()
     connect(showRoomIdsAction, &QAction::toggled, this, &dlgMapper::slot_toggleShowRoomIDsFromMenu);
     menu->addAction(showRoomIdsAction);
 
+    auto* showMapGrid = new QAction(tr("Show map grid"), this);
+    showMapGrid->setCheckable(true);
+    showMapGrid->setChecked(mpHost->mMapperShowGrid);
+    showMapGrid->setToolTip(tr("When enabled, grid will be shown on mapper."));
+
+    connect(showMapGrid, &QAction::toggled, this, &dlgMapper::slot_toggleShowGridFromMenu);
+    menu->addAction(showMapGrid);
+
 #if defined(INCLUDE_3DMAPPER)
     auto* show3DMapAction = new QAction(tr("Show map in 3D"), this);
     show3DMapAction->setCheckable(true);
@@ -611,6 +628,13 @@ void dlgMapper::slot_toggleShowRoomIDsFromMenu(bool enabled)
 {
     mp2dMap->mShowRoomID = enabled;
     mp2dMap->mpHost->mShowRoomID = enabled;
+    mp2dMap->update();
+}
+
+void dlgMapper::slot_toggleShowGridFromMenu(bool enabled)
+{
+    mp2dMap->mShowGrid = enabled;
+    mp2dMap->mpHost->mMapperShowGrid = enabled;
     mp2dMap->update();
 }
 

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -61,6 +61,7 @@ public slots:
     void slot_toggleRoundRooms(const bool);
     void slot_toggleShowRoomIDs(int toggle);
     void slot_toggleShowRoomNames(int toggle);
+    void slot_toggleShowGrid(int toggle);
     void slot_toggleStrongHighlight(int toggle);
     void slot_toggle3DView(const bool);
     void slot_togglePanel();
@@ -68,11 +69,13 @@ public slots:
     void slot_roomSize(int size);
     void slot_exitSize(int size);
     void slot_setShowRoomIds(bool showRoomIds);
+    void slot_setShowGrid(bool showGrid);
     void slot_updateInfoContributors();
     void slot_switchArea(const int);
     void slot_setupMapperMenu();
     void slot_toggleUpperLowerLevels(bool enabled);
     void slot_toggleShowRoomIDsFromMenu(bool enabled);
+    void slot_toggleShowGridFromMenu(bool enabled);
     void updateInfoMenu();
 
     static void paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, Host* pHost, TMap* pMap,

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -61,7 +61,6 @@ public slots:
     void slot_toggleRoundRooms(const bool);
     void slot_toggleShowRoomIDs(int toggle);
     void slot_toggleShowRoomNames(int toggle);
-    void slot_toggleShowGrid(int toggle);
     void slot_toggleStrongHighlight(int toggle);
     void slot_toggle3DView(const bool);
     void slot_togglePanel();
@@ -75,7 +74,6 @@ public slots:
     void slot_setupMapperMenu();
     void slot_toggleUpperLowerLevels(bool enabled);
     void slot_toggleShowRoomIDsFromMenu(bool enabled);
-    void slot_toggleShowGridFromMenu(bool enabled);
     void updateInfoMenu();
 
     static void paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, Host* pHost, TMap* pMap,

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1025,19 +1025,19 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
             }
         }
 
-        QLabel* pLabel_mapSymbolFontFudge = new QLabel(tr("2D Map Room Symbol scaling factor:"), groupBox_mapViewOptions);
-        mpDoubleSpinBox_mapSymbolFontFudge = new QDoubleSpinBox(groupBox_mapViewOptions);
+        QLabel* pLabel_mapSymbolFontFudge = new QLabel(tr("2D Map Room Symbol scaling factor:"), groupBox_mapSymbols);
+        mpDoubleSpinBox_mapSymbolFontFudge = new QDoubleSpinBox(groupBox_mapSymbols);
         mpDoubleSpinBox_mapSymbolFontFudge->setValue(pHost->mpMap->mMapSymbolFontFudgeFactor);
         mpDoubleSpinBox_mapSymbolFontFudge->setPrefix(qsl("×"));
         mpDoubleSpinBox_mapSymbolFontFudge->setRange(0.50, 2.00);
         mpDoubleSpinBox_mapSymbolFontFudge->setSingleStep(0.01);
-        auto * pmapViewLayout = qobject_cast<QGridLayout*>(groupBox_mapViewOptions->layout());
-        if (pmapViewLayout) {
-            const int existingRows = pmapViewLayout->rowCount();
-            pmapViewLayout->addWidget(pLabel_mapSymbolFontFudge, existingRows, 0);
-            pmapViewLayout->addWidget(mpDoubleSpinBox_mapSymbolFontFudge, existingRows, 1);
+        auto * pSymbolsLayout = qobject_cast<QGridLayout*>(groupBox_mapSymbols->layout());
+        if (pSymbolsLayout) {
+            const int existingRows = pSymbolsLayout->rowCount();
+            pSymbolsLayout->addWidget(pLabel_mapSymbolFontFudge, existingRows, 0);
+            pSymbolsLayout->addWidget(mpDoubleSpinBox_mapSymbolFontFudge, existingRows, 1);
         } else {
-            qWarning() << "dlgProfilePreferences::initWithHost(...) WARNING - Unable to cast groupBox_mapViewOptions layout to expected QGridLayout - someone has messed with the profile_preferences.ui file and the contents of the groupBox can not be shown...!";
+            qWarning() << "dlgProfilePreferences::initWithHost(...) WARNING - Unable to cast groupBox_mapSymbols layout to expected QGridLayout - someone has messed with the profile_preferences.ui file and the contents of the groupBox can not be shown...!";
         }
 
         label_mapSymbolsFont->setEnabled(true);
@@ -1077,8 +1077,10 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         // Initialize room and exit size controls
         spinBox_roomSize->setValue(pHost->mRoomSize * 10);
         spinBox_exitSize->setValue(pHost->mLineSize);
+        doubleSpinBox_gridSize->setValue(pHost->mMapGridLineSize);
         connect(spinBox_roomSize, qOverload<int>(&QSpinBox::valueChanged), this, &dlgProfilePreferences::slot_roomSizeChanged);
         connect(spinBox_exitSize, qOverload<int>(&QSpinBox::valueChanged), this, &dlgProfilePreferences::slot_exitSizeChanged);
+        connect(doubleSpinBox_gridSize, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &dlgProfilePreferences::slot_gridSizeChanged);
     } else {
         label_mapSymbolsFont->setEnabled(false);
         fontComboBox_mapSymbols->setEnabled(false);
@@ -1282,6 +1284,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     connect(pushButton_roomBorderColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapRoomBorderColor);
     connect(pushButton_mapInfoBg, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapInfoBgColor);
     connect(pushButton_roomCollisionBorderColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapRoomCollisionBorderColor);
+    connect(pushButton_mapGridColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapGridColor);
 
     connect(mEnableGMCP, &QAction::toggled, need_reconnect_for_data_protocol, &QWidget::show);
     connect(mEnableMSDP, &QAction::toggled, need_reconnect_for_data_protocol, &QWidget::show);
@@ -1443,6 +1446,7 @@ void dlgProfilePreferences::disconnectHostRelatedControls()
     disconnect(spinBox_playerRoomInnerDiameter, qOverload<int>(&QSpinBox::valueChanged), nullptr, nullptr);
     disconnect(spinBox_roomSize, qOverload<int>(&QSpinBox::valueChanged), nullptr, nullptr);
     disconnect(spinBox_exitSize, qOverload<int>(&QSpinBox::valueChanged), nullptr, nullptr);
+    disconnect(doubleSpinBox_gridSize, qOverload<double>(&QDoubleSpinBox::valueChanged), nullptr, nullptr);
     disconnect(checkBox_largeAreaExitArrows, &QCheckBox::toggled, nullptr, nullptr);
     disconnect(checkBox_invertMapZoom, &QCheckBox::toggled, nullptr, nullptr);
 
@@ -1711,6 +1715,7 @@ void dlgProfilePreferences::setColors2()
         setButtonColor(pushButton_roomBorderColor, pHost->mRoomBorderColor);
         setButtonColor(pushButton_mapInfoBg, pHost->mMapInfoBg, true);
         setButtonColor(pushButton_roomCollisionBorderColor, pHost->mRoomCollisionBorderColor);
+        setButtonColor(pushButton_mapGridColor, pHost->mMapGridColor, true);
     } else {
         // Using QColor() gives an "invalid" color:
         setButtonColor(pushButton_black_2, QColor());
@@ -1737,6 +1742,7 @@ void dlgProfilePreferences::setColors2()
         setButtonColor(pushButton_roomBorderColor, QColor());
         setButtonColor(pushButton_mapInfoBg, QColor());
         setButtonColor(pushButton_roomCollisionBorderColor, QColor());
+        setButtonColor(pushButton_mapGridColor, QColor());
     }
 }
 
@@ -1833,6 +1839,7 @@ void dlgProfilePreferences::slot_resetMapColors()
     pHost->mWhite_2 = QColorConstants::LightGray;
     pHost->mLightWhite_2 = QColorConstants::White;
     pHost->mMapInfoBg = QColor(150, 150, 150, 120);
+    pHost->mMapGridColor = QColor(211, 211, 211, 64);
 
     // This aplies the above colors to the buttons on display:
     setColors2();
@@ -2151,6 +2158,14 @@ void dlgProfilePreferences::slot_setMapRoomCollisionBorderColor()
     Host* pHost = mpHost;
     if (pHost) {
         setButtonAndProfileColor(pushButton_roomCollisionBorderColor, pHost->mRoomCollisionBorderColor);
+    }
+}
+
+void dlgProfilePreferences::slot_setMapGridColor()
+{
+    Host* pHost = mpHost;
+    if (pHost) {
+        setButtonAndProfileColor(pushButton_mapGridColor, pHost->mMapGridColor, true);
     }
 }
 
@@ -4747,6 +4762,16 @@ void dlgProfilePreferences::slot_exitSizeChanged(int size)
         mpHost->mLineSize = size;
         if (mpHost->mpMap && mpHost->mpMap->mpMapper && mpHost->mpMap->mpMapper->mp2dMap) {
             mpHost->mpMap->mpMapper->mp2dMap->setExitSize(size);
+            mpHost->mpMap->mpMapper->mp2dMap->update();
+        }
+    }
+}
+
+void dlgProfilePreferences::slot_gridSizeChanged(double size)
+{
+    if (mpHost) {
+        mpHost->mMapGridLineSize = size;
+        if (mpHost->mpMap && mpHost->mpMap->mpMapper && mpHost->mpMap->mpMapper->mp2dMap) {
             mpHost->mpMap->mpMapper->mp2dMap->update();
         }
     }

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -102,6 +102,7 @@ public slots:
     void slot_setMapRoomBorderColor();
     void slot_setMapInfoBgColor();
     void slot_setMapRoomCollisionBorderColor();
+    void slot_setMapGridColor();
     void slot_setLowerLevelColor();
     void slot_setUpperLevelColor();
     void slot_resetMapColors();
@@ -174,6 +175,7 @@ private slots:
     void slot_loadHistoryMap();
     void slot_roomSizeChanged(int size);
     void slot_exitSizeChanged(int size);
+    void slot_gridSizeChanged(double size);
     void slot_displayFontChanged();
     void slot_displayFontSizeChanged();
     void slot_displayFontAliasingChanged();

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -1271,6 +1271,7 @@ function getConfig(...)
       "mapperPanelVisible", 
       "mapRoomSize",
       "mapRoundRooms",
+      "mapShowGrid",
       "mapShowRoomBorders",
       "promptForMXPProcessorOn",
       "promptForVersionInTTYPE",

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>965</width>
-    <height>694</height>
+    <width>1055</width>
+    <height>876</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -571,7 +571,7 @@
           <item row="2" column="1">
            <spacer name="horizontalSpacer_disable_password_masking">
             <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -1383,7 +1383,6 @@ you can use it but there could be issues with aligning columns of text</string>
          </layout>
         </widget>
        </item>
-
        <item>
         <widget class="QGroupBox" name="groupBox_displayOptions">
          <property name="title">
@@ -2460,18 +2459,21 @@ you can use it but there could be issues with aligning columns of text</string>
           <string>Map view</string>
          </property>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="3" column="3" colspan="2">
-           <widget class="QFontComboBox" name="fontComboBox_mapSymbols"/>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="label_roomSize">
-            <property name="text">
-             <string>Room size:</string>
+          <item row="7" column="0">
+           <spacer name="roomSizeTopMarginSpacer">
+            <property name="orientation">
+             <enum>Qt::Orientation::Vertical</enum>
             </property>
-            <property name="buddy">
-             <cstring>spinBox_roomSize</cstring>
+            <property name="sizeType">
+             <enum>QSizePolicy::Policy::Fixed</enum>
             </property>
-           </widget>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>10</height>
+             </size>
+            </property>
+           </spacer>
           </item>
           <item row="1" column="3" colspan="2">
            <widget class="QCheckBox" name="checkBox_largeAreaExitArrows">
@@ -2480,6 +2482,94 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
             <property name="checked">
              <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="0" colspan="5">
+           <widget class="QGroupBox" name="groupBox_mapSymbols">
+            <property name="title">
+             <string>Symbols</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_groupBox_mapSymbols">
+             <item row="1" column="0" colspan="2">
+              <widget class="QCheckBox" name="checkBox_isOnlyMapSymbolFontToBeUsed">
+               <property name="text">
+                <string>Only use symbols (glyphs) from chosen font</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="2">
+              <widget class="QPushButton" name="pushButton_showGlyphUsage">
+               <property name="text">
+                <string>Show symbol usage...</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_mapSymbolsFont">
+               <property name="text">
+                <string>2D Map Room Symbol Font</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QFontComboBox" name="fontComboBox_mapSymbols"/>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="checkBox_drawUpperLowerLevels">
+            <property name="toolTip">
+             <string>&lt;p&gt;When enabled, rooms on floors above and below the current level will be drawn with a lighter color to show the map layout context.&lt;/p&gt;</string>
+            </property>
+            <property name="text">
+             <string>Draw rooms on upper and lower levels</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3">
+           <widget class="QCheckBox" name="checkBox_invertMapZoom">
+            <property name="toolTip">
+             <string>&lt;p&gt;If checked, scrolling up zooms out and scrolling down zooms in. If unchecked, scrolling up zooms in and scrolling down zooms out.&lt;/p&gt;</string>
+            </property>
+            <property name="text">
+             <string>Invert zoom direction</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <spacer name="roomSizeBottomMarginSpacer">
+            <property name="orientation">
+             <enum>Qt::Orientation::Vertical</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Policy::Fixed</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>10</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="0" column="3" colspan="2">
+           <widget class="QCheckBox" name="checkBox_showDefaultArea">
+            <property name="toolTip">
+             <string>&lt;p&gt;The default area (area id -1) is used by some mapper scripts as a temporary 'holding area' for rooms before they're placed in the correct area.&lt;/p&gt;</string>
+            </property>
+            <property name="text">
+             <string>Show the default area in map area selection</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -2496,113 +2586,6 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="0" colspan="3">
-           <widget class="QCheckBox" name="checkBox_isOnlyMapSymbolFontToBeUsed">
-            <property name="text">
-             <string>Only use symbols (glyphs) from chosen font</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="2">
-           <widget class="QLabel" name="label_mapSymbolsFont">
-            <property name="text">
-             <string>2D Map Room Symbol Font</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="2">
-           <widget class="QCheckBox" name="checkBox_invertMapZoom">
-            <property name="toolTip">
-             <string>&lt;p&gt;If checked, scrolling up zooms out and scrolling down zooms in. If unchecked, scrolling up zooms in and scrolling down zooms out.&lt;/p&gt;</string>
-            </property>
-            <property name="text">
-             <string>Invert zoom direction</string>
-            </property>
-            <property name="checked">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QCheckBox" name="checkBox_drawUpperLowerLevels">
-            <property name="toolTip">
-             <string>&lt;p&gt;When enabled, rooms on floors above and below the current level will be drawn with a lighter color to show the map layout context.&lt;/p&gt;</string>
-            </property>
-            <property name="text">
-             <string>Draw rooms on upper and lower levels</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="3">
-           <widget class="QLabel" name="label_exitSize">
-            <property name="text">
-             <string>Exit size:</string>
-            </property>
-            <property name="buddy">
-             <cstring>spinBox_exitSize</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="4">
-           <widget class="QSpinBox" name="spinBox_exitSize">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignmentFlag::AlignCenter</set>
-            </property>
-            <property name="minimum">
-             <number>2</number>
-            </property>
-            <property name="maximum">
-             <number>20</number>
-            </property>
-            <property name="value">
-             <number>7</number>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <widget class="QSpinBox" name="spinBox_roomSize">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignmentFlag::AlignCenter</set>
-            </property>
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>11</number>
-            </property>
-            <property name="value">
-             <number>5</number>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3" colspan="2">
-           <widget class="QCheckBox" name="checkBox_showDefaultArea">
-            <property name="toolTip">
-             <string>&lt;p&gt;The default area (area id -1) is used by some mapper scripts as a temporary 'holding area' for rooms before they're placed in the correct area.&lt;/p&gt;</string>
-            </property>
-            <property name="text">
-             <string>Show the default area in map area selection</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0" colspan="2">
            <widget class="QCheckBox" name="mMapperUseAntiAlias">
             <property name="toolTip">
@@ -2613,28 +2596,12 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="3" colspan="2">
-           <widget class="QPushButton" name="pushButton_showGlyphUsage">
-            <property name="text">
-             <string>Show symbol usage...</string>
+          <item row="11" column="0" colspan="5">
+           <widget class="QGroupBox" name="widget_playerRoomStyle">
+            <property name="title">
+             <string>Player room marker</string>
             </property>
-           </widget>
-          </item>
-          <item row="6" column="0" colspan="5">
-           <widget class="QWidget" name="widget_playerRoomStyle" native="true">
             <layout class="QGridLayout" name="gridLayout_widget_playerRoomStyle">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
              <item row="0" column="0">
               <widget class="QLabel" name="label_playerRoomStyle">
                <property name="text">
@@ -2739,6 +2706,156 @@ you can use it but there could be issues with aligning columns of text</string>
                </property>
                <property name="value">
                 <number>70</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="3">
+           <widget class="QGroupBox" name="gridGroupBox">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="flat">
+             <bool>true</bool>
+            </property>
+            <layout class="QGridLayout" name="groupBox_sizing">
+             <property name="rightMargin">
+              <number>1</number>
+             </property>
+             <property name="horizontalSpacing">
+              <number>-1</number>
+             </property>
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_roomSize">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Room size:</string>
+               </property>
+               <property name="buddy">
+                <cstring>spinBox_roomSize</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="2">
+              <widget class="QLabel" name="label_exitSize">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Exit size:</string>
+               </property>
+               <property name="buddy">
+                <cstring>spinBox_exitSize</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QSpinBox" name="spinBox_roomSize">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>30</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="maximum">
+                <number>11</number>
+               </property>
+               <property name="value">
+                <number>5</number>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="4">
+              <widget class="QLabel" name="label_gridSize">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Grid width:</string>
+               </property>
+               <property name="buddy">
+                <cstring>doubleSpinBox_gridSize</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="3">
+              <widget class="QSpinBox" name="spinBox_exitSize">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <property name="minimum">
+                <number>2</number>
+               </property>
+               <property name="maximum">
+                <number>20</number>
+               </property>
+               <property name="value">
+                <number>7</number>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="5">
+              <widget class="QDoubleSpinBox" name="doubleSpinBox_gridSize">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <property name="decimals">
+                <number>1</number>
+               </property>
+               <property name="minimum">
+                <double>0.100000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>5.000000000000000</double>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+               <property name="value">
+                <double>0.500000000000000</double>
                </property>
               </widget>
              </item>
@@ -2906,6 +3023,26 @@ you can use it but there could be issues with aligning columns of text</string>
           </item>
           <item row="3" column="1">
            <widget class="QPushButton" name="pushButton_roomCollisionBorderColor">
+            <property name="autoFillBackground">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QLabel" name="label_mapGridColor">
+            <property name="text">
+             <string>Grid color:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_mapGridColor</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="3">
+           <widget class="QPushButton" name="pushButton_mapGridColor">
             <property name="autoFillBackground">
              <bool>true</bool>
             </property>
@@ -4707,7 +4844,6 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>checkBox_showDefaultArea</tabstop>
   <tabstop>checkBox_largeAreaExitArrows</tabstop>
   <tabstop>fontComboBox_mapSymbols</tabstop>
-  <tabstop>pushButton_showGlyphUsage</tabstop>
   <tabstop>pushButton_playerRoomPrimaryColor</tabstop>
   <tabstop>spinBox_playerRoomOuterDiameter</tabstop>
   <tabstop>pushButton_playerRoomSecondaryColor</tabstop>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add toggle for showing map grid
Added as well to setConfig, so it can be turned on and off via lua api

<img width="645" height="789" alt="image" src="https://github.com/user-attachments/assets/094f08b9-a938-466e-85cf-47ff5a7344a6" />

While separating grid setting from exit settings I reorganized a bit map preferences as well:
<img width="1048" height="508" alt="image" src="https://github.com/user-attachments/assets/45f1fd57-ef75-4e46-9620-731e311281c2" />
Color setting for grid is now separated as well.


#### Motivation for adding to Mudlet
Especially when moving and creating rooms, it might be beneficial to see how grid looks like
Also some... like me, might like more "technical" look of mapper.

#### Other info (issues closed, discussion etc)
