### PR TITLE
Fix: setWindowWrap functions not updating Preferences UI

### DIFF
--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -3124,6 +3124,13 @@ int TLuaInterpreter::setWindowWrap(lua_State* L)
     const int luaFrom = getVerifiedInt(L, __func__, s, "wrapAt");
     auto console = CONSOLE(L, windowName);
     console->setWrapAt(luaFrom);
+
+    // Sync Host value for main console so Preferences UI reflects the change
+    if (windowName.isEmpty() || windowName == qsl("main")) {
+        Host& host = getHostFromLua(L);
+        host.mWrapAt = luaFrom;
+    }
+
     return 0;
 }
 
@@ -3134,6 +3141,13 @@ int TLuaInterpreter::setWindowWrapIndent(lua_State* L)
     const int luaFrom = getVerifiedInt(L, __func__, 2, "wrapTo");
     auto console = CONSOLE(L, windowName);
     console->setIndentCount(luaFrom);
+
+    // Sync Host value for main console so Preferences UI reflects the change
+    if (windowName.isEmpty() || windowName == qsl("main")) {
+        Host& host = getHostFromLua(L);
+        host.mWrapIndentCount = luaFrom;
+    }
+
     return 0;
 }
 
@@ -3144,6 +3158,13 @@ int TLuaInterpreter::setWindowWrapHangingIndent(lua_State* L)
     const int luaFrom = getVerifiedInt(L, __func__, 2, "wrapTo");
     auto console = CONSOLE(L, windowName);
     console->setHangingIndentCount(luaFrom);
+
+    // Sync Host value for main console so Preferences UI reflects the change
+    if (windowName.isEmpty() || windowName == qsl("main")) {
+        Host& host = getHostFromLua(L);
+        host.mWrapHangingIndentCount = luaFrom;
+    }
+
     return 0;
 }
 

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -3126,7 +3126,7 @@ int TLuaInterpreter::setWindowWrap(lua_State* L)
     console->setWrapAt(luaFrom);
 
     // Sync Host value for main console so Preferences UI reflects the change
-    if (windowName.isEmpty() || windowName == qsl("main")) {
+    if (console->getType() & TConsole::MainConsole) {
         Host& host = getHostFromLua(L);
         host.mWrapAt = luaFrom;
     }
@@ -3143,7 +3143,7 @@ int TLuaInterpreter::setWindowWrapIndent(lua_State* L)
     console->setIndentCount(luaFrom);
 
     // Sync Host value for main console so Preferences UI reflects the change
-    if (windowName.isEmpty() || windowName == qsl("main")) {
+    if (console->getType() & TConsole::MainConsole) {
         Host& host = getHostFromLua(L);
         host.mWrapIndentCount = luaFrom;
     }
@@ -3160,7 +3160,7 @@ int TLuaInterpreter::setWindowWrapHangingIndent(lua_State* L)
     console->setHangingIndentCount(luaFrom);
 
     // Sync Host value for main console so Preferences UI reflects the change
-    if (windowName.isEmpty() || windowName == qsl("main")) {
+    if (console->getType() & TConsole::MainConsole) {
         Host& host = getHostFromLua(L);
         host.mWrapHangingIndentCount = luaFrom;
     }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
When calling setWindowWrap(), setWindowWrapIndent(), or setWindowWrapHangingIndent() on the main console via Lua, the actual wrap settings were updated correctly in the console/buffer, but the Preferences dialog continued to show old values - this fixes it.
#### Motivation for adding to Mudlet
Fix #8522
#### Other info (issues closed, discussion etc)
