### PR TITLE
Fix: Create shortcuts when handling Squirrel install events

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -168,6 +168,15 @@ int main(int argc, char* argv[])
     for (int i = 1; i < argc; ++i) {
         const QString arg = QString::fromLocal8Bit(argv[i]);
         if (arg.startsWith(qsl("--squirrel-")) && arg != qsl("--squirrel-firstrun")) {
+            const QString appDir = QCoreApplication::applicationDirPath();
+            const QString updateExe = QDir(appDir).filePath(qsl("../Update.exe"));
+            const QString exeName = QFileInfo(QCoreApplication::applicationFilePath()).fileName();
+
+            if (arg.startsWith(qsl("--squirrel-install")) || arg.startsWith(qsl("--squirrel-updated"))) {
+                QProcess::execute(updateExe, {qsl("--createShortcut"), exeName, qsl("--shortcut-locations"), qsl("StartMenu")});
+            } else if (arg.startsWith(qsl("--squirrel-uninstall"))) {
+                QProcess::execute(updateExe, {qsl("--removeShortcut"), exeName});
+            }
             return 0;
         }
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
  When Mudlet is marked as Squirrel-aware, it must create its own shortcuts. This PR calls `Update.exe --createShortcut` on install/update and `--removeShortcut` on uninstall.

#### Motivation for adding to Mudlet
  Fixes missing Start Menu shortcuts after installing PTB builds since #8666 marked Mudlet as Squirrel-aware.

#### Other info (issues closed, discussion etc)
  Follow-up to #8666