### PR TITLE
Add more safeguards against profile settings being lost

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1901,8 +1901,9 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, enums::Pa
     if (thing != enums::PackageModuleType::Package) {
         if ((thing == enums::PackageModuleType::ModuleSync) && (mActiveModules.contains(packageName))) {
             uninstallPackage(packageName, enums::PackageModuleType::ModuleSync);
-        } else if ((thing == enums::PackageModuleType::ModuleFromUI) && (mInstalledModules.contains(packageName) || mActiveModules.contains(packageName))) {
+        } else if ((thing == enums::PackageModuleType::ModuleFromUI) && !mIsProfileLoadingSequence && (mInstalledModules.contains(packageName) || mActiveModules.contains(packageName))) {
             // Check if this is just a stale reference by verifying if module files actually exist
+            // Skip this check during profile loading - modules are expected to be in mInstalledModules already
             QString modulePath = mudlet::getMudletPath(enums::profilePackagePath, getName(), packageName);
             QString moduleFile = mInstalledModules.value(packageName).value(0); // Get the actual file path from stored reference
 

--- a/src/Host.h
+++ b/src/Host.h
@@ -612,6 +612,7 @@ public:
     // has the profile save data been loaded without issues?
     // if there were issues during loading, we should not save anything on close
     bool mLoadedOk = false;
+    QString mProfileLoadError;
 
     int mTimeout = 60;
 

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1216,6 +1216,18 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     }
 #endif
 
+    if (!pHost->mLoadedOk) {
+        notificationAreaIconLabelWarning->show();
+        frame_notificationArea->show();
+        notificationAreaMessageBox->show();
+        QString errorDetails = pHost->mProfileLoadError.isEmpty()
+            ? tr("unknown error")
+            : pHost->mProfileLoadError;
+        notificationAreaMessageBox->setText(tr("This profile could not be loaded correctly (%1). "
+                                               "Settings cannot be saved. Close the profile and try loading an older version from "
+                                               "'Connect - Options - Profile history'.").arg(errorDetails));
+    }
+
     groupBox_ssl->setChecked(pHost->mSslTsl);
     checkBox_self_signed->setChecked(pHost->mSslIgnoreSelfSigned);
     checkBox_expired->setChecked(pHost->mSslIgnoreExpired);
@@ -3280,6 +3292,10 @@ void dlgProfilePreferences::slot_saveAndClose()
     pMudlet->setAppearance(static_cast<enums::Appearance>(comboBox_appearance->currentIndex()));
 
     mudlet::self()->mDiscord.UpdatePresence();
+
+    if (pHost && pHost->mFORCE_SAVE_ON_EXIT) {
+        pHost->saveProfile();
+    }
 
     emit signal_preferencesSaved();
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -5456,12 +5456,14 @@ Host* mudlet::loadProfile(const QString& profile_name, const bool playOnline, co
     } else {
         QFile file(qsl("%1%2").arg(folder, saveFileName.isEmpty() ? entries.at(0) : saveFileName));
         if (!file.open(QFile::ReadOnly | QFile::Text)) {
+            pHost->mProfileLoadError = tr("Could not open profile file: %1").arg(file.errorString());
             qWarning() << "mudlet: failed to open profile file for reading:" << file.fileName() << file.errorString();
         }
         XMLimport importer(pHost);
 
         qDebug() << "[LOADING PROFILE]:" << file.fileName();
         if (auto [success, message] = importer.importPackage(&file); !success) {
+            pHost->mProfileLoadError = message;
             //: %1 is the path and file name (i.e. the location) of the problem fil
             pHost->postMessage(tr("[ ERROR ] - Something went wrong loading your Mudlet profile and it could not be loaded.\n"
             "Try loading an older version in 'Connect - Options - Profile history' or double-check that %1 looks correct.").arg(file.fileName()));

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4423,7 +4423,10 @@ void mudlet::installModulesList(Host* pHost, QStringList modules)
 {
     for (const auto& module : modules) {
         QStringList entry = pHost->mInstalledModules[module];
-        pHost->installPackage(entry[0], enums::PackageModuleType::ModuleFromUI);
+        auto [success, error] = pHost->installPackage(entry[0], enums::PackageModuleType::ModuleFromUI);
+        if (!success && !error.isEmpty()) {
+            qWarning() << "mudlet::installModulesList() WARNING - failed to load module" << module << ":" << error;
+        }
         //we repeat this step here b/c we use the same installPackage method for initial loading,
         //where we overwrite the globalSave flag.  This restores saved and loaded packages to their proper flag
         pHost->mInstalledModules[module] = entry;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Auto-save profile to disk when closing Profile Preferences (if auto-save is enabled)
- Show warning in Profile Preferences when profile failed to load, explaining why saves won't work

#### Motivation for adding to Mudlet
Users reported settings (like fonts) resetting unexpectedly. Investigation revealed settings only save on profile close, so crashes or force-quits lose changes. Also, if a profile fails to load, saves silently fail with no user feedback.

#### Other info (issues closed, discussion etc)
**Test case:**
1. Open a profile, change font in Profile Preferences, close the dialog
2. Check `~/.config/mudlet/profiles/<ProfileName>/` - a new XML file should be created with the updated font
3. To test the warning: corrupt a profile XML file, load it, open Profile Preferences - warning should appear with the error message