### PR TITLE
Infrastructure: Reduce noise in automated code review comments

### DIFF
--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -130,7 +130,7 @@ jobs:
           --target autogen
 
     - name: Check C++ changes against style guide
-      uses: ZedThree/clang-tidy-review@v0.22.3
+      uses: ZedThree/clang-tidy-review@v0.23.0
       id: static_analysis
       with:
         pr: ${{ inputs.pr_number || github.event.pull_request.number }}
@@ -142,6 +142,8 @@ jobs:
         # workaround for https://github.com/ZedThree/clang-tidy-review/issues/157
         extra_arguments: '--allow-no-checks'
         split_workflow: true
+        # skip posting compiler errors to reduce noise from cascading issues (e.g., missing includes)
+        error_action: skip
 
     - name: Upload check results
-      uses: ZedThree/clang-tidy-review/upload@v0.22.3
+      uses: ZedThree/clang-tidy-review/upload@v0.23.0

--- a/.github/workflows/clangtidy-post-comments.yml
+++ b/.github/workflows/clangtidy-post-comments.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: ZedThree/clang-tidy-review/post@v0.22.3
+      - uses: ZedThree/clang-tidy-review/post@v0.23.0
         with:
           # don't post any comments if the PR is fine
           lgtm_comment_body: ''


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Updates clang-tidy-review to v0.23.0 and enables `error_action: skip` to filter out compiler error comments.

#### Motivation for adding to Mudlet
PRs with missing includes can get flooded with cascading error messages that obscure actual code quality feedback. This keeps reviews focused on real issues.

#### Other info (issues closed, discussion etc)
Uses new feature from https://github.com/ZedThree/clang-tidy-review/pull/161
