### PR TITLE
Improve: error messages for easier troubleshooting

### DIFF
--- a/src/FileOpenHandler.cpp
+++ b/src/FileOpenHandler.cpp
@@ -30,8 +30,15 @@ bool FileOpenHandler::eventFilter(QObject* obj, QEvent* event)
 {
     if (event->type() == QEvent::FileOpen) {
         QFileOpenEvent* openEvent = static_cast<QFileOpenEvent*>(event);
-        Q_ASSERT(mudlet::self());
+        if (!mudlet::self()) {
+            qWarning() << "FileOpenHandler::eventFilter() - mudlet instance not available, cannot process file open event";
+            return false;
+        }
         MudletInstanceCoordinator* instanceCoordinator = mudlet::self()->getInstanceCoordinator();
+        if (!instanceCoordinator) {
+            qWarning() << "FileOpenHandler::eventFilter() - Instance coordinator not available, cannot process file open event";
+            return false;
+        }
         const QString absPath = QDir(openEvent->file()).absolutePath();
         instanceCoordinator->queuePackage(absPath);
         instanceCoordinator->installPackagesLocally();

--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -30,7 +30,16 @@ GMCPAuthenticator::GMCPAuthenticator(Host* pHost)
 
 void GMCPAuthenticator::saveSupportsSet(const QString& data)
 {
-    auto jsonDoc = QJsonDocument::fromJson(data.toUtf8());
+    QJsonParseError parseError;
+    auto jsonDoc = QJsonDocument::fromJson(data.toUtf8(), &parseError);
+    if (parseError.error != QJsonParseError::NoError) {
+        qWarning() << "GMCPAuthenticator::saveSupportsSet() - Failed to parse JSON:" << parseError.errorString();
+        return;
+    }
+    if (!jsonDoc.isObject()) {
+        qWarning() << "GMCPAuthenticator::saveSupportsSet() - JSON data is not an object";
+        return;
+    }
     auto jsonObj = jsonDoc.object();
 
     if (jsonObj.contains("type")) {
@@ -89,7 +98,18 @@ void GMCPAuthenticator::sendCredentials()
 
 void GMCPAuthenticator::handleAuthResult(const QString& data)
 {
-    auto doc = QJsonDocument::fromJson(data.toUtf8());
+    QJsonParseError parseError;
+    auto doc = QJsonDocument::fromJson(data.toUtf8(), &parseError);
+    if (parseError.error != QJsonParseError::NoError) {
+        qWarning() << "GMCPAuthenticator::handleAuthResult() - Failed to parse JSON:" << parseError.errorString();
+        mpHost->postMessage(tr("[ ERROR ] - Failed to parse authentication result from server"));
+        return;
+    }
+    if (!doc.isObject()) {
+        qWarning() << "GMCPAuthenticator::handleAuthResult() - JSON data is not an object";
+        mpHost->postMessage(tr("[ ERROR ] - Invalid authentication result format from server"));
+        return;
+    }
     auto obj = doc.object();
 
     // some game drivers can parse JSON for true or false, but may not be able to write booleans back

--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -28,16 +28,18 @@ GMCPAuthenticator::GMCPAuthenticator(Host* pHost)
 : mpHost(pHost)
 {}
 
-void GMCPAuthenticator::saveSupportsSet(const QString& data)
+void GMCPAuthenticator::saveSupportsSet(const QString& packageMessage, const QString& data)
 {
     QJsonParseError parseError;
     auto jsonDoc = QJsonDocument::fromJson(data.toUtf8(), &parseError);
     if (parseError.error != QJsonParseError::NoError) {
-        qWarning() << "GMCPAuthenticator::saveSupportsSet() - Failed to parse JSON:" << parseError.errorString();
+        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Failed to parse JSON: " << parseError.errorString()
+                                       << " at offset " << parseError.offset << ". Received data: \"" << data << "\"";
         return;
     }
     if (!jsonDoc.isObject()) {
-        qWarning() << "GMCPAuthenticator::saveSupportsSet() - JSON data is not an object";
+        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Expected JSON object but got "
+                                       << (jsonDoc.isArray() ? "array" : jsonDoc.isNull() ? "null" : "unknown type") << ".";
         return;
     }
     auto jsonObj = jsonDoc.object();
@@ -96,18 +98,18 @@ void GMCPAuthenticator::sendCredentials()
 }
 
 
-void GMCPAuthenticator::handleAuthResult(const QString& data)
+void GMCPAuthenticator::handleAuthResult(const QString& packageMessage, const QString& data)
 {
     QJsonParseError parseError;
     auto doc = QJsonDocument::fromJson(data.toUtf8(), &parseError);
     if (parseError.error != QJsonParseError::NoError) {
-        qWarning() << "GMCPAuthenticator::handleAuthResult() - Failed to parse JSON:" << parseError.errorString();
-        mpHost->postMessage(tr("[ ERROR ] - Failed to parse authentication result from server"));
+        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Failed to parse JSON: " << parseError.errorString()
+                                       << " at offset " << parseError.offset << ". Received data: \"" << data << "\"";
         return;
     }
     if (!doc.isObject()) {
-        qWarning() << "GMCPAuthenticator::handleAuthResult() - JSON data is not an object";
-        mpHost->postMessage(tr("[ ERROR ] - Invalid authentication result format from server"));
+        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Expected JSON object but got "
+                                       << (doc.isArray() ? "array" : doc.isNull() ? "null" : "unknown type") << ".";
         return;
     }
     auto obj = doc.object();
@@ -140,7 +142,7 @@ void GMCPAuthenticator::handleAuthResult(const QString& data)
 void GMCPAuthenticator::handleAuthGMCP(const QString& packageMessage, const QString& data)
 {
     if (packageMessage == qsl("Char.Login.Default")) {
-        saveSupportsSet(data);
+        saveSupportsSet(packageMessage, data);
 
         if (mSupportedAuthTypes.contains(qsl("password-credentials"))) {
             mpHost->mTelnet.cancelLoginTimers();
@@ -154,7 +156,7 @@ void GMCPAuthenticator::handleAuthGMCP(const QString& packageMessage, const QStr
     }
 
     if (packageMessage == qsl("Char.Login.Result")) {
-        handleAuthResult(data);
+        handleAuthResult(packageMessage, data);
         return;
     }
 

--- a/src/GMCPAuthenticator.h
+++ b/src/GMCPAuthenticator.h
@@ -39,9 +39,9 @@ public:
     explicit GMCPAuthenticator(Host* pHost);
     ~GMCPAuthenticator() = default;
 
-    void saveSupportsSet(const QString& data);
+    void saveSupportsSet(const QString& packageMessage, const QString& data);
     void sendCredentials();
-    void handleAuthResult(const QString& data);
+    void handleAuthResult(const QString& packageMessage, const QString& data);
     void handleAuthGMCP(const QString& packageMessage, const QString& data);
 
 private:

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -258,7 +258,9 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
     const QString logFileName = qsl("%1/errors.txt").arg(directoryLogFile);
     const QDir dirLogFile;
     if (!dirLogFile.exists(directoryLogFile)) {
-        dirLogFile.mkpath(directoryLogFile);
+        if (!dirLogFile.mkpath(directoryLogFile)) {
+            qWarning() << "Host: failed to create error log directory:" << directoryLogFile;
+        }
     }
     mErrorLogFile.setFileName(logFileName);
     if (!mErrorLogFile.open(QIODevice::Append)) {

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -514,7 +514,7 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         } else if (kType == LUA_TTABLE) {
             lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
         } else {
-            //FIXME: report error to user qDebug()<<"unknown key type"<<var->getKeyType();
+            qWarning() << "LuaInterface::renameCVar() - Unknown key type:" << var->getKeyType() << "for variable:" << var->getName();
             return;
         }
 
@@ -542,7 +542,7 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         } else if (kType == LUA_TTABLE || kType == LUA_TFUNCTION) {
             lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
         } else {
-            //FIXME: report error to user qDebug()<<"unknown key type"<<var->getKeyType();
+            qWarning() << "LuaInterface::renameCVar() - Unknown key type when retrieving old value:" << var->getKeyType() << "for variable:" << var->getName();
             return;
         }
         lua_gettable(mL, -2);
@@ -557,7 +557,7 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         } else if (kType == LUA_TTABLE) {
             lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
         } else {
-            //FIXME: report error to userqDebug()<<"unknown key type"<<var->getKeyType();
+            qWarning() << "LuaInterface::renameCVar() - Unknown key type when setting new key:" << var->getKeyType() << "for variable:" << var->getName();
             return;
         }
         pushCount++;
@@ -573,7 +573,7 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         } else if (kType == LUA_TTABLE || kType == LUA_TFUNCTION) {
             lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
         } else {
-            //FIXME: report error to userqDebug()<<"unknown key type"<<var->getKeyType();
+            qWarning() << "LuaInterface::renameCVar() - Unknown key type when deleting old key:" << var->getKeyType() << "for variable:" << var->getName();
             return;
         }
         lua_pushnil(mL);
@@ -614,7 +614,7 @@ bool LuaInterface::loadVar(TVar* var)
             return false;
         }
     } else {
-        //FIXME: report error to user qDebug()<<"panic in loadVar";
+        qWarning() << "LuaInterface::loadVar() - Lua panic occurred while loading variable:" << var->getName();
         return false;
     }
     return true;

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -143,18 +143,21 @@ bool LuaInterface::loadValue(lua_State* L, TVar* var, int index)
                 // Validate stack before attempting table access
                 const int stackTop = lua_gettop(L);
                 const int actualIndex = (index < 0) ? stackTop + index + 1 : index;
-                
+
                 if (actualIndex <= 0 || actualIndex > stackTop) {
-                    qWarning() << "LuaInterface::loadValue() - Invalid stack index:" << index 
-                               << "Stack size:" << stackTop << "Actual index:" << actualIndex;
+                    qWarning().noquote().nospace() << "LuaInterface::loadValue() - Invalid stack index " << index
+                                                   << " for variable \"" << var->getName() << "\". Stack size: " << stackTop
+                                                   << ", resolved index: " << actualIndex << ".";
                     return false;
                 }
-                
+
                 if (!lua_istable(L, index)) {
-                    qWarning() << "LuaInterface::loadValue() - Value at index" << index << "is not a table, type:" << lua_typename(L, lua_type(L, index));
+                    qWarning().noquote().nospace() << "LuaInterface::loadValue() - Value at stack index " << index
+                                                   << " is not a table for variable \"" << var->getName()
+                                                   << "\". Got type: " << lua_typename(L, lua_type(L, index)) << ".";
                     return false;
                 }
-                
+
                 lua_gettable(L, index);
             } else {
                 // Find the closest table on the stack
@@ -167,7 +170,8 @@ bool LuaInterface::loadValue(lua_State* L, TVar* var, int index)
                     }
                 }
                 if (!foundTable) {
-                    qWarning() << "LuaInterface::loadValue() - No table found on stack when index=0";
+                    qWarning().noquote().nospace() << "LuaInterface::loadValue() - No table found on stack for variable \"" << var->getName()
+                                                   << "\" when index=0. Stack size: " << lua_gettop(L) << ".";
                     return false;
                 }
             }
@@ -514,7 +518,9 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         } else if (kType == LUA_TTABLE) {
             lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
         } else {
-            qWarning() << "LuaInterface::renameCVar() - Unknown key type:" << var->getKeyType() << "for variable:" << var->getName();
+            qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type: " << lua_typename(mL, kType)
+                                           << " for variable \"" << var->getName()
+                                           << "\". Expected string, number, or table.";
             return;
         }
 
@@ -542,7 +548,9 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         } else if (kType == LUA_TTABLE || kType == LUA_TFUNCTION) {
             lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
         } else {
-            qWarning() << "LuaInterface::renameCVar() - Unknown key type when retrieving old value:" << var->getKeyType() << "for variable:" << var->getName();
+            qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type when retrieving old value: " << lua_typename(mL, kType)
+                                           << " for variable \"" << var->getName()
+                                           << "\". Expected string, number, table, or function.";
             return;
         }
         lua_gettable(mL, -2);
@@ -557,7 +565,9 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         } else if (kType == LUA_TTABLE) {
             lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
         } else {
-            qWarning() << "LuaInterface::renameCVar() - Unknown key type when setting new key:" << var->getKeyType() << "for variable:" << var->getName();
+            qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type when setting new key: " << lua_typename(mL, kType)
+                                           << " for variable \"" << var->getName()
+                                           << "\". Expected string, number, or table.";
             return;
         }
         pushCount++;
@@ -573,7 +583,9 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         } else if (kType == LUA_TTABLE || kType == LUA_TFUNCTION) {
             lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
         } else {
-            qWarning() << "LuaInterface::renameCVar() - Unknown key type when deleting old key:" << var->getKeyType() << "for variable:" << var->getName();
+            qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type when deleting old key: " << lua_typename(mL, kType)
+                                           << " for variable \"" << var->getName()
+                                           << "\". Expected string, number, table, or function.";
             return;
         }
         lua_pushnil(mL);
@@ -614,7 +626,9 @@ bool LuaInterface::loadVar(TVar* var)
             return false;
         }
     } else {
-        qWarning() << "LuaInterface::loadVar() - Lua panic occurred while loading variable:" << var->getName();
+        qWarning().noquote().nospace() << "LuaInterface::loadVar() - Lua panic occurred while loading variable \"" << var->getName()
+                                       << "\" with key type " << lua_typename(mL, var->getKeyType())
+                                       << " and value type " << lua_typename(mL, var->getValueType()) << ".";
         return false;
     }
     return true;

--- a/src/TForkedProcess.cpp
+++ b/src/TForkedProcess.cpp
@@ -24,6 +24,8 @@
 
 #include "TForkedProcess.h"
 
+#include <QDir>
+
 
 TForkedProcess::~TForkedProcess()
 {
@@ -67,7 +69,8 @@ TForkedProcess::TForkedProcess(TLuaInterpreter* pInterpreter, lua_State* L)
     setProcessChannelMode(QProcess::MergedChannels);
     start(prog, args, QIODevice::ReadWrite);
     if (!waitForStarted()) {
-        const QString errorMessage = qsl("Failed to start process '%1': %2").arg(prog, errorString());
+        const QString errorMessage = qsl("Failed to start process '%1': %2. Working directory: '%3'. PATH: '%4'")
+                                             .arg(prog, errorString(), QDir::currentPath(), qEnvironmentVariable("PATH"));
         lua_pushstring(L, errorMessage.toUtf8().constData());
         lua_error(L);
         return;

--- a/src/TForkedProcess.cpp
+++ b/src/TForkedProcess.cpp
@@ -66,7 +66,12 @@ TForkedProcess::TForkedProcess(TLuaInterpreter* pInterpreter, lua_State* L)
 
     setProcessChannelMode(QProcess::MergedChannels);
     start(prog, args, QIODevice::ReadWrite);
-    waitForStarted();
+    if (!waitForStarted()) {
+        const QString errorMessage = qsl("Failed to start process '%1': %2").arg(prog, errorString());
+        lua_pushstring(L, errorMessage.toUtf8().constData());
+        lua_error(L);
+        return;
+    }
     running = true;
 }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds detailed error messages with context to help diagnose issues:
- Process startup failures now show working directory and PATH
- GMCP authentication errors show the package name and malformed data
- Lua variable operations show variable names and type information
- File/directory operations report specific failures

#### Motivation for adding to Mudlet

When something goes wrong, vague error messages make troubleshooting difficult. These improvements help both users and game admins quickly identify the root cause of issues.

#### Other info (issues closed, discussion etc)

Test cases:
- Try to start a non-existent process via Lua
- Connect to a game server sending malformed GMCP auth JSON
- Trigger Lua variable rename with unsupported key types (this one would be hard to do, UI doesnt allow it)

Sample error messages:

```
Failed to start process 'python3': No such file or directory. Working directory: '/home/user/.config/mudlet/profiles/MyGame'. PATH: '/usr/local/bin:/usr/bin:/bin'

GMCP Char.Login.Result - Failed to parse JSON: illegal value at offset 15. Received data: "{invalid: json}"

GMCP Char.Login.Result - Expected JSON object but got null.

LuaInterface::renameCVar() - Unsupported key type: boolean for variable "myVar". Expected string, number, or table.

LuaInterface::loadValue() - Value at stack index 2 is not a table for variable "config". Got type: string.

Host: failed to create error log directory: /home/user/.config/mudlet/profiles/MyGame/log
```