### PR TITLE
Fix: table.update no longer errors when replacing non-table with table (#8694)

### DIFF
--- a/src/mudlet-lua/lua/TableUtils.lua
+++ b/src/mudlet-lua/lua/TableUtils.lua
@@ -528,10 +528,8 @@ function table.update(t1, t2)
     tbl[k] = v
   end
   for k, v in pairs(t2) do
-    if type(v) == "table" then
-      -- Only recurse if tbl[k] is also a table; otherwise replace entirely
-      local existing = tbl[k]
-      tbl[k] = table.update(type(existing) == "table" and existing or {}, v)
+    if type(v) == "table" and type(tbl[k]) == "table" then
+      tbl[k] = table.update(tbl[k], v)
     else
       tbl[k] = v
     end

--- a/src/mudlet-lua/lua/TableUtils.lua
+++ b/src/mudlet-lua/lua/TableUtils.lua
@@ -529,7 +529,9 @@ function table.update(t1, t2)
   end
   for k, v in pairs(t2) do
     if type(v) == "table" then
-      tbl[k] = table.update(tbl[k] or {}, v)
+      -- Only recurse if tbl[k] is also a table; otherwise replace entirely
+      local existing = tbl[k]
+      tbl[k] = table.update(type(existing) == "table" and existing or {}, v)
     else
       tbl[k] = v
     end

--- a/src/mudlet-lua/tests/TableUtils_spec.lua
+++ b/src/mudlet-lua/tests/TableUtils_spec.lua
@@ -743,5 +743,46 @@ describe("Tests TableUtils.lua functions", function()
       local actual = table.update(tblA, tblB)
       assert.same(expected, actual)
     end)
+
+    -- Tests for #8694: table.update should not error when t1 has non-table and t2 has table
+    it("should replace non-table value with table value at same key", function()
+      local tblA = {x = 1}
+      local tblB = {x = {y = 2}}
+      local expected = {x = {y = 2}}
+      local actual = table.update(tblA, tblB)
+      assert.same(expected, actual)
+    end)
+
+    it("should replace table value with non-table value at same key", function()
+      local tblA = {x = {y = 2}}
+      local tblB = {x = 1}
+      local expected = {x = 1}
+      local actual = table.update(tblA, tblB)
+      assert.same(expected, actual)
+    end)
+
+    it("should merge nested tables when both have table at same key", function()
+      local tblA = {x = {a = 1, b = 2}}
+      local tblB = {x = {b = 3, c = 4}}
+      local expected = {x = {a = 1, b = 3, c = 4}}
+      local actual = table.update(tblA, tblB)
+      assert.same(expected, actual)
+    end)
+
+    it("should handle string value being replaced by table", function()
+      local tblA = {config = "old"}
+      local tblB = {config = {setting = true}}
+      local expected = {config = {setting = true}}
+      local actual = table.update(tblA, tblB)
+      assert.same(expected, actual)
+    end)
+
+    it("should handle boolean value being replaced by table", function()
+      local tblA = {enabled = true}
+      local tblB = {enabled = {feature1 = true, feature2 = false}}
+      local expected = {enabled = {feature1 = true, feature2 = false}}
+      local actual = table.update(tblA, tblB)
+      assert.same(expected, actual)
+    end)
   end)
 end)


### PR DESCRIPTION
## Summary

Fixes #8694 - `table.update` would error when the first table had a non-table value (number, string, boolean) at a key where the second table had a table value.

**Example that crashed:**
```lua
table.update({ x = 1 }, { x = { y = 2 } })
-- Error: bad argument #1 to 'pairs' (table expected, got number)
```

**Root cause:** The recursion logic `tbl[k] = table.update(tbl[k] or {}, v)` only checked for nil/false before recursing, not for other non-table types.

**Fix:** Check `type(existing) == "table"` before passing to recursive call.

## Test plan

- [x] Added 5 new test cases in `TableUtils_spec.lua`:
  - Replace number with table
  - Replace table with number  
  - Merge nested tables (both tables)
  - Replace string with table
  - Replace boolean with table

- [x] Verified fix works: `luajit -e "dofile('...TableUtils.lua'); print(table.update({x=1}, {x={y=2}}).x.y)"` outputs `2`

## Notes

Tests require running inside Mudlet with `runTests` command (uses Busted framework loaded by Mudlet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)