### PR TITLE
Add: permExactMatchTrigger Lua API function

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5235,6 +5235,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "calcFontSize", TLuaInterpreter::calcFontSize);
     lua_register(pGlobalLua, "permRegexTrigger", TLuaInterpreter::permRegexTrigger);
     lua_register(pGlobalLua, "permSubstringTrigger", TLuaInterpreter::permSubstringTrigger);
+    lua_register(pGlobalLua, "permExactMatchTrigger", TLuaInterpreter::permExactMatchTrigger);
     lua_register(pGlobalLua, "permBeginOfLineStringTrigger", TLuaInterpreter::permBeginOfLineStringTrigger);
     lua_register(pGlobalLua, "tempComplexRegexTrigger", TLuaInterpreter::tempComplexRegexTrigger);
     lua_register(pGlobalLua, "permTimer", TLuaInterpreter::permTimer);
@@ -6469,6 +6470,34 @@ std::pair<int, QString> TLuaInterpreter::startPermSubstringTrigger(const QString
     QList<int> propertyList;
     for (int i = 0; i < patterns.size(); i++) {
         propertyList << REGEX_SUBSTRING;
+    }
+    if (parent.isEmpty()) {
+        pT = new TTrigger("a", patterns, propertyList, (patterns.size() > 1), mpHost);
+    } else {
+        TTrigger* pP = mpHost->getTriggerUnit()->findTrigger(parent);
+        if (!pP) {
+            return {-1, qsl("parent '%1' not found").arg(parent)};
+        }
+        pT = new TTrigger(pP, mpHost);
+        pT->setRegexCodeList(patterns, propertyList);
+    }
+    pT->setIsFolder(patterns.empty());
+    pT->setIsActive(true);
+    pT->setTemporary(false);
+    pT->registerTrigger();
+    pT->setScript(function);
+    pT->setName(name);
+    updateEditor();
+    return {pT->getID(), QString()};
+}
+
+// No documentation available in wiki - internal function
+std::pair<int, QString> TLuaInterpreter::startPermExactMatchTrigger(const QString& name, const QString& parent, const QStringList& patterns, const QString& function)
+{
+    TTrigger* pT;
+    QList<int> propertyList;
+    for (int i = 0; i < patterns.size(); i++) {
+        propertyList << REGEX_EXACT_MATCH;
     }
     if (parent.isEmpty()) {
         pT = new TTrigger("a", patterns, propertyList, (patterns.size() > 1), mpHost);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -162,6 +162,7 @@ public:
     int startTempPromptTrigger(const QString& function, int expiryCount = -1);
     std::pair<int, QString> startPermRegexTrigger(const QString& name, const QString& parent, QStringList& patterns, const QString& function);
     std::pair<int, QString> startPermSubstringTrigger(const QString& name, const QString& parent, const QStringList& patterns, const QString& function);
+    std::pair<int, QString> startPermExactMatchTrigger(const QString& name, const QString& parent, const QStringList& patterns, const QString& function);
     std::pair<int, QString> startPermBeginOfLineStringTrigger(const QString& name, const QString& parent, QStringList& patterns, const QString& function);
     std::pair<int, QString> startPermPromptTrigger(const QString& name, const QString& parent, const QString& function);
     std::pair<int, QString> startPermTimer(const QString& name, const QString& parent, double timeout, const QString& function);
@@ -527,6 +528,7 @@ public:
     static int calcFontSize(lua_State*);
     static int permRegexTrigger(lua_State*);
     static int permSubstringTrigger(lua_State*);
+    static int permExactMatchTrigger(lua_State*);
     static int permTimer(lua_State*);
     static int permScript(lua_State*);
     static int getScript(lua_State*);

--- a/src/lua-function-list.json
+++ b/src/lua-function-list.json
@@ -342,6 +342,7 @@
     "pauseSpeedwalk": "pauseSpeedwalk()",
     "permAlias": "permAlias(name, parent, regex, lua code)",
     "permBeginOfLineStringTrigger": "permBeginOfLineStringTrigger(name, parent, pattern table, lua code)",
+    "permExactMatchTrigger": "permExactMatchTrigger(name, parent, pattern table, lua code)",
     "permGroup": "permGroup(name, itemtype, [parent])",
     "permKey": "permKey(name, parent, [modifier], key code, lua code)",
     "permPromptTrigger": "permPromptTrigger(name, parent, lua code)",


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds the missing `permExactMatchTrigger()` function that creates permanent exact match triggers. This completes the set of permanent trigger functions, complementing the existing `tempExactMatchTrigger()`.

**Files changed:**
- `src/TLuaInterpreter.h` - Add function declarations
- `src/TLuaInterpreter.cpp` - Add `startPermExactMatchTrigger()` internal function and register Lua binding
- `src/TLuaInterpreterMudletObjects.cpp` - Add `permExactMatchTrigger()` Lua API function
- `src/lua-function-list.json` - Add for autocomplete support

**Usage:**
```lua
-- Create a permanent exact match trigger
permExactMatchTrigger("myTrigger", "parentGroup", {"exact text to match"}, [[
  echo("Matched!\n")
]])
```

#### Motivation for adding to Mudlet
Completes the API symmetry - we have:
- `permRegexTrigger` ✓
- `permSubstringTrigger` ✓
- `permBeginOfLineStringTrigger` ✓
- `tempExactMatchTrigger` ✓
- `permExactMatchTrigger` ✗ (missing until now)

#### Other info (issues closed, discussion etc)
Fixes #1573

🤖 Generated with [Claude Code](https://claude.com/claude-code)