### PR TITLE
Infrastructure: eliminate remains of qt-ordered-map from Mudlet

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "3rdparty/dblsqd"]
 	path = 3rdparty/dblsqd
 	url = https://github.com/Mudlet/dblsqd-sdk-qt.git
-[submodule "3rdparty/qt-ordered-map"]
-	path = 3rdparty/qt-ordered-map
-	url = https://github.com/Mudlet/qt-ordered-map
 [submodule "3rdparty/qt-tags-widget"]
 	path = 3rdparty/qt-tags-widget
 	url = https://github.com/julian-go/qt-tags-widget.git


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Removes this git submodule from the Mudlet project.

#### Motivation for removing from Mudlet
We haven't used this since I removed it from the used code in #6434 (in 2022)!

#### Other info (issues closed, discussion etc)