### PR TITLE
Infrastructure: Add a security policy for reporting vulnerabilities

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported Versions
+
+We provide security updates for versions released within the last two years.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 4.19.x  | :white_check_mark: |
+| 4.17.x  | :white_check_mark: |
+| < 4.17  | :x:                |
+
+## Reporting a Vulnerability
+
+To report a security vulnerability, please use GitHub's private vulnerability reporting feature:
+
+1. Go to the [Security Advisories](https://github.com/Mudlet/Mudlet/security/advisories) page
+2. Click "Report a vulnerability"
+3. Provide a detailed description of the vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+### What to expect
+
+- **Initial response**: Within 7 days of your report
+- **Status updates**: We will keep you informed of our progress
+- **Resolution**: We aim to address confirmed vulnerabilities promptly and will coordinate disclosure with you
+
+### What happens next
+
+- If the vulnerability is accepted, we will work on a fix and coordinate a release timeline with you
+- If the vulnerability is declined, we will explain our reasoning
+- Credit will be given to reporters in release notes unless anonymity is requested


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds a SECURITY.md file that documents how to report security vulnerabilities privately via GitHub's security advisories feature.

#### Motivation for adding to Mudlet

Helps with SignPath compliance and makes it clear to security researchers how to responsibly disclose vulnerabilities.

#### Other info (issues closed, discussion etc)

Lists supported versions (4.17.x and 4.19.x) based on 2-year support window.