### PR TITLE
Add: Clickable hyperlinks in labels with custom styling

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -4067,7 +4067,6 @@ bool Host::setBackgroundColor(const QString& name, int r, int g, int b, int alph
             QRegularExpression re("background-color:[^;]*;");
             styleSheet.replace(re, newColor);
         } else {
-            // Add newline before appending if stylesheet is not empty and doesn't end with newline
             if (!styleSheet.isEmpty() && !styleSheet.endsWith('\n')) {
                 styleSheet.append('\n');
             }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3347,6 +3347,66 @@ bool Host::setClickthrough(const QString& name, bool clickthrough)
     return false;
 }
 
+bool Host::setLabelStyleSheet(const QString& name, const QString& styleSheet)
+{
+    if (!mpConsole) {
+        return false;
+    }
+
+    auto pL = mpConsole->mLabelMap.value(name);
+    if (pL) {
+        pL->setStyleSheet(styleSheet);
+        return true;
+    }
+
+    return false;
+}
+
+bool Host::setLinkStyle(const QString& name, const QString& linkColor, const QString& linkVisitedColor, bool underline)
+{
+    if (!mpConsole) {
+        return false;
+    }
+
+    auto pL = mpConsole->mLabelMap.value(name);
+    if (pL) {
+        pL->setLinkStyle(linkColor, linkVisitedColor, underline);
+        return true;
+    }
+
+    return false;
+}
+
+bool Host::resetLinkStyle(const QString& name)
+{
+    if (!mpConsole) {
+        return false;
+    }
+
+    auto pL = mpConsole->mLabelMap.value(name);
+    if (pL) {
+        pL->resetLinkStyle();
+        return true;
+    }
+
+    return false;
+}
+
+bool Host::clearVisitedLinks(const QString& name)
+{
+    if (!mpConsole) {
+        return false;
+    }
+
+    auto pL = mpConsole->mLabelMap.value(name);
+    if (pL) {
+        pL->clearVisitedLinks();
+        return true;
+    }
+
+    return false;
+}
+
 void Host::hideMudletsVariables()
 {
     auto varUnit = getLuaInterface()->getVarUnit();
@@ -4004,9 +4064,13 @@ bool Host::setBackgroundColor(const QString& name, int r, int g, int b, int alph
         QString styleSheet = pL->styleSheet();
         QString newColor = QString("background-color: rgba(%1, %2, %3, %4);").arg(r).arg(g).arg(b).arg(alpha);
         if (styleSheet.contains(qsl("background-color"))) {
-            QRegularExpression re("background-color: .*;");
+            QRegularExpression re("background-color:[^;]*;");
             styleSheet.replace(re, newColor);
         } else {
+            // Add newline before appending if stylesheet is not empty and doesn't end with newline
+            if (!styleSheet.isEmpty() && !styleSheet.endsWith('\n')) {
+                styleSheet.append('\n');
+            }
             styleSheet.append(newColor);
         }
 
@@ -4414,6 +4478,9 @@ void Host::setFocusOnHostActiveCommandLine()
 
 void Host::recordActiveCommandLine(TCommandLine* pCommandLine)
 {
+    if (!pCommandLine) {
+        return;
+    }
     mpLastCommandLineUsed.removeAll(QPointer<TCommandLine>(pCommandLine));
     mpLastCommandLineUsed.push(QPointer<TCommandLine>(pCommandLine));
 }

--- a/src/Host.h
+++ b/src/Host.h
@@ -379,6 +379,10 @@ public:
     std::pair<bool, QString> createScrollBox(const QString& windowname, const QString& name, int x, int y, int width, int height) const;
     std::pair<bool, QString> createLabel(const QString& windowname, const QString& name, int x, int y, int width, int height, bool fillBg, bool clickthrough);
     bool setClickthrough(const QString& name, bool clickthrough);
+    bool setLabelStyleSheet(const QString& name, const QString& styleSheet);
+    bool setLinkStyle(const QString& name, const QString& linkColor, const QString& linkVisitedColor, bool underline);
+    bool resetLinkStyle(const QString& name);
+    bool clearVisitedLinks(const QString& name);
     void hideMudletsVariables();
     bool createBuffer(const QString& name);
     QSize calcFontSize(const QString& windowName);

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -403,7 +403,6 @@ void TLabel::slot_linkActivated(const QString& link)
             return;
         }
 
-        // Handle external URL schemes using QUrl for proper parsing
         if (scheme == qsl("http") || scheme == qsl("https")) {
             QDesktopServices::openUrl(QUrl(link));
             return;

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -338,7 +338,7 @@ void TLabel::resetLinkStyle()
     mLinkVisitedColor.clear();
     mLinkUnderline = true;
 
-    // Force update to re-render
+    // Force update to re-render with new styles
     update();
 }
 

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -119,7 +119,8 @@ void TLabel::setText(const QString& text)
                     // Already has a style attribute - merge our styles
                     // This is complex, so for now just prepend our styles
                     replacement = qsl("<a href=%1 style=\"%2\"").arg(hrefPart, linkStyle);
-                    // Keep other attributes after style
+                    // Intentionally overwrites any existing style attribute rather than merging
+                    // to keep implementation simple for the common case (labels without pre-existing inline styles)
                     otherAttrs.remove(QRegularExpression(qsl("style=([\"'][^\"']*[\"'])")));
                     replacement += otherAttrs + qsl(">");
                 } else {

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -42,18 +42,12 @@ TLabel::TLabel(Host* pH, const QString& name, QWidget* pW)
 {
     setMouseTracking(true);
     setObjectName(qsl("label_%1_%2").arg(pH->getName(), mName));
-    
-    // Enable HTML/rich text formatting so hyperlinks are rendered
+
     setTextFormat(Qt::RichText);
-    
-    // Enable clickable hyperlinks in HTML content
     setTextInteractionFlags(Qt::TextBrowserInteraction);
-    setOpenExternalLinks(false); // We'll handle links ourselves via slot_linkActivated
-    
-    // Connect the linkActivated signal to our custom handler
+    setOpenExternalLinks(false);
+
     connect(this, &QLabel::linkActivated, this, &TLabel::slot_linkActivated);
-    
-    // Note: Default link colors will be set via QPalette when setLinkStyle() is called
 }
 
 TLabel::~TLabel()
@@ -71,7 +65,7 @@ void TLabel::setText(const QString& text)
     // widget stylesheets or QPalette for link colors when a stylesheet exists
     if ((!mLinkColor.isEmpty() || !mLinkVisitedColor.isEmpty()) && text.contains(qsl("<a "))) {
         QString styledText = text;
-        
+
         // Replace all <a href="..."> tags with <a href="..." style="...">
         // Note: This regex is intentionally strict (lowercase, href first, no spacing around =)
         // because Mudlet's HTML generation (via echo(), setLabelText(), etc.) consistently
@@ -79,44 +73,39 @@ void TLabel::setText(const QString& text)
         // clickable links (Qt handles that), but won't receive custom styling.
         QRegularExpression anchorRegex(qsl("<a\\s+href=([\"'][^\"']*[\"'])([^>]*)>"));
         QRegularExpressionMatchIterator it = anchorRegex.globalMatch(styledText);
-        
+
         // Process matches in reverse order to avoid offset issues
         QList<QRegularExpressionMatch> matches;
         while (it.hasNext()) {
             matches.prepend(it.next());
         }
-        
+
         for (const auto& match : matches) {
             QString fullMatch = match.captured(0);
             QString hrefPart = match.captured(1);  // The href="..." part
             QString otherAttrs = match.captured(2); // Other attributes
-            
+
             // Extract the actual URL from hrefPart (remove quotes)
             QString url = hrefPart;
             url.remove(0, 1); // Remove opening quote
             url.chop(1);      // Remove closing quote
-            
-            // Check if this link has been visited
+
             bool isVisited = mVisitedLinks.contains(url);
-            
-            // Build the inline style for this specific link
+
             QString linkStyle;
             if (isVisited && !mLinkVisitedColor.isEmpty()) {
-                // Use visited color
                 linkStyle += qsl("color: %1; ").arg(mLinkVisitedColor);
             } else if (!mLinkColor.isEmpty()) {
-                // Use normal link color
                 linkStyle += qsl("color: %1; ").arg(mLinkColor);
             }
-            
+
             if (!mLinkUnderline) {
                 linkStyle += qsl("text-decoration: none; ");
             }
-            
+
             if (!linkStyle.isEmpty()) {
-                // Remove trailing space
                 linkStyle = linkStyle.trimmed();
-                
+
                 QString replacement;
                 if (otherAttrs.contains(qsl("style="))) {
                     // Already has a style attribute - merge our styles
@@ -127,14 +116,13 @@ void TLabel::setText(const QString& text)
                     otherAttrs.remove(QRegularExpression(qsl("style=([\"'][^\"']*[\"'])")));
                     replacement += otherAttrs + qsl(">");
                 } else {
-                    // No style attribute - add ours
                     replacement = qsl("<a href=%1 style=\"%2\"%3>").arg(hrefPart, linkStyle, otherAttrs);
                 }
-                
+
                 styledText.replace(match.capturedStart(), match.capturedLength(), replacement);
             }
         }
-        
+
         QLabel::setText(styledText);
     } else {
         QLabel::setText(text);
@@ -301,7 +289,7 @@ void TLabel::releaseFunc(const int existingFunction, const int newFunction)
 void TLabel::setClickThrough(bool clickthrough)
 {
     setAttribute(Qt::WA_TransparentForMouseEvents, clickthrough);
-    
+
     // If clickthrough is enabled, text interaction (including hyperlinks) won't work
     // So we need to disable text interaction when clickthrough is on
     if (clickthrough) {
@@ -318,27 +306,27 @@ void TLabel::setLinkStyle(const QString& linkColor, const QString& linkVisitedCo
     mLinkColor = linkColor;
     mLinkVisitedColor = linkVisitedColor;
     mLinkUnderline = underline;
-    
+
     // Set QPalette as a fallback (works if no stylesheet is set on the widget)
     QPalette palette = this->palette();
-    
+
     if (!linkColor.isEmpty()) {
         QColor color(linkColor);
         palette.setColor(QPalette::Active, QPalette::Link, color);
         palette.setColor(QPalette::Inactive, QPalette::Link, color);
     }
-    
+
     if (!linkVisitedColor.isEmpty()) {
         QColor color(linkVisitedColor);
         palette.setColor(QPalette::Active, QPalette::LinkVisited, color);
         palette.setColor(QPalette::Inactive, QPalette::LinkVisited, color);
     }
-    
+
     setPalette(palette);
-    
+
     // Note: Widget stylesheets don't affect QTextDocument rendering
     // Link colors are applied via inline styles in setText()
-    
+
     // Force update to re-render with new styles
     update();
 }
@@ -347,11 +335,11 @@ void TLabel::resetLinkStyle()
 {
     // Reset to default palette colors
     setPalette(QPalette());
-    
+
     mLinkColor.clear();
     mLinkVisitedColor.clear();
     mLinkUnderline = true;
-    
+
     // Force update to re-render
     update();
 }
@@ -359,7 +347,7 @@ void TLabel::resetLinkStyle()
 void TLabel::clearVisitedLinks()
 {
     mVisitedLinks.clear();
-    
+
     // Refresh the label to update link colors back to unvisited state
     QString currentText = text();
     if (!currentText.isEmpty() && currentText.contains(qsl("<a "))) {
@@ -376,7 +364,7 @@ void TLabel::slot_linkActivated(const QString& link)
     // Mark this link as visited for styling purposes
     if (!mLinkVisitedColor.isEmpty()) {
         mVisitedLinks.insert(link);
-        
+
         // Refresh the label to update link colors
         // We need to re-apply the current text to trigger the styling update
         QString currentText = text();
@@ -387,18 +375,18 @@ void TLabel::slot_linkActivated(const QString& link)
 
     // Check for custom schemes by looking for the colon separator
     const int colonPos = link.indexOf(':');
-    
+
     if (colonPos > 0) {
         const QString scheme = link.left(colonPos).toLower(); // RFC 3986: schemes are case-insensitive
         const QString payload = link.mid(colonPos + 1); // Everything after the colon
-        
+
         // Handle custom Mudlet URL schemes for Lua commands
         if (scheme == qsl("send")) {
             // send: scheme - send the command to the MUD immediately
             mpHost->send(payload);
             return;
         }
-        
+
         if (scheme == qsl("prompt")) {
             // prompt: scheme - put text in command line and wait for user to press enter
             if (mpHost->mpConsole && mpHost->mpConsole->mpCommandLine) {
@@ -418,18 +406,18 @@ void TLabel::slot_linkActivated(const QString& link)
             }
             return;
         }
-        
+
         // Handle external URL schemes using QUrl for proper parsing
         if (scheme == qsl("http") || scheme == qsl("https")) {
             QDesktopServices::openUrl(QUrl(link));
             return;
         }
-        
+
         // Unknown scheme - ignore safely to prevent unintended Lua execution
         // Only links without a scheme should be treated as Lua code
         return;
     }
-    
+
     // No scheme - treat as Lua code to execute
     mpHost->mLuaInterpreter.compileAndExecuteScript(link);
 }

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -27,6 +27,11 @@
 #include "TDockWidget.h"
 #include "mudlet.h"
 
+#include <QDesktopServices>
+#include <QRegularExpression>
+#include <QTextCursor>
+#include <QTimer>
+#include <QUrl>
 #include <QtEvents>
 
 
@@ -37,6 +42,18 @@ TLabel::TLabel(Host* pH, const QString& name, QWidget* pW)
 {
     setMouseTracking(true);
     setObjectName(qsl("label_%1_%2").arg(pH->getName(), mName));
+    
+    // Enable HTML/rich text formatting so hyperlinks are rendered
+    setTextFormat(Qt::RichText);
+    
+    // Enable clickable hyperlinks in HTML content
+    setTextInteractionFlags(Qt::TextBrowserInteraction);
+    setOpenExternalLinks(false); // We'll handle links ourselves via slot_linkActivated
+    
+    // Connect the linkActivated signal to our custom handler
+    connect(this, &QLabel::linkActivated, this, &TLabel::slot_linkActivated);
+    
+    // Note: Default link colors will be set via QPalette when setLinkStyle() is called
 }
 
 TLabel::~TLabel()
@@ -44,6 +61,79 @@ TLabel::~TLabel()
     if (mpMovie) {
         mpMovie->deleteLater();
         mpMovie = nullptr;
+    }
+}
+
+void TLabel::setText(const QString& text)
+{
+    // If we have link styling configured and the text contains HTML links,
+    // we need to inject inline styles because QTextDocument doesn't use
+    // widget stylesheets or QPalette for link colors when a stylesheet exists
+    if ((!mLinkColor.isEmpty() || !mLinkVisitedColor.isEmpty()) && text.contains(qsl("<a "))) {
+        QString styledText = text;
+        
+        // Replace all <a href="..."> tags with <a href="..." style="...">
+        // We need to handle both cases: with and without existing style attributes
+        QRegularExpression anchorRegex(qsl("<a\\s+href=([\"'][^\"']*[\"'])([^>]*)>"));
+        QRegularExpressionMatchIterator it = anchorRegex.globalMatch(styledText);
+        
+        // Process matches in reverse order to avoid offset issues
+        QList<QRegularExpressionMatch> matches;
+        while (it.hasNext()) {
+            matches.prepend(it.next());
+        }
+        
+        for (const auto& match : matches) {
+            QString fullMatch = match.captured(0);
+            QString hrefPart = match.captured(1);  // The href="..." part
+            QString otherAttrs = match.captured(2); // Other attributes
+            
+            // Extract the actual URL from hrefPart (remove quotes)
+            QString url = hrefPart;
+            url.remove(0, 1); // Remove opening quote
+            url.chop(1);      // Remove closing quote
+            
+            // Check if this link has been visited
+            bool isVisited = mVisitedLinks.contains(url);
+            
+            // Build the inline style for this specific link
+            QString linkStyle;
+            if (isVisited && !mLinkVisitedColor.isEmpty()) {
+                // Use visited color
+                linkStyle += qsl("color: %1; ").arg(mLinkVisitedColor);
+            } else if (!mLinkColor.isEmpty()) {
+                // Use normal link color
+                linkStyle += qsl("color: %1; ").arg(mLinkColor);
+            }
+            
+            if (!mLinkUnderline) {
+                linkStyle += qsl("text-decoration: none; ");
+            }
+            
+            if (!linkStyle.isEmpty()) {
+                // Remove trailing space
+                linkStyle = linkStyle.trimmed();
+                
+                QString replacement;
+                if (otherAttrs.contains(qsl("style="))) {
+                    // Already has a style attribute - merge our styles
+                    // This is complex, so for now just prepend our styles
+                    replacement = qsl("<a href=%1 style=\"%2\"").arg(hrefPart, linkStyle);
+                    // Keep other attributes after style
+                    otherAttrs.remove(QRegularExpression(qsl("style=([\"'][^\"']*[\"'])")));
+                    replacement += otherAttrs + qsl(">");
+                } else {
+                    // No style attribute - add ours
+                    replacement = qsl("<a href=%1 style=\"%2\"%3>").arg(hrefPart, linkStyle, otherAttrs);
+                }
+                
+                styledText.replace(match.capturedStart(), match.capturedLength(), replacement);
+            }
+        }
+        
+        QLabel::setText(styledText);
+    } else {
+        QLabel::setText(text);
     }
 }
 
@@ -91,6 +181,15 @@ void TLabel::setLeave(const int func)
 
 void TLabel::mousePressEvent(QMouseEvent* event)
 {
+    // If the label has rich text with potential hyperlinks, let QLabel handle the event first
+    // QLabel will emit linkActivated if a link was clicked
+    if (!text().isEmpty() && textFormat() == Qt::RichText && text().contains(qsl("<a "))) {
+        QLabel::mousePressEvent(event);
+        // If QLabel didn't accept the event, then it wasn't a link click
+        if (event->isAccepted()) {
+            return;
+        }
+    }
 
     if (mpHost && mClickFunction) {
         mpHost->getLuaInterpreter()->callLabelCallbackEvent(mClickFunction, event);
@@ -115,6 +214,15 @@ void TLabel::mouseDoubleClickEvent(QMouseEvent* event)
 
 void TLabel::mouseReleaseEvent(QMouseEvent* event)
 {
+    // If the label has rich text with potential hyperlinks, let QLabel handle the event first
+    if (!text().isEmpty() && textFormat() == Qt::RichText && text().contains(qsl("<a "))) {
+        QLabel::mouseReleaseEvent(event);
+        // If QLabel accepted the event, it was handling a link click
+        if (event->isAccepted()) {
+            return;
+        }
+    }
+
     auto labelParent = qobject_cast<TConsole*>(parent());
     if (labelParent && labelParent->mpDockWidget && labelParent->mpDockWidget->isFloating()) {
         // move focus back to the active console / command line:
@@ -189,4 +297,131 @@ void TLabel::releaseFunc(const int existingFunction, const int newFunction)
 void TLabel::setClickThrough(bool clickthrough)
 {
     setAttribute(Qt::WA_TransparentForMouseEvents, clickthrough);
+    
+    // If clickthrough is enabled, text interaction (including hyperlinks) won't work
+    // So we need to disable text interaction when clickthrough is on
+    if (clickthrough) {
+        setTextInteractionFlags(Qt::NoTextInteraction);
+    } else {
+        // Re-enable text interaction for clickable hyperlinks
+        setTextInteractionFlags(Qt::TextBrowserInteraction);
+    }
+}
+
+void TLabel::setLinkStyle(const QString& linkColor, const QString& linkVisitedColor, bool underline)
+{
+    // Store the link style parameters for use when setText() is called
+    mLinkColor = linkColor;
+    mLinkVisitedColor = linkVisitedColor;
+    mLinkUnderline = underline;
+    
+    // Set QPalette as a fallback (works if no stylesheet is set on the widget)
+    QPalette palette = this->palette();
+    
+    if (!linkColor.isEmpty()) {
+        QColor color(linkColor);
+        palette.setColor(QPalette::Active, QPalette::Link, color);
+        palette.setColor(QPalette::Inactive, QPalette::Link, color);
+    }
+    
+    if (!linkVisitedColor.isEmpty()) {
+        QColor color(linkVisitedColor);
+        palette.setColor(QPalette::Active, QPalette::LinkVisited, color);
+        palette.setColor(QPalette::Inactive, QPalette::LinkVisited, color);
+    }
+    
+    setPalette(palette);
+    
+    // Note: Widget stylesheets don't affect QTextDocument rendering
+    // Link colors are applied via inline styles in setText()
+    
+    // Force update to re-render with new styles
+    update();
+}
+
+void TLabel::resetLinkStyle()
+{
+    // Reset to default palette colors
+    setPalette(QPalette());
+    
+    mLinkColor.clear();
+    mLinkVisitedColor.clear();
+    mLinkUnderline = true;
+    
+    // Force update to re-render
+    update();
+}
+
+void TLabel::clearVisitedLinks()
+{
+    mVisitedLinks.clear();
+    
+    // Refresh the label to update link colors back to unvisited state
+    QString currentText = text();
+    if (!currentText.isEmpty() && currentText.contains(qsl("<a "))) {
+        setText(currentText);
+    }
+}
+
+void TLabel::slot_linkActivated(const QString& link)
+{
+    if (!mpHost) {
+        return;
+    }
+
+    // Mark this link as visited for styling purposes
+    if (!mLinkVisitedColor.isEmpty()) {
+        mVisitedLinks.insert(link);
+        
+        // Refresh the label to update link colors
+        // We need to re-apply the current text to trigger the styling update
+        QString currentText = text();
+        if (!currentText.isEmpty() && currentText.contains(qsl("<a "))) {
+            setText(currentText);
+        }
+    }
+
+    // Check for custom schemes by looking for the colon separator
+    const int colonPos = link.indexOf(':');
+    
+    if (colonPos > 0) {
+        const QString scheme = link.left(colonPos);
+        const QString payload = link.mid(colonPos + 1); // Everything after the colon
+        
+        // Handle custom Mudlet URL schemes for Lua commands
+        if (scheme == qsl("send")) {
+            // send: scheme - send the command to the MUD immediately
+            mpHost->send(payload);
+            return;
+        }
+        
+        if (scheme == qsl("prompt")) {
+            // prompt: scheme - put text in command line and wait for user to press enter
+            if (mpHost->mpConsole && mpHost->mpConsole->mpCommandLine) {
+                QPointer<TCommandLine> commandLine = mpHost->mpConsole->mpCommandLine;
+                commandLine->setPlainText(payload);
+                // Move cursor to end of text
+                QTextCursor cursor = commandLine->textCursor();
+                cursor.movePosition(QTextCursor::End);
+                commandLine->setTextCursor(cursor);
+                // Defer the focus operation to avoid issues with QPointer manipulation
+                // during the signal handler execution
+                QTimer::singleShot(0, commandLine.data(), [commandLine]() {
+                    if (commandLine) {
+                        commandLine->setFocus();
+                    }
+                });
+            }
+            return;
+        }
+        
+        // Handle external URL schemes using QUrl for proper parsing
+        if (scheme == qsl("http") || scheme == qsl("https")) {
+            QDesktopServices::openUrl(QUrl(link));
+            return;
+        }
+    }
+    
+    // No scheme - treat as Lua code to execute
+    mpHost->mLuaInterpreter.compileAndExecuteScript(link);
 }

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -302,7 +302,6 @@ void TLabel::setClickThrough(bool clickthrough)
 
 void TLabel::setLinkStyle(const QString& linkColor, const QString& linkVisitedColor, bool underline)
 {
-    // Store the link style parameters for use when setText() is called
     mLinkColor = linkColor;
     mLinkVisitedColor = linkVisitedColor;
     mLinkUnderline = underline;

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -358,7 +358,6 @@ void TLabel::slot_linkActivated(const QString& link)
         return;
     }
 
-    // Mark this link as visited for styling purposes
     if (!mLinkVisitedColor.isEmpty()) {
         mVisitedLinks.insert(link);
 

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -346,7 +346,6 @@ void TLabel::clearVisitedLinks()
 {
     mVisitedLinks.clear();
 
-    // Refresh the label to update link colors back to unvisited state
     QString currentText = text();
     if (!currentText.isEmpty() && currentText.contains(qsl("<a "))) {
         setText(currentText);

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -386,7 +386,7 @@ void TLabel::slot_linkActivated(const QString& link)
     const int colonPos = link.indexOf(':');
     
     if (colonPos > 0) {
-        const QString scheme = link.left(colonPos);
+        const QString scheme = link.left(colonPos).toLower(); // RFC 3986: schemes are case-insensitive
         const QString payload = link.mid(colonPos + 1); // Everything after the colon
         
         // Handle custom Mudlet URL schemes for Lua commands

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -73,7 +73,10 @@ void TLabel::setText(const QString& text)
         QString styledText = text;
         
         // Replace all <a href="..."> tags with <a href="..." style="...">
-        // We need to handle both cases: with and without existing style attributes
+        // Note: This regex is intentionally strict (lowercase, href first, no spacing around =)
+        // because Mudlet's HTML generation (via echo(), setLabelText(), etc.) consistently
+        // uses this format. User-provided HTML outside this pattern will still render as
+        // clickable links (Qt handles that), but won't receive custom styling.
         QRegularExpression anchorRegex(qsl("<a\\s+href=([\"'][^\"']*[\"'])([^>]*)>"));
         QRegularExpressionMatchIterator it = anchorRegex.globalMatch(styledText);
         

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -420,6 +420,10 @@ void TLabel::slot_linkActivated(const QString& link)
             QDesktopServices::openUrl(QUrl(link));
             return;
         }
+        
+        // Unknown scheme - ignore safely to prevent unintended Lua execution
+        // Only links without a scheme should be treated as Lua code
+        return;
     }
     
     // No scheme - treat as Lua code to execute

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -332,7 +332,6 @@ void TLabel::setLinkStyle(const QString& linkColor, const QString& linkVisitedCo
 
 void TLabel::resetLinkStyle()
 {
-    // Reset to default palette colors
     setPalette(QPalette());
 
     mLinkColor.clear();

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -388,7 +388,6 @@ void TLabel::slot_linkActivated(const QString& link)
             if (mpHost->mpConsole && mpHost->mpConsole->mpCommandLine) {
                 QPointer<TCommandLine> commandLine = mpHost->mpConsole->mpCommandLine;
                 commandLine->setPlainText(payload);
-                // Move cursor to end of text
                 QTextCursor cursor = commandLine->textCursor();
                 cursor.movePosition(QTextCursor::End);
                 commandLine->setTextCursor(cursor);

--- a/src/TLabel.h
+++ b/src/TLabel.h
@@ -32,6 +32,7 @@
 #include <QLabel>
 #include <QMovie>
 #include <QPointer>
+#include <QSet>
 #include <QString>
 #include <QVideoWidget>
 
@@ -47,6 +48,7 @@ public:
     explicit TLabel(Host*, const QString&, QWidget* pW = nullptr);
     ~TLabel();
 
+    void setText(const QString& text);
     void setClick(const int func);
     void setDoubleClick(const int func);
     void setRelease(const int func);
@@ -63,6 +65,9 @@ public:
     void enterEvent(TEnterEvent*) override;
     void resizeEvent(QResizeEvent* event) override;
     void setClickThrough(bool clickthrough);
+    void setLinkStyle(const QString& linkColor, const QString& linkVisitedColor, bool underline = true);
+    void resetLinkStyle();
+    void clearVisitedLinks();
 
     QPointer<Host> mpHost;
     QString mName;
@@ -75,9 +80,16 @@ public:
     int mLeaveFunction = 0;
     QMovie* mpMovie = nullptr;
     QVideoWidget* mpVideoWidget = nullptr;
+    QString mLinkColor;        // Store link color for inline style injection
+    QString mLinkVisitedColor; // Store visited color for inline style injection
+    bool mLinkUnderline = true; // Store underline preference
+    QSet<QString> mVisitedLinks; // Track which link URLs have been clicked
 
 private:
     void releaseFunc(const int existingFunction, const int newFunction);
+
+private slots:
+    void slot_linkActivated(const QString& link);
 
 signals:
     void resized();

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5471,7 +5471,6 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getMapSelection", TLuaInterpreter::getMapSelection);
     lua_register(pGlobalLua, "enableClickthrough", TLuaInterpreter::enableClickthrough);
     lua_register(pGlobalLua, "disableClickthrough", TLuaInterpreter::disableClickthrough);
-    lua_register(pGlobalLua, "setLabelStyleSheet", TLuaInterpreter::setLabelStyleSheet);
     lua_register(pGlobalLua, "setLinkStyle", TLuaInterpreter::setLinkStyle);
     lua_register(pGlobalLua, "resetLinkStyle", TLuaInterpreter::resetLinkStyle);
     lua_register(pGlobalLua, "clearVisitedLinks", TLuaInterpreter::clearVisitedLinks);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5471,6 +5471,10 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getMapSelection", TLuaInterpreter::getMapSelection);
     lua_register(pGlobalLua, "enableClickthrough", TLuaInterpreter::enableClickthrough);
     lua_register(pGlobalLua, "disableClickthrough", TLuaInterpreter::disableClickthrough);
+    lua_register(pGlobalLua, "setLabelStyleSheet", TLuaInterpreter::setLabelStyleSheet);
+    lua_register(pGlobalLua, "setLinkStyle", TLuaInterpreter::setLinkStyle);
+    lua_register(pGlobalLua, "resetLinkStyle", TLuaInterpreter::resetLinkStyle);
+    lua_register(pGlobalLua, "clearVisitedLinks", TLuaInterpreter::clearVisitedLinks);
     lua_register(pGlobalLua, "addWordToDictionary", TLuaInterpreter::addWordToDictionary);
     lua_register(pGlobalLua, "removeWordFromDictionary", TLuaInterpreter::removeWordFromDictionary);
     lua_register(pGlobalLua, "spellCheckWord", TLuaInterpreter::spellCheckWord);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -505,6 +505,10 @@ public:
     static int disableCommandLine(lua_State*);
     static int enableClickthrough(lua_State*);
     static int disableClickthrough(lua_State*);
+    static int setLabelStyleSheet(lua_State*);
+    static int setLinkStyle(lua_State*);
+    static int resetLinkStyle(lua_State*);
+    static int clearVisitedLinks(lua_State*);
     static int startLogging(lua_State*);
     static int appendLog(lua_State*);
     static int calcFontWidth(int size);
@@ -528,7 +532,6 @@ public:
     static int disableAlias(lua_State*);
     static int killAlias(lua_State*);
     static int permBeginOfLineStringTrigger(lua_State*);
-    static int setLabelStyleSheet(lua_State*);
     static int setUserWindowStyleSheet(lua_State*);
     static int getTime(lua_State*);
     static int getEpoch(lua_State*);

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -782,6 +782,7 @@ int TLuaInterpreter::resetLinkStyle(lua_State* L)
     return 1;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearVisitedLinks
 int TLuaInterpreter::clearVisitedLinks(lua_State* L)
 {
     const QString labelName = getVerifiedString(L, __func__, 1, "label name");

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -749,6 +749,53 @@ int TLuaInterpreter::enableClickthrough(lua_State* L)
     return 0;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setLinkStyle
+int TLuaInterpreter::setLinkStyle(lua_State* L)
+{
+    const QString labelName = getVerifiedString(L, __func__, 1, "label name");
+    const QString linkColor = getVerifiedString(L, __func__, 2, "link color", true);
+    const QString linkVisitedColor = getVerifiedString(L, __func__, 3, "link visited color", true);
+    const bool underline = (lua_gettop(L) >= 4) ? getVerifiedBool(L, __func__, 4, "underline", true) : true;
+
+    Host& host = getHostFromLua(L);
+
+    if (!host.setLinkStyle(labelName, linkColor, linkVisitedColor, underline)) {
+        return warnArgumentValue(L, __func__, qsl("label '%1' not found").arg(labelName));
+    }
+
+    lua_pushboolean(L, true);
+    return 1;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#resetLinkStyle
+int TLuaInterpreter::resetLinkStyle(lua_State* L)
+{
+    const QString labelName = getVerifiedString(L, __func__, 1, "label name");
+
+    Host& host = getHostFromLua(L);
+
+    if (!host.resetLinkStyle(labelName)) {
+        return warnArgumentValue(L, __func__, qsl("label '%1' not found").arg(labelName));
+    }
+
+    lua_pushboolean(L, true);
+    return 1;
+}
+
+int TLuaInterpreter::clearVisitedLinks(lua_State* L)
+{
+    const QString labelName = getVerifiedString(L, __func__, 1, "label name");
+
+    Host& host = getHostFromLua(L);
+
+    if (!host.clearVisitedLinks(labelName)) {
+        return warnArgumentValue(L, __func__, qsl("label '%1' not found").arg(labelName));
+    }
+
+    lua_pushboolean(L, true);
+    return 1;
+}
+
 // commandlines inserted by the createCommandLine(...) function:
 int TLuaInterpreter::enableCommandLine(lua_State* L)
 {

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -568,6 +568,28 @@ function Geyser.Label:setStyleSheet(css)
   self.stylesheet = css
   self:autoAdjustSize()
 end
+
+--- Sets the hyperlink styling for the label
+-- @param linkColor Color for normal links (e.g., "cyan", "#00ffff")
+-- @param visitedColor Color for visited links (e.g., "purple", "#ff00ff")
+-- @param underline Whether links should be underlined (default: true)
+function Geyser.Label:setLinkStyle(linkColor, visitedColor, underline)
+  if underline == nil then
+    underline = true
+  end
+  setLinkStyle(self.name, linkColor, visitedColor, underline)
+end
+
+--- Resets the hyperlink styling to Qt defaults
+function Geyser.Label:resetLinkStyle()
+  resetLinkStyle(self.name)
+end
+
+--- Clears the visited links history for this label
+function Geyser.Label:clearVisitedLinks()
+  clearVisitedLinks(self.name)
+end
+
 --- Sets the tooltip of the label
 -- @param txt the tooltip txt
 -- @param duration the duration of the tooltip


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds support for clickable HTML hyperlinks in labels (`Geyser.Label` and `TLabel`) with customizable link colors and visited link tracking.

**New Features:**
- HTML `<a href>` tags now clickable in labels
- Custom link colors for unvisited and visited states
- Visited link tracking per label (changes color after clicking)
- URL scheme support: `send:`, `prompt:`, `http:`, `https:`, and Lua code execution

**New Lua API:**
- [`setLinkStyle(labelName, linkColor, visitedColor, underline)`](https://wiki.mudlet.org/w/Area_51#setLinkStyle.2C_PR_.238527) - Style hyperlinks
- [`resetLinkStyle(labelName)`](https://wiki.mudlet.org/w/Area_51#resetLinkStyle.2C_PR_.238527) - Reset to defaults
- [`clearVisitedLinks(labelName)`](https://wiki.mudlet.org/w/Area_51#clearVisitedLinks.2C_PR_.238527) - Clear visited history
- Corresponding Geyser.Label methods: [`label:setLinkStyle()`](https://wiki.mudlet.org/w/Manual:Geyser#Clickable_hyperlinks), etc.

**Example Usage:**
```lua
-- Create a label with styled hyperlinks
myLabel = Geyser.Label:new({x=10, y=10, width=200, height=100})
myLabel:setLinkStyle("cyan", "purple") -- unvisited=cyan, visited=purple
myLabel:echo([[
  <a href="send:look">Look around</a> | 
  <a href="prompt:say hello">Say hello</a> |
  <a href="https://mudlet.org">Mudlet Website</a>
]])
```

#### Motivation for adding to Mudlet

Labels currently render HTML but hyperlinks were non-functional. This enables:

- Interactive navigation menus and clickable area lists for events/quests
- Quick-action buttons without creating separate GUI elements
- Better UX for scripters building informational dashboards
- Visual feedback (color changes) to track which links have been clicked

#### Other info (issues closed, discussion etc)

**Technical Details:**

- Uses Qt's native QTextDocument rich text with Qt::TextBrowserInteraction
- Inline CSS style injection for link colors (works with widget stylesheets)
- Visited links tracked per label using QSet<QString>
- Fully backward compatible - existing labels unchanged
- No performance impact for labels without links
- Fixed crash in Host::recordActiveCommandLine() null pointer check

**Security:**

- Follows Mudlet's existing trust model (users trust their own profiles/packages)
- Links without schemes execute Lua code (like triggers/aliases)
- External URLs (http/https) open in system browser

---

https://github.com/user-attachments/assets/b26414fa-270e-4fe8-af97-35bd77076d03
