### PR TITLE
Add multiple map views support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -151,6 +151,8 @@ set(mudlet_SRCS
     TMainConsole.cpp
     TMap.cpp
     TMapLabel.cpp
+    TMapView.cpp
+    TMapViewManager.cpp
     TMedia.cpp
     TMediaPlaylist.cpp
     TMxpElementDefinitionHandler.cpp
@@ -356,6 +358,8 @@ set(mudlet_HDRS
     TMainConsole.h
     TMap.h
     TMapLabel.h
+    TMapView.h
+    TMapViewManager.h
     TMatchState.h
     TMedia.h
     TMediaPlaylist.h

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3206,7 +3206,7 @@ std::pair<bool, QString> Host::setMapperTitle(const QString& title)
 std::pair<int, QString> Host::createMapView(int areaId)
 {
     if (!mpMap) {
-        return {0, qsl("no map present")};
+        return {0, qsl("no map present or loaded")};
     }
 
     auto* viewManager = mpMap->getViewManager();
@@ -3220,7 +3220,7 @@ std::pair<int, QString> Host::createMapView(int areaId)
 std::pair<bool, QString> Host::closeMapView(int viewId)
 {
     if (!mpMap) {
-        return {false, qsl("no map present")};
+        return {false, qsl("no map present or loaded")};
     }
 
     auto* viewManager = mpMap->getViewManager();
@@ -3234,7 +3234,7 @@ std::pair<bool, QString> Host::closeMapView(int viewId)
 std::pair<int, QString> Host::closeAllMapViews()
 {
     if (!mpMap) {
-        return {0, qsl("no map present")};
+        return {0, qsl("no map present or loaded")};
     }
 
     auto* viewManager = mpMap->getViewManager();
@@ -3248,7 +3248,7 @@ std::pair<int, QString> Host::closeAllMapViews()
 QList<int> Host::getMapViewIds() const
 {
     if (!mpMap) {
-        qWarning() << "Host::getMapViewIds() - no map present";
+        qWarning() << "Host::getMapViewIds() - no map present or loaded";
         return {};
     }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3248,11 +3248,13 @@ std::pair<int, QString> Host::closeAllMapViews()
 QList<int> Host::getMapViewIds() const
 {
     if (!mpMap) {
+        qWarning() << "Host::getMapViewIds() - no map present";
         return {};
     }
 
     auto* viewManager = mpMap->getViewManager();
     if (!viewManager) {
+        qWarning() << "Host::getMapViewIds() - no view manager available";
         return {};
     }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -44,6 +44,7 @@
 #include "TLabel.h"
 #include "TMainConsole.h"
 #include "TMap.h"
+#include "TMapViewManager.h"
 #include "TMedia.h"
 #include "TRoomDB.h"
 #include "TScript.h"
@@ -3200,6 +3201,62 @@ std::pair<bool, QString> Host::setMapperTitle(const QString& title)
     }
 
     return {true, QString()};
+}
+
+std::pair<int, QString> Host::createMapView(int areaId)
+{
+    if (!mpMap) {
+        return {0, qsl("no map present")};
+    }
+
+    auto* viewManager = mpMap->getViewManager();
+    if (!viewManager) {
+        return {0, qsl("no view manager available")};
+    }
+
+    return viewManager->createView(areaId);
+}
+
+std::pair<bool, QString> Host::closeMapView(int viewId)
+{
+    if (!mpMap) {
+        return {false, qsl("no map present")};
+    }
+
+    auto* viewManager = mpMap->getViewManager();
+    if (!viewManager) {
+        return {false, qsl("no view manager available")};
+    }
+
+    return viewManager->closeView(viewId);
+}
+
+std::pair<int, QString> Host::closeAllMapViews()
+{
+    if (!mpMap) {
+        return {0, qsl("no map present")};
+    }
+
+    auto* viewManager = mpMap->getViewManager();
+    if (!viewManager) {
+        return {0, qsl("no view manager available")};
+    }
+
+    return {viewManager->closeAllViews(), QString()};
+}
+
+QList<int> Host::getMapViewIds() const
+{
+    if (!mpMap) {
+        return {};
+    }
+
+    auto* viewManager = mpMap->getViewManager();
+    if (!viewManager) {
+        return {};
+    }
+
+    return viewManager->getViewIds();
 }
 
 void Host::setDebugShowAllProblemCodepoints(const bool state)

--- a/src/Host.h
+++ b/src/Host.h
@@ -370,6 +370,13 @@ public:
     void setSearchOptions(const dlgTriggerEditor::SearchOptions);
     void setBufferSearchOptions(const TConsole::SearchOptions);
     std::pair<bool, QString> setMapperTitle(const QString&);
+
+    // Multiple map views support
+    std::pair<int, QString> createMapView(int areaId = 0);
+    std::pair<bool, QString> closeMapView(int viewId);
+    std::pair<int, QString> closeAllMapViews();
+    QList<int> getMapViewIds() const;
+
     void setDebugShowAllProblemCodepoints(const bool);
     bool debugShowAllProblemCodepoints() const { return mDebugShowAllProblemCodepoints; }
     void setCompactInputLine(const bool state);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4189,7 +4189,7 @@ void T2DMap::slot_newMap()
     slot_toggleMapViewOnly();
 
     isCenterViewCall = true;
-    mpMap->update();
+    mpMap->updateArea(-1);
     isCenterViewCall = false;
     mpMap->setUnsaved(__func__);
     mpMap->mpMapper->resetAreaComboBoxToPlayerRoomArea();

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -781,27 +781,24 @@ void T2DMap::switchArea(int areaId)
     switchArea(areaName);
 }
 
-void T2DMap::centerview(int roomId)
+std::pair<bool, QString> T2DMap::centerview(int roomId)
 {
     if (!mpMap || !mpMap->mpRoomDB) {
-        qWarning() << "T2DMap::centerview(int) - map or roomDB is null";
-        return;
+        return {false, qsl("map or roomDB is null")};
     }
 
     TRoom* pR = mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
-        qWarning() << "T2DMap::centerview(int) - room" << roomId << "not found";
-        return;
+        return {false, qsl("room %1 not found").arg(roomId)};
     }
 
     const int areaId = pR->getArea();
     TArea* pArea = mpMap->mpRoomDB->getArea(areaId);
     if (!pArea) {
-        qWarning() << "T2DMap::centerview(int) - DATA INTEGRITY: room" << roomId << "references non-existent area" << areaId;
-        return;
+        return {false, qsl("room %1 references non-existent area %2").arg(roomId).arg(areaId)};
     }
 
-    // For secondary views, don't raise events or update player position
+    // For secondary views, don't raise sysMapAreaChanged event
     if (!mIsSecondaryView) {
         TEvent areaViewedChangedEvent{};
         if (mAreaID != areaId) {
@@ -829,6 +826,8 @@ void T2DMap::centerview(int roomId)
     isCenterViewCall = true;
     update();
     isCenterViewCall = false;
+
+    return {true, QString()};
 }
 
 // key format: <QColor.name()><QString of one or more QChars>

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -769,29 +769,35 @@ void T2DMap::switchArea(const QString& newAreaName)
 void T2DMap::switchArea(int areaId)
 {
     if (!mpMap || !mpMap->mpRoomDB) {
+        qWarning() << "T2DMap::switchArea(int) - cannot switch to area" << areaId << "- map or roomDB is null";
         return;
     }
 
     const QString areaName = mpMap->mpRoomDB->getAreaNamesMap().value(areaId);
-    if (!areaName.isEmpty()) {
-        switchArea(areaName);
+    if (areaName.isEmpty()) {
+        qWarning() << "T2DMap::switchArea(int) - area" << areaId << "not found in area names map";
+        return;
     }
+    switchArea(areaName);
 }
 
 void T2DMap::centerview(int roomId)
 {
     if (!mpMap || !mpMap->mpRoomDB) {
+        qWarning() << "T2DMap::centerview(int) - map or roomDB is null";
         return;
     }
 
     TRoom* pR = mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
+        qDebug() << "T2DMap::centerview(int) - room" << roomId << "not found";
         return;
     }
 
     const int areaId = pR->getArea();
     TArea* pArea = mpMap->mpRoomDB->getArea(areaId);
     if (!pArea) {
+        qWarning() << "T2DMap::centerview(int) - DATA INTEGRITY: room" << roomId << "references non-existent area" << areaId;
         return;
     }
 

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -790,7 +790,7 @@ void T2DMap::centerview(int roomId)
 
     TRoom* pR = mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
-        qDebug() << "T2DMap::centerview(int) - room" << roomId << "not found";
+        qWarning() << "T2DMap::centerview(int) - room" << roomId << "not found";
         return;
     }
 

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1686,7 +1686,8 @@ void T2DMap::paintEvent(QPaintEvent* e)
     // it at the end of the paintEvent:
     TEvent areaViewedChangedEvent{};
 
-    if ((!mPick && !mShiftMode) || mpMap->mNewMove) {
+    // Secondary views don't follow the player - they maintain their own independent view
+    if (!mIsSecondaryView && ((!mPick && !mShiftMode) || mpMap->mNewMove)) {
         mShiftMode = true;
         // that's of interest only here because the map editor is here ->
         // map might not be updated, thus I force a map update on centerview()

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3589,7 +3589,7 @@ void T2DMap::slot_setPlayerLocation()
         manualSetEvent.mArgumentList.append(QString::number(_newRoomId));
         manualSetEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
         mpHost->raiseEvent(manualSetEvent);
-        update();
+        mpMap->update();
         // don't update map on player location change, as this would cause unnecessary
         // autosaves while just speedwalking around
     }
@@ -4196,14 +4196,8 @@ void T2DMap::slot_newMap()
     mpMap->mNewMove = true;
     slot_toggleMapViewOnly();
 
-#if defined(INCLUDE_3DMAPPER)
-    if (mpMap->mpM) {
-        mpMap->mpM->update();
-    }
-#endif
-
     isCenterViewCall = true;
-    update();
+    mpMap->update();
     isCenterViewCall = false;
     mpMap->setUnsaved(__func__);
     mpMap->mpMapper->resetAreaComboBoxToPlayerRoomArea();

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -175,6 +175,7 @@ public:
     void clearSelection();
 
     // Secondary view support (for multiple map views feature)
+    // Secondary views are view-only displays that don't raise map events or support edit mode
     void setSecondaryView(bool isSecondary) { mIsSecondaryView = isSecondary; }
     bool isSecondaryView() const { return mIsSecondaryView; }
 
@@ -185,7 +186,7 @@ public:
     int getZLevel() const { return mMapCenterZ; }
 
     // Center view on a room. For secondary views, skips raising sysMapAreaChanged events.
-    void centerview(int roomId);
+    std::pair<bool, QString> centerview(int roomId);
     std::pair<bool, QString> exportAreaToImage(int areaId, const QString& filePath, std::optional<int> zLevel = std::nullopt, qreal zoom = 2.0, bool exportAllZLevels = false);
 
 

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -175,7 +175,6 @@ public:
     void clearSelection();
 
     // Secondary view support (for multiple map views feature)
-    // Secondary views are view-only displays that don't raise map events or support edit mode
     void setSecondaryView(bool isSecondary) { mIsSecondaryView = isSecondary; }
     bool isSecondaryView() const { return mIsSecondaryView; }
 
@@ -437,7 +436,6 @@ private:
     // is shown - because the value of these two are different:
     int mLastViewedAreaID = -2;
 
-    // Flag to indicate this is a secondary map view (view-only, no edit mode)
     bool mIsSecondaryView = false;
 
 private slots:

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -171,7 +171,21 @@ public:
     void addSymbolToPixmapCache(const QString, const QString, const QColor, const bool);
     void setPlayerRoomStyle(const int style);
     void switchArea(const QString& newAreaName);
+    void switchArea(int areaId);
     void clearSelection();
+
+    // Secondary view support (for multiple map views feature)
+    void setSecondaryView(bool isSecondary) { mIsSecondaryView = isSecondary; }
+    bool isSecondaryView() const { return mIsSecondaryView; }
+
+    // View state getters
+    int getAreaId() const { return mAreaID; }
+    int getCenterRoomId() const { return mRoomID; }
+    qreal getZoom() const { return xyzoom; }
+    int getZLevel() const { return mMapCenterZ; }
+
+    // Center view on a room (for secondary views, doesn't update player position)
+    void centerview(int roomId);
     std::pair<bool, QString> exportAreaToImage(int areaId, const QString& filePath, std::optional<int> zLevel = std::nullopt, qreal zoom = 2.0, bool exportAllZLevels = false);
 
 
@@ -421,6 +435,9 @@ private:
     // is initialised to - so that the xyzoom gets read for the first area that
     // is shown - because the value of these two are different:
     int mLastViewedAreaID = -2;
+
+    // Flag to indicate this is a secondary map view (view-only, no edit mode)
+    bool mIsSecondaryView = false;
 
 private slots:
     void slot_createRoom();

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -184,7 +184,7 @@ public:
     qreal getZoom() const { return xyzoom; }
     int getZLevel() const { return mMapCenterZ; }
 
-    // Center view on a room (for secondary views, doesn't update player position)
+    // Center view on a room. For secondary views, skips raising sysMapAreaChanged events.
     void centerview(int roomId);
     std::pair<bool, QString> exportAreaToImage(int areaId, const QString& filePath, std::optional<int> zLevel = std::nullopt, qreal zoom = 2.0, bool exportAllZLevels = false);
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5293,6 +5293,11 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "setMapPerspective", TLuaInterpreter::setMapPerspective);
 #endif
     lua_register(pGlobalLua, "centerview", TLuaInterpreter::centerview);
+    lua_register(pGlobalLua, "createMapView", TLuaInterpreter::createMapView);
+    lua_register(pGlobalLua, "closeMapView", TLuaInterpreter::closeMapView);
+    lua_register(pGlobalLua, "closeAllMapViews", TLuaInterpreter::closeAllMapViews);
+    lua_register(pGlobalLua, "getMapViewIds", TLuaInterpreter::getMapViewIds);
+    lua_register(pGlobalLua, "getMapViewInfo", TLuaInterpreter::getMapViewInfo);
     lua_register(pGlobalLua, "denyCurrentSend", TLuaInterpreter::denyCurrentSend);
     lua_register(pGlobalLua, "tempBeginOfLineTrigger", TLuaInterpreter::tempBeginOfLineTrigger);
     lua_register(pGlobalLua, "tempExactMatchTrigger", TLuaInterpreter::tempExactMatchTrigger);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -292,6 +292,11 @@ public:
     static int setMapPerspective(lua_State*);
 #endif
     static int centerview(lua_State*);
+    static int createMapView(lua_State*);
+    static int closeMapView(lua_State*);
+    static int closeAllMapViews(lua_State*);
+    static int getMapViewIds(lua_State*);
+    static int getMapViewInfo(lua_State*);
     static int getAreaTable(lua_State*);
     static int getAreaTableSwap(lua_State*);
     static int getPath(lua_State*);

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -4313,9 +4313,10 @@ int TLuaInterpreter::getMapViewIds(lua_State* L)
     const QList<int> viewIds = host.getMapViewIds();
 
     lua_newtable(L);
-    for (int i = 0; i < viewIds.size(); ++i) {
-        lua_pushinteger(L, viewIds.at(i));
-        lua_rawseti(L, -2, i + 1);
+    int luaIndex = 1;
+    for (int viewId : viewIds) {
+        lua_pushinteger(L, viewId);
+        lua_rawseti(L, -2, luaIndex++);
     }
     return 1;
 }

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -4301,6 +4301,9 @@ int TLuaInterpreter::closeAllMapViews(lua_State* L)
     Host& host = getHostFromLua(L);
 
     auto [count, errorMsg] = host.closeAllMapViews();
+    if (!errorMsg.isEmpty()) {
+        return warnArgumentValue(L, __func__, errorMsg);
+    }
     lua_pushinteger(L, count);
     return 1;
 }

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -729,15 +729,12 @@ int TLuaInterpreter::centerview(lua_State* L)
 
     host.mpMap->mRoomIdHash[host.getName()] = roomId;
     host.mpMap->mNewMove = true;
-#if defined(INCLUDE_3DMAPPER)
-    if (host.mpMap->mpM) {
-        host.mpMap->mpM->update();
-    }
-#endif
 
     if (host.mpMap->mpMapper->mp2dMap) {
         host.mpMap->mpMapper->mp2dMap->isCenterViewCall = true;
-        host.mpMap->mpMapper->mp2dMap->update();
+    }
+    host.mpMap->update();
+    if (host.mpMap->mpMapper->mp2dMap) {
         host.mpMap->mpMapper->mp2dMap->isCenterViewCall = false;
         host.mpMap->mpMapper->resetAreaComboBoxToPlayerRoomArea();
     }

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -262,11 +262,11 @@ int TLuaInterpreter::getExitWeights(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#deleteMapLabel
 int TLuaInterpreter::deleteMapLabel(lua_State* L)
 {
-    int area = getVerifiedInt(L, __func__, 1, "areaID");
-    int labelID = getVerifiedInt(L, __func__, 2, "labelID");
+    const int area = getVerifiedInt(L, __func__, 1, "areaID");
+    const int labelID = getVerifiedInt(L, __func__, 2, "labelID");
     Host& host = getHostFromLua(L);
     host.mpMap->deleteMapLabel(area, labelID);
-    host.mpMap->update();
+    host.mpMap->updateArea(area);
     return 0;
 }
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addAreaName
@@ -733,7 +733,7 @@ int TLuaInterpreter::centerview(lua_State* L)
     if (host.mpMap->mpMapper->mp2dMap) {
         host.mpMap->mpMapper->mp2dMap->isCenterViewCall = true;
     }
-    host.mpMap->update();
+    host.mpMap->updateArea(pR->getArea());
     if (host.mpMap->mpMapper->mp2dMap) {
         host.mpMap->mpMapper->mp2dMap->isCenterViewCall = false;
         host.mpMap->mpMapper->resetAreaComboBoxToPlayerRoomArea();
@@ -1081,7 +1081,7 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
 
     const Host& host = getHostFromLua(L);
     lua_pushinteger(L, host.mpMap->createMapLabel(area, text, posx, posy, posz, QColor(fgr, fgg, fgb, foregroundTransparency), QColor(bgr, bgg, bgb, backgroundTransparency), showOnTop, noScaling, temporary, zoom, fontSize, fontName, QColor(olr, olg, olb, foregroundTransparency)));
-    host.mpMap->update();
+    host.mpMap->updateArea(area);
     return 1;
 }
 
@@ -1105,7 +1105,7 @@ int TLuaInterpreter::createMapImageLabel(lua_State* L)
 
     const Host& host = getHostFromLua(L);
     lua_pushinteger(L, host.mpMap->createMapImageLabel(area, imagePathFileName, posx, posy, posz, width, height, zoom, showOnTop, temporary));
-    host.mpMap->update();
+    host.mpMap->updateArea(area);
     return 1;
 }
 

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -1403,7 +1403,7 @@ bool TMainConsole::loadMap(const QString& location)
         pHost->mpMap->pushErrorMessagesToFile(tr(R"(Loading map(1) "%1" at %2 report)").arg(location, now.toString(Qt::ISODate)), true);
     }
 
-    pHost->mpMap->update();
+    pHost->mpMap->updateArea(-1);
 
     return result;
 }
@@ -1502,7 +1502,7 @@ bool TMainConsole::importMap(const QString& location, QString* errMsg)
         return false;
     }
 
-    pHost->mpMap->update();
+    pHost->mpMap->updateArea(-1);
 
     return result;
 }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -27,6 +27,7 @@
 #include "TConsole.h"
 #include "TEvent.h"
 #include "TMapLabel.h"
+#include "TMapViewManager.h"
 #include "TRoomDB.h"
 #include "XMLimport.h"
 #include "dlgMapper.h"
@@ -47,6 +48,7 @@ TMap::TMap(Host* pH, const QString& profileName)
 : mDefaultAreaName(tr("Default Area"))
 , mUnnamedAreaName(tr("Unnamed Area"))
 , mpRoomDB(new TRoomDB(this))
+, mpViewManager(new TMapViewManager(pH, this))
 , mpHost(pH)
 , mProfileName(profileName)
 {
@@ -3371,6 +3373,11 @@ void TMap::update()
                     mpMapper->mp2dMap->mNewMoveAction = true;
                     mpMapper->mp2dMap->update();
                 }
+            }
+
+            // Update all secondary map views
+            if (mpViewManager) {
+                mpViewManager->updateAllViews();
             }
         });
     }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -3349,17 +3349,17 @@ bool TMap::incrementJsonProgressDialog(const bool isExportNotImport, const bool 
     return mpProgressDialog->wasCanceled();
 }
 
-/**
- * Update the the 2D and 3D map visually.
- *
- * It ensures debouncing internally to ensure that bulk calls are efficient.
- */
 void TMap::update()
+{
+    updateArea(-1);
+}
+
+void TMap::updateArea(int areaId)
 {
     static bool debounce;
     if (!debounce) {
         debounce = true;
-        QTimer::singleShot(0, this, [this]() {
+        QTimer::singleShot(0, this, [this, areaId]() {
             debounce = false;
 
 #if defined(INCLUDE_3DMAPPER)
@@ -3375,10 +3375,7 @@ void TMap::update()
                 }
             }
 
-            // Update all secondary map views
-            if (mpViewManager) {
-                mpViewManager->updateAllViews();
-            }
+            emit signal_areaChanged(areaId);
         });
     }
 }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -3349,11 +3349,6 @@ bool TMap::incrementJsonProgressDialog(const bool isExportNotImport, const bool 
     return mpProgressDialog->wasCanceled();
 }
 
-void TMap::update()
-{
-    updateArea(-1);
-}
-
 void TMap::updateArea(int areaId)
 {
     static bool debounce;

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -80,6 +80,7 @@ class TMap : public QObject
 
 signals:
     void signal_saveErrorChanged(bool hasError);
+    void signal_areaChanged(int areaId);
 
 private:
     QString mDefaultAreaName;
@@ -123,6 +124,7 @@ public:
     bool setExit(int from, int to, int dir);
     bool setRoomCoordinates(int id, int x, int y, int z);
     void update();
+    void updateArea(int areaId);
 
     void audit();
 

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -123,7 +123,6 @@ public:
     void logError(QString& msg);
     bool setExit(int from, int to, int dir);
     bool setRoomCoordinates(int id, int x, int y, int z);
-    void update();
     void updateArea(int areaId);
 
     void audit();

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -66,6 +66,7 @@ class Host;
 class QOpenGLWidget;
 #endif
 class TArea;
+class TMapViewManager;
 class TRoom;
 class TRoomDB;
 class QFile;
@@ -207,9 +208,12 @@ public:
 
 
     TRoomDB* mpRoomDB = nullptr;
+    QScopedPointer<TMapViewManager> mpViewManager;
     QMap<int, int> mEnvColors;
     QPointer<Host> mpHost;
     QString mProfileName;
+
+    TMapViewManager* getViewManager() { return mpViewManager.data(); }
 
     // Was a single int mRoomId but that breaks things when maps are
     // copied/shared between profiles - so now we track the profile name

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -208,12 +208,12 @@ public:
 
 
     TRoomDB* mpRoomDB = nullptr;
-    QScopedPointer<TMapViewManager> mpViewManager;
+    TMapViewManager* mpViewManager = nullptr;
     QMap<int, int> mEnvColors;
     QPointer<Host> mpHost;
     QString mProfileName;
 
-    TMapViewManager* getViewManager() { return mpViewManager.data(); }
+    TMapViewManager* getViewManager() { return mpViewManager; }
 
     // Was a single int mRoomId but that breaks things when maps are
     // copied/shared between profiles - so now we track the profile name

--- a/src/TMapView.cpp
+++ b/src/TMapView.cpp
@@ -1,0 +1,237 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by Mudlet Developers - mudlet@mudlet.org           *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "TMapView.h"
+
+#include "Host.h"
+#include "T2DMap.h"
+#include "TMap.h"
+#include "TRoomDB.h"
+#include "utils.h"
+
+#include <QApplication>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QVBoxLayout>
+
+TMapView::TMapView(int viewId, Host* pHost, TMap* pMap, QWidget* parent)
+: QWidget(parent)
+, mViewId(viewId)
+, mpHost(pHost)
+, mpMap(pMap)
+{
+    setupUi();
+
+    mp2dMap->mpMap = pMap;
+    mp2dMap->mpHost = pHost;
+    mp2dMap->setSecondaryView(true);
+    mp2dMap->setPlayerRoomStyle(pMap->mPlayerRoomStyle);
+
+    updateAreaComboBox();
+
+    if (mpHost) {
+        mp2dMap->init();
+    }
+
+    setFont(qApp->font());
+    setPalette(QApplication::palette());
+}
+
+TMapView::~TMapView() = default;
+
+void TMapView::setupUi()
+{
+    auto* mainLayout = new QVBoxLayout(this);
+    mainLayout->setSpacing(0);
+    mainLayout->setContentsMargins(0, 0, 0, 0);
+
+    mp2dMap = new T2DMap(this);
+    mp2dMap->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    mainLayout->addWidget(mp2dMap);
+
+    mpTogglePanelButton = new QToolButton(this);
+    mpTogglePanelButton->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    mpTogglePanelButton->setMaximumHeight(15);
+    mpTogglePanelButton->setText(qsl("^"));
+    mpTogglePanelButton->setCheckable(true);
+    mpTogglePanelButton->setChecked(true);
+    mainLayout->addWidget(mpTogglePanelButton);
+
+    mpPanelWidget = new QWidget(this);
+    mpPanelWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    mpPanelWidget->setAutoFillBackground(true);
+    auto* panelLayout = new QHBoxLayout(mpPanelWidget);
+    panelLayout->setSpacing(1);
+    panelLayout->setContentsMargins(0, 0, 0, 0);
+
+    mpZUpButton = new QToolButton(mpPanelWidget);
+    mpZUpButton->setMinimumSize(30, 20);
+    mpZUpButton->setMaximumSize(30, 20);
+    mpZUpButton->setFont(QFont(QString(), -1, QFont::Bold));
+    mpZUpButton->setText(qsl("+"));
+    mpZUpButton->setToolTip(tr("Go up one z-level"));
+    panelLayout->addWidget(mpZUpButton);
+
+    mpZDownButton = new QToolButton(mpPanelWidget);
+    mpZDownButton->setMinimumSize(30, 20);
+    mpZDownButton->setMaximumSize(30, 20);
+    mpZDownButton->setFont(QFont(QString(), -1, QFont::Bold));
+    mpZDownButton->setText(qsl("-"));
+    mpZDownButton->setToolTip(tr("Go down one z-level"));
+    panelLayout->addWidget(mpZDownButton);
+
+    auto* areaLabel = new QLabel(tr("Area:"), mpPanelWidget);
+    areaLabel->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    areaLabel->setMaximumHeight(20);
+    panelLayout->addWidget(areaLabel);
+
+    mpAreaComboBox = new QComboBox(mpPanelWidget);
+    mpAreaComboBox->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    mpAreaComboBox->setMaximumHeight(20);
+    mpAreaComboBox->setInsertPolicy(QComboBox::InsertAlphabetically);
+    panelLayout->addWidget(mpAreaComboBox);
+
+    mainLayout->addWidget(mpPanelWidget);
+
+    connect(mpTogglePanelButton, &QAbstractButton::clicked, this, [this](bool checked) {
+        mpPanelWidget->setVisible(checked);
+    });
+    connect(mpZUpButton, &QAbstractButton::clicked, mp2dMap, &T2DMap::slot_shiftZup);
+    connect(mpZDownButton, &QAbstractButton::clicked, mp2dMap, &T2DMap::slot_shiftZdown);
+    connect(mpAreaComboBox, qOverload<int>(&QComboBox::activated), this, &TMapView::slot_switchArea);
+}
+
+void TMapView::updateAreaComboBox()
+{
+    if (!mpMap || !mpMap->mpRoomDB) {
+        mpAreaComboBox->clear();
+        mpAreaComboBox->setEnabled(false);
+        return;
+    }
+
+    const QString oldValue = mpAreaComboBox->currentText();
+    QMapIterator<int, QString> it(mpMap->mpRoomDB->getAreaNamesMap());
+
+    QMap<QString, QString> areaNames;
+    while (it.hasNext()) {
+        it.next();
+        if (it.key() == -1 && !mpMap->getDefaultAreaShown()) {
+            continue;
+        }
+        const QString name = it.value();
+        areaNames.insert(name.toLower(), name);
+    }
+
+    mpAreaComboBox->clear();
+    QMapIterator<QString, QString> areaIt(areaNames);
+    while (areaIt.hasNext()) {
+        areaIt.next();
+        mpAreaComboBox->addItem(areaIt.value());
+    }
+
+    if (!oldValue.isEmpty()) {
+        int index = mpAreaComboBox->findText(oldValue);
+        if (index != -1) {
+            mpAreaComboBox->setCurrentIndex(index);
+        }
+    }
+
+    mpAreaComboBox->setEnabled(mpAreaComboBox->count() > 0);
+}
+
+void TMapView::slot_switchArea(int index)
+{
+    if (!mpMap || !mpMap->mpRoomDB || !mp2dMap) {
+        return;
+    }
+
+    const QString areaName = mpAreaComboBox->itemText(index);
+    const int areaId = mpMap->mpRoomDB->getAreaNamesMap().key(areaName, -1);
+
+    if (areaId != -1) {
+        mp2dMap->switchArea(areaId);
+    }
+}
+
+void TMapView::setArea(int areaId)
+{
+    if (!mpMap || !mpMap->mpRoomDB || !mp2dMap) {
+        return;
+    }
+
+    const QString areaName = mpMap->mpRoomDB->getAreaNamesMap().value(areaId);
+    if (areaName.isEmpty()) {
+        return;
+    }
+
+    int index = mpAreaComboBox->findText(areaName);
+    if (index != -1) {
+        mpAreaComboBox->setCurrentIndex(index);
+    }
+
+    mp2dMap->switchArea(areaId);
+}
+
+void TMapView::centerOnRoom(int roomId)
+{
+    if (!mp2dMap) {
+        return;
+    }
+    mp2dMap->centerview(roomId);
+}
+
+std::pair<bool, QString> TMapView::setZoom(qreal zoom)
+{
+    if (!mp2dMap) {
+        return {false, qsl("no map view")};
+    }
+    return mp2dMap->setMapZoom(zoom, getCurrentAreaId());
+}
+
+int TMapView::getCurrentAreaId() const
+{
+    if (!mp2dMap) {
+        return -1;
+    }
+    return mp2dMap->getAreaId();
+}
+
+int TMapView::getCenteredRoomId() const
+{
+    if (!mp2dMap) {
+        return 0;
+    }
+    return mp2dMap->getCenterRoomId();
+}
+
+qreal TMapView::getZoom() const
+{
+    if (!mp2dMap) {
+        return 0.0;
+    }
+    return mp2dMap->getZoom();
+}
+
+int TMapView::getZLevel() const
+{
+    if (!mp2dMap) {
+        return 0;
+    }
+    return mp2dMap->getZLevel();
+}

--- a/src/TMapView.cpp
+++ b/src/TMapView.cpp
@@ -196,13 +196,12 @@ void TMapView::setArea(int areaId)
     mp2dMap->switchArea(areaId);
 }
 
-void TMapView::centerOnRoom(int roomId)
+std::pair<bool, QString> TMapView::centerOnRoom(int roomId)
 {
     if (!mp2dMap) {
-        qWarning() << "TMapView::centerOnRoom() - mp2dMap is null for view" << mViewId;
-        return;
+        return {false, qsl("mp2dMap is null for view %1").arg(mViewId)};
     }
-    mp2dMap->centerview(roomId);
+    return mp2dMap->centerview(roomId);
 }
 
 std::pair<bool, QString> TMapView::setZoom(qreal zoom)

--- a/src/TMapView.cpp
+++ b/src/TMapView.cpp
@@ -191,6 +191,8 @@ void TMapView::setArea(int areaId)
     const int index = mpAreaComboBox->findText(areaName);
     if (index != -1) {
         mpAreaComboBox->setCurrentIndex(index);
+    } else {
+        qWarning() << "TMapView::setArea() - area" << areaName << "not found in combo box for view" << mViewId;
     }
 
     mp2dMap->switchArea(areaId);
@@ -207,7 +209,7 @@ std::pair<bool, QString> TMapView::centerOnRoom(int roomId)
 std::pair<bool, QString> TMapView::setZoom(qreal zoom)
 {
     if (!mp2dMap) {
-        return {false, qsl("no map view")};
+        return {false, qsl("mp2dMap is null for view %1").arg(mViewId)};
     }
     return mp2dMap->setMapZoom(zoom, getCurrentAreaId());
 }
@@ -215,6 +217,7 @@ std::pair<bool, QString> TMapView::setZoom(qreal zoom)
 int TMapView::getCurrentAreaId() const
 {
     if (!mp2dMap) {
+        qWarning() << "TMapView::getCurrentAreaId() - mp2dMap is null for view" << mViewId;
         return -1;
     }
     return mp2dMap->getAreaId();
@@ -223,6 +226,7 @@ int TMapView::getCurrentAreaId() const
 int TMapView::getCenteredRoomId() const
 {
     if (!mp2dMap) {
+        qWarning() << "TMapView::getCenteredRoomId() - mp2dMap is null for view" << mViewId;
         return 0;
     }
     return mp2dMap->getCenterRoomId();
@@ -231,6 +235,7 @@ int TMapView::getCenteredRoomId() const
 qreal TMapView::getZoom() const
 {
     if (!mp2dMap) {
+        qWarning() << "TMapView::getZoom() - mp2dMap is null for view" << mViewId;
         return 0.0;
     }
     return mp2dMap->getZoom();
@@ -239,6 +244,7 @@ qreal TMapView::getZoom() const
 int TMapView::getZLevel() const
 {
     if (!mp2dMap) {
+        qWarning() << "TMapView::getZLevel() - mp2dMap is null for view" << mViewId;
         return 0;
     }
     return mp2dMap->getZLevel();

--- a/src/TMapView.cpp
+++ b/src/TMapView.cpp
@@ -52,6 +52,12 @@ TMapView::TMapView(int viewId, Host* pHost, TMap* pMap, QWidget* parent)
         mp2dMap->init();
     }
 
+    connect(mpMap, &TMap::signal_areaChanged, this, [this](int areaId) {
+        if (areaId == -1 || areaId == mp2dMap->getAreaId()) {
+            mp2dMap->update();
+        }
+    });
+
     setFont(qApp->font());
     setPalette(QApplication::palette());
 }

--- a/src/TMapView.cpp
+++ b/src/TMapView.cpp
@@ -135,16 +135,17 @@ void TMapView::updateAreaComboBox()
     const auto& areaNamesMap = mpMap->mpRoomDB->getAreaNamesMap();
 
     QMap<QString, QString> areaNames;
-    for (auto it = areaNamesMap.constKeyValueBegin(); it != areaNamesMap.constKeyValueEnd(); ++it) {
-        if (it->first == -1 && !mpMap->getDefaultAreaShown()) {
+    for (const auto& [areaId, areaName] : areaNamesMap.asKeyValueRange()) {
+        if (areaId == -1 && !mpMap->getDefaultAreaShown()) {
             continue;
         }
-        areaNames.insert(it->second.toLower(), it->second);
+        areaNames.insert(areaName.toLower(), areaName);
     }
 
     mpAreaComboBox->clear();
-    for (auto it = areaNames.constKeyValueBegin(); it != areaNames.constKeyValueEnd(); ++it) {
-        mpAreaComboBox->addItem(it->second);
+    for (const auto& [sortKey, areaName] : areaNames.asKeyValueRange()) {
+        Q_UNUSED(sortKey)
+        mpAreaComboBox->addItem(areaName);
     }
 
     if (!oldValue.isEmpty()) {
@@ -169,6 +170,8 @@ void TMapView::slot_switchArea(int index)
 
     if (areaId != -1) {
         mp2dMap->switchArea(areaId);
+    } else {
+        qWarning() << "TMapView::slot_switchArea() - area" << areaName << "not found in area names map";
     }
 }
 

--- a/src/TMapView.h
+++ b/src/TMapView.h
@@ -30,9 +30,10 @@ class T2DMap;
 class TMap;
 
 /**
- * A secondary map view widget that provides a view-only display of the map.
+ * A secondary map view widget that provides a non-editing display of the map.
  * Unlike the primary mapper (dlgMapper), secondary views don't support
- * editing operations or affect the player's tracked position.
+ * room editing operations or affect the player's tracked position, but do allow
+ * navigation (area selection, z-level changes, zoom).
  */
 class TMapView : public QWidget
 {
@@ -47,7 +48,7 @@ public:
     T2DMap* get2DMap() { return mp2dMap; }
 
     void setArea(int areaId);
-    void centerOnRoom(int roomId);
+    std::pair<bool, QString> centerOnRoom(int roomId);
     std::pair<bool, QString> setZoom(qreal zoom);
 
     int getCurrentAreaId() const;

--- a/src/TMapView.h
+++ b/src/TMapView.h
@@ -30,10 +30,10 @@ class T2DMap;
 class TMap;
 
 /**
- * A secondary map view widget that provides a non-editing display of the map.
- * Unlike the primary mapper (dlgMapper), secondary views don't support
- * room editing operations or affect the player's tracked position, but do allow
- * navigation (area selection, z-level changes, zoom).
+ * A secondary map view widget that displays the map independently from the primary mapper.
+ * Unlike the primary mapper (dlgMapper), secondary views maintain their own view position
+ * independent of the player's current room, but do allow navigation (area selection,
+ * z-level changes, zoom).
  */
 class TMapView : public QWidget
 {
@@ -58,7 +58,7 @@ public:
 
     void updateAreaComboBox();
 
-public slots:
+private slots:
     void slot_switchArea(int index);
 
 private:

--- a/src/TMapView.h
+++ b/src/TMapView.h
@@ -29,6 +29,11 @@ class Host;
 class T2DMap;
 class TMap;
 
+/**
+ * A secondary map view widget that provides a view-only display of the map.
+ * Unlike the primary mapper (dlgMapper), secondary views don't support
+ * editing operations or affect the player's tracked position.
+ */
 class TMapView : public QWidget
 {
     Q_OBJECT
@@ -58,7 +63,7 @@ public slots:
 private:
     void setupUi();
 
-    int mViewId;
+    const int mViewId;
     QPointer<Host> mpHost;
     QPointer<TMap> mpMap;
     T2DMap* mp2dMap = nullptr;

--- a/src/TMapView.h
+++ b/src/TMapView.h
@@ -1,0 +1,73 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by Mudlet Developers - mudlet@mudlet.org           *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#ifndef MUDLET_TMAPVIEW_H
+#define MUDLET_TMAPVIEW_H
+
+#include <QComboBox>
+#include <QPointer>
+#include <QToolButton>
+#include <QWidget>
+
+class Host;
+class T2DMap;
+class TMap;
+
+class TMapView : public QWidget
+{
+    Q_OBJECT
+
+public:
+    Q_DISABLE_COPY(TMapView)
+    TMapView(int viewId, Host* pHost, TMap* pMap, QWidget* parent = nullptr);
+    ~TMapView() override;
+
+    int getViewId() const { return mViewId; }
+    T2DMap* get2DMap() { return mp2dMap; }
+
+    void setArea(int areaId);
+    void centerOnRoom(int roomId);
+    std::pair<bool, QString> setZoom(qreal zoom);
+
+    int getCurrentAreaId() const;
+    int getCenteredRoomId() const;
+    qreal getZoom() const;
+    int getZLevel() const;
+
+    void updateAreaComboBox();
+
+public slots:
+    void slot_switchArea(int index);
+
+private:
+    void setupUi();
+
+    int mViewId;
+    QPointer<Host> mpHost;
+    TMap* mpMap = nullptr;
+    T2DMap* mp2dMap = nullptr;
+
+    QComboBox* mpAreaComboBox = nullptr;
+    QToolButton* mpZUpButton = nullptr;
+    QToolButton* mpZDownButton = nullptr;
+    QWidget* mpPanelWidget = nullptr;
+    QToolButton* mpTogglePanelButton = nullptr;
+};
+
+#endif // MUDLET_TMAPVIEW_H

--- a/src/TMapView.h
+++ b/src/TMapView.h
@@ -60,7 +60,7 @@ private:
 
     int mViewId;
     QPointer<Host> mpHost;
-    TMap* mpMap = nullptr;
+    QPointer<TMap> mpMap;
     T2DMap* mp2dMap = nullptr;
 
     QComboBox* mpAreaComboBox = nullptr;

--- a/src/TMapViewManager.cpp
+++ b/src/TMapViewManager.cpp
@@ -73,6 +73,7 @@ std::pair<int, QString> TMapViewManager::createView(int initialAreaId)
 
     mudlet::self()->addDockWidget(Qt::RightDockWidgetArea, dockWidget);
     dockWidget->setFloating(true);
+    dockWidget->resize(400, 500);
     dockWidget->show();
     dockWidget->raise();
 

--- a/src/TMapViewManager.cpp
+++ b/src/TMapViewManager.cpp
@@ -24,6 +24,7 @@
 #include "T2DMap.h"
 #include "TMap.h"
 #include "TMapView.h"
+#include "TRoomDB.h"
 #include "utils.h"
 
 TMapViewManager::TMapViewManager(Host* pHost, TMap* pMap)
@@ -44,6 +45,11 @@ std::pair<int, QString> TMapViewManager::createView(int initialAreaId)
 {
     if (!mpHost || !mpMap) {
         return {0, qsl("no valid host or map")};
+    }
+
+    // Validate area ID if provided
+    if (initialAreaId > 0 && mpMap->mpRoomDB && !mpMap->mpRoomDB->getAreaNamesMap().contains(initialAreaId)) {
+        return {0, qsl("area %1 does not exist").arg(initialAreaId)};
     }
 
     const int viewId = mNextViewId++;

--- a/src/TMapViewManager.cpp
+++ b/src/TMapViewManager.cpp
@@ -93,6 +93,9 @@ std::pair<bool, QString> TMapViewManager::closeView(int viewId)
     mDockWidgets.remove(viewId);
     mViews.remove(viewId);
 
+    // Note: deleteLater() will trigger the destroyed signal, which is connected to slot_viewClosed().
+    // Since we already removed from tracking maps above, slot_viewClosed() will find viewId == 0
+    // and skip emitting viewClosed again.
     dockWidget->deleteLater();
 
     emit viewClosed(viewId);
@@ -128,25 +131,12 @@ TMapView* TMapViewManager::getView(int viewId)
 
 QList<int> TMapViewManager::getViewIds() const
 {
-    QList<int> result;
-    for (const auto& [viewId, view] : mViews.asKeyValueRange()) {
-        if (view) {
-            result.append(viewId);
-        }
-    }
-    return result;
+    return mViews.keys();
 }
 
 int TMapViewManager::getViewCount() const
 {
-    int count = 0;
-    for (const auto& [viewId, view] : mViews.asKeyValueRange()) {
-        Q_UNUSED(viewId)
-        if (view) {
-            ++count;
-        }
-    }
-    return count;
+    return mViews.size();
 }
 
 void TMapViewManager::updateAllViews()

--- a/src/TMapViewManager.cpp
+++ b/src/TMapViewManager.cpp
@@ -123,9 +123,9 @@ TMapView* TMapViewManager::getView(int viewId)
 QList<int> TMapViewManager::getViewIds() const
 {
     QList<int> result;
-    for (auto it = mViews.constKeyValueBegin(); it != mViews.constKeyValueEnd(); ++it) {
-        if (it->second) {
-            result.append(it->first);
+    for (const auto& [viewId, view] : mViews.asKeyValueRange()) {
+        if (view) {
+            result.append(viewId);
         }
     }
     return result;
@@ -134,8 +134,9 @@ QList<int> TMapViewManager::getViewIds() const
 int TMapViewManager::getViewCount() const
 {
     int count = 0;
-    for (auto it = mViews.constKeyValueBegin(); it != mViews.constKeyValueEnd(); ++it) {
-        if (it->second) {
+    for (const auto& [viewId, view] : mViews.asKeyValueRange()) {
+        Q_UNUSED(viewId)
+        if (view) {
             ++count;
         }
     }
@@ -144,8 +145,8 @@ int TMapViewManager::getViewCount() const
 
 void TMapViewManager::updateAllViews()
 {
-    for (auto it = mViews.constKeyValueBegin(); it != mViews.constKeyValueEnd(); ++it) {
-        TMapView* view = it->second;
+    for (const auto& [viewId, view] : mViews.asKeyValueRange()) {
+        Q_UNUSED(viewId)
         if (view && view->get2DMap()) {
             view->get2DMap()->update();
             view->updateAreaComboBox();

--- a/src/TMapViewManager.h
+++ b/src/TMapViewManager.h
@@ -1,0 +1,69 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by Mudlet Developers - mudlet@mudlet.org           *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#ifndef MUDLET_TMAPVIEWMANAGER_H
+#define MUDLET_TMAPVIEWMANAGER_H
+
+#include <QDockWidget>
+#include <QMap>
+#include <QObject>
+#include <QPointer>
+
+class Host;
+class TMap;
+class TMapView;
+
+class TMapViewManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    Q_DISABLE_COPY(TMapViewManager)
+    TMapViewManager(Host* pHost, TMap* pMap);
+    ~TMapViewManager() override;
+
+    // View lifecycle
+    std::pair<int, QString> createView(int initialAreaId = 0);
+    std::pair<bool, QString> closeView(int viewId);
+    int closeAllViews();
+
+    // View access
+    TMapView* getView(int viewId);
+    QList<int> getViewIds() const;
+    int getViewCount() const;
+
+    // Bulk operations
+    void updateAllViews();
+
+signals:
+    void viewCreated(int viewId);
+    void viewClosed(int viewId);
+
+private slots:
+    void slot_viewClosed();
+
+private:
+    int mNextViewId = 1;
+    QPointer<Host> mpHost;
+    TMap* mpMap = nullptr;
+    QMap<int, QPointer<QDockWidget>> mDockWidgets;
+    QMap<int, QPointer<TMapView>> mViews;
+};
+
+#endif // MUDLET_TMAPVIEWMANAGER_H

--- a/src/TMapViewManager.h
+++ b/src/TMapViewManager.h
@@ -61,7 +61,7 @@ private slots:
 private:
     int mNextViewId = 1;
     QPointer<Host> mpHost;
-    TMap* mpMap = nullptr;
+    QPointer<TMap> mpMap;
     QMap<int, QPointer<QDockWidget>> mDockWidgets;
     QMap<int, QPointer<TMapView>> mViews;
 };

--- a/src/TMapViewManager.h
+++ b/src/TMapViewManager.h
@@ -64,6 +64,7 @@ private slots:
     void slot_viewClosed();
 
 private:
+    // View IDs start at 1; 0 is reserved as an error/invalid indicator in return values
     int mNextViewId = 1;
     QPointer<Host> mpHost;
     QPointer<TMap> mpMap;

--- a/src/TMapViewManager.h
+++ b/src/TMapViewManager.h
@@ -29,6 +29,11 @@ class Host;
 class TMap;
 class TMapView;
 
+/**
+ * Manages the lifecycle of secondary map view windows.
+ * Secondary views are view-only map displays that can show different
+ * areas/z-levels independently from the main mapper window.
+ */
 class TMapViewManager : public QObject
 {
     Q_OBJECT

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -315,6 +315,7 @@ bool TRoomDB::removeRoom(int id)
             for (const auto& key : profilesWithUserInThisRoom) {
                 mpMap->mRoomIdHash[key] = 0;
             }
+            mpMap->update();
         }
         if (mpMap->mTargetID == id) {
             mpMap->mTargetID = 0;

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -315,7 +315,7 @@ bool TRoomDB::removeRoom(int id)
             for (const auto& key : profilesWithUserInThisRoom) {
                 mpMap->mRoomIdHash[key] = 0;
             }
-            mpMap->update();
+            mpMap->updateArea(-1);
         }
         if (mpMap->mTargetID == id) {
             mpMap->mTargetID = 0;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -3669,7 +3669,7 @@ void cTelnet::setATCPVariables(const QByteArray& msg)
             if (auto* pR = mpHost->mpMap->mpRoomDB->getRoom(roomId)) {
                 mpHost->mpMap->updateArea(pR->getArea());
             } else {
-                mpHost->mpMap->update();
+                mpHost->mpMap->updateArea(-1);
             }
         }
     }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -38,6 +38,7 @@
 #include "TMainConsole.h"
 #include "TMap.h"
 #include "TMedia.h"
+#include "TRoomDB.h"
 #include "GMCPAuthenticator.h"
 #include "TTextCodec.h"
 #include "TEncodingHelper.h"
@@ -3663,8 +3664,13 @@ void cTelnet::setATCPVariables(const QByteArray& msg)
     mpHost->mLuaInterpreter.setAtcpTable(var, arg);
     if (var.startsWith(QLatin1String("RoomNum"))) {
         if (mpHost->mpMap) {
-            mpHost->mpMap->mRoomIdHash[mProfileName] = arg.toInt();
-            mpHost->mpMap->update();
+            const int roomId = arg.toInt();
+            mpHost->mpMap->mRoomIdHash[mProfileName] = roomId;
+            if (auto* pR = mpHost->mpMap->mpRoomDB->getRoom(roomId)) {
+                mpHost->mpMap->updateArea(pR->getArea());
+            } else {
+                mpHost->mpMap->update();
+            }
         }
     }
 }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -3664,14 +3664,7 @@ void cTelnet::setATCPVariables(const QByteArray& msg)
     if (var.startsWith(QLatin1String("RoomNum"))) {
         if (mpHost->mpMap) {
             mpHost->mpMap->mRoomIdHash[mProfileName] = arg.toInt();
-#if defined(INCLUDE_3DMAPPER)
-            if (mpHost->mpMap->mpM && mpHost->mpMap->mpMapper) {
-                mpHost->mpMap->mpM->update();
-            }
-#endif
-            if (mpHost->mpMap->mpMapper && mpHost->mpMap->mpMapper->mp2dMap) {
-                mpHost->mpMap->mpMapper->mp2dMap->update();
-            }
+            mpHost->mpMap->update();
         }
     }
 }

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -600,6 +600,12 @@ void dlgMapper::slot_setupMapperMenu()
     mpInfoMenu = menu->addMenu(tr("Info overlays"));
     updateInfoMenu();
 
+    menu->addSeparator();
+    auto* newMapWindowAction = new QAction(tr("New map window"), this);
+    newMapWindowAction->setToolTip(tr("Open an additional map view"));
+    connect(newMapWindowAction, &QAction::triggered, mudlet::self(), &mudlet::slot_newMapWindow);
+    menu->addAction(newMapWindowAction);
+
     menu->exec(toolButton_mapperMenu->mapToGlobal(toolButton_mapperMenu->rect().bottomLeft()));
 }
 

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1864,7 +1864,7 @@ void dlgProfilePreferences::slot_resetMapColors()
     setColors2();
 
     if (pHost->mpMap) {
-        pHost->mpMap->update();
+        pHost->mpMap->updateArea(-1);
     }
 }
 
@@ -1930,7 +1930,7 @@ void dlgProfilePreferences::setButtonAndProfileColor(QPushButton* button, QColor
                     pHost->mpMap->restore16ColorSet();
                 }
                 // Redraw the map with the modified color:
-                pHost->mpMap->update();
+                pHost->mpMap->updateArea(-1);
             }
         }
 
@@ -4645,7 +4645,7 @@ void dlgProfilePreferences::slot_deleteMap()
     label_mapFileActionResult->setText(tr("Deleting map - please wait..."));
     qApp->processEvents(); // Allow the above message to show up when erasing big maps
     pHost->mpMap->mapClear();
-    pHost->mpMap->update();
+    pHost->mpMap->updateArea(-1);
 
     // Reset the button but leave it disabled
     pushButton_deleteMap->setChecked(false);

--- a/src/mapInfoContributorManager.cpp
+++ b/src/mapInfoContributorManager.cpp
@@ -59,7 +59,7 @@ bool MapInfoContributorManager::enableContributor(const QString &name)
         return false;
     }
     mpHost->mMapInfoContributors.insert(name);
-    mpHost->mpMap->update();
+    mpHost->mpMap->updateArea(-1);
     emit signal_contributorsUpdated();
     return true;
 }
@@ -70,7 +70,7 @@ bool MapInfoContributorManager::disableContributor(const QString &name)
         return false;
     }
     mpHost->mMapInfoContributors.remove(name);
-    mpHost->mpMap->update();
+    mpHost->mpMap->updateArea(-1);
     emit signal_contributorsUpdated();
     return true;
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -565,6 +565,7 @@ void mudlet::init()
     connect(dactionReattachDetachedWindows, &QAction::triggered, this, &mudlet::slot_reattachAllDetachedWindows);
     connect(dactionToggleAlwaysOnTop, &QAction::triggered, this, &mudlet::slot_toggleAlwaysOnTop);
     connect(dactionMinimize, &QAction::triggered, this, &mudlet::slot_minimize);
+    connect(dactionNewMapWindow, &QAction::triggered, this, &mudlet::slot_newMapWindow);
 
     connect(dactionHelp, &QAction::triggered, this, &mudlet::slot_showHelpDialog);
     connect(dactionVideo, &QAction::triggered, this, &mudlet::slot_showHelpDialogVideo);
@@ -1728,6 +1729,19 @@ void mudlet::slot_minimize()
     showMinimized();
 }
 
+void mudlet::slot_newMapWindow()
+{
+    Host* pHost = getActiveHost();
+    if (!pHost) {
+        return;
+    }
+
+    auto [viewId, errorMsg] = pHost->createMapView(0);
+    if (viewId == 0) {
+        qWarning() << "mudlet::slot_newMapWindow() - failed to create map view:" << errorMsg;
+    }
+}
+
 void mudlet::updateWindowMenu()
 {
     // Clean up existing window list actions
@@ -2208,6 +2222,7 @@ void mudlet::disableToolbarButtons()
 
     mpActionMapper->setEnabled(false);
     dactionShowMap->setEnabled(false);
+    dactionNewMapWindow->setEnabled(false);
 
     mpActionNotes->setEnabled(false);
     dactionNotepad->setEnabled(false);
@@ -2287,6 +2302,7 @@ void mudlet::updateMainWindowToolbarState()
 
     mpActionMapper->setEnabled(hasActiveProfileInMainWindow);
     dactionShowMap->setEnabled(hasActiveProfileInMainWindow);
+    dactionNewMapWindow->setEnabled(hasActiveProfileInMainWindow);
 
     mpActionNotes->setEnabled(hasActiveProfileInMainWindow);
     dactionNotepad->setEnabled(hasActiveProfileInMainWindow);
@@ -2394,6 +2410,7 @@ void mudlet::enableToolbarButtons()
 
     mpActionMapper->setEnabled(true);
     dactionShowMap->setEnabled(true);
+    dactionNewMapWindow->setEnabled(true);
 
     mpActionNotes->setEnabled(true);
     dactionNotepad->setEnabled(true);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -406,11 +406,20 @@ void mudlet::init()
     mpButtonDiscord->addAction(mpActionIRC);
     mpButtonDiscord->setDefaultAction(mpActionDiscord);
 
+    mpButtonMapper = new QToolButton(this);
+    mpButtonMapper->setObjectName(qsl("mapper"));
+    mpButtonMapper->setContextMenuPolicy(Qt::ActionsContextMenu);
+    mpButtonMapper->setPopupMode(QToolButton::MenuButtonPopup);
+    mpButtonMapper->setAutoRaise(true);
+    mpMainToolBar->addWidget(mpButtonMapper);
+
     mpActionMapper = new QAction(QIcon(qsl(":/icons/applications-internet.png")), tr("Map"), this);
     mpActionMapper->setToolTip(utils::richText(tr("Show/hide the map")));
-    mpMainToolBar->addAction(mpActionMapper);
     mpActionMapper->setObjectName(qsl("map_action"));
-    mpMainToolBar->widgetForAction(mpActionMapper)->setObjectName(mpActionMapper->objectName());
+
+    mpButtonMapper->addAction(mpActionMapper);
+    mpButtonMapper->addAction(dactionNewMapWindow);
+    mpButtonMapper->setDefaultAction(mpActionMapper);
 
     mpActionHelp = new QAction(QIcon(qsl(":/icons/help-hint.png")), tr("Manual"), this);
     mpActionHelp->setToolTip(utils::richText(tr("Browse reference material and documentation")));

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -406,20 +406,11 @@ void mudlet::init()
     mpButtonDiscord->addAction(mpActionIRC);
     mpButtonDiscord->setDefaultAction(mpActionDiscord);
 
-    mpButtonMapper = new QToolButton(this);
-    mpButtonMapper->setObjectName(qsl("mapper"));
-    mpButtonMapper->setContextMenuPolicy(Qt::ActionsContextMenu);
-    mpButtonMapper->setPopupMode(QToolButton::MenuButtonPopup);
-    mpButtonMapper->setAutoRaise(true);
-    mpMainToolBar->addWidget(mpButtonMapper);
-
     mpActionMapper = new QAction(QIcon(qsl(":/icons/applications-internet.png")), tr("Map"), this);
     mpActionMapper->setToolTip(utils::richText(tr("Show/hide the map")));
+    mpMainToolBar->addAction(mpActionMapper);
     mpActionMapper->setObjectName(qsl("map_action"));
-
-    mpButtonMapper->addAction(mpActionMapper);
-    mpButtonMapper->addAction(dactionNewMapWindow);
-    mpButtonMapper->setDefaultAction(mpActionMapper);
+    mpMainToolBar->widgetForAction(mpActionMapper)->setObjectName(mpActionMapper->objectName());
 
     mpActionHelp = new QAction(QIcon(qsl(":/icons/help-hint.png")), tr("Manual"), this);
     mpActionHelp->setToolTip(utils::richText(tr("Browse reference material and documentation")));

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -467,6 +467,7 @@ public slots:
     void slot_reattachAllDetachedWindows();
     void slot_toggleAlwaysOnTop();
     void slot_minimize();
+    void slot_newMapWindow();
     void updateWindowMenu();
     void slot_activateMainWindow();
     void slot_activateDetachedWindow();

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -699,7 +699,6 @@ private:
     QPointer<QToolButton> mpButtonAbout;
     QPointer<QToolButton> mpButtonConnect;
     QPointer<QToolButton> mpButtonDiscord;
-    QPointer<QToolButton> mpButtonMapper;
     QPointer<QToolButton> mpButtonMute;
     QPointer<QToolButton> mpButtonPackageManagers;
     QHBoxLayout* mpHBoxLayout_profileContainer = nullptr;

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -699,6 +699,7 @@ private:
     QPointer<QToolButton> mpButtonAbout;
     QPointer<QToolButton> mpButtonConnect;
     QPointer<QToolButton> mpButtonDiscord;
+    QPointer<QToolButton> mpButtonMapper;
     QPointer<QToolButton> mpButtonMute;
     QPointer<QToolButton> mpButtonPackageManagers;
     QHBoxLayout* mpHBoxLayout_profileContainer = nullptr;

--- a/src/ui/main_window.ui
+++ b/src/ui/main_window.ui
@@ -97,6 +97,7 @@
     <addaction name="dactionScriptEditor"/>
     <addaction name="dactionShowErrors"/>
     <addaction name="dactionShowMap"/>
+    <addaction name="dactionNewMapWindow"/>
     <addaction name="dactionInputLine"/>
     <addaction name="dactionNotepad"/>
     <addaction name="dactionIRC"/>
@@ -146,8 +147,6 @@
     <addaction name="dactionToggleFullScreen"/>
     <addaction name="dactionMultiView"/>
     <addaction name="dactionReattachDetachedWindows"/>
-    <addaction name="separator"/>
-    <addaction name="dactionNewMapWindow"/>
     <addaction name="separator"/>
     <addaction name="dactionToggleAlwaysOnTop"/>
     <addaction name="dactionMinimize"/>

--- a/src/ui/main_window.ui
+++ b/src/ui/main_window.ui
@@ -147,6 +147,8 @@
     <addaction name="dactionMultiView"/>
     <addaction name="dactionReattachDetachedWindows"/>
     <addaction name="separator"/>
+    <addaction name="dactionNewMapWindow"/>
+    <addaction name="separator"/>
     <addaction name="dactionToggleAlwaysOnTop"/>
     <addaction name="dactionMinimize"/>
    </widget>
@@ -513,6 +515,14 @@
    </property>
    <property name="toolTip">
     <string>&lt;p&gt;Toggle all triggers, aliases, timers, etc. on or off&lt;/p&gt;</string>
+   </property>
+  </action>
+  <action name="dactionNewMapWindow">
+   <property name="text">
+    <string>New map window</string>
+   </property>
+   <property name="toolTip">
+    <string>&lt;p&gt;Open an additional map view window for the current profile.&lt;/p&gt;</string>
    </property>
   </action>
  </widget>

--- a/src/ui/main_window.ui
+++ b/src/ui/main_window.ui
@@ -97,7 +97,6 @@
     <addaction name="dactionScriptEditor"/>
     <addaction name="dactionShowErrors"/>
     <addaction name="dactionShowMap"/>
-    <addaction name="dactionNewMapWindow"/>
     <addaction name="dactionInputLine"/>
     <addaction name="dactionNotepad"/>
     <addaction name="dactionIRC"/>


### PR DESCRIPTION
  #### Brief overview of PR changes/additions
  Open additional 2D map windows showing different areas of the same map. Views are dockable and controlled via menu or Lua.

  New Lua functions:
  - `createMapView([areaId])` - open a new map window
  - `closeMapView(viewId)` - close a specific window
  - `closeAllMapViews()` - close all extra windows
  - `getMapViewIds()` - list open windows
  - `getMapViewInfo(viewId)` - get window state

  Extended with optional `viewId` parameter:
  - `centerview(roomId, [viewId])`
  - `setMapZoom(zoom, [areaId], [viewId])`
  - `getMapZoom([areaId], [viewId])`

  #### Motivation for adding to Mudlet
  Allows viewing multiple map areas simultaneously - useful for navigation planning, comparing areas, or keeping a zoomed-out overview while exploring.

  Upvoted suggestion in https://discord.com/channels/283581582550237184/792073945922142259/1402147549585866854

  #### Other info (issues closed, discussion etc)
  **Test case:**
  1. Load a profile with a map
  2. Window → New map window (or run `createMapView()`)
  3. Select different area in new window's dropdown
  4. Verify both views update when moving rooms
  5. Dock/undock the new window
  6. Close via X button or `closeMapView(id)`

https://github.com/user-attachments/assets/1cd38f37-5b3e-4ae2-83e4-ea9478b9f68c



