### PR TITLE
Fix 8 CodeQL 'comparison result is always the same' warnings

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -3860,7 +3860,7 @@ void TBuffer::shrinkBuffer()
 
 bool TBuffer::deleteLines(int from, int to)
 {
-    if ((from >= 0) && (from < static_cast<int>(buffer.size())) && (from <= to) && (to >= 0) && (to < static_cast<int>(buffer.size()))) {
+    if ((from >= 0) && (from < static_cast<int>(buffer.size())) && (from <= to) && (to < static_cast<int>(buffer.size()))) {
         const int delta = to - from + 1;
 
         for (int i = from, total = from + delta; i < total; ++i) {

--- a/src/TEasyButtonBar.cpp
+++ b/src/TEasyButtonBar.cpp
@@ -104,15 +104,13 @@ void TEasyButtonBar::addButton(TFlipButton* pB)
         if (columns <= 0) {
             columns = 1;
         }
-        if (columns > 0) {
-            mItemCount++;
-            const int row = mItemCount / columns;
-            const int col = mItemCount % columns;
-            if (mVerticalOrientation) {
-                mpLayout->addWidget(pB, row, col);
-            } else {
-                mpLayout->addWidget(pB, col, row);
-            }
+        mItemCount++;
+        const int row = mItemCount / columns;
+        const int col = mItemCount % columns;
+        if (mVerticalOrientation) {
+            mpLayout->addWidget(pB, row, col);
+        } else {
+            mpLayout->addWidget(pB, col, row);
         }
     } else {
         pB->move(pB->mpTAction->mPosX, pB->mpTAction->mPosY);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2231,9 +2231,7 @@ int TLuaInterpreter::getTimestamp(lua_State* L)
 
     const Host& host = getHostFromLua(L);
     if (name.isEmpty()) {
-        if (luaLine > 0 && luaLine < host.mpConsole->buffer.timeBuffer.size()) {
-            // CHECK: Lua starts counting at 1 but we are indexing into a C/C++
-            // structure but the previous code did not accept a zero line number
+        if (luaLine < host.mpConsole->buffer.timeBuffer.size()) {
             lua_pushstring(L, host.mpConsole->buffer.timeBuffer.at(luaLine).toUtf8().constData());
         } else {
             lua_pushstring(L, "getTimestamp: invalid line number");
@@ -2244,7 +2242,7 @@ int TLuaInterpreter::getTimestamp(lua_State* L)
         if (!pC) {
             return warnArgumentValue(L, __func__, qsl("mini console, user window or buffer '%1' not found").arg(name));
         }
-        if (luaLine > 0 && luaLine < pC->buffer.timeBuffer.size()) {
+        if (luaLine < pC->buffer.timeBuffer.size()) {
             lua_pushstring(L, pC->buffer.timeBuffer.at(luaLine).toUtf8().constData());
         } else {
             lua_pushstring(L, "getTimestamp: invalid line number");

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -1372,7 +1372,7 @@ int TLuaInterpreter::getAreaExits(lua_State* L)
     }
 
     lua_newtable(L);
-    if (n < 2 || (n > 1 && !isFullDataRequired)) {
+    if (n < 2 || !isFullDataRequired) {
         // Replicate original implementation
         QList<int> areaExits = pA->getAreaExitRoomIds();
         if (areaExits.size() > 1) {
@@ -3697,10 +3697,9 @@ int TLuaInterpreter::setExitWeight(lua_State* L)
             .arg(QString::number(roomID), lua_tostring(L, 2)));
     }
 
-    qint64 const weight = getVerifiedInt(L, __func__, 3, "exit weight");
-    if (weight < 0 || weight > std::numeric_limits<int>::max()) {
-        return warnArgumentValue(L, __func__, qsl(
-            "weight %1 is outside of the usable range of 0 (which resets the weight back to that of the destination room) to %2")
+    const int weight = getVerifiedInt(L, __func__, 3, "exit weight");
+    if (weight < 0) {
+        return warnArgumentValue(L, __func__, qsl("weight %1 is outside of the usable range of 0 (which resets the weight back to that of the destination room) to %2")
             .arg(QString::number(weight), QString::number(std::numeric_limits<int>::max())));
     }
 

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -2148,8 +2148,7 @@ int TLuaInterpreter::selectSection(lua_State* L)
     const int to = getVerifiedInt(L, __func__, s, "length");
 
     auto console = CONSOLE(L, windowName);
-    const int ret = console->selectSection(from, to);
-    lua_pushboolean(L, ret != -1);
+    lua_pushboolean(L, console->selectSection(from, to));
     return 1;
 }
 

--- a/src/TToolBar.cpp
+++ b/src/TToolBar.cpp
@@ -143,15 +143,13 @@ void TToolBar::addButton(TFlipButton* pB)
         if (columns <= 0) {
             columns = 1;
         }
-        if (columns > 0) {
-            mItemCount++;
-            const int row = mItemCount / columns;
-            const int col = mItemCount % columns;
-            if (mVerticalOrientation) {
-                mpLayout->addWidget(pB, row, col);
-            } else {
-                mpLayout->addWidget(pB, col, row);
-            }
+        mItemCount++;
+        const int row = mItemCount / columns;
+        const int col = mItemCount % columns;
+        if (mVerticalOrientation) {
+            mpLayout->addWidget(pB, row, col);
+        } else {
+            mpLayout->addWidget(pB, col, row);
         }
     } else {
         pB->move(pB->mpTAction->mPosX, pB->mpTAction->mPosY);


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove redundant comparisons [that CodeQL flagged](https://github.com/Mudlet/Mudlet/security/code-scanning?query=%22Comparison+result+is+always+the+same%22+is%3Aopen+branch%3Adevelopment+) as always returning the same result:

- TLuaInterpreterUI.cpp: selectSection returns bool, not int, so directly use its return value instead of comparing != -1
- TLuaInterpreterMapper.cpp:1375: simplify condition since n > 1 is always true when n >= 2
- TLuaInterpreterMapper.cpp:3700: getVerifiedInt returns int, so use int type directly and remove impossible overflow check
- TToolBar.cpp, TEasyButtonBar.cpp: remove columns > 0 check after clamping columns to >= 1
- TLuaInterpreter.cpp: remove luaLine > 0 checks since luaLine >= 1 is already validated earlier
- TBuffer.cpp: remove to >= 0 check since from >= 0 && from <= to implies to >= 0
#### Motivation for adding to Mudlet
Cleaner code with fewer false-positive warnings from static analysis tools. This makes it easier to spot real issues in future CodeQL scans.
#### Other info (issues closed, discussion etc)
