### PR TITLE
Fix: ignoring macOS keychain for telnet functional test

### DIFF
--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -332,6 +332,7 @@ public:
     void showOptionsDialog(const QString&);
     void startAutoLogin(const QStringList&);
     bool storingPasswordsSecurely() const { return mStorePasswordsSecurely; }
+    void setStorePasswordsSecurely(const bool storeSecurely) { mStorePasswordsSecurely = storeSecurely; }
     enums::controlsVisibility toolBarVisibility() const { return mToolbarVisibility; }
     void updateDiscordNamedIcon();
     void updateMultiViewControls();

--- a/test/functional_tests/TelnetTextDisplayedTest.cpp
+++ b/test/functional_tests/TelnetTextDisplayedTest.cpp
@@ -55,6 +55,7 @@ private slots:
         mudlet::self()->setupConfig();
         mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
         mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
         deleteProfileDirectory(mpHostname);
     }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
The functional test no longer uses the macOS Keychain.
#### Motivation for adding to Mudlet
Fix CI failing https://github.com/Mudlet/Mudlet/pull/8572#issuecomment-3587918831
#### Other info (issues closed, discussion etc)
