### PR TITLE
Fix missing encodings in dropdown for Qt6

### DIFF
--- a/src/TEncodingHelper.cpp
+++ b/src/TEncodingHelper.cpp
@@ -18,6 +18,7 @@
  ***************************************************************************/
 
 #include "TEncodingHelper.h"
+#include "TEncodingTable.h"
 #include "TTextCodec.h"
 #include <QDebug>
 
@@ -35,6 +36,79 @@ std::optional<QStringConverter::Encoding> TEncodingHelper::getQtEncoding(const Q
 {
     auto enc = QStringConverter::encodingForName(encoding.constData());
     return enc;
+}
+
+bool TEncodingHelper::hasLookupTable(const QByteArray& encoding)
+{
+    const auto& table = TEncodingTable::csmDefaultInstance.getLookupTable(encoding);
+    return !table.isEmpty();
+}
+
+QString TEncodingHelper::decodeWithLookupTable(const QByteArray& bytes, const QByteArray& encoding)
+{
+    const auto& lookupTable = TEncodingTable::csmDefaultInstance.getLookupTable(encoding);
+    if (lookupTable.isEmpty()) {
+        return QString::fromLatin1(bytes);
+    }
+
+    QString result;
+    result.reserve(bytes.size());
+
+    for (const char c : bytes) {
+        const auto byte = static_cast<quint8>(c);
+        if (byte < 128) {
+            result.append(QChar(byte));
+        } else {
+            result.append(lookupTable.at(byte - 128));
+        }
+    }
+
+    return result;
+}
+
+QByteArray TEncodingHelper::encodeWithLookupTable(const QString& str, const QByteArray& encoding)
+{
+    const auto& lookupTable = TEncodingTable::csmDefaultInstance.getLookupTable(encoding);
+    if (lookupTable.isEmpty()) {
+        return str.toLatin1();
+    }
+
+    QByteArray result;
+    result.reserve(str.size());
+
+    for (const QChar& ch : str) {
+        if (ch.unicode() < 128) {
+            result.append(static_cast<char>(ch.unicode()));
+        } else {
+            int index = lookupTable.indexOf(ch);
+            if (index >= 0) {
+                result.append(static_cast<char>(index + 128));
+            } else {
+                result.append('?');
+            }
+        }
+    }
+
+    return result;
+}
+
+bool TEncodingHelper::canEncodeWithLookupTable(const QString& str, const QByteArray& encoding)
+{
+    const auto& lookupTable = TEncodingTable::csmDefaultInstance.getLookupTable(encoding);
+    if (lookupTable.isEmpty()) {
+        return false;
+    }
+
+    for (const QChar& ch : str) {
+        if (ch.unicode() < 128) {
+            continue;
+        }
+        if (lookupTable.indexOf(ch) < 0) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 QString TEncodingHelper::decode(const QByteArray& bytes, const QByteArray& encoding)
@@ -60,7 +134,11 @@ QString TEncodingHelper::decode(const QByteArray& bytes, const QByteArray& encod
         QStringDecoder decoder(*qtEnc);
         return decoder.decode(bytes);
     }
-    
+
+    if (hasLookupTable(encoding)) {
+        return decodeWithLookupTable(bytes, encoding);
+    }
+
     return QString::fromLatin1(bytes);
 }
 
@@ -87,7 +165,11 @@ QByteArray TEncodingHelper::encode(const QString& str, const QByteArray& encodin
         QStringEncoder encoder(*qtEnc);
         return encoder.encode(str);
     }
-    
+
+    if (hasLookupTable(encoding)) {
+        return encodeWithLookupTable(str, encoding);
+    }
+
     return str.toLatin1();
 }
 
@@ -111,7 +193,11 @@ bool TEncodingHelper::canEncode(const QString& str, const QByteArray& encoding)
         QByteArray encoded = encoder.encode(str);
         return encoder.hasError() == false;
     }
-    
+
+    if (hasLookupTable(encoding)) {
+        return canEncodeWithLookupTable(str, encoding);
+    }
+
     // Unknown encoding - cannot encode
     return false;
 }
@@ -119,6 +205,10 @@ bool TEncodingHelper::canEncode(const QString& str, const QByteArray& encoding)
 bool TEncodingHelper::isEncodingAvailable(const QByteArray& encoding)
 {
     if (isCustomEncoding(encoding)) {
+        return true;
+    }
+
+    if (hasLookupTable(encoding)) {
         return true;
     }
     

--- a/src/TEncodingHelper.h
+++ b/src/TEncodingHelper.h
@@ -43,6 +43,10 @@ public:
 private:
     static bool isCustomEncoding(const QByteArray& encoding);
     static std::optional<QStringConverter::Encoding> getQtEncoding(const QByteArray& encoding);
+    static bool hasLookupTable(const QByteArray& encoding);
+    static QString decodeWithLookupTable(const QByteArray& bytes, const QByteArray& encoding);
+    static QByteArray encodeWithLookupTable(const QString& str, const QByteArray& encoding);
+    static bool canEncodeWithLookupTable(const QString& str, const QByteArray& encoding);
 };
 
 #endif // TENCODINGHELPER_H


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Qt6's QStringConverter only supports UTF-8, UTF-16, and Latin1. Use TEncodingTable lookup tables for all other encodings like WINDOWS-1251, ISO 8859-*, KOI8-R/U, etc.
#### Motivation for adding to Mudlet
Fixes #8604
#### Other info (issues closed, discussion etc)
Doesn't address the error message on the Medieva font, I am not sure what is that about just yet.