### PR TITLE
Fix: Memory leaks in core components

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -394,6 +394,10 @@ Host::~Host()
     // which can lead to a crash when closing multiple profiles at once.
     mpLastCommandLineUsed.clear();
 
+    // Clean up QKeySequence pointers to prevent memory leak
+    qDeleteAll(profileShortcuts);
+    profileShortcuts.clear();
+
     if (mpDockableMapWidget) {
         mpDockableMapWidget->deleteLater();
     }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -394,13 +394,13 @@ Host::~Host()
     // which can lead to a crash when closing multiple profiles at once.
     mpLastCommandLineUsed.clear();
 
-    // Clean up QKeySequence pointers to prevent memory leak
     qDeleteAll(profileShortcuts);
     profileShortcuts.clear();
 
     if (mpDockableMapWidget) {
         mpDockableMapWidget->deleteLater();
     }
+
     mErrorLogStream.flush();
     mErrorLogFile.close();
     // Since this is a destructor, it's risky to rely on member variables within the destructor itself.

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -129,6 +129,10 @@ Discord::~Discord()
         // We might expect to have to do an mpLibrary->unload() but we do not
         // need to as it happens automagically on the application shutdown...
 
+        // Clean up the event handlers
+        delete mpHandlers;
+        mpHandlers = nullptr;
+
         // Clear out the localDiscordPresence collection:
         QMutableMapIterator<QString, localDiscordPresence*> itPresencePtrs(mPresencePtrs);
         while (itPresencePtrs.hasNext()) {

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -138,7 +138,6 @@ Discord::~Discord()
         }
     }
 
-    // Clean up event handlers - safe to call delete on nullptr if allocation failed
     delete mpHandlers;
     mpHandlers = nullptr;
 }

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -129,10 +129,6 @@ Discord::~Discord()
         // We might expect to have to do an mpLibrary->unload() but we do not
         // need to as it happens automagically on the application shutdown...
 
-        // Clean up the event handlers
-        delete mpHandlers;
-        mpHandlers = nullptr;
-
         // Clear out the localDiscordPresence collection:
         QMutableMapIterator<QString, localDiscordPresence*> itPresencePtrs(mPresencePtrs);
         while (itPresencePtrs.hasNext()) {
@@ -141,6 +137,10 @@ Discord::~Discord()
             itPresencePtrs.remove();
         }
     }
+
+    // Clean up event handlers - safe to call delete on nullptr if allocation failed
+    delete mpHandlers;
+    mpHandlers = nullptr;
 }
 
 // For all the setters below the caller is supposed to check that they have the

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -506,8 +506,6 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     connect(mpUndoStack, &EditorUndoStack::itemsChanged, this, &dlgTriggerEditor::slot_itemsChanged);
 
-    // Initialize the shared auto-complete provider once - ownership is transferred to Edbee
-    // via giveProvider() so it gets deleted automatically at app shutdown
     if (!smAutoCompleteInitialized) {
         auto* provider = new edbee::StringTextAutoCompleteProvider();
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -98,9 +98,9 @@ using namespace std::chrono_literals;
 // it is disabled):
 static const char* cButtonBaseColor = "baseColor";
 
-// Initialize static members for shared auto-complete provider
-edbee::StringTextAutoCompleteProvider* dlgTriggerEditor::smSharedAutoCompleteProvider = nullptr;
-int dlgTriggerEditor::smAutoCompleteProviderRefCount = 0;
+// Track whether the shared auto-complete provider has been initialized
+// The provider is owned by Edbee's global autoCompleteProviderList via giveProvider()
+bool dlgTriggerEditor::smAutoCompleteInitialized = false;
 
 dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 : mpHost(pH)
@@ -507,11 +507,10 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     connect(mpUndoStack, &EditorUndoStack::itemsChanged, this, &dlgTriggerEditor::slot_itemsChanged);
 
-    // Use shared auto-complete provider for all editor instances to avoid memory leaks
-    // and prevent ownership conflicts when multiple editors are open
-    if (!smSharedAutoCompleteProvider) {
-        smSharedAutoCompleteProvider = new edbee::StringTextAutoCompleteProvider();
-        auto* provider = smSharedAutoCompleteProvider;
+    // Initialize the shared auto-complete provider once - ownership is transferred to Edbee
+    // via giveProvider() so it gets deleted automatically at app shutdown
+    if (!smAutoCompleteInitialized) {
+        auto* provider = new edbee::StringTextAutoCompleteProvider();
 
         // Add lua functions and reserved lua terms to an AutoComplete provider
     for (const QString& key : mudlet::smLuaFunctionNames.keys()) {
@@ -698,12 +697,10 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     // DateTime utilities
     provider->add(qsl("datetime.parse"), 4, qsl("datetime.parse(format, date_string)"));
 
-        // Set the newly filled provider to be used by our Edbee instance (only once)
-        edbee::Edbee::instance()->autoCompleteProviderList()->setParentProvider(provider);
+        // Transfer ownership to Edbee - deleted automatically at app shutdown
+        edbee::Edbee::instance()->autoCompleteProviderList()->giveProvider(provider);
+        smAutoCompleteInitialized = true;
     }
-    
-    // Increment reference count for this editor instance
-    ++smAutoCompleteProviderRefCount;
 
     mpSourceEditorEdbee->textEditorComponent()->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(mpSourceEditorEdbee->textEditorComponent(), &QWidget::customContextMenuRequested, this, &dlgTriggerEditor::slot_editorContextMenu);
@@ -1425,27 +1422,6 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
         startTimer(mAutosaveInterval * 1min);
     }
 
-}
-
-// Destructor - properly handles shared auto-complete provider cleanup
-dlgTriggerEditor::~dlgTriggerEditor()
-{
-    // Decrement reference count
-    --smAutoCompleteProviderRefCount;
-    
-    // Only clean up the shared provider when the last editor instance is destroyed
-    if (smAutoCompleteProviderRefCount == 0 && smSharedAutoCompleteProvider) {
-        auto* globalList = edbee::Edbee::instance()->autoCompleteProviderList();
-        
-        // Clear the global parent provider reference
-        if (globalList) {
-            globalList->setParentProvider(nullptr);
-        }
-        
-        // Delete the shared provider - setParentProvider doesn't transfer ownership
-        delete smSharedAutoCompleteProvider;
-        smSharedAutoCompleteProvider = nullptr;
-    }
 }
 
 void dlgTriggerEditor::slot_searchSplitterMoved(const int pos, const int index)

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -99,7 +99,6 @@ using namespace std::chrono_literals;
 static const char* cButtonBaseColor = "baseColor";
 
 // Track whether the shared auto-complete provider has been initialized
-// The provider is owned by Edbee's global autoCompleteProviderList via giveProvider()
 bool dlgTriggerEditor::smAutoCompleteInitialized = false;
 
 dlgTriggerEditor::dlgTriggerEditor(Host* pH)

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -98,6 +98,10 @@ using namespace std::chrono_literals;
 // it is disabled):
 static const char* cButtonBaseColor = "baseColor";
 
+// Initialize static members for shared auto-complete provider
+edbee::StringTextAutoCompleteProvider* dlgTriggerEditor::smSharedAutoCompleteProvider = nullptr;
+int dlgTriggerEditor::smAutoCompleteProviderRefCount = 0;
+
 dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 : mpHost(pH)
 , mSearchOptions(pH->mSearchOptions)
@@ -503,10 +507,13 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     connect(mpUndoStack, &EditorUndoStack::itemsChanged, this, &dlgTriggerEditor::slot_itemsChanged);
 
-    mpAutoCompleteProvider = new edbee::StringTextAutoCompleteProvider();
-    auto* provider = mpAutoCompleteProvider; // Keep local reference for initialization
+    // Use shared auto-complete provider for all editor instances to avoid memory leaks
+    // and prevent ownership conflicts when multiple editors are open
+    if (!smSharedAutoCompleteProvider) {
+        smSharedAutoCompleteProvider = new edbee::StringTextAutoCompleteProvider();
+        auto* provider = smSharedAutoCompleteProvider;
 
-    // Add lua functions and reserved lua terms to an AutoComplete provider
+        // Add lua functions and reserved lua terms to an AutoComplete provider
     for (const QString& key : mudlet::smLuaFunctionNames.keys()) {
         provider->add(key, 3, mudlet::smLuaFunctionNames.value(key).toString());
     }
@@ -691,8 +698,12 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     // DateTime utilities
     provider->add(qsl("datetime.parse"), 4, qsl("datetime.parse(format, date_string)"));
 
-    // Set the newly filled provider to be used by our Edbee instance
-    edbee::Edbee::instance()->autoCompleteProviderList()->setParentProvider(provider);
+        // Set the newly filled provider to be used by our Edbee instance (only once)
+        edbee::Edbee::instance()->autoCompleteProviderList()->setParentProvider(provider);
+    }
+    
+    // Increment reference count for this editor instance
+    ++smAutoCompleteProviderRefCount;
 
     mpSourceEditorEdbee->textEditorComponent()->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(mpSourceEditorEdbee->textEditorComponent(), &QWidget::customContextMenuRequested, this, &dlgTriggerEditor::slot_editorContextMenu);
@@ -1416,33 +1427,24 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
 }
 
-// Fix StringTextAutoCompleteProvider leak (96KB identified by LeakSanitizer)
+// Destructor - properly handles shared auto-complete provider cleanup
 dlgTriggerEditor::~dlgTriggerEditor()
 {
-    // Clean up StringTextAutoCompleteProvider to prevent 96KB leak
-    if (mpAutoCompleteProvider) {
-        // Remove from global provider list before deletion
+    // Decrement reference count
+    --smAutoCompleteProviderRefCount;
+    
+    // Only clean up the shared provider when the last editor instance is destroyed
+    if (smAutoCompleteProviderRefCount == 0 && smSharedAutoCompleteProvider) {
         auto* globalList = edbee::Edbee::instance()->autoCompleteProviderList();
-
+        
+        // Clear the global parent provider reference
         if (globalList) {
-            // Use removeProvider to properly remove from lists
-            globalList->removeProvider(mpAutoCompleteProvider);
-            // Also clear parent provider if it points to ours
             globalList->setParentProvider(nullptr);
         }
         
-        delete mpAutoCompleteProvider;
-        mpAutoCompleteProvider = nullptr;
-    }
-    
-    // Disconnect text undo stack signals for safe cleanup
-    if (mpTextUndoStack) {
-        disconnect(mpTextUndoStack, nullptr, this, nullptr);
-    }
-    
-    // Disconnect undo stack signals for safe cleanup  
-    if (mpUndoStack) {
-        disconnect(mpUndoStack, nullptr, this, nullptr);
+        // Delete the shared provider - setParentProvider doesn't transfer ownership
+        delete smSharedAutoCompleteProvider;
+        smSharedAutoCompleteProvider = nullptr;
     }
 }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -503,8 +503,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     connect(mpUndoStack, &EditorUndoStack::itemsChanged, this, &dlgTriggerEditor::slot_itemsChanged);
 
-    auto* provider = new edbee::StringTextAutoCompleteProvider();
-    //QScopedPointer<edbee::StringTextAutoCompleteProvider> provider(new edbee::StringTextAutoCompleteProvider);
+    mpAutoCompleteProvider = new edbee::StringTextAutoCompleteProvider();
+    auto* provider = mpAutoCompleteProvider; // Keep local reference for initialization
 
     // Add lua functions and reserved lua terms to an AutoComplete provider
     for (const QString& key : mudlet::smLuaFunctionNames.keys()) {
@@ -1414,6 +1414,36 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
         startTimer(mAutosaveInterval * 1min);
     }
 
+}
+
+// Fix StringTextAutoCompleteProvider leak (96KB identified by LeakSanitizer)
+dlgTriggerEditor::~dlgTriggerEditor()
+{
+    // Clean up StringTextAutoCompleteProvider to prevent 96KB leak
+    if (mpAutoCompleteProvider) {
+        // Remove from global provider list before deletion
+        auto* globalList = edbee::Edbee::instance()->autoCompleteProviderList();
+
+        if (globalList) {
+            // Use removeProvider to properly remove from lists
+            globalList->removeProvider(mpAutoCompleteProvider);
+            // Also clear parent provider if it points to ours
+            globalList->setParentProvider(nullptr);
+        }
+        
+        delete mpAutoCompleteProvider;
+        mpAutoCompleteProvider = nullptr;
+    }
+    
+    // Disconnect text undo stack signals for safe cleanup
+    if (mpTextUndoStack) {
+        disconnect(mpTextUndoStack, nullptr, this, nullptr);
+    }
+    
+    // Disconnect undo stack signals for safe cleanup  
+    if (mpUndoStack) {
+        disconnect(mpUndoStack, nullptr, this, nullptr);
+    }
 }
 
 void dlgTriggerEditor::slot_searchSplitterMoved(const int pos, const int index)

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -173,7 +173,6 @@ public:
 
     Q_DISABLE_COPY(dlgTriggerEditor)
     dlgTriggerEditor(Host*);
-    ~dlgTriggerEditor();
 
     Q_DECLARE_FLAGS(SearchOptions,SearchOption)
 
@@ -674,9 +673,9 @@ private:
     // Guarded pointer to text editor's undo stack (for safe signal connections):
     QPointer<edbee::TextUndoStack> mpTextUndoStack;
 
-    // Shared auto-complete provider for all editor instances
-    static edbee::StringTextAutoCompleteProvider* smSharedAutoCompleteProvider;
-    static int smAutoCompleteProviderRefCount;
+    // Track whether auto-complete provider has been initialized
+    // The provider is owned by Edbee's global autoCompleteProviderList via giveProvider()
+    static bool smAutoCompleteInitialized;
 
     // tracks the duration of the "Save Profile As" action so
     // autosave doesn't kick in

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -69,6 +69,7 @@
 #include "edbee/models/texteditorconfig.h"
 #include "edbee/models/textgrammar.h"
 #include "edbee/models/textundostack.h"
+#include "edbee/models/textautocompleteprovider.h"
 #include "edbee/texteditorcommand.h"
 #include "edbee/texteditorcontroller.h"
 #include "edbee/texteditorwidget.h"
@@ -172,6 +173,7 @@ public:
 
     Q_DISABLE_COPY(dlgTriggerEditor)
     dlgTriggerEditor(Host*);
+    ~dlgTriggerEditor();
 
     Q_DECLARE_FLAGS(SearchOptions,SearchOption)
 
@@ -671,6 +673,9 @@ private:
 
     // Guarded pointer to text editor's undo stack (for safe signal connections):
     QPointer<edbee::TextUndoStack> mpTextUndoStack;
+
+    // Auto-complete provider (needs cleanup in destructor):
+    edbee::StringTextAutoCompleteProvider* mpAutoCompleteProvider = nullptr;
 
     // tracks the duration of the "Save Profile As" action so
     // autosave doesn't kick in

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -674,8 +674,9 @@ private:
     // Guarded pointer to text editor's undo stack (for safe signal connections):
     QPointer<edbee::TextUndoStack> mpTextUndoStack;
 
-    // Auto-complete provider (needs cleanup in destructor):
-    edbee::StringTextAutoCompleteProvider* mpAutoCompleteProvider = nullptr;
+    // Shared auto-complete provider for all editor instances
+    static edbee::StringTextAutoCompleteProvider* smSharedAutoCompleteProvider;
+    static int smAutoCompleteProviderRefCount;
 
     // tracks the duration of the "Save Profile As" action so
     // autosave doesn't kick in

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -674,7 +674,6 @@ private:
     QPointer<edbee::TextUndoStack> mpTextUndoStack;
 
     // Track whether auto-complete provider has been initialized
-    // The provider is owned by Edbee's global autoCompleteProviderList via giveProvider()
     static bool smAutoCompleteInitialized;
 
     // tracks the duration of the "Save Profile As" action so


### PR DESCRIPTION
## Brief overview of PR changes/additions

This PR fixes three memory leaks in Mudlet's core components that were causing gradual memory growth during extended sessions:

- **Trigger Editor:** Fixed 96KB leak per editor session by transferring auto-complete provider ownership to Edbee via `giveProvider()`
- **Profile Management:** Fixed 272-byte leak per profile load/unload by properly cleaning up QKeySequence shortcuts
- **Discord Integration:** Fixed 48-byte leak on shutdown by moving event handler cleanup outside conditional block

## Motivation for adding to Mudlet

These memory leaks were causing Mudlet to gradually consume more memory over time, particularly noticeable during extended play sessions. The fixes prevent unnecessary memory growth and improve overall application stability.

## Other info (issues closed, discussion etc)

- All changes maintain Qt6/C++20 compatibility
- The auto-complete provider ownership is transferred to Edbee via `giveProvider()`, which handles cleanup automatically at app shutdown
- Changes have been tested with successful builds on macOS

Based off of logs [message.txt](https://github.com/user-attachments/files/24362610/message.txt) [message_1.txt](https://github.com/user-attachments/files/24362611/message_1.txt) from this Discord [discussion](https://discord.com/channels/283581582550237184/427919962561052673/1454549976276533360).