### PR TITLE
Fix: GMCP commands fail after reconnection

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -136,6 +136,16 @@ void cTelnet::reset()
     iac = false;
     iac2 = false;
     insb = false;
+    
+    // Reset all protocol enable flags to ensure proper re-negotiation on reconnect
+    enableATCP = false;
+    enableGMCP = false;
+    enableMSSP = false;
+    enableMSDP = false;
+    enableMSP = false;
+    enableMXP = false;
+    enableChannel102 = false;
+    
     // Ensure we do not think that the game server is echoing for us:
     mpHost->setRemoteEchoingActive(false);
     mGA_Driver = false;


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes an issue where GMCP commands like `sendGMCP()` stop working after the client reconnects to a game server. The problem occurred because protocol state flags weren't being properly reset when connections were lost, causing inconsistent internal state.

#### Motivation for adding to Mudlet

Players reported that GMCP functionality would break after being connected for several hours and experiencing disconnections/reconnections. This affected scripts and packages that rely on GMCP communication with game servers, making them unreliable for long gaming sessions.

#### Other info (issues closed, discussion etc)

- Resolves state management inconsistency in telnet protocol handling
- Ensures `sysProtocolEnabled` events fire correctly on reconnect
- Maintains compatibility with existing GMCP-dependent scripts and packages
- No breaking changes to existing functionality