### PR TITLE
Fix: clicking on stacked rooms selects all of them

### DIFF
--- a/src/RoomMoveActivationHandler.cpp
+++ b/src/RoomMoveActivationHandler.cpp
@@ -77,16 +77,16 @@ bool RoomMoveActivationHandler::handle(T2DMap::MapInteractionContext& context)
             return false;
         }
 
-        const auto clickedRoomId = mMapWidget.roomIdAtWidgetPosition(context.widgetPosition, context.area);
-        if (!clickedRoomId.has_value()) {
+        const auto clickedRoomIds = mMapWidget.roomIdsAtWidgetPosition(context.widgetPosition, context.area);
+        if (clickedRoomIds.isEmpty()) {
             return false;
         }
 
-        const int roomId = clickedRoomId.value();
+        const int roomId = *clickedRoomIds.constBegin();
 
         if (!mMapWidget.mMultiSelectionSet.contains(roomId)) {
             mMapWidget.mMultiSelectionSet.clear();
-            mMapWidget.mMultiSelectionSet.insert(roomId);
+            mMapWidget.mMultiSelectionSet.unite(clickedRoomIds);
             mMapWidget.mMultiSelectionHighlightRoomId = roomId;
             mMapWidget.mMultiSelection = false;
         } else {

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -141,6 +141,43 @@ std::optional<int> T2DMap::roomIdAtWidgetPosition(const QPoint& widgetPosition, 
     return std::nullopt;
 }
 
+QSet<int> T2DMap::roomIdsAtWidgetPosition(const QPoint& widgetPosition, const TArea* area) const
+{
+    QSet<int> result;
+
+    if (!mpMap || !mpMap->mpRoomDB || !area) {
+        return result;
+    }
+
+    const float fx = ((xspan / 2.0f) - mMapCenterX) * mRoomWidth;
+    const float fy = ((yspan / 2.0f) - mMapCenterY) * mRoomHeight;
+
+    const int mx = widgetPosition.x();
+    const int my = widgetPosition.y();
+    const int mz = mMapCenterZ;
+
+    QSetIterator<int> roomIterator(area->getAreaRooms());
+    while (roomIterator.hasNext()) {
+        const int roomId = roomIterator.next();
+        TRoom* room = mpMap->mpRoomDB->getRoom(roomId);
+        if (!room) {
+            continue;
+        }
+
+        const int rx = room->x() * mRoomWidth + fx;
+        const int ry = room->y() * -1 * mRoomHeight + fy;
+        const int rz = room->z();
+
+        if ((qAbs(mx - rx) < qRound(mRoomWidth * rSize / 2.0))
+            && (qAbs(my - ry) < qRound(mRoomHeight * rSize / 2.0))
+            && (mz == rz)) {
+            result.insert(roomId);
+        }
+    }
+
+    return result;
+}
+
 void T2DMap::prepareSingleClickSelection(MapInteractionContext& context)
 {
     mMultiRect = QRect(context.widgetPosition, context.widgetPosition);

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -152,6 +152,7 @@ public:
     bool eventFilter(QObject* watched, QEvent* event) override;
     void prepareSingleClickSelection(MapInteractionContext& context);
     std::optional<int> roomIdAtWidgetPosition(const QPoint& widgetPosition, const TArea* area) const;
+    QSet<int> roomIdsAtWidgetPosition(const QPoint& widgetPosition, const TArea* area) const;
     void populateUserContextMenus(QMenu& menu);
 
     // Was getTopLeft() which returned an index into mMultiSelectionList but that


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix clicking on stacked rooms selects all of them once again.
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/8588
#### Other info (issues closed, discussion etc)
