### PR TITLE
Fix potential issue in area image export

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -5223,14 +5223,16 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
             painter.setBrush(QBrush(mpHost->mLowerLevelColor));
 
             // Draw shadow room using the same approach as paintEvent (lines 1426-1442)
+            // Cast to qreal before multiplication to ensure double precision and avoid potential overflow
+            const qreal scaledRoomSize = static_cast<qreal>(finalRoomSize) * rSize;
             if (mBubbleMode) {
                 const QPointF roomCenter(rx, ry);
-                const float roomRadius = (finalRoomSize * rSize) / 2.0f;
+                const qreal roomRadius = scaledRoomSize / 2.0;
                 QPainterPath diameterPath;
                 diameterPath.addEllipse(roomCenter, roomRadius, roomRadius);
                 painter.drawPath(diameterPath);
             } else {
-                const QRectF shadowRect(rx - (finalRoomSize * rSize * 0.8), ry - (finalRoomSize * rSize * 0.2), finalRoomSize * rSize, finalRoomSize * rSize);
+                const QRectF shadowRect(rx - (scaledRoomSize * 0.8), ry - (scaledRoomSize * 0.2), scaledRoomSize, scaledRoomSize);
                 painter.drawRect(shadowRect);
             }
             painter.restore();

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -5223,7 +5223,6 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
             painter.setBrush(QBrush(mpHost->mLowerLevelColor));
 
             // Draw shadow room using the same approach as paintEvent (lines 1426-1442)
-            // Cast to qreal before multiplication to ensure double precision and avoid potential overflow
             const qreal scaledRoomSize = static_cast<qreal>(finalRoomSize) * rSize;
             if (mBubbleMode) {
                 const QPointF roomCenter(rx, ry);


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Cast finalRoomSize to qreal before multiplying with rSize to ensure the calculation is performed in double precision, addressing CodeQL alert cpp/integer-multiplication-cast-to-long.

Also changes roomRadius from float to qreal for consistency.
#### Motivation for adding to Mudlet
Fix a potential issue as discovered by a static analyzer.
#### Other info (issues closed, discussion etc)
