### PR TITLE
Fix: Restore Windows application icon

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,22 +39,6 @@ if(USE_FONTS)
   endif()
 endif()
 
-if(WIN32)
-  # APP_BUILD should now be be available
-
-  if(APP_BUILD MATCHES "-ptb.+")
-    list(APPEND mudlet_RCCS icons/mudlet_ptb.ico)
-  elseif((APP_BUILD MATCHES "-dev.+" OR APP_BUILD MATCHES "-test.+"))
-    # The above test may not be correct as it won't pick up builds where
-    # MUDLET_VERSION_BUILD has been set in the environment - OTOH for
-    # "Packagers" they will likely want the original icon anyhow for their
-    # modified for their system packages of Mudlet:
-    list(APPEND mudlet_RCCS icons/mudlet_dev.ico)
-  else()
-    list(APPEND mudlet_RCCS icons/mudlet.ico)
-  endif()
-endif()
-
 set(mudlet_SRCS
     ActionUnit.cpp
     AliasUnit.cpp
@@ -737,6 +721,23 @@ if(WIN32)
   # The UNICODE and _UNICODE definitions are needed to make
   # (QString) mudlet::getShortPathName(const QString& name) work in Windows:
   target_compile_definitions(${EXE_MUDLET_TARGET} PRIVATE UNICODE _UNICODE)
+
+  # Select Windows executable icon based on build type
+  if(APP_BUILD MATCHES "-ptb.+")
+    set(MUDLET_ICON_FILE "${CMAKE_CURRENT_SOURCE_DIR}/icons/mudlet_ptb.ico")
+  elseif((APP_BUILD MATCHES "-dev.+") OR (APP_BUILD MATCHES "-test.+"))
+    set(MUDLET_ICON_FILE "${CMAKE_CURRENT_SOURCE_DIR}/icons/mudlet_dev.ico")
+  else()
+    set(MUDLET_ICON_FILE "${CMAKE_CURRENT_SOURCE_DIR}/icons/mudlet.ico")
+  endif()
+
+  # Configure and add the Windows resource file for the executable icon
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/mudlet.rc.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/mudlet.rc"
+    @ONLY
+  )
+  target_sources(${EXE_MUDLET_TARGET} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/mudlet.rc")
 endif()
 
 if(APPLE)

--- a/src/mudlet.rc.in
+++ b/src/mudlet.rc.in
@@ -1,0 +1,3 @@
+#include <windows.h>
+
+IDI_ICON1 ICON "@MUDLET_ICON_FILE@"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add Windows resource file handling to CMake build to embed the application icon in the executable.

#### Motivation for adding to Mudlet
The switch from qmake to CMake (#8515) didn't include Windows `.rc` resource file handling, causing the installed executable to have no icon.

#### Other info (issues closed, discussion etc)