### PR TITLE
add: Multi-file selection in import dialogs

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -972,6 +972,17 @@ void Host::waitForProfileSave()
     if (mModuleFuture.isRunning()) {
         mModuleFuture.waitForFinished();
     }
+    int iterations = 0;
+    while (currentlySavingProfile()) {
+        if (++iterations > 1000) {
+            qWarning().nospace() << "Host::waitForProfileSave() WARNING - save did not complete after 1000 event loop iterations. "
+                                 << "State: mWritingHostAndModules=" << mWritingHostAndModules
+                                 << ", writers pending=" << writers.size()
+                                 << ". Continuing without waiting.";
+            break;
+        }
+        qApp->processEvents();
+    }
 }
 
 void Host::setMmpMapLocation(const QString& data)

--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -29,6 +29,8 @@
 #include <QMessageBox>
 #include <QTimer>
 
+using namespace std::chrono_literals;
+
 
 dlgModuleManager::dlgModuleManager(QWidget* parent, Host* pHost)
 : QDialog(parent)
@@ -141,15 +143,13 @@ void dlgModuleManager::slot_installModule()
     lastDir = QFileInfo(fileNames.first()).absolutePath();
     settings.setValue("lastFileDialogLocation", lastDir);
 
-    int successCount = 0;
-    int failureCount = 0;
+    QStringList failedModules;
 
     for (const QString& fileName : fileNames) {
         if (mpHost->installPackage(fileName, enums::PackageModuleType::ModuleFromUI).first) {
-            ++successCount;
             mpHost->waitForProfileSave();
         } else {
-            ++failureCount;
+            failedModules << QFileInfo(fileName).fileName();
         }
     }
 
@@ -159,9 +159,9 @@ void dlgModuleManager::slot_installModule()
 
     layoutModules();
 
-    if (failureCount > 0) {
-        //: Module manager - status message shown when some modules failed to import
-        showImportStatus(tr("Failed to import %n module(s)", nullptr, failureCount));
+    if (!failedModules.isEmpty()) {
+        //: Module manager - status message shown when some modules failed to import. %1 is a comma-separated list of module names
+        showImportStatus(tr("Failed to import: %1").arg(failedModules.join(qsl(", "))));
     }
 }
 
@@ -271,7 +271,7 @@ void dlgModuleManager::showImportStatus(const QString& message, bool /*isError*/
     label_importStatus->setText(message);
     label_importStatus->setStyleSheet(qsl("QLabel { padding: 8px; }"));
     label_importStatus->show();
-    QTimer::singleShot(4000, label_importStatus, &QWidget::hide);
+    QTimer::singleShot(4s, label_importStatus, &QWidget::hide);
 }
 
 void dlgModuleManager::closeEvent(QCloseEvent* event)

--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -27,6 +27,7 @@
 
 #include <QFileDialog>
 #include <QMessageBox>
+#include <QTimer>
 
 
 dlgModuleManager::dlgModuleManager(QWidget* parent, Host* pHost)
@@ -131,26 +132,36 @@ void dlgModuleManager::slot_installModule()
     QSettings& settings = *mudlet::getQSettings();
     QString lastDir = settings.value("lastFileDialogLocation", QDir::homePath()).toString();
 
-    const QString fileName = QFileDialog::getOpenFileName(this, tr("Load Mudlet Module"), lastDir);
-    if (fileName.isEmpty()) {
+    //: Module manager - import modules from file dialog (multi-select enabled)
+    const QStringList fileNames = QFileDialog::getOpenFileNames(this, tr("Load Mudlet Module"), lastDir);
+    if (fileNames.isEmpty()) {
         return;
     }
 
-    lastDir = QFileInfo(fileName).absolutePath();
+    lastDir = QFileInfo(fileNames.first()).absolutePath();
     settings.setValue("lastFileDialogLocation", lastDir);
 
-    QFile file(fileName);
-    if (!file.open(QFile::ReadOnly | QFile::Text)) {
-        QMessageBox::warning(this, tr("Load Mudlet Module:"), tr("Cannot read file %1:\n%2.").arg(fileName.toHtmlEscaped(), file.errorString()));
-        return;
+    int successCount = 0;
+    int failureCount = 0;
+
+    for (const QString& fileName : fileNames) {
+        if (mpHost->installPackage(fileName, enums::PackageModuleType::ModuleFromUI).first) {
+            ++successCount;
+        } else {
+            ++failureCount;
+        }
     }
 
-    mpHost->installPackage(fileName, enums::PackageModuleType::ModuleFromUI);
     for (int i = moduleTable->rowCount() - 1; i >= 0; --i) {
         moduleTable->removeRow(i);
     }
 
     layoutModules();
+
+    if (failureCount > 0) {
+        //: Module manager - status message shown when some modules failed to import
+        showImportStatus(tr("Failed to import %n module(s)", nullptr, failureCount));
+    }
 }
 
 void dlgModuleManager::slot_uninstallModule()
@@ -252,6 +263,14 @@ void dlgModuleManager::slot_helpModule()
             }
         }
     }
+}
+
+void dlgModuleManager::showImportStatus(const QString& message, bool /*isError*/)
+{
+    label_importStatus->setText(message);
+    label_importStatus->setStyleSheet(qsl("QLabel { padding: 8px; }"));
+    label_importStatus->show();
+    QTimer::singleShot(4000, label_importStatus, &QWidget::hide);
 }
 
 void dlgModuleManager::closeEvent(QCloseEvent* event)

--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -135,7 +135,8 @@ void dlgModuleManager::slot_installModule()
     QString lastDir = settings.value(qsl("lastFileDialogLocation"), QDir::homePath()).toString();
 
     //: Module manager - import modules from file dialog (multi-select enabled)
-    const QStringList fileNames = QFileDialog::getOpenFileNames(this, tr("Load Mudlet Module"), lastDir);
+    //: Module manager - file filter for supported module types (mpackage, zip, xml)
+    const QStringList fileNames = QFileDialog::getOpenFileNames(this, tr("Load Mudlet Module"), lastDir, tr("Mudlet Packages (*.mpackage *.zip *.xml)"));
     if (fileNames.isEmpty()) {
         return;
     }

--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -147,6 +147,7 @@ void dlgModuleManager::slot_installModule()
     for (const QString& fileName : fileNames) {
         if (mpHost->installPackage(fileName, enums::PackageModuleType::ModuleFromUI).first) {
             ++successCount;
+            mpHost->waitForProfileSave();
         } else {
             ++failureCount;
         }

--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -132,7 +132,7 @@ void dlgModuleManager::slot_installModule()
     }
 
     QSettings& settings = *mudlet::getQSettings();
-    QString lastDir = settings.value("lastFileDialogLocation", QDir::homePath()).toString();
+    QString lastDir = settings.value(qsl("lastFileDialogLocation"), QDir::homePath()).toString();
 
     //: Module manager - import modules from file dialog (multi-select enabled)
     const QStringList fileNames = QFileDialog::getOpenFileNames(this, tr("Load Mudlet Module"), lastDir);
@@ -141,15 +141,18 @@ void dlgModuleManager::slot_installModule()
     }
 
     lastDir = QFileInfo(fileNames.first()).absolutePath();
-    settings.setValue("lastFileDialogLocation", lastDir);
+    settings.setValue(qsl("lastFileDialogLocation"), lastDir);
 
     QStringList failedModules;
 
     for (const QString& fileName : fileNames) {
-        if (mpHost->installPackage(fileName, enums::PackageModuleType::ModuleFromUI).first) {
+        auto [success, errorMsg] = mpHost->installPackage(fileName, enums::PackageModuleType::ModuleFromUI);
+        if (success) {
             mpHost->waitForProfileSave();
         } else {
-            failedModules << QFileInfo(fileName).fileName();
+            const QString baseName = QFileInfo(fileName).fileName();
+            failedModules << baseName;
+            qWarning() << "dlgModuleManager::slot_installModule() ERROR - failed to import" << baseName << ":" << errorMsg;
         }
     }
 
@@ -266,7 +269,7 @@ void dlgModuleManager::slot_helpModule()
     }
 }
 
-void dlgModuleManager::showImportStatus(const QString& message, bool /*isError*/)
+void dlgModuleManager::showImportStatus(const QString& message)
 {
     label_importStatus->setText(message);
     label_importStatus->setStyleSheet(qsl("QLabel { padding: 8px; }"));

--- a/src/dlgModuleManager.h
+++ b/src/dlgModuleManager.h
@@ -54,7 +54,7 @@ protected:
     void closeEvent(QCloseEvent* event) override;
 
 private:
-    void showImportStatus(const QString& message, bool isError = false);
+    void showImportStatus(const QString& message);
 
     Host* mpHost = nullptr;
 };

--- a/src/dlgModuleManager.h
+++ b/src/dlgModuleManager.h
@@ -54,6 +54,8 @@ protected:
     void closeEvent(QCloseEvent* event) override;
 
 private:
+    void showImportStatus(const QString& message, bool isError = false);
+
     Host* mpHost = nullptr;
 };
 

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -251,7 +251,8 @@ void dlgPackageManager::slot_installPackageFromFile()
     QString lastDir = settings.value(qsl("lastFileDialogLocation"), QDir::homePath()).toString();
 
     //: Package manager - import packages from file dialog (multi-select enabled)
-    const QStringList fileNames = QFileDialog::getOpenFileNames(this, tr("Import Mudlet Package"), lastDir);
+    //: Package manager - file filter for supported package types (mpackage, zip, xml)
+    const QStringList fileNames = QFileDialog::getOpenFileNames(this, tr("Import Mudlet Package"), lastDir, tr("Mudlet Packages (*.mpackage *.zip *.xml)"));
     if (fileNames.isEmpty()) {
         return;
     }

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -262,10 +262,13 @@ void dlgPackageManager::slot_installPackageFromFile()
     QStringList failedPackages;
 
     for (const QString& fileName : fileNames) {
-        if (mpHost->installPackage(fileName, enums::PackageModuleType::Package).first) {
+        auto [success, errorMsg] = mpHost->installPackage(fileName, enums::PackageModuleType::Package);
+        if (success) {
             mpHost->waitForProfileSave();
         } else {
-            failedPackages << QFileInfo(fileName).fileName();
+            const QString baseName = QFileInfo(fileName).fileName();
+            failedPackages << baseName;
+            qWarning() << "dlgPackageManager::slot_installPackageFromFile() ERROR - failed to import" << baseName << ":" << errorMsg;
         }
     }
 
@@ -703,7 +706,7 @@ void dlgPackageManager::slot_toggleRemoveButton()
     }
 }
 
-void dlgPackageManager::showImportStatus(const QString& message, bool /*isError*/)
+void dlgPackageManager::showImportStatus(const QString& message)
 {
     label_importStatus->setText(message);
     label_importStatus->setStyleSheet(qsl("QLabel { padding: 8px; }"));

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -30,6 +30,7 @@
 #include <QMessageBox>
 #include <QNetworkAccessManager>
 #include <QProgressDialog>
+#include <QTimer>
 
 
 dlgPackageManager::dlgPackageManager(QWidget* parent, Host* pHost)
@@ -247,26 +248,32 @@ void dlgPackageManager::slot_installPackageFromFile()
     QSettings& settings = *mudlet::getQSettings();
     QString lastDir = settings.value(qsl("lastFileDialogLocation"), QDir::homePath()).toString();
 
-    //: Package manager - import package from file dialog
-    const QString fileName = QFileDialog::getOpenFileName(this, tr("Import Mudlet Package"), lastDir);
-    if (fileName.isEmpty()) {
+    //: Package manager - import packages from file dialog (multi-select enabled)
+    const QStringList fileNames = QFileDialog::getOpenFileNames(this, tr("Import Mudlet Package"), lastDir);
+    if (fileNames.isEmpty()) {
         return;
     }
 
-    lastDir = QFileInfo(fileName).absolutePath();
+    lastDir = QFileInfo(fileNames.first()).absolutePath();
     settings.setValue(qsl("lastFileDialogLocation"), lastDir);
 
-    QFile file(fileName);
-    if (!file.open(QFile::ReadOnly | QFile::Text)) {
-        //: Package manager - error when attempting to read a file to import
-        QMessageBox::warning(this, tr("Import Mudlet Package:"), tr("Cannot read file %1:\n%2.").arg(fileName.toHtmlEscaped(), file.errorString()));
-        return;
+    int successCount = 0;
+    int failureCount = 0;
+
+    for (const QString& fileName : fileNames) {
+        if (mpHost->installPackage(fileName, enums::PackageModuleType::Package).first) {
+            ++successCount;
+        } else {
+            ++failureCount;
+        }
     }
 
-    mpHost->installPackage(fileName, enums::PackageModuleType::Package);
-
-    // Refresh the package list to show newly installed package
     resetPackageList();
+
+    if (failureCount > 0) {
+        //: Package manager - status message shown when some packages failed to import
+        showImportStatus(tr("Failed to import %n package(s)", nullptr, failureCount));
+    }
 }
 
 void dlgPackageManager::slot_installPackageFromRepository()
@@ -693,6 +700,14 @@ void dlgPackageManager::slot_toggleRemoveButton()
         pushButton_remove->setText(tr("Remove"));
         pushButton_remove->setEnabled(false);
     }
+}
+
+void dlgPackageManager::showImportStatus(const QString& message, bool /*isError*/)
+{
+    label_importStatus->setText(message);
+    label_importStatus->setStyleSheet(qsl("QLabel { padding: 8px; }"));
+    label_importStatus->show();
+    QTimer::singleShot(4000, label_importStatus, &QWidget::hide);
 }
 
 void dlgPackageManager::closeEvent(QCloseEvent* event)

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -263,6 +263,7 @@ void dlgPackageManager::slot_installPackageFromFile()
     for (const QString& fileName : fileNames) {
         if (mpHost->installPackage(fileName, enums::PackageModuleType::Package).first) {
             ++successCount;
+            mpHost->waitForProfileSave();
         } else {
             ++failureCount;
         }

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -32,6 +32,8 @@
 #include <QProgressDialog>
 #include <QTimer>
 
+using namespace std::chrono_literals;
+
 
 dlgPackageManager::dlgPackageManager(QWidget* parent, Host* pHost)
 : QDialog(parent)
@@ -257,23 +259,21 @@ void dlgPackageManager::slot_installPackageFromFile()
     lastDir = QFileInfo(fileNames.first()).absolutePath();
     settings.setValue(qsl("lastFileDialogLocation"), lastDir);
 
-    int successCount = 0;
-    int failureCount = 0;
+    QStringList failedPackages;
 
     for (const QString& fileName : fileNames) {
         if (mpHost->installPackage(fileName, enums::PackageModuleType::Package).first) {
-            ++successCount;
             mpHost->waitForProfileSave();
         } else {
-            ++failureCount;
+            failedPackages << QFileInfo(fileName).fileName();
         }
     }
 
     resetPackageList();
 
-    if (failureCount > 0) {
-        //: Package manager - status message shown when some packages failed to import
-        showImportStatus(tr("Failed to import %n package(s)", nullptr, failureCount));
+    if (!failedPackages.isEmpty()) {
+        //: Package manager - status message shown when some packages failed to import. %1 is a comma-separated list of package names
+        showImportStatus(tr("Failed to import: %1").arg(failedPackages.join(qsl(", "))));
     }
 }
 
@@ -708,7 +708,7 @@ void dlgPackageManager::showImportStatus(const QString& message, bool /*isError*
     label_importStatus->setText(message);
     label_importStatus->setStyleSheet(qsl("QLabel { padding: 8px; }"));
     label_importStatus->show();
-    QTimer::singleShot(4000, label_importStatus, &QWidget::hide);
+    QTimer::singleShot(4s, label_importStatus, &QWidget::hide);
 }
 
 void dlgPackageManager::closeEvent(QCloseEvent* event)

--- a/src/dlgPackageManager.h
+++ b/src/dlgPackageManager.h
@@ -67,7 +67,7 @@ private:
     void downloadIcon(const QString &packageName);
     void downloadRepositoryIndex();
     void fillPackageDetails(const QString &name, const QString &title, const QString &author, const QString &version);
-    void showImportStatus(const QString& message, bool isError = false);
+    void showImportStatus(const QString& message);
 
     Host* mpHost = nullptr;
     PackageItemDelegate* mpPackageItemDelegate = nullptr;

--- a/src/dlgPackageManager.h
+++ b/src/dlgPackageManager.h
@@ -65,8 +65,9 @@ private:
     void clearPackageDetails();
     void closeEvent(QCloseEvent* event) override;
     void downloadIcon(const QString &packageName);
-    void downloadRepositoryIndex();    
+    void downloadRepositoryIndex();
     void fillPackageDetails(const QString &name, const QString &title, const QString &author, const QString &version);
+    void showImportStatus(const QString& message, bool isError = false);
 
     Host* mpHost = nullptr;
     PackageItemDelegate* mpPackageItemDelegate = nullptr;

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -12781,15 +12781,13 @@ void dlgTriggerEditor::slot_import()
     lastDir = QFileInfo(fileNames.first()).absolutePath();
     settings.setValue("lastFileDialogLocation", lastDir);
 
-    int successCount = 0;
-    int failureCount = 0;
+    QStringList failedPackages;
 
     for (const QString& fileName : fileNames) {
         if (mpHost->installPackage(fileName, enums::PackageModuleType::Package).first) {
-            ++successCount;
             mpHost->waitForProfileSave();
         } else {
-            ++failureCount;
+            failedPackages << QFileInfo(fileName).fileName();
         }
     }
 
@@ -12814,9 +12812,9 @@ void dlgTriggerEditor::slot_import()
 
     slot_showTriggers();
 
-    if (failureCount > 0) {
-        //: Trigger editor - status bar message shown when some packages failed to import
-        statusBar()->showMessage(tr("Failed to import %n package(s)", nullptr, failureCount), 4000);
+    if (!failedPackages.isEmpty()) {
+        //: Trigger editor - status bar message shown when some packages failed to import. %1 is a comma-separated list of package names
+        statusBar()->showMessage(tr("Failed to import: %1").arg(failedPackages.join(qsl(", "))), std::chrono::milliseconds(4s).count());
     }
 }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -12773,14 +12773,24 @@ void dlgTriggerEditor::slot_import()
 
     QSettings& settings = *mudlet::getQSettings();
     QString lastDir = settings.value("lastFileDialogLocation", QDir::homePath()).toString();
-    const QString fileName = QFileDialog::getOpenFileName(this, tr("Import Mudlet Package"), lastDir);
-    if (fileName.isEmpty()) {
+    //: Trigger editor - import packages from file dialog (multi-select enabled)
+    const QStringList fileNames = QFileDialog::getOpenFileNames(this, tr("Import Mudlet Package"), lastDir);
+    if (fileNames.isEmpty()) {
         return;
     }
-    lastDir = QFileInfo(fileName).absolutePath();
+    lastDir = QFileInfo(fileNames.first()).absolutePath();
     settings.setValue("lastFileDialogLocation", lastDir);
 
-    mpHost->installPackage(fileName, enums::PackageModuleType::Package);
+    int successCount = 0;
+    int failureCount = 0;
+
+    for (const QString& fileName : fileNames) {
+        if (mpHost->installPackage(fileName, enums::PackageModuleType::Package).first) {
+            ++successCount;
+        } else {
+            ++failureCount;
+        }
+    }
 
     treeWidget_triggers->clear();
     treeWidget_aliases->clear();
@@ -12802,6 +12812,11 @@ void dlgTriggerEditor::slot_import()
     fillout_form();
 
     slot_showTriggers();
+
+    if (failureCount > 0) {
+        //: Trigger editor - status bar message shown when some packages failed to import
+        statusBar()->showMessage(tr("Failed to import %n package(s)", nullptr, failureCount), 4000);
+    }
 }
 
 void dlgTriggerEditor::doCleanReset()

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -12772,22 +12772,25 @@ void dlgTriggerEditor::slot_import()
     }
 
     QSettings& settings = *mudlet::getQSettings();
-    QString lastDir = settings.value("lastFileDialogLocation", QDir::homePath()).toString();
+    QString lastDir = settings.value(qsl("lastFileDialogLocation"), QDir::homePath()).toString();
     //: Trigger editor - import packages from file dialog (multi-select enabled)
     const QStringList fileNames = QFileDialog::getOpenFileNames(this, tr("Import Mudlet Package"), lastDir);
     if (fileNames.isEmpty()) {
         return;
     }
     lastDir = QFileInfo(fileNames.first()).absolutePath();
-    settings.setValue("lastFileDialogLocation", lastDir);
+    settings.setValue(qsl("lastFileDialogLocation"), lastDir);
 
     QStringList failedPackages;
 
     for (const QString& fileName : fileNames) {
-        if (mpHost->installPackage(fileName, enums::PackageModuleType::Package).first) {
+        auto [success, errorMsg] = mpHost->installPackage(fileName, enums::PackageModuleType::Package);
+        if (success) {
             mpHost->waitForProfileSave();
         } else {
-            failedPackages << QFileInfo(fileName).fileName();
+            const QString baseName = QFileInfo(fileName).fileName();
+            failedPackages << baseName;
+            qWarning() << "dlgTriggerEditor::slot_import() ERROR - failed to import" << baseName << ":" << errorMsg;
         }
     }
 
@@ -12813,7 +12816,7 @@ void dlgTriggerEditor::slot_import()
     slot_showTriggers();
 
     if (!failedPackages.isEmpty()) {
-        //: Trigger editor - status bar message shown when some packages failed to import. %1 is a comma-separated list of package names
+        //: Trigger editor - status message shown when some packages failed to import. %1 is a comma-separated list of package names
         statusBar()->showMessage(tr("Failed to import: %1").arg(failedPackages.join(qsl(", "))), std::chrono::milliseconds(4s).count());
     }
 }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -12774,7 +12774,8 @@ void dlgTriggerEditor::slot_import()
     QSettings& settings = *mudlet::getQSettings();
     QString lastDir = settings.value(qsl("lastFileDialogLocation"), QDir::homePath()).toString();
     //: Trigger editor - import packages from file dialog (multi-select enabled)
-    const QStringList fileNames = QFileDialog::getOpenFileNames(this, tr("Import Mudlet Package"), lastDir);
+    //: Trigger editor - file filter for supported package types (mpackage, zip, xml)
+    const QStringList fileNames = QFileDialog::getOpenFileNames(this, tr("Import Mudlet Package"), lastDir, tr("Mudlet Packages (*.mpackage *.zip *.xml)"));
     if (fileNames.isEmpty()) {
         return;
     }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -12787,6 +12787,7 @@ void dlgTriggerEditor::slot_import()
     for (const QString& fileName : fileNames) {
         if (mpHost->installPackage(fileName, enums::PackageModuleType::Package).first) {
             ++successCount;
+            mpHost->waitForProfileSave();
         } else {
             ++failureCount;
         }

--- a/src/ui/module_manager.ui
+++ b/src/ui/module_manager.ui
@@ -16,7 +16,7 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <layout class="QGridLayout" name="gridLayout" rowstretch="1,0,0" rowminimumheight="0,230,0">
+  <layout class="QGridLayout" name="gridLayout" rowstretch="1,0,0,0" rowminimumheight="0,230,0,0">
    <item row="0" column="0" colspan="2">
     <widget class="QTableWidget" name="moduleTable">
      <property name="sizePolicy">
@@ -91,7 +91,26 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="2" column="0" colspan="2">
+    <widget class="QLabel" name="label_importStatus">
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string notr="true"/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -104,7 +123,7 @@
      </property>
     </spacer>
    </item>
-   <item row="2" column="1">
+   <item row="3" column="1">
     <widget class="QWidget" name="widget_2" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Maximum">

--- a/src/ui/package_manager.ui
+++ b/src/ui/package_manager.ui
@@ -117,6 +117,25 @@
       </widget>
      </item>
      <item>
+      <widget class="QLabel" name="label_importStatus">
+       <property name="visible">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <widget class="QPushButton" name="pushButton_installRepo">


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Enable selecting multiple files at once in Package Manager, Module Manager, and Trigger Editor import dialogs.

#### Motivation for adding to Mudlet
Saves time when importing multiple packages/modules by eliminating repeated dialog interactions.

#### Other info (issues closed, discussion etc)
Closes #607

**Test case:**
- Package Manager: "Install from file" > select multiple .mpackage files > verify all appear in list
- Module Manager: "Install" > select multiple module files > verify all appear in table
- Trigger Editor: Edit menu > Import > select multiple .xml files > verify items imported
- Cancel dialog or select 0 files > verify no action taken
- Include an invalid file > verify error message appears and auto-hides after 4 seconds