### PR TITLE
Fix: Improve performance of hyperlink style parsing

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2795,7 +2795,7 @@ void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::Hyperlin
         // First, extract and parse any base properties (properties not in pseudo-classes)
         // These are properties that come before any pseudo-class or between pseudo-classes
         QString baseProperties;
-        QRegularExpression pseudoClassRegex(R"(:([\w-]+)\s*\{([^}]*)\})");
+        static const QRegularExpression pseudoClassRegex(R"(:([\w-]+)\s*\{([^}]*)\})");
 
         // Extract base properties by removing all pseudo-class blocks
         QString remainingStyle = styleString;


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Optimizes the parsing of OSC 8 hyperlink CSS styling by caching the regular expression used to parse pseudo-class selectors. Previously, the regex was compiled fresh on every call to the function, which is computationally expensive.

#### Motivation for adding to Mudlet

When games send hyperlinks with CSS styling (using pseudo-classes like `:hover`, `:visited`, etc.), Mudlet parses these styles using a regular expression. The regex was being compiled twice per hyperlink - once for extracting base properties and once for parsing pseudo-classes. Regular expression compilation is one of the more expensive operations in text processing.

By making the regex `static const`, it's compiled once when first used and reused for all subsequent hyperlinks, reducing CPU overhead when processing styled hyperlinks.

#### Other info (issues closed, discussion etc)

- Affects `parseHyperlinkStyling()` function in TBuffer.cpp
- No functional changes, purely a performance optimization
- Particularly beneficial for games that use OSC 8 hyperlinks with complex CSS styling