### PR TITLE
Fix: Restore Qt5 Core5Compat for third-party dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,9 @@ include_optional_module(ENVIRONMENT_VARIABLE WITH_OWN_QTKEYCHAIN
 
 find_package(Qt6 6.8.2 REQUIRED)
 
+# Find Core5Compat for third-party libraries (communi, edbee-lib) that still need it
+find_package(Qt6 COMPONENTS Core5Compat REQUIRED)
+
 find_package(Lua 5.1 EXACT)
 
 # Set Qt version for edbee-lib and dblsqd

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -81,7 +81,9 @@ win32 {
     DEFINES += INCLUDE_WINSOCK2
 }
 
-QT += network uitools multimedia multimediawidgets gui concurrent
+# Qt6 Core5Compat is needed by third-party libraries (communi, edbee-lib)
+# Mudlet itself doesn't use it, but these dependencies still require it
+QT += network uitools multimedia multimediawidgets gui concurrent core5compat
 qtHaveModule(texttospeech) {
     QT += texttospeech
     !build_pass : message("Using TextToSpeech module")


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Restores the Qt5 Core5Compat module as a dependency for third-party libraries (libcommuni and edbee-lib) that still require it, while keeping the rest of Mudlet's codebase using modern Qt6 APIs.

#### Motivation for adding to Mudlet

PR #8550 removed Core5Compat entirely, which broke compilation of third-party dependencies that haven't been updated to Qt6's native APIs yet. This fix adds Core5Compat back to the build system (CMake and qmake) so these dependencies can compile, while Mudlet's own code continues to use Qt6's modern encoding APIs.

#### Other info (issues closed, discussion etc)

Addresses build failures reported by @SlySven where edbee-lib and libcommuni failed to compile after #8550 was merged. This is a minimal restoration that only makes Core5Compat available to dependencies that need it, without reverting any of the modernization work done in #8550.

Changes:
- Added `find_package(Qt6 COMPONENTS Core5Compat REQUIRED)` to main CMakeLists.txt
- Added `core5compat` to QT modules in src/mudlet.pro
- Third-party libraries (communi, edbee-lib) already have Core5Compat in their build configs