### PR TITLE
Infrastructure: Improve code readability with cleaner empty checks

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2996,7 +2996,7 @@ void TBuffer::decodeOSC(const QString& sequence)
             }
 
             // Handle menu functionality by extending commands and hints
-            if (!mCurrentHyperlinkMenu.isEmpty() && mCurrentHyperlinkMenu.size() >= 1) {
+            if (!mCurrentHyperlinkMenu.isEmpty()) {
 #if defined(DEBUG_OSC_PROCESSING)
                 qDebug() << "[OSC] Building menu commands from" << mCurrentHyperlinkMenu.size() << "menu items";
 #endif
@@ -4619,7 +4619,7 @@ int TBuffer::wrapLine(int startLine, int maxWidth, int indentSize, int hangingIn
         QString newLineText;
         const QString time = timeBuffer[i];
         // trivial case
-        if (buffer[i].size() == 0) {
+        if (buffer[i].empty()) {
             tempList.append(newLineText);
             queue.push(newBufferLine);
             timeList.append(time);
@@ -4694,7 +4694,7 @@ int TBuffer::wrapLine(int startLine, int maxWidth, int indentSize, int hangingIn
 
     const int insertedLines = queue.size() - 1;
     for (int i = 0; i <= insertedLines; ++i) {
-        if (tempList[i].size() < 1) {
+        if (tempList[i].isEmpty()) {
             queue.pop();
             appendEmptyLine();
         } else {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -3940,7 +3940,7 @@ void cTelnet::setMSPVariables(const QByteArray& msg)
 
     QStringList argumentList = transcodedMsg.split(QChar::Space);
 
-    if (argumentList.size() > 0) {
+    if (!argumentList.isEmpty()) {
         for (int i = 0; i < argumentList.size(); ++i) {
             if (i < 1) {
                 mediaData.setMediaFileName(argumentList[i]);

--- a/src/utils.h
+++ b/src/utils.h
@@ -76,7 +76,7 @@ public:
     // Returns path unchanged if it was already absolute or an empty string
     static QString pathResolveRelative(const QString& path, const QString& base)
     {
-        if (path.size() == 0) {
+        if (path.isEmpty()) {
             return path;
         }
         if (QDir::isAbsolutePath(path)) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Replace `.size() == 0` / `.size() > 0` comparisons with `.isEmpty()` / `.empty()` across 3 files.

#### Motivation for adding to Mudlet

Using `.isEmpty()` (Qt) and `.empty()` (STL) is more readable and idiomatic than size comparisons. Also removed a redundant double-check (`!x.isEmpty() && x.size() >= 1`).

#### Other info (issues closed, discussion etc)

**Test case:** Build compiles without errors. No behavioral change - these are semantically equivalent checks.

Files changed:
- `src/ctelnet.cpp`
- `src/TBuffer.cpp`
- `src/utils.h`
- 