### PR TITLE
Fix: Update trigger icons immediately when dragging in editor

### DIFF
--- a/src/TTreeWidget.h
+++ b/src/TTreeWidget.h
@@ -62,6 +62,10 @@ public:
     void beginInsertRows(const QModelIndex& parent, int first, int last);
     void getAllChildren(QTreeWidgetItem*, QList<QTreeWidgetItem*>&);
 
+    void updateTriggerIcon(QTreeWidgetItem* pItem, int triggerID);
+    void updateTriggerIconsRecursively(QTreeWidgetItem* pItem);
+    QTreeWidgetItem* findItemByTriggerID(QTreeWidgetItem* pParent, int triggerID);
+
 signals:
     void itemMoved(int itemID, int oldParentID, int newParentID, int oldPosition, int newPosition);
     void batchMoveStarted();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
When triggers are dragged to create or break filter chains, their icons now update immediately instead of requiring a click to refresh.

**Changes to `src/TTreeWidget.cpp` and `src/TTreeWidget.h`:**

Added icon update logic to `TTreeWidget::rowsInserted()` for triggers, similar to the existing timer icon update logic. After a drag-drop operation:

1. **New parent's icon updates** - may become a filter chain (funnel icon)
2. **Old parent's icon updates** - may revert from funnel to checkbox
3. **Moved child and descendants update** - ancestor active state may change, affecting grayed icons

**New helper methods:**
- `updateTriggerIcon()` - Updates a single trigger's icon based on its current state (filter chain, folder, or regular trigger; active/inactive; ancestors active/inactive)
- `updateTriggerIconsRecursively()` - Updates a trigger and all its descendants
- `findItemByTriggerID()` - Finds a tree widget item by trigger ID

#### Motivation for adding to Mudlet
Currently, when you drag a trigger into another trigger (creating a filter chain), the parent trigger's icon doesn't change from checkbox to funnel until you click on it. Similarly, when you drag a trigger out, the old parent's icon doesn't update. This creates a confusing UX where the visual state doesn't match the actual state.

#### Other info (issues closed, discussion etc)
Fixes #7910

🤖 Generated with [Claude Code](https://claude.com/claude-code)