### PR TITLE
Fix crash in bi-daily update check

### DIFF
--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -178,15 +178,31 @@ void Updater::checkUpdatesOnStart()
 
     mDailyCheck->setInterval(12h);
     connect(mDailyCheck.get(), &QTimer::timeout, this, [this] {
-          auto updates = feed->getUpdates(dblsqd::Release::getCurrentRelease());
-          qWarning() << "Bi-daily check for updates:" << updates.size() << "update(s) available";
-          if (updates.isEmpty()) {
-              return;
-          } else if (!updateAutomatically()) {
-              emit signal_updateAvailable(updates.size());
-          } else {
-              feed->downloadRelease(updates.first());
-          }
+        KDToolBox::connectSingleShot(feed, &dblsqd::Feed::ready, this, [this]() {
+            auto updates = feed->getUpdates(dblsqd::Release::getCurrentRelease());
+            qWarning() << "Bi-daily check for updates:" << updates.size() << "update(s) available";
+            if (updates.isEmpty()) {
+                return;
+            }
+
+            if (!updateAutomatically()) {
+                emit signal_updateAvailable(updates.size());
+                return;
+            }
+
+            const auto& release = updates.first();
+            const QUrl downloadUrl = release.getDownloadUrl();
+            if (!downloadUrl.isValid() || downloadUrl.isEmpty()) {
+                qWarning() << "Bi-daily update check: invalid download URL for release" << release.getVersion();
+                return;
+            }
+
+            feed->downloadRelease(release);
+        });
+        KDToolBox::connectSingleShot(feed, &dblsqd::Feed::loadError, this, [](const QString& error) {
+            qWarning() << "Bi-daily update check: failed to load feed:" << error;
+        });
+        feed->load();
     });
     mDailyCheck->start();
 }


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix crash in bi-daily update check by re-loading the latest feed objects.
#### Motivation for adding to Mudlet
Fix crash, https://discord.com/channels/283581582550237184/283582439002210305/1446702585296846982
#### Other info (issues closed, discussion etc)
A bit of a guess as to what the issue could be, hopefully this is it.