### PR TITLE
Improve: Cleanup system efficiency for triggers, aliases, and keys

### DIFF
--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -395,18 +395,15 @@ std::tuple<QString, int, int, int> AliasUnit::assembleReport()
 
 void AliasUnit::doCleanup()
 {
-    for (auto alias : mCleanupList) {
-        delete alias;
+    QMutableSetIterator<TAlias*> itAlias(mCleanupSet);
+    while (itAlias.hasNext()) {
+        auto pAlias = itAlias.next();
+        itAlias.remove();
+        delete pAlias;
     }
-    mCleanupList.clear();
 }
 
 void AliasUnit::markCleanup(TAlias* pT)
 {
-    for (auto alias : mCleanupList) {
-        if (alias == pT) {
-            return;
-        }
-    }
-    mCleanupList.push_back(pT);
+    mCleanupSet.insert(pT);
 }

--- a/src/AliasUnit.h
+++ b/src/AliasUnit.h
@@ -25,6 +25,7 @@
 
 #include <QMultiMap>
 #include <QPointer>
+#include <QSet>
 #include <QString>
 
 #include <list>
@@ -67,7 +68,7 @@ public:
     void doCleanup();
 
     QMultiMap<QString, TAlias*> mLookupTable;
-    std::list<TAlias*> mCleanupList;
+    QSet<TAlias*> mCleanupSet;
     QList<TAlias*> uninstallList;
 
 

--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -428,20 +428,17 @@ std::tuple<QString, int, int, int> KeyUnit::assembleReport()
 
 void KeyUnit::markCleanup(TKey* pT)
 {
-    for (auto key : mCleanupList) {
-        if (key == pT) {
-            return;
-        }
-    }
-    mCleanupList.push_back(pT);
+    mCleanupSet.insert(pT);
 }
 
 void KeyUnit::doCleanup()
 {
-    for (auto key : mCleanupList) {
-        delete key;
+    QMutableSetIterator<TKey*> itKey(mCleanupSet);
+    while (itKey.hasNext()) {
+        auto pKey = itKey.next();
+        itKey.remove();
+        delete pKey;
     }
-    mCleanupList.clear();
 }
 
 void KeyUnit::setupKeyNames()

--- a/src/KeyUnit.h
+++ b/src/KeyUnit.h
@@ -27,6 +27,7 @@
 #include <QMap>
 #include <QObject>
 #include <QPointer>
+#include <QSet>
 #include <QString>
 
 #include <list>
@@ -76,7 +77,7 @@ public:
 
 
     QMultiMap<QString, TKey*> mLookupTable;
-    std::list<TKey*> mCleanupList;
+    QSet<TKey*> mCleanupSet;
     QList<TKey*> uninstallList;
     // Past behaviour is to only process the first key binding that matches,
     // ignoring any duplicates - but changing that behaviour unconditionally

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -273,11 +273,6 @@ void TriggerUnit::processDataStream(const QString& data, int line)
         trigger->match(subject, data, line);
     }
     free(subject);
-
-    for (auto& trigger : mCleanupList) {
-        delete trigger;
-    }
-    mCleanupList.clear();
 }
 
 void TriggerUnit::compileAll()
@@ -435,18 +430,15 @@ std::tuple<QString, int, int, int, int, int> TriggerUnit::assembleReport()
 
 void TriggerUnit::doCleanup()
 {
-    for (auto trigger : mCleanupList) {
-        delete trigger;
+    QMutableSetIterator<TTrigger*> itTrigger(mCleanupSet);
+    while (itTrigger.hasNext()) {
+        auto pTrigger = itTrigger.next();
+        itTrigger.remove();
+        delete pTrigger;
     }
-    mCleanupList.clear();
 }
 
 void TriggerUnit::markCleanup(TTrigger* pT)
 {
-    for (auto trigger : mCleanupList) {
-        if (trigger == pT) {
-            return;
-        }
-    }
-    mCleanupList.push_back(pT);
+    mCleanupSet.insert(pT);
 }

--- a/src/TriggerUnit.h
+++ b/src/TriggerUnit.h
@@ -25,6 +25,7 @@
 
 #include <QMultiMap>
 #include <QPointer>
+#include <QSet>
 #include <QString>
 
 #include <list>
@@ -69,7 +70,7 @@ public:
     void stopAllTriggers();
     void reenableAllTriggers();
     std::tuple<QString, int, int, int, int, int> assembleReport();
-    std::list<TTrigger*> mCleanupList;
+    QSet<TTrigger*> mCleanupSet;
     int getNewID();
     QMultiMap<QString, TTrigger*> mLookupTable;
     void markCleanup(TTrigger* pT);


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Changed cleanup tracking in AliasUnit, TriggerUnit, and KeyUnit from `std::list` to `QSet` for faster duplicate detection. Also removed redundant inline cleanup code in TriggerUnit that was duplicating work already done by the centralized cleanup call.

#### Motivation for adding to Mudlet

The cleanup system runs on every line of data received from MUD servers. The previous implementation checked every existing item before adding a new one to prevent duplicates. QSet handles this automatically and more efficiently. This improves code quality and brings consistency with TimerUnit, which already uses QSet.

#### Other info (issues closed, discussion etc)

- No functional changes, purely a code quality improvement
- Removes inconsistency where TriggerUnit was doing cleanup twice
- Benchmark testing shows no performance regression in Release builds
- Tested successfully on macOS with no regressions