### PR TITLE
Fix: Copy from console now works when command line has focus

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -180,12 +180,23 @@ bool TCommandLine::event(QEvent* event)
         }
 
         if (ke->matches(QKeySequence::Copy)){ // Copy is Ctrl+C and possibly Ctrl+Ins, F16
-            if (mpConsole->mUpperPane->mSelectedRegion != QRegion(0, 0, 0, 0)) {
-                // Only process if there is a selection active in the TConsole
+            // Check for console selections in both upper and lower panes
+            // Prioritize console selection over command line text
+            const bool hasUpperPaneSelection = mpConsole->mUpperPane->mSelectedRegion != QRegion(0, 0, 0, 0);
+            const bool hasLowerPaneSelection = mpConsole->mLowerPane->mSelectedRegion != QRegion(0, 0, 0, 0);
+            
+            if (hasUpperPaneSelection) {
+                // Copy from upper pane if it has a selection
                 mpConsole->mUpperPane->slot_copySelectionToClipboard();
                 ke->accept();
                 return true;
+            } else if (hasLowerPaneSelection) {
+                // Copy from lower pane if it has a selection
+                mpConsole->mLowerPane->slot_copySelectionToClipboard();
+                ke->accept();
+                return true;
             }
+            // If no console selection, fall through to default command line copy behavior
         }
 
         if (ke->matches(QKeySequence::Find)){ // Find is Ctrl+F

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -182,8 +182,8 @@ bool TCommandLine::event(QEvent* event)
         if (ke->matches(QKeySequence::Copy)){ // Copy is Ctrl+C and possibly Ctrl+Ins, F16
             // Check for console selections in both upper and lower panes
             // Prioritize console selection over command line text
-            const bool hasUpperPaneSelection = mpConsole->mUpperPane->mSelectedRegion != QRegion(0, 0, 0, 0);
-            const bool hasLowerPaneSelection = mpConsole->mLowerPane->mSelectedRegion != QRegion(0, 0, 0, 0);
+            const bool hasUpperPaneSelection = !mpConsole->mUpperPane->mSelectedRegion.isEmpty();
+            const bool hasLowerPaneSelection = !mpConsole->mLowerPane->mSelectedRegion.isEmpty();
             
             if (hasUpperPaneSelection) {
                 // Copy from upper pane if it has a selection


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

When you select text in the main game window and press Ctrl+C (or Cmd+C on Mac), that text is now copied to the clipboard even if the command line has text or focus. Previously, the command line would take priority and prevent copying from the main window unless the command line was empty.

#### Motivation for adding to Mudlet

This has been a long-standing usability issue affecting many users. It made copying text from the game window unnecessarily difficult, as users had to clear the command line first or use the right-click menu instead of the standard keyboard shortcut.

#### Other info (issues closed, discussion etc)

Closes #7114
See also: #3891, #7008, #6758, #6505, #7147, #7124, #7070, #4956, #4540, #3922, #604, #6504