### PR TITLE
Infrastructure: Replace foreach with C++17 structured bindings

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -951,8 +951,7 @@ void TCommandLine::mousePressEvent(QMouseEvent* event)
         }
 
         popup->addSeparator();
-        foreach(auto label, contextMenuItems.keys()) {
-            auto eventName = contextMenuItems.value(label);
+        for (const auto& [label, eventName] : contextMenuItems.asKeyValueRange()) {
             auto action = new QAction(label, this);
             connect(action, &QAction::triggered, this, [=, this]() {
                 TEvent mudletEvent = {};


### PR DESCRIPTION

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Use Qt6's asKeyValueRange() with structured bindings for cleaner, more efficient iteration over the context menu items map.
#### Motivation for adding to Mudlet
This eliminates the deprecated Qt foreach macro and avoids the inefficiency of calling .keys() followed by .value() lookups.
#### Other info (issues closed, discussion etc)
