### PR TITLE
Fix: luasql sqlite3 loading on ARM64 macOS

### DIFF
--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -49,7 +49,7 @@ if [ "${DEPLOY}" = "deploy" ]; then
   COMMIT_DATE=$(git show -s --pretty="tformat:%cI" | cut -d'T' -f1 | tr -d '-')
   YESTERDAY_DATE=$(date -v-1d '+%F' | tr -d '-')
 
-  git clone https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
+  git clone --branch fix-sqlite-dylib-path https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
 
   cd "${BUILD_DIR}/../installers/osx"
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fix install_name_tool to rewrite both versioned and unversioned sqlite dylib paths in luasql/sqlite3.so during macOS packaging.

#### Motivation for adding to Mudlet
ARM64 macOS builds fail to load luasql because luarocks linked against `libsqlite3.dylib` (symlink) but packaging only fixed references to `libsqlite3.0.dylib` (versioned).

#### Other info (issues closed, discussion etc)
Requires merging https://github.com/Mudlet/installers/compare/fix-sqlite-dylib-path first, then reverting the branch specification in this PR.