### PR TITLE
Fix: Handle Squirrel installer startup commands on Windows to prevent Mudlet getting closed

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -162,11 +162,6 @@ int main(int argc, char* argv[])
 {
     initializeQRCResources();
 
-    #ifdef WITH_SENTRY
-        initSentry();
-        auto sentryClose = qScopeGuard([] { sentry_close(); });
-    #endif
-
 #ifdef Q_OS_WINDOWS
     // Handle Squirrel installer commands - must exit quickly for install/update/uninstall
     // https://github.com/clowd/Clowd.Squirrel/blob/master/docs/using/custom-squirrel-events-non-cs.md
@@ -176,7 +171,14 @@ int main(int argc, char* argv[])
             return 0;
         }
     }
+#endif
 
+    #ifdef WITH_SENTRY
+        initSentry();
+        auto sentryClose = qScopeGuard([] { sentry_close(); });
+    #endif
+
+#ifdef Q_OS_WINDOWS
     if (AttachConsole(ATTACH_PARENT_PROCESS)) {
         if (qgetenv("MSYSTEM").isNull()) {
             // print stdout to console if Mudlet is started in a console in Windows

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -168,6 +168,15 @@ int main(int argc, char* argv[])
     #endif
 
 #ifdef Q_OS_WINDOWS
+    // Handle Squirrel installer commands - must exit quickly for install/update/uninstall
+    // https://github.com/clowd/Clowd.Squirrel/blob/master/docs/using/custom-squirrel-events-non-cs.md
+    for (int i = 1; i < argc; ++i) {
+        const QString arg = QString::fromLocal8Bit(argv[i]);
+        if (arg.startsWith(qsl("--squirrel-")) && arg != qsl("--squirrel-firstrun")) {
+            return 0;
+        }
+    }
+
     if (AttachConsole(ATTACH_PARENT_PROCESS)) {
         if (qgetenv("MSYSTEM").isNull()) {
             // print stdout to console if Mudlet is started in a console in Windows


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Handle Squirrel installer startup commands on Windows to prevent Mudlet getting closed
#### Motivation for adding to Mudlet
https://discord.com/channels/283581582550237184/283582439002210305/1452185255644758079
#### Other info (issues closed, discussion etc)
Came about as a result of https://github.com/Mudlet/Mudlet/commit/a4d9c98be0ce781f046594097ddbc984793a59a9