### PR TITLE
Infrastructure: allow Windows PTB builds to be re-done on the same day

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -145,6 +145,7 @@ jobs:
         GITHUB_REPO_NAME: ${{ github.repository }}
         GITHUB_REPO_TAG: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
         GITHUB_SCHEDULED_BUILD: ${{ github.event_name == 'schedule' || github.event.inputs.scheduled == 'true' }}
+        GITHUB_FORCE_BUILD: ${{ github.event.inputs.scheduled == 'true' }}
         GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         GITHUB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: $GITHUB_WORKSPACE/CI/deploy-mudlet-for-windows.sh

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -338,6 +338,7 @@ jobs:
         APPLE_PASSWORD: ${{secrets.APPLE_PASSWORD}}
         APPLE_TEAM_ID: ${{secrets.APPLE_TEAM_ID}}
         WITH_SENTRY: "ON"
+        GITHUB_FORCE_BUILD: ${{ github.event.inputs.scheduled == 'true' }}
 
     - name: Upload packaged Mudlet
       uses: actions/upload-artifact@v6

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -21,7 +21,8 @@
 
 set -x
 
-# Version: 2.2.0    Skip commit date check when build is manually forced
+# Version: 2.3.0    Add build counter suffix for multiple builds from same commit
+#          2.2.0    Skip commit date check when build is manually forced
 #          2.1.0    Remove MINGW32 since upstream no longer supports it
 #          2.0.0    Rework to build on an MSYS2 MINGW64 Github workflow
 
@@ -100,6 +101,34 @@ if [[ ${VERSION_LINE} =~ ${VERSION_REGEX} ]]; then
   VERSION="${BASH_REMATCH[1]}"
 fi
 
+# For PTB builds, check if we need a build counter suffix
+# This allows multiple builds from the same commit
+BUILD_COUNTER_SUFFIX=""
+if [[ "${MUDLET_VERSION_BUILD}" == -ptb* ]] && [[ -n "${BUILD_COMMIT}" ]]; then
+  # Query the dblsqd feed for existing versions with this commit
+  EXISTING_VERSIONS=$(curl --silent "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/win/x86_64" | \
+    jq --raw-output ".releases[].version" | \
+    grep -E "${BUILD_COMMIT}(\.[0-9]+)?$" || true)
+
+  if [[ -n "${EXISTING_VERSIONS}" ]]; then
+    # Count existing versions and find the highest build number
+    HIGHEST_BUILD=1
+    while IFS= read -r ver; do
+      if [[ "${ver}" =~ \.([0-9]+)$ ]]; then
+        NUM="${BASH_REMATCH[1]}"
+        if [[ "${NUM}" -gt "${HIGHEST_BUILD}" ]]; then
+          HIGHEST_BUILD="${NUM}"
+        fi
+      fi
+    done <<< "${EXISTING_VERSIONS}"
+
+    # Next build number
+    NEXT_BUILD=$((HIGHEST_BUILD + 1))
+    BUILD_COUNTER_SUFFIX=".${NEXT_BUILD}"
+    echo "=== Found existing PTB builds for commit ${BUILD_COMMIT}, using build counter: ${NEXT_BUILD} ==="
+  fi
+fi
+
 # Check if MUDLET_VERSION_BUILD is empty and print accordingly
 if [[ -z "${MUDLET_VERSION_BUILD}" ]]; then
   # Probably a release build - so typical output could be:
@@ -109,7 +138,8 @@ else
   # Include Git SHA1 in the build information
   # Probably a PTB - so typical output could be:
   #    "BUILDING MUDLET 4.19.1-ptb-2025-01-01-012345678
-  echo "BUILDING MUDLET ${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}"
+  # Or with build counter: "BUILDING MUDLET 4.19.1-ptb-2025-01-01-012345678.2
+  echo "BUILDING MUDLET ${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}${BUILD_COUNTER_SUFFIX}"
 fi
 
 # Check if we're building from the Mudlet/Mudlet repository and not a fork
@@ -214,7 +244,7 @@ else
   if [[ -z "${MUDLET_VERSION_BUILD}" ]]; then
     INTERMEDIATE_ARTIFACT_NAME="Mudlet-${VERSION}-windows-64"
   else
-    INTERMEDIATE_ARTIFACT_NAME="Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-windows-64"
+    INTERMEDIATE_ARTIFACT_NAME="Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}${BUILD_COUNTER_SUFFIX}-windows-64"
   fi
   # This intermediate will NOT be uploaded but will remain on the GH server as
   # an artifact for a default (90?) days
@@ -256,14 +286,15 @@ else
     # which cannot handle dotted numbers. So revert to original methodology that
     # appended the short commit SHA1 - and just not worry about any sort of
     # sorting:
-    INSTALLER_VERSION="${VERSION}-ptb-${BUILD_COMMIT,,}"
+    INSTALLER_VERSION="${VERSION}-ptb-${BUILD_COMMIT,,}${BUILD_COUNTER_SUFFIX}"
     # The name we want to use for the installer;
     # Typically of form: 'Mudlet-4.19.1-ptb-2025-01-01-012345678-windows-64.exe'
-    INSTALLER_EXE="Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-windows-64.exe"
-    DBLSQD_VERSION_STRING="${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT,,}"
+    # Or with build counter: 'Mudlet-4.19.1-ptb-2025-01-01-012345678.2-windows-64.exe'
+    INSTALLER_EXE="Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}${BUILD_COUNTER_SUFFIX}-windows-64.exe"
+    DBLSQD_VERSION_STRING="${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT,,}${BUILD_COUNTER_SUFFIX}"
     # The name that has to be passed as the artifact so that the Mudlet website
     # will accept it as a PTB:
-    ARTIFACT_NAME="Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-windows-64-installer.exe"
+    ARTIFACT_NAME="Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}${BUILD_COUNTER_SUFFIX}-windows-64-installer.exe"
   else
     NAME_SUFFIX='_64_'
     INSTALLER_ICON_WINFILE=$(cygpath -aw "${GITHUB_WORKSPACE}/src/icons/mudlet.ico")
@@ -534,7 +565,7 @@ if [[ -z "${MUDLET_VERSION_BUILD}" ]]; then
   echo "Finished deploying Mudlet ${VERSION}"
 else
   # Not a release build so include the Git SHA1 in the message
-  echo "Finished deploying Mudlet ${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}"
+  echo "Finished deploying Mudlet ${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}${BUILD_COUNTER_SUFFIX}"
 fi
 
 if [[ -n "${DEPLOY_URL}" ]]; then

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -21,7 +21,8 @@
 
 set -x
 
-# Version: 2.1.0    Remove MINGW32 since upstream no longer supports it
+# Version: 2.2.0    Skip commit date check when build is manually forced
+#          2.1.0    Remove MINGW32 since upstream no longer supports it
 #          2.0.0    Rework to build on an MSYS2 MINGW64 Github workflow
 
 # Exit codes:
@@ -150,16 +151,21 @@ else
   # Check if it's a Public Test Build
   if [[ "${GITHUB_SCHEDULED_BUILD}" == "true" ]]; then
 
-    # Get the commit date of the last commit
-    COMMIT_DATE=$(git show -s --format="%cs")
-    # Get yesterday's date in the same format
-    YESTERDAY_DATE=$(date --date="yesterday" +%Y-%m-%d)
-
-    if [[ "${COMMIT_DATE}" < "${YESTERDAY_DATE}" ]]; then
-      echo "=== No new commits, aborting public test build generation ==="
-      exit 0
+    # Skip commit check if this is a manually forced build
+    if [[ "${GITHUB_FORCE_BUILD}" == "true" ]]; then
+      echo "=== Forced build requested, skipping commit date check ==="
     else
-      echo "=== New commits, continuing to create a public test build ==="
+      # Get the commit date of the last commit
+      COMMIT_DATE=$(git show -s --format="%cs")
+      # Get yesterday's date in the same format
+      YESTERDAY_DATE=$(date --date="yesterday" +%Y-%m-%d)
+
+      if [[ "${COMMIT_DATE}" < "${YESTERDAY_DATE}" ]]; then
+        echo "=== No new commits, aborting public test build generation ==="
+        exit 0
+      else
+        echo "=== New commits, continuing to create a public test build ==="
+      fi
     fi
 
     # Squirrel uses the name of the binary for the Start menu, so need to rename

--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -73,7 +73,10 @@ then
   else # ptb/release build
     if [ "${public_test_build}" == "true" ]; then
 
-      if [[ "${COMMIT_DATE}" -lt "${YESTERDAY_DATE}" ]]; then
+      # Skip commit check if this is a manually forced build
+      if [[ "${GITHUB_FORCE_BUILD}" == "true" ]]; then
+        echo "== Forced build requested, skipping commit date check =="
+      elif [[ "${COMMIT_DATE}" -lt "${YESTERDAY_DATE}" ]]; then
         echo "== No new commits, aborting public test build generation =="
         exit 0
       fi

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -96,7 +96,10 @@ if [ "${DEPLOY}" = "deploy" ]; then
     app="${BUILD_DIR}/build/mudlet.app"
     if [ "${public_test_build}" == "true" ]; then
 
-      if [[ "${COMMIT_DATE}" -lt "${YESTERDAY_DATE}" ]]; then
+      # Skip commit check if this is a manually forced build
+      if [[ "${GITHUB_FORCE_BUILD}" == "true" ]]; then
+        echo "== Forced build requested, skipping commit date check =="
+      elif [[ "${COMMIT_DATE}" -lt "${YESTERDAY_DATE}" ]]; then
         echo "== No new commits, aborting public test build generation =="
         exit 0
       fi


### PR DESCRIPTION
 #### Brief overview of PR changes/additions

  - Skip the "no new commits since yesterday" check when a PTB build is manually triggered via workflow_dispatch with `scheduled=true`
  - Add a build counter suffix (`.2`, `.3`, etc.) when building multiple PTBs from the same commit, allowing the updater to see them as different versions

  #### Motivation for adding to Mudlet

  Testing the Windows installer update mechanism currently requires waiting for new commits or hacking around the commit date check. This change allows:
  1. Manually triggering PTB builds at any time via Actions → Run workflow with `scheduled=true`
  2. Building multiple PTBs from the same commit to test that version 1 can update to version 2

  #### Other info (issues closed, discussion etc)

  The build counter queries the dblsqd feed to find existing versions with the same commit SHA. First build has no suffix, second gets `.2`, third gets `.3`, etc.

  Verified that ci-snapshots (make.mudlet.org) will correctly parse filenames with the build counter - the existing regex already handles a `.` after the commit ID.