### PR TITLE
Fix: convert raw Qt pointers to QPointer to prevent use-after-free

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -535,11 +535,11 @@ public:
     bool mIsProfileLoadingSequence = false;
 
 
-    dlgTriggerEditor* mpEditorDialog{nullptr};
+    QPointer<dlgTriggerEditor> mpEditorDialog;
     QScopedPointer<TMap> mpMap;
     QScopedPointer<TMedia> mpMedia;
     QScopedPointer<GMCPAuthenticator> mpAuth;
-    dlgNotepad* mpNotePad{nullptr};
+    QPointer<dlgNotepad> mpNotePad;
 
     // Controls how sent commands are displayed on the main TConsole:
     enum class CommandEchoMode {

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -247,7 +247,7 @@ public:
     // centered on mRoomID - it seems to be needed if the room concerned
     // is being moved by the mouse as part of a selection:
     bool mShiftMode = false;
-    QComboBox* arealist_combobox = nullptr;
+    QPointer<QComboBox> arealist_combobox;
     QPointer<QDialog> mpCustomLinesDialog;
     int mCustomLinesRoomFrom = 0;
     int mCustomLinesRoomTo = 0;
@@ -413,8 +413,8 @@ private:
     // Holds the QRadialGradient details to use for the player room:
     QGradientStops mPlayerRoomColorGradentStops;
 
-    dlgRoomProperties* mpDlgRoomProperties = nullptr;
-    dlgMapLabel* mpDlgMapLabel = nullptr;
+    QPointer<dlgRoomProperties> mpDlgRoomProperties;
+    QPointer<dlgMapLabel> mpDlgMapLabel;
     // Track the area last viewed so we can raise an event when it changes,
     // initialised to an invalid area that is different to the one that mAreaID
     // is initialised to - so that the xyzoom gets read for the first area that

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -369,7 +369,7 @@ public:
     QWidget* mpRightToolBar = nullptr;
     QWidget* mpMainDisplay = nullptr;
 
-    dlgMapper* mpMapper = nullptr;
+    QPointer<dlgMapper> mpMapper;
 
     QScrollBar* mpScrollBar = nullptr;
     QScrollBar* mpHScrollBar = nullptr;

--- a/src/TDetachedWindow.h
+++ b/src/TDetachedWindow.h
@@ -282,7 +282,7 @@ private:
     // Window menu management for multiple windows
     QList<QAction*> mWindowListActions;
     QAction* mWindowListSeparator{nullptr};
-    QMenu* mpWindowMenu{nullptr};
+    QPointer<QMenu> mpWindowMenu;
 
     // Docked widgets management
     QMap<QString, QPointer<QDockWidget>> mDockWidgetMap;

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -248,7 +248,7 @@ public:
     bool mFORCE_GA_OFF = false;
     QPointer<dlgComposer> mpComposer;
     QNetworkAccessManager* mpDownloader = nullptr;
-    QProgressDialog* mpProgressDialog = nullptr;
+    QPointer<QProgressDialog> mpProgressDialog;
     QString mServerPackage;
     QString mProfileName;
 

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -86,7 +86,7 @@ public slots:
 private:
     TMap* mpMap = nullptr;
     QPointer<Host> mpHost;
-    QMenu* mpInfoMenu = nullptr;
+    QPointer<QMenu> mpInfoMenu;
     bool mIs3DMode = false;
 };
 

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -284,10 +284,9 @@ dlgRoomExits::dlgRoomExits(Host* pH, const int roomNumber, QWidget* pW)
 
 dlgRoomExits::~dlgRoomExits()
 {
-    delete mpAction_otherAreaExit;
-    delete mpAction_inAreaExit;
-    delete mpAction_invalidExit;
-    delete mpAction_noExit;
+    // QActions are children of this dialog (created with 'this' as parent),
+    // so Qt's parent-child system handles their deletion automatically.
+    // Manual deletion here would cause double-delete crashes.
 }
 
 void dlgRoomExits::slot_endEditSpecialExits()


### PR DESCRIPTION
Convert raw Qt pointers to QPointer in 7 files to prevent use-after-free crashes when dialogs/menus with WA_DeleteOnClose are destroyed, and fix a double-delete bug in dlgRoomExits destructor.
#### Motivation for adding to Mudlet
Less potential crashes 
#### Other info (issues closed, discussion etc)
