### PR TITLE
infra: Clarify CI build option label

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       scheduled:
-        description: 'Imitate a scheduled build'
+        description: 'Imitate a PTB'
         required: false
         default: 'false'
   schedule:

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       scheduled:
-        description: 'Imitate a scheduled build'
+        description: 'Imitate a PTB'
         required: false
         default: 'false'
   schedule:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Renames the manual workflow trigger option from "Imitate a scheduled build" to "Imitate a PTB" for clarity.

#### Motivation for adding to Mudlet
The option triggers PTB (Public Test Build) behavior, so the label should reflect that.

#### Other info (issues closed, discussion etc)
**Test case:** Go to Actions → Build Mudlet → Run workflow. The checkbox option should now read "Imitate a PTB".
