### PR TITLE
Fix: Windows updates failing due to locked folder

### DIFF
--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -443,8 +443,10 @@ void Updater::slot_installOrRestartClicked(QAbstractButton* button, const QStrin
         if (batchFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
             QString exeName = QFileInfo(QCoreApplication::applicationFilePath()).fileName();
             // Uses ping for delay instead of timeout.exe because timeout doesn't work when stdin is redirected.
+            // Change to temp directory immediately to release handle on Mudlet's app folder.
             QString batchContent = qsl(
                 "@echo off\r\n"
+                "cd /d %TEMP%\r\n"
                 "echo Mudlet updater: waiting for %1 to exit...\r\n"
                 ":wait_mudlet\r\n"
                 "tasklist /FI \"IMAGENAME eq %1\" 2>NUL | C:\\Windows\\System32\\find.exe /I \"%1\" >NUL\r\n"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add `cd /d %TEMP%` to update batch file to release handle on app folder.

#### Motivation for adding to Mudlet
The batch file inherits Mudlet's working directory, and cmd.exe holds a handle on its cwd. This prevents Squirrel from deleting the old app folder during updates.

#### Other info (issues closed, discussion etc)
Found via Sysinternals handle.exe monitoring.