### PR TITLE
Improve: show error message when variable can't be moved in the trigger editor

### DIFF
--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -84,10 +84,14 @@ QStringList LuaInterface::varName(TVar* var)
     return names;
 }
 
-bool LuaInterface::validMove(QTreeWidgetItem* pWidget)
+bool LuaInterface::validMove(QTreeWidgetItem* pWidget, QString* reasonMsg)
 {
     TVar* pNewParent = varUnit->getWVar(pWidget);
     if (pNewParent && pNewParent->getValueType() != LUA_TTABLE) {
+        if (reasonMsg) {
+            //: Error message shown when user tries to drag a variable onto a non-table variable
+            *reasonMsg = QObject::tr("Cannot move variable here - the target is not a table");
+        }
         return false;
     }
     return true;

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -84,17 +84,14 @@ QStringList LuaInterface::varName(TVar* var)
     return names;
 }
 
-bool LuaInterface::validMove(QTreeWidgetItem* pWidget, QString* reasonMsg)
+std::pair<bool, QString> LuaInterface::validMove(QTreeWidgetItem* pWidget)
 {
     TVar* pNewParent = varUnit->getWVar(pWidget);
     if (pNewParent && pNewParent->getValueType() != LUA_TTABLE) {
-        if (reasonMsg) {
-            //: Error message shown when user tries to drag a variable onto a non-table variable
-            *reasonMsg = QObject::tr("Cannot move variable here - the target is not a table");
-        }
-        return false;
+        //: Error message shown when user tries to drag a variable onto a non-table variable
+        return {false, QObject::tr("Cannot move variable here - the target is not a table")};
     }
-    return true;
+    return {true, QString()};
 }
 
 void LuaInterface::getAllChildren(TVar* var, QList<TVar*>* list)

--- a/src/LuaInterface.h
+++ b/src/LuaInterface.h
@@ -28,6 +28,8 @@
 #include <QScopedPointer>
 #include <QSet>
 
+#include <utility>
+
 extern "C" {
 #if defined(INCLUDE_VERSIONED_LUA_HEADERS)
 #include <lua5.1/lua.h>
@@ -66,7 +68,7 @@ public:
     bool loadVar(TVar* var);
     bool reparentCVariable(TVar* from, TVar* to, TVar* curVar);
     bool reparentVariable(QTreeWidgetItem*, QTreeWidgetItem*, QTreeWidgetItem*);
-    bool validMove(QTreeWidgetItem*, QString* reasonMsg = nullptr);
+    std::pair<bool, QString> validMove(QTreeWidgetItem*);
     void getAllChildren(TVar* var, QList<TVar*>* list);
     lua_State* getState();
     static int onPanic(lua_State*);

--- a/src/LuaInterface.h
+++ b/src/LuaInterface.h
@@ -66,7 +66,7 @@ public:
     bool loadVar(TVar* var);
     bool reparentCVariable(TVar* from, TVar* to, TVar* curVar);
     bool reparentVariable(QTreeWidgetItem*, QTreeWidgetItem*, QTreeWidgetItem*);
-    bool validMove(QTreeWidgetItem*);
+    bool validMove(QTreeWidgetItem*, QString* reasonMsg = nullptr);
     void getAllChildren(TVar* var, QList<TVar*>* list);
     lua_State* getState();
     static int onPanic(lua_State*);

--- a/src/TTreeWidget.cpp
+++ b/src/TTreeWidget.cpp
@@ -385,8 +385,8 @@ void TTreeWidget::dropEvent(QDropEvent* event)
 
     if (mIsVarTree) {
         LuaInterface* lI = mpHost->getLuaInterface();
-        QString errorMsg;
-        if (!lI->validMove(pItem, &errorMsg)) {
+        auto [isValid, errorMsg] = lI->validMove(pItem);
+        if (!isValid) {
             event->setDropAction(Qt::IgnoreAction);
             event->ignore();
             if (!errorMsg.isEmpty()) {

--- a/src/TTreeWidget.cpp
+++ b/src/TTreeWidget.cpp
@@ -29,6 +29,7 @@
 
 #include <QtEvents>
 #include <QHeaderView>
+#include <QToolTip>
 
 TTreeWidget::TTreeWidget(QWidget* pW)
 : QTreeWidget(pW)
@@ -384,9 +385,13 @@ void TTreeWidget::dropEvent(QDropEvent* event)
 
     if (mIsVarTree) {
         LuaInterface* lI = mpHost->getLuaInterface();
-        if (!lI->validMove(pItem)) {
+        QString errorMsg;
+        if (!lI->validMove(pItem, &errorMsg)) {
             event->setDropAction(Qt::IgnoreAction);
             event->ignore();
+            if (!errorMsg.isEmpty()) {
+                QToolTip::showText(QCursor::pos(), errorMsg, this);
+            }
             return;
         }
     }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Ahow error message when variable can't be moved in the trigger editor (dragged to a non-table, for example)
#### Motivation for adding to Mudlet
Better UX
#### Other info (issues closed, discussion etc)
