### PR TITLE
Infrastructure: simplify network connection handling

### DIFF
--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -282,6 +282,12 @@ signals:
 private:
     cTelnet() = default;
 
+#if defined(QT_NO_SSL)
+    void abortLosingSocket(QTcpSocket* losingSocket);
+#else
+    void abortLosingSocket(QSslSocket* losingSocket);
+#endif
+
     // loopbackTesting is for internal testing whilst OFF-LINE using the
     // feedTelnet(...) Lua function.
     void processSocketData(char *data, int size, const bool loopbackTesting = false);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Extract duplicated IPv4/IPv6 socket cleanup logic into a helper function, reducing code duplication in connection handling.

#### Motivation for adding to Mudlet
Code cleanup - removes ~40 lines of near-identical code and fixes a debug message bug that incorrectly reported IPv6 for both socket types.

#### Other info (issues closed, discussion etc)
Test: connect to a game server, verify connection succeeds and correct IP version is reported in messages.