### PR TITLE
Infrastructure: check for sentry-native submodule when Sentry enabled

### DIFF
--- a/src/cmake/WithSentry.cmake
+++ b/src/cmake/WithSentry.cmake
@@ -2,9 +2,19 @@ if(NOT WITH_SENTRY)
     return()
 endif()
 
-message(STATUS "Building with Sentry enabled")
-
 set(SENTRY_PATH "${CMAKE_SOURCE_DIR}/3rdparty/sentry-native")
+
+# Check if sentry-native submodule is initialized
+if(NOT EXISTS "${SENTRY_PATH}/CMakeLists.txt")
+    message(FATAL_ERROR
+        "Sentry is enabled (WITH_SENTRY=ON) but the sentry-native submodule is not initialized.\n"
+        "Either:\n"
+        "  1. Initialize it: git submodule update --init 3rdparty/sentry-native\n"
+        "  2. Disable Sentry: cmake -DWITH_SENTRY=OFF .."
+    )
+endif()
+
+message(STATUS "Building with Sentry enabled")
 set(SENTRY_COMMON_ARGS
     -DCMAKE_BUILD_TYPE=RelWithDebInfo
     -DCMAKE_C_COMPILER=clang

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -633,6 +633,11 @@ WITH_SENTRY {
 
     SENTRY_PATH = $$PWD/../3rdparty/sentry-native
 
+    # Check if sentry-native submodule is initialized
+    !exists($$SENTRY_PATH/CMakeLists.txt) {
+        error("Sentry is enabled (WITH_SENTRY) but the sentry-native submodule is not initialized. Either: 1) Initialize it: git submodule update --init 3rdparty/sentry-native, or 2) Disable Sentry by removing WITH_SENTRY from CONFIG")
+    }
+
     !exists($$SENTRY_PATH/install) {
         message("Sentry install missing, building sentry-native from sources")
 


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Adds a helpful error message if WITH_SENTRY=ON but the submodule is not initialized. Sentry is already OFF by default for local builds; CI explicitly enables it.
#### Motivation for adding to Mudlet
Better DevEx
#### Other info (issues closed, discussion etc)
