### PR TITLE
fix: Add outline to area exit arrows for visibility on matching backgrounds

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2722,6 +2722,16 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 areaExitsMap[k] = clickPoint;
                 // line ENDS at the center of the room, and the START sticks out
                 // in the appropriate direction
+
+                // Draw outline first for visibility on matching backgrounds
+                QPen outlinePen = pen;
+                outlinePen.setWidthF(exitWidth + 2.0);
+                outlinePen.setColor((mpHost->mBgColor_2.lightness() > 127) ? Qt::black : Qt::white);
+                painter.setPen(outlinePen);
+                painter.drawLine(line);
+
+                // Draw colored line on top
+                painter.setPen(pen);
                 painter.drawLine(line);
                 QLineF l0 = QLineF(line);
                 if (mLargeAreaExitArrows) {
@@ -2755,7 +2765,17 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 arrowPen.setJoinStyle(Qt::RoundJoin);
                 arrowPen.setCapStyle(Qt::RoundCap);
                 arrowPen.setCosmetic(mMapperUseAntiAlias);
-                painter.setPen(arrowPen);
+
+                // Draw outline first for visibility
+                QPen arrowOutlinePen = arrowPen;
+                arrowOutlinePen.setWidthF(2.0);
+                arrowOutlinePen.setColor((mpHost->mBgColor_2.lightness() > 127) ? Qt::black : Qt::white);
+                painter.setPen(arrowOutlinePen);
+                painter.setBrush(Qt::NoBrush);
+                painter.drawPolygon(polygon);
+
+                // Draw filled arrow head on top
+                painter.setPen(Qt::NoPen);
                 painter.setBrush(brush);
                 painter.drawPolygon(polygon);
                 painter.restore();
@@ -5642,9 +5662,16 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
                     areaPen.setCapStyle(Qt::RoundCap);
                     areaPen.setCosmetic(mMapperUseAntiAlias);
                     areaPen.setColor(mpMap->getColor(exitRoomId));
-                    painter.setPen(areaPen);
 
-                    // Draw the area exit stub line
+                    // Draw outline first for visibility on matching backgrounds
+                    QPen outlinePen = areaPen;
+                    outlinePen.setWidthF(exitWidth + 2.0);
+                    outlinePen.setColor((mpHost->mBgColor_2.lightness() > 127) ? Qt::black : Qt::white);
+                    painter.setPen(outlinePen);
+                    painter.drawLine(exitLine);
+
+                    // Draw colored line on top
+                    painter.setPen(areaPen);
                     painter.drawLine(exitLine);
 
                     // Draw arrow head (same logic as original paintRoomExits lines 2298-2333)
@@ -5683,7 +5710,17 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
                     arrowPen.setJoinStyle(Qt::RoundJoin);
                     arrowPen.setCapStyle(Qt::RoundCap);
                     arrowPen.setCosmetic(mMapperUseAntiAlias);
-                    painter.setPen(arrowPen);
+
+                    // Draw outline first for visibility
+                    QPen arrowOutlinePen = arrowPen;
+                    arrowOutlinePen.setWidthF(2.0);
+                    arrowOutlinePen.setColor((mpHost->mBgColor_2.lightness() > 127) ? Qt::black : Qt::white);
+                    painter.setPen(arrowOutlinePen);
+                    painter.setBrush(Qt::NoBrush);
+                    painter.drawPolygon(arrowHead);
+
+                    // Draw filled arrow head on top
+                    painter.setPen(Qt::NoPen);
                     painter.setBrush(arrowBrush);
                     painter.drawPolygon(arrowHead);
                     painter.restore();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add contrasting outline (white on dark backgrounds, black on light) to area exit arrow lines and arrowheads in the 2D mapper

#### Motivation for adding to Mudlet
Area exit arrows using the destination room's environment color become invisible when that color matches the map background.

#### Other info (issues closed, discussion etc)
N/A

**Test case:** Create rooms in different areas with black environment color, add exits between them, verify arrows are visible with outlines on both dark and light map backgrounds.

This area exit was previously invisible -
<img width="1026" height="420" alt="image" src="https://github.com/user-attachments/assets/9aad53a2-df20-4a04-b08e-594091eb875d" />
