### PR TITLE
Fix: Medievia encoding error in preferences dropdown

### DIFF
--- a/src/TEncodingHelper.cpp
+++ b/src/TEncodingHelper.cpp
@@ -27,8 +27,7 @@ bool TEncodingHelper::isCustomEncoding(const QByteArray& encoding)
            encoding == "CP437" ||
            encoding == "CP667" ||
            encoding == "CP737" ||
-           encoding == "CP869" ||
-           encoding == "MEDIEVIA";
+           encoding == "CP869";
 }
 
 std::optional<QStringConverter::Encoding> TEncodingHelper::getQtEncoding(const QByteArray& encoding)

--- a/src/TTextCodec.cpp
+++ b/src/TTextCodec.cpp
@@ -232,7 +232,7 @@ int TTextCodec_869::mibEnum()
 
 QList<QByteArray> TTextCodec_medievia::aliases()
 {
-    return {};
+    return {"M_MEDIEVIA"};
 }
 
 int TTextCodec_medievia::mibEnum()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixed the "Error, report to Mudlet Makers" message that appeared for the Medievia encoding option in the server encoding preferences dropdown. The Medievia encoding now displays properly with its correct description.

#### Motivation for adding to Mudlet

Users selecting the Medievia encoding from the preferences dropdown were seeing an error message instead of a proper description, making it appear broken. This fix ensures the encoding option works correctly and displays the intended "Medievia {Custom codec for that MUD}" description.

#### Other info (issues closed, discussion etc)

**Partial fix for #8604**: This PR addresses the "MEDIEVIA (*Error, report to Mudlet Makers*)" portion of issue #8604. While PR #8605 handles the missing Windows-1251 and other Qt6 encodings, this PR specifically fixes the Medievia encoding error that was also reported in the same issue.

Changes made:
- Modified `TTextCodec_medievia::aliases()` to return `{"M_MEDIEVIA"}` instead of empty list
- Removed "MEDIEVIA" from `TEncodingHelper::isCustomEncoding()` to allow proper encoding replacement
- Ensured encoding map lookup works correctly for the M_MEDIEVIA key

The fix ensures that when the encoding system processes available encodings, "MEDIEVIA" gets properly replaced with "M_MEDIEVIA" which matches the key in the encoding names map. This resolves the specific error message users were seeing for the Medievia encoding option.

<img width="314" height="270" alt="Screenshot 2025-12-01 at 9 33 20 PM" src="https://github.com/user-attachments/assets/3e63d7f2-3c55-447b-b37a-dbca2daad75c" />
