### PR TITLE
Fix: Forward secrets.SENTRY_DSN to CMake on Windows

### DIFF
--- a/CI/build-mudlet-for-windows.sh
+++ b/CI/build-mudlet-for-windows.sh
@@ -150,6 +150,7 @@ CMAKE_ARGS=(
 
 if [ "${WITH_SENTRY}" = "ON" ]; then
     CMAKE_ARGS+=("-DWITH_SENTRY=ON")
+    CMAKE_ARGS+=("-DSENTRY_DSN=${SENTRY_DSN}")
 fi
 
 if [ "${SENTRY_SEND_DEBUG}" = "1" ]; then

--- a/src/crash_reporter/CMakeLists.txt
+++ b/src/crash_reporter/CMakeLists.txt
@@ -5,13 +5,20 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+message(STATUS "=== Sentry Configuration ===")
+message(STATUS "WITH_SENTRY: ${WITH_SENTRY}")
 if(NOT SENTRY_DSN OR SENTRY_DSN STREQUAL "")
-    message(FATAL_ERROR
-        "WITH_SENTRY=ON but SENTRY_DSN is empty!\n"
-        "Please provide a SENTRY_DSN via -DSENTRY_DSN=...\n"
-        "For testing/development, you can use a placeholder DSN like '-DSENTRY_DSN=test'"
-    )
+    message(STATUS "SENTRY_DSN: NOT SET")
+else()
+    message(STATUS "SENTRY_DSN: SET")
 endif()
+
+if(NOT SENTRY_AUTH_TOKEN OR SENTRY_AUTH_TOKEN STREQUAL "")
+    message(STATUS "SENTRY_AUTH_TOKEN: NOT SET")
+else()
+    message(STATUS "SENTRY_AUTH_TOKEN: SET")
+endif()
+message(STATUS "============================")
 
 find_package(Qt6 COMPONENTS Core Widgets REQUIRED)
 

--- a/src/crash_reporter/CMakeLists.txt
+++ b/src/crash_reporter/CMakeLists.txt
@@ -5,6 +5,14 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+if(NOT SENTRY_DSN OR SENTRY_DSN STREQUAL "")
+    message(FATAL_ERROR
+        "WITH_SENTRY=ON but SENTRY_DSN is empty!\n"
+        "Please provide a SENTRY_DSN via -DSENTRY_DSN=...\n"
+        "For testing/development, you can use a placeholder DSN like '-DSENTRY_DSN=test'"
+    )
+endif()
+
 find_package(Qt6 COMPONENTS Core Widgets REQUIRED)
 
 add_executable(MudletCrashReporter main.cpp)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix Sentry DSN not passed to CMake
#### Motivation for adding to Mudlet
Sentry crash reports were not being sent because no DSN was provided.
