### PR TITLE
infrastructure: Guard undo/redo debug messages behind compile flag

### DIFF
--- a/src/EditorAddItemCommand.cpp
+++ b/src/EditorAddItemCommand.cpp
@@ -350,7 +350,9 @@ void EditorAddItemCommand::redo()
                     }
                 }
             } else {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorAddItemCommand::redo() - Failed to recreate trigger from snapshot";
+#endif
             }
             break;
         }
@@ -386,7 +388,9 @@ void EditorAddItemCommand::redo()
                     }
                 }
             } else {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorAddItemCommand::redo() - Failed to recreate alias from snapshot";
+#endif
             }
             break;
         }
@@ -422,7 +426,9 @@ void EditorAddItemCommand::redo()
                     }
                 }
             } else {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorAddItemCommand::redo() - Failed to recreate timer from snapshot";
+#endif
             }
             break;
         }
@@ -468,10 +474,14 @@ void EditorAddItemCommand::redo()
                         }
                     }
                 } else {
+#if defined(DEBUG_UNDO_REDO)
                     qWarning() << "EditorAddItemCommand::redo() - ID count mismatch! Old:" << mOldDescendantIDs.size() << "New:" << newDescendantIDs.size();
+#endif
                 }
             } else {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorAddItemCommand::redo() - Failed to recreate script from snapshot";
+#endif
             }
             break;
         }
@@ -507,7 +517,9 @@ void EditorAddItemCommand::redo()
                     }
                 }
             } else {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorAddItemCommand::redo() - Failed to recreate key from snapshot";
+#endif
             }
             break;
         }
@@ -543,7 +555,9 @@ void EditorAddItemCommand::redo()
                     }
                 }
             } else {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorAddItemCommand::redo() - Failed to recreate action from snapshot";
+#endif
             }
             break;
         }

--- a/src/EditorDeleteItemCommand.cpp
+++ b/src/EditorDeleteItemCommand.cpp
@@ -89,7 +89,9 @@ void EditorDeleteItemCommand::undo()
 
         // Safety check for circular dependencies or broken references
         if (!madeProgress && !remainingItems.isEmpty()) {
+#if defined(DEBUG_UNDO_REDO)
             qWarning() << "EditorDeleteItemCommand::undo() - Could not resolve parent-child dependencies for" << remainingItems.size() << "items, adding them anyway";
+#endif
             sortedItems.append(remainingItems);
             break;
         }
@@ -130,7 +132,9 @@ void EditorDeleteItemCommand::undo()
         // Find the corresponding item in mDeletedItems to update the ID
         auto it = std::find_if(mDeletedItems.begin(), mDeletedItems.end(), [&info](const DeletedItemInfo& item) { return item.itemName == info.itemName && item.parentID == info.parentID; });
         if (it == mDeletedItems.end()) {
+#if defined(DEBUG_UNDO_REDO)
             qWarning() << "EditorDeleteItemCommand::undo() - Could not find item in original list:" << info.itemName << "with parentID=" << info.parentID;
+#endif
             continue;
         }
         auto& originalInfo = *it;
@@ -145,15 +149,19 @@ void EditorDeleteItemCommand::undo()
             TTrigger* pParent = nullptr;
             if (info.parentID != -1) {
                 pParent = mpHost->getTriggerUnit()->getTrigger(info.parentID);
+#if defined(DEBUG_UNDO_REDO)
                 if (!pParent) {
                     qWarning() << "EditorDeleteItemCommand::undo() - Parent trigger not found for" << info.itemName << "parentID=" << info.parentID;
                 }
+#endif
             }
 
             // Restore the trigger from XML snapshot at its original position
             TTrigger* pRestoredTrigger = importTriggerFromXML(info.xmlSnapshot, pParent, mpHost, info.positionInParent);
             if (!pRestoredTrigger) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::undo() - Failed to restore trigger" << info.itemName;
+#endif
             } else {
                 mLastOperationWasValid = true;
                 int newID = pRestoredTrigger->getID();
@@ -224,7 +232,9 @@ void EditorDeleteItemCommand::undo()
 
             TAlias* pRestoredAlias = importAliasFromXML(info.xmlSnapshot, pParent, mpHost, info.positionInParent);
             if (!pRestoredAlias) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::undo() - Failed to restore alias" << info.itemName;
+#endif
             } else {
                 mLastOperationWasValid = true;
                 int newID = pRestoredAlias->getID();
@@ -291,7 +301,9 @@ void EditorDeleteItemCommand::undo()
 
             TTimer* pRestoredTimer = importTimerFromXML(info.xmlSnapshot, pParent, mpHost, info.positionInParent);
             if (!pRestoredTimer) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::undo() - Failed to restore timer" << info.itemName;
+#endif
             } else {
                 mLastOperationWasValid = true;
                 int newID = pRestoredTimer->getID();
@@ -358,7 +370,9 @@ void EditorDeleteItemCommand::undo()
 
             TScript* pRestoredScript = importScriptFromXML(info.xmlSnapshot, pParent, mpHost, info.positionInParent);
             if (!pRestoredScript) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::undo() - Failed to restore script" << info.itemName;
+#endif
             } else {
                 mLastOperationWasValid = true;
                 int newID = pRestoredScript->getID();
@@ -425,7 +439,9 @@ void EditorDeleteItemCommand::undo()
 
             TKey* pRestoredKey = importKeyFromXML(info.xmlSnapshot, pParent, mpHost, info.positionInParent);
             if (!pRestoredKey) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::undo() - Failed to restore key" << info.itemName;
+#endif
             } else {
                 mLastOperationWasValid = true;
                 int newID = pRestoredKey->getID();
@@ -492,7 +508,9 @@ void EditorDeleteItemCommand::undo()
 
             TAction* pRestoredAction = importActionFromXML(info.xmlSnapshot, pParent, mpHost, info.positionInParent);
             if (!pRestoredAction) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::undo() - Failed to restore action" << info.itemName;
+#endif
             } else {
                 mLastOperationWasValid = true;
                 int newID = pRestoredAction->getID();
@@ -552,7 +570,9 @@ void EditorDeleteItemCommand::undo()
             break;
         }
         default:
+#if defined(DEBUG_UNDO_REDO)
             qWarning() << "EditorDeleteItemCommand::undo() - Unknown item type";
+#endif
             break;
         }
     }
@@ -578,11 +598,15 @@ void EditorDeleteItemCommand::redo()
             TTrigger* trigger = mpHost->getTriggerUnit()->getTrigger(info.itemID);
             // Validate: item exists and has expected name (prevents deleting wrong item if ID reused)
             if (!trigger) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::redo() - Trigger" << info.itemName << "ID:" << info.itemID << "no longer exists, skipping";
+#endif
                 continue;
             }
             if (trigger->getName() != info.itemName) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::redo() - Trigger ID" << info.itemID << "expected name" << info.itemName << "but found" << trigger->getName() << ", skipping";
+#endif
                 continue;
             }
             // Valid item found
@@ -593,11 +617,15 @@ void EditorDeleteItemCommand::redo()
             TAlias* alias = mpHost->getAliasUnit()->getAlias(info.itemID);
             // Validate: item exists and has expected name
             if (!alias) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::redo() - Alias" << info.itemName << "ID:" << info.itemID << "no longer exists, skipping";
+#endif
                 continue;
             }
             if (alias->getName() != info.itemName) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::redo() - Alias ID" << info.itemID << "expected name" << info.itemName << "but found" << alias->getName() << ", skipping";
+#endif
                 continue;
             }
             // Valid item found
@@ -608,11 +636,15 @@ void EditorDeleteItemCommand::redo()
             TTimer* timer = mpHost->getTimerUnit()->getTimer(info.itemID);
             // Validate: item exists and has expected name
             if (!timer) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::redo() - Timer" << info.itemName << "ID:" << info.itemID << "no longer exists, skipping";
+#endif
                 continue;
             }
             if (timer->getName() != info.itemName) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::redo() - Timer ID" << info.itemID << "expected name" << info.itemName << "but found" << timer->getName() << ", skipping";
+#endif
                 continue;
             }
             // Valid item found
@@ -623,11 +655,15 @@ void EditorDeleteItemCommand::redo()
             TScript* script = mpHost->getScriptUnit()->getScript(info.itemID);
             // Validate: item exists and has expected name
             if (!script) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::redo() - Script" << info.itemName << "ID:" << info.itemID << "no longer exists, skipping";
+#endif
                 continue;
             }
             if (script->getName() != info.itemName) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::redo() - Script ID" << info.itemID << "expected name" << info.itemName << "but found" << script->getName() << ", skipping";
+#endif
                 continue;
             }
             // Valid item found
@@ -638,11 +674,15 @@ void EditorDeleteItemCommand::redo()
             TKey* key = mpHost->getKeyUnit()->getKey(info.itemID);
             // Validate: item exists and has expected name
             if (!key) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::redo() - Key" << info.itemName << "ID:" << info.itemID << "no longer exists, skipping";
+#endif
                 continue;
             }
             if (key->getName() != info.itemName) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::redo() - Key ID" << info.itemID << "expected name" << info.itemName << "but found" << key->getName() << ", skipping";
+#endif
                 continue;
             }
             // Valid item found
@@ -653,11 +693,15 @@ void EditorDeleteItemCommand::redo()
             TAction* action = mpHost->getActionUnit()->getAction(info.itemID);
             // Validate: item exists and has expected name
             if (!action) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::redo() - Action" << info.itemName << "ID:" << info.itemID << "no longer exists, skipping";
+#endif
                 continue;
             }
             if (action->getName() != info.itemName) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::redo() - Action ID" << info.itemID << "expected name" << info.itemName << "but found" << action->getName() << ", skipping";
+#endif
                 continue;
             }
             // Valid item found
@@ -691,9 +735,11 @@ void EditorDeleteItemCommand::redo()
                 break;
             }
             if (trigger->getName() != info.itemName) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::redo() - Trigger ID" << info.itemID
                            << "name changed from" << info.itemName << "to" << trigger->getName()
                            << "- not deleting";
+#endif
                 break;
             }
             mpHost->getTriggerUnit()->unregisterTrigger(trigger);
@@ -707,9 +753,11 @@ void EditorDeleteItemCommand::redo()
                 break;
             }
             if (alias->getName() != info.itemName) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::redo() - Alias ID" << info.itemID
                            << "name changed from" << info.itemName << "to" << alias->getName()
                            << "- not deleting";
+#endif
                 break;
             }
             mpHost->getAliasUnit()->unregisterAlias(alias);
@@ -723,9 +771,11 @@ void EditorDeleteItemCommand::redo()
                 break;
             }
             if (timer->getName() != info.itemName) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::redo() - Timer ID" << info.itemID
                            << "name changed from" << info.itemName << "to" << timer->getName()
                            << "- not deleting";
+#endif
                 break;
             }
             mpHost->getTimerUnit()->unregisterTimer(timer);
@@ -739,9 +789,11 @@ void EditorDeleteItemCommand::redo()
                 break;
             }
             if (script->getName() != info.itemName) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::redo() - Script ID" << info.itemID
                            << "name changed from" << info.itemName << "to" << script->getName()
                            << "- not deleting";
+#endif
                 break;
             }
             mpHost->getScriptUnit()->unregisterScript(script);
@@ -755,9 +807,11 @@ void EditorDeleteItemCommand::redo()
                 break;
             }
             if (key->getName() != info.itemName) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::redo() - Key ID" << info.itemID
                            << "name changed from" << info.itemName << "to" << key->getName()
                            << "- not deleting";
+#endif
                 break;
             }
             mpHost->getKeyUnit()->unregisterKey(key);
@@ -771,9 +825,11 @@ void EditorDeleteItemCommand::redo()
                 break;
             }
             if (action->getName() != info.itemName) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorDeleteItemCommand::redo() - Action ID" << info.itemID
                            << "name changed from" << info.itemName << "to" << action->getName()
                            << "- not deleting";
+#endif
                 break;
             }
             mpHost->getActionUnit()->unregisterAction(action);

--- a/src/EditorModifyPropertyCommand.cpp
+++ b/src/EditorModifyPropertyCommand.cpp
@@ -45,10 +45,14 @@ void EditorModifyPropertyCommand::undo()
         TTrigger* pTrigger = mpHost->getTriggerUnit()->getTrigger(mItemID);
         if (pTrigger) {
             if (!updateTriggerFromXML(pTrigger, mOldStateXML)) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorModifyPropertyCommand::undo() - Failed to restore trigger" << mItemName << "to old state";
+#endif
             }
         } else {
+#if defined(DEBUG_UNDO_REDO)
             qWarning() << "EditorModifyPropertyCommand::undo() - Trigger" << mItemName << "not found";
+#endif
         }
         break;
     }
@@ -56,10 +60,14 @@ void EditorModifyPropertyCommand::undo()
         TAlias* pAlias = mpHost->getAliasUnit()->getAlias(mItemID);
         if (pAlias) {
             if (!updateAliasFromXML(pAlias, mOldStateXML)) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorModifyPropertyCommand::undo() - Failed to restore alias" << mItemName << "to old state";
+#endif
             }
         } else {
+#if defined(DEBUG_UNDO_REDO)
             qWarning() << "EditorModifyPropertyCommand::undo() - Alias" << mItemName << "not found";
+#endif
         }
         break;
     }
@@ -67,10 +75,14 @@ void EditorModifyPropertyCommand::undo()
         TTimer* pTimer = mpHost->getTimerUnit()->getTimer(mItemID);
         if (pTimer) {
             if (!updateTimerFromXML(pTimer, mOldStateXML)) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorModifyPropertyCommand::undo() - Failed to restore timer" << mItemName << "to old state";
+#endif
             }
         } else {
+#if defined(DEBUG_UNDO_REDO)
             qWarning() << "EditorModifyPropertyCommand::undo() - Timer" << mItemName << "not found";
+#endif
         }
         break;
     }
@@ -78,10 +90,14 @@ void EditorModifyPropertyCommand::undo()
         TScript* pScript = mpHost->getScriptUnit()->getScript(mItemID);
         if (pScript) {
             if (!updateScriptFromXML(pScript, mOldStateXML)) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorModifyPropertyCommand::undo() - Failed to restore script" << mItemName << "to old state";
+#endif
             }
         } else {
+#if defined(DEBUG_UNDO_REDO)
             qWarning() << "EditorModifyPropertyCommand::undo() - Script" << mItemName << "not found";
+#endif
         }
         break;
     }
@@ -89,10 +105,14 @@ void EditorModifyPropertyCommand::undo()
         TKey* pKey = mpHost->getKeyUnit()->getKey(mItemID);
         if (pKey) {
             if (!updateKeyFromXML(pKey, mOldStateXML)) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorModifyPropertyCommand::undo() - Failed to restore key" << mItemName << "to old state";
+#endif
             }
         } else {
+#if defined(DEBUG_UNDO_REDO)
             qWarning() << "EditorModifyPropertyCommand::undo() - Key" << mItemName << "not found";
+#endif
         }
         break;
     }
@@ -100,10 +120,14 @@ void EditorModifyPropertyCommand::undo()
         TAction* pAction = mpHost->getActionUnit()->getAction(mItemID);
         if (pAction) {
             if (!updateActionFromXML(pAction, mOldStateXML)) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorModifyPropertyCommand::undo() - Failed to restore action" << mItemName << "to old state";
+#endif
             }
         } else {
+#if defined(DEBUG_UNDO_REDO)
             qWarning() << "EditorModifyPropertyCommand::undo() - Action" << mItemName << "not found";
+#endif
         }
         break;
     }
@@ -133,10 +157,14 @@ void EditorModifyPropertyCommand::redo()
         TTrigger* pTrigger = mpHost->getTriggerUnit()->getTrigger(mItemID);
         if (pTrigger) {
             if (!updateTriggerFromXML(pTrigger, mNewStateXML)) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorModifyPropertyCommand::redo() - Failed to apply new state to trigger" << mItemName;
+#endif
             }
         } else {
+#if defined(DEBUG_UNDO_REDO)
             qWarning() << "EditorModifyPropertyCommand::redo() - Trigger" << mItemName << "not found";
+#endif
         }
         break;
     }
@@ -144,10 +172,14 @@ void EditorModifyPropertyCommand::redo()
         TAlias* pAlias = mpHost->getAliasUnit()->getAlias(mItemID);
         if (pAlias) {
             if (!updateAliasFromXML(pAlias, mNewStateXML)) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorModifyPropertyCommand::redo() - Failed to apply new state to alias" << mItemName;
+#endif
             }
         } else {
+#if defined(DEBUG_UNDO_REDO)
             qWarning() << "EditorModifyPropertyCommand::redo() - Alias" << mItemName << "not found";
+#endif
         }
         break;
     }
@@ -155,10 +187,14 @@ void EditorModifyPropertyCommand::redo()
         TTimer* pTimer = mpHost->getTimerUnit()->getTimer(mItemID);
         if (pTimer) {
             if (!updateTimerFromXML(pTimer, mNewStateXML)) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorModifyPropertyCommand::redo() - Failed to apply new state to timer" << mItemName;
+#endif
             }
         } else {
+#if defined(DEBUG_UNDO_REDO)
             qWarning() << "EditorModifyPropertyCommand::redo() - Timer" << mItemName << "not found";
+#endif
         }
         break;
     }
@@ -166,10 +202,14 @@ void EditorModifyPropertyCommand::redo()
         TScript* pScript = mpHost->getScriptUnit()->getScript(mItemID);
         if (pScript) {
             if (!updateScriptFromXML(pScript, mNewStateXML)) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorModifyPropertyCommand::redo() - Failed to apply new state to script" << mItemName;
+#endif
             }
         } else {
+#if defined(DEBUG_UNDO_REDO)
             qWarning() << "EditorModifyPropertyCommand::redo() - Script" << mItemName << "not found";
+#endif
         }
         break;
     }
@@ -177,10 +217,14 @@ void EditorModifyPropertyCommand::redo()
         TKey* pKey = mpHost->getKeyUnit()->getKey(mItemID);
         if (pKey) {
             if (!updateKeyFromXML(pKey, mNewStateXML)) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorModifyPropertyCommand::redo() - Failed to apply new state to key" << mItemName;
+#endif
             }
         } else {
+#if defined(DEBUG_UNDO_REDO)
             qWarning() << "EditorModifyPropertyCommand::redo() - Key" << mItemName << "not found";
+#endif
         }
         break;
     }
@@ -188,10 +232,14 @@ void EditorModifyPropertyCommand::redo()
         TAction* pAction = mpHost->getActionUnit()->getAction(mItemID);
         if (pAction) {
             if (!updateActionFromXML(pAction, mNewStateXML)) {
+#if defined(DEBUG_UNDO_REDO)
                 qWarning() << "EditorModifyPropertyCommand::redo() - Failed to apply new state to action" << mItemName;
+#endif
             }
         } else {
+#if defined(DEBUG_UNDO_REDO)
             qWarning() << "EditorModifyPropertyCommand::redo() - Action" << mItemName << "not found";
+#endif
         }
         break;
     }

--- a/src/EditorUndoStack.cpp
+++ b/src/EditorUndoStack.cpp
@@ -82,7 +82,9 @@ void EditorUndoStack::emitChangesForCommand(const QUndoCommand* cmd)
             for (int id : itemIDs) {
                 if (id <= 0) {
                     allValid = false;
+#if defined(DEBUG_UNDO_REDO)
                     qWarning() << "EditorUndoStack::emitChangesForCommand() - Invalid item ID" << id << "found, skipping emission";
+#endif
                     break;
                 }
             }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Wrap all `qWarning()` and `qDebug()` statements in undo/redo command files with `#if defined(DEBUG_UNDO_REDO)` guards
- Affects EditorDeleteItemCommand, EditorModifyPropertyCommand, EditorAddItemCommand, EditorUndoStack

#### Motivation for adding to Mudlet
Prevents debug spam in console output during normal usage while keeping messages available when explicitly enabled for development.

#### Other info (issues closed, discussion etc)
**Test case:** Build and run Mudlet, perform undo/redo operations in the editor - no debug messages should appear in console. Enable `DEBUG_UNDO_REDO` in CMakeLists.txt to verify messages still work when needed.