### PR TITLE
Fix: Remove unnecessary allocation in filter trigger matching

### DIFF
--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -569,17 +569,10 @@ inline void TTrigger::filter(std::string& capture, int& posOffset)
     if (capture.empty()) {
         return;
     }
-    auto * filterSubject = static_cast<char*>(malloc(capture.size() + 2048));
-    if (filterSubject) {
-        strcpy(filterSubject, capture.c_str());
-    } else {
-        return;
-    }
-    const QString text = capture.c_str();
+    const QString text = QString::fromStdString(capture);
     for (auto& trigger : *mpMyChildrenList) {
-        trigger->match(filterSubject, text, -1, posOffset);
+        trigger->match(capture.data(), text, -1, posOffset);
     }
-    free(filterSubject);
 }
 
 int TTrigger::getExpiryCount() const


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Remove unnecessary malloc/free in filter trigger matching by using std::string's internal buffer directly.

#### Motivation for adding to Mudlet

Each filter trigger match was allocating a buffer with 2KB of extra padding, copying the captured text, then freeing it. This adds overhead for profiles with many filter triggers.

#### Other info (issues closed, discussion etc)

**Test case:**
1. Create a parent trigger with a filter child trigger
2. Verify filter triggers still match and fire correctly
3. For stress testing: rapid text with filter triggers should show reduced memory churn
