### PR TITLE
Fix: GMCP media finish parameter not working

### DIFF
--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -1783,7 +1783,7 @@ int TMedia::parseJSONByMediaFinish(QJsonObject& json)
 {
     int mediaFinish = TMediaData::MediaFinishNotSet;
 
-    auto mediaFinishJSON = json.value(qsl("end"));
+    auto mediaFinishJSON = json.value(qsl("finish"));
 
     if (mediaFinishJSON != QJsonValue::Undefined && mediaFinishJSON.isString() && !mediaFinishJSON.toString().isEmpty()) {
         mediaFinish = mediaFinishJSON.toString().toInt();


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes the GMCP media `finish` parameter which was not working correctly. The `finish` parameter allows games to specify when a media track should stop playing (in milliseconds).

#### Motivation for adding to Mudlet

The `finish` feature worked correctly when using the Lua API but failed when sent via GMCP. This was caused by the code looking for the wrong JSON key name (`"end"` instead of `"finish"`). This fix ensures consistency between GMCP and Lua API implementations, matching the official specification at https://wiki.mudlet.org/w/Manual:Scripting#finish

Credit to @sammerpetria for reporting this issue.

#### Other info (issues closed, discussion etc)

Changes one line in `src/TMedia.cpp` to use the correct JSON key `"finish"` instead of `"end"` in the `parseJSONByMediaFinish()` function.