### PR TITLE
Add: getBorderColor() Lua API function

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5223,6 +5223,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getBorderBottom", TLuaInterpreter::getBorderBottom);
     lua_register(pGlobalLua, "getBorderLeft", TLuaInterpreter::getBorderLeft);
     lua_register(pGlobalLua, "getBorderSizes", TLuaInterpreter::getBorderSizes);
+    lua_register(pGlobalLua, "getBorderColor", TLuaInterpreter::getBorderColor);
     lua_register(pGlobalLua, "getConsoleBufferSize", TLuaInterpreter::getConsoleBufferSize);
     lua_register(pGlobalLua, "setConsoleBufferSize", TLuaInterpreter::setConsoleBufferSize);
     lua_register(pGlobalLua, "enableScrollBar", TLuaInterpreter::enableScrollBar);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -502,6 +502,7 @@ public:
     static int getBorderLeft(lua_State*);
     static int getBorderRight(lua_State*);
     static int getBorderSizes(lua_State*);
+    static int getBorderColor(lua_State*);
     static int getConsoleBufferSize(lua_State*);
     static int setConsoleBufferSize(lua_State*);
     static int enableScrollBar(lua_State*);

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -968,6 +968,17 @@ int TLuaInterpreter::getBorderTop(lua_State* L)
     return 1;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderColor
+int TLuaInterpreter::getBorderColor(lua_State* L)
+{
+    const Host& host = getHostFromLua(L);
+    const QColor color = host.mpConsole->mpMainFrame->palette().color(QPalette::Window);
+    lua_pushnumber(L, color.red());
+    lua_pushnumber(L, color.green());
+    lua_pushnumber(L, color.blue());
+    return 3;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getClipboardText
 int TLuaInterpreter::getClipboardText(lua_State* L)
 {

--- a/src/lua-function-list.json
+++ b/src/lua-function-list.json
@@ -155,6 +155,7 @@
     "getBackgroundColor": "getBackgroundColor([windowName])",
     "getBgColor": "getBgColor(windowName)",
     "getBorderBottom": "getBorderBottom()",
+    "getBorderColor": "r, g, b = getBorderColor()",
     "getBorderLeft": "getBorderLeft()",
     "getBorderRight": "getBorderRight()",
     "getBorderSizes": "getBorderSizes()",


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
This adds a getter for the border color to complement the existing setBorderColor() function. The new function returns the RGB values of the main console frame border, allowing scripts to read the current border color.
#### Motivation for adding to Mudlet
Consistency with getBorderColor() for 3rd party packages to use.
#### Other info (issues closed, discussion etc)
