### PR TITLE
Fix: Down arrow saves typed text before clearing

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1186,6 +1186,21 @@ void TCommandLine::handleAutoCompletion()
 
 void TCommandLine::historyMove(MoveDirection direction)
 {
+    // DOWN at position 0 with text: save to history and clear input
+    if (direction == MOVE_DOWN && mHistoryBuffer == 0 && !toPlainText().isEmpty()) {
+        mHistoryList.removeAll(toPlainText());
+        if (!mHistoryList.isEmpty()) {
+            mHistoryList[0] = toPlainText();
+        } else {
+            mHistoryList.push_front(toPlainText());
+        }
+        mHistoryList.push_front(QString());
+
+        clear();
+        adjustHeight();
+        return;
+    }
+
     if (mHistoryList.empty()) {
         return;
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Pressing down arrow while typing now saves text to history before clearing the input line.

#### Motivation for adding to Mudlet
Previously, pressing down with all text selected would clear the input without saving to history. This re-implements the quick-clear feature from #7450 (reverted in #7566) with a fix for the selection bug.

Fixes https://discord.com/channels/283581582550237184/283582068334526464/1454275142401130536.