### PR TITLE
Fix: Prevent crash during Mudlet shutdown when closing profiles

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -4487,7 +4487,7 @@ void Host::setFocusOnHostActiveCommandLine()
 
 void Host::recordActiveCommandLine(TCommandLine* pCommandLine)
 {
-    if (!pCommandLine) {
+    if (!pCommandLine || mIsClosingDown) {
         return;
     }
     mpLastCommandLineUsed.removeAll(QPointer<TCommandLine>(pCommandLine));
@@ -4496,7 +4496,7 @@ void Host::recordActiveCommandLine(TCommandLine* pCommandLine)
 
 void Host::forgetCommandLine(TCommandLine* pCommandLine)
 {
-    if (pCommandLine) {
+    if (pCommandLine && !mIsClosingDown) {
         mpLastCommandLineUsed.removeAll(QPointer<TCommandLine>(pCommandLine));
     }
 }
@@ -4505,7 +4505,7 @@ void Host::forgetCommandLine(TCommandLine* pCommandLine)
 TCommandLine* Host::activeCommandLine()
 {
     TCommandLine* pCommandLine = nullptr;
-    if (mpLastCommandLineUsed.isEmpty()) {
+    if (mIsClosingDown || mpLastCommandLineUsed.isEmpty()) {
         return nullptr;
     }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Added safety checks to prevent accessing command line tracking during Host shutdown. The fix adds `mIsClosingDown` checks to three Host methods that manage the command line focus stack.

#### Motivation for adding to Mudlet

Mudlet was crashing with a segmentation fault when shutting down, especially when closing multiple profiles. The crash occurred because focus events were still trying to update command line tracking while the Host object was being destroyed, leading to access of invalid memory.

#### Other info (issues closed, discussion etc)

- Fixes #7478 
- Crash was happening in `Host::recordActiveCommandLine()` during shutdown
- Added protection to `recordActiveCommandLine()`, `forgetCommandLine()`, and `activeCommandLine()` methods
- Tested successfully - Mudlet now shuts down cleanly without crashes