### PR TITLE
Infrastructure: simplify cmake build configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,22 +53,6 @@ endif()
 
 enable_testing()
 
-if(POLICY CMP0020)
-  cmake_policy(SET CMP0020 NEW)
-endif()
-
-if(POLICY CMP0057)
-  cmake_policy(SET CMP0057 NEW)
-endif()
-
-if(POLICY CMP0144)
-  cmake_policy(SET CMP0144 NEW)
-endif()
-
-if(POLICY CMP0167)
-  cmake_policy(SET CMP0167 NEW)
-endif()
-
 if(WIN32)
   set(APP_TARGET mudlet.exe)
 elseif(APPLE)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Remove redundant CMake policy checks that are unnecessary with CMake 3.25+

#### Motivation for adding to Mudlet
Code cleanup - all policies (CMP0020, CMP0057, CMP0144, CMP0167) default to NEW in CMake 3.25+, and Mudlet requires 3.25.1 minimum.

#### Other info (issues closed, discussion etc)
Test: build completes successfully with `cmake --build .`