### PR TITLE
Fix: named captures indexed incorrectly in multimatches with special line types

### DIFF
--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -558,6 +558,8 @@ inline void TTrigger::updateMultistates(int regexNumber, std::list<std::string>&
                 matchStatePair.second->multiCapturePosList.push_back(posList);
                 if (nameMatches != nullptr) {
                     matchStatePair.second->nameCaptures.push_back(*nameMatches);
+                } else {
+                    matchStatePair.second->nameCaptures.push_back(QVector<QPair<QString, QString>>());
                 }
             }
         }
@@ -806,6 +808,7 @@ bool TTrigger::match_line_spacer(int patternNumber)
                     std::list<int> const posList;
                     matchStatePair.second->multiCaptureList.push_back(captureList);
                     matchStatePair.second->multiCapturePosList.push_back(posList);
+                    matchStatePair.second->nameCaptures.push_back(QVector<QPair<QString, QString>>());
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Fixes named capture groups being placed in wrong regex index in `multimatches` when multiline triggers use special line types (like line spacers)
- Root cause: `nameCaptures` vector not staying synchronized with `multiCaptureList`

## Changes
1. `match_line_spacer()`: Add empty `nameCaptures` entry when line spacer matches
2. `updateMultistates()`: Add else clause to push empty `nameCaptures` when `nameMatches` is null for non-first pattern conditions

## Test plan
- [x] Build succeeds
- [x] All 18 unit tests pass
- [x] Manual test with reproduction trigger from issue:
  - Create multiline trigger with: regex pattern, line spacer, regex with named capture
  - Verify named captures appear in correct `multimatches[n]` index

Fixes #7989

🤖 Generated with [Claude Code](https://claude.com/claude-code)