### PR TITLE
Fix: Modules not loading when reopening a profile

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1901,8 +1901,9 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, enums::Pa
     if (thing != enums::PackageModuleType::Package) {
         if ((thing == enums::PackageModuleType::ModuleSync) && (mActiveModules.contains(packageName))) {
             uninstallPackage(packageName, enums::PackageModuleType::ModuleSync);
-        } else if ((thing == enums::PackageModuleType::ModuleFromUI) && (mInstalledModules.contains(packageName) || mActiveModules.contains(packageName))) {
+        } else if ((thing == enums::PackageModuleType::ModuleFromUI) && !mIsProfileLoadingSequence && (mInstalledModules.contains(packageName) || mActiveModules.contains(packageName))) {
             // Check if this is just a stale reference by verifying if module files actually exist
+            // Skip this check during profile loading - modules are expected to be in mInstalledModules already
             QString modulePath = mudlet::getMudletPath(enums::profilePackagePath, getName(), packageName);
             QString moduleFile = mInstalledModules.value(packageName).value(0); // Get the actual file path from stored reference
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4423,7 +4423,10 @@ void mudlet::installModulesList(Host* pHost, QStringList modules)
 {
     for (const auto& module : modules) {
         QStringList entry = pHost->mInstalledModules[module];
-        pHost->installPackage(entry[0], enums::PackageModuleType::ModuleFromUI);
+        auto [success, error] = pHost->installPackage(entry[0], enums::PackageModuleType::ModuleFromUI);
+        if (!success && !error.isEmpty()) {
+            qWarning() << "mudlet::installModulesList() WARNING - failed to load module" << module << ":" << error;
+        }
         //we repeat this step here b/c we use the same installPackage method for initial loading,
         //where we overwrite the globalSave flag.  This restores saved and loaded packages to their proper flag
         pHost->mInstalledModules[module] = entry;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Skip duplicate module detection during profile loading sequence
- Add warning logs when module loading fails

#### Motivation for adding to Mudlet
PR #8039 introduced a check that blocks module installation if the module is already in `mInstalledModules`. During profile reopen, modules are pre-populated in `mInstalledModules` from the saved XML before `installModulesList()` runs, causing all modules to fail with "already installed" - silently, since the return value wasn't checked.

#### Other info (issues closed, discussion etc)
**Root cause:** The stale reference check added in #8039 didn't account for the profile loading path where `mInstalledModules` is populated before modules are actually loaded.

**Test case:**
1. Create a new profile
2. Install a module (e.g., via Module Manager)
3. Close the profile
4. Reopen the profile
5. Verify module scripts/triggers/UI are present and functional