### PR TITLE
fix: Memory leaks in ScriptUnit and ActionUnit (8,856 bytes) when opening/closing profile

### DIFF
--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -30,6 +30,24 @@
 #include "TToolBar.h"
 #include "mudlet.h"
 
+#include <functional>
+
+ActionUnit::~ActionUnit()
+{
+    for (auto action : mActionRootNodeList) {
+        action->mpHost = nullptr;
+        std::function<void(TAction*)> nullifyChildren = [&nullifyChildren](TAction* a) {
+            for (auto child : *a->mpMyChildrenList) {
+                child->mpHost = nullptr;
+                nullifyChildren(child);
+            }
+        };
+        nullifyChildren(action);
+    }
+    for (auto action : mActionRootNodeList) {
+        delete action;
+    }
+}
 
 void ActionUnit::_uninstall(TAction* pChild, const QString& packageName)
 {

--- a/src/ActionUnit.h
+++ b/src/ActionUnit.h
@@ -46,6 +46,7 @@ public:
     explicit ActionUnit(Host* pHost)
     : mpHost(pHost)
     {}
+    ~ActionUnit();
 
     std::list<TAction*> getActionRootNodeList()
     {

--- a/src/ScriptUnit.cpp
+++ b/src/ScriptUnit.cpp
@@ -26,6 +26,25 @@
 #include "Host.h"
 #include "TScript.h"
 
+#include <functional>
+
+ScriptUnit::~ScriptUnit()
+{
+    for (auto script : mScriptRootNodeList) {
+        script->mpHost = nullptr;
+        std::function<void(TScript*)> nullifyChildren = [&nullifyChildren](TScript* s) {
+            for (auto child : *s->mpMyChildrenList) {
+                child->mpHost = nullptr;
+                nullifyChildren(child);
+            }
+        };
+        nullifyChildren(script);
+    }
+    for (auto script : mScriptRootNodeList) {
+        delete script;
+    }
+}
+
 void ScriptUnit::resetStats()
 {
     statsItemsTotal = 0;

--- a/src/ScriptUnit.h
+++ b/src/ScriptUnit.h
@@ -43,6 +43,7 @@ public:
     explicit ScriptUnit(Host* pHost)
     : mpHost(pHost)
     {}
+    ~ScriptUnit();
 
     std::list<TScript*> getScriptRootNodeList()
     {

--- a/src/TScript.h
+++ b/src/TScript.h
@@ -39,6 +39,7 @@ class TScript : public Tree<TScript>
     friend class XMLimport;
     friend class DeleteItemCommand;
     friend class EditorDeleteItemCommand;
+    friend class ScriptUnit;
 
 public:
     virtual ~TScript();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add missing destructors to ScriptUnit and ActionUnit to properly clean up TScript and TAction objects when profiles are closed.

#### Motivation for adding to Mudlet
Fixes memory leaks detected by AddressSanitizer (8,856 bytes in 86 allocations).

#### Other info (issues closed, discussion etc)
Follows existing destructor pattern from TriggerUnit, AliasUnit, TimerUnit, and KeyUnit.

**Test case:** Run with AddressSanitizer, open a profile, close it, exit - no leaks from Script/Action units.