### PR TITLE
Infrastructure: Ignore lcf submodule in Dependabot, remove vcpkg

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,8 @@ updates:
       interval: "weekly"
       day: "friday"
     ignore:
-      # ignore vcpkg as it is updated often, and this goes off commits, not releases
-      - dependency-name: "3rdparty/vcpkg"
+      # ignore lcf as we track a specific branch (5.1-syntax_5.1), not master
+      # the update-3rdparty.yml workflow handles this correctly
+      - dependency-name: "3rdparty/lcf"
     commit-message:
       prefix: "Infrastructure:"


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Ignore lcf submodule in Dependabot, remove vcpkg
#### Motivation for adding to Mudlet
lcf is now archived and we also don't use the `master` branch, which depenadabot tried to get us to use.

vcpkg is no longer in use.
#### Other info (issues closed, discussion etc)
