### PR TITLE
improve - two seconds is longer than you think

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -953,7 +953,7 @@ function doNestLeave(label)
   if Geyser.Label.closeAllTimer then
     killTimer(Geyser.Label.closeAllTimer)
   end
-  Geyser.Label.closeAllTimer = tempTimer(2, function() closeAllLevels(label) end)
+  Geyser.Label.closeAllTimer = tempTimer(.5, function() closeAllLevels(label) end)
 end
 
 -- Save a reference to our parent constructor


### PR DESCRIPTION
Two seconds feels really unresponsive for right click menus to linger after moving out of frame. I used this technique as a work around to another problem. However, it's just a more prudent implementation anyway. Right clicking a menu puts you at the top left position, and technically INSIDE the right click menu. While hovering inside the menu this timer never fires. This timing makes it feel more snappy when the cursor leaves the menu.

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Modification of a menu hide timer

#### Motivation for adding to Mudlet
Lowering the timer make it feel more responsive and snappy. 

#### Other info (issues closed, discussion etc)
