### PR TITLE
infrastructure: Remove Azure trusted signing from Windows builds

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -130,20 +130,6 @@ jobs:
       env:
         WITH_SENTRY: "ON"
   
-    - name: (Windows) Login to Azure
-      uses: azure/login@v2
-      if: github.actor != 'dependabot[bot]' && (github.event_name == 'push' || github.event_name == 'schedule' || github.event.inputs.scheduled == 'true' || github.event.pull_request.head.repo.full_name == github.repository)
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-    - name: Get Azure access token for code signing
-      shell: pwsh
-      if: github.actor != 'dependabot[bot]' && (github.event_name == 'push' || github.event_name == 'schedule' || github.event.inputs.scheduled == 'true' || github.event.pull_request.head.repo.full_name == github.repository)
-      run: |
-        $token = (az account get-access-token --resource https://codesigning.azure.net | ConvertFrom-Json).accessToken
-        "::add-mask::$token"
-        "AZURE_ACCESS_TOKEN=$token" | Add-Content -Path $env:GITHUB_ENV
-
     - name: (Windows) Deploy
       shell: msys2 {0}
       env:
@@ -153,7 +139,6 @@ jobs:
         X_WP_DOWNLOAD_TOKEN: ${{secrets.X_WP_DOWNLOAD_TOKEN}}
         DEPLOY_SSH_KEY: ${{secrets.UPLOAD_PRIVATEKEY}}
         DEPLOY_PATH: ${{secrets.DEPLOY_PATH}}
-        AZURE_ACCESS_TOKEN: ${{ env.AZURE_ACCESS_TOKEN }}
         GITHUB_REPO_NAME: ${{ github.repository }}
         GITHUB_REPO_TAG: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
         GITHUB_SCHEDULED_BUILD: ${{ github.event_name == 'schedule' || github.event.inputs.scheduled == 'true' }}

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -220,26 +220,7 @@ else
   git clone https://github.com/Mudlet/installers.git "${GITHUB_WORKSPACE}/installers"
   cd "${GITHUB_WORKSPACE}/installers/windows" || exit 1
 
-  echo "=== Setting up Java 21 for signing ==="
-  # Java is installed by default, we just need to select which version to use:
-  JAVA_HOME="$(cygpath -au "${JAVA_HOME_21_X64}")"
-  export JAVA_HOME
-  export PATH="${JAVA_HOME}/bin:${PATH}"
-  JAVA_JAR_WINPATHFILE="$(cygpath -aw "${GITHUB_WORKSPACE}/installers/windows/jsign-7.0-SNAPSHOT.jar")"
-
-  if [ -z "${AZURE_ACCESS_TOKEN}" ]; then
-    echo "=== Code signing of Mudlet application and bundled libraries skipped - no Azure token provided ==="
-  else
-    echo "=== Signing Mudlet executable and bundled libraries ==="
-    java.exe -jar "${JAVA_JAR_WINPATHFILE}" \
-      --storetype TRUSTEDSIGNING \
-      --keystore eus.codesigning.azure.net \
-      --storepass "${AZURE_ACCESS_TOKEN}" \
-      --alias Mudlet/Mudlet \
-      "${PACKAGE_EXE_WINPATHFILE}" "${PACKAGE_WINPATH}\\**\\*.dll"
-  fi
-
-  echo "=== Preparing an intermediate artifact of the (signed) code ==="
+  echo "=== Preparing an intermediate artifact of the code ==="
   # What will it be called:
   if [[ -z "${MUDLET_VERSION_BUILD}" ]]; then
     INTERMEDIATE_ARTIFACT_NAME="Mudlet-${VERSION}-windows-64"
@@ -345,19 +326,6 @@ else
   INSTALLER_EXE_PATHFILE="$(cygpath -au "${RELEASE_DIR}/${INSTALLER_EXE}")"
   echo "Renaming \"Mudlet${NAME_SUFFIX}Setup.exe\" to \"${INSTALLER_EXE}\""
   mv "${RELEASE_DIR}/Mudlet${NAME_SUFFIX}Setup.exe" "${INSTALLER_EXE_PATHFILE}"
-
-  # Sign the final installer
-  if [ -z "${AZURE_ACCESS_TOKEN}" ]; then
-    echo "=== Code signing of Mudlet installer skipped - no Azure token provided ==="
-  else
-    echo "=== Signing installer ==="
-    java.exe -jar "${JAVA_JAR_WINPATHFILE}" \
-      --storetype TRUSTEDSIGNING \
-      --keystore eus.codesigning.azure.net \
-      --storepass "${AZURE_ACCESS_TOKEN}" \
-      --alias Mudlet/Mudlet \
-      "${INSTALLER_EXE_WINPATHFILE}"
-  fi
 
   if [[ "${GITHUB_SCHEDULED_BUILD}" == "true" ]]; then
     echo "=== Preparing artifact for PTB for upload to make.mudlet.org ==="


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Remove Azure trusted signing with jsign from Windows CI workflow and deploy script.

#### Motivation for adding to Mudlet
Azure failed to verify us and didn't respond on any support channels.

#### Other info (issues closed, discussion etc)
None.

**Test case:** Windows CI build completes successfully without signing steps.