### PR TITLE
Fix: Improve build documentation clarity for terminal execution

### DIFF
--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -190,8 +190,7 @@ cmake ../../Mudlet -DCMAKE_PREFIX_PATH=`brew --prefix qt6`
 make -j `sysctl -n hw.ncpu`
 
 # Run
-cd /path/to/Mudlet/build
-./src/mudlet.app/Contents/MacOS/mudlet
+cd /path/to/Mudlet/build && ./src/mudlet.app/Contents/MacOS/mudlet
 ```
 
 ### Building on Linux


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Combines the `cd` and execution commands into a single line in the macOS build instructions, ensuring commands run in the correct directory context.

#### Motivation for adding to Mudlet

When AI assistants help with building and running Mudlet, they start fresh terminal sessions that don't retain directory context. By combining the directory change with the executable path in a single command, the instructions ensure the command always executes from the correct location without requiring additional navigation steps.

This reduces the number of self-prompts AI assistants need to locate the executable, improving efficiency and reducing unnecessary token consumption during development assistance.

#### Other info (issues closed, discussion etc)

No issues closed. Minor documentation improvement to enhance AI assistant workflow efficiency.