### PR TITLE
Fix: set enableMXP when MXP is autodetected

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2323,6 +2323,7 @@ void cTelnet::autoEnableMXPProcessor()
     mpHost->mPromptedForMXPProcessorOn = true;
 
     // Automatically enable MXP processing
+    enableMXP = true;
     mpHost->setForceMXPProcessorOn(true);
 
     // Games that auto-enable MXP (without telnet negotiation) typically use


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Enable all MXP-related flags when autodetection kicks in, to be in alignment with properly negotiated MXP.
#### Motivation for adding to Mudlet
Bugfix.
#### Other info (issues closed, discussion etc)
Without this, isMXPEnabled() returns false after autodetection, causing TBuffer.cpp to skip processing MXP escape sequences.