### PR TITLE
Fix: Prevent crashpad_handler from getting a Windows Start Menu entry

### DIFF
--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -172,6 +172,11 @@ else
 
   echo "Renaming mudlet.exe to ${PACKAGE_EXE}"
   mv "${PACKAGE_PATH}/mudlet.exe" "${PACKAGE_PATH}/${PACKAGE_EXE}"
+
+  # Create squirrel sidecar file to mark only the main exe for Start Menu shortcut
+  # This prevents crashpad_handler.exe from getting its own Start Menu entry
+  echo "1" > "${PACKAGE_PATH}/${PACKAGE_EXE}.squirrel"
+
   PACKAGE_EXE_PATHFILE="$(cygpath -au "${PACKAGE_PATH}/${PACKAGE_EXE}")"
   PACKAGE_EXE_WINPATHFILE="$(cygpath -aw "${PACKAGE_EXE_PATHFILE}")"
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Prevent crashpad_handler from getting a Windows Start Menu entry
#### Motivation for adding to Mudlet
Bugfix, it should not have one.
#### Other info (issues closed, discussion etc)
