### PR TITLE
Fix: maintain backwards compatibility when loading rex_pcre2

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5641,9 +5641,12 @@ void TLuaInterpreter::initLuaGlobals()
         mpHost->postMessage(modLoadMessageQueue.dequeue());
     }
 
-    loaded = loadLuaModule(modLoadMessageQueue, QLatin1String("rex_pcre2"));
-    if (!loaded) {
-         loadLuaModule(modLoadMessageQueue, QLatin1String("rex_pcre"), tr("Some regular expression functions may not be available."), QString(), qsl("rex_pcre2"));
+    loaded = loadLuaModule(modLoadMessageQueue, QLatin1String("rex_pcre2"), QString(), QString(), qsl("rex_pcre"));
+    if (loaded) {
+        // PCRE2 renamed fullinfo() to patterninfo(), add wrapper for backwards compatibility
+        luaL_dostring(pGlobalLua, "rex_pcre.fullinfo = rex_pcre.patterninfo");
+    } else {
+        loadLuaModule(modLoadMessageQueue, QLatin1String("rex_pcre"), tr("Some regular expression functions may not be available."));
     }
 
     while (!modLoadMessageQueue.isEmpty()) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
- Load rex_pcre2 under the rex_pcre identifier so existing scripts find it
- Add fullinfo() wrapper mapping to patterninfo() for API compatibility
#### Motivation for adding to Mudlet
Maintain backwards compatibility with any scripts that might be requiring pcre explicitly
#### Other info (issues closed, discussion etc)
