### PR TITLE
Fix: default new profiles to UTF-8 encoding instead of ASCII

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -303,8 +303,12 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
     setAutoReconnect(!val.isEmpty() && val.toInt() == Qt::Checked);
 
     // This settings also need to be configured, note that the only time not to
-    // save the setting is on profile loading:
-    mTelnet.setEncoding(readProfileData(qsl("encoding")).toUtf8(), false);
+    // save the setting is on profile loading. Only override the default UTF-8
+    // encoding if a saved encoding exists:
+    const QByteArray savedEncoding = readProfileData(qsl("encoding")).toUtf8();
+    if (!savedEncoding.isEmpty()) {
+        mTelnet.setEncoding(savedEncoding, false);
+    }
 
     auto optin = readProfileData(qsl("discordserveroptin"));
     if (!optin.isEmpty()) {

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1773,8 +1773,12 @@ void dlgConnectionProfiles::loadProfile(bool alsoConnect)
         }
 
         // This settings also need to be configured, note that the only time not to
-        // save the setting is on profile loading:
-        pHost->mTelnet.setEncoding(readProfileData(profile_name, qsl("encoding")).toUtf8(), false);
+        // save the setting is on profile loading. Only override the default UTF-8
+        // encoding if a saved encoding exists:
+        const QByteArray savedEncoding = readProfileData(profile_name, qsl("encoding")).toUtf8();
+        if (!savedEncoding.isEmpty()) {
+            pHost->mTelnet.setEncoding(savedEncoding, false);
+        }
         // Needed to ensure setting is correct on start-up:
         pHost->setWideAmbiguousEAsianGlyphs(pHost->getWideAmbiguousEAsianGlyphsControlState());
         pHost->setAutoReconnect(auto_reconnect->isChecked());


### PR DESCRIPTION
  #### Brief overview of PR changes/additions

  New profiles now correctly default to UTF-8 encoding instead of ASCII.

  #### Motivation for adding to Mudlet

  New profiles were unintentionally defaulting to ASCII because empty profile data was treated as "ASCII" rather than "not yet set".

  #### Other info (issues closed, discussion etc)

  **Test case:**
  1. Create a new profile
  2. Go to Settings → General → Game protocols
  3. Encoding should show UTF-8, not ASCII

