### PR TITLE
Improve: Update QMake build for Sentry libraries with and without transport

### DIFF
--- a/CI/send_debug_files_to_sentry.sh
+++ b/CI/send_debug_files_to_sentry.sh
@@ -90,9 +90,6 @@ if [[ "$OS" == "Linux" ]]; then
 elif [[ "$OS" == "Darwin" ]]; then
     DEBUG_FILE="${MUDLET_EXEC}.dSYM"
     [[ -d "$DEBUG_FILE" ]] && FILES_TO_UPLOAD+=("$DEBUG_FILE")
-elif [[ "$OS" == "MINGW"* || "$OS" == "MSYS"* ]]; then
-    PDB_FILE="${MUDLET_EXEC%.exe}.pdb"
-    [[ -f "$PDB_FILE" ]] && FILES_TO_UPLOAD+=("$PDB_FILE")
 fi
 
 for f in "${FILES_TO_UPLOAD[@]}"; do

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -724,6 +724,7 @@ set_target_properties(${EXE_MUDLET_TARGET} PROPERTIES ENABLE_EXPORTS ON)
 if (WITH_SENTRY)
   include(cmake/WithSentry.cmake)
   add_subdirectory(crash_reporter)
+  add_dependencies(MudletCrashReporter sentry_with_transport)
 endif()
 
 if(WIN32)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -723,6 +723,7 @@ set_target_properties(${EXE_MUDLET_TARGET} PROPERTIES ENABLE_EXPORTS ON)
 
 if (WITH_SENTRY)
   include(cmake/WithSentry.cmake)
+  #add_dependencies(MudletCrashReporter sentry_with_transport)
   add_subdirectory(crash_reporter)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -723,7 +723,6 @@ set_target_properties(${EXE_MUDLET_TARGET} PROPERTIES ENABLE_EXPORTS ON)
 
 if (WITH_SENTRY)
   include(cmake/WithSentry.cmake)
-  #add_dependencies(MudletCrashReporter sentry_with_transport)
   add_subdirectory(crash_reporter)
 endif()
 

--- a/src/SentryWrapper.cpp
+++ b/src/SentryWrapper.cpp
@@ -22,6 +22,8 @@
 #include "sentry.h"
 #endif
 
+#include <QtSystemDetection>
+
 #ifdef Q_OS_WIN
 #include <windows.h>
 #elif defined(Q_OS_MAC)

--- a/src/cmake/WithSentry.cmake
+++ b/src/cmake/WithSentry.cmake
@@ -118,6 +118,7 @@ add_custom_command(OUTPUT ${STAMP_FILE}
 
 add_custom_target(copy_sentry ALL DEPENDS ${STAMP_FILE})
 add_dependencies(copy_sentry sentry_without_transport)
+add_dependencies(copy_sentry sentry_with_transport)
 add_dependencies(${EXE_MUDLET_TARGET} copy_sentry)
 
 if(APPLE)
@@ -154,6 +155,7 @@ else()
     )
 endif()
 
+
 if(SENTRY_SEND_DEBUG)
     if(NOT DEFINED ENV{SENTRY_AUTH_TOKEN} OR "$ENV{SENTRY_AUTH_TOKEN}" STREQUAL "")
         message(FATAL_ERROR
@@ -168,7 +170,7 @@ if(SENTRY_SEND_DEBUG)
     )
     endif()
 else()
-    if(WIN32)
+    if (WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Release")
         add_custom_command(TARGET ${EXE_MUDLET_TARGET} POST_BUILD
             COMMAND strip --strip-debug $<TARGET_FILE:${EXE_MUDLET_TARGET}>
         )

--- a/src/cmake/WithSentry.cmake
+++ b/src/cmake/WithSentry.cmake
@@ -118,7 +118,6 @@ add_custom_command(OUTPUT ${STAMP_FILE}
 
 add_custom_target(copy_sentry ALL DEPENDS ${STAMP_FILE})
 add_dependencies(copy_sentry sentry_without_transport)
-add_dependencies(copy_sentry sentry_with_transport)
 add_dependencies(${EXE_MUDLET_TARGET} copy_sentry)
 
 if(APPLE)

--- a/src/cmake/WithSentry.cmake
+++ b/src/cmake/WithSentry.cmake
@@ -155,7 +155,6 @@ else()
     )
 endif()
 
-
 if(SENTRY_SEND_DEBUG)
     if(NOT DEFINED ENV{SENTRY_AUTH_TOKEN} OR "$ENV{SENTRY_AUTH_TOKEN}" STREQUAL "")
         message(FATAL_ERROR

--- a/src/crash_reporter/CMakeLists.txt
+++ b/src/crash_reporter/CMakeLists.txt
@@ -31,8 +31,6 @@ if(TARGET ${EXE_MUDLET_TARGET})
     )
 endif()
 
-add_dependencies(MudletCrashReporter sentry_with_transport)
-
 target_include_directories(MudletCrashReporter PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../../3rdparty/sentry-native/install_with_transport/include
      ${CMAKE_CURRENT_SOURCE_DIR}/../../3rdparty/sentry-native/src

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -615,7 +615,7 @@ contains( DEFINES, INCLUDE_UPDATER ) {
     }
 }
 
-WITH_SENTRY {
+equals(WITH_SENTRY, ON) {
     DEFINES += WITH_SENTRY
 
 
@@ -641,8 +641,33 @@ WITH_SENTRY {
         system(cmake --install $$SENTRY_PATH/build --prefix $$SENTRY_PATH/install)
     }
 
-    INCLUDEPATH += $$SENTRY_PATH/install/include
-    LIBS        += -L$$SENTRY_PATH/install/lib
+    # Without Transport Curl (used by Mudlet)
+    SENTRY_INSTALL_NO_TRANSPORT = $$SENTRY_PATH/install_without_transport
+    !exists($$SENTRY_INSTALL_NO_TRANSPORT) {
+        message("Building Sentry without transport")
+        system(cmake -S $$SENTRY_PATH -B $$SENTRY_PATH/build_without_transport \
+            -DCMAKE_INSTALL_PREFIX=$$SENTRY_INSTALL_NO_TRANSPORT \
+            -DSENTRY_TRANSPORT=none \
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+            -DSENTRY_BACKEND=crashpad -DSENTRY_BUILD_SHARED_LIBS=OFF --log-level=ERROR)
+        system(cmake --build $$SENTRY_PATH/build_without_transport --parallel)
+        system(cmake --install $$SENTRY_PATH/build_without_transport --prefix $$SENTRY_INSTALL_NO_TRANSPORT)
+    }
+
+    # With Transport Curl (used by crash reporter)
+    SENTRY_INSTALL_WITH_TRANSPORT = $$SENTRY_PATH/install_with_transport
+    !exists($$SENTRY_INSTALL_WITH_TRANSPORT) {
+        message("Building Sentry with transport")
+        system(cmake -S $$SENTRY_PATH -B $$SENTRY_PATH/build_with_transport \
+            -DCMAKE_INSTALL_PREFIX=$$SENTRY_INSTALL_WITH_TRANSPORT \
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+            -DSENTRY_BACKEND=crashpad -DSENTRY_BUILD_SHARED_LIBS=OFF --log-level=ERROR)
+        system(cmake --build $$SENTRY_PATH/build_with_transport --parallel)
+        system(cmake --install $$SENTRY_PATH/build_with_transport --prefix $$SENTRY_INSTALL_WITH_TRANSPORT)
+    }
+
+    INCLUDEPATH += $$SENTRY_INSTALL_NO_TRANSPORT/include
+    LIBS += -L$$SENTRY_INSTALL_NO_TRANSPORT/lib
     LIBS += -lsentry \
         -lcrashpad_client -lcrashpad_handler_lib -lcrashpad_minidump \
         -lcrashpad_mpack -lcrashpad_snapshot -lcrashpad_tools \
@@ -653,9 +678,7 @@ WITH_SENTRY {
     QMAKE_LFLAGS_RELEASE    += -g -gcodeview
     QMAKE_LFLAGS_RELEASE    -= -Wl,-s
 
-
-    QMAKE_POST_LINK += $$quote($$QMAKE_MOVE $$OUT_PWD/mudlet.pdb $$APP_DIR_PATH/) ;
-    QMAKE_POST_LINK += $$quote(cp -f $$SENTRY_PATH/install/bin/* $$APP_DIR_PATH/) ;
+    QMAKE_POST_LINK += $$quote(cp -f $$SENTRY_INSTALL_NO_TRANSPORT/bin/* $$APP_DIR_PATH/) ;
 
     system(cmake -S $$PWD/crash_reporter/ -B $$PWD/crash_reporter/build/ -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=$$APP_DIR_PATH/)
     system(cmake --build $$PWD/crash_reporter/build/)

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -633,14 +633,6 @@ equals(WITH_SENTRY, ON) {
 
     SENTRY_PATH = $$PWD/../3rdparty/sentry-native
 
-    !exists($$SENTRY_PATH/install) {
-        message("Sentry install missing, building sentry-native from sources")
-
-        system(cmake -S $$SENTRY_PATH -B $$SENTRY_PATH/build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DSENTRY_BACKEND=crashpad -D SENTRY_BUILD_SHARED_LIBS=OFF --log-level=ERROR)
-        system(cmake --build $$SENTRY_PATH/build --parallel)
-        system(cmake --install $$SENTRY_PATH/build --prefix $$SENTRY_PATH/install)
-    }
-
     # Without Transport Curl (used by Mudlet)
     SENTRY_INSTALL_NO_TRANSPORT = $$SENTRY_PATH/install_without_transport
     !exists($$SENTRY_INSTALL_NO_TRANSPORT) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

 - Update `mudlet.pro` to handle Sentry libraries with and without transport, mirroring the CMake setup.
 - Remove the part that sends a `.pdb` file to Sentry for Windows (in `CI/send_debug_files_to_sentry.sh`)
 - Only strip debug symbols for Windows executables in Release mode.

#### Motivation for adding to Mudlet

The QMake build was not updated with the latest CMake changes related to Sentry. 

Additionally, a missing include was detected when building with QMake https://github.com/Mudlet/Mudlet/pull/8540#issuecomment-3642533603:

```diff
+#include <QtSystemDetection>
```

This header is required for the Q_OS_WIN, etc. platform macros.