### PR TITLE
Fix: Test builds now use keychain for password storage

### DIFF
--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -355,12 +355,13 @@ void CredentialManager::retrievePassword(const QString& profileName, const QStri
 
         retrieveCredential(service, key, fallbackCallback);
     } else {
-        // Use SecureStringUtils directly
+        // Use SecureStringUtils directly (portable/test mode)
         QString password = retrieveCredentialFromFile(profileName, key);
         bool success = !password.isEmpty();
 
         if (callback) {
-            callback(success, password, success ? QString() : qsl("Failed to retrieve password with SecureStringUtils"));
+            // Empty password is normal for first-time profiles - not an error
+            callback(success, password, success ? QString() : qsl("No password stored in encrypted file storage"));
         }
     }
 }

--- a/src/SecureStringUtils.cpp
+++ b/src/SecureStringUtils.cpp
@@ -410,14 +410,7 @@ bool SecureStringUtils::isTestEnvironment()
 {
     // Check if we're running in a test environment
     // This prevents keychain access during automated testing
-
-    // Check various indicators that we're in a test environment
-    QString appName = QCoreApplication::applicationName();
-    QStringList args = QCoreApplication::arguments();
-
-    return qEnvironmentVariableIsSet("MUDLET_TEST_MODE") ||
-           appName.contains("Test", Qt::CaseInsensitive) ||
-           args.first().contains("Test", Qt::CaseInsensitive);
+    return qEnvironmentVariableIsSet("MUDLET_TEST_MODE");
 }
 
 QByteArray SecureStringUtils::generateNonce()

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2301,9 +2301,9 @@ void dlgConnectionProfiles::slot_loadPasswordAsync()
                             qDebug() << "dlgConnectionProfiles: Successfully loaded password from keychain for" << profile_name;
                         }
                     } else {
-                        // Fallback to QSettings only if keychain operation failed
+                        // Fallback to QSettings only if credential retrieval failed
                         loadPasswordFromSettings(profile_name);
-                        qDebug() << "dlgConnectionProfiles: Keychain failed for" << profile_name << ", using file fallback:" << errorMessage;
+                        qDebug() << "dlgConnectionProfiles: Credential retrieval unsuccessful for" << profile_name << "-" << errorMessage;
                     }
                 }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Simplifies test environment detection to only check for the `MUDLET_TEST_MODE` environment variable. Also improves error messages to be clearer when no password has been saved yet.

#### Motivation for adding to Mudlet

Users manually testing PR builds (like `Mudlet-Test-PR-8369.AppImage`) were unintentionally bypassed from using the system keychain because "Test" appeared in the executable name. This caused confusion during testing and made password storage behave differently than in release builds.

#### Other info (issues closed, discussion etc)

Related to PR #8369 testing feedback. CI automated tests will continue to work by setting `MUDLET_TEST_MODE=1` environment variable.