### PR TITLE
Fix: SQLite dylib path on arm64 macOS when it is installed via Homebrew as well

### DIFF
--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -49,7 +49,7 @@ if [ "${DEPLOY}" = "deploy" ]; then
   COMMIT_DATE=$(git show -s --pretty="tformat:%cI" | cut -d'T' -f1 | tr -d '-')
   YESTERDAY_DATE=$(date -v-1d '+%F' | tr -d '-')
 
-  git clone https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
+  git clone --branch fix-sqlite-dylib-path-2 https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
 
   cd "${BUILD_DIR}/../installers/osx"
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Test fix for SQLite library loading on macOS by using the `fix-sqlite-dylib-path-2` installer branch.

#### Motivation for adding to Mudlet
SQLite fails to load on some macOS systems with error:
```
Library not loaded: @executable_path/../../Frameworks/libsqlite3.0.dylib
```

The fix changes `@executable_path/../../Frameworks/` to `@executable_path/../Frameworks/` - the original path was wrong because `@executable_path` always refers to the main executable location (`Contents/MacOS`), not the loading library's location.

#### Other info (issues closed, discussion etc)
Installer fix: https://github.com/Mudlet/installers/tree/fix-sqlite-dylib-path-2