### PR TITLE
Improve: trial change "Force MXP processing on" to "Force MXP processing off"

### DIFF
--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -49,7 +49,7 @@ if [ "${DEPLOY}" = "deploy" ]; then
   COMMIT_DATE=$(git show -s --pretty="tformat:%cI" | cut -d'T' -f1 | tr -d '-')
   YESTERDAY_DATE=$(date -v-1d '+%F' | tr -d '-')
 
-  git clone https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
+  git clone --branch fix-sqlite-dylib-path-2 https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
 
   cd "${BUILD_DIR}/../installers/osx"
 

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -49,7 +49,7 @@ if [ "${DEPLOY}" = "deploy" ]; then
   COMMIT_DATE=$(git show -s --pretty="tformat:%cI" | cut -d'T' -f1 | tr -d '-')
   YESTERDAY_DATE=$(date -v-1d '+%F' | tr -d '-')
 
-  git clone --branch fix-sqlite-dylib-path-2 https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
+  git clone https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
 
   cd "${BUILD_DIR}/../installers/osx"
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -332,36 +332,15 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 
     connect(&mTelnet, &cTelnet::signal_disconnected, this, [this]() {
         purgeTimer.start(1min);
-
-        if (getForceMXPProcessorOn()) {
-            mMxpProcessor.disable();
-        }
     });
     connect(&mTelnet, &cTelnet::signal_connected, this, [this]() {
         purgeTimer.stop();
-
-        if (getForceMXPProcessorOn()) {
-            mMxpProcessor.enable();
-            // When force-enabling MXP (typically for games like IRE MUDs that don't
-            // negotiate properly), lock to secure mode for compatibility
-            mMxpProcessor.setMode(6); // Lock secure mode
-            qDebug() << "MXP enabled (forced)";
-        }
     });
     connect(&purgeTimer, &QTimer::timeout, this, &Host::slot_purgeTemps);
-    connect(this, &Host::signal_forceMXPProcessorOnChanged, this, [this](bool enabled) {
-        if (enabled) {
-            if (!mMxpProcessor.isEnabled()) {
-                mMxpProcessor.enable();
-                // When force-enabling MXP (typically for games like IRE MUDs that don't
-                // negotiate properly), lock to secure mode for compatibility with games
-                // that use secure tags without sending mode switches
-                mMxpProcessor.setMode(6); // Lock secure mode
-                qDebug() << "MXP enabled (forced)";
-            }
-        } else if (mMxpProcessor.isEnabled() && !mTelnet.isMXPEnabled()) {
+    connect(this, &Host::signal_forceMXPProcessorOffChanged, this, [this](bool enabled) {
+        if (enabled && mMxpProcessor.isEnabled()) {
             mMxpProcessor.disable();
-            qDebug() << "MXP disabled (forced)";
+            qDebug() << "MXP disabled (force off enabled)";
         }
     });
 

--- a/src/Host.h
+++ b/src/Host.h
@@ -450,11 +450,11 @@ public:
             mpConsole->setF3SearchEnabled(enabled);
         }
     }
-    bool getForceMXPProcessorOn() const { return mForceMXPProcessorOn; }
-    void setForceMXPProcessorOn(bool value) {
-        if (mForceMXPProcessorOn != value) {
-            mForceMXPProcessorOn = value;
-            emit signal_forceMXPProcessorOnChanged(value);
+    bool getForceMXPProcessorOff() const { return mForceMXPProcessorOff; }
+    void setForceMXPProcessorOff(bool value) {
+        if (mForceMXPProcessorOff != value) {
+            mForceMXPProcessorOff = value;
+            emit signal_forceMXPProcessorOffChanged(value);
         }
     }
     void sendCmdLine(const QString& cmd);
@@ -808,7 +808,7 @@ signals:
     void signal_saveCommandLinesHistory();
     void signal_editorThemeChanged();
     void signal_remoteEchoChanged(bool enabled);
-    void signal_forceMXPProcessorOnChanged(bool enabled);
+    void signal_forceMXPProcessorOffChanged(bool enabled);
 
 private slots:
     void slot_purgeTemps();
@@ -1008,9 +1008,8 @@ private:
     // Whether F3 search functionality is enabled
     bool mF3SearchEnabled = false;
 
-    // Whether to force the MXP processor to be on, even if not negotiated with the
-    // MUD Server
-    bool mForceMXPProcessorOn = false;
+    // Whether to force the MXP processor to be off, to disable autodetected MXP
+    bool mForceMXPProcessorOff = false;
 
     // Set when the mudlet singleton demands that we close - used to force an
     // attempt to save the profile and map - without asking:

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -734,7 +734,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
 #if defined(DEBUG_MXP_PROCESSING)
                     qDebug().nospace().noquote() << "    Consider the MXP control sequence: \"" << localBuffer.substr(localBufferPosition, spanEnd - spanStart).c_str() << "\"";
 #endif
-                    if (isFromServer && (mpHost->mTelnet.isMXPEnabled() || mpHost->getForceMXPProcessorOn())) {
+                    if (isFromServer && mpHost->mTelnet.isMXPEnabled() && !mpHost->getForceMXPProcessorOff()) {
                         mGotCSI = false;
 
                         const QString code = QString(localBuffer.substr(localBufferPosition, spanEnd - spanStart).c_str());
@@ -855,7 +855,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
         // We are outside of a CSI or OSC sequence if we get to here:
 
         if (localBufferPosition >= endOfLiteralEntity && mpHost->mMxpProcessor.isEnabled()) {
-            if (mpHost->mTelnet.isMXPEnabled() || mpHost->getForceMXPProcessorOn()) {
+            if (mpHost->mTelnet.isMXPEnabled() && !mpHost->getForceMXPProcessorOff()) {
                 if (mpHost->mMxpProcessor.mode() != MXP_MODE_LOCKED) {
                     // The comparison signals to the processor, if custom entities may be resolved
                     // (countermeasure against infinite recursion)

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7763,7 +7763,7 @@ int TLuaInterpreter::getConfig(lua_State *L)
         } },
         { qsl("askTlsAvailable"), [&](){lua_pushboolean(L, host.mAskTlsAvailable); } },
         { qsl("promptForMXPProcessorOn"), [&](){lua_pushboolean(L, host.mPromptedForMXPProcessorOn); } },
-        { qsl("specialForceMXPProcessorOn"), [&](){lua_pushboolean(L, host.getForceMXPProcessorOn()); } },
+        { qsl("specialForceMXPProcessorOff"), [&](){lua_pushboolean(L, host.getForceMXPProcessorOff()); } },
         { qsl("promptForVersionInTTYPE"), [&](){lua_pushboolean(L, host.mPromptedForVersionInTTYPE); } },
         { qsl("versionInTTYPE"), [&](){ lua_pushboolean(L, host.mVersionInTTYPE); } },
         { qsl("inputLineStrictUnixEndings"), [&](){ lua_pushboolean(L, host.mUSE_UNIX_EOL); } },

--- a/src/TMxpClient.h
+++ b/src/TMxpClient.h
@@ -113,9 +113,6 @@ public:
     
     // Insert text directly into the output (e.g., for HR tag)
     virtual void insertText(const QString& text) { Q_UNUSED(text) }
-    
-    // Check if force MXP should prevent server from changing default mode
-    virtual bool shouldLockModeToSecure() const { return false; }
 };
 
 #endif //MUDLET_TMXPCLIENT_H

--- a/src/TMxpMudlet.cpp
+++ b/src/TMxpMudlet.cpp
@@ -285,8 +285,3 @@ void TMxpMudlet::insertText(const QString& text)
         mpHost->mpConsole->buffer.translateToPlainText(textToInsert, false);
     }
 }
-
-bool TMxpMudlet::shouldLockModeToSecure() const
-{
-    return mpHost && mpHost->getForceMXPProcessorOn();
-}

--- a/src/TMxpMudlet.h
+++ b/src/TMxpMudlet.h
@@ -145,7 +145,6 @@ public:
     
     // Get the encoding used by the connection
     QByteArray getEncoding() const override;
-    bool shouldLockModeToSecure() const override;
 
 private:
     bool isTagAllowedInMode(const QString& tagName, TMXPMode mode) const;

--- a/src/TMxpProcessor.cpp
+++ b/src/TMxpProcessor.cpp
@@ -99,10 +99,6 @@ bool TMxpProcessor::setMode(int modeCode)
         mMXP_MODE = MXP_MODE_TEMP_SECURE;
         break;
     case 5: // lock open mode (MXP 0.4 or later) - set open mode.  Mode remains in effect until changed.  OPEN mode becomes the new default mode.
-        // When force MXP is enabled with secure mode locked, prevent server from changing default back to OPEN
-        if (mMXP_DEFAULT == MXP_MODE_SECURE && mpMxpClient && mpMxpClient->shouldLockModeToSecure()) {
-            return true; // Acknowledge but don't change mode
-        }
         mMXP_DEFAULT = mMXP_MODE = MXP_MODE_OPEN;
         break;
     case 6: // lock secure mode (MXP 0.4 or later) - set secure mode.  Mode remains in effect until changed.  Secure mode becomes the new default mode.
@@ -113,10 +109,6 @@ bool TMxpProcessor::setMode(int modeCode)
         mMXP_DEFAULT = mMXP_MODE = MXP_MODE_SECURE;
         break;
     case 7: // lock locked mode (MXP 0.4 or later) - set locked mode.  Mode remains in effect until changed.  Locked mode becomes the new default mode.
-        // When force MXP is enabled with secure mode locked, prevent server from changing default to LOCKED
-        if (mMXP_DEFAULT == MXP_MODE_SECURE && mpMxpClient && mpMxpClient->shouldLockModeToSecure()) {
-            return true; // Acknowledge but don't change mode
-        }
         // When the mode is changed from OPEN mode to any other mode, any unclosed OPEN tags are automatically closed.
         if (mMXP_MODE == MXP_MODE_OPEN) {
             mpMxpClient->resetTextProperties();

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -440,7 +440,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mMapperShowRoomBorders") = pHost->mMapperShowRoomBorders ? "yes" : "no";
     host.append_attribute("mVersionInTTYPE") = pHost->mVersionInTTYPE ? "yes" : "no";
     host.append_attribute("mPromptedForVersionInTTYPE") = pHost->mPromptedForVersionInTTYPE ? "yes" : "no";
-    host.append_attribute("mForceMXPProcessorOn") = pHost->getForceMXPProcessorOn() ? "yes" : "no";
+    host.append_attribute("mForceMXPProcessorOff") = pHost->getForceMXPProcessorOff() ? "yes" : "no";
     host.append_attribute("mPromptedForMXPProcessorOn") = pHost->mPromptedForMXPProcessorOn ? "yes" : "no";
     host.append_attribute("enableTextAnalyzer") = pHost->mEnableTextAnalyzer ? "yes" : "no";
     host.append_attribute("mRoomSize") = QString::number(pHost->mRoomSize, 'f', 1).toUtf8().constData();

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -783,7 +783,7 @@ void XMLimport::readHost(Host* pHost)
     setBoolAttribute(qsl("mUseProxy"), pHost->mUseProxy);
     setBoolAttribute(qsl("f3SearchEnabled"), pHost->mF3SearchEnabled);
 
-    pHost->setForceMXPProcessorOn(attributes().value(qsl("mForceMXPProcessorOn")) == YES);
+    pHost->setForceMXPProcessorOff(attributes().value(qsl("mForceMXPProcessorOff")) == YES);
     pHost->mProxyAddress = attributes().value(qsl("mProxyAddress")).toString();
 
     if (attributes().hasAttribute(QLatin1String("mProxyPort"))) {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2284,17 +2284,21 @@ void cTelnet::autoEnableTTYPEVersion()
 // Auto-enable MXP processor when indicators are detected
 void cTelnet::autoEnableMXPProcessor()
 {
+    if (mpHost->getForceMXPProcessorOff()) {
+        return;
+    }
+
     mpHost->mPromptedForMXPProcessorOn = true;
 
     // Automatically enable MXP processing
-    mpHost->setForceMXPProcessorOn(true);
+    mpHost->mMxpProcessor.enable();
 
     // Games that auto-enable MXP (without telnet negotiation) typically use
     // IRE-style implementation that doesn't send mode switches but uses
     // secure tags. Lock to secure mode for compatibility.
     // Properly-negotiated MXP games will use mode switches as needed.
     mpHost->mMxpProcessor.setMode(6); // Lock secure mode
-    postMessage(tr("[ INFO ]  - This game appears to support MXP (Mud eXtension Protocol), but has not turned it on properly. MXP processing has been automatically enabled for clickable links, room info, and richer interactions. You can disable this setting in Settings > Special Options."));
+    postMessage(tr("[ INFO ]  - This game appears to support MXP (Mud eXtension Protocol), but has not turned it on properly. MXP processing has been automatically enabled for clickable links, room info, and richer interactions. You can force it off in Settings > Special Options."));
 }
 
 void cTelnet::processTelnetCommand(const std::string& telnetCommand)
@@ -2622,15 +2626,19 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
         if (option == OPT_MXP) {
             if (!mpHost->mEnableMXP) {
                 sendTelnetOption(TN_DONT, OPT_MXP);
-
-                if (!mpHost->getForceMXPProcessorOn()) {
-                    mpHost->mMxpProcessor.disable();
-                }
+                mpHost->mMxpProcessor.disable();
 
                 if (enableMXP) {
                     raiseProtocolEvent("sysProtocolDisabled", "MXP");
                 }
 
+                enableMXP = false;
+                break;
+            }
+
+            if (mpHost->getForceMXPProcessorOff()) {
+                sendTelnetOption(TN_DONT, OPT_MXP);
+                mpHost->mMxpProcessor.disable();
                 enableMXP = false;
                 break;
             }
@@ -2792,11 +2800,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             if (option == OPT_MXP) {
                 // MXP got turned off
                 enableMXP = false;
-
-                if (!mpHost->getForceMXPProcessorOn()) {
-                    mpHost->mMxpProcessor.disable();
-                }
-
+                mpHost->mMxpProcessor.disable();
                 raiseProtocolEvent("sysProtocolDisabled", "MXP");
             }
 
@@ -2974,17 +2978,14 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
         }
 
         if (option == OPT_MXP) {
-            if (mpHost->mEnableMXP) {
+            if (mpHost->mEnableMXP && !mpHost->getForceMXPProcessorOff()) {
                 enableMXP = true;
                 sendTelnetOption(TN_WILL, OPT_MXP);
                 mpHost->mMxpProcessor.enable();
                 raiseProtocolEvent("sysProtocolEnabled", "MXP");
             } else {
                 sendTelnetOption(TN_WONT, OPT_MXP);
-
-                if (!mpHost->getForceMXPProcessorOn()) {
-                    mpHost->mMxpProcessor.disable();
-                }
+                mpHost->mMxpProcessor.disable();
 
                 if (enableMXP) {
                     raiseProtocolEvent("sysProtocolDisabled", "MXP");
@@ -3100,11 +3101,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
         if (option == OPT_MXP) {
             // MXP got turned off
             enableMXP = false;
-
-            if (!mpHost->getForceMXPProcessorOn()) {
-                mpHost->mMxpProcessor.disable();
-            }
-
+            mpHost->mMxpProcessor.disable();
             raiseProtocolEvent("sysProtocolDisabled", "MXP");
         }
 
@@ -4236,7 +4233,7 @@ void cTelnet::gotPrompt(std::string& mud_data)
 
     mMudData += mud_data;
 
-    if (!mpHost->mPromptedForMXPProcessorOn && !mpHost->getForceMXPProcessorOn() && !isMXPEnabled()) {
+    if (!mpHost->mPromptedForMXPProcessorOn && !mpHost->getForceMXPProcessorOff() && !isMXPEnabled()) {
         trackMXPElementDetection(mud_data);
     }
 
@@ -4279,9 +4276,8 @@ void cTelnet::trackMXPElementDetection(const std::string& line)
         return;
     }
 
-    // If we've already prompted for MXP and it's not force-enabled, don't auto-detect again
-    // But if force MXP is enabled, continue to detect re-initialization
-    if (mpHost->mPromptedForMXPProcessorOn && !mpHost->getForceMXPProcessorOn()) {
+    // Don't auto-detect if force off is set or we've already prompted
+    if (mpHost->getForceMXPProcessorOff() || mpHost->mPromptedForMXPProcessorOn) {
         return;
     }
 
@@ -4300,13 +4296,6 @@ void cTelnet::trackMXPElementDetection(const std::string& line)
 
     for (const auto& esc : mxpEscapes) {
         if (line.find(esc) != std::string::npos) {
-            // If force MXP is already enabled, this is a re-initialization (e.g., after "config mxp on")
-            // Re-apply secure mode without showing the auto-enable message
-            if (mpHost->getForceMXPProcessorOn() && mpHost->mPromptedForMXPProcessorOn) {
-                mpHost->mMxpProcessor.setMode(6); // Re-lock to secure mode
-                return;
-            }
-            // Otherwise, this is the first time we're seeing MXP, so auto-enable it
             autoEnableMXPProcessor();
             return;
         }
@@ -4319,10 +4308,8 @@ void cTelnet::gotRest(std::string& mud_data)
         return;
     }
 
-    // MXP detection scan
-    // Always scan when force MXP is enabled to detect re-initialization (e.g., after "config mxp on")
-    // Otherwise, only scan if MXP hasn't been prompted for and isn't telnet-negotiated
-    if (mpHost->getForceMXPProcessorOn() || (!mpHost->mPromptedForMXPProcessorOn && !isMXPEnabled())) {
+    // MXP detection scan - only if force off is not set, MXP hasn't been prompted for, and isn't negotiated
+    if (!mpHost->getForceMXPProcessorOff() && !mpHost->mPromptedForMXPProcessorOn && !isMXPEnabled()) {
         trackMXPElementDetection(mud_data);
     }
 
@@ -4372,7 +4359,7 @@ void cTelnet::slot_timerPosting()
 
     mMudData += "\r";
 
-    if (!mpHost->mPromptedForMXPProcessorOn && !mpHost->getForceMXPProcessorOn() && !isMXPEnabled()) {
+    if (!mpHost->mPromptedForMXPProcessorOn && !mpHost->getForceMXPProcessorOff() && !isMXPEnabled()) {
         trackMXPElementDetection(mMudData);
     }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2291,6 +2291,7 @@ void cTelnet::autoEnableMXPProcessor()
     mpHost->mPromptedForMXPProcessorOn = true;
 
     // Automatically enable MXP processing
+    enableMXP = true;
     mpHost->mMxpProcessor.enable();
 
     // Games that auto-enable MXP (without telnet negotiation) typically use

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -659,7 +659,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     search_engine_combobox->setCurrentIndex(savedText == -1 ? 1 : savedText);
 
     checkBox_mVersionInTTYPE->setChecked(pHost->mVersionInTTYPE);
-    checkBox_mForceMXPProcessorOn->setChecked(pHost->getForceMXPProcessorOn());
+    checkBox_mForceMXPProcessorOff->setChecked(pHost->getForceMXPProcessorOff());
     mMapperUseAntiAlias->setChecked(pHost->mMapperUseAntiAlias);
     checkbox_mMapperShowRoomBorders->setChecked(pHost->mMapperShowRoomBorders);
     checkBox_drawUpperLowerLevels->setChecked(mudlet::self()->mDrawUpperLowerLevels);
@@ -1473,7 +1473,7 @@ void dlgProfilePreferences::clearHostDetails()
     edbeePreviewWidget->textDocument()->setText(QString());
 
     checkBox_mVersionInTTYPE->setChecked(false);
-    checkBox_mForceMXPProcessorOn->setChecked(false);
+    checkBox_mForceMXPProcessorOff->setChecked(false);
     mMapperUseAntiAlias->setChecked(false);
     checkbox_mMapperShowRoomBorders->setChecked(false);
     checkBox_drawUpperLowerLevels->setChecked(false);
@@ -3012,7 +3012,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         pHost->setBorders(newBorders);
         pHost->commandLineMinimumHeight = commandLineMinimumHeight->value();
         pHost->mVersionInTTYPE = checkBox_mVersionInTTYPE->isChecked();
-        pHost->setForceMXPProcessorOn(checkBox_mForceMXPProcessorOn->isChecked());
+        pHost->setForceMXPProcessorOff(checkBox_mForceMXPProcessorOff->isChecked());
         pHost->mIsNextLogFileInHtmlFormat = mIsToLogInHtml->isChecked();
         pHost->mIsLoggingTimestamps = mIsLoggingTimestamps->isChecked();
         pHost->mLogDir = mLogDirPath;

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -1239,7 +1239,7 @@ function getConfig(...)
     -- Please sort this list alphabetically (case insensitive) as it helps to follow changes:
     -- This list contains all configuration options that are available in both getConfig and setConfig
     -- NOTE: Some options like "showMapInfo", "hideMapInfo" are setConfig-only write operations
-    -- Some options like "logDirectory", "specialForceMXPProcessorOn" are getConfig-only read operations  
+    -- Some options like "logDirectory", "specialForceMXPProcessorOff" are getConfig-only read operations  
     local list = {
       "advertiseScreenReader",
       "ambiguousEAsianWidthCharacters",
@@ -1284,7 +1284,7 @@ function getConfig(...)
       "specialForceCompressionOff",
       "specialForceGAOff",
       "specialForceMxpNegotiationOff",
-      "specialForceMXPProcessorOn",      -- read-only in getConfig
+      "specialForceMXPProcessorOff",     -- read-only in getConfig
       "versionInTTYPE",
     }
     for _,v in ipairs(list) do

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -4395,12 +4395,12 @@ you can use it but there could be issues with aligning columns of text</string>
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QCheckBox" name="checkBox_mForceMXPProcessorOn">
+           <widget class="QCheckBox" name="checkBox_mForceMXPProcessorOff">
             <property name="toolTip">
-             <string>&lt;p&gt;Some servers do not negotiate Mud eXtension Protocol (MXP). When checked, this preference forces the MXP processor to be enabled. Note: To disable MXP entirely, leave this unchecked and also uncheck MXP in Choose protocols section of the General tab in Settings.&lt;/p&gt;</string>
+             <string>&lt;p&gt;MXP is auto-detected if enabled in the General tab. Check this to force MXP processing off if auto-detection does not work correctly for a particular game.&lt;/p&gt;</string>
             </property>
             <property name="text">
-             <string>Force MXP processing on</string>
+             <string>Force MXP processing off</string>
             </property>
            </widget>
           </item>
@@ -4933,7 +4933,7 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>mFORCE_MCCP_OFF</tabstop>
   <tabstop>mFORCE_GA_OFF</tabstop>
   <tabstop>checkBox_mVersionInTTYPE</tabstop>
-  <tabstop>checkBox_mForceMXPProcessorOn</tabstop>
+  <tabstop>checkBox_mForceMXPProcessorOff</tabstop>
   <tabstop>checkBox_mUSE_FORCE_LF_AFTER_PROMPT</tabstop>
   <tabstop>buttonPurgeMediaCache</tabstop>
   <tabstop>checkbox_noAutomaticUpdates</tabstop>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
With MXP autodetection now available, forcing MXP on is redundant. Change to force off instead so users can disable autodetection if it causes issues with a particular game.
#### Motivation for adding to Mudlet
Allow players to stay in control of MXP disabling, which was possible 
#### Other info (issues closed, discussion etc)
Tested on empire MUD and didn't notice adverse effects when forcing it to off, but Achaea is broken.