### PR TITLE
Infrastructure: remove debug logging from undo/redo feature

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -605,7 +605,7 @@ add_library(${LIB_MUDLET_TARGET} STATIC
 #
 # * Produce qDebug() messages about undo/redo operations in the trigger editor,
 #   including command execution, stack operations, and edbee text undo integration:
-target_compile_definitions(${LIB_MUDLET_TARGET} PRIVATE DEBUG_UNDO_REDO)
+# target_compile_definitions(${LIB_MUDLET_TARGET} PRIVATE DEBUG_UNDO_REDO)
 
 # target_compile_definitions(${LIB_MUDLET_TARGET} PUBLIC DEBUG_PLAYER_ICON_CONTROLS)
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Comment out the DEBUG_UNDO_REDO compile definition that was left enabled.

#### Motivation for adding to Mudlet
Cleaner stdout output.

#### Other info (issues closed, discussion etc)