### PR TITLE
Improve: Add error handling to unexpected scenarios

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3211,6 +3211,11 @@ void Host::setCompactInputLine(const bool state)
 
 QPointer<TConsole> Host::findConsole(QString name)
 {
+    if (!mpConsole) {
+        qWarning() << "Host::findConsole() ERROR: main console not initialized";
+        return nullptr;
+    }
+
     if (name.isEmpty() or name == qsl("main")) {
         // Reason for the deref-plus-ref in the next line: `QPointer`s do not
         // follow inheritance. See https://bugreports.qt.io/browse/QTBUG-2258

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -916,7 +916,10 @@ QList<QByteArray> TArea::convertImageToBase64Data(const QPixmap& pixmap) const
 {
     QBuffer imageInputBuffer;
 
-    imageInputBuffer.open(QIODevice::WriteOnly);
+    if (!imageInputBuffer.open(QIODevice::WriteOnly)) {
+        qWarning() << "TArea::convertImageToBase64Data() ERROR: failed to open image input buffer for writing";
+        return {};
+    }
     // Go for maximum compression - for the smallest amount of data, the second
     // argument is a const char[] so does not require a QString wrapper:
     pixmap.save(&imageInputBuffer, "PNG", 0);
@@ -924,7 +927,10 @@ QList<QByteArray> TArea::convertImageToBase64Data(const QPixmap& pixmap) const
     QByteArray encodedImageArray{imageInputBuffer.buffer().toBase64()};
     imageInputBuffer.close();
     imageOutputBuffer.setBuffer(&encodedImageArray);
-    imageOutputBuffer.open(QIODevice::ReadOnly);
+    if (!imageOutputBuffer.open(QIODevice::ReadOnly)) {
+        qWarning() << "TArea::convertImageToBase64Data() ERROR: failed to open image output buffer for reading";
+        return {};
+    }
 
     QList<QByteArray> pixmapArray;
     // Extract the image into lines of bytes (unsigned chars):

--- a/src/TMapLabel.cpp
+++ b/src/TMapLabel.cpp
@@ -23,6 +23,7 @@
 #include "TMapLabel.h"
 
 #include <QBuffer>
+#include <QDebug>
 
 QByteArray TMapLabel::base64EncodePixmap() const
 {

--- a/src/TMapLabel.cpp
+++ b/src/TMapLabel.cpp
@@ -27,7 +27,10 @@
 QByteArray TMapLabel::base64EncodePixmap() const
 {
     QBuffer buffer;
-    buffer.open(QIODevice::WriteOnly);
+    if (!buffer.open(QIODevice::WriteOnly)) {
+        qWarning() << "TMapLabel::base64EncodePixmap() ERROR: failed to open buffer for writing";
+        return {};
+    }
     pix.save(&buffer, "PNG");
     return buffer.data().toBase64();
 }

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -226,7 +226,10 @@ std::pair<EditorViewType, int> XMLimport::importFromClipboard()
     QBuffer xmlBuffer(&ba);
 
     setDevice(&xmlBuffer);
-    xmlBuffer.open(QIODevice::ReadOnly);
+    if (!xmlBuffer.open(QIODevice::ReadOnly)) {
+        qWarning() << "XMLimport::importFromClipboard() ERROR: failed to open XML buffer for reading";
+        return {EditorViewType::cmUnknownView, 0};
+    }
 
     while (!atEnd()) {
         readNext();


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
- Add QBuffer::open() return value checks in TArea::convertImageToBase64Data(), XMLimport::importFromClipboard(), and TMapLabel::base64EncodePixmap()
- Add bounds checking to TLuaInterpreter::generateElapsedTimeTable() to validate expected 6 elements in time string list
- Add null pointer check to Host::findConsole() for mpConsole
- Add array bounds validation to TLuaInterpreter::callEventHandler() to handle mismatched argument and type list sizes
#### Motivation for adding to Mudlet
Better code quality.
#### Other info (issues closed, discussion etc)
