### PR TITLE
Fix: Wait for Mudlet to exit before running installer on Windows

### DIFF
--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -523,7 +523,7 @@ void Updater::slot_installOrRestartClicked(QAbstractButton* button, const QStrin
                     "echo Mudlet updater: waiting for %1 to exit...\r\n"
                     ":wait\r\n"
                     "tasklist /FI \"IMAGENAME eq %1\" 2>NUL | find /I \"%1\" >NUL\r\n"
-                    "if %%ERRORLEVEL%%==0 (\r\n"
+                    "if %ERRORLEVEL%==0 (\r\n"
                     "    echo Mudlet updater: %1 still running, waiting...\r\n"
                     "    C:\\Windows\\System32\\timeout.exe /t 1 /nobreak > nul\r\n"
                     "    goto wait\r\n"
@@ -531,7 +531,7 @@ void Updater::slot_installOrRestartClicked(QAbstractButton* button, const QStrin
                     "echo Mudlet updater: %1 exited, launching installer...\r\n"
                     "echo Mudlet updater: running %2\r\n"
                     "\"%2\"\r\n"
-                    "echo Mudlet updater: installer finished with exit code %%ERRORLEVEL%%\r\n"
+                    "echo Mudlet updater: installer finished with exit code %ERRORLEVEL%\r\n"
                 ).arg(exeName, QDir::toNativeSeparators(launchPath));
                 batchFile.write(batchContent.toLocal8Bit());
                 batchFile.close();

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -513,6 +513,7 @@ void Updater::slot_installOrRestartClicked(QAbstractButton* button, const QStrin
             }
 
             // Create a batch file that waits for Mudlet to exit before launching the installer
+            // this avoids shell quoting issues that happen with QProcess::startDetached
             QString batchPath = qsl("%1/mudlet-update.bat").arg(QStandardPaths::writableLocation(QStandardPaths::TempLocation));
             QFile batchFile(batchPath);
             if (batchFile.open(QIODevice::WriteOnly | QIODevice::Text)) {

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -522,7 +522,7 @@ void Updater::slot_installOrRestartClicked(QAbstractButton* button, const QStrin
                     "@echo off\r\n"
                     "echo Mudlet updater: waiting for %1 to exit...\r\n"
                     ":wait\r\n"
-                    "tasklist /FI \"IMAGENAME eq %1\" 2>NUL | find /I \"%1\" >NUL\r\n"
+                    "tasklist /FI \"IMAGENAME eq %1\" 2>NUL | C:\\Windows\\System32\\find.exe /I \"%1\" >NUL\r\n"
                     "if %ERRORLEVEL%==0 (\r\n"
                     "    echo Mudlet updater: %1 still running, waiting...\r\n"
                     "    C:\\Windows\\System32\\timeout.exe /t 1 /nobreak > nul\r\n"

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -532,8 +532,7 @@ void Updater::slot_installOrRestartClicked(QAbstractButton* button, const QStrin
                     "echo Mudlet updater: %1 exited, launching installer...\r\n"
                     "echo Mudlet updater: running %2\r\n"
                     "\"%2\"\r\n"
-                    "echo Mudlet updater: installer finished with exit code %ERRORLEVEL%\r\n"
-                ).arg(exeName, QDir::toNativeSeparators(launchPath));
+                    "echo Mudlet updater: installer finished with exit code %ERRORLEVEL%\r\n").arg(exeName, QDir::toNativeSeparators(launchPath));
                 batchFile.write(batchContent.toLocal8Bit());
                 batchFile.close();
 

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -512,14 +512,27 @@ void Updater::slot_installOrRestartClicked(QAbstractButton* button, const QStrin
                 launchPath = installerPath;
             }
 
-            // Create a batch file to handle delayed launch - this avoids shell quoting issues
-            // that occur when passing complex commands through QProcess::startDetached
+            // Create a batch file that waits for Mudlet to exit before launching the installer
             QString batchPath = qsl("%1/mudlet-update.bat").arg(QStandardPaths::writableLocation(QStandardPaths::TempLocation));
             QFile batchFile(batchPath);
             if (batchFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
-                // Use full path to Windows timeout to avoid MSYS2/Cygwin conflicts
-                // /t 3 = wait 3 seconds, /nobreak = ignore keypresses
-                QString batchContent = qsl("@echo off\r\nC:\\Windows\\System32\\timeout.exe /t 3 /nobreak > nul\r\n\"%1\"\r\n").arg(QDir::toNativeSeparators(launchPath));
+                QString exeName = QFileInfo(QCoreApplication::applicationFilePath()).fileName();
+                // Wait for Mudlet process to exit before running installer, with debug output
+                QString batchContent = qsl(
+                    "@echo off\r\n"
+                    "echo Mudlet updater: waiting for %1 to exit...\r\n"
+                    ":wait\r\n"
+                    "tasklist /FI \"IMAGENAME eq %1\" 2>NUL | find /I \"%1\" >NUL\r\n"
+                    "if %%ERRORLEVEL%%==0 (\r\n"
+                    "    echo Mudlet updater: %1 still running, waiting...\r\n"
+                    "    C:\\Windows\\System32\\timeout.exe /t 1 /nobreak > nul\r\n"
+                    "    goto wait\r\n"
+                    ")\r\n"
+                    "echo Mudlet updater: %1 exited, launching installer...\r\n"
+                    "echo Mudlet updater: running %2\r\n"
+                    "\"%2\"\r\n"
+                    "echo Mudlet updater: installer finished with exit code %%ERRORLEVEL%%\r\n"
+                ).arg(exeName, QDir::toNativeSeparators(launchPath));
                 batchFile.write(batchContent.toLocal8Bit());
                 batchFile.close();
 

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -517,7 +517,8 @@ void Updater::slot_installOrRestartClicked(QAbstractButton* button, const QStrin
             QFile batchFile(batchPath);
             if (batchFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
                 QString exeName = QFileInfo(QCoreApplication::applicationFilePath()).fileName();
-                // Wait for Mudlet process to exit before running installer, with debug output
+                // Wait for Mudlet process to exit before running installer, with debug output.
+                // Uses ping for delay instead of timeout.exe because timeout doesn't work when stdin is redirected.
                 QString batchContent = qsl(
                     "@echo off\r\n"
                     "echo Mudlet updater: waiting for %1 to exit...\r\n"
@@ -525,7 +526,7 @@ void Updater::slot_installOrRestartClicked(QAbstractButton* button, const QStrin
                     "tasklist /FI \"IMAGENAME eq %1\" 2>NUL | C:\\Windows\\System32\\find.exe /I \"%1\" >NUL\r\n"
                     "if %ERRORLEVEL%==0 (\r\n"
                     "    echo Mudlet updater: %1 still running, waiting...\r\n"
-                    "    C:\\Windows\\System32\\timeout.exe /t 1 /nobreak > nul\r\n"
+                    "    ping -n 2 127.0.0.1 > nul\r\n"
                     "    goto wait\r\n"
                     ")\r\n"
                     "echo Mudlet updater: %1 exited, launching installer...\r\n"

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -518,7 +518,6 @@ void Updater::slot_installOrRestartClicked(QAbstractButton* button, const QStrin
             QFile batchFile(batchPath);
             if (batchFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
                 QString exeName = QFileInfo(QCoreApplication::applicationFilePath()).fileName();
-                // Wait for Mudlet process to exit before running installer, with debug output.
                 // Uses ping for delay instead of timeout.exe because timeout doesn't work when stdin is redirected.
                 QString batchContent = qsl(
                     "@echo off\r\n"


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Wait for Mudlet to exit before running installer on Windows by checking the list of processes.
#### Motivation for adding to Mudlet
Enable Windows PTBs to update themselves seamlessly again.
#### Other info (issues closed, discussion etc)
Follow up to https://github.com/Mudlet/Mudlet/pull/8663 which did not quite work.