### PR TITLE
Infra: Improve documentation to hide ui strings from translation

### DIFF
--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -54,6 +54,15 @@ QString displayText = tr("Connection failed: %1").arg(errorMessage);
 QString toastMessage = tr("Banner hidden. <a href='undo'>Undo</a>");
 ```
 
+```xml
+// In .ui files, set "notr" attribute to true for string literals which require no translation
+<widget>
+  <property name="text">
+    <string notr="true">-</string>
+  </property>
+</widget>
+```
+
 ### Memory management
 
 - Use Qt's parent-child system for automatic cleanup for Qt classes


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Document the a bit arcane "notr" option in .ui files

#### Motivation for adding to Mudlet
- Some UI text do not need translation after all

#### Other info (issues closed, discussion etc)
- Follow-up to #8506 as requested in there