### PR TITLE
Fix: Windows Start Menu shortcut missing after install

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -168,9 +168,10 @@ int main(int argc, char* argv[])
     for (int i = 1; i < argc; ++i) {
         const QString arg = QString::fromLocal8Bit(argv[i]);
         if (arg.startsWith(qsl("--squirrel-")) && arg != qsl("--squirrel-firstrun")) {
-            const QString appDir = QCoreApplication::applicationDirPath();
-            const QString updateExe = QDir(appDir).filePath(qsl("../Update.exe"));
-            const QString exeName = QFileInfo(QCoreApplication::applicationFilePath()).fileName();
+            // Use argv[0] directly since QCoreApplication isn't instantiated yet
+            const QFileInfo appInfo(QString::fromLocal8Bit(argv[0]));
+            const QString updateExe = QDir(appInfo.absolutePath()).filePath(qsl("../Update.exe"));
+            const QString exeName = appInfo.fileName();
 
             if (arg.startsWith(qsl("--squirrel-install")) || arg.startsWith(qsl("--squirrel-updated"))) {
                 QProcess::execute(updateExe, {qsl("--createShortcut"), exeName, qsl("--shortcut-locations"), qsl("StartMenu")});


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fix the Start Menu shortcut not being created when installing Mudlet on Windows.

#### Motivation for adding to Mudlet
The Start Menu shortcut was not being created because the code tried to get the executable name before Qt was fully initialized, resulting in an empty name being passed to Squirrel's shortcut creation.

#### Other info (issues closed, discussion etc)
Uses `argv[0]` directly instead of `QCoreApplication::applicationFilePath()` since the latter returns an empty string before `QCoreApplication` is instantiated.