### PR TITLE
Improve: Remove outdated FIXME comment from msleep call

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -594,7 +594,7 @@ int TLuaInterpreter::Wait(lua_State* L)
     }
 
     const int luaSleepMsec = getVerifiedInt(L, __func__, 1, "sleep time in msec");
-    msleep(luaSleepMsec); // FIXME thread::sleep()
+    msleep(luaSleepMsec);
     return 0;
 }
 


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
The FIXME suggesting to switch to std::this_thread::sleep_for() is not necessary - msleep() works fine and the alternative is more verbose without providing meaningful benefits in this context:

```cpp
    std::this_thread::sleep_for(std::chrono::milliseconds(luaSleepMsec));
```
#### Motivation for adding to Mudlet
Less outdated comments in codebase.
#### Other info (issues closed, discussion etc)
