### PR TITLE
Infrastructure: modernize loop syntax across codebase

### DIFF
--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -1426,11 +1426,11 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
     // Collect dock widgets to process to avoid iterator invalidation
     QList<QPair<QString, QPointer<QDockWidget>>> dockWidgetsToProcess;
 
-    for (auto&& [key, value] : mDockWidgetMap.asKeyValueRange()) {
-        if (value) {
-            dockWidgetsToProcess.append(qMakePair(key, value));
+    for (auto&& [key, dockWidget] : mDockWidgetMap.asKeyValueRange()) {
+        if (dockWidget) {
+            dockWidgetsToProcess.append(qMakePair(key, dockWidget));
 #if defined(DEBUG_WINDOW_HANDLING)
-            qDebug() << "TDetachedWindow: Found dock widget in map:" << key << "isVisible:" << value->isVisible();
+            qDebug() << "TDetachedWindow: Found dock widget in map:" << key << "isVisible:" << dockWidget->isVisible();
 #endif
         } else {
 #if defined(DEBUG_WINDOW_HANDLING)

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -113,11 +113,11 @@ TDetachedWindow::~TDetachedWindow()
     }
 
     // Clean up any docked widgets and restore main mappers
-    for (auto it = mDockWidgetMap.begin(); it != mDockWidgetMap.end(); ++it) {
-        if (it.value()) {
+    for (auto&& [key, dockWidget] : mDockWidgetMap.asKeyValueRange()) {
+        if (dockWidget) {
             // If this is a map dock widget, restore the main mapper
-            if (it.key().startsWith("map_")) {
-                QString profileName = it.key().mid(4); // Remove "map_" prefix
+            if (key.startsWith("map_")) {
+                QString profileName = key.mid(4); // Remove "map_" prefix
                 if (auto mudletInstance = mudlet::self()) {
                     if (auto pHost = mudletInstance->getHostManager().getHost(profileName)) {
                         auto pMap = pHost->mpMap.data();
@@ -134,7 +134,7 @@ TDetachedWindow::~TDetachedWindow()
                 }
             }
 
-            it.value()->deleteLater();
+            dockWidget->deleteLater();
         }
     }
 
@@ -1426,15 +1426,15 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
     // Collect dock widgets to process to avoid iterator invalidation
     QList<QPair<QString, QPointer<QDockWidget>>> dockWidgetsToProcess;
 
-    for (auto it = mDockWidgetMap.begin(); it != mDockWidgetMap.end(); ++it) {
-        if (it.value()) {
-            dockWidgetsToProcess.append(qMakePair(it.key(), it.value()));
+    for (auto&& [key, value] : mDockWidgetMap.asKeyValueRange()) {
+        if (value) {
+            dockWidgetsToProcess.append(qMakePair(key, value));
 #if defined(DEBUG_WINDOW_HANDLING)
-            qDebug() << "TDetachedWindow: Found dock widget in map:" << it.key() << "isVisible:" << it.value()->isVisible();
+            qDebug() << "TDetachedWindow: Found dock widget in map:" << key << "isVisible:" << value->isVisible();
 #endif
         } else {
 #if defined(DEBUG_WINDOW_HANDLING)
-            qDebug() << "TDetachedWindow: Found null dock widget in map for key:" << it.key();
+            qDebug() << "TDetachedWindow: Found null dock widget in map for key:" << key;
 #endif
         }
     }
@@ -1720,9 +1720,7 @@ void TDetachedWindow::updateWindowMenu()
         // Collect unique detached windows to avoid duplicates
         QSet<TDetachedWindow*> uniqueDetachedWindows;
 
-        for (auto it = detachedWindows.begin(); it != detachedWindows.end(); ++it) {
-            TDetachedWindow* detachedWindow = it.value();
-
+        for (const auto& detachedWindow : detachedWindows) {
             if (detachedWindow) {
                 uniqueDetachedWindows.insert(detachedWindow);
             }
@@ -1837,18 +1835,16 @@ void TDetachedWindow::slot_activateDetachedWindowProfile()
     // Find which detached window contains this profile
     const auto& detachedWindows = mudlet::self()->getDetachedWindows();
 
-    for (auto it = detachedWindows.begin(); it != detachedWindows.end(); ++it) {
-        TDetachedWindow* detachedWindow = it.value();
-
+    for (const auto& detachedWindow : detachedWindows) {
         if (detachedWindow && detachedWindow->getProfileNames().contains(profileName)) {
             // Activate the detached window
             detachedWindow->raise();
             detachedWindow->activateWindow();
             detachedWindow->show(); // Ensure it's not minimized
-            
+
             // Switch to the specific profile tab in the detached window
             detachedWindow->switchToProfile(profileName);
-            
+
             updateWindowMenu(); // Refresh checkmarks
             break;
         }
@@ -2265,12 +2261,12 @@ void TDetachedWindow::slot_tabMoved(int oldPos, int newPos)
     // Create a map of profile names to console widgets
     QMap<QString, TMainConsole*> consoleWidgetMap;
 
-    for (auto it = mProfileConsoleMap.begin(); it != mProfileConsoleMap.end(); ++it) {
-        if (it.value()) {
-            consoleWidgetMap.insert(it.key(), it.value());
+    for (auto&& [profileName, console] : mProfileConsoleMap.asKeyValueRange()) {
+        if (console) {
+            consoleWidgetMap.insert(profileName, console);
         } else {
-            qWarning().nospace().noquote() << "TDetachedWindow::slot_tabMoved(" << oldPos << ", " << newPos 
-                                           << ") WARNING - nullptr for TMainConsole for profile: " << it.key();
+            qWarning().nospace().noquote() << "TDetachedWindow::slot_tabMoved(" << oldPos << ", " << newPos
+                                           << ") WARNING - nullptr for TMainConsole for profile: " << profileName;
         }
     }
 
@@ -2364,9 +2360,7 @@ void TDetachedWindow::checkForWindowMergeOpportunity()
     // Look for overlapping detached windows
     const auto& detachedWindows = mudletInstance->getDetachedWindows();
 
-    for (auto it = detachedWindows.begin(); it != detachedWindows.end(); ++it) {
-        TDetachedWindow* otherWindow = it.value();
-
+    for (const auto& otherWindow : detachedWindows) {
         // Skip ourselves
         if (otherWindow == this || !otherWindow || !otherWindow->isVisible()) {
             continue;
@@ -2662,9 +2656,7 @@ void TDetachedWindow::slot_showMapperDialog()
     // Check other detached windows for conflicting maps
     const auto& detachedWindows = mudletInstance->getDetachedWindows();
 
-    for (auto it = detachedWindows.begin(); it != detachedWindows.end(); ++it) {
-        TDetachedWindow* otherWindow = it.value();
-
+    for (const auto& otherWindow : detachedWindows) {
         if (otherWindow && otherWindow != this) {
             auto otherMapDock = otherWindow->getDockWidget(mapKey);
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1439,8 +1439,8 @@ void dlgTriggerEditor::slot_clickedMessageBox(const QString& URL)
 
 void dlgTriggerEditor::slot_editorThemeChanged()
 {
-    for (int i = 0; i < mTriggerPatternEdit.size(); i++) {
-        applyPatternWidgetStyle(mTriggerPatternEdit.at(i));
+    for (auto* pattern : mTriggerPatternEdit) {
+        applyPatternWidgetStyle(pattern);
     }
 }
 
@@ -6572,13 +6572,13 @@ void dlgTriggerEditor::saveTrigger()
     QStringList patterns;
     QList<int> patternKinds;
     int validItems = 0;
-    for (int i = 0; i < mTriggerPatternEdit.size(); i++) {
-        QString pattern = mTriggerPatternEdit.at(i)->singleLineTextEdit_pattern->toPlainText();
+    for (auto* patternEdit : mTriggerPatternEdit) {
+        QString pattern = patternEdit->singleLineTextEdit_pattern->toPlainText();
 
         // Spaces in the pattern may be marked with middle dots, convert them back
         unmarkQString(&pattern);
 
-        const int patternType = mTriggerPatternEdit.at(i)->comboBox_patternType->currentIndex();
+        const int patternType = patternEdit->comboBox_patternType->currentIndex();
         if (pattern.isEmpty() && patternType != REGEX_PROMPT && patternType != REGEX_LINE_SPACER) {
             continue;
         }
@@ -6602,7 +6602,7 @@ void dlgTriggerEditor::saveTrigger()
             break;
         case 5:
             patternKinds << REGEX_LINE_SPACER;
-            pattern = mTriggerPatternEdit.at(i)->spinBox_lineSpacer->text();
+            pattern = patternEdit->spinBox_lineSpacer->text();
             break;
         case 6:
             patternKinds << REGEX_COLOR_PATTERN;
@@ -13800,18 +13800,18 @@ void dlgTriggerEditor::slot_restoreEditorItemsToolbar()
 void dlgTriggerEditor::clearTriggerForm()
 {
     // Clear pattern fields
-    for (int i = 0; i < mTriggerPatternEdit.size(); i++) {
-        mTriggerPatternEdit[i]->singleLineTextEdit_pattern->clear();
-        if (mTriggerPatternEdit[i]->singleLineTextEdit_pattern->isHidden()) {
-            mTriggerPatternEdit[i]->singleLineTextEdit_pattern->show();
+    for (auto* patternEdit : mTriggerPatternEdit) {
+        patternEdit->singleLineTextEdit_pattern->clear();
+        if (patternEdit->singleLineTextEdit_pattern->isHidden()) {
+            patternEdit->singleLineTextEdit_pattern->show();
         }
-        mTriggerPatternEdit[i]->pushButton_fgColor->hide();
-        mTriggerPatternEdit[i]->pushButton_bgColor->hide();
-        mTriggerPatternEdit[i]->label_prompt->hide();
-        mTriggerPatternEdit[i]->spinBox_lineSpacer->hide();
+        patternEdit->pushButton_fgColor->hide();
+        patternEdit->pushButton_bgColor->hide();
+        patternEdit->label_prompt->hide();
+        patternEdit->spinBox_lineSpacer->hide();
         // Nudge the type up and down so that the appropriate (coloured) icon is copied across to the QLineEdit:
-        mTriggerPatternEdit[i]->comboBox_patternType->setCurrentIndex(1);
-        mTriggerPatternEdit[i]->comboBox_patternType->setCurrentIndex(0);
+        patternEdit->comboBox_patternType->setCurrentIndex(1);
+        patternEdit->comboBox_patternType->setCurrentIndex(0);
     }
 
     mpTriggersMainArea->lineEdit_trigger_name->clear();
@@ -14176,17 +14176,17 @@ void dlgTriggerEditor::slot_itemsChanged(EditorViewType viewType, QList<int> aff
                 }
             }
         } else {
-            for (int i = 0; i < mTriggerPatternEdit.size(); i++) {
-                mTriggerPatternEdit[i]->singleLineTextEdit_pattern->clear();
-                if (mTriggerPatternEdit[i]->singleLineTextEdit_pattern->isHidden()) {
-                    mTriggerPatternEdit[i]->singleLineTextEdit_pattern->show();
+            for (auto* patternEdit : mTriggerPatternEdit) {
+                patternEdit->singleLineTextEdit_pattern->clear();
+                if (patternEdit->singleLineTextEdit_pattern->isHidden()) {
+                    patternEdit->singleLineTextEdit_pattern->show();
                 }
-                mTriggerPatternEdit[i]->pushButton_fgColor->hide();
-                mTriggerPatternEdit[i]->pushButton_bgColor->hide();
-                mTriggerPatternEdit[i]->label_prompt->hide();
-                mTriggerPatternEdit[i]->spinBox_lineSpacer->hide();
-                mTriggerPatternEdit[i]->comboBox_patternType->setCurrentIndex(1);
-                mTriggerPatternEdit[i]->comboBox_patternType->setCurrentIndex(0);
+                patternEdit->pushButton_fgColor->hide();
+                patternEdit->pushButton_bgColor->hide();
+                patternEdit->label_prompt->hide();
+                patternEdit->spinBox_lineSpacer->hide();
+                patternEdit->comboBox_patternType->setCurrentIndex(1);
+                patternEdit->comboBox_patternType->setCurrentIndex(0);
             }
 
             mpTriggersMainArea->lineEdit_trigger_name->clear();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1439,8 +1439,8 @@ void dlgTriggerEditor::slot_clickedMessageBox(const QString& URL)
 
 void dlgTriggerEditor::slot_editorThemeChanged()
 {
-    for (auto* pattern : mTriggerPatternEdit) {
-        applyPatternWidgetStyle(pattern);
+    for (auto* patternEdit : mTriggerPatternEdit) {
+        applyPatternWidgetStyle(patternEdit);
     }
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -8050,11 +8050,11 @@ void mudlet::updateMainWindowDockWidgetVisibilityForProfile(const QString& profi
     // Collect dock widgets to process to avoid iterator invalidation
     QList<QPair<QString, QPointer<QDockWidget>>> dockWidgetsToProcess;
 
-    for (auto&& [key, value] : mMainWindowDockWidgetMap.asKeyValueRange()) {
-        if (value) {
-            dockWidgetsToProcess.append(qMakePair(key, value));
+    for (auto&& [key, dockWidget] : mMainWindowDockWidgetMap.asKeyValueRange()) {
+        if (dockWidget) {
+            dockWidgetsToProcess.append(qMakePair(key, dockWidget));
 #if defined(DEBUG_WINDOW_HANDLING)
-            qDebug() << "mudlet: Found main window dock widget in map:" << key << "isVisible:" << value->isVisible();
+            qDebug() << "mudlet: Found main window dock widget in map:" << key << "isVisible:" << dockWidget->isVisible();
 #endif
         } else {
 #if defined(DEBUG_WINDOW_HANDLING)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1686,10 +1686,7 @@ void mudlet::slot_reattachAllDetachedWindows()
     qDebug() << "slot_reattachAllDetachedWindows: Reattaching" << detachedWindowsCopy.size() << "detached windows";
 #endif
 
-    for (auto it = detachedWindowsCopy.begin(); it != detachedWindowsCopy.end(); ++it) {
-        const QString& profileName = it.key();
-        TDetachedWindow* detachedWindow = it.value();
-
+    for (auto&& [profileName, detachedWindow] : detachedWindowsCopy.asKeyValueRange()) {
         if (detachedWindow) {
 #if defined(DEBUG_WINDOW_HANDLING)
             qDebug() << "slot_reattachAllDetachedWindows: Reattaching profile" << profileName;
@@ -1791,9 +1788,7 @@ void mudlet::updateWindowMenu()
         // Collect unique detached windows to avoid duplicates
         QSet<TDetachedWindow*> uniqueDetachedWindows;
 
-        for (auto it = mDetachedWindows.begin(); it != mDetachedWindows.end(); ++it) {
-            TDetachedWindow* detachedWindow = it.value();
-
+        for (const auto& detachedWindow : mDetachedWindows) {
             if (detachedWindow) {
                 uniqueDetachedWindows.insert(detachedWindow);
             }
@@ -1818,9 +1813,7 @@ void mudlet::updateWindowMenu()
     }
 
     // Also update window menus on all detached windows
-    for (auto it = mDetachedWindows.begin(); it != mDetachedWindows.end(); ++it) {
-        TDetachedWindow* detachedWindow = it.value();
-
+    for (const auto& detachedWindow : mDetachedWindows) {
         if (detachedWindow) {
             detachedWindow->updateWindowMenu();
         }
@@ -1903,9 +1896,7 @@ void mudlet::slot_activateDetachedWindowProfile()
     QString profileName = action->data().toString();
 
     // Find which detached window contains this profile
-    for (auto it = mDetachedWindows.begin(); it != mDetachedWindows.end(); ++it) {
-        TDetachedWindow* detachedWindow = it.value();
-
+    for (const auto& detachedWindow : mDetachedWindows) {
         if (detachedWindow && detachedWindow->getProfileNames().contains(profileName)) {
             // Activate the detached window
             detachedWindow->raise();
@@ -3734,9 +3725,7 @@ void mudlet::slot_showMapperDialog()
     // Close any existing map for this profile in detached windows first
     const auto& detachedWindows = getDetachedWindows();
 
-    for (auto it = detachedWindows.begin(); it != detachedWindows.end(); ++it) {
-        TDetachedWindow* detachedWindow = it.value();
-
+    for (const auto& detachedWindow : detachedWindows) {
         if (detachedWindow) {
             auto detachedMapDock = detachedWindow->getDockWidget(mapKey);
 
@@ -6636,9 +6625,7 @@ void mudlet::refreshTabBar()
     }
 
     // Also refresh all detached windows to ensure they show CDC identifiers
-    for (auto it = mDetachedWindows.begin(); it != mDetachedWindows.end(); ++it) {
-        TDetachedWindow* detachedWindow = it.value();
-
+    for (const auto& detachedWindow : mDetachedWindows) {
         if (detachedWindow) {
             detachedWindow->refreshTabBar();
         }
@@ -6934,8 +6921,7 @@ void mudlet::shutdownAI()
 
 void mudlet::saveDetachedWindowsGeometry()
 {
-    for (auto it = mDetachedWindows.begin(); it != mDetachedWindows.end(); ++it) {
-        TDetachedWindow* detachedWindow = it.value();
+    for (const auto& detachedWindow : mDetachedWindows) {
         if (detachedWindow) {
             detachedWindow->saveWindowGeometry();
         }
@@ -7492,10 +7478,8 @@ void mudlet::updateDetachedWindowToolbars()
     cleanupDetachedWindowsMap();
 
     // Update toolbars in all detached windows
-    for (auto it = mDetachedWindows.begin(); it != mDetachedWindows.end(); ++it) {
-        QPointer<TDetachedWindow> detachedWindow = it.value();
+    for (auto&& [profileName, detachedWindow] : mDetachedWindows.asKeyValueRange()) {
         if (detachedWindow) {
-            const QString& profileName = it.key();
             Host* pHost = mHostManager.getHost(profileName);
             detachedWindow->updateToolbarForProfile(pHost);
         }
@@ -7589,9 +7573,7 @@ void mudlet::updateDetachedWindowTabIndicators()
     // Update tab indicators for all detached windows
     const auto& detachedWindows = getDetachedWindows();
 
-    for (auto it = detachedWindows.begin(); it != detachedWindows.end(); ++it) {
-        TDetachedWindow* detachedWindow = it.value();
-
+    for (const auto& detachedWindow : detachedWindows) {
         if (detachedWindow) {
             // Update all tabs in this detached window
             detachedWindow->updateAllTabIndicators();
@@ -8068,15 +8050,15 @@ void mudlet::updateMainWindowDockWidgetVisibilityForProfile(const QString& profi
     // Collect dock widgets to process to avoid iterator invalidation
     QList<QPair<QString, QPointer<QDockWidget>>> dockWidgetsToProcess;
 
-    for (auto it = mMainWindowDockWidgetMap.begin(); it != mMainWindowDockWidgetMap.end(); ++it) {
-        if (it.value()) {
-            dockWidgetsToProcess.append(qMakePair(it.key(), it.value()));
+    for (auto&& [key, value] : mMainWindowDockWidgetMap.asKeyValueRange()) {
+        if (value) {
+            dockWidgetsToProcess.append(qMakePair(key, value));
 #if defined(DEBUG_WINDOW_HANDLING)
-            qDebug() << "mudlet: Found main window dock widget in map:" << it.key() << "isVisible:" << it.value()->isVisible();
+            qDebug() << "mudlet: Found main window dock widget in map:" << key << "isVisible:" << value->isVisible();
 #endif
         } else {
 #if defined(DEBUG_WINDOW_HANDLING)
-            qDebug() << "mudlet: Found null main window dock widget in map for key:" << it.key();
+            qDebug() << "mudlet: Found null main window dock widget in map for key:" << key;
 #endif
         }
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Convert iterator-based and index-based loops to modern range-based for loops using C++17 structured bindings where applicable.

#### Motivation for adding to Mudlet
Code modernization - range-based for loops are more readable and less error-prone than manual iterator manipulation.

#### Other info (issues closed, discussion etc)
Test: build completes, trigger editor and detached windows function correctly.