### PR TITLE
Fix: Update Medievia encoding display name to use proper capitalization

### DIFF
--- a/src/TEncodingHelper.cpp
+++ b/src/TEncodingHelper.cpp
@@ -27,8 +27,7 @@ bool TEncodingHelper::isCustomEncoding(const QByteArray& encoding)
            encoding == "CP437" ||
            encoding == "CP667" ||
            encoding == "CP737" ||
-           encoding == "CP869" ||
-           encoding == "MEDIEVIA";
+           encoding == "CP869";
 }
 
 std::optional<QStringConverter::Encoding> TEncodingHelper::getQtEncoding(const QByteArray& encoding)

--- a/src/TTextCodec.cpp
+++ b/src/TTextCodec.cpp
@@ -232,7 +232,7 @@ int TTextCodec_869::mibEnum()
 
 QList<QByteArray> TTextCodec_medievia::aliases()
 {
-    return {};
+    return {"M_MEDIEVIA"};
 }
 
 int TTextCodec_medievia::mibEnum()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1280,7 +1280,7 @@ void mudlet::loadMaps()
                         //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
                         {"MACINTOSH", tr("MACINTOSH")},
                         //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"M_MEDIEVIA",  qsl("m ") % tr("Medievia {Custom codec for that MUD}")},
+                        {"M_MEDIEVIA", tr("MEDIEVIA (Custom codec for that MUD)")},
                         //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
                         {"WINDOWS-1250", tr("WINDOWS-1250 (Central European)")},
                         //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Updates the display name for the Medievia custom encoding in the preferences dropdown from "Medievia (Custom codec for that MUD)" to "MEDIEVIA (Custom codec for that MUD)" to use proper all-caps formatting.

#### Motivation for adding to Mudlet

Improves consistency with the expected naming convention for the Medievia MUD's custom encoding option in the user interface.

#### Other info (issues closed, discussion etc)

Follow-up to PR #8608 to address the display formatting of the Medievia encoding option in the preferences dialog.