### PR TITLE
Add: NAWS protocol toggle setting

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -501,6 +501,7 @@ public:
     bool mEnableMNES = false;
     bool mEnableMXP = true;
     bool mEnableCHARSET = true;
+    bool mEnableNAWS = true;
     bool mEnableNEWENVIRON = true;
     bool mPromptedForMXPProcessorOn = false;
     bool mAskTlsAvailable = true;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7448,6 +7448,10 @@ int TLuaInterpreter::setConfig(lua_State * L)
         host.mEnableMXP = getVerifiedBool(L, __func__, 2, "value");
         return success();
     }
+    if (key == qsl("enableNAWS")) {
+        host.mEnableNAWS = getVerifiedBool(L, __func__, 2, "value");
+        return success();
+    }
     if (key == qsl("askTlsAvailable")) {
         host.mAskTlsAvailable = getVerifiedBool(L, __func__, 2, "value");
         return success();
@@ -7752,6 +7756,7 @@ int TLuaInterpreter::getConfig(lua_State *L)
         { qsl("enableMTTS"), [&](){ lua_pushboolean(L, host.mEnableMTTS); } },
         { qsl("enableMNES"), [&](){ lua_pushboolean(L, host.mEnableMNES); } },
         { qsl("enableMXP"), [&](){ lua_pushboolean(L, host.mEnableMXP); } },
+        { qsl("enableNAWS"), [&](){ lua_pushboolean(L, host.mEnableNAWS); } },
         { qsl("logDirectory"), [&](){
             const auto logDir = host.mLogDir;
 

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -421,6 +421,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mEnableMTTS") = pHost->mEnableMTTS ? "yes" : "no";
     host.append_attribute("mEnableMNES") = pHost->mEnableMNES ? "yes" : "no";
     host.append_attribute("mEnableMXP") = pHost->mEnableMXP ? "yes" : "no";
+    host.append_attribute("mEnableNAWS") = pHost->mEnableNAWS ? "yes" : "no";
     host.append_attribute("mEnableCHARSET") = pHost->mEnableCHARSET ? "yes" : "no";
     host.append_attribute("mEnableNEWENVIRON") = pHost->mEnableNEWENVIRON ? "yes" : "no";
     host.append_attribute("mMapStrongHighlight") = pHost->mMapStrongHighlight ? "yes" : "no";

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -728,6 +728,7 @@ void XMLimport::readHost(Host* pHost)
     setBoolAttributeWithDefault(qsl("mEnableMTTS"), pHost->mEnableMTTS, true);
     setBoolAttributeWithDefault(qsl("mEnableMNES"), pHost->mEnableMNES, false);
     setBoolAttributeWithDefault(qsl("mEnableMXP"), pHost->mEnableMXP, getBoolValueFromLegacyAttributeOrDefault(qsl("mFORCE_MXP_NEGOTIATION_OFF"), true, true));
+    setBoolAttributeWithDefault(qsl("mEnableNAWS"), pHost->mEnableNAWS, true);
     setBoolAttributeWithDefault(qsl("mEnableCHARSET"), pHost->mEnableCHARSET, getBoolValueFromLegacyAttributeOrDefault(qsl("mFORCE_CHARSET_NEGOTIATION_OFF"), true, true));
     setBoolAttributeWithDefault(qsl("mEnableNEWENVIRON"), pHost->mEnableNEWENVIRON, getBoolValueFromLegacyAttributeOrDefault(qsl("forceNewEnvironNegotiationOff"), true, true));
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -3066,7 +3066,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 }
 
                 if (option == OPT_NAWS) {
-                    qDebug() << "We ARE willing to enable telnet option NAWS";
+                    qDebug() << "NAWS enabled";
                     raiseProtocolEvent("sysProtocolEnabled", "NAWS");
                 }
 
@@ -3074,7 +3074,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 myOptionState[idxOption] = true;
                 announcedState[idxOption] = true;
             } else if (option == OPT_NAWS && !mpHost->mEnableNAWS) {
-                qDebug() << "We are NOT WILLING to enable telnet option NAWS (disabled in preferences)";
+                qDebug() << "NAWS disabled (user preference)";
                 sendTelnetOption(TN_WONT, option);
                 myOptionState[idxOption] = false;
                 announcedState[idxOption] = true;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2729,9 +2729,12 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                         }
                         mTimerPasswordModeTimeout->start(std::chrono::duration_cast<std::chrono::milliseconds>(PASSWORD_TIMEOUT_MS).count());
                     }
-                } else if ((option == OPT_STATUS) || (option == OPT_TERMINAL_TYPE) || (option == OPT_NAWS)) {
+                } else if (option == OPT_STATUS || option == OPT_TERMINAL_TYPE || (option == OPT_NAWS && mpHost->mEnableNAWS)) {
                     sendTelnetOption(TN_DO, option);
                     hisOptionState[idxOption] = true;
+                } else if (option == OPT_NAWS && !mpHost->mEnableNAWS) {
+                    sendTelnetOption(TN_DONT, option);
+                    hisOptionState[idxOption] = false;
                 } else if ((option == OPT_COMPRESS) || (option == OPT_COMPRESS2)) {
                     //these are handled separately, as they're a bit special
                     if (mpHost->mFORCE_NO_COMPRESSION) {
@@ -3047,7 +3050,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
         } else if (!myOptionState[idxOption]) {
             // only if the option is currently disabled
 
-            if ((option == OPT_STATUS) || (option == OPT_NAWS) || (option == OPT_TERMINAL_TYPE)) {
+            if (option == OPT_STATUS || option == OPT_TERMINAL_TYPE || (option == OPT_NAWS && mpHost->mEnableNAWS)) {
                 if (option == OPT_STATUS) {
                     qDebug() << "We ARE willing to enable telnet option STATUS";
                 }
@@ -3059,6 +3062,11 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 }
                 sendTelnetOption(TN_WILL, option);
                 myOptionState[idxOption] = true;
+                announcedState[idxOption] = true;
+            } else if (option == OPT_NAWS && !mpHost->mEnableNAWS) {
+                qDebug() << "We are NOT WILLING to enable telnet option NAWS (disabled in preferences)";
+                sendTelnetOption(TN_WONT, option);
+                myOptionState[idxOption] = false;
                 announcedState[idxOption] = true;
             } else {
                 qDebug() << "We are NOT WILLING to enable this telnet option.";

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2733,18 +2733,20 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                         }
                         mTimerPasswordModeTimeout->start(std::chrono::duration_cast<std::chrono::milliseconds>(PASSWORD_TIMEOUT_MS).count());
                     }
-                } else if (option == OPT_STATUS || option == OPT_TERMINAL_TYPE || (option == OPT_NAWS && mpHost->mEnableNAWS)) {
+                } else if (option == OPT_STATUS || option == OPT_TERMINAL_TYPE) {
                     sendTelnetOption(TN_DO, option);
                     hisOptionState[idxOption] = true;
-
-                    if (option == OPT_NAWS) {
+                } else if (option == OPT_NAWS) {
+                    if (mpHost->mEnableNAWS) {
+                        sendTelnetOption(TN_DO, option);
+                        hisOptionState[idxOption] = true;
                         qDebug() << "NAWS enabled";
                         raiseProtocolEvent("sysProtocolEnabled", "NAWS");
+                    } else {
+                        sendTelnetOption(TN_DONT, option);
+                        hisOptionState[idxOption] = false;
+                        raiseProtocolEvent("sysProtocolDisabled", "NAWS");
                     }
-                } else if (option == OPT_NAWS && !mpHost->mEnableNAWS) {
-                    sendTelnetOption(TN_DONT, option);
-                    hisOptionState[idxOption] = false;
-                    raiseProtocolEvent("sysProtocolDisabled", "NAWS");
                 } else if ((option == OPT_COMPRESS) || (option == OPT_COMPRESS2)) {
                     //these are handled separately, as they're a bit special
                     if (mpHost->mFORCE_NO_COMPRESSION) {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2732,9 +2732,15 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 } else if (option == OPT_STATUS || option == OPT_TERMINAL_TYPE || (option == OPT_NAWS && mpHost->mEnableNAWS)) {
                     sendTelnetOption(TN_DO, option);
                     hisOptionState[idxOption] = true;
+
+                    if (option == OPT_NAWS) {
+                        qDebug() << "NAWS enabled";
+                        raiseProtocolEvent("sysProtocolEnabled", "NAWS");
+                    }
                 } else if (option == OPT_NAWS && !mpHost->mEnableNAWS) {
                     sendTelnetOption(TN_DONT, option);
                     hisOptionState[idxOption] = false;
+                    raiseProtocolEvent("sysProtocolDisabled", "NAWS");
                 } else if ((option == OPT_COMPRESS) || (option == OPT_COMPRESS2)) {
                     //these are handled separately, as they're a bit special
                     if (mpHost->mFORCE_NO_COMPRESSION) {
@@ -3054,12 +3060,16 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 if (option == OPT_STATUS) {
                     qDebug() << "We ARE willing to enable telnet option STATUS";
                 }
+
                 if (option == OPT_TERMINAL_TYPE) {
                     qDebug() << "We ARE willing to enable telnet option TERMINAL_TYPE";
                 }
+
                 if (option == OPT_NAWS) {
                     qDebug() << "We ARE willing to enable telnet option NAWS";
+                    raiseProtocolEvent("sysProtocolEnabled", "NAWS");
                 }
+
                 sendTelnetOption(TN_WILL, option);
                 myOptionState[idxOption] = true;
                 announcedState[idxOption] = true;
@@ -3068,6 +3078,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 sendTelnetOption(TN_WONT, option);
                 myOptionState[idxOption] = false;
                 announcedState[idxOption] = true;
+                raiseProtocolEvent("sysProtocolDisabled", "NAWS");
             } else {
                 qDebug() << "We are NOT WILLING to enable this telnet option.";
                 sendTelnetOption(TN_WONT, option);

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -3066,7 +3066,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 }
 
                 if (option == OPT_TERMINAL_TYPE) {
-                    qDebug() << "We ARE willing to enable telnet option TERMINAL_TYPE";
+                    qDebug() << "TERMINAL_TYPE enabled";
                 }
 
                 if (option == OPT_NAWS) {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1359,6 +1359,10 @@ void cTelnet::checkNAWS()
 // https://www.rfc-editor.org/rfc/rfc1073
 void cTelnet::sendNAWS(int width, int height)
 {
+    if (!mpHost || !mpHost->mEnableNAWS) {
+        return;
+    }
+
     std::string message;
     message += TN_IAC; // Interpret As Command
     message += TN_SB;  // Sub-negotiation begins

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -957,6 +957,11 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     mEnableMXP->setChecked(pHost->mEnableMXP);
     protocolMenu->addAction(mEnableMXP);
 
+    mEnableNAWS = new QAction(tr("NAWS: Negotiate About Window Size"), nullptr);
+    mEnableNAWS->setCheckable(true);
+    mEnableNAWS->setChecked(pHost->mEnableNAWS);
+    protocolMenu->addAction(mEnableNAWS);
+
     mEnableNEWENVIRON = new QAction(tr("NEW-ENVIRON: Client Variables Standard"), nullptr);
     mEnableNEWENVIRON->setCheckable(true);
     mEnableNEWENVIRON->setChecked(pHost->mEnableNEWENVIRON);
@@ -1305,6 +1310,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     connect(mEnableMXP, &QAction::toggled, need_reconnect_for_data_protocol, &QWidget::show);
     connect(mEnableMTTS, &QAction::toggled, need_reconnect_for_data_protocol, &QWidget::show);
     connect(mEnableMNES, &QAction::toggled, need_reconnect_for_data_protocol, &QWidget::show);
+    connect(mEnableNAWS, &QAction::toggled, need_reconnect_for_data_protocol, &QWidget::show);
     connect(mEnableCHARSET, &QAction::toggled, need_reconnect_for_data_protocol, &QWidget::show);
     connect(mEnableNEWENVIRON, &QAction::toggled, need_reconnect_for_data_protocol, &QWidget::show);
 
@@ -1433,6 +1439,7 @@ void dlgProfilePreferences::disconnectHostRelatedControls()
     disconnect(mEnableMXP, &QAction::toggled, nullptr, nullptr);
     disconnect(mEnableMTTS, &QAction::toggled, nullptr, nullptr);
     disconnect(mEnableMNES, &QAction::toggled, nullptr, nullptr);
+    disconnect(mEnableNAWS, &QAction::toggled, nullptr, nullptr);
     disconnect(mEnableCHARSET, &QAction::toggled, nullptr, nullptr);
     disconnect(mEnableNEWENVIRON, &QAction::toggled, nullptr, nullptr);
 
@@ -2979,6 +2986,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         pHost->mEnableMXP = mEnableMXP->isChecked();
         pHost->mEnableMTTS = mEnableMTTS->isChecked();
         pHost->mEnableMNES = mEnableMNES->isChecked();
+        pHost->mEnableNAWS = mEnableNAWS->isChecked();
         pHost->mEnableCHARSET = mEnableCHARSET->isChecked();
         pHost->mEnableNEWENVIRON = mEnableNEWENVIRON->isChecked();
         pHost->mMapperUseAntiAlias = mMapperUseAntiAlias->isChecked();

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -238,6 +238,7 @@ private:
     QPointer<QAction> mEnableMXP;
     QPointer<QAction> mEnableMTTS;
     QPointer<QAction> mEnableMNES;
+    QPointer<QAction> mEnableNAWS;
     QPointer<QAction> mEnableCHARSET;
     QPointer<QAction> mEnableNEWENVIRON;
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds a new setting to control NAWS (window size) protocol negotiation. Users can now disable NAWS for servers that have problems with automatic window size updates.

#### Motivation for adding to Mudlet

[Discord](https://discord.com/channels/283581582550237184/283582439002210305/1448174522900414495) conversation.

Some MUD servers have issues handling NAWS protocol messages, which can cause connection problems or unwanted behavior. This setting gives users control over whether Mudlet sends window size information to the server.

#### Other info (issues closed, discussion etc)

- New Lua API: `setConfig("enableNAWS", true/false)` and `getConfig("enableNAWS")`
- NAWS is enabled by default (existing behavior preserved)
- Window size tracking continues even when disabled for smooth re-enabling
- Improved debug message consistency across telnet protocols

<img width="492" height="223" alt="Screenshot 2025-12-26 at 1 28 47 PM" src="https://github.com/user-attachments/assets/9606d2fd-3cd9-4962-a9b9-138581da1a1f" />