### PR TITLE
Fix connections to MMapper

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -893,8 +893,15 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
         }
     }
 
-    const bool hasIPv4_address = (addressList_ipV4.count());
-    const bool hasIPv6_address = (addressList_ipV6.count());
+    bool hasIPv4_address = (addressList_ipV4.count());
+    bool hasIPv6_address = (addressList_ipV6.count());
+
+    const bool onlyLocalhost = (addressList_ipV4.isEmpty() || addressList_ipV4 == QStringList{qsl("127.0.0.1")})
+                            && (addressList_ipV6.isEmpty() || addressList_ipV6 == QStringList{qsl("::1")});
+    if (onlyLocalhost && hasIPv4_address && hasIPv6_address) {
+        hasIPv6_address = false;
+    }
+
     if (!(hasIPv4_address || hasIPv6_address)) {
         /*: This text is used in the (expected) case when the user has provided
          * a URL for the Game Server rather than (unusually) an IP address.

--- a/test/functional_tests/TelnetServerStub.cpp
+++ b/test/functional_tests/TelnetServerStub.cpp
@@ -22,7 +22,6 @@
 #include <QTimer>
 #include <QHostAddress>
 #include <QDebug>
-#include <QHostInfo>
 
 #include "TelnetServerStub.h"
 #include "utils.h"
@@ -35,20 +34,14 @@ TelnetServerStub::TelnetServerStub(QObject* parent)
 
 void TelnetServerStub::start(const QString& host, quint16 port)
 {
-    QHostInfo info = QHostInfo::fromName(host);
-
-    if (!info.addresses().isEmpty()) {
-        QHostAddress addr = info.addresses().first();
-        if (listen(addr, port)) {
-            qInfo().noquote() << qsl("✅ TelnetServerStub listening on %1 (%2):%3")
-                        .arg(host)
-                        .arg(addr.toString())
-                        .arg(port);
-        } else {
-            qCritical().noquote() << qsl("❌ Failed to start TelnetServerStub: %1").arg(errorString());
-        }
+    Q_UNUSED(host)
+    const QHostAddress addr = QHostAddress::LocalHost;
+    if (listen(addr, port)) {
+        qInfo().noquote() << qsl("✅ TelnetServerStub listening on %1:%2")
+                    .arg(addr.toString())
+                    .arg(port);
     } else {
-        qCritical() << "Could not resolve host:" << host;
+        qCritical().noquote() << qsl("❌ Failed to start TelnetServerStub: %1").arg(errorString());
     }
 }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Skip Happy Eyeballs algorithm for localhost connections, using IPv4 directly instead.

#### Motivation for adding to Mudlet
Happy Eyeballs races IPv4 and IPv6 connections to find the fastest path - unnecessary overhead for localhost where both work instantly.

#### Other info (issues closed, discussion etc)
**Test case:** Connect to a local server (e.g. `localhost:23`). Connection should use IPv4 only instead of racing both protocols.