### PR TITLE
Improve: add error handling with clear error messages

### DIFF
--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -951,7 +951,9 @@ QPixmap TArea::convertBase64DataToImage(const QList<QByteArray>& pixmapArray) co
 {
     const QByteArray decodedImageArray = QByteArray::fromBase64(pixmapArray.join());
     QPixmap pixmap;
-    pixmap.loadFromData(decodedImageArray);
+    if (!pixmap.loadFromData(decodedImageArray)) {
+        qWarning() << "TArea::convertBase64DataToImage() ERROR - failed to load pixmap from base64 data, data size:" << decodedImageArray.size() << "bytes";
+    }
 
     return pixmap;
 }

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -368,7 +368,7 @@ bool XMLexport::saveXmlFile(QSaveFile& file)
         qWarning() << "XMLexport::saveXmlFile() ERROR - failed to write XML data:" << file.errorString();
         return false;
     }
-    if (static_cast<size_t>(bytesWritten) != output.size()) {
+    if (bytesWritten != static_cast<qint64>(output.size())) {
         qWarning() << "XMLexport::saveXmlFile() ERROR - incomplete write: wrote" << bytesWritten << "of" << output.size() << "bytes";
         return false;
     }

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -363,7 +363,15 @@ bool XMLexport::saveXmlFile(QSaveFile& file)
     sanitizeForQxml(output);
     // Now we can use Qt's file handling which does handle non-Latin1 named
     // files - which MinGW's STL file handling (on Windows platform) does not:
-    file.write(output.data());
+    const qint64 bytesWritten = file.write(output.data(), static_cast<qint64>(output.size()));
+    if (bytesWritten == -1) {
+        qWarning() << "XMLexport::saveXmlFile() ERROR - failed to write XML data:" << file.errorString();
+        return false;
+    }
+    if (static_cast<size_t>(bytesWritten) != output.size()) {
+        qWarning() << "XMLexport::saveXmlFile() ERROR - incomplete write: wrote" << bytesWritten << "of" << output.size() << "bytes";
+        return false;
+    }
     return file.error() == QFileDevice::NoError;
 }
 

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -137,6 +137,7 @@ void dlgPackageManager::downloadRepositoryIndex()
         const QByteArray data = reply->readAll();
         if (file->write(data) != data.size()) {
             qWarning() << "dlgPackageManager::downloadRepositoryIndex() ERROR - failed to write downloaded data:" << file->errorString();
+            reply->abort();
         }
     });
 
@@ -347,13 +348,20 @@ void dlgPackageManager::slot_installPackageFromRepository()
         }
 
         QObject::connect(reply, &QNetworkReply::readyRead, [file, reply]() {
-            file->write(reply->readAll());
+            const QByteArray data = reply->readAll();
+            if (file->write(data) != data.size()) {
+                qWarning() << "dlgPackageManager::slot_installMultiple() ERROR - failed to write downloaded data:" << file->errorString();
+                reply->abort();
+            }
         });
 
         pendingDownloads->insert(packageName, outPath);
 
         QObject::connect(reply, &QNetworkReply::finished, this, [reply, file, this, outPath, packageName, pendingDownloads, remainingDownloads, manager, progress, cancelled, activeReplies]() {
-            file->write(reply->readAll());
+            const QByteArray data = reply->readAll();
+            if (!data.isEmpty() && file->write(data) != data.size()) {
+                qWarning() << "dlgPackageManager::slot_installMultiple() ERROR - failed to write final data:" << file->errorString();
+            }
             file->close();
             reply->deleteLater();
             file->deleteLater();

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -134,11 +134,21 @@ void dlgPackageManager::downloadRepositoryIndex()
     }
 
     QObject::connect(reply, &QNetworkReply::readyRead, [file, reply]() {
-        file->write(reply->readAll());
+        const QByteArray data = reply->readAll();
+        if (file->write(data) != data.size()) {
+            qWarning() << "dlgPackageManager::downloadRepositoryIndex() ERROR - failed to write downloaded data:" << file->errorString();
+        }
     });
 
     QObject::connect(reply, &QNetworkReply::finished, [reply, file, manager, this]() {
-        file->write(reply->readAll());
+        if (reply->error() != QNetworkReply::NoError) {
+            qWarning() << "dlgPackageManager::downloadRepositoryIndex() ERROR - network request failed:" << reply->errorString();
+        } else {
+            const QByteArray data = reply->readAll();
+            if (!data.isEmpty() && file->write(data) != data.size()) {
+                qWarning() << "dlgPackageManager::downloadRepositoryIndex() ERROR - failed to write final data:" << file->errorString();
+            }
+        }
         file->close();
         reply->deleteLater();
         file->deleteLater();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -6107,9 +6107,8 @@ bool mudlet::overwriteAffixFile(const QString& affixPath, const QHash<QString, u
     as << affixLines.join(QChar::LineFeed).toUtf8();
     as << QChar(QChar::LineFeed);
     as.flush();
-    aff.commit();
-    if (aff.error() != QFile::NoError) {
-        qWarning().nospace().noquote() << "mudlet::overwriteAffixFile(...) ERROR - failed to completely write affix file: \"" << aff.fileName() << "\" status: " << aff.errorString();
+    if (!aff.commit()) {
+        qWarning().nospace().noquote() << "mudlet::overwriteAffixFile(...) ERROR - failed to commit affix file: \"" << aff.fileName() << "\" reason: " << aff.errorString();
         return false;
     }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds proper error handling and logging to file/network operations that previously failed silently:
- Fix critical bug in TMedia where code continued after file open failure
- Add JSON parse validation for theme loading
- Check return values for file write and commit operations
- Add network error handling for package manager downloads

#### Motivation for adding to Mudlet

Silent failures make debugging difficult. Users and developers now get clear error messages when file operations fail instead of unexplained broken behavior.

#### Other info (issues closed, discussion etc)

**Test case for TMedia bug:**
1. Create a scenario where media download destination is read-only (e.g., chmod 444 the directory)
2. Before fix: Code attempts to write to unopened file, causing undefined behavior
3. After fix: Proper sysDownloadError event raised with clear message

