### PR TITLE
Infrastructure: Remove else-after-return anti-pattern

### DIFF
--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -199,18 +199,16 @@ TAction* ActionUnit::getAction(int id)
 {
     if (mActionMap.contains(id)) {
         return mActionMap.value(id);
-    } else {
-        return nullptr;
     }
+    return nullptr;
 }
 
 TAction* ActionUnit::getActionPrivate(int id)
 {
     if (mActionMap.find(id) != mActionMap.end()) {
         return mActionMap.value(id);
-    } else {
-        return nullptr;
     }
+    return nullptr;
 }
 
 bool ActionUnit::registerAction(TAction* pT)

--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -167,18 +167,16 @@ TAlias* AliasUnit::getAlias(int id)
 {
     if (mAliasMap.find(id) != mAliasMap.end()) {
         return mAliasMap.value(id);
-    } else {
-        return nullptr;
     }
+    return nullptr;
 }
 
 TAlias* AliasUnit::getAliasPrivate(int id)
 {
     if (mAliasMap.find(id) != mAliasMap.end()) {
         return mAliasMap.value(id);
-    } else {
-        return nullptr;
     }
+    return nullptr;
 }
 
 bool AliasUnit::registerAlias(TAlias* pT)

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1218,9 +1218,8 @@ QPair<QString, QString> Host::getSearchEngine()
 {
     if (mSearchEngineData.contains(mSearchEngineName)) {
         return qMakePair(mSearchEngineName, mSearchEngineData.value(mSearchEngineName));
-    } else {
-        return qMakePair(qsl("Google"), mSearchEngineData.value(qsl("Google")));
     }
+    return qMakePair(qsl("Google"), mSearchEngineData.value(qsl("Google")));
 }
 
 // cmd is UTF-16BE encoded here, but will be transcoded to Server's one by
@@ -1370,9 +1369,8 @@ QPair<bool, double> Host::getStopWatchTime(const int id) const
     auto pStopWatch = mStopWatchMap.value(id);
     if (pStopWatch) {
         return qMakePair(true, pStopWatch->getElapsedMilliSeconds() / 1000.0);
-    } else {
-        return qMakePair(false, 0.0);
     }
+    return qMakePair(false, 0.0);
 }
 
 QPair<bool, QString> Host::getBrokenDownStopWatchTime(const int id) const
@@ -1380,9 +1378,8 @@ QPair<bool, QString> Host::getBrokenDownStopWatchTime(const int id) const
     auto pStopWatch = mStopWatchMap.value(id);
     if (pStopWatch) {
         return qMakePair(true, pStopWatch->getElapsedDayTimeString());
-    } else {
-        return qMakePair(false, qsl("stopwatch with id %1 not found").arg(id));
     }
+    return qMakePair(false, qsl("stopwatch with id %1 not found").arg(id));
 }
 
 QPair<bool, QString> Host::startStopWatch(const QString& name)
@@ -1391,9 +1388,8 @@ QPair<bool, QString> Host::startStopWatch(const QString& name)
     if (!watchId) {
         if (name.isEmpty()) {
             return qMakePair(false, QLatin1String("no unnamed stopwatches found"));
-        } else {
-            return qMakePair(false, qsl("stopwatch with name '%1' not found").arg(name));
         }
+        return qMakePair(false, qsl("stopwatch with name '%1' not found").arg(name));
     }
 
     auto pStopWatch = mStopWatchMap.value(watchId);
@@ -1430,9 +1426,8 @@ QPair<bool, QString> Host::stopStopWatch(const QString& name)
     if (!watchId) {
         if (name.isEmpty()) {
             return qMakePair(false, QLatin1String("no unnamed stopwatches found"));
-        } else {
-            return qMakePair(false, qsl("stopwatch with name '%1' not found").arg(name));
         }
+        return qMakePair(false, qsl("stopwatch with name '%1' not found").arg(name));
     }
 
     auto pStopWatch = mStopWatchMap.value(watchId);
@@ -1469,9 +1464,8 @@ QPair<bool, QString> Host::resetStopWatch(const QString& name)
     if (!watchId) {
         if (name.isEmpty()) {
             return qMakePair(false, QLatin1String("no unnamed stopwatches found"));
-        } else {
-            return qMakePair(false, qsl("stopwatch with name '%1' not found").arg(name));
         }
+        return qMakePair(false, qsl("stopwatch with name '%1' not found").arg(name));
     }
 
     auto pStopWatch = mStopWatchMap.value(watchId);
@@ -1482,9 +1476,8 @@ QPair<bool, QString> Host::resetStopWatch(const QString& name)
 
         if (name.isEmpty()) {
             return qMakePair(false, qsl("the first unnamed stopwatch (id:%1) was already reset").arg(watchId));
-        } else {
-            return qMakePair(false, qsl("stopwatch with name '%1' (id:%2) was already reset").arg(name, QString::number(watchId)));
         }
+        return qMakePair(false, qsl("stopwatch with name '%1' (id:%2) was already reset").arg(name, QString::number(watchId)));
     }
 
     // This should, indeed, be:
@@ -1601,9 +1594,8 @@ QPair<bool, QString> Host::setStopWatchName(const QString& currentName, const QS
     if (!pStopWatch) {
         if (currentName.isEmpty()) {
             return qMakePair(false, QLatin1String("no unnamed stopwatches found"));
-        } else {
-            return qMakePair(false, qsl("stopwatch with name '%1' not found").arg(currentName));
         }
+        return qMakePair(false, qsl("stopwatch with name '%1' not found").arg(currentName));
     }
 
     if (isAlreadyUsed) {
@@ -2501,9 +2493,8 @@ QPair<bool, QString> Host::writeProfileData(const QString& item, const QString& 
 
     if (file.error() == QFile::NoError) {
         return qMakePair(true, QString());
-    } else {
-        return qMakePair(false, file.errorString());
     }
+    return qMakePair(false, file.errorString());
 }
 
 // Similar to the above, a convenience for reading profile data for this host.
@@ -2907,9 +2898,8 @@ bool Host::discordUserIdMatch(const QString& userName, const QString& userDiscri
 
     if (!userDiscriminator.isEmpty() && !mRequiredDiscordUserDiscriminator.isEmpty() && userDiscriminator != mRequiredDiscordUserDiscriminator) {
         return false;
-    } else {
-        return true;
     }
+    return true;
 }
 
 QString  Host::getSpellDic()
@@ -3167,9 +3157,8 @@ QPointer<TConsole> Host::findConsole(QString name)
         // Reason for the deref-plus-ref in the next line: `QPointer`s do not
         // follow inheritance. See https://bugreports.qt.io/browse/QTBUG-2258
         return &*mpConsole;
-    } else {
-        return mpConsole->mSubConsoleMap.value(name);
     }
+    return mpConsole->mSubConsoleMap.value(name);
 }
 
 QPair<bool, QStringList> Host::getLines(const QString& windowName, const int lineFrom, const int lineTo)
@@ -3278,9 +3267,8 @@ std::pair<bool, QString> Host::openWindow(const QString& name, bool loadLayout, 
             dockwidget->setFloating(false);
             mudlet::self()->addDockWidget(Qt::BottomDockWidgetArea, dockwidget);
             return {true, QString()};
-        } else {
-            return {false, qsl(R"("docking option "%1" not available. available docking options are "t" top, "b" bottom, "r" right, "l" left and "f" floating")").arg(area)};
         }
+        return {false, qsl(R"("docking option "%1" not available. available docking options are "t" top, "b" bottom, "r" right, "l" left and "f" floating")").arg(area)};
     }
 }
 
@@ -3500,9 +3488,8 @@ bool Host::showWindow(const QString& name)
             pD->show();
             // TODO: conside refactoring TConsole::showWindow(name) so that there is a TConsole::showWindow() that can be called directly on the TConsole concerned?
             return mpConsole->showWindow(name);
-        } else {
-            return mpConsole->showWindow(name);
         }
+        return mpConsole->showWindow(name);
     }
 
     if (pS) {
@@ -3785,9 +3772,8 @@ std::pair<bool, QString> Host::openMapWidget(const QString& area, int x, int y, 
             pM->setFloating(false);
             mudlet::self()->addDockWidget(Qt::BottomDockWidgetArea, pM);
             return {true, QString()};
-        } else {
-            return {false, qsl(R"("docking option "%1" not available. available docking options are "t" top, "b" bottom, "r" right, "l" left and "f" floating")").arg(area)};
         }
+        return {false, qsl(R"("docking option "%1" not available. available docking options are "t" top, "b" bottom, "r" right, "l" left and "f" floating")").arg(area)};
     }
 }
 
@@ -3840,9 +3826,8 @@ bool Host::echoWindow(const QString& name, const QString& text)
     } else if (pL) {
         pL->setText(text);
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 bool Host::pasteWindow(const QString& name)
@@ -3855,9 +3840,8 @@ bool Host::pasteWindow(const QString& name)
     if (pC) {
         pC->pasteWindow(mpConsole->mClipboard);
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 bool Host::setCmdLineAction(const QString& name, const int func)

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -170,9 +170,8 @@ bool LuaInterface::loadValue(lua_State* L, TVar* var, int index)
                     return false;
                 }
             }
-        } else {
-            return false;
         }
+        return false;
         if (lua_gettop(L)) {
             return lua_type(L, -1) == var->getValueType();
         }
@@ -609,9 +608,8 @@ bool LuaInterface::loadVar(TVar* var)
             lua_pushboolean(mL, var->getValue().toLower() == "true" ? 1 : 0);
         } else if (vType == LUA_TSTRING) {
             lua_pushstring(mL, QString(var->getName()).toUtf8().constData());
-        } else {
-            return false;
         }
+        return false;
     } else {
         //FIXME: report error to user qDebug()<<"panic in loadVar";
         return false;

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -608,8 +608,9 @@ bool LuaInterface::loadVar(TVar* var)
             lua_pushboolean(mL, var->getValue().toLower() == "true" ? 1 : 0);
         } else if (vType == LUA_TSTRING) {
             lua_pushstring(mL, QString(var->getName()).toUtf8().constData());
+        } else {
+            return false;
         }
-        return false;
     } else {
         //FIXME: report error to user qDebug()<<"panic in loadVar";
         return false;

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -170,8 +170,9 @@ bool LuaInterface::loadValue(lua_State* L, TVar* var, int index)
                     return false;
                 }
             }
+        } else {
+            return false;
         }
-        return false;
         if (lua_gettop(L)) {
             return lua_type(L, -1) == var->getValueType();
         }

--- a/src/ScriptUnit.cpp
+++ b/src/ScriptUnit.cpp
@@ -127,18 +127,16 @@ TScript* ScriptUnit::getScript(int id)
 {
     if (mScriptMap.find(id) != mScriptMap.end()) {
         return mScriptMap.value(id);
-    } else {
-        return nullptr;
     }
+    return nullptr;
 }
 
 TScript* ScriptUnit::getScriptPrivate(int id)
 {
     if (mScriptMap.find(id) != mScriptMap.end()) {
         return mScriptMap.value(id);
-    } else {
-        return nullptr;
     }
+    return nullptr;
 }
 
 bool ScriptUnit::registerScript(TScript* pT)

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4273,9 +4273,8 @@ bool T2DMap::getCenterSelection()
             }
         }
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 void T2DMap::wheelEvent(QWheelEvent* e)

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -3939,9 +3939,8 @@ bool TBuffer::deleteLines(int from, int to)
 
         buffer.erase(buffer.begin() + from, buffer.begin() + to + 1);
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 bool TBuffer::applyLink(const QPoint& P_begin, const QPoint& P_end, const QStringList& linkFunction, const QStringList& linkHint, QVector<int> luaReference)
@@ -3983,9 +3982,8 @@ bool TBuffer::applyLink(const QPoint& P_begin, const QPoint& P_end, const QStrin
             }
         }
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 // Replaces (bool)TBuffer::applyXxxx(QPoint& P_begin, QPoint& P_end, bool state)
@@ -4028,9 +4026,8 @@ bool TBuffer::applyAttribute(const QPoint& P_begin, const QPoint& P_end, const T
             }
         }
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 bool TBuffer::applyFgColor(const QPoint& P_begin, const QPoint& P_end, const QColor& newColor)
@@ -4070,9 +4067,8 @@ bool TBuffer::applyFgColor(const QPoint& P_begin, const QPoint& P_end, const QCo
             }
         }
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 bool TBuffer::applyBgColor(const QPoint& P_begin, const QPoint& P_end, const QColor& newColor)
@@ -5714,9 +5710,8 @@ Mudlet::HyperlinkStyling::LinkState TBuffer::getLinkState(int linkIndex) const
 {
     if (linkIndex <= 0) {
         return Mudlet::HyperlinkStyling::StateDefault;
-    } else {
-        return mLinkStates.value(linkIndex, Mudlet::HyperlinkStyling::StateDefault);
     }
+    return mLinkStates.value(linkIndex, Mudlet::HyperlinkStyling::StateDefault);
 }
 
 Mudlet::HyperlinkStyling TBuffer::getEffectiveHyperlinkStyling(int linkIndex) const

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1450,8 +1450,9 @@ bool TConsole::setConsoleBackgroundImage(const QString& imgPath, int mode)
         styleSheet = qsl("QWidget#MainDisplay{background-color: rgba(%1); background-image: url(%2);}").arg(getColorCode(bgColor)).arg(imgPath);
     } else if (mode == 4) {
         styleSheet = qsl("QWidget#MainDisplay{background-color: rgba(%1); %2}").arg(getColorCode(bgColor)).arg(imgPath);
+    } else {
+        return false;
     }
-    return false;
     mpMainDisplay->setStyleSheet(styleSheet);
     mBgImageMode = mode;
     mBgImagePath = imgPath;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1269,9 +1269,8 @@ bool TConsole::hasSelection()
 {
     if (P_begin != P_end) {
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 void TConsole::insertText(const QString& msg)
@@ -1451,9 +1450,8 @@ bool TConsole::setConsoleBackgroundImage(const QString& imgPath, int mode)
         styleSheet = qsl("QWidget#MainDisplay{background-color: rgba(%1); background-image: url(%2);}").arg(getColorCode(bgColor)).arg(imgPath);
     } else if (mode == 4) {
         styleSheet = qsl("QWidget#MainDisplay{background-color: rgba(%1); %2}").arg(getColorCode(bgColor)).arg(imgPath);
-    } else {
-        return false;
     }
+    return false;
     mpMainDisplay->setStyleSheet(styleSheet);
     mBgImageMode = mode;
     mBgImagePath = imgPath;
@@ -1601,9 +1599,8 @@ bool TConsole::moveCursor(int x, int y)
         mUserCursor.setX(x);
         mUserCursor.setY(y);
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 int TConsole::select(const QString& text, int numOfMatch)

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -75,9 +75,8 @@ bool TKey::match(const Qt::Key key, const Qt::KeyboardModifiers modifier, const 
                 execute();
                 if (isToMatchAll) {
                     isAMatch = true;
-                } else {
-                    return true;
                 }
+                return true;
             }
         }
 
@@ -85,9 +84,8 @@ bool TKey::match(const Qt::Key key, const Qt::KeyboardModifiers modifier, const 
             if (childKey->match(key, modifier, isToMatchAll)) {
                 if (isToMatchAll) {
                     isAMatch = true;
-                } else {
-                    return true;
                 }
+                return true;
             }
         }
     }

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -75,8 +75,9 @@ bool TKey::match(const Qt::Key key, const Qt::KeyboardModifiers modifier, const 
                 execute();
                 if (isToMatchAll) {
                     isAMatch = true;
+                } else {
+                    return true;
                 }
-                return true;
             }
         }
 
@@ -84,8 +85,9 @@ bool TKey::match(const Qt::Key key, const Qt::KeyboardModifiers modifier, const 
             if (childKey->match(key, modifier, isToMatchAll)) {
                 if (isToMatchAll) {
                     isAMatch = true;
+                } else {
+                    return true;
                 }
-                return true;
             }
         }
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -673,13 +673,11 @@ QString TLuaInterpreter::dirToString(lua_State* L, int position)
             return QLatin1String("in");
         } else if (!direction.compare(QLatin1String("o"), Qt::CaseInsensitive) || !direction.compare(QLatin1String("out"), Qt::CaseInsensitive)) {
             return QLatin1String("out");
-        } else {
-            return direction;
         }
+        return direction;
 
-    } else {
-        return QString();
     }
+    return QString();
 }
 
 // No documentation available in wiki - internal function
@@ -1570,9 +1568,8 @@ int TLuaInterpreter::setLabelCallback(lua_State* L, const QString& funcName)
         lua_result = host.setLabelOnEnter(labelName, func);
     } else if (funcName == qsl("setLabelOnLeave")) {
         lua_result = host.setLabelOnLeave(labelName, func);
-    } else {
-        return warnArgumentValue(L, __func__, qsl("'%1' is not a known function name - bug in Mudlet, please report it").arg(funcName));
     }
+    return warnArgumentValue(L, __func__, qsl("'%1' is not a known function name - bug in Mudlet, please report it").arg(funcName));
 
     if (!lua_result) {
         return warnArgumentValue(L, __func__, qsl("label name '%1' not found").arg(labelName));
@@ -4553,9 +4550,8 @@ bool TLuaInterpreter::callLabelCallbackEvent(const int func, const QEvent* qE)
             // No-op - this silences warnings about unhandled QEvent types
         }
         }
-    } else {
-        return callReference(L, name, 0);
     }
+    return callReference(L, name, 0);
     lua_pop(L, lua_gettop(L));
     return true;
 }
@@ -4884,9 +4880,8 @@ QString TLuaInterpreter::getLuaString(const QString& stringName)
     const int error = luaL_dostring(L, qsl("return %1").arg(stringName).toUtf8().constData());
     if (!error) {
         return lua_tostring(L, 1);
-    } else {
-        return QString();
     }
+    return QString();
 }
 
 // check for <whitespace><no_valid_representation> as output

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1568,8 +1568,9 @@ int TLuaInterpreter::setLabelCallback(lua_State* L, const QString& funcName)
         lua_result = host.setLabelOnEnter(labelName, func);
     } else if (funcName == qsl("setLabelOnLeave")) {
         lua_result = host.setLabelOnLeave(labelName, func);
+    } else {
+        return warnArgumentValue(L, __func__, qsl("'%1' is not a known function name - bug in Mudlet, please report it").arg(funcName));
     }
-    return warnArgumentValue(L, __func__, qsl("'%1' is not a known function name - bug in Mudlet, please report it").arg(funcName));
 
     if (!lua_result) {
         return warnArgumentValue(L, __func__, qsl("label name '%1' not found").arg(labelName));
@@ -4550,8 +4551,9 @@ bool TLuaInterpreter::callLabelCallbackEvent(const int func, const QEvent* qE)
             // No-op - this silences warnings about unhandled QEvent types
         }
         }
+    } else {
+        return callReference(L, name, 0);
     }
-    return callReference(L, name, 0);
     lua_pop(L, lua_gettop(L));
     return true;
 }

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -431,11 +431,10 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
         line_style = Qt::DashDotLine;
     } else if (!lineStyleString.compare(QLatin1String("dash dot dot line"))) {
         line_style = Qt::DashDotDotLine;
-    } else {
-        return warnArgumentValue(L, __func__, qsl(
+    }
+    return warnArgumentValue(L, __func__, qsl(
             "invalid line style '%1', only use one of: 'solid line', 'dot line', 'dash line', 'dash dot line' or 'dash dot dot line'")
             .arg(lineStyleString));
-    }
 
     if (!lua_istable(L, 5)) {
         lua_pushfstring(L, "addCustomLine: bad argument #5 type (RGB color components as a table expected, got %s!)", luaL_typename(L, 5));
@@ -707,9 +706,8 @@ int TLuaInterpreter::centerview(lua_State* L)
         }
         lua_pushboolean(L, true);
         return 1;
-    } else {
-        return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
     }
+    return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearAreaUserData
@@ -2126,9 +2124,8 @@ int TLuaInterpreter::getRoomExits(lua_State* L)
             lua_settable(L, -3);
         }
         return 1;
-    } else {
-        return 0;
     }
+    return 0;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomHashByID
@@ -2287,9 +2284,8 @@ int TLuaInterpreter::getRoomWeight(lua_State* L)
     if (pR) {
         lua_pushnumber(L, pR->getWeight());
         return 1;
-    } else {
-        return 0;
     }
+    return 0;
 }
 
 // documented in the wiki!
@@ -2565,9 +2561,8 @@ int TLuaInterpreter::loadMap(lua_State* L)
             if (!errMsg.isEmpty()) {
                 lua_pushstring(L, errMsg.toUtf8().constData());
                 return 2;
-            } else {
-                return 1;
             }
+            return 1;
         }
     } else {
         isOk = host.mpConsole->loadMap(location);

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -431,10 +431,11 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
         line_style = Qt::DashDotLine;
     } else if (!lineStyleString.compare(QLatin1String("dash dot dot line"))) {
         line_style = Qt::DashDotDotLine;
+    } else {
+        return warnArgumentValue(L, __func__, qsl(
+                "invalid line style '%1', only use one of: 'solid line', 'dot line', 'dash line', 'dash dot line' or 'dash dot dot line'")
+                .arg(lineStyleString));
     }
-    return warnArgumentValue(L, __func__, qsl(
-            "invalid line style '%1', only use one of: 'solid line', 'dot line', 'dash line', 'dash dot line' or 'dash dot dot line'")
-            .arg(lineStyleString));
 
     if (!lua_istable(L, 5)) {
         lua_pushfstring(L, "addCustomLine: bad argument #5 type (RGB color components as a table expected, got %s!)", luaL_typename(L, 5));

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -523,9 +523,10 @@ int TLuaInterpreter::exists(lua_State* L)
         }
 
         count = host.getScriptUnit()->findItems(nameOrId).size();
+    } else {
+        return warnArgumentValue(L, __func__, qsl(
+                "invalid item type '%1' given, it should be one of: 'alias', 'button', 'script', 'keybind', 'timer' or 'trigger'").arg(type));
     }
-    return warnArgumentValue(L, __func__, qsl(
-            "invalid item type '%1' given, it should be one of: 'alias', 'button', 'script', 'keybind', 'timer' or 'trigger'").arg(type));
     // If we get here we have successfully identified a type and have looked for
     // the item type with a specific NAME - so now just return the count of
     // those found:
@@ -986,9 +987,10 @@ int TLuaInterpreter::isActive(lua_State* L)
             }
         }
 
+    } else {
+        return warnArgumentValue(L, __func__, qsl(
+                "invalid item type '%1' given, it should be one (case insensitive) of: 'alias', 'button', 'script', 'keybind', 'timer' or 'trigger'").arg(type));
     }
-    return warnArgumentValue(L, __func__, qsl(
-            "invalid item type '%1' given, it should be one (case insensitive) of: 'alias', 'button', 'script', 'keybind', 'timer' or 'trigger'").arg(type));
     lua_pushnumber(L, cnt);
     return 1;
 }

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -523,10 +523,9 @@ int TLuaInterpreter::exists(lua_State* L)
         }
 
         count = host.getScriptUnit()->findItems(nameOrId).size();
-    } else {
-        return warnArgumentValue(L, __func__, qsl(
-            "invalid item type '%1' given, it should be one of: 'alias', 'button', 'script', 'keybind', 'timer' or 'trigger'").arg(type));
     }
+    return warnArgumentValue(L, __func__, qsl(
+            "invalid item type '%1' given, it should be one of: 'alias', 'button', 'script', 'keybind', 'timer' or 'trigger'").arg(type));
     // If we get here we have successfully identified a type and have looked for
     // the item type with a specific NAME - so now just return the count of
     // those found:
@@ -987,10 +986,9 @@ int TLuaInterpreter::isActive(lua_State* L)
             }
         }
 
-    } else {
-        return warnArgumentValue(L, __func__, qsl(
-            "invalid item type '%1' given, it should be one (case insensitive) of: 'alias', 'button', 'script', 'keybind', 'timer' or 'trigger'").arg(type));
     }
+    return warnArgumentValue(L, __func__, qsl(
+            "invalid item type '%1' given, it should be one (case insensitive) of: 'alias', 'button', 'script', 'keybind', 'timer' or 'trigger'").arg(type));
     lua_pushnumber(L, cnt);
     return 1;
 }

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -892,9 +892,8 @@ int TLuaInterpreter::getBackgroundColor(lua_State* L)
         color = host.mpConsole->getConsoleBgColor();
     } else if (auto optionalColor = host.getBackgroundColor(windowName)) {
         color = optionalColor.value();
-    } else {
-        return warnArgumentValue(L, __func__, qsl("window '%1' does not exist").arg(windowName));
     }
+    return warnArgumentValue(L, __func__, qsl("window '%1' does not exist").arg(windowName));
 
     lua_pushnumber(L, color.red());
     lua_pushnumber(L, color.green());
@@ -1990,9 +1989,8 @@ int TLuaInterpreter::resetCmdLineAction(lua_State* L){
     if (lua_result) {
         lua_pushboolean(L, true);
         return 1;
-    } else {
-        return warnArgumentValue(L, __func__, qsl("command line name '%1' not found").arg(name));
     }
+    return warnArgumentValue(L, __func__, qsl("command line name '%1' not found").arg(name));
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#resetBackgroundImage
@@ -3517,9 +3515,8 @@ int TLuaInterpreter::movieFunc(lua_State* L, const QString& funcName)
         } else {
             pN->disconnect(SIGNAL(resized()));
         }
-    } else {
-        return warnArgumentValue(L, __func__, qsl("'%1' is not a known function name - bug in Mudlet, please report it").arg(funcName));
     }
+    return warnArgumentValue(L, __func__, qsl("'%1' is not a known function name - bug in Mudlet, please report it").arg(funcName));
 
     lua_pushboolean(L, true);
     return 1;

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -892,8 +892,9 @@ int TLuaInterpreter::getBackgroundColor(lua_State* L)
         color = host.mpConsole->getConsoleBgColor();
     } else if (auto optionalColor = host.getBackgroundColor(windowName)) {
         color = optionalColor.value();
+    } else {
+        return warnArgumentValue(L, __func__, qsl("window '%1' does not exist").arg(windowName));
     }
-    return warnArgumentValue(L, __func__, qsl("window '%1' does not exist").arg(windowName));
 
     lua_pushnumber(L, color.red());
     lua_pushnumber(L, color.green());
@@ -3515,8 +3516,9 @@ int TLuaInterpreter::movieFunc(lua_State* L, const QString& funcName)
         } else {
             pN->disconnect(SIGNAL(resized()));
         }
+    } else {
+        return warnArgumentValue(L, __func__, qsl("'%1' is not a known function name - bug in Mudlet, please report it").arg(funcName));
     }
-    return warnArgumentValue(L, __func__, qsl("'%1' is not a known function name - bug in Mudlet, please report it").arg(funcName));
 
     lua_pushboolean(L, true);
     return 1;

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -513,9 +513,8 @@ TConsole* TMainConsole::createMiniConsole(const QString& windowname, const QStri
         pC->show();
 
         return pC;
-    } else {
-        return nullptr;
     }
+    return nullptr;
 }
 
 // This is a scrollBox overlaid on to the main console
@@ -720,9 +719,8 @@ std::pair<bool, QString> TMainConsole::setLabelCursor(const QString& name, int s
             pL->setCursor(static_cast<Qt::CursorShape>(shape));
         } else if (shape == -1) {
             pL->unsetCursor();
-        } else {
-            return {false, qsl("cursor shape '%1' not found. see https://doc.qt.io/qt-5/qt.html#CursorShape-enum").arg(shape)};
         }
+        return {false, qsl("cursor shape '%1' not found. see https://doc.qt.io/qt-5/qt.html#CursorShape-enum").arg(shape)};
         return {true, QString()};
     }
     return {false, qsl("label name '%1' not found").arg(name)};
@@ -851,9 +849,8 @@ bool TMainConsole::setBackgroundImage(const QString& name, const QString& path)
         const QPixmap bgPixmap(path);
         pL->setPixmap(bgPixmap);
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 // Does NOT act on the TMainConsole itself:
@@ -881,9 +878,8 @@ bool TMainConsole::setBackgroundColor(const QString& name, int r, int g, int b, 
         mainPalette.setColor(QPalette::Window, QColor(r, g, b, alpha));
         pL->setPalette(mainPalette);
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 bool TMainConsole::raiseWindow(const QString& name)
@@ -969,9 +965,8 @@ bool TMainConsole::showWindow(const QString& name)
     } else if (pL) {
         pL->show();
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 bool TMainConsole::hideWindow(const QString& name)
@@ -984,9 +979,8 @@ bool TMainConsole::hideWindow(const QString& name)
     } else if (pL) {
         pL->hide();
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 bool TMainConsole::printWindow(const QString& name, const QString& text)
@@ -999,9 +993,8 @@ bool TMainConsole::printWindow(const QString& name, const QString& text)
     } else if (pL) {
         pL->setText(text);
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 //getUserWindowSize for resizing in Geyser
@@ -1165,9 +1158,8 @@ QSet<QString> TMainConsole::getWordSet() const
 
     if (!mUseSharedDictionary) {
         return mWordSet_profile;
-    } else {
-        return mudlet::self()->getWordSet();
     }
+    return mudlet::self()->getWordSet();
 }
 
 void TMainConsole::setProfileName(const QString& newName)

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -719,8 +719,9 @@ std::pair<bool, QString> TMainConsole::setLabelCursor(const QString& name, int s
             pL->setCursor(static_cast<Qt::CursorShape>(shape));
         } else if (shape == -1) {
             pL->unsetCursor();
+        } else {
+            return {false, qsl("cursor shape '%1' not found. see https://doc.qt.io/qt-5/qt.html#CursorShape-enum").arg(shape)};
         }
-        return {false, qsl("cursor shape '%1' not found. see https://doc.qt.io/qt-5/qt.html#CursorShape-enum").arg(shape)};
         return {true, QString()};
     }
     return {false, qsl("label name '%1' not found").arg(name)};

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -874,7 +874,8 @@ bool TMainConsole::setBackgroundColor(const QString& name, int r, int g, int b, 
             pC->mLowerPane->forceUpdate();
         }
         return true;
-    } else if (pL) {
+    }
+    if (pL) {
         QPalette mainPalette;
         mainPalette.setColor(QPalette::Window, QColor(r, g, b, alpha));
         pL->setPalette(mainPalette);
@@ -963,7 +964,8 @@ bool TMainConsole::showWindow(const QString& name)
         pC->mLowerPane->updateScreenView();
         pC->mLowerPane->forceUpdate();
         return true;
-    } else if (pL) {
+    }
+    if (pL) {
         pL->show();
         return true;
     }
@@ -977,7 +979,8 @@ bool TMainConsole::hideWindow(const QString& name)
     if (pC) {
         pC->hide();
         return true;
-    } else if (pL) {
+    }
+    if (pL) {
         pL->hide();
         return true;
     }

--- a/src/TMxpLinkTagHandler.cpp
+++ b/src/TMxpLinkTagHandler.cpp
@@ -78,9 +78,8 @@ QString TMxpLinkTagHandler::getHref(const MxpStartTag* tag)
         return tag->getAttributeValue("href");
     } else if (!tag->getAttribute(0).hasValue()) {
         return tag->getAttribute(0).getName();
-    } else {
-        return "";
     }
+    return "";
 }
 void TMxpLinkTagHandler::handleContent(char ch)
 {

--- a/src/TMxpLinkTagHandler.cpp
+++ b/src/TMxpLinkTagHandler.cpp
@@ -74,9 +74,11 @@ QString TMxpLinkTagHandler::getHref(const MxpStartTag* tag)
         // <A>http://someurl.com/<A>
         mIsHrefInContent = true;
         return "&text;";
-    } else if (tag->hasAttribute("href")) {
+    }
+    if (tag->hasAttribute("href")) {
         return tag->getAttributeValue("href");
-    } else if (!tag->getAttribute(0).hasValue()) {
+    }
+    if (!tag->getAttribute(0).hasValue()) {
         return tag->getAttribute(0).getName();
     }
     return "";

--- a/src/TMxpNodeBuilder.cpp
+++ b/src/TMxpNodeBuilder.cpp
@@ -142,9 +142,8 @@ bool TMxpNodeBuilder::acceptAttribute(char ch)
     if (ch == '=' && !mReadingAttrValue) {
         mReadingAttrValue = true;
         return false;
-    } else {
-        return true;
     }
+    return true;
 }
 void TMxpNodeBuilder::resetCurrentAttribute()
 {

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -183,9 +183,8 @@ bool TRoom::hasExitStub(int direction)
 {
     if (exitStubs.contains(direction)) {
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 void TRoom::setExitStub(int direction, bool status)
@@ -223,12 +222,10 @@ bool TRoom::hasExitWeight(const QString& cmd)
     if (exitWeights.contains(cmd)) {
         if (exitWeights.value(cmd) > 0) {
             return true;
-        } else {
-            return false;
         }
-    } else {
         return false;
     }
+    return false;
 }
 
 void TRoom::setWeight(int w)

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -387,9 +387,8 @@ bool TRoomDB::removeArea(const QString& name)
 {
     if (areaNamesMap.values().contains(name)) {
         return removeArea(areaNamesMap.key(name)); // i.e. call the removeArea(int) method
-    } else {
-        return false;
     }
+    return false;
 }
 
 void TRoomDB::removeArea(TArea* pA)
@@ -460,9 +459,8 @@ TArea* TRoomDB::getArea(int id)
     //area id of -1 is a room in the "void", 0 is a failure
     if (id > 0 || id == -1) {
         return areas.value(id, nullptr);
-    } else {
-        return nullptr;
     }
+    return nullptr;
 }
 
 // Used by TMap::audit() - can detect and return areas with normally invalids Id (less than -1 or zero)!
@@ -580,9 +578,8 @@ bool TRoomDB::addArea(int id, QString name)
             areaNamesMap[id] = name;
         }
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 // Used by TMap::readJsonMapFile(...) to insert an already populated area in:

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2148,9 +2148,8 @@ int TTextEdit::imageTopLine()
         }
 
         return mCursorY - mScreenHeight;
-    } else {
-        return 0;
     }
+    return 0;
 }
 
 
@@ -2385,9 +2384,8 @@ inline QString TTextEdit::convertWhitespaceToVisual(const QChar& first, const QC
             } else if ((value >= 0xFFF0 && value <= 0xFFF8) || value == 0xFFFE || value == 0xFFFF) {
                 //: Unicode codepoint in range U+FFFx - not a character.
                 return htmlCenter(tr("{noncharacter}")); break;
-            } else {
-                return htmlCenter(first);
             }
+            return htmlCenter(first);
         }
     } else {
         // The code point is NOT on the BMP
@@ -2429,9 +2427,8 @@ inline QString TTextEdit::byteToLuaCodeOrChar(const char* byte)
         // HTML/Rich-text formatting opening tag and has to be converted to
         // "&lt;":
         return qsl("&lt;");
-    } else {
-        return qsl("%1").arg(*byte);
     }
+    return qsl("%1").arg(*byte);
 }
 
 /*

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2381,7 +2381,8 @@ inline QString TTextEdit::convertWhitespaceToVisual(const QChar& first, const QC
             if (value >= 0xFDD0 && value <= 0xFDEF) {
                 //: Unicode codepoint in range U+FFD0 to U+FDEF - not a character
                 return htmlCenter(tr("{noncharacter}")); break;
-            } else if ((value >= 0xFFF0 && value <= 0xFFF8) || value == 0xFFFE || value == 0xFFFF) {
+            }
+            if ((value >= 0xFFF0 && value <= 0xFFF8) || value == 0xFFFE || value == 0xFFFF) {
                 //: Unicode codepoint in range U+FFFx - not a character.
                 return htmlCenter(tr("{noncharacter}")); break;
             }
@@ -2406,10 +2407,9 @@ inline QString TTextEdit::convertWhitespaceToVisual(const QChar& first, const QC
             if ((value % 0x10000 == 0xFFFE) || (value % 0x10000 == 0xFFFF)) {
                 //: Unicode codepoint is U+00xxFFFE or U+00xxFFFF - not a character.
                 return htmlCenter(tr("{noncharacter}")); break;
-            } else {
-                // The '%' is the QStringBuilder append operator here:
-                return htmlCenter(first % second);
             }
+            // The '%' is the QStringBuilder append operator here:
+            return htmlCenter(first % second);
         }
     }
     // clang-format on

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -252,12 +252,10 @@ bool TTimer::canBeUnlocked()
     if (shouldBeActive()) {
         if (!mpParent) {
             return true;
-        } else {
-            return mpParent->canBeUnlocked();
         }
-    } else {
-        return false;
+        return mpParent->canBeUnlocked();
     }
+    return false;
 }
 
 void TTimer::enableTimer(int id)

--- a/src/TVar.cpp
+++ b/src/TVar.cpp
@@ -89,9 +89,8 @@ bool TVarLessThan(TVar* varA, TVar* varB)
     // of whether one or both of the QStrings was NOT actually a number
     if (a.toInt(&isAOk) && b.toInt(&isBOk) && isAOk && isBOk) {
         return a.toInt() < b.toInt();
-    } else {
-        return a.toLower() < b.toLower();
     }
+    return a.toLower() < b.toLower();
 }
 
 QList<TVar*> TVar::getChildren(const bool isToSort)

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -160,18 +160,16 @@ TTrigger* TriggerUnit::getTrigger(int id)
 {
     if (mTriggerMap.find(id) != mTriggerMap.end()) {
         return mTriggerMap.value(id);
-    } else {
-        return nullptr;
     }
+    return nullptr;
 }
 
 TTrigger* TriggerUnit::getTriggerPrivate(int id)
 {
     if (mTriggerMap.find(id) != mTriggerMap.end()) {
         return mTriggerMap.value(id);
-    } else {
-        return nullptr;
     }
+    return nullptr;
 }
 
 bool TriggerUnit::registerTrigger(TTrigger* pT)

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -707,9 +707,8 @@ void XMLimport::readHost(Host* pHost)
         if (attributes().hasAttribute(legacyAttribute)) {
             bool value = attributes().value(legacyAttribute) == YES;
             return invert ? !value : value;
-        } else {
-            return defaultsTo;
         }
+        return defaultsTo;
     };
 
     auto setBoolAttributeWithDefault = [&](const QString& attribute, bool& target, const bool defaultsTo) {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -4951,9 +4951,8 @@ QByteArray cTelnet::decodeBytes(const char* bytes)
     if (!mEncoding.isEmpty() && mEncoding != "ASCII") {
         // Convert from given encoding to QString UTF-16BE Unicode form, then to UTF-8:
         return TEncodingHelper::decode(QByteArray(bytes), mEncoding).toUtf8();
-    } else {
-        return QByteArray(bytes);
     }
+    return QByteArray(bytes);
 }
 
 // Converts a Unicode (UTF-8) encoded std::string into the current Mud Server
@@ -4971,9 +4970,8 @@ std::string cTelnet::encodeAndCookBytes(const std::string& data)
     if (!mEncoding.isEmpty() && mEncoding != "ASCII") {
         // Convert from UTF8 std::string to QString, then encode to Mud Server encoding
         return mudlet::replaceString(TEncodingHelper::encode(QString::fromStdString(data), mEncoding).toStdString(), "\xff", "\xff\xff");
-    } else {
-        return mudlet::replaceString(data, "\xff", "\xff\xff");
     }
+    return mudlet::replaceString(data, "\xff", "\xff\xff");
 }
 
 void cTelnet::setPostingTimeout(const int timeout)

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -542,9 +542,8 @@ QPair<bool, QString> Discord::gameIntegrationSupported(const QString& address)
     // Handle using localhost as an off-line testing case
     if (deducedName == QLatin1String("localhost")) {
         return qMakePair(true, deducedName);
-    } else {
-        return qMakePair((!deducedName.isEmpty() && mKnownGames.contains(deducedName)), deducedName);
     }
+    return qMakePair((!deducedName.isEmpty() && mKnownGames.contains(deducedName)), deducedName);
 }
 
 bool Discord::libraryLoaded()
@@ -582,9 +581,8 @@ bool Discord::setApplicationID(Host* pHost, const QString& text)
         UpdatePresence();
 
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 void Discord::resetData(Host* pHost){

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -933,9 +933,8 @@ QPair<bool, QString> dlgConnectionProfiles::writeProfileData(const QString& prof
 
     if (file.error() == QFileDevice::NoError) {
         return {true, QString()};
-    } else {
-        return {false, file.errorString()};
     }
+    return {false, file.errorString()};
 }
 
 QString dlgConnectionProfiles::getDescription(const QString& profile_name) const

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -1457,8 +1457,8 @@ std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDi
 
             // If successful will get to HERE...
 
-        } else {
-            return {false,
+        }
+        return {false,
                     tr("Required file \"%1\" was not found in the staging area. "
                        "This area contains the Mudlet items chosen for the package, "
                        "which you selected to be included in the package file. "
@@ -1466,7 +1466,6 @@ std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDi
                        "\"%2\" - "
                        "Do you have the necessary permissions and free disk-space?")
                             .arg(xmlPathFileName, QDir(stagingDirName).canonicalPath())};
-        }
     }
 
     if (isOk) {

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -11956,9 +11956,8 @@ QString dlgTriggerEditor::generateButtonStyleSheet(const QColor& color, const bo
         const QColor disabledColor = QColor::fromHsl(color.hslHue(), color.hslSaturation()/4, color.lightness());
         return mudlet::self()->mTEXT_ON_BG_STYLESHEET
                 .arg(QLatin1String("darkGray"), disabledColor.name());
-    } else {
-        return QString();
     }
+    return QString();
 }
 
 // Retrieve the background-color or color setting from the previous method, the

--- a/src/glwidget_integration.cpp
+++ b/src/glwidget_integration.cpp
@@ -24,9 +24,8 @@ QOpenGLWidget* GLWidgetFactory::createGLWidget(TMap* pMap, Host* pHost, QWidget*
 {
     if (pHost && pHost->getUseModern3DMapper()) {
         return new ModernGLWidget(pMap, pHost, parent);
-    } else {
-        return new GLWidget(pMap, pHost, parent);
     }
+    return new GLWidget(pMap, pHost, parent);
 }
 
 bool GLWidgetFactory::isCorrectWidgetType(QOpenGLWidget* widget, Host* pHost)
@@ -51,7 +50,6 @@ QString GLWidgetFactory::getWidgetTypeName(QOpenGLWidget* widget)
         return QStringLiteral("ModernGLWidget");
     } else if (dynamic_cast<GLWidget*>(widget)) {
         return QStringLiteral("GLWidget");
-    } else {
-        return QStringLiteral("Unknown");
     }
+    return QStringLiteral("Unknown");
 }

--- a/src/glwidget_integration.cpp
+++ b/src/glwidget_integration.cpp
@@ -45,10 +45,11 @@ QString GLWidgetFactory::getWidgetTypeName(QOpenGLWidget* widget)
     if (!widget) {
         return QStringLiteral("null");
     }
-    
+
     if (dynamic_cast<ModernGLWidget*>(widget)) {
         return QStringLiteral("ModernGLWidget");
-    } else if (dynamic_cast<GLWidget*>(widget)) {
+    }
+    if (dynamic_cast<GLWidget*>(widget)) {
         return QStringLiteral("GLWidget");
     }
     return QStringLiteral("Unknown");

--- a/src/ircmessageformatter.cpp
+++ b/src/ircmessageformatter.cpp
@@ -159,9 +159,8 @@ QString IrcMessageFormatter::formatJoinMessage(IrcJoinMessage* message, bool isF
     Q_UNUSED(isForLua)
     if (message->flags() & IrcMessage::Own) {
         return QObject::tr("! You have joined %1 as %2").arg(message->channel(), message->nick());
-    } else {
-        return QObject::tr("! %1 has joined %2").arg(message->nick(), message->channel());
     }
+    return QObject::tr("! %1 has joined %2").arg(message->nick(), message->channel());
 }
 
 QString IrcMessageFormatter::formatKickMessage(IrcKickMessage* message, bool isForLua)
@@ -176,9 +175,8 @@ QString IrcMessageFormatter::formatModeMessage(IrcModeMessage* message, bool isF
     const QString args = message->arguments().join(" ");
     if (message->isReply()) {
         return QObject::tr("! %1 mode is %2 %3").arg(message->target(), message->mode(), args);
-    } else {
-        return QObject::tr("! %1 sets mode %2 %3 %4").arg(message->nick(), message->target(), message->mode(), args);
     }
+    return QObject::tr("! %1 sets mode %2 %3 %4").arg(message->nick(), message->target(), message->mode(), args);
 }
 
 QString IrcMessageFormatter::formatMotdMessage(IrcMotdMessage* message, bool isForLua)
@@ -207,9 +205,8 @@ QString IrcMessageFormatter::formatNamesMessage(IrcNamesMessage* message, bool i
         // list from the UI userModel alone would be limiting to the IRC commands.
         const QString nameList = message->names().join(" ");
         return QObject::tr("! %1 has %2 users: %3").arg(message->channel(), count, nameList);
-    } else {
-        return QObject::tr("! %1 has %2 users").arg(message->channel(), count);
     }
+    return QObject::tr("! %1 has %2 users").arg(message->channel(), count);
 }
 
 QString IrcMessageFormatter::formatNickMessage(IrcNickMessage* message, bool isForLua)
@@ -330,9 +327,8 @@ QString IrcMessageFormatter::formatPartMessage(IrcPartMessage* message, bool isF
     Q_UNUSED(isForLua)
     if (message->reason().isEmpty()) {
         return QObject::tr("! %1 has left %2").arg(message->nick(), message->channel());
-    } else {
-        return QObject::tr("! %1 has left %2 (%3)").arg(message->nick(), message->channel(), message->reason());
     }
+    return QObject::tr("! %1 has left %2 (%3)").arg(message->nick(), message->channel(), message->reason());
 }
 
 QString IrcMessageFormatter::formatPongMessage(IrcPongMessage* message, bool isForLua)
@@ -370,9 +366,8 @@ QString IrcMessageFormatter::formatQuitMessage(IrcQuitMessage* message, bool isF
     Q_UNUSED(isForLua)
     if (message->reason().isEmpty()) {
         return QObject::tr("! %1 has quit").arg(message->nick());
-    } else {
-        return QObject::tr("! %1 has quit (%2)").arg(message->nick(), message->reason());
     }
+    return QObject::tr("! %1 has quit (%2)").arg(message->nick(), message->reason());
 }
 
 QString IrcMessageFormatter::formatTopicMessage(IrcTopicMessage* message, bool isForLua)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -399,9 +399,8 @@ int main(int argc, char* argv[])
             const bool successful = instanceCoordinator->installPackagesRemotely();
             if (successful) {
                 return 0;
-            } else {
-                return 1;
             }
+            return 1;
         }
     }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -126,9 +126,8 @@ bool TConsoleMonitor::eventFilter(QObject* obj, QEvent* event)
         mudlet::smDebugMode = false;
         mudlet::self()->refreshTabBar();
         return QObject::eventFilter(obj, event);
-    } else {
-        return QObject::eventFilter(obj, event);
     }
+    return QObject::eventFilter(obj, event);
 }
 
 /*static*/ void mudlet::start()
@@ -2479,9 +2478,8 @@ bool mudlet::saveWindowLayout()
         }
         mHasSavedLayout = true;
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 bool mudlet::loadWindowLayout()
@@ -5427,9 +5425,8 @@ Host* mudlet::loadProfile(const QString& profile_name, const bool playOnline, co
         if (!pHost) {
             return pHost;
         }
-    } else {
-        return pHost;
     }
+    return pHost;
 
     LuaInterface* lI = pHost->getLuaInterface();
     lI->getVars(true);
@@ -6755,12 +6752,11 @@ void mudlet::onlyShowProfiles(const QStringList& predefinedProfiles)
             return original.mirrored(true, true);
 #endif
         }
-    } else {
-        return QImage(releaseVersion
+    }
+    return QImage(releaseVersion
                               ? qsl(":/splash/Mudlet_splashscreen_main.png")
                               : testVersion ? qsl(":/splash/Mudlet_splashscreen_ptb.png")
                                                                : qsl(":/splash/Mudlet_splashscreen_development.png"));
-    }
 #else
     return QImage(qsl(":/splash/Mudlet_splashscreen_main.png"));
 #endif // INCLUDE_VARIABLE_SPLASH_SCREEN

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -5420,13 +5420,13 @@ Host* mudlet::loadProfile(const QString& profile_name, const bool playOnline, co
     }
 
     // load an old profile if there is any
-    if (mHostManager.addHost(profile_name, QString(), QString(), QString())) {
-        pHost = mHostManager.getHost(profile_name);
-        if (!pHost) {
-            return pHost;
-        }
+    if (!mHostManager.addHost(profile_name, QString(), QString(), QString())) {
+        return pHost;
     }
-    return pHost;
+    pHost = mHostManager.getHost(profile_name);
+    if (!pHost) {
+        return pHost;
+    }
 
     LuaInterface* lI = pHost->getLuaInterface();
     lI->getVars(true);
@@ -6739,19 +6739,18 @@ void mudlet::onlyShowProfiles(const QStringList& predefinedProfiles)
         if (egg) {
             auto eggFileName = qsl(":/splash/Mudlet_splashscreen_other_%1.png").arg(egg, 2, 10, QLatin1Char('0'));
             return QImage(eggFileName);
-        } else {
-            // For the zeroth case just rotate the picture 180 degrees:
-            const QImage original(releaseVersion
-                                    ? qsl(":/splash/Mudlet_splashscreen_main.png")
-                                    : testVersion ? qsl(":/splash/Mudlet_splashscreen_ptb.png")
-                                                                     : qsl(":/splash/Mudlet_splashscreen_development.png"));
-#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
-            return original.flipped(Qt::Horizontal|Qt::Vertical);
-#else
-            // Deprecated in 6.9 and due for removal in 6.13:
-            return original.mirrored(true, true);
-#endif
         }
+        // For the zeroth case just rotate the picture 180 degrees:
+        const QImage original(releaseVersion
+                                ? qsl(":/splash/Mudlet_splashscreen_main.png")
+                                : testVersion ? qsl(":/splash/Mudlet_splashscreen_ptb.png")
+                                                                 : qsl(":/splash/Mudlet_splashscreen_development.png"));
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+        return original.flipped(Qt::Horizontal|Qt::Vertical);
+#else
+        // Deprecated in 6.9 and due for removal in 6.13:
+        return original.mirrored(true, true);
+#endif
     }
     return QImage(releaseVersion
                               ? qsl(":/splash/Mudlet_splashscreen_main.png")

--- a/src/utils.h
+++ b/src/utils.h
@@ -55,9 +55,8 @@ public:
                                                                  .arg(offset >= 0 ? QLatin1Char('+') : QLatin1Char('-'))
                                                                  .arg(hoursOff, 2, 10, QLatin1Char('0'))
                                                                  .arg(minutesOff, 2, 10, QLatin1Char('0')));
-        } else {
-            return localNow.toString(Qt::ISODate).append(qsl("+00:00"));
         }
+        return localNow.toString(Qt::ISODate).append(qsl("+00:00"));
 #else
         auto localNow = QDateTime::currentDateTime();
         const int offset = localNow.offsetFromUtc();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove unnecessary else blocks following return statements throughout the codebase.
#### Motivation for adding to Mudlet
Better code readability 
#### Other info (issues closed, discussion etc)
Other anti patterns are visible in this PR thanks to this, but let's keep this PR focused on one pattern only.