### PR TITLE
Add: Optional static analysis during build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,8 @@ set(LIB_MUDLET_TARGET "mudlet_core")
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
-# Include static analysis configuration (enable with -DENABLE_STATIC_ANALYSIS=ON)
+# Static analysis support - always included, but only active when configured with
+# -DENABLE_STATIC_ANALYSIS=ON (see cmake/StaticAnalysis.cmake for details)
 include(StaticAnalysis)
 
 include(IncludeOptionalModule)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,8 +126,8 @@ set(LIB_MUDLET_TARGET "mudlet_core")
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
-# Include static analysis configuration
-# include(StaticAnalysis)
+# Include static analysis configuration (enable with -DENABLE_STATIC_ANALYSIS=ON)
+include(StaticAnalysis)
 
 include(IncludeOptionalModule)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,9 @@ set(LIB_MUDLET_TARGET "mudlet_core")
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
+# Include static analysis configuration
+# include(StaticAnalysis)
+
 include(IncludeOptionalModule)
 
 include_optional_module(ENVIRONMENT_VARIABLE WITH_UPDATER

--- a/cmake/StaticAnalysis.cmake
+++ b/cmake/StaticAnalysis.cmake
@@ -6,12 +6,22 @@
 # Usage:
 #   1. Uncomment include(StaticAnalysis) in root CMakeLists.txt
 #   2. Configure: cmake -DENABLE_STATIC_ANALYSIS=ON ..
-#   3. Build normally: make -j $(nproc)
+#   3. Build normally:
+#      - Linux: make -j $(nproc)
+#      - macOS: make -j `sysctl -n hw.ncpu`
 #
 # Notes:
 #   - clang-analyzer-* checks run the Clang Static Analyzer via clang-tidy
 #   - Analysis warnings appear in build output but don't fail the build
 #   - For scan-build wrapper usage, see: https://clang-analyzer.llvm.org/scan-build
+#
+# Clazy (Qt-specific static analysis):
+#   Clazy requires using clang as the compiler (separate from clang-tidy integration).
+#   Install: brew install clazy (macOS) or apt install clazy (Linux)
+#   Usage (clean build directory required):
+#     CLAZY_CHECKS="level0,level1" CXX=clazy cmake ..
+#     make -j `sysctl -n hw.ncpu`
+#   See: https://github.com/KDE/clazy
 
 option(ENABLE_STATIC_ANALYSIS "Enable static analysis with clang-tidy and cppcheck" OFF)
 

--- a/cmake/StaticAnalysis.cmake
+++ b/cmake/StaticAnalysis.cmake
@@ -1,5 +1,17 @@
 # Static Analysis Configuration for Mudlet
-# Add this to enable static analysis during builds
+# 
+# This module integrates clang-tidy and cppcheck into the CMake build process.
+# Static analysis runs during compilation without breaking the build.
+#
+# Usage:
+#   1. Uncomment include(StaticAnalysis) in root CMakeLists.txt
+#   2. Configure: cmake -DENABLE_STATIC_ANALYSIS=ON ..
+#   3. Build normally: make -j $(nproc)
+#
+# Notes:
+#   - clang-analyzer-* checks run the Clang Static Analyzer via clang-tidy
+#   - Analysis warnings appear in build output but don't fail the build
+#   - For scan-build wrapper usage, see: https://clang-analyzer.llvm.org/scan-build
 
 option(ENABLE_STATIC_ANALYSIS "Enable static analysis with clang-tidy and cppcheck" OFF)
 
@@ -11,6 +23,7 @@ if(ENABLE_STATIC_ANALYSIS)
         message(STATUS "Found clang-tidy: ${CLANG_TIDY_EXE}")
         
         # Configure clang-tidy checks
+        # Note: clang-analyzer-* enables the Clang Static Analyzer
         set(CLANG_TIDY_CHECKS
             "performance-*" 
             "bugprone-*"
@@ -23,17 +36,21 @@ if(ENABLE_STATIC_ANALYSIS)
         set(CMAKE_CXX_CLANG_TIDY 
             ${CLANG_TIDY_EXE};
             --checks=${CLANG_TIDY_CHECKS_STR};
-            --header-filter=.*
+            --header-filter=.*;
         )
         
-        message(STATUS "clang-tidy integration enabled")
+        message(STATUS "clang-tidy integration enabled with checks: ${CLANG_TIDY_CHECKS_STR}")
+        message(STATUS "  - performance-*: Performance optimizations")
+        message(STATUS "  - bugprone-*: Bug detection")
+        message(STATUS "  - clang-analyzer-*: Clang Static Analyzer (deep analysis)")
     else()
         message(WARNING "clang-tidy not found, static analysis disabled")
     endif()
     
     if(CPPCHECK_EXE)
         message(STATUS "Found cppcheck: ${CPPCHECK_EXE}")
-        set(CMAKE_CXX_CPPCHECK ${CPPCHECK_EXE};
+        set(CMAKE_CXX_CPPCHECK 
+            ${CPPCHECK_EXE};
             --enable=all;
             --inconclusive;
             --std=c++20;
@@ -42,18 +59,7 @@ if(ENABLE_STATIC_ANALYSIS)
             --suppress=unmatchedSuppression;
         )
         message(STATUS "cppcheck integration enabled")
-    endif()
-endif()
-
-# Compiler-specific static analysis flags
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    option(ENABLE_CLANG_ANALYZER "Enable Clang Static Analyzer" OFF)
-    
-    if(ENABLE_CLANG_ANALYZER)
-        message(STATUS "Enabling Clang Static Analyzer")
-        add_compile_options(--analyze)
-        # Store analyzer results in build directory
-        add_compile_options(-Xanalyzer -analyzer-output=html-single-file)
-        add_compile_options(-Xanalyzer -analyzer-output-dir=${CMAKE_BINARY_DIR}/analyzer-reports)
+    else()
+        message(STATUS "cppcheck not found, skipping cppcheck analysis")
     endif()
 endif()

--- a/cmake/StaticAnalysis.cmake
+++ b/cmake/StaticAnalysis.cmake
@@ -1,0 +1,59 @@
+# Static Analysis Configuration for Mudlet
+# Add this to enable static analysis during builds
+
+option(ENABLE_STATIC_ANALYSIS "Enable static analysis with clang-tidy and cppcheck" OFF)
+
+if(ENABLE_STATIC_ANALYSIS)
+    find_program(CLANG_TIDY_EXE NAMES "clang-tidy")
+    find_program(CPPCHECK_EXE NAMES "cppcheck")
+    
+    if(CLANG_TIDY_EXE)
+        message(STATUS "Found clang-tidy: ${CLANG_TIDY_EXE}")
+        
+        # Configure clang-tidy checks
+        set(CLANG_TIDY_CHECKS
+            "performance-*" 
+            "bugprone-*"
+            "clang-analyzer-*"
+        )
+        
+        # Convert list to comma-separated string
+        string(JOIN "," CLANG_TIDY_CHECKS_STR ${CLANG_TIDY_CHECKS})
+        
+        set(CMAKE_CXX_CLANG_TIDY 
+            ${CLANG_TIDY_EXE};
+            --checks=${CLANG_TIDY_CHECKS_STR};
+            --header-filter=.*
+        )
+        
+        message(STATUS "clang-tidy integration enabled")
+    else()
+        message(WARNING "clang-tidy not found, static analysis disabled")
+    endif()
+    
+    if(CPPCHECK_EXE)
+        message(STATUS "Found cppcheck: ${CPPCHECK_EXE}")
+        set(CMAKE_CXX_CPPCHECK ${CPPCHECK_EXE};
+            --enable=all;
+            --inconclusive;
+            --std=c++20;
+            --suppress=missingInclude;
+            --suppress=unusedFunction;
+            --suppress=unmatchedSuppression;
+        )
+        message(STATUS "cppcheck integration enabled")
+    endif()
+endif()
+
+# Compiler-specific static analysis flags
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    option(ENABLE_CLANG_ANALYZER "Enable Clang Static Analyzer" OFF)
+    
+    if(ENABLE_CLANG_ANALYZER)
+        message(STATUS "Enabling Clang Static Analyzer")
+        add_compile_options(--analyze)
+        # Store analyzer results in build directory
+        add_compile_options(-Xanalyzer -analyzer-output=html-single-file)
+        add_compile_options(-Xanalyzer -analyzer-output-dir=${CMAKE_BINARY_DIR}/analyzer-reports)
+    endif()
+endif()

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -125,6 +125,10 @@ if (!file.open(QIODevice::ReadOnly)) {
 - Check code quality with clang-tidy using `.clang-tidy` configuration file
 - Allow up to 10mins for a build - it can take a while
 
+### Static analysis
+
+For complete setup instructions on how to run static analysis during a build see, see: https://wiki.mudlet.org/w/Compiling_Mudlet#Static_Analysis
+
 ### Debugging options
 
 Both `src/CMakeLists.txt` and `src/mudlet.pro` contain commented debugging defines for development (search "Debugging code inclusions"):


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds optional static analysis integration to the CMake build system. Developers can now enable clang-tidy and cppcheck during compilation by passing `-DENABLE_STATIC_ANALYSIS=ON` to cmake. The analysis runs automatically during builds and helps catch bugs, performance issues, and code quality problems.

**Changes:**
- New `cmake/StaticAnalysis.cmake` module with clang-tidy and cppcheck configuration
- Enabled by default in `CMakeLists.txt` but requires opt-in flag to activate
- Updated AI assistant instructions with wiki reference
- Performs performance-*, bugprone-*, and clang-analyzer-* checks

#### Motivation for adding to Mudlet

Static analysis helps developers catch issues early without requiring manual code review:
- **Bug detection**: Identifies null pointer dereferences, memory leaks, and logic errors
- **Performance**: Finds unnecessary copies and inefficient patterns
- **Code quality**: Enforces best practices and consistent patterns
- **Developer experience**: Optional feature - doesn't impact regular builds

Mudlet already uses static analysis in CI, but this makes it available locally for faster feedback during development.

#### Other info (issues closed, discussion etc)

- Static analysis is **disabled by default** - developers opt-in with the cmake flag
- Build output can be captured and filtered to focus on Mudlet-specific issues
- Uses existing `.clang-tidy` configuration already in the repository
- Wiki documentation will be added at https://wiki.mudlet.org/w/Compiling_Mudlet#Static_Analysis