### PR TITLE
Improve: OSC 8 hyperlink selection behavior and visual styling

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -596,7 +596,7 @@ add_library(${LIB_MUDLET_TARGET} STATIC
 #   target_compile_definitions(${LIB_MUDLET_TARGET} PUBLIC DEBUG_SGR_PROCESSING)
 #
 # * Produce qDebug() messages about the decoding of ANSI OSC sequences:
-# target_compile_definitions(${LIB_MUDLET_TARGET} PUBLIC DEBUG_OSC_PROCESSING)
+#   target_compile_definitions(${LIB_MUDLET_TARGET} PUBLIC DEBUG_OSC_PROCESSING)
 #
 # * Produce qDebug() messages about the decoding of ANSI MXP sequences although
 #   there is not much against this item at present {only an announcement of the

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,6 +148,7 @@ set(mudlet_SRCS
     TEntityResolver.cpp
     TFlipButton.cpp
     TForkedProcess.cpp
+    THyperlinkCompactManager.cpp
     THyperlinkSelectionManager.cpp
     TimerUnit.cpp
     TKey.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,6 +148,7 @@ set(mudlet_SRCS
     TEntityResolver.cpp
     TFlipButton.cpp
     TForkedProcess.cpp
+    THyperlinkSelectionManager.cpp
     TimerUnit.cpp
     TKey.cpp
     TLabel.cpp

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -26,6 +26,7 @@
 #include "mudlet.h"
 #include "TEvent.h"
 #include "TStringUtils.h"
+#include "TTextEdit.h"
 #include "TTextProperties.h"
 #include "widechar_width.h"
 #include "TEncodingHelper.h"
@@ -37,6 +38,7 @@
 #include <QJsonParseError>
 #include <QJsonValue>
 #include <QTextBoundaryFinder>
+#include <QTimer>
 #include <QRegularExpression>
 
 TChar::TChar(const QColor& foreground, const QColor& background, const TChar::AttributeFlags flags, const int linkIndex)
@@ -2512,6 +2514,26 @@ void TBuffer::decodeOSC(const QString& sequence)
 #if defined(DEBUG_OSC_PROCESSING)
             qDebug().noquote() << "[OSC8] Hyperlink terminator - closing active hyperlink";
 #endif
+            
+            // Apply initial selection styling now that the link text has been fully rendered
+            if (mCurrentHyperlinkLinkId > 0 && mCurrentHyperlinkStyling.selection.hasSelectionSettings) {
+#if defined(DEBUG_OSC_PROCESSING)
+                qDebug() << "[OSC8] Queuing initial selection styling for link" << mCurrentHyperlinkLinkId
+                         << "selected:" << mCurrentHyperlinkStyling.selection.selected
+                         << "disabled:" << mCurrentHyperlinkStyling.selection.disabled
+                         << "selectedStyle.hasCustomStyling:" << mCurrentHyperlinkStyling.selectedStyle.hasCustomStyling;
+#endif
+                if (mCurrentHyperlinkStyling.selection.selected) {
+                    setLinkState(mCurrentHyperlinkLinkId, Mudlet::HyperlinkStyling::StateSelected);
+                    // Queue for styling after buffer commit
+                    mPendingSelectionStyling.insert(mCurrentHyperlinkLinkId);
+                } else if (mCurrentHyperlinkStyling.selection.disabled) {
+                    setLinkState(mCurrentHyperlinkLinkId, Mudlet::HyperlinkStyling::StateDisabled);
+                    // Queue for styling after buffer commit
+                    mPendingSelectionStyling.insert(mCurrentHyperlinkLinkId);
+                }
+            }
+            
             mCurrentHyperlinkCommand.clear();
             mCurrentHyperlinkHint.clear();
             mCurrentHyperlinkLinkId = 0;
@@ -2708,7 +2730,7 @@ void TBuffer::decodeOSC(const QString& sequence)
                     mCurrentHyperlinkStyling.selection.selected, 
                     mCurrentHyperlinkStyling.selection.exclusive);
                 
-                // Update link visual state to match initial selection
+                // Update link selection state (visual styling will be applied when link closes)
                 setLinkSelected(mCurrentHyperlinkLinkId, mCurrentHyperlinkStyling.selection.selected);
                 if (mCurrentHyperlinkStyling.selection.selected) {
                     setLinkState(mCurrentHyperlinkLinkId, Mudlet::HyperlinkStyling::StateSelected);
@@ -5411,10 +5433,14 @@ void TBuffer::injectOSC8DocumentationExamples()
     output += "══════════════════════════════════════════════════════════════════════\n\n";
 
     output += "Radio Button Mode (Exclusive Selection):\n";
-    output += "Choose difficulty: ";
-    output += "\x1b]8;;send:easy?config={\"selection\":{\"group\":\"difficulty\",\"value\":\"easy\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#88ff88\",\"underline\":true,\"selected\":{\"bg\":\"#00aa00\",\"color\":\"#ffffff\",\"bold\":true,\"underline\":false}}}\x1b\\[ Easy ]\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:normal?config={\"selection\":{\"group\":\"difficulty\",\"value\":\"normal\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#ffff88\",\"underline\":true,\"selected\":{\"bg\":\"#cccc00\",\"color\":\"#000000\",\"bold\":true,\"underline\":false}}}\x1b\\[ Normal ]\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:hard?config={\"selection\":{\"group\":\"difficulty\",\"value\":\"hard\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#ff8888\",\"underline\":true,\"selected\":{\"bg\":\"#cc0000\",\"color\":\"#ffffff\",\"bold\":true,\"underline\":false}}}\x1b\\[ Hard ]\x1b]8;;\x1b\\\n\n";
+    output += "React: ";
+    output += "\x1b]8;;send:like?config={\"selection\":{\"group\":\"reaction\",\"value\":\"like\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#8899ff\",\"selected\":{\"bg\":\"#0066cc\",\"color\":\"#ffffff\",\"bold\":true}}}\x1b\\👍 Like\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:love?config={\"selection\":{\"group\":\"reaction\",\"value\":\"love\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#8899ff\",\"selected\":{\"bg\":\"#ff0066\",\"color\":\"#ffffff\",\"bold\":true}}}\x1b\\❤️ Love\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:care?config={\"selection\":{\"group\":\"reaction\",\"value\":\"care\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#8899ff\",\"selected\":{\"bg\":\"#ff9900\",\"color\":\"#ffffff\",\"bold\":true}}}\x1b\\🤗 Care\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:laugh?config={\"selection\":{\"group\":\"reaction\",\"value\":\"laugh\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#8899ff\",\"selected\":{\"bg\":\"#ffcc00\",\"color\":\"#000000\",\"bold\":true}}}\x1b\\😂 Laugh\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:wow?config={\"selection\":{\"group\":\"reaction\",\"value\":\"wow\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#8899ff\",\"selected\":{\"bg\":\"#9933ff\",\"color\":\"#ffffff\",\"bold\":true}}}\x1b\\😮 Wow\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:sad?config={\"selection\":{\"group\":\"reaction\",\"value\":\"sad\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#8899ff\",\"selected\":{\"bg\":\"#3366cc\",\"color\":\"#ffffff\",\"bold\":true}}}\x1b\\😢 Sad\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:angry?config={\"selection\":{\"group\":\"reaction\",\"value\":\"angry\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#8899ff\",\"selected\":{\"bg\":\"#cc0000\",\"color\":\"#ffffff\",\"bold\":true}}}\x1b\\😠 Angry\x1b]8;;\x1b\\\n\n";
 
     output += "Checkbox Mode (Multi-Select):\n";
     output += "Enable buffs: ";
@@ -5446,9 +5472,9 @@ void TBuffer::injectOSC8DocumentationExamples()
 
     output += "Toggle Switches:\n";
     output += "Settings: ";
-    output += "\x1b]8;;send:auto-loot?config={\"selection\":{\"group\":\"settings\",\"value\":\"auto-loot\",\"toggle\":true,\"exclusive\":false},\"style\":{\"color\":\"#888888\",\"selected\":{\"color\":\"#00ff00\",\"bold\":true}}}\x1b\\[OFF] Auto-Loot\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:auto-heal?config={\"selection\":{\"group\":\"settings\",\"value\":\"auto-heal\",\"toggle\":true,\"exclusive\":false,\"selected\":true},\"style\":{\"color\":\"#888888\",\"selected\":{\"color\":\"#00ff00\",\"bold\":true}}}\x1b\\[OFF] Auto-Heal\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:sound?config={\"selection\":{\"group\":\"settings\",\"value\":\"sound\",\"toggle\":true,\"exclusive\":false},\"style\":{\"color\":\"#888888\",\"selected\":{\"color\":\"#00ff00\",\"bold\":true}}}\x1b\\[OFF] Sound\x1b]8;;\x1b\\\n";
+    output += "\x1b]8;;send:auto-loot?config={\"selection\":{\"group\":\"settings\",\"value\":\"auto-loot\",\"toggle\":true,\"exclusive\":false},\"style\":{\"color\":\"#888888\",\"selected\":{\"color\":\"#00ff00\",\"bold\":true}}}\x1b\\Auto-Loot\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:auto-heal?config={\"selection\":{\"group\":\"settings\",\"value\":\"auto-heal\",\"toggle\":true,\"exclusive\":false,\"selected\":true},\"style\":{\"color\":\"#888888\",\"selected\":{\"color\":\"#00ff00\",\"bold\":true}}}\x1b\\Auto-Heal\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:sound?config={\"selection\":{\"group\":\"settings\",\"value\":\"sound\",\"toggle\":true,\"exclusive\":false},\"style\":{\"color\":\"#888888\",\"selected\":{\"color\":\"#00ff00\",\"bold\":true}}}\x1b\\Sound\x1b]8;;\x1b\\\n";
     output += "  (Toggle each setting on/off)\n\n";
 
     output += "Server Callback Example:\n";
@@ -5472,6 +5498,25 @@ void TBuffer::injectOSC8DocumentationExamples()
     mSkipTriggerProcessing = true;
     translateToPlainText(outputBytes, true); // Mark as from server
     mSkipTriggerProcessing = false;
+
+    // Apply pending selection styling now that characters are committed to buffer
+    if (!mPendingSelectionStyling.isEmpty()) {
+#if defined(DEBUG_OSC_PROCESSING)
+        qDebug() << "[OSC8] Processing pending selection styling for" << mPendingSelectionStyling.size() << "links";
+#endif
+        for (int linkId : mPendingSelectionStyling) {
+            updateLinkCharacters(linkId);
+        }
+        mPendingSelectionStyling.clear();
+        
+        // Force display refresh after applying selection styling
+        if (mpConsole) {
+            mpConsole->mUpperPane->updateScreenView();
+            mpConsole->mUpperPane->repaint();
+            mpConsole->mLowerPane->updateScreenView();
+            mpConsole->mLowerPane->repaint();
+        }
+    }
 }
 
 // ============================================================================
@@ -5953,12 +5998,29 @@ void TBuffer::updateLinkCharacters(int linkIndex)
              << "currentState:" << effectiveStyling.currentState << "useAnsiBase:" << useAnsiBase;
 #endif
 
+    // Debug: Count how many characters we're checking and how many match
+#if defined(DEBUG_OSC_PROCESSING)
+    int totalCharacters = 0;
+    int matchingCharacters = 0;
+#endif
+
     // Iterate through all lines in the buffer
     for (auto& line : buffer) {
         // Iterate through all characters in the line
         for (auto& tchar : line) {
+#if defined(DEBUG_OSC_PROCESSING)
+            totalCharacters++;
+#endif
             // Check if this character belongs to the link we're updating
             if (tchar.linkIndex() == linkIndex) {
+#if defined(DEBUG_OSC_PROCESSING)
+                matchingCharacters++;
+                qDebug() << "[OSC8] Found character for link" << linkIndex 
+                         << "- Current FgColor:" << tchar.mFgColor.name()
+                         << "Current Bold:" << bool(tchar.mFlags & TChar::Bold)
+                         << "Will apply FgColor:" << (effectiveStyling.hasForegroundColor ? effectiveStyling.foregroundColor.name() : "none")
+                         << "Will apply Bold:" << effectiveStyling.isBold;
+#endif
                 // Apply the effective styling to this character
 
                 // If we should use ANSI base (no base styling but in default/visited state),
@@ -6067,5 +6129,21 @@ void TBuffer::updateLinkCharacters(int linkIndex)
                 }
             }
         }
+    }
+
+    // Debug: Report search results
+#if defined(DEBUG_OSC_PROCESSING)
+    qDebug() << "[OSC8] Character search completed for link" << linkIndex 
+             << "- Total characters searched:" << totalCharacters
+             << "- Matching characters found:" << matchingCharacters;
+#endif
+
+    // Refresh the display to show the updated character styling
+    // Use updateScreenView and repaint for immediate Qt rendering
+    if (mpConsole) {
+        mpConsole->mUpperPane->updateScreenView();
+        mpConsole->mUpperPane->repaint();
+        mpConsole->mLowerPane->updateScreenView();
+        mpConsole->mLowerPane->repaint();
     }
 }

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2812,10 +2812,65 @@ QMap<QString, QString> TBuffer::parseUriQueryParameters(const QString& uri, Mudl
     qDebug() << "[OSC8] Decoded query string:" << decodedQueryString;
 #endif
 
-    // Only process JSON config parameters - no legacy CSS support
-    if (decodedQueryString.startsWith(qsl("config={"))) {
-        QString jsonString = decodedQueryString.mid(7); // Remove "config="
-        parseJsonHyperlinkConfig(jsonString, parameters, styling);
+    // Parse query parameters
+    QStringList paramPairs = decodedQueryString.split('&');
+    QString presetName;
+    QString configJson;
+
+    for (const QString& pair : paramPairs) {
+        int eqPos = pair.indexOf('=');
+        if (eqPos == -1) {
+            continue;
+        }
+
+        QString key = pair.left(eqPos);
+        QString value = pair.mid(eqPos + 1);
+
+        if (key == qsl("p") || key == qsl("preset")) {
+            presetName = value;
+        } else if (key == qsl("config")) {
+            configJson = value;
+        }
+    }
+
+    // Start with preset config if specified
+    QJsonObject baseConfig;
+
+    if (!presetName.isEmpty() && mpConsole && mpConsole->mpCompactSyntaxManager) {
+        baseConfig = mpConsole->mpCompactSyntaxManager->getPreset(presetName);
+#if defined(DEBUG_OSC_PROCESSING)
+        if (!baseConfig.isEmpty()) {
+            qDebug() << "[OSC8] Resolved preset" << presetName;
+        }
+#endif
+    }
+
+    // Merge with override config if present
+    if (!configJson.isEmpty()) {
+        QJsonParseError parseError;
+        QJsonDocument overrideDoc = QJsonDocument::fromJson(configJson.toUtf8(), &parseError);
+        
+        if (parseError.error == QJsonParseError::NoError && overrideDoc.isObject()) {
+            QJsonObject overrideConfig = overrideDoc.object();
+            
+            if (!baseConfig.isEmpty() && mpConsole && mpConsole->mpCompactSyntaxManager) {
+                // Deep merge: override takes precedence
+                baseConfig = mpConsole->mpCompactSyntaxManager->mergeConfigs(baseConfig, overrideConfig);
+#if defined(DEBUG_OSC_PROCESSING)
+                qDebug() << "[OSC8] Merged preset with override config";
+#endif
+            } else {
+                baseConfig = overrideConfig;
+            }
+        }
+    }
+
+    // Parse the final merged config
+    if (!baseConfig.isEmpty()) {
+        // Convert back to JSON string for parseJsonHyperlinkConfig
+        QJsonDocument finalDoc(baseConfig);
+        QString finalJson = QString::fromUtf8(finalDoc.toJson(QJsonDocument::Compact));
+        parseJsonHyperlinkConfig(finalJson, parameters, styling);
     }
 
 #if defined(DEBUG_OSC_PROCESSING)

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2488,8 +2488,6 @@ void TBuffer::decodeOSC(const QString& sequence)
         }
         break;
     case static_cast<quint8>('8'): {
-        // Handle OSC 8 hyperlinks in the form: "8;params;URI"
-
         QStringView rest = QStringView(sequence).mid(1);  // skip selector "8"
         int firstSemi = rest.indexOf(';');
 
@@ -2554,7 +2552,6 @@ void TBuffer::decodeOSC(const QString& sequence)
                 return;
             }
 
-            // Handle preset: URI scheme for preset definitions
             if (rawUrl.startsWith(qsl("preset:"))) {
                 QUrl presetUrl(rawUrl);
                 QString presetName = presetUrl.path();
@@ -2848,7 +2845,6 @@ QMap<QString, QString> TBuffer::parseUriQueryParameters(const QString& uri, Mudl
         return parameters;
     }
 
-    // Parse query parameters for new format: ?preset=NAME&config={...}
     QStringList paramPairs = decodedQueryString.split('&');
     QString presetName;
     QString configJson;
@@ -2869,13 +2865,9 @@ QMap<QString, QString> TBuffer::parseUriQueryParameters(const QString& uri, Mudl
         }
     }
 
-    // Handle preset and config parameters
-    // Priority: preset as base, config as override
-    
     if (!presetName.isEmpty() || !configJson.isEmpty()) {
         QJsonObject baseConfig;
 
-        // Start with preset config if specified
         if (!presetName.isEmpty() && mpConsole && mpConsole->mpCompactSyntaxManager) {
             baseConfig = mpConsole->mpCompactSyntaxManager->getPreset(presetName);
 #if defined(DEBUG_OSC_PROCESSING)
@@ -2908,7 +2900,6 @@ QMap<QString, QString> TBuffer::parseUriQueryParameters(const QString& uri, Mudl
                     qDebug() << "[OSC8] Merged preset with override config";
 #endif
                 } else {
-                    // No preset, just use the config directly
                     baseConfig = overrideConfig;
                 }
             }
@@ -2916,7 +2907,6 @@ QMap<QString, QString> TBuffer::parseUriQueryParameters(const QString& uri, Mudl
 
         // Parse the final merged config
         if (!baseConfig.isEmpty()) {
-            // Convert back to JSON string for parseJsonHyperlinkConfig
             QJsonDocument finalDoc(baseConfig);
             QString finalJson = QString::fromUtf8(finalDoc.toJson(QJsonDocument::Compact));
             parseJsonHyperlinkConfig(finalJson, parameters, styling);
@@ -2932,7 +2922,6 @@ QMap<QString, QString> TBuffer::parseUriQueryParameters(const QString& uri, Mudl
 
 QJsonObject TBuffer::expandJsonShorthands(const QJsonObject& obj)
 {
-    // Use the compact syntax manager for consistent shorthand expansion
     if (!mpConsole || !mpConsole->mpCompactSyntaxManager) {
         return obj; // No manager available, return unchanged
     }
@@ -2943,7 +2932,6 @@ QJsonObject TBuffer::expandJsonShorthands(const QJsonObject& obj)
         QString originalKey = it.key();
         QJsonValue value = it.value();
         
-        // Check if this key is a registered shorthand using the manager
         QMap<QString, QString> singleKeyMap;
         singleKeyMap.insert(originalKey, qsl("placeholder")); // Value doesn't matter for key expansion
         QMap<QString, QString> expandedMap = mpConsole->mpCompactSyntaxManager->expandShorthand(singleKeyMap);
@@ -2960,9 +2948,7 @@ QJsonObject TBuffer::expandJsonShorthands(const QJsonObject& obj)
             QJsonObject existing = result[resultKey].toObject();
             QJsonObject toAdd = resultValue.toObject();
             
-            // Important: when both shorthand and full names exist, shorthand should take precedence
-            // The "existing" value comes from a shorthand expansion and should be the overlay
-            // The "toAdd" value is the full name and should be the base
+            // When both shorthand and full names exist, shorthand takes precedence
             result[resultKey] = mpConsole->mpCompactSyntaxManager->mergeConfigs(toAdd, existing);
         } else {
             result[resultKey] = resultValue;

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2698,6 +2698,31 @@ void TBuffer::decodeOSC(const QString& sequence)
             // when the link styling doesn't specify a background
             mLinkOriginalBackgrounds[mCurrentHyperlinkLinkId] = mBackGroundColor;
 
+            // Initialize selection state if this link has selection settings
+            if (mCurrentHyperlinkStyling.selection.hasSelectionSettings && mpConsole && mpConsole->mpSelectionManager) {
+                const QString& group = mCurrentHyperlinkStyling.selection.group;
+                const QString& value = mCurrentHyperlinkStyling.selection.value;
+                
+                // Register the link with the selection manager
+                mpConsole->mpSelectionManager->setSelected(group, value, 
+                    mCurrentHyperlinkStyling.selection.selected, 
+                    mCurrentHyperlinkStyling.selection.exclusive);
+                
+                // Update link visual state to match initial selection
+                setLinkSelected(mCurrentHyperlinkLinkId, mCurrentHyperlinkStyling.selection.selected);
+                if (mCurrentHyperlinkStyling.selection.selected) {
+                    setLinkState(mCurrentHyperlinkLinkId, Mudlet::HyperlinkStyling::StateSelected);
+                } else if (mCurrentHyperlinkStyling.selection.disabled) {
+                    setLinkState(mCurrentHyperlinkLinkId, Mudlet::HyperlinkStyling::StateDisabled);
+                }
+#if defined(DEBUG_OSC_PROCESSING)
+                qDebug() << "[OSC8] Link" << mCurrentHyperlinkLinkId << "initialized with selection state:"
+                         << "group=" << group << "value=" << value 
+                         << "selected=" << mCurrentHyperlinkStyling.selection.selected 
+                         << "disabled=" << mCurrentHyperlinkStyling.selection.disabled;
+#endif
+            }
+
 #if defined(DEBUG_OSC_PROCESSING)
             qDebug().noquote() << "[OSC8] Hyperlink activated:" << rawUrl.left(50) + (rawUrl.length() > 50 ? "..." : "");
 #endif
@@ -3049,6 +3074,14 @@ void TBuffer::parseJsonStyleToHyperlinkStyling(const QJsonObject& styleObj, Mudl
 
     if (styleObj.contains(qsl("any-link")) && styleObj[qsl("any-link")].isObject()) {
         parseJsonStateStyle(styleObj[qsl("any-link")].toObject(), styling.anyLinkStyle);
+    }
+
+    if (styleObj.contains(qsl("selected")) && styleObj[qsl("selected")].isObject()) {
+        parseJsonStateStyle(styleObj[qsl("selected")].toObject(), styling.selectedStyle);
+    }
+
+    if (styleObj.contains(qsl("disabled")) && styleObj[qsl("disabled")].isObject()) {
+        parseJsonStateStyle(styleObj[qsl("disabled")].toObject(), styling.disabledStyle);
     }
 
     applyAccessibilityEnhancements(styling);
@@ -5379,39 +5412,44 @@ void TBuffer::injectOSC8DocumentationExamples()
 
     output += "Radio Button Mode (Exclusive Selection):\n";
     output += "Choose difficulty: ";
-    output += "\x1b]8;;send:easy?config={\"selection\":{\"group\":\"difficulty\",\"value\":\"easy\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"green\",\"selected\":{\"bg\":\"green\",\"color\":\"white\",\"bold\":true}}}\x1b\\Easy\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:normal?config={\"selection\":{\"group\":\"difficulty\",\"value\":\"normal\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"yellow\",\"selected\":{\"bg\":\"yellow\",\"color\":\"black\",\"bold\":true}}}\x1b\\Normal\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:hard?config={\"selection\":{\"group\":\"difficulty\",\"value\":\"hard\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"red\",\"selected\":{\"bg\":\"red\",\"color\":\"white\",\"bold\":true}}}\x1b\\Hard\x1b]8;;\x1b\\\n\n";
+    output += "\x1b]8;;send:easy?config={\"selection\":{\"group\":\"difficulty\",\"value\":\"easy\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#88ff88\",\"underline\":true,\"selected\":{\"bg\":\"#00aa00\",\"color\":\"#ffffff\",\"bold\":true,\"underline\":false}}}\x1b\\[ Easy ]\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:normal?config={\"selection\":{\"group\":\"difficulty\",\"value\":\"normal\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#ffff88\",\"underline\":true,\"selected\":{\"bg\":\"#cccc00\",\"color\":\"#000000\",\"bold\":true,\"underline\":false}}}\x1b\\[ Normal ]\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:hard?config={\"selection\":{\"group\":\"difficulty\",\"value\":\"hard\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#ff8888\",\"underline\":true,\"selected\":{\"bg\":\"#cc0000\",\"color\":\"#ffffff\",\"bold\":true,\"underline\":false}}}\x1b\\[ Hard ]\x1b]8;;\x1b\\\n\n";
 
     output += "Checkbox Mode (Multi-Select):\n";
     output += "Enable buffs: ";
-    output += "\x1b]8;;send:buff-strength?config={\"selection\":{\"group\":\"buffs\",\"value\":\"strength\",\"toggle\":true},\"style\":{\"color\":\"#cc6600\",\"selected\":{\"color\":\"#ff9900\",\"bold\":true,\"underline\":true}}}\x1b\\💪 Strength\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:buff-speed?config={\"selection\":{\"group\":\"buffs\",\"value\":\"speed\",\"toggle\":true},\"style\":{\"color\":\"#0066cc\",\"selected\":{\"color\":\"#3399ff\",\"bold\":true,\"underline\":true}}}\x1b\\⚡ Speed\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:buff-defense?config={\"selection\":{\"group\":\"buffs\",\"value\":\"defense\",\"toggle\":true},\"style\":{\"color\":\"#006600\",\"selected\":{\"color\":\"#00cc00\",\"bold\":true,\"underline\":true}}}\x1b\\🛡️ Defense\x1b]8;;\x1b\\\n\n";
+    output += "\x1b]8;;send:buff-strength?config={\"selection\":{\"group\":\"buffs\",\"value\":\"strength\",\"toggle\":true,\"exclusive\":false},\"style\":{\"color\":\"#ff9944\",\"selected\":{\"bg\":\"#ff6600\",\"color\":\"#ffffff\",\"bold\":true}}}\x1b\\[ ] Strength\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:buff-speed?config={\"selection\":{\"group\":\"buffs\",\"value\":\"speed\",\"toggle\":true,\"exclusive\":false},\"style\":{\"color\":\"#66ccff\",\"selected\":{\"bg\":\"#0088ff\",\"color\":\"#ffffff\",\"bold\":true}}}\x1b\\[ ] Speed\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:buff-defense?config={\"selection\":{\"group\":\"buffs\",\"value\":\"defense\",\"toggle\":true,\"exclusive\":false},\"style\":{\"color\":\"#66ff66\",\"selected\":{\"bg\":\"#00aa00\",\"color\":\"#ffffff\",\"bold\":true}}}\x1b\\[ ] Defense\x1b]8;;\x1b\\\n";
+    output += "  (Click to toggle, multiple can be selected)\n\n";
 
     output += "Pre-Selected Options:\n";
     output += "Combat style: ";
-    output += "\x1b]8;;send:aggressive?config={\"selection\":{\"group\":\"combat\",\"value\":\"aggressive\",\"toggle\":true,\"exclusive\":true,\"selected\":true},\"style\":{\"color\":\"red\",\"selected\":{\"bg\":\"darkred\",\"color\":\"white\"}}}\x1b\\Aggressive\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:balanced?config={\"selection\":{\"group\":\"combat\",\"value\":\"balanced\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"yellow\",\"selected\":{\"bg\":\"olive\",\"color\":\"white\"}}}\x1b\\Balanced\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:defensive?config={\"selection\":{\"group\":\"combat\",\"value\":\"defensive\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"green\",\"selected\":{\"bg\":\"darkgreen\",\"color\":\"white\"}}}\x1b\\Defensive\x1b]8;;\x1b\\\n\n";
+    output += "\x1b]8;;send:aggressive?config={\"selection\":{\"group\":\"combat\",\"value\":\"aggressive\",\"toggle\":true,\"exclusive\":true,\"selected\":true},\"style\":{\"color\":\"#ff6666\",\"selected\":{\"bg\":\"#990000\",\"color\":\"#ffff00\",\"bold\":true}}}\x1b\\⚔️ Aggressive\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:balanced?config={\"selection\":{\"group\":\"combat\",\"value\":\"balanced\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#ffcc66\",\"selected\":{\"bg\":\"#996600\",\"color\":\"#ffff00\",\"bold\":true}}}\x1b\\⚖️ Balanced\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:defensive?config={\"selection\":{\"group\":\"combat\",\"value\":\"defensive\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#66ff66\",\"selected\":{\"bg\":\"#009900\",\"color\":\"#ffff00\",\"bold\":true}}}\x1b\\🛡️ Defensive\x1b]8;;\x1b\\\n";
+    output += "  (Aggressive is pre-selected)\n\n";
 
     output += "Disabled Options:\n";
     output += "Choose class: ";
-    output += "\x1b]8;;send:warrior?config={\"selection\":{\"group\":\"class\",\"value\":\"warrior\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#cc6600\",\"selected\":{\"bg\":\"#cc6600\",\"color\":\"white\"}}}\x1b\\⚔️ Warrior\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:mage?config={\"selection\":{\"group\":\"class\",\"value\":\"mage\",\"toggle\":true,\"exclusive\":true,\"disabled\":true},\"style\":{\"color\":\"#6600cc\",\"selected\":{\"bg\":\"#6600cc\",\"color\":\"white\"},\"disabled\":{\"color\":\"#666666\",\"strikethrough\":true}}}\x1b\\🔮 Mage (Locked)\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:rogue?config={\"selection\":{\"group\":\"class\",\"value\":\"rogue\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#006600\",\"selected\":{\"bg\":\"#006600\",\"color\":\"white\"}}}\x1b\\🗡️ Rogue\x1b]8;;\x1b\\\n\n";
+    output += "\x1b]8;;send:warrior?config={\"selection\":{\"group\":\"class\",\"value\":\"warrior\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#ff9944\",\"hover\":{\"color\":\"#ffaa66\"},\"selected\":{\"bg\":\"#cc6600\",\"color\":\"#000000\",\"bold\":true}}}\x1b\\⚔️ Warrior\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:mage?config={\"selection\":{\"group\":\"class\",\"value\":\"mage\",\"toggle\":true,\"exclusive\":true,\"disabled\":true},\"style\":{\"color\":\"#9966ff\",\"selected\":{\"bg\":\"#6600cc\",\"color\":\"#000000\",\"bold\":true},\"disabled\":{\"color\":\"#444444\",\"strikethrough\":true}}}\x1b\\🔮 Mage\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:rogue?config={\"selection\":{\"group\":\"class\",\"value\":\"rogue\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#66ff66\",\"hover\":{\"color\":\"#88ff88\"},\"selected\":{\"bg\":\"#00aa00\",\"color\":\"#000000\",\"bold\":true}}}\x1b\\🗡️ Rogue\x1b]8;;\x1b\\\n";
+    output += "  (Mage is locked/disabled)\n\n";
 
     output += "Interactive Selection with Hover:\n";
     output += "Select weapon: ";
-    output += "\x1b]8;;send:sword?config={\"selection\":{\"group\":\"weapon\",\"value\":\"sword\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"blue\",\"hover\":{\"bg\":\"lightblue\",\"color\":\"black\"},\"selected\":{\"bg\":\"darkblue\",\"color\":\"white\",\"bold\":true}}}\x1b\\⚔️ Sword\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:axe?config={\"selection\":{\"group\":\"weapon\",\"value\":\"axe\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"orange\",\"hover\":{\"bg\":\"lightyellow\",\"color\":\"black\"},\"selected\":{\"bg\":\"darkorange\",\"color\":\"white\",\"bold\":true}}}\x1b\\🪓 Axe\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:bow?config={\"selection\":{\"group\":\"weapon\",\"value\":\"bow\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"green\",\"hover\":{\"bg\":\"lightgreen\",\"color\":\"black\"},\"selected\":{\"bg\":\"darkgreen\",\"color\":\"white\",\"bold\":true}}}\x1b\\🏹 Bow\x1b]8;;\x1b\\\n\n";
+    output += "\x1b]8;;send:sword?config={\"selection\":{\"group\":\"weapon\",\"value\":\"sword\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#6699ff\",\"hover\":{\"color\":\"#99ccff\",\"bold\":true},\"selected\":{\"bg\":\"#0066cc\",\"color\":\"#ffff00\",\"bold\":true}}}\x1b\\⚔️ Sword\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:axe?config={\"selection\":{\"group\":\"weapon\",\"value\":\"axe\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#ff9944\",\"hover\":{\"color\":\"#ffbb66\",\"bold\":true},\"selected\":{\"bg\":\"#cc6600\",\"color\":\"#ffff00\",\"bold\":true}}}\x1b\\🪓 Axe\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:bow?config={\"selection\":{\"group\":\"weapon\",\"value\":\"bow\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#66ff66\",\"hover\":{\"color\":\"#88ff88\",\"bold\":true},\"selected\":{\"bg\":\"#00aa00\",\"color\":\"#ffff00\",\"bold\":true}}}\x1b\\🏹 Bow\x1b]8;;\x1b\\\n";
+    output += "  (Hover to see preview, click to select)\n\n";
 
     output += "Toggle Switches:\n";
     output += "Settings: ";
-    output += "\x1b]8;;send:auto-loot?config={\"selection\":{\"group\":\"settings\",\"value\":\"auto-loot\",\"toggle\":true},\"style\":{\"color\":\"#666666\",\"selected\":{\"color\":\"#00cc00\",\"bold\":true}}}\x1b\\[Auto-Loot]\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:auto-heal?config={\"selection\":{\"group\":\"settings\",\"value\":\"auto-heal\",\"toggle\":true,\"selected\":true},\"style\":{\"color\":\"#666666\",\"selected\":{\"color\":\"#00cc00\",\"bold\":true}}}\x1b\\[Auto-Heal]\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:sound?config={\"selection\":{\"group\":\"settings\",\"value\":\"sound\",\"toggle\":true},\"style\":{\"color\":\"#666666\",\"selected\":{\"color\":\"#00cc00\",\"bold\":true}}}\x1b\\[Sound]\x1b]8;;\x1b\\\n\n";
+    output += "\x1b]8;;send:auto-loot?config={\"selection\":{\"group\":\"settings\",\"value\":\"auto-loot\",\"toggle\":true,\"exclusive\":false},\"style\":{\"color\":\"#888888\",\"selected\":{\"color\":\"#00ff00\",\"bold\":true}}}\x1b\\[OFF] Auto-Loot\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:auto-heal?config={\"selection\":{\"group\":\"settings\",\"value\":\"auto-heal\",\"toggle\":true,\"exclusive\":false,\"selected\":true},\"style\":{\"color\":\"#888888\",\"selected\":{\"color\":\"#00ff00\",\"bold\":true}}}\x1b\\[OFF] Auto-Heal\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:sound?config={\"selection\":{\"group\":\"settings\",\"value\":\"sound\",\"toggle\":true,\"exclusive\":false},\"style\":{\"color\":\"#888888\",\"selected\":{\"color\":\"#00ff00\",\"bold\":true}}}\x1b\\[OFF] Sound\x1b]8;;\x1b\\\n";
+    output += "  (Toggle each setting on/off)\n\n";
 
     output += "Server Callback Example:\n";
     output += "When clicked, selection state is sent to server via &selected=true/false\n";
@@ -5483,10 +5521,39 @@ Mudlet::HyperlinkStyling::StateStyle Mudlet::HyperlinkStyling::getEffectiveStyle
 
     switch (currentState) {
         case StateDisabled:
-            if (disabledStyle.hasCustomStyling) stateStyle = &disabledStyle;
+            if (disabledStyle.hasCustomStyling) {
+                stateStyle = &disabledStyle;
+#if defined(DEBUG_OSC_PROCESSING)
+                qDebug() << "[OSC8] Using disabled style - hasCustomStyling:" << disabledStyle.hasCustomStyling
+                         << "hasForegroundColor:" << disabledStyle.hasForegroundColor 
+                         << "foregroundColor:" << (disabledStyle.hasForegroundColor ? disabledStyle.foregroundColor.name() : "none")
+                         << "hasBackgroundColor:" << disabledStyle.hasBackgroundColor 
+                         << "backgroundColor:" << (disabledStyle.hasBackgroundColor ? disabledStyle.backgroundColor.name() : "none")
+                         << "isBold:" << disabledStyle.isBold
+                         << "isStrikeOut:" << disabledStyle.isStrikeOut;
+#endif
+            } else {
+#if defined(DEBUG_OSC_PROCESSING)
+                qDebug() << "[OSC8] Disabled style has no custom styling - hasCustomStyling:" << disabledStyle.hasCustomStyling;
+#endif
+            }
             break;
         case StateSelected:
-            if (selectedStyle.hasCustomStyling) stateStyle = &selectedStyle;
+            if (selectedStyle.hasCustomStyling) {
+                stateStyle = &selectedStyle;
+#if defined(DEBUG_OSC_PROCESSING)
+                qDebug() << "[OSC8] Using selected style - hasCustomStyling:" << selectedStyle.hasCustomStyling
+                         << "hasForegroundColor:" << selectedStyle.hasForegroundColor 
+                         << "foregroundColor:" << (selectedStyle.hasForegroundColor ? selectedStyle.foregroundColor.name() : "none")
+                         << "hasBackgroundColor:" << selectedStyle.hasBackgroundColor 
+                         << "backgroundColor:" << (selectedStyle.hasBackgroundColor ? selectedStyle.backgroundColor.name() : "none")
+                         << "isBold:" << selectedStyle.isBold;
+#endif
+            } else {
+#if defined(DEBUG_OSC_PROCESSING)
+                qDebug() << "[OSC8] Selected style has no custom styling - hasCustomStyling:" << selectedStyle.hasCustomStyling;
+#endif
+            }
             break;
         case StateVisited:
             if (visitedStyle.hasCustomStyling) stateStyle = &visitedStyle;
@@ -5590,6 +5657,8 @@ void TBuffer::setLinkState(int linkIndex, Mudlet::HyperlinkStyling::LinkState st
         case Mudlet::HyperlinkStyling::StateActive: stateName = "Active"; break;
         case Mudlet::HyperlinkStyling::StateFocus: stateName = "Focus"; break;
         case Mudlet::HyperlinkStyling::StateFocusVisible: stateName = "FocusVisible"; break;
+        case Mudlet::HyperlinkStyling::StateSelected: stateName = "Selected"; break;
+        case Mudlet::HyperlinkStyling::StateDisabled: stateName = "Disabled"; break;
     }
     qDebug() << "[OSC8] Link" << linkIndex << "state changed to:" << stateName;
 #endif
@@ -5621,6 +5690,16 @@ Mudlet::HyperlinkStyling TBuffer::getEffectiveHyperlinkStyling(int linkIndex) co
 
         auto effective = styling.getEffectiveStyle();
 
+#if defined(DEBUG_OSC_PROCESSING)
+        qDebug() << "[OSC8] getEffectiveHyperlinkStyling for link" << linkIndex
+                 << "state:" << styling.currentState
+                 << "hasForegroundColor:" << effective.hasForegroundColor 
+                 << "foregroundColor:" << (effective.hasForegroundColor ? effective.foregroundColor.name() : "none")
+                 << "hasBackgroundColor:" << effective.hasBackgroundColor 
+                 << "backgroundColor:" << (effective.hasBackgroundColor ? effective.backgroundColor.name() : "none")
+                 << "isBold:" << effective.isBold;
+#endif
+
         // Copy effective state back to base properties for rendering
         styling.foregroundColor = effective.foregroundColor;
         styling.backgroundColor = effective.backgroundColor;
@@ -5649,13 +5728,20 @@ void TBuffer::setHoveredLink(int linkIndex)
     int previousHoveredLink = mCurrentHoveredLinkIndex;
     mCurrentHoveredLinkIndex = linkIndex;
 
-    // Reset previous hovered link to its base state (default or visited)
+    // Reset previous hovered link to its base state (default, visited, or selected)
     if (previousHoveredLink > 0 && previousHoveredLink != linkIndex) {
         auto currentState = getLinkState(previousHoveredLink);
 
         if (currentState == Mudlet::HyperlinkStyling::StateHover) {
-            // Return to visited state if it was visited, otherwise to default
-            if (isLinkVisited(previousHoveredLink)) {
+            // Return to the appropriate base state:
+            // Priority: disabled > selected > visited > default
+            // Disabled links should stay disabled
+            Mudlet::HyperlinkStyling linkStyling = getEffectiveHyperlinkStyling(previousHoveredLink);
+            if (linkStyling.selection.hasSelectionSettings && linkStyling.selection.disabled) {
+                setLinkState(previousHoveredLink, Mudlet::HyperlinkStyling::StateDisabled);
+            } else if (isLinkSelected(previousHoveredLink)) {
+                setLinkState(previousHoveredLink, Mudlet::HyperlinkStyling::StateSelected);
+            } else if (isLinkVisited(previousHoveredLink)) {
                 setLinkState(previousHoveredLink, Mudlet::HyperlinkStyling::StateVisited);
             } else {
                 setLinkState(previousHoveredLink, Mudlet::HyperlinkStyling::StateDefault);
@@ -5668,9 +5754,10 @@ void TBuffer::setHoveredLink(int linkIndex)
     // Set new link to hover state
     if (linkIndex > 0) {
         auto currentState = getLinkState(linkIndex);
-        // Don't override active state with hover
-        // But we can hover over visited links to show hover styling
-        if (currentState != Mudlet::HyperlinkStyling::StateActive) {
+        // Don't override active or disabled states with hover
+        // Disabled links should stay disabled and show their disabled styling
+        if (currentState != Mudlet::HyperlinkStyling::StateActive && 
+            currentState != Mudlet::HyperlinkStyling::StateDisabled) {
             setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateHover);
             updateLinkCharacters(linkIndex); // Update displayed characters
         }
@@ -5685,12 +5772,17 @@ void TBuffer::setActiveLink(int linkIndex)
     // Reset previous active link
     if (previousActiveLink > 0 && previousActiveLink != linkIndex) {
 
-        // Return to hover if it's still hovered
-        if (previousActiveLink == mCurrentHoveredLinkIndex) {
+        // Return to appropriate state based on priority: disabled > hover > selected > visited > default
+        Mudlet::HyperlinkStyling linkStyling = getEffectiveHyperlinkStyling(previousActiveLink);
+        if (linkStyling.selection.hasSelectionSettings && linkStyling.selection.disabled) {
+            setLinkState(previousActiveLink, Mudlet::HyperlinkStyling::StateDisabled);
+        } else if (previousActiveLink == mCurrentHoveredLinkIndex) {
             setLinkState(previousActiveLink, Mudlet::HyperlinkStyling::StateHover);
-        } else if (isLinkVisited(previousActiveLink)) {  // Check base state: visited or default
+        } else if (isLinkSelected(previousActiveLink)) {
+            setLinkState(previousActiveLink, Mudlet::HyperlinkStyling::StateSelected);
+        } else if (isLinkVisited(previousActiveLink)) {
             setLinkState(previousActiveLink, Mudlet::HyperlinkStyling::StateVisited);
-        } else {  // Otherwise return to default
+        } else {
             setLinkState(previousActiveLink, Mudlet::HyperlinkStyling::StateDefault);
         }
 
@@ -5709,9 +5801,19 @@ void TBuffer::setFocusedLink(int linkIndex)
     int previousFocusedLink = mCurrentFocusedLinkIndex;
     mCurrentFocusedLinkIndex = linkIndex;
 
-    // Reset previous focused link
+    // Reset previous focused link to appropriate base state
     if (previousFocusedLink > 0 && previousFocusedLink != linkIndex) {
-        setLinkState(previousFocusedLink, Mudlet::HyperlinkStyling::StateDefault);
+        // Preserve disabled state, otherwise return to base state
+        Mudlet::HyperlinkStyling linkStyling = getEffectiveHyperlinkStyling(previousFocusedLink);
+        if (linkStyling.selection.hasSelectionSettings && linkStyling.selection.disabled) {
+            setLinkState(previousFocusedLink, Mudlet::HyperlinkStyling::StateDisabled);
+        } else if (isLinkSelected(previousFocusedLink)) {
+            setLinkState(previousFocusedLink, Mudlet::HyperlinkStyling::StateSelected);
+        } else if (isLinkVisited(previousFocusedLink)) {
+            setLinkState(previousFocusedLink, Mudlet::HyperlinkStyling::StateVisited);
+        } else {
+            setLinkState(previousFocusedLink, Mudlet::HyperlinkStyling::StateDefault);
+        }
     }
 
     // Set new link to focus state
@@ -5745,6 +5847,58 @@ void TBuffer::markLinkAsVisited(int linkIndex)
 bool TBuffer::isLinkVisited(int linkIndex) const
 {
     return mVisitedLinks.value(linkIndex, false);
+}
+
+void TBuffer::setLinkSelected(int linkIndex, bool selected)
+{
+    mLinkSelectionState[linkIndex] = selected;
+}
+
+bool TBuffer::isLinkSelected(int linkIndex) const
+{
+    return mLinkSelectionState.value(linkIndex, false);
+}
+
+void TBuffer::clearGroupSelection(const QString& group, const QString& exceptValue)
+{
+    // Update visual states for all links that belong to this group (except the specified value)
+    // Iterate through reasonable range of link IDs up to current max
+    int maxLinkId = mLinkStore.getCurrentLinkID();
+    int clearedCount = 0;
+    
+    for (int linkIndex = 0; linkIndex <= maxLinkId; ++linkIndex) {
+        auto styling = mLinkStore.getStyling(linkIndex);
+        if (styling.selection.hasSelectionSettings && 
+            styling.selection.group == group && 
+            styling.selection.value != exceptValue) {
+            
+            // Update selection manager state first
+            if (mpHost && mpHost->mpConsole && mpHost->mpConsole->mpSelectionManager) {
+                mpHost->mpConsole->mpSelectionManager->setSelected(styling.selection.group, styling.selection.value, false, false);
+            }
+            
+            // Set visual state to unselected (preserve disabled state)
+            setLinkSelected(linkIndex, false);
+            if (styling.selection.disabled) {
+                setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateDisabled);
+            } else {
+                setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateDefault);
+            }
+            
+            // CRITICAL: Update visual characters to reflect the state change
+            updateLinkCharacters(linkIndex);
+            clearedCount++;
+            
+#if defined(DEBUG_OSC_PROCESSING)
+            qDebug() << "[OSC8] clearGroupSelection: Deselected link" << linkIndex 
+                     << "group:" << group << "value:" << styling.selection.value;
+#endif
+        }
+    }
+    
+#if defined(DEBUG_OSC_PROCESSING)
+    qDebug() << "[OSC8] clearGroupSelection: Cleared" << clearedCount << "links in group" << group;
+#endif
 }
 
 int TBuffer::getLinkIndexAt(int line, int column) const
@@ -5788,7 +5942,8 @@ void TBuffer::updateLinkCharacters(int linkIndex)
     // Check if we should use ANSI base with pseudo-class overlays:
     // - Has pseudo-class styling (hasCustomStyling = true)
     // - But NO base styling (hasBaseCustomStyling = false)
-    // - And we're in default/visited state (not hover/active/focus)
+    // - And we're in a state that should preserve original ANSI as base (default/visited only)
+    // NOTE: Selected and disabled states should always use custom styling, not ANSI base
     bool useAnsiBase = !effectiveStyling.hasBaseCustomStyling &&
                        (effectiveStyling.currentState == Mudlet::HyperlinkStyling::StateDefault ||
                         effectiveStyling.currentState == Mudlet::HyperlinkStyling::StateVisited);

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2820,6 +2820,14 @@ bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, 
         parameters.insert(qsl("tooltip"), root[qsl("tooltip")].toString());
     }
 
+    if (root.contains(qsl("selection")) && root[qsl("selection")].isObject()) {
+        QJsonObject selectionObj = root[qsl("selection")].toObject();
+        parseJsonSelectionConfig(selectionObj, styling.selection);
+#if defined(DEBUG_OSC_PROCESSING)
+        qDebug() << "[OSC8] Selection config parsed from JSON";
+#endif
+    }
+
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC8] JSON converted to parameters:" << parameters;
 #endif
@@ -2941,6 +2949,34 @@ void TBuffer::parseJsonStateStyle(const QJsonObject& stateObj, Mudlet::Hyperlink
     }
 
     stateStyle.hasCustomStyling = hasAnyCustomStyling;
+}
+
+void TBuffer::parseJsonSelectionConfig(const QJsonObject& selectionObj, Mudlet::HyperlinkStyling::SelectionSettings& settings)
+{
+    if (selectionObj.contains(qsl("group")) && selectionObj[qsl("group")].isString()) {
+        settings.group = selectionObj[qsl("group")].toString();
+        settings.hasSelectionSettings = true;
+    }
+
+    if (selectionObj.contains(qsl("value")) && selectionObj[qsl("value")].isString()) {
+        settings.value = selectionObj[qsl("value")].toString();
+    }
+
+    if (selectionObj.contains(qsl("toggle")) && selectionObj[qsl("toggle")].isBool()) {
+        settings.toggle = selectionObj[qsl("toggle")].toBool();
+    }
+
+    if (selectionObj.contains(qsl("selected")) && selectionObj[qsl("selected")].isBool()) {
+        settings.selected = selectionObj[qsl("selected")].toBool();
+    }
+
+    if (selectionObj.contains(qsl("exclusive")) && selectionObj[qsl("exclusive")].isBool()) {
+        settings.exclusive = selectionObj[qsl("exclusive")].toBool();
+    }
+
+    if (selectionObj.contains(qsl("disabled")) && selectionObj[qsl("disabled")].isBool()) {
+        settings.disabled = selectionObj[qsl("disabled")].toBool();
+    }
 }
 
 void TBuffer::parseJsonStyleToHyperlinkStyling(const QJsonObject& styleObj, Mudlet::HyperlinkStyling& styling)
@@ -5335,6 +5371,54 @@ void TBuffer::injectOSC8DocumentationExamples()
     output += "  \x1b]8;;send:sword?config={\"style\":{\"color\":\"#cc6600\",\"bold\":true,\"hover\":{\"bg\":\"#ffcc99\",\"color\":\"#000000\"}},\"menu\":[{\"Equip\":\"send:equip\"},{\"Examine\":\"send:examine\"},\"-\",{\"Drop\":\"send:drop\"}],\"tooltip\":\"Flaming Sword: +5 damage, fire enchantment\"}\x1b\\🗡️ Flaming Sword\x1b]8;;\x1b\\\n\n";
 
     // ═══════════════════════════════════════════════════════════════════
+    // Hyperlink Selection (Radio & Checkbox Modes)
+    // ═══════════════════════════════════════════════════════════════════
+    output += "══════════════════════════════════════════════════════════════════════\n";
+    output += "HYPERLINK SELECTION (RADIO & CHECKBOX MODES)\n";
+    output += "══════════════════════════════════════════════════════════════════════\n\n";
+
+    output += "Radio Button Mode (Exclusive Selection):\n";
+    output += "Choose difficulty: ";
+    output += "\x1b]8;;send:easy?config={\"selection\":{\"group\":\"difficulty\",\"value\":\"easy\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"green\",\"selected\":{\"bg\":\"green\",\"color\":\"white\",\"bold\":true}}}\x1b\\Easy\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:normal?config={\"selection\":{\"group\":\"difficulty\",\"value\":\"normal\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"yellow\",\"selected\":{\"bg\":\"yellow\",\"color\":\"black\",\"bold\":true}}}\x1b\\Normal\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:hard?config={\"selection\":{\"group\":\"difficulty\",\"value\":\"hard\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"red\",\"selected\":{\"bg\":\"red\",\"color\":\"white\",\"bold\":true}}}\x1b\\Hard\x1b]8;;\x1b\\\n\n";
+
+    output += "Checkbox Mode (Multi-Select):\n";
+    output += "Enable buffs: ";
+    output += "\x1b]8;;send:buff-strength?config={\"selection\":{\"group\":\"buffs\",\"value\":\"strength\",\"toggle\":true},\"style\":{\"color\":\"#cc6600\",\"selected\":{\"color\":\"#ff9900\",\"bold\":true,\"underline\":true}}}\x1b\\💪 Strength\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:buff-speed?config={\"selection\":{\"group\":\"buffs\",\"value\":\"speed\",\"toggle\":true},\"style\":{\"color\":\"#0066cc\",\"selected\":{\"color\":\"#3399ff\",\"bold\":true,\"underline\":true}}}\x1b\\⚡ Speed\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:buff-defense?config={\"selection\":{\"group\":\"buffs\",\"value\":\"defense\",\"toggle\":true},\"style\":{\"color\":\"#006600\",\"selected\":{\"color\":\"#00cc00\",\"bold\":true,\"underline\":true}}}\x1b\\🛡️ Defense\x1b]8;;\x1b\\\n\n";
+
+    output += "Pre-Selected Options:\n";
+    output += "Combat style: ";
+    output += "\x1b]8;;send:aggressive?config={\"selection\":{\"group\":\"combat\",\"value\":\"aggressive\",\"toggle\":true,\"exclusive\":true,\"selected\":true},\"style\":{\"color\":\"red\",\"selected\":{\"bg\":\"darkred\",\"color\":\"white\"}}}\x1b\\Aggressive\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:balanced?config={\"selection\":{\"group\":\"combat\",\"value\":\"balanced\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"yellow\",\"selected\":{\"bg\":\"olive\",\"color\":\"white\"}}}\x1b\\Balanced\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:defensive?config={\"selection\":{\"group\":\"combat\",\"value\":\"defensive\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"green\",\"selected\":{\"bg\":\"darkgreen\",\"color\":\"white\"}}}\x1b\\Defensive\x1b]8;;\x1b\\\n\n";
+
+    output += "Disabled Options:\n";
+    output += "Choose class: ";
+    output += "\x1b]8;;send:warrior?config={\"selection\":{\"group\":\"class\",\"value\":\"warrior\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#cc6600\",\"selected\":{\"bg\":\"#cc6600\",\"color\":\"white\"}}}\x1b\\⚔️ Warrior\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:mage?config={\"selection\":{\"group\":\"class\",\"value\":\"mage\",\"toggle\":true,\"exclusive\":true,\"disabled\":true},\"style\":{\"color\":\"#6600cc\",\"selected\":{\"bg\":\"#6600cc\",\"color\":\"white\"},\"disabled\":{\"color\":\"#666666\",\"strikethrough\":true}}}\x1b\\🔮 Mage (Locked)\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:rogue?config={\"selection\":{\"group\":\"class\",\"value\":\"rogue\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#006600\",\"selected\":{\"bg\":\"#006600\",\"color\":\"white\"}}}\x1b\\🗡️ Rogue\x1b]8;;\x1b\\\n\n";
+
+    output += "Interactive Selection with Hover:\n";
+    output += "Select weapon: ";
+    output += "\x1b]8;;send:sword?config={\"selection\":{\"group\":\"weapon\",\"value\":\"sword\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"blue\",\"hover\":{\"bg\":\"lightblue\",\"color\":\"black\"},\"selected\":{\"bg\":\"darkblue\",\"color\":\"white\",\"bold\":true}}}\x1b\\⚔️ Sword\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:axe?config={\"selection\":{\"group\":\"weapon\",\"value\":\"axe\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"orange\",\"hover\":{\"bg\":\"lightyellow\",\"color\":\"black\"},\"selected\":{\"bg\":\"darkorange\",\"color\":\"white\",\"bold\":true}}}\x1b\\🪓 Axe\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:bow?config={\"selection\":{\"group\":\"weapon\",\"value\":\"bow\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"green\",\"hover\":{\"bg\":\"lightgreen\",\"color\":\"black\"},\"selected\":{\"bg\":\"darkgreen\",\"color\":\"white\",\"bold\":true}}}\x1b\\🏹 Bow\x1b]8;;\x1b\\\n\n";
+
+    output += "Toggle Switches:\n";
+    output += "Settings: ";
+    output += "\x1b]8;;send:auto-loot?config={\"selection\":{\"group\":\"settings\",\"value\":\"auto-loot\",\"toggle\":true},\"style\":{\"color\":\"#666666\",\"selected\":{\"color\":\"#00cc00\",\"bold\":true}}}\x1b\\[Auto-Loot]\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:auto-heal?config={\"selection\":{\"group\":\"settings\",\"value\":\"auto-heal\",\"toggle\":true,\"selected\":true},\"style\":{\"color\":\"#666666\",\"selected\":{\"color\":\"#00cc00\",\"bold\":true}}}\x1b\\[Auto-Heal]\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:sound?config={\"selection\":{\"group\":\"settings\",\"value\":\"sound\",\"toggle\":true},\"style\":{\"color\":\"#666666\",\"selected\":{\"color\":\"#00cc00\",\"bold\":true}}}\x1b\\[Sound]\x1b]8;;\x1b\\\n\n";
+
+    output += "Server Callback Example:\n";
+    output += "When clicked, selection state is sent to server via &selected=true/false\n";
+    output += "Server receives: send:easy&selected=true (for radio buttons)\n";
+    output += "Server receives: send:buff-strength&selected=true/false (for checkboxes)\n\n";
+
+    // ═══════════════════════════════════════════════════════════════════
     // Summary
     // ═══════════════════════════════════════════════════════════════════
     output += "══════════════════════════════════════════════════════════════════════\n\n";
@@ -5394,9 +5478,16 @@ Mudlet::HyperlinkStyling::StateStyle Mudlet::HyperlinkStyling::getEffectiveStyle
     }
 
     // Apply state-specific styles with proper cascade order
+    // Priority: disabled > selected > active > focus-visible > focus > hover > visited > link > default
     const StateStyle* stateStyle = nullptr;
 
     switch (currentState) {
+        case StateDisabled:
+            if (disabledStyle.hasCustomStyling) stateStyle = &disabledStyle;
+            break;
+        case StateSelected:
+            if (selectedStyle.hasCustomStyling) stateStyle = &selectedStyle;
+            break;
         case StateVisited:
             if (visitedStyle.hasCustomStyling) stateStyle = &visitedStyle;
             break;
@@ -5457,7 +5548,8 @@ Mudlet::HyperlinkStyling::StateStyle Mudlet::HyperlinkStyling::getEffectiveStyle
         if (linkStyle.hasCustomStyling || visitedStyle.hasCustomStyling ||
             hoverStyle.hasCustomStyling || activeStyle.hasCustomStyling ||
             focusStyle.hasCustomStyling || focusVisibleStyle.hasCustomStyling ||
-            anyLinkStyle.hasCustomStyling) {
+            anyLinkStyle.hasCustomStyling || selectedStyle.hasCustomStyling ||
+            disabledStyle.hasCustomStyling) {
             effective.hasCustomStyling = true;
         }
     }

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1014,7 +1014,7 @@ COMMIT_LINE:
         if (mHyperlinkActive) {
             c.mLinkIndex = mCurrentHyperlinkLinkId;
 
-            // Store the original ANSI-formatted character before applying CSS styling
+            // Store the original ANSI-formatted character before applying JSON styling
             // This is needed for ANSI base restoration when pseudo-classes are inactive
             if (!mLinkOriginalCharacters.contains(mCurrentHyperlinkLinkId)) {
                 mLinkOriginalCharacters[mCurrentHyperlinkLinkId] = c;
@@ -1030,6 +1030,7 @@ COMMIT_LINE:
             if (mCurrentHyperlinkStyling.hasForegroundColor) {
                 c.mFgColor = mCurrentHyperlinkStyling.foregroundColor;
             }
+
             if (mCurrentHyperlinkStyling.hasBackgroundColor) {
                 c.mBgColor = mCurrentHyperlinkStyling.backgroundColor;
             }
@@ -1056,9 +1057,11 @@ COMMIT_LINE:
                         break;
                 }
             }
+
             if (mCurrentHyperlinkStyling.isOverlined) {
                 c.mFlags |= TChar::Overline;
             }
+
             if (mCurrentHyperlinkStyling.isStrikeOut) {
                 c.mFlags |= TChar::StrikeOut;
             }
@@ -1067,9 +1070,11 @@ COMMIT_LINE:
             if (mCurrentHyperlinkStyling.hasUnderlineColor && mCurrentHyperlinkStyling.isUnderlined) {
                 c.setUnderlineColor(mCurrentHyperlinkStyling.underlineColor);
             }
+
             if (mCurrentHyperlinkStyling.hasOverlineColor && mCurrentHyperlinkStyling.isOverlined) {
                 c.setOverlineColor(mCurrentHyperlinkStyling.overlineColor);
             }
+
             if (mCurrentHyperlinkStyling.hasStrikeoutColor && mCurrentHyperlinkStyling.isStrikeOut) {
                 c.setStrikeoutColor(mCurrentHyperlinkStyling.strikeoutColor);
             }
@@ -1077,6 +1082,7 @@ COMMIT_LINE:
             if (mCurrentHyperlinkStyling.isBold) {
                 c.mFlags |= TChar::Bold;
             }
+
             if (mCurrentHyperlinkStyling.isItalic) {
                 c.mFlags |= TChar::Italic;
             }
@@ -1180,7 +1186,9 @@ bool TBuffer::commitLine(char ch, size_t& localBufferPosition)
         mMudLine.clear();
         mMudBuffer.clear();
         const int line = lineBuffer.size() - 1;
-        mpHost->mpConsole->runTriggers(line);
+        if (!mSkipTriggerProcessing) {
+            mpHost->mpConsole->runTriggers(line);
+        }
 
         // Only use of TBuffer::wrap(), breaks up new text
         // NOTE: it MAY have been clobbered by the trigger engine!
@@ -2529,20 +2537,13 @@ void TBuffer::decodeOSC(const QString& sequence)
 #if defined(DEBUG_OSC_PROCESSING)
             qDebug() << "[OSC8] Raw URL for parameter parsing:" << rawUrl;
 #endif
-            QMap<QString, QString> queryParams = parseUriQueryParameters(rawUrl);
+            // Reset styling to defaults before parsing
+            mCurrentHyperlinkStyling = Mudlet::HyperlinkStyling();
+            QMap<QString, QString> queryParams = parseUriQueryParameters(rawUrl, mCurrentHyperlinkStyling);
 
-            // Extract styling parameters
-            if (queryParams.contains(qsl("style"))) {
 #if defined(DEBUG_OSC_PROCESSING)
-                qDebug() << "[OSC8] Found style parameter, applying custom styling";
+            qDebug() << "[OSC8] Styling parsed directly from JSON (isUnderlined=" << mCurrentHyperlinkStyling.isUnderlined << ")";
 #endif
-                parseHyperlinkStyling(queryParams.value(qsl("style")), mCurrentHyperlinkStyling);
-            } else {
-                mCurrentHyperlinkStyling = Mudlet::HyperlinkStyling(); // Reset to defaults
-#if defined(DEBUG_OSC_PROCESSING)
-                qDebug() << "[OSC8] No style parameter provided, using defaults (isUnderlined=" << mCurrentHyperlinkStyling.isUnderlined << ")";
-#endif
-            }
 
             // Extract menu parameters
             if (queryParams.contains(qsl("menu"))) {
@@ -2569,7 +2570,8 @@ void TBuffer::decodeOSC(const QString& sequence)
 
             // Remove styling/menu/tooltip query parameters from URL for command processing
             QString baseUrl = rawUrl;
-            QMap<QString, QString> allParams = parseUriQueryParameters(rawUrl);
+            // Reuse the already parsed params for URL reconstruction
+            QMap<QString, QString> allParams = queryParams;
 
             // For web URLs, preserve original parameters except our special ones
             if (rawUrl.startsWith(qsl("http://")) || rawUrl.startsWith(qsl("https://")) || rawUrl.startsWith(qsl("ftp://"))) {
@@ -2737,7 +2739,7 @@ QString TBuffer::appendQueryParameters(const QString& uri, const QMap<QString, Q
     return result;
 }
 
-QMap<QString, QString> TBuffer::parseUriQueryParameters(const QString& uri)
+QMap<QString, QString> TBuffer::parseUriQueryParameters(const QString& uri, Mudlet::HyperlinkStyling& styling)
 {
     QMap<QString, QString> parameters;
 
@@ -2768,7 +2770,7 @@ QMap<QString, QString> TBuffer::parseUriQueryParameters(const QString& uri)
     // Only process JSON config parameters - no legacy CSS support
     if (decodedQueryString.startsWith(qsl("config={"))) {
         QString jsonString = decodedQueryString.mid(7); // Remove "config="
-        parseJsonHyperlinkConfig(jsonString, parameters);
+        parseJsonHyperlinkConfig(jsonString, parameters, styling);
     }
 
 #if defined(DEBUG_OSC_PROCESSING)
@@ -2778,7 +2780,7 @@ QMap<QString, QString> TBuffer::parseUriQueryParameters(const QString& uri)
     return parameters;
 }
 
-bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, QString>& parameters)
+bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, QString>& parameters, Mudlet::HyperlinkStyling& styling)
 {
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC8] parseJsonHyperlinkConfig called with jsonString:" << jsonString;
@@ -2803,13 +2805,13 @@ bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, 
 
     QJsonObject root = doc.object();
 
-    // Parse style object
+    // Parse style object directly into HyperlinkStyling
     if (root.contains(qsl("style")) && root[qsl("style")].isObject()) {
         QJsonObject styleObj = root[qsl("style")].toObject();
-        QString cssStyleString = jsonStyleObjectToCss(styleObj);
-        if (!cssStyleString.isEmpty()) {
-            parameters.insert(qsl("style"), cssStyleString);
-        }
+        parseJsonStyleToHyperlinkStyling(styleObj, styling);
+#if defined(DEBUG_OSC_PROCESSING)
+        qDebug() << "[OSC8] Style parsed directly from JSON";
+#endif
     }
 
     // Parse menu array
@@ -2831,95 +2833,6 @@ bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, 
 #endif
 
     return true;
-}
-
-QString TBuffer::jsonStyleObjectToCss(const QJsonObject& styleObj)
-{
-    QStringList cssProperties;
-
-    // Basic style properties
-    if (styleObj.contains(qsl("color")) && styleObj[qsl("color")].isString()) {
-        cssProperties << qsl("color:") + styleObj[qsl("color")].toString();
-    }
-
-    if (styleObj.contains(qsl("bg")) && styleObj[qsl("bg")].isString()) {
-        cssProperties << qsl("background-color:") + styleObj[qsl("bg")].toString();
-    }
-
-    if (styleObj.contains(qsl("bold")) && styleObj[qsl("bold")].isBool() && styleObj[qsl("bold")].toBool()) {
-        cssProperties << qsl("font-weight:bold");
-    }
-
-    if (styleObj.contains(qsl("italic")) && styleObj[qsl("italic")].isBool() && styleObj[qsl("italic")].toBool()) {
-        cssProperties << qsl("font-style:italic");
-    }
-
-    // Text decorations - combine multiple decorations into single CSS property
-    QStringList decorationParts;
-    QString underlineStyle = qsl("solid"); // Default underline style
-
-    // Process underline
-    if (styleObj.contains(qsl("underline"))) {
-        QJsonValue underlineVal = styleObj[qsl("underline")];
-        if (underlineVal.isBool() && underlineVal.toBool()) {
-            decorationParts << qsl("underline");
-        } else if (underlineVal.isString()) {
-            decorationParts << qsl("underline");
-            underlineStyle = underlineVal.toString(); // Store style for later
-        }
-    }
-
-    // Process overline
-    if (styleObj.contains(qsl("overline"))) {
-        QJsonValue overlineVal = styleObj[qsl("overline")];
-        if (overlineVal.isBool() && overlineVal.toBool()) {
-            decorationParts << qsl("overline");
-        } else if (overlineVal.isString()) {
-            decorationParts << qsl("overline");
-            // Note: overline styles are currently limited to solid in the parser
-        }
-    }
-
-    // Process strikethrough
-    if (styleObj.contains(qsl("strikethrough"))) {
-        QJsonValue strikeVal = styleObj[qsl("strikethrough")];
-        if (strikeVal.isBool() && strikeVal.toBool()) {
-            decorationParts << qsl("line-through");
-        } else if (strikeVal.isString()) {
-            decorationParts << qsl("line-through");
-            // Note: strikethrough styles are currently limited to solid in the parser
-        }
-    }
-
-    // Combine all decorations into a single CSS property
-    if (!decorationParts.isEmpty()) {
-        QString decorationValue = decorationParts.join(qsl(" "));
-        // Add underline style if it's not solid and underline is present
-        if (decorationParts.contains(qsl("underline")) && underlineStyle != qsl("solid")) {
-            decorationValue += qsl(" ") + underlineStyle;
-        }
-        cssProperties << qsl("text-decoration:") + decorationValue;
-    }
-
-    // Text decoration color
-    if (styleObj.contains(qsl("text-decoration-color")) && styleObj[qsl("text-decoration-color")].isString()) {
-        cssProperties << qsl("text-decoration-color:") + styleObj[qsl("text-decoration-color")].toString();
-    }
-
-    // Pseudo-class states
-    QStringList pseudoClasses = {qsl("hover"), qsl("active"), qsl("visited"), qsl("link"), qsl("focus"), qsl("focus-visible"), qsl("any-link")};
-
-    for (const QString& pseudoClass : pseudoClasses) {
-        if (styleObj.contains(pseudoClass) && styleObj[pseudoClass].isObject()) {
-            QJsonObject pseudoObj = styleObj[pseudoClass].toObject();
-            QString pseudoCss = jsonStyleObjectToCss(pseudoObj);
-            if (!pseudoCss.isEmpty()) {
-                cssProperties << qsl(":") + pseudoClass + qsl("{") + pseudoCss + qsl("}");
-            }
-        }
-    }
-
-    return cssProperties.join(qsl(";"));
 }
 
 QString TBuffer::jsonMenuArrayToString(const QJsonArray& menuArray)
@@ -2944,322 +2857,181 @@ QString TBuffer::jsonMenuArrayToString(const QJsonArray& menuArray)
     return menuItems.join(qsl("|"));
 }
 
-void TBuffer::parseHyperlinkStyling(const QString& styleString, Mudlet::HyperlinkStyling& styling)
+void TBuffer::parseJsonStateStyle(const QJsonObject& stateObj, Mudlet::HyperlinkStyling::StateStyle& stateStyle)
+{
+    bool hasAnyCustomStyling = false;
+
+    // Color
+    if (stateObj.contains(qsl("color")) && stateObj[qsl("color")].isString()) {
+        QColor color = parseColorValue(stateObj[qsl("color")].toString());
+        if (color.isValid()) {
+            stateStyle.foregroundColor = color;
+            stateStyle.hasForegroundColor = true;
+            hasAnyCustomStyling = true;
+        }
+    }
+
+    // Background color
+    if (stateObj.contains(qsl("bg")) && stateObj[qsl("bg")].isString()) {
+        QColor color = parseColorValue(stateObj[qsl("bg")].toString());
+        if (color.isValid()) {
+            stateStyle.backgroundColor = color;
+            stateStyle.hasBackgroundColor = true;
+            hasAnyCustomStyling = true;
+        }
+    }
+
+    // Bold
+    if (stateObj.contains(qsl("bold")) && stateObj[qsl("bold")].isBool()) {
+        stateStyle.isBold = stateObj[qsl("bold")].toBool();
+        hasAnyCustomStyling = true;
+    }
+
+    // Italic
+    if (stateObj.contains(qsl("italic")) && stateObj[qsl("italic")].isBool()) {
+        stateStyle.isItalic = stateObj[qsl("italic")].toBool();
+        hasAnyCustomStyling = true;
+    }
+
+    // Underline
+    if (stateObj.contains(qsl("underline"))) {
+        QJsonValue underlineVal = stateObj[qsl("underline")];
+        if (underlineVal.isBool()) {
+            stateStyle.isUnderlined = underlineVal.toBool();
+            if (stateStyle.isUnderlined) {
+                stateStyle.underlineStyle = Mudlet::HyperlinkStyling::UnderlineSolid;
+            }
+            hasAnyCustomStyling = true;
+        } else if (underlineVal.isString()) {
+            stateStyle.isUnderlined = true;
+            QString style = underlineVal.toString().toLower();
+            if (style == qsl("wavy")) {
+                stateStyle.underlineStyle = Mudlet::HyperlinkStyling::UnderlineWavy;
+            } else if (style == qsl("dotted")) {
+                stateStyle.underlineStyle = Mudlet::HyperlinkStyling::UnderlineDotted;
+            } else if (style == qsl("dashed")) {
+                stateStyle.underlineStyle = Mudlet::HyperlinkStyling::UnderlineDashed;
+            } else {
+                stateStyle.underlineStyle = Mudlet::HyperlinkStyling::UnderlineSolid;
+            }
+            hasAnyCustomStyling = true;
+        }
+    }
+
+    // Overline
+    if (stateObj.contains(qsl("overline"))) {
+        QJsonValue overlineVal = stateObj[qsl("overline")];
+        if (overlineVal.isBool()) {
+            stateStyle.isOverlined = overlineVal.toBool();
+            hasAnyCustomStyling = true;
+        } else if (overlineVal.isString()) {
+            stateStyle.isOverlined = true;
+            hasAnyCustomStyling = true;
+        }
+    }
+
+    // Strikethrough
+    if (stateObj.contains(qsl("strikethrough"))) {
+        QJsonValue strikeVal = stateObj[qsl("strikethrough")];
+        if (strikeVal.isBool()) {
+            stateStyle.isStrikeOut = strikeVal.toBool();
+            hasAnyCustomStyling = true;
+        } else if (strikeVal.isString()) {
+            stateStyle.isStrikeOut = true;
+            hasAnyCustomStyling = true;
+        }
+    }
+
+    // Text decoration color
+    if (stateObj.contains(qsl("text-decoration-color")) && stateObj[qsl("text-decoration-color")].isString()) {
+        QColor decorationColor = parseColorValue(stateObj[qsl("text-decoration-color")].toString());
+        if (decorationColor.isValid()) {
+            stateStyle.underlineColor = decorationColor;
+            stateStyle.hasUnderlineColor = true;
+            stateStyle.overlineColor = decorationColor;
+            stateStyle.hasOverlineColor = true;
+            stateStyle.strikeoutColor = decorationColor;
+            stateStyle.hasStrikeoutColor = true;
+            hasAnyCustomStyling = true;
+        }
+    }
+
+    stateStyle.hasCustomStyling = hasAnyCustomStyling;
+}
+
+void TBuffer::parseJsonStyleToHyperlinkStyling(const QJsonObject& styleObj, Mudlet::HyperlinkStyling& styling)
 {
 #if defined(DEBUG_OSC_PROCESSING)
-    qDebug() << "[OSC8] parseHyperlinkStyling called with styleString:" << styleString;
+    qDebug() << "[OSC8] parseJsonStyleToHyperlinkStyling called with JSON object";
 #endif
 
-    // Reset styling to defaults
-    styling = Mudlet::HyperlinkStyling();
+    // Parse base style properties directly into the default state
+    Mudlet::HyperlinkStyling::StateStyle baseStyle;
+    parseJsonStateStyle(styleObj, baseStyle);
 
-    // Check if this is a CSS selector with pseudo-classes
-    // Format: "property:value;:pseudo-class{property:value;property:value}:pseudo-class{...}"
-    // or just: ":pseudo-class{property:value;property:value}:pseudo-class{...}"
-    if (styleString.contains('{') && styleString.contains('}')) {
-        // First, extract and parse any base properties (properties not in pseudo-classes)
-        // These are properties that come before any pseudo-class or between pseudo-classes
-        QString baseProperties;
-        static const QRegularExpression pseudoClassRegex(R"(:([\w-]+)\s*\{([^}]*)\})");
-
-        // Extract base properties by removing all pseudo-class blocks
-        QString remainingStyle = styleString;
-        QRegularExpressionMatchIterator matches = pseudoClassRegex.globalMatch(styleString);
-
-        // Remove pseudo-class blocks to get base properties
-        while (matches.hasNext()) {
-            QRegularExpressionMatch match = matches.next();
-            remainingStyle.replace(match.captured(0), "");
-        }
-
-        // Parse base properties if any exist
-        // Filter out strings that are only semicolons and whitespace
-        QString filteredBase = remainingStyle;
-        filteredBase.remove(';');
-        filteredBase = filteredBase.trimmed();
-
-        if (!filteredBase.isEmpty()) {
-            baseProperties = remainingStyle.trimmed();
-#if defined(DEBUG_OSC_PROCESSING)
-            qDebug() << "[OSC8] Found base properties:" << baseProperties;
-#endif
-            // Mark that we have base styling (not just pseudo-class styling)
-            styling.hasBaseCustomStyling = true;
-
-            // Parse base properties as simple CSS
-            QStringList basePairs = baseProperties.split(';', Qt::SkipEmptyParts);
-
-            for (const QString& pair : basePairs) {
-                QStringList propertyValue = pair.split(':', Qt::KeepEmptyParts);
-
-                if (propertyValue.size() != 2) {
-                    continue;
-                }
-
-                QString property = propertyValue[0].trimmed().toLower();
-                QString value = propertyValue[1].trimmed();
-
-                // Apply base properties to the default state
-                if (property == qsl("color")) {
-                    QColor color = parseColorValue(value);
-                    if (color.isValid()) {
-                        styling.foregroundColor = color;
-                        styling.hasForegroundColor = true;
-                        styling.hasCustomStyling = true;
-                    }
-                } else if (property == qsl("background-color") || property == qsl("background")) {
-                    QColor color = parseColorValue(value);
-                    if (color.isValid()) {
-                        styling.backgroundColor = color;
-                        styling.hasBackgroundColor = true;
-                        styling.hasCustomStyling = true;
-                    }
-                } else if (property == qsl("font-weight")) {
-                    styling.isBold = (value.toLower() == qsl("bold"));
-                    styling.hasCustomStyling = true;
-                } else if (property == qsl("font-style")) {
-                    styling.isItalic = (value.toLower() == qsl("italic"));
-                    styling.hasCustomStyling = true;
-                }
-            }
-        }
-
-        // Now parse pseudo-class specific styles
-        matches = pseudoClassRegex.globalMatch(styleString);
-
-        while (matches.hasNext()) {
-            QRegularExpressionMatch match = matches.next();
-            QString pseudoClass = ":" + match.captured(1);
-            QString properties = match.captured(2);
-
-#if defined(DEBUG_OSC_PROCESSING)
-            qDebug() << "[OSC8] Found pseudo-class:" << pseudoClass << "with properties:" << properties;
-#endif
-
-            parseHyperlinkStateStyle(pseudoClass, properties, styling);
-        }
-
-        // If no base styling was provided, but we have :link or :any-link styles,
-        // use them as the default/base state since links need a default appearance
-        if (!styling.hasCustomStyling) {
-            // First try :any-link (applies to both :link and :visited)
-            if (styling.anyLinkStyle.hasCustomStyling) {
-#if defined(DEBUG_OSC_PROCESSING)
-                qDebug() << "[OSC8] No base styling found, using :any-link as default";
-#endif
-                styling.foregroundColor = styling.anyLinkStyle.foregroundColor;
-                styling.backgroundColor = styling.anyLinkStyle.backgroundColor;
-                styling.underlineColor = styling.anyLinkStyle.underlineColor;
-                styling.overlineColor = styling.anyLinkStyle.overlineColor;
-                styling.strikeoutColor = styling.anyLinkStyle.strikeoutColor;
-                styling.hasForegroundColor = styling.anyLinkStyle.hasForegroundColor;
-                styling.hasBackgroundColor = styling.anyLinkStyle.hasBackgroundColor;
-                styling.hasUnderlineColor = styling.anyLinkStyle.hasUnderlineColor;
-                styling.hasOverlineColor = styling.anyLinkStyle.hasOverlineColor;
-                styling.hasStrikeoutColor = styling.anyLinkStyle.hasStrikeoutColor;
-                styling.isBold = styling.anyLinkStyle.isBold;
-                styling.isItalic = styling.anyLinkStyle.isItalic;
-                styling.isUnderlined = styling.anyLinkStyle.isUnderlined;
-                styling.isStrikeOut = styling.anyLinkStyle.isStrikeOut;
-                styling.isOverlined = styling.anyLinkStyle.isOverlined;
-                styling.underlineStyle = styling.anyLinkStyle.underlineStyle;
-                styling.hasCustomStyling = true;
-            } else if (styling.linkStyle.hasCustomStyling) {
-                // Fall back to :link style
-#if defined(DEBUG_OSC_PROCESSING)
-                qDebug() << "[OSC8] No base styling found, using :link as default";
-#endif
-                styling.foregroundColor = styling.linkStyle.foregroundColor;
-                styling.backgroundColor = styling.linkStyle.backgroundColor;
-                styling.underlineColor = styling.linkStyle.underlineColor;
-                styling.overlineColor = styling.linkStyle.overlineColor;
-                styling.strikeoutColor = styling.linkStyle.strikeoutColor;
-                styling.hasForegroundColor = styling.linkStyle.hasForegroundColor;
-                styling.hasBackgroundColor = styling.linkStyle.hasBackgroundColor;
-                styling.hasUnderlineColor = styling.linkStyle.hasUnderlineColor;
-                styling.hasOverlineColor = styling.linkStyle.hasOverlineColor;
-                styling.hasStrikeoutColor = styling.linkStyle.hasStrikeoutColor;
-                styling.isBold = styling.linkStyle.isBold;
-                styling.isItalic = styling.linkStyle.isItalic;
-                styling.isUnderlined = styling.linkStyle.isUnderlined;
-                styling.isStrikeOut = styling.linkStyle.isStrikeOut;
-                styling.isOverlined = styling.linkStyle.isOverlined;
-                styling.underlineStyle = styling.linkStyle.underlineStyle;
-                styling.hasCustomStyling = true;
-            }
-        }
-
-        // Apply accessibility enhancements
-        applyAccessibilityEnhancements(styling);
-        return;
+    // Apply base style to the main styling object
+    if (baseStyle.hasForegroundColor) {
+        styling.foregroundColor = baseStyle.foregroundColor;
+        styling.hasForegroundColor = true;
     }
 
-    // Fallback: Parse as simple CSS-like style string: "property:value;property:value"
-    QStringList stylePairs = styleString.split(';', Qt::SkipEmptyParts);
-
-    bool hasAnyCustomStyling = false;
-    bool textDecorationExplicitlySet = false;
-
-    for (const QString& pair : stylePairs) {
-        QStringList propertyValue = pair.split(':', Qt::KeepEmptyParts);
-
-        if (propertyValue.size() != 2) {
-            continue; // Skip malformed property
-        }
-
-        QString property = propertyValue[0].trimmed().toLower();
-        QString value = propertyValue[1].trimmed();
-
-        if (property == "color") {
-            QColor color = parseColorValue(value);
-
-            if (color.isValid()) {
-                styling.foregroundColor = color;
-                styling.hasForegroundColor = true;
-                hasAnyCustomStyling = true;
-            }
-        } else if (property == "background-color") {
-            QColor color = parseColorValue(value);
-
-            if (color.isValid()) {
-                styling.backgroundColor = color;
-                styling.hasBackgroundColor = true;
-                hasAnyCustomStyling = true;
-            }
-        } else if (property == "font-weight") {
-            styling.isBold = (value.toLower() == qsl("bold"));
-            hasAnyCustomStyling = true;
-        } else if (property == "font-style") {
-            styling.isItalic = (value.toLower() == qsl("italic"));
-            hasAnyCustomStyling = true;
-        } else if (property == "text-decoration") {
-            // Handle text-decoration with optional style: "underline", "underline wavy", "overline", "line-through", "none"
-            // Can also handle multiple values: "underline overline", "underline wavy red"
-            QStringList decorationParts = value.toLower().split(' ', Qt::SkipEmptyParts);
-
-            // Reset decoration flags when text-decoration is explicitly set
-            styling.isUnderlined = false;
-            styling.isOverlined = false;
-            styling.isStrikeOut = false;
-            styling.underlineStyle = Mudlet::HyperlinkStyling::UnderlineNone;
-
-            for (const QString& part : decorationParts) {
-                if (part == "underline") {
-                    styling.isUnderlined = true;
-                    styling.underlineStyle = Mudlet::HyperlinkStyling::UnderlineSolid;
-                } else if (part == "overline") {
-                    styling.isOverlined = true;
-                } else if (part == "line-through") {
-                    styling.isStrikeOut = true;
-                } else if (part == "none") {
-                    styling.isUnderlined = false;
-                    styling.isOverlined = false;
-                    styling.isStrikeOut = false;
-                    styling.underlineStyle = Mudlet::HyperlinkStyling::UnderlineNone;
-                } else if (part == "wavy" && styling.isUnderlined) {
-                    styling.underlineStyle = Mudlet::HyperlinkStyling::UnderlineWavy;
-                } else if (part == "dotted" && styling.isUnderlined) {
-                    styling.underlineStyle = Mudlet::HyperlinkStyling::UnderlineDotted;
-                } else if (part == "dashed" && styling.isUnderlined) {
-                    styling.underlineStyle = Mudlet::HyperlinkStyling::UnderlineDashed;
-                } else if (part == "solid" && styling.isUnderlined) {
-                    styling.underlineStyle = Mudlet::HyperlinkStyling::UnderlineSolid;
-                } else {
-                    // Check if it's a color for the decoration
-                    QColor decorationColor = parseColorValue(part);
-
-                    if (decorationColor.isValid()) {
-                        if (styling.isUnderlined) {
-                            styling.underlineColor = decorationColor;
-                            styling.hasUnderlineColor = true;
-#if defined(DEBUG_OSC_PROCESSING)
-                            qDebug() << "[OSC8] Set underline color to" << decorationColor.name();
-#endif
-                        } else if (styling.isOverlined) {
-                            styling.overlineColor = decorationColor;
-                            styling.hasOverlineColor = true;
-#if defined(DEBUG_OSC_PROCESSING)
-                            qDebug() << "[OSC8] Set overline color to" << decorationColor.name();
-#endif
-                        } else if (styling.isStrikeOut) {
-                            styling.strikeoutColor = decorationColor;
-                            styling.hasStrikeoutColor = true;
-#if defined(DEBUG_OSC_PROCESSING)
-                            qDebug() << "[OSC8] Set strikeout color to" << decorationColor.name();
-#endif
-                        }
-                    }
-                }
-            }
-
-            textDecorationExplicitlySet = true;
-            hasAnyCustomStyling = true;
-        } else if (property == "text-decoration-line") {
-            // CSS3 specific property for decoration lines
-            // Reset decoration flags when text-decoration-line is explicitly set
-            styling.isUnderlined = false;
-            styling.isOverlined = false;
-            styling.isStrikeOut = false;
-
-            QStringList decorations = value.toLower().split(' ', Qt::SkipEmptyParts);
-
-            for (const QString& decoration : decorations) {
-                if (decoration == qsl("underline")) {
-                    styling.isUnderlined = true;
-                } else if (decoration == qsl("overline")) {
-                    styling.isOverlined = true;
-                } else if (decoration == qsl("line-through")) {
-                    styling.isStrikeOut = true;
-                } else if (decoration == qsl("none")) {
-                    styling.isUnderlined = false;
-                    styling.isOverlined = false;
-                    styling.isStrikeOut = false;
-                }
-            }
-
-            textDecorationExplicitlySet = true;
-            hasAnyCustomStyling = true;
-        } else if (property == "text-decoration-style") {
-            // CSS3 specific property for decoration style
-            QString decorationStyle = value.toLower();
-
-            if (decorationStyle == qsl("wavy")) {
-                styling.underlineStyle = Mudlet::HyperlinkStyling::UnderlineWavy;
-            } else if (decorationStyle == qsl("dotted")) {
-                styling.underlineStyle = Mudlet::HyperlinkStyling::UnderlineDotted;
-            } else if (decorationStyle == qsl("dashed")) {
-                styling.underlineStyle = Mudlet::HyperlinkStyling::UnderlineDashed;
-            } else if (decorationStyle == qsl("solid")) {
-                styling.underlineStyle = Mudlet::HyperlinkStyling::UnderlineSolid;
-            }
-            hasAnyCustomStyling = true;
-        } else if (property == "text-decoration-color") {
-            // CSS3 specific property for decoration color
-            QColor decorationColor = parseColorValue(value);
-
-            if (decorationColor.isValid()) {
-                // Store the color for all decoration types - we'll apply to active decorations later
-                styling.underlineColor = decorationColor;
-                styling.hasUnderlineColor = true;
-                styling.overlineColor = decorationColor;
-                styling.hasOverlineColor = true;
-                styling.strikeoutColor = decorationColor;
-                styling.hasStrikeoutColor = true;
-            }
-
-            hasAnyCustomStyling = true;
-        }
+    if (baseStyle.hasBackgroundColor) {
+        styling.backgroundColor = baseStyle.backgroundColor;
+        styling.hasBackgroundColor = true;
     }
 
-    // If custom styling was provided, mark it and disable default underline if text-decoration wasn't explicitly set
-    if (hasAnyCustomStyling) {
-        styling.hasCustomStyling = true;
-        // Only disable default underline if text-decoration wasn't explicitly specified
-        if (!textDecorationExplicitlySet) {
-            styling.isUnderlined = false;
-            styling.underlineStyle = Mudlet::HyperlinkStyling::UnderlineNone;
-        }
+    styling.isBold = baseStyle.isBold;
+    styling.isItalic = baseStyle.isItalic;
+    styling.isUnderlined = baseStyle.isUnderlined;
+    styling.underlineStyle = baseStyle.underlineStyle;
+    styling.isOverlined = baseStyle.isOverlined;
+    styling.isStrikeOut = baseStyle.isStrikeOut;
+
+    if (baseStyle.hasUnderlineColor) {
+        styling.underlineColor = baseStyle.underlineColor;
+        styling.hasUnderlineColor = true;
     }
+
+    if (baseStyle.hasOverlineColor) {
+        styling.overlineColor = baseStyle.overlineColor;
+        styling.hasOverlineColor = true;
+    }
+
+    if (baseStyle.hasStrikeoutColor) {
+        styling.strikeoutColor = baseStyle.strikeoutColor;
+        styling.hasStrikeoutColor = true;
+    }
+
+    // Parse pseudo-class states
+    if (styleObj.contains(qsl("link")) && styleObj[qsl("link")].isObject()) {
+        parseJsonStateStyle(styleObj[qsl("link")].toObject(), styling.linkStyle);
+    }
+
+    if (styleObj.contains(qsl("visited")) && styleObj[qsl("visited")].isObject()) {
+        parseJsonStateStyle(styleObj[qsl("visited")].toObject(), styling.visitedStyle);
+    }
+
+    if (styleObj.contains(qsl("hover")) && styleObj[qsl("hover")].isObject()) {
+        parseJsonStateStyle(styleObj[qsl("hover")].toObject(), styling.hoverStyle);
+    }
+
+    if (styleObj.contains(qsl("active")) && styleObj[qsl("active")].isObject()) {
+        parseJsonStateStyle(styleObj[qsl("active")].toObject(), styling.activeStyle);
+    }
+
+    if (styleObj.contains(qsl("focus")) && styleObj[qsl("focus")].isObject()) {
+        parseJsonStateStyle(styleObj[qsl("focus")].toObject(), styling.focusStyle);
+    }
+
+    if (styleObj.contains(qsl("focus-visible")) && styleObj[qsl("focus-visible")].isObject()) {
+        parseJsonStateStyle(styleObj[qsl("focus-visible")].toObject(), styling.focusVisibleStyle);
+    }
+
+    if (styleObj.contains(qsl("any-link")) && styleObj[qsl("any-link")].isObject()) {
+        parseJsonStateStyle(styleObj[qsl("any-link")].toObject(), styling.anyLinkStyle);
+    }
+
+    applyAccessibilityEnhancements(styling);
 }
 
 QColor TBuffer::parseColorValue(const QString& value)
@@ -3412,15 +3184,23 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
     }
 
     // Check for OSC 8 documentation examples trigger phrase
+    // Use a 1-second debounce to prevent duplicate injection from echo + server response
     if (text.contains("!osc8-docs")) {
+        const qint64 now = QDateTime::currentMSecsSinceEpoch();
+        TBuffer& mainBuffer = mpHost->mpConsole->buffer;
+
+        if (now - mainBuffer.mLastOSC8DocsInjectionTime > 1000) {
 #if defined(DEBUG_OSC_PROCESSING)
-        qDebug() << "[OSC8] Documentation examples trigger phrase detected";
+            qDebug() << "[OSC8] Documentation examples trigger phrase detected";
 #endif
-        injectOSC8DocumentationExamples();
+            mainBuffer.mLastOSC8DocsInjectionTime = now;
+            mainBuffer.injectOSC8DocumentationExamples();
+        }
         return; // Don't display the trigger phrase itself
     }
 
     int lastLine = buffer.size() - 1;
+
     if (Q_UNLIKELY(lastLine < 0)) {
         // There are NO lines in the buffer - so initialize with a new empty line
         appendEmptyLine();
@@ -3435,27 +3215,31 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
     if (text.isEmpty()) {
         return;
     }
+
     bool firstChar = (lineBuffer.back().isEmpty());
     const int length = std::min(static_cast<int>(text.size()), MAX_CHARACTERS_PER_ECHO);
     int lineEndPos = sub_end;
+
     if (lineEndPos >= length) {
         lineEndPos = text.size() - 1;
     }
 
     for (int i = sub_start; i <= (sub_start + lineEndPos); i++) {
         const QChar thisChar = text.at(i);
+
         if (thisChar == QChar::LineFeed) {
             firstChar = true;
             appendEmptyLine();
             continue;
         }
+
         lineBuffer.back().append(thisChar);
         const TChar styling(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags), linkID);
         buffer.back().push_back(styling);
 
         // Note: Original character storage for ANSI-styled OSC 8 links happens in
         // translateToPlainText() where the TChar is created with ANSI formatting
-        // before CSS styling is applied
+        // before JSON styling is applied
 
         if (firstChar) {
             timeBuffer.back() = QTime::currentTime().toString(mudlet::smTimeStampFormat);
@@ -5575,15 +5359,18 @@ void TBuffer::injectOSC8DocumentationExamples()
     output += "All examples above are clickable - try them!\n\n";
 
     // Process the output through the normal text processing pipeline
+    // Skip trigger processing to avoid re-entrancy issues during injection
     std::string outputBytes = output.toStdString();
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC8] About to process documentation examples through translateToPlainText, length:" << outputBytes.length();
 #endif
+    mSkipTriggerProcessing = true;
     translateToPlainText(outputBytes, true); // Mark as from server
+    mSkipTriggerProcessing = false;
 }
 
 // ============================================================================
-// CSS Link States Implementation with Accessibility Best Practices
+// Link States Implementation with Accessibility Best Practices
 // ============================================================================
 
 Mudlet::HyperlinkStyling::StateStyle Mudlet::HyperlinkStyling::getEffectiveStyle() const
@@ -5693,144 +5480,6 @@ Mudlet::HyperlinkStyling::StateStyle Mudlet::HyperlinkStyling::getEffectiveStyle
     }
 
     return effective;
-}
-
-void TBuffer::parseHyperlinkStateStyle(const QString& pseudoClass, const QString& styleString, Mudlet::HyperlinkStyling& styling)
-{
-#if defined(DEBUG_OSC_PROCESSING)
-    qDebug() << "[OSC8] parseHyperlinkStateStyle called with pseudoClass:" << pseudoClass
-             << "styleString:" << styleString;
-#endif
-
-    QString cleanPseudoClass = pseudoClass.trimmed().toLower();
-    Mudlet::HyperlinkStyling::StateStyle* targetStyle = nullptr;
-
-    // Map pseudo-class selectors to appropriate state styles
-    if (cleanPseudoClass == qsl(":link")) {
-        targetStyle = &styling.linkStyle;
-    } else if (cleanPseudoClass == qsl(":visited")) {
-        targetStyle = &styling.visitedStyle;
-    } else if (cleanPseudoClass == qsl(":hover")) {
-        targetStyle = &styling.hoverStyle;
-    } else if (cleanPseudoClass == qsl(":active")) {
-        targetStyle = &styling.activeStyle;
-    } else if (cleanPseudoClass == qsl(":focus")) {
-        targetStyle = &styling.focusStyle;
-    } else if (cleanPseudoClass == qsl(":focus-visible")) {
-        targetStyle = &styling.focusVisibleStyle;
-    } else if (cleanPseudoClass == qsl(":any-link")) {
-        targetStyle = &styling.anyLinkStyle;
-    } else {
-#if defined(DEBUG_OSC_PROCESSING)
-        qDebug() << "[OSC8] Unknown pseudo-class:" << cleanPseudoClass;
-#endif
-        return;
-    }
-
-    if (targetStyle) {
-        parseStateStyleProperties(styleString, *targetStyle);
-        applyAccessibilityEnhancements(styling);
-    }
-}
-
-void TBuffer::parseStateStyleProperties(const QString& styleString, Mudlet::HyperlinkStyling::StateStyle& stateStyle)
-{
-    // Parse CSS-like style string: "property:value;property:value"
-    QStringList stylePairs = styleString.split(';', Qt::SkipEmptyParts);
-
-    bool hasAnyCustomStyling = false;
-
-    for (const QString& pair : stylePairs) {
-        QStringList propertyValue = pair.split(':', Qt::KeepEmptyParts);
-        if (propertyValue.size() != 2) {
-            continue; // Skip malformed property
-        }
-
-        QString property = propertyValue[0].trimmed().toLower();
-        QString value = propertyValue[1].trimmed();
-
-        if (property == qsl("color")) {
-            QColor color = parseColorValue(value);
-            if (color.isValid()) {
-                stateStyle.foregroundColor = color;
-                stateStyle.hasForegroundColor = true;
-                hasAnyCustomStyling = true;
-            }
-        } else if (property == qsl("background") || property == qsl("background-color")) {
-            // Support both "background" and "background-color" properties
-            QColor color = parseColorValue(value);
-            if (color.isValid()) {
-                stateStyle.backgroundColor = color;
-                stateStyle.hasBackgroundColor = true;
-                hasAnyCustomStyling = true;
-            }
-        } else if (property == qsl("font-weight")) {
-            stateStyle.isBold = (value.toLower() == qsl("bold") || value == "700" || value.toInt() >= 700);
-            hasAnyCustomStyling = true;
-        } else if (property == qsl("font-style")) {
-            stateStyle.isItalic = (value.toLower() == qsl("italic"));
-            hasAnyCustomStyling = true;
-        } else if (property == qsl("text-decoration")) {
-            // Handle text-decoration with optional style
-            QStringList decorationParts = value.toLower().split(' ', Qt::SkipEmptyParts);
-
-            // Reset decoration flags
-            stateStyle.isUnderlined = false;
-            stateStyle.isOverlined = false;
-            stateStyle.isStrikeOut = false;
-            stateStyle.underlineStyle = Mudlet::HyperlinkStyling::UnderlineNone;
-
-            for (const QString& part : decorationParts) {
-                if (part == qsl("underline")) {
-                    stateStyle.isUnderlined = true;
-                    stateStyle.underlineStyle = Mudlet::HyperlinkStyling::UnderlineSolid;
-                } else if (part == qsl("overline")) {
-                    stateStyle.isOverlined = true;
-                } else if (part == qsl("line-through")) {
-                    stateStyle.isStrikeOut = true;
-                } else if (part == qsl("none")) {
-                    stateStyle.isUnderlined = false;
-                    stateStyle.isOverlined = false;
-                    stateStyle.isStrikeOut = false;
-                } else if (part == qsl("wavy") && stateStyle.isUnderlined) {
-                    stateStyle.underlineStyle = Mudlet::HyperlinkStyling::UnderlineWavy;
-                } else if (part == qsl("dotted") && stateStyle.isUnderlined) {
-                    stateStyle.underlineStyle = Mudlet::HyperlinkStyling::UnderlineDotted;
-                } else if (part == qsl("dashed") && stateStyle.isUnderlined) {
-                    stateStyle.underlineStyle = Mudlet::HyperlinkStyling::UnderlineDashed;
-                } else {
-                    // Check if it's a color for the decoration
-                    QColor decorationColor = parseColorValue(part);
-                    if (decorationColor.isValid()) {
-                        if (stateStyle.isUnderlined) {
-                            stateStyle.underlineColor = decorationColor;
-                            stateStyle.hasUnderlineColor = true;
-                        } else if (stateStyle.isOverlined) {
-                            stateStyle.overlineColor = decorationColor;
-                            stateStyle.hasOverlineColor = true;
-                        } else if (stateStyle.isStrikeOut) {
-                            stateStyle.strikeoutColor = decorationColor;
-                            stateStyle.hasStrikeoutColor = true;
-                        }
-                    }
-                }
-            }
-            hasAnyCustomStyling = true;
-        } else if (property == qsl("text-decoration-color")) {
-            QColor decorationColor = parseColorValue(value);
-            if (decorationColor.isValid()) {
-                stateStyle.underlineColor = decorationColor;
-                stateStyle.hasUnderlineColor = true;
-                stateStyle.overlineColor = decorationColor;
-                stateStyle.hasOverlineColor = true;
-                stateStyle.strikeoutColor = decorationColor;
-                stateStyle.hasStrikeoutColor = true;
-                hasAnyCustomStyling = true;
-            }
-        }
-    }
-
-    stateStyle.hasCustomStyling = hasAnyCustomStyling;
 }
 
 void TBuffer::applyAccessibilityEnhancements(Mudlet::HyperlinkStyling& styling)
@@ -6052,8 +5701,8 @@ void TBuffer::updateLinkCharacters(int linkIndex)
     // Get the effective styling for this link's current state
     Mudlet::HyperlinkStyling effectiveStyling = getEffectiveHyperlinkStyling(linkIndex);
 
-    // IMPORTANT: If this link has no custom CSS styling at all (neither base nor pseudo-class),
-    // don't modify the characters. This preserves ANSI formatting for links without any CSS.
+    // IMPORTANT: If this link has no custom styling at all (neither base nor pseudo-class),
+    // don't modify the characters. This preserves ANSI formatting for links without styling.
     if (!effectiveStyling.hasCustomStyling) {
 #if defined(DEBUG_OSC_PROCESSING)
         qDebug() << "[OSC8] Link" << linkIndex << "has no custom styling - preserving ANSI formatting";
@@ -6063,7 +5712,7 @@ void TBuffer::updateLinkCharacters(int linkIndex)
 
     // Check if we should use ANSI base with pseudo-class overlays:
     // - Has pseudo-class styling (hasCustomStyling = true)
-    // - But NO base CSS styling (hasBaseCustomStyling = false)
+    // - But NO base styling (hasBaseCustomStyling = false)
     // - And we're in default/visited state (not hover/active/focus)
     bool useAnsiBase = !effectiveStyling.hasBaseCustomStyling &&
                        (effectiveStyling.currentState == Mudlet::HyperlinkStyling::StateDefault ||
@@ -6082,9 +5731,9 @@ void TBuffer::updateLinkCharacters(int linkIndex)
             if (tchar.linkIndex() == linkIndex) {
                 // Apply the effective styling to this character
 
-                // If we should use ANSI base (no base CSS but in default/visited state),
+                // If we should use ANSI base (no base styling but in default/visited state),
                 // restore the original ANSI colors and formatting as a BASE,
-                // then let pseudo-class CSS styling override it
+                // then let pseudo-class styling override it
                 if (useAnsiBase && mLinkOriginalCharacters.contains(linkIndex)) {
                     TChar originalChar = mLinkOriginalCharacters.value(linkIndex);
 #if defined(DEBUG_OSC_PROCESSING)
@@ -6095,22 +5744,22 @@ void TBuffer::updateLinkCharacters(int linkIndex)
                              << "Current FgColor:" << tchar.mFgColor.name()
                              << "Current Bold:" << bool(tchar.mFlags & TChar::Bold);
 #endif
-                    // Restore ANSI base - these will be overridden below if CSS specifies them
+                    // Restore ANSI base - these will be overridden below if styling specifies them
                     tchar.mFgColor = originalChar.mFgColor;
                     tchar.mBgColor = originalChar.mBgColor;
                     tchar.mFlags = originalChar.mFlags; // Restore ALL ANSI formatting flags including decorations
 
-                    // Clear any custom decoration colors that were applied by CSS pseudo-classes
+                    // Clear any custom decoration colors that were applied by pseudo-classes
                     // ANSI doesn't support custom decoration colors, so we clear them when restoring ANSI base
                     tchar.clearCustomUnderlineColor();
                     tchar.clearCustomOverlineColor();
                     tchar.clearCustomStrikeoutColor();
 
-                    // DON'T continue here - let the CSS pseudo-class styling below override the ANSI base
+                    // DON'T continue here - let the pseudo-class styling below override the ANSI base
                     // This allows e.g. :visited{color:#bb66dd} to work with ANSI base formatting
                 }
 
-                // Apply CSS styling
+                // Apply styling
 
                 // Update foreground color
                 if (effectiveStyling.hasForegroundColor) {

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2513,6 +2513,13 @@ void TBuffer::decodeOSC(const QString& sequence)
 #endif
         QString rawUrl = rest.mid(secondSemi + 1).toString();
 
+#if defined(DEBUG_OSC_PROCESSING)
+        if (!rawUrl.isEmpty()) {
+            qDebug().noquote().nospace() << "[OSC8] Received OSC 8 sequence with URL (length=" << rawUrl.length() << "): " 
+                                         << (rawUrl.length() > 80 ? rawUrl.left(80) + "..." : rawUrl);
+        }
+#endif
+
         // OSC 8 ;; closes the hyperlink
         if ((param.isEmpty() && rawUrl.isEmpty())) {
 #if defined(DEBUG_OSC_PROCESSING)
@@ -2553,9 +2560,25 @@ void TBuffer::decodeOSC(const QString& sequence)
             }
 
             if (rawUrl.startsWith(qsl("preset:"))) {
-                QUrl presetUrl(rawUrl);
-                QString presetName = presetUrl.path();
-                QString configParam = presetUrl.hasQuery() ? QUrlQuery(presetUrl).queryItemValue("config") : QString();
+#if defined(DEBUG_OSC_PROCESSING)
+                qDebug() << "[OSC8] Detected preset: URL:" << rawUrl;
+#endif
+                // Extract preset name (between "preset:" and "?")
+                int queryStart = rawUrl.indexOf('?');
+                QString presetName = (queryStart > 7) ? rawUrl.mid(7, queryStart - 7) : rawUrl.mid(7);
+                
+                // Extract config parameter manually to avoid QUrl parsing issues with custom schemes
+                QString configParam;
+                if (queryStart != -1) {
+                    QString queryString = rawUrl.mid(queryStart + 1);
+                    QUrlQuery query(queryString);
+                    configParam = query.queryItemValue(qsl("config"), QUrl::FullyDecoded);
+                }
+#if defined(DEBUG_OSC_PROCESSING)
+                qDebug() << "[OSC8] Preset name extracted:" << presetName;
+                qDebug() << "[OSC8] Config param length:" << configParam.length();
+                qDebug() << "[OSC8] Config param preview:" << (configParam.length() > 100 ? configParam.left(100) + "..." : configParam);
+#endif
                 
                 if (!presetName.isEmpty() && !configParam.isEmpty() && mpConsole && mpConsole->mpCompactSyntaxManager) {
                     // Parse the JSON configuration
@@ -2565,11 +2588,21 @@ void TBuffer::decodeOSC(const QString& sequence)
                     if (parseError.error == QJsonParseError::NoError && doc.isObject()) {
                         mpConsole->mpCompactSyntaxManager->registerPreset(presetName, doc.object());
 #if defined(DEBUG_OSC_PROCESSING)
-                        qDebug() << "[OSC8] Registered preset:" << presetName << "with config:" << configParam;
+                        qDebug() << "[OSC8] Successfully registered preset:" << presetName;
 #endif
                     } else {
-                        qWarning() << "TBuffer::decodeOSC(...) - Failed to parse preset JSON:" << parseError.errorString();
+                        qWarning().noquote().nospace() << "TBuffer::decodeOSC(...) - Failed to parse preset JSON for \"" << presetName << "\": " << parseError.errorString();
+#if defined(DEBUG_OSC_PROCESSING)
+                        qDebug() << "[OSC8] Failed JSON:" << configParam;
+#endif
                     }
+                } else {
+#if defined(DEBUG_OSC_PROCESSING)
+                    qDebug() << "[OSC8] Preset registration skipped - presetName empty:" << presetName.isEmpty() 
+                             << "configParam empty:" << configParam.isEmpty()
+                             << "mpConsole:" << (mpConsole != nullptr)
+                             << "mpCompactSyntaxManager:" << (mpConsole && mpConsole->mpCompactSyntaxManager != nullptr);
+#endif
                 }
                 // Preset definitions don't create visible hyperlinks
                 return;

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1030,12 +1030,64 @@ COMMIT_LINE:
 #endif
             }
 
+            // Apply base styling first (if any)
             if (mCurrentHyperlinkStyling.hasForegroundColor) {
                 c.mFgColor = mCurrentHyperlinkStyling.foregroundColor;
             }
 
             if (mCurrentHyperlinkStyling.hasBackgroundColor) {
                 c.mBgColor = mCurrentHyperlinkStyling.backgroundColor;
+            }
+            
+            // For preset-only links, base styling may be empty but pseudo-class styling exists
+            // Apply effective styling with :link pseudo-class to ensure preset colors show
+            Mudlet::HyperlinkStyling effectiveStyling = getEffectiveHyperlinkStyling(mCurrentHyperlinkLinkId);
+            if (effectiveStyling.hasCustomStyling) {
+                if (effectiveStyling.hasForegroundColor) {
+                    c.mFgColor = effectiveStyling.foregroundColor;
+                }
+                if (effectiveStyling.hasBackgroundColor) {
+                    c.mBgColor = effectiveStyling.backgroundColor;
+                }
+                if (effectiveStyling.isBold) {
+                    c.mFlags |= TChar::Bold;
+                }
+                if (effectiveStyling.isItalic) {
+                    c.mFlags |= TChar::Italic;
+                }
+                if (effectiveStyling.isUnderlined) {
+                    c.mFlags |= TChar::Underline;
+                    switch (effectiveStyling.underlineStyle) {
+                        case Mudlet::HyperlinkStyling::UnderlineWavy:
+                            c.mFlags |= TChar::UnderlineWavy;
+                            break;
+                        case Mudlet::HyperlinkStyling::UnderlineDotted:
+                            c.mFlags |= TChar::UnderlineDotted;
+                            break;
+                        case Mudlet::HyperlinkStyling::UnderlineDashed:
+                            c.mFlags |= TChar::UnderlineDashed;
+                            break;
+                        case Mudlet::HyperlinkStyling::UnderlineSolid:
+                        case Mudlet::HyperlinkStyling::UnderlineNone:
+                        default:
+                            break;
+                    }
+                }
+                if (effectiveStyling.isOverlined) {
+                    c.mFlags |= TChar::Overline;
+                }
+                if (effectiveStyling.isStrikeOut) {
+                    c.mFlags |= TChar::StrikeOut;
+                }
+                if (effectiveStyling.hasUnderlineColor && effectiveStyling.isUnderlined) {
+                    c.setUnderlineColor(effectiveStyling.underlineColor);
+                }
+                if (effectiveStyling.hasOverlineColor && effectiveStyling.isOverlined) {
+                    c.setOverlineColor(effectiveStyling.overlineColor);
+                }
+                if (effectiveStyling.hasStrikeoutColor && effectiveStyling.isStrikeOut) {
+                    c.setStrikeoutColor(effectiveStyling.strikeoutColor);
+                }
             }
 
             if (mCurrentHyperlinkStyling.isUnderlined) {
@@ -2526,7 +2578,8 @@ void TBuffer::decodeOSC(const QString& sequence)
             qDebug().noquote() << "[OSC8] Hyperlink terminator - closing active hyperlink";
 #endif
             
-            // Apply initial selection/disabled state styling when link closes
+            // Apply initial selection/disabled state styling when link closes (from selection branch)
+            // OR apply :link pseudo-class styling for preset-only links (from compact branch)
             if (mCurrentHyperlinkLinkId > 0 && mCurrentHyperlinkStyling.selection.hasSelectionSettings) {
 #if defined(DEBUG_OSC_PROCESSING)
                 qDebug() << "[OSC8] Queuing initial selection styling for link" << mCurrentHyperlinkLinkId
@@ -2541,6 +2594,11 @@ void TBuffer::decodeOSC(const QString& sequence)
                     setLinkState(mCurrentHyperlinkLinkId, Mudlet::HyperlinkStyling::StateDisabled);
                     mPendingSelectionStyling.insert(mCurrentHyperlinkLinkId);
                 }
+            } else if (mCurrentHyperlinkLinkId > 0) {
+                // Set initial :link pseudo-class state for regular links
+                setLinkState(mCurrentHyperlinkLinkId, Mudlet::HyperlinkStyling::StateDefault);
+                // Update any characters already in buffer with :link styling
+                updateLinkCharacters(mCurrentHyperlinkLinkId);
             }
             
             mCurrentHyperlinkCommand.clear();
@@ -6218,6 +6276,16 @@ void TBuffer::updateLinkCharacters(int linkIndex)
     // Get the effective styling for this link's current state
     Mudlet::HyperlinkStyling effectiveStyling = getEffectiveHyperlinkStyling(linkIndex);
 
+#if defined(DEBUG_OSC_PROCESSING)
+    qDebug() << "[OSC8] Link" << linkIndex << "effective styling:"
+             << "hasFg:" << effectiveStyling.hasForegroundColor
+             << "fg:" << (effectiveStyling.hasForegroundColor ? effectiveStyling.foregroundColor.name() : "none")
+             << "hasBg:" << effectiveStyling.hasBackgroundColor
+             << "bold:" << effectiveStyling.isBold
+             << "underline:" << effectiveStyling.isUnderlined
+             << "hasCustom:" << effectiveStyling.hasCustomStyling;
+#endif
+
     // IMPORTANT: If this link has no custom styling at all (neither base nor pseudo-class),
     // don't modify the characters. This preserves ANSI formatting for links without styling.
     if (!effectiveStyling.hasCustomStyling) {
@@ -6227,14 +6295,11 @@ void TBuffer::updateLinkCharacters(int linkIndex)
         return; // Don't modify characters - preserve original ANSI formatting
     }
 
-    // Check if we should use ANSI base with pseudo-class overlays:
-    // - Has pseudo-class styling (hasCustomStyling = true)
-    // - But NO base styling (hasBaseCustomStyling = false)
-    // - And we're in a state that should preserve original ANSI as base (default/visited only)
-    // NOTE: Selected and disabled states should always use custom styling, not ANSI base
-    bool useAnsiBase = !effectiveStyling.hasBaseCustomStyling &&
-                       (effectiveStyling.currentState == Mudlet::HyperlinkStyling::StateDefault ||
-                        effectiveStyling.currentState == Mudlet::HyperlinkStyling::StateVisited);
+    // Never restore ANSI base when effective styling has custom properties.
+    // This includes both base-level styling AND pseudo-class styling.
+    // If the cascade resolved custom colors/formatting from :link, :hover, etc.,
+    // use those instead of reverting to ANSI.
+    bool useAnsiBase = false;
 
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC8] Updating link" << linkIndex << "- hasBaseCustomStyling:" << effectiveStyling.hasBaseCustomStyling
@@ -6258,11 +6323,13 @@ void TBuffer::updateLinkCharacters(int linkIndex)
             if (tchar.linkIndex() == linkIndex) {
 #if defined(DEBUG_OSC_PROCESSING)
                 matchingCharacters++;
-                qDebug() << "[OSC8] Found character for link" << linkIndex 
-                         << "- Current FgColor:" << tchar.mFgColor.name()
-                         << "Current Bold:" << bool(tchar.mFlags & TChar::Bold)
-                         << "Will apply FgColor:" << (effectiveStyling.hasForegroundColor ? effectiveStyling.foregroundColor.name() : "none")
-                         << "Will apply Bold:" << effectiveStyling.isBold;
+                static int charUpdateCount = 0;
+                if (charUpdateCount++ < 2) { // Only log first 2 characters to avoid spam
+                    qDebug() << "[OSC8] Before update - char with linkIndex" << linkIndex
+                             << "- FgColor:" << tchar.mFgColor.name()
+                             << "hasFg:" << effectiveStyling.hasForegroundColor
+                             << "new fg:" << (effectiveStyling.hasForegroundColor ? effectiveStyling.foregroundColor.name() : "none");
+                }
 #endif
                 // Apply the effective styling to this character
 
@@ -6299,6 +6366,13 @@ void TBuffer::updateLinkCharacters(int linkIndex)
                 // Update foreground color
                 if (effectiveStyling.hasForegroundColor) {
                     tchar.mFgColor = effectiveStyling.foregroundColor;
+#if defined(DEBUG_OSC_PROCESSING)
+                    static int fgUpdateCount = 0;
+                    if (fgUpdateCount++ < 2) {
+                        qDebug() << "[OSC8] Applied FG color to link" << linkIndex
+                                 << "- New FgColor:" << tchar.mFgColor.name();
+                    }
+#endif
                 }
 
                 // Update background color - restore original if not specified in styling

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -5733,8 +5733,7 @@ void TBuffer::injectOSC8DocumentationExamples()
     output += "\x1b]8;;send:bag?config={\"style\":{\"color\":\"#6600cc\",\"hover\":{\"color\":\"#9933ff\",\"underline\":true}},\"menu\":[{\"Open\":\"send:open\"},{\"Sort\":\"send:sort\"},\"-\",{\"Drop\":\"send:drop\"}]}\x1b\\🎒 Backpack\x1b]8;;\x1b\\\n\n";
 
     output += "Status Indicators:\n";
-    output += "  \x1b]8;;send:warning?config={\"style\":{\"bg\":\"#ffcc00\",\"color\":\"#000000\",\"bold\":true}}\x1b\\⚠️ Warning\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:error?config={\"style\":{\"bg\":\"#cc0000\",\"color\":\"#ffffff\",\"bold\":true}}\x1b\\❌ Error\x1b]8;;\x1b\\ ";
+    output += "  \x1b]8;;send:error?config={\"style\":{\"bg\":\"#cc0000\",\"color\":\"#ffffff\",\"bold\":true}}\x1b\\❌ Error\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:success?config={\"style\":{\"bg\":\"#006600\",\"color\":\"#ffffff\",\"bold\":true}}\x1b\\✅ Success\x1b]8;;\x1b\\\n\n";
 
     output += "Complete Example (All Features):\n";
@@ -5751,18 +5750,16 @@ void TBuffer::injectOSC8DocumentationExamples()
     output += "React: ";
     output += "\x1b]8;;send:like?config={\"selection\":{\"group\":\"reaction\",\"value\":\"like\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#8899ff\",\"selected\":{\"bg\":\"#0066cc\",\"color\":\"#ffffff\",\"bold\":true}}}\x1b\\👍 Like\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:love?config={\"selection\":{\"group\":\"reaction\",\"value\":\"love\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#8899ff\",\"selected\":{\"bg\":\"#ff0066\",\"color\":\"#ffffff\",\"bold\":true}}}\x1b\\❤️ Love\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:care?config={\"selection\":{\"group\":\"reaction\",\"value\":\"care\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#8899ff\",\"selected\":{\"bg\":\"#ff9900\",\"color\":\"#ffffff\",\"bold\":true}}}\x1b\\🤗 Care\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:laugh?config={\"selection\":{\"group\":\"reaction\",\"value\":\"laugh\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#8899ff\",\"selected\":{\"bg\":\"#ffcc00\",\"color\":\"#000000\",\"bold\":true}}}\x1b\\😂 Laugh\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:wow?config={\"selection\":{\"group\":\"reaction\",\"value\":\"wow\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#8899ff\",\"selected\":{\"bg\":\"#9933ff\",\"color\":\"#ffffff\",\"bold\":true}}}\x1b\\😮 Wow\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:sad?config={\"selection\":{\"group\":\"reaction\",\"value\":\"sad\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#8899ff\",\"selected\":{\"bg\":\"#3366cc\",\"color\":\"#ffffff\",\"bold\":true}}}\x1b\\😢 Sad\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:angry?config={\"selection\":{\"group\":\"reaction\",\"value\":\"angry\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#8899ff\",\"selected\":{\"bg\":\"#cc0000\",\"color\":\"#ffffff\",\"bold\":true}}}\x1b\\😠 Angry\x1b]8;;\x1b\\\n\n";
+    output += "\x1b]8;;send:sad?config={\"selection\":{\"group\":\"reaction\",\"value\":\"sad\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#8899ff\",\"selected\":{\"bg\":\"#3366cc\",\"color\":\"#ffffff\",\"bold\":true}}}\x1b\\😢 Sad\x1b]8;;\x1b\\\n";
+    output += "  (Only one can be selected at a time)\n\n";
 
     output += "Checkbox Mode (Multi-Select):\n";
     output += "Enable buffs: ";
     output += "\x1b]8;;send:buff-strength?config={\"selection\":{\"group\":\"buffs\",\"value\":\"strength\",\"toggle\":true,\"exclusive\":false},\"style\":{\"color\":\"#ff9944\",\"selected\":{\"bg\":\"#ff6600\",\"color\":\"#ffffff\",\"bold\":true}}}\x1b\\[ ] Strength\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:buff-speed?config={\"selection\":{\"group\":\"buffs\",\"value\":\"speed\",\"toggle\":true,\"exclusive\":false},\"style\":{\"color\":\"#66ccff\",\"selected\":{\"bg\":\"#0088ff\",\"color\":\"#ffffff\",\"bold\":true}}}\x1b\\[ ] Speed\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:buff-defense?config={\"selection\":{\"group\":\"buffs\",\"value\":\"defense\",\"toggle\":true,\"exclusive\":false},\"style\":{\"color\":\"#66ff66\",\"selected\":{\"bg\":\"#00aa00\",\"color\":\"#ffffff\",\"bold\":true}}}\x1b\\[ ] Defense\x1b]8;;\x1b\\\n";
-    output += "  (Click to toggle, multiple can be selected)\n\n";
+    output += "  (Multiple can be selected)\n\n";
 
     output += "Pre-Selected Options:\n";
     output += "Combat style: ";
@@ -5776,26 +5773,9 @@ void TBuffer::injectOSC8DocumentationExamples()
     output += "\x1b]8;;send:warrior?config={\"selection\":{\"group\":\"class\",\"value\":\"warrior\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#ff9944\",\"selected\":{\"bg\":\"#cc6600\",\"color\":\"#000000\",\"bold\":true}}}\x1b\\⚔️ Warrior\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:mage?config={\"selection\":{\"group\":\"class\",\"value\":\"mage\",\"toggle\":true,\"exclusive\":true,\"disabled\":true},\"style\":{\"color\":\"#9966ff\",\"selected\":{\"bg\":\"#6600cc\",\"color\":\"#000000\",\"bold\":true},\"disabled\":{\"color\":\"#444444\",\"strikethrough\":true}}}\x1b\\🔮 Mage\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:rogue?config={\"selection\":{\"group\":\"class\",\"value\":\"rogue\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#66ff66\",\"selected\":{\"bg\":\"#00aa00\",\"color\":\"#000000\",\"bold\":true}}}\x1b\\🗡️ Rogue\x1b]8;;\x1b\\\n";
-    output += "  (Mage is locked/disabled)\n\n";
+    output += "  (Mage is locked)\n\n";
 
-    output += "Interactive Selection with Hover:\n";
-    output += "Select weapon: ";
-    output += "\x1b]8;;send:sword?config={\"selection\":{\"group\":\"weapon\",\"value\":\"sword\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#6699ff\",\"selected\":{\"bg\":\"#0066cc\",\"color\":\"#ffff00\",\"bold\":true}}}\x1b\\⚔️ Sword\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:axe?config={\"selection\":{\"group\":\"weapon\",\"value\":\"axe\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#ff9944\",\"selected\":{\"bg\":\"#cc6600\",\"color\":\"#ffff00\",\"bold\":true}}}\x1b\\🪓 Axe\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:bow?config={\"selection\":{\"group\":\"weapon\",\"value\":\"bow\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#66ff66\",\"selected\":{\"bg\":\"#00aa00\",\"color\":\"#ffff00\",\"bold\":true}}}\x1b\\🏹 Bow\x1b]8;;\x1b\\\n";
-    output += "  (Click to select)\n\n";
-
-    output += "Toggle Switches:\n";
-    output += "Settings: ";
-    output += "\x1b]8;;send:auto-loot?config={\"selection\":{\"group\":\"settings\",\"value\":\"auto-loot\",\"toggle\":true,\"exclusive\":false},\"style\":{\"color\":\"#888888\",\"selected\":{\"color\":\"#00ff00\",\"bold\":true}}}\x1b\\Auto-Loot\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:auto-heal?config={\"selection\":{\"group\":\"settings\",\"value\":\"auto-heal\",\"toggle\":true,\"exclusive\":false,\"selected\":true},\"style\":{\"color\":\"#888888\",\"selected\":{\"color\":\"#00ff00\",\"bold\":true}}}\x1b\\Auto-Heal\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:sound?config={\"selection\":{\"group\":\"settings\",\"value\":\"sound\",\"toggle\":true,\"exclusive\":false},\"style\":{\"color\":\"#888888\",\"selected\":{\"color\":\"#00ff00\",\"bold\":true}}}\x1b\\Sound\x1b]8;;\x1b\\\n";
-    output += "  (Toggle each setting on/off)\n\n";
-
-    output += "Server Callback Example:\n";
-    output += "When clicked, selection state is sent to server via &selected=true/false\n";
-    output += "Server receives: send:easy&selected=true (for radio buttons)\n";
-    output += "Server receives: send:buff-strength&selected=true/false (for checkboxes)\n\n";
+    output += "Server receives selection state via &selected=true/false query parameter\n\n";
 
     // ═══════════════════════════════════════════════════════════════════
     // Summary

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1026,7 +1026,6 @@ COMMIT_LINE:
 #endif
             }
 
-            // Apply enhanced hyperlink styling
             if (mCurrentHyperlinkStyling.hasForegroundColor) {
                 c.mFgColor = mCurrentHyperlinkStyling.foregroundColor;
             }
@@ -1035,11 +1034,9 @@ COMMIT_LINE:
                 c.mBgColor = mCurrentHyperlinkStyling.backgroundColor;
             }
 
-            // Apply text decorations
             if (mCurrentHyperlinkStyling.isUnderlined) {
                 c.mFlags |= TChar::Underline;
 
-                // Apply specific underline style based on underlineStyle enum
                 switch (mCurrentHyperlinkStyling.underlineStyle) {
                     case Mudlet::HyperlinkStyling::UnderlineWavy:
                         c.mFlags |= TChar::UnderlineWavy;
@@ -1053,7 +1050,6 @@ COMMIT_LINE:
                     case Mudlet::HyperlinkStyling::UnderlineSolid:
                     case Mudlet::HyperlinkStyling::UnderlineNone:
                     default:
-                        // Standard solid underline (no additional flags needed)
                         break;
                 }
             }
@@ -1066,7 +1062,6 @@ COMMIT_LINE:
                 c.mFlags |= TChar::StrikeOut;
             }
 
-            // Apply decoration colors - only for active decorations
             if (mCurrentHyperlinkStyling.hasUnderlineColor && mCurrentHyperlinkStyling.isUnderlined) {
                 c.setUnderlineColor(mCurrentHyperlinkStyling.underlineColor);
             }
@@ -2805,7 +2800,6 @@ bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, 
 
     QJsonObject root = doc.object();
 
-    // Parse style object directly into HyperlinkStyling
     if (root.contains(qsl("style")) && root[qsl("style")].isObject()) {
         QJsonObject styleObj = root[qsl("style")].toObject();
         parseJsonStyleToHyperlinkStyling(styleObj, styling);
@@ -2814,7 +2808,6 @@ bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, 
 #endif
     }
 
-    // Parse menu array
     if (root.contains(qsl("menu")) && root[qsl("menu")].isArray()) {
         QJsonArray menuArray = root[qsl("menu")].toArray();
         QString menuString = jsonMenuArrayToString(menuArray);
@@ -2823,7 +2816,6 @@ bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, 
         }
     }
 
-    // Parse tooltip string
     if (root.contains(qsl("tooltip")) && root[qsl("tooltip")].isString()) {
         parameters.insert(qsl("tooltip"), root[qsl("tooltip")].toString());
     }
@@ -2861,7 +2853,6 @@ void TBuffer::parseJsonStateStyle(const QJsonObject& stateObj, Mudlet::Hyperlink
 {
     bool hasAnyCustomStyling = false;
 
-    // Color
     if (stateObj.contains(qsl("color")) && stateObj[qsl("color")].isString()) {
         QColor color = parseColorValue(stateObj[qsl("color")].toString());
         if (color.isValid()) {
@@ -2871,7 +2862,6 @@ void TBuffer::parseJsonStateStyle(const QJsonObject& stateObj, Mudlet::Hyperlink
         }
     }
 
-    // Background color
     if (stateObj.contains(qsl("bg")) && stateObj[qsl("bg")].isString()) {
         QColor color = parseColorValue(stateObj[qsl("bg")].toString());
         if (color.isValid()) {
@@ -2881,19 +2871,16 @@ void TBuffer::parseJsonStateStyle(const QJsonObject& stateObj, Mudlet::Hyperlink
         }
     }
 
-    // Bold
     if (stateObj.contains(qsl("bold")) && stateObj[qsl("bold")].isBool()) {
         stateStyle.isBold = stateObj[qsl("bold")].toBool();
         hasAnyCustomStyling = true;
     }
 
-    // Italic
     if (stateObj.contains(qsl("italic")) && stateObj[qsl("italic")].isBool()) {
         stateStyle.isItalic = stateObj[qsl("italic")].toBool();
         hasAnyCustomStyling = true;
     }
 
-    // Underline
     if (stateObj.contains(qsl("underline"))) {
         QJsonValue underlineVal = stateObj[qsl("underline")];
         if (underlineVal.isBool()) {
@@ -2918,7 +2905,6 @@ void TBuffer::parseJsonStateStyle(const QJsonObject& stateObj, Mudlet::Hyperlink
         }
     }
 
-    // Overline
     if (stateObj.contains(qsl("overline"))) {
         QJsonValue overlineVal = stateObj[qsl("overline")];
         if (overlineVal.isBool()) {
@@ -2930,7 +2916,6 @@ void TBuffer::parseJsonStateStyle(const QJsonObject& stateObj, Mudlet::Hyperlink
         }
     }
 
-    // Strikethrough
     if (stateObj.contains(qsl("strikethrough"))) {
         QJsonValue strikeVal = stateObj[qsl("strikethrough")];
         if (strikeVal.isBool()) {
@@ -2942,7 +2927,6 @@ void TBuffer::parseJsonStateStyle(const QJsonObject& stateObj, Mudlet::Hyperlink
         }
     }
 
-    // Text decoration color
     if (stateObj.contains(qsl("text-decoration-color")) && stateObj[qsl("text-decoration-color")].isString()) {
         QColor decorationColor = parseColorValue(stateObj[qsl("text-decoration-color")].toString());
         if (decorationColor.isValid()) {
@@ -3183,7 +3167,6 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
         return;
     }
 
-    // Check for OSC 8 documentation examples trigger phrase
     // Use a 1-second debounce to prevent duplicate injection from echo + server response
     if (text.contains("!osc8-docs")) {
         const qint64 now = QDateTime::currentMSecsSinceEpoch();

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2848,7 +2848,7 @@ QMap<QString, QString> TBuffer::parseUriQueryParameters(const QString& uri, Mudl
         return parameters;
     }
 
-    // Parse query parameters for new format: ?p=preset&config={...}
+    // Parse query parameters for new format: ?preset=NAME&config={...}
     QStringList paramPairs = decodedQueryString.split('&');
     QString presetName;
     QString configJson;
@@ -2862,7 +2862,7 @@ QMap<QString, QString> TBuffer::parseUriQueryParameters(const QString& uri, Mudl
         QString key = pair.left(eqPos);
         QString value = pair.mid(eqPos + 1);
 
-        if (key == qsl("p") || key == qsl("preset")) {
+        if (key == qsl("preset")) {
             presetName = value;
         } else if (key == qsl("config")) {
             configJson = value;
@@ -5615,8 +5615,8 @@ void TBuffer::injectOSC8DocumentationExamples()
     output += "\x1b]8;;preset:btn?config={\"style\":{\"bg\":\"blue\",\"color\":\"white\",\"bold\":true},\"menu\":[{\"Click\":\"send:click\"}]}\x1b\\\x1b]8;;\x1b\\";
     
     output += "Use presets:\n";
-    output += "• Basic preset: \x1b]8;;send:action?p=btn\x1b\\Button Style\x1b]8;;\x1b\\ (uses preset 'btn')\n";
-    output += "• Preset + override: \x1b]8;;send:custom?p=btn&config={\"s\":{\"c\":\"yellow\"}}\x1b\\Custom Button\x1b]8;;\x1b\\ (btn preset + yellow text)\n\n";
+    output += "• Basic preset: \x1b]8;;send:action?preset=btn\x1b\\Button Style\x1b]8;;\x1b\\ (uses preset 'btn')\n";
+    output += "• Preset + override: \x1b]8;;send:custom?preset=btn&config={\"s\":{\"c\":\"yellow\"}}\x1b\\Custom Button\x1b]8;;\x1b\\ (btn preset + yellow text)\n\n";
 
     output += "Define multiple presets:\n";
     output += "\x1b]8;;preset:warn?config={\"style\":{\"bg\":\"orange\",\"color\":\"black\",\"bold\":true}}\x1b\\\x1b]8;;\x1b\\";
@@ -5624,12 +5624,12 @@ void TBuffer::injectOSC8DocumentationExamples()
     output += "\x1b]8;;preset:danger?config={\"style\":{\"bg\":\"red\",\"color\":\"white\",\"bold\":true}}\x1b\\\x1b]8;;\x1b\\";
     
     output += "Use different presets:\n";
-    output += "• \x1b]8;;send:warning?p=warn\x1b\\Warning\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:ok?p=success\x1b\\Success\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:error?p=danger\x1b\\Danger\x1b]8;;\x1b\\\n\n";
+    output += "• \x1b]8;;send:warning?preset=warn\x1b\\Warning\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:ok?preset=success\x1b\\Success\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:error?preset=danger\x1b\\Danger\x1b]8;;\x1b\\\n\n";
 
     output += "Combine presets with shorthand overrides:\n";
-    output += "• \x1b]8;;send:special?p=btn&config={\"s\":{\"c\":\"gold\",\"u\":\"wavy\"},\"t\":\"Special action\"}\x1b\\Special Button\x1b]8;;\x1b\\\n\n";
+    output += "• \x1b]8;;send:special?preset=btn&config={\"s\":{\"c\":\"gold\",\"u\":\"wavy\"},\"t\":\"Special action\"}\x1b\\Special Button\x1b]8;;\x1b\\\n\n";
 
     // ═══════════════════════════════════════════════════════════════════
     // Real World Examples

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -24,7 +24,9 @@
 #include "TBuffer.h"
 
 #include "mudlet.h"
+#include "TConsole.h"
 #include "TEvent.h"
+#include "THyperlinkCompactManager.h"
 #include "TStringUtils.h"
 #include "TTextEdit.h"
 #include "TTextProperties.h"
@@ -2823,6 +2825,55 @@ QMap<QString, QString> TBuffer::parseUriQueryParameters(const QString& uri, Mudl
     return parameters;
 }
 
+QJsonObject TBuffer::expandJsonShorthands(const QJsonObject& obj)
+{
+    if (!mpConsole || !mpConsole->mpCompactSyntaxManager) {
+        return obj;
+    }
+
+    QJsonObject expanded;
+
+    for (auto it = obj.constBegin(); it != obj.constEnd(); ++it) {
+        QString key = it.key();
+        QJsonValue value = it.value();
+
+        // Expand the key if it's a shorthand
+        QMap<QString, QString> keyMap;
+        keyMap.insert(key, QString());
+        QMap<QString, QString> expandedKeys = mpConsole->mpCompactSyntaxManager->expandShorthand(keyMap);
+        QString expandedKey = expandedKeys.value(key, key);
+
+        // Recursively expand nested objects
+        if (value.isObject()) {
+            expanded[expandedKey] = expandJsonShorthands(value.toObject());
+        } else if (value.isArray()) {
+            // For arrays, expand each object element
+            QJsonArray array = value.toArray();
+            QJsonArray expandedArray;
+
+            for (const QJsonValue& item : array) {
+                if (item.isObject()) {
+                    expandedArray.append(expandJsonShorthands(item.toObject()));
+                } else {
+                    expandedArray.append(item);
+                }
+            }
+
+            expanded[expandedKey] = expandedArray;
+        } else {
+            expanded[expandedKey] = value;
+        }
+    }
+
+#if defined(DEBUG_OSC_PROCESSING)
+    if (expanded != obj) {
+        qDebug() << "[OSC8] Expanded shorthands in JSON";
+    }
+#endif
+
+    return expanded;
+}
+
 bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, QString>& parameters, Mudlet::HyperlinkStyling& styling)
 {
 #if defined(DEBUG_OSC_PROCESSING)
@@ -2847,6 +2898,9 @@ bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, 
     }
 
     QJsonObject root = doc.object();
+
+    // Expand shorthands in the JSON object (recursive)
+    root = expandJsonShorthands(root);
 
     if (root.contains(qsl("style")) && root[qsl("style")].isObject()) {
         QJsonObject styleObj = root[qsl("style")].toObject();

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1214,6 +1214,9 @@ bool TBuffer::commitLine(char ch, size_t& localBufferPosition)
             // (translateToPlainText(...)) method is ONLY for that one:
             shrinkBuffer();
         }
+        
+        applyPendingSelectionStyling();
+        
         return true;
     }
     return false;
@@ -2515,7 +2518,7 @@ void TBuffer::decodeOSC(const QString& sequence)
             qDebug().noquote() << "[OSC8] Hyperlink terminator - closing active hyperlink";
 #endif
             
-            // Apply initial selection styling now that the link text has been fully rendered
+            // Apply initial selection/disabled state styling when link closes
             if (mCurrentHyperlinkLinkId > 0 && mCurrentHyperlinkStyling.selection.hasSelectionSettings) {
 #if defined(DEBUG_OSC_PROCESSING)
                 qDebug() << "[OSC8] Queuing initial selection styling for link" << mCurrentHyperlinkLinkId
@@ -2525,11 +2528,9 @@ void TBuffer::decodeOSC(const QString& sequence)
 #endif
                 if (mCurrentHyperlinkStyling.selection.selected) {
                     setLinkState(mCurrentHyperlinkLinkId, Mudlet::HyperlinkStyling::StateSelected);
-                    // Queue for styling after buffer commit
                     mPendingSelectionStyling.insert(mCurrentHyperlinkLinkId);
                 } else if (mCurrentHyperlinkStyling.selection.disabled) {
                     setLinkState(mCurrentHyperlinkLinkId, Mudlet::HyperlinkStyling::StateDisabled);
-                    // Queue for styling after buffer commit
                     mPendingSelectionStyling.insert(mCurrentHyperlinkLinkId);
                 }
             }
@@ -5458,17 +5459,17 @@ void TBuffer::injectOSC8DocumentationExamples()
 
     output += "Disabled Options:\n";
     output += "Choose class: ";
-    output += "\x1b]8;;send:warrior?config={\"selection\":{\"group\":\"class\",\"value\":\"warrior\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#ff9944\",\"hover\":{\"color\":\"#ffaa66\"},\"selected\":{\"bg\":\"#cc6600\",\"color\":\"#000000\",\"bold\":true}}}\x1b\\⚔️ Warrior\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:warrior?config={\"selection\":{\"group\":\"class\",\"value\":\"warrior\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#ff9944\",\"selected\":{\"bg\":\"#cc6600\",\"color\":\"#000000\",\"bold\":true}}}\x1b\\⚔️ Warrior\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:mage?config={\"selection\":{\"group\":\"class\",\"value\":\"mage\",\"toggle\":true,\"exclusive\":true,\"disabled\":true},\"style\":{\"color\":\"#9966ff\",\"selected\":{\"bg\":\"#6600cc\",\"color\":\"#000000\",\"bold\":true},\"disabled\":{\"color\":\"#444444\",\"strikethrough\":true}}}\x1b\\🔮 Mage\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:rogue?config={\"selection\":{\"group\":\"class\",\"value\":\"rogue\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#66ff66\",\"hover\":{\"color\":\"#88ff88\"},\"selected\":{\"bg\":\"#00aa00\",\"color\":\"#000000\",\"bold\":true}}}\x1b\\🗡️ Rogue\x1b]8;;\x1b\\\n";
+    output += "\x1b]8;;send:rogue?config={\"selection\":{\"group\":\"class\",\"value\":\"rogue\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#66ff66\",\"selected\":{\"bg\":\"#00aa00\",\"color\":\"#000000\",\"bold\":true}}}\x1b\\🗡️ Rogue\x1b]8;;\x1b\\\n";
     output += "  (Mage is locked/disabled)\n\n";
 
     output += "Interactive Selection with Hover:\n";
     output += "Select weapon: ";
-    output += "\x1b]8;;send:sword?config={\"selection\":{\"group\":\"weapon\",\"value\":\"sword\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#6699ff\",\"hover\":{\"color\":\"#99ccff\",\"bold\":true},\"selected\":{\"bg\":\"#0066cc\",\"color\":\"#ffff00\",\"bold\":true}}}\x1b\\⚔️ Sword\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:axe?config={\"selection\":{\"group\":\"weapon\",\"value\":\"axe\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#ff9944\",\"hover\":{\"color\":\"#ffbb66\",\"bold\":true},\"selected\":{\"bg\":\"#cc6600\",\"color\":\"#ffff00\",\"bold\":true}}}\x1b\\🪓 Axe\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:bow?config={\"selection\":{\"group\":\"weapon\",\"value\":\"bow\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#66ff66\",\"hover\":{\"color\":\"#88ff88\",\"bold\":true},\"selected\":{\"bg\":\"#00aa00\",\"color\":\"#ffff00\",\"bold\":true}}}\x1b\\🏹 Bow\x1b]8;;\x1b\\\n";
-    output += "  (Hover to see preview, click to select)\n\n";
+    output += "\x1b]8;;send:sword?config={\"selection\":{\"group\":\"weapon\",\"value\":\"sword\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#6699ff\",\"selected\":{\"bg\":\"#0066cc\",\"color\":\"#ffff00\",\"bold\":true}}}\x1b\\⚔️ Sword\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:axe?config={\"selection\":{\"group\":\"weapon\",\"value\":\"axe\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#ff9944\",\"selected\":{\"bg\":\"#cc6600\",\"color\":\"#ffff00\",\"bold\":true}}}\x1b\\🪓 Axe\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:bow?config={\"selection\":{\"group\":\"weapon\",\"value\":\"bow\",\"toggle\":true,\"exclusive\":true},\"style\":{\"color\":\"#66ff66\",\"selected\":{\"bg\":\"#00aa00\",\"color\":\"#ffff00\",\"bold\":true}}}\x1b\\🏹 Bow\x1b]8;;\x1b\\\n";
+    output += "  (Click to select)\n\n";
 
     output += "Toggle Switches:\n";
     output += "Settings: ";
@@ -5498,25 +5499,6 @@ void TBuffer::injectOSC8DocumentationExamples()
     mSkipTriggerProcessing = true;
     translateToPlainText(outputBytes, true); // Mark as from server
     mSkipTriggerProcessing = false;
-
-    // Apply pending selection styling now that characters are committed to buffer
-    if (!mPendingSelectionStyling.isEmpty()) {
-#if defined(DEBUG_OSC_PROCESSING)
-        qDebug() << "[OSC8] Processing pending selection styling for" << mPendingSelectionStyling.size() << "links";
-#endif
-        for (int linkId : mPendingSelectionStyling) {
-            updateLinkCharacters(linkId);
-        }
-        mPendingSelectionStyling.clear();
-        
-        // Force display refresh after applying selection styling
-        if (mpConsole) {
-            mpConsole->mUpperPane->updateScreenView();
-            mpConsole->mUpperPane->repaint();
-            mpConsole->mLowerPane->updateScreenView();
-            mpConsole->mLowerPane->repaint();
-        }
-    }
 }
 
 // ============================================================================
@@ -5906,8 +5888,6 @@ bool TBuffer::isLinkSelected(int linkIndex) const
 
 void TBuffer::clearGroupSelection(const QString& group, const QString& exceptValue)
 {
-    // Update visual states for all links that belong to this group (except the specified value)
-    // Iterate through reasonable range of link IDs up to current max
     int maxLinkId = mLinkStore.getCurrentLinkID();
     int clearedCount = 0;
     
@@ -5917,12 +5897,10 @@ void TBuffer::clearGroupSelection(const QString& group, const QString& exceptVal
             styling.selection.group == group && 
             styling.selection.value != exceptValue) {
             
-            // Update selection manager state first
-            if (mpHost && mpHost->mpConsole && mpHost->mpConsole->mpSelectionManager) {
-                mpHost->mpConsole->mpSelectionManager->setSelected(styling.selection.group, styling.selection.value, false, false);
+            if (mpConsole && mpConsole->mpSelectionManager) {
+                mpConsole->mpSelectionManager->setSelected(styling.selection.group, styling.selection.value, false, false);
             }
             
-            // Set visual state to unselected (preserve disabled state)
             setLinkSelected(linkIndex, false);
             if (styling.selection.disabled) {
                 setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateDisabled);
@@ -5930,7 +5908,6 @@ void TBuffer::clearGroupSelection(const QString& group, const QString& exceptVal
                 setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateDefault);
             }
             
-            // CRITICAL: Update visual characters to reflect the state change
             updateLinkCharacters(linkIndex);
             clearedCount++;
             
@@ -5944,6 +5921,19 @@ void TBuffer::clearGroupSelection(const QString& group, const QString& exceptVal
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC8] clearGroupSelection: Cleared" << clearedCount << "links in group" << group;
 #endif
+}
+
+void TBuffer::applyPendingSelectionStyling()
+{
+    if (!mPendingSelectionStyling.isEmpty()) {
+#if defined(DEBUG_OSC_PROCESSING)
+        qDebug() << "[OSC8] Processing pending selection styling for" << mPendingSelectionStyling.size() << "links";
+#endif
+        for (int linkId : mPendingSelectionStyling) {
+            updateLinkCharacters(linkId);
+        }
+        mPendingSelectionStyling.clear();
+    }
 }
 
 int TBuffer::getLinkIndexAt(int line, int column) const

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2490,7 +2490,7 @@ void TBuffer::decodeOSC(const QString& sequence)
     case static_cast<quint8>('8'): {
         // Handle OSC 8 hyperlinks in the form: "8;params;URI"
 
-        QStringView rest = QStringView(sequence).mid(1);  // skip selector "8;"
+        QStringView rest = QStringView(sequence).mid(1);  // skip selector "8"
         int firstSemi = rest.indexOf(';');
 
         if (firstSemi == -1) {
@@ -2507,6 +2507,7 @@ void TBuffer::decodeOSC(const QString& sequence)
 
         QString param = rest.left(firstSemi).toString();
 
+        // Parameters are available but not used by Mudlet currently
 #if defined(DEBUG_OSC_PROCESSING)
         if (!param.isEmpty()) {
             qDebug().noquote().nospace() << "[OSC 8] Params provided (not used by Mudlet but shown for debugging): \"" << param << "\"";
@@ -2550,6 +2551,30 @@ void TBuffer::decodeOSC(const QString& sequence)
         if (!rawUrl.isEmpty()) {
             if (rawUrl.length() > 8192) {
                 qWarning() << "TBuffer::decodeOSC(...) - Rejected hyperlink: URL too long:" << rawUrl;
+                return;
+            }
+
+            // Handle preset: URI scheme for preset definitions
+            if (rawUrl.startsWith(qsl("preset:"))) {
+                QUrl presetUrl(rawUrl);
+                QString presetName = presetUrl.path();
+                QString configParam = presetUrl.hasQuery() ? QUrlQuery(presetUrl).queryItemValue("config") : QString();
+                
+                if (!presetName.isEmpty() && !configParam.isEmpty() && mpConsole && mpConsole->mpCompactSyntaxManager) {
+                    // Parse the JSON configuration
+                    QJsonParseError parseError;
+                    QJsonDocument doc = QJsonDocument::fromJson(configParam.toUtf8(), &parseError);
+                    
+                    if (parseError.error == QJsonParseError::NoError && doc.isObject()) {
+                        mpConsole->mpCompactSyntaxManager->registerPreset(presetName, doc.object());
+#if defined(DEBUG_OSC_PROCESSING)
+                        qDebug() << "[OSC8] Registered preset:" << presetName << "with config:" << configParam;
+#endif
+                    } else {
+                        qWarning() << "TBuffer::decodeOSC(...) - Failed to parse preset JSON:" << parseError.errorString();
+                    }
+                }
+                // Preset definitions don't create visible hyperlinks
                 return;
             }
 
@@ -2652,7 +2677,7 @@ void TBuffer::decodeOSC(const QString& sequence)
             }
 
             // Handle menu functionality by extending commands and hints
-            if (!mCurrentHyperlinkMenu.isEmpty() && mCurrentHyperlinkMenu.size() >= 2) {
+            if (!mCurrentHyperlinkMenu.isEmpty() && mCurrentHyperlinkMenu.size() >= 1) {
 #if defined(DEBUG_OSC_PROCESSING)
                 qDebug() << "[OSC8] Building menu commands from" << mCurrentHyperlinkMenu.size() << "menu items";
 #endif
@@ -2812,7 +2837,18 @@ QMap<QString, QString> TBuffer::parseUriQueryParameters(const QString& uri, Mudl
     qDebug() << "[OSC8] Decoded query string:" << decodedQueryString;
 #endif
 
-    // Parse query parameters
+    // Check for standard format: ?config={...} (entire query string is the config JSON)
+    // The JSON may have escaped quotes: config={\"style\":{...}} or unescaped: config={"style":{...}}
+    if (decodedQueryString.startsWith(qsl("config="))) {
+        QString configJson = decodedQueryString.mid(7); // Remove "config="
+        parseJsonHyperlinkConfig(configJson, parameters, styling);
+#if defined(DEBUG_OSC_PROCESSING)
+        qDebug() << "[OSC8] Parsed config={...} format";
+#endif
+        return parameters;
+    }
+
+    // Parse query parameters for new format: ?p=preset&config={...}
     QStringList paramPairs = decodedQueryString.split('&');
     QString presetName;
     QString configJson;
@@ -2833,44 +2869,58 @@ QMap<QString, QString> TBuffer::parseUriQueryParameters(const QString& uri, Mudl
         }
     }
 
-    // Start with preset config if specified
-    QJsonObject baseConfig;
+    // Handle preset and config parameters
+    // Priority: preset as base, config as override
+    
+    if (!presetName.isEmpty() || !configJson.isEmpty()) {
+        QJsonObject baseConfig;
 
-    if (!presetName.isEmpty() && mpConsole && mpConsole->mpCompactSyntaxManager) {
-        baseConfig = mpConsole->mpCompactSyntaxManager->getPreset(presetName);
+        // Start with preset config if specified
+        if (!presetName.isEmpty() && mpConsole && mpConsole->mpCompactSyntaxManager) {
+            baseConfig = mpConsole->mpCompactSyntaxManager->getPreset(presetName);
 #if defined(DEBUG_OSC_PROCESSING)
-        if (!baseConfig.isEmpty()) {
-            qDebug() << "[OSC8] Resolved preset" << presetName;
-        }
-#endif
-    }
-
-    // Merge with override config if present
-    if (!configJson.isEmpty()) {
-        QJsonParseError parseError;
-        QJsonDocument overrideDoc = QJsonDocument::fromJson(configJson.toUtf8(), &parseError);
-        
-        if (parseError.error == QJsonParseError::NoError && overrideDoc.isObject()) {
-            QJsonObject overrideConfig = overrideDoc.object();
-            
-            if (!baseConfig.isEmpty() && mpConsole && mpConsole->mpCompactSyntaxManager) {
-                // Deep merge: override takes precedence
-                baseConfig = mpConsole->mpCompactSyntaxManager->mergeConfigs(baseConfig, overrideConfig);
-#if defined(DEBUG_OSC_PROCESSING)
-                qDebug() << "[OSC8] Merged preset with override config";
-#endif
+            if (!baseConfig.isEmpty()) {
+                qDebug() << "[OSC8] Resolved preset" << presetName;
             } else {
-                baseConfig = overrideConfig;
+                qDebug() << "[OSC8] Preset" << presetName << "not found or empty";
+            }
+#endif
+        } else {
+#if defined(DEBUG_OSC_PROCESSING)
+            if (!presetName.isEmpty()) {
+                qDebug() << "[OSC8] Cannot resolve preset - missing console or manager";
+            }
+#endif
+        }
+
+        // Merge with override config if present
+        if (!configJson.isEmpty()) {
+            QJsonParseError parseError;
+            QJsonDocument overrideDoc = QJsonDocument::fromJson(configJson.toUtf8(), &parseError);
+            
+            if (parseError.error == QJsonParseError::NoError && overrideDoc.isObject()) {
+                QJsonObject overrideConfig = overrideDoc.object();
+                
+                if (!baseConfig.isEmpty() && mpConsole && mpConsole->mpCompactSyntaxManager) {
+                    // Deep merge: override takes precedence
+                    baseConfig = mpConsole->mpCompactSyntaxManager->mergeConfigs(baseConfig, overrideConfig);
+#if defined(DEBUG_OSC_PROCESSING)
+                    qDebug() << "[OSC8] Merged preset with override config";
+#endif
+                } else {
+                    // No preset, just use the config directly
+                    baseConfig = overrideConfig;
+                }
             }
         }
-    }
 
-    // Parse the final merged config
-    if (!baseConfig.isEmpty()) {
-        // Convert back to JSON string for parseJsonHyperlinkConfig
-        QJsonDocument finalDoc(baseConfig);
-        QString finalJson = QString::fromUtf8(finalDoc.toJson(QJsonDocument::Compact));
-        parseJsonHyperlinkConfig(finalJson, parameters, styling);
+        // Parse the final merged config
+        if (!baseConfig.isEmpty()) {
+            // Convert back to JSON string for parseJsonHyperlinkConfig
+            QJsonDocument finalDoc(baseConfig);
+            QString finalJson = QString::fromUtf8(finalDoc.toJson(QJsonDocument::Compact));
+            parseJsonHyperlinkConfig(finalJson, parameters, styling);
+        }
     }
 
 #if defined(DEBUG_OSC_PROCESSING)
@@ -2882,51 +2932,44 @@ QMap<QString, QString> TBuffer::parseUriQueryParameters(const QString& uri, Mudl
 
 QJsonObject TBuffer::expandJsonShorthands(const QJsonObject& obj)
 {
+    // Use the compact syntax manager for consistent shorthand expansion
     if (!mpConsole || !mpConsole->mpCompactSyntaxManager) {
-        return obj;
+        return obj; // No manager available, return unchanged
     }
-
-    QJsonObject expanded;
-
-    for (auto it = obj.constBegin(); it != obj.constEnd(); ++it) {
-        QString key = it.key();
+    
+    QJsonObject result;
+    
+    for (auto it = obj.begin(); it != obj.end(); ++it) {
+        QString originalKey = it.key();
         QJsonValue value = it.value();
-
-        // Expand the key if it's a shorthand
-        QMap<QString, QString> keyMap;
-        keyMap.insert(key, QString());
-        QMap<QString, QString> expandedKeys = mpConsole->mpCompactSyntaxManager->expandShorthand(keyMap);
-        QString expandedKey = expandedKeys.value(key, key);
-
+        
+        // Check if this key is a registered shorthand using the manager
+        QMap<QString, QString> singleKeyMap;
+        singleKeyMap.insert(originalKey, qsl("placeholder")); // Value doesn't matter for key expansion
+        QMap<QString, QString> expandedMap = mpConsole->mpCompactSyntaxManager->expandShorthand(singleKeyMap);
+        
+        // The expanded map will have either the original key or the expanded key
+        QString resultKey = expandedMap.firstKey();
+        
         // Recursively expand nested objects
-        if (value.isObject()) {
-            expanded[expandedKey] = expandJsonShorthands(value.toObject());
-        } else if (value.isArray()) {
-            // For arrays, expand each object element
-            QJsonArray array = value.toArray();
-            QJsonArray expandedArray;
-
-            for (const QJsonValue& item : array) {
-                if (item.isObject()) {
-                    expandedArray.append(expandJsonShorthands(item.toObject()));
-                } else {
-                    expandedArray.append(item);
-                }
-            }
-
-            expanded[expandedKey] = expandedArray;
+        QJsonValue resultValue = value.isObject() ? expandJsonShorthands(value.toObject()) : value;
+        
+        // Handle duplicate keys by merging objects (e.g., both "style" and "s" -> "style")
+        if (result.contains(resultKey) && result[resultKey].isObject() && resultValue.isObject()) {
+            // Merge the objects using the compact manager's deep merge functionality
+            QJsonObject existing = result[resultKey].toObject();
+            QJsonObject toAdd = resultValue.toObject();
+            
+            // Important: when both shorthand and full names exist, shorthand should take precedence
+            // The "existing" value comes from a shorthand expansion and should be the overlay
+            // The "toAdd" value is the full name and should be the base
+            result[resultKey] = mpConsole->mpCompactSyntaxManager->mergeConfigs(toAdd, existing);
         } else {
-            expanded[expandedKey] = value;
+            result[resultKey] = resultValue;
         }
     }
-
-#if defined(DEBUG_OSC_PROCESSING)
-    if (expanded != obj) {
-        qDebug() << "[OSC8] Expanded shorthands in JSON";
-    }
-#endif
-
-    return expanded;
+    
+    return result;
 }
 
 bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, QString>& parameters, Mudlet::HyperlinkStyling& styling)
@@ -2957,6 +3000,12 @@ bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, 
     // Expand shorthands in the JSON object (recursive)
     root = expandJsonShorthands(root);
 
+#if defined(DEBUG_OSC_PROCESSING)
+    qDebug() << "[OSC8] After expansion, root contains:" << root.keys();
+    qDebug() << "[OSC8] Has 'menu':" << root.contains(qsl("menu"));
+    qDebug() << "[OSC8] Has 'tooltip':" << root.contains(qsl("tooltip"));
+#endif
+
     if (root.contains(qsl("style")) && root[qsl("style")].isObject()) {
         QJsonObject styleObj = root[qsl("style")].toObject();
         parseJsonStyleToHyperlinkStyling(styleObj, styling);
@@ -2970,11 +3019,21 @@ bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, 
         QString menuString = jsonMenuArrayToString(menuArray);
         if (!menuString.isEmpty()) {
             parameters.insert(qsl("menu"), menuString);
+            // Enable custom styling for links with menus
+            styling.hasCustomStyling = true;
+#if defined(DEBUG_OSC_PROCESSING)
+            qDebug() << "[OSC8] Menu parameter added:" << menuString;
+#endif
         }
     }
 
     if (root.contains(qsl("tooltip")) && root[qsl("tooltip")].isString()) {
         parameters.insert(qsl("tooltip"), root[qsl("tooltip")].toString());
+        // Enable custom styling for links with tooltips
+        styling.hasCustomStyling = true;
+#if defined(DEBUG_OSC_PROCESSING)
+        qDebug() << "[OSC8] Tooltip parameter added:" << root[qsl("tooltip")].toString();
+#endif
     }
 
     if (root.contains(qsl("selection")) && root[qsl("selection")].isObject()) {
@@ -3029,6 +3088,16 @@ void TBuffer::parseJsonStateStyle(const QJsonObject& stateObj, Mudlet::Hyperlink
 
     if (stateObj.contains(qsl("bg")) && stateObj[qsl("bg")].isString()) {
         QColor color = parseColorValue(stateObj[qsl("bg")].toString());
+        if (color.isValid()) {
+            stateStyle.backgroundColor = color;
+            stateStyle.hasBackgroundColor = true;
+            hasAnyCustomStyling = true;
+        }
+    }
+
+    // Also support full CSS property name
+    if (stateObj.contains(qsl("background-color")) && stateObj[qsl("background-color")].isString()) {
+        QColor color = parseColorValue(stateObj[qsl("background-color")].toString());
         if (color.isValid()) {
             stateStyle.backgroundColor = color;
             stateStyle.hasBackgroundColor = true;
@@ -3162,6 +3231,12 @@ void TBuffer::parseJsonStyleToHyperlinkStyling(const QJsonObject& styleObj, Mudl
     styling.isUnderlined = baseStyle.isUnderlined;
     styling.underlineStyle = baseStyle.underlineStyle;
     styling.isOverlined = baseStyle.isOverlined;
+
+    // CRITICAL: Set custom styling flags if any base properties were found
+    if (baseStyle.hasCustomStyling) {
+        styling.hasCustomStyling = true;
+        styling.hasBaseCustomStyling = true;
+    }
     styling.isStrikeOut = baseStyle.isStrikeOut;
 
     if (baseStyle.hasUnderlineColor) {
@@ -3214,6 +3289,15 @@ void TBuffer::parseJsonStyleToHyperlinkStyling(const QJsonObject& styleObj, Mudl
 
     if (styleObj.contains(qsl("disabled")) && styleObj[qsl("disabled")].isObject()) {
         parseJsonStateStyle(styleObj[qsl("disabled")].toObject(), styling.disabledStyle);
+    }
+
+    // Update hasCustomStyling flag if any pseudo-class states have custom styling
+    if (styling.linkStyle.hasCustomStyling || styling.visitedStyle.hasCustomStyling ||
+        styling.hoverStyle.hasCustomStyling || styling.activeStyle.hasCustomStyling ||
+        styling.focusStyle.hasCustomStyling || styling.focusVisibleStyle.hasCustomStyling ||
+        styling.anyLinkStyle.hasCustomStyling || styling.selectedStyle.hasCustomStyling ||
+        styling.disabledStyle.hasCustomStyling) {
+        styling.hasCustomStyling = true;
     }
 
     applyAccessibilityEnhancements(styling);
@@ -5507,6 +5591,47 @@ void TBuffer::injectOSC8DocumentationExamples()
     output += "• RGB: \x1b]8;;send:rgb?config={\"style\":{\"color\":\"rgb(255,0,0)\"}}\x1b\\Red (RGB)\x1b]8;;\x1b\\\n\n";
 
     // ═══════════════════════════════════════════════════════════════════
+    // Shorthand Syntax & Presets
+    // ═══════════════════════════════════════════════════════════════════
+    output += "══════════════════════════════════════════════════════════════════════\n";
+    output += "SHORTHAND SYNTAX & PRESETS\n";
+    output += "══════════════════════════════════════════════════════════════════════\n\n";
+
+    output += "Shorthand Syntax (compact JSON keys):\n";
+    output += "• Short style: \x1b]8;;send:short?config={\"s\":{\"c\":\"red\",\"b\":true}}\x1b\\Shorthand Style\x1b]8;;\x1b\\ (s=style, c=color, b=bold)\n";
+    output += "• Short menu: \x1b]8;;send:menu?config={\"m\":[{\"Attack\":\"send:attack\"},{\"Defend\":\"send:defend\"}]}\x1b\\Shorthand Menu\x1b]8;;\x1b\\ (m=menu)\n";
+    output += "• Short tooltip: \x1b]8;;send:tip?config={\"t\":\"Click for info\",\"s\":{\"c\":\"blue\"}}\x1b\\Shorthand Tooltip\x1b]8;;\x1b\\ (t=tooltip)\n";
+    output += "• Mixed syntax: \x1b]8;;send:mixed?config={\"s\":{\"c\":\"green\",\"b\":true},\"menu\":[{\"Go\":\"send:go\"}]}\x1b\\Mixed Short/Full\x1b]8;;\x1b\\\n";
+    output += "• Full syntax test: \x1b]8;;send:fulltest?config={\"style\":{\"color\":\"blue\"},\"menu\":[{\"Test\":\"send:test\"}]}\x1b\\Full Syntax Menu\x1b]8;;\x1b\\\n";
+    output += "• Single menu test: \x1b]8;;send:single?config={\"menu\":[{\"Defend\":\"send:defend\"}]}\x1b\\Single Item Menu\x1b]8;;\x1b\\\n";
+    output += "• Simple test: \x1b]8;;send:simple\x1b\\Simple Link\x1b]8;;\x1b\\\n\n";
+
+    output += "Style shortcuts inside 's' object:\n";
+    output += "• Color shortcuts: \x1b]8;;send:colors?config={\"s\":{\"c\":\"red\",\"bg\":\"yellow\"}}\x1b\\Color Shorts\x1b]8;;\x1b\\ (c=color, bg=background-color)\n";
+    output += "• Text shortcuts: \x1b]8;;send:text?config={\"s\":{\"b\":true,\"i\":true,\"u\":true}}\x1b\\Text Shorts\x1b]8;;\x1b\\ (b=bold, i=italic, u=underline)\n";
+    output += "• Decoration shortcuts: \x1b]8;;send:deco?config={\"s\":{\"u\":\"wavy\",\"st\":true,\"o\":true}}\x1b\\Deco Shorts\x1b]8;;\x1b\\ (st=strikethrough, o=overline)\n\n";
+
+    output += "Define a preset (invisible - defines 'btn' preset):\n";
+    output += "\x1b]8;;preset:btn?config={\"style\":{\"bg\":\"blue\",\"color\":\"white\",\"bold\":true},\"menu\":[{\"Click\":\"send:click\"}]}\x1b\\\x1b]8;;\x1b\\";
+    
+    output += "Use presets:\n";
+    output += "• Basic preset: \x1b]8;;send:action?p=btn\x1b\\Button Style\x1b]8;;\x1b\\ (uses preset 'btn')\n";
+    output += "• Preset + override: \x1b]8;;send:custom?p=btn&config={\"s\":{\"c\":\"yellow\"}}\x1b\\Custom Button\x1b]8;;\x1b\\ (btn preset + yellow text)\n\n";
+
+    output += "Define multiple presets:\n";
+    output += "\x1b]8;;preset:warn?config={\"style\":{\"bg\":\"orange\",\"color\":\"black\",\"bold\":true}}\x1b\\\x1b]8;;\x1b\\";
+    output += "\x1b]8;;preset:success?config={\"style\":{\"bg\":\"green\",\"color\":\"white\",\"bold\":true}}\x1b\\\x1b]8;;\x1b\\";
+    output += "\x1b]8;;preset:danger?config={\"style\":{\"bg\":\"red\",\"color\":\"white\",\"bold\":true}}\x1b\\\x1b]8;;\x1b\\";
+    
+    output += "Use different presets:\n";
+    output += "• \x1b]8;;send:warning?p=warn\x1b\\Warning\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:ok?p=success\x1b\\Success\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:error?p=danger\x1b\\Danger\x1b]8;;\x1b\\\n\n";
+
+    output += "Combine presets with shorthand overrides:\n";
+    output += "• \x1b]8;;send:special?p=btn&config={\"s\":{\"c\":\"gold\",\"u\":\"wavy\"},\"t\":\"Special action\"}\x1b\\Special Button\x1b]8;;\x1b\\\n\n";
+
+    // ═══════════════════════════════════════════════════════════════════
     // Real World Examples
     // ═══════════════════════════════════════════════════════════════════
     output += "══════════════════════════════════════════════════════════════════════\n";
@@ -5521,7 +5646,7 @@ void TBuffer::injectOSC8DocumentationExamples()
 
     output += "Combat:\n";
     output += "  \x1b]8;;send:attack?config={\"style\":{\"color\":\"#cc0000\",\"bold\":true,\"hover\":{\"bg\":\"#ffcccc\",\"color\":\"#000000\"}},\"menu\":[{\"Quick Strike\":\"send:quick\"},{\"Power Attack\":\"send:power\"},\"-\",{\"Feint\":\"send:feint\"}]}\x1b\\⚔️ Attack\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:defend?config={\"style\":{\"color\":\"#006600\",\"bold\":true,\"hover\":{\"bg\":\"#ccffcc\",\"color\":\"#000000\"}},\"tooltip\":\"Defensive stance - reduces damage by 50%\"}\x1b\\🛡️ Defend\x1b]8;;\x1b\\\n\n";
+    output += "\x1b]8;;send:defend?config={\"style\":{\"color\":\"#006600\",\"bold\":true,\"hover\":{\"bg\":\"#ccffcc\",\"color\":\"#000000\"}},\"tooltip\":\"Defensive stance - reduces damage by 50 percent\"}\x1b\\🛡️ Defend\x1b]8;;\x1b\\\n\n";
 
     output += "RPG Items:\n";
     output += "  \x1b]8;;send:examine?config={\"style\":{\"color\":\"#cc6600\",\"italic\":true,\"hover\":{\"bg\":\"#ffe6cc\",\"color\":\"#000000\"}},\"tooltip\":\"Magic sword with fire enchantment\"}\x1b\\🗡️ Flaming Blade\x1b]8;;\x1b\\ ";

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2597,8 +2597,11 @@ void TBuffer::decodeOSC(const QString& sequence)
             } else if (mCurrentHyperlinkLinkId > 0) {
                 // Set initial :link pseudo-class state for regular links
                 setLinkState(mCurrentHyperlinkLinkId, Mudlet::HyperlinkStyling::StateDefault);
-                // Update any characters already in buffer with :link styling
-                updateLinkCharacters(mCurrentHyperlinkLinkId);
+                // DON'T call updateLinkCharacters() here - the link text hasn't been added to
+                // the buffer yet! It gets added later during COMMIT_LINE. Calling it now would
+                // scan the entire buffer looking for characters that don't exist yet, causing
+                // severe performance degradation with many links.
+                // The :link styling will be applied when characters are created in COMMIT_LINE.
             }
             
             mCurrentHyperlinkCommand.clear();

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -643,6 +643,7 @@ public:
     void setLinkSelected(int linkIndex, bool selected); // Set link selected state
     bool isLinkSelected(int linkIndex) const; // Check if link is selected
     void clearGroupSelection(const QString& group, const QString& exceptValue); // Clear selection for group except specified value
+    void applyPendingSelectionStyling(); // Apply queued selection styling after buffer commit
     int getHoveredLink() const { return mCurrentHoveredLinkIndex; }
     int getActiveLink() const { return mCurrentActiveLinkIndex; }
     int getFocusedLink() const { return mCurrentFocusedLinkIndex; }

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -501,6 +501,8 @@ private:
     QMap<QString, QString> parseUriQueryParameters(const QString& uri, Mudlet::HyperlinkStyling& styling);
     // Helper function for parsing JSON format hyperlink configuration
     bool parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, QString>& parameters, Mudlet::HyperlinkStyling& styling);
+    // Helper function for expanding shorthands in JSON object (recursive)
+    QJsonObject expandJsonShorthands(const QJsonObject& obj);
     // Helper function for directly parsing JSON style object to HyperlinkStyling
     void parseJsonStyleToHyperlinkStyling(const QJsonObject& styleObj, Mudlet::HyperlinkStyling& styling);
     // Helper function for parsing JSON state style to StateStyle

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -498,23 +498,21 @@ private:
     TChar::AttributeFlags computeCurrentAttributeFlags() const;
 
     // Helper function for parsing URI query parameters in OSC 8 hyperlinks
-    QMap<QString, QString> parseUriQueryParameters(const QString& uri);
+    QMap<QString, QString> parseUriQueryParameters(const QString& uri, Mudlet::HyperlinkStyling& styling);
     // Helper function for parsing JSON format hyperlink configuration
-    bool parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, QString>& parameters);
-    // Helper functions for JSON to CSS conversion
-    QString jsonStyleObjectToCss(const QJsonObject& styleObj);
+    bool parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, QString>& parameters, Mudlet::HyperlinkStyling& styling);
+    // Helper function for directly parsing JSON style object to HyperlinkStyling
+    void parseJsonStyleToHyperlinkStyling(const QJsonObject& styleObj, Mudlet::HyperlinkStyling& styling);
+    // Helper function for parsing JSON state style to StateStyle
+    void parseJsonStateStyle(const QJsonObject& stateObj, Mudlet::HyperlinkStyling::StateStyle& stateStyle);
+    // Helper function for JSON menu array conversion
     QString jsonMenuArrayToString(const QJsonArray& menuArray);
     // Helper function for appending query parameters to URIs (handles existing params)
     QString appendQueryParameters(const QString& uri, const QMap<QString, QString>& parameters);
-    // Helper function for parsing CSS-like style strings
-    void parseHyperlinkStyling(const QString& styleString, Mudlet::HyperlinkStyling& styling);
     // Helper function for parsing color values (hex, named, rgb)
     QColor parseColorValue(const QString& value);
-    // CSS Link State parsing and management
-    void parseHyperlinkStateStyle(const QString& pseudoClass, const QString& styleString, Mudlet::HyperlinkStyling& styling);
-    void parseStateStyleProperties(const QString& styleString, Mudlet::HyperlinkStyling::StateStyle& stateStyle);
+    // Accessibility enhancements for hyperlink styling
     void applyAccessibilityEnhancements(Mudlet::HyperlinkStyling& styling);
-
 
     QPointer<TConsole> mpConsole;
 
@@ -619,6 +617,12 @@ private:
     int mCurrentHoveredLinkIndex = 0;  // Which link is currently hovered (0 = none)
     int mCurrentActiveLinkIndex = 0;   // Which link is currently being clicked (0 = none)
     int mCurrentFocusedLinkIndex = 0;  // Which link has keyboard focus (0 = none)
+
+    // Flag to skip trigger processing during documentation injection
+    bool mSkipTriggerProcessing = false;
+
+    // Timestamp to prevent duplicate OSC 8 documentation injection
+    qint64 mLastOSC8DocsInjectionTime = 0;
 
 public:
     // Methods for link state management (used by TTextEdit event handlers)

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -627,6 +627,9 @@ private:
     // Timestamp to prevent duplicate OSC 8 documentation injection
     qint64 mLastOSC8DocsInjectionTime = 0;
 
+    // Track links that need selection styling applied after buffer commit
+    QSet<int> mPendingSelectionStyling;
+
 public:
     // Methods for link state management (used by TTextEdit event handlers)
     void setLinkState(int linkIndex, Mudlet::HyperlinkStyling::LinkState state);

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -622,6 +622,7 @@ private:
     int mCurrentHoveredLinkIndex = 0;  // Which link is currently hovered (0 = none)
     int mCurrentActiveLinkIndex = 0;   // Which link is currently being clicked (0 = none)
     int mCurrentFocusedLinkIndex = 0;  // Which link has keyboard focus (0 = none)
+    int mLastClickedLinkIndex = 0;     // Last clicked link - suppresses hover until mouse leaves
 
     // Flag to skip trigger processing during documentation injection
     bool mSkipTriggerProcessing = false;
@@ -646,14 +647,13 @@ public:
     bool isLinkSelected(int linkIndex) const; // Check if link is selected
     void clearGroupSelection(const QString& group, const QString& exceptValue); // Clear selection for group except specified value
     void applyPendingSelectionStyling(); // Apply queued selection styling after buffer commit
+    void updateLinkCharacters(int linkIndex); // Update all TChar objects that belong to a specific link with effective styling
     int getHoveredLink() const { return mCurrentHoveredLinkIndex; }
     int getActiveLink() const { return mCurrentActiveLinkIndex; }
     int getFocusedLink() const { return mCurrentFocusedLinkIndex; }
     int getLinkIndexAt(int line, int column) const; // Get link index at specific position
 
 private:
-    // Update all TChar objects that belong to a specific link with effective styling
-    void updateLinkCharacters(int linkIndex);
 };
 
 #ifndef QT_NO_DEBUG_STREAM

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -614,6 +614,7 @@ private:
     // Link state tracking for interactive pseudo-classes
     QMap<int, Mudlet::HyperlinkStyling::LinkState> mLinkStates; // Track current state per linkIndex
     QMap<int, bool> mVisitedLinks; // Track which links have been visited (base state)
+    QMap<int, bool> mLinkSelectionState; // Track which links are selected (base state)
     QMap<int, QColor> mLinkOriginalBackgrounds; // Track original background color per link
     QMap<int, TChar> mLinkOriginalCharacters; // Track original ANSI formatting per link
     int mCurrentHoveredLinkIndex = 0;  // Which link is currently hovered (0 = none)
@@ -636,6 +637,9 @@ public:
     void setFocusedLink(int linkIndex);
     void markLinkAsVisited(int linkIndex); // Mark a link as visited (base state)
     bool isLinkVisited(int linkIndex) const; // Check if link has been visited
+    void setLinkSelected(int linkIndex, bool selected); // Set link selected state
+    bool isLinkSelected(int linkIndex) const; // Check if link is selected
+    void clearGroupSelection(const QString& group, const QString& exceptValue); // Clear selection for group except specified value
     int getHoveredLink() const { return mCurrentHoveredLinkIndex; }
     int getActiveLink() const { return mCurrentActiveLinkIndex; }
     int getFocusedLink() const { return mCurrentFocusedLinkIndex; }

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -92,7 +92,9 @@ struct HyperlinkStyling {
         StateHover,         // Mouse hover (:hover)
         StateActive,        // Mouse down/active (:active)
         StateFocus,         // Keyboard focus (:focus)
-        StateFocusVisible   // Visible keyboard focus (:focus-visible)
+        StateFocusVisible,  // Visible keyboard focus (:focus-visible)
+        StateSelected,      // Selected state (from selection object)
+        StateDisabled       // Disabled state (from selection object)
     };
 
     // State-specific styling containers
@@ -124,12 +126,30 @@ struct HyperlinkStyling {
     StateStyle focusStyle;          // :focus
     StateStyle focusVisibleStyle;   // :focus-visible
     StateStyle anyLinkStyle;        // :any-link (applies to both :link and :visited)
+    StateStyle selectedStyle;       // :selected (from selection object)
+    StateStyle disabledStyle;       // :disabled (from selection object)
 
     // State tracking
     LinkState currentState = StateDefault;
 
     // Methods to get effective styling for current state
     StateStyle getEffectiveStyle() const;
+
+    // Selection control: toggleable, stateful links (radio/checkbox behavior)
+    // JSON: {"group": "string", "value": "string", "toggle": bool, "selected": bool, "exclusive": bool, "disabled": bool}
+    // When exclusive=true: radio button behavior (only one selected per group)
+    // When exclusive=false: checkbox behavior (multiple selections per group)
+    struct SelectionSettings {
+        QString group;              // Group identifier for related selections
+        QString value;              // Unique value within the group
+        bool toggle = true;         // Allow deselecting when already selected
+        bool selected = false;      // Initial selection state
+        bool exclusive = true;      // Radio (true) vs checkbox (false) mode
+        bool disabled = false;      // Cannot be clicked when disabled
+        bool hasSelectionSettings = false;
+    };
+
+    SelectionSettings selection;
 };
 
 } // namespace Mudlet

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -505,6 +505,8 @@ private:
     void parseJsonStyleToHyperlinkStyling(const QJsonObject& styleObj, Mudlet::HyperlinkStyling& styling);
     // Helper function for parsing JSON state style to StateStyle
     void parseJsonStateStyle(const QJsonObject& stateObj, Mudlet::HyperlinkStyling::StateStyle& stateStyle);
+    // Helper function for parsing JSON selection config to SelectionSettings
+    void parseJsonSelectionConfig(const QJsonObject& selectionObj, Mudlet::HyperlinkStyling::SelectionSettings& settings);
     // Helper function for JSON menu array conversion
     QString jsonMenuArrayToString(const QJsonArray& menuArray);
     // Helper function for appending query parameters to URIs (handles existing params)

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -28,6 +28,7 @@
 
 #include "Host.h"
 #include "TCommandLine.h"
+#include "THyperlinkCompactManager.h"
 #include "TDebug.h"
 #include "TDockWidget.h"
 #include "TEvent.h"
@@ -77,9 +78,11 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
 , mControlCharacter(pH->getControlCharacterMode())
 , mType(type)
 {
+    // Initialize compact syntax framework FIRST (pure utility, no features)
+    mpCompactSyntaxManager = new THyperlinkCompactManager(this, this);
     // Initialize hyperlink selection manager
     mpSelectionManager = new THyperlinkSelectionManager(this);
-    
+
     auto quitShortcut = new QShortcut(this);
     quitShortcut->setKey(Qt::CTRL | Qt::Key_W);
     quitShortcut->setContext(Qt::WidgetShortcut);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -78,9 +78,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
 , mControlCharacter(pH->getControlCharacterMode())
 , mType(type)
 {
-    mpCompactSyntaxManager = std::make_unique<THyperlinkCompactManager>(this, this);
-    mpSelectionManager = std::make_unique<THyperlinkSelectionManager>(this);
-
+    mpCompactSyntaxManager = std::make_unique<THyperlinkCompactManager>(this);
     initializeOSC8StyleFeature();
     initializeOSC8MenuFeature();
     initializeOSC8TooltipFeature();
@@ -658,7 +656,6 @@ void TConsole::resizeEvent(QResizeEvent* event)
         // main console to a width of zero - but that is not useful from a NAWS
         // or event handling system point of view - so abort doing anything
         // with the event:
-        QWidget::resizeEvent(event);
         return;
     }
 

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2725,7 +2725,7 @@ void TConsole::initializeOSC8StyleFeature()
     mpCompactSyntaxManager->registerShorthand(qsl("al"), qsl("any-link"), this);
 
     // Register preset-allowed properties
-    mpCompactSyntaxManager->registerPresetProperty(qsl("style"), this);
+    mpCompactSyntaxManager->registerPresetProperty(qsl("style"), this, true);
 }
 
 void TConsole::initializeOSC8MenuFeature()
@@ -2738,7 +2738,7 @@ void TConsole::initializeOSC8MenuFeature()
     mpCompactSyntaxManager->registerShorthand(qsl("m"), qsl("menu"), this);
 
     // Register preset-allowed property
-    mpCompactSyntaxManager->registerPresetProperty(qsl("menu"), this);
+    mpCompactSyntaxManager->registerPresetProperty(qsl("menu"), this, true);
 }
 
 void TConsole::initializeOSC8TooltipFeature()
@@ -2751,5 +2751,5 @@ void TConsole::initializeOSC8TooltipFeature()
     mpCompactSyntaxManager->registerShorthand(qsl("t"), qsl("tooltip"), this);
 
     // Register preset-allowed property
-    mpCompactSyntaxManager->registerPresetProperty(qsl("tooltip"), this);
+    mpCompactSyntaxManager->registerPresetProperty(qsl("tooltip"), this, true);
 }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -83,6 +83,11 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     // Initialize hyperlink selection manager
     mpSelectionManager = new THyperlinkSelectionManager(this);
 
+    // Register existing OSC 8 features with the framework
+    initializeOSC8StyleFeature();
+    initializeOSC8MenuFeature();
+    initializeOSC8TooltipFeature();
+
     auto quitShortcut = new QShortcut(this);
     quitShortcut->setKey(Qt::CTRL | Qt::Key_W);
     quitShortcut->setContext(Qt::WidgetShortcut);
@@ -2693,4 +2698,58 @@ void TConsole::restoreCommandSearchSettings()
     }
 
     commandSplitter->restoreState(pQSettings->value("commandSearchSplitterState").toByteArray());
+}
+
+void TConsole::initializeOSC8StyleFeature()
+{
+    if (!mpCompactSyntaxManager) {
+        return;
+    }
+
+    // Register shorthands for style property names
+    mpCompactSyntaxManager->registerShorthand(qsl("s"), qsl("style"), this);
+    mpCompactSyntaxManager->registerShorthand(qsl("c"), qsl("color"), this);
+    mpCompactSyntaxManager->registerShorthand(qsl("bg"), qsl("bg"), this);
+    mpCompactSyntaxManager->registerShorthand(qsl("b"), qsl("bold"), this);
+    mpCompactSyntaxManager->registerShorthand(qsl("i"), qsl("italic"), this);
+    mpCompactSyntaxManager->registerShorthand(qsl("u"), qsl("underline"), this);
+    mpCompactSyntaxManager->registerShorthand(qsl("o"), qsl("overline"), this);
+    mpCompactSyntaxManager->registerShorthand(qsl("st"), qsl("strikethrough"), this);
+    mpCompactSyntaxManager->registerShorthand(qsl("tdc"), qsl("text-decoration-color"), this);
+    mpCompactSyntaxManager->registerShorthand(qsl("h"), qsl("hover"), this);
+    mpCompactSyntaxManager->registerShorthand(qsl("a"), qsl("active"), this);
+    mpCompactSyntaxManager->registerShorthand(qsl("f"), qsl("focus"), this);
+    mpCompactSyntaxManager->registerShorthand(qsl("fv"), qsl("focus-visible"), this);
+    mpCompactSyntaxManager->registerShorthand(qsl("vi"), qsl("visited"), this);
+    mpCompactSyntaxManager->registerShorthand(qsl("l"), qsl("link"), this);
+    mpCompactSyntaxManager->registerShorthand(qsl("al"), qsl("any-link"), this);
+
+    // Register preset-allowed properties
+    mpCompactSyntaxManager->registerPresetProperty(qsl("style"), this);
+}
+
+void TConsole::initializeOSC8MenuFeature()
+{
+    if (!mpCompactSyntaxManager) {
+        return;
+    }
+
+    // Register shorthand for menu property
+    mpCompactSyntaxManager->registerShorthand(qsl("m"), qsl("menu"), this);
+
+    // Register preset-allowed property
+    mpCompactSyntaxManager->registerPresetProperty(qsl("menu"), this);
+}
+
+void TConsole::initializeOSC8TooltipFeature()
+{
+    if (!mpCompactSyntaxManager) {
+        return;
+    }
+
+    // Register shorthand for tooltip property
+    mpCompactSyntaxManager->registerShorthand(qsl("t"), qsl("tooltip"), this);
+
+    // Register preset-allowed property
+    mpCompactSyntaxManager->registerPresetProperty(qsl("tooltip"), this);
 }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -77,6 +77,9 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
 , mControlCharacter(pH->getControlCharacterMode())
 , mType(type)
 {
+    // Initialize hyperlink selection manager
+    mpSelectionManager = new THyperlinkSelectionManager(this);
+    
     auto quitShortcut = new QShortcut(this);
     quitShortcut->setKey(Qt::CTRL | Qt::Key_W);
     quitShortcut->setContext(Qt::WidgetShortcut);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -79,6 +79,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
 , mType(type)
 {
     mpCompactSyntaxManager = std::make_unique<THyperlinkCompactManager>(this);
+    mpSelectionManager = std::make_unique<THyperlinkSelectionManager>(this);
     initializeOSC8StyleFeature();
     initializeOSC8MenuFeature();
     initializeOSC8TooltipFeature();

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -78,12 +78,9 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
 , mControlCharacter(pH->getControlCharacterMode())
 , mType(type)
 {
-    // Initialize compact syntax framework FIRST (pure utility, no features)
     mpCompactSyntaxManager = new THyperlinkCompactManager(this, this);
-    // Initialize hyperlink selection manager
     mpSelectionManager = new THyperlinkSelectionManager(this);
 
-    // Register existing OSC 8 features with the framework
     initializeOSC8StyleFeature();
     initializeOSC8MenuFeature();
     initializeOSC8TooltipFeature();
@@ -2724,7 +2721,6 @@ void TConsole::initializeOSC8StyleFeature()
     mpCompactSyntaxManager->registerShorthand(qsl("l"), qsl("link"), this);
     mpCompactSyntaxManager->registerShorthand(qsl("al"), qsl("any-link"), this);
 
-    // Register preset-allowed properties
     mpCompactSyntaxManager->registerPresetProperty(qsl("style"), this, true);
 }
 
@@ -2737,7 +2733,6 @@ void TConsole::initializeOSC8MenuFeature()
     // Register shorthand for menu property
     mpCompactSyntaxManager->registerShorthand(qsl("m"), qsl("menu"), this);
 
-    // Register preset-allowed property
     mpCompactSyntaxManager->registerPresetProperty(qsl("menu"), this, true);
 }
 
@@ -2750,6 +2745,5 @@ void TConsole::initializeOSC8TooltipFeature()
     // Register shorthand for tooltip property
     mpCompactSyntaxManager->registerShorthand(qsl("t"), qsl("tooltip"), this);
 
-    // Register preset-allowed property
     mpCompactSyntaxManager->registerPresetProperty(qsl("tooltip"), this, true);
 }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -78,8 +78,8 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
 , mControlCharacter(pH->getControlCharacterMode())
 , mType(type)
 {
-    mpCompactSyntaxManager = new THyperlinkCompactManager(this, this);
-    mpSelectionManager = new THyperlinkSelectionManager(this);
+    mpCompactSyntaxManager = std::make_unique<THyperlinkCompactManager>(this, this);
+    mpSelectionManager = std::make_unique<THyperlinkSelectionManager>(this);
 
     initializeOSC8StyleFeature();
     initializeOSC8MenuFeature();

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -326,7 +326,7 @@ public:
     TFontAttributes mDisplayFontDetails;
 
     // Manager for OSC 8 hyperlink selection state (radio/checkbox behavior)
-    class THyperlinkSelectionManager* mpSelectionManager = nullptr;
+    THyperlinkSelectionManager* mpSelectionManager = nullptr;
 
     // Only assigned a value for user windows:
     QPointer<TDockWidget> mpDockWidget;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -23,8 +23,6 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
-
-#include <memory>
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
@@ -52,6 +50,7 @@
 
 #include <list>
 #include <map>
+#include <memory>
 
 // This contains the details of a font that we might want to maintain a record
 // of, independently of a QFont instance:

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -28,6 +28,7 @@
 
 
 #include "TBuffer.h"
+#include "THyperlinkSelectionManager.h"
 
 
 #include "TTextCodec.h"
@@ -323,6 +324,9 @@ public:
 
     // Initialised in the constructor:
     TFontAttributes mDisplayFontDetails;
+
+    // Manager for OSC 8 hyperlink selection state (radio/checkbox behavior)
+    class THyperlinkSelectionManager* mpSelectionManager = nullptr;
 
     // Only assigned a value for user windows:
     QPointer<TDockWidget> mpDockWidget;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -329,7 +329,7 @@ public:
     TFontAttributes mDisplayFontDetails;
 
     // Compact syntax framework (shorthand + presets)
-    // Features plugin to this system when they initialize
+    // Features plug into this system when they initialize
     std::unique_ptr<THyperlinkCompactManager> mpCompactSyntaxManager;
     // Manager for OSC 8 hyperlink selection state (radio/checkbox behavior)
     std::unique_ptr<THyperlinkSelectionManager> mpSelectionManager;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -157,6 +157,7 @@ class Host;
 class TTextEdit;
 class TCommandLine;
 class TDockWidget;
+class THyperlinkCompactManager;
 class TLabel;
 class TScrollBox;
 class TSplitter;
@@ -325,6 +326,9 @@ public:
     // Initialised in the constructor:
     TFontAttributes mDisplayFontDetails;
 
+    // Compact syntax framework (shorthand + presets)
+    // Features plugin to this system when they initialize
+    QPointer<THyperlinkCompactManager> mpCompactSyntaxManager;
     // Manager for OSC 8 hyperlink selection state (radio/checkbox behavior)
     THyperlinkSelectionManager* mpSelectionManager = nullptr;
 

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -452,6 +452,9 @@ private:
     void createSearchOptionIcon();
     void raiseFontChangeEvent();
     void restoreCommandSearchSettings();
+    void initializeOSC8StyleFeature();
+    void initializeOSC8MenuFeature();
+    void initializeOSC8TooltipFeature();
 
     ConsoleType mType = UnknownType;
     QSize mOldSize;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -23,6 +23,8 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
+
+#include <memory>
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
@@ -328,9 +330,9 @@ public:
 
     // Compact syntax framework (shorthand + presets)
     // Features plugin to this system when they initialize
-    QPointer<THyperlinkCompactManager> mpCompactSyntaxManager;
+    std::unique_ptr<THyperlinkCompactManager> mpCompactSyntaxManager;
     // Manager for OSC 8 hyperlink selection state (radio/checkbox behavior)
-    THyperlinkSelectionManager* mpSelectionManager = nullptr;
+    std::unique_ptr<THyperlinkSelectionManager> mpSelectionManager;
 
     // Only assigned a value for user windows:
     QPointer<TDockWidget> mpDockWidget;

--- a/src/THyperlinkCompactManager.cpp
+++ b/src/THyperlinkCompactManager.cpp
@@ -37,10 +37,6 @@ THyperlinkCompactManager::THyperlinkCompactManager(TConsole* pConsole, QObject* 
 
 THyperlinkCompactManager::~THyperlinkCompactManager() = default;
 
-// ═══════════════════════════════════════════════════════════
-// Shorthand Registration (Phase 1)
-// ═══════════════════════════════════════════════════════════
-
 void THyperlinkCompactManager::registerShorthand(const QString& shorthand, const QString& fullName, QObject* owner)
 {
     if (shorthand.isEmpty() || fullName.isEmpty()) {
@@ -63,7 +59,6 @@ void THyperlinkCompactManager::unregisterOwner(QObject* owner)
         return;
     }
 
-    // Remove all shortcuts owned by this object
     auto it = mShorthandRegistry.begin();
     while (it != mShorthandRegistry.end()) {
         if (it.value().second == owner) {
@@ -95,12 +90,10 @@ QMap<QString, QString> THyperlinkCompactManager::expandShorthand(const QMap<QStr
     for (auto it = params.constBegin(); it != params.constEnd(); ++it) {
         const QString& key = it.key();
 
-        // Check if this key is a registered shorthand
         if (mShorthandRegistry.contains(key)) {
             const auto& registration = mShorthandRegistry[key];
             const QPointer<QObject>& owner = registration.second;
 
-            // Only expand if owner is still valid (or nullptr = core shortcut)
             if (owner.isNull() || !owner.isNull()) {
                 expanded.insert(registration.first, it.value());
 #if defined(DEBUG_OSC_PROCESSING)
@@ -109,17 +102,11 @@ QMap<QString, QString> THyperlinkCompactManager::expandShorthand(const QMap<QStr
                 continue;
             }
         }
-
-        // Not a shorthand or owner destroyed - keep original key
         expanded.insert(key, it.value());
     }
 
     return expanded;
 }
-
-// ═══════════════════════════════════════════════════════════
-// Preset System (Phase 2)
-// ═══════════════════════════════════════════════════════════
 
 void THyperlinkCompactManager::registerPresetProperty(const QString& propertyName, QObject* owner, bool isCore)
 {

--- a/src/THyperlinkCompactManager.cpp
+++ b/src/THyperlinkCompactManager.cpp
@@ -76,7 +76,7 @@ void THyperlinkCompactManager::unregisterOwner(QObject* owner)
     // Remove all preset properties owned by this object
     auto it2 = mPresetPropertyRegistry.begin();
     while (it2 != mPresetPropertyRegistry.end()) {
-        if (it2.value() == owner) {
+        if (it2.value().owner == owner) {
             it2 = mPresetPropertyRegistry.erase(it2);
         } else {
             ++it2;
@@ -121,19 +121,20 @@ QMap<QString, QString> THyperlinkCompactManager::expandShorthand(const QMap<QStr
 // Preset System (Phase 2)
 // ═══════════════════════════════════════════════════════════
 
-void THyperlinkCompactManager::registerPresetProperty(const QString& propertyName, QObject* owner)
+void THyperlinkCompactManager::registerPresetProperty(const QString& propertyName, QObject* owner, bool isCore)
 {
     if (propertyName.isEmpty()) {
         qWarning() << "THyperlinkCompactManager::registerPresetProperty: empty propertyName";
         return;
     }
 
-    mPresetPropertyRegistry.insert(propertyName, QPointer<QObject>(owner));
+    mPresetPropertyRegistry.insert(propertyName, PresetPropertyEntry(owner, isCore));
     emit presetPropertyRegistered(propertyName);
 
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[CompactSyntax] Registered preset property:" << propertyName
-             << "(owner:" << (owner ? owner->objectName() : "core") << ")";
+             << "(owner:" << (owner ? owner->objectName() : "none")
+             << ", isCore:" << isCore << ")";
 #endif
 }
 
@@ -143,9 +144,9 @@ bool THyperlinkCompactManager::isPresetProperty(const QString& propertyName) con
         return false;
     }
 
-    // Check if owner is still valid
-    const QPointer<QObject>& owner = mPresetPropertyRegistry[propertyName];
-    return owner.isNull() || !owner.isNull(); // null = core property (always valid)
+    const PresetPropertyEntry& entry = mPresetPropertyRegistry[propertyName];
+    // Valid if core property OR owner still exists
+    return entry.isCore || !entry.owner.isNull();
 }
 
 void THyperlinkCompactManager::registerPreset(const QString& name, const QJsonObject& config)

--- a/src/THyperlinkCompactManager.cpp
+++ b/src/THyperlinkCompactManager.cpp
@@ -24,15 +24,11 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 
-THyperlinkCompactManager::THyperlinkCompactManager(TConsole* pConsole, QObject* parent)
+THyperlinkCompactManager::THyperlinkCompactManager(QObject* parent)
 : QObject(parent)
-, mpConsole(pConsole)
 {
     // Pure framework - no feature knowledge!
     // Features register themselves when they initialize
-    if (!pConsole) {
-        qWarning() << "THyperlinkCompactManager: pConsole parameter is null";
-    }
 }
 
 THyperlinkCompactManager::~THyperlinkCompactManager() = default;

--- a/src/THyperlinkCompactManager.cpp
+++ b/src/THyperlinkCompactManager.cpp
@@ -18,7 +18,6 @@
  ***************************************************************************/
 
 #include "THyperlinkCompactManager.h"
-#include "TConsole.h"
 
 #include <QDebug>
 #include <QJsonArray>
@@ -38,6 +37,16 @@ void THyperlinkCompactManager::registerShorthand(const QString& shorthand, const
     if (shorthand.isEmpty() || fullName.isEmpty()) {
         qWarning() << "THyperlinkCompactManager::registerShorthand: empty shorthand or fullName";
         return;
+    }
+
+    // Check for existing entry and warn about collision
+    if (mShorthandRegistry.contains(shorthand)) {
+        const ShorthandEntry& existing = mShorthandRegistry.value(shorthand);
+        qWarning() << "THyperlinkCompactManager::registerShorthand: Replacing existing shorthand"
+                   << shorthand << "→" << existing.fullName
+                   << "(owner:" << (existing.owner ? existing.owner->objectName() : "core") << ")"
+                   << "with new mapping:" << shorthand << "→" << fullName
+                   << "(owner:" << (owner ? owner->objectName() : "core") << ")";
     }
 
     bool isCore = (owner == nullptr);
@@ -88,7 +97,7 @@ QMap<QString, QString> THyperlinkCompactManager::expandShorthand(const QMap<QStr
         const QString& key = it.key();
 
         if (mShorthandRegistry.contains(key)) {
-            const auto& registration = mShorthandRegistry[key];
+            const auto& registration = mShorthandRegistry.value(key);
 
             if (registration.isCore || !registration.owner.isNull()) {
                 expanded.insert(registration.fullName, it.value());
@@ -108,6 +117,13 @@ void THyperlinkCompactManager::registerPresetProperty(const QString& propertyNam
 {
     if (propertyName.isEmpty()) {
         qWarning() << "THyperlinkCompactManager::registerPresetProperty: empty propertyName";
+        return;
+    }
+
+    // Non-core properties require a valid owner
+    if (!isCore && !owner) {
+        qWarning() << "THyperlinkCompactManager::registerPresetProperty: non-core property"
+                   << propertyName << "requires a valid owner (owner is null)";
         return;
     }
 
@@ -170,11 +186,18 @@ void THyperlinkCompactManager::clearPresets()
 
 QJsonObject THyperlinkCompactManager::mergeConfigs(const QJsonObject& base, const QJsonObject& overlay) const
 {
-    return deepMerge(base, overlay);
+    return deepMerge(base, overlay, 0);
 }
 
-QJsonObject THyperlinkCompactManager::deepMerge(const QJsonObject& base, const QJsonObject& overlay) const
+QJsonObject THyperlinkCompactManager::deepMerge(const QJsonObject& base, const QJsonObject& overlay, int depth) const
 {
+    // Check recursion depth limit to prevent stack overflow
+    if (depth >= MAX_MERGE_DEPTH) {
+        qWarning() << "THyperlinkCompactManager::deepMerge: Maximum recursion depth"
+                   << MAX_MERGE_DEPTH << "reached. Stopping recursion and using overlay.";
+        return overlay;
+    }
+
     QJsonObject result = base;
 
     // Iterate through all keys in overlay
@@ -193,7 +216,7 @@ QJsonObject THyperlinkCompactManager::deepMerge(const QJsonObject& base, const Q
         // Both values exist - determine merge strategy
         if (overlayValue.isObject() && baseValue.isObject()) {
             // Both are objects - recursive merge
-            result.insert(key, deepMerge(baseValue.toObject(), overlayValue.toObject()));
+            result.insert(key, deepMerge(baseValue.toObject(), overlayValue.toObject(), depth + 1));
         } else if (overlayValue.isArray() && baseValue.isArray()) {
             // Both are arrays - overlay completely replaces base (CSS behavior)
             result.insert(key, overlayValue);

--- a/src/THyperlinkCompactManager.cpp
+++ b/src/THyperlinkCompactManager.cpp
@@ -44,7 +44,8 @@ void THyperlinkCompactManager::registerShorthand(const QString& shorthand, const
         return;
     }
 
-    mShorthandRegistry.insert(shorthand, qMakePair(fullName, QPointer<QObject>(owner)));
+    bool isCore = (owner == nullptr);
+    mShorthandRegistry.insert(shorthand, ShorthandEntry(fullName, owner, isCore));
     emit shorthandRegistered(shorthand, fullName);
 
 #if defined(DEBUG_OSC_PROCESSING)
@@ -61,7 +62,7 @@ void THyperlinkCompactManager::unregisterOwner(QObject* owner)
 
     auto it = mShorthandRegistry.begin();
     while (it != mShorthandRegistry.end()) {
-        if (it.value().second == owner) {
+        if (it.value().owner == owner) {
             it = mShorthandRegistry.erase(it);
         } else {
             ++it;
@@ -92,12 +93,11 @@ QMap<QString, QString> THyperlinkCompactManager::expandShorthand(const QMap<QStr
 
         if (mShorthandRegistry.contains(key)) {
             const auto& registration = mShorthandRegistry[key];
-            const QPointer<QObject>& owner = registration.second;
 
-            if (owner.isNull() || !owner.isNull()) {
-                expanded.insert(registration.first, it.value());
+            if (registration.isCore || !registration.owner.isNull()) {
+                expanded.insert(registration.fullName, it.value());
 #if defined(DEBUG_OSC_PROCESSING)
-                qDebug() << "[CompactSyntax] Expanded shorthand:" << key << "→" << registration.first;
+                qDebug() << "[CompactSyntax] Expanded shorthand:" << key << "→" << registration.fullName;
 #endif
                 continue;
             }

--- a/src/THyperlinkCompactManager.cpp
+++ b/src/THyperlinkCompactManager.cpp
@@ -1,0 +1,223 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by Mike Conley - mike.conley@stickmud.com          *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "THyperlinkCompactManager.h"
+#include "TConsole.h"
+
+#include <QDebug>
+#include <QJsonArray>
+#include <QJsonDocument>
+
+THyperlinkCompactManager::THyperlinkCompactManager(TConsole* pConsole, QObject* parent)
+: QObject(parent)
+, mpConsole(pConsole)
+{
+    // Pure framework - no feature knowledge!
+    // Features register themselves when they initialize
+    if (!pConsole) {
+        qWarning() << "THyperlinkCompactManager: pConsole parameter is null";
+    }
+}
+
+THyperlinkCompactManager::~THyperlinkCompactManager() = default;
+
+// ═══════════════════════════════════════════════════════════
+// Shorthand Registration (Phase 1)
+// ═══════════════════════════════════════════════════════════
+
+void THyperlinkCompactManager::registerShorthand(const QString& shorthand, const QString& fullName, QObject* owner)
+{
+    if (shorthand.isEmpty() || fullName.isEmpty()) {
+        qWarning() << "THyperlinkCompactManager::registerShorthand: empty shorthand or fullName";
+        return;
+    }
+
+    mShorthandRegistry.insert(shorthand, qMakePair(fullName, QPointer<QObject>(owner)));
+    emit shorthandRegistered(shorthand, fullName);
+
+#if defined(DEBUG_OSC_PROCESSING)
+    qDebug() << "[CompactSyntax] Registered shorthand:" << shorthand << "→" << fullName
+             << "(owner:" << (owner ? owner->objectName() : "core") << ")";
+#endif
+}
+
+void THyperlinkCompactManager::unregisterOwner(QObject* owner)
+{
+    if (!owner) {
+        return;
+    }
+
+    // Remove all shortcuts owned by this object
+    auto it = mShorthandRegistry.begin();
+    while (it != mShorthandRegistry.end()) {
+        if (it.value().second == owner) {
+            it = mShorthandRegistry.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    // Remove all preset properties owned by this object
+    auto it2 = mPresetPropertyRegistry.begin();
+    while (it2 != mPresetPropertyRegistry.end()) {
+        if (it2.value() == owner) {
+            it2 = mPresetPropertyRegistry.erase(it2);
+        } else {
+            ++it2;
+        }
+    }
+
+#if defined(DEBUG_OSC_PROCESSING)
+    qDebug() << "[CompactSyntax] Unregistered all entries for owner:" << owner->objectName();
+#endif
+}
+
+QMap<QString, QString> THyperlinkCompactManager::expandShorthand(const QMap<QString, QString>& params)
+{
+    QMap<QString, QString> expanded;
+
+    for (auto it = params.constBegin(); it != params.constEnd(); ++it) {
+        const QString& key = it.key();
+
+        // Check if this key is a registered shorthand
+        if (mShorthandRegistry.contains(key)) {
+            const auto& registration = mShorthandRegistry[key];
+            const QPointer<QObject>& owner = registration.second;
+
+            // Only expand if owner is still valid (or nullptr = core shortcut)
+            if (owner.isNull() || !owner.isNull()) {
+                expanded.insert(registration.first, it.value());
+#if defined(DEBUG_OSC_PROCESSING)
+                qDebug() << "[CompactSyntax] Expanded shorthand:" << key << "→" << registration.first;
+#endif
+                continue;
+            }
+        }
+
+        // Not a shorthand or owner destroyed - keep original key
+        expanded.insert(key, it.value());
+    }
+
+    return expanded;
+}
+
+// ═══════════════════════════════════════════════════════════
+// Preset System (Phase 2)
+// ═══════════════════════════════════════════════════════════
+
+void THyperlinkCompactManager::registerPresetProperty(const QString& propertyName, QObject* owner)
+{
+    if (propertyName.isEmpty()) {
+        qWarning() << "THyperlinkCompactManager::registerPresetProperty: empty propertyName";
+        return;
+    }
+
+    mPresetPropertyRegistry.insert(propertyName, QPointer<QObject>(owner));
+    emit presetPropertyRegistered(propertyName);
+
+#if defined(DEBUG_OSC_PROCESSING)
+    qDebug() << "[CompactSyntax] Registered preset property:" << propertyName
+             << "(owner:" << (owner ? owner->objectName() : "core") << ")";
+#endif
+}
+
+bool THyperlinkCompactManager::isPresetProperty(const QString& propertyName) const
+{
+    if (!mPresetPropertyRegistry.contains(propertyName)) {
+        return false;
+    }
+
+    // Check if owner is still valid
+    const QPointer<QObject>& owner = mPresetPropertyRegistry[propertyName];
+    return owner.isNull() || !owner.isNull(); // null = core property (always valid)
+}
+
+void THyperlinkCompactManager::registerPreset(const QString& name, const QJsonObject& config)
+{
+    if (name.isEmpty()) {
+        qWarning() << "THyperlinkCompactManager::registerPreset: empty name";
+        return;
+    }
+
+    mPresets.insert(name, config);
+    emit presetRegistered(name);
+
+#if defined(DEBUG_OSC_PROCESSING)
+    qDebug() << "[CompactSyntax] Registered preset:" << name
+             << "config:" << QJsonDocument(config).toJson(QJsonDocument::Compact);
+#endif
+}
+
+QJsonObject THyperlinkCompactManager::getPreset(const QString& name) const
+{
+    return mPresets.value(name, QJsonObject());
+}
+
+bool THyperlinkCompactManager::hasPreset(const QString& name) const
+{
+    return mPresets.contains(name);
+}
+
+void THyperlinkCompactManager::clearPresets()
+{
+    mPresets.clear();
+    emit presetsCleared();
+
+#if defined(DEBUG_OSC_PROCESSING)
+    qDebug() << "[CompactSyntax] Cleared all presets";
+#endif
+}
+
+QJsonObject THyperlinkCompactManager::mergeConfigs(const QJsonObject& base, const QJsonObject& overlay) const
+{
+    return deepMerge(base, overlay);
+}
+
+QJsonObject THyperlinkCompactManager::deepMerge(const QJsonObject& base, const QJsonObject& overlay) const
+{
+    QJsonObject result = base;
+
+    // Iterate through all keys in overlay
+    for (auto it = overlay.constBegin(); it != overlay.constEnd(); ++it) {
+        const QString& key = it.key();
+        const QJsonValue& overlayValue = it.value();
+
+        if (!base.contains(key)) {
+            // Key doesn't exist in base - add it
+            result.insert(key, overlayValue);
+            continue;
+        }
+
+        const QJsonValue& baseValue = base[key];
+
+        // Both values exist - determine merge strategy
+        if (overlayValue.isObject() && baseValue.isObject()) {
+            // Both are objects - recursive merge
+            result.insert(key, deepMerge(baseValue.toObject(), overlayValue.toObject()));
+        } else if (overlayValue.isArray() && baseValue.isArray()) {
+            // Both are arrays - overlay completely replaces base (CSS behavior)
+            result.insert(key, overlayValue);
+        } else {
+            // Primitives or type mismatch - overlay wins
+            result.insert(key, overlayValue);
+        }
+    }
+
+    return result;
+}

--- a/src/THyperlinkCompactManager.cpp
+++ b/src/THyperlinkCompactManager.cpp
@@ -80,7 +80,7 @@ void THyperlinkCompactManager::unregisterOwner(QObject* owner)
 #endif
 }
 
-QMap<QString, QString> THyperlinkCompactManager::expandShorthand(const QMap<QString, QString>& params)
+QMap<QString, QString> THyperlinkCompactManager::expandShorthand(const QMap<QString, QString>& params) const
 {
     QMap<QString, QString> expanded;
 

--- a/src/THyperlinkCompactManager.h
+++ b/src/THyperlinkCompactManager.h
@@ -58,7 +58,7 @@ class THyperlinkCompactManager : public QObject
     Q_DISABLE_COPY(THyperlinkCompactManager)
 
 public:
-    explicit THyperlinkCompactManager(TConsole* pConsole, QObject* parent = nullptr);
+    explicit THyperlinkCompactManager(QObject* parent = nullptr);
     ~THyperlinkCompactManager();
 
     // ═══════════════════════════════════════════════════════════
@@ -113,8 +113,6 @@ signals:
     void presetsCleared();
 
 private:
-    QPointer<TConsole> mpConsole;
-
     // Shorthand registry: shorthand → (fullName, owner)
     // Owner is nullptr for core shortcuts (always available)
     // Owner is QPointer for feature shortcuts (auto-cleanup when feature destroyed)

--- a/src/THyperlinkCompactManager.h
+++ b/src/THyperlinkCompactManager.h
@@ -30,6 +30,15 @@
 
 class TConsole;
 
+// Registry entry for preset properties
+struct PresetPropertyEntry {
+    QPointer<QObject> owner;
+    bool isCore;
+    
+    PresetPropertyEntry() : owner(nullptr), isCore(false) {}
+    PresetPropertyEntry(QObject* o, bool core) : owner(o), isCore(core) {}
+};
+
 // Pure plugin framework for OSC 8 hyperlink compact syntax
 // Features (style, menu, tooltip, visibility, selection, etc.) register themselves
 // Provides shorthand expansion and preset management with deep merge support
@@ -65,7 +74,7 @@ public:
     // ═══════════════════════════════════════════════════════════
 
     // Register a property as preset-aware (allows it to be included in presets)
-    void registerPresetProperty(const QString& propertyName, QObject* owner = nullptr);
+    void registerPresetProperty(const QString& propertyName, QObject* owner = nullptr, bool isCore = false);
 
     // Check if a property can be used in presets
     bool isPresetProperty(const QString& propertyName) const;
@@ -101,9 +110,9 @@ private:
     // Owner is QPointer for feature shortcuts (auto-cleanup when feature destroyed)
     QHash<QString, QPair<QString, QPointer<QObject>>> mShorthandRegistry;
 
-    // Preset property registry: propertyName → owner
-    // Same ownership model as shorthand registry
-    QHash<QString, QPointer<QObject>> mPresetPropertyRegistry;
+    // Preset property registry: propertyName → {owner, isCore}
+    // Core properties are always valid, non-core depend on owner validity
+    QHash<QString, PresetPropertyEntry> mPresetPropertyRegistry;
 
     // Preset storage: name → config JSON
     // Session-scoped: cleared when connection closes

--- a/src/THyperlinkCompactManager.h
+++ b/src/THyperlinkCompactManager.h
@@ -61,10 +61,6 @@ public:
     explicit THyperlinkCompactManager(QObject* parent = nullptr);
     ~THyperlinkCompactManager();
 
-    // ═══════════════════════════════════════════════════════════
-    // Shorthand Registration (Phase 1)
-    // ═══════════════════════════════════════════════════════════
-
     // Register a shorthand expansion (e.g., "s" → "style")
     // Owner parameter enables automatic cleanup when feature is destroyed
     void registerShorthand(const QString& shorthand, const QString& fullName, QObject* owner = nullptr);
@@ -78,10 +74,6 @@ public:
     // Query registered shortcuts (for debugging/introspection)
     int getShorthandCount() const { return mShorthandRegistry.size(); }
     QStringList getRegisteredShorthands() const { return mShorthandRegistry.keys(); }
-
-    // ═══════════════════════════════════════════════════════════
-    // Preset System (Phase 2)
-    // ═══════════════════════════════════════════════════════════
 
     // Register a property as preset-aware (allows it to be included in presets)
     void registerPresetProperty(const QString& propertyName, QObject* owner = nullptr, bool isCore = false);

--- a/src/THyperlinkCompactManager.h
+++ b/src/THyperlinkCompactManager.h
@@ -1,0 +1,116 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by Mike Conley - mike.conley@stickmud.com          *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#ifndef MUDLET_THYPERLINKCOMPACTMANAGER_H
+#define MUDLET_THYPERLINKCOMPACTMANAGER_H
+
+#include <QHash>
+#include <QJsonObject>
+#include <QMap>
+#include <QObject>
+#include <QPair>
+#include <QPointer>
+#include <QString>
+
+class TConsole;
+
+// Pure plugin framework for OSC 8 hyperlink compact syntax
+// Features (style, menu, tooltip, visibility, selection, etc.) register themselves
+// Provides shorthand expansion and preset management with deep merge support
+class THyperlinkCompactManager : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(THyperlinkCompactManager)
+
+public:
+    explicit THyperlinkCompactManager(TConsole* pConsole, QObject* parent = nullptr);
+    ~THyperlinkCompactManager();
+
+    // ═══════════════════════════════════════════════════════════
+    // Shorthand Registration (Phase 1)
+    // ═══════════════════════════════════════════════════════════
+
+    // Register a shorthand expansion (e.g., "s" → "style")
+    // Owner parameter enables automatic cleanup when feature is destroyed
+    void registerShorthand(const QString& shorthand, const QString& fullName, QObject* owner = nullptr);
+
+    // Unregister all shortcuts owned by a specific object
+    void unregisterOwner(QObject* owner);
+
+    // Expand shorthand properties to full names
+    QMap<QString, QString> expandShorthand(const QMap<QString, QString>& params);
+
+    // Query registered shortcuts (for debugging/introspection)
+    int getShorthandCount() const { return mShorthandRegistry.size(); }
+    QStringList getRegisteredShorthands() const { return mShorthandRegistry.keys(); }
+
+    // ═══════════════════════════════════════════════════════════
+    // Preset System (Phase 2)
+    // ═══════════════════════════════════════════════════════════
+
+    // Register a property as preset-aware (allows it to be included in presets)
+    void registerPresetProperty(const QString& propertyName, QObject* owner = nullptr);
+
+    // Check if a property can be used in presets
+    bool isPresetProperty(const QString& propertyName) const;
+
+    // Query registered preset properties (for debugging/introspection)
+    int getPresetPropertyCount() const { return mPresetPropertyRegistry.size(); }
+    QStringList getRegisteredPresetProperties() const { return mPresetPropertyRegistry.keys(); }
+
+    // Preset storage and retrieval (session-scoped, cleared on disconnect)
+    void registerPreset(const QString& name, const QJsonObject& config);
+    QJsonObject getPreset(const QString& name) const;
+    bool hasPreset(const QString& name) const;
+    void clearPresets();
+
+    // Deep merge for config overrides (preset as base, override on top)
+    // Returns merged JSON object following CSS cascade rules:
+    // - Nested objects: properties combine, overlay wins on conflicts
+    // - Arrays: overlay completely replaces base array
+    // - Primitives: overlay value wins
+    QJsonObject mergeConfigs(const QJsonObject& base, const QJsonObject& overlay) const;
+
+signals:
+    void shorthandRegistered(const QString& shorthand, const QString& fullName);
+    void presetPropertyRegistered(const QString& propertyName);
+    void presetRegistered(const QString& name);
+    void presetsCleared();
+
+private:
+    QPointer<TConsole> mpConsole;
+
+    // Shorthand registry: shorthand → (fullName, owner)
+    // Owner is nullptr for core shortcuts (always available)
+    // Owner is QPointer for feature shortcuts (auto-cleanup when feature destroyed)
+    QHash<QString, QPair<QString, QPointer<QObject>>> mShorthandRegistry;
+
+    // Preset property registry: propertyName → owner
+    // Same ownership model as shorthand registry
+    QHash<QString, QPointer<QObject>> mPresetPropertyRegistry;
+
+    // Preset storage: name → config JSON
+    // Session-scoped: cleared when connection closes
+    QHash<QString, QJsonObject> mPresets;
+
+    // Helper for deep merge algorithm (recursive)
+    QJsonObject deepMerge(const QJsonObject& base, const QJsonObject& overlay) const;
+};
+
+#endif // MUDLET_THYPERLINKCOMPACTMANAGER_H

--- a/src/THyperlinkCompactManager.h
+++ b/src/THyperlinkCompactManager.h
@@ -118,8 +118,11 @@ private:
     // Session-scoped: cleared when connection closes
     QHash<QString, QJsonObject> mPresets;
 
+    // Maximum recursion depth for deepMerge to prevent stack overflow
+    static constexpr int MAX_MERGE_DEPTH = 32;
+
     // Helper for deep merge algorithm (recursive)
-    QJsonObject deepMerge(const QJsonObject& base, const QJsonObject& overlay) const;
+    QJsonObject deepMerge(const QJsonObject& base, const QJsonObject& overlay, int depth = 0) const;
 };
 
 #endif // MUDLET_THYPERLINKCOMPACTMANAGER_H

--- a/src/THyperlinkCompactManager.h
+++ b/src/THyperlinkCompactManager.h
@@ -39,6 +39,16 @@ struct PresetPropertyEntry {
     PresetPropertyEntry(QObject* o, bool core) : owner(o), isCore(core) {}
 };
 
+// Registry entry for shorthand mappings
+struct ShorthandEntry {
+    QString fullName;
+    QPointer<QObject> owner;
+    bool isCore;
+    
+    ShorthandEntry() : owner(nullptr), isCore(false) {}
+    ShorthandEntry(const QString& full, QObject* o, bool core) : fullName(full), owner(o), isCore(core) {}
+};
+
 // Pure plugin framework for OSC 8 hyperlink compact syntax
 // Features (style, menu, tooltip, visibility, selection, etc.) register themselves
 // Provides shorthand expansion and preset management with deep merge support
@@ -108,7 +118,7 @@ private:
     // Shorthand registry: shorthand → (fullName, owner)
     // Owner is nullptr for core shortcuts (always available)
     // Owner is QPointer for feature shortcuts (auto-cleanup when feature destroyed)
-    QHash<QString, QPair<QString, QPointer<QObject>>> mShorthandRegistry;
+    QHash<QString, ShorthandEntry> mShorthandRegistry;
 
     // Preset property registry: propertyName → {owner, isCore}
     // Core properties are always valid, non-core depend on owner validity

--- a/src/THyperlinkCompactManager.h
+++ b/src/THyperlinkCompactManager.h
@@ -73,7 +73,7 @@ public:
     void unregisterOwner(QObject* owner);
 
     // Expand shorthand properties to full names
-    QMap<QString, QString> expandShorthand(const QMap<QString, QString>& params);
+    QMap<QString, QString> expandShorthand(const QMap<QString, QString>& params) const;
 
     // Query registered shortcuts (for debugging/introspection)
     int getShorthandCount() const { return mShorthandRegistry.size(); }

--- a/src/THyperlinkSelectionManager.cpp
+++ b/src/THyperlinkSelectionManager.cpp
@@ -24,6 +24,9 @@ THyperlinkSelectionManager::THyperlinkSelectionManager(TConsole* pConsole)
 : QObject(pConsole)
 , mpConsole(pConsole)
 {
+    if (!pConsole) {
+        qFatal("THyperlinkSelectionManager: pConsole parameter cannot be null");
+    }
 }
 
 THyperlinkSelectionManager::~THyperlinkSelectionManager() = default;
@@ -40,16 +43,19 @@ bool THyperlinkSelectionManager::isSelected(const QString& group, const QString&
 // Set selection state for a value in a group
 void THyperlinkSelectionManager::setSelected(const QString& group, const QString& value, bool selected, bool exclusive)
 {
-    // Register this value in the group if not already registered
     registerGroupMember(group, value);
     
-    // Handle exclusive selection (radio button behavior)
+    bool previousState = isSelected(group, value);
+    
     if (selected && exclusive) {
         handleExclusiveSelection(group, value);
     }
     
-    // Set the selection state
     mSelectionState[group][value] = selected;
+    
+    if (previousState != selected) {
+        emit selectionChanged(group, value, selected);
+    }
 }
 
 // Toggle selection state for a value in a group
@@ -70,6 +76,7 @@ void THyperlinkSelectionManager::clearGroup(const QString& group)
 {
     if (mSelectionState.contains(group)) {
         mSelectionState[group].clear();
+        emit groupCleared(group);
     }
 }
 
@@ -77,6 +84,7 @@ void THyperlinkSelectionManager::clearGroup(const QString& group)
 void THyperlinkSelectionManager::clearAllSelections()
 {
     mSelectionState.clear();
+    emit allSelectionsCleared();
 }
 
 // Modify URI to append &selected=true or &selected=false for server callback
@@ -117,7 +125,9 @@ QString THyperlinkSelectionManager::modifyUriForSelection(const QString& baseUri
     }
     
     // For other URI formats (like openUrl), return as-is
+#if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "No modification - returning as-is";
+#endif
     return baseUri;
 }
 

--- a/src/THyperlinkSelectionManager.cpp
+++ b/src/THyperlinkSelectionManager.cpp
@@ -34,10 +34,7 @@ THyperlinkSelectionManager::~THyperlinkSelectionManager() = default;
 // Check if a value in a group is currently selected
 bool THyperlinkSelectionManager::isSelected(const QString& group, const QString& value) const
 {
-    if (!mSelectionState.contains(group)) {
-        return false;
-    }
-    return mSelectionState[group].value(value, false);
+    return mSelectionState.value(group).value(value, false);
 }
 
 // Set selection state for a value in a group
@@ -150,7 +147,11 @@ void THyperlinkSelectionManager::handleExclusiveSelection(const QString& group, 
     const QStringList members = getGroupMembers(group);
     for (const QString& member : members) {
         if (member != value) {
+            bool previousState = isSelected(group, member);
             mSelectionState[group][member] = false;
+            if (previousState) {
+                emit selectionChanged(group, member, false);
+            }
         }
     }
 }

--- a/src/THyperlinkSelectionManager.cpp
+++ b/src/THyperlinkSelectionManager.cpp
@@ -82,27 +82,37 @@ void THyperlinkSelectionManager::clearAllSelections()
 // Modify URI to append &selected=true or &selected=false for server callback
 QString THyperlinkSelectionManager::modifyUriForSelection(const QString& baseUri, bool isSelected) const
 {
-    // Extract base URI without ?config= parameter
-    // The URI structure is: SCHEME:COMMAND?config=JSON
-    // We need to append &selected=true/false to COMMAND (before ?config=)
+    // The baseUri is already in Lua format: send([[command]]) or sendCmdLine([[command]])
+    // We need to extract the command, append &selected=true/false, and reconstruct
     
-    int configPos = baseUri.indexOf(qsl("?config="));
-    QString command;
-    QString configPart;
+    qDebug() << "modifyUriForSelection called with baseUri:" << baseUri << "isSelected:" << isSelected;
     
-    if (configPos != -1) {
-        command = baseUri.left(configPos);
-        configPart = baseUri.mid(configPos);
-    } else {
-        command = baseUri;
+    // Check if it's a send() or sendCmdLine() call
+    if (baseUri.startsWith(qsl("send([[")) && baseUri.endsWith(qsl("]])"))) {
+        // Extract: send([[command]]) -> command
+        QString command = baseUri.mid(7, baseUri.length() - 10);
+        // Append selection state to command
+        QString separator = command.contains('?') ? qsl("&") : qsl("?");
+        command += separator + qsl("selected=") + (isSelected ? qsl("true") : qsl("false"));
+        // Reconstruct: send([[command&selected=true]])
+        QString result = qsl("send([[%1]])").arg(command);
+        qDebug() << "Modified to:" << result;
+        return result;
+    } else if (baseUri.startsWith(qsl("sendCmdLine([[")) && baseUri.endsWith(qsl("]])"))) {
+        // Extract: sendCmdLine([[command]]) -> command
+        QString command = baseUri.mid(14, baseUri.length() - 17);
+        // Append selection state to command
+        QString separator = command.contains('?') ? qsl("&") : qsl("?");
+        command += separator + qsl("selected=") + (isSelected ? qsl("true") : qsl("false"));
+        // Reconstruct: sendCmdLine([[command&selected=true]])
+        QString result = qsl("sendCmdLine([[%1]])").arg(command);
+        qDebug() << "Modified to:" << result;
+        return result;
     }
     
-    // Append selection state
-    QString separator = command.contains('?') ? qsl("&") : qsl("?");
-    command += separator + qsl("selected=") + (isSelected ? qsl("true") : qsl("false"));
-    
-    // Re-append config if it existed
-    return command + configPart;
+    // For other URI formats (like openUrl), return as-is
+    qDebug() << "No modification - returning as-is";
+    return baseUri;
 }
 
 // Register a value as a member of a group

--- a/src/THyperlinkSelectionManager.cpp
+++ b/src/THyperlinkSelectionManager.cpp
@@ -1,0 +1,130 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by Mike Conley - https://github.com/mconley       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "THyperlinkSelectionManager.h"
+#include "TConsole.h"
+
+THyperlinkSelectionManager::THyperlinkSelectionManager(TConsole* pConsole)
+: QObject(pConsole)
+, mpConsole(pConsole)
+{
+}
+
+THyperlinkSelectionManager::~THyperlinkSelectionManager() = default;
+
+// Check if a value in a group is currently selected
+bool THyperlinkSelectionManager::isSelected(const QString& group, const QString& value) const
+{
+    if (!mSelectionState.contains(group)) {
+        return false;
+    }
+    return mSelectionState[group].value(value, false);
+}
+
+// Set selection state for a value in a group
+void THyperlinkSelectionManager::setSelected(const QString& group, const QString& value, bool selected, bool exclusive)
+{
+    // Register this value in the group if not already registered
+    registerGroupMember(group, value);
+    
+    // Handle exclusive selection (radio button behavior)
+    if (selected && exclusive) {
+        handleExclusiveSelection(group, value);
+    }
+    
+    // Set the selection state
+    mSelectionState[group][value] = selected;
+}
+
+// Toggle selection state for a value in a group
+void THyperlinkSelectionManager::toggleSelection(const QString& group, const QString& value, bool exclusive)
+{
+    bool currentState = isSelected(group, value);
+    setSelected(group, value, !currentState, exclusive);
+}
+
+// Get all values registered in a group
+QStringList THyperlinkSelectionManager::getGroupMembers(const QString& group) const
+{
+    return mGroupMembers.value(group, QStringList());
+}
+
+// Clear all selections in a group
+void THyperlinkSelectionManager::clearGroup(const QString& group)
+{
+    if (mSelectionState.contains(group)) {
+        mSelectionState[group].clear();
+    }
+}
+
+// Clear all selections across all groups
+void THyperlinkSelectionManager::clearAllSelections()
+{
+    mSelectionState.clear();
+}
+
+// Modify URI to append &selected=true or &selected=false for server callback
+QString THyperlinkSelectionManager::modifyUriForSelection(const QString& baseUri, bool isSelected) const
+{
+    // Extract base URI without ?config= parameter
+    // The URI structure is: SCHEME:COMMAND?config=JSON
+    // We need to append &selected=true/false to COMMAND (before ?config=)
+    
+    int configPos = baseUri.indexOf(qsl("?config="));
+    QString command;
+    QString configPart;
+    
+    if (configPos != -1) {
+        command = baseUri.left(configPos);
+        configPart = baseUri.mid(configPos);
+    } else {
+        command = baseUri;
+    }
+    
+    // Append selection state
+    QString separator = command.contains('?') ? qsl("&") : qsl("?");
+    command += separator + qsl("selected=") + (isSelected ? qsl("true") : qsl("false"));
+    
+    // Re-append config if it existed
+    return command + configPart;
+}
+
+// Register a value as a member of a group
+void THyperlinkSelectionManager::registerGroupMember(const QString& group, const QString& value)
+{
+    if (!mGroupMembers.contains(group)) {
+        mGroupMembers[group] = QStringList();
+    }
+    
+    if (!mGroupMembers[group].contains(value)) {
+        mGroupMembers[group].append(value);
+    }
+}
+
+// Handle exclusive selection: deselect all other values in the group (radio button behavior)
+void THyperlinkSelectionManager::handleExclusiveSelection(const QString& group, const QString& value)
+{
+    // Deselect all other members of this group
+    const QStringList members = getGroupMembers(group);
+    for (const QString& member : members) {
+        if (member != value) {
+            mSelectionState[group][member] = false;
+        }
+    }
+}

--- a/src/THyperlinkSelectionManager.cpp
+++ b/src/THyperlinkSelectionManager.cpp
@@ -85,7 +85,9 @@ QString THyperlinkSelectionManager::modifyUriForSelection(const QString& baseUri
     // The baseUri is already in Lua format: send([[command]]) or sendCmdLine([[command]])
     // We need to extract the command, append &selected=true/false, and reconstruct
     
+#if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "modifyUriForSelection called with baseUri:" << baseUri << "isSelected:" << isSelected;
+#endif
     
     // Check if it's a send() or sendCmdLine() call
     if (baseUri.startsWith(qsl("send([[")) && baseUri.endsWith(qsl("]])"))) {
@@ -96,7 +98,9 @@ QString THyperlinkSelectionManager::modifyUriForSelection(const QString& baseUri
         command += separator + qsl("selected=") + (isSelected ? qsl("true") : qsl("false"));
         // Reconstruct: send([[command&selected=true]])
         QString result = qsl("send([[%1]])").arg(command);
+#if defined(DEBUG_OSC_PROCESSING)
         qDebug() << "Modified to:" << result;
+#endif
         return result;
     } else if (baseUri.startsWith(qsl("sendCmdLine([[")) && baseUri.endsWith(qsl("]])"))) {
         // Extract: sendCmdLine([[command]]) -> command
@@ -106,7 +110,9 @@ QString THyperlinkSelectionManager::modifyUriForSelection(const QString& baseUri
         command += separator + qsl("selected=") + (isSelected ? qsl("true") : qsl("false"));
         // Reconstruct: sendCmdLine([[command&selected=true]])
         QString result = qsl("sendCmdLine([[%1]])").arg(command);
+#if defined(DEBUG_OSC_PROCESSING)
         qDebug() << "Modified to:" << result;
+#endif
         return result;
     }
     

--- a/src/THyperlinkSelectionManager.cpp
+++ b/src/THyperlinkSelectionManager.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2025 by Mike Conley - https://github.com/mconley       *
+ *   Copyright (C) 2025 by Mike Conley - mike.conley@stickmud.com          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/THyperlinkSelectionManager.h
+++ b/src/THyperlinkSelectionManager.h
@@ -22,7 +22,6 @@
 
 #include <QHash>
 #include <QObject>
-#include <QPair>
 #include <QString>
 
 class TConsole;
@@ -33,6 +32,7 @@ class TConsole;
 class THyperlinkSelectionManager : public QObject
 {
     Q_OBJECT
+    Q_DISABLE_COPY(THyperlinkSelectionManager)
 
 public:
     explicit THyperlinkSelectionManager(TConsole* pConsole);
@@ -50,6 +50,16 @@ public:
 
     // URI modification before execution
     QString modifyUriForSelection(const QString& baseUri, bool isSelected) const;
+
+signals:
+    // Emitted when a selection state changes
+    void selectionChanged(const QString& group, const QString& value, bool selected);
+    
+    // Emitted when all selections in a group are cleared
+    void groupCleared(const QString& group);
+    
+    // Emitted when all selections across all groups are cleared
+    void allSelectionsCleared();
 
 private:
     TConsole* mpConsole;

--- a/src/THyperlinkSelectionManager.h
+++ b/src/THyperlinkSelectionManager.h
@@ -2,7 +2,7 @@
 #define MUDLET_THYPERLINKSELECTIONMANAGER_H
 
 /***************************************************************************
- *   Copyright (C) 2025 by Mike Conley - https://github.com/mconley       *
+ *   Copyright (C) 2025 by Mike Conley - mike.conley@stickmud.com          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/THyperlinkSelectionManager.h
+++ b/src/THyperlinkSelectionManager.h
@@ -1,0 +1,70 @@
+#ifndef MUDLET_THYPERLINKSELECTIONMANAGER_H
+#define MUDLET_THYPERLINKSELECTIONMANAGER_H
+
+/***************************************************************************
+ *   Copyright (C) 2025 by Mike Conley - https://github.com/mconley       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QHash>
+#include <QObject>
+#include <QPair>
+#include <QString>
+
+class TConsole;
+
+// Manages selection state for OSC 8 hyperlinks with selection support
+// Handles group exclusivity (radio button behavior) and multi-select (checkbox behavior)
+// Maintains per-console selection state and group membership tracking
+class THyperlinkSelectionManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit THyperlinkSelectionManager(TConsole* pConsole);
+    ~THyperlinkSelectionManager();
+
+    // Core selection operations
+    bool isSelected(const QString& group, const QString& value) const;
+    void setSelected(const QString& group, const QString& value, bool selected, bool exclusive);
+    void toggleSelection(const QString& group, const QString& value, bool exclusive);
+    
+    // Group management
+    QStringList getGroupMembers(const QString& group) const;
+    void clearGroup(const QString& group);
+    void clearAllSelections();
+
+    // URI modification before execution
+    QString modifyUriForSelection(const QString& baseUri, bool isSelected) const;
+
+private:
+    TConsole* mpConsole;
+    
+    // Selection state tracking: group -> (value -> selected)
+    QHash<QString, QHash<QString, bool>> mSelectionState;
+    
+    // Group membership tracking: group -> list of values
+    QHash<QString, QStringList> mGroupMembers;
+    
+    // Register a value in a group (called when link is created)
+    void registerGroupMember(const QString& group, const QString& value);
+    
+    // Handle exclusive selection (radio button: deselect others in group)
+    void handleExclusiveSelection(const QString& group, const QString& value);
+};
+
+#endif // MUDLET_THYPERLINKSELECTIONMANAGER_H

--- a/src/THyperlinkSelectionManager.h
+++ b/src/THyperlinkSelectionManager.h
@@ -23,6 +23,7 @@
 #include <QHash>
 #include <QObject>
 #include <QString>
+#include <QStringList>
 
 class TConsole;
 

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1425,68 +1425,65 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
                         qDebug() << "TTextEdit::mousePressEvent - Link clicked, func:" << func << "luaReference:" << luaReference;
 #endif
 
-                        // Set active state for CSS pseudo-class support
                         mpBuffer->setActiveLink(linkIndex);
-                        forceUpdate(); // Trigger re-render with active state
 
-                        // Handle hyperlink selection if selection settings are present
                         Mudlet::HyperlinkStyling hyperlinkStyling = mpBuffer->getEffectiveHyperlinkStyling(linkIndex);
                         if (hyperlinkStyling.selection.hasSelectionSettings) {
-                            // Check if link is disabled
                             if (hyperlinkStyling.selection.disabled) {
-                                // Don't execute disabled links, just set state and return
+                                // Disabled links only update visual state, don't execute
                                 mpBuffer->setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateDisabled);
                                 forceUpdate();
                                 return;
                             }
 
-                            const QString& group = hyperlinkStyling.selection.group;
-                            const QString& value = hyperlinkStyling.selection.value;
-                            bool currentlySelected = mpConsole->mpSelectionManager->isSelected(group, value);
-
-                            // Update selection state based on toggle and exclusive settings
-                            if (hyperlinkStyling.selection.toggle) {
-                                // Toggle mode: toggle selection state (works for both radio and checkbox)
-                                mpConsole->mpSelectionManager->toggleSelection(group, value, hyperlinkStyling.selection.exclusive);
+                            auto mgr = mpConsole ? mpConsole->mpSelectionManager : nullptr;
+                            if (!mgr) {
+                                qWarning() << "TTextEdit::mousePressEvent - Selection manager is null, skipping selection handling for link" << linkIndex;
                             } else {
-                                // Non-toggle mode: just set to selected
-                                mpConsole->mpSelectionManager->setSelected(group, value, true, hyperlinkStyling.selection.exclusive);
+                                const QString& group = hyperlinkStyling.selection.group;
+                                const QString& value = hyperlinkStyling.selection.value;
+                                bool currentlySelected = mgr->isSelected(group, value);
+
+                                if (hyperlinkStyling.selection.toggle) {
+                                    mgr->toggleSelection(group, value, hyperlinkStyling.selection.exclusive);
+                                } else {
+                                    mgr->setSelected(group, value, true, hyperlinkStyling.selection.exclusive);
+                                }
+
+                                bool newSelected = mgr->isSelected(group, value);
+
+                                if (hyperlinkStyling.selection.exclusive && newSelected) {
+                                    // Exclusive selection clears other group members
+                                    mpBuffer->clearGroupSelection(group, value);
+#if defined(DEBUG_OSC_PROCESSING)
+                                    qDebug() << "[OSC8] Exclusive selection: Cleared other selections in group" << group << "except" << value;
+#endif
+                                }
+
+                                func = mgr->modifyUriForSelection(func, newSelected);
+
+#if defined(DEBUG_OSC_PROCESSING)
+                                qDebug() << "TTextEdit::mousePressEvent - Setting link" << linkIndex << "selected=" << newSelected;
+#endif
+                                mpBuffer->setLinkSelected(linkIndex, newSelected);
+                                if (newSelected) {
+#if defined(DEBUG_OSC_PROCESSING)
+                                    qDebug() << "TTextEdit::mousePressEvent - Setting link" << linkIndex << "to StateSelected";
+#endif
+                                    mpBuffer->setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateSelected);
+                                } else {
+#if defined(DEBUG_OSC_PROCESSING)
+                                    qDebug() << "TTextEdit::mousePressEvent - Setting link" << linkIndex << "to StateDefault";
+#endif
+                                    mpBuffer->setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateDefault);
+                                }
                             }
-
-                            // Get updated selection state after selection manager operations
-                            bool newSelected = mpConsole->mpSelectionManager->isSelected(group, value);
-
-                            // Handle visual state updates for exclusive selection
-                            if (hyperlinkStyling.selection.exclusive && newSelected) {
-                                // Clear visual selection for other links in this group
-                                mpBuffer->clearGroupSelection(group, value);
-                                forceUpdate(); // Ensure visual updates are applied immediately
-#if defined(DEBUG_OSC_PROCESSING)
-                                qDebug() << "[OSC8] Exclusive selection: Cleared other selections in group" << group << "except" << value;
-#endif
-                            }
-
-                            // Modify URI to include selection state before execution
-                            func = mpConsole->mpSelectionManager->modifyUriForSelection(func, newSelected);
-
-                            // Update link visual state and selection tracking to reflect selection
-#if defined(DEBUG_OSC_PROCESSING)
-                            qDebug() << "TTextEdit::mousePressEvent - Setting link" << linkIndex << "selected=" << newSelected;
-#endif
-                            mpBuffer->setLinkSelected(linkIndex, newSelected);
-                            if (newSelected) {
-#if defined(DEBUG_OSC_PROCESSING)
-                                qDebug() << "TTextEdit::mousePressEvent - Setting link" << linkIndex << "to StateSelected";
-#endif
-                                mpBuffer->setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateSelected);
-                            } else {
-#if defined(DEBUG_OSC_PROCESSING)
-                                qDebug() << "TTextEdit::mousePressEvent - Setting link" << linkIndex << "to StateDefault";
-#endif
-                                mpBuffer->setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateDefault);
-                            }
-                            forceUpdate(); // Re-render with new selection state
                         }
+                        
+                        // Clear hover to show selection immediately; mouse move will restore it
+                        mpBuffer->setHoveredLink(0);
+                        
+                        forceUpdate();
 
                         if (!luaReference) {
                             mpHost->mLuaInterpreter.compileAndExecuteScript(func);

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1421,7 +1421,9 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
                     QString func;
                     if (!command.empty() && mpHost) {
                         func = command.at(0);
+#if defined(DEBUG_OSC_PROCESSING)
                         qDebug() << "TTextEdit::mousePressEvent - Link clicked, func:" << func << "luaReference:" << luaReference;
+#endif
 
                         // Set active state for CSS pseudo-class support
                         mpBuffer->setActiveLink(linkIndex);
@@ -1468,13 +1470,19 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
                             func = mpConsole->mpSelectionManager->modifyUriForSelection(func, newSelected);
 
                             // Update link visual state and selection tracking to reflect selection
+#if defined(DEBUG_OSC_PROCESSING)
                             qDebug() << "TTextEdit::mousePressEvent - Setting link" << linkIndex << "selected=" << newSelected;
+#endif
                             mpBuffer->setLinkSelected(linkIndex, newSelected);
                             if (newSelected) {
+#if defined(DEBUG_OSC_PROCESSING)
                                 qDebug() << "TTextEdit::mousePressEvent - Setting link" << linkIndex << "to StateSelected";
+#endif
                                 mpBuffer->setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateSelected);
                             } else {
+#if defined(DEBUG_OSC_PROCESSING)
                                 qDebug() << "TTextEdit::mousePressEvent - Setting link" << linkIndex << "to StateDefault";
+#endif
                                 mpBuffer->setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateDefault);
                             }
                             forceUpdate(); // Re-render with new selection state

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1954,9 +1954,9 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
                     QStringList command = mpBuffer->mLinkStore.getLinks(mpBuffer->buffer.at(static_cast<size_t>(y)).at(static_cast<size_t>(x)).linkIndex());
                     QStringList hint = mpBuffer->mLinkStore.getHints(mpBuffer->buffer.at(static_cast<size_t>(y)).at(static_cast<size_t>(x)).linkIndex());
                     QVector<int> luaReference = mpBuffer->mLinkStore.getReference(mpBuffer->buffer.at(static_cast<size_t>(y)).at(static_cast<size_t>(x)).linkIndex());
-                    if (command.size() > 1) {
+                    if (command.size() > 1 || hint.size() > command.size()) {
                         // This is a popup menu rather than a link as it has
-                        // more than one item.
+                        // more than one item, or has menu hints indicating menu items.
 
                         // Skip a special tooltip hint (at the start of the
                         // hints), if one was given, i.e. there is (at least)

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1422,6 +1422,48 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
                         mpBuffer->setActiveLink(linkIndex);
                         forceUpdate(); // Trigger re-render with active state
 
+                        // Handle hyperlink selection if selection settings are present
+                        Mudlet::HyperlinkStyling hyperlinkStyling = mpBuffer->getEffectiveHyperlinkStyling(linkIndex);
+                        if (hyperlinkStyling.selection.hasSelectionSettings) {
+                            // Check if link is disabled
+                            if (hyperlinkStyling.selection.disabled) {
+                                // Don't execute disabled links, just set state and return
+                                mpBuffer->setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateDisabled);
+                                forceUpdate();
+                                return;
+                            }
+
+                            const QString& group = hyperlinkStyling.selection.group;
+                            const QString& value = hyperlinkStyling.selection.value;
+                            bool currentlySelected = mpConsole->mpSelectionManager->isSelected(group, value);
+
+                            // Update selection state based on toggle and exclusive settings
+                            if (hyperlinkStyling.selection.exclusive) {
+                                // Radio button mode: always select this, deselect others in group
+                                mpConsole->mpSelectionManager->setSelected(group, value, true, hyperlinkStyling.selection.exclusive);
+                            } else if (hyperlinkStyling.selection.toggle) {
+                                // Checkbox mode: toggle selection state
+                                mpConsole->mpSelectionManager->toggleSelection(group, value, hyperlinkStyling.selection.exclusive);
+                            } else {
+                                // Non-toggle mode: just set to selected
+                                mpConsole->mpSelectionManager->setSelected(group, value, true, hyperlinkStyling.selection.exclusive);
+                            }
+
+                            // Get updated selection state
+                            bool newSelected = mpConsole->mpSelectionManager->isSelected(group, value);
+
+                            // Modify URI to include selection state before execution
+                            func = mpConsole->mpSelectionManager->modifyUriForSelection(func, newSelected);
+
+                            // Update link visual state to reflect selection
+                            if (newSelected) {
+                                mpBuffer->setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateSelected);
+                            } else {
+                                mpBuffer->setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateDefault);
+                            }
+                            forceUpdate(); // Re-render with new selection state
+                        }
+
                         if (!luaReference) {
                             mpHost->mLuaInterpreter.compileAndExecuteScript(func);
                         } else {

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1436,7 +1436,7 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
                                 return;
                             }
 
-                            auto mgr = mpConsole ? mpConsole->mpSelectionManager : nullptr;
+                            auto mgr = mpConsole ? mpConsole->mpSelectionManager.get() : nullptr;
                             if (!mgr) {
                                 qWarning() << "TTextEdit::mousePressEvent - Selection manager is null, skipping selection handling for link" << linkIndex;
                             } else {

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1237,9 +1237,13 @@ void TTextEdit::updateTextCursor(const QMouseEvent* event, int lineIndex, int tC
                 QToolTip::showText(event->globalPosition().toPoint(), tooltip.size() > commands.size() ? tooltip[0] : tooltip.join(QChar::LineFeed));
 
                 // Update hover state for CSS pseudo-class support
+                // Don't set hover state for disabled links - they should stay disabled
                 if (mpBuffer->getHoveredLink() != linkIndex) {
-                    mpBuffer->setHoveredLink(linkIndex);
-                    forceUpdate(); // Trigger re-render with new hover state
+                    auto currentState = mpBuffer->getLinkState(linkIndex);
+                    if (currentState != Mudlet::HyperlinkStyling::StateDisabled) {
+                        mpBuffer->setHoveredLink(linkIndex);
+                        forceUpdate(); // Trigger re-render with new hover state
+                    }
                 }
             } else {
                 setCursor(Qt::IBeamCursor);
@@ -1417,6 +1421,7 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
                     QString func;
                     if (!command.empty() && mpHost) {
                         func = command.at(0);
+                        qDebug() << "TTextEdit::mousePressEvent - Link clicked, func:" << func << "luaReference:" << luaReference;
 
                         // Set active state for CSS pseudo-class support
                         mpBuffer->setActiveLink(linkIndex);
@@ -1438,27 +1443,38 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
                             bool currentlySelected = mpConsole->mpSelectionManager->isSelected(group, value);
 
                             // Update selection state based on toggle and exclusive settings
-                            if (hyperlinkStyling.selection.exclusive) {
-                                // Radio button mode: always select this, deselect others in group
-                                mpConsole->mpSelectionManager->setSelected(group, value, true, hyperlinkStyling.selection.exclusive);
-                            } else if (hyperlinkStyling.selection.toggle) {
-                                // Checkbox mode: toggle selection state
+                            if (hyperlinkStyling.selection.toggle) {
+                                // Toggle mode: toggle selection state (works for both radio and checkbox)
                                 mpConsole->mpSelectionManager->toggleSelection(group, value, hyperlinkStyling.selection.exclusive);
                             } else {
                                 // Non-toggle mode: just set to selected
                                 mpConsole->mpSelectionManager->setSelected(group, value, true, hyperlinkStyling.selection.exclusive);
                             }
 
-                            // Get updated selection state
+                            // Get updated selection state after selection manager operations
                             bool newSelected = mpConsole->mpSelectionManager->isSelected(group, value);
+
+                            // Handle visual state updates for exclusive selection
+                            if (hyperlinkStyling.selection.exclusive && newSelected) {
+                                // Clear visual selection for other links in this group
+                                mpBuffer->clearGroupSelection(group, value);
+                                forceUpdate(); // Ensure visual updates are applied immediately
+#if defined(DEBUG_OSC_PROCESSING)
+                                qDebug() << "[OSC8] Exclusive selection: Cleared other selections in group" << group << "except" << value;
+#endif
+                            }
 
                             // Modify URI to include selection state before execution
                             func = mpConsole->mpSelectionManager->modifyUriForSelection(func, newSelected);
 
-                            // Update link visual state to reflect selection
+                            // Update link visual state and selection tracking to reflect selection
+                            qDebug() << "TTextEdit::mousePressEvent - Setting link" << linkIndex << "selected=" << newSelected;
+                            mpBuffer->setLinkSelected(linkIndex, newSelected);
                             if (newSelected) {
+                                qDebug() << "TTextEdit::mousePressEvent - Setting link" << linkIndex << "to StateSelected";
                                 mpBuffer->setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateSelected);
                             } else {
+                                qDebug() << "TTextEdit::mousePressEvent - Setting link" << linkIndex << "to StateDefault";
                                 mpBuffer->setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateDefault);
                             }
                             forceUpdate(); // Re-render with new selection state

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1238,9 +1238,11 @@ void TTextEdit::updateTextCursor(const QMouseEvent* event, int lineIndex, int tC
 
                 // Update hover state for CSS pseudo-class support
                 // Don't set hover state for disabled links - they should stay disabled
+                // Also don't set hover if this link was just clicked - wait for mouse to leave first
                 if (mpBuffer->getHoveredLink() != linkIndex) {
                     auto currentState = mpBuffer->getLinkState(linkIndex);
-                    if (currentState != Mudlet::HyperlinkStyling::StateDisabled) {
+                    if (currentState != Mudlet::HyperlinkStyling::StateDisabled 
+                        && linkIndex != mpBuffer->mLastClickedLinkIndex) {
                         mpBuffer->setHoveredLink(linkIndex);
                         forceUpdate(); // Trigger re-render with new hover state
                     }
@@ -1253,6 +1255,11 @@ void TTextEdit::updateTextCursor(const QMouseEvent* event, int lineIndex, int tC
                 if (mpBuffer->getHoveredLink() != 0) {
                     mpBuffer->setHoveredLink(0);
                     forceUpdate(); // Trigger re-render
+                }
+                
+                // Clear last clicked link when mouse leaves - allows hover to work again
+                if (mpBuffer->mLastClickedLinkIndex != 0) {
+                    mpBuffer->mLastClickedLinkIndex = 0;
                 }
             }
         }
@@ -1477,11 +1484,15 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
 #endif
                                     mpBuffer->setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateDefault);
                                 }
+                                mpBuffer->updateLinkCharacters(linkIndex);
                             }
                         }
                         
                         // Clear hover to show selection immediately; mouse move will restore it
                         mpBuffer->setHoveredLink(0);
+                        
+                        // Remember this link was just clicked - suppress hover until mouse leaves
+                        mpBuffer->mLastClickedLinkIndex = linkIndex;
                         
                         forceUpdate();
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -4649,7 +4649,10 @@ void cTelnet::processSocketData(char* in_buffer, int amount, const bool loopback
         return;
     }
 
-    std::string cleandata = "";
+    std::string cleandata;
+    // Pre-allocate for worst case: decompressed data can be much larger than input
+    // BUFFER_SIZE is 100000, so reserve enough for typical usage
+    cleandata.reserve(static_cast<size_t>(BUFFER_SIZE) * 4);
     qint32 datalen = 0;
     do {
         datalen = amount;
@@ -4831,7 +4834,11 @@ Some data loss is likely - please mention this problem to the game admins.)", co
                 }
             }
         } //for
-    } while (datalen == BUFFER_SIZE);
+        // BUG FIX: The original do-while condition `datalen == BUFFER_SIZE` caused an infinite
+        // loop when exactly BUFFER_SIZE bytes were read from the socket. The loop body never
+        // reads new data - `amount` is fixed for this function call. Qt's signal/slot mechanism
+        // will call slot_socketReadyToBeRead() again when more socket data is available.
+    } while (false); // Single iteration - loop preserved for minimal code diff
 
     if (!cleandata.empty()) {
         gotRest(cleandata);

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -4642,9 +4642,11 @@ void cTelnet::processSocketData(char* in_buffer, int amount, const bool loopback
     char out_buffer[BUFFER_SIZE + 10];
 
     in_buffer[amount + 1] = '\0';
+
     if (amount == -1) {
         return;
     }
+
     if (amount == 0) {
         return;
     }
@@ -4654,198 +4656,205 @@ void cTelnet::processSocketData(char* in_buffer, int amount, const bool loopback
     // BUFFER_SIZE is 100000, so reserve enough for typical usage
     cleandata.reserve(static_cast<size_t>(BUFFER_SIZE) * 4);
     qint32 datalen = 0;
-    do {
-        datalen = amount;
-        char* buffer = in_buffer;
-        if (mNeedDecompression) {
-            datalen = decompressBuffer(in_buffer, amount, out_buffer);
-            buffer = out_buffer;
-        }
-        // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (4 of 7) - investigate switching from using `char[]` to `std::array<char>`
-        buffer[static_cast<size_t>(datalen)] = '\0';
-        if (!loopbackTesting && mpHost && mpHost->mpConsole && mpHost->mpConsole->mRecordReplay) {
-            ++mRecordingChunkCount;
-            // QElapsedTimer::elapsed() returns a qint64, it replaces a
-            // previous QTime::elapsed() which returns a int (effectively a
-            // qint32):
-            qint32 recordingChunkInterval = static_cast<qint32>(mRecordingChunkTimer.elapsed()) - mRecordLastChunkMSecTimeOffset;
-            mpHost->mpConsole->mReplayStream << recordingChunkInterval; // 4 bytes
-            mpHost->mpConsole->mReplayStream << datalen;                // 4 bytes
-            mpHost->mpConsole->mReplayStream.writeRawData(buffer, datalen);
+    datalen = amount;
+    char* buffer = in_buffer;
+
+    if (mNeedDecompression) {
+        datalen = decompressBuffer(in_buffer, amount, out_buffer);
+        buffer = out_buffer;
+    }
+    // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (4 of 7) - investigate switching from using `char[]` to `std::array<char>`
+    buffer[static_cast<size_t>(datalen)] = '\0';
+
+    if (!loopbackTesting && mpHost && mpHost->mpConsole && mpHost->mpConsole->mRecordReplay) {
+        ++mRecordingChunkCount;
+        // QElapsedTimer::elapsed() returns a qint64, it replaces a
+        // previous QTime::elapsed() which returns a int (effectively a
+        // qint32):
+        qint32 recordingChunkInterval = static_cast<qint32>(mRecordingChunkTimer.elapsed()) - mRecordLastChunkMSecTimeOffset;
+        mpHost->mpConsole->mReplayStream << recordingChunkInterval; // 4 bytes
+        mpHost->mpConsole->mReplayStream << datalen;                // 4 bytes
+        mpHost->mpConsole->mReplayStream.writeRawData(buffer, datalen);
 #if defined(DEBUG_RECORDING)
-            qDebug().noquote().nospace() << "cTelnet::processSocketData(...) INFO - recording chunk: " << mRecordingChunkCount << " is " << datalen
-                                         << " bytes and has an interval of: " << recordingChunkInterval << " mSecond since the previous chunk.";
+        qDebug().noquote().nospace() << "cTelnet::processSocketData(...) INFO - recording chunk: " << mRecordingChunkCount << " is " << datalen
+                                        << " bytes and has an interval of: " << recordingChunkInterval << " mSecond since the previous chunk.";
 #endif
-        }
+    }
 
-        recvdGA = false;
-        for (int i = 0; i < datalen; ++i) {
-            char ch = buffer[i];
+    recvdGA = false;
 
-            if (iac || iac2 || insb || (ch == TN_IAC)) {
-                if (!(iac || iac2 || insb) && (ch == TN_IAC)) {
-                    iac = true;
-                    command += ch;
-                } else if (iac && (ch == TN_IAC) && (!insb)) {
-                    //2. seq. of two IACs
-                    iac = false;
-                    cleandata += ch;
-                    command = "";
-                } else if (iac && (!insb) && ((ch == TN_WILL) || (ch == TN_WONT) || (ch == TN_DO) || (ch == TN_DONT))) {
-                    //3. IAC DO/DONT/WILL/WONT
-                    iac = false;
-                    iac2 = true;
-                    command += ch;
-                } else if (iac2) {
-                    //4. IAC DO/DONT/WILL/WONT <command code>
-                    iac2 = false;
-                    command += ch;
-                    processTelnetCommand(command);
-                    command = "";
-                } else if (iac && (!insb) && (ch == TN_SB)) {
-                    //5. IAC SB
-                    iac = false;
-                    insb = true;
-                    command += ch;
-                } else if (iac && (!insb) && (ch == TN_SE)) {
-                    //6. IAC SE without IAC SB - error - ignored
-                    command = "";
-                    iac = false;
-                } else if (insb) {
-                    // IAC SB COMPRESS WILL SE for MCCP v1 (unterminated invalid telnet sequence)
-                    // IAC SB COMPRESS2 IAC SE for MCCP v2
-                    if ((mMCCP_version_1 || mMCCP_version_2) && (!mNeedDecompression)) {
-                        // TODO this code looks ahead instead of using the state machine.
-                        // This is not a good idea.
-                        char _ch = buffer[i];
-                        if ((_ch == OPT_COMPRESS) || (_ch == OPT_COMPRESS2)) {
-                            bool _compress = false;
-                            if ((i > 1) && (i + 2 < datalen)) {
-                                if ((buffer[i - 2] == TN_IAC) && (buffer[i - 1] == TN_SB) && (buffer[i + 1] == TN_WILL) && (buffer[i + 2] == TN_SE)) {
-                                    qDebug() << "MCCP version 1 starting sequence";
-                                    _compress = true;
-                                }
-                                if ((buffer[i - 2] == TN_IAC) && (buffer[i - 1] == TN_SB) && (buffer[i + 1] == TN_IAC) && (buffer[i + 2] == TN_SE)) {
-                                    qDebug() << "MCCP version 2 starting sequence";
-                                    _compress = true;
-                                }
+    for (int i = 0; i < datalen; ++i) {
+        char ch = buffer[i];
+
+        if (iac || iac2 || insb || (ch == TN_IAC)) {
+            if (!(iac || iac2 || insb) && (ch == TN_IAC)) {
+                iac = true;
+                command += ch;
+            } else if (iac && (ch == TN_IAC) && (!insb)) {
+                //2. seq. of two IACs
+                iac = false;
+                cleandata += ch;
+                command = "";
+            } else if (iac && (!insb) && ((ch == TN_WILL) || (ch == TN_WONT) || (ch == TN_DO) || (ch == TN_DONT))) {
+                //3. IAC DO/DONT/WILL/WONT
+                iac = false;
+                iac2 = true;
+                command += ch;
+            } else if (iac2) {
+                //4. IAC DO/DONT/WILL/WONT <command code>
+                iac2 = false;
+                command += ch;
+                processTelnetCommand(command);
+                command = "";
+            } else if (iac && (!insb) && (ch == TN_SB)) {
+                //5. IAC SB
+                iac = false;
+                insb = true;
+                command += ch;
+            } else if (iac && (!insb) && (ch == TN_SE)) {
+                //6. IAC SE without IAC SB - error - ignored
+                command = "";
+                iac = false;
+            } else if (insb) {
+                // IAC SB COMPRESS WILL SE for MCCP v1 (unterminated invalid telnet sequence)
+                // IAC SB COMPRESS2 IAC SE for MCCP v2
+                if ((mMCCP_version_1 || mMCCP_version_2) && (!mNeedDecompression)) {
+                    // TODO this code looks ahead instead of using the state machine.
+                    // This is not a good idea.
+                    char _ch = buffer[i];
+                    if ((_ch == OPT_COMPRESS) || (_ch == OPT_COMPRESS2)) {
+                        bool _compress = false;
+
+                        if ((i > 1) && (i + 2 < datalen)) {
+                            if ((buffer[i - 2] == TN_IAC) && (buffer[i - 1] == TN_SB) && (buffer[i + 1] == TN_WILL) && (buffer[i + 2] == TN_SE)) {
+                                qDebug() << "MCCP version 1 starting sequence";
+                                _compress = true;
                             }
-                            if (_compress) {
-                                mNeedDecompression = true;
-                                // from this position in stream onwards, data will be compressed by zlib
-                                gotRest(cleandata);
-                                cleandata = "";
-                                initStreamDecompressor();
-                                buffer += i + 3; //bugfix: BenH
-                                int restLength = datalen - i - 3;
-                                if (restLength > 0) {
-                                    datalen = decompressBuffer(buffer, restLength, out_buffer);
-                                    buffer = out_buffer;
-                                    i = -1; // start processing buffer from the beginning.
-                                } else {
-                                    datalen = 0;
-                                    i = -1; // end the loop, this will make i and datalen the same.
-                                }
-                                // compressed data starts in clean state
-                                iac = false;
-                                insb = false;
-                                command = "";
-                                goto MAIN_LOOP_END;
+
+                            if ((buffer[i - 2] == TN_IAC) && (buffer[i - 1] == TN_SB) && (buffer[i + 1] == TN_IAC) && (buffer[i + 2] == TN_SE)) {
+                                qDebug() << "MCCP version 2 starting sequence";
+                                _compress = true;
                             }
                         }
-                    }
-                    //7. inside IAC SB
 
-                    command += ch;
-                    if (iac && (ch == TN_SE)) { //IAC SE - end of subcommand
-                        processTelnetCommand(command);
-                        command = "";
-                        iac = false;
-                        insb = false;
-                    } else if (iac && (ch == TN_IAC)) { // escaped TN_IAC
-                        command.pop_back();
-                        iac = false;
-                    } else if (iac) {
-                        // Telnet options within a subcommand are not supported.
-                        // We assume that the SE went missing, possibly due to a
-                        // server bug, and try to recover.
-                        // Cf. https://github.com/Mudlet/Mudlet/issues/4385
-                        command.pop_back();
-                        command += TN_SE;
-                        processTelnetCommand(command);
-                        if (!mIncompleteSB) {
-                            mIncompleteSB = true;
-                            qWarning(R"("TELNET: the server did not properly complete a subnegotiation (code %02x).
+                        if (_compress) {
+                            mNeedDecompression = true;
+                            // from this position in stream onwards, data will be compressed by zlib
+                            gotRest(cleandata);
+                            cleandata = "";
+                            initStreamDecompressor();
+                            buffer += i + 3; //bugfix: BenH
+                            int restLength = datalen - i - 3;
+
+                            if (restLength > 0) {
+                                datalen = decompressBuffer(buffer, restLength, out_buffer);
+                                buffer = out_buffer;
+                                i = -1; // start processing buffer from the beginning.
+                            } else {
+                                datalen = 0;
+                                i = -1; // end the loop, this will make i and datalen the same.
+                            }
+                            // compressed data starts in clean state
+                            iac = false;
+                            insb = false;
+                            command = "";
+                            goto MAIN_LOOP_END;
+                        }
+                    }
+                }
+
+                //7. inside IAC SB
+                command += ch;
+
+                if (iac && (ch == TN_SE)) { //IAC SE - end of subcommand
+                    processTelnetCommand(command);
+                    command = "";
+                    iac = false;
+                    insb = false;
+                } else if (iac && (ch == TN_IAC)) { // escaped TN_IAC
+                    command.pop_back();
+                    iac = false;
+                } else if (iac) {
+                    // Telnet options within a subcommand are not supported.
+                    // We assume that the SE went missing, possibly due to a
+                    // server bug, and try to recover.
+                    // Cf. https://github.com/Mudlet/Mudlet/issues/4385
+                    command.pop_back();
+                    command += TN_SE;
+                    processTelnetCommand(command);
+
+                    if (!mIncompleteSB) {
+                        mIncompleteSB = true;
+                        qWarning(R"("TELNET: the server did not properly complete a subnegotiation (code %02x).
 Some data loss is likely - please mention this problem to the game admins.)", command[2]);
-                        }
-
-
-                        // Re-enter the state machine.
-                        command = TN_IAC;
-                        iac = true;
-                        insb = false;
-                        i -= 1;
-                    } else if (ch == TN_IAC) {
-                        iac = true;
                     }
-                } else
-                //8. IAC fol. by something else than IAC, SB, SE, DO, DONT, WILL, WONT
-                {
-                    iac = false;
-                    command += ch;
-                    processTelnetCommand(command);
-                    //this could have set receivedGA to true; we'll handle that later
-                    command = "";
+
+                    // Re-enter the state machine.
+                    command = TN_IAC;
+                    iac = true;
+                    insb = false;
+                    i -= 1;
+                } else if (ch == TN_IAC) {
+                    iac = true;
                 }
             } else {
-                if (ch == TN_BELL) {
-                    // Flash taskbar for 3 seconds on the telnet bell, note
-                    // by processing it here rather than in the TTextEdit class
-                    // it is not possible to fake/test it with a Lua
-                    // feedTriggers(...) call - OTOH doing it there would make
-                    // a beep every time the screen was refreshed!
-                    // TODO: https://github.com/Mudlet/Mudlet/issues/5836 - provide option to actually make a (void) QApplication::beep() or a user-selected sound (different for each profile) and/or instead of the visual alert
-                    QApplication::alert(mudlet::self(), 3000);
-                    if (!mudlet::self()->muteGame()) {
-                        QApplication::beep();
-                    }
-                }
-                if (ch != '\r' && ch != '\0') {
-                    cleandata += ch;
+                //8. IAC fol. by something else than IAC, SB, SE, DO, DONT, WILL, WONT
+                iac = false;
+                command += ch;
+                processTelnetCommand(command);
+                //this could have set receivedGA to true; we'll handle that later
+                command = "";
+            }
+        } else {
+            if (ch == TN_BELL) {
+                // Flash taskbar for 3 seconds on the telnet bell, note
+                // by processing it here rather than in the TTextEdit class
+                // it is not possible to fake/test it with a Lua
+                // feedTriggers(...) call - OTOH doing it there would make
+                // a beep every time the screen was refreshed!
+                // TODO: https://github.com/Mudlet/Mudlet/issues/5836 - provide option to actually make a (void) QApplication::beep() or a user-selected sound (different for each profile) and/or instead of the visual alert
+                QApplication::alert(mudlet::self(), 3000);
+
+                if (!mudlet::self()->muteGame()) {
+                    QApplication::beep();
                 }
             }
-        MAIN_LOOP_END:;
-            if (recvdGA) {
-                if (!mFORCE_GA_OFF) //FIXME: isn't initialized correctly
-                {
-                    mGA_Driver = true;
-                    if (mCommands > 0) {
-                        mCommands--;
-                        if (networkLatencyTimer.elapsed() > 2000) {
-                            mCommands = 0;
-                        }
-                    }
-                    cleandata.push_back('\xff');
-                    recvdGA = false;
-                    gotPrompt(cleandata);
-                    cleandata = "";
-                } else {
-                    cleandata.push_back('\n');
-                }
+
+            if (ch != '\r' && ch != '\0') {
+                cleandata += ch;
             }
-        } //for
-        // BUG FIX: The original do-while condition `datalen == BUFFER_SIZE` caused an infinite
-        // loop when exactly BUFFER_SIZE bytes were read from the socket. The loop body never
-        // reads new data - `amount` is fixed for this function call. Qt's signal/slot mechanism
-        // will call slot_socketReadyToBeRead() again when more socket data is available.
-    } while (false); // Single iteration - loop preserved for minimal code diff
+        }
+    MAIN_LOOP_END:;
+        if (recvdGA) {
+            if (!mFORCE_GA_OFF) { //FIXME: isn't initialized correctly
+                mGA_Driver = true;
+
+                if (mCommands > 0) {
+                    mCommands--;
+
+                    if (networkLatencyTimer.elapsed() > 2000) {
+                        mCommands = 0;
+                    }
+                }
+
+                cleandata.push_back('\xff');
+                recvdGA = false;
+                gotPrompt(cleandata);
+                cleandata = "";
+            } else {
+                cleandata.push_back('\n');
+            }
+        }
+    } //for
 
     if (!cleandata.empty()) {
         gotRest(cleandata);
     }
+
     if (mpHost && mpHost->mpConsole) {
         mpHost->mpConsole->finalize();
     }
+
     mRecordLastChunkMSecTimeOffset = mRecordingChunkTimer.elapsed();
 }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1822,6 +1822,11 @@ QString cTelnet::getNewEnvironOSCHyperlinksCompact()
     return qsl("1");
 }
 
+QString cTelnet::getNewEnvironOSCHyperlinksPresets()
+{
+    return qsl("1");
+}
+
 QString cTelnet::getNewEnvironScreenReader()
 {
     return mpHost->mAdvertiseScreenReader ? qsl("1") : qsl("0");
@@ -1888,6 +1893,7 @@ QMap<QString, QPair<bool, QString>> cTelnet::getNewEnvironDataMap()
     newEnvironDataMap.insert(qsl("OSC_HYPERLINKS_TOOLTIP"), qMakePair(isUserVar, getNewEnvironOSCHyperlinksTooltip()));
     newEnvironDataMap.insert(qsl("OSC_HYPERLINKS_MENU"), qMakePair(isUserVar, getNewEnvironOSCHyperlinksMenu()));
     newEnvironDataMap.insert(qsl("OSC_HYPERLINKS_COMPACT"), qMakePair(isUserVar, getNewEnvironOSCHyperlinksCompact()));
+    newEnvironDataMap.insert(qsl("OSC_HYPERLINKS_PRESETS"), qMakePair(isUserVar, getNewEnvironOSCHyperlinksPresets()));
     newEnvironDataMap.insert(qsl("SCREEN_READER"), qMakePair(isUserVar, getNewEnvironScreenReader()));
     newEnvironDataMap.insert(qsl("TRUECOLOR"), qMakePair(isUserVar, getNewEnvironTruecolor()));
     newEnvironDataMap.insert(qsl("TLS"), qMakePair(isUserVar, getNewEnvironTLS()));

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1817,6 +1817,11 @@ QString cTelnet::getNewEnvironOSCHyperlinksMenu()
     return qsl("1");
 }
 
+QString cTelnet::getNewEnvironOSCHyperlinksCompact()
+{
+    return qsl("1");
+}
+
 QString cTelnet::getNewEnvironScreenReader()
 {
     return mpHost->mAdvertiseScreenReader ? qsl("1") : qsl("0");
@@ -1882,6 +1887,7 @@ QMap<QString, QPair<bool, QString>> cTelnet::getNewEnvironDataMap()
     newEnvironDataMap.insert(qsl("OSC_HYPERLINKS_STYLE_STATES"), qMakePair(isUserVar, getNewEnvironOSCHyperlinksStyleStates()));
     newEnvironDataMap.insert(qsl("OSC_HYPERLINKS_TOOLTIP"), qMakePair(isUserVar, getNewEnvironOSCHyperlinksTooltip()));
     newEnvironDataMap.insert(qsl("OSC_HYPERLINKS_MENU"), qMakePair(isUserVar, getNewEnvironOSCHyperlinksMenu()));
+    newEnvironDataMap.insert(qsl("OSC_HYPERLINKS_COMPACT"), qMakePair(isUserVar, getNewEnvironOSCHyperlinksCompact()));
     newEnvironDataMap.insert(qsl("SCREEN_READER"), qMakePair(isUserVar, getNewEnvironScreenReader()));
     newEnvironDataMap.insert(qsl("TRUECOLOR"), qMakePair(isUserVar, getNewEnvironTruecolor()));
     newEnvironDataMap.insert(qsl("TLS"), qMakePair(isUserVar, getNewEnvironTLS()));

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -308,6 +308,7 @@ private:
     QString getNewEnvironOSCHyperlinksTooltip();
     QString getNewEnvironOSCHyperlinksMenu();
     QString getNewEnvironOSCHyperlinksCompact();
+    QString getNewEnvironOSCHyperlinksPresets();
     QString getNewEnvironScreenReader();
     QString getNewEnvironTruecolor();
     QString getNewEnvironTLS();

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -307,6 +307,7 @@ private:
     QString getNewEnvironOSCHyperlinksStyleStates();
     QString getNewEnvironOSCHyperlinksTooltip();
     QString getNewEnvironOSCHyperlinksMenu();
+    QString getNewEnvironOSCHyperlinksCompact();
     QString getNewEnvironScreenReader();
     QString getNewEnvironTruecolor();
     QString getNewEnvironTLS();

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -768,6 +768,7 @@ SOURCES += \
     TEntityResolver.cpp \
     TFlipButton.cpp \
     TForkedProcess.cpp \
+    THyperlinkCompactManager.cpp \
     THyperlinkSelectionManager.cpp \
     TimerUnit.cpp \
     TKey.cpp \
@@ -931,6 +932,7 @@ HEADERS += \
     TFlipButton.h \
     TForkedProcess.h \
     TGameDetails.h \
+    THyperlinkCompactManager.h \
     THyperlinkSelectionManager.h \
     TimerUnit.h \
     TKey.h \

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -768,6 +768,7 @@ SOURCES += \
     TEntityResolver.cpp \
     TFlipButton.cpp \
     TForkedProcess.cpp \
+    THyperlinkSelectionManager.cpp \
     TimerUnit.cpp \
     TKey.cpp \
     TLabel.cpp \
@@ -930,6 +931,7 @@ HEADERS += \
     TFlipButton.h \
     TForkedProcess.h \
     TGameDetails.h \
+    THyperlinkSelectionManager.h \
     TimerUnit.h \
     TKey.h \
     TLabel.h \


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This PR enhances OSC 8 hyperlink selection functionality with improved selection behaviors and visual styling.

**New features:**

**Radio Button Mode (Exclusive Selection)**: Links within a group allow only one selection at a time. When one link is selected, all others in the same group are automatically deselected. Perfect for mutually exclusive choices like difficulty levels or character classes.

**Multi-select Checkbox Mode**: Checkbox-style hyperlinks support multiple simultaneous selections within a group. Users can toggle individual options on/off independently. Ideal for enabling multiple character buffs, settings, or features.

**Enhanced Disabled Link Styling**: Disabled links consistently display with strikethrough text and muted colors, providing clear visual feedback that the option is unavailable or locked.

**Robust State Management**: Link states (selected, disabled, hover) maintain proper visual feedback during all mouse interactions, ensuring consistent user experience.

**JSON Configuration Example**:
```json
config={
  "tooltip": "Choose the Warrior class",
  "style": {
    "color": "#ffaa00",
    "background": "#2a2a2a"
  },
  "selection": {
    "group": "character-class",
    "exclusive": true,
    "selected": {
      "color": "#ffffff",
      "background": "#0066cc"
    },
    "disabled": {
      "color": "#666666",
      "strikethrough": true
    }
  }
}
```

Documentation: https://wiki.mudlet.org/w/Area_51#Hyperlink_Selection.2C_PR_.238650

#### Motivation for adding to Mudlet

OSC 8 hyperlinks with selection behaviors enable rich, interactive user interfaces within MUD games. Radio button functionality provides intuitive single-choice selection (character class, difficulty mode), while checkbox mode enables multi-option scenarios (equipment upgrades, spell preparations). Enhanced disabled styling ensures players understand when options are unavailable due to level requirements, quest prerequisites, or other game conditions.

#### Other info (issues closed, discussion etc)

- Full backward compatibility with existing OSC 8 hyperlink functionality
- No breaking changes to the hyperlink API
- Supports both exclusive (radio button) and non-exclusive (checkbox) selection modes via `"exclusive": true/false`
- Maintains consistent visual styling across all supported platforms
- Selection state persists during hover and other mouse interactions

---

https://github.com/user-attachments/assets/291dbd2f-cda3-4cea-acba-6c059a395247

<img width="613" height="247" alt="Screenshot 2025-12-18 at 7 12 26 AM" src="https://github.com/user-attachments/assets/0f699f23-c352-4834-a867-e34642a2d424" />
