### PR TITLE
Fix: crash when rapidly reloading plugins due to thread-safety issue in XML export

### DIFF
--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -173,22 +173,21 @@ void XMLexport::runAsyncSave(const QString& fileName, const QString& xmlSavedKey
     // Clone XML document on main thread, then serialize and save on background thread.
     // Cloning is fast and safe; each document owns its own tree, so the clone can be
     // serialized on a background thread without thread-safety issues.
-    // Capture shared_ptr to keep XMLexport alive during async operation
-    auto self = shared_from_this();
+    QPointer<Host> host = mpHost;
     pugi::xml_document docClone;
     // Deep copy the entire document tree
     for (pugi::xml_node child = mExportDoc.first_child(); child; child = child.next_sibling()) {
         docClone.append_copy(child);
     }
-    auto future = QtConcurrent::run([self, fileName, docClone = std::move(docClone)]() mutable { 
+    auto future = QtConcurrent::run([fileName, docClone = std::move(docClone)]() mutable { 
         return XMLexport::saveXmlDocToFile(fileName, docClone); 
     });
     auto watcher = new QFutureWatcher<bool>;
-    connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [self, this, xmlSavedKey]() {
-        if (!mpHost) {
+    connect(watcher, &QFutureWatcher<bool>::finished, host, [host, xmlSavedKey]() {
+        if (!host) {
             return;
         }
-        mpHost->xmlSaved(xmlSavedKey);
+        host->xmlSaved(xmlSavedKey);
     });
     connect(watcher, &QFutureWatcher<bool>::finished, watcher, &QObject::deleteLater);
     watcher->setFuture(future);

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -151,29 +151,7 @@ void XMLexport::writeModuleXML(const QString& moduleName, const QString& fileNam
         helpPackage.append_child("helpURL").text().set("");
     }
     if (async) {
-        // Clone XML document on main thread, then serialize and save on background thread.
-        // Cloning is fast and safe; each document owns its own tree, so the clone can be
-        // serialized on a background thread without thread-safety issues.
-        // Capture shared_ptr to keep XMLexport alive during async operation
-        auto self = shared_from_this();
-        pugi::xml_document docClone;
-        // Deep copy the entire document tree
-        for (pugi::xml_node child = mExportDoc.first_child(); child; child = child.next_sibling()) {
-            docClone.append_copy(child);
-        }
-        auto future = QtConcurrent::run([self, fileName, docClone = std::move(docClone)]() mutable { 
-            return XMLexport::saveXmlDocToFile(fileName, docClone); 
-        });
-        auto watcher = new QFutureWatcher<bool>;
-        connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [self, this, fileName]() {
-            if (!mpHost) {
-                return;
-            }
-            mpHost->xmlSaved(fileName);
-        });
-        connect(watcher, &QFutureWatcher<bool>::finished, watcher, &QObject::deleteLater);
-        watcher->setFuture(future);
-        saveFutures.append(future);
+        runAsyncSave(fileName, fileName);
     } else {
         saveXml(fileName);
         mpHost->xmlSaved(fileName);
@@ -185,6 +163,13 @@ void XMLexport::exportHost(const QString& filename_pugi_xml)
     auto mudletPackage = writeXmlHeader();
     writeHost(mpHost, mudletPackage);
 
+    runAsyncSave(filename_pugi_xml, qsl("profile"));
+}
+
+// Helper to encapsulate async save pattern: clone document, save in background thread,
+// notify host when complete
+void XMLexport::runAsyncSave(const QString& fileName, const QString& xmlSavedKey)
+{
     // Clone XML document on main thread, then serialize and save on background thread.
     // Cloning is fast and safe; each document owns its own tree, so the clone can be
     // serialized on a background thread without thread-safety issues.
@@ -195,16 +180,15 @@ void XMLexport::exportHost(const QString& filename_pugi_xml)
     for (pugi::xml_node child = mExportDoc.first_child(); child; child = child.next_sibling()) {
         docClone.append_copy(child);
     }
-    auto future = QtConcurrent::run([self, filename_pugi_xml, docClone = std::move(docClone)]() mutable { 
-        return XMLexport::saveXmlDocToFile(filename_pugi_xml, docClone); 
+    auto future = QtConcurrent::run([self, fileName, docClone = std::move(docClone)]() mutable { 
+        return XMLexport::saveXmlDocToFile(fileName, docClone); 
     });
-
     auto watcher = new QFutureWatcher<bool>;
-    connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [self, this]() {
+    connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [self, this, xmlSavedKey]() {
         if (!mpHost) {
             return;
         }
-        mpHost->xmlSaved(qsl("profile"));
+        mpHost->xmlSaved(xmlSavedKey);
     });
     connect(watcher, &QFutureWatcher<bool>::finished, watcher, &QObject::deleteLater);
     watcher->setFuture(future);
@@ -326,8 +310,8 @@ bool XMLexport::saveXml(const QString& fileName)
 // Save an XML document to a file. This is thread-safe and can be called from a background thread
 // as long as the document is not being modified concurrently (which we ensure by passing a clone).
 // Static method so it can be called without keeping XMLexport alive.
-// Note: This method is intentionally NOT a member function to make it clear that it doesn't
-// access any instance state and is safe to call from background threads.
+// Note: This is a static member method that doesn't access any instance state,
+// making it safe to call from background threads.
 bool XMLexport::saveXmlDocToFile(const QString& fileName, const pugi::xml_document& doc)
 {
     QSaveFile file(fileName);
@@ -347,79 +331,7 @@ bool XMLexport::saveXmlDocToFile(const QString& fileName, const pugi::xml_docume
     std::string output(saveStringStream.str());
     
     // Apply sanitization for control characters
-    // We need to duplicate the sanitization logic here since this is a static method
-    // and sanitizeForQxml is a member function. This is acceptable since the logic
-    // is simple and well-encapsulated.
-    QMap<std::string, std::string> replacements{
-            {"&#1;", "\uFFFC\u2401"},   // SOH
-            {"&#01;", "\uFFFC\u2401"},  // SOH
-            {"&#2;", "\uFFFC\u2402"},   // STX
-            {"&#02;", "\uFFFC\u2402"},  // STX
-            {"&#3;", "\uFFFC\u2403"},   // ETX
-            {"&#03;", "\uFFFC\u2403"},  // ETX
-            {"&#4;", "\uFFFC\u2404"},   // EOT
-            {"&#04;", "\uFFFC\u2404"},  // EOT
-            {"&#5;", "\uFFFC\u2405"},   // ENQ
-            {"&#05;", "\uFFFC\u2405"},  // ENQ
-            {"&#6;", "\uFFFC\u2406"},   // ACK
-            {"&#06;", "\uFFFC\u2406"},  // ACK
-            {"&#7;", "\uFFFC\u2407"},   // BEL
-            {"&#07;", "\uFFFC\u2407"},  // BEL
-            {"&#8;", "\uFFFC\u2408"},   // BS
-            {"&#08;", "\uFFFC\u2408"},  // BS
-            {"&#11;", "\uFFFC\u240B"},  // VT
-            {"&#12;", "\uFFFC\u240C"},  // FF
-            {"&#14;", "\uFFFC\u240E"},  // SO
-            {"&#15;", "\uFFFC\u240F"},  // SI
-            {"&#10;", "\uFFFC\u2410"},  // DLE
-            {"&#16;", "\uFFFC\u2411"},  // DC1
-            {"&#18;", "\uFFFC\u2412"},  // DC2
-            {"&#19;", "\uFFFC\u2413"},  // DC3
-            {"&#20;", "\uFFFC\u2414"},  // DC4
-            {"&#21;", "\uFFFC\u2415"},  // NAK
-            {"&#22;", "\uFFFC\u2416"},  // SYN
-            {"&#17;", "\uFFFC\u2417"},  // ETB
-            {"&#23;", "\uFFFC\u2418"},  // CAN
-            {"&#25;", "\uFFFC\u2419"},  // EM
-            {"&#26;", "\uFFFC\u241A"},  // SUB
-            {"&#27;", "\uFFFC\u241B"},  // ESC
-            {"&#28;", "\uFFFC\u241C"},  // FS
-            {"&#29;", "\uFFFC\u241D"},  // GS
-            {"&#30;", "\uFFFC\u241E"},  // RS
-            {"&#31;", "\uFFFC\u241F"},  // US
-            {"&#127;", "\uFFFC\u2421"}, // DEL
-    };
-
-    // Look for each replacement in data and if not present remove it from the list
-    QMutableMapIterator<std::string, std::string> itReplacement(replacements);
-    while (itReplacement.hasNext()) {
-        itReplacement.next();
-        if (output.find(itReplacement.key()) == std::string::npos) {
-            itReplacement.remove();
-        }
-    }
-
-    if (!replacements.isEmpty()) {
-        itReplacement.toFront();
-        while (itReplacement.hasNext()) {
-            itReplacement.next();
-            // Inline version of replaceAll
-            std::string newString;
-            newString.reserve(output.length());
-            std::string::size_type lastPos = 0;
-            std::string::size_type findPos;
-            const std::string& from = itReplacement.key();
-            const std::string& to = itReplacement.value();
-
-            while (std::string::npos != (findPos = output.find(from, lastPos))) {
-                newString.append(output, lastPos, findPos - lastPos);
-                newString += to;
-                lastPos = findPos + from.length();
-            }
-            newString += output.substr(lastPos);
-            output.swap(newString);
-        }
-    }
+    sanitizeForQxml(output);
 
     file.write(output.data(), output.size());
     bool success = file.error() == QFileDevice::NoError;
@@ -929,30 +841,7 @@ bool XMLexport::exportProfile(const QString& exportFileName)
     auto mudletPackage = writeXmlHeader();
 
     if (writeGenericPackage(mpHost, mudletPackage)) {
-        // Clone XML document on main thread, then serialize and save on background thread.
-        // Cloning is fast and safe; each document owns its own tree, so the clone can be
-        // serialized on a background thread without thread-safety issues.
-        // Capture shared_ptr to keep XMLexport alive during async operation
-        auto self = shared_from_this();
-        pugi::xml_document docClone;
-        // Deep copy the entire document tree
-        for (pugi::xml_node child = mExportDoc.first_child(); child; child = child.next_sibling()) {
-            docClone.append_copy(child);
-        }
-        auto future = QtConcurrent::run([self, exportFileName, docClone = std::move(docClone)]() mutable { 
-            return XMLexport::saveXmlDocToFile(exportFileName, docClone); 
-        });
-        auto watcher = new QFutureWatcher<bool>;
-        QObject::connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [self, this]() {
-            if (!mpHost) {
-                return;
-            }
-            mpHost->xmlSaved(qsl("profile"));
-        });
-        QObject::connect(watcher, &QFutureWatcher<bool>::finished, watcher, &QObject::deleteLater);
-        watcher->setFuture(future);
-        saveFutures.append(future);
-
+        runAsyncSave(exportFileName, qsl("profile"));
         return true;
     }
 

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -151,13 +151,18 @@ void XMLexport::writeModuleXML(const QString& moduleName, const QString& fileNam
         helpPackage.append_child("helpURL").text().set("");
     }
     if (async) {
-        // Serialize XML on main thread to avoid thread-safety issues with pugi::xml_document
-        // which is not thread-safe and should not be accessed from multiple threads
+        // Clone XML document on main thread, then serialize and save on background thread.
+        // Cloning is fast and safe; each document owns its own tree, so the clone can be
+        // serialized on a background thread without thread-safety issues.
         // Capture shared_ptr to keep XMLexport alive during async operation
         auto self = shared_from_this();
-        std::string xmlContent = serializeXmlDoc();
-        auto future = QtConcurrent::run([self, fileName, xmlContent = std::move(xmlContent)]() { 
-            return self->saveXmlFromString(fileName, xmlContent); 
+        pugi::xml_document docClone;
+        // Deep copy the entire document tree
+        for (pugi::xml_node child = mExportDoc.first_child(); child; child = child.next_sibling()) {
+            docClone.append_copy(child);
+        }
+        auto future = QtConcurrent::run([self, fileName, docClone = std::move(docClone)]() mutable { 
+            return XMLexport::saveXmlDocToFile(fileName, docClone); 
         });
         auto watcher = new QFutureWatcher<bool>;
         connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [self, this, fileName]() {
@@ -180,13 +185,18 @@ void XMLexport::exportHost(const QString& filename_pugi_xml)
     auto mudletPackage = writeXmlHeader();
     writeHost(mpHost, mudletPackage);
 
-    // Serialize XML on main thread to avoid thread-safety issues with pugi::xml_document
-    // which is not thread-safe and should not be accessed from multiple threads
+    // Clone XML document on main thread, then serialize and save on background thread.
+    // Cloning is fast and safe; each document owns its own tree, so the clone can be
+    // serialized on a background thread without thread-safety issues.
     // Capture shared_ptr to keep XMLexport alive during async operation
     auto self = shared_from_this();
-    std::string xmlContent = serializeXmlDoc();
-    auto future = QtConcurrent::run([self, filename_pugi_xml, xmlContent = std::move(xmlContent)]() { 
-        return self->saveXmlFromString(filename_pugi_xml, xmlContent); 
+    pugi::xml_document docClone;
+    // Deep copy the entire document tree
+    for (pugi::xml_node child = mExportDoc.first_child(); child; child = child.next_sibling()) {
+        docClone.append_copy(child);
+    }
+    auto future = QtConcurrent::run([self, filename_pugi_xml, docClone = std::move(docClone)]() mutable { 
+        return XMLexport::saveXmlDocToFile(filename_pugi_xml, docClone); 
     });
 
     auto watcher = new QFutureWatcher<bool>;
@@ -313,26 +323,17 @@ bool XMLexport::saveXml(const QString& fileName)
     return success;
 }
 
-// Serialize the XML document to a string. Must be called on the main thread.
-// This is separated from the file-writing operation to ensure thread-safety,
-// as pugi::xml_document is not thread-safe and should not be accessed from
-// multiple threads concurrently.
-std::string XMLexport::serializeXmlDoc()
-{
-    std::stringstream saveStringStream(std::ios::out);
-    mExportDoc.save(saveStringStream);
-    std::string output(saveStringStream.str());
-    sanitizeForQxml(output);
-    return output;
-}
-
-// Save pre-serialized XML content to a file. This can be called from a background thread.
-bool XMLexport::saveXmlFromString(const QString& fileName, const std::string& xmlContent)
+// Save an XML document to a file. This is thread-safe and can be called from a background thread
+// as long as the document is not being modified concurrently (which we ensure by passing a clone).
+// Static method so it can be called without keeping XMLexport alive.
+// Note: This method is intentionally NOT a member function to make it clear that it doesn't
+// access any instance state and is safe to call from background threads.
+bool XMLexport::saveXmlDocToFile(const QString& fileName, const pugi::xml_document& doc)
 {
     QSaveFile file(fileName);
 
     auto printErrorMessage = [&](const QString& errorString) {
-        qDebug().noquote().nospace() << "XMLexport::saveXmlFromString(\"" << fileName << "\") ERROR - failed to save package, reason: " << errorString << ".";
+        qDebug().noquote().nospace() << "XMLexport::saveXmlDocToFile(\"" << fileName << "\") ERROR - failed to save package, reason: " << errorString << ".";
     };
 
     if (!file.open(QIODevice::WriteOnly)) {
@@ -340,7 +341,87 @@ bool XMLexport::saveXmlFromString(const QString& fileName, const std::string& xm
         return false;
     }
 
-    file.write(xmlContent.data(), xmlContent.size());
+    // Serialize the document to a stringstream
+    std::stringstream saveStringStream(std::ios::out);
+    doc.save(saveStringStream);
+    std::string output(saveStringStream.str());
+    
+    // Apply sanitization for control characters
+    // We need to duplicate the sanitization logic here since this is a static method
+    // and sanitizeForQxml is a member function. This is acceptable since the logic
+    // is simple and well-encapsulated.
+    QMap<std::string, std::string> replacements{
+            {"&#1;", "\uFFFC\u2401"},   // SOH
+            {"&#01;", "\uFFFC\u2401"},  // SOH
+            {"&#2;", "\uFFFC\u2402"},   // STX
+            {"&#02;", "\uFFFC\u2402"},  // STX
+            {"&#3;", "\uFFFC\u2403"},   // ETX
+            {"&#03;", "\uFFFC\u2403"},  // ETX
+            {"&#4;", "\uFFFC\u2404"},   // EOT
+            {"&#04;", "\uFFFC\u2404"},  // EOT
+            {"&#5;", "\uFFFC\u2405"},   // ENQ
+            {"&#05;", "\uFFFC\u2405"},  // ENQ
+            {"&#6;", "\uFFFC\u2406"},   // ACK
+            {"&#06;", "\uFFFC\u2406"},  // ACK
+            {"&#7;", "\uFFFC\u2407"},   // BEL
+            {"&#07;", "\uFFFC\u2407"},  // BEL
+            {"&#8;", "\uFFFC\u2408"},   // BS
+            {"&#08;", "\uFFFC\u2408"},  // BS
+            {"&#11;", "\uFFFC\u240B"},  // VT
+            {"&#12;", "\uFFFC\u240C"},  // FF
+            {"&#14;", "\uFFFC\u240E"},  // SO
+            {"&#15;", "\uFFFC\u240F"},  // SI
+            {"&#10;", "\uFFFC\u2410"},  // DLE
+            {"&#16;", "\uFFFC\u2411"},  // DC1
+            {"&#18;", "\uFFFC\u2412"},  // DC2
+            {"&#19;", "\uFFFC\u2413"},  // DC3
+            {"&#20;", "\uFFFC\u2414"},  // DC4
+            {"&#21;", "\uFFFC\u2415"},  // NAK
+            {"&#22;", "\uFFFC\u2416"},  // SYN
+            {"&#17;", "\uFFFC\u2417"},  // ETB
+            {"&#23;", "\uFFFC\u2418"},  // CAN
+            {"&#25;", "\uFFFC\u2419"},  // EM
+            {"&#26;", "\uFFFC\u241A"},  // SUB
+            {"&#27;", "\uFFFC\u241B"},  // ESC
+            {"&#28;", "\uFFFC\u241C"},  // FS
+            {"&#29;", "\uFFFC\u241D"},  // GS
+            {"&#30;", "\uFFFC\u241E"},  // RS
+            {"&#31;", "\uFFFC\u241F"},  // US
+            {"&#127;", "\uFFFC\u2421"}, // DEL
+    };
+
+    // Look for each replacement in data and if not present remove it from the list
+    QMutableMapIterator<std::string, std::string> itReplacement(replacements);
+    while (itReplacement.hasNext()) {
+        itReplacement.next();
+        if (output.find(itReplacement.key()) == std::string::npos) {
+            itReplacement.remove();
+        }
+    }
+
+    if (!replacements.isEmpty()) {
+        itReplacement.toFront();
+        while (itReplacement.hasNext()) {
+            itReplacement.next();
+            // Inline version of replaceAll
+            std::string newString;
+            newString.reserve(output.length());
+            std::string::size_type lastPos = 0;
+            std::string::size_type findPos;
+            const std::string& from = itReplacement.key();
+            const std::string& to = itReplacement.value();
+
+            while (std::string::npos != (findPos = output.find(from, lastPos))) {
+                newString.append(output, lastPos, findPos - lastPos);
+                newString += to;
+                lastPos = findPos + from.length();
+            }
+            newString += output.substr(lastPos);
+            output.swap(newString);
+        }
+    }
+
+    file.write(output.data(), output.size());
     bool success = file.error() == QFileDevice::NoError;
     
     if (!success) {
@@ -848,13 +929,18 @@ bool XMLexport::exportProfile(const QString& exportFileName)
     auto mudletPackage = writeXmlHeader();
 
     if (writeGenericPackage(mpHost, mudletPackage)) {
-        // Serialize XML on main thread to avoid thread-safety issues with pugi::xml_document
-        // which is not thread-safe and should not be accessed from multiple threads
+        // Clone XML document on main thread, then serialize and save on background thread.
+        // Cloning is fast and safe; each document owns its own tree, so the clone can be
+        // serialized on a background thread without thread-safety issues.
         // Capture shared_ptr to keep XMLexport alive during async operation
         auto self = shared_from_this();
-        std::string xmlContent = serializeXmlDoc();
-        auto future = QtConcurrent::run([self, exportFileName, xmlContent = std::move(xmlContent)]() { 
-            return self->saveXmlFromString(exportFileName, xmlContent); 
+        pugi::xml_document docClone;
+        // Deep copy the entire document tree
+        for (pugi::xml_node child = mExportDoc.first_child(); child; child = child.next_sibling()) {
+            docClone.append_copy(child);
+        }
+        auto future = QtConcurrent::run([self, exportFileName, docClone = std::move(docClone)]() mutable { 
+            return XMLexport::saveXmlDocToFile(exportFileName, docClone); 
         });
         auto watcher = new QFutureWatcher<bool>;
         QObject::connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [self, this]() {

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -151,9 +151,15 @@ void XMLexport::writeModuleXML(const QString& moduleName, const QString& fileNam
         helpPackage.append_child("helpURL").text().set("");
     }
     if (async) {
+        // Serialize XML on main thread to avoid thread-safety issues with pugi::xml_document
+        // which is not thread-safe and should not be accessed from multiple threads
+        std::string xmlContent = serializeXmlDoc();
+        
         // Capture shared_ptr to keep XMLexport alive during async operation
         auto self = shared_from_this();
-        auto future = QtConcurrent::run([self, fileName]() { return self->saveXml(fileName); });
+        auto future = QtConcurrent::run([self, fileName, xmlContent]() { 
+            return self->saveXmlFromString(fileName, xmlContent); 
+        });
         auto watcher = new QFutureWatcher<bool>;
         connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [self, this, fileName]() {
             if (!mpHost) {
@@ -175,9 +181,15 @@ void XMLexport::exportHost(const QString& filename_pugi_xml)
     auto mudletPackage = writeXmlHeader();
     writeHost(mpHost, mudletPackage);
 
+    // Serialize XML on main thread to avoid thread-safety issues with pugi::xml_document
+    // which is not thread-safe and should not be accessed from multiple threads
+    std::string xmlContent = serializeXmlDoc();
+
     // Capture shared_ptr to keep XMLexport alive during async operation
     auto self = shared_from_this();
-    auto future = QtConcurrent::run([self, filename_pugi_xml]() { return self->saveXml(filename_pugi_xml); });
+    auto future = QtConcurrent::run([self, filename_pugi_xml, xmlContent]() { 
+        return self->saveXmlFromString(filename_pugi_xml, xmlContent); 
+    });
 
     auto watcher = new QFutureWatcher<bool>;
     connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [self, this]() {
@@ -295,6 +307,46 @@ bool XMLexport::saveXml(const QString& fileName)
     bool success = saveXmlFile(file);
     if (!success) {
         printErrorMessage((file.error() != QFileDevice::NoError) ? file.errorString() : "XML document preparation failure");
+    } else if (!file.commit()) {
+        printErrorMessage(file.errorString());
+        success = false;
+    }
+
+    return success;
+}
+
+// Serialize the XML document to a string. Must be called on the main thread.
+// This is separated from the file-writing operation to ensure thread-safety,
+// as pugi::xml_document is not thread-safe and should not be accessed from
+// multiple threads concurrently.
+std::string XMLexport::serializeXmlDoc()
+{
+    std::stringstream saveStringStream(std::ios::out);
+    mExportDoc.save(saveStringStream);
+    std::string output(saveStringStream.str());
+    sanitizeForQxml(output);
+    return output;
+}
+
+// Save pre-serialized XML content to a file. This can be called from a background thread.
+bool XMLexport::saveXmlFromString(const QString& fileName, const std::string& xmlContent)
+{
+    QSaveFile file(fileName);
+
+    auto printErrorMessage = [&](const QString& errorString) {
+        qDebug().noquote().nospace() << "XMLexport::saveXmlFromString(\"" << fileName << "\") ERROR - failed to save package, reason: " << errorString << ".";
+    };
+
+    if (!file.open(QIODevice::WriteOnly)) {
+        printErrorMessage(file.errorString().prepend("failed to open file, "));
+        return false;
+    }
+
+    file.write(xmlContent.data());
+    bool success = file.error() == QFileDevice::NoError;
+    
+    if (!success) {
+        printErrorMessage(file.errorString());
     } else if (!file.commit()) {
         printErrorMessage(file.errorString());
         success = false;
@@ -798,9 +850,15 @@ bool XMLexport::exportProfile(const QString& exportFileName)
     auto mudletPackage = writeXmlHeader();
 
     if (writeGenericPackage(mpHost, mudletPackage)) {
+        // Serialize XML on main thread to avoid thread-safety issues with pugi::xml_document
+        // which is not thread-safe and should not be accessed from multiple threads
+        std::string xmlContent = serializeXmlDoc();
+        
         // Capture shared_ptr to keep XMLexport alive during async operation
         auto self = shared_from_this();
-        auto future = QtConcurrent::run([self, exportFileName]() { return self->saveXml(exportFileName); });
+        auto future = QtConcurrent::run([self, exportFileName, xmlContent]() { 
+            return self->saveXmlFromString(exportFileName, xmlContent); 
+        });
         auto watcher = new QFutureWatcher<bool>;
         QObject::connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [self, this]() {
             if (!mpHost) {

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -153,11 +153,10 @@ void XMLexport::writeModuleXML(const QString& moduleName, const QString& fileNam
     if (async) {
         // Serialize XML on main thread to avoid thread-safety issues with pugi::xml_document
         // which is not thread-safe and should not be accessed from multiple threads
-        std::string xmlContent = serializeXmlDoc();
-        
         // Capture shared_ptr to keep XMLexport alive during async operation
         auto self = shared_from_this();
-        auto future = QtConcurrent::run([self, fileName, xmlContent]() { 
+        std::string xmlContent = serializeXmlDoc();
+        auto future = QtConcurrent::run([self, fileName, xmlContent = std::move(xmlContent)]() { 
             return self->saveXmlFromString(fileName, xmlContent); 
         });
         auto watcher = new QFutureWatcher<bool>;
@@ -183,11 +182,10 @@ void XMLexport::exportHost(const QString& filename_pugi_xml)
 
     // Serialize XML on main thread to avoid thread-safety issues with pugi::xml_document
     // which is not thread-safe and should not be accessed from multiple threads
-    std::string xmlContent = serializeXmlDoc();
-
     // Capture shared_ptr to keep XMLexport alive during async operation
     auto self = shared_from_this();
-    auto future = QtConcurrent::run([self, filename_pugi_xml, xmlContent]() { 
+    std::string xmlContent = serializeXmlDoc();
+    auto future = QtConcurrent::run([self, filename_pugi_xml, xmlContent = std::move(xmlContent)]() { 
         return self->saveXmlFromString(filename_pugi_xml, xmlContent); 
     });
 
@@ -342,7 +340,7 @@ bool XMLexport::saveXmlFromString(const QString& fileName, const std::string& xm
         return false;
     }
 
-    file.write(xmlContent.data());
+    file.write(xmlContent.data(), xmlContent.size());
     bool success = file.error() == QFileDevice::NoError;
     
     if (!success) {
@@ -852,11 +850,10 @@ bool XMLexport::exportProfile(const QString& exportFileName)
     if (writeGenericPackage(mpHost, mudletPackage)) {
         // Serialize XML on main thread to avoid thread-safety issues with pugi::xml_document
         // which is not thread-safe and should not be accessed from multiple threads
-        std::string xmlContent = serializeXmlDoc();
-        
         // Capture shared_ptr to keep XMLexport alive during async operation
         auto self = shared_from_this();
-        auto future = QtConcurrent::run([self, exportFileName, xmlContent]() { 
+        std::string xmlContent = serializeXmlDoc();
+        auto future = QtConcurrent::run([self, exportFileName, xmlContent = std::move(xmlContent)]() { 
             return self->saveXmlFromString(exportFileName, xmlContent); 
         });
         auto watcher = new QFutureWatcher<bool>;

--- a/src/XMLexport.h
+++ b/src/XMLexport.h
@@ -107,12 +107,13 @@ private:
     void writeScriptPackage(const Host* pHost, pugi::xml_node& mMudletPackage, bool skipModuleMembers);
     void writeKeyPackage(const Host* pHost, pugi::xml_node& mMudletPackage, bool skipModuleMembers);
     void writeVariablePackage(Host* pHost, pugi::xml_node& mMudletPackage);
-    void inline replaceAll(std::string& source, const std::string& from, const std::string& to);
+    static void inline replaceAll(std::string& source, const std::string& from, const std::string& to);
     bool saveXmlFile(QSaveFile& file);
     bool saveXml(const QString&);
     static bool saveXmlDocToFile(const QString& fileName, const pugi::xml_document& doc);
     pugi::xml_node writeXmlHeader();
-    void sanitizeForQxml(std::string& output);
+    static void sanitizeForQxml(std::string& output);
+    void runAsyncSave(const QString& fileName, const QString& xmlSavedKey);
     QString saveXml();
     QStringList remapAnsiToColorNumber(const QStringList&, const QList<int>&);
 };

--- a/src/XMLexport.h
+++ b/src/XMLexport.h
@@ -110,8 +110,7 @@ private:
     void inline replaceAll(std::string& source, const std::string& from, const std::string& to);
     bool saveXmlFile(QSaveFile& file);
     bool saveXml(const QString&);
-    bool saveXmlFromString(const QString& fileName, const std::string& xmlContent);
-    std::string serializeXmlDoc();
+    static bool saveXmlDocToFile(const QString& fileName, const pugi::xml_document& doc);
     pugi::xml_node writeXmlHeader();
     void sanitizeForQxml(std::string& output);
     QString saveXml();

--- a/src/XMLexport.h
+++ b/src/XMLexport.h
@@ -110,6 +110,8 @@ private:
     void inline replaceAll(std::string& source, const std::string& from, const std::string& to);
     bool saveXmlFile(QSaveFile& file);
     bool saveXml(const QString&);
+    bool saveXmlFromString(const QString& fileName, const std::string& xmlContent);
+    std::string serializeXmlDoc();
     pugi::xml_node writeXmlHeader();
     void sanitizeForQxml(std::string& output);
     QString saveXml();


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixed a critical thread-safety bug in XMLexport where `pugi::xml_document` was being accessed concurrently from multiple threads. The fix ensures XML serialization happens entirely on the main thread before async file operations begin, eliminating data races that caused segmentation faults.

#### Motivation for adding to Mudlet

Resolves crashes that occur when rapidly reloading plugins, such as when using the Muddler CI helper tool. The crash was caused by multiple background threads attempting to serialize the same XML document simultaneously, which is not supported by pugixml.

#### Other info (issues closed, discussion etc)

Closes #7479