### PR TITLE
Infrastructure: Cache sentry build output on Windows

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -47,6 +47,22 @@ jobs:
         $GITHUB_WORKSPACE/CI/setup-windows-sdk.sh
         $GITHUB_WORKSPACE/CI/validate-deployment-for-windows.sh
 
+    - name: Get sentry-native commit for cache key
+      id: sentry-commit
+      shell: bash
+      run: echo "hash=$(git -C 3rdparty/sentry-native rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+    - name: Restore sentry build cache
+      id: restore-sentry
+      uses: actions/cache/restore@v5
+      with:
+        path: |
+          3rdparty/sentry-native/install_without_transport
+          3rdparty/sentry-native/install_with_transport
+          build-MINGW64/sentry_without_transport-prefix
+          build-MINGW64/sentry_with_transport-prefix
+        key: sentry-${{matrix.os}}-${{matrix.buildname}}-${{ steps.sentry-commit.outputs.hash }}
+
     - name: Restore ccache
       id: restore-ccache
       uses: actions/cache/restore@v5
@@ -54,6 +70,12 @@ jobs:
         path: ${{runner.workspace}}/ccache
         key: ccache-${{matrix.os}}-${{matrix.buildname}}-${{ github.sha }}
         restore-keys: ccache-${{matrix.os}}-${{matrix.buildname}}
+
+    - name: Check ccache stats prior to build
+      shell: msys2 {0}
+      env:
+        CCACHE_DIR: ${{runner.workspace}}/ccache
+      run: ccache --zero-stats --show-stats
 
     - name: (Windows) Build
       shell: msys2 {0}
@@ -68,6 +90,12 @@ jobs:
         SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         WITH_SENTRY: "ON"
       run: $GITHUB_WORKSPACE/CI/build-mudlet-for-windows.sh
+
+    - name: Check ccache stats post build
+      shell: msys2 {0}
+      env:
+        CCACHE_DIR: ${{runner.workspace}}/ccache
+      run: ccache --show-stats
 
     - name: (Windows) Run QTest
       shell: msys2 {0}
@@ -104,6 +132,17 @@ jobs:
           echo "Lua tests failed - see the action called 'Run Lua tests' above for detailed output."
           exit 1
         fi
+
+    - name: Save sentry build cache
+      if: always() && steps.restore-sentry.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: |
+          3rdparty/sentry-native/install_without_transport
+          3rdparty/sentry-native/install_with_transport
+          build-MINGW64/sentry_without_transport-prefix
+          build-MINGW64/sentry_with_transport-prefix
+        key: sentry-${{matrix.os}}-${{matrix.buildname}}-${{ steps.sentry-commit.outputs.hash }}
 
     - name: Save ccache
       if: always() && steps.restore-ccache.outputs.cache-hit != 'true'


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Cache sentry ExternalProject build output on Windows to skip ~4 min rebuild when nothing changed.

#### Motivation for adding to Mudlet
Sentry builds take ~4 minutes even on incremental builds due to CMake ExternalProject always re-running configure. Caching the build output using sentry-native submodule commit as key should reduce build time from ~6 min to ~2 min.

#### Other info (issues closed, discussion etc)
Also includes ccache stats fix (CCACHE_DIR env var) from #8671.