### PR TITLE
Fix: Reduce redundant UTF-8 conversions in trigger processing

### DIFF
--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -260,13 +260,17 @@ void TriggerUnit::processDataStream(const QString& data, int line)
         return;
     }
 
+    const QByteArray utf8Data = data.toUtf8();
+    const char* utf8Ptr = utf8Data.constData();
+    const int utf8Length = utf8Data.size();
+
 #if defined(Q_OS_WINDOWS)
     // strndup(3) - a safe strdup(3) does not seem to be available in the
     // original mingw or the replacement mingw-w64 enmvironment we use:
-    char* subject = static_cast<char*>(malloc(strlen(data.toUtf8().constData()) + 1));
-    strcpy(subject, data.toUtf8().constData());
+    char* subject = static_cast<char*>(malloc(utf8Length + 1));
+    strcpy(subject, utf8Ptr);
 #else
-    char* subject = strndup(data.toUtf8().constData(), strlen(data.toUtf8().constData()));
+    char* subject = strndup(utf8Ptr, utf8Length);
 #endif
 
     for (auto trigger : mTriggerRootNodeList) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Optimized `TriggerUnit::processDataStream()` to convert the incoming data to UTF-8 once instead of twice. The conversion is now cached in a single `QByteArray` and reused for both size calculation and string duplication.

#### Motivation for adding to Mudlet

This function runs on every line of data received from MUD servers. Previously, `data.toUtf8()` was called twice per line - each call allocates a temporary QByteArray, performs the conversion, then destroys it. This was happening on both Windows (in `strlen()` and `strcpy()`) and Unix (in `strlen()` and `strndup()`). 

By converting once and reusing the result, we eliminate one redundant string conversion and memory allocation per line of MUD output, improving performance during high-volume data streams.

#### Other info (issues closed, discussion etc)

- No functional changes, purely performance optimization
- Affects the main data processing hot path
- Tested successfully on macOS with no regressions