### PR TITLE
infrastructure: upload Qt module debug symbols to Sentry using cv2pdb

### DIFF
--- a/CI/send_debug_files_to_sentry.sh
+++ b/CI/send_debug_files_to_sentry.sh
@@ -106,77 +106,64 @@ if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
     MINGW_BIN="${MSYSTEM_PREFIX}/bin"
 
     echo ""
-    echo "=== Converting Qt debug files to Breakpad symbols for Sentry ==="
+    echo "=== Converting Qt DWARF debug files to PDB for Sentry ==="
 
-    # Download Mozilla's dump_syms (better DWARF support than MSYS2 breakpad)
-    DUMP_SYMS_URL="https://github.com/mozilla/dump_syms/releases/download/v2.3.5/dump_syms-x86_64-pc-windows-msvc.zip"
-    echo "Downloading Mozilla dump_syms..."
-    curl -sL "$DUMP_SYMS_URL" -o dump_syms.zip
-    unzip -q dump_syms.zip
-    DUMP_SYMS="./dump_syms.exe"
+    # Download cv2pdb (converts MinGW DWARF to PDB format)
+    CV2PDB_URL="https://github.com/rainers/cv2pdb/releases/download/v0.54/cv2pdb-0.54.zip"
+    echo "Downloading cv2pdb..."
+    curl -sL "$CV2PDB_URL" -o cv2pdb.zip
+    unzip -q cv2pdb.zip
+    CV2PDB="./cv2pdb.exe"
 
-    if [[ -d "$MINGW_BIN" && -x "$DUMP_SYMS" ]]; then
-        # Create temporary directory for symbol files
-        SYM_DIR=$(mktemp -d)
-        SYM_FILES=()
+    if [[ -d "$MINGW_BIN" && -x "$CV2PDB" ]]; then
+        # Create temporary directory for PDB files
+        PDB_DIR=$(mktemp -d)
+        PDB_FILES=()
 
         for dll in "$MINGW_BIN"/Qt6*.dll; do
             if [[ -f "$dll" ]]; then
                 dll_name=$(basename "$dll")
                 base_name="${dll_name%.dll}"
-                sym_file="${SYM_DIR}/${base_name}.sym"
                 debug_file="${MINGW_BIN}/${base_name}.debug"
-
-                echo "Converting $dll_name to Breakpad symbols..."
+                pdb_file="${PDB_DIR}/${base_name}.pdb"
 
                 # Check if companion .debug file exists (contains DWARF debug info)
                 if [[ -f "$debug_file" ]]; then
-                    echo "  Found debug file: ${base_name}.debug ($(stat -c%s "$debug_file") bytes)"
-                    echo "  File format: $(file "$debug_file" | cut -d: -f2-)"
-                    # Try just the debug file first (it should contain all DWARF info)
-                    "$DUMP_SYMS" "$debug_file" > "$sym_file" 2>"${sym_file}.err" || true
-                    if [[ -s "${sym_file}.err" ]]; then
-                        echo "  dump_syms stderr: $(head -1 "${sym_file}.err")"
-                    fi
-                    rm -f "${sym_file}.err"
-                else
-                    echo "  No debug file found, trying DLL only..."
-                    "$DUMP_SYMS" "$dll" > "$sym_file" 2>/dev/null || true
-                fi
+                    echo "Converting $dll_name to PDB..."
+                    echo "  Debug file: ${base_name}.debug ($(stat -c%s "$debug_file") bytes)"
 
-                if [[ -s "$sym_file" ]]; then
-                    # Show first line (MODULE line) for diagnostics
-                    echo "  Sym file header: $(head -1 "$sym_file")"
-                    # Check if sym file has actual debug symbols (FILE/FUNC/LINE records)
-                    if grep -q "^FUNC " "$sym_file"; then
-                        func_count=$(grep -c "^FUNC " "$sym_file")
-                        line_count=$(grep -c "^[0-9a-f]" "$sym_file" || echo 0)
-                        echo "  Generated symbols: $func_count functions, $line_count line records"
-                        SYM_FILES+=("$sym_file")
+                    # cv2pdb converts DWARF in PE files to PDB format
+                    # Usage: cv2pdb <exe> [<output_exe>] [<pdb>]
+                    if "$CV2PDB" "$debug_file" "$pdb_file" 2>"${pdb_file}.err"; then
+                        if [[ -f "$pdb_file" ]]; then
+                            pdb_size=$(stat -c%s "$pdb_file")
+                            echo "  Generated PDB: ${base_name}.pdb ($pdb_size bytes)"
+                            PDB_FILES+=("$pdb_file")
+                        else
+                            echo "  Warning: PDB file not created"
+                        fi
                     else
-                        total_lines=$(wc -l < "$sym_file")
-                        public_count=$(grep -c "^PUBLIC " "$sym_file" || echo 0)
-                        echo "  Warning: No FUNC records ($total_lines lines, $public_count PUBLIC), skipping"
-                        rm -f "$sym_file"
+                        echo "  cv2pdb failed: $(cat "${pdb_file}.err" 2>/dev/null || echo 'unknown error')"
                     fi
+                    rm -f "${pdb_file}.err"
                 else
-                    echo "  Warning: Empty symbol file for $dll_name, skipping"
-                    rm -f "$sym_file"
+                    echo "Skipping $dll_name (no .debug file)"
                 fi
             fi
         done
 
-        if [[ ${#SYM_FILES[@]} -gt 0 ]]; then
-            echo "Uploading ${#SYM_FILES[@]} Breakpad symbol files to Sentry..."
-            ./sentry-cli debug-files upload "${SYM_FILES[@]}" --project "mudlet"
-            echo "Qt Breakpad symbols uploaded successfully"
+        if [[ ${#PDB_FILES[@]} -gt 0 ]]; then
+            echo ""
+            echo "Uploading ${#PDB_FILES[@]} PDB files to Sentry..."
+            ./sentry-cli debug-files upload "${PDB_FILES[@]}" --project "mudlet"
+            echo "Qt PDB symbols uploaded successfully"
         else
-            echo "No Qt symbol files were generated"
+            echo "No Qt PDB files were generated"
         fi
 
-        rm -rf "$SYM_DIR"
-    elif [[ ! -x "$DUMP_SYMS" ]]; then
-        echo "Warning: dump_syms not found at $DUMP_SYMS, skipping Qt debug symbols"
+        rm -rf "$PDB_DIR"
+    elif [[ ! -x "$CV2PDB" ]]; then
+        echo "Warning: cv2pdb not found at $CV2PDB, skipping Qt debug symbols"
     fi
 
     strip --strip-debug "$MUDLET_EXEC"

--- a/CI/send_debug_files_to_sentry.sh
+++ b/CI/send_debug_files_to_sentry.sh
@@ -125,20 +125,21 @@ if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
 
                 # Check if companion .debug file exists (contains DWARF debug info)
                 if [[ -f "$debug_file" ]]; then
-                    echo "  Found debug file: ${base_name}.debug"
-                    # Pass both DLL and debug file to dump_syms
-                    if "$DUMP_SYMS" "$dll" "$debug_file" > "$sym_file" 2>&1; then
-                        :
-                    elif "$DUMP_SYMS" "$debug_file" > "$sym_file" 2>&1; then
-                        # Fallback: try just the debug file
-                        :
+                    echo "  Found debug file: ${base_name}.debug ($(stat -c%s "$debug_file") bytes)"
+                    # Try just the debug file first (it should contain all DWARF info)
+                    "$DUMP_SYMS" "$debug_file" > "$sym_file" 2>"${sym_file}.err" || true
+                    if [[ -s "${sym_file}.err" ]]; then
+                        echo "  dump_syms stderr: $(head -1 "${sym_file}.err")"
                     fi
+                    rm -f "${sym_file}.err"
                 else
                     echo "  No debug file found, trying DLL only..."
-                    "$DUMP_SYMS" "$dll" > "$sym_file" 2>&1 || true
+                    "$DUMP_SYMS" "$dll" > "$sym_file" 2>/dev/null || true
                 fi
 
                 if [[ -s "$sym_file" ]]; then
+                    # Show first line (MODULE line) for diagnostics
+                    echo "  Sym file header: $(head -1 "$sym_file")"
                     # Check if sym file has actual debug symbols (FILE/FUNC/LINE records)
                     if grep -q "^FUNC " "$sym_file"; then
                         func_count=$(grep -c "^FUNC " "$sym_file")
@@ -146,7 +147,9 @@ if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
                         echo "  Generated symbols: $func_count functions, $line_count line records"
                         SYM_FILES+=("$sym_file")
                     else
-                        echo "  Warning: No FUNC records in $dll_name symbols, skipping"
+                        total_lines=$(wc -l < "$sym_file")
+                        public_count=$(grep -c "^PUBLIC " "$sym_file" || echo 0)
+                        echo "  Warning: No FUNC records ($total_lines lines, $public_count PUBLIC), skipping"
                         rm -f "$sym_file"
                     fi
                 else

--- a/CI/send_debug_files_to_sentry.sh
+++ b/CI/send_debug_files_to_sentry.sh
@@ -116,9 +116,10 @@ if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
     CV2PDB="./cv2pdb.exe"
 
     if [[ -d "$MINGW_BIN" && -x "$CV2PDB" ]]; then
-        # Use current directory for PDB files (cv2pdb can't write to MSYS temp)
-        PDB_DIR="./qt_pdbs"
+        # Use absolute Windows path for PDB files (cv2pdb is native Windows app)
+        PDB_DIR="$(pwd)/qt_pdbs"
         mkdir -p "$PDB_DIR"
+        WIN_PDB_DIR=$(cygpath -w "$PDB_DIR")
         PDB_FILES=()
 
         for dll in "$MINGW_BIN"/Qt6*.dll; do
@@ -138,7 +139,7 @@ if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
                     # Convert paths to Windows format for native Windows cv2pdb.exe
                     win_debug_file=$(cygpath -w "$debug_file")
                     win_dll=$(cygpath -w "$dll")
-                    win_pdb_file=$(cygpath -w "$pdb_file")
+                    win_pdb_file="${WIN_PDB_DIR}\\${base_name}.pdb"
                     if "$CV2PDB" "-l${win_debug_file}" "$win_dll" "$win_pdb_file" 2>"${pdb_file}.err"; then
                         if [[ -f "$pdb_file" ]]; then
                             pdb_size=$(stat -c%s "$pdb_file")

--- a/CI/send_debug_files_to_sentry.sh
+++ b/CI/send_debug_files_to_sentry.sh
@@ -109,11 +109,12 @@ if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
     echo "=== Converting Qt DWARF debug files to PDB for Sentry ==="
 
     # Download cv2pdb (converts MinGW DWARF to PDB format)
+    # Use 64-bit version to handle large debug files like Qt6Core (198MB)
     CV2PDB_URL="https://github.com/rainers/cv2pdb/releases/download/v0.54/cv2pdb-0.54.zip"
     echo "Downloading cv2pdb..."
     curl -sL "$CV2PDB_URL" -o cv2pdb.zip
     unzip -q cv2pdb.zip
-    CV2PDB="./cv2pdb.exe"
+    CV2PDB="./cv2pdb64.exe"
 
     if [[ -d "$MINGW_BIN" && -x "$CV2PDB" ]]; then
         # Use absolute Windows path for PDB files (cv2pdb is native Windows app)

--- a/CI/send_debug_files_to_sentry.sh
+++ b/CI/send_debug_files_to_sentry.sh
@@ -132,9 +132,10 @@ if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
                     echo "Converting $dll_name to PDB..."
                     echo "  Debug file: ${base_name}.debug ($(stat -c%s "$debug_file") bytes)"
 
-                    # cv2pdb converts DWARF in PE files to PDB format
-                    # Usage: cv2pdb <exe> [<output_exe>] [<pdb>]
-                    if "$CV2PDB" "$debug_file" "$pdb_file" 2>"${pdb_file}.err"; then
+                    # cv2pdb converts DWARF to PDB format
+                    # Usage: cv2pdb -l<debug-file> <dll> [<output-dll>] [<pdb>]
+                    # Pass DLL as input, use -l to specify separate debug file
+                    if "$CV2PDB" "-l${debug_file}" "$dll" "$pdb_file" 2>"${pdb_file}.err"; then
                         if [[ -f "$pdb_file" ]]; then
                             pdb_size=$(stat -c%s "$pdb_file")
                             echo "  Generated PDB: ${base_name}.pdb ($pdb_size bytes)"

--- a/CI/send_debug_files_to_sentry.sh
+++ b/CI/send_debug_files_to_sentry.sh
@@ -123,12 +123,16 @@ if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
         WIN_PDB_DIR="$(cygpath -w "$PDB_DIR")"
         PDB_FILES=()
 
-        for dll in "$MINGW_BIN"/Qt6*.dll; do
+        # Function to convert a DLL to PDB format
+        convert_dll_to_pdb() {
+            local dll="$1"
+            local source_dir="$2"
+
             if [[ -f "$dll" ]]; then
-                dll_name=$(basename "$dll")
-                base_name="${dll_name%.dll}"
-                debug_file="${MINGW_BIN}/${base_name}.debug"
-                pdb_file="${PDB_DIR}/${base_name}.pdb"
+                local dll_name=$(basename "$dll")
+                local base_name="${dll_name%.dll}"
+                local debug_file="${source_dir}/${base_name}.debug"
+                local pdb_file="${PDB_DIR}/${base_name}.pdb"
 
                 # Check if companion .debug file exists (contains DWARF debug info)
                 if [[ -f "$debug_file" ]]; then
@@ -138,12 +142,12 @@ if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
                     # cv2pdb converts DWARF to PDB format
                     # Usage: cv2pdb -l<debug-file> <dll> [<output-dll>] [<pdb>]
                     # Convert paths to Windows format for native Windows cv2pdb.exe
-                    win_debug_file=$(cygpath -w "$debug_file")
-                    win_dll=$(cygpath -w "$dll")
-                    win_pdb_file="${WIN_PDB_DIR}\\${base_name}.pdb"
+                    local win_debug_file=$(cygpath -w "$debug_file")
+                    local win_dll=$(cygpath -w "$dll")
+                    local win_pdb_file="${WIN_PDB_DIR}\\${base_name}.pdb"
                     if "$CV2PDB" "-l${win_debug_file}" "$win_dll" "$win_dll" "$win_pdb_file" 2>"${pdb_file}.err"; then
                         if [[ -f "$pdb_file" ]]; then
-                            pdb_size=$(stat -c%s "$pdb_file")
+                            local pdb_size=$(stat -c%s "$pdb_file")
                             echo "  Generated PDB: ${base_name}.pdb ($pdb_size bytes)"
                             PDB_FILES+=("$pdb_file")
                         else
@@ -157,7 +161,43 @@ if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
                     echo "Skipping $dll_name (no .debug file)"
                 fi
             fi
+        }
+
+        # Process main Qt6 DLLs from bin directory
+        for dll in "$MINGW_BIN"/Qt6*.dll; do
+            convert_dll_to_pdb "$dll" "$MINGW_BIN"
         done
+
+        # Process Qt plugin DLLs from share/qt6/plugins subdirectories
+        # These plugins can appear in crash stack traces and need debug symbols
+        QT_PLUGINS_DIR="${MSYSTEM_PREFIX}/share/qt6/plugins"
+        if [[ -d "$QT_PLUGINS_DIR" ]]; then
+            echo ""
+            echo "=== Converting Qt plugin debug files ==="
+
+            # Plugin directories and their DLLs (based on what Mudlet uses)
+            declare -A PLUGIN_DLLS=(
+                ["generic"]="qtuiotouchplugin"
+                ["iconengines"]="qsvgicon"
+                ["imageformats"]="qgif qicns qico qjp2 qjpeg qmng qsvg qtga qtiff qwbmp qwebp"
+                ["multimedia"]="ffmpegmediaplugin windowsmediaplugin"
+                ["networkinformation"]="qglib qnetworklistmanager"
+                ["platforms"]="qwindows"
+                ["styles"]="qmodernwindowsstyle"
+                ["texttospeech"]="qtexttospeech_mock qtexttospeech_sapi"
+                ["tls"]="qcertonlybackend qopensslbackend qschannelbackend"
+            )
+
+            for plugin_dir in "${!PLUGIN_DLLS[@]}"; do
+                plugin_path="${QT_PLUGINS_DIR}/${plugin_dir}"
+                if [[ -d "$plugin_path" ]]; then
+                    for plugin_name in ${PLUGIN_DLLS[$plugin_dir]}; do
+                        dll="${plugin_path}/${plugin_name}.dll"
+                        convert_dll_to_pdb "$dll" "$plugin_path"
+                    done
+                fi
+            done
+        fi
 
         if [[ ${#PDB_FILES[@]} -gt 0 ]]; then
             echo ""

--- a/CI/send_debug_files_to_sentry.sh
+++ b/CI/send_debug_files_to_sentry.sh
@@ -140,7 +140,7 @@ if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
                     win_debug_file=$(cygpath -w "$debug_file")
                     win_dll=$(cygpath -w "$dll")
                     win_pdb_file="${WIN_PDB_DIR}\\${base_name}.pdb"
-                    if "$CV2PDB" "-l${win_debug_file}" "$win_dll" "$win_pdb_file" 2>"${pdb_file}.err"; then
+                    if "$CV2PDB" "-l${win_debug_file}" "$win_dll" "$win_dll" "$win_pdb_file" 2>"${pdb_file}.err"; then
                         if [[ -f "$pdb_file" ]]; then
                             pdb_size=$(stat -c%s "$pdb_file")
                             echo "  Generated PDB: ${base_name}.pdb ($pdb_size bytes)"

--- a/CI/send_debug_files_to_sentry.sh
+++ b/CI/send_debug_files_to_sentry.sh
@@ -104,28 +104,47 @@ done
 # and MSYSTEM_PREFIX for the path (supports MINGW64, CLANG64, UCRT64, etc.)
 if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
     MINGW_BIN="${MSYSTEM_PREFIX}/bin"
-    if [[ -d "$MINGW_BIN" ]]; then
-        echo ""
-        echo "=== Uploading Qt debug files for full stack traces ==="
+    DUMP_SYMS="${MSYSTEM_PREFIX}/bin/dump_syms.exe"
 
-        QT_FILES=()
+    if [[ -d "$MINGW_BIN" && -x "$DUMP_SYMS" ]]; then
+        echo ""
+        echo "=== Converting Qt debug files to Breakpad symbols for Sentry ==="
+
+        # Create temporary directory for symbol files
+        SYM_DIR=$(mktemp -d)
+        SYM_FILES=()
+
         for dll in "$MINGW_BIN"/Qt6*.dll; do
             if [[ -f "$dll" ]]; then
-                QT_FILES+=("$dll")
-                debug_file="${dll%.dll}.debug"
-                if [[ -f "$debug_file" ]]; then
-                    QT_FILES+=("$debug_file")
+                dll_name=$(basename "$dll")
+                sym_file="${SYM_DIR}/${dll_name%.dll}.sym"
+
+                echo "Converting $dll_name to Breakpad symbols..."
+                if "$DUMP_SYMS" "$dll" > "$sym_file" 2>/dev/null; then
+                    if [[ -s "$sym_file" ]]; then
+                        SYM_FILES+=("$sym_file")
+                    else
+                        echo "  Warning: Empty symbol file for $dll_name, skipping"
+                        rm -f "$sym_file"
+                    fi
+                else
+                    echo "  Warning: Failed to convert $dll_name, skipping"
+                    rm -f "$sym_file"
                 fi
             fi
         done
 
-        if [[ ${#QT_FILES[@]} -gt 0 ]]; then
-            echo "Found ${#QT_FILES[@]} Qt files to upload"
-            ./sentry-cli debug-files upload "${QT_FILES[@]}" --project "mudlet"
-            echo "Qt debug files uploaded successfully"
+        if [[ ${#SYM_FILES[@]} -gt 0 ]]; then
+            echo "Uploading ${#SYM_FILES[@]} Breakpad symbol files to Sentry..."
+            ./sentry-cli debug-files upload "${SYM_FILES[@]}" --project "mudlet"
+            echo "Qt Breakpad symbols uploaded successfully"
         else
-            echo "No Qt debug files found in $MINGW_BIN"
+            echo "No Qt symbol files were generated"
         fi
+
+        rm -rf "$SYM_DIR"
+    elif [[ ! -x "$DUMP_SYMS" ]]; then
+        echo "Warning: dump_syms not found at $DUMP_SYMS, skipping Qt debug symbols"
     fi
 
     strip --strip-debug "$MUDLET_EXEC"

--- a/CI/send_debug_files_to_sentry.sh
+++ b/CI/send_debug_files_to_sentry.sh
@@ -120,15 +120,23 @@ if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
                 sym_file="${SYM_DIR}/${dll_name%.dll}.sym"
 
                 echo "Converting $dll_name to Breakpad symbols..."
-                if "$DUMP_SYMS" "$dll" > "$sym_file" 2>/dev/null; then
+                if "$DUMP_SYMS" "$dll" > "$sym_file"; then
                     if [[ -s "$sym_file" ]]; then
-                        SYM_FILES+=("$sym_file")
+                        # Check if sym file has actual symbols (more than just MODULE line)
+                        line_count=$(wc -l < "$sym_file")
+                        if [[ $line_count -gt 5 ]]; then
+                            SYM_FILES+=("$sym_file")
+                            echo "  Generated $line_count lines of symbols"
+                        else
+                            echo "  Warning: Only $line_count lines in $dll_name symbols (no debug info?), skipping"
+                            rm -f "$sym_file"
+                        fi
                     else
                         echo "  Warning: Empty symbol file for $dll_name, skipping"
                         rm -f "$sym_file"
                     fi
                 else
-                    echo "  Warning: Failed to convert $dll_name, skipping"
+                    echo "  Warning: Failed to convert $dll_name (exit code $?), skipping"
                     rm -f "$sym_file"
                 fi
             fi

--- a/CI/send_debug_files_to_sentry.sh
+++ b/CI/send_debug_files_to_sentry.sh
@@ -104,12 +104,18 @@ done
 # and MSYSTEM_PREFIX for the path (supports MINGW64, CLANG64, UCRT64, etc.)
 if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
     MINGW_BIN="${MSYSTEM_PREFIX}/bin"
-    DUMP_SYMS="${MSYSTEM_PREFIX}/bin/dump_syms.exe"
+
+    echo ""
+    echo "=== Converting Qt debug files to Breakpad symbols for Sentry ==="
+
+    # Download Mozilla's dump_syms (better DWARF support than MSYS2 breakpad)
+    DUMP_SYMS_URL="https://github.com/mozilla/dump_syms/releases/download/v2.3.5/dump_syms-x86_64-pc-windows-msvc.zip"
+    echo "Downloading Mozilla dump_syms..."
+    curl -sL "$DUMP_SYMS_URL" -o dump_syms.zip
+    unzip -q dump_syms.zip
+    DUMP_SYMS="./dump_syms.exe"
 
     if [[ -d "$MINGW_BIN" && -x "$DUMP_SYMS" ]]; then
-        echo ""
-        echo "=== Converting Qt debug files to Breakpad symbols for Sentry ==="
-
         # Create temporary directory for symbol files
         SYM_DIR=$(mktemp -d)
         SYM_FILES=()
@@ -126,6 +132,7 @@ if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
                 # Check if companion .debug file exists (contains DWARF debug info)
                 if [[ -f "$debug_file" ]]; then
                     echo "  Found debug file: ${base_name}.debug ($(stat -c%s "$debug_file") bytes)"
+                    echo "  File format: $(file "$debug_file" | cut -d: -f2-)"
                     # Try just the debug file first (it should contain all DWARF info)
                     "$DUMP_SYMS" "$debug_file" > "$sym_file" 2>"${sym_file}.err" || true
                     if [[ -s "${sym_file}.err" ]]; then

--- a/CI/send_debug_files_to_sentry.sh
+++ b/CI/send_debug_files_to_sentry.sh
@@ -134,8 +134,11 @@ if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
 
                     # cv2pdb converts DWARF to PDB format
                     # Usage: cv2pdb -l<debug-file> <dll> [<output-dll>] [<pdb>]
-                    # Pass DLL as input, use -l to specify separate debug file
-                    if "$CV2PDB" "-l${debug_file}" "$dll" "$pdb_file" 2>"${pdb_file}.err"; then
+                    # Convert paths to Windows format for native Windows cv2pdb.exe
+                    win_debug_file=$(cygpath -w "$debug_file")
+                    win_dll=$(cygpath -w "$dll")
+                    win_pdb_file=$(cygpath -w "$pdb_file")
+                    if "$CV2PDB" "-l${win_debug_file}" "$win_dll" "$win_pdb_file" 2>"${pdb_file}.err"; then
                         if [[ -f "$pdb_file" ]]; then
                             pdb_size=$(stat -c%s "$pdb_file")
                             echo "  Generated PDB: ${base_name}.pdb ($pdb_size bytes)"

--- a/CI/send_debug_files_to_sentry.sh
+++ b/CI/send_debug_files_to_sentry.sh
@@ -116,8 +116,9 @@ if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
     CV2PDB="./cv2pdb.exe"
 
     if [[ -d "$MINGW_BIN" && -x "$CV2PDB" ]]; then
-        # Create temporary directory for PDB files
-        PDB_DIR=$(mktemp -d)
+        # Use current directory for PDB files (cv2pdb can't write to MSYS temp)
+        PDB_DIR="./qt_pdbs"
+        mkdir -p "$PDB_DIR"
         PDB_FILES=()
 
         for dll in "$MINGW_BIN"/Qt6*.dll; do

--- a/CI/send_debug_files_to_sentry.sh
+++ b/CI/send_debug_files_to_sentry.sh
@@ -117,26 +117,40 @@ if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
         for dll in "$MINGW_BIN"/Qt6*.dll; do
             if [[ -f "$dll" ]]; then
                 dll_name=$(basename "$dll")
-                sym_file="${SYM_DIR}/${dll_name%.dll}.sym"
+                base_name="${dll_name%.dll}"
+                sym_file="${SYM_DIR}/${base_name}.sym"
+                debug_file="${MINGW_BIN}/${base_name}.debug"
 
                 echo "Converting $dll_name to Breakpad symbols..."
-                if "$DUMP_SYMS" "$dll" > "$sym_file"; then
-                    if [[ -s "$sym_file" ]]; then
-                        # Check if sym file has actual symbols (more than just MODULE line)
-                        line_count=$(wc -l < "$sym_file")
-                        if [[ $line_count -gt 5 ]]; then
-                            SYM_FILES+=("$sym_file")
-                            echo "  Generated $line_count lines of symbols"
-                        else
-                            echo "  Warning: Only $line_count lines in $dll_name symbols (no debug info?), skipping"
-                            rm -f "$sym_file"
-                        fi
+
+                # Check if companion .debug file exists (contains DWARF debug info)
+                if [[ -f "$debug_file" ]]; then
+                    echo "  Found debug file: ${base_name}.debug"
+                    # Pass both DLL and debug file to dump_syms
+                    if "$DUMP_SYMS" "$dll" "$debug_file" > "$sym_file" 2>&1; then
+                        :
+                    elif "$DUMP_SYMS" "$debug_file" > "$sym_file" 2>&1; then
+                        # Fallback: try just the debug file
+                        :
+                    fi
+                else
+                    echo "  No debug file found, trying DLL only..."
+                    "$DUMP_SYMS" "$dll" > "$sym_file" 2>&1 || true
+                fi
+
+                if [[ -s "$sym_file" ]]; then
+                    # Check if sym file has actual debug symbols (FILE/FUNC/LINE records)
+                    if grep -q "^FUNC " "$sym_file"; then
+                        func_count=$(grep -c "^FUNC " "$sym_file")
+                        line_count=$(grep -c "^[0-9a-f]" "$sym_file" || echo 0)
+                        echo "  Generated symbols: $func_count functions, $line_count line records"
+                        SYM_FILES+=("$sym_file")
                     else
-                        echo "  Warning: Empty symbol file for $dll_name, skipping"
+                        echo "  Warning: No FUNC records in $dll_name symbols, skipping"
                         rm -f "$sym_file"
                     fi
                 else
-                    echo "  Warning: Failed to convert $dll_name (exit code $?), skipping"
+                    echo "  Warning: Empty symbol file for $dll_name, skipping"
                     rm -f "$sym_file"
                 fi
             fi

--- a/CI/send_debug_files_to_sentry.sh
+++ b/CI/send_debug_files_to_sentry.sh
@@ -120,7 +120,7 @@ if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
         # Use absolute Windows path for PDB files (cv2pdb is native Windows app)
         PDB_DIR="$(pwd)/qt_pdbs"
         mkdir -p "$PDB_DIR"
-        WIN_PDB_DIR=$(cygpath -w "$PDB_DIR")
+        WIN_PDB_DIR="$(cygpath -w "$PDB_DIR")"
         PDB_FILES=()
 
         for dll in "$MINGW_BIN"/Qt6*.dll; do

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -152,7 +152,7 @@ echo "    Completed"
 echo ""
 
 if [ "${SENTRY_SEND_DEBUG}" = "1" ]; then
-  echo "=== Installing Qt debug packages for Sentry ==="
+  echo "=== Installing Qt debug packages and breakpad for Sentry ==="
   pacman_attempts=0
   while true; do
     if /usr/bin/pacman -S --needed --noconfirm \
@@ -162,7 +162,8 @@ if [ "${SENTRY_SEND_DEBUG}" = "1" ]; then
       "${MINGW_PACKAGE_PREFIX}-qt6-speech-debug" \
       "${MINGW_PACKAGE_PREFIX}-qt6-imageformats-debug" \
       "${MINGW_PACKAGE_PREFIX}-qt6-tools-debug" \
-      "${MINGW_PACKAGE_PREFIX}-qt6-5compat-debug"; then
+      "${MINGW_PACKAGE_PREFIX}-qt6-5compat-debug" \
+      "${MINGW_PACKAGE_PREFIX}-breakpad-git"; then
         break
     fi
 

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -152,7 +152,7 @@ echo "    Completed"
 echo ""
 
 if [ "${SENTRY_SEND_DEBUG}" = "1" ]; then
-  echo "=== Installing Qt debug packages and breakpad for Sentry ==="
+  echo "=== Installing Qt debug packages for Sentry ==="
   pacman_attempts=0
   while true; do
     if /usr/bin/pacman -S --needed --noconfirm \
@@ -162,8 +162,7 @@ if [ "${SENTRY_SEND_DEBUG}" = "1" ]; then
       "${MINGW_PACKAGE_PREFIX}-qt6-speech-debug" \
       "${MINGW_PACKAGE_PREFIX}-qt6-imageformats-debug" \
       "${MINGW_PACKAGE_PREFIX}-qt6-tools-debug" \
-      "${MINGW_PACKAGE_PREFIX}-qt6-5compat-debug" \
-      "${MINGW_PACKAGE_PREFIX}-breakpad-git"; then
+      "${MINGW_PACKAGE_PREFIX}-qt6-5compat-debug"; then
         break
     fi
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Convert Qt DWARF debug symbols to PDB format using cv2pdb before uploading to Sentry.

#### Motivation for adding to Mudlet
Enables Sentry to process Qt debug symbols for Windows crash reports, providing better stack traces.

#### What was tried

Approaches that failed:
- sentry-cli direct upload: Rejected with "invalid PE file" - doesn't support MinGW's PE+DWARF format
- MSYS2 breakpad dump_syms: Crashes with assertion failure in DWARF bytereader
- Mozilla dump_syms: Can't parse PE files with DWARF (expects PDB or ELF+DWARF)

What works:
- cv2pdb v0.54: Converts DWARF to PDB format. Successfully generates PDBs for 25/26 Qt modules.
- Only Qt6Core fails (198MB debug file causes segfault) - bug filed: https://github.com/rainers/cv2pdb/issues/102

#### Results
- 25 Qt PDB files uploaded to Sentry (~220MB total)
- Includes Qt6Gui, Qt6Widgets, Qt6Network, Qt6Multimedia, and most other modules
- Only Qt6Core missing due to cv2pdb crash on large files

#### Other info
Follow-up to #8777 which uploaded Mudlet's own symbols but couldn't handle Qt debug files.

Test case: Trigger a PTB build and verify Qt libraries show debug info in Sentry crash reports.