### PR TITLE
Fix: Container overflow crash when processing text

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -3853,11 +3853,11 @@ int TBuffer::wrapLine(int startLine, int maxWidth, int indentSize, int hangingIn
         const QString qHangingIndent(hangingIndent, QChar::Space);
         for (WrapInfo w : lineBreaks) {
             // skip TChars as needed
-            while (newBufferCharPosition < w.firstChar) {
+            while (newBufferCharPosition < w.firstChar && !buffer[i].empty()) {
                 buffer[i].pop_front();
                 newBufferCharPosition++;
             }
-            if (w.needsIndent) {
+            if (w.needsIndent && !buffer[i].empty()) {
                 // background color of indentation spaces should match first char in the line
                 const TChar indentSpace = buffer[i].front();
                 // add indentation to TChar buffer and newLineText
@@ -3874,7 +3874,7 @@ int TBuffer::wrapLine(int startLine, int maxWidth, int indentSize, int hangingIn
                 }
             }
             // append TChars of the wrapped lineText to TChar buffer
-            while (newBufferCharPosition < w.lastChar) {
+            while (newBufferCharPosition < w.lastChar && !buffer[i].empty()) {
                 newBufferLine.push_back(buffer[i].front());
                 buffer[i].pop_front();
                 newBufferCharPosition++;


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Added bounds checking in `TBuffer::wrapLine()` to prevent accessing empty containers during text wrapping operations. The fix adds `!buffer[i].empty()` conditions before calling `buffer[i].front()` to avoid container overflow.

#### Motivation for adding to Mudlet

Fixes a critical AddressSanitizer container-overflow crash that occurred when processing telnet data during text wrapping. This crash caused Mudlet to abort with exit code 134 when handling certain text formatting scenarios.

#### Other info (issues closed, discussion etc)

The crash could be reproduced in the development branch by connecting to StickMUD (telnet stickmud.com 7680) and typing `help movement`. The issue occurred in the `TChar` copy constructor when `TBuffer::wrapLine()` attempted to access elements from an empty `std::deque<TChar>` after multiple `pop_front()` operations.

This fix ensures robust container access and prevents memory corruption during buffer management operations.