### PR TITLE
infra: update communi to qt6

### DIFF
--- a/3rdparty/communi/CMakeLists.txt
+++ b/3rdparty/communi/CMakeLists.txt
@@ -26,8 +26,6 @@ endif()
 
 project(communi)
 
-option(WITH_QT6 "Whether to build with Qt6 or Qt5." ON)
-
 find_package(Qt6 REQUIRED COMPONENTS Core Network)
 set(QT_LIBS Qt6::Core Qt6::Network)
 

--- a/3rdparty/communi/CMakeLists.txt
+++ b/3rdparty/communi/CMakeLists.txt
@@ -28,19 +28,8 @@ project(communi)
 
 option(WITH_QT6 "Whether to build with Qt6 or Qt5." ON)
 
-if(WITH_QT6)
-  find_package(Qt6 REQUIRED COMPONENTS Core Network Core5Compat)
-  set(QT_LIBS Qt6::Core Qt6::Network Qt6::Core5Compat)
-else()
-  find_package(Qt5 REQUIRED COMPONENTS Core Network)
-  set(QT_LIBS Qt5::Core Qt5::Network)
-  # Versionless QT_* commands are only supported since Qt 5.15
-  if (Qt5Core_VERSION VERSION_LESS 5.15)
-    macro(QT_GENERATE_MOC)
-      QT5_GENERATE_MOC(${ARGN})
-    endmacro()
-  endif()
-endif()
+find_package(Qt6 REQUIRED COMPONENTS Core Network)
+set(QT_LIBS Qt6::Core Qt6::Network)
 
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/IrcCore

--- a/3rdparty/communi/include/IrcCore/ircmessagedecoder_p.h
+++ b/3rdparty/communi/include/IrcCore/ircmessagedecoder_p.h
@@ -31,7 +31,7 @@
 
 #include <IrcGlobal>
 #include <QtCore/qbytearray.h>
-#include <QTextCodec>
+//#include <QTextCodec>
 
 IRC_BEGIN_NAMESPACE
 

--- a/3rdparty/communi/include/IrcCore/ircmessagedecoder_p.h
+++ b/3rdparty/communi/include/IrcCore/ircmessagedecoder_p.h
@@ -31,7 +31,7 @@
 
 #include <IrcGlobal>
 #include <QtCore/qbytearray.h>
-//#include <QTextCodec>
+
 
 IRC_BEGIN_NAMESPACE
 

--- a/3rdparty/communi/src/core/irccommand.cpp
+++ b/3rdparty/communi/src/core/irccommand.cpp
@@ -31,7 +31,7 @@
 #include "ircconnection.h"
 #include "ircmessage.h"
 #include "irccore_p.h"
-#include <QTextCodec>
+//#include <QTextCodec>
 #include <QMetaEnum>
 #include <QDebug>
 

--- a/3rdparty/communi/src/core/irccommand.cpp
+++ b/3rdparty/communi/src/core/irccommand.cpp
@@ -31,7 +31,6 @@
 #include "ircconnection.h"
 #include "ircmessage.h"
 #include "irccore_p.h"
-//#include <QTextCodec>
 #include <QMetaEnum>
 #include <QDebug>
 

--- a/3rdparty/communi/src/core/irccommand.cpp
+++ b/3rdparty/communi/src/core/irccommand.cpp
@@ -370,14 +370,11 @@ void IrcCommand::setParameters(const QStringList& parameters)
     This property holds the encoding that is used when
     sending the command via IrcConnection::sendCommand().
 
-    See QTextCodec::availableCodes() for the list of
-    supported encodings. The default value is \c "UTF-8".
+    The default value is \c "UTF-8".
 
     \par Access functions:
     \li QByteArray <b>encoding</b>() const
     \li void <b>setEncoding</b>(const QByteArray& encoding)
-
-    \sa QTextCodec::availableCodecs()
  */
 QByteArray IrcCommand::encoding() const
 {

--- a/3rdparty/communi/src/core/ircconnection.cpp
+++ b/3rdparty/communi/src/core/ircconnection.cpp
@@ -641,14 +641,7 @@ IrcConnection* IrcConnection::clone(QObject *parent) const
 }
 
 /*!
-    This property holds the FALLBACK encoding for received messages.
-
-    The fallback encoding is used when the message is detected not
-    to be valid \c UTF-8 and the consequent auto-detection of message
-    encoding fails. See QTextCodec::availableCodecs() for the list of
-    supported encodings.
-
-    The default value is \c ISO-8859-15.
+    Only support UTF-8 encoding for now.
 
     \par Access functions:
     \li QByteArray <b>encoding</b>() const

--- a/3rdparty/communi/src/core/ircconnection.cpp
+++ b/3rdparty/communi/src/core/ircconnection.cpp
@@ -42,7 +42,7 @@
 #include <QRegularExpression>
 #include <QDateTime>
 #include <QTcpSocket>
-#include <QTextCodec>
+//#include <QTextCodec>
 #include <QMetaObject>
 #include <QMetaMethod>
 #include <QMetaEnum>
@@ -1439,6 +1439,8 @@ void IrcConnection::quit(const QString& reason)
 
     \sa sendData()
  */
+
+
 bool IrcConnection::sendCommand(IrcCommand* command)
 {
     Q_D(IrcConnection);
@@ -1455,18 +1457,19 @@ bool IrcConnection::sendCommand(IrcCommand* command)
                 d->activeCommandFilters.pop();
             }
         }
-        if (filtered) {
-            res = false;
-        } else {
-            QTextCodec* codec = QTextCodec::codecForName(command->encoding());
-            Q_ASSERT(codec);
-            res = sendData(codec->fromUnicode(command->toString()));
+        if (!filtered) {
+            QStringEncoder encoder(QStringEncoder::Utf8);
+            QByteArray encoded = encoder.encode(command->toString());
+            res = sendData(encoded);
         }
         if (!command->parent())
             command->deleteLater();
     }
     return res;
 }
+
+
+
 
 /*!
     Sends raw \a data to the server.

--- a/3rdparty/communi/src/core/ircconnection.cpp
+++ b/3rdparty/communi/src/core/ircconnection.cpp
@@ -42,7 +42,6 @@
 #include <QRegularExpression>
 #include <QDateTime>
 #include <QTcpSocket>
-//#include <QTextCodec>
 #include <QMetaObject>
 #include <QMetaMethod>
 #include <QMetaEnum>
@@ -646,8 +645,6 @@ IrcConnection* IrcConnection::clone(QObject *parent) const
     \par Access functions:
     \li QByteArray <b>encoding</b>() const
     \li void <b>setEncoding</b>(const QByteArray& encoding)
-
-    \sa QTextCodec::availableCodecs(), QTextCodec::codecForLocale()
  */
 QByteArray IrcConnection::encoding() const
 {

--- a/3rdparty/communi/src/core/ircmessage.cpp
+++ b/3rdparty/communi/src/core/ircmessage.cpp
@@ -605,20 +605,11 @@ void IrcMessage::setTimeStamp(const QDateTime& timeStamp)
 }
 
 /*!
-    This property holds the FALLBACK encoding for the message.
-
-    The fallback encoding is used when the message is detected not
-    to be valid UTF-8 and the consequent auto-detection of message
-    encoding fails. See QTextCodec::availableCodes() for the list of
-    supported encodings.
-
-    The default value is ISO-8859-15.
+    Only support UTF-8.
 
     \par Access functions:
     \li QByteArray <b>encoding</b>() const
     \li void <b>setEncoding</b>(const QByteArray& encoding)
-
-    \sa QTextCodec::availableCodecs(), QTextCodec::codecForLocale()
  */
 QByteArray IrcMessage::encoding() const
 {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Update communi (IRC) to use only Qt6 libraries.

#### Motivation for adding to Mudlet
We use Qt6.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d2f2cbba-4043-4168-8692-6611ae90d471" />

#### Other info (issues closed, discussion etc)
Only support for UTF-8 which is the most common character encoding for IRC.

#8550 
#8578 