### PR TITLE
infrastructure: Upload Qt debug symbols to Sentry for better crash reports

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -43,6 +43,7 @@ jobs:
       shell: msys2 {0}
       env:
         GITHUB_REPO_TAG: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+        SENTRY_SEND_DEBUG: ${{ (startsWith(github.ref, 'refs/tags/') || github.event_name == 'schedule' || github.event.inputs.scheduled == 'true') && '1' || '0' }}
       run: |
         $GITHUB_WORKSPACE/CI/setup-windows-sdk.sh
         $GITHUB_WORKSPACE/CI/validate-deployment-for-windows.sh

--- a/CI/send_debug_files_to_sentry.sh
+++ b/CI/send_debug_files_to_sentry.sh
@@ -100,8 +100,10 @@ for f in "${FILES_TO_UPLOAD[@]}"; do
     ./sentry-cli debug-files upload "$f" --project "mudlet"
 done
 
-if [[ "$OS" == MINGW* ]] || [[ "$OS" == MSYS* ]] || [[ "$OS" == CYGWIN* ]]; then
-    MINGW_BIN="/mingw64/bin"
+# Use MSYSTEM variable for MSYS2 detection (consistent with other CI scripts)
+# and MSYSTEM_PREFIX for the path (supports MINGW64, CLANG64, UCRT64, etc.)
+if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
+    MINGW_BIN="${MSYSTEM_PREFIX}/bin"
     if [[ -d "$MINGW_BIN" ]]; then
         echo ""
         echo "=== Uploading Qt debug files for full stack traces ==="

--- a/CI/send_debug_files_to_sentry.sh
+++ b/CI/send_debug_files_to_sentry.sh
@@ -101,6 +101,31 @@ for f in "${FILES_TO_UPLOAD[@]}"; do
 done
 
 if [[ "$OS" == MINGW* ]] || [[ "$OS" == MSYS* ]] || [[ "$OS" == CYGWIN* ]]; then
+    MINGW_BIN="/mingw64/bin"
+    if [[ -d "$MINGW_BIN" ]]; then
+        echo ""
+        echo "=== Uploading Qt debug files for full stack traces ==="
+
+        QT_FILES=()
+        for dll in "$MINGW_BIN"/Qt6*.dll; do
+            if [[ -f "$dll" ]]; then
+                QT_FILES+=("$dll")
+                debug_file="${dll%.dll}.debug"
+                if [[ -f "$debug_file" ]]; then
+                    QT_FILES+=("$debug_file")
+                fi
+            fi
+        done
+
+        if [[ ${#QT_FILES[@]} -gt 0 ]]; then
+            echo "Found ${#QT_FILES[@]} Qt files to upload"
+            ./sentry-cli debug-files upload "${QT_FILES[@]}" --project "mudlet"
+            echo "Qt debug files uploaded successfully"
+        else
+            echo "No Qt debug files found in $MINGW_BIN"
+        fi
+    fi
+
     strip --strip-debug "$MUDLET_EXEC"
 fi
 

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -156,13 +156,13 @@ if [ "${SENTRY_SEND_DEBUG}" = "1" ]; then
   pacman_attempts=0
   while true; do
     if /usr/bin/pacman -S --needed --noconfirm \
-      "mingw-w64-${BUILDCOMPONENT}-qt6-base-debug" \
-      "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia-debug" \
-      "mingw-w64-${BUILDCOMPONENT}-qt6-svg-debug" \
-      "mingw-w64-${BUILDCOMPONENT}-qt6-speech-debug" \
-      "mingw-w64-${BUILDCOMPONENT}-qt6-imageformats-debug" \
-      "mingw-w64-${BUILDCOMPONENT}-qt6-tools-debug" \
-      "mingw-w64-${BUILDCOMPONENT}-qt6-5compat-debug"; then
+      "${MINGW_PACKAGE_PREFIX}-qt6-base-debug" \
+      "${MINGW_PACKAGE_PREFIX}-qt6-multimedia-debug" \
+      "${MINGW_PACKAGE_PREFIX}-qt6-svg-debug" \
+      "${MINGW_PACKAGE_PREFIX}-qt6-speech-debug" \
+      "${MINGW_PACKAGE_PREFIX}-qt6-imageformats-debug" \
+      "${MINGW_PACKAGE_PREFIX}-qt6-tools-debug" \
+      "${MINGW_PACKAGE_PREFIX}-qt6-5compat-debug"; then
         break
     fi
 

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -151,6 +151,35 @@ echo ""
 echo "    Completed"
 echo ""
 
+if [ "${SENTRY_SEND_DEBUG}" = "1" ]; then
+  echo "=== Installing Qt debug packages for Sentry ==="
+  pacman_attempts=0
+  while true; do
+    if /usr/bin/pacman -S --needed --noconfirm \
+      "mingw-w64-${BUILDCOMPONENT}-qt6-base-debug" \
+      "mingw-w64-${BUILDCOMPONENT}-qt6-multimedia-debug" \
+      "mingw-w64-${BUILDCOMPONENT}-qt6-svg-debug" \
+      "mingw-w64-${BUILDCOMPONENT}-qt6-speech-debug" \
+      "mingw-w64-${BUILDCOMPONENT}-qt6-imageformats-debug" \
+      "mingw-w64-${BUILDCOMPONENT}-qt6-tools-debug" \
+      "mingw-w64-${BUILDCOMPONENT}-qt6-5compat-debug"; then
+        break
+    fi
+
+    pacman_attempts=$((pacman_attempts +1))
+
+    if [ ${pacman_attempts} -lt 10 ]; then
+      echo "=== Some Qt debug packages failed to install, waiting and trying again ==="
+      sleep 10
+    else
+      echo "=== Some Qt debug packages failed to install after ${pacman_attempts} attempts, giving up ==="
+      exit 7
+    fi
+  done
+  echo ""
+  echo "    Qt debug packages installed"
+  echo ""
+fi
 
 if [ "$(grep -c "/.luarocks-${MSYSTEM}" ${MINGW_INTERNAL_BASE_DIR}/etc/luarocks/config-5.1.lua)" -eq 0 ]; then
   # The luarocks config file has not been tweaked to put the compiled rocks in


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Install Qt debug packages during Windows CI and upload Qt6 DLLs with their .debug files to Sentry for PTB/release builds.

#### Motivation for adding to Mudlet
Enables full stack traces in Sentry crash reports by providing Qt library debug symbols, which were previously missing and causing incomplete crash analysis.

#### Other info (issues closed, discussion etc)
Previously Sentry showed "Missing" status for Qt libraries (Qt6Core.dll, Qt6Gui.dll, etc.) because only Mudlet's own symbols were uploaded.

**Test case:** Trigger a PTB build and verify in Sentry dashboard that Qt libraries show "Ok" status for both Symbolication and Stack Unwinding in crash reports.