### PR TITLE
infra: remove item check in saveSelectedItem

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -9849,12 +9849,8 @@ void dlgTriggerEditor::slot_deleteItemOrGroup()
     }
 }
 
-void dlgTriggerEditor::slot_saveSelectedItem(QTreeWidgetItem* pItem)
+void dlgTriggerEditor::slot_saveSelectedItem()
 {
-    if (!pItem) {
-        return;
-    }
-
     switch (mCurrentView) {
     case EditorViewType::cmTriggerView:
         saveTrigger();

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -251,7 +251,7 @@ public slots:
     void slot_soundTrigger();
     void slot_colorizeTriggerSetBgColor();
     void slot_colorizeTriggerSetFgColor();
-    void slot_saveSelectedItem(QTreeWidgetItem* pItem);
+    void slot_saveSelectedItem();
     void slot_export();
     void slot_import();
     void slot_createModule();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Since all calls to this function are from item widgets the check is not necessary as QT guarantees the item to exist.  It's also not used and all farmed out save functions check the item is valid again anyway.

#### Motivation for adding to Mudlet
Simpler code.

#### Other info (issues closed, discussion etc)
closes #8299 