### PR TITLE
Fix: Improve selection contrast in mapper room list and area dropdown

### DIFF
--- a/src/HostManager.cpp
+++ b/src/HostManager.cpp
@@ -138,6 +138,17 @@ void HostManager::changeAllHostColour(const Host* pHost)
         auto mapper = host->mpMap->mpMapper;
         if (mapper) {
             mapper->setPalette(QApplication::palette());
+            // Update area dropdown and its view
+            if (mapper->comboBox_showArea) {
+                mapper->comboBox_showArea->setPalette(QApplication::palette());
+                if (auto* view = mapper->comboBox_showArea->view()) {
+                    view->setPalette(QApplication::palette());
+                }
+            }
+            // Update room selection list widget
+            if (mapper->mp2dMap) {
+                mapper->mp2dMap->mMultiSelectionListWidget.setPalette(QApplication::palette());
+            }
         }
         QMutableMapIterator<QString, TConsole*> itSubConsole(host->mpConsole->mSubConsoleMap);
         while (itSubConsole.hasNext()) {

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -387,6 +387,8 @@ T2DMap::T2DMap(QWidget* parent)
     mMultiSelectionListWidget.resize(120, 100);
     mMultiSelectionListWidget.move(0, 0);
     mMultiSelectionListWidget.hide();
+    // Explicitly set the palette to ensure proper selection colors in both light and dark themes
+    mMultiSelectionListWidget.setPalette(qApp->palette());
     connect(&mMultiSelectionListWidget, &QTreeWidget::itemSelectionChanged, this, &T2DMap::slot_roomSelectionChanged);
 
     mCustomLineSession = std::make_unique<CustomLineSession>(*this);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -438,8 +438,18 @@ void T2DMap::init()
         return;
     }
 
-    // Apply application palette to ensure proper selection colors in both light and dark themes
-    mMultiSelectionListWidget.setPalette(qApp->palette());
+    // Apply stylesheet to ensure proper selection colors in both light and dark themes
+    // Using QSS instead of palette for reliable cross-platform behavior
+    mMultiSelectionListWidget.setStyleSheet(qsl(
+        "QTreeWidget::item:selected:active {"
+        "    background-color: palette(highlight);"
+        "    color: palette(highlighted-text);"
+        "}"
+        "QTreeWidget::item:selected:!active {"
+        "    background-color: palette(highlight);"
+        "    color: palette(highlighted-text);"
+        "}"
+    ));
 
     eSize = mpHost->mLineSize;
     rSize = mpHost->mRoomSize;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -438,17 +438,8 @@ void T2DMap::init()
         return;
     }
 
-    // Apply stylesheet to ensure proper selection colors in both light and dark themes
-    // Using QSS instead of palette for reliable cross-platform behavior
-    mMultiSelectionListWidget.setStyleSheet(
-        qsl("QTreeWidget::item:selected:active {"
-            "    background-color: palette(highlight);"
-            "    color: palette(highlighted-text);"
-            "}"
-            "QTreeWidget::item:selected:!active {"
-            "    background-color: palette(highlight);"
-            "    color: palette(highlighted-text);"
-            "}"));
+    // Apply application palette to ensure proper selection colors in both light and dark themes
+    mMultiSelectionListWidget.setPalette(qApp->palette());
 
     eSize = mpHost->mLineSize;
     rSize = mpHost->mRoomSize;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -448,8 +448,7 @@ void T2DMap::init()
         "QTreeWidget::item:selected:!active {"
         "    background-color: palette(highlight);"
         "    color: palette(highlighted-text);"
-        "}"
-    ));
+        "}));
 
     eSize = mpHost->mLineSize;
     rSize = mpHost->mRoomSize;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -387,8 +387,6 @@ T2DMap::T2DMap(QWidget* parent)
     mMultiSelectionListWidget.resize(120, 100);
     mMultiSelectionListWidget.move(0, 0);
     mMultiSelectionListWidget.hide();
-    // Explicitly set the palette to ensure proper selection colors in both light and dark themes
-    mMultiSelectionListWidget.setPalette(qApp->palette());
     connect(&mMultiSelectionListWidget, &QTreeWidget::itemSelectionChanged, this, &T2DMap::slot_roomSelectionChanged);
 
     mCustomLineSession = std::make_unique<CustomLineSession>(*this);
@@ -439,6 +437,9 @@ void T2DMap::init()
     if (!mpHost || !mpMap) {
         return;
     }
+
+    // Set palette after parent (dlgMapper) has set its palette to ensure proper selection colors
+    mMultiSelectionListWidget.setPalette(qApp->palette());
 
     eSize = mpHost->mLineSize;
     rSize = mpHost->mRoomSize;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -440,15 +440,15 @@ void T2DMap::init()
 
     // Apply stylesheet to ensure proper selection colors in both light and dark themes
     // Using QSS instead of palette for reliable cross-platform behavior
-    mMultiSelectionListWidget.setStyleSheet(qsl(
-        "QTreeWidget::item:selected:active {"
-        "    background-color: palette(highlight);"
-        "    color: palette(highlighted-text);"
-        "}"
-        "QTreeWidget::item:selected:!active {"
-        "    background-color: palette(highlight);"
-        "    color: palette(highlighted-text);"
-        "}));
+    mMultiSelectionListWidget.setStyleSheet(
+        qsl("QTreeWidget::item:selected:active {"
+            "    background-color: palette(highlight);"
+            "    color: palette(highlighted-text);"
+            "}"
+            "QTreeWidget::item:selected:!active {"
+            "    background-color: palette(highlight);"
+            "    color: palette(highlighted-text);"
+            "}"));
 
     eSize = mpHost->mLineSize;
     rSize = mpHost->mRoomSize;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -438,7 +438,7 @@ void T2DMap::init()
         return;
     }
 
-    // Set palette after parent (dlgMapper) has set its palette to ensure proper selection colors
+    // Apply application palette to ensure proper selection colors in both light and dark themes
     mMultiSelectionListWidget.setPalette(qApp->palette());
 
     eSize = mpHost->mLineSize;

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -119,8 +119,6 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
     } else {
         qDebug() << "dlgMapper::dlgMapper(...) INFO constructor called, mpHost is null";
     }
-    //stops inheritance of palette from mpConsole->mpMainFrame
-    setPalette(QApplication::palette());
 
     connect(mpMap->mMapInfoContributorManager, &MapInfoContributorManager::signal_contributorsUpdated, this, &dlgMapper::slot_updateInfoContributors);
     slot_updateInfoContributors();

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -89,10 +89,20 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
     connect(toolButton_mapperMenu, &QToolButton::clicked, this, &dlgMapper::slot_setupMapperMenu);
     connect(toolButton_togglePanel, &QAbstractButton::clicked, this, &dlgMapper::slot_togglePanel);
     connect(comboBox_showArea, qOverload<int>(&QComboBox::activated), this, &dlgMapper::slot_switchArea);
-    // Explicitly set the palette to ensure proper selection colors in both light and dark themes
-    comboBox_showArea->setPalette(qApp->palette());
+    // Apply stylesheet to ensure proper selection colors in both light and dark themes
+    // Using QSS for reliable cross-platform behavior, especially on Windows
+    // Apply only to the dropdown view to avoid affecting the combobox button itself
     if (auto* view = comboBox_showArea->view()) {
-        view->setPalette(qApp->palette());
+        view->setStyleSheet(qsl(
+            "QAbstractItemView::item:selected:active {"
+            "    background-color: palette(highlight);"
+            "    color: palette(highlighted-text);"
+            "}"
+            "QAbstractItemView::item:selected:!active {"
+            "    background-color: palette(highlight);"
+            "    color: palette(highlighted-text);"
+            "}"
+        ));
     }
 #if defined(INCLUDE_3DMAPPER)
     mIs3DMode = mpHost->mShow3DView;

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -91,6 +91,9 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
     connect(comboBox_showArea, qOverload<int>(&QComboBox::activated), this, &dlgMapper::slot_switchArea);
     // Explicitly set the palette to ensure proper selection colors in both light and dark themes
     comboBox_showArea->setPalette(qApp->palette());
+    if (auto* view = comboBox_showArea->view()) {
+        view->setPalette(qApp->palette());
+    }
 #if defined(INCLUDE_3DMAPPER)
     mIs3DMode = mpHost->mShow3DView;
     if (mpHost->mShow3DView) {

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -93,15 +93,15 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
     // Using QSS for reliable cross-platform behavior, especially on Windows
     // Apply only to the dropdown view to avoid affecting the combobox button itself
     if (auto* view = comboBox_showArea->view()) {
-        view->setStyleSheet(qsl(
-            "QAbstractItemView::item:selected:active {"
-            "    background-color: palette(highlight);"
-            "    color: palette(highlighted-text);"
-            "}"
-            "QAbstractItemView::item:selected:!active {"
-            "    background-color: palette(highlight);"
-            "    color: palette(highlighted-text);"
-            "}));
+        view->setStyleSheet(
+            qsl("QAbstractItemView::item:selected:active {"
+                "    background-color: palette(highlight);"
+                "    color: palette(highlighted-text);"
+                "}"
+                "QAbstractItemView::item:selected:!active {"
+                "    background-color: palette(highlight);"
+                "    color: palette(highlighted-text);"
+                "}"));
     }
 #if defined(INCLUDE_3DMAPPER)
     mIs3DMode = mpHost->mShow3DView;

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -89,6 +89,8 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
     connect(toolButton_mapperMenu, &QToolButton::clicked, this, &dlgMapper::slot_setupMapperMenu);
     connect(toolButton_togglePanel, &QAbstractButton::clicked, this, &dlgMapper::slot_togglePanel);
     connect(comboBox_showArea, qOverload<int>(&QComboBox::activated), this, &dlgMapper::slot_switchArea);
+    // Explicitly set the palette to ensure proper selection colors in both light and dark themes
+    comboBox_showArea->setPalette(qApp->palette());
 #if defined(INCLUDE_3DMAPPER)
     mIs3DMode = mpHost->mShow3DView;
     if (mpHost->mShow3DView) {

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -101,8 +101,7 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
             "QAbstractItemView::item:selected:!active {"
             "    background-color: palette(highlight);"
             "    color: palette(highlighted-text);"
-            "}"
-        ));
+            "}));
     }
 #if defined(INCLUDE_3DMAPPER)
     mIs3DMode = mpHost->mShow3DView;

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -89,19 +89,10 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
     connect(toolButton_mapperMenu, &QToolButton::clicked, this, &dlgMapper::slot_setupMapperMenu);
     connect(toolButton_togglePanel, &QAbstractButton::clicked, this, &dlgMapper::slot_togglePanel);
     connect(comboBox_showArea, qOverload<int>(&QComboBox::activated), this, &dlgMapper::slot_switchArea);
-    // Apply stylesheet to ensure proper selection colors in both light and dark themes
-    // Using QSS for reliable cross-platform behavior, especially on Windows
-    // Apply only to the dropdown view to avoid affecting the combobox button itself
+    // Explicitly set the palette to ensure proper selection colors in both light and dark themes
+    comboBox_showArea->setPalette(qApp->palette());
     if (auto* view = comboBox_showArea->view()) {
-        view->setStyleSheet(
-            qsl("QAbstractItemView::item:selected:active {"
-                "    background-color: palette(highlight);"
-                "    color: palette(highlighted-text);"
-                "}"
-                "QAbstractItemView::item:selected:!active {"
-                "    background-color: palette(highlight);"
-                "    color: palette(highlighted-text);"
-                "}"));
+        view->setPalette(qApp->palette());
     }
 #if defined(INCLUDE_3DMAPPER)
     mIs3DMode = mpHost->mShow3DView;


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes poor contrast in mapper selection lists by explicitly setting the application palette on the room selection widget and area dropdown combobox. This ensures proper highlight colors (blue background with white text) are used in both light and dark themes.

#### Motivation for adding to Mudlet

Addresses issue #8219 where selected items in the mapper's room selection list and area dropdown had very poor contrast:
- Dark mode: black text on dark grey background
- Light mode: light grey text on white background

This made it extremely difficult to identify which rooms or areas were selected.

#### Other info (issues closed, discussion etc)

Closes #8219

The fix applies the application-level palette to both widgets, ensuring they inherit the proper `QPalette::Highlight` and `QPalette::HighlightedText` colors configured by Mudlet's `DarkTheme` class and system defaults.