### PR TITLE
infrastructure: Fix Windows nightly build failure when no new commits

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -175,7 +175,7 @@ jobs:
 
     - name: Register PTB Release
       shell: msys2 {0}
-      if: ${{ github.event_name == 'schedule' || github.event.inputs.scheduled == 'true' }}
+      if: ${{ (github.event_name == 'schedule' || github.event.inputs.scheduled == 'true') && env.VERSION_STRING != '' }}
       env:
         VERSION_STRING: ${{env.VERSION_STRING}}
         BUILD_COMMIT: ${{env.BUILD_COMMIT}}


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Add `VERSION_STRING` check to "Register PTB Release" step condition to skip when deploy script exits early due to no new commits

#### Motivation for adding to Mudlet
Fixes nightly Windows build failures (exit code 127) that occur when the deploy script exits early because there are no new commits, leaving `dblsqd-cli` uninstalled.

#### Other info (issues closed, discussion etc)
Failed build: https://github.com/Mudlet/Mudlet/actions/runs/21054529642/job/60547761814

**Test case:** Trigger a scheduled Windows build when HEAD commit is >1 day old; the "Register PTB Release" step should be skipped instead of failing.