### PR TITLE
Fix table.update crash when merging tables

### DIFF
--- a/src/mudlet-lua/lua/TableUtils.lua
+++ b/src/mudlet-lua/lua/TableUtils.lua
@@ -528,8 +528,8 @@ function table.update(t1, t2)
     tbl[k] = v
   end
   for k, v in pairs(t2) do
-    if type(v) == "table" then
-      tbl[k] = table.update(tbl[k] or {}, v)
+    if type(v) == "table" and type(tbl[k]) == "table" then
+      tbl[k] = table.update(tbl[k], v)
     else
       tbl[k] = v
     end


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fix `table.update` crashing when the second table has a nested table at a key where the first table has a simple value.

#### Motivation for adding to Mudlet
`table.update({ x = 1 }, { x = { y = 2 } })` would crash instead of working.

#### Other info (issues closed, discussion etc)
Closes #8694