### PR TITLE
Fix: heap-use-after-free when cleanup runs during alias/trigger/key processing

### DIFF
--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -251,12 +251,21 @@ bool AliasUnit::processDataStream(const QString& data)
     bool state = false;
     //Using copy fixes https://github.com/Mudlet/Mudlet/issues/4297
     auto copyOfNodeList = mAliasRootNodeList;
+
+    // Set processing flag to prevent re-entrant cleanup during alias execution
+    mIsProcessing = true;
+
     for (auto alias : copyOfNodeList) {
         // = data.replace( "\n", "" );
         if (alias->match(data)) {
             state = true;
         }
     }
+
+    // Clear processing flag and perform any deferred cleanup
+    mIsProcessing = false;
+    doCleanup();
+
     // the idea to get "command" after alias processing is finished and send its value
     // was too difficult for users because if multiple alias change the value of command it becomes too difficult to handle for many users
     // it's easier if we simply intercepts the command and hand responsibility for
@@ -395,6 +404,12 @@ std::tuple<QString, int, int, int> AliasUnit::assembleReport()
 
 void AliasUnit::doCleanup()
 {
+    // Skip cleanup if we're currently processing aliases to prevent iterator invalidation
+    // Cleanup will be performed when processDataStream() completes
+    if (mIsProcessing) {
+        return;
+    }
+
     for (auto alias : mCleanupList) {
         delete alias;
     }

--- a/src/AliasUnit.h
+++ b/src/AliasUnit.h
@@ -90,6 +90,7 @@ private:
     int statsItemsTotal = 0;
     int statsTempItems = 0;
     int statsActiveItems = 0;
+    bool mIsProcessing = false;
 };
 
 #endif // MUDLET_ALIASUNIT_H

--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -93,6 +93,10 @@ void KeyUnit::uninstall(const QString& packageName)
 bool KeyUnit::processDataStream(const Qt::Key key, const Qt::KeyboardModifiers modifiers)
 {
     bool isMatchFound = false;
+
+    // Set processing flag to prevent re-entrant cleanup during key execution
+    mIsProcessing = true;
+
     for (auto keyObject : mKeyRootNodeList) {
         // Skip null or invalid key objects during profile closing/destruction
         // Skip null or invalid key objects during profile closing/destruction
@@ -102,11 +106,18 @@ bool KeyUnit::processDataStream(const Qt::Key key, const Qt::KeyboardModifiers m
 
         if (keyObject->match(key, modifiers, mRunAllKeyMatches)) {
             if (!mRunAllKeyMatches) {
+                // Clear processing flag and perform any deferred cleanup before returning
+                mIsProcessing = false;
+                doCleanup();
                 return true;
             }
             isMatchFound = true;
         }
     }
+
+    // Clear processing flag and perform any deferred cleanup
+    mIsProcessing = false;
+    doCleanup();
 
     return isMatchFound;
 }
@@ -438,6 +449,12 @@ void KeyUnit::markCleanup(TKey* pT)
 
 void KeyUnit::doCleanup()
 {
+    // Skip cleanup if we're currently processing keys to prevent iterator invalidation
+    // Cleanup will be performed when processDataStream() completes
+    if (mIsProcessing) {
+        return;
+    }
+
     for (auto key : mCleanupList) {
         delete key;
     }

--- a/src/KeyUnit.h
+++ b/src/KeyUnit.h
@@ -105,6 +105,7 @@ private:
     int statsItemsTotal = 0;
     int statsTempItems = 0;
     int statsActiveItems = 0;
+    bool mIsProcessing = false;
 };
 
 #endif // MUDLET_KEYUNIT_H

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -269,11 +269,16 @@ void TriggerUnit::processDataStream(const QString& data, int line)
     char* subject = strndup(data.toUtf8().constData(), strlen(data.toUtf8().constData()));
 #endif
 
+    // Set processing flag to prevent re-entrant cleanup during trigger execution
+    mIsProcessing = true;
+
     for (auto trigger : mTriggerRootNodeList) {
         trigger->match(subject, data, line);
     }
     free(subject);
 
+    // Clear processing flag and perform cleanup
+    mIsProcessing = false;
     for (auto& trigger : mCleanupList) {
         delete trigger;
     }
@@ -435,6 +440,12 @@ std::tuple<QString, int, int, int, int, int> TriggerUnit::assembleReport()
 
 void TriggerUnit::doCleanup()
 {
+    // Skip cleanup if we're currently processing triggers to prevent iterator invalidation
+    // Cleanup will be performed when processDataStream() completes
+    if (mIsProcessing) {
+        return;
+    }
+
     for (auto trigger : mCleanupList) {
         delete trigger;
     }

--- a/src/TriggerUnit.h
+++ b/src/TriggerUnit.h
@@ -98,6 +98,7 @@ private:
     int statsActiveItems = 0;
     int statsPatternsTotal = 0;
     int statsPatternsActive = 0;
+    bool mIsProcessing = false;
 };
 
 #endif // MUDLET_TRIGGERUNIT_H


### PR DESCRIPTION

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix: heap-use-after-free when cleanup runs during alias/trigger/key processing
#### Motivation for adding to Mudlet
Fixes crash when running https://github.com/Mudlet/Mudlet/pull/8559#issuecomment-3564150911 benchmark on Linux.
#### Other info (issues closed, discussion etc)
==617553==ERROR: AddressSanitizer: heap-use-after-free on address 0x51200086e6d0 at pc 0x589b650367f6 bp 0x7ffc44dbc700 sp 0x7ffc44dbc6f8
READ of size 8 at 0x51200086e6d0 thread T0
    #0 0x589b650367f5 in Tree<TAlias>::isActive() const (/home/vadi/Programs/Mudlet/build/src/mudlet+0xe8a7f5) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #1 0x589b65d81408 in TAlias::match(QString const&) (/home/vadi/Programs/Mudlet/build/src/mudlet+0x1bd5408) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #2 0x589b6560c156 in AliasUnit::processDataStream(QString const&) (/home/vadi/Programs/Mudlet/build/src/mudlet+0x1460156) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #3 0x589b65c872b4 in Host::send(QString, bool, bool) (/home/vadi/Programs/Mudlet/build/src/mudlet+0x1adb2b4) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #4 0x589b65d96517 in TCommandLine::enterCommand(QKeyEvent*) (/home/vadi/Programs/Mudlet/build/src/mudlet+0x1bea517) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #5 0x589b65d93095 in TCommandLine::event(QEvent*) (/home/vadi/Programs/Mudlet/build/src/mudlet+0x1be7095) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #6 0x7ac668391c8a in QApplicationPrivate::notify_helper(QObject*, QEvent*) /home/qt/work/qt/qtbase/src/widgets/kernel/qapplication.cpp:3307:31
    #7 0x7ac66839b2f0 in QApplication::notify(QObject*, QEvent*) /home/qt/work/qt/qtbase/src/widgets/kernel/qapplication.cpp:2725:39
    #8 0x7ac668b83f7f in QCoreApplication::notifyInternal2(QObject*, QEvent*) /home/qt/work/qt/qtbase/src/corelib/kernel/qcoreapplication.cpp:1109:24
    #9 0x7ac66840cc0b in QWidgetWindow::event(QEvent*) /home/qt/work/qt/qtbase/src/widgets/kernel/qwidgetwindow.cpp:285:23
    #10 0x7ac668391c8a in QApplicationPrivate::notify_helper(QObject*, QEvent*) /home/qt/work/qt/qtbase/src/widgets/kernel/qapplication.cpp:3307:31
    #11 0x7ac668b83f7f in QCoreApplication::notifyInternal2(QObject*, QEvent*) /home/qt/work/qt/qtbase/src/corelib/kernel/qcoreapplication.cpp:1109:24
    #12 0x7ac6677ee8e2 in QGuiApplicationPrivate::processKeyEvent(QWindowSystemInterfacePrivate::KeyEvent*) /home/qt/work/qt/qtbase/src/gui/kernel/qguiapplication.cpp:2609:46
    #13 0x7ac655cf9a04 in QIBusPlatformInputContext::filterEventFinished(QDBusPendingCallWatcher*) /home/qt/work/qt/qtbase/src/plugins/platforminputcontexts/ibus/qibusplatforminputcontext.cpp:523:57
    #14 0x7ac668be8b74 in QtPrivate::QSlotObjectBase::call(QObject*, void**) /home/qt/work/qt/qtbase/src/corelib/kernel/qobjectdefs_impl.h:461:57
    #15 0x7ac668be8b74 in void doActivate<false>(QObject*, int, void**) /home/qt/work/qt/qtbase/src/corelib/kernel/qobject.cpp:4255:30
    #16 0x7ac6671e5142 in void QMetaObject::activate<void, QDBusPendingCallWatcher*>(QObject*, QMetaObject const*, int, void*, QDBusPendingCallWatcher* const&) /home/qt/work/qt/qtbase/src/corelib/kernel/qobjectdefs.h:319:17
    #17 0x7ac6671e5142 in QDBusPendingCallWatcher::finished(QDBusPendingCallWatcher*) /home/qt/work/qt/qtbase_build/src/dbus/DBus_autogen/include/moc_qdbuspendingcall.cpp:137:32
    #18 0x7ac668bdd56b in QObject::event(QEvent*) /home/qt/work/qt/qtbase/src/corelib/kernel/qobject.cpp:1411:31
    #19 0x7ac668391c8a in QApplicationPrivate::notify_helper(QObject*, QEvent*) /home/qt/work/qt/qtbase/src/widgets/kernel/qapplication.cpp:3307:31
    #20 0x7ac668b83f7f in QCoreApplication::notifyInternal2(QObject*, QEvent*) /home/qt/work/qt/qtbase/src/corelib/kernel/qcoreapplication.cpp:1109:24
    #21 0x7ac668b879e4 in QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) /home/qt/work/qt/qtbase/src/corelib/kernel/qcoreapplication.cpp:1904:36
    #22 0x7ac668e7d416 in postEventSourceDispatch /home/qt/work/qt/qtbase/src/corelib/kernel/qeventdispatcher_glib.cpp:246:39
    #23 0x7ac6667145c4  (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x5d5c4) (BuildId: 1eb6131419edb83b2178b682829a6913cf682d75)
    #24 0x7ac666773736  (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0xbc736) (BuildId: 1eb6131419edb83b2178b682829a6913cf682d75)
    #25 0x7ac666713a62 in g_main_context_iteration (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x5ca62) (BuildId: 1eb6131419edb83b2178b682829a6913cf682d75)
    #26 0x7ac668e7caad in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) /home/qt/work/qt/qtbase/src/corelib/kernel/qeventdispatcher_glib.cpp:399:43
    #27 0x7ac668b9002a in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) /home/qt/work/qt/qtbase/src/corelib/kernel/qeventloop.cpp:186:22
    #28 0x7ac668b8ba59 in QCoreApplication::exec() /home/qt/work/qt/qtbase/src/corelib/kernel/qcoreapplication.cpp:1452:36
    #29 0x589b64ab0675 in main (/home/vadi/Programs/Mudlet/build/src/mudlet+0x904675) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #30 0x7ac66602a1c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #31 0x7ac66602a28a in __libc_start_main csu/../csu/libc-start.c:360:3
    #32 0x589b649c1d04 in _start (/home/vadi/Programs/Mudlet/build/src/mudlet+0x815d04) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)

0x51200086e6d0 is located 16 bytes inside of 296-byte region [0x51200086e6c0,0x51200086e7e8)
freed by thread T0 here:
    #0 0x589b64a9b9f1 in operator delete(void*) (/home/vadi/Programs/Mudlet/build/src/mudlet+0x8ef9f1) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #1 0x589b65d80711 in TAlias::~TAlias() (/home/vadi/Programs/Mudlet/build/src/mudlet+0x1bd4711) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #2 0x589b6560eefc in AliasUnit::doCleanup() (/home/vadi/Programs/Mudlet/build/src/mudlet+0x1462efc) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #3 0x589b65c8e88d in Host::incomingStreamProcessor(QString const&, int) (/home/vadi/Programs/Mudlet/build/src/mudlet+0x1ae288d) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #4 0x589b651b73b5 in TMainConsole::runTriggers(int) (/home/vadi/Programs/Mudlet/build/src/mudlet+0x100b3b5) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #5 0x589b64e39c4b in TBuffer::commitLine(char, unsigned long&) (/home/vadi/Programs/Mudlet/build/src/mudlet+0xc8dc4b) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #6 0x589b64e28d4e in TBuffer::translateToPlainText(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>&, bool) (/home/vadi/Programs/Mudlet/build/src/mudlet+0xc7cd4e) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #7 0x589b651b638d in TMainConsole::printOnDisplay(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>&, bool) (/home/vadi/Programs/Mudlet/build/src/mudlet+0x100a38d) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #8 0x589b64f9ed5b in TLuaInterpreter::feedTriggers(lua_State*) (/home/vadi/Programs/Mudlet/build/src/mudlet+0xdf2d5b) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #9 0x7ac66942ffa0 in luaD_precall /build/lua5.1-rMDsVj/lua5.1-5.1.5/src/ldo.c:320:10
    #10 0x7ac66943ad7a in luaV_execute /build/lua5.1-rMDsVj/lua5.1-5.1.5/src/lvm.c:591:17
    #11 0x7ac66942e96c in luaD_call /build/lua5.1-rMDsVj/lua5.1-5.1.5/src/ldo.c:378:5
    #12 0x7ac66942af70 in luaD_rawrunprotected /build/lua5.1-rMDsVj/lua5.1-5.1.5/src/ldo.c:116:3
    #13 0x7ac66942bb94 in luaD_pcall /build/lua5.1-rMDsVj/lua5.1-5.1.5/src/ldo.c:464:12
    #14 0x7ac66942bce0 in lua_pcall /build/lua5.1-rMDsVj/lua5.1-5.1.5/src/lapi.c:821:12
    #15 0x589b64fd65f1 in TLuaInterpreter::call(QString const&, QString const&, bool) (/home/vadi/Programs/Mudlet/build/src/mudlet+0xe2a5f1) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #16 0x589b65d84d31 in TAlias::execute() (/home/vadi/Programs/Mudlet/build/src/mudlet+0x1bd8d31) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #17 0x589b65d84577 in TAlias::match(QString const&) (/home/vadi/Programs/Mudlet/build/src/mudlet+0x1bd8577) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #18 0x589b6560c156 in AliasUnit::processDataStream(QString const&) (/home/vadi/Programs/Mudlet/build/src/mudlet+0x1460156) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #19 0x589b65c872b4 in Host::send(QString, bool, bool) (/home/vadi/Programs/Mudlet/build/src/mudlet+0x1adb2b4) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #20 0x589b65d96517 in TCommandLine::enterCommand(QKeyEvent*) (/home/vadi/Programs/Mudlet/build/src/mudlet+0x1bea517) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #21 0x589b65d93095 in TCommandLine::event(QEvent*) (/home/vadi/Programs/Mudlet/build/src/mudlet+0x1be7095) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #22 0x7ac668391c8a in QApplicationPrivate::notify_helper(QObject*, QEvent*) /home/qt/work/qt/qtbase/src/widgets/kernel/qapplication.cpp:3307:31

previously allocated by thread T0 here:
    #0 0x589b64a9b171 in operator new(unsigned long) (/home/vadi/Programs/Mudlet/build/src/mudlet+0x8ef171) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #1 0x589b6500f595 in TLuaInterpreter::startTempAlias(QString const&, QString const&) (/home/vadi/Programs/Mudlet/build/src/mudlet+0xe63595) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #2 0x589b6512c41d in TLuaInterpreter::tempAlias(lua_State*) (/home/vadi/Programs/Mudlet/build/src/mudlet+0xf8041d) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #3 0x7ac66942ffa0 in luaD_precall /build/lua5.1-rMDsVj/lua5.1-5.1.5/src/ldo.c:320:10
    #4 0x7ac66943ad7a in luaV_execute /build/lua5.1-rMDsVj/lua5.1-5.1.5/src/lvm.c:591:17
    #5 0x7ac66942e96c in luaD_call /build/lua5.1-rMDsVj/lua5.1-5.1.5/src/ldo.c:378:5
    #6 0x7ac66942af70 in luaD_rawrunprotected /build/lua5.1-rMDsVj/lua5.1-5.1.5/src/ldo.c:116:3
    #7 0x7ac66942bb94 in luaD_pcall /build/lua5.1-rMDsVj/lua5.1-5.1.5/src/ldo.c:464:12
    #8 0x7ac66942bce0 in lua_pcall /build/lua5.1-rMDsVj/lua5.1-5.1.5/src/lapi.c:821:12
    #9 0x589b64fd65f1 in TLuaInterpreter::call(QString const&, QString const&, bool) (/home/vadi/Programs/Mudlet/build/src/mudlet+0xe2a5f1) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #10 0x589b65d84d31 in TAlias::execute() (/home/vadi/Programs/Mudlet/build/src/mudlet+0x1bd8d31) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #11 0x589b65d84577 in TAlias::match(QString const&) (/home/vadi/Programs/Mudlet/build/src/mudlet+0x1bd8577) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #12 0x589b6560c156 in AliasUnit::processDataStream(QString const&) (/home/vadi/Programs/Mudlet/build/src/mudlet+0x1460156) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #13 0x589b65c872b4 in Host::send(QString, bool, bool) (/home/vadi/Programs/Mudlet/build/src/mudlet+0x1adb2b4) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #14 0x589b65d96517 in TCommandLine::enterCommand(QKeyEvent*) (/home/vadi/Programs/Mudlet/build/src/mudlet+0x1bea517) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #15 0x589b65d93095 in TCommandLine::event(QEvent*) (/home/vadi/Programs/Mudlet/build/src/mudlet+0x1be7095) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4)
    #16 0x7ac668391c8a in QApplicationPrivate::notify_helper(QObject*, QEvent*) /home/qt/work/qt/qtbase/src/widgets/kernel/qapplication.cpp:3307:31

SUMMARY: AddressSanitizer: heap-use-after-free (/home/vadi/Programs/Mudlet/build/src/mudlet+0xe8a7f5) (BuildId: c98a5e4208b6daa52aa1b083c4ee6c4ab4552cc4) in Tree<TAlias>::isActive() const
Shadow bytes around the buggy address:
  0x51200086e400: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x51200086e480: fd fd fd fd fd fd fd fd fd fd fd fd fd fa fa fa
  0x51200086e500: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x51200086e580: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x51200086e600: fd fd fd fd fd fd fd fd fd fd fd fd fd fa fa fa
=>0x51200086e680: fa fa fa fa fa fa fa fa fd fd[fd]fd fd fd fd fd
  0x51200086e700: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x51200086e780: fd fd fd fd fd fd fd fd fd fd fd fd fd fa fa fa
  0x51200086e800: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x51200086e880: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x51200086e900: fd fd fd fd fd fd fd fd fd fd fd fd fd fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==617553==ABORTING
