### PR TITLE
Improve safety of internal text handling

### DIFF
--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -89,14 +89,11 @@ bool TAlias::match(const QString& haystack)
         return false; //regex compile error
     }
 
-#if defined(Q_OS_WINDOWS)
-    // strndup(3) - a safe strdup(3) does not seem to be available in the
-    // original Mingw or the replacement Mingw-w64 environment we use:
-    char* haystackC = static_cast<char*>(malloc(strlen(haystack.toUtf8().constData()) + 1));
-    strcpy(haystackC, haystack.toUtf8().constData());
-#else
-    char* haystackC = strndup(haystack.toUtf8().constData(), strlen(haystack.toUtf8().constData()));
-#endif
+    const QByteArray utf8Data = haystack.toUtf8();
+    const int utf8Length = utf8Data.size();
+    char* haystackC = static_cast<char*>(malloc(utf8Length + 1));
+    memcpy(haystackC, utf8Data.constData(), utf8Length);
+    haystackC[utf8Length] = '\0';
 
     // These must be initialised before any goto so the latter does not jump
     // over them:

--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -90,8 +90,11 @@ bool TAlias::match(const QString& haystack)
     }
 
     const QByteArray utf8Data = haystack.toUtf8();
-    const int utf8Length = utf8Data.size();
+    const size_t utf8Length = utf8Data.size();
     char* haystackC = static_cast<char*>(malloc(utf8Length + 1));
+    if (!haystackC) {
+        return false;
+    }
     memcpy(haystackC, utf8Data.constData(), utf8Length);
     haystackC[utf8Length] = '\0';
 

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2616,7 +2616,6 @@ void TTextEdit::slot_analyseSelection()
     // in Lua.
     short int utf8Index = 1;
     char utf8Bytes[5];
-    utf8Bytes[4] = '\0';
 
     int total = 0;
     startColumn = mPA.x();
@@ -2652,7 +2651,7 @@ void TTextEdit::slot_analyseSelection()
 
         if (mpBuffer->lineBuffer.at(line).at(index).isHighSurrogate() && ((index + 1) < lineLength)) {
             const QByteArray utf8Data = mpBuffer->lineBuffer.at(line).mid(index, 2).toUtf8();
-            const size_t utf8Width = qMin(static_cast<size_t>(utf8Data.size()), static_cast<size_t>(4));
+            const size_t utf8Width = qMin(static_cast<size_t>(utf8Data.size()), size_t{4});
             memcpy(utf8Bytes, utf8Data.constData(), utf8Width);
             utf8Bytes[utf8Width] = '\0';
             quint8 columnsToUse = qMax(static_cast<size_t>(2), utf8Width);
@@ -2747,7 +2746,7 @@ void TTextEdit::slot_analyseSelection()
             index += 1;
         } else {
             const QByteArray utf8Data = mpBuffer->lineBuffer.at(line).mid(index, 1).toUtf8();
-            const size_t utf8Width = qMin(static_cast<size_t>(utf8Data.size()), static_cast<size_t>(4));
+            const size_t utf8Width = qMin(static_cast<size_t>(utf8Data.size()), size_t{4});
             memcpy(utf8Bytes, utf8Data.constData(), utf8Width);
             utf8Bytes[utf8Width] = '\0';
             quint8 columnsToUse = qMax(static_cast<size_t>(1), utf8Width);

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2651,8 +2651,10 @@ void TTextEdit::slot_analyseSelection()
         }
 
         if (mpBuffer->lineBuffer.at(line).at(index).isHighSurrogate() && ((index + 1) < lineLength)) {
-            strncpy(utf8Bytes, mpBuffer->lineBuffer.at(line).mid(index, 2).toUtf8().constData(), 4);
-            size_t utf8Width = strnlen(utf8Bytes, 4);
+            const QByteArray utf8Data = mpBuffer->lineBuffer.at(line).mid(index, 2).toUtf8();
+            const size_t utf8Width = qMin(static_cast<size_t>(utf8Data.size()), static_cast<size_t>(4));
+            memcpy(utf8Bytes, utf8Data.constData(), utf8Width);
+            utf8Bytes[utf8Width] = '\0';
             quint8 columnsToUse = qMax(static_cast<size_t>(2), utf8Width);
 
             if (includeThisCodePoint) {
@@ -2744,8 +2746,10 @@ void TTextEdit::slot_analyseSelection()
             // for the surrogate pair:
             index += 1;
         } else {
-            strncpy(utf8Bytes, mpBuffer->lineBuffer.at(line).mid(index, 1).toUtf8().constData(), 4);
-            size_t utf8Width = strnlen(utf8Bytes, 4);
+            const QByteArray utf8Data = mpBuffer->lineBuffer.at(line).mid(index, 1).toUtf8();
+            const size_t utf8Width = qMin(static_cast<size_t>(utf8Data.size()), static_cast<size_t>(4));
+            memcpy(utf8Bytes, utf8Data.constData(), utf8Width);
+            utf8Bytes[utf8Width] = '\0';
             quint8 columnsToUse = qMax(static_cast<size_t>(1), utf8Width);
 
             if (includeThisCodePoint) {

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -34,6 +34,7 @@
 #include "THyperlinkSelectionManager.h"
 #include "THyperlinkVisibilityManager.h"
 #include "mudlet.h"
+#include "utils.h"
 #include "widechar_width.h"
 #include "TTextProperties.h"
 
@@ -2651,10 +2652,8 @@ void TTextEdit::slot_analyseSelection()
 
         if (mpBuffer->lineBuffer.at(line).at(index).isHighSurrogate() && ((index + 1) < lineLength)) {
             const QByteArray utf8Data = mpBuffer->lineBuffer.at(line).mid(index, 2).toUtf8();
-            const size_t utf8Width = qMin(static_cast<size_t>(utf8Data.size()), size_t{4});
-            memcpy(utf8Bytes, utf8Data.constData(), utf8Width);
-            utf8Bytes[utf8Width] = '\0';
-            quint8 columnsToUse = qMax(static_cast<size_t>(2), utf8Width);
+            const size_t utf8Width = utils::copyString(utf8Bytes, sizeof(utf8Bytes), utf8Data.constData(), utf8Data.size());
+            quint8 columnsToUse = qMax(size_t{2}, utf8Width);
 
             if (includeThisCodePoint) {
                 utf16indexes.append(qsl("<th colspan=\"%1\"><center>%2 & %3</center></th>").arg(QString::number(columnsToUse), QString::number(index + 1), QString::number(index + 2)));
@@ -2746,10 +2745,8 @@ void TTextEdit::slot_analyseSelection()
             index += 1;
         } else {
             const QByteArray utf8Data = mpBuffer->lineBuffer.at(line).mid(index, 1).toUtf8();
-            const size_t utf8Width = qMin(static_cast<size_t>(utf8Data.size()), size_t{4});
-            memcpy(utf8Bytes, utf8Data.constData(), utf8Width);
-            utf8Bytes[utf8Width] = '\0';
-            quint8 columnsToUse = qMax(static_cast<size_t>(1), utf8Width);
+            const size_t utf8Width = utils::copyString(utf8Bytes, sizeof(utf8Bytes), utf8Data.constData(), utf8Data.size());
+            quint8 columnsToUse = qMax(size_t{1}, utf8Width);
 
             if (includeThisCodePoint) {
                 utf16indexes.append(qsl("<th colspan=\"%1\"><center>%2</center></th>").arg(QString::number(columnsToUse), QString::number(index + 1)));

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -569,12 +569,13 @@ inline void TTrigger::filter(std::string& capture, int& posOffset)
     if (capture.empty()) {
         return;
     }
-    auto * filterSubject = static_cast<char*>(malloc(capture.size() + 2048));
-    if (filterSubject) {
-        strcpy(filterSubject, capture.c_str());
-    } else {
+    const size_t captureLen = capture.size();
+    auto* filterSubject = static_cast<char*>(malloc(captureLen + 2048));
+    if (!filterSubject) {
         return;
     }
+    memcpy(filterSubject, capture.c_str(), captureLen);
+    filterSubject[captureLen] = '\0';
     const QString text = capture.c_str();
     for (auto& trigger : *mpMyChildrenList) {
         trigger->match(filterSubject, text, -1, posOffset);

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -278,9 +278,12 @@ void TriggerUnit::processDataStream(const QString& data, int line)
 
     const QByteArray utf8Data = data.toUtf8();
     const char* utf8Ptr = utf8Data.constData();
-    const int utf8Length = utf8Data.size();
+    const size_t utf8Length = utf8Data.size();
 
     char* subject = static_cast<char*>(malloc(utf8Length + 1));
+    if (!subject) {
+        return;
+    }
     memcpy(subject, utf8Ptr, utf8Length);
     subject[utf8Length] = '\0';
 

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -280,14 +280,9 @@ void TriggerUnit::processDataStream(const QString& data, int line)
     const char* utf8Ptr = utf8Data.constData();
     const int utf8Length = utf8Data.size();
 
-#if defined(Q_OS_WINDOWS)
-    // strndup(3) - a safe strdup(3) does not seem to be available in the
-    // original mingw or the replacement mingw-w64 enmvironment we use:
     char* subject = static_cast<char*>(malloc(utf8Length + 1));
-    strcpy(subject, utf8Ptr);
-#else
-    char* subject = strndup(utf8Ptr, utf8Length);
-#endif
+    memcpy(subject, utf8Ptr, utf8Length);
+    subject[utf8Length] = '\0';
 
     // Set processing flag to prevent re-entrant cleanup during trigger execution
     mIsProcessing = true;

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -21,10 +21,10 @@
 
 #include "discord.h"
 #include "mudlet.h"
+#include "utils.h"
 
 #include <QtDebug>
 #include <QHash>
-#include <string.h>
 
 // Uncomment this to provide some additional qDebug() output:
 // #define DEBUG_DISCORD 1
@@ -632,73 +632,55 @@ DiscordRichPresence localDiscordPresence::convert() const
 void localDiscordPresence::setDetailText(const QString& text)
 {
     const QByteArray utf8Data = text.toUtf8();
-    const size_t copyLen = qMin(static_cast<size_t>(utf8Data.size()), sizeof(mDetails) - 1);
-    memcpy(mDetails, utf8Data.constData(), copyLen);
-    mDetails[copyLen] = '\0';
+    utils::copyString(mDetails, sizeof(mDetails), utf8Data.constData(), utf8Data.size());
 }
 
 void localDiscordPresence::setStateText(const QString& text)
 {
     const QByteArray utf8Data = text.toUtf8();
-    const size_t copyLen = qMin(static_cast<size_t>(utf8Data.size()), sizeof(mState) - 1);
-    memcpy(mState, utf8Data.constData(), copyLen);
-    mState[copyLen] = '\0';
+    utils::copyString(mState, sizeof(mState), utf8Data.constData(), utf8Data.size());
 }
 
 void localDiscordPresence::setLargeImageText(const QString& text)
 {
     const QByteArray utf8Data = text.toUtf8();
-    const size_t copyLen = qMin(static_cast<size_t>(utf8Data.size()), sizeof(mLargeImageText) - 1);
-    memcpy(mLargeImageText, utf8Data.constData(), copyLen);
-    mLargeImageText[copyLen] = '\0';
+    utils::copyString(mLargeImageText, sizeof(mLargeImageText), utf8Data.constData(), utf8Data.size());
 }
 
 void localDiscordPresence::setLargeImageKey(const QString& text)
 {
     const QByteArray utf8Data = text.toUtf8();
-    const size_t copyLen = qMin(static_cast<size_t>(utf8Data.size()), sizeof(mLargeImageKey) - 1);
-    memcpy(mLargeImageKey, utf8Data.constData(), copyLen);
-    mLargeImageKey[copyLen] = '\0';
+    utils::copyString(mLargeImageKey, sizeof(mLargeImageKey), utf8Data.constData(), utf8Data.size());
 }
 
 void localDiscordPresence::setSmallImageText(const QString& text)
 {
     const QByteArray utf8Data = text.toUtf8();
-    const size_t copyLen = qMin(static_cast<size_t>(utf8Data.size()), sizeof(mSmallImageText) - 1);
-    memcpy(mSmallImageText, utf8Data.constData(), copyLen);
-    mSmallImageText[copyLen] = '\0';
+    utils::copyString(mSmallImageText, sizeof(mSmallImageText), utf8Data.constData(), utf8Data.size());
 }
 
 void localDiscordPresence::setSmallImageKey(const QString& text)
 {
     const QByteArray utf8Data = text.toUtf8();
-    const size_t copyLen = qMin(static_cast<size_t>(utf8Data.size()), sizeof(mSmallImageKey) - 1);
-    memcpy(mSmallImageKey, utf8Data.constData(), copyLen);
-    mSmallImageKey[copyLen] = '\0';
+    utils::copyString(mSmallImageKey, sizeof(mSmallImageKey), utf8Data.constData(), utf8Data.size());
 }
 
 void localDiscordPresence::setJoinSecret(const QString& text)
 {
     const QByteArray utf8Data = text.toUtf8();
-    const size_t copyLen = qMin(static_cast<size_t>(utf8Data.size()), sizeof(mJoinSecret) - 1);
-    memcpy(mJoinSecret, utf8Data.constData(), copyLen);
-    mJoinSecret[copyLen] = '\0';
+    utils::copyString(mJoinSecret, sizeof(mJoinSecret), utf8Data.constData(), utf8Data.size());
 }
 
 void localDiscordPresence::setMatchSecret(const QString& text)
 {
     const QByteArray utf8Data = text.toUtf8();
-    const size_t copyLen = qMin(static_cast<size_t>(utf8Data.size()), sizeof(mMatchSecret) - 1);
-    memcpy(mMatchSecret, utf8Data.constData(), copyLen);
-    mMatchSecret[copyLen] = '\0';
+    utils::copyString(mMatchSecret, sizeof(mMatchSecret), utf8Data.constData(), utf8Data.size());
 }
 
 void localDiscordPresence::setSpectateSecret(const QString& text)
 {
     const QByteArray utf8Data = text.toUtf8();
-    const size_t copyLen = qMin(static_cast<size_t>(utf8Data.size()), sizeof(mSpectateSecret) - 1);
-    memcpy(mSpectateSecret, utf8Data.constData(), copyLen);
-    mSpectateSecret[copyLen] = '\0';
+    utils::copyString(mSpectateSecret, sizeof(mSpectateSecret), utf8Data.constData(), utf8Data.size());
 }
 
 bool Discord::usingMudletsDiscordID(Host* pHost) const

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -631,52 +631,74 @@ DiscordRichPresence localDiscordPresence::convert() const
 
 void localDiscordPresence::setDetailText(const QString& text)
 {
-    // Set the amount to be copied to be one less than the size of the buffer
-    // so that the last byte is untouched and always contains the initial
-    // null that was placed there when the thing pointed to by
-    // pDiscordPresence was created:
-
-    strncpy(mDetails, text.toUtf8().constData(), 127);
+    const QByteArray utf8Data = text.toUtf8();
+    const size_t copyLen = qMin(static_cast<size_t>(utf8Data.size()), sizeof(mDetails) - 1);
+    memcpy(mDetails, utf8Data.constData(), copyLen);
+    mDetails[copyLen] = '\0';
 }
 
 void localDiscordPresence::setStateText(const QString& text)
 {
-    strncpy(mState, text.toUtf8().constData(), 127);
+    const QByteArray utf8Data = text.toUtf8();
+    const size_t copyLen = qMin(static_cast<size_t>(utf8Data.size()), sizeof(mState) - 1);
+    memcpy(mState, utf8Data.constData(), copyLen);
+    mState[copyLen] = '\0';
 }
 
 void localDiscordPresence::setLargeImageText(const QString& text)
 {
-    strncpy(mLargeImageText, text.toUtf8().constData(), 127);
+    const QByteArray utf8Data = text.toUtf8();
+    const size_t copyLen = qMin(static_cast<size_t>(utf8Data.size()), sizeof(mLargeImageText) - 1);
+    memcpy(mLargeImageText, utf8Data.constData(), copyLen);
+    mLargeImageText[copyLen] = '\0';
 }
 
 void localDiscordPresence::setLargeImageKey(const QString& text)
 {
-    strncpy(mLargeImageKey, text.toUtf8().constData(), 31);
+    const QByteArray utf8Data = text.toUtf8();
+    const size_t copyLen = qMin(static_cast<size_t>(utf8Data.size()), sizeof(mLargeImageKey) - 1);
+    memcpy(mLargeImageKey, utf8Data.constData(), copyLen);
+    mLargeImageKey[copyLen] = '\0';
 }
 
 void localDiscordPresence::setSmallImageText(const QString& text)
 {
-    strncpy(mSmallImageText, text.toUtf8().constData(), 127);
+    const QByteArray utf8Data = text.toUtf8();
+    const size_t copyLen = qMin(static_cast<size_t>(utf8Data.size()), sizeof(mSmallImageText) - 1);
+    memcpy(mSmallImageText, utf8Data.constData(), copyLen);
+    mSmallImageText[copyLen] = '\0';
 }
 
 void localDiscordPresence::setSmallImageKey(const QString& text)
 {
-    strncpy(mSmallImageKey, text.toUtf8().constData(), 31);
+    const QByteArray utf8Data = text.toUtf8();
+    const size_t copyLen = qMin(static_cast<size_t>(utf8Data.size()), sizeof(mSmallImageKey) - 1);
+    memcpy(mSmallImageKey, utf8Data.constData(), copyLen);
+    mSmallImageKey[copyLen] = '\0';
 }
 
 void localDiscordPresence::setJoinSecret(const QString& text)
 {
-    strncpy(mJoinSecret, text.toUtf8().constData(), 127);
+    const QByteArray utf8Data = text.toUtf8();
+    const size_t copyLen = qMin(static_cast<size_t>(utf8Data.size()), sizeof(mJoinSecret) - 1);
+    memcpy(mJoinSecret, utf8Data.constData(), copyLen);
+    mJoinSecret[copyLen] = '\0';
 }
 
 void localDiscordPresence::setMatchSecret(const QString& text)
 {
-    strncpy(mMatchSecret, text.toUtf8().constData(), 127);
+    const QByteArray utf8Data = text.toUtf8();
+    const size_t copyLen = qMin(static_cast<size_t>(utf8Data.size()), sizeof(mMatchSecret) - 1);
+    memcpy(mMatchSecret, utf8Data.constData(), copyLen);
+    mMatchSecret[copyLen] = '\0';
 }
 
 void localDiscordPresence::setSpectateSecret(const QString& text)
 {
-    strncpy(mSpectateSecret, text.toUtf8().constData(), 127);
+    const QByteArray utf8Data = text.toUtf8();
+    const size_t copyLen = qMin(static_cast<size_t>(utf8Data.size()), sizeof(mSpectateSecret) - 1);
+    memcpy(mSpectateSecret, utf8Data.constData(), copyLen);
+    mSpectateSecret[copyLen] = '\0';
 }
 
 bool Discord::usingMudletsDiscordID(Host* pHost) const

--- a/src/utils.h
+++ b/src/utils.h
@@ -30,6 +30,8 @@
 #include <QScreen>
 #include <QWidget>
 
+#include <cstring>
+
 #define qsl(s) QStringLiteral(s)
 
 using TEnterEvent = QEnterEvent;
@@ -44,6 +46,19 @@ enum class TreeItemInsertMode {
 class utils
 {
 public:
+    // Safe string copy: copies up to destSize-1 bytes and always null-terminates.
+    // Returns the number of bytes copied (excluding null terminator).
+    static size_t copyString(char* dest, size_t destSize, const char* src, size_t srcLen)
+    {
+        if (destSize == 0) {
+            return 0;
+        }
+        const size_t copyLen = (srcLen < destSize) ? srcLen : destSize - 1;
+        std::memcpy(dest, src, copyLen);
+        dest[copyLen] = '\0';
+        return copyLen;
+    }
+
     // This construct will be very useful for formatting tooltips and by
     // defining a static function/method here we can save using the same
     // qsl all over the place:


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Replace C-style string copy functions (`strcpy`/`strncpy`) with safer `memcpy` + explicit null termination across 5 files. Adds null checks for memory allocation failures.

#### Motivation for adding to Mudlet

Follows [curl's security guidance](https://daniel.haxx.se/blog/2025/12/29/no-strcpy-either/) on eliminating unsafe string functions. Also fixes a latent bug in `TAlias.cpp` where a dangling pointer could occur from temporary object lifetimes.

#### Other info (issues closed, discussion etc)

**Test case:** Verify triggers, aliases, and Discord Rich Presence still work:
1. Create a regex alias (e.g. `^test (.+)$`) and confirm it captures groups correctly
2. Create a trigger with a filter chain and confirm child triggers match
3. If Discord integration is enabled, verify game status displays in Discord

No functional changes intended - this is a defensive code quality improvement.
