### PR TITLE
Improve error message visibility in module creation dialog

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -1906,8 +1906,8 @@ void dlgPackageExporter::listTimers()
 void dlgPackageExporter::displayResultMessage(const QString& html, const bool isSuccessMessage)
 {
     if (!isSuccessMessage) {
-        // Big RED error message
-        ui->infoLabel->setText(qsl("<p><font color='red'><b><big>%1</big><b></font></p>").arg(html));
+        // Light coral red error message - #FF6B6B has good contrast on both light and dark backgrounds
+        ui->infoLabel->setText(qsl("<p><font color='#FF6B6B'><b><big>%1</big><b></font></p>").arg(html));
         return;
     }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Changed error message color from red to light coral (#FF6B6B) for better contrast on dark themes.

#### Motivation for adding to Mudlet

Red error text is hard to read on dark backgrounds in the "Create Module" dialog.

#### Other info (issues closed, discussion etc)

**Test case:**
1. Use a dark theme
2. Open Editor → Export Package
3. Enter any package name, uncheck all items, click "Create Package"
4. Verify error text is readable

<img width="559" height="688" alt="image" src="https://github.com/user-attachments/assets/c5d85c61-a1bf-4be5-8ff8-8dc25f257923" />
