### PR TITLE
Improve: Enable OSC 8 hyperlink visibility by default

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -4677,8 +4677,7 @@ const QSet<QString> Host::mValidExperiments = {
     qsl("experiment.rendering.more-transparent"),
     qsl("experiment.3dmap.modernmapper"),
     qsl("experiment.render-in-out-exits"),
-    qsl("experiment.3d-player-icon"),
-    qsl("experiment.osc8.visibility")
+    qsl("experiment.3d-player-icon")
 };
 
 bool Host::experimentEnabled(const QString& experimentKey) const

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2661,7 +2661,7 @@ void TBuffer::decodeOSC(const QString& sequence)
             // Visibility currently only supports single-line hyperlinks
             // Multi-line links will not have visibility management applied
             if (mCurrentHyperlinkLinkId > 0 && mCurrentHyperlinkStyling.visibility.hasVisibilitySettings 
-                && mpConsole && isOsc8VisibilityEnabled()
+                && mpConsole
                 && mCurrentHyperlinkStartLine == static_cast<int>(lineBuffer.size()) - 1) {
                 
                 int currentColumn = mMudLine.length();
@@ -2704,7 +2704,6 @@ void TBuffer::decodeOSC(const QString& sequence)
 #endif
                 }
             } else if (mCurrentHyperlinkLinkId > 0 && mCurrentHyperlinkStyling.visibility.hasVisibilitySettings
-                       && isOsc8VisibilityEnabled()
                        && mCurrentHyperlinkStartLine != static_cast<int>(lineBuffer.size()) - 1) {
 #if defined(DEBUG_OSC_PROCESSING)
                 qDebug() << "[OSC] Skipping visibility registration for multi-line hyperlink"
@@ -6306,17 +6305,6 @@ void TBuffer::applyAccessibilityEnhancements(Mudlet::HyperlinkStyling& styling)
 
         styling.focusVisibleStyle = styling.focusStyle; // Copy focus style to focus-visible
     }
-}
-
-bool TBuffer::isOsc8VisibilityEnabled() const
-{
-    if (mpConsole) {
-        Host* pHost = mpConsole->getHost();
-        if (pHost) {
-            return pHost->experimentEnabled(qsl("experiment.osc8.visibility"));
-        }
-    }
-    return false;
 }
 
 // Link state management methods for interactive pseudo-classes

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -558,8 +558,6 @@ private:
     QColor parseColorValue(const QString& value);
     // Accessibility enhancements for hyperlink styling
     void applyAccessibilityEnhancements(Mudlet::HyperlinkStyling& styling);
-    // Helper function to check if OSC 8 visibility experiment is enabled
-    bool isOsc8VisibilityEnabled() const;
 
     QPointer<TConsole> mpConsole;
 

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1439,9 +1439,6 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
 
                         Mudlet::HyperlinkStyling hyperlinkStyling = mpBuffer->getEffectiveHyperlinkStyling(linkIndex);
                         
-                        // Check if OSC 8 visibility experiment is enabled
-                        bool osc8VisibilityEnabled = mpHost && mpHost->experimentEnabled(qsl("experiment.osc8.visibility"));
-                        
 #if defined(DEBUG_OSC_PROCESSING)
                         qDebug() << "TTextEdit::mousePressEvent - Link" << linkIndex << "disabled:" << hyperlinkStyling.selection.disabled << "hasSelectionSettings:" << hyperlinkStyling.selection.hasSelectionSettings << "isSpoiler:" << hyperlinkStyling.isSpoiler;
 #endif
@@ -1549,7 +1546,7 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
                         forceUpdate();
 
                         // Notify visibility manager that link was clicked (activates timers)
-                        if (osc8VisibilityEnabled && mpConsole) {
+                        if (mpConsole) {
                             mpConsole->getHyperlinkVisibilityManager().onLinkClicked(linkIndex);
                         }
 
@@ -3320,8 +3317,7 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
                 QStringList commands = mpBuffer->mLinkStore.getLinksConst(focusedLink);
                 if (!commands.isEmpty()) {
                     // Notify visibility manager that link was clicked (activates timers)
-                    bool osc8VisibilityEnabled = mpHost && mpHost->experimentEnabled(qsl("experiment.osc8.visibility"));
-                    if (osc8VisibilityEnabled && mpConsole) {
+                    if (mpConsole) {
                         mpConsole->getHyperlinkVisibilityManager().onLinkClicked(focusedLink);
                     }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Enables OSC 8 hyperlink visibility feature by default without requiring the experimental setting.

#### Motivation for adding to Mudlet

The `experiment.osc8.visibility` feature has been tested and accepted. Users should no longer need to manually enable an experimental flag to access hyperlink visibility improvements.

#### Other info (issues closed, discussion etc)

- Removes experimental feature flag requirement from PR #8677
- Simplifies code by removing conditional checks throughout
- Hyperlink visibility feature now works out of the box