### PR TITLE
Improve: Enable PCRE2 JIT compilation for triggers and aliases

### DIFF
--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -276,6 +276,7 @@ void TAlias::compileRegex()
         }
         setError(qsl("<b><font color='blue'>%1</font></b>").arg(tr(R"(Error: in "Pattern:", faulty regular expression, reason: "%1".)").arg(error)));
     } else {
+        pcre2_jit_compile(re.data(), PCRE2_JIT_COMPLETE);
         mOK_init = true;
     }
 

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -187,6 +187,7 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds, b
                              .arg(QString::number(i + 1), QString(regexp.constData()).toHtmlEscaped(), QString(error).toHtmlEscaped())));
                     state = false;
                 } else {
+                    pcre2_jit_compile(re.data(), PCRE2_JIT_COMPLETE);
                     if (mudlet::smDebugMode) {
                         TDebug(Qt::white, Qt::darkGreen) << "[OK]: REGEX_COMPILE OK\n" >> mpHost;
                     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Enable PCRE2 JIT (Just-In-Time) compilation for regex patterns in triggers and aliases.

#### Motivation for adding to Mudlet

JIT compilation can provide 2-10x faster regex matching. Benefits users with many regex-based triggers, especially large profiles with thousands of triggers.

#### Other info (issues closed, discussion etc)

JIT failure is non-fatal - PCRE2 falls back to the interpreter automatically.

**Test case:**
1. Create a trigger with a Perl regex pattern (e.g., `^You have (\d+) gold`)
2. Connect to a MUD and observe trigger matching works as before
3. For performance testing: create 10000+ regex triggers and compare CPU usage when receiving rapid text
