### PR TITLE
Fix: CodeQL inconsistent nullness check errors in temp trigger functions

### DIFF
--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -1871,6 +1871,13 @@ int TLuaInterpreter::tempAnsiColorTrigger(lua_State* L)
     const int triggerID = pLuaInterpreter->startTempColorTrigger(ansiFgColor, ansiBgColor, code, expiryCount);
     if (code.isNull()) {
         auto trigger = host.getTriggerUnit()->getTrigger(triggerID);
+        Q_ASSERT_X(trigger,
+                   "TLuaInterpreter::tempAnsiColorTrigger(...)",
+                   "Got a positive result from LuaInterpreter::startTempColorTrigger(...) but that failed to produce pointer to it from Host::mTriggerUnit::getTrigger(...)");
+        if (!trigger) {
+            lua_pushnumber(L, -1);
+            return 1;
+        }
         trigger->mRegisteredAnonymousLuaFunction = true;
         lua_pushlightuserdata(L, trigger);
         lua_pushvalue(L, s-1);
@@ -1949,6 +1956,13 @@ int TLuaInterpreter::tempBeginOfLineTrigger(lua_State* L)
         triggerID = pLuaInterpreter->startTempBeginOfLineTrigger(pattern, QString(), expiryCount);
 
         auto trigger = host.getTriggerUnit()->getTrigger(triggerID);
+        Q_ASSERT_X(trigger,
+                   "TLuaInterpreter::tempBeginOfLineTrigger(...)",
+                   "Got a positive result from LuaInterpreter::startTempBeginOfLineTrigger(...) but that failed to produce pointer to it from Host::mTriggerUnit::getTrigger(...)");
+        if (!trigger) {
+            lua_pushnumber(L, -1);
+            return 1;
+        }
         trigger->mRegisteredAnonymousLuaFunction = true;
         lua_pushlightuserdata(L, trigger);
         lua_pushvalue(L, 2);
@@ -2159,6 +2173,13 @@ int TLuaInterpreter::tempColorTrigger(lua_State* L)
         triggerID = pLuaInterpreter->startTempColorTrigger(foregroundColor, backgroundColor, QString(), expiryCount);
 
         auto trigger = host.getTriggerUnit()->getTrigger(triggerID);
+        Q_ASSERT_X(trigger,
+                   "TLuaInterpreter::tempColorTrigger(...)",
+                   "Got a positive result from LuaInterpreter::startTempColorTrigger(...) but that failed to produce pointer to it from Host::mTriggerUnit::getTrigger(...)");
+        if (!trigger) {
+            lua_pushnumber(L, -1);
+            return 1;
+        }
         trigger->mRegisteredAnonymousLuaFunction = true;
         lua_pushlightuserdata(L, trigger);
         lua_pushvalue(L, 3);
@@ -2345,6 +2366,13 @@ int TLuaInterpreter::tempExactMatchTrigger(lua_State* L)
         triggerID = pLuaInterpreter->startTempExactMatchTrigger(exactMatchPattern, QString(), expiryCount);
 
         auto trigger = host.getTriggerUnit()->getTrigger(triggerID);
+        Q_ASSERT_X(trigger,
+                   "TLuaInterpreter::tempExactMatchTrigger(...)",
+                   "Got a positive result from LuaInterpreter::startTempExactMatchTrigger(...) but that failed to produce pointer to it from Host::mTriggerUnit::getTrigger(...)");
+        if (!trigger) {
+            lua_pushnumber(L, -1);
+            return 1;
+        }
         trigger->mRegisteredAnonymousLuaFunction = true;
         lua_pushlightuserdata(L, trigger);
         lua_pushvalue(L, 2);
@@ -2424,6 +2452,13 @@ int TLuaInterpreter::tempLineTrigger(lua_State* L)
         triggerID = pLuaInterpreter->startTempLineTrigger(from, howMany, QString(), dontExpire);
 
         auto trigger = host.getTriggerUnit()->getTrigger(triggerID);
+        Q_ASSERT_X(trigger,
+                   "TLuaInterpreter::tempLineTrigger(...)",
+                   "Got a positive result from LuaInterpreter::startTempLineTrigger(...) but that failed to produce pointer to it from Host::mTriggerUnit::getTrigger(...)");
+        if (!trigger) {
+            lua_pushnumber(L, -1);
+            return 1;
+        }
         trigger->mRegisteredAnonymousLuaFunction = true;
         lua_pushlightuserdata(L, trigger);
         lua_pushvalue(L, 3);
@@ -2464,6 +2499,13 @@ int TLuaInterpreter::tempPromptTrigger(lua_State* L)
         triggerID = pLuaInterpreter->startTempPromptTrigger(QString(), expiryCount);
 
         auto trigger = host.getTriggerUnit()->getTrigger(triggerID);
+        Q_ASSERT_X(trigger,
+                   "TLuaInterpreter::tempPromptTrigger(...)",
+                   "Got a positive result from LuaInterpreter::startTempPromptTrigger(...) but that failed to produce pointer to it from Host::mTriggerUnit::getTrigger(...)");
+        if (!trigger) {
+            lua_pushnumber(L, -1);
+            return 1;
+        }
         trigger->mRegisteredAnonymousLuaFunction = true;
         lua_pushlightuserdata(L, trigger);
         lua_pushvalue(L, 1);
@@ -2504,6 +2546,13 @@ int TLuaInterpreter::tempRegexTrigger(lua_State* L)
         triggerID = pLuaInterpreter->startTempRegexTrigger(regexPattern, QString(), expiryCount);
 
         auto trigger = host.getTriggerUnit()->getTrigger(triggerID);
+        Q_ASSERT_X(trigger,
+                   "TLuaInterpreter::tempRegexTrigger(...)",
+                   "Got a positive result from LuaInterpreter::startTempRegexTrigger(...) but that failed to produce pointer to it from Host::mTriggerUnit::getTrigger(...)");
+        if (!trigger) {
+            lua_pushnumber(L, -1);
+            return 1;
+        }
         trigger->mRegisteredAnonymousLuaFunction = true;
         lua_pushlightuserdata(L, trigger);
         lua_pushvalue(L, 2);
@@ -2594,6 +2643,13 @@ int TLuaInterpreter::tempTrigger(lua_State* L)
         triggerID = pLuaInterpreter->startTempTrigger(substringPattern, QString(), expiryCount);
 
         auto trigger = host.getTriggerUnit()->getTrigger(triggerID);
+        Q_ASSERT_X(trigger,
+                   "TLuaInterpreter::tempTrigger(...)",
+                   "Got a positive result from LuaInterpreter::startTempTrigger(...) but that failed to produce pointer to it from Host::mTriggerUnit::getTrigger(...)");
+        if (!trigger) {
+            lua_pushnumber(L, -1);
+            return 1;
+        }
         trigger->mRegisteredAnonymousLuaFunction = true;
         lua_pushlightuserdata(L, trigger);
         lua_pushvalue(L, 2);


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds missing safety checks when creating temporary triggers with Lua functions. Previously, 8 temp trigger functions could crash if an internal lookup failed. Now they consistently check for this edge case and return an error code (-1) instead of crashing.

Affected functions: `tempAnsiColorTrigger`, `tempBeginOfLineTrigger`, `tempColorTrigger`, `tempExactMatchTrigger`, `tempLineTrigger`, `tempPromptTrigger`, `tempRegexTrigger`, `tempTrigger`

#### Motivation for adding to Mudlet

CodeQL static analysis flagged these as "Inconsistent nullness check" errors - 83% of similar `getTrigger()` calls in the codebase check for null, but these 8 did not. This brings them in line with the existing pattern used by `tempAlias`, `tempKey`, and `tempTimer`.

#### Other info (issues closed, discussion etc)
