### PR TITLE
improve: Fix compiler warnings about potential data loss in type conversions

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2895,7 +2895,7 @@ void T2DMap::updateMapLabel(QRectF labelRectangle, int labelId, TArea* pArea)
     label.showOnTop = mpDlgMapLabel->isOnTop();
     label.noScaling = mpDlgMapLabel->noScale();
 
-    QPixmap pixmap(fabs(labelRectangle.width()), fabs(labelRectangle.height()));
+    QPixmap pixmap(static_cast<int>(fabs(labelRectangle.width())), static_cast<int>(fabs(labelRectangle.height())));
     pixmap.fill(Qt::transparent);
     QRect drawRectangle = labelRectangle.normalized().toRect();
     drawRectangle.moveTo(0, 0);

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -661,7 +661,7 @@ void TCommandLine::adjustHeight()
         qWarning() << "TCommandLine::adjustHeight() ERROR: mpConsole->layerCommandLine is NULL!";
         return;
     }
-    int lines = document()->size().height();
+    int lines = static_cast<int>(document()->size().height());
     // Workaround for SubCommandLines textCursor not visible in some situations
     // SubCommandLines cannot autoresize
     if (mType == SubCommandLine) {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -612,7 +612,7 @@ int TLuaInterpreter::Wait(lua_State* L)
 QString TLuaInterpreter::dirToString(lua_State* L, int position)
 {
     if (lua_isnumber(L, position)) {
-        qint64 const dirNum = lua_tonumber(L, position);
+        qint64 const dirNum = static_cast<qint64>(lua_tonumber(L, position));
         switch (dirNum) {
         // breaks not needed - all handled cases end in a return!
         case 1:
@@ -726,7 +726,7 @@ int TLuaInterpreter::dirToNumber(lua_State* L, int position)
         }
     }
     if (lua_type(L, position) == LUA_TNUMBER) {
-        dirNum = lua_tonumber(L, position);
+        dirNum = static_cast<int>(lua_tonumber(L, position));
         return (dirNum >= DIR_NORTH && dirNum <= DIR_OUT ? dirNum : 0);
     }
     return 0;
@@ -7364,7 +7364,7 @@ int TLuaInterpreter::setConfig(lua_State * L)
                 lua_pop(L, 1);
                 return warnArgumentValue(L, __func__, qsl("mapInfoColor table must have red component at index 1"));
             }
-            const int r = lua_tonumber(L, -1);
+            const int r = static_cast<int>(lua_tonumber(L, -1));
             lua_pop(L, 1);
             if (r < 0 || r > 255) {
                 return warnArgumentValue(L, __func__, csmInvalidRedValue.arg(r));
@@ -7376,7 +7376,7 @@ int TLuaInterpreter::setConfig(lua_State * L)
                 lua_pop(L, 1);
                 return warnArgumentValue(L, __func__, qsl("mapInfoColor table must have green component at index 2"));
             }
-            const int g = lua_tonumber(L, -1);
+            const int g = static_cast<int>(lua_tonumber(L, -1));
             lua_pop(L, 1);
             if (g < 0 || g > 255) {
                 return warnArgumentValue(L, __func__, csmInvalidGreenValue.arg(g));
@@ -7388,7 +7388,7 @@ int TLuaInterpreter::setConfig(lua_State * L)
                 lua_pop(L, 1);
                 return warnArgumentValue(L, __func__, qsl("mapInfoColor table must have blue component at index 3"));
             }
-            const int b = lua_tonumber(L, -1);
+            const int b = static_cast<int>(lua_tonumber(L, -1));
             lua_pop(L, 1);
             if (b < 0 || b > 255) {
                 return warnArgumentValue(L, __func__, csmInvalidBlueValue.arg(b));
@@ -7398,7 +7398,7 @@ int TLuaInterpreter::setConfig(lua_State * L)
             int a = 255;
             lua_rawgeti(L, 2, 4);
             if (lua_isnumber(L, -1)) {
-                a = lua_tonumber(L, -1);
+                a = static_cast<int>(lua_tonumber(L, -1));
                 if (a < 0 || a > 255) {
                     lua_pop(L, 1);
                     return warnArgumentValue(L, __func__, csmInvalidAlphaValue.arg(a));

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -1148,7 +1148,7 @@ int TLuaInterpreter::deleteArea(lua_State* L)
     }
 
     if (lua_isnumber(L, 1)) {
-        id = lua_tonumber(L, 1);
+        id = static_cast<int>(lua_tonumber(L, 1));
         if (id < 1) {
             return warnArgumentValue(L, __func__, qsl("number %1 is not a valid areaID greater than zero").arg(id));
         }
@@ -1969,7 +1969,7 @@ int TLuaInterpreter::getRoomAreaName(lua_State* L)
         }
         name = lua_tostring(L, 1);
     } else {
-        id = lua_tonumber(L, 1);
+        id = static_cast<int>(lua_tonumber(L, 1));
     }
 
     if (!name.isNull()) {
@@ -2748,13 +2748,13 @@ int TLuaInterpreter::registerMapInfo(lua_State* L)
         int g = -1;
         int b = -1;
         if (!lua_isnil(L, ++index)) {
-            r = lua_tonumber(L, index);
+            r = static_cast<int>(lua_tonumber(L, index));
         }
         if (!lua_isnil(L, ++index)) {
-            g = lua_tonumber(L, index);
+            g = static_cast<int>(lua_tonumber(L, index));
         }
         if (!lua_isnil(L, ++index)) {
-            b = lua_tonumber(L, index);
+            b = static_cast<int>(lua_tonumber(L, index));
         }
         QColor color;
         if (r >= 0 && r <= 255 && g >= 0 && g <= 255 && b >= 0 && b <= 255) {
@@ -3269,7 +3269,7 @@ int TLuaInterpreter::setAreaName(lua_State* L)
     }
 
     if (lua_isnumber(L, 1)) {
-        id = lua_tonumber(L, 1);
+        id = static_cast<int>(lua_tonumber(L, 1));
         if (id < 1) {
             return warnArgumentValue(L, __func__, qsl("number %1 is not a valid areaID greater than zero").arg(id));
         }
@@ -3808,7 +3808,7 @@ int TLuaInterpreter::setRoomArea(lua_State* L)
     int areaId = -1;
     QString areaName;
     if (lua_isnumber(L, 2)) {
-        areaId = lua_tonumber(L, 2);
+        areaId = static_cast<int>(lua_tonumber(L, 2));
         if (areaId < 1) {
             return warnArgumentValue(L, __func__, qsl(
                 "number %1 is not a valid areaID greater than zero. "

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -1858,7 +1858,7 @@ int TLuaInterpreter::tempAnsiColorTrigger(lua_State* L)
 
     int expiryCount = -1;
     if (lua_isnumber(L, ++s)) {
-        expiryCount = lua_tonumber(L, s);
+        expiryCount = static_cast<int>(lua_tonumber(L, s));
         if (expiryCount < 1) {
             return warnArgumentValue(L, __func__, qsl(
                 "trigger expiration count must be nil or greater than zero, got %1").arg(expiryCount));
@@ -1939,7 +1939,7 @@ int TLuaInterpreter::tempBeginOfLineTrigger(lua_State* L)
     const QString pattern = getVerifiedString(L, __func__, 1, "pattern");
 
     if (lua_isnumber(L, 3)) {
-        expiryCount = lua_tonumber(L, 3);
+        expiryCount = static_cast<int>(lua_tonumber(L, 3));
 
         if (expiryCount < 1) {
             return warnArgumentValue(L, __func__, qsl(
@@ -2156,7 +2156,7 @@ int TLuaInterpreter::tempColorTrigger(lua_State* L)
     int expiryCount = -1;
 
     if (lua_isnumber(L, 4)) {
-        expiryCount = lua_tonumber(L, 4);
+        expiryCount = static_cast<int>(lua_tonumber(L, 4));
 
         if (expiryCount < 1) {
             return warnArgumentValue(L, __func__, qsl(
@@ -2209,19 +2209,19 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
         lua_pushfstring(L, "tempComplexRegexTrigger: bad argument #4 type (multiline flag as number expected, got %s!)", luaL_typename(L, 4));
         return lua_error(L);
     }
-    const bool multiLine = lua_tonumber(L, 4);
+    const bool multiLine = static_cast<bool>(lua_tonumber(L, 4));
 
     if (!lua_isnumber(L, 7)) {
         lua_pushfstring(L, "tempComplexRegexTrigger: bad argument #7 type (filter flag as number expected, got %s!)", luaL_typename(L, 7));
         return lua_error(L);
     }
-    const bool filter = lua_tonumber(L, 7);
+    const bool filter = static_cast<bool>(lua_tonumber(L, 7));
 
     if (!lua_isnumber(L, 8)) {
         lua_pushfstring(L, "tempComplexRegexTrigger: bad argument #8 type (match all flag as number expected, got %s!)", luaL_typename(L, 8));
         return lua_error(L);
     }
-    const bool matchAll = lua_tonumber(L, 8);
+    const bool matchAll = static_cast<bool>(lua_tonumber(L, 8));
 
     const int fireLength = getVerifiedInt(L, __func__, 12, "fire length");
     const int lineDelta = getVerifiedInt(L, __func__, 13, "line delta");
@@ -2278,7 +2278,7 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
     int expiryCount = -1;
 
     if (lua_isnumber(L, 14)) {
-        expiryCount = lua_tonumber(L, 14);
+        expiryCount = static_cast<int>(lua_tonumber(L, 14));
 
         if (expiryCount < 1) {
             return warnArgumentValue(L, __func__, qsl(
@@ -2349,7 +2349,7 @@ int TLuaInterpreter::tempExactMatchTrigger(lua_State* L)
     const QString exactMatchPattern = getVerifiedString(L, __func__, 1, "exact match pattern");
 
     if (lua_isnumber(L, 3)) {
-        expiryCount = lua_tonumber(L, 3);
+        expiryCount = static_cast<int>(lua_tonumber(L, 3));
 
         if (expiryCount < 1) {
             return warnArgumentValue(L, __func__, qsl(
@@ -2482,7 +2482,7 @@ int TLuaInterpreter::tempPromptTrigger(lua_State* L)
     int expiryCount = -1;
 
     if (lua_isnumber(L, 2)) {
-        expiryCount = lua_tonumber(L, 2);
+        expiryCount = static_cast<int>(lua_tonumber(L, 2));
 
         if (expiryCount < 1) {
             return warnArgumentValue(L, __func__, qsl(
@@ -2529,7 +2529,7 @@ int TLuaInterpreter::tempRegexTrigger(lua_State* L)
     const QString regexPattern = getVerifiedString(L, __func__, 1, "regex pattern");
 
     if (lua_isnumber(L, 3)) {
-        expiryCount = lua_tonumber(L, 3);
+        expiryCount = static_cast<int>(lua_tonumber(L, 3));
 
         if (expiryCount < 1) {
             return warnArgumentValue(L, __func__, qsl(
@@ -2626,7 +2626,7 @@ int TLuaInterpreter::tempTrigger(lua_State* L)
     const QString substringPattern = getVerifiedString(L, __func__, 1, "substring pattern");
 
     if (lua_isnumber(L, 3)) {
-        expiryCount = lua_tonumber(L, 3);
+        expiryCount = static_cast<int>(lua_tonumber(L, 3));
 
         if (expiryCount < 1) {
             return warnArgumentValue(L, __func__, qsl(

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2137,7 +2137,8 @@ int TMap::createMapLabel(int area, const QString& text, float x, float y, float 
     lp.drawText(QRect(20, 70, 2000, 2000), Qt::AlignLeft | Qt::AlignTop, label.text, &br);
 
     label.size = br.normalized().size();
-    label.pix = pix.copy(br.normalized().topLeft().x(), br.normalized().topLeft().y(), br.normalized().width(), br.normalized().height());
+    const QRect brRect = br.normalized().toRect();
+    label.pix = pix.copy(brRect.topLeft().x(), brRect.topLeft().y(), brRect.width(), brRect.height());
     const QSizeF s = QSizeF(label.size.width() / zoom, label.size.height() / zoom);
     label.size = s;
     label.clickSize = s;

--- a/src/modern_glwidget.cpp
+++ b/src/modern_glwidget.cpp
@@ -1168,9 +1168,9 @@ void ModernGLWidget::mouseReleaseEvent(QMouseEvent* event)
     mPanMode = false;
     mCameraController.snapTargetToGrid();
     const QVector3D newCenter = mCameraController.getTarget();
-    mMapCenterX = newCenter.x();
-    mMapCenterY = newCenter.y();
-    mMapCenterZ = newCenter.z();
+    mMapCenterX = static_cast<int>(newCenter.x());
+    mMapCenterY = static_cast<int>(newCenter.y());
+    mMapCenterZ = static_cast<int>(newCenter.z());
     QOpenGLWidget::mouseReleaseEvent(event);
     update();
 }


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds explicit type casts to fix "lossy function result cast" compiler warnings across 7 files. These occur when wider numeric types (like `double`) are assigned to narrower types (like `int`).

#### Motivation for adding to Mudlet

Cleaner build output with fewer warnings, making it easier to spot real issues during development.

#### Other info (issues closed, discussion etc)

All casts are safe - values are either validated after conversion (colors 0-255, expiry counts ≥1) or truncation is intentional (map grid coordinates).
