### PR TITLE
Add: functional GUI tests using QTest

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -64,6 +64,10 @@ jobs:
         GITHUB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: $GITHUB_WORKSPACE/CI/build-mudlet-for-windows.sh
 
+    - name: (Windows) Run QTest
+      shell: msys2 {0}
+      run: ctest --test-dir $GITHUB_WORKSPACE/build-$MSYSTEM/release --output-on-failure
+
     - name: (Windows) Run Lua tests
       timeout-minutes: 5
       shell: msys2 {0}

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -66,7 +66,15 @@ jobs:
 
     - name: (Windows) Run QTest
       shell: msys2 {0}
-      run: ctest --test-dir $GITHUB_WORKSPACE/build-$MSYSTEM/release --output-on-failure
+      run: |
+        LUA_PATH=$(cygpath -u "$(luarocks --lua-version 5.1 path --lr-path)" )
+        export LUA_PATH
+        LUA_CPATH=$(cygpath -u "$(luarocks --lua-version 5.1 path --lr-cpath)" )
+        export LUA_CPATH
+
+        ctest --test-dir $GITHUB_WORKSPACE/build-$MSYSTEM/test --output-on-failure
+      env:
+        QT_FORCE_STDERR_LOGGING: 1
 
     - name: (Windows) Run Lua tests
       timeout-minutes: 5

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -255,6 +255,9 @@ jobs:
       working-directory: '${{runner.workspace}}/b/ninja'
       run: ctest --output-on-failure
 
+    - name: Run QTest
+      run: ctest --test-dir ${{runner.workspace}}/b/ninja -L functional --output-on-failure
+
     - name: install dependencies for packaging/tests
       if: matrix.deploy == 'deploy' || matrix.run_tests == 'true'
       run: |

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -257,6 +257,8 @@ jobs:
 
     - name: Run QTest
       run: ctest --test-dir ${{runner.workspace}}/b/ninja -L functional --output-on-failure
+      env:
+        QT_FORCE_STDERR_LOGGING: 1
 
     - name: install dependencies for packaging/tests
       if: matrix.deploy == 'deploy' || matrix.run_tests == 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,8 @@ file(WRITE ${CMAKE_SOURCE_DIR}/src/app-build.txt "${BUILD_VALUE}")
 message(STATUS "Value written to app-build.txt file: ${BUILD_VALUE}")
 set(APP_BUILD ${BUILD_VALUE} CACHE STRING "Auto-set during CMake run. Do not alter manually." FORCE)
 
+set(LIB_MUDLET_TARGET "mudlet_core")
+
 # For release builds, comment out the above and uncomment below:
 # file(WRITE ${CMAKE_SOURCE_DIR}/src/app-build.txt " ")
 # message(STATUS "Value written to app-build.txt file: {nothing}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,7 +22,6 @@
 #    59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
 ############################################################################
 
-set(LIB_MUDLET_TARGET "mudlet_core")
 set(EXE_MUDLET_NAME "mudlet")
 set(EXE_MUDLET_TARGET "mudlet_executable")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -450,12 +450,6 @@ if(NOT "${USE_ALTERNATE_LINKER}" STREQUAL "")
   set_alternate_linker(${USE_ALTERNATE_LINKER})
 endif()
 
-if(NOT WIN32)
-  include(cmake/EnableSanitizers.cmake)
-else()
-  message(STATUS "Sanitizers disabled on Windows")
-endif()
-
 find_package(Qt6 6.4.0 REQUIRED
     COMPONENTS Core
                Multimedia
@@ -686,6 +680,12 @@ if(USE_VARIABLE_SPLASH_SCREEN)
 endif()
 
 target_compile_options(${LIB_MUDLET_TARGET} PUBLIC -Wno-deprecated)
+
+if(NOT WIN32)
+  include(cmake/EnableSanitizers.cmake)
+else()
+  message(STATUS "Sanitizers disabled on Windows")
+endif()
 
 add_executable(${EXE_MUDLET_TARGET} emptyFile.cpp)
 set_target_properties(${EXE_MUDLET_TARGET} PROPERTIES OUTPUT_NAME ${EXE_MUDLET_NAME})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -450,6 +450,12 @@ if(NOT "${USE_ALTERNATE_LINKER}" STREQUAL "")
   set_alternate_linker(${USE_ALTERNATE_LINKER})
 endif()
 
+if(NOT WIN32)
+  include(cmake/EnableSanitizers.cmake)
+else()
+  message(STATUS "Sanitizers disabled on Windows")
+endif()
+
 find_package(Qt6 6.4.0 REQUIRED
     COMPONENTS Core
                Multimedia
@@ -680,12 +686,6 @@ if(USE_VARIABLE_SPLASH_SCREEN)
 endif()
 
 target_compile_options(${LIB_MUDLET_TARGET} PUBLIC -Wno-deprecated)
-
-if(NOT WIN32)
-  include(cmake/EnableSanitizers.cmake)
-else()
-  message(STATUS "Sanitizers disabled on Windows")
-endif()
 
 add_executable(${EXE_MUDLET_TARGET} emptyFile.cpp)
 set_target_properties(${EXE_MUDLET_TARGET} PROPERTIES OUTPUT_NAME ${EXE_MUDLET_NAME})

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -323,7 +323,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
     }
 
     if (mudlet::self()->smFirstLaunch) {
-        QTimer::singleShot(0, this, [this]() { 
+        QTimer::singleShot(0, this, [this]() {
             if (mpConsole) {
                 mpConsole->mpCommandLine->setPlaceholderText(tr("Text to send to the game"));
             }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -323,7 +323,11 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
     }
 
     if (mudlet::self()->smFirstLaunch) {
-        QTimer::singleShot(0, this, [this]() { mpConsole->mpCommandLine->setPlaceholderText(tr("Text to send to the game")); });
+        QTimer::singleShot(0, this, [this]() { 
+            if (mpConsole) {
+                mpConsole->mpCommandLine->setPlaceholderText(tr("Text to send to the game"));
+            }
+        });
     }
 
     connect(&mTelnet, &cTelnet::signal_disconnected, this, [this]() {

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -83,9 +83,11 @@ TMainConsole::~TMainConsole()
     if (mpHunspell_profile) {
         Hunspell_destroy(mpHunspell_profile);
         mpHunspell_profile = nullptr;
-        // Need to commit any changes to personal dictionary
-        qDebug() << "TCommandLine::~TConsole(...) INFO - Saving profile's own Hunspell dictionary...";
-        mudlet::self()->saveDictionary(mudlet::self()->getMudletPath(enums::profileDataItemPath, mProfileName, qsl("profile")), mWordSet_profile);
+        if (mudlet::self()) {
+            // Need to commit any changes to personal dictionary
+            qDebug() << "TCommandLine::~TConsole(...) INFO - Saving profile's own Hunspell dictionary...";
+            mudlet::self()->saveDictionary(mudlet::self()->getMudletPath(enums::profileDataItemPath, mProfileName, qsl("profile")), mWordSet_profile);
+        }
     }
 }
 
@@ -411,7 +413,7 @@ void TMainConsole::luaWrapLine(QString& buf, int line)
     }
 }
 
-QString TMainConsole::getCurrentLine(std::string& buf)
+QString TMainConsole::getCurrentLine(const std::string& buf)
 {
     const QString key = buf.c_str();
     if (key.isEmpty() || key == QLatin1String("main")) {

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -61,7 +61,7 @@ public:
     std::list<int> getBgColor(QString& buf);
     QPair<quint8, TChar> getTextAttributes(const QString&) const;
     void luaWrapLine(QString& buf, int line);
-    QString getCurrentLine(std::string&);
+    QString getCurrentLine(const std::string&);
     TConsole* createBuffer(const QString& name);
     std::pair<bool, QString> setUserWindowStyleSheet(const QString& name, const QString& userWindowStyleSheet);
     std::pair<bool, QString> setUserWindowTitle(const QString& name, const QString& text);

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -315,6 +315,9 @@ void TTextEdit::showNewLines()
         // content has been deleted
         if (previousOldScrollPos > mOldScrollPos) {
             QAccessibleTextInterface* ti = QAccessible::queryAccessibleInterface(this)->textInterface();
+            if (!ti) {
+                return;
+            }
             auto totalCharacterCount = ti->characterCount();
             ti->setCursorPosition(totalCharacterCount);
             QAccessibleTextRemoveEvent event(this, totalCharacterCount, QString());

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4417,6 +4417,7 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
     event.mArgumentTypeList.append(ARGUMENT_TYPE_BOOLEAN);
     pHost->raiseEvent(event);
     pHost->mIsProfileLoadingSequence = false;
+    emit signal_profileLoaded();
 }
 
 void mudlet::installModulesList(Host* pHost, QStringList modules)

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -555,7 +555,7 @@ signals:
     void signal_aiStatusChanged(bool running);
     void signal_aiModelChanged(const QString& modelPath);
     void signal_showTabConnectionIndicatorsChanged(bool);
-
+    void signal_profileLoaded();
 
 private slots:
     void slot_assignShortcutsFromProfile(Host* pHost = nullptr);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -118,3 +118,5 @@ if(USE_OWN_QTKEYCHAIN)
     target_compile_definitions(CredentialManagerTest PRIVATE INCLUDE_OWN_QT6_KEYCHAIN QTKEYCHAIN_NO_EXPORT)
 endif()
 add_test(NAME CredentialManagerTest COMMAND CredentialManagerTest)
+
+add_subdirectory(functional_tests)

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -1,4 +1,6 @@
-include(${CMAKE_SOURCE_DIR}/src/cmake/EnableSanitizers.cmake)
+if(NOT WIN32)
+    include(${CMAKE_SOURCE_DIR}/src/cmake/EnableSanitizers.cmake)
+endif()
 
 set(FUNCTIONAL_TEST_SOURCES
     TelnetTextDisplayedTest.cpp

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(${CMAKE_SOURCE_DIR}/src/cmake/EnableSanitizers.cmake)
+
 set(FUNCTIONAL_TEST_SOURCES
     TelnetTextDisplayedTest.cpp
 )
@@ -14,7 +16,7 @@ foreach(test_file ${FUNCTIONAL_TEST_SOURCES})
     set_target_properties(${test_name} PROPERTIES ENABLE_EXPORTS ON)
     add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
     set_tests_properties(${test_name} PROPERTIES
-        ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen;ASAN_OPTIONS=detect_leaks=0"
         LABELS "functional"
         TIMEOUT 60  # seconds
     )

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -13,12 +13,9 @@ foreach(test_file ${FUNCTIONAL_TEST_SOURCES})
     target_link_libraries(${test_name} PRIVATE Qt6::Test ${LIB_MUDLET_TARGET})
     set_target_properties(${test_name} PROPERTIES ENABLE_EXPORTS ON)
     add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
-    
-    # By default, tests run in offscreen mode to avoid opening windows.
-    # If you want to actually see the GUI during the test, you can comment out
-    # the QT_QPA_PLATFORM=offscreen line below.
     set_tests_properties(${test_name} PROPERTIES
         ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
         LABELS "functional"
+        TIMEOUT 60  # seconds
     )
 endforeach()

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -6,7 +6,6 @@ set(FUNCTIONAL_TEST_UTILS
     TelnetServerStub.cpp
 )
 
-
 foreach(test_file ${FUNCTIONAL_TEST_SOURCES})
     get_filename_component(test_name ${test_file} NAME_WE)
     add_executable(${test_name} ${test_file} ${FUNCTIONAL_TEST_UTILS})

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -1,0 +1,25 @@
+set(FUNCTIONAL_TEST_SOURCES
+    TelnetTextDisplayedTest.cpp
+)
+
+set(FUNCTIONAL_TEST_UTILS
+    TelnetServerStub.cpp
+)
+
+
+foreach(test_file ${FUNCTIONAL_TEST_SOURCES})
+    get_filename_component(test_name ${test_file} NAME_WE)
+    add_executable(${test_name} ${test_file} ${FUNCTIONAL_TEST_UTILS})
+    add_dependencies(${test_name} ${LIB_MUDLET_TARGET})
+    target_link_libraries(${test_name} PRIVATE Qt6::Test ${LIB_MUDLET_TARGET})
+    set_target_properties(${test_name} PROPERTIES ENABLE_EXPORTS ON)
+    add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
+    
+    # By default, tests run in offscreen mode to avoid opening windows.
+    # If you want to actually see the GUI during the test, you can comment out
+    # the QT_QPA_PLATFORM=offscreen line below.
+    set_tests_properties(${test_name} PROPERTIES
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+        LABELS "functional"
+    )
+endforeach()

--- a/test/functional_tests/TelnetServerStub.cpp
+++ b/test/functional_tests/TelnetServerStub.cpp
@@ -22,7 +22,9 @@
 #include <QTimer>
 #include <QHostAddress>
 #include <QDebug>
+
 #include "TelnetServerStub.h"
+#include "utils.h"
 
 TelnetServerStub::TelnetServerStub(QObject* parent)
     : QTcpServer(parent)
@@ -33,11 +35,9 @@ TelnetServerStub::TelnetServerStub(QObject* parent)
 void TelnetServerStub::start(const QString& host, quint16 port)
 {
     if (listen(QHostAddress(host), port)) {
-        qInfo().noquote()
-            << QStringLiteral("✅ TelnetServerStub listening on %1:%2").arg(host).arg(port);
+        qInfo().noquote() << qsl("✅ TelnetServerStub listening on %1:%2").arg(host).arg(port);
     } else {
-        qCritical().noquote()
-            << QStringLiteral("❌ Failed to start TelnetServerStub: %1").arg(errorString());
+        qCritical().noquote() << qsl("❌ Failed to start TelnetServerStub: %1").arg(errorString());
     }
 }
 
@@ -49,8 +49,7 @@ void TelnetServerStub::onNewConnection()
         qWarning() << "⚠️ onNewConnection called but no pending connection.";
         return;
     }
-    qInfo().noquote() << QStringLiteral("🔌 Client connected: %1")
-                         .arg(client->peerAddress().toString());
+    qInfo().noquote() << qsl("🔌 Client connected: %1").arg(client->peerAddress().toString());
 
     QPointer<QTcpSocket> safeClient = client;
 
@@ -62,7 +61,7 @@ void TelnetServerStub::onNewConnection()
         const auto bytesWritten = safeClient->write(welcomeMessage.toUtf8() + "\r\n");
         safeClient->flush();
         if (bytesWritten <= 0) {
-            qWarning().noquote() << QStringLiteral("⚠️ Failed to send welcome message to %1")
+            qWarning().noquote() << qsl("⚠️ Failed to send welcome message to %1")
                                     .arg(safeClient->peerAddress().toString());
         }
     });
@@ -72,8 +71,7 @@ void TelnetServerStub::onNewConnection()
         if (!safeClient) {
             return;
         }
-        qInfo().noquote() << QStringLiteral("Client disconnected: %1")
-                             .arg(safeClient->peerAddress().toString());
+        qInfo().noquote() << qsl("Client disconnected: %1").arg(safeClient->peerAddress().toString());
         safeClient->deleteLater();
     });
 }

--- a/test/functional_tests/TelnetServerStub.cpp
+++ b/test/functional_tests/TelnetServerStub.cpp
@@ -1,0 +1,79 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by Nicolas Keita - nicolaskeita2@@gmail.com        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QPointer>
+#include <QTcpSocket>
+#include <QTimer>
+#include <QHostAddress>
+#include <QDebug>
+#include "TelnetServerStub.h"
+
+TelnetServerStub::TelnetServerStub(QObject* parent)
+    : QTcpServer(parent)
+{
+    connect(this, &QTcpServer::newConnection, this, &TelnetServerStub::onNewConnection);
+}
+
+void TelnetServerStub::start(const QString& host, quint16 port)
+{
+    if (listen(QHostAddress(host), port)) {
+        qInfo().noquote()
+            << QStringLiteral("✅ TelnetServerStub listening on %1:%2").arg(host).arg(port);
+    } else {
+        qCritical().noquote()
+            << QStringLiteral("❌ Failed to start TelnetServerStub: %1").arg(errorString());
+    }
+}
+
+void TelnetServerStub::onNewConnection()
+{
+    QTcpSocket*             client = nextPendingConnection();
+
+    if (!client) {
+        qWarning() << "⚠️ onNewConnection called but no pending connection.";
+        return;
+    }
+    qInfo().noquote() << QStringLiteral("🔌 Client connected: %1")
+                         .arg(client->peerAddress().toString());
+
+    QPointer<QTcpSocket>    safeClient = client;
+
+    QTimer::singleShot(100, [safeClient, welcomeMessage = mpWelcomeMessage]()
+    {
+        if (!safeClient) {
+            return;
+        }
+        const auto bytesWritten = safeClient->write(welcomeMessage.toUtf8() + "\r\n");
+        safeClient->flush();
+        if (bytesWritten <= 0) {
+            qWarning().noquote() << QStringLiteral("⚠️ Failed to send welcome message to %1")
+                                    .arg(safeClient->peerAddress().toString());
+        }
+    });
+
+    connect(client, &QTcpSocket::disconnected, [safeClient]()
+    {
+        if (!safeClient) {
+            return;
+        }
+        qInfo().noquote() << QStringLiteral("Client disconnected: %1")
+                             .arg(safeClient->peerAddress().toString());
+        safeClient->deleteLater();
+    });
+}

--- a/test/functional_tests/TelnetServerStub.cpp
+++ b/test/functional_tests/TelnetServerStub.cpp
@@ -43,7 +43,7 @@ void TelnetServerStub::start(const QString& host, quint16 port)
 
 void TelnetServerStub::onNewConnection()
 {
-    QTcpSocket*             client = nextPendingConnection();
+    QTcpSocket* client = nextPendingConnection();
 
     if (!client) {
         qWarning() << "⚠️ onNewConnection called but no pending connection.";
@@ -52,7 +52,7 @@ void TelnetServerStub::onNewConnection()
     qInfo().noquote() << QStringLiteral("🔌 Client connected: %1")
                          .arg(client->peerAddress().toString());
 
-    QPointer<QTcpSocket>    safeClient = client;
+    QPointer<QTcpSocket> safeClient = client;
 
     QTimer::singleShot(100, [safeClient, welcomeMessage = mpWelcomeMessage]()
     {

--- a/test/functional_tests/TelnetServerStub.cpp
+++ b/test/functional_tests/TelnetServerStub.cpp
@@ -22,6 +22,7 @@
 #include <QTimer>
 #include <QHostAddress>
 #include <QDebug>
+#include <QHostInfo>
 
 #include "TelnetServerStub.h"
 #include "utils.h"
@@ -34,10 +35,20 @@ TelnetServerStub::TelnetServerStub(QObject* parent)
 
 void TelnetServerStub::start(const QString& host, quint16 port)
 {
-    if (listen(QHostAddress(host), port)) {
-        qInfo().noquote() << qsl("✅ TelnetServerStub listening on %1:%2").arg(host).arg(port);
+    QHostInfo info = QHostInfo::fromName(host);
+
+    if (!info.addresses().isEmpty()) {
+        QHostAddress addr = info.addresses().first();
+        if (listen(addr, port)) {
+            qInfo().noquote() << qsl("✅ TelnetServerStub listening on %1 (%2):%3")
+                        .arg(host)
+                        .arg(addr.toString())
+                        .arg(port);
+        } else {
+            qCritical().noquote() << qsl("❌ Failed to start TelnetServerStub: %1").arg(errorString());
+        }
     } else {
-        qCritical().noquote() << qsl("❌ Failed to start TelnetServerStub: %1").arg(errorString());
+        qCritical() << "Could not resolve host:" << host;
     }
 }
 

--- a/test/functional_tests/TelnetServerStub.h
+++ b/test/functional_tests/TelnetServerStub.h
@@ -35,7 +35,7 @@ public:
     explicit TelnetServerStub(QObject* parent = nullptr);
 
     void start(const QString& host, quint16 port);
-    void setWelcomeMessage(const QString& msg) { mpWelcomeMessage = msg; }
+    void setWelcomeMessage(const QString& message) { mpWelcomeMessage = message; }
 
 private slots:
     void onNewConnection();

--- a/test/functional_tests/TelnetServerStub.h
+++ b/test/functional_tests/TelnetServerStub.h
@@ -1,0 +1,44 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by Nicolas Keita - nicolaskeita2@@gmail.com        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#ifndef TELNET_SERVER_STUB_H
+#define TELNET_SERVER_STUB_H
+
+#include <QtNetwork/QTcpServer>
+#include <QtNetwork/QTcpSocket>
+#include <QTimer>
+#include <QDebug>
+
+class TelnetServerStub : public QTcpServer
+{
+    Q_OBJECT
+
+    QString mpWelcomeMessage = "";
+
+public:
+    explicit TelnetServerStub(QObject* parent = nullptr);
+
+    void start(const QString& host, quint16 port);
+    void setWelcomeMessage(const QString& msg) { mpWelcomeMessage = msg; }
+
+private slots:
+    void onNewConnection();
+};
+
+#endif // TELNET_SERVER_STUB_H

--- a/test/functional_tests/TelnetTextDisplayedTest.cpp
+++ b/test/functional_tests/TelnetTextDisplayedTest.cpp
@@ -39,7 +39,7 @@ private:
     TelnetServerStub* mpServer = nullptr;
     const QString mpHostname = "Test-Telnet";
     const QString mpPort = "4000";
-    const QString mpLocalhost = "127.0.0.1";
+    const QString mpLocalhost = "localhost";
 
 private slots:
     void initTestCase()
@@ -103,7 +103,12 @@ private slots:
         if (!spy.wait(1000)) {
             QFAIL("Profile took too long to load.");
         }
-        QSignalSpy spy2(&(mudlet::self()->getActiveHost()->mTelnet), &cTelnet::signal_connected);
+        auto host = mudlet::self()->getActiveHost();
+        if (!host) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
         if (!spy2.wait(500)) {
             QFAIL("Could not connect with the host.");
         }

--- a/test/functional_tests/TelnetTextDisplayedTest.cpp
+++ b/test/functional_tests/TelnetTextDisplayedTest.cpp
@@ -103,7 +103,6 @@ private slots:
         if (!spy.wait(1000)) {
             QFAIL("Profile took too long to load.");
         }
-
         QSignalSpy spy2(&(mudlet::self()->getActiveHost()->mTelnet), &cTelnet::signal_connected);
         if (!spy2.wait(500)) {
             QFAIL("Could not connect with the host.");

--- a/test/functional_tests/TelnetTextDisplayedTest.cpp
+++ b/test/functional_tests/TelnetTextDisplayedTest.cpp
@@ -41,7 +41,6 @@ private:
     const QString mpPort = "4000";
     const QString mpLocalhost = "127.0.0.1";
 
-
 private slots:
     void initTestCase()
     {
@@ -54,9 +53,7 @@ private slots:
         mpServer->start(mpLocalhost, mpPort.toUShort());
         mudlet::start();
         mudlet::self()->setupConfig();
-        mudlet::self()->takeOwnershipOfInstanceCoordinator(
-            std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator")
-        );
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
         mudlet::self()->init();
         deleteProfileDirectory(mpHostname);
     }

--- a/test/functional_tests/TelnetTextDisplayedTest.cpp
+++ b/test/functional_tests/TelnetTextDisplayedTest.cpp
@@ -37,7 +37,7 @@ class TelnetTextDisplayedTest : public QObject {
 
 private:
     TelnetServerStub* mpServer = nullptr;
-    const QString mpHostname = "Test-Telnet"; 
+    const QString mpHostname = "Test-Telnet";
     const QString mpPort = "4000";
     const QString mpLocalhost = "127.0.0.1";
 
@@ -57,7 +57,7 @@ private slots:
         mudlet::self()->init();
         deleteProfileDirectory(mpHostname);
     }
- 
+
     void test_TelnetTextDisplayed()
     {
         QString messageFromTheMud("\x1B[1z<B>Greetings < hunters & sorcerers</B>\x1B[7z");

--- a/test/functional_tests/TelnetTextDisplayedTest.cpp
+++ b/test/functional_tests/TelnetTextDisplayedTest.cpp
@@ -1,0 +1,145 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by Nicolas Keita - nicolaskeita2@@gmail.com        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QtTest/QtTest>
+#include <cstdlib>
+
+#include "TelnetServerStub.h"
+#include "mudlet.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void        initializeQRCResources();
+
+class TelnetTextDisplayedTest : public QObject {
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    const QString mpHostname = "Test-Telnet"; 
+    const QString mpPort = "4000";
+    const QString mpLocalhost = "127.0.0.1";
+
+
+private slots:
+    void initTestCase()
+    {
+        initializeQRCResources();
+    }
+
+    void init()
+    {
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mpLocalhost, mpPort.toUShort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(
+            std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator")
+        );
+        mudlet::self()->init();
+        deleteProfileDirectory(mpHostname);
+    }
+ 
+    void test_TelnetTextDisplayed()
+    {
+        QString messageFromTheMud("\x1B[1z<B>Greetings < hunters & sorcerers</B>\x1B[7z");
+        QString messageToExpect("Greetings < hunters & sorcerers");
+
+        mpServer->setWelcomeMessage(messageFromTheMud);
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        QSignalSpy(mudlet::self()->getActiveHost()->mpConsole, &TMainConsole::signal_newDataAlert).wait(200);
+
+        QCOMPARE(mudlet::self()->getActiveHost()->mpConsole->getCurrentLine(""), messageToExpect);
+    }
+
+    void cleanup()
+    {
+        delete mpServer;
+        mpServer = nullptr;
+        deleteProfileDirectory(mpHostname);
+        delete mudlet::self();
+    }
+
+    // Utility function to manually start a profile like a user would do via the GUI
+    void startProfile(const QString& hostname, const QString& address, const QString& port)
+    {
+        QTimer::singleShot(0, qApp, [hostname, address, port]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), hostname);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), address);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), port);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(1000)) {
+            QFAIL("Profile took too long to load.");
+        }
+
+        QSignalSpy spy2(&(mudlet::self()->getActiveHost()->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(500)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    // Utility function
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, profileName);
+        QDir dir(path);
+
+        if (!dir.exists()) {
+            qInfo() << "Profile directory does not exist:" << path;
+            return;
+        }
+        dir.removeRecursively();
+    }
+};
+
+void initializeQRCResources() {
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "TelnetTextDisplayedTest.moc"
+QTEST_MAIN(TelnetTextDisplayedTest)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Adds functional GUI tests simulating a user logging into a MUD via Mudlet. A mock Telnet server sends messages then we verify the GUI correctly receives and displays them.

For example, the test checks that a welcome message like:

```
QString messageFromTheMud("\x1B[1z<B>Greetings < hunters & sorcerers</B>\x1B[7z");
QString messageToExpect("Greetings < hunters & sorcerers");
```


is correctly parsed and displayed in the client.


#### Motivation for adding to Mudlet
Allows testing GUI behavior and Telnet messages, including malformed MXP messages (https://github.com/Mudlet/Mudlet/issues/7896).

#### Other info (issues closed, discussion etc)

This also improves test coverage.

Command that I use:
`ctest --test-dir build/test -L functional --output-on-failure`
