### PR TITLE
fix: Map labels appear crisp at all zoom levels

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -484,6 +484,7 @@ void T2DMap::init()
         slot_toggleMapViewOnly();
     }
     flushSymbolPixmapCache();
+    flushTextLabelPixmapCache();
     mLargeAreaExitArrows = mpHost->getLargeAreaExitArrows();
 }
 
@@ -850,6 +851,51 @@ void T2DMap::addSymbolToPixmapCache(const QString key, const QString text, const
 
     if (!mSymbolPixmapCache.insert(key, pixmap)) {
         qDebug("T2DMap::addSymbolToPixmapCache() ALERT: Map Room Symbol Pixmap cache is full...!");
+    }
+}
+
+void T2DMap::addTextLabelToCache(const QString& key, const TMapLabel& label, const QSize& targetSize)
+{
+    auto pixmap = new QPixmap(targetSize);
+    pixmap->fill(label.bgColor);
+
+    QPainter painter(pixmap);
+    painter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing, mMapperUseAntiAlias);
+
+    QFont scaledFont = label.font;
+    QRectF targetRect(0, 0, targetSize.width(), targetSize.height());
+    if (!sizeFontToFitTextInRect(scaledFont, targetRect, label.text, 5, 4.0)) {
+        // Font too small to be legible - fall back to smooth-scaled original pixmap
+        delete pixmap;
+        pixmap = new QPixmap(label.pix.scaled(targetSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+        if (!mTextLabelPixmapCache.insert(key, pixmap)) {
+            qDebug("T2DMap::addTextLabelToCache() ALERT: Text Label Pixmap cache is full...!");
+        }
+        return;
+    }
+
+    painter.setFont(scaledFont);
+
+    const int labelWidth = targetSize.width();
+    const int labelHeight = targetSize.height();
+
+    if (label.fgColor != label.outlineColor) {
+        QPen outlinePen(label.outlineColor);
+        outlinePen.setCosmetic(mMapperUseAntiAlias);
+        outlinePen.setWidth(1);
+        painter.setPen(outlinePen);
+
+        painter.drawText(QRect(-1, 0, labelWidth, labelHeight), Qt::AlignHCenter | Qt::AlignVCenter, label.text);
+        painter.drawText(QRect(1, 0, labelWidth, labelHeight), Qt::AlignHCenter | Qt::AlignVCenter, label.text);
+        painter.drawText(QRect(0, -1, labelWidth, labelHeight), Qt::AlignHCenter | Qt::AlignVCenter, label.text);
+        painter.drawText(QRect(0, 1, labelWidth, labelHeight), Qt::AlignHCenter | Qt::AlignVCenter, label.text);
+    }
+
+    painter.setPen(label.fgColor);
+    painter.drawText(QRect(0, 0, labelWidth, labelHeight), Qt::AlignHCenter | Qt::AlignVCenter, label.text);
+
+    if (!mTextLabelPixmapCache.insert(key, pixmap)) {
+        qDebug("T2DMap::addTextLabelToCache() ALERT: Text Label Pixmap cache is full...!");
     }
 }
 
@@ -1870,7 +1916,18 @@ void T2DMap::paintEvent(QPaintEvent* e)
         QRectF labelPaintRectangle = QRect(mapLabel.pos.x() * mRoomWidth + mRX, mapLabel.pos.y() * mRoomHeight * -1 + mRY, labelWidth, labelHeight);
         if (!mapLabel.showOnTop) {
             if (!mapLabel.noScaling) {
-                painter.drawPixmap(labelPosition, mapLabel.pix.scaled(labelPaintRectangle.size().toSize()));
+                const QSize targetSize = labelPaintRectangle.size().toSize();
+                if (!mapLabel.text.isEmpty() && !mapLabel.font.family().isEmpty()) {
+                    const QString cacheKey = qsl("%1_%2_%3x%4").arg(mAreaID).arg(itMapLabel.key()).arg(targetSize.width()).arg(targetSize.height());
+                    if (!mTextLabelPixmapCache.contains(cacheKey)) {
+                        addTextLabelToCache(cacheKey, mapLabel, targetSize);
+                    }
+                    if (auto* pix = mTextLabelPixmapCache.object(cacheKey)) {
+                        painter.drawPixmap(labelPosition, *pix);
+                    }
+                } else {
+                    painter.drawPixmap(labelPosition, mapLabel.pix.scaled(targetSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+                }
                 mapLabel.clickSize = QSizeF(labelPaintRectangle.width(), labelPaintRectangle.height());
             } else {
                 painter.drawPixmap(labelPosition, mapLabel.pix);
@@ -1988,7 +2045,18 @@ void T2DMap::paintEvent(QPaintEvent* e)
         QRectF labelPaintRectangle = QRect(mapLabel.pos.x() * mRoomWidth + mRX, mapLabel.pos.y() * mRoomHeight * -1 + mRY, labelWidth, labelHeight);
         if (mapLabel.showOnTop) {
             if (!mapLabel.noScaling) {
-                painter.drawPixmap(labelPosition, mapLabel.pix.scaled(labelPaintRectangle.size().toSize()));
+                const QSize targetSize = labelPaintRectangle.size().toSize();
+                if (!mapLabel.text.isEmpty() && !mapLabel.font.family().isEmpty()) {
+                    const QString cacheKey = qsl("%1_%2_%3x%4").arg(mAreaID).arg(itMapLabel.key()).arg(targetSize.width()).arg(targetSize.height());
+                    if (!mTextLabelPixmapCache.contains(cacheKey)) {
+                        addTextLabelToCache(cacheKey, mapLabel, targetSize);
+                    }
+                    if (auto* pix = mTextLabelPixmapCache.object(cacheKey)) {
+                        painter.drawPixmap(labelPosition, *pix);
+                    }
+                } else {
+                    painter.drawPixmap(labelPosition, mapLabel.pix.scaled(targetSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+                }
                 mapLabel.clickSize = QSizeF(labelPaintRectangle.width(), labelPaintRectangle.height());
             } else {
                 painter.drawPixmap(labelPosition, mapLabel.pix);
@@ -2891,6 +2959,7 @@ void T2DMap::updateMapLabel(QRectF labelRectangle, int labelId, TArea* pArea)
         label.text = mpDlgMapLabel->getText();
         label.fgColor = mpDlgMapLabel->getFgColor();
         font = mpDlgMapLabel->getFont();
+        label.font = font;
     } else {
         label.text.clear();
         imagePath = mpDlgMapLabel->getImagePath();
@@ -4410,6 +4479,7 @@ void T2DMap::wheelEvent(QWheelEvent* e)
             mMapCenterY += dy * (oldZoom - xyzoom) / 2.0 * ys;
 
             flushSymbolPixmapCache();
+            flushTextLabelPixmapCache();
             update();
         }
         e->accept();
@@ -4462,6 +4532,7 @@ std::pair<bool, QString> T2DMap::setMapZoom(const qreal zoom, const int areaId)
 
     // We are adjusting the zoom for the currently viewed area so redraw it
     flushSymbolPixmapCache();
+    flushTextLabelPixmapCache();
     update();
     return {true, QString()};
 }
@@ -4473,6 +4544,7 @@ void T2DMap::setRoomSize(double f)
         mpHost->mRoomSize = f;
     }
     flushSymbolPixmapCache();
+    flushTextLabelPixmapCache();
     update();
     mpMap->setUnsaved(__func__);
 }
@@ -5239,7 +5311,7 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
         QRectF labelPaintRectangle = QRect(labelX, labelY, labelWidth, labelHeight);
         if (!mapLabel.showOnTop) {
             if (!mapLabel.noScaling) {
-                painter.drawPixmap(labelPosition, mapLabel.pix.scaled(labelPaintRectangle.size().toSize()));
+                painter.drawPixmap(labelPosition, mapLabel.pix.scaled(labelPaintRectangle.size().toSize(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
                 mapLabel.clickSize = QSizeF(labelPaintRectangle.width(), labelPaintRectangle.height());
             } else {
                 painter.drawPixmap(labelPosition, mapLabel.pix);
@@ -5756,7 +5828,7 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
         if (mapLabel.showOnTop) {
             QPointF labelPosition(labelX, labelY);
             if (!mapLabel.noScaling) {
-                painter.drawPixmap(labelPosition, mapLabel.pix.scaled(labelPaintRectangle.size().toSize()));
+                painter.drawPixmap(labelPosition, mapLabel.pix.scaled(labelPaintRectangle.size().toSize(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
                 mapLabel.clickSize = QSizeF(labelPaintRectangle.width(), labelPaintRectangle.height());
             } else {
                 painter.drawPixmap(labelPosition, mapLabel.pix);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -856,20 +856,19 @@ void T2DMap::addSymbolToPixmapCache(const QString key, const QString text, const
 
 void T2DMap::addTextLabelToCache(const QString& key, const TMapLabel& label, const QSize& targetSize)
 {
-    auto pixmap = new QPixmap(targetSize);
+    auto pixmap = std::make_unique<QPixmap>(targetSize);
     pixmap->fill(label.bgColor);
 
-    QPainter painter(pixmap);
+    QPainter painter(pixmap.get());
     painter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing, mMapperUseAntiAlias);
 
     QFont scaledFont = label.font;
     QRectF targetRect(0, 0, targetSize.width(), targetSize.height());
     if (!sizeFontToFitTextInRect(scaledFont, targetRect, label.text, 5, 4.0)) {
         // Font too small to be legible - fall back to smooth-scaled original pixmap
-        delete pixmap;
-        pixmap = new QPixmap(label.pix.scaled(targetSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-        if (!mTextLabelPixmapCache.insert(key, pixmap)) {
-            qDebug("T2DMap::addTextLabelToCache() ALERT: Text Label Pixmap cache is full...!");
+        pixmap = std::make_unique<QPixmap>(label.pix.scaled(targetSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+        if (!mTextLabelPixmapCache.insert(key, pixmap.release())) {
+            qWarning("T2DMap::addTextLabelToCache() ALERT: Text Label Pixmap cache is full for key: %s", qUtf8Printable(key));
         }
         return;
     }
@@ -894,9 +893,31 @@ void T2DMap::addTextLabelToCache(const QString& key, const TMapLabel& label, con
     painter.setPen(label.fgColor);
     painter.drawText(QRect(0, 0, labelWidth, labelHeight), Qt::AlignHCenter | Qt::AlignVCenter, label.text);
 
-    if (!mTextLabelPixmapCache.insert(key, pixmap)) {
-        qDebug("T2DMap::addTextLabelToCache() ALERT: Text Label Pixmap cache is full...!");
+    // End the painter before releasing the pixmap to avoid accessing released memory
+    painter.end();
+    if (!mTextLabelPixmapCache.insert(key, pixmap.release())) {
+        qWarning("T2DMap::addTextLabelToCache() ALERT: Text Label Pixmap cache is full for key: %s", qUtf8Printable(key));
     }
+}
+
+void T2DMap::drawScaledLabel(QPainter& painter, const QPointF& position, TMapLabel& label, int labelKey, const QRectF& paintRect)
+{
+    const QSize targetSize = paintRect.size().toSize();
+    if (!label.text.isEmpty() && !label.font.family().isEmpty()) {
+        const QString cacheKey = qsl("%1_%2_%3x%4").arg(mAreaID).arg(labelKey).arg(targetSize.width()).arg(targetSize.height());
+        if (!mTextLabelPixmapCache.contains(cacheKey)) {
+            addTextLabelToCache(cacheKey, label, targetSize);
+        }
+        if (auto* pix = mTextLabelPixmapCache.object(cacheKey)) {
+            painter.drawPixmap(position, *pix);
+        } else {
+            qWarning("T2DMap::drawScaledLabel() ALERT: Cache lookup failed for label %d in area %d, using fallback", labelKey, mAreaID);
+            painter.drawPixmap(position, label.pix.scaled(targetSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+        }
+    } else {
+        painter.drawPixmap(position, label.pix.scaled(targetSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+    }
+    label.clickSize = QSizeF(paintRect.width(), paintRect.height());
 }
 
 /*
@@ -1916,19 +1937,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
         QRectF labelPaintRectangle = QRect(mapLabel.pos.x() * mRoomWidth + mRX, mapLabel.pos.y() * mRoomHeight * -1 + mRY, labelWidth, labelHeight);
         if (!mapLabel.showOnTop) {
             if (!mapLabel.noScaling) {
-                const QSize targetSize = labelPaintRectangle.size().toSize();
-                if (!mapLabel.text.isEmpty() && !mapLabel.font.family().isEmpty()) {
-                    const QString cacheKey = qsl("%1_%2_%3x%4").arg(mAreaID).arg(itMapLabel.key()).arg(targetSize.width()).arg(targetSize.height());
-                    if (!mTextLabelPixmapCache.contains(cacheKey)) {
-                        addTextLabelToCache(cacheKey, mapLabel, targetSize);
-                    }
-                    if (auto* pix = mTextLabelPixmapCache.object(cacheKey)) {
-                        painter.drawPixmap(labelPosition, *pix);
-                    }
-                } else {
-                    painter.drawPixmap(labelPosition, mapLabel.pix.scaled(targetSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-                }
-                mapLabel.clickSize = QSizeF(labelPaintRectangle.width(), labelPaintRectangle.height());
+                drawScaledLabel(painter, labelPosition, mapLabel, itMapLabel.key(), labelPaintRectangle);
             } else {
                 painter.drawPixmap(labelPosition, mapLabel.pix);
                 mapLabel.clickSize = QSizeF(mapLabel.pix.width(), mapLabel.pix.height());
@@ -2045,22 +2054,10 @@ void T2DMap::paintEvent(QPaintEvent* e)
         QRectF labelPaintRectangle = QRect(mapLabel.pos.x() * mRoomWidth + mRX, mapLabel.pos.y() * mRoomHeight * -1 + mRY, labelWidth, labelHeight);
         if (mapLabel.showOnTop) {
             if (!mapLabel.noScaling) {
-                const QSize targetSize = labelPaintRectangle.size().toSize();
-                if (!mapLabel.text.isEmpty() && !mapLabel.font.family().isEmpty()) {
-                    const QString cacheKey = qsl("%1_%2_%3x%4").arg(mAreaID).arg(itMapLabel.key()).arg(targetSize.width()).arg(targetSize.height());
-                    if (!mTextLabelPixmapCache.contains(cacheKey)) {
-                        addTextLabelToCache(cacheKey, mapLabel, targetSize);
-                    }
-                    if (auto* pix = mTextLabelPixmapCache.object(cacheKey)) {
-                        painter.drawPixmap(labelPosition, *pix);
-                    }
-                } else {
-                    painter.drawPixmap(labelPosition, mapLabel.pix.scaled(targetSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-                }
-                mapLabel.clickSize = QSizeF(labelPaintRectangle.width(), labelPaintRectangle.height());
+                drawScaledLabel(painter, labelPosition, mapLabel, itMapLabel.key(), labelPaintRectangle);
             } else {
                 painter.drawPixmap(labelPosition, mapLabel.pix);
-                mapLabel.clickSize = QSize(mapLabel.pix.width(), mapLabel.pix.height());
+                mapLabel.clickSize = QSizeF(mapLabel.pix.width(), mapLabel.pix.height());
             }
             pDrawnArea->mMapLabels[itMapLabel.key()] = mapLabel;
         }

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -172,6 +172,7 @@ public:
     void addSymbolToPixmapCache(const QString, const QString, const QColor, const bool);
     void flushTextLabelPixmapCache() {mTextLabelPixmapCache.clear();}
     void addTextLabelToCache(const QString& key, const TMapLabel& label, const QSize& targetSize);
+    void drawScaledLabel(QPainter& painter, const QPointF& position, TMapLabel& label, int labelKey, const QRectF& paintRect);
     void setPlayerRoomStyle(const int style);
     void switchArea(const QString& newAreaName);
     void clearSelection();

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -47,6 +47,7 @@
 class Host;
 class TArea;
 class TMap;
+class TMapLabel;
 class TRoom;
 struct MapInfoProperties;
 class CustomLineDrawContextMenuHandler;
@@ -169,6 +170,8 @@ public:
     // Clears cache so new symbols are built at next paintEvent():
     void flushSymbolPixmapCache() {mSymbolPixmapCache.clear();}
     void addSymbolToPixmapCache(const QString, const QString, const QColor, const bool);
+    void flushTextLabelPixmapCache() {mTextLabelPixmapCache.clear();}
+    void addTextLabelToCache(const QString& key, const TMapLabel& label, const QSize& targetSize);
     void setPlayerRoomStyle(const int style);
     void switchArea(const QString& newAreaName);
     void clearSelection();
@@ -408,6 +411,7 @@ private:
     // as we now show room names (if present) as well.
     bool mIsSelectionUsingNames = false;
     QCache<QString, QPixmap> mSymbolPixmapCache;
+    QCache<QString, QPixmap> mTextLabelPixmapCache;
     ushort mSymbolFontSize = 1;
     QFont mMapSymbolFont;
     QPointer<QAction> mpCreateRoomAction;

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -801,6 +801,15 @@ void TArea::writeJsonLabel(QJsonArray& array, const int id, const TMapLabel* pLa
     // Invert the logic here as we are saying "scaled" rather than "unscaled":
     labelObj.insert(QLatin1String("scaledels"), !pLabel->noScaling);
 
+    if (!pLabel->font.family().isEmpty()) {
+        QJsonObject fontObj;
+        fontObj.insert(QLatin1String("family"), pLabel->font.family());
+        fontObj.insert(QLatin1String("pointSize"), pLabel->font.pointSize());
+        fontObj.insert(QLatin1String("weight"), pLabel->font.weight());
+        fontObj.insert(QLatin1String("italic"), pLabel->font.italic());
+        labelObj.insert(QLatin1String("font"), fontObj);
+    }
+
     const QJsonValue labelValue{labelObj};
     array.append(labelValue);
 }
@@ -842,6 +851,14 @@ void TArea::readJsonLabel(const QJsonObject& labelObj)
     label.showOnTop = labelObj.value(QLatin1String("showOnTop")).toBool();
 
     label.noScaling = !labelObj.value(QLatin1String("scaledels")).toBool(true);
+
+    if (labelObj.contains(QLatin1String("font"))) {
+        const QJsonObject fontObj = labelObj.value(QLatin1String("font")).toObject();
+        label.font = QFont(fontObj.value(QLatin1String("family")).toString(),
+                           fontObj.value(QLatin1String("pointSize")).toInt(),
+                           fontObj.value(QLatin1String("weight")).toInt(),
+                           fontObj.value(QLatin1String("italic")).toBool());
+    }
 
     mMapLabels.insert(labelId, label);
 }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -47,6 +47,24 @@
 #include <QSizeF>
 
 
+namespace {
+// Restores font information from userData that was stored during binary serialization.
+// Font data is stored as "family|pointSize|weight|italic" to avoid binary format version changes.
+void restoreLabelFontFromUserData(TMapLabel& label, int labelId, QMap<QString, QString>& userData)
+{
+    const QString fontKey = qsl("system.labelFont_%1").arg(labelId);
+    if (userData.contains(fontKey)) {
+        const QStringList fontParts = userData.take(fontKey).split(QLatin1Char('|'));
+        if (fontParts.size() == 4) {
+            label.font = QFont(fontParts.at(0), fontParts.at(1).toInt(),
+                               fontParts.at(2).toInt(), fontParts.at(3).toInt() != 0);
+        } else {
+            qWarning("TMap: Failed to parse font data for label %d, expected 4 parts but got %lld", labelId, fontParts.size());
+        }
+    }
+}
+} // anonymous namespace
+
 TMap::TMap(Host* pH, const QString& profileName)
 : mDefaultAreaName(tr("Default Area"))
 , mUnnamedAreaName(tr("Unnamed Area"))
@@ -1149,6 +1167,10 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
         for (const auto labelID : permanentLabelsList) {
             const auto label = pA->mMapLabels.value(labelID);
             if (!label.font.family().isEmpty()) {
+                if (label.font.family().contains(QLatin1Char('|'))) {
+                    qWarning("TMap::serialize() - Font family '%s' for label %d contains pipe character, font may not deserialize correctly",
+                             qUtf8Printable(label.font.family()), labelID);
+                }
                 const QString fontKey = qsl("system.labelFont_%1").arg(labelID);
                 const QString fontValue = qsl("%1|%2|%3|%4")
                     .arg(label.font.family())
@@ -1745,15 +1767,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
                         ifs >> label.pix;
                         ifs >> label.noScaling;
                         ifs >> label.showOnTop;
-                        // Restore font from area userData
-                        const QString fontKey = qsl("system.labelFont_%1").arg(labelId);
-                        if (pA->mUserData.contains(fontKey)) {
-                            const QStringList fontParts = pA->mUserData.take(fontKey).split(QLatin1Char('|'));
-                            if (fontParts.size() == 4) {
-                                label.font = QFont(fontParts.at(0), fontParts.at(1).toInt(),
-                                                   fontParts.at(2).toInt(), fontParts.at(3).toInt() != 0);
-                            }
-                        }
+                        restoreLabelFontFromUserData(label, labelId, pA->mUserData);
                         pA->mMapLabels.insert(labelId, label);
                     }
                 }
@@ -1822,15 +1836,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
                         ifs >> label.showOnTop;
                     }
                     if (pA) {
-                        // Restore font from area userData
-                        const QString fontKey = qsl("system.labelFont_%1").arg(labelID);
-                        if (pA->mUserData.contains(fontKey)) {
-                            const QStringList fontParts = pA->mUserData.take(fontKey).split(QLatin1Char('|'));
-                            if (fontParts.size() == 4) {
-                                label.font = QFont(fontParts.at(0), fontParts.at(1).toInt(),
-                                                   fontParts.at(2).toInt(), fontParts.at(3).toInt() != 0);
-                            }
-                        }
+                        restoreLabelFontFromUserData(label, labelID, pA->mUserData);
                         pA->mMapLabels.insert(labelID, label);
                     }
                     ++areaLabelCounter;

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1144,12 +1144,25 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
         } else {
             pA->mUserData.insert(QLatin1String("system.fallback_map2DZoom"), QString::number(pA->get2DMapZoom()));
         }
+        // Store font info for labels in userData (avoids binary format version change)
+        const auto permanentLabelsList{pA->getPermanentLabelIds()};
+        for (const auto labelID : permanentLabelsList) {
+            const auto label = pA->mMapLabels.value(labelID);
+            if (!label.font.family().isEmpty()) {
+                const QString fontKey = qsl("system.labelFont_%1").arg(labelID);
+                const QString fontValue = qsl("%1|%2|%3|%4")
+                    .arg(label.font.family())
+                    .arg(label.font.pointSize())
+                    .arg(label.font.weight())
+                    .arg(label.font.italic() ? 1 : 0);
+                pA->mUserData.insert(fontKey, fontValue);
+            }
+        }
         ofs << pA->mUserData;
         if (mSaveVersion >= 21) {
             // Revised in version 21 to store labels within the TArea class:
             // Also we now have temporary labels, so we need to count the
             // permanent ones first to use as the count for ones to store:
-            const auto permanentLabelsList{pA->getPermanentLabelIds()};
             ofs << static_cast<qint32>(permanentLabelsList.size());
             QListIterator<int> itMapLabelId(permanentLabelsList);
             while (itMapLabelId.hasNext()) {
@@ -1732,6 +1745,15 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
                         ifs >> label.pix;
                         ifs >> label.noScaling;
                         ifs >> label.showOnTop;
+                        // Restore font from area userData
+                        const QString fontKey = qsl("system.labelFont_%1").arg(labelId);
+                        if (pA->mUserData.contains(fontKey)) {
+                            const QStringList fontParts = pA->mUserData.take(fontKey).split(QLatin1Char('|'));
+                            if (fontParts.size() == 4) {
+                                label.font = QFont(fontParts.at(0), fontParts.at(1).toInt(),
+                                                   fontParts.at(2).toInt(), fontParts.at(3).toInt() != 0);
+                            }
+                        }
                         pA->mMapLabels.insert(labelId, label);
                     }
                 }
@@ -1800,6 +1822,15 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
                         ifs >> label.showOnTop;
                     }
                     if (pA) {
+                        // Restore font from area userData
+                        const QString fontKey = qsl("system.labelFont_%1").arg(labelID);
+                        if (pA->mUserData.contains(fontKey)) {
+                            const QStringList fontParts = pA->mUserData.take(fontKey).split(QLatin1Char('|'));
+                            if (fontParts.size() == 4) {
+                                label.font = QFont(fontParts.at(0), fontParts.at(1).toInt(),
+                                                   fontParts.at(2).toInt(), fontParts.at(3).toInt() != 0);
+                            }
+                        }
                         pA->mMapLabels.insert(labelID, label);
                     }
                     ++areaLabelCounter;
@@ -2136,6 +2167,7 @@ int TMap::createMapLabel(int area, const QString& text, float x, float y, float 
     lp.setRenderHint(QPainter::Antialiasing);
 
     QFont font(fontName.has_value() ? fontName.value() : QString(), fontSize);
+    label.font = font;
     lp.setFont(font);
 
     QPen outlinePen(label.outlineColor);

--- a/src/TMapLabel.h
+++ b/src/TMapLabel.h
@@ -26,6 +26,7 @@
 
 #include <QtGlobal>
 #include <QColor>
+#include <QFont>
 #include <QPixmap>
 #include <QSizeF>
 #include <QVector3D>
@@ -43,6 +44,7 @@ public:
     QColor fgColor = QColorConstants::Black;
     QColor bgColor = QColorConstants::Black;
     QColor outlineColor = QColorConstants::Black;
+    QFont font;
     QPixmap pix;
     bool highlight = false;
     bool showOnTop = false;

--- a/src/dlgMapLabel.cpp
+++ b/src/dlgMapLabel.cpp
@@ -242,7 +242,7 @@ bool dlgMapLabel::stretchImage()
 
 void dlgMapLabel::slot_updateControls()
 {
-    //: Font display format in map label dialog (excluding size since it auto-scales)
+    //: Font display format in map label dialog. %1 is font family name, %2 is style (e.g. "Bold", "Italic"). Size excluded since it auto-scales.
     lineEdit_font->setText(tr("%1 %2").arg(font.family(), font.styleName()));
     pushButton_fgColor->setStyleSheet(BUTTON_STYLESHEET.arg(QString::number(fgColor.red()), QString::number(fgColor.green()), QString::number(fgColor.blue()), QString::number(fgColor.alpha())));
     pushButton_bgColor->setStyleSheet(BUTTON_STYLESHEET.arg(QString::number(bgColor.red()), QString::number(bgColor.green()), QString::number(bgColor.blue()), QString::number(bgColor.alpha())));

--- a/src/dlgMapLabel.cpp
+++ b/src/dlgMapLabel.cpp
@@ -66,6 +66,8 @@ dlgMapLabel::dlgMapLabel(QWidget* pParentWidget)
     font = QApplication::font();
     font.setStyle(QFont::StyleNormal);
     text = plainTextEdit_labelText->placeholderText();
+    //: Tooltip for font display in map label dialog
+    lineEdit_font->setToolTip(tr("Font size is automatically calculated to fit the label"));
 
     QSettings& settings = *mudlet::getQSettings();
     fgColor = settings.value("fgColorDialogMapLabel", fgColor).value<QColor>();
@@ -240,7 +242,8 @@ bool dlgMapLabel::stretchImage()
 
 void dlgMapLabel::slot_updateControls()
 {
-    lineEdit_font->setText(QString("%1, %2pt %3").arg(font.family(), QString::number(font.pointSize()), font.styleName()));
+    //: Font display format in map label dialog (excluding size since it auto-scales)
+    lineEdit_font->setText(tr("%1 %2").arg(font.family(), font.styleName()));
     pushButton_fgColor->setStyleSheet(BUTTON_STYLESHEET.arg(QString::number(fgColor.red()), QString::number(fgColor.green()), QString::number(fgColor.blue()), QString::number(fgColor.alpha())));
     pushButton_bgColor->setStyleSheet(BUTTON_STYLESHEET.arg(QString::number(bgColor.red()), QString::number(bgColor.green()), QString::number(bgColor.blue()), QString::number(bgColor.alpha())));
     pushButton_outlineColor->setStyleSheet(BUTTON_STYLESHEET.arg(QString::number(outlineColor.red()), QString::number(outlineColor.green()), QString::number(outlineColor.blue()), QString::number(outlineColor.alpha())));


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Text labels are now re-rendered at the current zoom level with dynamic font sizing, eliminating blurriness when zoomed.

#### Motivation for adding to Mudlet
Map labels were blurry when zoomed because they used fast scaling instead of re-rendering.

#### Other info (issues closed, discussion etc)
Font size selection removed from label dialog since it's now auto-calculated to fit.

**Test case:** Create a text label on the map, set it to scale, zoom in/out, verify text remains crisp at all zoom levels.


https://github.com/user-attachments/assets/14308b15-706a-4d73-a881-bb57416fecae

