### PR TITLE
Improve: Auto-recover from stuck password masking during login

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2675,11 +2675,11 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                     // to network issues or bugs, while not affecting legitimate
                     // password prompts later in the session (e.g., admin commands).
                     // Skip this if the user has disabled password masking entirely.
-                    constexpr qint64 LOGIN_PHASE_MS = 5 * 60 * 1000;  // 5 minutes
-                    constexpr int PASSWORD_TIMEOUT_MS = 60 * 1000;    // 60 seconds
+                    constexpr auto LOGIN_PHASE_MS = 5min;
+                    constexpr auto PASSWORD_TIMEOUT_MS = 60s;
                     if (!mpHost->mDisablePasswordMasking
                         && mConnectionTimer.isValid()
-                        && mConnectionTimer.elapsed() < LOGIN_PHASE_MS) {
+                        && mConnectionTimer.elapsed() < LOGIN_PHASE_MS.count()) {
                         if (!mTimerPasswordModeTimeout) {
                             mTimerPasswordModeTimeout = new QTimer(this);
                             mTimerPasswordModeTimeout->setSingleShot(true);
@@ -2690,7 +2690,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                                 }
                             });
                         }
-                        mTimerPasswordModeTimeout->start(PASSWORD_TIMEOUT_MS);
+                        mTimerPasswordModeTimeout->start(std::chrono::duration_cast<std::chrono::milliseconds>(PASSWORD_TIMEOUT_MS).count());
                     }
                 } else if ((option == OPT_STATUS) || (option == OPT_TERMINAL_TYPE) || (option == OPT_NAWS)) {
                     sendTelnetOption(TN_DO, option);

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -136,6 +136,10 @@ void cTelnet::reset()
     iac = false;
     iac2 = false;
     insb = false;
+    // Stop any pending password mode timeout
+    if (mTimerPasswordModeTimeout) {
+        mTimerPasswordModeTimeout->stop();
+    }
     // Ensure we do not think that the game server is echoing for us:
     mpHost->setRemoteEchoingActive(false);
     mGA_Driver = false;
@@ -154,6 +158,9 @@ cTelnet::~cTelnet()
     }
     if (mTimerPass) {
         mTimerPass->stop();
+    }
+    if (mTimerPasswordModeTimeout) {
+        mTimerPasswordModeTimeout->stop();
     }
     if (mpPostingTimer) {
         mpPostingTimer->stop();
@@ -2661,6 +2668,30 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                     hisOptionState[idxOption] = true;
                     mpHost->setRemoteEchoingActive(true);
                     qDebug() << "ECHO: Server requesting password mode - enabling content preservation";
+
+                    // Start a safety timeout for password mode, but only during
+                    // the first 5 minutes of a connection (login phase). This
+                    // protects against servers that fail to send WONT ECHO due
+                    // to network issues or bugs, while not affecting legitimate
+                    // password prompts later in the session (e.g., admin commands).
+                    // Skip this if the user has disabled password masking entirely.
+                    constexpr qint64 LOGIN_PHASE_MS = 5 * 60 * 1000;  // 5 minutes
+                    constexpr int PASSWORD_TIMEOUT_MS = 60 * 1000;    // 60 seconds
+                    if (!mpHost->mDisablePasswordMasking
+                        && mConnectionTimer.isValid()
+                        && mConnectionTimer.elapsed() < LOGIN_PHASE_MS) {
+                        if (!mTimerPasswordModeTimeout) {
+                            mTimerPasswordModeTimeout = new QTimer(this);
+                            mTimerPasswordModeTimeout->setSingleShot(true);
+                            connect(mTimerPasswordModeTimeout, &QTimer::timeout, this, [this]() {
+                                if (mpHost && mpHost->isRemoteEchoingActive()) {
+                                    qWarning() << "ECHO: Password mode timeout - server never sent WONT ECHO, clearing masking";
+                                    mpHost->setRemoteEchoingActive(false);
+                                }
+                            });
+                        }
+                        mTimerPasswordModeTimeout->start(PASSWORD_TIMEOUT_MS);
+                    }
                 } else if ((option == OPT_STATUS) || (option == OPT_TERMINAL_TYPE) || (option == OPT_NAWS)) {
                     sendTelnetOption(TN_DO, option);
                     hisOptionState[idxOption] = true;
@@ -2781,6 +2812,10 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 hisOptionState[idxOption] = false;
 
                 if (option == OPT_ECHO) {
+                    // Cancel any pending password mode timeout since we got the proper WONT ECHO
+                    if (mTimerPasswordModeTimeout) {
+                        mTimerPasswordModeTimeout->stop();
+                    }
                     mpHost->setRemoteEchoingActive(false);
                     qDebug() << "ECHO: Server ending password mode - restoring normal operation and preserved content";
                 }

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -409,6 +409,7 @@ private:
     bool mIsTimerPosting = false;
     QTimer* mTimerLogin = nullptr;
     QTimer* mTimerPass = nullptr;
+    QTimer* mTimerPasswordModeTimeout = nullptr;
     QElapsedTimer mRecordingChunkTimer;
     QElapsedTimer mConnectionTimer;
     qint32 mRecordLastChunkMSecTimeOffset = 0;


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds a safety timeout that automatically clears password masking if it gets stuck during the login phase. The timeout only applies during the first 5 minutes of a connection and respects the user's password masking preference.

#### Motivation for adding to Mudlet

Some users on slow connections experience password masking getting stuck after login, requiring them to disable the feature entirely. This happens when the game server fails to properly signal the end of password entry due to network issues. This change provides automatic recovery while preserving the security benefit of password masking.

#### Other info (issues closed, discussion etc)

Reported by @zookaongit - intermittent issue on slow connections where password masking doesn't clear after login.