### PR TITLE
Fix: Special exit text unreadable when editing

### DIFF
--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -101,6 +101,8 @@ QWidget* RoomIdLineEditDelegate::createEditor(QWidget* parent, const QStyleOptio
     mpEditor = new QLineEdit(parent);
     mpEditor->setFrame(false);
     mpEditor->setPlaceholderText(mpDlgRoomExits->mSpecialExitRoomIdPlaceholder);
+    // Hide anything in the original QLineEdit that this sits on top of:
+    mpEditor->setAutoFillBackground(true);
     if (mpDlgRoomExits) {
         if (!mpHost) {
             mpHost = mpDlgRoomExits->getHost();


### PR DESCRIPTION
### Brief overview of PR changes/additions

Fixes the double/misaligned text rendering issue when editing special exit room IDs in the mapper's "Configure exits" dialog.

#### Motivation for adding to Mudlet

When users clicked on a special exit command to edit it, the text appeared doubled and misaligned, making it unreadable. This was a regression that appeared in recent PTB builds but wasn't present in version 4.19.

The fix adds `setAutoFillBackground(true)` to the QLineEdit delegate, ensuring the editor properly paints its background and hides the underlying text.

#### Other info (issues closed, discussion etc)

Closes #8258