### PR TITLE
Infrastructure: Fix CMake CMP0167 warning for Boost 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -496,10 +496,8 @@ find_package(ZLIB REQUIRED)
 find_package(PCRE REQUIRED)
 find_package(PUGIXML REQUIRED)
 find_package(HUNSPELL REQUIRED)
-find_package(Boost 1.44 CONFIG)
-if(Boost_FOUND)
-  message(STATUS "Found Boost: ${Boost_DIR} (found version \"${Boost_VERSION}\")")
-endif()
+find_package(Boost 1.44 CONFIG REQUIRED)
+message(STATUS "Found Boost: ${Boost_DIR} (found version \"${Boost_VERSION}\")")
 
 
 # FreeBSD's sysinfo() call is done in a package, libsysinfo.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -496,7 +496,7 @@ find_package(ZLIB REQUIRED)
 find_package(PCRE REQUIRED)
 find_package(PUGIXML REQUIRED)
 find_package(HUNSPELL REQUIRED)
-find_package(Boost 1.44)
+find_package(Boost 1.44 CONFIG)
 
 
 # FreeBSD's sysinfo() call is done in a package, libsysinfo.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -497,6 +497,9 @@ find_package(PCRE REQUIRED)
 find_package(PUGIXML REQUIRED)
 find_package(HUNSPELL REQUIRED)
 find_package(Boost 1.44 CONFIG)
+if(Boost_FOUND)
+  message(STATUS "Found Boost: ${Boost_DIR} (found version \"${Boost_VERSION}\")")
+endif()
 
 
 # FreeBSD's sysinfo() call is done in a package, libsysinfo.


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix CMake CMP0167 warning for Boost discovery by using Boost's own package configuration instead of the deprecated FindBoost module.
#### Motivation for adding to Mudlet
Less warnings when configuring cmake
#### Other info (issues closed, discussion etc)
