### PR TITLE
improve: Allow nil to clear label callbacks

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1557,7 +1557,6 @@ int TLuaInterpreter::setLabelCallback(lua_State* L, const QString& funcName)
 
     int func = 0;
     if (lua_isnil(L, 1)) {
-        // Passing nil clears the callback - see https://github.com/Mudlet/Mudlet/issues/823
         lua_pop(L, 1);
     } else if (lua_isfunction(L, 1)) {
         func = luaL_ref(L, LUA_REGISTRYINDEX);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1555,11 +1555,16 @@ int TLuaInterpreter::setLabelCallback(lua_State* L, const QString& funcName)
     }
     lua_remove(L, 1);
 
-    if (!lua_isfunction(L, 1)) {
-        lua_pushfstring(L, "%s: bad argument #2 type (function expected, got %s!)", funcName.toUtf8().constData(), luaL_typename(L, 1));
+    int func = 0;
+    if (lua_isnil(L, 1)) {
+        // Passing nil clears the callback - see https://github.com/Mudlet/Mudlet/issues/823
+        lua_pop(L, 1);
+    } else if (lua_isfunction(L, 1)) {
+        func = luaL_ref(L, LUA_REGISTRYINDEX);
+    } else {
+        lua_pushfstring(L, "%s: bad argument #2 type (function or nil expected, got %s!)", funcName.toUtf8().constData(), luaL_typename(L, 1));
         return lua_error(L);
     }
-    const int func = luaL_ref(L, LUA_REGISTRYINDEX);
 
     bool lua_result = false;
     if (funcName == qsl("setLabelClickCallback")) {

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -2647,6 +2647,9 @@ end
 -- setCallBackFunction (name,function as string,args)
 -- it is used by setLabelCallBack functions and setCmdLineAction
 local function setActionCallback(callbackFunc, funcName, name, func, ...)
+  if func == nil then
+    return callbackFunc(name, nil)
+  end
   local nr = arg.n + 1
   arg.n = arg.n + 1
   if type(func) == "string" then

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -2647,7 +2647,7 @@ end
 -- setCallBackFunction (name,function as string,args)
 -- it is used by setLabelCallBack functions and setCmdLineAction
 local function setActionCallback(callbackFunc, funcName, name, func, ...)
-  if func == nil then
+  if func == nil and funcName ~= "setCmdLineAction" then
     return callbackFunc(name, nil)
   end
   local nr = arg.n + 1

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -1118,9 +1118,6 @@ function Geyser.Label:new2 (cons, container)
   return me
 end
 
-function fakeFunction()
-end
-
 --- internal function that adds the "More..." scrollbars
 function Geyser.Label:addScrollbars(parent, layout)
   local label = parent.nestedLabels[1]
@@ -1182,19 +1179,6 @@ function Geyser.Label:addChild(cons, container)
   me.nestParent = self
   me:setOnEnter("doNestEnter", me)
   me:setOnLeave("doNestLeave", me)
-
-  if not me.clickCallback then
-    --used in instances where an element only meant to serve as
-    --a nest container is clicked on.  Without this, we get
-    --seg faults
-    me:setClickCallback("fakeFunction")
-  end
-  if not me.releaseCallback then
-    --used in instances where an element only meant to serve as
-    --a nest container is released over.  Without this, we get
-    --seg faults
-    me:setReleaseCallback("fakeFunction")
-  end
 
   me.flyDir = flyDir
   me.layoutDir = layoutDir

--- a/src/mudlet-lua/tests/UI_spec.lua
+++ b/src/mudlet-lua/tests/UI_spec.lua
@@ -1244,4 +1244,38 @@ describe("Tests UI functions", function()
     assert.are.equal(selection, "Qux")
     deselect()
   end)
+
+  -- Tests for label callback functions accepting nil to clear callbacks
+  -- See: https://github.com/Mudlet/Mudlet/issues/823
+  describe("label callback functions accept nil", function()
+    local testLabelName = "testCallbackLabel"
+
+    setup(function()
+      createLabel(testLabelName, 0, 0, 100, 100, 1)
+    end)
+
+    teardown(function()
+      deleteLabel(testLabelName)
+    end)
+
+    it("setLabelClickCallback accepts nil to clear callback", function()
+      setLabelClickCallback(testLabelName, function() end)
+      assert.is_true(setLabelClickCallback(testLabelName, nil))
+    end)
+
+    it("setLabelOnEnter accepts nil to clear callback", function()
+      setLabelOnEnter(testLabelName, function() end)
+      assert.is_true(setLabelOnEnter(testLabelName, nil))
+    end)
+
+    it("setLabelOnLeave accepts nil to clear callback", function()
+      setLabelOnLeave(testLabelName, function() end)
+      assert.is_true(setLabelOnLeave(testLabelName, nil))
+    end)
+
+    it("setLabelReleaseCallback accepts nil to clear callback", function()
+      setLabelReleaseCallback(testLabelName, function() end)
+      assert.is_true(setLabelReleaseCallback(testLabelName, nil))
+    end)
+  end)
 end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Label callback functions now accept nil to clear callbacks, removing the need for empty function workarounds

#### Motivation for adding to Mudlet
Allows users to clear label callbacks using the natural Lua idiom `setLabelClickCallback("label", nil)` instead of requiring empty functions.

#### Other info (issues closed, discussion etc)
Fixes #823

**Test case:** Create a label, set a click callback, then call `setLabelClickCallback("labelName", nil)` - should return true without error.