### PR TITLE
infrastructure: Apply clang-format to all CPP files

### DIFF
--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -532,7 +532,8 @@ void ActionUnit::constructToolbar(TAction* pAction, TToolBar* pToolBar)
     pToolBar->setFeatures(QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
     if (pAction->mLocation == 4) {
         if (pAction->mToolbarLastDockArea == Qt::NoDockWidgetArea) {
-            qWarning() << "ActionUnit::constructToolbar(TAction*, TToolBar*) WARNING - no last dockarea was set for the TAction (\"" << pAction->getName() << "\"), for this toolbar forcing it to the Left one!";
+            qWarning() << "ActionUnit::constructToolbar(TAction*, TToolBar*) WARNING - no last dockarea was set for the TAction (\"" << pAction->getName()
+                       << "\"), for this toolbar forcing it to the Left one!";
         }
         mudlet::self()->addDockWidget(((pAction->mToolbarLastDockArea != Qt::NoDockWidgetArea) ? pAction->mToolbarLastDockArea : Qt::LeftDockWidgetArea), pToolBar);
         if (pAction->mToolbarLastFloatingState) {

--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -58,7 +58,7 @@ void AliasUnit::_uninstall(TAlias* pChild, const QString& packageName)
 }
 
 
-void AliasUnit::uninstall(const QString &packageName)
+void AliasUnit::uninstall(const QString& packageName)
 {
     for (auto rootAlias : mAliasRootNodeList) {
         if (rootAlias->mPackageName == packageName) {
@@ -400,15 +400,9 @@ std::tuple<QString, int, int, int> AliasUnit::assembleReport()
         assembleReport(pItem);
     }
     QStringList msg;
-    msg << QLatin1String("Aliases current total: ") << QString::number(statsItemsTotal) << QLatin1String("\n")
-        << QLatin1String("tempAliases current total: ") << QString::number(statsTempItems) << QLatin1String("\n")
-        << QLatin1String("active Aliases: ") << QString::number(statsActiveItems) << QLatin1String("\n");
-    return {
-        msg.join(QString()),
-        statsItemsTotal,
-        statsTempItems,
-        statsActiveItems
-    };
+    msg << QLatin1String("Aliases current total: ") << QString::number(statsItemsTotal) << QLatin1String("\n") << QLatin1String("tempAliases current total: ") << QString::number(statsTempItems)
+        << QLatin1String("\n") << QLatin1String("active Aliases: ") << QString::number(statsActiveItems) << QLatin1String("\n");
+    return {msg.join(QString()), statsItemsTotal, statsTempItems, statsActiveItems};
 }
 
 void AliasUnit::doCleanup()

--- a/src/AltFocusMenuBarDisable.cpp
+++ b/src/AltFocusMenuBarDisable.cpp
@@ -25,11 +25,12 @@ AltFocusMenuBarDisable::AltFocusMenuBarDisable()
     setObjectName(baseStyle()->objectName());
 }
 
-AltFocusMenuBarDisable::AltFocusMenuBarDisable(const QString &style)
+AltFocusMenuBarDisable::AltFocusMenuBarDisable(const QString& style)
 : QProxyStyle(QStyleFactory::create(style))
-{}
+{
+}
 
-int AltFocusMenuBarDisable::styleHint(StyleHint styleHint, const QStyleOption *opt, const QWidget *widget, QStyleHintReturn *returnData) const
+int AltFocusMenuBarDisable::styleHint(StyleHint styleHint, const QStyleOption* opt, const QWidget* widget, QStyleHintReturn* returnData) const
 {
     if (styleHint == QStyle::SH_MenuBar_AltKeyNavigation) {
         return 0;

--- a/src/CameraController.cpp
+++ b/src/CameraController.cpp
@@ -36,16 +36,16 @@ void CameraController::setPosition(float r, float theta, float phi)
 {
     // convert from degrees into radians
     theta = qBound(2.0f, theta, 82.0f);
-    theta = theta/360 * 2 * pi;
-    phi = phi/360 * 2 * pi;
+    theta = theta / 360 * 2 * pi;
+    phi = phi / 360 * 2 * pi;
 
     mDistance = r;
     mPositionVector.setX(std::sin(theta) * std::cos(phi));
     mPositionVector.setY(std::sin(theta) * std::sin(phi));
     mPositionVector.setZ(std::cos(theta));
-    mUpVector.setX(std::sin(theta - pi/2) * std::cos(phi));
-    mUpVector.setY(std::sin(theta - pi/2) * std::sin(phi));
-    mUpVector.setZ(std::cos(theta - pi/2));
+    mUpVector.setX(std::sin(theta - pi / 2) * std::cos(phi));
+    mUpVector.setY(std::sin(theta - pi / 2) * std::sin(phi));
+    mUpVector.setZ(std::cos(theta - pi / 2));
     mRightVector = QVector3D::crossProduct(mPositionVector, mUpVector);
 }
 
@@ -132,9 +132,8 @@ QVector3D CameraController::rotateAround(QVector3D currentVector, QVector3D rota
     // convert degrees to radians
     rotationAngle = rotationAngle / 360 * 2 * pi;
     // Apply Rodrigues rotation formula
-    return std::cos(rotationAngle) * currentVector
-        + std::sin(rotationAngle) * QVector3D::crossProduct(rotationAxis, currentVector)
-        + QVector3D::dotProduct(rotationAxis, currentVector) * (1 - std::cos(rotationAngle)) * rotationAxis;
+    return std::cos(rotationAngle) * currentVector + std::sin(rotationAngle) * QVector3D::crossProduct(rotationAxis, currentVector)
+           + QVector3D::dotProduct(rotationAxis, currentVector) * (1 - std::cos(rotationAngle)) * rotationAxis;
 }
 
 QVector3D CameraController::getPosition()

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -43,7 +43,7 @@
 class mudlet;
 
 CredentialManager::CredentialManager(QObject* parent)
-    : QObject(parent)
+: QObject(parent)
 {
 }
 
@@ -206,8 +206,7 @@ bool CredentialManager::shouldUseKeychain(const QString& profileName) const
     return true;
 }
 
-void CredentialManager::storePassword(const QString& profileName, const QString& key,
-                                     const QString& password, CredentialCallback callback)
+void CredentialManager::storePassword(const QString& profileName, const QString& key, const QString& password, CredentialCallback callback)
 {
     if (profileName.isEmpty() || key.isEmpty()) {
         if (callback) {
@@ -242,8 +241,7 @@ void CredentialManager::storePassword(const QString& profileName, const QString&
     }
 }
 
-void CredentialManager::retrievePassword(const QString& profileName, const QString& key,
-                                        CredentialRetrievalCallback callback)
+void CredentialManager::retrievePassword(const QString& profileName, const QString& key, CredentialRetrievalCallback callback)
 {
     if (profileName.isEmpty() || key.isEmpty()) {
         if (callback) {
@@ -366,8 +364,7 @@ void CredentialManager::retrievePassword(const QString& profileName, const QStri
     }
 }
 
-void CredentialManager::removePassword(const QString& profileName, const QString& key,
-                                      CredentialCallback callback)
+void CredentialManager::removePassword(const QString& profileName, const QString& key, CredentialCallback callback)
 {
     if (profileName.isEmpty() || key.isEmpty()) {
         if (callback) {
@@ -415,8 +412,7 @@ void CredentialManager::removePassword(const QString& profileName, const QString
     }
 }
 
-void CredentialManager::migratePassword(const QString& profileName, const QString& key,
-                                       const QString& plaintextPassword, CredentialCallback callback)
+void CredentialManager::migratePassword(const QString& profileName, const QString& key, const QString& plaintextPassword, CredentialCallback callback)
 {
     if (profileName.isEmpty() || key.isEmpty() || plaintextPassword.isEmpty()) {
         if (callback) {
@@ -442,8 +438,7 @@ void CredentialManager::migratePassword(const QString& profileName, const QStrin
     storePassword(profileName, key, plaintextPassword, callback);
 }
 
-void CredentialManager::storeCredential(const QString& service, const QString& account,
-                                       const QString& password, CredentialCallback callback)
+void CredentialManager::storeCredential(const QString& service, const QString& account, const QString& password, CredentialCallback callback)
 {
     if (service.isEmpty() || account.isEmpty()) {
         if (callback) {
@@ -481,54 +476,58 @@ void CredentialManager::storeCredential(const QString& service, const QString& a
     setupTimeout();
 
     // Connect signals with queued connection for safety
-    connect(writeJob, &QKeychain::WritePasswordJob::finished, this, [this, writeJob, service, account, password]() {
-        // Early exit if operation is no longer valid
-        if (!isOperationValid()) {
-            qWarning() << "CredentialManager: Ignoring keychain callback - operation no longer valid";
-            writeJob->deleteLater();
-            return;
-        }
+    connect(
+            writeJob,
+            &QKeychain::WritePasswordJob::finished,
+            this,
+            [this, writeJob, service, account, password]() {
+                // Early exit if operation is no longer valid
+                if (!isOperationValid()) {
+                    qWarning() << "CredentialManager: Ignoring keychain callback - operation no longer valid";
+                    writeJob->deleteLater();
+                    return;
+                }
 
-        cleanupTimeout();
+                cleanupTimeout();
 
-        bool success = (writeJob->error() == QKeychain::NoError);
-        QString errorMessage = success ? QString() : writeJob->errorString();
+                bool success = (writeJob->error() == QKeychain::NoError);
+                QString errorMessage = success ? QString() : writeJob->errorString();
 
-        // If keychain failed, try file storage fallback
-        if (!success) {
-            qDebug() << "CredentialManager: Keychain storage failed, using encrypted file storage:" << errorMessage;
+                // If keychain failed, try file storage fallback
+                if (!success) {
+                    qDebug() << "CredentialManager: Keychain storage failed, using encrypted file storage:" << errorMessage;
 
-            // Use service as profile name and account as key for file storage
-            bool fileSuccess = storeCredentialToFile(service, account, password);
+                    // Use service as profile name and account as key for file storage
+                    bool fileSuccess = storeCredentialToFile(service, account, password);
 
-            if (fileSuccess) {
-                success = true;
-                errorMessage = QString(); // Clear error message on successful fallback
-                qDebug() << "CredentialManager: Password stored to encrypted file storage";
-            } else {
-                errorMessage = qsl("Both keychain and encrypted file storage failed. Keychain error: %1").arg(errorMessage);
-            }
-        } else {
-            qDebug() << "CredentialManager: Password stored to keychain service:" << service;
-        }
+                    if (fileSuccess) {
+                        success = true;
+                        errorMessage = QString(); // Clear error message on successful fallback
+                        qDebug() << "CredentialManager: Password stored to encrypted file storage";
+                    } else {
+                        errorMessage = qsl("Both keychain and encrypted file storage failed. Keychain error: %1").arg(errorMessage);
+                    }
+                } else {
+                    qDebug() << "CredentialManager: Password stored to keychain service:" << service;
+                }
 
-        // Final validity check before calling callback
-        if (mCurrentCallback && isOperationValid()) {
-            auto callback = mCurrentCallback; // Copy callback to avoid use-after-free
-            mCurrentCallback = nullptr;
-            mCurrentJob = nullptr;
+                // Final validity check before calling callback
+                if (mCurrentCallback && isOperationValid()) {
+                    auto callback = mCurrentCallback; // Copy callback to avoid use-after-free
+                    mCurrentCallback = nullptr;
+                    mCurrentJob = nullptr;
 
-            callback(success, errorMessage);
-        }
+                    callback(success, errorMessage);
+                }
 
-        writeJob->deleteLater();
-    }, Qt::QueuedConnection); // Use queued connection for additional safety
+                writeJob->deleteLater();
+            },
+            Qt::QueuedConnection); // Use queued connection for additional safety
 
     writeJob->start();
 }
 
-void CredentialManager::retrieveCredential(const QString& service, const QString& account,
-                                          CredentialRetrievalCallback callback)
+void CredentialManager::retrieveCredential(const QString& service, const QString& account, CredentialRetrievalCallback callback)
 {
     if (service.isEmpty() || account.isEmpty()) {
         if (callback) {
@@ -563,176 +562,182 @@ void CredentialManager::retrieveCredential(const QString& service, const QString
     setupTimeout();
 
     // Connect signals with queued connection for safety
-    connect(readJob, &QKeychain::ReadPasswordJob::finished, this, [this, readJob, service, account]() {
-        // Early exit if operation is no longer valid
-        if (!isOperationValid()) {
-            qWarning() << "CredentialManager: Ignoring keychain callback - operation no longer valid";
-            readJob->deleteLater();
-            return;
-        }
+    connect(
+            readJob,
+            &QKeychain::ReadPasswordJob::finished,
+            this,
+            [this, readJob, service, account]() {
+                // Early exit if operation is no longer valid
+                if (!isOperationValid()) {
+                    qWarning() << "CredentialManager: Ignoring keychain callback - operation no longer valid";
+                    readJob->deleteLater();
+                    return;
+                }
 
-        cleanupTimeout();
+                cleanupTimeout();
 
-        bool success = (readJob->error() == QKeychain::NoError);
-        QString password;
-        QString errorMessage;
+                bool success = (readJob->error() == QKeychain::NoError);
+                QString password;
+                QString errorMessage;
 
-        if (success) {
-            // Get password directly from keychain (keychain handles decryption)
-            password = readJob->textData();
-            // No additional decryption needed for keychain passwords
-            qDebug() << "CredentialManager: Retrieved password from keychain service:" << service;
-        } else {
-            // Keychain failed, try file storage fallback with specific error context
-            QString errorContext;
-            switch (readJob->error()) {
-                case QKeychain::EntryNotFound:
-                    errorContext = "No password stored in keychain";
-                    break;
-                case QKeychain::AccessDeniedByUser:
-                    errorContext = "User denied keychain access";
-                    break;
-                case QKeychain::AccessDenied:
-                    errorContext = "Keychain access denied by system";
-                    break;
-                case QKeychain::NoBackendAvailable:
-                    errorContext = "No keychain service available";
-                    break;
-                case QKeychain::NotImplemented:
-                    errorContext = "Keychain not supported on this platform";
-                    break;
-                default:
-                    errorContext = qsl("Keychain error: %1").arg(readJob->errorString());
-                    break;
-            }
-            qDebug() << "CredentialManager:" << errorContext << ", trying fallback storage";
+                if (success) {
+                    // Get password directly from keychain (keychain handles decryption)
+                    password = readJob->textData();
+                    // No additional decryption needed for keychain passwords
+                    qDebug() << "CredentialManager: Retrieved password from keychain service:" << service;
+                } else {
+                    // Keychain failed, try file storage fallback with specific error context
+                    QString errorContext;
+                    switch (readJob->error()) {
+                    case QKeychain::EntryNotFound:
+                        errorContext = "No password stored in keychain";
+                        break;
+                    case QKeychain::AccessDeniedByUser:
+                        errorContext = "User denied keychain access";
+                        break;
+                    case QKeychain::AccessDenied:
+                        errorContext = "Keychain access denied by system";
+                        break;
+                    case QKeychain::NoBackendAvailable:
+                        errorContext = "No keychain service available";
+                        break;
+                    case QKeychain::NotImplemented:
+                        errorContext = "Keychain not supported on this platform";
+                        break;
+                    default:
+                        errorContext = qsl("Keychain error: %1").arg(readJob->errorString());
+                        break;
+                    }
+                    qDebug() << "CredentialManager:" << errorContext << ", trying fallback storage";
 
-            // Try legacy keychain format if this is a character password and service follows new format
-            if (account == "character" && service.startsWith("Mudlet-") && service.endsWith("-character")) {
-                // Extract profile name from service (format: "Mudlet-ProfileName-character")
-                QString profileName = service.mid(7); // Remove "Mudlet-" prefix
-                profileName.chop(10); // Remove "-character" suffix
+                    // Try legacy keychain format if this is a character password and service follows new format
+                    if (account == "character" && service.startsWith("Mudlet-") && service.endsWith("-character")) {
+                        // Extract profile name from service (format: "Mudlet-ProfileName-character")
+                        QString profileName = service.mid(7); // Remove "Mudlet-" prefix
+                        profileName.chop(10);                 // Remove "-character" suffix
 
-                qDebug() << "CredentialManager: Checking for legacy keychain format for profile" << profileName;
+                        qDebug() << "CredentialManager: Checking for legacy keychain format for profile" << profileName;
 
-                // Capture the error string now while readJob is still valid
-                QString keychainError = readJob->errorString();
+                        // Capture the error string now while readJob is still valid
+                        QString keychainError = readJob->errorString();
 
-                // Check legacy keychain format asynchronously
-                auto* legacyReadJob = new QKeychain::ReadPasswordJob("Mudlet profile", this);
-                legacyReadJob->setKey(profileName);
-                legacyReadJob->setAutoDelete(false);
+                        // Check legacy keychain format asynchronously
+                        auto* legacyReadJob = new QKeychain::ReadPasswordJob("Mudlet profile", this);
+                        legacyReadJob->setKey(profileName);
+                        legacyReadJob->setAutoDelete(false);
 
-                // Store the current callback and clear it to prevent double-calling
-                auto originalCallback = mCurrentRetrievalCallback;
-                mCurrentRetrievalCallback = nullptr;
+                        // Store the current callback and clear it to prevent double-calling
+                        auto originalCallback = mCurrentRetrievalCallback;
+                        mCurrentRetrievalCallback = nullptr;
 
-                connect(legacyReadJob, &QKeychain::ReadPasswordJob::finished, this, [this, legacyReadJob, profileName, service, account, originalCallback, keychainError]() {
-                    bool legacyFound = (legacyReadJob->error() == QKeychain::NoError);
-                    QString legacyPassword = legacyFound ? legacyReadJob->textData() : QString();
+                        connect(legacyReadJob, &QKeychain::ReadPasswordJob::finished, this, [this, legacyReadJob, profileName, service, account, originalCallback, keychainError]() {
+                            bool legacyFound = (legacyReadJob->error() == QKeychain::NoError);
+                            QString legacyPassword = legacyFound ? legacyReadJob->textData() : QString();
 
-                    if (legacyFound && !legacyPassword.isEmpty()) {
-                        qDebug() << "CredentialManager: Found legacy password for profile" << profileName;
+                            if (legacyFound && !legacyPassword.isEmpty()) {
+                                qDebug() << "CredentialManager: Found legacy password for profile" << profileName;
 
-                        // Migrate to new format asynchronously
-                        qDebug() << "CredentialManager: Migrating legacy password to new format for profile" << profileName;
+                                // Migrate to new format asynchronously
+                                qDebug() << "CredentialManager: Migrating legacy password to new format for profile" << profileName;
 
-                        // Extract original profile name and key from service name for migration
-                        QString originalProfileName = service.mid(7); // Remove "Mudlet-" prefix
-                        originalProfileName.chop(10); // Remove "-character" suffix
+                                // Extract original profile name and key from service name for migration
+                                QString originalProfileName = service.mid(7); // Remove "Mudlet-" prefix
+                                originalProfileName.chop(10);                 // Remove "-character" suffix
 
-                        // Store in new format
-                        auto* migrationManager = new CredentialManager();
-                        migrationManager->storePassword(originalProfileName, account, legacyPassword,
-                            [migrationManager, profileName, originalCallback, legacyPassword](bool migrationSuccess, const QString& migrationError) {
-                                if (migrationSuccess) {
-                                    qDebug() << "CredentialManager: Legacy migration successful for profile" << profileName;
+                                // Store in new format
+                                auto* migrationManager = new CredentialManager();
+                                migrationManager->storePassword(originalProfileName,
+                                                                account,
+                                                                legacyPassword,
+                                                                [migrationManager, profileName, originalCallback, legacyPassword](bool migrationSuccess, const QString& migrationError) {
+                                                                    if (migrationSuccess) {
+                                                                        qDebug() << "CredentialManager: Legacy migration successful for profile" << profileName;
 
-                                    // Clean up legacy entry if migration succeeded
+                                // Clean up legacy entry if migration succeeded
 #ifdef APP_VERSION
-                                    const QString currentVersion = QString(APP_VERSION);
-                                    const QVersionNumber appVersion = QVersionNumber::fromString(currentVersion);
-                                    const QVersionNumber secureStorageVersion = QVersionNumber(4, 20, 0);
+                                                                        const QString currentVersion = QString(APP_VERSION);
+                                                                        const QVersionNumber appVersion = QVersionNumber::fromString(currentVersion);
+                                                                        const QVersionNumber secureStorageVersion = QVersionNumber(4, 20, 0);
 
-                                    if (appVersion >= secureStorageVersion) {
-                                        // Clean up legacy entry asynchronously
-                                        auto* cleanupManager = new CredentialManager();
-                                        cleanupManager->deleteLegacyKeychainEntry(profileName);
-                                        cleanupManager->deleteLater();
-                                        qDebug() << "CredentialManager: Legacy cleanup initiated for version" << currentVersion;
-                                    } else {
-                                        qDebug() << "CredentialManager: Legacy cleanup skipped for version" << currentVersion;
-                                    }
+                                                                        if (appVersion >= secureStorageVersion) {
+                                                                            // Clean up legacy entry asynchronously
+                                                                            auto* cleanupManager = new CredentialManager();
+                                                                            cleanupManager->deleteLegacyKeychainEntry(profileName);
+                                                                            cleanupManager->deleteLater();
+                                                                            qDebug() << "CredentialManager: Legacy cleanup initiated for version" << currentVersion;
+                                                                        } else {
+                                                                            qDebug() << "CredentialManager: Legacy cleanup skipped for version" << currentVersion;
+                                                                        }
 #else
                                     qDebug() << "CredentialManager: Legacy cleanup skipped (test mode)";
 #endif
-                                } else {
-                                    qWarning() << "CredentialManager: Legacy migration failed for profile" << profileName << ":" << migrationError;
+                                                                    } else {
+                                                                        qWarning() << "CredentialManager: Legacy migration failed for profile" << profileName << ":" << migrationError;
+                                                                    }
+
+                                                                    // Return the legacy password regardless of migration result
+                                                                    if (originalCallback) {
+                                                                        originalCallback(true, legacyPassword, QString());
+                                                                    }
+
+                                                                    migrationManager->deleteLater();
+                                                                });
+                            } else {
+                                qDebug() << "CredentialManager: No legacy password found for profile" << profileName;
+
+                                // No legacy password, try file storage
+                                QString filePassword = retrieveCredentialFromFile(service, account);
+                                bool fileSuccess = !filePassword.isNull();
+                                QString finalError = fileSuccess ? QString() : qsl("Both keychain and encrypted file storage failed for credentials. Keychain: %1").arg(keychainError);
+
+                                if (fileSuccess) {
+                                    qDebug() << "CredentialManager: Retrieved password from encrypted file storage";
                                 }
 
-                                // Return the legacy password regardless of migration result
                                 if (originalCallback) {
-                                    originalCallback(true, legacyPassword, QString());
+                                    originalCallback(fileSuccess, filePassword, finalError);
                                 }
+                            }
 
-                                migrationManager->deleteLater();
-                            });
-                    } else {
-                        qDebug() << "CredentialManager: No legacy password found for profile" << profileName;
+                            legacyReadJob->deleteLater();
+                        });
 
-                        // No legacy password, try file storage
-                        QString filePassword = retrieveCredentialFromFile(service, account);
-                        bool fileSuccess = !filePassword.isNull();
-                        QString finalError = fileSuccess ? QString() : qsl("Both keychain and encrypted file storage failed for credentials. Keychain: %1").arg(keychainError);
+                        legacyReadJob->start();
 
-                        if (fileSuccess) {
-                            qDebug() << "CredentialManager: Retrieved password from encrypted file storage";
-                        }
-
-                        if (originalCallback) {
-                            originalCallback(fileSuccess, filePassword, finalError);
-                        }
+                        // Early return to avoid the file storage check below
+                        readJob->deleteLater();
+                        return;
                     }
 
-                    legacyReadJob->deleteLater();
-                });
+                    // Not a character password or not new format, try file storage directly
+                    password = retrieveCredentialFromFile(service, account);
 
-                legacyReadJob->start();
+                    if (!password.isNull()) {
+                        success = true;
+                        errorMessage = QString(); // Clear error message on successful fallback
+                        qDebug() << "CredentialManager: Retrieved password from encrypted file storage";
+                    } else {
+                        errorMessage = qsl("Both keychain and encrypted file storage failed for credentials. Keychain: %1").arg(readJob->errorString());
+                    }
+                }
 
-                // Early return to avoid the file storage check below
+                // Final validity check before calling callback
+                if (mCurrentRetrievalCallback && isOperationValid()) {
+                    auto callback = mCurrentRetrievalCallback; // Copy callback to avoid use-after-free
+                    mCurrentRetrievalCallback = nullptr;
+                    mCurrentJob = nullptr;
+
+                    callback(success, password, errorMessage);
+                }
+
                 readJob->deleteLater();
-                return;
-            }
-
-            // Not a character password or not new format, try file storage directly
-            password = retrieveCredentialFromFile(service, account);
-
-            if (!password.isNull()) {
-                success = true;
-                errorMessage = QString(); // Clear error message on successful fallback
-                qDebug() << "CredentialManager: Retrieved password from encrypted file storage";
-            } else {
-                errorMessage = qsl("Both keychain and encrypted file storage failed for credentials. Keychain: %1").arg(readJob->errorString());
-            }
-        }
-
-        // Final validity check before calling callback
-        if (mCurrentRetrievalCallback && isOperationValid()) {
-            auto callback = mCurrentRetrievalCallback; // Copy callback to avoid use-after-free
-            mCurrentRetrievalCallback = nullptr;
-            mCurrentJob = nullptr;
-
-            callback(success, password, errorMessage);
-        }
-
-        readJob->deleteLater();
-    }, Qt::QueuedConnection); // Use queued connection for additional safety
+            },
+            Qt::QueuedConnection); // Use queued connection for additional safety
 
     readJob->start();
 }
 
-void CredentialManager::removeCredential(const QString& service, const QString& account,
-                                        CredentialCallback callback)
+void CredentialManager::removeCredential(const QString& service, const QString& account, CredentialCallback callback)
 {
     if (service.isEmpty() || account.isEmpty()) {
         if (callback) {
@@ -767,43 +772,47 @@ void CredentialManager::removeCredential(const QString& service, const QString& 
     setupTimeout();
 
     // Connect signals with queued connection for safety
-    connect(deleteJob, &QKeychain::DeletePasswordJob::finished, this, [this, deleteJob, service, account]() {
-        // Early exit if operation is no longer valid
-        if (!isOperationValid()) {
-            qWarning() << "CredentialManager: Ignoring keychain callback - operation no longer valid";
-            deleteJob->deleteLater();
-            return;
-        }
+    connect(
+            deleteJob,
+            &QKeychain::DeletePasswordJob::finished,
+            this,
+            [this, deleteJob, service, account]() {
+                // Early exit if operation is no longer valid
+                if (!isOperationValid()) {
+                    qWarning() << "CredentialManager: Ignoring keychain callback - operation no longer valid";
+                    deleteJob->deleteLater();
+                    return;
+                }
 
-        cleanupTimeout();
+                cleanupTimeout();
 
-        bool keychainSuccess = (deleteJob->error() == QKeychain::NoError ||
-                               deleteJob->error() == QKeychain::EntryNotFound);
+                bool keychainSuccess = (deleteJob->error() == QKeychain::NoError || deleteJob->error() == QKeychain::EntryNotFound);
 
-        // Always try to remove from file storage as well (for cleanup)
-        bool fileSuccess = removeCredentialFromFile(service, account);
+                // Always try to remove from file storage as well (for cleanup)
+                bool fileSuccess = removeCredentialFromFile(service, account);
 
-        // Consider success if either method succeeded
-        bool success = keychainSuccess || fileSuccess;
-        QString errorMessage;
+                // Consider success if either method succeeded
+                bool success = keychainSuccess || fileSuccess;
+                QString errorMessage;
 
-        if (!success) {
-            errorMessage = qsl("Failed to remove from both keychain and file storage. Keychain error: %1").arg(deleteJob->errorString());
-        } else if (!keychainSuccess) {
-            qDebug() << "Keychain removal failed but file removal succeeded:" << deleteJob->errorString();
-        }
+                if (!success) {
+                    errorMessage = qsl("Failed to remove from both keychain and file storage. Keychain error: %1").arg(deleteJob->errorString());
+                } else if (!keychainSuccess) {
+                    qDebug() << "Keychain removal failed but file removal succeeded:" << deleteJob->errorString();
+                }
 
-        // Final validity check before calling callback
-        if (mCurrentCallback && isOperationValid()) {
-            auto callback = mCurrentCallback; // Copy callback to avoid use-after-free
-            mCurrentCallback = nullptr;
-            mCurrentJob = nullptr;
+                // Final validity check before calling callback
+                if (mCurrentCallback && isOperationValid()) {
+                    auto callback = mCurrentCallback; // Copy callback to avoid use-after-free
+                    mCurrentCallback = nullptr;
+                    mCurrentJob = nullptr;
 
-            callback(success, errorMessage);
-        }
+                    callback(success, errorMessage);
+                }
 
-        deleteJob->deleteLater();
-    }, Qt::QueuedConnection); // Use queued connection for additional safety
+                deleteJob->deleteLater();
+            },
+            Qt::QueuedConnection); // Use queued connection for additional safety
 
     deleteJob->start();
 }
@@ -842,37 +851,41 @@ void CredentialManager::isKeychainAvailable(AvailabilityCallback callback)
     setupTimeout();
 
     // Connect signals with queued connection for safety
-    connect(testJob, &QKeychain::ReadPasswordJob::finished, this, [this, testJob]() {
-        // Early exit if operation is no longer valid
-        if (!isOperationValid()) {
-            qWarning() << "CredentialManager: Ignoring keychain callback - operation no longer valid";
-            testJob->deleteLater();
-            return;
-        }
+    connect(
+            testJob,
+            &QKeychain::ReadPasswordJob::finished,
+            this,
+            [this, testJob]() {
+                // Early exit if operation is no longer valid
+                if (!isOperationValid()) {
+                    qWarning() << "CredentialManager: Ignoring keychain callback - operation no longer valid";
+                    testJob->deleteLater();
+                    return;
+                }
 
-        cleanupTimeout();
+                cleanupTimeout();
 
-        bool available = true;
-        QString message = "Keychain is available";
+                bool available = true;
+                QString message = "Keychain is available";
 
-        // Check for specific errors that indicate keychain is not available
-        if (testJob->error() == QKeychain::AccessDenied ||
-            testJob->error() == QKeychain::OtherError) {
-            available = false;
-            message = qsl("Keychain not available: %1").arg(testJob->errorString());
-        }
+                // Check for specific errors that indicate keychain is not available
+                if (testJob->error() == QKeychain::AccessDenied || testJob->error() == QKeychain::OtherError) {
+                    available = false;
+                    message = qsl("Keychain not available: %1").arg(testJob->errorString());
+                }
 
-        // Final validity check before calling callback
-        if (mCurrentAvailabilityCallback && isOperationValid()) {
-            auto callback = mCurrentAvailabilityCallback; // Copy callback to avoid use-after-free
-            mCurrentAvailabilityCallback = nullptr;
-            mCurrentJob = nullptr;
+                // Final validity check before calling callback
+                if (mCurrentAvailabilityCallback && isOperationValid()) {
+                    auto callback = mCurrentAvailabilityCallback; // Copy callback to avoid use-after-free
+                    mCurrentAvailabilityCallback = nullptr;
+                    mCurrentJob = nullptr;
 
-            callback(available, message);
-        }
+                    callback(available, message);
+                }
 
-        testJob->deleteLater();
-    }, Qt::QueuedConnection); // Use queued connection for additional safety
+                testJob->deleteLater();
+            },
+            Qt::QueuedConnection); // Use queued connection for additional safety
 
     testJob->start();
 }
@@ -1133,8 +1146,7 @@ bool CredentialManager::isValidKeyName(const QString& key)
     return !key.contains(dangerousPattern);
 }
 
-void CredentialManager::checkLegacyKeychainFormat(const QString& profileName,
-                                                 std::function<void(bool, const QString&)> callback)
+void CredentialManager::checkLegacyKeychainFormat(const QString& profileName, std::function<void(bool, const QString&)> callback)
 {
     if (profileName.isEmpty() || !callback) {
         if (callback) {

--- a/src/CustomLineSession.cpp
+++ b/src/CustomLineSession.cpp
@@ -175,11 +175,11 @@ void CustomLineSession::clearOriginalPoints()
 std::optional<CustomLineSession::LineKey> CustomLineSession::currentLineKey() const
 {
     if (mMapWidget.mCustomLineSelectedRoom > 0 && !mMapWidget.mCustomLineSelectedExit.isEmpty()) {
-        return LineKey { mMapWidget.mCustomLineSelectedRoom, mMapWidget.mCustomLineSelectedExit };
+        return LineKey{mMapWidget.mCustomLineSelectedRoom, mMapWidget.mCustomLineSelectedExit};
     }
 
     if (mMapWidget.mCustomLinesRoomFrom > 0 && !mMapWidget.mCustomLinesRoomExit.isEmpty()) {
-        return LineKey { mMapWidget.mCustomLinesRoomFrom, mMapWidget.mCustomLinesRoomExit };
+        return LineKey{mMapWidget.mCustomLinesRoomFrom, mMapWidget.mCustomLinesRoomExit};
     }
 
     return std::nullopt;
@@ -211,7 +211,7 @@ void CustomLineSession::rememberOriginalLine(const LineKey& key, const QList<QPo
         return;
     }
 
-    mOriginalLine = OriginalLine { key, points };
+    mOriginalLine = OriginalLine{key, points};
 }
 
 void CustomLineSession::snapLineToGrid(LineKey key, QList<QPointF>& points, TRoom& room)
@@ -319,4 +319,3 @@ std::optional<int> CustomLineSession::resolveCustomLineTargetRoomId(const TRoom&
 
     return std::nullopt;
 }
-

--- a/src/DarkTheme.cpp
+++ b/src/DarkTheme.cpp
@@ -24,11 +24,13 @@
 //DarkTheme only works with Fusion style
 DarkTheme::DarkTheme()
 : DarkTheme(new AltFocusMenuBarDisable(qsl("Fusion")))
-{}
+{
+}
 
 DarkTheme::DarkTheme(QStyle* style)
 : QProxyStyle(style)
-{}
+{
+}
 
 void DarkTheme::polish(QPalette& palette)
 {

--- a/src/EditorAddItemCommand.cpp
+++ b/src/EditorAddItemCommand.cpp
@@ -642,4 +642,3 @@ QString EditorAddItemCommand::generateText(EditorViewType viewType, const QStrin
         }
     }
 }
-

--- a/src/EditorDeleteItemCommand.cpp
+++ b/src/EditorDeleteItemCommand.cpp
@@ -31,7 +31,9 @@
 #include <algorithm>
 
 EditorDeleteItemCommand::EditorDeleteItemCommand(EditorViewType viewType, const QList<DeletedItemInfo>& deletedItems, Host* host)
-: EditorCommand(generateText(viewType, deletedItems.size(), deletedItems.isEmpty() ? QString() : deletedItems.first().itemName), host), mViewType(viewType), mDeletedItems(deletedItems)
+: EditorCommand(generateText(viewType, deletedItems.size(), deletedItems.isEmpty() ? QString() : deletedItems.first().itemName), host)
+, mViewType(viewType)
+, mDeletedItems(deletedItems)
 {
 }
 
@@ -67,7 +69,9 @@ void EditorDeleteItemCommand::undo()
                 canRestore = true;
             } else {
                 // Check if parent was also deleted
-                bool parentWasDeleted = std::any_of(mDeletedItems.begin(), mDeletedItems.end(), [&item](const DeletedItemInfo& info) { return info.itemID == item.parentID; });
+                bool parentWasDeleted = std::any_of(mDeletedItems.begin(), mDeletedItems.end(), [&item](const DeletedItemInfo& info) {
+                    return info.itemID == item.parentID;
+                });
                 if (parentWasDeleted) {
                     // Parent was deleted - check if it's already been processed
                     if (processedIDs.contains(item.parentID)) {
@@ -130,7 +134,9 @@ void EditorDeleteItemCommand::undo()
         }
 
         // Find the corresponding item in mDeletedItems to update the ID
-        auto it = std::find_if(mDeletedItems.begin(), mDeletedItems.end(), [&info](const DeletedItemInfo& item) { return item.itemName == info.itemName && item.parentID == info.parentID; });
+        auto it = std::find_if(mDeletedItems.begin(), mDeletedItems.end(), [&info](const DeletedItemInfo& item) {
+            return item.itemName == info.itemName && item.parentID == info.parentID;
+        });
         if (it == mDeletedItems.end()) {
 #if defined(DEBUG_UNDO_REDO)
             qWarning() << "EditorDeleteItemCommand::undo() - Could not find item in original list:" << info.itemName << "with parentID=" << info.parentID;
@@ -722,7 +728,9 @@ void EditorDeleteItemCommand::redo()
         // Skip items whose parent is also in the deletion list
         // (they will be automatically deleted when the parent is deleted)
         if (info.parentID != -1) {
-            bool parentBeingDeleted = std::any_of(mDeletedItems.begin(), mDeletedItems.end(), [&info](const DeletedItemInfo& item) { return item.itemID == info.parentID; });
+            bool parentBeingDeleted = std::any_of(mDeletedItems.begin(), mDeletedItems.end(), [&info](const DeletedItemInfo& item) {
+                return item.itemID == info.parentID;
+            });
             if (parentBeingDeleted) {
                 continue; // Skip this item - it will be deleted by its parent
             }
@@ -736,9 +744,7 @@ void EditorDeleteItemCommand::redo()
             }
             if (trigger->getName() != info.itemName) {
 #if defined(DEBUG_UNDO_REDO)
-                qWarning() << "EditorDeleteItemCommand::redo() - Trigger ID" << info.itemID
-                           << "name changed from" << info.itemName << "to" << trigger->getName()
-                           << "- not deleting";
+                qWarning() << "EditorDeleteItemCommand::redo() - Trigger ID" << info.itemID << "name changed from" << info.itemName << "to" << trigger->getName() << "- not deleting";
 #endif
                 break;
             }
@@ -754,9 +760,7 @@ void EditorDeleteItemCommand::redo()
             }
             if (alias->getName() != info.itemName) {
 #if defined(DEBUG_UNDO_REDO)
-                qWarning() << "EditorDeleteItemCommand::redo() - Alias ID" << info.itemID
-                           << "name changed from" << info.itemName << "to" << alias->getName()
-                           << "- not deleting";
+                qWarning() << "EditorDeleteItemCommand::redo() - Alias ID" << info.itemID << "name changed from" << info.itemName << "to" << alias->getName() << "- not deleting";
 #endif
                 break;
             }
@@ -772,9 +776,7 @@ void EditorDeleteItemCommand::redo()
             }
             if (timer->getName() != info.itemName) {
 #if defined(DEBUG_UNDO_REDO)
-                qWarning() << "EditorDeleteItemCommand::redo() - Timer ID" << info.itemID
-                           << "name changed from" << info.itemName << "to" << timer->getName()
-                           << "- not deleting";
+                qWarning() << "EditorDeleteItemCommand::redo() - Timer ID" << info.itemID << "name changed from" << info.itemName << "to" << timer->getName() << "- not deleting";
 #endif
                 break;
             }
@@ -790,9 +792,7 @@ void EditorDeleteItemCommand::redo()
             }
             if (script->getName() != info.itemName) {
 #if defined(DEBUG_UNDO_REDO)
-                qWarning() << "EditorDeleteItemCommand::redo() - Script ID" << info.itemID
-                           << "name changed from" << info.itemName << "to" << script->getName()
-                           << "- not deleting";
+                qWarning() << "EditorDeleteItemCommand::redo() - Script ID" << info.itemID << "name changed from" << info.itemName << "to" << script->getName() << "- not deleting";
 #endif
                 break;
             }
@@ -808,9 +808,7 @@ void EditorDeleteItemCommand::redo()
             }
             if (key->getName() != info.itemName) {
 #if defined(DEBUG_UNDO_REDO)
-                qWarning() << "EditorDeleteItemCommand::redo() - Key ID" << info.itemID
-                           << "name changed from" << info.itemName << "to" << key->getName()
-                           << "- not deleting";
+                qWarning() << "EditorDeleteItemCommand::redo() - Key ID" << info.itemID << "name changed from" << info.itemName << "to" << key->getName() << "- not deleting";
 #endif
                 break;
             }
@@ -826,9 +824,7 @@ void EditorDeleteItemCommand::redo()
             }
             if (action->getName() != info.itemName) {
 #if defined(DEBUG_UNDO_REDO)
-                qWarning() << "EditorDeleteItemCommand::redo() - Action ID" << info.itemID
-                           << "name changed from" << info.itemName << "to" << action->getName()
-                           << "- not deleting";
+                qWarning() << "EditorDeleteItemCommand::redo() - Action ID" << info.itemID << "name changed from" << info.itemName << "to" << action->getName() << "- not deleting";
 #endif
                 break;
             }

--- a/src/EditorItemXMLHelpers.cpp
+++ b/src/EditorItemXMLHelpers.cpp
@@ -44,7 +44,8 @@
 // =============================================================================
 
 // Internal helper functions for compression (static to keep them local to this file)
-static QString compressXML(const QString& xml) {
+static QString compressXML(const QString& xml)
+{
     if (xml.isEmpty()) {
         return QString();
     }
@@ -53,7 +54,8 @@ static QString compressXML(const QString& xml) {
     return QString::fromLatin1(compressed.toBase64());
 }
 
-static QString decompressXML(const QString& data) {
+static QString decompressXML(const QString& data)
+{
     if (data.isEmpty()) {
         return QString();
     }
@@ -73,7 +75,8 @@ static QString decompressXML(const QString& data) {
 }
 
 // XML Export/Import functions - used by both EditorUndoSystem and EditorAddItemCommand
-QString exportTriggerToXML(TTrigger* trigger) {
+QString exportTriggerToXML(TTrigger* trigger)
+{
     if (!trigger) {
         return QString();
     }
@@ -89,7 +92,8 @@ QString exportTriggerToXML(TTrigger* trigger) {
     return compressXML(QString::fromStdString(oss.str()));
 }
 
-QString exportAliasToXML(TAlias* alias) {
+QString exportAliasToXML(TAlias* alias)
+{
     if (!alias) {
         return QString();
     }
@@ -105,7 +109,8 @@ QString exportAliasToXML(TAlias* alias) {
     return compressXML(QString::fromStdString(oss.str()));
 }
 
-QString exportTimerToXML(TTimer* timer) {
+QString exportTimerToXML(TTimer* timer)
+{
     if (!timer) {
         return QString();
     }
@@ -121,7 +126,8 @@ QString exportTimerToXML(TTimer* timer) {
     return compressXML(QString::fromStdString(oss.str()));
 }
 
-QString exportScriptToXML(TScript* script) {
+QString exportScriptToXML(TScript* script)
+{
     if (!script) {
         return QString();
     }
@@ -137,7 +143,8 @@ QString exportScriptToXML(TScript* script) {
     return compressXML(QString::fromStdString(oss.str()));
 }
 
-QString exportKeyToXML(TKey* key) {
+QString exportKeyToXML(TKey* key)
+{
     if (!key) {
         return QString();
     }
@@ -153,7 +160,8 @@ QString exportKeyToXML(TKey* key) {
     return compressXML(QString::fromStdString(oss.str()));
 }
 
-QString exportActionToXML(TAction* action) {
+QString exportActionToXML(TAction* action)
+{
     if (!action) {
         return QString();
     }
@@ -169,7 +177,8 @@ QString exportActionToXML(TAction* action) {
     return compressXML(QString::fromStdString(oss.str()));
 }
 
-QString getItemName(EditorViewType viewType, int itemID, Host* host) {
+QString getItemName(EditorViewType viewType, int itemID, Host* host)
+{
     switch (viewType) {
     case EditorViewType::cmTriggerView: {
         TTrigger* trigger = host->getTriggerUnit()->getTrigger(itemID);
@@ -200,7 +209,8 @@ QString getItemName(EditorViewType viewType, int itemID, Host* host) {
     }
 }
 
-QString getViewTypeName(EditorViewType viewType) {
+QString getViewTypeName(EditorViewType viewType)
+{
     switch (viewType) {
     case EditorViewType::cmTriggerView:
         //: Display name for trigger items in editor
@@ -226,7 +236,8 @@ QString getViewTypeName(EditorViewType viewType) {
     }
 }
 
-TTrigger* importTriggerFromXML(const QString& xmlSnapshot, TTrigger* pParent, Host* host, int position) {
+TTrigger* importTriggerFromXML(const QString& xmlSnapshot, TTrigger* pParent, Host* host, int position)
+{
     if (xmlSnapshot.isEmpty() || !host) {
         return nullptr;
     }
@@ -355,7 +366,8 @@ TTrigger* importTriggerFromXML(const QString& xmlSnapshot, TTrigger* pParent, Ho
     return pT;
 }
 
-bool updateTriggerFromXML(TTrigger* pT, const QString& xmlSnapshot) {
+bool updateTriggerFromXML(TTrigger* pT, const QString& xmlSnapshot)
+{
     if (!pT || xmlSnapshot.isEmpty()) {
         return false;
     }
@@ -452,7 +464,8 @@ bool updateTriggerFromXML(TTrigger* pT, const QString& xmlSnapshot) {
 // =============================================================================
 
 // Import a single alias from XML string
-TAlias* importAliasFromXML(const QString& xmlSnapshot, TAlias* pParent, Host* host, int position) {
+TAlias* importAliasFromXML(const QString& xmlSnapshot, TAlias* pParent, Host* host, int position)
+{
     if (xmlSnapshot.isEmpty() || !host) {
         return nullptr;
     }
@@ -548,7 +561,8 @@ TAlias* importAliasFromXML(const QString& xmlSnapshot, TAlias* pParent, Host* ho
 }
 
 // Update an existing alias from XML string
-bool updateAliasFromXML(TAlias* pA, const QString& xmlSnapshot) {
+bool updateAliasFromXML(TAlias* pA, const QString& xmlSnapshot)
+{
     if (!pA || xmlSnapshot.isEmpty()) {
         return false;
     }
@@ -612,7 +626,8 @@ bool updateAliasFromXML(TAlias* pA, const QString& xmlSnapshot) {
 // =============================================================================
 
 // Import a single timer from XML string
-TTimer* importTimerFromXML(const QString& xmlSnapshot, TTimer* pParent, Host* host, int position) {
+TTimer* importTimerFromXML(const QString& xmlSnapshot, TTimer* pParent, Host* host, int position)
+{
     if (xmlSnapshot.isEmpty() || !host) {
         return nullptr;
     }
@@ -708,7 +723,8 @@ TTimer* importTimerFromXML(const QString& xmlSnapshot, TTimer* pParent, Host* ho
 }
 
 // Update an existing timer from XML string
-bool updateTimerFromXML(TTimer* pT, const QString& xmlSnapshot) {
+bool updateTimerFromXML(TTimer* pT, const QString& xmlSnapshot)
+{
     if (!pT || xmlSnapshot.isEmpty()) {
         return false;
     }
@@ -772,7 +788,8 @@ bool updateTimerFromXML(TTimer* pT, const QString& xmlSnapshot) {
 // =============================================================================
 
 // Import a single script from XML string
-TScript* importScriptFromXML(const QString& xmlSnapshot, TScript* pParent, Host* host, int position) {
+TScript* importScriptFromXML(const QString& xmlSnapshot, TScript* pParent, Host* host, int position)
+{
     if (xmlSnapshot.isEmpty() || !host) {
         return nullptr;
     }
@@ -873,7 +890,8 @@ TScript* importScriptFromXML(const QString& xmlSnapshot, TScript* pParent, Host*
 }
 
 // Update an existing script from XML string
-bool updateScriptFromXML(TScript* pS, const QString& xmlSnapshot) {
+bool updateScriptFromXML(TScript* pS, const QString& xmlSnapshot)
+{
     if (!pS || xmlSnapshot.isEmpty()) {
         return false;
     }
@@ -942,7 +960,8 @@ bool updateScriptFromXML(TScript* pS, const QString& xmlSnapshot) {
 // =============================================================================
 
 // Import a single key from XML string
-TKey* importKeyFromXML(const QString& xmlSnapshot, TKey* pParent, Host* host, int position) {
+TKey* importKeyFromXML(const QString& xmlSnapshot, TKey* pParent, Host* host, int position)
+{
     if (xmlSnapshot.isEmpty() || !host) {
         return nullptr;
     }
@@ -1039,7 +1058,8 @@ TKey* importKeyFromXML(const QString& xmlSnapshot, TKey* pParent, Host* host, in
 }
 
 // Update an existing key from XML string
-bool updateKeyFromXML(TKey* pK, const QString& xmlSnapshot) {
+bool updateKeyFromXML(TKey* pK, const QString& xmlSnapshot)
+{
     if (!pK || xmlSnapshot.isEmpty()) {
         return false;
     }
@@ -1104,7 +1124,8 @@ bool updateKeyFromXML(TKey* pK, const QString& xmlSnapshot) {
 // =============================================================================
 
 // Import a single action from XML string
-TAction* importActionFromXML(const QString& xmlSnapshot, TAction* pParent, Host* host, int position) {
+TAction* importActionFromXML(const QString& xmlSnapshot, TAction* pParent, Host* host, int position)
+{
     if (xmlSnapshot.isEmpty() || !host) {
         return nullptr;
     }
@@ -1224,7 +1245,8 @@ TAction* importActionFromXML(const QString& xmlSnapshot, TAction* pParent, Host*
 }
 
 // Update an existing action from XML string
-bool updateActionFromXML(TAction* pA, const QString& xmlSnapshot) {
+bool updateActionFromXML(TAction* pA, const QString& xmlSnapshot)
+{
     if (!pA || xmlSnapshot.isEmpty()) {
         return false;
     }

--- a/src/EditorModifyPropertyCommand.cpp
+++ b/src/EditorModifyPropertyCommand.cpp
@@ -29,7 +29,12 @@
 #include "TTrigger.h"
 
 EditorModifyPropertyCommand::EditorModifyPropertyCommand(EditorViewType viewType, int itemID, const QString& itemName, const QString& oldStateXML, const QString& newStateXML, Host* host)
-: EditorCommand(generateText(viewType, itemName), host), mViewType(viewType), mItemID(itemID), mItemName(itemName), mOldStateXML(oldStateXML), mNewStateXML(newStateXML)
+: EditorCommand(generateText(viewType, itemName), host)
+, mViewType(viewType)
+, mItemID(itemID)
+, mItemName(itemName)
+, mOldStateXML(oldStateXML)
+, mNewStateXML(newStateXML)
 {
     mCreationTime.start();
 }

--- a/src/EditorToggleActiveCommand.cpp
+++ b/src/EditorToggleActiveCommand.cpp
@@ -28,7 +28,12 @@
 #include "TTrigger.h"
 
 EditorToggleActiveCommand::EditorToggleActiveCommand(EditorViewType viewType, int itemID, bool oldState, bool newState, const QString& itemName, Host* host)
-: EditorCommand(generateText(viewType, itemName, newState), host), mViewType(viewType), mItemID(itemID), mOldActiveState(oldState), mNewActiveState(newState), mItemName(itemName)
+: EditorCommand(generateText(viewType, itemName, newState), host)
+, mViewType(viewType)
+, mItemID(itemID)
+, mOldActiveState(oldState)
+, mNewActiveState(newState)
+, mItemName(itemName)
 {
 }
 

--- a/src/EditorUndoStack.cpp
+++ b/src/EditorUndoStack.cpp
@@ -25,7 +25,8 @@
 #include <QDebug>
 #include <typeinfo>
 
-EditorUndoStack::EditorUndoStack(QObject* parent) : QUndoStack(parent)
+EditorUndoStack::EditorUndoStack(QObject* parent)
+: QUndoStack(parent)
 {
     // Connect to indexChanged signal to emit itemsChanged after undo/redo
     connect(this, &QUndoStack::indexChanged, this, [this](int newIndex) {
@@ -108,9 +109,7 @@ void EditorUndoStack::collectAffectedItems(const QUndoCommand* cmd, QMap<EditorV
     }
 
 #if defined(DEBUG_UNDO_REDO)
-    qDebug() << "EditorUndoStack::collectAffectedItems() - Examining command:" << cmd->text()
-             << "pointer:" << static_cast<const void*>(cmd)
-             << "type:" << typeid(*cmd).name();
+    qDebug() << "EditorUndoStack::collectAffectedItems() - Examining command:" << cmd->text() << "pointer:" << static_cast<const void*>(cmd) << "type:" << typeid(*cmd).name();
 #endif
 
     // If this is a EditorCommand, collect its affected items
@@ -300,8 +299,7 @@ void EditorUndoStack::remapItemIDs(int oldID, int newID)
         }
 
 #if defined(DEBUG_UNDO_REDO)
-        qDebug() << "EditorUndoStack::remapItemIDs() - Remapping in command:" << cmd->text()
-                 << "pointer:" << static_cast<const void*>(cmd);
+        qDebug() << "EditorUndoStack::remapItemIDs() - Remapping in command:" << cmd->text() << "pointer:" << static_cast<const void*>(cmd);
 #endif
 
         // Remap this command

--- a/src/FileOpenHandler.cpp
+++ b/src/FileOpenHandler.cpp
@@ -21,7 +21,8 @@
 #include "MudletInstanceCoordinator.h"
 #include "mudlet.h"
 
-FileOpenHandler::FileOpenHandler(QObject* parent) : QObject(parent)
+FileOpenHandler::FileOpenHandler(QObject* parent)
+: QObject(parent)
 {
     QCoreApplication::instance()->installEventFilter(this);
 }
@@ -46,4 +47,3 @@ bool FileOpenHandler::eventFilter(QObject* obj, QEvent* event)
     }
     return QObject::eventFilter(obj, event);
 }
-

--- a/src/FontManager.cpp
+++ b/src/FontManager.cpp
@@ -73,9 +73,9 @@ void FontManager::loadFont(const QString& filePath, const QString& belongsTo)
 
     if (fontID == -1) {
         qWarning() << "FontManager::loadFont() WARNING - Could not load the font(s) in the file: " << filePath;
-// Uncomment the next pair of lines to get details about fonts that ARE loaded:
-//    } else {
-//        qDebug().noquote().nospace() << "FontManager::loadFont() INFO - Loaded font(s) in the file: \"" << filePath << "\"\n    with ID: " << fontID << " providing: \"" << QFontDatabase::applicationFontFamilies(fontID).join(QLatin1String("\", \"")).append(QLatin1String("\"\n"));
+        // Uncomment the next pair of lines to get details about fonts that ARE loaded:
+        //    } else {
+        //        qDebug().noquote().nospace() << "FontManager::loadFont() INFO - Loaded font(s) in the file: \"" << filePath << "\"\n    with ID: " << fontID << " providing: \"" << QFontDatabase::applicationFontFamilies(fontID).join(QLatin1String("\", \"")).append(QLatin1String("\"\n"));
     }
 }
 

--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -26,20 +26,20 @@
 
 GMCPAuthenticator::GMCPAuthenticator(Host* pHost)
 : mpHost(pHost)
-{}
+{
+}
 
 void GMCPAuthenticator::saveSupportsSet(const QString& packageMessage, const QString& data)
 {
     QJsonParseError parseError;
     auto jsonDoc = QJsonDocument::fromJson(data.toUtf8(), &parseError);
     if (parseError.error != QJsonParseError::NoError) {
-        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Failed to parse JSON: " << parseError.errorString()
-                                       << " at offset " << parseError.offset << ". Received data: \"" << data << "\"";
+        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Failed to parse JSON: " << parseError.errorString() << " at offset " << parseError.offset << ". Received data: \"" << data
+                                       << "\"";
         return;
     }
     if (!jsonDoc.isObject()) {
-        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Expected JSON object but got "
-                                       << (jsonDoc.isArray() ? "array" : jsonDoc.isNull() ? "null" : "unknown type") << ".";
+        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Expected JSON object but got " << (jsonDoc.isArray() ? "array" : jsonDoc.isNull() ? "null" : "unknown type") << ".";
         return;
     }
     auto jsonObj = jsonDoc.object();
@@ -60,22 +60,22 @@ void GMCPAuthenticator::sendCredentials()
 {
     auto character = mpHost->getLogin();
     auto password = mpHost->getPass();
-    
+
     QJsonObject credentials;
 
     if (!character.isEmpty() && !password.isEmpty()) {
         credentials["account"] = character;
         credentials["password"] = password;
     }
-    
+
     QJsonDocument doc(credentials);
     QString gmcpMessage = doc.toJson(QJsonDocument::Compact);
-    
+
     // Clear sensitive data from memory as soon as possible
-    credentials = QJsonObject(); // Clear JSON object
-    doc = QJsonDocument();       // Clear document
+    credentials = QJsonObject();                    // Clear JSON object
+    doc = QJsonDocument();                          // Clear document
     SecureStringUtils::secureStringClear(password); // Clear password copy
-    
+
     // Build and send the GMCP message
     std::string output;
     output += TN_IAC;
@@ -88,10 +88,10 @@ void GMCPAuthenticator::sendCredentials()
 
     // Send credentials to server
     mpHost->mTelnet.socketOutRaw(output);
-    
+
     // Clear message from memory
     SecureStringUtils::secureStringClear(gmcpMessage);
-    
+
 #if defined(DEBUG_GMCP_AUTHENTICATION)
     qDebug() << "Sent GMCP credentials";
 #endif
@@ -103,13 +103,12 @@ void GMCPAuthenticator::handleAuthResult(const QString& packageMessage, const QS
     QJsonParseError parseError;
     auto doc = QJsonDocument::fromJson(data.toUtf8(), &parseError);
     if (parseError.error != QJsonParseError::NoError) {
-        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Failed to parse JSON: " << parseError.errorString()
-                                       << " at offset " << parseError.offset << ". Received data: \"" << data << "\"";
+        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Failed to parse JSON: " << parseError.errorString() << " at offset " << parseError.offset << ". Received data: \"" << data
+                                       << "\"";
         return;
     }
     if (!doc.isObject()) {
-        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Expected JSON object but got "
-                                       << (doc.isArray() ? "array" : doc.isNull() ? "null" : "unknown type") << ".";
+        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Expected JSON object but got " << (doc.isArray() ? "array" : doc.isNull() ? "null" : "unknown type") << ".";
         return;
     }
     auto obj = doc.object();
@@ -134,7 +133,6 @@ void GMCPAuthenticator::handleAuthResult(const QString& packageMessage, const QS
             //: %1 shows the reason for failure, could be authentication, etc.
             mpHost->postMessage(tr("[ WARN ]  - Could not log in to the game: %1").arg(message));
         }
-
     }
 }
 

--- a/src/GeometryManager.cpp
+++ b/src/GeometryManager.cpp
@@ -24,9 +24,7 @@
 #include <QFile>
 #include <QImage>
 
-GeometryManager::GeometryManager()
-{
-}
+GeometryManager::GeometryManager() {}
 
 GeometryManager::~GeometryManager()
 {
@@ -71,53 +69,83 @@ void GeometryManager::generateCubeTemplate()
     // Define 24 unique vertices + normals for a unit cube
     // Vertex order: front face (counter-clockwise from bottom-left), then back face
     // Front bottom-left
-    mCubeTemplate.vertices << -1.0f << -1.0f <<  1.0f << 0.0 << 0.0 << 1.0;   // 0: Front bottom-left (normal:front)
-    mCubeTemplate.vertices << -1.0f << -1.0f <<  1.0f << 0.0 << -1.0 << 0.0;  // 1: Front bottom-left (normal:bottom)
-    mCubeTemplate.vertices << -1.0f << -1.0f <<  1.0f << -1.0 << 0.0 << 0.0;  // 2: Front bottom-left (normal:left)
+    mCubeTemplate.vertices << -1.0f << -1.0f << 1.0f << 0.0 << 0.0 << 1.0;  // 0: Front bottom-left (normal:front)
+    mCubeTemplate.vertices << -1.0f << -1.0f << 1.0f << 0.0 << -1.0 << 0.0; // 1: Front bottom-left (normal:bottom)
+    mCubeTemplate.vertices << -1.0f << -1.0f << 1.0f << -1.0 << 0.0 << 0.0; // 2: Front bottom-left (normal:left)
     // Front bottom-right
-    mCubeTemplate.vertices <<  1.0f << -1.0f <<  1.0f << 0.0 << 0.0 << 1.0;   // 3: Front bottom-right (normal:front)
-    mCubeTemplate.vertices <<  1.0f << -1.0f <<  1.0f << 0.0 << -1.0 << 0.0;  // 4: Front bottom-right (normal:bottom)
-    mCubeTemplate.vertices <<  1.0f << -1.0f <<  1.0f << 1.0 << 0.0 << 0.0;   // 5: Front bottom-right (normal:right)
+    mCubeTemplate.vertices << 1.0f << -1.0f << 1.0f << 0.0 << 0.0 << 1.0;  // 3: Front bottom-right (normal:front)
+    mCubeTemplate.vertices << 1.0f << -1.0f << 1.0f << 0.0 << -1.0 << 0.0; // 4: Front bottom-right (normal:bottom)
+    mCubeTemplate.vertices << 1.0f << -1.0f << 1.0f << 1.0 << 0.0 << 0.0;  // 5: Front bottom-right (normal:right)
     // Front top-right
-    mCubeTemplate.vertices <<  1.0f <<  1.0f <<  1.0f << 0.0 << 0.0 << 1.0;   // 6: Front top-right (normal:front)
-    mCubeTemplate.vertices <<  1.0f <<  1.0f <<  1.0f << 0.0 << 1.0 << 0.0;   // 7: Front top-right (normal:top)
-    mCubeTemplate.vertices <<  1.0f <<  1.0f <<  1.0f << 1.0 << 0.0 << 0.0;   // 8: Front top-right (normal:right)
+    mCubeTemplate.vertices << 1.0f << 1.0f << 1.0f << 0.0 << 0.0 << 1.0; // 6: Front top-right (normal:front)
+    mCubeTemplate.vertices << 1.0f << 1.0f << 1.0f << 0.0 << 1.0 << 0.0; // 7: Front top-right (normal:top)
+    mCubeTemplate.vertices << 1.0f << 1.0f << 1.0f << 1.0 << 0.0 << 0.0; // 8: Front top-right (normal:right)
     // Front top-left
-    mCubeTemplate.vertices << -1.0f <<  1.0f <<  1.0f << 0.0 << 0.0 << 1.0;   // 9: Front top-left (normal:front)
-    mCubeTemplate.vertices << -1.0f <<  1.0f <<  1.0f << 0.0 << 1.0 << 0.0;   // 10: Front top-left (normal:top)
-    mCubeTemplate.vertices << -1.0f <<  1.0f <<  1.0f << -1.0 << 0.0 << 0.0;  // 11: Front top-left (normal:left)
+    mCubeTemplate.vertices << -1.0f << 1.0f << 1.0f << 0.0 << 0.0 << 1.0;  // 9: Front top-left (normal:front)
+    mCubeTemplate.vertices << -1.0f << 1.0f << 1.0f << 0.0 << 1.0 << 0.0;  // 10: Front top-left (normal:top)
+    mCubeTemplate.vertices << -1.0f << 1.0f << 1.0f << -1.0 << 0.0 << 0.0; // 11: Front top-left (normal:left)
     // Back bottom-left
-    mCubeTemplate.vertices << -1.0f << -1.0f << -1.0f << 0.0 << 0.0 << -1.0;  // 12: Back bottom-left (normal:back)
-    mCubeTemplate.vertices << -1.0f << -1.0f << -1.0f << 0.0 << -1.0 << 0.0;  // 13: Back bottom-left (normal:bottom)
-    mCubeTemplate.vertices << -1.0f << -1.0f << -1.0f << -1.0 << 0.0 << 0.0;  // 14: Back bottom-left (normal:left)
+    mCubeTemplate.vertices << -1.0f << -1.0f << -1.0f << 0.0 << 0.0 << -1.0; // 12: Back bottom-left (normal:back)
+    mCubeTemplate.vertices << -1.0f << -1.0f << -1.0f << 0.0 << -1.0 << 0.0; // 13: Back bottom-left (normal:bottom)
+    mCubeTemplate.vertices << -1.0f << -1.0f << -1.0f << -1.0 << 0.0 << 0.0; // 14: Back bottom-left (normal:left)
     // Back bottom-right
-    mCubeTemplate.vertices <<  1.0f << -1.0f << -1.0f << 0.0 << 0.0 << -1.0;  // 15: Back bottom-right (normal:back)
-    mCubeTemplate.vertices <<  1.0f << -1.0f << -1.0f << 0.0 << -1.0 << 0.0;  // 16: Back bottom-right (normal:bottom)
-    mCubeTemplate.vertices <<  1.0f << -1.0f << -1.0f << 1.0 << 0.0 << 0.0;   // 17: Back bottom-right (normal:right)
+    mCubeTemplate.vertices << 1.0f << -1.0f << -1.0f << 0.0 << 0.0 << -1.0; // 15: Back bottom-right (normal:back)
+    mCubeTemplate.vertices << 1.0f << -1.0f << -1.0f << 0.0 << -1.0 << 0.0; // 16: Back bottom-right (normal:bottom)
+    mCubeTemplate.vertices << 1.0f << -1.0f << -1.0f << 1.0 << 0.0 << 0.0;  // 17: Back bottom-right (normal:right)
     // Back top-right
-    mCubeTemplate.vertices <<  1.0f <<  1.0f << -1.0f << 0.0 << 0.0 << -1.0;  // 18: Back top-right (normal:back)
-    mCubeTemplate.vertices <<  1.0f <<  1.0f << -1.0f << 0.0 << 1.0 << 0.0;   // 19: Back top-right (normal:top)
-    mCubeTemplate.vertices <<  1.0f <<  1.0f << -1.0f << 1.0 << 0.0 << 0.0;   // 20: Back top-right (normal:right)
+    mCubeTemplate.vertices << 1.0f << 1.0f << -1.0f << 0.0 << 0.0 << -1.0; // 18: Back top-right (normal:back)
+    mCubeTemplate.vertices << 1.0f << 1.0f << -1.0f << 0.0 << 1.0 << 0.0;  // 19: Back top-right (normal:top)
+    mCubeTemplate.vertices << 1.0f << 1.0f << -1.0f << 1.0 << 0.0 << 0.0;  // 20: Back top-right (normal:right)
     // Back top-left
-    mCubeTemplate.vertices << -1.0f <<  1.0f << -1.0f << 0.0 << 0.0 << -1.0;  // 21: Back top-left (normal:back)
-    mCubeTemplate.vertices << -1.0f <<  1.0f << -1.0f << 0.0 << 1.0 << 0.0;   // 22: Back top-left (normal:top)
-    mCubeTemplate.vertices << -1.0f <<  1.0f << -1.0f << -1.0 << 0.0 << 0.0;  // 23: Back top-left (normal:left)
+    mCubeTemplate.vertices << -1.0f << 1.0f << -1.0f << 0.0 << 0.0 << -1.0; // 21: Back top-left (normal:back)
+    mCubeTemplate.vertices << -1.0f << 1.0f << -1.0f << 0.0 << 1.0 << 0.0;  // 22: Back top-left (normal:top)
+    mCubeTemplate.vertices << -1.0f << 1.0f << -1.0f << -1.0 << 0.0 << 0.0; // 23: Back top-left (normal:left)
 
     // Define indices for the 12 triangles (6 faces × 2 triangles each)
     // Counter-clockwise winding order for front-facing triangles
     QVector<unsigned int> indices = {
-        // Front face
-        0, 3, 6,  0, 6, 9,
-        // Back face
-        12, 15, 18,  12, 18, 21,
-        // Left face
-        2, 11, 23,  2, 23, 14,
-        // Right face
-        5, 8, 20,  5, 20, 17,
-        // Bottom face
-        1, 4, 16,  1, 13, 16,
-        // Top face
-        7, 10, 22,  7, 22, 19,
+            // Front face
+            0,
+            3,
+            6,
+            0,
+            6,
+            9,
+            // Back face
+            12,
+            15,
+            18,
+            12,
+            18,
+            21,
+            // Left face
+            2,
+            11,
+            23,
+            2,
+            23,
+            14,
+            // Right face
+            5,
+            8,
+            20,
+            5,
+            20,
+            17,
+            // Bottom face
+            1,
+            4,
+            16,
+            1,
+            13,
+            16,
+            // Top face
+            7,
+            10,
+            22,
+            7,
+            22,
+            19,
     };
 
     mCubeTemplate.indices = indices;
@@ -132,14 +160,14 @@ GeometryData GeometryManager::transformCubeTemplate(QMatrix4x4 transform, float 
     // Transform vertices and copy normals
     for (int i = 0; i < mCubeTemplate.vertices.size(); i += 6) {
         // Scale and translate vertex
-        QVector3D vertex = QVector3D(mCubeTemplate.vertices[i], mCubeTemplate.vertices[i+1], mCubeTemplate.vertices[i+2]);
+        QVector3D vertex = QVector3D(mCubeTemplate.vertices[i], mCubeTemplate.vertices[i + 1], mCubeTemplate.vertices[i + 2]);
         vertex = transform.map(vertex);
         result.vertices << vertex.x();
         result.vertices << vertex.y();
         result.vertices << vertex.z();
 
         // Copy normal (no transformation needed since it's a uniform scale)
-        vertex = QVector3D(mCubeTemplate.vertices[i+3], mCubeTemplate.vertices[i+4], mCubeTemplate.vertices[i+5]);
+        vertex = QVector3D(mCubeTemplate.vertices[i + 3], mCubeTemplate.vertices[i + 4], mCubeTemplate.vertices[i + 5]);
         vertex = transform.map(vertex) - transform.map(QVector3D());
         vertex.normalize();
         result.vertices << vertex.x();
@@ -200,8 +228,8 @@ GeometryData GeometryManager::generateTriangleGeometry(const QVector<float>& ver
     result.colors = colors;
 
     // add normals pointing up
-    for (int i=0; i < vertices.size(); i+=3) {
-        result.vertices << vertices[i] << vertices[i+1] << vertices[i+2] << 0.0f << 0.0f << 1.0f;
+    for (int i = 0; i < vertices.size(); i += 3) {
+        result.vertices << vertices[i] << vertices[i + 1] << vertices[i + 2] << 0.0f << 0.0f << 1.0f;
     }
 
     return result;
@@ -485,13 +513,8 @@ void GeometryManager::loadPlayerIconTemplate(float scale, float rotX, float rotY
     mPlayerIconTemplate = std::move(result);
 }
 
-void GeometryManager::renderGeometry(const GeometryData& geometry,
-                                   QOpenGLVertexArrayObject& vao,
-                                   QOpenGLBuffer& vertexBuffer,
-                                   QOpenGLBuffer& colorBuffer,
-                                   QOpenGLBuffer& normalBuffer,
-                                   QOpenGLBuffer& indexBuffer,
-                                   GLenum drawMode)
+void GeometryManager::renderGeometry(
+        const GeometryData& geometry, QOpenGLVertexArrayObject& vao, QOpenGLBuffer& vertexBuffer, QOpenGLBuffer& colorBuffer, QOpenGLBuffer& normalBuffer, QOpenGLBuffer& indexBuffer, GLenum drawMode)
 {
     if (geometry.isEmpty()) {
         return;
@@ -544,13 +567,13 @@ void GeometryManager::renderGeometry(const GeometryData& geometry,
 }
 
 void GeometryManager::renderGeometry(const GeometryData& geometry,
-                                   QOpenGLVertexArrayObject& vao,
-                                   QOpenGLBuffer& vertexBuffer,
-                                   QOpenGLBuffer& colorBuffer,
-                                   QOpenGLBuffer& normalBuffer,
-                                   QOpenGLBuffer& indexBuffer,
-                                   ResourceManager* resourceManager,
-                                   GLenum drawMode)
+                                     QOpenGLVertexArrayObject& vao,
+                                     QOpenGLBuffer& vertexBuffer,
+                                     QOpenGLBuffer& colorBuffer,
+                                     QOpenGLBuffer& normalBuffer,
+                                     QOpenGLBuffer& indexBuffer,
+                                     ResourceManager* resourceManager,
+                                     GLenum drawMode)
 {
     if (geometry.isEmpty()) {
         return;
@@ -570,13 +593,13 @@ void GeometryManager::renderGeometry(const GeometryData& geometry,
 }
 
 void GeometryManager::renderGeometry(const GeometryData& geometry,
-                                   QOpenGLVertexArrayObject& vao,
-                                   QOpenGLBuffer& vertexBuffer,
-                                   QOpenGLBuffer& colorBuffer,
-                                   QOpenGLBuffer& normalBuffer,
-                                   QOpenGLBuffer& indexBuffer,
-                                   QOpenGLBuffer& texCoordBuffer,
-                                   GLenum drawMode)
+                                     QOpenGLVertexArrayObject& vao,
+                                     QOpenGLBuffer& vertexBuffer,
+                                     QOpenGLBuffer& colorBuffer,
+                                     QOpenGLBuffer& normalBuffer,
+                                     QOpenGLBuffer& indexBuffer,
+                                     QOpenGLBuffer& texCoordBuffer,
+                                     GLenum drawMode)
 {
     if (geometry.isEmpty()) {
         return;
@@ -586,7 +609,6 @@ void GeometryManager::renderGeometry(const GeometryData& geometry,
 
     // Bind PBR textures if available
     if (geometry.hasPBRTextures()) {
-
         // Bind base color texture to unit 0
         if (geometry.baseColorTextureId != 0) {
             glActiveTexture(GL_TEXTURE0);
@@ -672,14 +694,14 @@ void GeometryManager::renderGeometry(const GeometryData& geometry,
 }
 
 void GeometryManager::renderGeometry(const GeometryData& geometry,
-                                   QOpenGLVertexArrayObject& vao,
-                                   QOpenGLBuffer& vertexBuffer,
-                                   QOpenGLBuffer& colorBuffer,
-                                   QOpenGLBuffer& normalBuffer,
-                                   QOpenGLBuffer& indexBuffer,
-                                   QOpenGLBuffer& texCoordBuffer,
-                                   ResourceManager* resourceManager,
-                                   GLenum drawMode)
+                                     QOpenGLVertexArrayObject& vao,
+                                     QOpenGLBuffer& vertexBuffer,
+                                     QOpenGLBuffer& colorBuffer,
+                                     QOpenGLBuffer& normalBuffer,
+                                     QOpenGLBuffer& indexBuffer,
+                                     QOpenGLBuffer& texCoordBuffer,
+                                     ResourceManager* resourceManager,
+                                     GLenum drawMode)
 {
     if (geometry.isEmpty()) {
         return;
@@ -699,13 +721,13 @@ void GeometryManager::renderGeometry(const GeometryData& geometry,
 }
 
 void GeometryManager::renderInstancedCubes(const QVector<CubeInstanceData>& instances,
-                                          QOpenGLVertexArrayObject& vao,
-                                          QOpenGLBuffer& vertexBuffer,
-                                          QOpenGLBuffer& colorBuffer,
-                                          QOpenGLBuffer& normalBuffer,
-                                          QOpenGLBuffer& indexBuffer,
-                                          QOpenGLBuffer& instanceBuffer,
-                                          GLenum drawMode)
+                                           QOpenGLVertexArrayObject& vao,
+                                           QOpenGLBuffer& vertexBuffer,
+                                           QOpenGLBuffer& colorBuffer,
+                                           QOpenGLBuffer& normalBuffer,
+                                           QOpenGLBuffer& indexBuffer,
+                                           QOpenGLBuffer& instanceBuffer,
+                                           GLenum drawMode)
 {
     if (!mInitialized || instances.isEmpty()) {
         return;
@@ -780,14 +802,14 @@ void GeometryManager::renderInstancedCubes(const QVector<CubeInstanceData>& inst
 }
 
 void GeometryManager::renderInstancedCubes(const QVector<CubeInstanceData>& instances,
-                                          QOpenGLVertexArrayObject& vao,
-                                          QOpenGLBuffer& vertexBuffer,
-                                          QOpenGLBuffer& colorBuffer,
-                                          QOpenGLBuffer& normalBuffer,
-                                          QOpenGLBuffer& indexBuffer,
-                                          QOpenGLBuffer& instanceBuffer,
-                                          ResourceManager* resourceManager,
-                                          GLenum drawMode)
+                                           QOpenGLVertexArrayObject& vao,
+                                           QOpenGLBuffer& vertexBuffer,
+                                           QOpenGLBuffer& colorBuffer,
+                                           QOpenGLBuffer& normalBuffer,
+                                           QOpenGLBuffer& indexBuffer,
+                                           QOpenGLBuffer& instanceBuffer,
+                                           ResourceManager* resourceManager,
+                                           GLenum drawMode)
 {
     if (instances.isEmpty()) {
         return;

--- a/src/GifTracker.cpp
+++ b/src/GifTracker.cpp
@@ -31,7 +31,6 @@ bool GifTracker::registerGif(QMovie* pT)
 
     mMovieList.push_back(pT);
     return true;
-
 }
 
 void GifTracker::unregisterGif(QMovie* pT)
@@ -42,7 +41,6 @@ void GifTracker::unregisterGif(QMovie* pT)
 
     mMovieList.remove(pT);
     return;
-
 }
 
 std::tuple<QString, int, int> GifTracker::assembleReport()
@@ -56,12 +54,7 @@ std::tuple<QString, int, int> GifTracker::assembleReport()
         }
     }
     QStringList msg;
-    msg << QLatin1String("Gifs current total: ") << QString::number(statsItemsTotal) << QLatin1String("\n")
-        << QLatin1String("active Gifs: ") << QString::number(statsActiveItems) << QLatin1String("\n");
-    return {
-        msg.join(QString()),
-        statsItemsTotal,
-        statsActiveItems
-    };
+    msg << QLatin1String("Gifs current total: ") << QString::number(statsItemsTotal) << QLatin1String("\n") << QLatin1String("active Gifs: ") << QString::number(statsActiveItems)
+        << QLatin1String("\n");
+    return {msg.join(QString()), statsItemsTotal, statsActiveItems};
 }
-

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -212,7 +212,13 @@ QString stopWatch::getElapsedDayTimeString() const
     remainder = remainder - (minutes * std::chrono::milliseconds(1min).count());
     quint8 const seconds = static_cast<quint8>(remainder / std::chrono::milliseconds(1s).count());
     quint16 const milliSeconds = static_cast<quint16>(remainder - (seconds * std::chrono::milliseconds(1s).count()));
-    return qsl("%1:%2:%3:%4:%5:%6").arg((isNegative ? QLatin1String("-") : QLatin1String("+")), QString::number(days), QString::number(hours), QString::number(minutes), QString::number(seconds), QString::number(milliSeconds));
+    return qsl("%1:%2:%3:%4:%5:%6")
+            .arg((isNegative ? QLatin1String("-") : QLatin1String("+")),
+                 QString::number(days),
+                 QString::number(hours),
+                 QString::number(minutes),
+                 QString::number(seconds),
+                 QString::number(milliSeconds));
 }
 
 Host::Host(int port, const QString& hostname, const QString& login, const QString& pass, int id)
@@ -536,7 +542,7 @@ void Host::startMapAutosave(const int interval)
     }
 }
 
-void Host::timerEvent(QTimerEvent *event)
+void Host::timerEvent(QTimerEvent* event)
 {
     Q_UNUSED(event)
 
@@ -576,13 +582,13 @@ void Host::loadPackageInfo()
     }
 }
 
-void Host::createModuleBackup(const QString &filename, const QString &saveName)
+void Host::createModuleBackup(const QString& filename, const QString& saveName)
 {
     const QString time = QDateTime::currentDateTime().toString("yyyy-MM-dd#HH-mm-ss");
     QFile::copy(filename, saveName + time);
 }
 
-void Host::writeModule(const QString &moduleName, const QString &filename)
+void Host::writeModule(const QString& moduleName, const QString& filename)
 {
     QString xml_filename = filename;
     if (filename.endsWith(qsl("mpackage"), Qt::CaseInsensitive) || filename.endsWith(qsl("zip"), Qt::CaseInsensitive)) {
@@ -686,7 +692,8 @@ void Host::updateModuleZips(const QString& zipName, const QString& moduleName)
          * existing file that is to be overwritten may be a source of problems
          * here.
         */
-        qWarning().noquote().nospace() << "Host::updateModuleZips(\"" << zipName << "\", \"" << moduleName << "\") WARNING - failed to open module to update it, error: \"" << zip_error_strerror(&zipError) << "\"";
+        qWarning().noquote().nospace() << "Host::updateModuleZips(\"" << zipName << "\", \"" << moduleName << "\") WARNING - failed to open module to update it, error: \""
+                                       << zip_error_strerror(&zipError) << "\"";
         zip_error_fini(&zipError);
         return;
     }
@@ -699,8 +706,7 @@ void Host::updateModuleZips(const QString& zipName, const QString& moduleName)
     struct zip_source* s = zip_source_file(zipFile, filename_xml.toUtf8().constData(), 0, -1);
     if (mudlet::smDebugMode && s == nullptr) {
         //: This error message will appear when the xml file inside the module zip cannot be updated for some reason.
-        TDebug(QColor(Qt::white), QColor(Qt::red)) << tr("Failed to open xml file \"%1\" inside module %2 to update it. Error message was: \"%3\".")
-                                                              .arg(filename_xml, zipName, zip_strerror(zipFile));
+        TDebug(QColor(Qt::white), QColor(Qt::red)) << tr("Failed to open xml file \"%1\" inside module %2 to update it. Error message was: \"%3\".").arg(filename_xml, zipName, zip_strerror(zipFile));
     }
     err = zip_file_add(zipFile, qsl("%1.xml").arg(moduleName).toUtf8().constData(), s, ZIP_FL_ENC_UTF_8 | ZIP_FL_OVERWRITE);
 
@@ -713,8 +719,7 @@ void Host::updateModuleZips(const QString& zipName, const QString& moduleName)
     if (err == -1) {
         if (mudlet::smDebugMode && err == -1) {
             //: This error message will appear when a module is saved as package but cannot be done for some reason.
-            TDebug(QColor(Qt::white), QColor(Qt::red)) << tr("Failed to save \"%1\" to module \"%2\". Error message was: \"%3\".")
-                                                                  .arg(moduleName, zipName, zip_strerror(zipFile));
+            TDebug(QColor(Qt::white), QColor(Qt::red)) << tr("Failed to save \"%1\" to module \"%2\". Error message was: \"%3\".").arg(moduleName, zipName, zip_strerror(zipFile));
         }
         // Properly dispose of things after failing to zip_close(...) the
         // archive:
@@ -844,7 +849,7 @@ void Host::resetProfile_phase2()
     mLuaInterpreter.updateAnsi16ColorsInTable();
     mLuaInterpreter.updateExtendedAnsiColorsInTable();
 
-    TEvent event {};
+    TEvent event{};
     event.mArgumentList.append(QLatin1String("sysLoadEvent"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
 
@@ -1043,7 +1048,7 @@ void Host::updateConsolesFont()
 // a little message to make the player feel special for helping us find bugs
 void Host::thankForUsingPTB()
 {
-    const QStringList happyIcons {"😀", "😃", "😄", "😁", "🙂", "🙃", "🤩", "🎉", "🚀", "🤟", "✌️", "👊"};
+    const QStringList happyIcons{"😀", "😃", "😄", "😁", "🙂", "🙃", "🤩", "🎉", "🚀", "🤟", "✌️", "👊"};
     const auto randomIcon = happyIcons.at(QRandomGenerator::global()->bounded(happyIcons.size()));
     postMessage(tr(R"([  OK  ]  - %1 Thanks a lot for using the Public Test Build!)", "%1 will be a random happy emoji").arg(randomIcon));
     postMessage(tr(R"([  OK  ]  - %1 Help us make Mudlet better by reporting any problems.)", "%1 will be a random happy emoji").arg(randomIcon));
@@ -1151,22 +1156,20 @@ QFont Host::createFontWithSettings(const QString& fontName, int pointSize) const
 std::pair<QString, QFont::Weight> Host::parseFontNameAndStyle(const QString& fontName) const
 {
     // Map of style keywords to QFont::Weight values
-    static const QMap<QString, QFont::Weight> styleWeightMap = {
-        {qsl("thin"), QFont::Thin},
-        {qsl("extralight"), QFont::ExtraLight},
-        {qsl("ultralight"), QFont::ExtraLight},
-        {qsl("light"), QFont::Light},
-        {qsl("normal"), QFont::Normal},
-        {qsl("regular"), QFont::Normal},
-        {qsl("medium"), QFont::Medium},
-        {qsl("demibold"), QFont::DemiBold},
-        {qsl("semibold"), QFont::DemiBold},
-        {qsl("bold"), QFont::Bold},
-        {qsl("extrabold"), QFont::ExtraBold},
-        {qsl("ultrabold"), QFont::ExtraBold},
-        {qsl("black"), QFont::Black},
-        {qsl("heavy"), QFont::Black}
-    };
+    static const QMap<QString, QFont::Weight> styleWeightMap = {{qsl("thin"), QFont::Thin},
+                                                                {qsl("extralight"), QFont::ExtraLight},
+                                                                {qsl("ultralight"), QFont::ExtraLight},
+                                                                {qsl("light"), QFont::Light},
+                                                                {qsl("normal"), QFont::Normal},
+                                                                {qsl("regular"), QFont::Normal},
+                                                                {qsl("medium"), QFont::Medium},
+                                                                {qsl("demibold"), QFont::DemiBold},
+                                                                {qsl("semibold"), QFont::DemiBold},
+                                                                {qsl("bold"), QFont::Bold},
+                                                                {qsl("extrabold"), QFont::ExtraBold},
+                                                                {qsl("ultrabold"), QFont::ExtraBold},
+                                                                {qsl("black"), QFont::Black},
+                                                                {qsl("heavy"), QFont::Black}};
 
     // Try each possible split point from the end of the font name
     const QStringList words = fontName.split(' ', Qt::SkipEmptyParts);
@@ -1439,7 +1442,7 @@ int Host::findStopWatchId(const QString& name) const
     if (total > 1) {
         std::sort(stopWatchIdList.begin(), stopWatchIdList.end());
     }
-    for (const int currentId: stopWatchIdList) {
+    for (const int currentId : stopWatchIdList) {
         auto pCurrentStopWatch = mStopWatchMap.value(currentId);
         if (pCurrentStopWatch->name() == name) {
             return currentId;
@@ -1800,7 +1803,7 @@ void Host::raiseEvent(const TEvent& pE)
 
 void Host::postIrcMessage(const QString& a, const QString& b, const QString& c)
 {
-    TEvent event {};
+    TEvent event{};
     event.mArgumentList << QLatin1String("sysIrcMessage");
     event.mArgumentList << a << b << c;
     event.mArgumentTypeList << ARGUMENT_TYPE_STRING << ARGUMENT_TYPE_STRING << ARGUMENT_TYPE_STRING << ARGUMENT_TYPE_STRING;
@@ -1967,7 +1970,7 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, enums::Pa
                 return {false, qsl("could not load unpacking progress dialog")};
             }
 
-            auto * pLabel = pUnzipDialog->findChild<QLabel*>(qsl("label"));
+            auto* pLabel = pUnzipDialog->findChild<QLabel*>(qsl("label"));
             if (pLabel) {
                 if (thing != enums::PackageModuleType::Package) {
                     pLabel->setText(tr("Unpacking module:\n\"%1\"\nplease wait...").arg(packageName));
@@ -2112,14 +2115,14 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, enums::Pa
         // raise 2 events - a generic one and a more detailed one to serve both
         // a simple need ("I just want the install event") and a more specific need
         // ("I specifically need to know when the module was synced")
-        TEvent genericInstallEvent {};
+        TEvent genericInstallEvent{};
         genericInstallEvent.mArgumentList.append(QLatin1String("sysInstall"));
         genericInstallEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         genericInstallEvent.mArgumentList.append(packageName);
         genericInstallEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         raiseEvent(genericInstallEvent);
 
-        TEvent detailedInstallEvent {};
+        TEvent detailedInstallEvent{};
         switch (thing) {
         case enums::PackageModuleType::Package:
             detailedInstallEvent.mArgumentList.append(QLatin1String("sysInstallPackage"));
@@ -2196,7 +2199,7 @@ bool Host::removeDir(const QString& dirName, const QString& originalPath)
     return result;
 }
 
-void Host::removePackageInfo(const QString &packageName, const bool isModule)
+void Host::removePackageInfo(const QString& packageName, const bool isModule)
 {
     if (isModule) {
         mModuleInfo.remove(packageName);
@@ -2238,14 +2241,14 @@ bool Host::uninstallPackage(const QString& packageName, enums::PackageModuleType
     // raise 2 events - a generic one and a more detailed one to serve both
     // a simple need ("I just want the uninstall event") and a more specific need
     // ("I specifically need to know when the module was uninstalled via Lua")
-    TEvent genericUninstallEvent {};
+    TEvent genericUninstallEvent{};
     genericUninstallEvent.mArgumentList.append(QLatin1String("sysUninstall"));
     genericUninstallEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     genericUninstallEvent.mArgumentList.append(packageName);
     genericUninstallEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     raiseEvent(genericUninstallEvent);
 
-    TEvent detailedUninstallEvent {};
+    TEvent detailedUninstallEvent{};
     switch (thing) {
     case enums::PackageModuleType::Package:
         detailedUninstallEvent.mArgumentList.append(QLatin1String("sysUninstallPackage"));
@@ -2357,18 +2360,23 @@ void Host::setupSandboxedLuaState(lua_State* L)
     luaopen_math(L);
 
     // Remove dangerous functions
-    const char* dangerousFunctions[] = {
-        // File operations
-        "dofile", "loadfile", "load", "loadstring",
-        // Module system
-        "require", "module",
-        // Library access
-        "io", "os", "debug",
-        // Environment manipulation
-        "getfenv", "setfenv",
-        // Raw memory access
-        "collectgarbage"
-    };
+    const char* dangerousFunctions[] = {// File operations
+                                        "dofile",
+                                        "loadfile",
+                                        "load",
+                                        "loadstring",
+                                        // Module system
+                                        "require",
+                                        "module",
+                                        // Library access
+                                        "io",
+                                        "os",
+                                        "debug",
+                                        // Environment manipulation
+                                        "getfenv",
+                                        "setfenv",
+                                        // Raw memory access
+                                        "collectgarbage"};
 
     for (const auto& function : dangerousFunctions) {
         lua_pushnil(L);
@@ -2382,9 +2390,7 @@ void Host::setupSandboxedLuaState(lua_State* L)
     // Remove potentially dangerous base functions
     lua_getglobal(L, "_G");
     if (lua_istable(L, -1)) {
-        const char* removedBaseFunctions[] = {
-            "rawget", "rawset", "rawequal", "rawlen"
-        };
+        const char* removedBaseFunctions[] = {"rawget", "rawset", "rawequal", "rawlen"};
 
         for (const auto& function : removedBaseFunctions) {
             lua_pushnil(L);
@@ -2625,7 +2631,7 @@ QString Host::readProfileData(const QString& item)
 
 // makes fonts in a given package/module be available for Mudlet scripting
 // does not install font system-wide
-void Host::installPackageFonts(const QString &packageName)
+void Host::installPackageFonts(const QString& packageName)
 {
     auto packagePath = mudlet::getMudletPath(enums::profilePackagePath, getName(), packageName);
 
@@ -2633,9 +2639,8 @@ void Host::installPackageFonts(const QString &packageName)
     while (it.hasNext()) {
         auto filePath = it.next();
 
-        if (filePath.endsWith(QLatin1String(".otf"), Qt::CaseInsensitive) || filePath.endsWith(QLatin1String(".ttf"), Qt::CaseInsensitive) ||
-            filePath.endsWith(QLatin1String(".ttc"), Qt::CaseInsensitive) || filePath.endsWith(QLatin1String(".otc"), Qt::CaseInsensitive)) {
-
+        if (filePath.endsWith(QLatin1String(".otf"), Qt::CaseInsensitive) || filePath.endsWith(QLatin1String(".ttf"), Qt::CaseInsensitive)
+            || filePath.endsWith(QLatin1String(".ttc"), Qt::CaseInsensitive) || filePath.endsWith(QLatin1String(".otc"), Qt::CaseInsensitive)) {
             mudlet::self()->mFontManager.loadFont(filePath, packageName);
         }
     }
@@ -2659,12 +2664,7 @@ void Host::setWideAmbiguousEAsianGlyphs(const Qt::CheckState state)
         // Set things automatically
         mAutoAmbigousWidthGlyphsSetting = true;
 
-        if (encoding == "GBK"
-            || encoding == "GB18030"
-            || encoding == "BIG5"
-            || encoding == "BIG5-HKSCS"
-            || encoding == "EUC-KR") {
-
+        if (encoding == "GBK" || encoding == "GB18030" || encoding == "BIG5" || encoding == "BIG5-HKSCS" || encoding == "EUC-KR") {
             // Need to use wide width for ambiguous characters
             if (!mWideAmbigousWidthGlyphs) {
                 // But the last setting was narrow - so we need to change
@@ -2681,7 +2681,6 @@ void Host::setWideAmbiguousEAsianGlyphs(const Qt::CheckState state)
                 localState = false;
                 needToEmit = true;
             }
-
         }
 
     } else {
@@ -2694,7 +2693,6 @@ void Host::setWideAmbiguousEAsianGlyphs(const Qt::CheckState state)
             localState = (state == Qt::Checked);
             needToEmit = true;
         }
-
     }
 
     if (needToEmit) {
@@ -2957,26 +2955,26 @@ void Host::processDiscordMSDP(const QString& variable, QString value)
 
     Q_UNUSED(variable)
     Q_UNUSED(value)
-// TODO:
-//    if (!(variable == QLatin1String("SERVER_ID") || variable == QLatin1String("AREA_NAME"))) {
-//        return;
-//    }
+    // TODO:
+    //    if (!(variable == QLatin1String("SERVER_ID") || variable == QLatin1String("AREA_NAME"))) {
+    //        return;
+    //    }
 
-//    // MSDP value comes padded with quotes - strip them (from the local copy of
-//    // the supplied argument):
-//    if (value.startsWith(QLatin1String("\""))) {
-//        value = value.mid(1);
-//    }
+    //    // MSDP value comes padded with quotes - strip them (from the local copy of
+    //    // the supplied argument):
+    //    if (value.startsWith(QLatin1String("\""))) {
+    //        value = value.mid(1);
+    //    }
 
-//    if (value.endsWith(QLatin1String("\""))) {
-//        value.chop(1);
-//    }
+    //    if (value.endsWith(QLatin1String("\""))) {
+    //        value.chop(1);
+    //    }
 
-//    if (variable == QLatin1String("SERVER_ID")) {
-//        mudlet::self()->mDiscord.setGame(this, value);
-//    } else if (variable == QLatin1String("AREA_NAME")) {
-//        mudlet::self()->mDiscord.setArea(this, value);
-//    }
+    //    if (variable == QLatin1String("SERVER_ID")) {
+    //        mudlet::self()->mDiscord.setGame(this, value);
+    //    } else if (variable == QLatin1String("AREA_NAME")) {
+    //        mudlet::self()->mDiscord.setArea(this, value);
+    //    }
 }
 
 void Host::setDiscordApplicationID(const QString& s)
@@ -3010,7 +3008,7 @@ bool Host::discordUserIdMatch(const QString& userName, const QString& userDiscri
     return true;
 }
 
-QString  Host::getSpellDic()
+QString Host::getSpellDic()
 {
     if (!mSpellDic.isEmpty()) {
         return mSpellDic;
@@ -3043,7 +3041,7 @@ void Host::setUserDictionaryOptions(const bool _useDictionary, const bool useSha
 {
     Q_UNUSED(_useDictionary)
     const bool useDictionary = true;
-    bool dictionaryChanged {};
+    bool dictionaryChanged{};
     // Copy the value while we have the lock:
     const bool isSpellCheckingEnabled = mEnableSpellCheck;
     if (mEnableUserDictionary != useDictionary) {
@@ -3163,19 +3161,18 @@ void Host::loadSecuredPassword()
     // Use async API for QtKeychain integration with file fallback
     auto* credManager = new CredentialManager(this);
 
-    credManager->retrieveCredential(getName(), "character",
-        [this, credManager](bool success, const QString& password, const QString& errorMessage) {
-            if (success && !password.isEmpty()) {
-                setPass(password);
-                QString passwordCopy = password; // Make a copy for secure clearing
-                SecureStringUtils::secureStringClear(passwordCopy);
-            } else if (!success && !errorMessage.isEmpty()) {
-                qDebug() << "Host::loadSecuredPassword() - Failed to retrieve password:" << errorMessage;
-            }
+    credManager->retrieveCredential(getName(), "character", [this, credManager](bool success, const QString& password, const QString& errorMessage) {
+        if (success && !password.isEmpty()) {
+            setPass(password);
+            QString passwordCopy = password; // Make a copy for secure clearing
+            SecureStringUtils::secureStringClear(passwordCopy);
+        } else if (!success && !errorMessage.isEmpty()) {
+            qDebug() << "Host::loadSecuredPassword() - Failed to retrieve password:" << errorMessage;
+        }
 
-            // Clean up the credential manager
-            credManager->deleteLater();
-        });
+        // Clean up the credential manager
+        credManager->deleteLater();
+    });
 }
 
 // Only needed for places outside of this class:
@@ -3379,7 +3376,7 @@ std::pair<bool, QString> Host::openWindow(const QString& name, bool loadLayout, 
         dockwidget = new TDockWidget(this, name);
         dockwidget->setObjectName(qsl("dockWindow_%1_%2").arg(hostName, name));
         dockwidget->setContentsMargins(0, 0, 0, 0);
-        dockwidget->setFeatures(QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable);
+        dockwidget->setFeatures(QDockWidget::DockWidgetClosable | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
         dockwidget->setWindowTitle(name);
         mpConsole->mDockWidgetMap.insert(name, dockwidget);
         // It wasn't obvious but the parent passed to the TConsole constructor
@@ -3510,7 +3507,6 @@ std::pair<bool, QString> Host::createLabel(const QString& windowname, const QStr
         return {false, qsl("a miniconsole/userwindow with the name '%1' already exists").arg(name)};
     }
     return {false, QString()};
-
 }
 
 bool Host::setClickthrough(const QString& name, bool clickthrough)
@@ -4169,7 +4165,6 @@ std::pair<bool, QString> Host::setMovie(const QString& name, const QString& movi
     pL->setMovie(myMovie);
     myMovie->start();
     return {true, QString()};
-
 }
 
 QSize Host::calcFontSize(const QString& windowName)
@@ -4308,7 +4303,7 @@ bool Host::setBackgroundImage(const QString& name, QString& imgPath, int mode)
     return false;
 }
 
-bool Host::resetBackgroundImage(const QString &name)
+bool Host::resetBackgroundImage(const QString& name)
 {
     if (!mpConsole) {
         return false;
@@ -4410,11 +4405,7 @@ void Host::createMapper(const bool loadDefaultMap)
     mpDockableMapWidget->setObjectName(qsl("dockMap_%1").arg(hostName));
     // Arrange for TMap member values to be copied from the Host masters so they
     // are in place when the 2D mapper is created:
-    getPlayerRoomStyleDetails(pMap->mPlayerRoomStyle,
-                                     pMap->mPlayerRoomOuterDiameterPercentage,
-                                     pMap->mPlayerRoomInnerDiameterPercentage,
-                                     pMap->mPlayerRoomOuterColor,
-                                     pMap->mPlayerRoomInnerColor);
+    getPlayerRoomStyleDetails(pMap->mPlayerRoomStyle, pMap->mPlayerRoomOuterDiameterPercentage, pMap->mPlayerRoomInnerDiameterPercentage, pMap->mPlayerRoomOuterColor, pMap->mPlayerRoomInnerColor);
 
     pMap->mpMapper = new dlgMapper(mpDockableMapWidget, this, pMap); //FIXME: mpHost definieren
     pMap->mpMapper->setStyleSheet(mProfileStyleSheet);
@@ -4455,7 +4446,7 @@ void Host::createMapper(const bool loadDefaultMap)
     mpDockableMapWidget->show();
 
     check_for_mappingscript();
-    TEvent mapOpenEvent {};
+    TEvent mapOpenEvent{};
     mapOpenEvent.mArgumentList.append(QLatin1String("mapOpenEvent"));
     mapOpenEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     raiseEvent(mapOpenEvent);
@@ -4532,9 +4523,7 @@ void Host::setupIreDriverBugfix()
 
 void Host::setControlCharacterMode(const ControlCharacterMode mode)
 {
-    if (Q_UNLIKELY(!(mode == ControlCharacterMode::AsIs
-                     || mode == ControlCharacterMode::Picture
-                     || mode == ControlCharacterMode::OEM))) {
+    if (Q_UNLIKELY(!(mode == ControlCharacterMode::AsIs || mode == ControlCharacterMode::Picture || mode == ControlCharacterMode::OEM))) {
         return;
     }
 
@@ -4795,13 +4784,11 @@ QFont Host::getAndClearTempDisplayFont()
 }
 
 // Static whitelist of valid experiments
-const QSet<QString> Host::mValidExperiments = {
-    qsl("experiment.rendering.originalish"),
-    qsl("experiment.rendering.more-transparent"),
-    qsl("experiment.3dmap.modernmapper"),
-    qsl("experiment.render-in-out-exits"),
-    qsl("experiment.3d-player-icon")
-};
+const QSet<QString> Host::mValidExperiments = {qsl("experiment.rendering.originalish"),
+                                               qsl("experiment.rendering.more-transparent"),
+                                               qsl("experiment.3dmap.modernmapper"),
+                                               qsl("experiment.render-in-out-exits"),
+                                               qsl("experiment.3d-player-icon")};
 
 bool Host::experimentEnabled(const QString& experimentKey) const
 {

--- a/src/HostManager.cpp
+++ b/src/HostManager.cpp
@@ -164,12 +164,12 @@ HostManager::Iter::Iter(HostManager* manager, bool at_start)
     }
 }
 
-bool HostManager::Iter::operator== (const Iter& other) const
+bool HostManager::Iter::operator==(const Iter& other) const
 {
     return it == other.it;
 }
 
-bool HostManager::Iter::operator!= (const Iter& other) const
+bool HostManager::Iter::operator!=(const Iter& other) const
 {
     return it != other.it;
 }

--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -386,12 +386,9 @@ int KeyUnit::getNewID()
 QString KeyUnit::getKeyName(const Qt::Key keyCode, const Qt::KeyboardModifiers modifierCode) const
 {
     QString name;
-    name = ((modifierCode & Qt::ShiftModifier) ? "shift + " : QString())
-         % ((modifierCode & Qt::ControlModifier) ? "control + " : QString())
-         % ((modifierCode & Qt::AltModifier) ? "alt + " : QString())
-         % ((modifierCode & Qt::MetaModifier) ? "meta + " : QString())
-         % ((modifierCode & Qt::KeypadModifier) ? "keypad + " : QString())
-         % ((modifierCode & Qt::GroupSwitchModifier) ? "groupswitch + " : QString());
+    name = ((modifierCode & Qt::ShiftModifier) ? "shift + " : QString()) % ((modifierCode & Qt::ControlModifier) ? "control + " : QString()) % ((modifierCode & Qt::AltModifier) ? "alt + " : QString())
+           % ((modifierCode & Qt::MetaModifier) ? "meta + " : QString()) % ((modifierCode & Qt::KeypadModifier) ? "keypad + " : QString())
+           % ((modifierCode & Qt::GroupSwitchModifier) ? "groupswitch + " : QString());
 
 
     if (mKeys.contains(keyCode)) {
@@ -403,7 +400,9 @@ QString KeyUnit::getKeyName(const Qt::Key keyCode, const Qt::KeyboardModifiers m
               "%1 is a string describing the modifier keys (e.g. \"shift\" or \"control\") "
               "used with the key, whose 'code' number, in %2 is not one that we have a name "
               "for. This is probably one of those extra keys around the edge of the keyboard "
-              "that some people have.").arg(name).arg(keyCode, 4, 16, QLatin1Char('0'));
+              "that some people have.")
+            .arg(name)
+            .arg(keyCode, 4, 16, QLatin1Char('0'));
 }
 
 void KeyUnit::assembleReport(TKey* pItem)
@@ -435,16 +434,10 @@ std::tuple<QString, int, int, int> KeyUnit::assembleReport()
         assembleReport(pItem);
     }
     QStringList msg;
-    msg << QLatin1String("Keys current total: ") << QString::number(statsItemsTotal) << QLatin1String("\n")
-        << QLatin1String("tempKeys current total: ") << QString::number(statsTempItems) << QLatin1String("\n")
-        << QLatin1String("active Keys: ") << QString::number(statsActiveItems) << QLatin1String("\n");
+    msg << QLatin1String("Keys current total: ") << QString::number(statsItemsTotal) << QLatin1String("\n") << QLatin1String("tempKeys current total: ") << QString::number(statsTempItems)
+        << QLatin1String("\n") << QLatin1String("active Keys: ") << QString::number(statsActiveItems) << QLatin1String("\n");
 
-    return {
-        msg.join(QString()),
-        statsItemsTotal,
-        statsTempItems,
-        statsActiveItems
-    };
+    return {msg.join(QString()), statsItemsTotal, statsTempItems, statsActiveItems};
 }
 
 void KeyUnit::markCleanup(TKey* pT)

--- a/src/LlamaFileManager.cpp
+++ b/src/LlamaFileManager.cpp
@@ -27,15 +27,14 @@
 #include <QJsonParseError>
 
 LlamafileManager::LlamafileManager(QObject* parent)
-    : QObject(parent)
-    , process(std::make_unique<QProcess>(this))
-    , healthCheckTimer(std::make_unique<QTimer>(this))
-    , networkManager(std::make_unique<QNetworkAccessManager>(this))
+: QObject(parent)
+, process(std::make_unique<QProcess>(this))
+, healthCheckTimer(std::make_unique<QTimer>(this))
+, networkManager(std::make_unique<QNetworkAccessManager>(this))
 {
     // Configure process
     connect(process.get(), &QProcess::started, this, &LlamafileManager::onProcessStarted);
-    connect(process.get(), QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
-            this, &LlamafileManager::onProcessFinished);
+    connect(process.get(), QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this, &LlamafileManager::onProcessFinished);
     connect(process.get(), &QProcess::errorOccurred, this, &LlamafileManager::onProcessError);
     connect(process.get(), &QProcess::stateChanged, this, &LlamafileManager::onProcessStateChanged);
 
@@ -47,13 +46,15 @@ LlamafileManager::LlamafileManager(QObject* parent)
     networkManager->setTransferTimeout(10000); // 10 second timeout
 }
 
-LlamafileManager::~LlamafileManager() {
+LlamafileManager::~LlamafileManager()
+{
     if (isRunning()) {
         stop();
     }
 }
 
-bool LlamafileManager::start(const Config& newConfig) {
+bool LlamafileManager::start(const Config& newConfig)
+{
     if (currentStatus == Status::Starting || currentStatus == Status::Running) {
         qDebug() << "LlamafileManager: Already starting or running";
         return currentStatus == Status::Running;
@@ -94,7 +95,8 @@ bool LlamafileManager::start(const Config& newConfig) {
     return true;
 }
 
-void LlamafileManager::stop() {
+void LlamafileManager::stop()
+{
     if (currentStatus == Status::Stopped || currentStatus == Status::Stopping) {
         return;
     }
@@ -119,14 +121,16 @@ void LlamafileManager::stop() {
     emit processStopped();
 }
 
-std::optional<qint64> LlamafileManager::processId() const noexcept {
+std::optional<qint64> LlamafileManager::processId() const noexcept
+{
     if (process && process->state() == QProcess::Running) {
         return process->processId();
     }
     return std::nullopt;
 }
 
-void LlamafileManager::chatCompletion(const ApiRequest& request, ApiCallback callback) {
+void LlamafileManager::chatCompletion(const ApiRequest& request, ApiCallback callback)
+{
     if (!isRunning()) {
         callback({false, "Llamafile not running", {}, 0});
         return;
@@ -147,7 +151,8 @@ void LlamafileManager::chatCompletion(const ApiRequest& request, ApiCallback cal
     makeApiRequest("/v1/chat/completions", requestData, std::move(callback));
 }
 
-void LlamafileManager::textCompletion(const ApiRequest& request, ApiCallback callback) {
+void LlamafileManager::textCompletion(const ApiRequest& request, ApiCallback callback)
+{
     if (!isRunning()) {
         callback({false, "Llamafile not running", {}, 0});
         return;
@@ -169,7 +174,8 @@ void LlamafileManager::textCompletion(const ApiRequest& request, ApiCallback cal
     makeApiRequest("/completion", requestData, std::move(callback));
 }
 
-void LlamafileManager::embeddings(const ApiRequest& request, ApiCallback callback) {
+void LlamafileManager::embeddings(const ApiRequest& request, ApiCallback callback)
+{
     if (!isRunning()) {
         callback({false, "Llamafile not running", {}, 0});
         return;
@@ -191,7 +197,8 @@ void LlamafileManager::embeddings(const ApiRequest& request, ApiCallback callbac
     makeApiRequest("/v1/embeddings", requestData, std::move(callback));
 }
 
-void LlamafileManager::getModels(ApiCallback callback) {
+void LlamafileManager::getModels(ApiCallback callback)
+{
     if (!isRunning()) {
         callback({false, "Llamafile not running", {}, 0});
         return;
@@ -200,7 +207,8 @@ void LlamafileManager::getModels(ApiCallback callback) {
     makeApiRequest("/v1/models", {}, std::move(callback));
 }
 
-void LlamafileManager::enableHealthCheck(bool enable) {
+void LlamafileManager::enableHealthCheck(bool enable)
+{
     if (enable && isRunning()) {
         healthCheckTimer->start(config.healthCheckIntervalMs);
     } else {
@@ -208,7 +216,8 @@ void LlamafileManager::enableHealthCheck(bool enable) {
     }
 }
 
-bool LlamafileManager::isLlamafileExecutable(const QString& path) {
+bool LlamafileManager::isLlamafileExecutable(const QString& path)
+{
     QFileInfo info(path);
     if (!info.exists() || !info.isFile()) {
         return false;
@@ -228,21 +237,20 @@ bool LlamafileManager::isLlamafileExecutable(const QString& path) {
 #endif
 }
 
-QString LlamafileManager::findLlamafileExecutable(const QStringList& searchPaths) {
+QString LlamafileManager::findLlamafileExecutable(const QStringList& searchPaths)
+{
     QStringList paths = searchPaths;
 
     // Add default search paths
     if (paths.isEmpty()) {
-        paths << QCoreApplication::applicationDirPath()
-              << QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
-              << QStandardPaths::writableLocation(QStandardPaths::DownloadLocation)
-              << "/usr/local/bin"
-              << "/opt/llamafile";
+        paths << QCoreApplication::applicationDirPath() << QStandardPaths::writableLocation(QStandardPaths::HomeLocation) << QStandardPaths::writableLocation(QStandardPaths::DownloadLocation)
+              << "/usr/local/bin" << "/opt/llamafile";
     }
 
     for (const QString& path : paths) {
         QDir dir(path);
-        if (!dir.exists()) continue;
+        if (!dir.exists())
+            continue;
 
         const QStringList filters{"*.llamafile"};
         const auto entries = dir.entryInfoList(filters, QDir::Files | QDir::Executable);
@@ -257,12 +265,14 @@ QString LlamafileManager::findLlamafileExecutable(const QStringList& searchPaths
     return {};
 }
 
-QUrl LlamafileManager::apiBaseUrl() const {
+QUrl LlamafileManager::apiBaseUrl() const
+{
     return QUrl(qsl("http://%1:%2").arg(config.host).arg(config.port));
 }
 
 // Private slots
-void LlamafileManager::onProcessStarted() {
+void LlamafileManager::onProcessStarted()
+{
     qDebug() << "LlamafileManager: Process started with PID" << process->processId();
 
     // Wait a moment for the server to initialize before declaring it running
@@ -291,7 +301,8 @@ void LlamafileManager::onProcessFinished(int exitCode, QProcess::ExitStatus exit
 
     // Get last few lines of output for context
     auto getLastLines = [](const QString& text, int maxLines = 5) -> QString {
-        if (text.isEmpty()) return QString();
+        if (text.isEmpty())
+            return QString();
 
         QStringList lines = text.split('\n', Qt::SkipEmptyParts);
         if (lines.size() <= maxLines) {
@@ -310,8 +321,7 @@ void LlamafileManager::onProcessFinished(int exitCode, QProcess::ExitStatus exit
 
     if (currentStatus != Status::Stopping) {
         if (config.autoRestart && restartAttempts < config.maxRestartAttempts) {
-            qDebug() << "LlamafileManager: Attempting restart" << (restartAttempts + 1)
-                     << "of" << config.maxRestartAttempts;
+            qDebug() << "LlamafileManager: Attempting restart" << (restartAttempts + 1) << "of" << config.maxRestartAttempts;
 
             // Log the output for debugging restart scenarios
             if (!recentStdout.isEmpty()) {
@@ -343,7 +353,8 @@ void LlamafileManager::onProcessFinished(int exitCode, QProcess::ExitStatus exit
     }
 }
 
-void LlamafileManager::onProcessError(QProcess::ProcessError error) {
+void LlamafileManager::onProcessError(QProcess::ProcessError error)
+{
     // Llama seems to have issues erroring when shutting down, squelch such messages
     if (currentStatus == Status::Stopping) {
         return;
@@ -351,24 +362,24 @@ void LlamafileManager::onProcessError(QProcess::ProcessError error) {
 
     QString errorString;
     switch (error) {
-        case QProcess::FailedToStart:
-            errorString = "Failed to start: " + process->errorString();
-            break;
-        case QProcess::Crashed:
-            errorString = "Process crashed";
-            break;
-        case QProcess::Timedout:
-            errorString = "Process timed out";
-            break;
-        case QProcess::WriteError:
-            errorString = "Write error: " + process->errorString();
-            break;
-        case QProcess::ReadError:
-            errorString = "Read error: " + process->errorString();
-            break;
-        default:
-            errorString = "Unknown error: " + process->errorString();
-            break;
+    case QProcess::FailedToStart:
+        errorString = "Failed to start: " + process->errorString();
+        break;
+    case QProcess::Crashed:
+        errorString = "Process crashed";
+        break;
+    case QProcess::Timedout:
+        errorString = "Process timed out";
+        break;
+    case QProcess::WriteError:
+        errorString = "Write error: " + process->errorString();
+        break;
+    case QProcess::ReadError:
+        errorString = "Read error: " + process->errorString();
+        break;
+    default:
+        errorString = "Unknown error: " + process->errorString();
+        break;
     }
 
     qDebug() << "LlamafileManager: Process error:" << errorString;
@@ -380,11 +391,13 @@ void LlamafileManager::onProcessError(QProcess::ProcessError error) {
     }
 }
 
-void LlamafileManager::onProcessStateChanged(QProcess::ProcessState newState) {
+void LlamafileManager::onProcessStateChanged(QProcess::ProcessState newState)
+{
     qDebug() << "LlamafileManager: Process state changed to" << newState;
 }
 
-void LlamafileManager::performHealthCheck() {
+void LlamafileManager::performHealthCheck()
+{
     if (!isRunning()) {
         return;
     }
@@ -401,9 +414,11 @@ void LlamafileManager::performHealthCheck() {
     reply->setProperty("isHealthCheck", true);
 }
 
-void LlamafileManager::onHealthCheckReply() {
+void LlamafileManager::onHealthCheckReply()
+{
     auto* reply = qobject_cast<QNetworkReply*>(sender());
-    if (!reply) return;
+    if (!reply)
+        return;
 
     reply->deleteLater();
 
@@ -417,9 +432,7 @@ void LlamafileManager::onHealthCheckReply() {
         }
     } else {
         healthy = false;
-        const QString reason = qsl("HTTP %1: %2")
-                              .arg(reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt())
-                              .arg(reply->errorString());
+        const QString reason = qsl("HTTP %1: %2").arg(reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt()).arg(reply->errorString());
 
         qDebug() << "LlamafileManager: Health check failed:" << reason;
         setStatus(Status::Unhealthy);
@@ -437,7 +450,8 @@ void LlamafileManager::onHealthCheckReply() {
 }
 
 // Private helper methods
-void LlamafileManager::setStatus(Status newStatus) {
+void LlamafileManager::setStatus(Status newStatus)
+{
     if (currentStatus != newStatus) {
         const Status oldStatus = currentStatus;
         currentStatus = newStatus;
@@ -448,7 +462,8 @@ void LlamafileManager::setStatus(Status newStatus) {
     }
 }
 
-void LlamafileManager::makeApiRequest(const QString& endpoint, const QJsonObject& requestData, ApiCallback callback) {
+void LlamafileManager::makeApiRequest(const QString& endpoint, const QJsonObject& requestData, ApiCallback callback)
+{
     const QUrl url = apiBaseUrl().resolved(QUrl(endpoint));
     QNetworkRequest request(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
@@ -467,7 +482,8 @@ void LlamafileManager::makeApiRequest(const QString& endpoint, const QJsonObject
     });
 }
 
-void LlamafileManager::handleApiReply(QNetworkReply* reply, ApiCallback callback) {
+void LlamafileManager::handleApiReply(QNetworkReply* reply, ApiCallback callback)
+{
     reply->deleteLater();
 
     ApiResponse response;
@@ -493,7 +509,8 @@ void LlamafileManager::handleApiReply(QNetworkReply* reply, ApiCallback callback
     callback(response);
 }
 
-QString LlamafileManager::constructExecutablePath() const {
+QString LlamafileManager::constructExecutablePath() const
+{
     QString executable;
 
 #if defined(Q_OS_LINUX)
@@ -505,7 +522,8 @@ QString LlamafileManager::constructExecutablePath() const {
     return executable;
 }
 
-QStringList LlamafileManager::buildProcessArguments() const {
+QStringList LlamafileManager::buildProcessArguments() const
+{
     QStringList args;
 
     // Basic server arguments
@@ -535,7 +553,8 @@ QStringList LlamafileManager::buildProcessArguments() const {
     return args;
 }
 
-void LlamafileManager::attemptRestart() {
+void LlamafileManager::attemptRestart()
+{
     if (restartAttempts >= config.maxRestartAttempts) {
         setStatus(Status::Error);
         lastError = qsl("Max restart attempts (%1) exceeded").arg(config.maxRestartAttempts);
@@ -552,7 +571,8 @@ void LlamafileManager::attemptRestart() {
     });
 }
 
-bool LlamafileManager::validateConfig() {
+bool LlamafileManager::validateConfig()
+{
     if (config.modelPath.isEmpty()) {
         lastError = "Model path is empty";
         return false;
@@ -577,7 +597,8 @@ bool LlamafileManager::validateConfig() {
     return true;
 }
 
-bool LlamafileManager::isPortAvailable(int port) const {
+bool LlamafileManager::isPortAvailable(int port) const
+{
     QTcpSocket socket;
     socket.connectToHost(config.host, port);
     const bool available = !socket.waitForConnected(100);
@@ -585,7 +606,8 @@ bool LlamafileManager::isPortAvailable(int port) const {
     return available;
 }
 
-void LlamafileManager::textCompletionStream(const ApiRequest& request, StreamChunkCallback chunkCallback, StreamErrorCallback errorCallback) {
+void LlamafileManager::textCompletionStream(const ApiRequest& request, StreamChunkCallback chunkCallback, StreamErrorCallback errorCallback)
+{
     if (!isRunning()) {
         errorCallback("Llamafile not running");
         return;
@@ -607,7 +629,8 @@ void LlamafileManager::textCompletionStream(const ApiRequest& request, StreamChu
     makeStreamingApiRequest("/completion", requestData, chunkCallback, errorCallback);
 }
 
-void LlamafileManager::makeStreamingApiRequest(const QString& endpoint, const QJsonObject& requestData, StreamChunkCallback chunkCallback, StreamErrorCallback errorCallback) {
+void LlamafileManager::makeStreamingApiRequest(const QString& endpoint, const QJsonObject& requestData, StreamChunkCallback chunkCallback, StreamErrorCallback errorCallback)
+{
     const QUrl url = apiBaseUrl().resolved(QUrl(endpoint));
     QNetworkRequest request(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -145,15 +145,13 @@ bool LuaInterface::loadValue(lua_State* L, TVar* var, int index)
                 const int actualIndex = (index < 0) ? stackTop + index + 1 : index;
 
                 if (actualIndex <= 0 || actualIndex > stackTop) {
-                    qWarning().noquote().nospace() << "LuaInterface::loadValue() - Invalid stack index " << index
-                                                   << " for variable \"" << var->getName() << "\". Stack size: " << stackTop
+                    qWarning().noquote().nospace() << "LuaInterface::loadValue() - Invalid stack index " << index << " for variable \"" << var->getName() << "\". Stack size: " << stackTop
                                                    << ", resolved index: " << actualIndex << ".";
                     return false;
                 }
 
                 if (!lua_istable(L, index)) {
-                    qWarning().noquote().nospace() << "LuaInterface::loadValue() - Value at stack index " << index
-                                                   << " is not a table for variable \"" << var->getName()
+                    qWarning().noquote().nospace() << "LuaInterface::loadValue() - Value at stack index " << index << " is not a table for variable \"" << var->getName()
                                                    << "\". Got type: " << lua_typename(L, lua_type(L, index)) << ".";
                     return false;
                 }
@@ -170,8 +168,8 @@ bool LuaInterface::loadValue(lua_State* L, TVar* var, int index)
                     }
                 }
                 if (!foundTable) {
-                    qWarning().noquote().nospace() << "LuaInterface::loadValue() - No table found on stack for variable \"" << var->getName()
-                                                   << "\" when index=0. Stack size: " << lua_gettop(L) << ".";
+                    qWarning().noquote().nospace() << "LuaInterface::loadValue() - No table found on stack for variable \"" << var->getName() << "\" when index=0. Stack size: " << lua_gettop(L)
+                                                   << ".";
                     return false;
                 }
             }
@@ -423,18 +421,12 @@ bool LuaInterface::setValue(TVar* var)
     }
     int error = luaL_loadstring(mL, variableChangeCode.toUtf8().constData());
     if (error) {
-        qWarning().noquote().nospace() << "LuaInterface::setValue(...) WARNING - Internal Lua (parsing) error: \""
-                                       << lua_tostring(mL, -1)
-                                       << "\" in code:\n\""
-                                       << variableChangeCode << "\".";
+        qWarning().noquote().nospace() << "LuaInterface::setValue(...) WARNING - Internal Lua (parsing) error: \"" << lua_tostring(mL, -1) << "\" in code:\n\"" << variableChangeCode << "\".";
         return false;
     }
     error = lua_pcall(mL, 0, LUA_MULTRET, 0);
     if (error) {
-        qWarning().noquote().nospace() << "LuaInterface::setValue(...) WARNING - Internal Lua (executing) error: \""
-                                       << lua_tostring(mL, -1)
-                                       << "\" in code:\n\""
-                                       << variableChangeCode << "\".";
+        qWarning().noquote().nospace() << "LuaInterface::setValue(...) WARNING - Internal Lua (executing) error: \"" << lua_tostring(mL, -1) << "\" in code:\n\"" << variableChangeCode << "\".";
         return false;
     }
     return true;
@@ -442,7 +434,6 @@ bool LuaInterface::setValue(TVar* var)
 
 void LuaInterface::deleteVar(TVar* var)
 {
-
     QList<TVar*> vars = varOrder(var);
     QString oldName = vars[0]->getName();
     for (int i = 1; i < vars.size(); i++) {
@@ -456,18 +447,12 @@ void LuaInterface::deleteVar(TVar* var)
     oldName.append(qsl(" = nil"));
     int error = luaL_loadstring(mL, oldName.toUtf8().constData());
     if (error) {
-        qWarning().noquote().nospace() << "LuaInterface::deleteVar(...) WARNING - Internal Lua (parsing) error: \""
-                                       << lua_tostring(mL, -1)
-                                       << "\" in code:\n\""
-                                       << oldName << "\".";
+        qWarning().noquote().nospace() << "LuaInterface::deleteVar(...) WARNING - Internal Lua (parsing) error: \"" << lua_tostring(mL, -1) << "\" in code:\n\"" << oldName << "\".";
         return;
     }
     error = lua_pcall(mL, 0, LUA_MULTRET, 0);
     if (error) {
-        qWarning().noquote().nospace() << "LuaInterface::deleteVar(...) WARNING - Internal Lua (executing) error: \""
-                                       << lua_tostring(mL, -1)
-                                       << "\" in code:\n\""
-                                       << oldName << "\".";
+        qWarning().noquote().nospace() << "LuaInterface::deleteVar(...) WARNING - Internal Lua (executing) error: \"" << lua_tostring(mL, -1) << "\" in code:\n\"" << oldName << "\".";
     }
 }
 
@@ -518,8 +503,7 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         } else if (kType == LUA_TTABLE) {
             lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
         } else {
-            qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type: " << lua_typename(mL, kType)
-                                           << " for variable \"" << var->getName()
+            qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type: " << lua_typename(mL, kType) << " for variable \"" << var->getName()
                                            << "\". Expected string, number, or table.";
             return;
         }
@@ -548,8 +532,7 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         } else if (kType == LUA_TTABLE || kType == LUA_TFUNCTION) {
             lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
         } else {
-            qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type when retrieving old value: " << lua_typename(mL, kType)
-                                           << " for variable \"" << var->getName()
+            qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type when retrieving old value: " << lua_typename(mL, kType) << " for variable \"" << var->getName()
                                            << "\". Expected string, number, table, or function.";
             return;
         }
@@ -565,8 +548,7 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         } else if (kType == LUA_TTABLE) {
             lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
         } else {
-            qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type when setting new key: " << lua_typename(mL, kType)
-                                           << " for variable \"" << var->getName()
+            qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type when setting new key: " << lua_typename(mL, kType) << " for variable \"" << var->getName()
                                            << "\". Expected string, number, or table.";
             return;
         }
@@ -583,8 +565,7 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         } else if (kType == LUA_TTABLE || kType == LUA_TFUNCTION) {
             lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
         } else {
-            qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type when deleting old key: " << lua_typename(mL, kType)
-                                           << " for variable \"" << var->getName()
+            qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type when deleting old key: " << lua_typename(mL, kType) << " for variable \"" << var->getName()
                                            << "\". Expected string, number, table, or function.";
             return;
         }
@@ -598,7 +579,6 @@ bool LuaInterface::loadVar(TVar* var)
 {
     //puts the value of a variable on the -1 position of the stack
     if (setjmp(buf) == 0) {
-
         const int kType = var->getKeyType();
         const int vType = var->getValueType();
         if (vType == LUA_TTABLE) {
@@ -626,8 +606,7 @@ bool LuaInterface::loadVar(TVar* var)
             return false;
         }
     } else {
-        qWarning().noquote().nospace() << "LuaInterface::loadVar() - Lua panic occurred while loading variable \"" << var->getName()
-                                       << "\" with key type " << lua_typename(mL, var->getKeyType())
+        qWarning().noquote().nospace() << "LuaInterface::loadVar() - Lua panic occurred while loading variable \"" << var->getName() << "\" with key type " << lua_typename(mL, var->getKeyType())
                                        << " and value type " << lua_typename(mL, var->getValueType()) << ".";
         return false;
     }
@@ -680,18 +659,14 @@ void LuaInterface::renameVar(TVar* var)
     auto renameCode = qsl("%1 = %2").arg(newName, oldVariable);
     int error = luaL_loadstring(mL, renameCode.toUtf8().constData());
     if (error) {
-        qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - In copying (first) stage, internal Lua (parsing) error: \""
-                                       << lua_tostring(mL, -1)
-                                       << "\" in code:\n\""
-                                       << renameCode << "\".";
+        qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - In copying (first) stage, internal Lua (parsing) error: \"" << lua_tostring(mL, -1) << "\" in code:\n\"" << renameCode
+                                       << "\".";
         var->clearNewName();
         return;
     }
     error = lua_pcall(mL, 0, LUA_MULTRET, 0);
     if (error) {
-        qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - In copying (first) stage, internal Lua (executing) error: \""
-                                       << lua_tostring(mL, -1)
-                                       << "\" in code:\n\""
+        qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - In copying (first) stage, internal Lua (executing) error: \"" << lua_tostring(mL, -1) << "\" in code:\n\""
                                        << renameCode << "\".";
         var->clearNewName();
         return;
@@ -700,18 +675,14 @@ void LuaInterface::renameVar(TVar* var)
     //delete it
     error = luaL_loadstring(mL, oldVariable.append(QLatin1String(" = nil")).toUtf8().constData());
     if (error) {
-        qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - In deleting (second) stage, internal Lua (parsing) error: \""
-                                       << lua_tostring(mL, -1)
-                                       << "\" in code:\n\""
+        qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - In deleting (second) stage, internal Lua (parsing) error: \"" << lua_tostring(mL, -1) << "\" in code:\n\""
                                        << renameCode << "\".";
         var->clearNewName();
         return;
     }
     error = lua_pcall(mL, 0, LUA_MULTRET, 0);
     if (error) {
-        qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - In deleting (second) stage, internal Lua (executing) error: \""
-                                       << lua_tostring(mL, -1)
-                                       << "\" in code:\n\""
+        qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - In deleting (second) stage, internal Lua (executing) error: \"" << lua_tostring(mL, -1) << "\" in code:\n\""
                                        << renameCode << "\".";
     }
     var->clearNewName();
@@ -734,9 +705,8 @@ QString LuaInterface::getValue(TVar* var)
             lua_rawgeti(mL, LUA_GLOBALSINDEX, firstVariable->getName().toInt());
         }
         if (lua_isnoneornil(mL, lua_gettop(mL))) {
-            qDebug() << "LuaInterface::getValue: Couldn't put root value" << firstVariable->getName()
-                << "onto the Lua stack in order to get value of" << var->getName()
-                << ", perhaps the key type isn't supported?";
+            qDebug() << "LuaInterface::getValue: Couldn't put root value" << firstVariable->getName() << "onto the Lua stack in order to get value of" << var->getName()
+                     << ", perhaps the key type isn't supported?";
             return {};
         }
         for (int i = 1; i < vars.size(); i++) {

--- a/src/MiddleMousePanHandler.cpp
+++ b/src/MiddleMousePanHandler.cpp
@@ -25,8 +25,7 @@
 #include <algorithm>
 #include <cmath>
 
-namespace
-{
+namespace {
 constexpr int csmTimerIntervalMs = 16;
 constexpr int csmHoldThresholdMs = 300;
 constexpr qreal csmDeadZone = 9.0;
@@ -38,7 +37,9 @@ constexpr qreal csmMovementScale = 0.3;
 MiddleMousePanHandler::MiddleMousePanHandler(T2DMap& mapWidget)
 : mMapWidget(mapWidget)
 {
-    QObject::connect(&mTimer, &QTimer::timeout, [this]() { handleTick(); });
+    QObject::connect(&mTimer, &QTimer::timeout, [this]() {
+        handleTick();
+    });
 }
 
 bool MiddleMousePanHandler::matches(const T2DMap::MapInteractionContext& context) const
@@ -295,9 +296,7 @@ void MiddleMousePanHandler::renderIndicator(QPainter& painter)
     const QPointF perpendicular(-unitDirection.y(), unitDirection.x());
 
     QPolygonF triangle;
-    triangle << triangleTip
-             << triangleBase + perpendicular * triangleHalfWidth
-             << triangleBase - perpendicular * triangleHalfWidth;
+    triangle << triangleTip << triangleBase + perpendicular * triangleHalfWidth << triangleBase - perpendicular * triangleHalfWidth;
 
     QPen trianglePen(QColor(255, 255, 255, 180));
     trianglePen.setWidthF(1.5);

--- a/src/MudletInstanceCoordinator.cpp
+++ b/src/MudletInstanceCoordinator.cpp
@@ -24,7 +24,11 @@
 
 const int WAIT_FOR_RESPONSE_MS = 500;
 
-MudletInstanceCoordinator::MudletInstanceCoordinator(const QString& serverName, QObject* parent) : QLocalServer(parent), mServerName(serverName) {}
+MudletInstanceCoordinator::MudletInstanceCoordinator(const QString& serverName, QObject* parent)
+: QLocalServer(parent)
+, mServerName(serverName)
+{
+}
 
 void MudletInstanceCoordinator::queuePackage(const QString& packageName)
 {

--- a/src/MxpTag.cpp
+++ b/src/MxpTag.cpp
@@ -24,18 +24,20 @@
 
 MxpTagAttribute::MxpTagAttribute(const QString& name, const QString& value)
 : QPair<QString, QString>(name, value)
-{}
+{
+}
 
 MxpTagAttribute::MxpTagAttribute(const QString& name)
 : MxpTagAttribute(name, QString())
-{}
+{
+}
 
 MxpTagAttribute::MxpTagAttribute()
 : QPair<QString, QString>()
-{}
+{
+}
 
-MxpTagAttribute::~MxpTagAttribute()
-{}
+MxpTagAttribute::~MxpTagAttribute() {}
 
 const MxpTagAttribute& MxpStartTag::getAttribute(int attrIndex) const
 {

--- a/src/PanInteractionHandler.cpp
+++ b/src/PanInteractionHandler.cpp
@@ -37,13 +37,11 @@ bool PanInteractionHandler::matches(const T2DMap::MapInteractionContext& context
 
     switch (context.event->type()) {
     case QEvent::MouseButtonPress:
-        return context.button == Qt::LeftButton
-            && (context.modifiers.testFlag(Qt::AltModifier) || context.isMapViewOnly);
+        return context.button == Qt::LeftButton && (context.modifiers.testFlag(Qt::AltModifier) || context.isMapViewOnly);
     case QEvent::MouseMove:
         return mMapWidget.mpMap->mLeftDown || mMapWidget.mpMap->m2DPanMode;
     case QEvent::MouseButtonRelease:
-        return context.button == Qt::LeftButton
-            && (mMapWidget.mpMap->mLeftDown || mMapWidget.mpMap->m2DPanMode);
+        return context.button == Qt::LeftButton && (mMapWidget.mpMap->mLeftDown || mMapWidget.mpMap->m2DPanMode);
     default:
         return false;
     }
@@ -159,4 +157,3 @@ bool PanInteractionHandler::handleMouseRelease(T2DMap::MapInteractionContext& co
 
     return false;
 }
-

--- a/src/RenderCommand.cpp
+++ b/src/RenderCommand.cpp
@@ -21,23 +21,32 @@
 
 #include <QDebug>
 
-RenderCubeCommand::RenderCubeCommand(float x, float y, float z, float size, float r, float g, float b, float a,
-                                   const QMatrix4x4& projectionMatrix, const QMatrix4x4& viewMatrix, const QMatrix4x4& modelMatrix)
-    : mX(x), mY(y), mZ(z), mSize(size), mR(r), mG(g), mB(b), mA(a)
-    , mProjectionMatrix(projectionMatrix), mViewMatrix(viewMatrix), mModelMatrix(modelMatrix)
+RenderCubeCommand::RenderCubeCommand(
+        float x, float y, float z, float size, float r, float g, float b, float a, const QMatrix4x4& projectionMatrix, const QMatrix4x4& viewMatrix, const QMatrix4x4& modelMatrix)
+: mX(x)
+, mY(y)
+, mZ(z)
+, mSize(size)
+, mR(r)
+, mG(g)
+, mB(b)
+, mA(a)
+, mProjectionMatrix(projectionMatrix)
+, mViewMatrix(viewMatrix)
+, mModelMatrix(modelMatrix)
 {
 }
 
 void RenderCubeCommand::execute(QOpenGLFunctions* gl,
-                               QOpenGLShaderProgram* shader,
-                               GeometryManager* geometryManager,
-                               ResourceManager* resourceManager,
-                               QOpenGLVertexArrayObject& vao,
-                               QOpenGLBuffer& vertexBuffer,
-                               QOpenGLBuffer& colorBuffer,
-                               QOpenGLBuffer& normalBuffer,
-                               QOpenGLBuffer& indexBuffer,
-                               QOpenGLBuffer& texCoordBuffer)
+                                QOpenGLShaderProgram* shader,
+                                GeometryManager* geometryManager,
+                                ResourceManager* resourceManager,
+                                QOpenGLVertexArrayObject& vao,
+                                QOpenGLBuffer& vertexBuffer,
+                                QOpenGLBuffer& colorBuffer,
+                                QOpenGLBuffer& normalBuffer,
+                                QOpenGLBuffer& indexBuffer,
+                                QOpenGLBuffer& texCoordBuffer)
 {
     Q_UNUSED(gl)
     Q_UNUSED(texCoordBuffer)
@@ -59,23 +68,25 @@ void RenderCubeCommand::execute(QOpenGLFunctions* gl,
     geometryManager->renderGeometry(cubeGeometry, vao, vertexBuffer, colorBuffer, normalBuffer, indexBuffer, resourceManager, GL_TRIANGLES);
 }
 
-RenderLinesCommand::RenderLinesCommand(const QVector<float>& vertices, const QVector<float>& colors,
-                                     const QMatrix4x4& projectionMatrix, const QMatrix4x4& viewMatrix, const QMatrix4x4& modelMatrix)
-    : mVertices(vertices), mColors(colors)
-    , mProjectionMatrix(projectionMatrix), mViewMatrix(viewMatrix), mModelMatrix(modelMatrix)
+RenderLinesCommand::RenderLinesCommand(const QVector<float>& vertices, const QVector<float>& colors, const QMatrix4x4& projectionMatrix, const QMatrix4x4& viewMatrix, const QMatrix4x4& modelMatrix)
+: mVertices(vertices)
+, mColors(colors)
+, mProjectionMatrix(projectionMatrix)
+, mViewMatrix(viewMatrix)
+, mModelMatrix(modelMatrix)
 {
 }
 
 void RenderLinesCommand::execute(QOpenGLFunctions* gl,
-                                QOpenGLShaderProgram* shader,
-                                GeometryManager* geometryManager,
-                                ResourceManager* resourceManager,
-                                QOpenGLVertexArrayObject& vao,
-                                QOpenGLBuffer& vertexBuffer,
-                                QOpenGLBuffer& colorBuffer,
-                                QOpenGLBuffer& normalBuffer,
-                                QOpenGLBuffer& indexBuffer,
-                                QOpenGLBuffer& texCoordBuffer)
+                                 QOpenGLShaderProgram* shader,
+                                 GeometryManager* geometryManager,
+                                 ResourceManager* resourceManager,
+                                 QOpenGLVertexArrayObject& vao,
+                                 QOpenGLBuffer& vertexBuffer,
+                                 QOpenGLBuffer& colorBuffer,
+                                 QOpenGLBuffer& normalBuffer,
+                                 QOpenGLBuffer& indexBuffer,
+                                 QOpenGLBuffer& texCoordBuffer)
 {
     Q_UNUSED(gl)
     Q_UNUSED(texCoordBuffer)
@@ -100,23 +111,26 @@ void RenderLinesCommand::execute(QOpenGLFunctions* gl,
     geometryManager->renderGeometry(lineGeometry, vao, vertexBuffer, colorBuffer, normalBuffer, indexBuffer, resourceManager, GL_LINES);
 }
 
-RenderTrianglesCommand::RenderTrianglesCommand(const QVector<float>& vertices, const QVector<float>& colors,
-                                             const QMatrix4x4& projectionMatrix, const QMatrix4x4& viewMatrix, const QMatrix4x4& modelMatrix)
-    : mVertices(vertices), mColors(colors)
-    , mProjectionMatrix(projectionMatrix), mViewMatrix(viewMatrix), mModelMatrix(modelMatrix)
+RenderTrianglesCommand::RenderTrianglesCommand(
+        const QVector<float>& vertices, const QVector<float>& colors, const QMatrix4x4& projectionMatrix, const QMatrix4x4& viewMatrix, const QMatrix4x4& modelMatrix)
+: mVertices(vertices)
+, mColors(colors)
+, mProjectionMatrix(projectionMatrix)
+, mViewMatrix(viewMatrix)
+, mModelMatrix(modelMatrix)
 {
 }
 
 void RenderTrianglesCommand::execute(QOpenGLFunctions* gl,
-                                    QOpenGLShaderProgram* shader,
-                                    GeometryManager* geometryManager,
-                                    ResourceManager* resourceManager,
-                                    QOpenGLVertexArrayObject& vao,
-                                    QOpenGLBuffer& vertexBuffer,
-                                    QOpenGLBuffer& colorBuffer,
-                                    QOpenGLBuffer& normalBuffer,
-                                    QOpenGLBuffer& indexBuffer,
-                                    QOpenGLBuffer& texCoordBuffer)
+                                     QOpenGLShaderProgram* shader,
+                                     GeometryManager* geometryManager,
+                                     ResourceManager* resourceManager,
+                                     QOpenGLVertexArrayObject& vao,
+                                     QOpenGLBuffer& vertexBuffer,
+                                     QOpenGLBuffer& colorBuffer,
+                                     QOpenGLBuffer& normalBuffer,
+                                     QOpenGLBuffer& indexBuffer,
+                                     QOpenGLBuffer& texCoordBuffer)
 {
     Q_UNUSED(gl)
     Q_UNUSED(texCoordBuffer)
@@ -141,43 +155,45 @@ void RenderTrianglesCommand::execute(QOpenGLFunctions* gl,
     geometryManager->renderGeometry(triangleGeometry, vao, vertexBuffer, colorBuffer, normalBuffer, indexBuffer, resourceManager, GL_TRIANGLES);
 }
 
-RenderTexturedTrianglesCommand::RenderTexturedTrianglesCommand(const GeometryData& geometry,
-                                                              const QMatrix4x4& projectionMatrix, const QMatrix4x4& viewMatrix, const QMatrix4x4& modelMatrix)
-    : mGeometry(geometry), mProjectionMatrix(projectionMatrix), mViewMatrix(viewMatrix), mModelMatrix(modelMatrix)
+RenderTexturedTrianglesCommand::RenderTexturedTrianglesCommand(const GeometryData& geometry, const QMatrix4x4& projectionMatrix, const QMatrix4x4& viewMatrix, const QMatrix4x4& modelMatrix)
+: mGeometry(geometry)
+, mProjectionMatrix(projectionMatrix)
+, mViewMatrix(viewMatrix)
+, mModelMatrix(modelMatrix)
 {
 }
 
 void RenderTexturedTrianglesCommand::execute(QOpenGLFunctions* gl,
-                                           QOpenGLShaderProgram* shader,
-                                           GeometryManager* geometryManager,
-                                           ResourceManager* resourceManager,
-                                           QOpenGLVertexArrayObject& vao,
-                                           QOpenGLBuffer& vertexBuffer,
-                                           QOpenGLBuffer& colorBuffer,
-                                           QOpenGLBuffer& normalBuffer,
-                                           QOpenGLBuffer& indexBuffer,
-                                           QOpenGLBuffer& texCoordBuffer)
+                                             QOpenGLShaderProgram* shader,
+                                             GeometryManager* geometryManager,
+                                             ResourceManager* resourceManager,
+                                             QOpenGLVertexArrayObject& vao,
+                                             QOpenGLBuffer& vertexBuffer,
+                                             QOpenGLBuffer& colorBuffer,
+                                             QOpenGLBuffer& normalBuffer,
+                                             QOpenGLBuffer& indexBuffer,
+                                             QOpenGLBuffer& texCoordBuffer)
 {
     Q_UNUSED(gl)
 
     if (mGeometry.isEmpty()) {
         return;
     }
-    
+
     // Set uniforms
     QMatrix4x4 mvp = mProjectionMatrix * mViewMatrix * mModelMatrix;
     shader->setUniformValue("uMVP", mvp);
     shader->setUniformValue("uModel", mModelMatrix);
     shader->setUniformValue("uUseInstancing", false);
-    
+
     // Set texture uniforms based on available textures
     if (mGeometry.hasPBRTextures()) {
         shader->setUniformValue("uUsePBR", true);
         shader->setUniformValue("uUseTexture", false);
         shader->setUniformValue("uBaseColorTexture", 0);         // Texture unit 0
-        shader->setUniformValue("uMetallicRoughnessTexture", 1); // Texture unit 1  
+        shader->setUniformValue("uMetallicRoughnessTexture", 1); // Texture unit 1
         shader->setUniformValue("uNormalTexture", 2);            // Texture unit 2
-        
+
         // Set PBR material factors
         shader->setUniformValue("uBaseColorFactor", QVector4D(mGeometry.baseColorFactor[0], mGeometry.baseColorFactor[1], mGeometry.baseColorFactor[2], mGeometry.baseColorFactor[3]));
         shader->setUniformValue("uMetallicFactor", mGeometry.metallicFactor);
@@ -185,33 +201,35 @@ void RenderTexturedTrianglesCommand::execute(QOpenGLFunctions* gl,
     } else {
         shader->setUniformValue("uUsePBR", false);
         shader->setUniformValue("uUseTexture", mGeometry.hasTexture());
-        shader->setUniformValue("uTexture", 0);          // Use texture unit 0
+        shader->setUniformValue("uTexture", 0); // Use texture unit 0
     }
 
     // Normal matrix (inverse transpose of model matrix)
     QMatrix3x3 normalMatrix = mModelMatrix.normalMatrix();
     shader->setUniformValue("uNormalMatrix", normalMatrix);
-    
+
     // Use the textured rendering method
     geometryManager->renderGeometry(mGeometry, vao, vertexBuffer, colorBuffer, normalBuffer, indexBuffer, texCoordBuffer, resourceManager, GL_TRIANGLES);
 }
 
-RenderInstancedCubesCommand::RenderInstancedCubesCommand(const QVector<CubeInstanceData>& instances,
-                                                       const QMatrix4x4& projectionMatrix, const QMatrix4x4& viewMatrix, const QMatrix4x4& modelMatrix)
-    : mInstances(instances), mProjectionMatrix(projectionMatrix), mViewMatrix(viewMatrix), mModelMatrix(modelMatrix)
+RenderInstancedCubesCommand::RenderInstancedCubesCommand(const QVector<CubeInstanceData>& instances, const QMatrix4x4& projectionMatrix, const QMatrix4x4& viewMatrix, const QMatrix4x4& modelMatrix)
+: mInstances(instances)
+, mProjectionMatrix(projectionMatrix)
+, mViewMatrix(viewMatrix)
+, mModelMatrix(modelMatrix)
 {
 }
 
 void RenderInstancedCubesCommand::execute(QOpenGLFunctions* gl,
-                                         QOpenGLShaderProgram* shader,
-                                         GeometryManager* geometryManager,
-                                         ResourceManager* resourceManager,
-                                         QOpenGLVertexArrayObject& vao,
-                                         QOpenGLBuffer& vertexBuffer,
-                                         QOpenGLBuffer& colorBuffer,
-                                         QOpenGLBuffer& normalBuffer,
-                                         QOpenGLBuffer& indexBuffer,
-                                         QOpenGLBuffer& texCoordBuffer)
+                                          QOpenGLShaderProgram* shader,
+                                          GeometryManager* geometryManager,
+                                          ResourceManager* resourceManager,
+                                          QOpenGLVertexArrayObject& vao,
+                                          QOpenGLBuffer& vertexBuffer,
+                                          QOpenGLBuffer& colorBuffer,
+                                          QOpenGLBuffer& normalBuffer,
+                                          QOpenGLBuffer& indexBuffer,
+                                          QOpenGLBuffer& texCoordBuffer)
 {
     Q_UNUSED(gl)
     Q_UNUSED(texCoordBuffer)
@@ -242,20 +260,20 @@ void RenderInstancedCubesCommand::execute(QOpenGLFunctions* gl,
 }
 
 GLStateCommand::GLStateCommand(StateType stateType)
-    : mStateType(stateType)
+: mStateType(stateType)
 {
 }
 
 void GLStateCommand::execute(QOpenGLFunctions* gl,
-                            QOpenGLShaderProgram* shader,
-                            GeometryManager* geometryManager,
-                            ResourceManager* resourceManager,
-                            QOpenGLVertexArrayObject& vao,
-                            QOpenGLBuffer& vertexBuffer,
-                            QOpenGLBuffer& colorBuffer,
-                            QOpenGLBuffer& normalBuffer,
-                            QOpenGLBuffer& indexBuffer,
-                            QOpenGLBuffer& texCoordBuffer)
+                             QOpenGLShaderProgram* shader,
+                             GeometryManager* geometryManager,
+                             ResourceManager* resourceManager,
+                             QOpenGLVertexArrayObject& vao,
+                             QOpenGLBuffer& vertexBuffer,
+                             QOpenGLBuffer& colorBuffer,
+                             QOpenGLBuffer& normalBuffer,
+                             QOpenGLBuffer& indexBuffer,
+                             QOpenGLBuffer& texCoordBuffer)
 {
     Q_UNUSED(shader)
     Q_UNUSED(geometryManager)
@@ -268,20 +286,20 @@ void GLStateCommand::execute(QOpenGLFunctions* gl,
     Q_UNUSED(texCoordBuffer)
 
     switch (mStateType) {
-        case ENABLE_DEPTH_TEST:
-            gl->glEnable(GL_DEPTH_TEST);
-            break;
-        case DISABLE_DEPTH_TEST:
-            gl->glDisable(GL_DEPTH_TEST);
-            break;
-        case ENABLE_BLEND:
-            gl->glEnable(GL_BLEND);
-            break;
-        case DISABLE_BLEND:
-            gl->glDisable(GL_BLEND);
-            break;
-        case CLEAR_BUFFERS:
-            gl->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-            break;
+    case ENABLE_DEPTH_TEST:
+        gl->glEnable(GL_DEPTH_TEST);
+        break;
+    case DISABLE_DEPTH_TEST:
+        gl->glDisable(GL_DEPTH_TEST);
+        break;
+    case ENABLE_BLEND:
+        gl->glEnable(GL_BLEND);
+        break;
+    case DISABLE_BLEND:
+        gl->glDisable(GL_BLEND);
+        break;
+    case CLEAR_BUFFERS:
+        gl->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        break;
     }
 }

--- a/src/RenderCommandQueue.cpp
+++ b/src/RenderCommandQueue.cpp
@@ -22,9 +22,7 @@
 #include <QDebug>
 #include <cstring>
 
-RenderCommandQueue::RenderCommandQueue()
-{
-}
+RenderCommandQueue::RenderCommandQueue() {}
 
 RenderCommandQueue::~RenderCommandQueue()
 {
@@ -55,14 +53,14 @@ void RenderCommandQueue::addCommand(std::unique_ptr<RenderCommand> command)
 }
 
 void RenderCommandQueue::executeAll(QOpenGLShaderProgram* shader,
-                                   GeometryManager* geometryManager,
-                                   ResourceManager* resourceManager,
-                                   QOpenGLVertexArrayObject& vao,
-                                   QOpenGLBuffer& vertexBuffer,
-                                   QOpenGLBuffer& colorBuffer,
-                                   QOpenGLBuffer& normalBuffer,
-                                   QOpenGLBuffer& indexBuffer,
-                                   QOpenGLBuffer& texCoordBuffer)
+                                    GeometryManager* geometryManager,
+                                    ResourceManager* resourceManager,
+                                    QOpenGLVertexArrayObject& vao,
+                                    QOpenGLBuffer& vertexBuffer,
+                                    QOpenGLBuffer& colorBuffer,
+                                    QOpenGLBuffer& normalBuffer,
+                                    QOpenGLBuffer& indexBuffer,
+                                    QOpenGLBuffer& texCoordBuffer)
 {
     if (!mInitialized) {
         qWarning() << "RenderCommandQueue: Not initialized";

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -22,9 +22,7 @@
 
 #include <QOpenGLContext>
 
-ResourceManager::ResourceManager()
-{
-}
+ResourceManager::ResourceManager() {}
 
 ResourceManager::~ResourceManager()
 {
@@ -43,8 +41,7 @@ void ResourceManager::initialize()
     mErrorCheckingEnabled = true;
 
     mInitialized = true;
-    qDebug() << "ResourceManager: Initialized with error checking"
-             << (mErrorCheckingEnabled ? "enabled" : "disabled");
+    qDebug() << "ResourceManager: Initialized with error checking" << (mErrorCheckingEnabled ? "enabled" : "disabled");
 }
 
 void ResourceManager::cleanup()
@@ -67,24 +64,24 @@ bool ResourceManager::checkGLError(const QString& operation) const
     if (error != GL_NO_ERROR) {
         const char* errorString;
         switch (error) {
-            case GL_INVALID_ENUM:
-                errorString = "GL_INVALID_ENUM";
-                break;
-            case GL_INVALID_VALUE:
-                errorString = "GL_INVALID_VALUE";
-                break;
-            case GL_INVALID_OPERATION:
-                errorString = "GL_INVALID_OPERATION";
-                break;
-            case GL_OUT_OF_MEMORY:
-                errorString = "GL_OUT_OF_MEMORY";
-                break;
-            case GL_INVALID_FRAMEBUFFER_OPERATION:
-                errorString = "GL_INVALID_FRAMEBUFFER_OPERATION";
-                break;
-            default:
-                errorString = "UNKNOWN_GL_ERROR";
-                break;
+        case GL_INVALID_ENUM:
+            errorString = "GL_INVALID_ENUM";
+            break;
+        case GL_INVALID_VALUE:
+            errorString = "GL_INVALID_VALUE";
+            break;
+        case GL_INVALID_OPERATION:
+            errorString = "GL_INVALID_OPERATION";
+            break;
+        case GL_OUT_OF_MEMORY:
+            errorString = "GL_OUT_OF_MEMORY";
+            break;
+        case GL_INVALID_FRAMEBUFFER_OPERATION:
+            errorString = "GL_INVALID_FRAMEBUFFER_OPERATION";
+            break;
+        default:
+            errorString = "UNKNOWN_GL_ERROR";
+            break;
         }
 
         qWarning() << "OpenGL Error in" << operation << ":" << errorString << "(" << error << ")";

--- a/src/RoomContextMenuHandler.cpp
+++ b/src/RoomContextMenuHandler.cpp
@@ -143,10 +143,11 @@ bool RoomContextMenuHandler::handle(T2DMap::MapInteractionContext& context)
     popup->addSeparator();
 
     const QString viewModeItem = context.isMapViewOnly ?
-        //: 2D Mapper context menu (room) item
-        T2DMap::tr("Switch to editing mode") :
-        //: 2D Mapper context menu (room) item
-        T2DMap::tr("Switch to viewing mode");
+                                                       //: 2D Mapper context menu (room) item
+                                         T2DMap::tr("Switch to editing mode")
+                                                       :
+                                                       //: 2D Mapper context menu (room) item
+                                         T2DMap::tr("Switch to viewing mode");
     auto setMapViewOnly = new QAction(viewModeItem, &mMapWidget);
     QObject::connect(setMapViewOnly, &QAction::triggered, &mMapWidget, &T2DMap::slot_toggleMapViewOnly);
     popup->addAction(setMapViewOnly);

--- a/src/RoomMoveActivationHandler.cpp
+++ b/src/RoomMoveActivationHandler.cpp
@@ -51,8 +51,7 @@ bool RoomMoveActivationHandler::matches(const T2DMap::MapInteractionContext& con
             return false;
         }
 
-        if (context.modifiers.testFlag(Qt::ShiftModifier) || context.modifiers.testFlag(Qt::ControlModifier)
-            || context.modifiers.testFlag(Qt::AltModifier)) {
+        if (context.modifiers.testFlag(Qt::ShiftModifier) || context.modifiers.testFlag(Qt::ControlModifier) || context.modifiers.testFlag(Qt::AltModifier)) {
             return false;
         }
 

--- a/src/ScriptUnit.cpp
+++ b/src/ScriptUnit.cpp
@@ -292,13 +292,7 @@ std::tuple<QString, int, int, int> ScriptUnit::assembleReport()
         assembleReport(pItem);
     }
     QStringList msg;
-    msg << QLatin1String("Scripts current total: ") << QString::number(statsItemsTotal) << QLatin1String("\n")
-        << QLatin1String("tempScripts current total: ") << QString::number(statsTempItems) << QLatin1String("\n")
-        << QLatin1String("active Scripts: ") << QString::number(statsActiveItems) << QLatin1String("\n");
-    return {
-        msg.join(QString()),
-        statsItemsTotal,
-        statsTempItems,
-        statsActiveItems
-    };
+    msg << QLatin1String("Scripts current total: ") << QString::number(statsItemsTotal) << QLatin1String("\n") << QLatin1String("tempScripts current total: ") << QString::number(statsTempItems)
+        << QLatin1String("\n") << QLatin1String("active Scripts: ") << QString::number(statsActiveItems) << QLatin1String("\n");
+    return {msg.join(QString()), statsItemsTotal, statsTempItems, statsActiveItems};
 }

--- a/src/SecureStringUtils.cpp
+++ b/src/SecureStringUtils.cpp
@@ -54,8 +54,10 @@ QString SecureStringUtils::getSSLBackendInfo()
 
         // Check supported protocols
         QStringList protocols;
-        if (QSslSocket::isProtocolSupported(QSsl::TlsV1_2)) protocols << "TLS 1.2";
-        if (QSslSocket::isProtocolSupported(QSsl::TlsV1_3)) protocols << "TLS 1.3";
+        if (QSslSocket::isProtocolSupported(QSsl::TlsV1_2))
+            protocols << "TLS 1.2";
+        if (QSslSocket::isProtocolSupported(QSsl::TlsV1_3))
+            protocols << "TLS 1.3";
         info << QString("Supported protocols: %1").arg(protocols.join(", "));
 
     } else {
@@ -377,16 +379,16 @@ bool SecureStringUtils::storeEncryptionKeyToFile(const QString& profileName, con
     QDir dir;
 
     if (!dir.mkpath(profileDir)) {
-        qDebug().nospace().noquote() << "SecureStringUtils::storeEncryptionKeyToFile() WARNING - could not create profile directory for \""
-                                     << profileName << "\". Falling back to deterministic key derivation.";
+        qDebug().nospace().noquote() << "SecureStringUtils::storeEncryptionKeyToFile() WARNING - could not create profile directory for \"" << profileName
+                                     << "\". Falling back to deterministic key derivation.";
         return false;
     }
 
     QSaveFile file(keyFilePath);
 
     if (!file.open(QIODevice::WriteOnly | QIODevice::Unbuffered)) {
-        qDebug().nospace().noquote() << "SecureStringUtils::storeEncryptionKeyToFile() WARNING - could not create encryption key file for profile \""
-                                     << profileName << "\", error: " << file.errorString() << ". Falling back to deterministic key derivation.";
+        qDebug().nospace().noquote() << "SecureStringUtils::storeEncryptionKeyToFile() WARNING - could not create encryption key file for profile \"" << profileName
+                                     << "\", error: " << file.errorString() << ". Falling back to deterministic key derivation.";
         return false;
     }
 
@@ -398,8 +400,8 @@ bool SecureStringUtils::storeEncryptionKeyToFile(const QString& profileName, con
     ofs << base64Key;
 
     if (!file.commit()) {
-        qDebug().nospace().noquote() << "SecureStringUtils::storeEncryptionKeyToFile() WARNING - could not save encryption key file for profile \""
-                                     << profileName << "\", error: " << file.errorString() << ". Falling back to deterministic key derivation.";
+        qDebug().nospace().noquote() << "SecureStringUtils::storeEncryptionKeyToFile() WARNING - could not save encryption key file for profile \"" << profileName
+                                     << "\", error: " << file.errorString() << ". Falling back to deterministic key derivation.";
         return false;
     }
 
@@ -427,9 +429,7 @@ QByteArray SecureStringUtils::generateNonce()
     return nonce;
 }
 
-QByteArray SecureStringUtils::encryptData(const QByteArray& plaintext, const QByteArray& key,
-                                               const QByteArray& salt, const QByteArray& nonce,
-                                               QByteArray& hmac)
+QByteArray SecureStringUtils::encryptData(const QByteArray& plaintext, const QByteArray& key, const QByteArray& salt, const QByteArray& nonce, QByteArray& hmac)
 {
     if (plaintext.isEmpty() || key.size() != KEY_SIZE || salt.size() != SALT_SIZE || nonce.size() != NONCE_SIZE) {
         return QByteArray();
@@ -457,12 +457,9 @@ QByteArray SecureStringUtils::encryptData(const QByteArray& plaintext, const QBy
     return encrypted;
 }
 
-QByteArray SecureStringUtils::decryptData(const QByteArray& ciphertext, const QByteArray& key,
-                                               const QByteArray& salt, const QByteArray& nonce,
-                                               const QByteArray& hmac)
+QByteArray SecureStringUtils::decryptData(const QByteArray& ciphertext, const QByteArray& key, const QByteArray& salt, const QByteArray& nonce, const QByteArray& hmac)
 {
-    if (ciphertext.isEmpty() || key.size() != KEY_SIZE || salt.size() != SALT_SIZE ||
-        nonce.size() != NONCE_SIZE || hmac.size() != HMAC_SIZE) {
+    if (ciphertext.isEmpty() || key.size() != KEY_SIZE || salt.size() != SALT_SIZE || nonce.size() != NONCE_SIZE || hmac.size() != HMAC_SIZE) {
         return QByteArray();
     }
 

--- a/src/SelectionRectangleHandler.cpp
+++ b/src/SelectionRectangleHandler.cpp
@@ -46,15 +46,11 @@ bool SelectionRectangleHandler::matches(const T2DMap::MapInteractionContext& con
 
     switch (context.event->type()) {
     case QEvent::MouseButtonPress:
-        return context.button == Qt::LeftButton
-            && !context.isCustomLineDrawing
-            && !context.isRoomBeingMoved
-            && !context.modifiers.testFlag(Qt::AltModifier);
+        return context.button == Qt::LeftButton && !context.isCustomLineDrawing && !context.isRoomBeingMoved && !context.modifiers.testFlag(Qt::AltModifier);
     case QEvent::MouseMove:
         return context.isMultiSelectionActive || context.isSizingLabel;
     case QEvent::MouseButtonRelease:
-        return context.button == Qt::LeftButton
-            && (context.isMultiSelectionActive || context.isSizingLabel);
+        return context.button == Qt::LeftButton && (context.isMultiSelectionActive || context.isSizingLabel);
     default:
         return false;
     }
@@ -110,11 +106,10 @@ bool SelectionRectangleHandler::handleMousePress(T2DMap::MapInteractionContext& 
         if (!mMapWidget.mMapViewOnly) {
             mMapWidget.mHelpMsg = T2DMap::tr("Drag to select multiple rooms or labels, release to finish...");
             //: %1 is the platform-specific key name for Shift
-            mMapWidget.mHelpMsg += qsl(" ")
-                + T2DMap::tr("Hold %1 to add rooms or labels to your current selection.").arg(QKeySequence(Qt::ShiftModifier).toString(QKeySequence::NativeText).remove(QLatin1Char('+')));
+            mMapWidget.mHelpMsg +=
+                    qsl(" ") + T2DMap::tr("Hold %1 to add rooms or labels to your current selection.").arg(QKeySequence(Qt::ShiftModifier).toString(QKeySequence::NativeText).remove(QLatin1Char('+')));
             //: %1 is the platform-specific key name for Alt (Alt on Windows/Linux, Option on macOS)
-            mMapWidget.mHelpMsg += qsl(" ")
-                + T2DMap::tr("Hold %1 and drag to pan the map.").arg(QKeySequence(Qt::AltModifier).toString(QKeySequence::NativeText).remove(QLatin1Char('+')));
+            mMapWidget.mHelpMsg += qsl(" ") + T2DMap::tr("Hold %1 and drag to pan the map.").arg(QKeySequence(Qt::AltModifier).toString(QKeySequence::NativeText).remove(QLatin1Char('+')));
         }
         if (!hasShift) {
             mMapWidget.mMultiSelectionSet.clear();
@@ -196,9 +191,15 @@ bool SelectionRectangleHandler::handleMouseMove(T2DMap::MapInteractionContext& c
             const float ry = static_cast<float>(room->y() * -1) * mMapWidget.mRoomHeight + fy;
             QRectF dr;
             if (area->gridMode) {
-                dr = QRectF(static_cast<qreal>(rx - (mMapWidget.mRoomWidth / 2.0f)), static_cast<qreal>(ry - (mMapWidget.mRoomHeight / 2.0f)), static_cast<qreal>(mMapWidget.mRoomWidth), static_cast<qreal>(mMapWidget.mRoomHeight));
+                dr = QRectF(static_cast<qreal>(rx - (mMapWidget.mRoomWidth / 2.0f)),
+                            static_cast<qreal>(ry - (mMapWidget.mRoomHeight / 2.0f)),
+                            static_cast<qreal>(mMapWidget.mRoomWidth),
+                            static_cast<qreal>(mMapWidget.mRoomHeight));
             } else {
-                dr = QRectF(static_cast<qreal>(rx - mMapWidget.mRoomWidth * static_cast<float>(mMapWidget.rSize / 2.0)), static_cast<qreal>(ry - mMapWidget.mRoomHeight * static_cast<float>(mMapWidget.rSize / 2.0)), static_cast<qreal>(mMapWidget.mRoomWidth) * mMapWidget.rSize, static_cast<qreal>(mMapWidget.mRoomHeight) * mMapWidget.rSize);
+                dr = QRectF(static_cast<qreal>(rx - mMapWidget.mRoomWidth * static_cast<float>(mMapWidget.rSize / 2.0)),
+                            static_cast<qreal>(ry - mMapWidget.mRoomHeight * static_cast<float>(mMapWidget.rSize / 2.0)),
+                            static_cast<qreal>(mMapWidget.mRoomWidth) * mMapWidget.rSize,
+                            static_cast<qreal>(mMapWidget.mRoomHeight) * mMapWidget.rSize);
             }
             if (mMapWidget.mMultiRect.contains(dr)) {
                 rectangleSelection.insert(currentRoomId);

--- a/src/SentryWrapper.cpp
+++ b/src/SentryWrapper.cpp
@@ -49,38 +49,38 @@
 //   Windows : C:\Users\...\AppData\Local\Cache\Mudlet\sentry
 void initSentry()
 {
-    #ifdef WITH_SENTRY
-        sentry_options_t*   options = sentry_options_new();
-        std::string         runtimeAppDir = getExeDir();
-        QString             path = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/mudlet/sentry";
+#ifdef WITH_SENTRY
+    sentry_options_t* options = sentry_options_new();
+    std::string runtimeAppDir = getExeDir();
+    QString path = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/mudlet/sentry";
 
-        if (!options) {
-            return;
-        }
+    if (!options) {
+        return;
+    }
 
-        QString appBuild;
-        QFile gitShaFile(qsl(":/app-build.txt"));
-        if (gitShaFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-            appBuild = QString::fromUtf8(gitShaFile.readAll()).trimmed();
-        }
-        const std::string release = qsl("mudlet@%1%2").arg(APP_VERSION, appBuild).toStdString();
+    QString appBuild;
+    QFile gitShaFile(qsl(":/app-build.txt"));
+    if (gitShaFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        appBuild = QString::fromUtf8(gitShaFile.readAll()).trimmed();
+    }
+    const std::string release = qsl("mudlet@%1%2").arg(APP_VERSION, appBuild).toStdString();
 
-        sentry_options_set_database_path(options, path.toUtf8().constData());
-        sentry_options_set_release(options, release.c_str());
-        sentry_options_set_handler_path(options, makeExecutablePath(runtimeAppDir, "crashpad_handler").c_str());
-        sentry_options_set_external_crash_reporter_path(options, makeExecutablePath(runtimeAppDir, "MudletCrashReporter").c_str());
+    sentry_options_set_database_path(options, path.toUtf8().constData());
+    sentry_options_set_release(options, release.c_str());
+    sentry_options_set_handler_path(options, makeExecutablePath(runtimeAppDir, "crashpad_handler").c_str());
+    sentry_options_set_external_crash_reporter_path(options, makeExecutablePath(runtimeAppDir, "MudletCrashReporter").c_str());
 
-        sentry_init(options);
-    #endif
+    sentry_init(options);
+#endif
 }
 
 std::string makeExecutablePath(const std::string& dir, const std::string& name)
 {
-    #ifdef Q_OS_WIN
-        return dir + "/" + name + ".exe";
-    #else
-        return dir + "/" + name;
-    #endif
+#ifdef Q_OS_WIN
+    return dir + "/" + name + ".exe";
+#else
+    return dir + "/" + name;
+#endif
 }
 
 // Returns the directory containing the current executable
@@ -128,7 +128,7 @@ void crashIfRequested()
 {
     const char* environmentVariable = std::getenv("MUDLET_CRASH_TEST");
 
-     if (environmentVariable && *environmentVariable == '1') {
+    if (environmentVariable && *environmentVariable == '1') {
         int* p = nullptr;
         *p = 42;
     }

--- a/src/ShaderManager.cpp
+++ b/src/ShaderManager.cpp
@@ -30,13 +30,13 @@
 #include "utils.h"
 
 ShaderManager::ShaderManager(ResourceManager* resourceManager, QObject* parent)
-    : QObject(parent)
-    , mDevelopmentMode(false)
-    , mInitialized(false)
-    , mUniformMVP(-1)
-    , mUniformModel(-1)
-    , mUniformNormalMatrix(-1)
-    , mResourceManager(resourceManager)
+: QObject(parent)
+, mDevelopmentMode(false)
+, mInitialized(false)
+, mUniformMVP(-1)
+, mUniformModel(-1)
+, mUniformNormalMatrix(-1)
+, mResourceManager(resourceManager)
 {
     mReloadTimer = new QTimer(this);
     mReloadTimer->setSingleShot(true);
@@ -62,18 +62,16 @@ bool ShaderManager::initialize()
 
     if (mDevelopmentMode) {
         // Try multiple well-known locations for shader files
-        QStringList possiblePaths = {
-            // CMake build from build/src/
-            qsl("../src/shaders/"),
-            // CMake build from build/
-            qsl("src/shaders/"),
-            // In-source build
-            qsl("../../src/shaders/"),
-            // Qt Creator build
-            qsl("../../../src/shaders/"),
-            // Relative to current directory
-            qsl("shaders/")
-        };
+        QStringList possiblePaths = {// CMake build from build/src/
+                                     qsl("../src/shaders/"),
+                                     // CMake build from build/
+                                     qsl("src/shaders/"),
+                                     // In-source build
+                                     qsl("../../src/shaders/"),
+                                     // Qt Creator build
+                                     qsl("../../../src/shaders/"),
+                                     // Relative to current directory
+                                     qsl("shaders/")};
 
         QString appDir = QCoreApplication::applicationDirPath();
         QString foundPath;
@@ -81,9 +79,7 @@ bool ShaderManager::initialize()
         for (const QString& relativePath : possiblePaths) {
             QString testPath = QDir(appDir).filePath(relativePath);
             QDir testDir(testPath);
-            if (testDir.exists() &&
-                QFile::exists(testDir.filePath(qsl("vertex.glsl"))) &&
-                QFile::exists(testDir.filePath(qsl("fragment.glsl")))) {
+            if (testDir.exists() && QFile::exists(testDir.filePath(qsl("vertex.glsl"))) && QFile::exists(testDir.filePath(qsl("fragment.glsl")))) {
                 foundPath = testPath;
                 break;
             }
@@ -251,5 +247,3 @@ bool ShaderManager::detectDevelopmentMode()
     return false;
 #endif
 }
-
-

--- a/src/SingleLineTextEdit.cpp
+++ b/src/SingleLineTextEdit.cpp
@@ -22,8 +22,8 @@
 #include <QKeyEvent>
 #include <QPalette>
 
-SingleLineTextEdit::SingleLineTextEdit(QWidget *parent)
-    : QPlainTextEdit(parent)
+SingleLineTextEdit::SingleLineTextEdit(QWidget* parent)
+: QPlainTextEdit(parent)
 {
     highlighter = new TriggerHighlighter(this->document());
     highlighter->setHighlightingEnabled(true);
@@ -34,7 +34,7 @@ SingleLineTextEdit::SingleLineTextEdit(QWidget *parent)
 }
 
 // trap some commonly used multi-line key shortcuts
-void SingleLineTextEdit::keyPressEvent(QKeyEvent *event)
+void SingleLineTextEdit::keyPressEvent(QKeyEvent* event)
 {
     if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) {
         return;
@@ -43,13 +43,13 @@ void SingleLineTextEdit::keyPressEvent(QKeyEvent *event)
 }
 
 // ensure height remains on single line
-void SingleLineTextEdit::resizeEvent(QResizeEvent *event)
+void SingleLineTextEdit::resizeEvent(QResizeEvent* event)
 {
     QPlainTextEdit::resizeEvent(event);
 }
 
 // ensure we can't paste multiple lines
-void SingleLineTextEdit::insertFromMimeData(const QMimeData *source)
+void SingleLineTextEdit::insertFromMimeData(const QMimeData* source)
 {
     if (source->hasText()) {
         QString text = source->text();

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -130,9 +130,7 @@ std::optional<int> T2DMap::roomIdAtWidgetPosition(const QPoint& widgetPosition, 
         const int ry = room->y() * -1 * mRoomHeight + fy;
         const int rz = room->z();
 
-        if ((qAbs(mx - rx) < qRound(mRoomWidth * rSize / 2.0))
-            && (qAbs(my - ry) < qRound(mRoomHeight * rSize / 2.0))
-            && (mz == rz)) {
+        if ((qAbs(mx - rx) < qRound(mRoomWidth * rSize / 2.0)) && (qAbs(my - ry) < qRound(mRoomHeight * rSize / 2.0)) && (mz == rz)) {
             return roomId;
         }
     }
@@ -167,9 +165,7 @@ QSet<int> T2DMap::roomIdsAtWidgetPosition(const QPoint& widgetPosition, const TA
         const int ry = room->y() * -1 * mRoomHeight + fy;
         const int rz = room->z();
 
-        if ((qAbs(mx - rx) < qRound(mRoomWidth * rSize / 2.0))
-            && (qAbs(my - ry) < qRound(mRoomHeight * rSize / 2.0))
-            && (mz == rz)) {
+        if ((qAbs(mx - rx) < qRound(mRoomWidth * rSize / 2.0)) && (qAbs(my - ry) < qRound(mRoomHeight * rSize / 2.0)) && (mz == rz)) {
             result.insert(roomId);
         }
     }
@@ -220,9 +216,7 @@ void T2DMap::prepareSingleClickSelection(MapInteractionContext& context)
         const int my = context.widgetPosition.y();
         const int mz = mMapCenterZ;
 
-        if ((qAbs(mx - rx) < qRound(mRoomWidth * rSize / 2.0))
-            && (qAbs(my - ry) < qRound(mRoomHeight * rSize / 2.0))
-            && (mz == rz)) {
+        if ((qAbs(mx - rx) < qRound(mRoomWidth * rSize / 2.0)) && (qAbs(my - ry) < qRound(mRoomHeight * rSize / 2.0)) && (mz == rz)) {
             const bool hasShift = context.modifiers.testFlag(Qt::ShiftModifier);
             const bool hasCtrl = context.modifiers.testFlag(Qt::ControlModifier);
             const bool isAlreadySelected = mMultiSelectionSet.contains(roomId);
@@ -360,10 +354,8 @@ bool T2DMap::eventFilter(QObject* watched, QEvent* event)
                     const QPointF localPosF(localPos);
                     const QPointF globalPosF(globalPos);
 
-                    auto* pressEvent = new QMouseEvent(QEvent::MouseButtonPress, localPosF, localPosF, globalPosF,
-                        button, button, mouseEvent->modifiers());
-                    auto* releaseEvent = new QMouseEvent(QEvent::MouseButtonRelease, localPosF, localPosF, globalPosF,
-                        button, Qt::NoButton, mouseEvent->modifiers());
+                    auto* pressEvent = new QMouseEvent(QEvent::MouseButtonPress, localPosF, localPosF, globalPosF, button, button, mouseEvent->modifiers());
+                    auto* releaseEvent = new QMouseEvent(QEvent::MouseButtonRelease, localPosF, localPosF, globalPosF, button, Qt::NoButton, mouseEvent->modifiers());
 
                     QCoreApplication::postEvent(this, pressEvent);
                     QCoreApplication::postEvent(this, releaseEvent);
@@ -384,7 +376,6 @@ const QString& key_icon_dialog_cancel = qsl(":/icons/dialog-cancel.png");
 T2DMap::T2DMap(QWidget* parent)
 : QWidget(parent)
 {
-
     if (auto* app = qApp) {
         // This allows to forward clicks to widget even if popup menu is opened, therefore e.g. one click is enough to close popup and select room
         // No more need to first close popup and then perform click on ob
@@ -396,10 +387,10 @@ T2DMap::T2DMap(QWidget* parent)
     mMultiSelectionListWidget.hideColumn(1);
     QStringList headerLabels;
     headerLabels <<
-        //: Room ID in the mapper widget
-        tr("ID") <<
-        //: Room name in the mapper widget
-        tr("Name");
+            //: Room ID in the mapper widget
+            tr("ID") <<
+            //: Room name in the mapper widget
+            tr("Name");
     mMultiSelectionListWidget.setHeaderLabels(headerLabels);
     //: Tooltip for the room selection list. This text will be formatted with HTML line breaks between sentences.
     mMultiSelectionListWidget.setToolTip(utils::richText(tr("Click on a line to select or deselect that room number "
@@ -648,7 +639,7 @@ void T2DMap::switchArea(const QString& newAreaName)
                     float mean_y = 0.0;
                     uint processedRoomCount = 0;
                     QSet<TRoom*> roomsToConsider; // Hold on to relevant rooms for
-                                         // following step
+                                                  // following step
                     while (itRoom.hasNext()) {
                         TRoom* room = mpMap->mpRoomDB->getRoom(itRoom.next());
                         if (!room || room->z() != minLevelWithMaxRoomCount) {
@@ -710,7 +701,7 @@ void T2DMap::switchArea(const QString& newAreaName)
                 float mean_y = 0.0;
                 uint processedRoomCount = 0;
                 QSet<TRoom*> roomsToConsider; // Hold on to relevant rooms for
-                                     // following step
+                                              // following step
                 QSetIterator<int> itRoom(area->getAreaRooms());
                 while (itRoom.hasNext()) {
                     TRoom* room = mpMap->mpRoomDB->getRoom(itRoom.next());
@@ -819,7 +810,7 @@ std::pair<bool, QString> T2DMap::centerview(int roomId)
     mLastViewedAreaID = areaId;
     mRoomID = roomId;
     mMapCenterX = pR->x();
-    mMapCenterY = -pR->y();  // Map y coordinates are reversed
+    mMapCenterY = -pR->y(); // Map y coordinates are reversed
     mMapCenterZ = pR->z();
     xyzoom = mpMap->mpRoomDB->get2DMapZoom(areaId);
 
@@ -990,7 +981,7 @@ void T2DMap::drawScaledLabel(QPainter& painter, const QPointF& position, TMapLab
  * reduced by the margin (0-40) as a percentage). This margin is defaulted to
  * 10%.
  */
-bool T2DMap::sizeFontToFitTextInRect( QFont & font, const QRectF & boundaryRect, const QString & text, const quint8 percentageMargin, qreal minFontSize )
+bool T2DMap::sizeFontToFitTextInRect(QFont& font, const QRectF& boundaryRect, const QString& text, const quint8 percentageMargin, qreal minFontSize)
 {
     QFont _font = font;
 
@@ -1002,11 +993,11 @@ bool T2DMap::sizeFontToFitTextInRect( QFont & font, const QRectF & boundaryRect,
         return false;
     }
 
-    qreal fontSize = qMax(minFontSize, font.pointSizeF());  // protect against too-small initial value
+    qreal fontSize = qMax(minFontSize, font.pointSizeF()); // protect against too-small initial value
     const QRectF testRect(boundaryRect.width() * (100 - percentageMargin) / 200.0,
-                    boundaryRect.height() * (100 - percentageMargin) / 200.0,
-                    boundaryRect.width() * (100 - percentageMargin) / 100.0,
-                    boundaryRect.height() * (100 - percentageMargin) / 100.);
+                          boundaryRect.height() * (100 - percentageMargin) / 200.0,
+                          boundaryRect.width() * (100 - percentageMargin) / 100.0,
+                          boundaryRect.height() * (100 - percentageMargin) / 100.);
 
     // Increase the test font (using somewhat-large steps) until it does not fit any more
     QRectF neededRect;
@@ -1054,9 +1045,8 @@ void T2DMap::initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWa
         } else if (mpMap->findPath(speedWalkStartRoomId, speedWalkTargetRoomId)) {
             mpHost->startSpeedWalk();
         } else {
-            mpHost->mpConsole->printSystemMessage(qsl("%1\n").arg(tr("Mapper: Cannot find a path from %1 to %2 using known exits.")
-                                                          .arg(QString::number(speedWalkStartRoomId),
-                                                               QString::number(speedWalkTargetRoomId))));
+            mpHost->mpConsole->printSystemMessage(
+                    qsl("%1\n").arg(tr("Mapper: Cannot find a path from %1 to %2 using known exits.").arg(QString::number(speedWalkStartRoomId), QString::number(speedWalkTargetRoomId))));
         }
     }
 }
@@ -1068,18 +1058,18 @@ void T2DMap::initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWa
 // or extra markings for it do not get overwritten by the drawing of the other
 // rooms)...
 /* inline */ void T2DMap::drawRoom(QPainter& painter,
-                             QFont& roomVNumFont,
-                             QFont& mapNameFont,
-                             QPen& pen,
-                             TRoom* pRoom,
-                             const bool isGridMode,
-                             const bool areRoomIdsLegible,
-                             const bool showRoomName,
-                             const int speedWalkStartRoomId,
-                             const float rx,
-                             const float ry,
-                             const QMap<int, QPointF>& areaExitsMap,
-                             const bool showRoomCollision)
+                                   QFont& roomVNumFont,
+                                   QFont& mapNameFont,
+                                   QPen& pen,
+                                   TRoom* pRoom,
+                                   const bool isGridMode,
+                                   const bool areRoomIdsLegible,
+                                   const bool showRoomName,
+                                   const int speedWalkStartRoomId,
+                                   const float rx,
+                                   const float ry,
+                                   const QMap<int, QPointF>& areaExitsMap,
+                                   const bool showRoomCollision)
 {
     const int currentRoomId = pRoom->getId();
     pRoom->rendered = false;
@@ -1110,7 +1100,7 @@ void T2DMap::initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWa
         if (showThisRoomName) {
             painter.save();
             painter.setFont(mapNameFont);
-            roomNameRectangle = painter.boundingRect(roomNameRectangle, Qt::Alignment(Qt::AlignTop|Qt::AlignCenter) | Qt::TextFlag(Qt::TextSingleLine), pRoom->name);
+            roomNameRectangle = painter.boundingRect(roomNameRectangle, Qt::Alignment(Qt::AlignTop | Qt::AlignCenter) | Qt::TextFlag(Qt::TextSingleLine), pRoom->name);
             painter.restore();
         }
     }
@@ -1120,7 +1110,8 @@ void T2DMap::initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWa
     // on NON-grid mode areas:
     const QRectF roomClickTestRectangle(QRectF(static_cast<qreal>(rx) - (static_cast<qreal>(mRoomWidth) / 2.0),
                                                static_cast<qreal>(ry) - (static_cast<qreal>(mRoomHeight) / 2.0),
-                                               static_cast<qreal>(mRoomWidth), static_cast<qreal>(mRoomHeight)));
+                                               static_cast<qreal>(mRoomWidth),
+                                               static_cast<qreal>(mRoomHeight)));
 
     QColor roomColor;
     int roomEnvironment = pRoom->environment;
@@ -1309,9 +1300,8 @@ void T2DMap::initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWa
                 * similarly for the y-offset
                 */
 
-            painter.drawPixmap(
-                    QPoint(qRound(roomRectangle.left() + ((roomRectangle.width() - pix->width()) / 2.0)), qRound(roomRectangle.top() + ((roomRectangle.height() - pix->height()) / 2.0))),
-                    *pix);
+            painter.drawPixmap(QPoint(qRound(roomRectangle.left() + ((roomRectangle.width() - pix->width()) / 2.0)), qRound(roomRectangle.top() + ((roomRectangle.height() - pix->height()) / 2.0))),
+                               *pix);
         }
 
         painter.restore();
@@ -1353,20 +1343,20 @@ void T2DMap::initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWa
 
         const QString namePosData = pRoom->userData.value(ROOM_UI_NAMEPOS);
         if (!namePosData.isEmpty()) {
-            QPointF nameOffset {0, 0};
+            QPointF nameOffset{0, 0};
             QStringList posXY = namePosData.split(" ");
             bool ok1, ok2;
             double posX, posY;
 
             switch (posXY.count()) {
-                case 1:
+            case 1:
                 // one value: treat as Y offset
                 posY = posXY[0].toDouble(&ok1);
                 if (ok1) {
                     nameOffset.setY(posY);
                 }
                 break;
-                case 2:
+            case 2:
                 posX = posXY[0].toDouble(&ok1);
                 posY = posXY[1].toDouble(&ok2);
                 if (ok1 && ok2) {
@@ -1375,13 +1365,9 @@ void T2DMap::initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWa
                 }
                 break;
             }
-            roomNameRectangle.adjust(mRoomWidth * nameOffset.x(),
-                                    mRoomHeight * nameOffset.y(),
-                                    mRoomWidth * nameOffset.x(),
-                                    mRoomHeight * nameOffset.y());
+            roomNameRectangle.adjust(mRoomWidth * nameOffset.x(), mRoomHeight * nameOffset.y(), mRoomWidth * nameOffset.x(), mRoomHeight * nameOffset.y());
         }
-        auto roomNameColor = QColor((mpHost->mBgColor_2.lightness() > 127)
-                                    ? Qt::black : Qt::white);
+        auto roomNameColor = QColor((mpHost->mBgColor_2.lightness() > 127) ? Qt::black : Qt::white);
         painter.setPen(QPen(roomNameColor));
         painter.setFont(mapNameFont);
         painter.drawText(roomNameRectangle, Qt::AlignCenter, pRoom->name);
@@ -1619,7 +1605,6 @@ void T2DMap::initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWa
                  && mPHighlight.y() >= (dr.y() - mRoomHeight / 3.0)
                  && mPHighlight.y() <= (dr.y() + mRoomHeight / 3.0))
                 && mStartSpeedWalk) {
-
                 // clang-format on
                 mStartSpeedWalk = false;
                 // This draws a red circle around the out of area exit that
@@ -1653,7 +1638,7 @@ void T2DMap::initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWa
 void T2DMap::paintEvent(QPaintEvent* e)
 {
     Q_UNUSED(e)
-    if (!mpMap||mpHost.isNull()) {
+    if (!mpMap || mpHost.isNull()) {
         return;
     }
     QElapsedTimer renderTimer;
@@ -1856,7 +1841,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
         // size - which is important for good rendering over a range of sizes
         // QFont::PreferAntialias will look better - except perhaps at very small
         // sizes (but we prevent that by checking in the method call afterwards):
-        roomVNumFont.setStyleStrategy(QFont::StyleStrategy(QFont::PreferNoShaping|QFont::PreferAntialias|QFont::PreferOutline));
+        roomVNumFont.setStyleStrategy(QFont::StyleStrategy(QFont::PreferNoShaping | QFont::PreferAntialias | QFont::PreferOutline));
 
         isFontBigEnoughToShowRoomVnum = sizeFontToFitTextInRect(roomVNumFont, roomTestRect, qsl("8").repeated(mMaxRoomIdDigits), roomVnumMargin);
     }
@@ -1868,7 +1853,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
          */
         mapNameFont.setBold(true);
 
-        mapNameFont.setStyleStrategy(QFont::StyleStrategy(QFont::PreferNoShaping|QFont::PreferAntialias|QFont::PreferOutline));
+        mapNameFont.setStyleStrategy(QFont::StyleStrategy(QFont::PreferNoShaping | QFont::PreferAntialias | QFont::PreferOutline));
 
         const double sizeAdjust = 0;
         mapNameFont.setPointSizeF(static_cast<qreal>(mRoomWidth) * rSize * pow(1.1, sizeAdjust) / 2.0);
@@ -1958,7 +1943,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
                     } else {
                         painter.drawRect(rx - (mRoomWidth * rSize * 0.8), ry - (mRoomHeight * rSize * 0.2), mRoomWidth * rSize, mRoomHeight * rSize);
                     }
-                painter.restore();
+                    painter.restore();
                 }
             }
         }
@@ -2057,7 +2042,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
             continue;
         }
 
-        const float rx = room->x() *       mRoomWidth + static_cast<float>(mRX);
+        const float rx = room->x() * mRoomWidth + static_cast<float>(mRX);
         const float ry = room->y() * -1 * mRoomHeight + static_cast<float>(mRY);
         if (rx < 0 || ry < 0 || rx > widgetWidth || ry > widgetHeight) {
             continue;
@@ -2079,7 +2064,19 @@ void T2DMap::paintEvent(QPaintEvent* e)
     if (isPlayerRoomVisible) {
         const QPair<int, int> roomPos{pPlayerRoom->x(), pPlayerRoom->y()};
         const bool roomCollision = usedRoomPositions.contains(roomPos);
-        drawRoom(painter, roomVNumFont, mapNameFont, pen, pPlayerRoom, pDrawnArea->gridMode, isFontBigEnoughToShowRoomVnum, showRoomNames, playerRoomId, static_cast<float>(playerRoomOnWidgetCoordinates.x()), static_cast<float>(playerRoomOnWidgetCoordinates.y()), areaExitsMap, roomCollision);
+        drawRoom(painter,
+                 roomVNumFont,
+                 mapNameFont,
+                 pen,
+                 pPlayerRoom,
+                 pDrawnArea->gridMode,
+                 isFontBigEnoughToShowRoomVnum,
+                 showRoomNames,
+                 playerRoomId,
+                 static_cast<float>(playerRoomOnWidgetCoordinates.x()),
+                 static_cast<float>(playerRoomOnWidgetCoordinates.y()),
+                 areaExitsMap,
+                 roomCollision);
         painter.save();
         const QPen transparentPen(Qt::transparent);
         QPainterPath myPath;
@@ -2089,8 +2086,9 @@ void T2DMap::paintEvent(QPaintEvent* e)
             // Never set, no means to except via XMLImport, as dlgMapper class's
             // slot_toggleStrongHighlight is not wired up to anything
             const QRectF dr = QRectF(playerRoomOnWidgetCoordinates.x() - (static_cast<double>(mRoomWidth) * rSize) / 2.0,
-                               playerRoomOnWidgetCoordinates.y() - (static_cast<double>(mRoomHeight) * rSize) / 2.0,
-                               static_cast<double>(mRoomWidth) * rSize, static_cast<double>(mRoomHeight) * rSize);
+                                     playerRoomOnWidgetCoordinates.y() - (static_cast<double>(mRoomHeight) * rSize) / 2.0,
+                                     static_cast<double>(mRoomWidth) * rSize,
+                                     static_cast<double>(mRoomHeight) * rSize);
             painter.fillRect(dr, QColor(255, 0, 0, 150));
 
             gradient.setColorAt(0.95, QColor(255, 0, 0, 150));
@@ -2211,9 +2209,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
         xOffset += mMultiSelectionListWidget.x() + mMultiSelectionListWidget.rect().width();
     }
 
-    dlgMapper::paintMapInfo(renderTimer, painter, mpHost, mpMap,
-                            roomID, mAreaID, mMultiSelectionSet.size(), infoColor,
-                            xOffset, 20, width(), mFontHeight);
+    dlgMapper::paintMapInfo(renderTimer, painter, mpHost, mpMap, roomID, mAreaID, mMultiSelectionSet.size(), infoColor, xOffset, 20, width(), mFontHeight);
 
     static bool isAreaWidgetValid = true; // Remember between uses
     QFont _f = mpMap->mpMapper->comboBox_showArea->font();
@@ -2841,36 +2837,28 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 pen.setColor(mpMap->getColor(k));
                 painter.setPen(pen);
                 if (room->getSouth() == rID) {
-                    line = QLineF(p2.x(), p2.y() + exitArrowScale * mRoomHeight,
-                                  p2.x(), p2.y());
+                    line = QLineF(p2.x(), p2.y() + exitArrowScale * mRoomHeight, p2.x(), p2.y());
                     clickPoint = QPointF(p2.x(), p2.y() + mRoomHeight);
                 } else if (room->getNorth() == rID) {
-                    line = QLineF(p2.x(), p2.y() - exitArrowScale * mRoomHeight,
-                                  p2.x(), p2.y());
+                    line = QLineF(p2.x(), p2.y() - exitArrowScale * mRoomHeight, p2.x(), p2.y());
                     clickPoint = QPointF(p2.x(), p2.y() - mRoomHeight);
                 } else if (room->getWest() == rID) {
-                    line = QLineF(p2.x() - exitArrowScale * mRoomWidth, p2.y(),
-                                  p2.x(), p2.y());
+                    line = QLineF(p2.x() - exitArrowScale * mRoomWidth, p2.y(), p2.x(), p2.y());
                     clickPoint = QPointF(p2.x() - mRoomWidth, p2.y());
                 } else if (room->getEast() == rID) {
-                    line = QLineF(p2.x() + exitArrowScale * mRoomWidth, p2.y(),
-                                  p2.x(), p2.y());
+                    line = QLineF(p2.x() + exitArrowScale * mRoomWidth, p2.y(), p2.x(), p2.y());
                     clickPoint = QPointF(p2.x() + mRoomWidth, p2.y());
                 } else if (room->getNorthwest() == rID) {
-                    line = QLineF(p2.x() - exitArrowScale * mRoomWidth, p2.y() - exitArrowScale * mRoomHeight,
-                                  p2.x(), p2.y());
+                    line = QLineF(p2.x() - exitArrowScale * mRoomWidth, p2.y() - exitArrowScale * mRoomHeight, p2.x(), p2.y());
                     clickPoint = QPointF(p2.x() - mRoomWidth, p2.y() - mRoomHeight);
                 } else if (room->getNortheast() == rID) {
-                    line = QLineF(p2.x() + exitArrowScale * mRoomWidth, p2.y() - exitArrowScale * mRoomHeight,
-                                  p2.x(), p2.y());
+                    line = QLineF(p2.x() + exitArrowScale * mRoomWidth, p2.y() - exitArrowScale * mRoomHeight, p2.x(), p2.y());
                     clickPoint = QPointF(p2.x() + mRoomWidth, p2.y() - mRoomHeight);
                 } else if (room->getSoutheast() == rID) {
-                    line = QLineF(p2.x() + exitArrowScale * mRoomWidth, p2.y() + exitArrowScale * mRoomHeight,
-                                  p2.x(), p2.y());
+                    line = QLineF(p2.x() + exitArrowScale * mRoomWidth, p2.y() + exitArrowScale * mRoomHeight, p2.x(), p2.y());
                     clickPoint = QPointF(p2.x() + mRoomWidth, p2.y() + mRoomHeight);
                 } else if (room->getSouthwest() == rID) {
-                    line = QLineF(p2.x() - exitArrowScale * mRoomWidth, p2.y() + exitArrowScale * mRoomHeight,
-                                  p2.x(), p2.y());
+                    line = QLineF(p2.x() - exitArrowScale * mRoomWidth, p2.y() + exitArrowScale * mRoomHeight, p2.x(), p2.y());
                     clickPoint = QPointF(p2.x() - mRoomWidth, p2.y() + mRoomHeight);
                 }
                 areaExitsMap[k] = clickPoint;
@@ -3011,10 +2999,9 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
 }
 
 
-
 void T2DMap::mouseDoubleClickEvent(QMouseEvent* event)
 {
-    if (!mpMap||!mpMap->mpRoomDB) {
+    if (!mpMap || !mpMap->mpRoomDB) {
         // No map loaded!
         event->ignore();
         return;
@@ -3086,7 +3073,6 @@ void T2DMap::updateMapLabel(QRectF labelRectangle, int labelId, TArea* pArea)
     int labelHeight = drawRectangle.height();
 
     if (mpDlgMapLabel->isTextLabel()) {
-
         lp.setFont(font);
         QRectF br;
 
@@ -3151,22 +3137,22 @@ bool T2DMap::event(QEvent* event)
     // day the setFocusPolicy() calls in the constructor need to be uncommented
 
     if (event->type() == QEvent::KeyPress) {
-//        auto* ke = static_cast<QKeyEvent*>(event);
-//        if (ke->key() == Qt::Key_Delete ) {
-//            if (mCustomLineSelectedRoom != 0  ) {
-//                if (mpMap->rooms.contains(mCustomLineSelectedRoom)) {
-//                    TRoom * pR = mpMap->rooms[mCustomLineSelectedRoom];
-//                    if (pR->customLines.contains( mCustomLineSelectedExit)) {
-//                        pR->customLines.remove(mCustomLineSelectedExit);
-//                        repaint();
-//                        mCustomLineSelectedRoom = 0;
-//                        mCustomLineSelectedExit = "";
-//                        mCustomLineSelectedPoint = -1;
-//                        return QWidget::event(event);
-//                    }
-//                }
-//            }
-//        }
+        //        auto* ke = static_cast<QKeyEvent*>(event);
+        //        if (ke->key() == Qt::Key_Delete ) {
+        //            if (mCustomLineSelectedRoom != 0  ) {
+        //                if (mpMap->rooms.contains(mCustomLineSelectedRoom)) {
+        //                    TRoom * pR = mpMap->rooms[mCustomLineSelectedRoom];
+        //                    if (pR->customLines.contains( mCustomLineSelectedExit)) {
+        //                        pR->customLines.remove(mCustomLineSelectedExit);
+        //                        repaint();
+        //                        mCustomLineSelectedRoom = 0;
+        //                        mCustomLineSelectedExit = "";
+        //                        mCustomLineSelectedPoint = -1;
+        //                        return QWidget::event(event);
+        //                    }
+        //                }
+        //            }
+        //        }
     } else if (event->type() == QEvent::Resize) { // Tweak the room selection widget to fit
         resizeMultiSelectionWidget();
     }
@@ -3270,7 +3256,7 @@ void T2DMap::updateSelectionWidget()
             const int multiSelectionRoomId = itRoom.next();
             _item->setText(0, key_plain.arg(multiSelectionRoomId, mMaxRoomIdDigits));
             _item->setTextAlignment(0, Qt::AlignRight);
-            TRoom *pR_multiSelection = mpMap->mpRoomDB->getRoom(multiSelectionRoomId);
+            TRoom* pR_multiSelection = mpMap->mpRoomDB->getRoom(multiSelectionRoomId);
             if (pR_multiSelection) {
                 const QString multiSelectionRoomName = pR_multiSelection->name;
                 if (!multiSelectionRoomName.isEmpty()) {
@@ -3406,7 +3392,8 @@ void T2DMap::slot_customLineProperties()
             } else if (room->getSpecialExits().contains(exit)) {
                 le_toId->setText(QString::number(room->getSpecialExits().value(exit)));
             } else {
-                qWarning().noquote().nospace() << "T2DMap::slot_customLineProperties() WARNING - missing no exit \"" << exit << "\" to be associated with a custom exit line with that designation in room id " << room->getId();
+                qWarning().noquote().nospace() << "T2DMap::slot_customLineProperties() WARNING - missing no exit \"" << exit
+                                               << "\" to be associated with a custom exit line with that designation in room id " << room->getId();
             }
 
             mpCurrentLineStyle->setIconSize(QSize(48, 24));
@@ -3453,10 +3440,7 @@ void T2DMap::slot_customLineAddPoint()
 
     QLineF segment;
     if (mCustomLineSelectedPoint > 0) {
-        segment = QLineF(room->customLines.value(mCustomLineSelectedExit)
-                                .at(mCustomLineSelectedPoint - 1),
-                                room->customLines.value(mCustomLineSelectedExit)
-                                .at(mCustomLineSelectedPoint));
+        segment = QLineF(room->customLines.value(mCustomLineSelectedExit).at(mCustomLineSelectedPoint - 1), room->customLines.value(mCustomLineSelectedExit).at(mCustomLineSelectedPoint));
     } else if (mCustomLineSelectedPoint == 0) {
         // The first user manipulable point IS zero - line is drawn to it from a
         // point around room symbol dependent on the exit direction
@@ -3509,7 +3493,6 @@ void T2DMap::slot_setSnapCustomLinePointsToGrid(bool enabled)
 }
 
 
-
 void T2DMap::slot_customLineRemovePoint()
 {
     TRoom* room = mpMap->mpRoomDB->getRoom(mCustomLineSelectedRoom);
@@ -3540,7 +3523,6 @@ bool T2DMap::isSnapCustomLinePointsToGridEnabled() const
 }
 
 
-
 QPointF T2DMap::snapPointToGrid(const QPointF& point) const
 {
     if (mCustomLineSession) {
@@ -3551,12 +3533,10 @@ QPointF T2DMap::snapPointToGrid(const QPointF& point) const
 }
 
 
-
 bool T2DMap::canMoveSelectedCustomLineLastPointToTargetRoom() const
 {
     return mCustomLineSession && mCustomLineSession->canMoveSelectedCustomLineLastPointToTargetRoom();
 }
-
 
 
 bool T2DMap::canMoveCustomLineLastPointToTargetRoom(const TRoom& room, const QString& exitKey) const
@@ -3565,14 +3545,12 @@ bool T2DMap::canMoveCustomLineLastPointToTargetRoom(const TRoom& room, const QSt
 }
 
 
-
 void T2DMap::slot_moveCustomLineLastPointToTargetRoom()
 {
     if (mCustomLineSession) {
         mCustomLineSession->moveCustomLineLastPointToTargetRoom();
     }
 }
-
 
 
 void T2DMap::slot_undoCustomLineLastPoint()
@@ -3679,9 +3657,7 @@ void T2DMap::slot_deleteLabel()
     }
 }
 
-void T2DMap::slot_editLabel()
-{
-}
+void T2DMap::slot_editLabel() {}
 
 void T2DMap::slot_setPlayerLocation()
 {
@@ -3694,7 +3670,7 @@ void T2DMap::slot_setPlayerLocation()
         // No need to check it is a DIFFERENT room - that is taken care of by en/dis-abling the control
         mpMap->mRoomIdHash[mpMap->mProfileName] = _newRoomId;
         mpMap->mNewMove = true;
-        TEvent manualSetEvent {};
+        TEvent manualSetEvent{};
         manualSetEvent.mArgumentList.append(QLatin1String("sysManualLocationSetEvent"));
         manualSetEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         manualSetEvent.mArgumentList.append(QString::number(_newRoomId));
@@ -3779,7 +3755,7 @@ void T2DMap::populateUserContextMenus(QMenu& menu)
 
 void T2DMap::slot_userAction(QString uniqueName)
 {
-    TEvent event {};
+    TEvent event{};
     QStringList userEvent = mUserActions[uniqueName];
     event.mArgumentList.append(userEvent[0]);
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
@@ -3835,7 +3811,7 @@ void T2DMap::slot_movePosition()
     QLabel* pLa0 = new QLabel(tr("Move the selection, centered on the highlighted room (%1) to:",
                                  // Intentional comment to separate arguments
                                  "%1 is a room number")
-                              .arg(mMultiSelectionHighlightRoomId));
+                                      .arg(mMultiSelectionHighlightRoomId));
     pLa0->setWordWrap(true);
     // Record the starting coordinates - can be a help when working out how to move a block of rooms!
     QLabel* pLa1 = new QLabel(tr("x coordinate (was %1):").arg(pR_start->x()));
@@ -4013,16 +3989,23 @@ void T2DMap::slot_showPropertiesDialog()
 }
 
 
-void T2DMap::slot_setRoomProperties(
-    bool changeName, QString newName,
-    bool changeRoomColor, int newRoomColor,
-    bool changeSymbol, QString newSymbol,
-    bool changeSymbolColor, QColor newSymbolColor,
-    bool changeWeight, int newWeight,
-    bool changeLockStatus, std::optional<bool> newLockStatus,
-    bool changeBorderColor, QColor newBorderColor,
-    bool changeBorderThickness, int newBorderThickness,
-    QSet<TRoom*> rooms)
+void T2DMap::slot_setRoomProperties(bool changeName,
+                                    QString newName,
+                                    bool changeRoomColor,
+                                    int newRoomColor,
+                                    bool changeSymbol,
+                                    QString newSymbol,
+                                    bool changeSymbolColor,
+                                    QColor newSymbolColor,
+                                    bool changeWeight,
+                                    int newWeight,
+                                    bool changeLockStatus,
+                                    std::optional<bool> newLockStatus,
+                                    bool changeBorderColor,
+                                    QColor newBorderColor,
+                                    bool changeBorderThickness,
+                                    int newBorderThickness,
+                                    QSet<TRoom*> rooms)
 {
     if (newName.isEmpty()) {
         newName = QString();
@@ -4091,9 +4074,7 @@ void T2DMap::slot_previewBorderProperties(QSet<TRoom*> rooms)
     update();
 }
 
-void T2DMap::slot_setImage()
-{
-}
+void T2DMap::slot_setImage() {}
 
 void T2DMap::slot_deleteRoom()
 {
@@ -4122,17 +4103,17 @@ void T2DMap::slot_spread()
     // determined to be null (no change) case, also handle "Cancel" being pressed
     bool isOk = false;
     const int spread = QInputDialog::getInt(this,
-                                      tr("Spread out rooms"),
-                                      tr("Increase the spacing of\n"
-                                         "the selected rooms,\n"
-                                         "centered on the\n"
-                                         "highlighted room by a\n"
-                                         "factor of:"),
-                                      5,          // Initial value
-                                      1,          // Minimum value
-                                      1000,       // Maximum value
-                                      1,          // Step
-                                      &isOk);
+                                            tr("Spread out rooms"),
+                                            tr("Increase the spacing of\n"
+                                               "the selected rooms,\n"
+                                               "centered on the\n"
+                                               "highlighted room by a\n"
+                                               "factor of:"),
+                                            5,    // Initial value
+                                            1,    // Minimum value
+                                            1000, // Maximum value
+                                            1,    // Step
+                                            &isOk);
     if (spread == 1 || !isOk) {
         return;
     }
@@ -4151,9 +4132,7 @@ void T2DMap::slot_spread()
         }
 
         doneSomething = true;
-        pMovingR->setCoordinates(((pMovingR->x() - dx) * spread + dx),
-                                 ((pMovingR->y() - dy) * spread + dy),
-                                 pMovingR->z());
+        pMovingR->setCoordinates(((pMovingR->x() - dx) * spread + dx), ((pMovingR->y() - dy) * spread + dy), pMovingR->z());
         QMapIterator<QString, QList<QPointF>> itCustomLine(pMovingR->customLines);
         QMap<QString, QList<QPointF>> newCustomLinePointsMap;
         while (itCustomLine.hasNext()) {
@@ -4194,17 +4173,17 @@ void T2DMap::slot_shrink()
     // determined to be null (no change) case, also handle "Cancel" being pressed
     bool isOk = false;
     const int spread = QInputDialog::getInt(this,
-                                      tr("Shrink in rooms"),
-                                      tr("Decrease the spacing of\n"
-                                         "the selected rooms,\n"
-                                         "centered on the\n"
-                                         "highlighted room by a\n"
-                                         "factor of:"),
-                                      5,          // Initial value
-                                      1,          // Minimum value
-                                      1000,       // Maximum value
-                                      1,          // Step
-                                      &isOk);
+                                            tr("Shrink in rooms"),
+                                            tr("Decrease the spacing of\n"
+                                               "the selected rooms,\n"
+                                               "centered on the\n"
+                                               "highlighted room by a\n"
+                                               "factor of:"),
+                                            5,    // Initial value
+                                            1,    // Minimum value
+                                            1000, // Maximum value
+                                            1,    // Step
+                                            &isOk);
     if (spread == 1 || !isOk) {
         return;
     }
@@ -4223,9 +4202,7 @@ void T2DMap::slot_shrink()
         }
 
         doneSomething = true;
-        pMovingR->setCoordinates(((pMovingR->x() - dx) / spread + dx),
-                                 ((pMovingR->y() - dy) / spread + dy),
-                                 pMovingR->z());
+        pMovingR->setCoordinates(((pMovingR->x() - dx) / spread + dx), ((pMovingR->y() - dy) / spread + dy), pMovingR->z());
         QMapIterator<QString, QList<QPointF>> itCustomLine(pMovingR->customLines);
         QMap<QString, QList<QPointF>> newCustomLinePointsMap;
         while (itCustomLine.hasNext()) {
@@ -4265,9 +4242,7 @@ void T2DMap::slot_setExits()
 }
 
 
-void T2DMap::slot_setUserData()
-{
-}
+void T2DMap::slot_setUserData() {}
 
 void T2DMap::slot_loadMap()
 {
@@ -4279,13 +4254,12 @@ void T2DMap::slot_loadMap()
     QString lastDir = settings.value("lastFileDialogLocation", mudlet::getMudletPath(enums::profileHomePath, mpHost->getName())).toString();
 
 
-    const QString fileName = QFileDialog::getOpenFileName(
-                           this,
-                           tr("Load Mudlet map"),
-                           lastDir,
-                           tr("Mudlet map (*.dat);;Xml map data (*.xml);;Any file (*)",
-                              // Intentional comment to separate arguments
-                              "Do not change extensions (in braces) or the ;;s as they are used programmatically"));
+    const QString fileName = QFileDialog::getOpenFileName(this,
+                                                          tr("Load Mudlet map"),
+                                                          lastDir,
+                                                          tr("Mudlet map (*.dat);;Xml map data (*.xml);;Any file (*)",
+                                                             // Intentional comment to separate arguments
+                                                             "Do not change extensions (in braces) or the ;;s as they are used programmatically"));
     if (fileName.isEmpty()) {
         return;
     }
@@ -4361,7 +4335,7 @@ void T2DMap::slot_setArea()
     sorter.setNumericMode(true);
     sorter.setCaseSensitivity(Qt::CaseInsensitive);
 
-    std::sort( sortedAreaList.begin(), sortedAreaList.end(), sorter);
+    std::sort(sortedAreaList.begin(), sortedAreaList.end(), sorter);
 
     const QMap<int, QString>& areaNamesMap = mpMap->mpRoomDB->getAreaNamesMap();
     for (const QString& areaName : sortedAreaList) {
@@ -4372,8 +4346,7 @@ void T2DMap::slot_setArea()
     connect(arealist_combobox, &QComboBox::currentTextChanged, this, [=, this](const QString newText) {
         auto buttonBox = set_room_area_dialog->findChild<QDialogButtonBox*>("buttonBox");
         buttonBox->button(QDialogButtonBox::Ok)->setEnabled(!newText.trimmed().isEmpty());
-        if (!newText.trimmed().isEmpty() && arealist_combobox->findText(newText.trimmed(), Qt::MatchExactly) == -1
-            && !sortedAreaList.contains(newText.trimmed())) {
+        if (!newText.trimmed().isEmpty() && arealist_combobox->findText(newText.trimmed(), Qt::MatchExactly) == -1 && !sortedAreaList.contains(newText.trimmed())) {
             label_info->setText(tr("This will create new area: %1").arg(arealist_combobox->currentText()));
         } else {
             label_info->clear();
@@ -4392,13 +4365,12 @@ void T2DMap::slot_setArea()
             if (!newAreaId) {
                 mpMap->postMessage(tr("[ ERROR ] - Unable to add \"%1\" as an area to the map.\n"
                                       "See the \"[MAP ERROR:]\" message for the reason.",
-                        // Intentional separator between argument
-                                      "The '[MAP ERROR:]' text should be the same as that used for the translation of \"[MAP ERROR:]%1\n\" in the 'TMAP::logerror(...)' function.").arg(
-                        newAreaName));
+                                      // Intentional separator between argument
+                                      "The '[MAP ERROR:]' text should be the same as that used for the translation of \"[MAP ERROR:]%1\n\" in the 'TMAP::logerror(...)' function.")
+                                           .arg(newAreaName));
                 return;
             }
-            mpMap->postMessage(
-                    tr("[  OK  ]  - Added \"%1\" (%2) area to map.").arg(newAreaName, QString::number(newAreaId)));
+            mpMap->postMessage(tr("[  OK  ]  - Added \"%1\" (%2) area to map.").arg(newAreaName, QString::number(newAreaId)));
             mpMap->setUnsaved(__func__);
 
             mpMap->mpMapper->updateAreaComboBox();
@@ -4424,7 +4396,7 @@ void T2DMap::slot_setArea()
                         pArea->clean();
                     }
                 }
-                const auto &targetAreaName = mpMap->mpRoomDB->getAreaNamesMap().value(newAreaId);
+                const auto& targetAreaName = mpMap->mpRoomDB->getAreaNamesMap().value(newAreaId);
                 mpMap->mpMapper->comboBox_showArea->setCurrentText(targetAreaName);
                 switchArea(targetAreaName);
             }
@@ -5101,7 +5073,7 @@ void T2DMap::resizeMultiSelectionWidget()
         if (width() <= 750) {
             newWidth = 160;
         } else if (width() <= 890) { // 750-890 => 160-300
-            newWidth = 160+width()-750;
+            newWidth = 160 + width() - 750;
         } else { // 890+ => 300
             newWidth = 300;
         }
@@ -5152,7 +5124,7 @@ void T2DMap::setPlayerRoomStyle(const int type)
             mPlayerRoomColorGradentStops[0] = QGradientStop(0.000, QColor(255, 0, 0, 255));
             mPlayerRoomColorGradentStops[1] = QGradientStop(0.990, QColor(255, 0, 0, 255));
             mPlayerRoomColorGradentStops[2] = QGradientStop(1.000, QColor(255, 0, 0, 0));
-        } else  {
+        } else {
             mPlayerRoomColorGradentStops.resize(5);
             mPlayerRoomColorGradentStops[0] = QGradientStop(0.000, QColor(255, 0, 0, 0));
             mPlayerRoomColorGradentStops[1] = QGradientStop(factor * 0.950, QColor(255, 0, 0, 0));
@@ -5169,7 +5141,7 @@ void T2DMap::setPlayerRoomStyle(const int type)
             mPlayerRoomColorGradentStops[0] = QGradientStop(0.000, QColor(255, 255, 0, 255));
             mPlayerRoomColorGradentStops[1] = QGradientStop(0.990, QColor(0, 0, 255, 255));
             mPlayerRoomColorGradentStops[2] = QGradientStop(1.000, QColor(0, 0, 255, 0));
-        } else  {
+        } else {
             mPlayerRoomColorGradentStops.resize(5);
             mPlayerRoomColorGradentStops[0] = QGradientStop(0.000, QColor(255, 255, 0, 0));
             mPlayerRoomColorGradentStops[1] = QGradientStop(factor * 0.950, QColor(255, 255, 0, 0));
@@ -5188,7 +5160,7 @@ void T2DMap::setPlayerRoomStyle(const int type)
             QColor transparentColor(mpMap->mPlayerRoomOuterColor);
             transparentColor.setAlpha(0);
             mPlayerRoomColorGradentStops[2] = QGradientStop(1.000, transparentColor);
-        } else  {
+        } else {
             mPlayerRoomColorGradentStops.resize(5);
             QColor transparentColor(mpMap->mPlayerRoomInnerColor);
             transparentColor.setAlpha(0);
@@ -5201,7 +5173,7 @@ void T2DMap::setPlayerRoomStyle(const int type)
             mPlayerRoomColorGradentStops[4] = QGradientStop(1.000, transparentColor);
         }
         break;
-        } // End of case 3:
+    } // End of case 3:
 
     default: // Sort of emulates the original code:
         mPlayerRoomColorGradentStops.resize(5);
@@ -5226,7 +5198,6 @@ void T2DMap::clearSelection()
 
 std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& filePath, std::optional<int> zLevel, qreal zoom, bool exportAllZLevels)
 {
-
     // Validate zoom parameter
     if (zoom <= 0.0 || zoom > 10.0) {
         return {false, qsl("Zoom must be between 0.1 and 10.0")};
@@ -5259,11 +5230,7 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
 
         // Export each Z level as a separate file
         for (int currentZLevel : pArea->zLevels) {
-            QString levelFileName = QString("%1/%2_level_%3.%4")
-                                  .arg(basePath)
-                                  .arg(baseFileName)
-                                  .arg(currentZLevel)
-                                  .arg(extension.isEmpty() ? "png" : extension);
+            QString levelFileName = QString("%1/%2_level_%3.%4").arg(basePath).arg(baseFileName).arg(currentZLevel).arg(extension.isEmpty() ? "png" : extension);
 
             // Recursively call this function for each Z level (without exportAllZLevels flag)
             auto [success, message] = exportAreaToImage(areaId, levelFileName, currentZLevel, zoom, false);
@@ -5507,7 +5474,6 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
 
     // Third pass: draw room exits (moved to correct position after upper-level rooms)
     if (!pArea->gridMode) {
-
         // paintRoomExits uses width() and height() for visibility filtering, but we need to use imageWidth/imageHeight
         // Since we can't easily override those methods, we'll create a custom export-specific exit drawing
 
@@ -5655,14 +5621,22 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
                     if (exitRoom) {
                         // Check if it's a one-way exit (return direction doesn't point back)
                         bool isOneWay = false;
-                        if (dirKey == "n" && exitRoom->getSouth() != roomId) isOneWay = true;
-                        else if (dirKey == "s" && exitRoom->getNorth() != roomId) isOneWay = true;
-                        else if (dirKey == "e" && exitRoom->getWest() != roomId) isOneWay = true;
-                        else if (dirKey == "w" && exitRoom->getEast() != roomId) isOneWay = true;
-                        else if (dirKey == "ne" && exitRoom->getSouthwest() != roomId) isOneWay = true;
-                        else if (dirKey == "nw" && exitRoom->getSoutheast() != roomId) isOneWay = true;
-                        else if (dirKey == "se" && exitRoom->getNorthwest() != roomId) isOneWay = true;
-                        else if (dirKey == "sw" && exitRoom->getNortheast() != roomId) isOneWay = true;
+                        if (dirKey == "n" && exitRoom->getSouth() != roomId)
+                            isOneWay = true;
+                        else if (dirKey == "s" && exitRoom->getNorth() != roomId)
+                            isOneWay = true;
+                        else if (dirKey == "e" && exitRoom->getWest() != roomId)
+                            isOneWay = true;
+                        else if (dirKey == "w" && exitRoom->getEast() != roomId)
+                            isOneWay = true;
+                        else if (dirKey == "ne" && exitRoom->getSouthwest() != roomId)
+                            isOneWay = true;
+                        else if (dirKey == "nw" && exitRoom->getSoutheast() != roomId)
+                            isOneWay = true;
+                        else if (dirKey == "se" && exitRoom->getNorthwest() != roomId)
+                            isOneWay = true;
+                        else if (dirKey == "sw" && exitRoom->getNortheast() != roomId)
+                            isOneWay = true;
 
                         if (isOneWay) {
                             roomOneWayExits.push_back(exitRoomId);
@@ -5712,10 +5686,12 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
 
             // Draw regular exit lines to destination rooms (same as paintRoomExits logic)
             for (const int exitRoomId : roomExitList) {
-                if (exitRoomId <= 0) continue;
+                if (exitRoomId <= 0)
+                    continue;
 
                 TRoom* exitRoom = mpMap->mpRoomDB->getRoom(exitRoomId);
-                if (!exitRoom) continue;
+                if (!exitRoom)
+                    continue;
 
                 // Determine if this is an area exit (like original paintRoomExits)
                 const bool areaExit = exitRoom->getArea() != areaId;
@@ -5728,50 +5704,42 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
                 if (room->getNorth() == exitRoomId) {
                     doorKey = "n";
                     if (areaExit) {
-                        exitLine = QLineF(rx, ry - exitArrowScale * finalRoomSize,
-                                         rx, ry);
+                        exitLine = QLineF(rx, ry - exitArrowScale * finalRoomSize, rx, ry);
                     }
                 } else if (room->getSouth() == exitRoomId) {
                     doorKey = "s";
                     if (areaExit) {
-                        exitLine = QLineF(rx, ry + exitArrowScale * finalRoomSize,
-                                         rx, ry);
+                        exitLine = QLineF(rx, ry + exitArrowScale * finalRoomSize, rx, ry);
                     }
                 } else if (room->getEast() == exitRoomId) {
                     doorKey = "e";
                     if (areaExit) {
-                        exitLine = QLineF(rx + exitArrowScale * finalRoomSize, ry,
-                                         rx, ry);
+                        exitLine = QLineF(rx + exitArrowScale * finalRoomSize, ry, rx, ry);
                     }
                 } else if (room->getWest() == exitRoomId) {
                     doorKey = "w";
                     if (areaExit) {
-                        exitLine = QLineF(rx - exitArrowScale * finalRoomSize, ry,
-                                         rx, ry);
+                        exitLine = QLineF(rx - exitArrowScale * finalRoomSize, ry, rx, ry);
                     }
                 } else if (room->getNortheast() == exitRoomId) {
                     doorKey = "ne";
                     if (areaExit) {
-                        exitLine = QLineF(rx + exitArrowScale * finalRoomSize, ry - exitArrowScale * finalRoomSize,
-                                         rx, ry);
+                        exitLine = QLineF(rx + exitArrowScale * finalRoomSize, ry - exitArrowScale * finalRoomSize, rx, ry);
                     }
                 } else if (room->getNorthwest() == exitRoomId) {
                     doorKey = "nw";
                     if (areaExit) {
-                        exitLine = QLineF(rx - exitArrowScale * finalRoomSize, ry - exitArrowScale * finalRoomSize,
-                                         rx, ry);
+                        exitLine = QLineF(rx - exitArrowScale * finalRoomSize, ry - exitArrowScale * finalRoomSize, rx, ry);
                     }
                 } else if (room->getSoutheast() == exitRoomId) {
                     doorKey = "se";
                     if (areaExit) {
-                        exitLine = QLineF(rx + exitArrowScale * finalRoomSize, ry + exitArrowScale * finalRoomSize,
-                                         rx, ry);
+                        exitLine = QLineF(rx + exitArrowScale * finalRoomSize, ry + exitArrowScale * finalRoomSize, rx, ry);
                     }
                 } else if (room->getSouthwest() == exitRoomId) {
                     doorKey = "sw";
                     if (areaExit) {
-                        exitLine = QLineF(rx - exitArrowScale * finalRoomSize, ry + exitArrowScale * finalRoomSize,
-                                         rx, ry);
+                        exitLine = QLineF(rx - exitArrowScale * finalRoomSize, ry + exitArrowScale * finalRoomSize, rx, ry);
                     }
                 }
 
@@ -5902,17 +5870,26 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
         }
 
         // Use the existing drawRoom method!
-        drawRoom(painter, roomVNumFont, mapNameFont, pen, pRoom, pArea->gridMode,
-                areRoomIdsLegible, false /* showRoomNames */,
-                -1 /* speedWalkStartRoomId */, rx, ry, areaExitsMap, false /* showRoomCollision */);
+        drawRoom(painter,
+                 roomVNumFont,
+                 mapNameFont,
+                 pen,
+                 pRoom,
+                 pArea->gridMode,
+                 areRoomIdsLegible,
+                 false /* showRoomNames */,
+                 -1 /* speedWalkStartRoomId */,
+                 rx,
+                 ry,
+                 areaExitsMap,
+                 false /* showRoomCollision */);
 
         roomsDrawn++;
-
     }
 
 
     // Draw the ("foreground") labels that are on the top of the map - same as paintEvent
-    itMapLabel.toFront();  // Reset the iterator
+    itMapLabel.toFront(); // Reset the iterator
     while (itMapLabel.hasNext()) {
         itMapLabel.next();
         auto mapLabel = itMapLabel.value();
@@ -5984,9 +5961,7 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
     });
 
     // Start async save task - fire & forget
-    auto future = QtConcurrent::task(&T2DMap::performImageSave)
-                      .withArguments(this, pixmap, filePath, format)
-                      .spawn();
+    auto future = QtConcurrent::task(&T2DMap::performImageSave).withArguments(this, pixmap, filePath, format).spawn();
     mpExportWatcher->setFuture(future);
 
     return {true, {}};
@@ -6026,10 +6001,7 @@ void T2DMap::slot_exportAreaToImage()
     }
 
     QString fullPath = qsl("%1/%2").arg(lastDir, defaultFileName);
-    QString filePath = QFileDialog::getSaveFileName(this,
-                                                    tr("Export Area %1 to Image").arg(areaName),
-                                                    fullPath,
-                                                    tr("Image Files (*.png *.jpg *.jpeg *.bmp *.tiff);;All Files (*)"));
+    QString filePath = QFileDialog::getSaveFileName(this, tr("Export Area %1 to Image").arg(areaName), fullPath, tr("Image Files (*.png *.jpg *.jpeg *.bmp *.tiff);;All Files (*)"));
 
     if (filePath.isEmpty()) {
         return;

--- a/src/TAccessibleTextEdit.cpp
+++ b/src/TAccessibleTextEdit.cpp
@@ -50,7 +50,7 @@ bool TAccessibleTextEdit::offsetIsInvalid(int offset) const
 }
 
 // performance note - this is called extremely frequently on the same line
-int TAccessibleTextEdit::lineForOffset(int offset, int *lengthSoFar = nullptr) const
+int TAccessibleTextEdit::lineForOffset(int offset, int* lengthSoFar = nullptr) const
 {
     const QStringList& lineBuffer = textEdit()->mpBuffer->lineBuffer;
     int lengthSoFar_ = 0;
@@ -105,7 +105,7 @@ int TAccessibleTextEdit::columnForOffset(int offset) const
  * The accessibility APIs support multiple selections. For most widgets though,
  * only one selection is supported with selectionIndex equal to 0.
  */
-void TAccessibleTextEdit::selection(int selectionIndex, int *startOffset, int *endOffset) const
+void TAccessibleTextEdit::selection(int selectionIndex, int* startOffset, int* endOffset) const
 {
     if (selectionIndex != 0) {
         *startOffset = *endOffset = 0;
@@ -151,7 +151,7 @@ void TAccessibleTextEdit::addSelection(int startOffset, int endOffset)
         std::swap(startOffset, endOffset);
     }
 
-    TTextEdit *edit = textEdit();
+    TTextEdit* edit = textEdit();
     edit->mPA.setX(columnForOffset(startOffset));
     edit->mPA.setY(lineForOffset(startOffset));
     edit->mDragStart = edit->mPA;
@@ -345,7 +345,7 @@ void TAccessibleTextEdit::scrollToSubstring(int startIndex, int endIndex)
  * Returns the text attributes at the position offset. In addition the
  * range of the attributes is returned in startOffset and endOffset.
  */
-QString TAccessibleTextEdit::attributes(int offset, int *startOffset, int *endOffset) const
+QString TAccessibleTextEdit::attributes(int offset, int* startOffset, int* endOffset) const
 {
     // IAccessible2 defines -1 as length and -2 as cursor position.
     if (offset == -2) {
@@ -390,7 +390,7 @@ QString TAccessibleTextEdit::attributes(int offset, int *startOffset, int *endOf
     const int line = lineForOffset(offset);
     const int column = columnForOffset(offset);
     const QFont::Style style = font.style();
-    const TChar &charStyle = textEdit()->mpBuffer->buffer.at(line).at(column);
+    const TChar& charStyle = textEdit()->mpBuffer->buffer.at(line).at(column);
     // IAccessible2's text attributes don't support the overline attribute.
     const TChar::AttributeFlags attributes = charStyle.allDisplayAttributes();
     const bool isBold = (attributes & TChar::Bold) || font.weight() > QFont::Normal;
@@ -398,8 +398,7 @@ QString TAccessibleTextEdit::attributes(int offset, int *startOffset, int *endOf
     const bool isStrikeOut = attributes & TChar::StrikeOut;
     const bool isUnderline = attributes & TChar::Underline;
     const bool isReverse = attributes & TChar::Reverse;
-    const bool caretIsHere = textEdit()->mpHost->caretEnabled() && textEdit()->mCaretLine == line &&
-        textEdit()->mCaretColumn == column;
+    const bool caretIsHere = textEdit()->mpHost->caretEnabled() && textEdit()->mCaretLine == line && textEdit()->mCaretColumn == column;
 
     // Different weight values are not handled.
     if (isBold) {
@@ -433,19 +432,14 @@ QString TAccessibleTextEdit::attributes(int offset, int *startOffset, int *endOf
 /*
  * Auxiliary function for textAtOffset() and textAfterOffset().
  */
-QString TAccessibleTextEdit::textAroundOffset(TAccessibleTextEdit::TextOp operation, int offset,
-                                              QAccessible::TextBoundaryType boundaryType,
-                                              int* startOffset, int* endOffset) const
+QString TAccessibleTextEdit::textAroundOffset(TAccessibleTextEdit::TextOp operation, int offset, QAccessible::TextBoundaryType boundaryType, int* startOffset, int* endOffset) const
 {
     // There's no code overlap between the text*Offset() methods in this case, so
     // NoBoundary is always handled by the caller.
-    Q_ASSERT_X(boundaryType != QAccessible::TextBoundaryType::NoBoundary,
-               "TAccessibleTextEdit::textAroundOffset", "The caller should have handled NoBoundary.");
+    Q_ASSERT_X(boundaryType != QAccessible::TextBoundaryType::NoBoundary, "TAccessibleTextEdit::textAroundOffset", "The caller should have handled NoBoundary.");
 
-    if (boundaryType != QAccessible::TextBoundaryType::CharBoundary &&
-        boundaryType != QAccessible::TextBoundaryType::WordBoundary &&
-        boundaryType != QAccessible::TextBoundaryType::SentenceBoundary &&
-        boundaryType != QAccessible::TextBoundaryType::LineBoundary) {
+    if (boundaryType != QAccessible::TextBoundaryType::CharBoundary && boundaryType != QAccessible::TextBoundaryType::WordBoundary && boundaryType != QAccessible::TextBoundaryType::SentenceBoundary
+        && boundaryType != QAccessible::TextBoundaryType::LineBoundary) {
         *startOffset = *endOffset = -1;
         return QString();
     }
@@ -457,10 +451,8 @@ QString TAccessibleTextEdit::textAroundOffset(TAccessibleTextEdit::TextOp operat
 
     const QString contents = text(QAccessible::Value);
 
-    if (boundaryType == QAccessible::TextBoundaryType::WordBoundary ||
-        boundaryType == QAccessible::TextBoundaryType::SentenceBoundary) {
-        QTextBoundaryFinder::BoundaryType type = boundaryType == QAccessible::TextBoundaryType::WordBoundary ?
-            QTextBoundaryFinder::BoundaryType::Word : QTextBoundaryFinder::BoundaryType::Sentence;
+    if (boundaryType == QAccessible::TextBoundaryType::WordBoundary || boundaryType == QAccessible::TextBoundaryType::SentenceBoundary) {
+        QTextBoundaryFinder::BoundaryType type = boundaryType == QAccessible::TextBoundaryType::WordBoundary ? QTextBoundaryFinder::BoundaryType::Word : QTextBoundaryFinder::BoundaryType::Sentence;
         QTextBoundaryFinder finder = QTextBoundaryFinder(type, contents);
         int start = 0, end = 0;
 
@@ -491,7 +483,7 @@ QString TAccessibleTextEdit::textAroundOffset(TAccessibleTextEdit::TextOp operat
     }
 
     QString ret;
-    TBuffer *buffer = textEdit()->mpBuffer;
+    TBuffer* buffer = textEdit()->mpBuffer;
 
     if (boundaryType == QAccessible::TextBoundaryType::CharBoundary) {
         if (operation == TAccessibleTextEdit::TextOp::BeforeOffset) {
@@ -568,7 +560,7 @@ QString TAccessibleTextEdit::textAroundOffset(TAccessibleTextEdit::TextOp operat
  * used for the text length and custom implementations of this function
  * have to return the result as if the length was passed in as offset.
  */
-QString TAccessibleTextEdit::textAfterOffset(int offset, QAccessible::TextBoundaryType boundaryType, int *startOffset, int *endOffset) const
+QString TAccessibleTextEdit::textAfterOffset(int offset, QAccessible::TextBoundaryType boundaryType, int* startOffset, int* endOffset) const
 {
     // This is the simplest case to implement, so get it over with now.
     if (boundaryType == QAccessible::TextBoundaryType::NoBoundary) {
@@ -599,8 +591,7 @@ QString TAccessibleTextEdit::textAfterOffset(int offset, QAccessible::TextBounda
  * used for the text length and custom implementations of this function
  * have to return the result as if the length was passed in as offset.
  */
-QString TAccessibleTextEdit::textAtOffset(int offset, QAccessible::TextBoundaryType boundaryType,
-                                         int *startOffset, int *endOffset) const
+QString TAccessibleTextEdit::textAtOffset(int offset, QAccessible::TextBoundaryType boundaryType, int* startOffset, int* endOffset) const
 {
     // This is the simplest case to implement, so get it over with now.
     if (boundaryType == QAccessible::TextBoundaryType::NoBoundary) {
@@ -631,7 +622,7 @@ QString TAccessibleTextEdit::textAtOffset(int offset, QAccessible::TextBoundaryT
  * used for the text length and custom implementations of this function
  * have to return the result as if the length was passed in as offset.
  */
-QString TAccessibleTextEdit::textBeforeOffset(int offset, QAccessible::TextBoundaryType boundaryType, int *startOffset, int *endOffset) const
+QString TAccessibleTextEdit::textBeforeOffset(int offset, QAccessible::TextBoundaryType boundaryType, int* startOffset, int* endOffset) const
 {
     // This is the simplest case to implement, so get it over with now.
     if (boundaryType == QAccessible::TextBoundaryType::NoBoundary) {

--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -30,7 +30,7 @@
 #include "mudlet.h"
 
 TAlias::TAlias(TAlias* parent, Host* pHost)
-: Tree<TAlias>( parent )
+: Tree<TAlias>(parent)
 , mpHost(pHost)
 {
 }
@@ -164,8 +164,8 @@ bool TAlias::match(const QString& haystack)
         for (uint32_t j = 0; j < namecount; ++j) {
             const int n = (tabptr[0] << 8) | tabptr[1];
             auto name = QString::fromUtf8(reinterpret_cast<const char*>(&tabptr[2])).trimmed();
-            auto* substring_start = haystackC + ovector[2*n];
-            auto substring_length = ovector[2*n+1] - ovector[2*n];
+            auto* substring_start = haystackC + ovector[2 * n];
+            auto substring_length = ovector[2 * n + 1] - ovector[2 * n];
             auto utf16_pos = haystack.indexOf(QString::fromUtf8(substring_start, substring_length));
             auto capture = QString::fromUtf8(substring_start, substring_length);
             nameGroups << qMakePair(name, capture);
@@ -215,14 +215,14 @@ bool TAlias::match(const QString& haystack)
         }
     }
 
-END : {
-        TLuaInterpreter* pL = mpHost->getLuaInterpreter();
-        pL->setCaptureGroups(captureList, posList);
-        pL->setCaptureNameGroups(nameGroups, namePositions);
-        // call lua trigger function with number of matches and matches itselves as arguments
-        execute();
-        pL->clearCaptureGroups();
-    }
+END: {
+    TLuaInterpreter* pL = mpHost->getLuaInterpreter();
+    pL->setCaptureGroups(captureList, posList);
+    pL->setCaptureNameGroups(nameGroups, namePositions);
+    // call lua trigger function with number of matches and matches itselves as arguments
+    execute();
+    pL->clearCaptureGroups();
+}
 
     if (match_data) {
         pcre2_match_data_free(match_data);
@@ -257,13 +257,8 @@ void TAlias::compileRegex()
 
     // PCRE2_UTF needed to run compile in UTF-8 mode
     // PCRE2_UCP needed for \d, \w etc. to use Unicode properties:
-    QSharedPointer<pcre2_code> re(pcre2_compile(
-        reinterpret_cast<PCRE2_SPTR>(mRegexCode.toUtf8().constData()),
-        PCRE2_ZERO_TERMINATED,
-        PCRE2_UTF | PCRE2_UCP,
-        &errorcode,
-        &erroffset,
-        nullptr), pcre2_code_deleter);
+    QSharedPointer<pcre2_code> re(pcre2_compile(reinterpret_cast<PCRE2_SPTR>(mRegexCode.toUtf8().constData()), PCRE2_ZERO_TERMINATED, PCRE2_UTF | PCRE2_UCP, &errorcode, &erroffset, nullptr),
+                                  pcre2_code_deleter);
 
     if (re == nullptr) {
         mOK_init = false;

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -62,7 +62,7 @@ TArea::~TArea()
     }
     if (!mpRoomDB->mBulkDeletionMode) {
         mpRoomDB->removeArea(this);
-     }
+    }
 }
 
 int TArea::getAreaID()
@@ -529,19 +529,45 @@ const QMultiMap<int, QPair<QString, int>> TArea::getAreaExitRoomData() const
         QPair<QString, int> exitData;
         exitData.second = itAreaExit.value().first;
         switch (itAreaExit.value().second) {
-        case DIR_NORTH:     exitData.first = QString("north");                         break;
-        case DIR_NORTHEAST: exitData.first = QString("northeast");                     break;
-        case DIR_NORTHWEST: exitData.first = QString("northwest");                     break;
-        case DIR_SOUTH:     exitData.first = QString("south");                         break;
-        case DIR_WEST:      exitData.first = QString("west");                          break;
-        case DIR_EAST:      exitData.first = QString("east");                          break;
-        case DIR_SOUTHEAST: exitData.first = QString("southeast");                     break;
-        case DIR_SOUTHWEST: exitData.first = QString("southwest");                     break;
-        case DIR_UP:        exitData.first = QString("up");                            break;
-        case DIR_DOWN:      exitData.first = QString("down");                          break;
-        case DIR_IN:        exitData.first = QString("in");                            break;
-        case DIR_OUT:       exitData.first = QString("out");                           break;
-        case DIR_OTHER:     roomsWithOtherAreaSpecialExits.insert(itAreaExit.key());   break;
+        case DIR_NORTH:
+            exitData.first = QString("north");
+            break;
+        case DIR_NORTHEAST:
+            exitData.first = QString("northeast");
+            break;
+        case DIR_NORTHWEST:
+            exitData.first = QString("northwest");
+            break;
+        case DIR_SOUTH:
+            exitData.first = QString("south");
+            break;
+        case DIR_WEST:
+            exitData.first = QString("west");
+            break;
+        case DIR_EAST:
+            exitData.first = QString("east");
+            break;
+        case DIR_SOUTHEAST:
+            exitData.first = QString("southeast");
+            break;
+        case DIR_SOUTHWEST:
+            exitData.first = QString("southwest");
+            break;
+        case DIR_UP:
+            exitData.first = QString("up");
+            break;
+        case DIR_DOWN:
+            exitData.first = QString("down");
+            break;
+        case DIR_IN:
+            exitData.first = QString("in");
+            break;
+        case DIR_OUT:
+            exitData.first = QString("out");
+            break;
+        case DIR_OTHER:
+            roomsWithOtherAreaSpecialExits.insert(itAreaExit.key());
+            break;
         default:
             qWarning("TArea::getAreaExitRoomData() Warning: unrecognised exit code %i found for exit from room %i to room %i.", itAreaExit.value().second, itAreaExit.key(), itAreaExit.value().first);
         }
@@ -578,7 +604,8 @@ const QMultiMap<int, QPair<QString, int>> TArea::getAreaExitRoomData() const
 int TArea::createLabelId() const
 {
     int labelId = -1;
-    do {} while (mMapLabels.contains(++labelId));
+    do {
+    } while (mMapLabels.contains(++labelId));
     if (labelId < 0) {
         labelId = -1;
     }
@@ -760,15 +787,9 @@ void TArea::writeJsonLabel(QJsonArray& array, const int id, const TMapLabel* pLa
         labelObj.insert(QLatin1String("text"), textValue);
     }
 
-    if (!(pLabel->fgColor.red() == defaultLabelForeground.red()
-          && pLabel->fgColor.green() == defaultLabelForeground.green()
-          && pLabel->fgColor.blue() == defaultLabelForeground.blue()
-          && pLabel->fgColor.alpha() == defaultLabelForeground.alpha()
-          && pLabel->bgColor.red() == defaultLabelBackground.red()
-          && pLabel->bgColor.green() == defaultLabelBackground.green()
-          && pLabel->bgColor.blue() == defaultLabelBackground.blue()
-          && pLabel->bgColor.alpha() == defaultLabelBackground.alpha())) {
-
+    if (!(pLabel->fgColor.red() == defaultLabelForeground.red() && pLabel->fgColor.green() == defaultLabelForeground.green() && pLabel->fgColor.blue() == defaultLabelForeground.blue()
+          && pLabel->fgColor.alpha() == defaultLabelForeground.alpha() && pLabel->bgColor.red() == defaultLabelBackground.red() && pLabel->bgColor.green() == defaultLabelBackground.green()
+          && pLabel->bgColor.blue() == defaultLabelBackground.blue() && pLabel->bgColor.alpha() == defaultLabelBackground.alpha())) {
         // For an image the colors are not used and tend to be set to black, if
         // so skip them. Unfortunately because of the way QColour s are
         // assembled the operator== is too picky for our purposes as even the

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -55,7 +55,8 @@ constexpr size_t MAX_OSC_SEQUENCE_LENGTH = 4096;
 
 // Helper to interpret JSON values as boolean
 // Accepts both boolean true and numeric non-zero values (servers may send 1 instead of true)
-bool jsonBoolValue(const QJsonValue& val) {
+bool jsonBoolValue(const QJsonValue& val)
+{
     return val.toBool() || (val.isDouble() && val.toDouble() != 0);
 }
 
@@ -176,7 +177,9 @@ TBuffer::TBuffer(Host* pH, TConsole* pConsole)
 , mTagWatchdog(std::make_unique<QTimer>())
 {
     mTagWatchdog->setSingleShot(true);
-    QObject::connect(mTagWatchdog.get(), &QTimer::timeout, [this]() { processMxpWatchdogCallback(); });
+    QObject::connect(mTagWatchdog.get(), &QTimer::timeout, [this]() {
+        processMxpWatchdogCallback();
+    });
     // All additions to the buffer must use append()/appendLine() to preserve formatting via TChar.
     // Direct modification of the `buffer` vector may bypass formatting and should be avoided.
     clear();
@@ -274,7 +277,9 @@ TBuffer::TBuffer(const TBuffer& other)
 , mCurrentFocusedLinkIndex(other.mCurrentFocusedLinkIndex)
 {
     mTagWatchdog->setSingleShot(true);
-    QObject::connect(mTagWatchdog.get(), &QTimer::timeout, [this]() { processMxpWatchdogCallback(); });
+    QObject::connect(mTagWatchdog.get(), &QTimer::timeout, [this]() {
+        processMxpWatchdogCallback();
+    });
 }
 
 TBuffer& TBuffer::operator=(const TBuffer& other)
@@ -353,18 +358,21 @@ TBuffer& TBuffer::operator=(const TBuffer& other)
         mCurrentHoveredLinkIndex = other.mCurrentHoveredLinkIndex;
         mCurrentActiveLinkIndex = other.mCurrentActiveLinkIndex;
         mCurrentFocusedLinkIndex = other.mCurrentFocusedLinkIndex;
-        
+
         mTagWatchdog = std::make_unique<QTimer>();
         mTagWatchdog->setSingleShot(true);
-        QObject::connect(mTagWatchdog.get(), &QTimer::timeout, [this]() { processMxpWatchdogCallback(); });
+        QObject::connect(mTagWatchdog.get(), &QTimer::timeout, [this]() {
+            processMxpWatchdogCallback();
+        });
     }
     return *this;
 }
 
 // user-defined literal to represent megabytes
-auto operator""_MB(unsigned long long const x)
-        -> long
-{ return 1024L*1024L*x; }
+auto operator""_MB(unsigned long long const x) -> long
+{
+    return 1024L * 1024L * x;
+}
 
 void TBuffer::setBufferSize(int requestedLinesLimit, int batch)
 {
@@ -377,8 +385,7 @@ void TBuffer::setBufferSize(int requestedLinesLimit, int batch)
     // clip the maximum to something reasonable that the machine can handle
     auto max = getMaxBufferSize();
     if (requestedLinesLimit > max) {
-        qWarning().nospace() << "setBufferSize(): " << requestedLinesLimit <<
-                "lines for buffer requested but your computer can only handle " << max << ", clipping it";
+        qWarning().nospace() << "setBufferSize(): " << requestedLinesLimit << "lines for buffer requested but your computer can only handle " << max << ", clipping it";
         mLinesLimit = max;
     } else {
         mLinesLimit = requestedLinesLimit;
@@ -582,9 +589,11 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
         // sequences that were not complete at the end of the last packet:
         if (!mIncompleteSequenceBytes.empty()) {
 #if defined(DEBUG_SGR_PROCESSING) || defined(DEBUG_OSC_PROCESSING) || defined(DEBUG_UTF8_PROCESSING) || defined(DEBUG_GB_PROCESSING) || defined(DEBUG_BIG5_PROCESSING)
-            qDebug() << "TBuffer::translateToPlainText(...) WARNING - Dumping residual bytes that were carried over from previous packet onto incoming data - the encoding has changed and they may no longer be usable!";
+            qDebug() << "TBuffer::translateToPlainText(...) WARNING - Dumping residual bytes that were carried over from previous packet onto incoming data - the encoding has changed and they may no "
+                        "longer be usable!";
 #endif
-            mIncompleteSequenceBytes.clear();;
+            mIncompleteSequenceBytes.clear();
+            ;
         }
     }
 
@@ -684,8 +693,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
             size_t const spanStart = localBufferPosition;
             size_t spanEnd = spanStart;
             while (spanEnd < localBufferLength
-                   && ((((spanStart < spanEnd) && cParameterInitial.indexOf(localBuffer[spanEnd]) >= 0))
-                      ||((spanStart == spanEnd) && cParameter.indexOf(localBuffer[spanEnd]) >= 0))) {
+                   && ((((spanStart < spanEnd) && cParameterInitial.indexOf(localBuffer[spanEnd]) >= 0)) || ((spanStart == spanEnd) && cParameter.indexOf(localBuffer[spanEnd]) >= 0))) {
                 ++spanEnd;
             }
 
@@ -696,7 +704,8 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                 // the reserved characters ('<', '=', '>' or '?') which we
                 // can/do not handle
 
-                qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - detected a private/reserved CSI sequence beginning with \"CSI" << localBuffer.substr(spanStart, spanEnd - spanStart).c_str() << "\" which Mudlet cannot interpret.";
+                qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - detected a private/reserved CSI sequence beginning with \"CSI"
+                                             << localBuffer.substr(spanStart, spanEnd - spanStart).c_str() << "\" which Mudlet cannot interpret.";
                 // So skip over it as far as we can - will still possibly have
                 // garbage beyond the end which will still be shown...
                 localBufferPosition += 1 + spanEnd - spanStart;
@@ -728,9 +737,11 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                 // afterwards is as it might help to debug things
                 if (spanEnd + 1 < localBufferLength) {
                     // Yeah there is another byte we can report as the final byte
-                    qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - detected a CSI sequence with an 'intermediate' byte ('" << localBuffer[spanEnd] << "') and a 'final' byte ('" << localBuffer[spanEnd+1] << "') which Mudlet cannot interpret.";
+                    qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - detected a CSI sequence with an 'intermediate' byte ('" << localBuffer[spanEnd]
+                                                 << "') and a 'final' byte ('" << localBuffer[spanEnd + 1] << "') which Mudlet cannot interpret.";
                 } else {
-                    qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - detected a CSI sequence with an 'intermediate' byte ('" << localBuffer[spanEnd] << "') which Mudlet cannot interpret.";
+                    qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - detected a CSI sequence with an 'intermediate' byte ('" << localBuffer[spanEnd]
+                                                 << "') which Mudlet cannot interpret.";
                 }
                 // So skip over it as far as we can - will still be possible to
                 // have garbage beyond the end which will still be shown...
@@ -786,13 +797,13 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                             mMudBuffer.push_back(c);
                         }
                         // For debugging:
-//                        qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - CUF (cursor forward) sequence of form CSI" << temp << "C received, converting into " << spacesNeeded << " spaces.";
+                        //                        qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - CUF (cursor forward) sequence of form CSI" << temp << "C received, converting into " << spacesNeeded << " spaces.";
                     } else {
-                        qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - Unhandled sequence of form CSI..." << temp << "C received, that is supposed to be a CUF (cursor forward) sequence but doesn't make sense, Mudlet will ignore it.";
+                        qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - Unhandled sequence of form CSI..." << temp
+                                                     << "C received, that is supposed to be a CUF (cursor forward) sequence but doesn't make sense, Mudlet will ignore it.";
                     }
 
-                }
-                    break;
+                } break;
 
                 case static_cast<quint8>('J'): {
                     /*
@@ -811,23 +822,26 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                     const int argValue = temp.toInt(&isOk);
                     if (isOk) {
                         if (argValue >= 0 && argValue < 3) {
-                            qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - ED (erase in display) sequence of form CSI" << temp << "J received,\nrejecting as incompatible with Mudlet.";
+                            qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - ED (erase in display) sequence of form CSI" << temp
+                                                         << "J received,\nrejecting as incompatible with Mudlet.";
                         } else {
-                            qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - Invalid ED (erase in display) sequence of form CSI" << temp << "J received,\nwhich Mudlet will ignore.";
+                            qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - Invalid ED (erase in display) sequence of form CSI" << temp
+                                                         << "J received,\nwhich Mudlet will ignore.";
                         }
                     } else {
-                        qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - Unhandled sequence of form CSI..." << temp << "J received, that is supposed to\nbe a ED (erase in display) sequence but it doesn't make sense, Mudlet will ignore it.";
+                        qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - Unhandled sequence of form CSI..." << temp
+                                                     << "J received, that is supposed to\nbe a ED (erase in display) sequence but it doesn't make sense, Mudlet will ignore it.";
                     }
-                }
-                    break;
+                } break;
 
                 default: // Unhandled other (valid) CSI final byte sequences will end up here
                     qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - Unhandled sequence of form CSI..." << localBuffer[spanEnd] << " received, Mudlet will ignore it.";
 
                 } // End of switch(modeChar) {}
             } else {
-                qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - detected an invalid CSI sequence beginning with \"CSI" << localBuffer.substr(spanStart, spanEnd - spanStart).c_str() << " which Mudlet will ignore.";
-            }  // End of (isAValidFinalByte) {}
+                qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - detected an invalid CSI sequence beginning with \"CSI"
+                                             << localBuffer.substr(spanStart, spanEnd - spanStart).c_str() << " which Mudlet will ignore.";
+            } // End of (isAValidFinalByte) {}
 
             mGotCSI = false;
             localBufferPosition += 1 + spanEnd - spanStart;
@@ -855,17 +869,14 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
             // because we already know that the localBuffer extends backwards
             // that far (it will be the ']' character!)
             // Loop until we find ST (ESC \), BEL, exceed length limit, or run out of data
-            while (spanEnd < localBufferLength
-                   && (spanEnd - spanStart) < MAX_OSC_SEQUENCE_LENGTH
-                   && localBuffer[spanEnd] != '\x07'
+            while (spanEnd < localBufferLength && (spanEnd - spanStart) < MAX_OSC_SEQUENCE_LENGTH && localBuffer[spanEnd] != '\x07'
                    && !((spanEnd > 0 && localBuffer[spanEnd - 1] == '\033') && localBuffer[spanEnd] == '\\')) {
                 ++spanEnd;
             }
 
             // Determine what terminated the loop
             bool const foundBEL = (spanEnd < localBufferLength && localBuffer[spanEnd] == '\x07');
-            bool const foundST = (spanEnd < localBufferLength && spanEnd > 0
-                                  && localBuffer[spanEnd - 1] == '\033' && localBuffer[spanEnd] == '\\');
+            bool const foundST = (spanEnd < localBufferLength && spanEnd > 0 && localBuffer[spanEnd - 1] == '\033' && localBuffer[spanEnd] == '\\');
             bool const exceededLength = ((spanEnd - spanStart) >= MAX_OSC_SEQUENCE_LENGTH);
 
             if (foundBEL) {
@@ -882,12 +893,10 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                 continue;
             } else if (exceededLength) {
                 // Length limit exceeded - scan forward for a terminator to skip the malformed sequence
-                qWarning().noquote().nospace() << "TBuffer::translateToPlainText(...) WARNING - OSC sequence exceeded "
-                                               << MAX_OSC_SEQUENCE_LENGTH << " bytes without terminator, scanning for terminator to recover.";
+                qWarning().noquote().nospace() << "TBuffer::translateToPlainText(...) WARNING - OSC sequence exceeded " << MAX_OSC_SEQUENCE_LENGTH
+                                               << " bytes without terminator, scanning for terminator to recover.";
                 // Continue scanning from where we left off to find a terminator
-                while (spanEnd < localBufferLength
-                       && localBuffer[spanEnd] != '\x07'
-                       && !((spanEnd > 0 && localBuffer[spanEnd - 1] == '\033') && localBuffer[spanEnd] == '\\')) {
+                while (spanEnd < localBufferLength && localBuffer[spanEnd] != '\x07' && !((spanEnd > 0 && localBuffer[spanEnd - 1] == '\033') && localBuffer[spanEnd] == '\\')) {
                     ++spanEnd;
                 }
                 // Check if we found a terminator
@@ -896,8 +905,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                     mGotOSC = false;
                     localBufferPosition = spanEnd + 1;
                     continue;
-                } else if (spanEnd < localBufferLength && spanEnd > 0
-                           && localBuffer[spanEnd - 1] == '\033' && localBuffer[spanEnd] == '\\') {
+                } else if (spanEnd < localBufferLength && spanEnd > 0 && localBuffer[spanEnd - 1] == '\033' && localBuffer[spanEnd] == '\\') {
                     // Found ST - skip to after it
                     mGotOSC = false;
                     localBufferPosition = spanEnd + 1;
@@ -923,11 +931,8 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                 if (mpHost->mMxpProcessor.mode() != MXP_MODE_LOCKED) {
                     // The comparison signals to the processor, if custom entities may be resolved
                     // (countermeasure against infinite recursion)
-                    TMxpProcessingResult const result =
-                            mpHost->mMxpProcessor.processMxpInput(ch, localBufferPosition >= endOfMXPEntity);
-                    if (!mTagWatchdog->isActive()
-                    && mpHost->mMxpProcessor.getMxpTagBuilder().isInsideTag()
-                    && !mpHost->mMxpProcessor.getMxpTagBuilder().getRawTagContent().empty()) {
+                    TMxpProcessingResult const result = mpHost->mMxpProcessor.processMxpInput(ch, localBufferPosition >= endOfMXPEntity);
+                    if (!mTagWatchdog->isActive() && mpHost->mMxpProcessor.getMxpTagBuilder().isInsideTag() && !mpHost->mMxpProcessor.getMxpTagBuilder().getRawTagContent().empty()) {
                         mWatchdogPhase = WatchdogPhase::Phase1_Snapshot;
                         mTagWatchdog->start(MAX_TAG_TIMEOUT_MS);
                     }
@@ -1016,9 +1021,8 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                 } else if (mpHost->mMxpProcessor.getMxpTagBuilder().isInsideTag()) {
                     // Mode is LOCKED but we're inside a tag that started in a different mode.
                     // We need to continue feeding characters to the tag builder to complete the tag.
-                    TMxpProcessingResult const result =
-                            mpHost->mMxpProcessor.processMxpInput(ch, localBufferPosition >= endOfMXPEntity);
-                    
+                    TMxpProcessingResult const result = mpHost->mMxpProcessor.processMxpInput(ch, localBufferPosition >= endOfMXPEntity);
+
                     switch (result) {
                     case HANDLER_NEXT_CHAR:
                         localBufferPosition++;
@@ -1067,7 +1071,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
             }
         }
 
-COMMIT_LINE:
+    COMMIT_LINE:
         if (commitLine(ch, localBufferPosition)) {
             continue;
         }
@@ -1140,10 +1144,8 @@ COMMIT_LINE:
             if (!mLinkOriginalCharacters.contains(mCurrentHyperlinkLinkId)) {
                 mLinkOriginalCharacters[mCurrentHyperlinkLinkId] = c;
 #if defined(DEBUG_OSC_PROCESSING)
-                qDebug().nospace().noquote() << "TBuffer::translateToPlainText(): Stored original character for link " << mCurrentHyperlinkLinkId
-                                              << " with ANSI colors: fg=" << c.mFgColor.name()
-                                              << " bg=" << c.mBgColor.name()
-                                              << " flags=" << c.mFlags;
+                qDebug().nospace().noquote() << "TBuffer::translateToPlainText(): Stored original character for link " << mCurrentHyperlinkLinkId << " with ANSI colors: fg=" << c.mFgColor.name()
+                                             << " bg=" << c.mBgColor.name() << " flags=" << c.mFlags;
 #endif
             }
 
@@ -1155,7 +1157,7 @@ COMMIT_LINE:
             if (mCurrentHyperlinkStyling.hasBackgroundColor) {
                 c.mBgColor = mCurrentHyperlinkStyling.backgroundColor;
             }
-            
+
             // For preset-only links, base styling may be empty but pseudo-class styling exists
             // Apply effective styling with :link pseudo-class to ensure preset colors show
             Mudlet::HyperlinkStyling effectiveStyling = getEffectiveHyperlinkStyling(mCurrentHyperlinkLinkId);
@@ -1175,19 +1177,19 @@ COMMIT_LINE:
                 if (effectiveStyling.isUnderlined) {
                     c.mFlags |= TChar::Underline;
                     switch (effectiveStyling.underlineStyle) {
-                        case Mudlet::HyperlinkStyling::UnderlineWavy:
-                            c.mFlags |= TChar::UnderlineWavy;
-                            break;
-                        case Mudlet::HyperlinkStyling::UnderlineDotted:
-                            c.mFlags |= TChar::UnderlineDotted;
-                            break;
-                        case Mudlet::HyperlinkStyling::UnderlineDashed:
-                            c.mFlags |= TChar::UnderlineDashed;
-                            break;
-                        case Mudlet::HyperlinkStyling::UnderlineSolid:
-                        case Mudlet::HyperlinkStyling::UnderlineNone:
-                        default:
-                            break;
+                    case Mudlet::HyperlinkStyling::UnderlineWavy:
+                        c.mFlags |= TChar::UnderlineWavy;
+                        break;
+                    case Mudlet::HyperlinkStyling::UnderlineDotted:
+                        c.mFlags |= TChar::UnderlineDotted;
+                        break;
+                    case Mudlet::HyperlinkStyling::UnderlineDashed:
+                        c.mFlags |= TChar::UnderlineDashed;
+                        break;
+                    case Mudlet::HyperlinkStyling::UnderlineSolid:
+                    case Mudlet::HyperlinkStyling::UnderlineNone:
+                    default:
+                        break;
                     }
                 }
                 if (effectiveStyling.isOverlined) {
@@ -1214,19 +1216,19 @@ COMMIT_LINE:
                     c.mFlags |= TChar::Underline;
 
                     switch (mCurrentHyperlinkStyling.underlineStyle) {
-                        case Mudlet::HyperlinkStyling::UnderlineWavy:
-                            c.mFlags |= TChar::UnderlineWavy;
-                            break;
-                        case Mudlet::HyperlinkStyling::UnderlineDotted:
-                            c.mFlags |= TChar::UnderlineDotted;
-                            break;
-                        case Mudlet::HyperlinkStyling::UnderlineDashed:
-                            c.mFlags |= TChar::UnderlineDashed;
-                            break;
-                        case Mudlet::HyperlinkStyling::UnderlineSolid:
-                        case Mudlet::HyperlinkStyling::UnderlineNone:
-                        default:
-                            break;
+                    case Mudlet::HyperlinkStyling::UnderlineWavy:
+                        c.mFlags |= TChar::UnderlineWavy;
+                        break;
+                    case Mudlet::HyperlinkStyling::UnderlineDotted:
+                        c.mFlags |= TChar::UnderlineDotted;
+                        break;
+                    case Mudlet::HyperlinkStyling::UnderlineDashed:
+                        c.mFlags |= TChar::UnderlineDashed;
+                        break;
+                    case Mudlet::HyperlinkStyling::UnderlineSolid:
+                    case Mudlet::HyperlinkStyling::UnderlineNone:
+                    default:
+                        break;
                     }
                 }
 
@@ -1283,7 +1285,7 @@ COMMIT_LINE:
             if (mHyperlinkActive) {
                 // Capture the column position when the first character of the hyperlink is added
                 if (mCurrentHyperlinkText.isEmpty()) {
-                    mCurrentHyperlinkStartColumn = static_cast<int>(mMudBuffer.size()) - 2;  // -2 because we just added 2 chars
+                    mCurrentHyperlinkStartColumn = static_cast<int>(mMudBuffer.size()) - 2; // -2 because we just added 2 chars
                 }
                 mCurrentHyperlinkText += QString(QChar(ch));
                 mCurrentHyperlinkText += QString(QChar(ch));
@@ -1293,7 +1295,7 @@ COMMIT_LINE:
             if (mHyperlinkActive) {
                 // Capture the column position when the first character of the hyperlink is added
                 if (mCurrentHyperlinkText.isEmpty()) {
-                    mCurrentHyperlinkStartColumn = static_cast<int>(mMudBuffer.size()) - 1;  // -1 because we just added 1 char
+                    mCurrentHyperlinkStartColumn = static_cast<int>(mMudBuffer.size()) - 1; // -1 because we just added 1 char
                 }
                 mCurrentHyperlinkText += QString(QChar(ch));
             }
@@ -1308,7 +1310,7 @@ void TBuffer::flushPendingDestinationContent()
     if (!mpHost || mMudLine.isEmpty()) {
         return;
     }
-    
+
     if (mpHost->mMxpFrameManager.hasActiveDestination()) {
         TConsole* destConsole = mpHost->mMxpFrameManager.getCurrentDestinationConsole();
 
@@ -1325,7 +1327,7 @@ void TBuffer::resetCurrentTextFormat()
     if (!mpHost) {
         return;
     }
-    
+
     // Reset to default colors and attributes - equivalent to SGR 0
     mIsDefaultColor = true;
     mForeGroundColor = mpHost->mFgColor;
@@ -1390,7 +1392,7 @@ bool TBuffer::commitLine(char ch, size_t& localBufferPosition)
 
         if (static_cast<size_t>(mMudLine.size()) != mMudBuffer.size()) {
             qWarning() << "TBuffer::translateToPlainText(...) WARNING: mismatch in new text "
-                        "data character and attribute data items!";
+                          "data character and attribute data items!";
         }
         if (!lineBuffer.back().isEmpty()) {
             if (!mMudLine.isEmpty()) {
@@ -1461,9 +1463,9 @@ bool TBuffer::commitLine(char ch, size_t& localBufferPosition)
             // (translateToPlainText(...)) method is ONLY for that one:
             shrinkBuffer();
         }
-        
+
         applyPendingSelectionStyling();
-        
+
         return true;
     }
     return false;
@@ -1476,11 +1478,9 @@ void TBuffer::processMxpWatchdogCallback()
         return;
     }
 
-    TMxpNodeBuilder&    tagBuilder = mpHost->mMxpProcessor.getMxpTagBuilder();
-    std::string         currentTagContent = tagBuilder.getRawTagContent();
-    bool                isMxpParserFrozen = !currentTagContent.empty()
-                                            && currentTagContent.starts_with(mWatchdogTagSnapshot)
-                                            && tagBuilder.isInsideTag();
+    TMxpNodeBuilder& tagBuilder = mpHost->mMxpProcessor.getMxpTagBuilder();
+    std::string currentTagContent = tagBuilder.getRawTagContent();
+    bool isMxpParserFrozen = !currentTagContent.empty() && currentTagContent.starts_with(mWatchdogTagSnapshot) && tagBuilder.isInsideTag();
 
     if (mWatchdogPhase == WatchdogPhase::Phase1_Snapshot) {
         mWatchdogTagSnapshot = currentTagContent;
@@ -1492,12 +1492,12 @@ void TBuffer::processMxpWatchdogCallback()
             const TChar style(mForeGroundColor, mBackGroundColor, computeCurrentAttributeFlags());
             QPointer<Host> hostGuard = mpHost;
             QPointer<TConsole> consoleGuard = mpConsole;
-            QTimer::singleShot(0, mpConsole, [this, style, hostGuard, consoleGuard] () {
+            QTimer::singleShot(0, mpConsole, [this, style, hostGuard, consoleGuard]() {
                 if (!hostGuard || !consoleGuard) {
                     return;
                 }
-                QString     lastEntityValue = hostGuard->mMxpProcessor.getEntityValue();
-                size_t      unusedBufferPosition = 0;
+                QString lastEntityValue = hostGuard->mMxpProcessor.getEntityValue();
+                size_t unusedBufferPosition = 0;
 
                 mMudLine.append(lastEntityValue);
                 for (qsizetype i = 0; i < lastEntityValue.size(); ++i) {
@@ -1512,25 +1512,19 @@ void TBuffer::processMxpWatchdogCallback()
     }
 }
 
-TChar::AttributeFlags TBuffer::computeCurrentAttributeFlags() const {
-    return ((mIsDefaultColor ? mBold || mpHost->mMxpClient.bold() : false) ? TChar::Bold : TChar::None)
-            | (mItalics || mpHost->mMxpClient.italic() ? TChar::Italic : TChar::None)
-            | (mOverline ? TChar::Overline : TChar::None)
-            | (mReverse ? TChar::Reverse : TChar::None)
-            | (mStrikeOut || mpHost->mMxpClient.strikeOut() ? TChar::StrikeOut : TChar::None)
-            | (mUnderline || mpHost->mMxpClient.underline() ? TChar::Underline : TChar::None)
-            | (mUnderlineWavy ? TChar::UnderlineWavy : TChar::None)
-            | (mUnderlineDotted ? TChar::UnderlineDotted : TChar::None)
-            | (mUnderlineDashed ? TChar::UnderlineDashed : TChar::None)
-            | (mFastBlink ? TChar::FastBlink : (mBlink ? TChar::Blink :TChar::None))
-            | (TChar::alternateFontFlag(mAltFont))
-            | (mConcealed ? TChar::Concealed : TChar::None);
+TChar::AttributeFlags TBuffer::computeCurrentAttributeFlags() const
+{
+    return ((mIsDefaultColor ? mBold || mpHost->mMxpClient.bold() : false) ? TChar::Bold : TChar::None) | (mItalics || mpHost->mMxpClient.italic() ? TChar::Italic : TChar::None)
+           | (mOverline ? TChar::Overline : TChar::None) | (mReverse ? TChar::Reverse : TChar::None) | (mStrikeOut || mpHost->mMxpClient.strikeOut() ? TChar::StrikeOut : TChar::None)
+           | (mUnderline || mpHost->mMxpClient.underline() ? TChar::Underline : TChar::None) | (mUnderlineWavy ? TChar::UnderlineWavy : TChar::None)
+           | (mUnderlineDotted ? TChar::UnderlineDotted : TChar::None) | (mUnderlineDashed ? TChar::UnderlineDashed : TChar::None)
+           | (mFastBlink ? TChar::FastBlink : (mBlink ? TChar::Blink : TChar::None)) | (TChar::alternateFontFlag(mAltFont)) | (mConcealed ? TChar::Concealed : TChar::None);
 }
 
 void TBuffer::decodeSGR38(const QStringList& parameters, bool isColonSeparated)
 {
 #if defined(DEBUG_SGR_PROCESSING)
-    qDebug() << "    TBuffer::decodeSGR38(" << parameters << "," << isColonSeparated <<") INFO - called";
+    qDebug() << "    TBuffer::decodeSGR38(" << parameters << "," << isColonSeparated << ") INFO - called";
 #endif
     if (parameters.at(1) == QLatin1String("5")) {
         int tag = 0;
@@ -1540,9 +1534,11 @@ void TBuffer::decodeSGR38(const QStringList& parameters, bool isColonSeparated)
 #if defined(DEBUG_SGR_PROCESSING)
             if (!isOk) {
                 if (isColonSeparated) {
-                    qDebug().noquote().nospace() << "TBuffer::decodeSGR38(...) ERROR - failed to parse color index parameter element (the third part) in a SGR...;38:5:" << parameters.at(2) << ":...;...m sequence treating it as a zero!";
+                    qDebug().noquote().nospace() << "TBuffer::decodeSGR38(...) ERROR - failed to parse color index parameter element (the third part) in a SGR...;38:5:" << parameters.at(2)
+                                                 << ":...;...m sequence treating it as a zero!";
                 } else {
-                    qDebug().noquote().nospace() << "TBuffer::decodeSGR38(...) ERROR - failed to parse color index parameter string (the third part) in a SGR...;38;5;" << parameters.at(2) << ";...m sequence treating it as a zero!";
+                    qDebug().noquote().nospace() << "TBuffer::decodeSGR38(...) ERROR - failed to parse color index parameter string (the third part) in a SGR...;38;5;" << parameters.at(2)
+                                                 << ";...m sequence treating it as a zero!";
                 }
             }
 #endif
@@ -1603,7 +1599,7 @@ void TBuffer::decodeSGR38(const QStringList& parameters, bool isColonSeparated)
 
         } else if (tag < 232) {
             // because color 1-15 behave like normal ANSI colors
-           tag -= 16;
+            tag -= 16;
             // 6x6x6 RGB color space
             quint8 const r = tag / 36;
             quint8 const g = (tag - (r * 36)) / 6;
@@ -1612,9 +1608,7 @@ void TBuffer::decodeSGR38(const QStringList& parameters, bool isColonSeparated)
             // To match the common terminal palettes, the values are
             // scaled as follows:
             // 0: 0, 1: 95, 2:135, 3:175, 4:215, 5:255
-            mForeGroundColor = QColor(r == 0 ? 0 : (r - 1) * 40 + 95,
-                                      g == 0 ? 0 : (g - 1) * 40 + 95,
-                                      b == 0 ? 0 : (b - 1) * 40 + 95);
+            mForeGroundColor = QColor(r == 0 ? 0 : (r - 1) * 40 + 95, g == 0 ? 0 : (g - 1) * 40 + 95, b == 0 ? 0 : (b - 1) * 40 + 95);
             mForeGroundColorLight = mForeGroundColor;
 
         } else {
@@ -1638,7 +1632,7 @@ void TBuffer::decodeSGR38(const QStringList& parameters, bool isColonSeparated)
             // but green and blue components are
             // zero
             mForeGroundColor = QColor(qBound(0, parameters.at(3).toInt(), 255), 0, 0);
-        } else  {
+        } else {
             // No codes left for any colour
             // components so colour must be black,
             // as all of red, green and blue
@@ -1648,22 +1642,22 @@ void TBuffer::decodeSGR38(const QStringList& parameters, bool isColonSeparated)
 
         if (parameters.count() >= 3 && !parameters.at(2).isEmpty()) {
             if (!isColonSeparated) {
-#if ! defined(DEBUG_SGR_PROCESSING)
-                qDebug() << "Unhandled color space identifier in a SGR...;38;2;" << parameters.at(2) << ";...m sequence - if 16M colors items are missing blue elements you may have checked the \"Expect Color Space Id in SGR...(3|4)8;2;....m codes\" option on the Special Options tab of the preferences when it is not needed!";
+#if !defined(DEBUG_SGR_PROCESSING)
+                qDebug() << "Unhandled color space identifier in a SGR...;38;2;" << parameters.at(2)
+                         << ";...m sequence - if 16M colors items are missing blue elements you may have checked the \"Expect Color Space Id in SGR...(3|4)8;2;....m codes\" option on the Special "
+                            "Options tab of the preferences when it is not needed!";
 #else
-                qDebug().noquote().nospace() << "TBuffer::decodeSGR38(...) WARNING - unhandled color space identifier in a SGR...;38;2;" << parameters.at(2) << ";...m sequence treating it as the default (empty) case!";
+                qDebug().noquote().nospace() << "TBuffer::decodeSGR38(...) WARNING - unhandled color space identifier in a SGR...;38;2;" << parameters.at(2)
+                                             << ";...m sequence treating it as the default (empty) case!";
             } else {
-                qDebug().noquote().nospace() << "TBuffer::decodeSGR38(...) WARNING - unhandled color space identifier in a SGR...;38:2:" << parameters.at(2) << ":...;...m sequence treating it as the default (empty) case!";
+                qDebug().noquote().nospace() << "TBuffer::decodeSGR38(...) WARNING - unhandled color space identifier in a SGR...;38:2:" << parameters.at(2)
+                                             << ":...;...m sequence treating it as the default (empty) case!";
 #endif
             }
         }
         mForeGroundColorLight = mForeGroundColor;
 
-    } else if (parameters.at(1) == QLatin1String("4")
-            || parameters.at(1) == QLatin1String("3")
-            || parameters.at(1) == QLatin1String("1")
-            || parameters.at(1) == QLatin1String("0")) {
-
+    } else if (parameters.at(1) == QLatin1String("4") || parameters.at(1) == QLatin1String("3") || parameters.at(1) == QLatin1String("1") || parameters.at(1) == QLatin1String("0")) {
 #if defined(DEBUG_SGR_PROCESSING)
         if (isColonSeparated) {
             qDebug().noquote().nospace() << "TBuffer::decodeSGR38(...) WARNING - unhandled SGR code: SGR...;38:" << parameters.at(1) << ":...;...m ignoring sequence!";
@@ -1673,7 +1667,6 @@ void TBuffer::decodeSGR38(const QStringList& parameters, bool isColonSeparated)
 #endif
 
     } else {
-
 #if defined(DEBUG_SGR_PROCESSING)
         if (isColonSeparated) {
             qDebug().noquote().nospace() << "TBuffer::decodeSGR38(...) WARNING - unexpected SGR code: SGR...;38:" << parameters.at(1) << ":...;...m ignoring sequence!";
@@ -1681,14 +1674,13 @@ void TBuffer::decodeSGR38(const QStringList& parameters, bool isColonSeparated)
             qDebug().noquote().nospace() << "TBuffer::decodeSGR38(...) WARNING - unexpected SGR code: SGR...;38;" << parameters.at(1) << ";...m ignoring sequence!";
         }
 #endif
-
     }
 }
 
 void TBuffer::decodeSGR48(const QStringList& parameters, bool isColonSeparated)
 {
 #if defined(DEBUG_SGR_PROCESSING)
-    qDebug() << "    TBuffer::decodeSGR48(" << parameters << "," << isColonSeparated <<") INFO - called";
+    qDebug() << "    TBuffer::decodeSGR48(" << parameters << "," << isColonSeparated << ") INFO - called";
 #endif
     bool useLightColor = false;
 
@@ -1700,9 +1692,11 @@ void TBuffer::decodeSGR48(const QStringList& parameters, bool isColonSeparated)
 #if defined(DEBUG_SGR_PROCESSING)
             if (!isOk) {
                 if (isColonSeparated) {
-                    qDebug().noquote().nospace() << "TBuffer::decodeSGR48(...) ERROR - failed to parse color index parameter element (the third part) in a SGR...;48:5:" << parameters.at(2) << ":...;...m sequence treating it as a zero!";
+                    qDebug().noquote().nospace() << "TBuffer::decodeSGR48(...) ERROR - failed to parse color index parameter element (the third part) in a SGR...;48:5:" << parameters.at(2)
+                                                 << ":...;...m sequence treating it as a zero!";
                 } else {
-                    qDebug().noquote().nospace() << "TBuffer::decodeSGR48(...) ERROR - failed to parse color index parameter string (the third part) in a SGR...;48;5;" << parameters.at(2) << ";...m sequence treating it as a zero!";
+                    qDebug().noquote().nospace() << "TBuffer::decodeSGR48(...) ERROR - failed to parse color index parameter string (the third part) in a SGR...;48;5;" << parameters.at(2)
+                                                 << ";...m sequence treating it as a zero!";
                 }
             }
 #endif
@@ -1776,9 +1770,7 @@ void TBuffer::decodeSGR48(const QStringList& parameters, bool isColonSeparated)
             // To match the common terminal palettes, the values are
             // scaled as follows:
             // 0: 0, 1: 95, 2:135, 3:175, 4:215, 5:255
-            mBackGroundColor = QColor(r == 0 ? 0 : (r - 1) * 40 + 95,
-                                      g == 0 ? 0 : (g - 1) * 40 + 95,
-                                      b == 0 ? 0 : (b - 1) * 40 + 95);
+            mBackGroundColor = QColor(r == 0 ? 0 : (r - 1) * 40 + 95, g == 0 ? 0 : (g - 1) * 40 + 95, b == 0 ? 0 : (b - 1) * 40 + 95);
 
         } else {
             const int value = (tag - 232) * 10 + 8;
@@ -1803,7 +1795,7 @@ void TBuffer::decodeSGR48(const QStringList& parameters, bool isColonSeparated)
             // zero
             mBackGroundColor = QColor(qBound(0, parameters.at(3).toInt(), 255), 0, 0);
 
-        } else  {
+        } else {
             // No codes left for any colour
             // components so colour must be black,
             // as all of red, green and blue
@@ -1813,21 +1805,21 @@ void TBuffer::decodeSGR48(const QStringList& parameters, bool isColonSeparated)
 
         if (parameters.count() >= 3 && !parameters.at(2).isEmpty()) {
             if (!isColonSeparated) {
-#if ! defined(DEBUG_SGR_PROCESSING)
-                qDebug() << "Unhandled color space identifier in a SGR...;48;2;" << parameters.at(2) << ";...m sequence - if 16M colors items are missing blue elements you may have checked the \"Expect Color Space Id in SGR...(3|4)8;2;....m codes\" option on the Special Options tab of the preferences when it is not needed!";
+#if !defined(DEBUG_SGR_PROCESSING)
+                qDebug() << "Unhandled color space identifier in a SGR...;48;2;" << parameters.at(2)
+                         << ";...m sequence - if 16M colors items are missing blue elements you may have checked the \"Expect Color Space Id in SGR...(3|4)8;2;....m codes\" option on the Special "
+                            "Options tab of the preferences when it is not needed!";
 #else
-                qDebug().noquote().nospace() << "TBuffer::decodeSGR48(...) WARNING - unhandled color space identifier in a SGR...;48;2;" << parameters.at(2) << ";...m sequence treating it as the default (empty) case!";
+                qDebug().noquote().nospace() << "TBuffer::decodeSGR48(...) WARNING - unhandled color space identifier in a SGR...;48;2;" << parameters.at(2)
+                                             << ";...m sequence treating it as the default (empty) case!";
             } else {
-                qDebug().noquote().nospace() << "TBuffer::decodeSGR48(...) WARNING - unhandled color space identifier in a SGR...;48:2:" << parameters.at(2) << ":...;...m sequence treating it as the default (empty) case!";
+                qDebug().noquote().nospace() << "TBuffer::decodeSGR48(...) WARNING - unhandled color space identifier in a SGR...;48:2:" << parameters.at(2)
+                                             << ":...;...m sequence treating it as the default (empty) case!";
 #endif
             }
         }
 
-    } else if (parameters.at(1) == QLatin1String("4")
-            || parameters.at(1) == QLatin1String("3")
-            || parameters.at(1) == QLatin1String("1")
-            || parameters.at(1) == QLatin1String("0")) {
-
+    } else if (parameters.at(1) == QLatin1String("4") || parameters.at(1) == QLatin1String("3") || parameters.at(1) == QLatin1String("1") || parameters.at(1) == QLatin1String("0")) {
 #if defined(DEBUG_SGR_PROCESSING)
         if (isColonSeparated) {
             qDebug().noquote().nospace() << "TBuffer::decodeSGR48(...) WARNING - unhandled SGR code: SGR...;48:" << parameters.at(1) << ":...;...m ignoring sequence!";
@@ -1837,7 +1829,6 @@ void TBuffer::decodeSGR48(const QStringList& parameters, bool isColonSeparated)
 #endif
 
     } else {
-
 #if defined(DEBUG_SGR_PROCESSING)
         if (isColonSeparated) {
             qDebug().noquote().nospace() << "TBuffer::decodeSGR48(...) WARNING - unexpected SGR code: SGR...;48:" << parameters.at(1) << ":...;...m ignoring sequence!";
@@ -1846,7 +1837,6 @@ void TBuffer::decodeSGR48(const QStringList& parameters, bool isColonSeparated)
         }
 #endif
     }
-
 }
 
 void TBuffer::decodeSGR(const QString& sequence)
@@ -1886,7 +1876,7 @@ void TBuffer::decodeSGR(const QString& sequence)
                     // Okay we have one more parameter at least - so examine it
                     // and grab the needed number of arguments:
                     QStringList madeElements;
-                    madeElements << parameterStrings.at(paraIndex); // "38"
+                    madeElements << parameterStrings.at(paraIndex);     // "38"
                     madeElements << parameterStrings.at(paraIndex + 1); // "2" or "5" hopefully
                     bool isOk = false;
                     const int sgr38_type = madeElements.at(1).toInt(&isOk);
@@ -1962,9 +1952,8 @@ void TBuffer::decodeSGR(const QString& sequence)
                     default:
                         break;
                     }
-
                 }
-            // End of if (parameterElements.at(0) == QLatin1String("38"))
+                // End of if (parameterElements.at(0) == QLatin1String("38"))
             } else if (parameterElements.at(0) == QLatin1String("48")) {
                 if (parameterElements.count() >= 2) {
                     decodeSGR48(parameterElements, true);
@@ -2059,16 +2048,16 @@ void TBuffer::decodeSGR(const QString& sequence)
                     default:
                         break;
                     }
-
                 }
-            // End of if (parameterElements.at(0) == QLatin1String("48"))
+                // End of if (parameterElements.at(0) == QLatin1String("48"))
             } else if (parameterElements.at(0) == QLatin1String("4")) {
                 // New way of controlling underline
                 bool isOk = false;
                 const int value = parameterElements.at(1).toInt(&isOk);
                 if (!isOk) {
                     // missing value
-                    qDebug().noquote().nospace() << "TBuffer::decodeSGR(\"" << sequence << "\") ERROR - failed to detect underline parameter element (the second part) in a SGR...;4:?;..m sequence assuming it is a zero!";
+                    qDebug().noquote().nospace() << "TBuffer::decodeSGR(\"" << sequence
+                                                 << "\") ERROR - failed to detect underline parameter element (the second part) in a SGR...;4:?;..m sequence assuming it is a zero!";
                 }
                 switch (value) {
                 case 0: // Underline off
@@ -2102,7 +2091,9 @@ void TBuffer::decodeSGR(const QString& sequence)
                     mUnderlineDashed = false;
                     break;
                 default: // Something unexpected
-                    qDebug().noquote().nospace() << "TBuffer::decodeSGR(\"" << sequence << "\") ERROR - unexpected underline parameter element (the second part) in a SGR...;4:" << parameterElements.at(1) << ";../m sequence treating it as a zero!";
+                    qDebug().noquote().nospace() << "TBuffer::decodeSGR(\"" << sequence
+                                                 << "\") ERROR - unexpected underline parameter element (the second part) in a SGR...;4:" << parameterElements.at(1)
+                                                 << ";../m sequence treating it as a zero!";
                     mUnderline = false;
                     mUnderlineWavy = false;
                     mUnderlineDotted = false;
@@ -2115,7 +2106,8 @@ void TBuffer::decodeSGR(const QString& sequence)
                 const int value = parameterElements.at(1).toInt(&isOk);
                 if (!isOk) {
                     // missing value
-                    qDebug().noquote().nospace() << "TBuffer::decodeSGR(\"" << sequence << "\") ERROR - failed to detect italic parameter element (the second part) in a SGR...;3:?;../m sequence assuming it is a zero!";
+                    qDebug().noquote().nospace() << "TBuffer::decodeSGR(\"" << sequence
+                                                 << "\") ERROR - failed to detect italic parameter element (the second part) in a SGR...;3:?;../m sequence assuming it is a zero!";
                 }
                 switch (value) {
                 case 0: // Italics/Slant off
@@ -2125,16 +2117,20 @@ void TBuffer::decodeSGR(const QString& sequence)
                     mItalics = true;
                     break;
                 case 2: // Slant on - not supported, treat as italics
-                    qDebug().noquote().nospace() << "TBuffer::decodeSGR(\"" << sequence << "\") ERROR - unsupported italic parameter element (the second part) in a SGR...;3:" << parameterElements.at(1) << ";../m sequence treating it as a one!";
+                    qDebug().noquote().nospace() << "TBuffer::decodeSGR(\"" << sequence
+                                                 << "\") ERROR - unsupported italic parameter element (the second part) in a SGR...;3:" << parameterElements.at(1)
+                                                 << ";../m sequence treating it as a one!";
                     mUnderline = true;
                     break;
                 default: // Something unexpected
-                    qDebug().noquote().nospace() << "TBuffer::decodeSGR(\"" << sequence << "\") ERROR - unexpected italic parameter element (the second part) in a SGR...;3:" << parameterElements.at(1) << ";../m sequence treating it as a zero!";
+                    qDebug().noquote().nospace() << "TBuffer::decodeSGR(\"" << sequence << "\") ERROR - unexpected italic parameter element (the second part) in a SGR...;3:" << parameterElements.at(1)
+                                                 << ";../m sequence treating it as a zero!";
                     mUnderline = false;
                     break;
                 }
             } else {
-                qDebug().noquote().nospace() << "TBuffer::decodeSGR(\"" << sequence << "\") ERROR - parameter string with an unexpected initial parameter element in a SGR...;" << parameterElements.at(0) << ":" << parameterElements.at(1) << "...;.../m sequence, ignoring it!";
+                qDebug().noquote().nospace() << "TBuffer::decodeSGR(\"" << sequence << "\") ERROR - parameter string with an unexpected initial parameter element in a SGR...;"
+                                             << parameterElements.at(0) << ":" << parameterElements.at(1) << "...;.../m sequence, ignoring it!";
             }
         } else {
             /******************************************************************
@@ -2403,8 +2399,7 @@ void TBuffer::decodeSGR(const QString& sequence)
                     default:
                         break;
                     }
-                }
-                    break;
+                } break;
                 case 39: //default foreground color
                     mForeGroundColor = pHost->mFgColor;
                     break;
@@ -2520,8 +2515,7 @@ void TBuffer::decodeSGR(const QString& sequence)
                     default:
                         break;
                     }
-                }
-                    break;
+                } break;
                 case 49: // default background color
                     mBackGroundColor = pHost->mBgColor;
                     break;
@@ -2732,12 +2726,14 @@ void TBuffer::decodeOSC(const QString& sequence)
 
                 } else {
 #if defined(DEBUG_OSC_PROCESSING)
-                    qDebug().noquote().nospace() << "TBuffer::decodeOSC(\"" << sequence << "\") ERROR - Unable to parse this as a <OSC>P<I><RR><GG><BB><ST> string to redefined one of the 16 ANSI colors.";
+                    qDebug().noquote().nospace() << "TBuffer::decodeOSC(\"" << sequence
+                                                 << "\") ERROR - Unable to parse this as a <OSC>P<I><RR><GG><BB><ST> string to redefined one of the 16 ANSI colors.";
 #endif
                 }
             } else {
 #if defined(DEBUG_OSC_PROCESSING)
-                qDebug().noquote().nospace() << "TBuffer::decodeOSC(\"" << sequence << "\") ERROR - Wrong length of string, unable to decode this as a <OSC>P<I><RR><GG><BB><ST> string to redefined one of the 16 ANSI colors.";
+                qDebug().noquote().nospace() << "TBuffer::decodeOSC(\"" << sequence
+                                             << "\") ERROR - Wrong length of string, unable to decode this as a <OSC>P<I><RR><GG><BB><ST> string to redefined one of the 16 ANSI colors.";
 #endif
             }
         }
@@ -2748,7 +2744,7 @@ void TBuffer::decodeOSC(const QString& sequence)
         }
         break;
     case static_cast<quint8>('8'): {
-        QStringView rest = QStringView(sequence).mid(1);  // skip selector "8"
+        QStringView rest = QStringView(sequence).mid(1); // skip selector "8"
         int firstSemi = rest.indexOf(';');
 
         if (firstSemi == -1) {
@@ -2775,8 +2771,7 @@ void TBuffer::decodeOSC(const QString& sequence)
 
 #if defined(DEBUG_OSC_PROCESSING)
         if (!rawUrl.isEmpty()) {
-            qDebug().noquote().nospace() << "[OSC] Received OSC 8 sequence with URL (length=" << rawUrl.length() << "): " 
-                                         << (rawUrl.length() > 80 ? rawUrl.left(80) + "..." : rawUrl);
+            qDebug().noquote().nospace() << "[OSC] Received OSC 8 sequence with URL (length=" << rawUrl.length() << "): " << (rawUrl.length() > 80 ? rawUrl.left(80) + "..." : rawUrl);
         }
 #endif
 
@@ -2785,15 +2780,13 @@ void TBuffer::decodeOSC(const QString& sequence)
 #if defined(DEBUG_OSC_PROCESSING)
             qDebug().noquote() << "[OSC] Hyperlink terminator - closing active hyperlink";
 #endif
-            
+
             // Apply initial selection/disabled state styling when link closes (from selection branch)
             // OR apply :link pseudo-class styling for preset-only links (from compact branch)
             if (mCurrentHyperlinkLinkId > 0 && mCurrentHyperlinkStyling.selection.hasSelectionSettings) {
 #if defined(DEBUG_OSC_PROCESSING)
-                qDebug() << "[OSC] Queuing initial selection styling for link" << mCurrentHyperlinkLinkId
-                         << "selected:" << mCurrentHyperlinkStyling.selection.selected
-                         << "disabled:" << mCurrentHyperlinkStyling.selection.disabled
-                         << "selectedStyle.hasCustomStyling:" << mCurrentHyperlinkStyling.selectedStyle.hasCustomStyling;
+                qDebug() << "[OSC] Queuing initial selection styling for link" << mCurrentHyperlinkLinkId << "selected:" << mCurrentHyperlinkStyling.selection.selected
+                         << "disabled:" << mCurrentHyperlinkStyling.selection.disabled << "selectedStyle.hasCustomStyling:" << mCurrentHyperlinkStyling.selectedStyle.hasCustomStyling;
 #endif
                 if (mCurrentHyperlinkStyling.selection.selected) {
                     setLinkState(mCurrentHyperlinkLinkId, Mudlet::HyperlinkStyling::StateSelected);
@@ -2811,18 +2804,18 @@ void TBuffer::decodeOSC(const QString& sequence)
                 // severe performance degradation with many links.
                 // The :link styling will be applied when characters are created in COMMIT_LINE.
             }
-            
+
             // For spoilers, capture original text BEFORE any visibility concealment
             // This ensures spoiler reveal works even when combined with visibility actions
             if (mCurrentHyperlinkLinkId > 0 && mCurrentHyperlinkStyling.isSpoiler) {
                 int currentColumn = mMudLine.length();
                 int linkLength = currentColumn - mCurrentHyperlinkStartColumn;
-                
+
                 if (linkLength > 0) {
                     // Store the original text before any replacements
                     QString originalText = mMudLine.mid(mCurrentHyperlinkStartColumn, linkLength);
                     mLinkOriginalText[mCurrentHyperlinkLinkId] = originalText;
-                    
+
 #if defined(DEBUG_OSC_PROCESSING)
                     qDebug() << "[OSC] Spoiler link" << mCurrentHyperlinkLinkId << "- storing original text:" << originalText << "and replacing with spaces, length:" << linkLength;
 #endif
@@ -2831,36 +2824,25 @@ void TBuffer::decodeOSC(const QString& sequence)
                     mMudLine.replace(mCurrentHyperlinkStartColumn, linkLength, spaces);
                 }
             }
-            
+
             // Register with visibility manager if visibility settings exist
             // Visibility currently only supports single-line hyperlinks
             // Multi-line links will not have visibility management applied
-            if (mCurrentHyperlinkLinkId > 0 && mCurrentHyperlinkStyling.visibility.hasVisibilitySettings 
-                && mpConsole
-                && mCurrentHyperlinkStartLine == static_cast<int>(lineBuffer.size()) - 1) {
-                
+            if (mCurrentHyperlinkLinkId > 0 && mCurrentHyperlinkStyling.visibility.hasVisibilitySettings && mpConsole && mCurrentHyperlinkStartLine == static_cast<int>(lineBuffer.size()) - 1) {
                 int currentColumn = mMudLine.length();
                 int linkLength = currentColumn - mCurrentHyperlinkStartColumn;
 
                 if (linkLength > 0) {
                     // Only register if we have a valid link range
                     QString linkText = mMudLine.mid(mCurrentHyperlinkStartColumn, linkLength);
-                    
+
 #if defined(DEBUG_OSC_PROCESSING)
-                    qDebug() << "[OSC] Registering hyperlink" << mCurrentHyperlinkLinkId
-                             << "line:" << mCurrentHyperlinkStartLine
-                             << "col:" << mCurrentHyperlinkStartColumn
-                             << "length:" << linkLength
+                    qDebug() << "[OSC] Registering hyperlink" << mCurrentHyperlinkLinkId << "line:" << mCurrentHyperlinkStartLine << "col:" << mCurrentHyperlinkStartColumn << "length:" << linkLength
                              << "text:" << linkText;
 #endif
                     bool shouldStartConcealed = mpConsole->getHyperlinkVisibilityManager().registerHyperlink(
-                        mCurrentHyperlinkLinkId,
-                        mCurrentHyperlinkStartLine,
-                        mCurrentHyperlinkStartColumn,
-                        linkLength,
-                        linkText,
-                        mCurrentHyperlinkStyling);
-                    
+                            mCurrentHyperlinkLinkId, mCurrentHyperlinkStartLine, mCurrentHyperlinkStartColumn, linkLength, linkText, mCurrentHyperlinkStyling);
+
                     // If link should start concealed, replace its text with spaces in mMudLine
                     // Skip if spoiler already did this to avoid double-replacement
                     if (shouldStartConcealed && !mCurrentHyperlinkStyling.isSpoiler) {
@@ -2878,16 +2860,13 @@ void TBuffer::decodeOSC(const QString& sequence)
                     qDebug() << "[OSC] Skipping registration for hyperlink with invalid length:" << linkLength;
 #endif
                 }
-            } else if (mCurrentHyperlinkLinkId > 0 && mCurrentHyperlinkStyling.visibility.hasVisibilitySettings
-                       && mCurrentHyperlinkStartLine != static_cast<int>(lineBuffer.size()) - 1) {
+            } else if (mCurrentHyperlinkLinkId > 0 && mCurrentHyperlinkStyling.visibility.hasVisibilitySettings && mCurrentHyperlinkStartLine != static_cast<int>(lineBuffer.size()) - 1) {
 #if defined(DEBUG_OSC_PROCESSING)
-                qDebug() << "[OSC] Skipping visibility registration for multi-line hyperlink"
-                         << "(visibility only applies to single-line links)"
-                         << "- started on line" << mCurrentHyperlinkStartLine
+                qDebug() << "[OSC] Skipping visibility registration for multi-line hyperlink" << "(visibility only applies to single-line links)" << "- started on line" << mCurrentHyperlinkStartLine
                          << "ending on line" << static_cast<int>(lineBuffer.size()) - 1;
 #endif
             }
-            
+
             mCurrentHyperlinkCommand.clear();
             mCurrentHyperlinkHint.clear();
             mCurrentHyperlinkLinkId = 0;
@@ -2915,7 +2894,7 @@ void TBuffer::decodeOSC(const QString& sequence)
                 // Extract preset name (between "preset:" and "?")
                 int queryStart = rawUrl.indexOf('?');
                 QString presetName = (queryStart > 7) ? rawUrl.mid(7, queryStart - 7) : rawUrl.mid(7);
-                
+
                 // Extract config parameter manually to avoid QUrl parsing issues with custom schemes
                 QString configParam;
                 if (queryStart != -1) {
@@ -2928,12 +2907,12 @@ void TBuffer::decodeOSC(const QString& sequence)
                 qDebug() << "[OSC] Config param length:" << configParam.length();
                 qDebug() << "[OSC] Config param preview:" << (configParam.length() > 100 ? configParam.left(100) + "..." : configParam);
 #endif
-                
+
                 if (!presetName.isEmpty() && !configParam.isEmpty() && mpConsole) {
                     // Parse the JSON configuration
                     QJsonParseError parseError;
                     QJsonDocument doc = QJsonDocument::fromJson(configParam.toUtf8(), &parseError);
-                    
+
                     if (parseError.error == QJsonParseError::NoError && doc.isObject()) {
                         mpConsole->getHyperlinkCompactManager().registerPreset(presetName, doc.object());
 #if defined(DEBUG_OSC_PROCESSING)
@@ -2947,10 +2926,8 @@ void TBuffer::decodeOSC(const QString& sequence)
                     }
                 } else {
 #if defined(DEBUG_OSC_PROCESSING)
-                    qDebug() << "[OSC] Preset registration skipped - presetName empty:" << presetName.isEmpty() 
-                             << "configParam empty:" << configParam.isEmpty()
-                             << "mpConsole:" << (mpConsole != nullptr)
-                             << "mpHyperlinkCompactManager:" << (mpConsole != nullptr);
+                    qDebug() << "[OSC] Preset registration skipped - presetName empty:" << presetName.isEmpty() << "configParam empty:" << configParam.isEmpty()
+                             << "mpConsole:" << (mpConsole != nullptr) << "mpHyperlinkCompactManager:" << (mpConsole != nullptr);
 #endif
                 }
                 // Preset definitions don't create visible hyperlinks
@@ -3028,19 +3005,19 @@ void TBuffer::decodeOSC(const QString& sequence)
 
             if (baseUrl.startsWith(qsl("send:"))) {
                 QString innerCommand = QUrl::fromPercentEncoding(baseUrl.mid(5).toUtf8());
-                command = { qsl("send([[%1]])").arg(innerCommand) };
-                hint = { qsl("%1: %2").arg(QObject::tr("Send"), innerCommand) };
+                command = {qsl("send([[%1]])").arg(innerCommand)};
+                hint = {qsl("%1: %2").arg(QObject::tr("Send"), innerCommand)};
             } else if (baseUrl.startsWith(qsl("prompt:"))) {
                 QString innerCommand = QUrl::fromPercentEncoding(baseUrl.mid(7).toUtf8());
-                command = { qsl("sendCmdLine([[%1]])").arg(innerCommand) };
-                hint = { qsl("%1: %2").arg(QObject::tr("Prompt"), innerCommand) };
+                command = {qsl("sendCmdLine([[%1]])").arg(innerCommand)};
+                hint = {qsl("%1: %2").arg(QObject::tr("Prompt"), innerCommand)};
             } else {
                 QUrl qurl(baseUrl);
                 QString scheme = qurl.scheme().toLower();
 
                 if (scheme == qsl("http") || scheme == qsl("https") || scheme == qsl("ftp")) {
-                    command = { qsl("openUrl([[%1]])").arg(baseUrl) };
-                    hint = { qsl("%1: %2").arg(QObject::tr("Open browser to"), baseUrl) };
+                    command = {qsl("openUrl([[%1]])").arg(baseUrl)};
+                    hint = {qsl("%1: %2").arg(QObject::tr("Open browser to"), baseUrl)};
                 } else {
                     qWarning().noquote().nospace() << "TBuffer::decodeOSC(...) - Ignored untrusted or unsupported URI scheme: \"" << scheme << "\"";
                     return;
@@ -3050,7 +3027,7 @@ void TBuffer::decodeOSC(const QString& sequence)
             // Add standalone tooltip support (for links without menus)
             if (!customTooltip.isEmpty() && (mCurrentHyperlinkMenu.isEmpty() || mCurrentHyperlinkMenu.size() < 2)) {
                 // Replace the default hint with the custom tooltip
-                hint = { customTooltip };
+                hint = {customTooltip};
 #if defined(DEBUG_OSC_PROCESSING)
                 qDebug() << "[OSC] Added standalone tooltip:" << customTooltip;
 #endif
@@ -3132,14 +3109,13 @@ void TBuffer::decodeOSC(const QString& sequence)
             if (mCurrentHyperlinkStyling.selection.hasSelectionSettings && mpConsole) {
                 const QString& group = mCurrentHyperlinkStyling.selection.group;
                 const QString& value = mCurrentHyperlinkStyling.selection.value;
-                
+
                 // Configure group exclusivity mode
                 mpConsole->getHyperlinkSelectionManager().setGroupExclusive(group, mCurrentHyperlinkStyling.selection.exclusive);
-                
+
                 // Register the link with the selection manager
-                mpConsole->getHyperlinkSelectionManager().setSelected(group, value, 
-                    mCurrentHyperlinkStyling.selection.selected);
-                
+                mpConsole->getHyperlinkSelectionManager().setSelected(group, value, mCurrentHyperlinkStyling.selection.selected);
+
                 // Update link selection state (visual styling will be applied when link closes)
                 setLinkSelected(mCurrentHyperlinkLinkId, mCurrentHyperlinkStyling.selection.selected);
                 if (mCurrentHyperlinkStyling.selection.selected) {
@@ -3148,10 +3124,8 @@ void TBuffer::decodeOSC(const QString& sequence)
                     setLinkState(mCurrentHyperlinkLinkId, Mudlet::HyperlinkStyling::StateDisabled);
                 }
 #if defined(DEBUG_OSC_PROCESSING)
-                qDebug() << "[OSC] Link" << mCurrentHyperlinkLinkId << "initialized with selection state:"
-                         << "group=" << group << "value=" << value 
-                         << "selected=" << mCurrentHyperlinkStyling.selection.selected 
-                         << "disabled=" << mCurrentHyperlinkStyling.selection.disabled;
+                qDebug() << "[OSC] Link" << mCurrentHyperlinkLinkId << "initialized with selection state:" << "group=" << group << "value=" << value
+                         << "selected=" << mCurrentHyperlinkStyling.selection.selected << "disabled=" << mCurrentHyperlinkStyling.selection.disabled;
 #endif
             }
 
@@ -3159,7 +3133,7 @@ void TBuffer::decodeOSC(const QString& sequence)
             qDebug().noquote() << "[OSC] Hyperlink activated:" << rawUrl.left(50) + (rawUrl.length() > 50 ? "..." : "");
 #endif
             mHyperlinkActive = true;
-            
+
             // Record start position for visibility manager registration
             // Use mMudLine.length() since that's where link text will be added
             // (mMudLine is the current line being built, lineBuffer contains completed lines)
@@ -3286,10 +3260,10 @@ bool TBuffer::parseUriQueryParameters(const QString& uri, Mudlet::HyperlinkStyli
         if (!configJson.isEmpty()) {
             QJsonParseError parseError;
             QJsonDocument overrideDoc = QJsonDocument::fromJson(configJson.toUtf8(), &parseError);
-            
+
             if (parseError.error == QJsonParseError::NoError && overrideDoc.isObject()) {
                 QJsonObject overrideConfig = overrideDoc.object();
-                
+
                 if (!baseConfig.isEmpty() && mpConsole) {
                     // Deep merge: override takes precedence
                     baseConfig = mpConsole->getHyperlinkCompactManager().mergeConfigs(baseConfig, overrideConfig);
@@ -3322,17 +3296,17 @@ QJsonObject TBuffer::expandJsonShorthands(const QJsonObject& obj)
     if (!mpConsole) {
         return obj; // No manager available, return unchanged
     }
-    
+
     QJsonObject result;
-    
+
     for (auto it = obj.begin(); it != obj.end(); ++it) {
         QString originalKey = it.key();
         QJsonValue value = it.value();
-        
+
         QMap<QString, QString> singleKeyMap;
         singleKeyMap.insert(originalKey, qsl("placeholder")); // Value doesn't matter for key expansion
         QMap<QString, QString> expandedMap = mpConsole->getHyperlinkCompactManager().expandShorthand(singleKeyMap);
-        
+
         // Guard against empty or multi-key expanded maps to prevent assertion/UB
         QString resultKey;
         if (expandedMap.isEmpty()) {
@@ -3345,27 +3319,26 @@ QJsonObject TBuffer::expandJsonShorthands(const QJsonObject& obj)
             // Unexpected: multiple keys from single input - use first deterministically and log
             resultKey = expandedMap.firstKey();
 #if defined(DEBUG_OSC_PROCESSING)
-            qWarning() << "[OSC] expandShorthand returned multiple keys for single input:" << originalKey 
-                       << "-> expanded to:" << expandedMap.keys() << "using first key:" << resultKey;
+            qWarning() << "[OSC] expandShorthand returned multiple keys for single input:" << originalKey << "-> expanded to:" << expandedMap.keys() << "using first key:" << resultKey;
 #endif
         }
-        
+
         // Recursively expand nested objects
         QJsonValue resultValue = value.isObject() ? expandJsonShorthands(value.toObject()) : value;
-        
+
         // Handle duplicate keys by merging objects (e.g., both "style" and "s" -> "style")
         if (result.contains(resultKey) && result[resultKey].isObject() && resultValue.isObject()) {
             // Merge the objects using the compact manager's deep merge functionality
             QJsonObject existing = result[resultKey].toObject();
             QJsonObject toAdd = resultValue.toObject();
-            
+
             // When both shorthand and full names exist, shorthand takes precedence
             result[resultKey] = mpConsole->getHyperlinkCompactManager().mergeConfigs(toAdd, existing);
         } else {
             result[resultKey] = resultValue;
         }
     }
-    
+
     return result;
 }
 
@@ -3456,16 +3429,14 @@ bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, 
         styling.isSpoiler = jsonBoolValue(root[qsl("spoiler")]);
         if (styling.isSpoiler) {
             styling.hasCustomStyling = true;
-            
+
             if (!styling.hasBackgroundColor) {
                 QColor spoilerBackground = mBackGroundColor;
-                
-                qreal luminance = 0.2126 * spoilerBackground.redF() + 
-                                 0.7152 * spoilerBackground.greenF() + 
-                                 0.0722 * spoilerBackground.blueF();
-                
+
+                qreal luminance = 0.2126 * spoilerBackground.redF() + 0.7152 * spoilerBackground.greenF() + 0.0722 * spoilerBackground.blueF();
+
                 QColor originalBackground = spoilerBackground;
-                
+
                 if (luminance < 0.5) {
                     if (luminance < 0.1) {
                         spoilerBackground = QColor(40, 40, 40);
@@ -3475,14 +3446,12 @@ bool TBuffer::parseJsonHyperlinkConfig(const QString& jsonString, QMap<QString, 
                 } else {
                     spoilerBackground = spoilerBackground.darker(140);
                 }
-                
+
                 styling.backgroundColor = spoilerBackground;
                 styling.hasBackgroundColor = true;
-                
+
 #if defined(DEBUG_OSC_PROCESSING)
-                qDebug() << "[OSC] EARLY SPOILER BACKGROUND: Generated" << spoilerBackground.name()
-                         << "from original" << originalBackground.name()
-                         << "luminance:" << luminance;
+                qDebug() << "[OSC] EARLY SPOILER BACKGROUND: Generated" << spoilerBackground.name() << "from original" << originalBackground.name() << "luminance:" << luminance;
 #endif
             }
         }
@@ -3697,7 +3666,7 @@ bool TBuffer::parseVisibilityFromJson(const QJsonObject& visibilityObj, Mudlet::
             qWarning() << "[OSC] FOUND REVEAL ACTION - setting isConcealed=true";
 #endif
             settings.action = Mudlet::HyperlinkStyling::VisibilitySettings::Action::Reveal;
-            settings.isConcealed = true;  // Start concealed, will be revealed later
+            settings.isConcealed = true; // Start concealed, will be revealed later
 #if defined(DEBUG_OSC_PROCESSING)
             qWarning() << "[OSC] Setting reveal action: isConcealed=true, action=Reveal";
 #endif
@@ -3711,9 +3680,8 @@ bool TBuffer::parseVisibilityFromJson(const QJsonObject& visibilityObj, Mudlet::
         }
     } else if (actionValue.isArray()) {
         QJsonArray actionArray = actionValue.toArray();
-        if (actionArray.size() == 2 
-            && actionArray[0].isString() && actionArray[0].toString().toLower() == qsl("reveal")
-            && actionArray[1].isString() && actionArray[1].toString().toLower() == qsl("conceal")) {
+        if (actionArray.size() == 2 && actionArray[0].isString() && actionArray[0].toString().toLower() == qsl("reveal") && actionArray[1].isString()
+            && actionArray[1].toString().toLower() == qsl("conceal")) {
             settings.action = Mudlet::HyperlinkStyling::VisibilitySettings::Action::RevealThenConceal;
             settings.isConcealed = true; // Start concealed, reveal after delay, then conceal on click
         } else {
@@ -3738,8 +3706,8 @@ bool TBuffer::parseVisibilityFromJson(const QJsonObject& visibilityObj, Mudlet::
                 qWarning() << "TBuffer::parseVisibilityFromJson: Delay cannot be negative:" << delayDouble << "(using 0)";
                 settings.delayMs = 0;
             } else if (delayDouble > Mudlet::HyperlinkStyling::VisibilitySettings::MaxDelayMs) {
-                qWarning() << "TBuffer::parseVisibilityFromJson: Delay exceeds maximum ("
-                           << Mudlet::HyperlinkStyling::VisibilitySettings::MaxDelayMs << "ms):" << delayDouble << "(clamping to maximum)";
+                qWarning() << "TBuffer::parseVisibilityFromJson: Delay exceeds maximum (" << Mudlet::HyperlinkStyling::VisibilitySettings::MaxDelayMs << "ms):" << delayDouble
+                           << "(clamping to maximum)";
                 settings.delayMs = Mudlet::HyperlinkStyling::VisibilitySettings::MaxDelayMs;
             } else {
                 settings.delayMs = static_cast<quint32>(delayDouble);
@@ -3755,19 +3723,19 @@ bool TBuffer::parseVisibilityFromJson(const QJsonObject& visibilityObj, Mudlet::
     // Parse expire triggers (optional)
     if (visibilityObj.contains(qsl("expire")) && visibilityObj[qsl("expire")].isObject()) {
         QJsonObject expireObj = visibilityObj[qsl("expire")].toObject();
-        
+
         if (expireObj.contains(qsl("input"))) {
             settings.expireOnInput = jsonBoolValue(expireObj[qsl("input")]);
         }
-        
+
         if (expireObj.contains(qsl("prompt"))) {
             settings.expireOnPrompt = jsonBoolValue(expireObj[qsl("prompt")]);
         }
-        
+
         if (expireObj.contains(qsl("output"))) {
             settings.expireOnOutput = jsonBoolValue(expireObj[qsl("output")]);
         }
-        
+
         if (expireObj.contains(qsl("outputDelay"))) {
             QJsonValue outputDelayValue = expireObj[qsl("outputDelay")];
             if (outputDelayValue.isDouble()) {
@@ -3776,8 +3744,8 @@ bool TBuffer::parseVisibilityFromJson(const QJsonObject& visibilityObj, Mudlet::
                     qWarning() << "TBuffer::parseVisibilityFromJson: outputDelay cannot be negative:" << delayDouble << "(using 0)";
                     settings.outputDelayMs = 0;
                 } else if (delayDouble > Mudlet::HyperlinkStyling::VisibilitySettings::MaxDelayMs) {
-                    qWarning() << "TBuffer::parseVisibilityFromJson: outputDelay exceeds maximum ("
-                               << Mudlet::HyperlinkStyling::VisibilitySettings::MaxDelayMs << "ms):" << delayDouble << "(clamping to maximum)";
+                    qWarning() << "TBuffer::parseVisibilityFromJson: outputDelay exceeds maximum (" << Mudlet::HyperlinkStyling::VisibilitySettings::MaxDelayMs << "ms):" << delayDouble
+                               << "(clamping to maximum)";
                     settings.outputDelayMs = Mudlet::HyperlinkStyling::VisibilitySettings::MaxDelayMs;
                 } else {
                     settings.outputDelayMs = static_cast<quint32>(delayDouble);
@@ -3852,7 +3820,7 @@ void TBuffer::clearLinkIndices(int lineNumber, int startColumn, int length)
     }
 
     std::deque<TChar>& line = buffer[lineNumber];
-    
+
     // Extra safety: ensure we don't go out of bounds
     if (line.empty()) {
 #if defined(DEBUG_OSC_PROCESSING)
@@ -3860,16 +3828,15 @@ void TBuffer::clearLinkIndices(int lineNumber, int startColumn, int length)
 #endif
         return;
     }
-    
+
     startColumn = std::max(0, std::min(startColumn, static_cast<int>(line.size())));
-    
+
     int endColumn = std::min(static_cast<int>(line.size()), startColumn + std::max(0, length));
-    
+
 #if defined(DEBUG_OSC_PROCESSING)
-    qDebug() << "[OSC] clearLinkIndices: line" << lineNumber << "startCol" << startColumn << "length" << length 
-             << "endCol" << endColumn << "lineSize" << line.size();
+    qDebug() << "[OSC] clearLinkIndices: line" << lineNumber << "startCol" << startColumn << "length" << length << "endCol" << endColumn << "lineSize" << line.size();
 #endif
-    
+
     for (int col = startColumn; col < endColumn; ++col) {
         // Additional bounds check inside the loop
         if (col >= static_cast<int>(line.size())) {
@@ -3899,7 +3866,7 @@ void TBuffer::restoreLinkIndices(int lineNumber, int startColumn, int length, in
     }
 
     std::deque<TChar>& line = buffer[lineNumber];
-    
+
     // Extra safety: ensure we don't go out of bounds
     if (line.empty()) {
 #if defined(DEBUG_OSC_PROCESSING)
@@ -3907,11 +3874,11 @@ void TBuffer::restoreLinkIndices(int lineNumber, int startColumn, int length, in
 #endif
         return;
     }
-    
+
     startColumn = std::max(0, std::min(startColumn, static_cast<int>(line.size())));
-    
+
     int endColumn = std::min(static_cast<int>(line.size()), startColumn + std::max(0, length));
-    
+
     for (int col = startColumn; col < endColumn; ++col) {
         // Additional bounds check inside the loop
         if (col >= static_cast<int>(line.size())) {
@@ -3919,7 +3886,7 @@ void TBuffer::restoreLinkIndices(int lineNumber, int startColumn, int length, in
         }
         line[col].mLinkIndex = linkId;
     }
-    
+
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC] Link" << linkId << "restored";
 #endif
@@ -4012,11 +3979,9 @@ void TBuffer::parseJsonStyleToHyperlinkStyling(const QJsonObject& styleObj, Mudl
     }
 
     // Update hasCustomStyling flag if any pseudo-class states have custom styling
-    if (styling.linkStyle.hasCustomStyling || styling.visitedStyle.hasCustomStyling ||
-        styling.hoverStyle.hasCustomStyling || styling.activeStyle.hasCustomStyling ||
-        styling.focusStyle.hasCustomStyling || styling.focusVisibleStyle.hasCustomStyling ||
-        styling.anyLinkStyle.hasCustomStyling || styling.selectedStyle.hasCustomStyling ||
-        styling.disabledStyle.hasCustomStyling) {
+    if (styling.linkStyle.hasCustomStyling || styling.visitedStyle.hasCustomStyling || styling.hoverStyle.hasCustomStyling || styling.activeStyle.hasCustomStyling
+        || styling.focusStyle.hasCustomStyling || styling.focusVisibleStyle.hasCustomStyling || styling.anyLinkStyle.hasCustomStyling || styling.selectedStyle.hasCustomStyling
+        || styling.disabledStyle.hasCustomStyling) {
         styling.hasCustomStyling = true;
     }
 
@@ -4146,8 +4111,7 @@ void TBuffer::appendFormatted(const QString& text, const std::deque<TChar>& form
 
     // Check for text/formatting size mismatch - this is a programming error
     if (text.size() != static_cast<qsizetype>(formatting.size())) {
-        qWarning() << "TBuffer::appendFormatted: text size" << text.size() 
-                   << "differs from formatting size" << formatting.size()
+        qWarning() << "TBuffer::appendFormatted: text size" << text.size() << "differs from formatting size" << formatting.size()
                    << "- using longer length with default formatting for missing entries";
     }
 
@@ -4164,27 +4128,25 @@ void TBuffer::appendFormatted(const QString& text, const std::deque<TChar>& form
         if (i >= text.size()) {
             break;
         }
-        
+
         const QChar ch = text.at(i);
         if (ch == QChar::LineFeed) {
             firstChar = true;
             appendEmptyLine();
             continue;
         }
-        
+
         const TChar& srcChar = (i < static_cast<qsizetype>(formatting.size())) ? formatting.at(i) : defaultChar;
-        
+
         const int sourceLinkId = srcChar.linkIndex();
         if (sourceLinkId && (oldSourceLinkId != sourceLinkId)) {
-            destLinkId = mLinkStore.addLinks(sourceLinkStore.getLinksConst(sourceLinkId), 
-                                              sourceLinkStore.getHintsConst(sourceLinkId), 
-                                              mpHost);
+            destLinkId = mLinkStore.addLinks(sourceLinkStore.getLinksConst(sourceLinkId), sourceLinkStore.getHintsConst(sourceLinkId), mpHost);
             mLinkStore.setStyling(destLinkId, sourceLinkStore.getStyling(sourceLinkId));
             oldSourceLinkId = sourceLinkId;
         } else if (!sourceLinkId) {
             destLinkId = 0;
         }
-        
+
         lineBuffer.back().append(ch);
         TChar destChar(srcChar);
         destChar.mLinkIndex = destLinkId;
@@ -4214,9 +4176,7 @@ void TBuffer::appendFormatted(const QString& text, const std::deque<TChar>& form
     }
 }
 
-void TBuffer::append(const QString& text, int sub_start, int sub_end,
-                     const QColor& fgColor, const QColor& bgColor,
-                     TChar::AttributeFlags flags, int linkID)
+void TBuffer::append(const QString& text, int sub_start, int sub_end, const QColor& fgColor, const QColor& bgColor, TChar::AttributeFlags flags, int linkID)
 {
     const int lastLineBeforeWrap = buffer.size() - 1;
     const int lastLineLength = lineBuffer.at(lastLineBeforeWrap).size();
@@ -4245,9 +4205,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end,
     }
 }
 
-void TBuffer::appendLine(const QString& text, const int sub_start, const int sub_end,
-                         const QColor& fgColor, const QColor& bgColor,
-                         const TChar::AttributeFlags flags, const int linkID)
+void TBuffer::appendLine(const QString& text, const int sub_start, const int sub_end, const QColor& fgColor, const QColor& bgColor, const TChar::AttributeFlags flags, const int linkID)
 {
     if (sub_end < 0) {
         return;
@@ -4275,9 +4233,7 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
         appendEmptyLine();
         lastLine = 0;
         // The ternary operator is used here to set/reset only the TChar::Echo bit in the flags:
-        const TChar styling(fgColor, bgColor,
-                (mEchoingText ? (TChar::Echo | (flags & TChar::TestMask))
-                 : (flags & TChar::TestMask)));
+        const TChar styling(fgColor, bgColor, (mEchoingText ? (TChar::Echo | (flags & TChar::TestMask)) : (flags & TChar::TestMask)));
         buffer.back().push_back(styling);
     }
 
@@ -4505,8 +4461,7 @@ inline int TBuffer::skipSpacesAtBeginOfLine(const int row, const int column)
 }
 
 // find lindbreaks and indents (if not necessary, return empty list)
-inline QList<WrapInfo> TBuffer::getWrapInfo(const QString& lineText, bool isNewline,
-    const int maxWidth, const int indent, const int hangingIndent)
+inline QList<WrapInfo> TBuffer::getWrapInfo(const QString& lineText, bool isNewline, const int maxWidth, const int indent, const int hangingIndent)
 {
     QList<WrapInfo> output;
     if (lineText.isEmpty()) {
@@ -4551,8 +4506,7 @@ inline QList<WrapInfo> TBuffer::getWrapInfo(const QString& lineText, bool isNewl
         const QString grapheme = lineText.mid(indexOfChar, nextBoundary - indexOfChar);
         const uint unicode = graphemeInfo::getBaseCharacter(grapheme);
         // Safety check: during destruction, mpHost might be null
-        const int charWidth = mpHost ? graphemeInfo::getWidth(unicode, mpHost->wideAmbiguousEAsianGlyphs())
-                                     : graphemeInfo::getWidth(unicode, false);
+        const int charWidth = mpHost ? graphemeInfo::getWidth(unicode, mpHost->wideAmbiguousEAsianGlyphs()) : graphemeInfo::getWidth(unicode, false);
         const int indentationHere = isNewline ? indent : hangingIndent;
         if (xPos + charWidth > maxWidth - (needsIndent ? indentationHere : 0)) {
             if (isNewline) {
@@ -4649,7 +4603,7 @@ void TBuffer::logRemainingOutput()
 }
 
 // logs a string directly to the log file
-void TBuffer::appendLog(const QString &text)
+void TBuffer::appendLog(const QString& text)
 {
     TBuffer* pB = &mpHost->mpConsole->buffer;
     if (pB != this || !mpHost->mpConsole->mLogToLogFile) {
@@ -5023,7 +4977,7 @@ void TBuffer::shrinkBuffer()
     // Clean up unreferenced links after removing old lines
     clearLinkState();
 
-    if (mpConsole->getType() & (TConsole::MainConsole|TConsole::UserWindow|TConsole::SubConsole|TConsole::Buffer)) {
+    if (mpConsole->getType() & (TConsole::MainConsole | TConsole::UserWindow | TConsole::SubConsole | TConsole::Buffer)) {
         // Signal to lua subsystem that indexes into the Console will need adjusting
         TEvent bufferShrinkEvent{};
         bufferShrinkEvent.mArgumentList.append(QLatin1String("sysBufferShrinkEvent"));
@@ -5131,7 +5085,7 @@ bool TBuffer::applyAttribute(const QPoint& P_begin, const QPoint& P_end, const T
                         return true;
                     }
                 }
-                buffer.at(y).at(x).mFlags = (buffer.at(y).at(x).mFlags &~(attributes)) | (state ? attributes : TChar::None);
+                buffer.at(y).at(x).mFlags = (buffer.at(y).at(x).mFlags & ~(attributes)) | (state ? attributes : TChar::None);
                 ++x;
             }
         }
@@ -5239,9 +5193,7 @@ QStringList TBuffer::getEndLines(int n)
 // Note: spacePadding is expected to be non-zero on ONLY the first call to this
 // method - it is needed to pad the first line out when the first line of a
 // selection is not a complete line of text and there are more lines to follow
-QString TBuffer::bufferToHtml(const bool showTimeStamp /*= false*/, const int row /*= -1*/,
-                              const int endColumn /*= -1*/, const int startColumn /*= 0*/,
-                              int spacePadding /*= 0*/)
+QString TBuffer::bufferToHtml(const bool showTimeStamp /*= false*/, const int row /*= -1*/, const int endColumn /*= -1*/, const int startColumn /*= 0*/, int spacePadding /*= 0*/)
 {
     int pos = startColumn;
     QString s;
@@ -5307,11 +5259,8 @@ QString TBuffer::bufferToHtml(const bool showTimeStamp /*= false*/, const int ro
 
     for (auto cookedPos = static_cast<unsigned long>(pos); pos < lastPos; ++cookedPos, ++pos) {
         // Do we need to start a new span?
-        if (firstSpan
-            || buffer.at(cookedRow).at(cookedPos).mFgColor != currentFgColor
-            || buffer.at(cookedRow).at(cookedPos).mBgColor != currentBgColor
+        if (firstSpan || buffer.at(cookedRow).at(cookedPos).mFgColor != currentFgColor || buffer.at(cookedRow).at(cookedPos).mBgColor != currentBgColor
             || (buffer.at(cookedRow).at(cookedPos).mFlags & TChar::TestMask) != currentFlags) {
-
             if (firstSpan) {
                 firstSpan = false; // The first span - won't need to close the previous one
             } else {
@@ -5439,19 +5388,19 @@ bool TBuffer::processUtf8Sequence(const std::string& bufferData, const bool isFr
                 isValid = false;
                 isToUseReplacementMark = true;
             } else if (((bufferData.at(pos) & 0x07) > 0x04) || (((bufferData.at(pos) & 0x07) == 0x04) && ((bufferData.at(pos + 1) & 0x3F) > 0x0F))) {
-// For 4 byte values the bits are distributed:
-//  Byte 1    Byte 2    Byte 3    Byte 4
-// 11110ABC  10DEFGHI  10JKLMNO  10PQRSTU   A is MSB
-// U+10FFFF in binary is: 1 0000 1111 1111 1111 1111
-// So this (the maximum valid character) is:
-//      ABC    DEFGHI    JKLMNO    PQRSTU
-//      100    001111    111111    111111
-// So if the first byte bufferData.at(pos] & 0x07 is:
-//  < 0x04 then must be in range
-//  > 0x04 then must be out of range
-// == 0x04 then consider bufferData.at(pos+1] & 0x3F:
-//     <= 001111 0x0F then must be in range
-//      > 001111 0x0F then must be out of range
+                // For 4 byte values the bits are distributed:
+                //  Byte 1    Byte 2    Byte 3    Byte 4
+                // 11110ABC  10DEFGHI  10JKLMNO  10PQRSTU   A is MSB
+                // U+10FFFF in binary is: 1 0000 1111 1111 1111 1111
+                // So this (the maximum valid character) is:
+                //      ABC    DEFGHI    JKLMNO    PQRSTU
+                //      100    001111    111111    111111
+                // So if the first byte bufferData.at(pos] & 0x07 is:
+                //  < 0x04 then must be in range
+                //  > 0x04 then must be out of range
+                // == 0x04 then consider bufferData.at(pos+1] & 0x3F:
+                //     <= 001111 0x0F then must be in range
+                //      > 001111 0x0F then must be out of range
 
 #if defined(DEBUG_UTF8_PROCESSING)
                 qDebug() << "TBuffer::processUtf8Sequence(...) 4 byte UTF-8 sequence is valid but is beyond range of legal codepoints!";
@@ -5460,7 +5409,7 @@ bool TBuffer::processUtf8Sequence(const std::string& bufferData, const bool isFr
                 isToUseReplacementMark = true;
             }
 
-        // Fall-through
+            // Fall-through
             [[fallthrough]];
         case 3:
             // Check the 3rd byte is a valid continuation byte (2 MS-Bits are 10)
@@ -5511,10 +5460,7 @@ bool TBuffer::processUtf8Sequence(const std::string& bufferData, const bool isFr
 #endif
                 isValid = false;
                 isToUseReplacementMark = true;
-            } else if (   (static_cast<quint8>(bufferData.at(pos + 2)) == 0xBF)
-                       && (static_cast<quint8>(bufferData.at(pos + 1)) == 0xBB)
-                       && (static_cast<quint8>(bufferData.at(pos    )) == 0xEF)) {
-
+            } else if ((static_cast<quint8>(bufferData.at(pos + 2)) == 0xBF) && (static_cast<quint8>(bufferData.at(pos + 1)) == 0xBB) && (static_cast<quint8>(bufferData.at(pos)) == 0xEF)) {
                 // Got caught out by this one - it is the UTF-8 BOM (or
                 // Zero-Width No-Break Space) and needs to be detected specially
                 // as Qt's codec ignores it and transcodes it to NO codepoints!
@@ -5525,7 +5471,7 @@ bool TBuffer::processUtf8Sequence(const std::string& bufferData, const bool isFr
                 isToUseByteOrderMark = true;
             }
 
-        // Fall-through
+            // Fall-through
             [[fallthrough]];
         case 2:
             // Check the 2nd byte is a valid continuation byte (2 MS-Bits are 10)
@@ -5545,7 +5491,7 @@ bool TBuffer::processUtf8Sequence(const std::string& bufferData, const bool isFr
             if (  ( ((static_cast<quint8>(bufferData.at(pos    )) & 0xFE) == 0xC0) && ( ( static_cast<quint8>(bufferData.at(pos + 1)) & 0xC0) == 0x80) )
                 ||( ( static_cast<quint8>(bufferData.at(pos    )        ) == 0xE0) && ( ( static_cast<quint8>(bufferData.at(pos + 1)) & 0xE0) == 0x80) )
                 ||( ( static_cast<quint8>(bufferData.at(pos    )        ) == 0xF0) && ( ( static_cast<quint8>(bufferData.at(pos + 1)) & 0xF0) == 0x80) ) ) {
-// clang-format on
+                // clang-format on
 
 #if defined(DEBUG_UTF8_PROCESSING)
                 qDebug().nospace() << "TBuffer::processUtf8Sequence(...) Overlong " << utf8SequenceLength << "-byte sequence as UTF-8 rejected!";
@@ -5586,8 +5532,9 @@ bool TBuffer::processUtf8Sequence(const std::string& bufferData, const bool isFr
                 mMudLine.append(codePoint);
                 break;
             case 0:
-                qWarning().nospace() << "TBuffer::processUtf8Sequence(...) " << utf8SequenceLength << "-byte UTF-8 sequence accepted, but it did not encode to "
-                                                                                                      "ANY QChar(s)!!!";
+                qWarning().nospace() << "TBuffer::processUtf8Sequence(...) " << utf8SequenceLength
+                                     << "-byte UTF-8 sequence accepted, but it did not encode to "
+                                        "ANY QChar(s)!!!";
                 isValid = false;
                 isToUseReplacementMark = true;
             }
@@ -5621,15 +5568,15 @@ bool TBuffer::processUtf8Sequence(const std::string& bufferData, const bool isFr
 
 bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFromServer, const bool isGB18030, const size_t len, size_t& pos, bool& isNonBmpCharacter)
 {
-// In GBK/GB18030 mode we have to process the data more than one byte at a
-// time because there is not necessarily a one-byte to one TChar
-// mapping, instead we use one TChar per QChar - and that has to be
-// tweaked for non-BMP characters that use TWO QChars per codepoint.
-// GB2312 is the predecessor to both and - according to Wikipedia (EN) covers
-// over 99% of the characters of contemporary usage.
-// GBK is a sub-set of GB18030 so can be processed in the same method
-// Assume we are at the first byte of a single (ASCII), pair (GBK/GB18030)
-// or four byte (GB18030) sequence
+    // In GBK/GB18030 mode we have to process the data more than one byte at a
+    // time because there is not necessarily a one-byte to one TChar
+    // mapping, instead we use one TChar per QChar - and that has to be
+    // tweaked for non-BMP characters that use TWO QChars per codepoint.
+    // GB2312 is the predecessor to both and - according to Wikipedia (EN) covers
+    // over 99% of the characters of contemporary usage.
+    // GBK is a sub-set of GB18030 so can be processed in the same method
+    // Assume we are at the first byte of a single (ASCII), pair (GBK/GB18030)
+    // or four byte (GB18030) sequence
 
 #if defined(DEBUG_GB_PROCESSING)
     std::string dataIdentity;
@@ -5671,8 +5618,8 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
             if        (  (static_cast<quint8>(bufferData.at(pos    )) >= 0x81) && (static_cast<quint8>(bufferData.at(pos    )) <= 0xA0)
                       && (static_cast<quint8>(bufferData.at(pos + 1)) >= 0x40) && (static_cast<quint8>(bufferData.at(pos + 1)) <= 0xFE)
                       && (static_cast<quint8>(bufferData.at(pos + 1)) != 0x7F) ) {
-// clang-format on
-// GBK Area 3 sequence
+                // clang-format on
+                // GBK Area 3 sequence
 
 #if defined(DEBUG_GB_PROCESSING)
                 dataIdentity = "GBK Area 3";
@@ -5681,8 +5628,8 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
                 // clang-format off
             } else if (  (static_cast<quint8>(bufferData.at(pos    )) >= 0xA1) && (static_cast<quint8>(bufferData.at(pos    )) <= 0xA9)
                       && (static_cast<quint8>(bufferData.at(pos + 1)) >= 0xA1) && (static_cast<quint8>(bufferData.at(pos + 1)) <= 0xFE) ) {
-// clang-format on
-// GBK Area 1 (& GB2312) sequence
+                // clang-format on
+                // GBK Area 1 (& GB2312) sequence
 
 #if defined(DEBUG_GB_PROCESSING)
                 dataIdentity = "GBK Area 1 (or GB2312)";
@@ -5691,8 +5638,8 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
                 // clang-format off
             } else if (  (static_cast<quint8>(bufferData.at(pos    )) >= 0xB0) && (static_cast<quint8>(bufferData.at(pos    )) <= 0xF7)
                       && (static_cast<quint8>(bufferData.at(pos + 1)) >= 0xA1) && (static_cast<quint8>(bufferData.at(pos + 1)) <= 0xFE) ) {
-// clang-format on
-// GBK Area 2 (& GB2312) sequence
+                // clang-format on
+                // GBK Area 2 (& GB2312) sequence
 
 #if defined(DEBUG_GB_PROCESSING)
                 dataIdentity = "GBK Area 2 (or GB2312)";
@@ -5702,8 +5649,8 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
             } else if (  (static_cast<quint8>(bufferData.at(pos    )) >= 0xA8) && (static_cast<quint8>(bufferData.at(pos    )) <= 0xA9)
                       && (static_cast<quint8>(bufferData.at(pos + 1)) >= 0x40) && (static_cast<quint8>(bufferData.at(pos + 1)) <= 0xA0)
                       && (static_cast<quint8>(bufferData.at(pos + 1)) != 0x7F) ) {
-// clang-format on
-// GBK/5 sequence
+                // clang-format on
+                // GBK/5 sequence
 
 #if defined(DEBUG_GB_PROCESSING)
                 dataIdentity = "GBK Area 5";
@@ -5713,8 +5660,8 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
             } else if (  (static_cast<quint8>(bufferData.at(pos    )) >= 0xAA) && (static_cast<quint8>(bufferData.at(pos    )) <= 0xFE)
                       && (static_cast<quint8>(bufferData.at(pos + 1)) >= 0x40) && (static_cast<quint8>(bufferData.at(pos + 1)) <= 0xA0)
                       && (static_cast<quint8>(bufferData.at(pos + 1)) != 0x7F) ) {
-// clang-format on
-// GBK/4 sequence
+                // clang-format on
+                // GBK/4 sequence
 
 #if defined(DEBUG_GB_PROCESSING)
                 dataIdentity = "GBK Area 4";
@@ -5723,9 +5670,9 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
                 // clang-format off
             } else if (  (static_cast<quint8>(bufferData.at(pos    )) >= 0xAA) && (static_cast<quint8>(bufferData.at(pos    )) <= 0xAF)
                       && (static_cast<quint8>(bufferData.at(pos + 1)) >= 0xA1) && (static_cast<quint8>(bufferData.at(pos + 1)) <= 0xFE) ) {
-// clang-format on
-// User Defined 1 sequence - possibly invalid for us but if the
-// MUD supplies their own font it could be used:
+                // clang-format on
+                // User Defined 1 sequence - possibly invalid for us but if the
+                // MUD supplies their own font it could be used:
 
 #if defined(DEBUG_GB_PROCESSING)
                 dataIdentity = "User Defined (PU) Area 1";
@@ -5734,9 +5681,9 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
                 // clang-format off
             } else if (  (static_cast<quint8>(bufferData.at(pos    )) >= 0xF8) && (static_cast<quint8>(bufferData.at(pos    )) <= 0xFE)
                       && (static_cast<quint8>(bufferData.at(pos + 1)) >= 0xA1) && (static_cast<quint8>(bufferData.at(pos + 1)) <= 0xFE) ) {
-// clang-format on
-// User Defined 2 sequence - possibly invalid for us but if the
-// MUD supplies their own font it could be used:
+                // clang-format on
+                // User Defined 2 sequence - possibly invalid for us but if the
+                // MUD supplies their own font it could be used:
 
 #if defined(DEBUG_GB_PROCESSING)
                 dataIdentity = "User Defined (PU) Area 2";
@@ -5746,9 +5693,9 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
             } else if (  (static_cast<quint8>(bufferData.at(pos    )) >= 0xA1) && (static_cast<quint8>(bufferData.at(pos    )) <= 0xA7)
                       && (static_cast<quint8>(bufferData.at(pos + 1)) >= 0xA1) && (static_cast<quint8>(bufferData.at(pos + 1)) <= 0xFE)
                       && (static_cast<quint8>(bufferData.at(pos + 1)) != 0x7F) ) {
-// clang-format on
-// User Defined 3 sequence - possibly invalid for us but if the
-// MUD supplies their own font it could be used:
+                // clang-format on
+                // User Defined 3 sequence - possibly invalid for us but if the
+                // MUD supplies their own font it could be used:
 
 #if defined(DEBUG_GB_PROCESSING)
                 dataIdentity = "User Defined (PU) Area 3";
@@ -5757,9 +5704,9 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
                 // clang-format off
             } else if (  (static_cast<quint8>(bufferData.at(pos    )) >= 0x90) && (static_cast<quint8>(bufferData.at(pos    )) <= 0xE3)
                       && (static_cast<quint8>(bufferData.at(pos + 1)) >= 0x30) && (static_cast<quint8>(bufferData.at(pos + 1)) <= 0x39) ) {
-// clang-format on
-// First two bytes of a 4-byte GB18030 sequence - for a non-BMP mapped Unicode
-// codepoint if byte 3 is within 0x81-00xFE and byte 4 is within 0x30-0x39
+                // clang-format on
+                // First two bytes of a 4-byte GB18030 sequence - for a non-BMP mapped Unicode
+                // codepoint if byte 3 is within 0x81-00xFE and byte 4 is within 0x30-0x39
                 isValid = false;
                 isToUseReplacementMark = true;
 #if defined(DEBUG_GB_PROCESSING)
@@ -5770,9 +5717,9 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
                 // clang-format off
             } else if (  (static_cast<quint8>(bufferData.at(pos    )) >= 0xFD) && (static_cast<quint8>(bufferData.at(pos    )) <= 0xFE)
                       && (static_cast<quint8>(bufferData.at(pos + 1)) >= 0x30) && (static_cast<quint8>(bufferData.at(pos + 1)) <= 0x39) ) {
-// clang-format on
-// First two bytes of a 4-byte GB18030 sequence - for a non-BMP mapped Unicode
-// codepoint if byte 3 is within 0x81-00xFE and byte 4 is within 0x30-0x39
+                // clang-format on
+                // First two bytes of a 4-byte GB18030 sequence - for a non-BMP mapped Unicode
+                // codepoint if byte 3 is within 0x81-00xFE and byte 4 is within 0x30-0x39
                 isValid = false;
                 isToUseReplacementMark = true;
 #if defined(DEBUG_GB_PROCESSING)
@@ -5887,7 +5834,7 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
                     dataIdentity = "GBK Area 3";
 #endif
 
-                // clang-format off
+                    // clang-format off
                 } else if (  (static_cast<quint8>(bufferData.at(pos    )) >= 0xA1) && (static_cast<quint8>(bufferData.at(pos    )) <= 0xA9)
                           && (static_cast<quint8>(bufferData.at(pos + 1)) >= 0xA1) && (static_cast<quint8>(bufferData.at(pos + 1)) <= 0xFE) ) {
                     // clang-format on
@@ -5897,7 +5844,7 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
                     dataIdentity = "GBK Area 1";
 #endif
 
-                // clang-format off
+                    // clang-format off
                 } else if (  (static_cast<quint8>(bufferData.at(pos    )) >= 0xB0) && (static_cast<quint8>(bufferData.at(pos    )) <= 0xF7)
                           && (static_cast<quint8>(bufferData.at(pos + 1)) >= 0xA1) && (static_cast<quint8>(bufferData.at(pos + 1)) <= 0xFE) ) {
                     // clang-format on
@@ -5907,7 +5854,7 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
                     dataIdentity = "GBK Area 2";
 #endif
 
-                // clang-format off
+                    // clang-format off
                 } else if (  (static_cast<quint8>(bufferData.at(pos    )) >= 0xA8) && (static_cast<quint8>(bufferData.at(pos    )) <= 0xA9)
                           && (static_cast<quint8>(bufferData.at(pos + 1)) >= 0x40) && (static_cast<quint8>(bufferData.at(pos + 1)) <= 0xA0)
                           && (static_cast<quint8>(bufferData.at(pos + 1)) != 0x7F) ) {
@@ -5918,7 +5865,7 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
                     dataIdentity = "GBK Area 5";
 #endif
 
-                // clang-format off
+                    // clang-format off
                 } else if (  (static_cast<quint8>(bufferData.at(pos    )) >= 0xAA) && (static_cast<quint8>(bufferData.at(pos    )) <= 0xFE)
                           && (static_cast<quint8>(bufferData.at(pos + 1)) >= 0x40) && (static_cast<quint8>(bufferData.at(pos + 1)) <= 0xA0)
                           && (static_cast<quint8>(bufferData.at(pos + 1)) != 0x7F) ) {
@@ -5929,7 +5876,7 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
                     dataIdentity = "GBK Area 4";
 #endif
 
-                // clang-format off
+                    // clang-format off
                 } else if (  (static_cast<quint8>(bufferData.at(pos    )) >= 0xAA) && (static_cast<quint8>(bufferData.at(pos    )) <= 0xAF)
                           && (static_cast<quint8>(bufferData.at(pos + 1)) >= 0xA1) && (static_cast<quint8>(bufferData.at(pos + 1)) <= 0xFE) ) {
                     // clang-format on
@@ -5940,7 +5887,7 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
                     dataIdentity = "User Defined (PU) Area 1";
 #endif
 
-                // clang-format off
+                    // clang-format off
                 } else if (  (static_cast<quint8>(bufferData.at(pos    )) >= 0xF8) && (static_cast<quint8>(bufferData.at(pos    )) <= 0xFE)
                           && (static_cast<quint8>(bufferData.at(pos + 1)) >= 0xA1) && (static_cast<quint8>(bufferData.at(pos + 1)) <= 0xFE) ) {
                     // clang-format on
@@ -5951,7 +5898,7 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
                     dataIdentity = "User Defined (PU) Area 2";
 #endif
 
-                // clang-format off
+                    // clang-format off
                 } else if (  (static_cast<quint8>(bufferData.at(pos    )) >= 0xA1) && (static_cast<quint8>(bufferData.at(pos    )) <= 0xA7)
                           && (static_cast<quint8>(bufferData.at(pos + 1)) >= 0xA1) && (static_cast<quint8>(bufferData.at(pos + 1)) <= 0xFE)
                           && (static_cast<quint8>(bufferData.at(pos + 1)) != 0x7F) ) {
@@ -5982,9 +5929,8 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
             // we only have one - so store what we have and return
             if (isFromServer) {
 #if defined(DEBUG_GB_PROCESSING)
-                qDebug().nospace() << "TBuffer::processGBSequence(...) Insufficient bytes in buffer to complete GB18030 sequence, need at least:"
-                                   << gbSequenceLength << " but we currently only have: " << bufferData.substr(pos).length()
-                                   << " bytes (which we will store for next call to this method)...";
+                qDebug().nospace() << "TBuffer::processGBSequence(...) Insufficient bytes in buffer to complete GB18030 sequence, need at least:" << gbSequenceLength
+                                   << " but we currently only have: " << bufferData.substr(pos).length() << " bytes (which we will store for next call to this method)...";
 #endif
                 mIncompleteSequenceBytes = bufferData.substr(pos);
             }
@@ -6012,7 +5958,7 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
                 break;
             case 2:
                 isNonBmpCharacter = true;
-            // Fall-through
+                // Fall-through
                 [[fallthrough]];
             case 1:
 #if defined(DEBUG_GB_PROCESSING)
@@ -6104,7 +6050,6 @@ bool TBuffer::processBig5Sequence(const std::string& bufferData, const bool isFr
                 isToUseReplacementMark = true;
             }
         }
-
     }
 
     // At this point we know how many bytes to consume, and whether they are in
@@ -6118,34 +6063,33 @@ bool TBuffer::processBig5Sequence(const std::string& bufferData, const bool isFr
         if (TEncodingHelper::isEncodingAvailable(mEncoding)) {
             codePoint = TEncodingHelper::decode(QByteArray::fromRawData(bufferData.substr(pos, big5SequenceLength).c_str(), big5SequenceLength), mEncoding);
             switch (codePoint.size()) {
-                default:
-                    Q_UNREACHABLE(); // This can't happen, unless we got start or length wrong in std::string::substr()
-                    qWarning().nospace() << "TBuffer::processBig5Sequence(...) " << big5SequenceLength << "-byte Big5 sequence accepted, and it encoded to "
-                                         << codePoint.size() << " QChars which does not make sense!!!";
+            default:
+                Q_UNREACHABLE(); // This can't happen, unless we got start or length wrong in std::string::substr()
+                qWarning().nospace() << "TBuffer::processBig5Sequence(...) " << big5SequenceLength << "-byte Big5 sequence accepted, and it encoded to " << codePoint.size()
+                                     << " QChars which does not make sense!!!";
+                isValid = false;
+                isToUseReplacementMark = true;
+                break;
+            case 2:
+                // Fall-through
+                [[fallthrough]];
+            case 1:
+                // If Qt's decoder found bad characters, update status flags to reflect that.
+                if (codePoint.contains(QChar::ReplacementCharacter)) {
                     isValid = false;
                     isToUseReplacementMark = true;
                     break;
-                case 2:
-                    // Fall-through
-                    [[fallthrough]];
-                case 1:
-                    // If Qt's decoder found bad characters, update status flags to reflect that.
-                    if (codePoint.contains(QChar::ReplacementCharacter)) {
-                        isValid = false;
-                        isToUseReplacementMark = true;
-                        break;
-                    }
+                }
 #if defined(DEBUG_BIG5_PROCESSING)
-                    qDebug().nospace() << "TBuffer::processBig5Sequence(...) " << big5SequenceLength << "-byte Big5 sequence accepted, it is " << codePoint.size()
-                                   << " QChar(s) long [" << codePoint << "] and is in the " << dataIdentity.c_str() << " range";
+                qDebug().nospace() << "TBuffer::processBig5Sequence(...) " << big5SequenceLength << "-byte Big5 sequence accepted, it is " << codePoint.size() << " QChar(s) long [" << codePoint
+                                   << "] and is in the " << dataIdentity.c_str() << " range";
 #endif
-                    mMudLine.append(codePoint);
-                    break;
-                case 0:
-                    qWarning().nospace() << "TBuffer::processBig5Sequence(...) " << big5SequenceLength << "-byte Big5"
-                                   << "sequence accepted, but it did not encode to ANY QChar(s)!!!";
-                    isValid = false;
-                    isToUseReplacementMark = true;
+                mMudLine.append(codePoint);
+                break;
+            case 0:
+                qWarning().nospace() << "TBuffer::processBig5Sequence(...) " << big5SequenceLength << "-byte Big5" << "sequence accepted, but it did not encode to ANY QChar(s)!!!";
+                isValid = false;
+                isToUseReplacementMark = true;
             }
         } else {
             // Unable to decode it - no Qt decoder...!
@@ -6211,23 +6155,22 @@ bool TBuffer::processEUC_KRSequence(const std::string& bufferData, const bool is
             // Not enough bytes to process yet - so store what we have and return
             if (isFromServer) {
 #if defined(DEBUG_EUC_KR_PROCESSING)
-                    qDebug().nospace() << "TBuffer::processEUC_KRSequence(...) Insufficient bytes in buffer to "
-                                          "complete EUC-KR sequence, need at least: "
-                                       << eucSequenceLength << " but we currently only have: " << bufferData.substr(pos).length() << " bytes (which we will store for next call to this method)...";
+                qDebug().nospace() << "TBuffer::processEUC_KRSequence(...) Insufficient bytes in buffer to "
+                                      "complete EUC-KR sequence, need at least: "
+                                   << eucSequenceLength << " but we currently only have: " << bufferData.substr(pos).length() << " bytes (which we will store for next call to this method)...";
 #endif
-                    mIncompleteSequenceBytes = bufferData.substr(pos);
+                mIncompleteSequenceBytes = bufferData.substr(pos);
             }
             return false; // Bail out
         } else {
             // check if second byte range is valid
             auto val2 = static_cast<quint8>(bufferData.at(pos + 1));
             if (val2 < 0xA1 || val2 == 0xFF) {
-                    // second byte range is invalid
-                    isValid = false;
-                    isToUseReplacementMark = true;
+                // second byte range is invalid
+                isValid = false;
+                isToUseReplacementMark = true;
             }
         }
-
     }
 
     // At this point we know how many bytes to consume, and whether they are in
@@ -6242,33 +6185,32 @@ bool TBuffer::processEUC_KRSequence(const std::string& bufferData, const bool is
             codePoint = TEncodingHelper::decode(QByteArray::fromRawData(bufferData.substr(pos, eucSequenceLength).c_str(), eucSequenceLength), mEncoding);
             switch (codePoint.size()) {
             default:
-                    Q_UNREACHABLE(); // This can't happen, unless we got start or length wrong in std::string::substr()
-                    qWarning().nospace() << "TBuffer::processEUC_KRSequence(...) " << eucSequenceLength << "-byte EUC-KR sequence accepted, and it encoded to "
-                                         << codePoint.size() << " QChars which does not make sense!!!";
-                    isValid = false;
-                    isToUseReplacementMark = true;
-                    break;
+                Q_UNREACHABLE(); // This can't happen, unless we got start or length wrong in std::string::substr()
+                qWarning().nospace() << "TBuffer::processEUC_KRSequence(...) " << eucSequenceLength << "-byte EUC-KR sequence accepted, and it encoded to " << codePoint.size()
+                                     << " QChars which does not make sense!!!";
+                isValid = false;
+                isToUseReplacementMark = true;
+                break;
             case 2:
-                    // Fall-through
-                    [[fallthrough]];
+                // Fall-through
+                [[fallthrough]];
             case 1:
-                    // If Qt's decoder found bad characters, update status flags to reflect that.
-                    if (codePoint.contains(QChar::ReplacementCharacter)) {
-                        isValid = false;
-                        isToUseReplacementMark = true;
-                        break;
-                    }
-#if defined(DEBUG_EUC_KR_PROCESSING)
-                    qDebug().nospace() << "TBuffer::processEUC_KRSequence(...) " << eucSequenceLength << "-byte EUC-KR sequence accepted, it is " << codePoint.size()
-                                       << " QChar(s) long [" << codePoint << "] and is in the " << dataIdentity.c_str() << " range";
-#endif
-                    mMudLine.append(codePoint);
-                    break;
-            case 0:
-                    qWarning().nospace() << "TBuffer::processEUC_KRSequence(...) " << eucSequenceLength << "-byte EUC-KR"
-                                         << "sequence accepted, but it did not encode to ANY QChar(s)!!!";
+                // If Qt's decoder found bad characters, update status flags to reflect that.
+                if (codePoint.contains(QChar::ReplacementCharacter)) {
                     isValid = false;
                     isToUseReplacementMark = true;
+                    break;
+                }
+#if defined(DEBUG_EUC_KR_PROCESSING)
+                qDebug().nospace() << "TBuffer::processEUC_KRSequence(...) " << eucSequenceLength << "-byte EUC-KR sequence accepted, it is " << codePoint.size() << " QChar(s) long [" << codePoint
+                                   << "] and is in the " << dataIdentity.c_str() << " range";
+#endif
+                mMudLine.append(codePoint);
+                break;
+            case 0:
+                qWarning().nospace() << "TBuffer::processEUC_KRSequence(...) " << eucSequenceLength << "-byte EUC-KR" << "sequence accepted, but it did not encode to ANY QChar(s)!!!";
+                isValid = false;
+                isToUseReplacementMark = true;
             }
         } else {
             // Unable to decode it - no Qt decoder...!
@@ -6333,7 +6275,7 @@ int TBuffer::lengthInGraphemes(const QString& text)
 
 const QList<QByteArray> TBuffer::getEncodingNames()
 {
-     return csmEncodingTable.getEncodingNames();
+    return csmEncodingTable.getEncodingNames();
 }
 
 void TBuffer::clearSearchHighlights()
@@ -6399,9 +6341,11 @@ void TBuffer::injectOSC8DocumentationExamples()
     // 4. MENUS & TOOLTIPS
     // ═══════════════════════════════════════════════════════════════════
     output += "── MENUS & TOOLTIPS ───────────────────────────────────────────────────\n";
-    output += "Menu: \x1b]8;;send:attack?config={\"menu\":[{\"Strike\":\"send:strike\"},{\"Power\":\"send:power\"},\"-\",{\"Flee\":\"send:flee\"}]}\x1b\\⚔️ Combat\x1b]8;;\x1b\\ ← right-click (left=primary, \"-\"=separator)\n";
+    output += "Menu: \x1b]8;;send:attack?config={\"menu\":[{\"Strike\":\"send:strike\"},{\"Power\":\"send:power\"},\"-\",{\"Flee\":\"send:flee\"}]}\x1b\\⚔️ Combat\x1b]8;;\x1b\\ ← right-click "
+              "(left=primary, \"-\"=separator)\n";
     output += "Tip:  \x1b]8;;send:item?config={\"tooltip\":\"Legendary sword +5 damage\",\"style\":{\"color\":\"orange\"}}\x1b\\🗡️ Flaming Blade\x1b]8;;\x1b\\ ← hover for tooltip\n";
-    output += "Both: \x1b]8;;send:spell?config={\"menu\":[{\"Fire\":\"send:fireball\"},{\"Ice\":\"send:icebolt\"}],\"tooltip\":\"Magic spells\",\"style\":{\"color\":\"#9966ff\"}}\x1b\\✨ Magic\x1b]8;;\x1b\\\n\n";
+    output += "Both: \x1b]8;;send:spell?config={\"menu\":[{\"Fire\":\"send:fireball\"},{\"Ice\":\"send:icebolt\"}],\"tooltip\":\"Magic spells\",\"style\":{\"color\":\"#9966ff\"}}\x1b\\✨ "
+              "Magic\x1b]8;;\x1b\\\n\n";
 
     // ═══════════════════════════════════════════════════════════════════
     // 5. VISIBILITY - Hide/reveal
@@ -6409,7 +6353,8 @@ void TBuffer::injectOSC8DocumentationExamples()
     output += "── VISIBILITY (auto-hide/reveal) ──────────────────────────────────────\n";
     output += "Click-hide: \x1b]8;;send:h1?config={\"style\":{\"color\":\"yellow\"},\"visibility\":{\"action\":\"conceal\",\"delay\":2000}}\x1b\\I vanish 2s after click\x1b]8;;\x1b\\\n";
     output += "Expire:     \x1b]8;;send:h2?config={\"style\":{\"color\":\"cyan\"},\"visibility\":{\"action\":\"conceal\",\"expire\":{\"input\":true}}}\x1b\\Send any command to hide\x1b]8;;\x1b\\\n";
-    output += "Reveal:     Wait... \x1b]8;;send:h3?config={\"style\":{\"color\":\"lime\",\"bold\":true},\"visibility\":{\"action\":\"reveal\",\"delay\":5000}}\x1b\\I APPEAR!\x1b]8;;\x1b\\ (5 seconds)\n";
+    output += "Reveal:     Wait... \x1b]8;;send:h3?config={\"style\":{\"color\":\"lime\",\"bold\":true},\"visibility\":{\"action\":\"reveal\",\"delay\":5000}}\x1b\\I APPEAR!\x1b]8;;\x1b\\ (5 "
+              "seconds)\n";
     output += "Wide chars: \x1b]8;;send:h4?config={\"style\":{\"bg\":\"blue\"},\"visibility\":{\"action\":\"conceal\",\"delay\":2000}}\x1b\\🎉🚀💎\x1b]8;;\x1b\\ ← emojis handled correctly\n\n";
 
     // ═══════════════════════════════════════════════════════════════════
@@ -6433,12 +6378,15 @@ void TBuffer::injectOSC8DocumentationExamples()
     // ═══════════════════════════════════════════════════════════════════
     output += "── SELECTION (stateful toggles) ───────────────────────────────────────\n";
     output += "Radio:    ";
-    output += "\x1b]8;;send:easy?config={\"selection\":{\"group\":\"diff\",\"value\":\"easy\",\"exclusive\":true},\"style\":{\"color\":\"#8f8\",\"selected\":{\"bg\":\"green\",\"bold\":true}}}\x1b\\Easy\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:hard?config={\"selection\":{\"group\":\"diff\",\"value\":\"hard\",\"exclusive\":true},\"style\":{\"color\":\"#f88\",\"selected\":{\"bg\":\"red\",\"bold\":true}}}\x1b\\Hard\x1b]8;;\x1b\\ (one at a time)\n";
+    output += "\x1b]8;;send:easy?config={\"selection\":{\"group\":\"diff\",\"value\":\"easy\",\"exclusive\":true},\"style\":{\"color\":\"#8f8\",\"selected\":{\"bg\":\"green\",\"bold\":true}}}"
+              "\x1b\\Easy\x1b]8;;\x1b\\ ";
+    output += "\x1b]8;;send:hard?config={\"selection\":{\"group\":\"diff\",\"value\":\"hard\",\"exclusive\":true},\"style\":{\"color\":\"#f88\",\"selected\":{\"bg\":\"red\",\"bold\":true}}}"
+              "\x1b\\Hard\x1b]8;;\x1b\\ (one at a time)\n";
     output += "Checkbox: ";
     output += "\x1b]8;;send:b1?config={\"selection\":{\"group\":\"buffs\",\"value\":\"str\",\"exclusive\":false},\"style\":{\"selected\":{\"bg\":\"#f60\",\"bold\":true}}}\x1b\\[STR]\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:b2?config={\"selection\":{\"group\":\"buffs\",\"value\":\"dex\",\"exclusive\":false},\"style\":{\"selected\":{\"bg\":\"#08f\",\"bold\":true}}}\x1b\\[DEX]\x1b]8;;\x1b\\ ";
-    output += "\x1b]8;;send:b3?config={\"selection\":{\"group\":\"buffs\",\"value\":\"int\",\"exclusive\":false},\"style\":{\"selected\":{\"bg\":\"#a0f\",\"bold\":true}}}\x1b\\[INT]\x1b]8;;\x1b\\ (multi-select)\n";
+    output += "\x1b]8;;send:b3?config={\"selection\":{\"group\":\"buffs\",\"value\":\"int\",\"exclusive\":false},\"style\":{\"selected\":{\"bg\":\"#a0f\",\"bold\":true}}}\x1b\\[INT]\x1b]8;;\x1b\\ "
+              "(multi-select)\n";
     output += "Server receives: &selected=true/false in callback\n\n";
 
     // ═══════════════════════════════════════════════════════════════════
@@ -6474,7 +6422,9 @@ void TBuffer::injectOSC8DocumentationExamples()
     output += "\x1b]8;;send:south?config={\"s\":{\"c\":\"#0af\",\"b\":true,\"h\":{\"u\":true}}}\x1b\\South\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:east?config={\"s\":{\"c\":\"#0af\",\"b\":true,\"h\":{\"u\":true}}}\x1b\\East\x1b]8;;\x1b\\ ";
     output += "\x1b]8;;send:west?config={\"s\":{\"c\":\"#0af\",\"b\":true,\"h\":{\"u\":true}}}\x1b\\West\x1b]8;;\x1b\\\n";
-    output += "Item: \x1b]8;;send:sword?config={\"style\":{\"color\":\"#f80\",\"bold\":true,\"hover\":{\"bg\":\"#fc9\",\"color\":\"black\"}},\"menu\":[{\"Equip\":\"send:equip\"},{\"Examine\":\"send:exam\"},\"-\",{\"Drop\":\"send:drop\"}],\"tooltip\":\"+5 Fire Damage\"}\x1b\\🗡️ Flaming Sword\x1b]8;;\x1b\\\n\n";
+    output += "Item: "
+              "\x1b]8;;send:sword?config={\"style\":{\"color\":\"#f80\",\"bold\":true,\"hover\":{\"bg\":\"#fc9\",\"color\":\"black\"}},\"menu\":[{\"Equip\":\"send:equip\"},{\"Examine\":\"send:exam\"}"
+              ",\"-\",{\"Drop\":\"send:drop\"}],\"tooltip\":\"+5 Fire Damage\"}\x1b\\🗡️ Flaming Sword\x1b]8;;\x1b\\\n\n";
 
     output += "───────────────────────────────────────────────────────────────────────\n";
     output += "Docs: https://wiki.mudlet.org/w/Area_51#OSC_8:_Hyperlink_Protocol\n";
@@ -6518,11 +6468,16 @@ Mudlet::HyperlinkStyling::StateStyle Mudlet::HyperlinkStyling::getEffectiveStyle
 
     // Apply :any-link styles (applies to both :link and :visited)
     if (anyLinkStyle.hasCustomStyling) {
-        if (anyLinkStyle.hasForegroundColor) effective.foregroundColor = anyLinkStyle.foregroundColor;
-        if (anyLinkStyle.hasBackgroundColor) effective.backgroundColor = anyLinkStyle.backgroundColor;
-        if (anyLinkStyle.hasUnderlineColor) effective.underlineColor = anyLinkStyle.underlineColor;
-        if (anyLinkStyle.hasOverlineColor) effective.overlineColor = anyLinkStyle.overlineColor;
-        if (anyLinkStyle.hasStrikeoutColor) effective.strikeoutColor = anyLinkStyle.strikeoutColor;
+        if (anyLinkStyle.hasForegroundColor)
+            effective.foregroundColor = anyLinkStyle.foregroundColor;
+        if (anyLinkStyle.hasBackgroundColor)
+            effective.backgroundColor = anyLinkStyle.backgroundColor;
+        if (anyLinkStyle.hasUnderlineColor)
+            effective.underlineColor = anyLinkStyle.underlineColor;
+        if (anyLinkStyle.hasOverlineColor)
+            effective.overlineColor = anyLinkStyle.overlineColor;
+        if (anyLinkStyle.hasStrikeoutColor)
+            effective.strikeoutColor = anyLinkStyle.strikeoutColor;
         effective.isBold = anyLinkStyle.isBold;
         effective.isItalic = anyLinkStyle.isItalic;
         effective.isUnderlined = anyLinkStyle.isUnderlined;
@@ -6536,60 +6491,60 @@ Mudlet::HyperlinkStyling::StateStyle Mudlet::HyperlinkStyling::getEffectiveStyle
     const StateStyle* stateStyle = nullptr;
 
     switch (currentState) {
-        case StateDisabled:
-            if (disabledStyle.hasCustomStyling) {
-                stateStyle = &disabledStyle;
+    case StateDisabled:
+        if (disabledStyle.hasCustomStyling) {
+            stateStyle = &disabledStyle;
 #if defined(DEBUG_OSC_PROCESSING)
-                qDebug() << "[OSC] Using disabled style - hasCustomStyling:" << disabledStyle.hasCustomStyling
-                         << "hasForegroundColor:" << disabledStyle.hasForegroundColor 
-                         << "foregroundColor:" << (disabledStyle.hasForegroundColor ? disabledStyle.foregroundColor.name() : "none")
-                         << "hasBackgroundColor:" << disabledStyle.hasBackgroundColor 
-                         << "backgroundColor:" << (disabledStyle.hasBackgroundColor ? disabledStyle.backgroundColor.name() : "none")
-                         << "isBold:" << disabledStyle.isBold
-                         << "isStrikeOut:" << disabledStyle.isStrikeOut;
+            qDebug() << "[OSC] Using disabled style - hasCustomStyling:" << disabledStyle.hasCustomStyling << "hasForegroundColor:" << disabledStyle.hasForegroundColor
+                     << "foregroundColor:" << (disabledStyle.hasForegroundColor ? disabledStyle.foregroundColor.name() : "none") << "hasBackgroundColor:" << disabledStyle.hasBackgroundColor
+                     << "backgroundColor:" << (disabledStyle.hasBackgroundColor ? disabledStyle.backgroundColor.name() : "none") << "isBold:" << disabledStyle.isBold
+                     << "isStrikeOut:" << disabledStyle.isStrikeOut;
 #endif
-            } else {
+        } else {
 #if defined(DEBUG_OSC_PROCESSING)
-                qDebug() << "[OSC] Disabled style has no custom styling - hasCustomStyling:" << disabledStyle.hasCustomStyling;
+            qDebug() << "[OSC] Disabled style has no custom styling - hasCustomStyling:" << disabledStyle.hasCustomStyling;
 #endif
-            }
-            break;
-        case StateSelected:
-            if (selectedStyle.hasCustomStyling) {
-                stateStyle = &selectedStyle;
+        }
+        break;
+    case StateSelected:
+        if (selectedStyle.hasCustomStyling) {
+            stateStyle = &selectedStyle;
 #if defined(DEBUG_OSC_PROCESSING)
-                qDebug() << "[OSC] Using selected style - hasCustomStyling:" << selectedStyle.hasCustomStyling
-                         << "hasForegroundColor:" << selectedStyle.hasForegroundColor 
-                         << "foregroundColor:" << (selectedStyle.hasForegroundColor ? selectedStyle.foregroundColor.name() : "none")
-                         << "hasBackgroundColor:" << selectedStyle.hasBackgroundColor 
-                         << "backgroundColor:" << (selectedStyle.hasBackgroundColor ? selectedStyle.backgroundColor.name() : "none")
-                         << "isBold:" << selectedStyle.isBold;
+            qDebug() << "[OSC] Using selected style - hasCustomStyling:" << selectedStyle.hasCustomStyling << "hasForegroundColor:" << selectedStyle.hasForegroundColor
+                     << "foregroundColor:" << (selectedStyle.hasForegroundColor ? selectedStyle.foregroundColor.name() : "none") << "hasBackgroundColor:" << selectedStyle.hasBackgroundColor
+                     << "backgroundColor:" << (selectedStyle.hasBackgroundColor ? selectedStyle.backgroundColor.name() : "none") << "isBold:" << selectedStyle.isBold;
 #endif
-            } else {
+        } else {
 #if defined(DEBUG_OSC_PROCESSING)
-                qDebug() << "[OSC] Selected style has no custom styling - hasCustomStyling:" << selectedStyle.hasCustomStyling;
+            qDebug() << "[OSC] Selected style has no custom styling - hasCustomStyling:" << selectedStyle.hasCustomStyling;
 #endif
-            }
-            break;
-        case StateVisited:
-            if (visitedStyle.hasCustomStyling) stateStyle = &visitedStyle;
-            break;
-        case StateHover:
-            if (hoverStyle.hasCustomStyling) stateStyle = &hoverStyle;
-            break;
-        case StateActive:
-            if (activeStyle.hasCustomStyling) stateStyle = &activeStyle;
-            break;
-        case StateFocus:
-            if (focusStyle.hasCustomStyling) stateStyle = &focusStyle;
-            break;
-        case StateFocusVisible:
-            if (focusVisibleStyle.hasCustomStyling) stateStyle = &focusVisibleStyle;
-            break;
-        case StateDefault:
-        default:
-            if (linkStyle.hasCustomStyling) stateStyle = &linkStyle;
-            break;
+        }
+        break;
+    case StateVisited:
+        if (visitedStyle.hasCustomStyling)
+            stateStyle = &visitedStyle;
+        break;
+    case StateHover:
+        if (hoverStyle.hasCustomStyling)
+            stateStyle = &hoverStyle;
+        break;
+    case StateActive:
+        if (activeStyle.hasCustomStyling)
+            stateStyle = &activeStyle;
+        break;
+    case StateFocus:
+        if (focusStyle.hasCustomStyling)
+            stateStyle = &focusStyle;
+        break;
+    case StateFocusVisible:
+        if (focusVisibleStyle.hasCustomStyling)
+            stateStyle = &focusVisibleStyle;
+        break;
+    case StateDefault:
+    default:
+        if (linkStyle.hasCustomStyling)
+            stateStyle = &linkStyle;
+        break;
     }
 
     // Apply the selected state style
@@ -6628,11 +6583,8 @@ Mudlet::HyperlinkStyling::StateStyle Mudlet::HyperlinkStyling::getEffectiveStyle
     // This ensures ANSI base links with only :hover (but no :link) styling get updated.
     if (!effective.hasCustomStyling) {
         // Check if ANY pseudo-class state has custom styling
-        if (linkStyle.hasCustomStyling || visitedStyle.hasCustomStyling ||
-            hoverStyle.hasCustomStyling || activeStyle.hasCustomStyling ||
-            focusStyle.hasCustomStyling || focusVisibleStyle.hasCustomStyling ||
-            anyLinkStyle.hasCustomStyling || selectedStyle.hasCustomStyling ||
-            disabledStyle.hasCustomStyling) {
+        if (linkStyle.hasCustomStyling || visitedStyle.hasCustomStyling || hoverStyle.hasCustomStyling || activeStyle.hasCustomStyling || focusStyle.hasCustomStyling
+            || focusVisibleStyle.hasCustomStyling || anyLinkStyle.hasCustomStyling || selectedStyle.hasCustomStyling || disabledStyle.hasCustomStyling) {
             effective.hasCustomStyling = true;
         }
     }
@@ -6667,14 +6619,30 @@ void TBuffer::setLinkState(int linkIndex, Mudlet::HyperlinkStyling::LinkState st
 #if defined(DEBUG_OSC_PROCESSING)
     QString stateName;
     switch (state) {
-        case Mudlet::HyperlinkStyling::StateDefault: stateName = "Default"; break;
-        case Mudlet::HyperlinkStyling::StateVisited: stateName = "Visited"; break;
-        case Mudlet::HyperlinkStyling::StateHover: stateName = "Hover"; break;
-        case Mudlet::HyperlinkStyling::StateActive: stateName = "Active"; break;
-        case Mudlet::HyperlinkStyling::StateFocus: stateName = "Focus"; break;
-        case Mudlet::HyperlinkStyling::StateFocusVisible: stateName = "FocusVisible"; break;
-        case Mudlet::HyperlinkStyling::StateSelected: stateName = "Selected"; break;
-        case Mudlet::HyperlinkStyling::StateDisabled: stateName = "Disabled"; break;
+    case Mudlet::HyperlinkStyling::StateDefault:
+        stateName = "Default";
+        break;
+    case Mudlet::HyperlinkStyling::StateVisited:
+        stateName = "Visited";
+        break;
+    case Mudlet::HyperlinkStyling::StateHover:
+        stateName = "Hover";
+        break;
+    case Mudlet::HyperlinkStyling::StateActive:
+        stateName = "Active";
+        break;
+    case Mudlet::HyperlinkStyling::StateFocus:
+        stateName = "Focus";
+        break;
+    case Mudlet::HyperlinkStyling::StateFocusVisible:
+        stateName = "FocusVisible";
+        break;
+    case Mudlet::HyperlinkStyling::StateSelected:
+        stateName = "Selected";
+        break;
+    case Mudlet::HyperlinkStyling::StateDisabled:
+        stateName = "Disabled";
+        break;
     }
     qDebug() << "[OSC] Link" << linkIndex << "state changed to:" << stateName;
 #endif
@@ -6707,15 +6675,10 @@ Mudlet::HyperlinkStyling TBuffer::getEffectiveHyperlinkStyling(int linkIndex) co
         auto effective = styling.getEffectiveStyle();
 
 #if defined(DEBUG_OSC_PROCESSING)
-        qDebug() << "[OSC] getEffectiveHyperlinkStyling for link" << linkIndex
-                 << "state:" << styling.currentState
-                 << "isSpoiler:" << styling.isSpoiler
-                 << "base hasBackgroundColor:" << styling.hasBackgroundColor
-                 << "base backgroundColor:" << (styling.hasBackgroundColor ? styling.backgroundColor.name() : "none")
-                 << "effective hasForegroundColor:" << effective.hasForegroundColor 
-                 << "effective foregroundColor:" << (effective.hasForegroundColor ? effective.foregroundColor.name() : "none")
-                 << "effective hasBackgroundColor:" << effective.hasBackgroundColor 
-                 << "effective backgroundColor:" << (effective.hasBackgroundColor ? effective.backgroundColor.name() : "none")
+        qDebug() << "[OSC] getEffectiveHyperlinkStyling for link" << linkIndex << "state:" << styling.currentState << "isSpoiler:" << styling.isSpoiler
+                 << "base hasBackgroundColor:" << styling.hasBackgroundColor << "base backgroundColor:" << (styling.hasBackgroundColor ? styling.backgroundColor.name() : "none")
+                 << "effective hasForegroundColor:" << effective.hasForegroundColor << "effective foregroundColor:" << (effective.hasForegroundColor ? effective.foregroundColor.name() : "none")
+                 << "effective hasBackgroundColor:" << effective.hasBackgroundColor << "effective backgroundColor:" << (effective.hasBackgroundColor ? effective.backgroundColor.name() : "none")
                  << "effective isBold:" << effective.isBold;
 #endif
 
@@ -6750,9 +6713,8 @@ Mudlet::HyperlinkStyling TBuffer::getEffectiveHyperlinkStyling(int linkIndex) co
                 styling.hasBackgroundColor = true;
                 styling.hasCustomStyling = true;
 #if defined(DEBUG_OSC_PROCESSING)
-                qDebug() << "[OSC] SPOILER FIX: Forced spoiler background" << baseStyling.backgroundColor.name() 
-                         << "over effective background" << (effective.hasBackgroundColor ? effective.backgroundColor.name() : "none")
-                         << "for link" << linkIndex;
+                qDebug() << "[OSC] SPOILER FIX: Forced spoiler background" << baseStyling.backgroundColor.name() << "over effective background"
+                         << (effective.hasBackgroundColor ? effective.backgroundColor.name() : "none") << "for link" << linkIndex;
 #endif
             }
         }
@@ -6794,8 +6756,7 @@ void TBuffer::setHoveredLink(int linkIndex)
         auto currentState = getLinkState(linkIndex);
         // Don't override active or disabled states with hover
         // Disabled links should stay disabled and show their disabled styling
-        if (currentState != Mudlet::HyperlinkStyling::StateActive && 
-            currentState != Mudlet::HyperlinkStyling::StateDisabled) {
+        if (currentState != Mudlet::HyperlinkStyling::StateActive && currentState != Mudlet::HyperlinkStyling::StateDisabled) {
             setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateHover);
             updateLinkCharacters(linkIndex); // Update displayed characters
         }
@@ -6809,7 +6770,6 @@ void TBuffer::setActiveLink(int linkIndex)
 
     // Reset previous active link
     if (previousActiveLink > 0 && previousActiveLink != linkIndex) {
-
         // Return to appropriate state based on priority: disabled > hover > selected > visited > default
         Mudlet::HyperlinkStyling linkStyling = getEffectiveHyperlinkStyling(previousActiveLink);
         if (linkStyling.selection.hasSelectionSettings && linkStyling.selection.disabled) {
@@ -6904,7 +6864,7 @@ void TBuffer::revealSpoilerLink(int linkIndex)
     }
 
     QString originalText = mLinkOriginalText[linkIndex];
-    
+
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC] Revealing spoiler link" << linkIndex << "with text:" << originalText;
 #endif
@@ -6914,12 +6874,12 @@ void TBuffer::revealSpoilerLink(int linkIndex)
     }
 
     Mudlet::HyperlinkStyling styling = mLinkStore.getStyling(linkIndex);
-    
+
     if (styling.isSpoiler) {
         QStringList hints = mLinkStore.getHintsConst(linkIndex);
         if (!hints.isEmpty() && hints.first() == QObject::tr("Click to reveal")) {
             mLinkStore.getHints(linkIndex).clear();
-            
+
 #if defined(DEBUG_OSC_PROCESSING)
             qDebug() << "[OSC] Cleared auto-generated 'Click to reveal' tooltip for spoiler link" << linkIndex;
 #endif
@@ -6928,9 +6888,9 @@ void TBuffer::revealSpoilerLink(int linkIndex)
         if (styling.hasBackgroundColor && mLinkOriginalBackgrounds.contains(linkIndex)) {
             QColor originalBackground = mLinkOriginalBackgrounds[linkIndex];
             styling.backgroundColor = originalBackground;
-            
+
             mLinkStore.setStyling(linkIndex, styling);
-            
+
 #if defined(DEBUG_OSC_PROCESSING)
             qDebug() << "[OSC] Restored original background color for spoiler link" << linkIndex;
 #endif
@@ -6943,7 +6903,7 @@ void TBuffer::revealSpoilerLink(int linkIndex)
         auto& line = buffer[lineNum];
         QString lineText = lineBuffer.at(static_cast<int>(lineNum));
         bool lineModified = false;
-        
+
         for (size_t charPos = 0; charPos < line.size(); ++charPos) {
             if (line[charPos].linkIndex() == linkIndex && charIndex < originalText.length()) {
                 // Replace the space character with the original character
@@ -6955,7 +6915,7 @@ void TBuffer::revealSpoilerLink(int linkIndex)
                 charIndex++;
             }
         }
-        
+
         if (lineModified) {
             lineBuffer[static_cast<int>(lineNum)] = lineText;
         }
@@ -6964,7 +6924,7 @@ void TBuffer::revealSpoilerLink(int linkIndex)
     updateLinkCharacters(linkIndex);
 
     mLinkOriginalText.remove(linkIndex);
-    
+
     if (mpConsole) {
         mpConsole->update();
     }
@@ -6974,38 +6934,34 @@ void TBuffer::clearGroupSelection(const QString& group, const QString& exceptVal
 {
     int maxLinkId = mLinkStore.getCurrentLinkID();
     int clearedCount = 0;
-    
+
     for (int linkIndex = 1; linkIndex <= maxLinkId; ++linkIndex) {
         if (!mLinkStore.hasStyling(linkIndex)) {
             continue;
         }
-        
+
         auto styling = mLinkStore.getStyling(linkIndex);
-        if (styling.selection.hasSelectionSettings && 
-            styling.selection.group == group && 
-            styling.selection.value != exceptValue) {
-            
+        if (styling.selection.hasSelectionSettings && styling.selection.group == group && styling.selection.value != exceptValue) {
             if (mpConsole) {
                 mpConsole->getHyperlinkSelectionManager().setSelected(styling.selection.group, styling.selection.value, false);
             }
-            
+
             setLinkSelected(linkIndex, false);
             if (styling.selection.disabled) {
                 setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateDisabled);
             } else {
                 setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateDefault);
             }
-            
+
             updateLinkCharacters(linkIndex);
             clearedCount++;
-            
+
 #if defined(DEBUG_OSC_PROCESSING)
-            qDebug() << "[OSC] clearGroupSelection: Deselected link" << linkIndex 
-                     << "group:" << group << "value:" << styling.selection.value;
+            qDebug() << "[OSC] clearGroupSelection: Deselected link" << linkIndex << "group:" << group << "value:" << styling.selection.value;
 #endif
         }
     }
-    
+
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "[OSC] clearGroupSelection: Cleared" << clearedCount << "links in group" << group;
 #endif
@@ -7054,13 +7010,9 @@ void TBuffer::updateLinkCharacters(int linkIndex)
     Mudlet::HyperlinkStyling effectiveStyling = getEffectiveHyperlinkStyling(linkIndex);
 
 #if defined(DEBUG_OSC_PROCESSING)
-    qDebug() << "[OSC] Link" << linkIndex << "effective styling:"
-             << "hasFg:" << effectiveStyling.hasForegroundColor
-             << "fg:" << (effectiveStyling.hasForegroundColor ? effectiveStyling.foregroundColor.name() : "none")
-             << "hasBg:" << effectiveStyling.hasBackgroundColor
-             << "bold:" << effectiveStyling.isBold
-             << "underline:" << effectiveStyling.isUnderlined
-             << "hasCustom:" << effectiveStyling.hasCustomStyling;
+    qDebug() << "[OSC] Link" << linkIndex << "effective styling:" << "hasFg:" << effectiveStyling.hasForegroundColor
+             << "fg:" << (effectiveStyling.hasForegroundColor ? effectiveStyling.foregroundColor.name() : "none") << "hasBg:" << effectiveStyling.hasBackgroundColor
+             << "bold:" << effectiveStyling.isBold << "underline:" << effectiveStyling.isUnderlined << "hasCustom:" << effectiveStyling.hasCustomStyling;
 #endif
 
     // IMPORTANT: If this link has no custom styling at all (neither base nor pseudo-class),
@@ -7079,8 +7031,8 @@ void TBuffer::updateLinkCharacters(int linkIndex)
     bool useAnsiBase = false;
 
 #if defined(DEBUG_OSC_PROCESSING)
-    qDebug() << "[OSC] Updating link" << linkIndex << "- hasBaseCustomStyling:" << effectiveStyling.hasBaseCustomStyling
-             << "currentState:" << effectiveStyling.currentState << "useAnsiBase:" << useAnsiBase;
+    qDebug() << "[OSC] Updating link" << linkIndex << "- hasBaseCustomStyling:" << effectiveStyling.hasBaseCustomStyling << "currentState:" << effectiveStyling.currentState
+             << "useAnsiBase:" << useAnsiBase;
 #endif
 
     // Debug: Count how many characters we're checking and how many match
@@ -7102,9 +7054,7 @@ void TBuffer::updateLinkCharacters(int linkIndex)
                 matchingCharacters++;
                 static int charUpdateCount = 0;
                 if (charUpdateCount++ < 2) { // Only log first 2 characters to avoid spam
-                    qDebug() << "[OSC] Before update - char with linkIndex" << linkIndex
-                             << "- FgColor:" << tchar.mFgColor.name()
-                             << "hasFg:" << effectiveStyling.hasForegroundColor
+                    qDebug() << "[OSC] Before update - char with linkIndex" << linkIndex << "- FgColor:" << tchar.mFgColor.name() << "hasFg:" << effectiveStyling.hasForegroundColor
                              << "new fg:" << (effectiveStyling.hasForegroundColor ? effectiveStyling.foregroundColor.name() : "none");
                 }
 #endif
@@ -7116,12 +7066,8 @@ void TBuffer::updateLinkCharacters(int linkIndex)
                 if (useAnsiBase && mLinkOriginalCharacters.contains(linkIndex)) {
                     TChar originalChar = mLinkOriginalCharacters.value(linkIndex);
 #if defined(DEBUG_OSC_PROCESSING)
-                    qDebug() << "[OSC] Restoring ANSI base for link" << linkIndex
-                             << "- Original FgColor:" << originalChar.mFgColor.name()
-                             << "Original BgColor:" << originalChar.mBgColor.name()
-                             << "Original Bold:" << bool(originalChar.mFlags & TChar::Bold)
-                             << "Current FgColor:" << tchar.mFgColor.name()
-                             << "Current Bold:" << bool(tchar.mFlags & TChar::Bold);
+                    qDebug() << "[OSC] Restoring ANSI base for link" << linkIndex << "- Original FgColor:" << originalChar.mFgColor.name() << "Original BgColor:" << originalChar.mBgColor.name()
+                             << "Original Bold:" << bool(originalChar.mFlags & TChar::Bold) << "Current FgColor:" << tchar.mFgColor.name() << "Current Bold:" << bool(tchar.mFlags & TChar::Bold);
 #endif
                     // Restore ANSI base - these will be overridden below if styling specifies them
                     tchar.mFgColor = originalChar.mFgColor;
@@ -7146,8 +7092,7 @@ void TBuffer::updateLinkCharacters(int linkIndex)
 #if defined(DEBUG_OSC_PROCESSING)
                     static int fgUpdateCount = 0;
                     if (fgUpdateCount++ < 2) {
-                        qDebug() << "[OSC] Applied FG color to link" << linkIndex
-                                 << "- New FgColor:" << tchar.mFgColor.name();
+                        qDebug() << "[OSC] Applied FG color to link" << linkIndex << "- New FgColor:" << tchar.mFgColor.name();
                     }
 #endif
                 }
@@ -7169,17 +7114,17 @@ void TBuffer::updateLinkCharacters(int linkIndex)
                     tchar.mFlags &= ~(TChar::UnderlineWavy | TChar::UnderlineDotted | TChar::UnderlineDashed);
 
                     switch (effectiveStyling.underlineStyle) {
-                        case Mudlet::HyperlinkStyling::UnderlineWavy:
-                            tchar.mFlags |= TChar::UnderlineWavy;
-                            break;
-                        case Mudlet::HyperlinkStyling::UnderlineDotted:
-                            tchar.mFlags |= TChar::UnderlineDotted;
-                            break;
-                        case Mudlet::HyperlinkStyling::UnderlineDashed:
-                            tchar.mFlags |= TChar::UnderlineDashed;
-                            break;
-                        default:
-                            break;
+                    case Mudlet::HyperlinkStyling::UnderlineWavy:
+                        tchar.mFlags |= TChar::UnderlineWavy;
+                        break;
+                    case Mudlet::HyperlinkStyling::UnderlineDotted:
+                        tchar.mFlags |= TChar::UnderlineDotted;
+                        break;
+                    case Mudlet::HyperlinkStyling::UnderlineDashed:
+                        tchar.mFlags |= TChar::UnderlineDashed;
+                        break;
+                    default:
+                        break;
                     }
                 } else {
                     tchar.mFlags &= ~TChar::Underline;
@@ -7227,9 +7172,7 @@ void TBuffer::updateLinkCharacters(int linkIndex)
 
     // Debug: Report search results
 #if defined(DEBUG_OSC_PROCESSING)
-    qDebug() << "[OSC] Character search completed for link" << linkIndex 
-             << "- Total characters searched:" << totalCharacters
-             << "- Matching characters found:" << matchingCharacters;
+    qDebug() << "[OSC] Character search completed for link" << linkIndex << "- Total characters searched:" << totalCharacters << "- Matching characters found:" << matchingCharacters;
 #endif
 
     // Refresh the display to show the updated character styling

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -70,7 +70,7 @@ TCommandLine::TCommandLine(Host* pHost, const QString& name, CommandLineType typ
         connect(mpPasswordToggleButton, &QToolButton::clicked, this, &TCommandLine::slot_togglePasswordVisibility);
     }
 
-    if (mType & (MainCommandLine|ConsoleCommandLine)) {
+    if (mType & (MainCommandLine | ConsoleCommandLine)) {
         // put an outline around the command line when it is integrated into
         // bottom of a TConsole - so that it can be visually separated from
         // the text output area - particulary when "dark" mode is in effect
@@ -181,12 +181,12 @@ bool TCommandLine::event(QEvent* event)
             return false;
         }
 
-        if (ke->matches(QKeySequence::Copy)){ // Copy is Ctrl+C and possibly Ctrl+Ins, F16
+        if (ke->matches(QKeySequence::Copy)) { // Copy is Ctrl+C and possibly Ctrl+Ins, F16
             // Check for console selections in both upper and lower panes
             // Prioritize console selection over command line text
             const bool hasUpperPaneSelection = !mpConsole->mUpperPane->mSelectedRegion.isEmpty();
             const bool hasLowerPaneSelection = !mpConsole->mLowerPane->mSelectedRegion.isEmpty();
-            
+
             if (hasUpperPaneSelection) {
                 // Copy from upper pane if it has a selection
                 mpConsole->mUpperPane->slot_copySelectionToClipboard();
@@ -201,8 +201,8 @@ bool TCommandLine::event(QEvent* event)
             // If no console selection, fall through to default command line copy behavior
         }
 
-        if (ke->matches(QKeySequence::Find)){ // Find is Ctrl+F
-            if (keybindingMatched(ke)) { // If user has set up a keybind then do that instead.
+        if (ke->matches(QKeySequence::Find)) { // Find is Ctrl+F
+            if (keybindingMatched(ke)) {       // If user has set up a keybind then do that instead.
                 return true;
             }
 
@@ -221,8 +221,7 @@ bool TCommandLine::event(QEvent* event)
         }
 
         // Shortcut for keypad keys
-        if ((ke->modifiers() & Qt::KeypadModifier) &&
-            mpKeyUnit->processDataStream(static_cast<Qt::Key>(ke->key()), static_cast<Qt::KeyboardModifiers>(ke->modifiers()))) {
+        if ((ke->modifiers() & Qt::KeypadModifier) && mpKeyUnit->processDataStream(static_cast<Qt::Key>(ke->key()), static_cast<Qt::KeyboardModifiers>(ke->modifiers()))) {
             ke->accept();
             return true;
         }
@@ -261,7 +260,7 @@ bool TCommandLine::event(QEvent* event)
                 return true;
             }
 
-            if ((ke->modifiers() & (allModifiers & ~(Qt::ShiftModifier))) ==  Qt::NoModifier) {
+            if ((ke->modifiers() & (allModifiers & ~(Qt::ShiftModifier))) == Qt::NoModifier) {
                 // Process as plain <BACKTAB> - (ignoring implicit <SHIFT>)
                 handleTabCompletion(false);
                 adjustHeight();
@@ -277,8 +276,8 @@ bool TCommandLine::event(QEvent* event)
             break;
 
         case Qt::Key_Tab:
-            if ((mpHost->mCaretShortcut == Host::CaretShortcut::Tab && !(ke->modifiers() & Qt::ControlModifier)) ||
-                (mpHost->mCaretShortcut == Host::CaretShortcut::CtrlTab && (ke->modifiers() & Qt::ControlModifier))) {
+            if ((mpHost->mCaretShortcut == Host::CaretShortcut::Tab && !(ke->modifiers() & Qt::ControlModifier))
+                || (mpHost->mCaretShortcut == Host::CaretShortcut::CtrlTab && (ke->modifiers() & Qt::ControlModifier))) {
                 mpHost->setCaretEnabled(true);
                 ke->accept();
                 return true;
@@ -325,7 +324,7 @@ bool TCommandLine::event(QEvent* event)
             break;
 
         case Qt::Key_Backspace:
-            if ((ke->modifiers() & (allModifiers & ~(Qt::ControlModifier|Qt::ShiftModifier))) == Qt::NoModifier) {
+            if ((ke->modifiers() & (allModifiers & ~(Qt::ControlModifier | Qt::ShiftModifier))) == Qt::NoModifier) {
                 // Ignore state of <CTRL> and <SHIFT> keys
                 mHistoryBuffer = 0;
 
@@ -382,7 +381,6 @@ bool TCommandLine::event(QEvent* event)
                 mpConsole->clearSplit();
                 ke->accept();
                 return true;
-
             }
 
             if ((ke->modifiers() & allModifiers) == Qt::ShiftModifier) {
@@ -390,7 +388,6 @@ bool TCommandLine::event(QEvent* event)
                 ke->accept();
                 adjustHeight();
                 return true;
-
             }
 
             if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
@@ -428,7 +425,7 @@ bool TCommandLine::event(QEvent* event)
 
         case Qt::Key_Down:
 #if defined(Q_OS_MACOS)
-            if ((ke->modifiers() & allModifiers) == (Qt::ControlModifier|Qt::KeypadModifier)) {
+            if ((ke->modifiers() & allModifiers) == (Qt::ControlModifier | Qt::KeypadModifier)) {
 #else
             if ((ke->modifiers() & allModifiers) == Qt::ControlModifier) {
 #endif
@@ -461,7 +458,7 @@ bool TCommandLine::event(QEvent* event)
 
         case Qt::Key_Up:
 #if defined(Q_OS_MACOS)
-            if ((ke->modifiers() & allModifiers) == (Qt::ControlModifier|Qt::KeypadModifier)) {
+            if ((ke->modifiers() & allModifiers) == (Qt::ControlModifier | Qt::KeypadModifier)) {
 #else
             if ((ke->modifiers() & allModifiers) == Qt::ControlModifier) {
 #endif
@@ -482,7 +479,6 @@ bool TCommandLine::event(QEvent* event)
                 historyMove(MOVE_UP);
                 ke->accept();
                 return true;
-
             }
 
             if (keybindingMatched(ke)) {
@@ -515,7 +511,9 @@ bool TCommandLine::event(QEvent* event)
         case Qt::Key_PageUp:
             if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
                 mpConsole->scrollUp(0);
-                QTimer::singleShot(0, this, [this]() {  mpConsole->scrollUp(mpConsole->mUpperPane->getScreenHeight()); });
+                QTimer::singleShot(0, this, [this]() {
+                    mpConsole->scrollUp(mpConsole->mUpperPane->getScreenHeight());
+                });
                 ke->accept();
                 return true;
             }
@@ -531,7 +529,6 @@ bool TCommandLine::event(QEvent* event)
                 mpConsole->scrollDown(mpConsole->mUpperPane->getScreenHeight());
                 ke->accept();
                 return true;
-
             }
             if (keybindingMatched(ke)) {
                 // Process as a possible key binding if there are ANY modifiers,
@@ -1006,7 +1003,7 @@ void TCommandLine::enterCommand(QKeyEvent* event)
             mpHost->send(command);
         }
         // send command to your MiniConsole
-        if (mType == ConsoleCommandLine && !mActionFunction && mpHost->mCommandEchoMode != Host::CommandEchoMode::Never){
+        if (mType == ConsoleCommandLine && !mActionFunction && mpHost->mCommandEchoMode != Host::CommandEchoMode::Never) {
             // This usage of commandList modifies the content!!!
             mpConsole->printCommand(command);
         }
@@ -1029,14 +1026,14 @@ void TCommandLine::enterCommand(QKeyEvent* event)
     }
 
     if (mpHost->mAutoClearCommandLineAfterSend) {
-#if defined (Q_OS_MACOS)
+#if defined(Q_OS_MACOS)
         // clearing the input line on macOS 11.6 makes VoiceOver announce the removed text,
         // essentially re-announcing everything we've typed. This workaround fixes this behaviour
         // and does not seem to negatively affect other platforms
         hide();
 #endif
         clear();
-#if defined (Q_OS_MACOS)
+#if defined(Q_OS_MACOS)
         show();
 #endif
     } else {
@@ -1074,7 +1071,9 @@ void TCommandLine::handleTabCompletion(bool direction)
     buffer.replace(QChar::LineFeed, QChar::Space);
 
     QStringList wordList = buffer.split(QRegularExpression(qsl(R"(\b)"), QRegularExpression::UseUnicodePropertiesOption), Qt::SkipEmptyParts);
-    wordList.append(commandLineSuggestions.values()); // hindsight 20/20 I do not need to split this to a separate table, a check to not append buffer to this table and only append suggested list does same thing for far less overhead.
+    wordList.append(
+            commandLineSuggestions
+                    .values()); // hindsight 20/20 I do not need to split this to a separate table, a check to not append buffer to this table and only append suggested list does same thing for far less overhead.
     const QStringList blacklist = tabCompleteBlacklist.values();
     QStringList toDelete;
 
@@ -1112,7 +1111,8 @@ void TCommandLine::handleTabCompletion(bool direction)
             return;
         }
         int offset = 0;
-        forever {
+        forever
+        {
             const QString tmp = filterList.back();
             filterList.removeAll(tmp);
             filterList.insert(offset, tmp);
@@ -1396,7 +1396,8 @@ void TCommandLine::clearMarksOnWholeLine()
     setTextCursor(oldCursor);
 }
 
-void TCommandLine::setAction(const int func){
+void TCommandLine::setAction(const int func)
+{
     releaseFunc(mActionFunction, func);
     mActionFunction = func;
 }
@@ -1472,7 +1473,8 @@ void TCommandLine::slot_adjustAccessibleNames()
             kept as short as possible.
             */
             setAccessibleDescription(tr("Type in text to send to the game server for the \"%1\" profile, or enter an alias "
-                                        "to run commands locally.").arg(hostName));
+                                        "to run commands locally.")
+                                             .arg(hostName));
         } else {
             /*:
             Accessibility-friendly name to describe the main command line for a
@@ -1497,15 +1499,15 @@ void TCommandLine::slot_adjustAccessibleNames()
             the command line name, %2 is the name of the window/console that
             it is on and %3 is the name of the profile.
             */
-            setAccessibleName(tr("Additional input line \"%1\" on \"%2\" window of \"%3\"profile.")
-                                      .arg(mCommandLineName, mpConsole->mConsoleName, hostName));
+            setAccessibleName(tr("Additional input line \"%1\" on \"%2\" window of \"%3\"profile.").arg(mCommandLineName, mpConsole->mConsoleName, hostName));
             /*:
             Accessibility-friendly description for an extra command line on top of a
             console/window when more than one profile is loaded, %1 is the profile
             name.
             */
             setAccessibleDescription(tr("Type in text to send to the game server for the \"%1\" profile, or enter an alias "
-                                        "to run commands locally.").arg(hostName));
+                                        "to run commands locally.")
+                                             .arg(hostName));
         } else {
             /*:
             Accessibility-friendly name to describe an extra command line on
@@ -1513,8 +1515,7 @@ void TCommandLine::slot_adjustAccessibleNames()
             command line name and %2 is the name of the window/console that
             it is on.
             */
-            setAccessibleName(tr("Additional input line \"%1\" on \"%2\" window.")
-                                      .arg(mCommandLineName, mpConsole->mConsoleName));
+            setAccessibleName(tr("Additional input line \"%1\" on \"%2\" window.").arg(mCommandLineName, mpConsole->mConsoleName));
             /*:
             Accessibility-friendly description for an extra command line on
             top of a console/window when only one profile is loaded.
@@ -1539,15 +1540,15 @@ void TCommandLine::slot_adjustAccessibleNames()
             loaded, %1 is the profile name.
             */
             setAccessibleDescription(tr("Type in text to send to the game server for the \"%1\" profile, or enter an alias "
-                                        "to run commands locally.").arg(hostName));
+                                        "to run commands locally.")
+                                             .arg(hostName));
         } else {
             /*:
             Accessibility-friendly name to describe the built-in command line
             of a console/window other than the main one, when only one
             profile is loaded, %1 is the name of the window/console.
             */
-            setAccessibleName(tr("Input line of \"%1\" window.")
-                                      .arg(mCommandLineName));
+            setAccessibleName(tr("Input line of \"%1\" window.").arg(mCommandLineName));
             /*:
             Accessibility-friendly description for the built-in command line of a
             console/window other than the main window's one when only one profile is
@@ -1596,8 +1597,7 @@ void TCommandLine::restoreHistory()
 
         // else failed to open the file despite it existing
         if (historyFile.error() != QFileDevice::NoError) {
-            qWarning() << "TCommandLine::restoreHistory() ERROR - unable to open command history for the command line called: "
-                       << mCommandLineName << " of type: " << mType
+            qWarning() << "TCommandLine::restoreHistory() ERROR - unable to open command history for the command line called: " << mCommandLineName << " of type: " << mType
                        << " reason: " << historyFile.errorString();
             return;
         }
@@ -1605,10 +1605,8 @@ void TCommandLine::restoreHistory()
     // else no such file - which will be the case for the first time the
     // command line is created - so it might not be an error:
     if (mCommandLineName != qsl("main")) {
-        qDebug() << "TCommandLine::restoreHistory() ALERT - unable to open command history for the command line called: "
-                << mCommandLineName << " of type: " << mType
-                << " because the file: " << mBackingFileName
-                << " does not exist in the profile's home directory, unless this is a new command line then this is an unexpected error.";
+        qDebug() << "TCommandLine::restoreHistory() ALERT - unable to open command history for the command line called: " << mCommandLineName << " of type: " << mType
+                 << " because the file: " << mBackingFileName << " does not exist in the profile's home directory, unless this is a new command line then this is an unexpected error.";
     }
 }
 
@@ -1639,8 +1637,8 @@ void TCommandLine::slot_saveHistory()
         // unsent text in the command line?
         ofs << mHistoryList.mid(0, saveSize + 1).join(QChar::LineFeed);
         if (!historyFile.commit()) {
-            qDebug().nospace().noquote() << "TCommandLine::slot_saveHistory() ERROR - unable to save command history for the command line called: " << mCommandLineName
-                                         << " of type: " << mType << " reason: " << historyFile.errorString();
+            qDebug().nospace().noquote() << "TCommandLine::slot_saveHistory() ERROR - unable to save command history for the command line called: " << mCommandLineName << " of type: " << mType
+                                         << " reason: " << historyFile.errorString();
         }
     }
 }
@@ -1694,8 +1692,8 @@ void TCommandLine::setEchoSuppression(bool suppress)
         // 4. Command line is empty - simple case, just start password mode
 
         const QString currentText = toPlainText();
-        QString textToRestoreAfterPassword;  // Command text to restore after password entry
-        QString partialPasswordToKeep;       // Password chars user typed before suppression activated
+        QString textToRestoreAfterPassword; // Command text to restore after password entry
+        QString partialPasswordToKeep;      // Password chars user typed before suppression activated
 
         // Analyze what the user currently has in the command line
         if (!currentText.isEmpty()) {
@@ -1748,7 +1746,7 @@ void TCommandLine::setEchoSuppression(bool suppress)
         // Store the command text for later restoration (empty if none to restore)
         mTextToRestoreAfterEchoSuppression = textToRestoreAfterPassword;
         mUserTypedDuringEchoSuppression = false; // Reset typing tracking
-        clear();  // Clear command line for password input
+        clear();                                 // Clear command line for password input
 
         // Show password toggle button and reset visibility state
         if (mpPasswordToggleButton) {
@@ -1762,7 +1760,7 @@ void TCommandLine::setEchoSuppression(bool suppress)
         if (!partialPasswordToKeep.isEmpty()) {
             setPlainText(partialPasswordToKeep);
             QTextCursor cursor = textCursor();
-            cursor.movePosition(QTextCursor::End);  // Position cursor for continued typing
+            cursor.movePosition(QTextCursor::End); // Position cursor for continued typing
             setTextCursor(cursor);
         }
     } else {
@@ -1770,7 +1768,7 @@ void TCommandLine::setEchoSuppression(bool suppress)
         // Password entry is complete, restore the command line to its previous state
         // This handles the transition from hidden password input back to normal command entry
 
-        clear();  // Clear the password field first for security
+        clear(); // Clear the password field first for security
 
         // Hide password toggle button
         if (mpPasswordToggleButton) {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -89,7 +89,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     mpHyperlinkCompactManager = std::make_unique<THyperlinkCompactManager>();
     mpHyperlinkSelectionManager = std::make_unique<THyperlinkSelectionManager>(*this);
     mpHyperlinkVisibilityManager = std::make_unique<THyperlinkVisibilityManager>(this);
-    
+
     initializeOSC8StyleFeature();
     initializeOSC8MenuFeature();
     initializeOSC8TooltipFeature();
@@ -233,23 +233,20 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
         // zero-timer at the end of this constructor
 
         // Connect user input trigger (command submission only, not typing)
-        connect(mpCommandLine, &TCommandLine::commandSubmitted,
-                mpHyperlinkVisibilityManager.get(), &THyperlinkVisibilityManager::onUserInput);
-        
+        connect(mpCommandLine, &TCommandLine::commandSubmitted, mpHyperlinkVisibilityManager.get(), &THyperlinkVisibilityManager::onUserInput);
+
         // Connect GA/EOR prompt signal from telnet
-        connect(&(pH->mTelnet), &cTelnet::signal_promptReceived,
-                mpHyperlinkVisibilityManager.get(), &THyperlinkVisibilityManager::onPromptReceived);
-        
+        connect(&(pH->mTelnet), &cTelnet::signal_promptReceived, mpHyperlinkVisibilityManager.get(), &THyperlinkVisibilityManager::onPromptReceived);
+
         // Refresh display when hyperlink visibility changes
-        connect(mpHyperlinkVisibilityManager.get(), &THyperlinkVisibilityManager::visibilityChanged,
-                this, [this]() {
-                    if (mUpperPane) {
-                        mUpperPane->forceUpdate();
-                    }
-                    if (mLowerPane) {
-                        mLowerPane->forceUpdate();
-                    }
-                });
+        connect(mpHyperlinkVisibilityManager.get(), &THyperlinkVisibilityManager::visibilityChanged, this, [this]() {
+            if (mUpperPane) {
+                mUpperPane->forceUpdate();
+            }
+            if (mLowerPane) {
+                mLowerPane->forceUpdate();
+            }
+        });
     }
 
     layer = new QWidget(mpMainDisplay);
@@ -295,7 +292,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
         setFocusProxy(mpCommandLine);
         mUpperPane->setFocusProxy(mpCommandLine);
         mLowerPane->setFocusProxy(mpCommandLine);
-    } else if (mType & (UserWindow|SubConsole)) {
+    } else if (mType & (UserWindow | SubConsole)) {
         // These will need to be changed when the built in TCommandLine is
         // enabled or an additional one is added to them:
         setFocusProxy(mpHost->mpConsole->mpCommandLine);
@@ -421,21 +418,17 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
         The first argument 'N' represents the 'N'etwork latency; the second 'S' the
         'S'ystem (processing) time
         */
-        const QString dummyTextA = tr("N:%1 S:%2")
-                                     .arg(0.0, 0, 'f', 3)
-                                     .arg(0.0, 0, 'f', 3);
+        const QString dummyTextA = tr("N:%1 S:%2").arg(0.0, 0, 'f', 3).arg(0.0, 0, 'f', 3);
         /*:
         The argument 'S' represents the 'S'ystem (processing) time, in this situation
         the Game Server is not sending "GoAhead" signals so we cannot deduce the
         network latency...
         */
-        const QString dummyTextB = tr("<no GA> S:%1")
-                                     .arg(0.0, 0, 'f', 3);
+        const QString dummyTextB = tr("<no GA> S:%1").arg(0.0, 0, 'f', 3);
         do {
             latencyFont.setPointSize(--latencyFontPointSize);
         } while (latencyFontPointSize > 6
-                 && qMax(QFontMetrics(latencyFont).boundingRect(dummyTextA).width(),
-                         QFontMetrics(latencyFont).boundingRect(dummyTextB).width()) + latencyFontSizeMargin
+                 && qMax(QFontMetrics(latencyFont).boundingRect(dummyTextA).width(), QFontMetrics(latencyFont).boundingRect(dummyTextB).width()) + latencyFontSizeMargin
                             > mpLineEdit_networkLatency->maximumWidth());
 
         mpLineEdit_networkLatency->setFont(latencyFont);
@@ -459,7 +452,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
 
     mpBufferSearchBox->setClearButtonEnabled(true);
     for (auto child : mpBufferSearchBox->children()) {
-        auto *pAction_clear(qobject_cast<QAction *>(child));
+        auto* pAction_clear(qobject_cast<QAction*>(child));
         if (pAction_clear && pAction_clear->objectName() == QLatin1String("_q_qlineeditclearaction")) {
             connect(pAction_clear, &QAction::triggered, this, &TConsole::slot_clearSearchResults, Qt::QueuedConnection);
             break;
@@ -575,7 +568,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
         mHScrollBarEnabled = true;
     }
 
-    if (mType & (ErrorConsole|SubConsole|UserWindow)) {
+    if (mType & (ErrorConsole | SubConsole | UserWindow)) {
         mpScrollBar->hide();
         mLowerPane->hide();
         layerCommandLine->hide();
@@ -605,7 +598,6 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
 
     // error and debug consoles inherit font of the main console
     if (mType & (ErrorConsole | CentralDebugConsole)) {
-
         // They always use "Control Pictures" to show control characters:
         mControlCharacter = ControlCharacterMode::Picture;
         refreshView();
@@ -664,7 +656,7 @@ void TConsole::raiseMudletSysWindowResizeEvent(const int overallWidth, const int
     if (mpHost.isNull()) {
         return;
     }
-    TEvent mudletEvent {};
+    TEvent mudletEvent{};
     mudletEvent.mArgumentList.append(QLatin1String("sysWindowResizeEvent"));
     mudletEvent.mArgumentList.append(QString::number(overallWidth - mBorders.left() - mBorders.right()));
     mudletEvent.mArgumentList.append(QString::number(overallHeight - mBorders.top() - mBorders.bottom() - mpCommandLine->height()));
@@ -699,24 +691,23 @@ void TConsole::resizeEvent(QResizeEvent* event)
         layoutLayer2->activate();
     }
 
-    if (mType & (MainConsole|SubConsole|UserWindow) && mpCommandLine && !mpCommandLine->isHidden()) {
+    if (mType & (MainConsole | SubConsole | UserWindow) && mpCommandLine && !mpCommandLine->isHidden()) {
         mpMainFrame->resize(x, y);
         mpBaseVFrame->resize(x, y);
         mpBaseHFrame->resize(x, y);
         x -= (mpLeftToolBar->width() + mpRightToolBar->width());
         y -= mpTopToolBar->height();
         // The mBorders components will be all zeros for all but the MainConsole:
-        mpMainDisplay->resize(x - mBorders.left() - mBorders.right(),
-                              y - mBorders.top() - mBorders.bottom() - mpCommandLine->height());
+        mpMainDisplay->resize(x - mBorders.left() - mBorders.right(), y - mBorders.top() - mBorders.bottom() - mpCommandLine->height());
     } else {
         mpMainFrame->resize(x, y);
         mpMainDisplay->resize(x, y);
     }
     mpMainDisplay->move(mBorders.left(), mBorders.top());
 
-    if (mType & (CentralDebugConsole|ErrorConsole)) {
+    if (mType & (CentralDebugConsole | ErrorConsole)) {
         layerCommandLine->hide();
-    } else if (mType & ~(SubConsole|UserWindow)) {
+    } else if (mType & ~(SubConsole | UserWindow)) {
         // does nothing for SubConsole or UserWindows
         layerCommandLine->move(0, mpBaseVFrame->height() - layerCommandLine->height());
     }
@@ -740,14 +731,14 @@ void TConsole::resizeEvent(QResizeEvent* event)
             raiseMudletSysWindowResizeEvent(x, y);
         }
     }
-//create the sysUserWindowResize Event for automatic resizing with Geyser
+    //create the sysUserWindowResize Event for automatic resizing with Geyser
     if (mType & (UserWindow) && !mpHost.isNull()) {
         TLuaInterpreter* pLua = mpHost->getLuaInterpreter();
         const QString func = "handleWindowResizeEvent";
         const QString n = "WindowResizeEvent";
         pLua->call(func, n);
 
-        TEvent mudletEvent {};
+        TEvent mudletEvent{};
         mudletEvent.mArgumentList.append(QLatin1String("sysUserWindowResizeEvent"));
         mudletEvent.mArgumentList.append(QString::number(x));
         mudletEvent.mArgumentList.append(QString::number(y));
@@ -835,7 +826,7 @@ void TConsole::closeEvent(QCloseEvent* event)
         return;
     }
 
-    if (mType & (SubConsole|Buffer)) {
+    if (mType & (SubConsole | Buffer)) {
         if (mudlet::self()->isGoingDown() || mpHost->isClosingDown()) {
             auto pC = mpHost->mpConsole->mSubConsoleMap.take(mConsoleName);
             if (pC) {
@@ -902,7 +893,7 @@ int TConsole::getButtonState()
 // generated for Lua user control by the Lua subsystem.
 void TConsole::slot_toggleLogging()
 {
-    if (mType & (CentralDebugConsole|ErrorConsole|SubConsole|UserWindow)) {
+    if (mType & (CentralDebugConsole | ErrorConsole | SubConsole | UserWindow)) {
         return;
         // We don't support logging anything other than main console (at present?)
     }
@@ -964,7 +955,7 @@ void TConsole::changeColors()
 {
     if (mType == CentralDebugConsole) {
         // No-op now?
-    } else if (mType & (ErrorConsole|SubConsole|UserWindow|Buffer)) {
+    } else if (mType & (ErrorConsole | SubConsole | UserWindow | Buffer)) {
         if (!mBgImageMode) {
             auto styleSheet = qsl("QWidget#MainDisplay{background-color: rgba(%1);}").arg(getColorCode(mBgColor));
             mpMainDisplay->setStyleSheet(styleSheet);
@@ -1013,7 +1004,7 @@ void TConsole::changeColors()
     }
 
     buffer.updateColors();
-    if (mType & (MainConsole|Buffer)) {
+    if (mType & (MainConsole | Buffer)) {
         buffer.mWrapAt = mpHost->mWrapAt;
         buffer.mWrapIndent = mpHost->mWrapIndentCount;
         buffer.mWrapHangingIndent = mpHost->mWrapHangingIndentCount;
@@ -1090,13 +1081,12 @@ void TConsole::setConsoleBgColor(int r, int g, int b, int a)
 
 void TConsole::scrollDown(int lines)
 {
-    if ((mType & (UserWindow|SubConsole)) && !mScrollingEnabled) {
+    if ((mType & (UserWindow | SubConsole)) && !mScrollingEnabled) {
         return;
     }
 
     mUpperPane->scrollDown(lines);
-    if (!mUpperPane->mIsTailMode &&
-        (mUpperPane->imageTopLine() + mUpperPane->getScreenHeight() >= buffer.lineBuffer.size() - mLowerPane->getRowCount())) {
+    if (!mUpperPane->mIsTailMode && (mUpperPane->imageTopLine() + mUpperPane->getScreenHeight() >= buffer.lineBuffer.size() - mLowerPane->getRowCount())) {
         mUpperPane->scrollDown(mLowerPane->getRowCount() + 100); // Gets to the bottom
         mUpperPane->scrollDown(100);                             // needs another scroll to force mIsTailMode
     }
@@ -1113,7 +1103,7 @@ void TConsole::scrollDown(int lines)
 
 void TConsole::scrollUp(int lines)
 {
-    if ((mType & (UserWindow|SubConsole)) && !mScrollingEnabled) {
+    if ((mType & (UserWindow | SubConsole)) && !mScrollingEnabled) {
         return;
     }
 
@@ -1124,7 +1114,9 @@ void TConsole::scrollUp(int lines)
     mLowerPane->forceUpdate();
 
     if (lowerAppears) {
-        QTimer::singleShot(0, this, [this, lines]() {  mUpperPane->scrollUp(mLowerPane->getRowCount() + lines); });
+        QTimer::singleShot(0, this, [this, lines]() {
+            mUpperPane->scrollUp(mLowerPane->getRowCount() + lines);
+        });
         if (mudlet::self()->showSplitscreenTutorial()) {
 #if defined(Q_OS_MACOS)
             const QString infoMsg = tr("[ INFO ]  - Split-screen scrollback activated. Press <⌘>+<ENTER> to cancel.");
@@ -1148,7 +1140,7 @@ void TConsole::deselect()
 
 void TConsole::showEvent(QShowEvent* event)
 {
-    if (mType & (MainConsole|Buffer)) {
+    if (mType & (MainConsole | Buffer)) {
         if (mpHost) {
             mAlertOnNewData = false;
         }
@@ -1158,7 +1150,7 @@ void TConsole::showEvent(QShowEvent* event)
 
 void TConsole::hideEvent(QHideEvent* event)
 {
-    if (mType & (MainConsole|Buffer)) {
+    if (mType & (MainConsole | Buffer)) {
         if (mpHost) {
             if (mudlet::self()->mWindowMinimized) {
                 if (mpHost->mAlertOnNewData) {
@@ -1266,7 +1258,6 @@ void TConsole::insertText(const QString& text, QPoint P)
                 mUpperPane->needUpdate(y_tmp, y_tmp + 1);
             }
         }
-
     }
 }
 
@@ -1565,7 +1556,7 @@ void TConsole::raiseFontChangeEvent()
     if (!mpHost) {
         return;
     }
-    if (!(mType & (MainConsole|UserWindow|SubConsole))) {
+    if (!(mType & (MainConsole | UserWindow | SubConsole))) {
         return;
     }
 
@@ -1588,7 +1579,7 @@ void TConsole::setFont(const QFont& newFont, const bool forceChange)
         mDisplayFontDetails = newFontDetails;
         QWidget::setFont(newFont);
         // Update associated TCommandLine's:
-        if (mType & (MainConsole|SubConsole|UserWindow)) {
+        if (mType & (MainConsole | SubConsole | UserWindow)) {
             if (mpHost->mpConsole) {
                 for (auto& commandLine : mpHost->mpConsole->mSubCommandLineMap) {
                     auto pConsole = commandLine->console();
@@ -1654,7 +1645,7 @@ int TConsole::select(const QString& text, int numOfMatch)
     if (mudlet::smDebugMode) {
         TDebug(Qt::darkMagenta, Qt::black) << "line under current user cursor: " >> mpHost;
         TDebug(Qt::red, Qt::black) << TDebug::csmContinue << mUserCursor.y() << "#:" >> mpHost;
-        TDebug(Qt::gray, Qt::black) << TDebug::csmContinue << buffer.line(mUserCursor.y()) << "\n" >>  mpHost;
+        TDebug(Qt::gray, Qt::black) << TDebug::csmContinue << buffer.line(mUserCursor.y()) << "\n" >> mpHost;
     }
 
     int begin = -1;
@@ -1681,7 +1672,7 @@ int TConsole::select(const QString& text, int numOfMatch)
 
     if (mudlet::smDebugMode) {
         TDebug(Qt::darkRed, Qt::black) << "P_begin(" << P_begin.x() << "/" << P_begin.y() << "), P_end(" << P_end.x() << "/" << P_end.y()
-                                                       << ") selectedText = " << buffer.line(mUserCursor.y()).mid(P_begin.x(), P_end.x() - P_begin.x()) << "\n"
+                                       << ") selectedText = " << buffer.line(mUserCursor.y()).mid(P_begin.x(), P_end.x() - P_begin.x()) << "\n"
                 >> mpHost;
     }
     return begin;
@@ -1830,7 +1821,7 @@ void TConsole::printCommand(QString& msg)
         msg.append(QChar::LineFeed);
         const int lineBeforeNewContent = buffer.getLastLineNumber();
         if (lineBeforeNewContent >= 0 && !buffer.lineBuffer.back().isEmpty()) {
-                msg.prepend(QChar::LineFeed);
+            msg.prepend(QChar::LineFeed);
         }
         buffer.appendLine(msg, 0, msg.size() - 1, mCommandFgColor, mCommandBgColor);
     } else {
@@ -2031,7 +2022,6 @@ void TConsole::slot_searchBufferUp()
         } while (searchX > -1);
 
         if (found) {
-
             // Scroll to show the match
             scrollUp(buffer.mCursorY - searchY - 3);
             mUpperPane->forceUpdate();
@@ -2075,7 +2065,6 @@ void TConsole::slot_searchBufferDown()
         } while (searchX > -1);
 
         if (found) {
-
             // Scroll to show the match
             scrollUp(buffer.mCursorY - searchY - 3);
             mUpperPane->forceUpdate();
@@ -2193,34 +2182,89 @@ void TConsole::raiseMudletMousePressOrReleaseEvent(QMouseEvent* event, const boo
     TEvent mudletEvent{};
     mudletEvent.mArgumentList.append(isPressEvent ? qsl("sysWindowMousePressEvent") : qsl("sysWindowMouseReleaseEvent"));
     switch (event->button()) {
-    case Qt::LeftButton:    mudletEvent.mArgumentList.append(QString::number(1));   break;
-    case Qt::RightButton:   mudletEvent.mArgumentList.append(QString::number(2));   break;
-    case Qt::MiddleButton:  mudletEvent.mArgumentList.append(QString::number(3));   break;
-    case Qt::BackButton:    mudletEvent.mArgumentList.append(QString::number(4));   break;
-    case Qt::ForwardButton: mudletEvent.mArgumentList.append(QString::number(5));   break;
-    case Qt::TaskButton:    mudletEvent.mArgumentList.append(QString::number(6));   break;
-    case Qt::ExtraButton4:  mudletEvent.mArgumentList.append(QString::number(7));   break;
-    case Qt::ExtraButton5:  mudletEvent.mArgumentList.append(QString::number(8));   break;
-    case Qt::ExtraButton6:  mudletEvent.mArgumentList.append(QString::number(9));   break;
-    case Qt::ExtraButton7:  mudletEvent.mArgumentList.append(QString::number(10));  break;
-    case Qt::ExtraButton8:  mudletEvent.mArgumentList.append(QString::number(11));  break;
-    case Qt::ExtraButton9:  mudletEvent.mArgumentList.append(QString::number(12));  break;
-    case Qt::ExtraButton10: mudletEvent.mArgumentList.append(QString::number(13));  break;
-    case Qt::ExtraButton11: mudletEvent.mArgumentList.append(QString::number(14));  break;
-    case Qt::ExtraButton12: mudletEvent.mArgumentList.append(QString::number(15));  break;
-    case Qt::ExtraButton13: mudletEvent.mArgumentList.append(QString::number(16));  break;
-    case Qt::ExtraButton14: mudletEvent.mArgumentList.append(QString::number(17));  break;
-    case Qt::ExtraButton15: mudletEvent.mArgumentList.append(QString::number(18));  break;
-    case Qt::ExtraButton16: mudletEvent.mArgumentList.append(QString::number(19));  break;
-    case Qt::ExtraButton17: mudletEvent.mArgumentList.append(QString::number(20));  break;
-    case Qt::ExtraButton18: mudletEvent.mArgumentList.append(QString::number(21));  break;
-    case Qt::ExtraButton19: mudletEvent.mArgumentList.append(QString::number(22));  break;
-    case Qt::ExtraButton20: mudletEvent.mArgumentList.append(QString::number(23));  break;
-    case Qt::ExtraButton21: mudletEvent.mArgumentList.append(QString::number(24));  break;
-    case Qt::ExtraButton22: mudletEvent.mArgumentList.append(QString::number(25));  break;
-    case Qt::ExtraButton23: mudletEvent.mArgumentList.append(QString::number(26));  break;
-    case Qt::ExtraButton24: mudletEvent.mArgumentList.append(QString::number(27));  break;
-    default:                mudletEvent.mArgumentList.append(QString::number(0));
+    case Qt::LeftButton:
+        mudletEvent.mArgumentList.append(QString::number(1));
+        break;
+    case Qt::RightButton:
+        mudletEvent.mArgumentList.append(QString::number(2));
+        break;
+    case Qt::MiddleButton:
+        mudletEvent.mArgumentList.append(QString::number(3));
+        break;
+    case Qt::BackButton:
+        mudletEvent.mArgumentList.append(QString::number(4));
+        break;
+    case Qt::ForwardButton:
+        mudletEvent.mArgumentList.append(QString::number(5));
+        break;
+    case Qt::TaskButton:
+        mudletEvent.mArgumentList.append(QString::number(6));
+        break;
+    case Qt::ExtraButton4:
+        mudletEvent.mArgumentList.append(QString::number(7));
+        break;
+    case Qt::ExtraButton5:
+        mudletEvent.mArgumentList.append(QString::number(8));
+        break;
+    case Qt::ExtraButton6:
+        mudletEvent.mArgumentList.append(QString::number(9));
+        break;
+    case Qt::ExtraButton7:
+        mudletEvent.mArgumentList.append(QString::number(10));
+        break;
+    case Qt::ExtraButton8:
+        mudletEvent.mArgumentList.append(QString::number(11));
+        break;
+    case Qt::ExtraButton9:
+        mudletEvent.mArgumentList.append(QString::number(12));
+        break;
+    case Qt::ExtraButton10:
+        mudletEvent.mArgumentList.append(QString::number(13));
+        break;
+    case Qt::ExtraButton11:
+        mudletEvent.mArgumentList.append(QString::number(14));
+        break;
+    case Qt::ExtraButton12:
+        mudletEvent.mArgumentList.append(QString::number(15));
+        break;
+    case Qt::ExtraButton13:
+        mudletEvent.mArgumentList.append(QString::number(16));
+        break;
+    case Qt::ExtraButton14:
+        mudletEvent.mArgumentList.append(QString::number(17));
+        break;
+    case Qt::ExtraButton15:
+        mudletEvent.mArgumentList.append(QString::number(18));
+        break;
+    case Qt::ExtraButton16:
+        mudletEvent.mArgumentList.append(QString::number(19));
+        break;
+    case Qt::ExtraButton17:
+        mudletEvent.mArgumentList.append(QString::number(20));
+        break;
+    case Qt::ExtraButton18:
+        mudletEvent.mArgumentList.append(QString::number(21));
+        break;
+    case Qt::ExtraButton19:
+        mudletEvent.mArgumentList.append(QString::number(22));
+        break;
+    case Qt::ExtraButton20:
+        mudletEvent.mArgumentList.append(QString::number(23));
+        break;
+    case Qt::ExtraButton21:
+        mudletEvent.mArgumentList.append(QString::number(24));
+        break;
+    case Qt::ExtraButton22:
+        mudletEvent.mArgumentList.append(QString::number(25));
+        break;
+    case Qt::ExtraButton23:
+        mudletEvent.mArgumentList.append(QString::number(26));
+        break;
+    case Qt::ExtraButton24:
+        mudletEvent.mArgumentList.append(QString::number(27));
+        break;
+    default:
+        mudletEvent.mArgumentList.append(QString::number(0));
     }
     QPoint pos = event->position().toPoint();
     mudletEvent.mArgumentList.append(QString::number(pos.x()));
@@ -2364,7 +2408,8 @@ void TConsole::slot_adjustAccessibleNames()
         } else {
             setAccessibleName(tr("User window \"%1\".").arg(mConsoleName));
         }
-        setAccessibleDescription(tr("Game content or locally generated text may be sent to this window that may be floated away from the Mudlet application or docked within the main application window."));
+        setAccessibleDescription(
+                tr("Game content or locally generated text may be sent to this window that may be floated away from the Mudlet application or docked within the main application window."));
         if (mLowerPane->isVisible()) {
             if (multipleProfilesActive) {
                 //: accessibility-friendly name to describe the upper half of a Mudlet profile's floating/dockable user window when you've scrolled up, %1 is the name of the profile when more than one is loaded and %2 is the name of the window.
@@ -2495,7 +2540,7 @@ void TConsole::setCaretMode(bool enabled)
     } else {
 #if defined(Q_OS_WINDOWS) || defined(Q_OS_LINUX)
         // NVDA breaks focus reset, so do it on a timer
-        QTimer::singleShot(0, this, [this] () {
+        QTimer::singleShot(0, this, [this]() {
             mUpperPane->releaseKeyboard();
         });
 #endif
@@ -2610,7 +2655,7 @@ void TConsole::handleLinesOverflowEvent(const int lineCount)
     }
 
     // Else we do have an overflow situation so let's raise an event for it:
-    TEvent sysWindowOverflow {};
+    TEvent sysWindowOverflow{};
     sysWindowOverflow.mArgumentList.append(QLatin1String("sysWindowOverflowEvent"));
     sysWindowOverflow.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     sysWindowOverflow.mArgumentList.append(mConsoleName);

--- a/src/TDebug.cpp
+++ b/src/TDebug.cpp
@@ -81,7 +81,7 @@ TDebug& TDebug::operator>>(Host* pHost)
             return *this;
         }
 
-        // Safety check: if pHost is not null but not in smIdentifierMap, 
+        // Safety check: if pHost is not null but not in smIdentifierMap,
         // the Host is probably being destroyed, so treat as system message
         if (pHost && !smIdentifierMap.contains(pHost)) {
             QPointer<TConsole> localDebugConsole = debugConsole;
@@ -211,12 +211,9 @@ void TDebug::changeHostName(const Host* pHost, const QString& newName)
 /* static */ void TDebug::addHost(Host* pHost, const QString hostName)
 {
     if (!initialised) {
-        smAvailableIdentifiers << qsl("[A] ") << qsl("[B] ") << qsl("[C] ") << qsl("[D] ") << qsl("[E] ")
-                               << qsl("[F] ") << qsl("[G] ") << qsl("[H] ") << qsl("[I] ") << qsl("[J] ")
-                               << qsl("[K] ") << qsl("[L] ") << qsl("[M] ") << qsl("[N] ") << qsl("[O] ")
-                               << qsl("[P] ") << qsl("[Q] ") << qsl("[R] ") << qsl("[S] ") << qsl("[T] ")
-                               << qsl("[U] ") << qsl("[V] ") << qsl("[W] ") << qsl("[X] ") << qsl("[Y] ")
-                               << qsl("[Z] ");
+        smAvailableIdentifiers << qsl("[A] ") << qsl("[B] ") << qsl("[C] ") << qsl("[D] ") << qsl("[E] ") << qsl("[F] ") << qsl("[G] ") << qsl("[H] ") << qsl("[I] ") << qsl("[J] ") << qsl("[K] ")
+                               << qsl("[L] ") << qsl("[M] ") << qsl("[N] ") << qsl("[O] ") << qsl("[P] ") << qsl("[Q] ") << qsl("[R] ") << qsl("[S] ") << qsl("[T] ") << qsl("[U] ") << qsl("[V] ")
+                               << qsl("[W] ") << qsl("[X] ") << qsl("[Y] ") << qsl("[Z] ");
         initialised = true;
     }
 
@@ -251,7 +248,7 @@ void TDebug::changeHostName(const Host* pHost, const QString& newName)
 /* static */ void TDebug::removeHost(Host* pHost, const QString hostName)
 {
     QPair<QString, QString> identifier;
-    
+
     if (pHost) {
         // Normal case: remove by Host pointer
         identifier = TDebug::smIdentifierMap.take(pHost);
@@ -271,7 +268,7 @@ void TDebug::changeHostName(const Host* pHost, const QString& newName)
             smIdentifierMap.remove(foundHost);
         }
     }
-    
+
     // Check for the use of non-profile specific tags:
     if (identifier.second != csmTagOverflow && identifier.second != csmTagSystemMessage && identifier.second != csmTagFault) {
         // is a normal identifier so push it in at the back of the queue for reuse:
@@ -310,7 +307,7 @@ void TDebug::changeHostName(const Host* pHost, const QString& newName)
     // because the default size will clip the text otherwise, unless the
     // user resizes the CDC:
     messageLines.prepend(qsl("%1 profiles active now. Each message from a profile \n"
-                                        "will be prefixed as follows:")
+                             "will be prefixed as follows:")
                                  .arg(TDebug::smIdentifierMap.count()));
 
     return messageLines.join(QChar::LineFeed).append(QChar::LineFeed);

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -60,8 +60,8 @@
 #include <QUrl>
 
 TDetachedWindow::TDetachedWindow(const QString& profileName, TMainConsole* console, QWidget* parent, bool toolbarVisible)
-    : QMainWindow(parent)
-    , mCurrentProfileName(profileName)
+: QMainWindow(parent)
+, mCurrentProfileName(profileName)
 {
     // Add the initial profile
     mProfileConsoleMap[profileName] = console;
@@ -95,7 +95,7 @@ TDetachedWindow::~TDetachedWindow()
 {
     // Set flag to prevent event handlers from accessing potentially invalid data
     mIsBeingDestroyed = true;
-    
+
     // Immediately remove all references to this window from the main mudlet window
     if (auto mudletInstance = mudlet::self()) {
         auto& detachedWindowsMap = const_cast<QMap<QString, QPointer<TDetachedWindow>>&>(mudletInstance->getDetachedWindows());
@@ -107,7 +107,7 @@ TDetachedWindow::~TDetachedWindow()
                 ++it;
             }
         }
-        
+
         // Update multi-view controls since detached windows changed
         mudletInstance->updateMultiViewControls();
     }
@@ -139,7 +139,7 @@ TDetachedWindow::~TDetachedWindow()
     }
 
     mDockWidgetMap.clear();
-    
+
     if (mpMapDockWidget) {
         // Restore main mapper if this detached window had an active map
         if (!mCurrentProfileName.isEmpty()) {
@@ -189,7 +189,7 @@ void TDetachedWindow::setupUI()
     // Add initial tab for the first profile
     if (!mCurrentProfileName.isEmpty()) {
         QString displayText = mCurrentProfileName;
-        
+
         // Apply CDC identifier prefix if debug mode is active
         if (mudlet::smDebugMode) {
             Host* pHost = mudlet::self()->getHostManager().getHost(mCurrentProfileName);
@@ -202,7 +202,7 @@ void TDetachedWindow::setupUI()
                 }
             }
         }
-        
+
         mpTabBar->addTab(displayText);
         mpTabBar->setTabData(0, mCurrentProfileName);
     }
@@ -224,7 +224,7 @@ void TDetachedWindow::setupUI()
         }
     }
 
-    updateTabIndicator(0);  // Set initial connection status
+    updateTabIndicator(0); // Set initial connection status
 
     // Connect signals
     connect(mpTabBar, &TTabBar::tabDetachRequested, this, &TDetachedWindow::onReattachAction);
@@ -237,8 +237,7 @@ void TDetachedWindow::setupUI()
 
     // Connect context menu for right-click reattach
     mpTabBar->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(mpTabBar, &QWidget::customContextMenuRequested,
-            this, &TDetachedWindow::showTabContextMenu);
+    connect(mpTabBar, &QWidget::customContextMenuRequested, this, &TDetachedWindow::showTabContextMenu);
 }
 
 void TDetachedWindow::createMenus()
@@ -565,7 +564,7 @@ void TDetachedWindow::closeEvent(QCloseEvent* event)
     if (!mIsReattaching) {
         // Get a copy of profile names before we start closing them
         QStringList profilesToClose = mProfileConsoleMap.keys();
-        
+
         // Properly close each profile - this ensures proper cleanup and save prompts
         for (const QString& profileName : profilesToClose) {
 #if defined(DEBUG_WINDOW_HANDLING)
@@ -573,7 +572,7 @@ void TDetachedWindow::closeEvent(QCloseEvent* event)
 #endif
             mudlet::self()->slot_closeProfileByName(profileName);
         }
-        
+
         // Remove all consoles from the stacked widget and reset their parents
         for (auto console : mProfileConsoleMap) {
             if (console) {
@@ -583,7 +582,7 @@ void TDetachedWindow::closeEvent(QCloseEvent* event)
         }
 
         mProfileConsoleMap.clear();
-        
+
         // Emit signal to notify main window for any remaining cleanup
         for (const QString& profileName : profilesToClose) {
             emit windowClosed(profileName);
@@ -722,8 +721,8 @@ void TDetachedWindow::showTabContextMenu(const QPoint& position)
     QMenu contextMenu(this);
 
     auto reattachAction = contextMenu.addAction(QIcon(qsl(":/icons/view-restore.png")),
-    //: This is an item in the context menu when clicked on a detached tab, and %1 is the name of the profile.
-                                               tr("Reattach '%1' to Main Window").arg(profileName));
+                                                //: This is an item in the context menu when clicked on a detached tab, and %1 is the name of the profile.
+                                                tr("Reattach '%1' to Main Window").arg(profileName));
     connect(reattachAction, &QAction::triggered, [this, profileName] {
         // Switch to this profile first, then reattach
         switchToProfile(profileName);
@@ -733,8 +732,8 @@ void TDetachedWindow::showTabContextMenu(const QPoint& position)
     contextMenu.addSeparator();
 
     auto closeTabAction = contextMenu.addAction(QIcon(qsl(":/icons/profile-close.png")),
-    //: This is an item in the context menu when clicked on a detached tab, and %1 is the name of the profile.
-                                               tr("Close Profile '%1'").arg(profileName));
+                                                //: This is an item in the context menu when clicked on a detached tab, and %1 is the name of the profile.
+                                                tr("Close Profile '%1'").arg(profileName));
     connect(closeTabAction, &QAction::triggered, [this, tabIndex] {
         closeProfileByIndex(tabIndex);
     });
@@ -743,8 +742,8 @@ void TDetachedWindow::showTabContextMenu(const QPoint& position)
         contextMenu.addSeparator();
 
         auto closeWindowAction = contextMenu.addAction(QIcon(qsl(":/icons/dialog-close.png")),
-    //: This is an item in the context menu when clicked on a detached tab.
-                                                      tr("Close Window (All Profiles)"));
+                                                       //: This is an item in the context menu when clicked on a detached tab.
+                                                       tr("Close Window (All Profiles)"));
         connect(closeWindowAction, &QAction::triggered, this, &QWidget::close);
     }
 
@@ -1243,15 +1242,15 @@ void TDetachedWindow::updateToolBarActions()
 void TDetachedWindow::updateDiscordNamedIcon()
 {
     Host* pHost = nullptr;
-    
+
     if (!mCurrentProfileName.isEmpty()) {
         pHost = mudlet::self()->getHostManager().getHost(mCurrentProfileName);
     }
-    
+
     if (!pHost) {
         // No active host - reset Discord icon to default state
         mpActionDiscord->setIconText(qsl("Discord"));
-        
+
         // Hide Mudlet Discord action as there's no game with custom invite
         if (mpActionMudletDiscord->isVisible()) {
             mpActionMudletDiscord->setVisible(false);
@@ -1308,7 +1307,7 @@ void TDetachedWindow::updateWindowTitle()
                     title += tr("Connected to %1").arg(pHost->getUrl());
                 } else {
                     //: This text will be part of to the title of a detached Mudlet window, if it is currently connected but we don't know to where. The whole title will be like "Mudlet PROFILENAME (Detached) - Connected"
-                    title += tr("Connected");                    
+                    title += tr("Connected");
                 }
             } else if (isConnecting) {
                 //: This text will be part of the title of a detached Mudlet window, if it is about to be connected. The whole title will be like "Mudlet PROFILENAME (Detached) - Connecting..."
@@ -1321,9 +1320,7 @@ void TDetachedWindow::updateWindowTitle()
     } else {
         // Multiple profiles - show count and current
         //: This is the title of a Mudlet window which was detached from the main Mudlet window, and has multiple profiles opened in this window. %1 is the number of profiles, %2 is the name of the profile currently shown.
-        title = tr("Mudlet (%1 profiles) - %2 (Detached)")
-                .arg(mProfileConsoleMap.size())
-                .arg(mCurrentProfileName);
+        title = tr("Mudlet (%1 profiles) - %2 (Detached)").arg(mProfileConsoleMap.size()).arg(mCurrentProfileName);
     }
 
     setWindowTitle(title);
@@ -1370,7 +1367,7 @@ void TDetachedWindow::updateTabIndicator(int tabIndex)
 
     // Set the tab text and icon, accounting for CDC identifiers
     QString displayText = profileName;
-    
+
     // Apply CDC identifier prefix if debug mode is active (like main window does)
     if (mudlet::smDebugMode && pHost) {
         QString debugTag = TDebug::getTag(pHost);
@@ -1379,7 +1376,7 @@ void TDetachedWindow::updateTabIndicator(int tabIndex)
             displayText = debugTag + profileName;
         }
     }
-    
+
     mpTabBar->setTabText(tabIndex, displayText);
     mpTabBar->setTabIcon(tabIndex, tabIcon);
 }
@@ -1400,15 +1397,14 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
 {
     // Clear the global map dock widget reference first
     mpMapDockWidget = nullptr;
-    
+
 #if defined(DEBUG_WINDOW_HANDLING)
-    qDebug() << "TDetachedWindow::updateDockWidgetVisibilityForProfile: Starting for profile" << profileName
-             << "- mDockWidgetMap.size():" << mDockWidgetMap.size();
+    qDebug() << "TDetachedWindow::updateDockWidgetVisibilityForProfile: Starting for profile" << profileName << "- mDockWidgetMap.size():" << mDockWidgetMap.size();
 
     // Track if we found and showed a dock widget for the current profile
     bool currentProfileHasVisibleDockWidget = false;
 #endif
-    
+
     // Collect dock widgets to process to avoid iterator invalidation
     QList<QPair<QString, QPointer<QDockWidget>>> dockWidgetsToProcess;
 
@@ -1429,38 +1425,35 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
     for (const auto& dockPair : dockWidgetsToProcess) {
         const QString& dockKey = dockPair.first;
         QPointer<QDockWidget> dockWidget = dockPair.second;
-        
+
         // Check if the dock widget still exists and is in our map
         if (!dockWidget || !mDockWidgetMap.contains(dockKey)) {
 #if defined(DEBUG_WINDOW_HANDLING)
-            qDebug() << "TDetachedWindow: Skipping dock widget" << dockKey << "- widget exists:" << (dockWidget != nullptr) 
-                     << "in map:" << mDockWidgetMap.contains(dockKey);
+            qDebug() << "TDetachedWindow: Skipping dock widget" << dockKey << "- widget exists:" << (dockWidget != nullptr) << "in map:" << mDockWidgetMap.contains(dockKey);
 #endif
             continue;
         }
-        
+
         // Check if this docked widget belongs to the current profile
         if (dockKey.startsWith("map_")) {
             QString dockProfileName = dockKey.mid(4); // Remove "map_" prefix
 #if defined(DEBUG_WINDOW_HANDLING)
             qDebug() << "TDetachedWindow: Processing map dock" << dockKey << "profile:" << dockProfileName << "current:" << profileName;
 #endif
-            
+
             if (dockProfileName == profileName) {
                 // This dock widget belongs to the current profile
                 // Check the user's preference for dock widget visibility
                 bool shouldBeVisible = mDockWidgetUserPreference.value(dockKey, false);
 #if defined(DEBUG_WINDOW_HANDLING)
-                qDebug() << "TDetachedWindow: Found dock widget for current profile" << profileName 
-                         << "currently visible:" << dockWidget->isVisible() 
-                         << "should be visible:" << shouldBeVisible;
+                qDebug() << "TDetachedWindow: Found dock widget for current profile" << profileName << "currently visible:" << dockWidget->isVisible() << "should be visible:" << shouldBeVisible;
 #endif
-                
+
                 // Show or hide based on intended visibility
                 if (shouldBeVisible) {
                     dockWidget->show();
                     dockWidget->raise();
-                    
+
                     // Set this as the global map dock widget reference
                     mpMapDockWidget = dockWidget;
 #if defined(DEBUG_WINDOW_HANDLING)
@@ -1476,7 +1469,7 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
                     qDebug() << "TDetachedWindow: Dock widget should be hidden - respecting user preference";
 #endif
                 }
-                
+
                 // Ensure the map's active mapper points to our detached instance (if visible)
                 if (auto pHost = mudlet::self()->getHostManager().getHost(profileName)) {
                     if (auto pMap = pHost->mpMap.data()) {
@@ -1502,7 +1495,7 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
                 dockWidget->blockSignals(true);
                 dockWidget->setVisible(false);
                 dockWidget->blockSignals(false);
-                
+
                 // Restore main mapper for the other profile
                 if (auto pHost = mudlet::self()->getHostManager().getHost(dockProfileName)) {
                     if (auto pMap = pHost->mpMap.data()) {
@@ -1522,13 +1515,11 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
         }
         // Add other dock widget types here as they are implemented
     }
-    
+
     // Debug output to help track dock widget visibility changes
 #if defined(DEBUG_WINDOW_HANDLING)
-    qDebug() << "TDetachedWindow::updateDockWidgetVisibilityForProfile:" << profileName 
-             << "- Found visible dock widget:" << currentProfileHasVisibleDockWidget
-             << "- Total dock widgets:" << dockWidgetsToProcess.size()
-             << "- mpMapDockWidget set:" << (mpMapDockWidget != nullptr);
+    qDebug() << "TDetachedWindow::updateDockWidgetVisibilityForProfile:" << profileName << "- Found visible dock widget:" << currentProfileHasVisibleDockWidget
+             << "- Total dock widgets:" << dockWidgetsToProcess.size() << "- mpMapDockWidget set:" << (mpMapDockWidget != nullptr);
 #endif
 }
 
@@ -1558,7 +1549,7 @@ void TDetachedWindow::slot_toggleAlwaysOnTop()
         setWindowFlags(flags | Qt::WindowStaysOnTopHint);
     }
 
-    show();  // Required after changing window flags
+    show(); // Required after changing window flags
 
     // Reset flag after a short delay to allow the window operations to complete
     QTimer::singleShot(100, this, [this]() {
@@ -1573,7 +1564,7 @@ void TDetachedWindow::slot_toggleToolBarVisibility()
     }
 
     bool newVisibility = !isToolBarVisible();
-    
+
     // Synchronize toolbar visibility across all windows
     auto mudletInstance = mudlet::self();
 
@@ -1589,13 +1580,13 @@ void TDetachedWindow::slot_showDetachedToolBarContextMenu(const QPoint& position
     }
 
     QMenu menu(this);
-    
+
     // Create "Profile Toolbar" toggle action
     QAction* toolbarToggleAction = menu.addAction(tr("Profile Toolbar"));
     toolbarToggleAction->setCheckable(true);
     toolbarToggleAction->setChecked(mpToolBar->isVisible());
     connect(toolbarToggleAction, &QAction::triggered, this, &TDetachedWindow::slot_toggleToolBarVisibility);
-    
+
     // Show the context menu at the clicked position
     menu.exec(mpToolBar->mapToGlobal(position));
 }
@@ -1641,7 +1632,7 @@ void TDetachedWindow::updateWindowMenu()
     if (mIsBeingDestroyed) {
         return;
     }
-    
+
     // Clean up existing window list actions
     for (QAction* action : mWindowListActions) {
         mpWindowMenu->removeAction(action);
@@ -1659,7 +1650,7 @@ void TDetachedWindow::updateWindowMenu()
 
     // Get the detached windows from mudlet
     const auto& detachedWindows = mudlet::self()->getDetachedWindows();
-    
+
     // Count total windows (main + detached)
     int totalWindows = 1; // Main window
     totalWindows += detachedWindows.size();
@@ -1687,14 +1678,11 @@ void TDetachedWindow::updateWindowMenu()
         // Add main window profiles
         if (!mainWindowProfiles.isEmpty()) {
             for (const QString& profileName : mainWindowProfiles) {
-
                 //: This is an item in list of profiles in the "Window" menu of a detached Mudlet window. %1 is the name of the profile, and it is located not in the detached window, but in Mudlet's main window.
                 QString actionText = tr("%1 (Main Window)").arg(profileName);
                 QAction* profileAction = new QAction(actionText, this);
                 profileAction->setCheckable(true);
-                profileAction->setChecked(mudlet::self()->isActiveWindow() && 
-                    mudlet::self()->getActiveHost() && 
-                    mudlet::self()->getActiveHost()->getName() == profileName);
+                profileAction->setChecked(mudlet::self()->isActiveWindow() && mudlet::self()->getActiveHost() && mudlet::self()->getActiveHost()->getName() == profileName);
                 profileAction->setData(profileName); // Store profile name for identification
                 connect(profileAction, &QAction::triggered, this, &TDetachedWindow::slot_activateMainWindowProfile);
                 mpWindowMenu->addAction(profileAction);
@@ -1711,7 +1699,7 @@ void TDetachedWindow::updateWindowMenu()
                 uniqueDetachedWindows.insert(detachedWindow);
             }
         }
-        
+
         // Process each unique detached window
         for (TDetachedWindow* detachedWindow : uniqueDetachedWindows) {
             // Get all profiles in this detached window
@@ -1754,7 +1742,7 @@ void TDetachedWindow::slot_activateDetachedWindow()
 
     QString profileName = action->data().toString();
     const auto& detachedWindows = mudlet::self()->getDetachedWindows();
-    
+
     if (detachedWindows.contains(profileName)) {
         TDetachedWindow* detachedWindow = detachedWindows[profileName];
 
@@ -1762,7 +1750,7 @@ void TDetachedWindow::slot_activateDetachedWindow()
             detachedWindow->raise();
             detachedWindow->activateWindow();
             detachedWindow->show(); // Ensure it's not minimized
-            updateWindowMenu(); // Refresh checkmarks
+            updateWindowMenu();     // Refresh checkmarks
         }
     }
 }
@@ -1776,7 +1764,7 @@ void TDetachedWindow::slot_activateMainWindowProfile()
     }
 
     QString profileName = action->data().toString();
-    
+
     // Delegate to mudlet's main window profile activation
     mudlet* mainWindow = mudlet::self();
 
@@ -1796,13 +1784,13 @@ void TDetachedWindow::slot_activateMainWindowProfile()
             mainWindow->raise();
             mainWindow->activateWindow();
             mainWindow->show(); // Ensure it's not minimized
-            
+
             // Switch to the specific tab
             mainWindow->mpTabBar->setCurrentIndex(tabIndex);
-            
+
             // Trigger the tab change logic to ensure the profile is properly activated
             mainWindow->slot_tabChanged(tabIndex);
-            
+
             updateWindowMenu(); // Refresh checkmarks
         }
     }
@@ -1817,7 +1805,7 @@ void TDetachedWindow::slot_activateDetachedWindowProfile()
     }
 
     QString profileName = action->data().toString();
-    
+
     // Find which detached window contains this profile
     const auto& detachedWindows = mudlet::self()->getDetachedWindows();
 
@@ -1872,7 +1860,7 @@ bool TDetachedWindow::addProfile(const QString& profileName, TMainConsole* conso
 
     // Clear any size constraints that might have been set in the previous window
     console->setMinimumSize(0, 0);
-    console->setMaximumSize(16777215, 16777215);  // Qt's maximum size
+    console->setMaximumSize(16777215, 16777215); // Qt's maximum size
 
     // Force immediate visibility and geometry updates
     console->setVisible(true);
@@ -1942,15 +1930,15 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
 #if defined(DEBUG_WINDOW_HANDLING)
             qDebug() << "TDetachedWindow::removeProfile: Cleaning up dock widget for profile" << profileName;
 #endif
-            
+
             // If this is the currently active map dock, clear the global reference
             if (mpMapDockWidget == mapDockWidget) {
                 mpMapDockWidget = nullptr;
             }
-            
+
             // Remove the dock widget from Qt's dock widget management
             QMainWindow::removeDockWidget(mapDockWidget);
-            
+
             // Restore the main window's mapper before deleting our dock widget
             if (auto pHost = mudlet::self()->getHostManager().getHost(profileName)) {
                 if (auto pMap = pHost->mpMap.data()) {
@@ -1966,11 +1954,11 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
                     }
                 }
             }
-            
+
             // Clean up the dock widget
             mapDockWidget->deleteLater();
         }
-        
+
         // Remove from our tracking maps
         mDockWidgetMap.remove(mapKey);
         mDockWidgetUserPreference.remove(mapKey);
@@ -2144,7 +2132,7 @@ void TDetachedWindow::switchToProfile(const QString& profileName)
         // Ensure console has proper size policy and constraints for the container
         console->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
         console->setMinimumSize(0, 0);
-        console->setMaximumSize(16777215, 16777215);  // Qt's maximum size
+        console->setMaximumSize(16777215, 16777215); // Qt's maximum size
 
         // Force console visibility and proper sizing
         console->setVisible(true);
@@ -2190,7 +2178,7 @@ void TDetachedWindow::switchToProfile(const QString& profileName)
     updateToolBarActions();
     updateWindowTitle();
     updateTabIndicator();
-    
+
     // Update docked window visibility based on the new active profile
     updateDockWidgetVisibilityForProfile(profileName);
 
@@ -2210,7 +2198,7 @@ void TDetachedWindow::switchToProfile(const QString& profileName)
             console->repaint();
         }
     });
-    
+
     // Ensure the detached window itself gets focus and is brought to the front
     raise();
     activateWindow();
@@ -2235,11 +2223,10 @@ void TDetachedWindow::slot_tabMoved(int oldPos, int newPos)
     // Get the current order of profile names from the tab bar
     const QStringList& profileNamesInOrder = mpTabBar->tabNames();
     const int itemsCount = mpConsoleContainer->count();
-    
+
     // Validate that tab count matches console count
     if (itemsCount != profileNamesInOrder.count()) {
-        qWarning().nospace().noquote() << "TDetachedWindow::slot_tabMoved(" << oldPos << ", " << newPos 
-                                       << ") WARNING - mismatch in count of tabs (" << profileNamesInOrder.count() 
+        qWarning().nospace().noquote() << "TDetachedWindow::slot_tabMoved(" << oldPos << ", " << newPos << ") WARNING - mismatch in count of tabs (" << profileNamesInOrder.count()
                                        << ") and TMainConsoles (" << itemsCount << ")";
         return;
     }
@@ -2251,8 +2238,7 @@ void TDetachedWindow::slot_tabMoved(int oldPos, int newPos)
         if (console) {
             consoleWidgetMap.insert(profileName, console);
         } else {
-            qWarning().nospace().noquote() << "TDetachedWindow::slot_tabMoved(" << oldPos << ", " << newPos
-                                           << ") WARNING - nullptr for TMainConsole for profile: " << profileName;
+            qWarning().nospace().noquote() << "TDetachedWindow::slot_tabMoved(" << oldPos << ", " << newPos << ") WARNING - nullptr for TMainConsole for profile: " << profileName;
         }
     }
 
@@ -2314,7 +2300,7 @@ void TDetachedWindow::closeProfileByIndex(int index)
         // Since the profile map is now empty, closeEvent() won't emit windowClosed signals
         // so we need to notify the main window about the window closure here
         emit windowClosed(profileName);
-        
+
         QTimer::singleShot(0, this, [this] {
             close();
         });
@@ -2474,18 +2460,18 @@ void TDetachedWindow::showScriptEditorDialog(std::function<void(dlgTriggerEditor
 {
     // Store the originating profile for focus restoration
     QString originatingProfile = mCurrentProfileName;
-    
+
     withCurrentProfileActive([this, originatingProfile, showMethod]() {
         auto mudletInstance = mudlet::self();
         if (!mudletInstance) {
             return;
         }
-        
+
         Host* pHost = mudletInstance->getActiveHost();
         if (!pHost) {
             return;
         }
-        
+
         // Create or get the editor directly, avoiding the main window's focus restoration logic
         dlgTriggerEditor* pEditor = nullptr;
         if (pHost->mpEditorDialog != nullptr) {
@@ -2498,22 +2484,22 @@ void TDetachedWindow::showScriptEditorDialog(std::function<void(dlgTriggerEditor
             connect(pHost, &Host::profileSaveFinished, pHost->mpEditorDialog, &dlgTriggerEditor::slot_profileSaveFinished);
             pEditor->fillout_form();
         }
-        
+
         if (!pEditor) {
             return;
         }
-        
+
         // Use centralized focus restoration with this detached window as target
         mudlet::setupEditorFocusRestoration(pEditor, originatingProfile, this);
-        
+
         // Call the specific show method (slot_showAliases, slot_showTimers, etc.)
         if (showMethod) {
             showMethod(pEditor);
         }
-        
+
         // Position dialog on the same screen as this detached window
         utils::positionDialogOnParentScreen(pEditor, this);
-        
+
         // Show and activate the editor
         pEditor->raise();
         pEditor->showNormal();
@@ -2545,7 +2531,7 @@ void TDetachedWindow::slot_reconnectProfile()
 
 void TDetachedWindow::slot_closeCurrentProfile()
 {
-    // Use the detached window's own close profile logic instead of 
+    // Use the detached window's own close profile logic instead of
     // delegating to the main window, which would use the wrong tab bar
     closeProfile();
 }
@@ -2625,7 +2611,7 @@ void TDetachedWindow::slot_showMapperDialog()
     // Close any existing map for this profile in other windows first
     auto mudletInstance = mudlet::self();
     QString mapKey = qsl("map_%1").arg(mCurrentProfileName);
-    
+
     // Check if main window has a map for this profile and close it
     auto mainMapDock = mudletInstance->getMainWindowDockWidget(mapKey);
 
@@ -2638,7 +2624,7 @@ void TDetachedWindow::slot_showMapperDialog()
         mainMapDock->setVisible(false);
         mainMapDock->blockSignals(false);
     }
-    
+
     // Check other detached windows for conflicting maps
     const auto& detachedWindows = mudletInstance->getDetachedWindows();
 
@@ -2660,16 +2646,16 @@ void TDetachedWindow::slot_showMapperDialog()
 
     // Check if we already have a mapper dock widget for this profile
     QPointer<QDockWidget> existingMapDock = mDockWidgetMap.value(mapKey);
-    
+
     if (existingMapDock) {
         // Toggle visibility of existing mapper and update global reference
         bool newVisibility = !existingMapDock->isVisible();
         existingMapDock->setVisible(newVisibility);
-        
+
         // Update mpMapDockWidget to point to the current profile's map if it's being shown
         if (newVisibility) {
             mpMapDockWidget = existingMapDock;
-            
+
             // Ensure the map's active mapper points to our detached instance
             auto mapWidget = existingMapDock->widget();
             if (auto detachedMapper = qobject_cast<dlgMapper*>(mapWidget)) {
@@ -2678,7 +2664,7 @@ void TDetachedWindow::slot_showMapperDialog()
         } else if (mpMapDockWidget == existingMapDock) {
             // If we're hiding the current map, clear the global reference and restore main mapper
             mpMapDockWidget = nullptr;
-            
+
             // Restore the main window's mapper as the active one
             if (pHost->mpDockableMapWidget) {
                 auto mainMapWidget = pHost->mpDockableMapWidget->widget();
@@ -2694,18 +2680,15 @@ void TDetachedWindow::slot_showMapperDialog()
     //: This is to create a new docked mapper widget for a profile in a detached Mudlet window. %1 is the name of the profile.
     auto newMapDockWidget = new QDockWidget(tr("Map - %1").arg(mCurrentProfileName), this);
     newMapDockWidget->setObjectName(qsl("dockMap_%1_detached").arg(mCurrentProfileName));
-    
+
     // Store the main window's mapper temporarily so we can restore it later
     QPointer<dlgMapper> mainMapper = pMap->mpMapper;
     QPointer<QDockWidget> mainDockWidget = pHost->mpDockableMapWidget;
-    
+
     // Create a new mapper instance for the detached window
     // We need to copy player room style details first
-    pHost->getPlayerRoomStyleDetails(pMap->mPlayerRoomStyle,
-                                   pMap->mPlayerRoomOuterDiameterPercentage,
-                                   pMap->mPlayerRoomInnerDiameterPercentage,
-                                   pMap->mPlayerRoomOuterColor,
-                                   pMap->mPlayerRoomInnerColor);
+    pHost->getPlayerRoomStyleDetails(
+            pMap->mPlayerRoomStyle, pMap->mPlayerRoomOuterDiameterPercentage, pMap->mPlayerRoomInnerDiameterPercentage, pMap->mPlayerRoomOuterColor, pMap->mPlayerRoomInnerColor);
 
     // Create the mapper dialog
     auto detachedMapper = new dlgMapper(newMapDockWidget, pHost, pMap);
@@ -2726,13 +2709,13 @@ void TDetachedWindow::slot_showMapperDialog()
 
     // Add the dock widget to this detached window
     QMainWindow::addDockWidget(Qt::RightDockWidgetArea, newMapDockWidget);
-    
+
     // Store reference in our map for cleanup and profile-specific access
     mDockWidgetMap[mapKey] = newMapDockWidget;
-    
+
     // Set user preference to true since we're initially showing this dock widget
     mDockWidgetUserPreference[mapKey] = true;
-    
+
     // Set global reference to the currently active map
     mpMapDockWidget = newMapDockWidget;
 
@@ -2742,42 +2725,42 @@ void TDetachedWindow::slot_showMapperDialog()
         if (!mapDockWidget) {
             return;
         }
-        
+
         // Track user-initiated visibility changes - always update user preference
         // to ensure dock widget state is properly tracked regardless of which profile is active
         mDockWidgetUserPreference[mapKey] = visible;
 #if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "TDetachedWindow: User changed dock widget visibility for" << mapKey << "to" << visible;
 #endif
-        
+
         // Extract profile name from mapKey to safely look up objects
         QString profileName = mapKey;
         if (profileName.startsWith("map_")) {
             profileName = profileName.mid(4); // Remove "map_" prefix
         }
-        
+
         // Safely get the host and map - they might be null during shutdown
         auto mudletInstance = mudlet::self();
         if (!mudletInstance) {
             return;
         }
-        
+
         Host* pHost = mudletInstance->getHostManager().getHost(profileName);
         if (!pHost) {
             return;
         }
-        
+
         auto pMap = pHost->mpMap.data();
         if (!pMap) {
             return;
         }
-        
+
         if (!visible) {
             // If this is the currently active map dock, clear the global reference
             if (mpMapDockWidget == mapDockWidget) {
                 mpMapDockWidget = nullptr;
             }
-            
+
             // Restore the main window's mapper as the active one when hiding
             if (pHost->mpDockableMapWidget) {
                 auto mainMapWidget = pHost->mpDockableMapWidget->widget();
@@ -2788,14 +2771,14 @@ void TDetachedWindow::slot_showMapperDialog()
         } else {
             // When showing, set this as the active mapper
             mpMapDockWidget = mapDockWidget;
-            
+
             // Ensure the map's active mapper points to our detached instance
             auto mapWidget = mapDockWidget->widget();
             if (auto detachedMapper = qobject_cast<dlgMapper*>(mapWidget)) {
                 pMap->mpMapper = detachedMapper;
             }
         }
-        
+
 #if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "TDetachedWindow: Map dock visibility changed for" << mapKey << "visible:" << visible;
 #endif
@@ -2817,22 +2800,22 @@ void TDetachedWindow::slot_showPreferencesDialog()
     withCurrentProfileActive([this]() {
         // Store originating profile for focus restoration
         QString originatingProfile = mCurrentProfileName;
-        
+
         auto mudletInstance = mudlet::self();
         if (!mudletInstance) {
             return;
         }
-        
+
         Host* pHost = mudletInstance->getActiveHost();
-        
+
         // Open preferences dialog
         mudletInstance->slot_showPreferencesDialog();
-        
+
         // Position the preferences dialog on the same screen as this detached window
         auto pPrefs = pHost ? pHost->mpDlgProfilePreferences : mudletInstance->mpDlgProfilePreferences;
         if (pPrefs) {
             utils::positionDialogOnParentScreen(pPrefs, this);
-            
+
             // Set up focus restoration for the preferences dialog to return to this detached window
             mudletInstance->setupPreferencesFocusRestoration(pPrefs);
         }
@@ -2844,24 +2827,24 @@ void TDetachedWindow::slot_showNotesDialog()
     withCurrentProfileActive([this]() {
         // Store originating profile for focus restoration
         QString originatingProfile = mCurrentProfileName;
-        
+
         auto mudletInstance = mudlet::self();
         if (!mudletInstance) {
             return;
         }
-        
+
         Host* pHost = mudletInstance->getActiveHost();
         if (!pHost) {
             return;
         }
-        
+
         // Open notes dialog
         mudletInstance->slot_notes();
-        
+
         // Position the notes dialog on the same screen as this detached window
         if (pHost->mpNotePad) {
             utils::positionDialogOnParentScreen(pHost->mpNotePad, this);
-            
+
             // Set up focus restoration for the notepad to return to this detached window
             mudletInstance->setupNotepadFocusRestoration(pHost->mpNotePad);
         }
@@ -2880,24 +2863,24 @@ void TDetachedWindow::slot_showPackageManagerDialog()
     withCurrentProfileActive([this]() {
         // Store originating profile for focus restoration
         QString originatingProfile = mCurrentProfileName;
-        
+
         auto mudletInstance = mudlet::self();
         if (!mudletInstance) {
             return;
         }
-        
+
         Host* pHost = mudletInstance->getActiveHost();
         if (!pHost) {
             return;
         }
-        
+
         // Open package manager dialog
         mudletInstance->slot_packageManager();
-        
+
         // Position the package manager dialog on the same screen as this detached window
         if (pHost->mpPackageManager) {
             utils::positionDialogOnParentScreen(pHost->mpPackageManager, this);
-            
+
             // Set up focus restoration for the package manager to return to this detached window
             mudletInstance->setupPackageManagerFocusRestoration(pHost->mpPackageManager);
         }
@@ -2909,24 +2892,24 @@ void TDetachedWindow::slot_showModuleManagerDialog()
     withCurrentProfileActive([this]() {
         // Store originating profile for focus restoration
         QString originatingProfile = mCurrentProfileName;
-        
+
         auto mudletInstance = mudlet::self();
         if (!mudletInstance) {
             return;
         }
-        
+
         Host* pHost = mudletInstance->getActiveHost();
         if (!pHost) {
             return;
         }
-        
+
         // Open module manager dialog
         mudletInstance->slot_moduleManager();
-        
+
         // Position the module manager dialog on the same screen as this detached window
         if (pHost->mpModuleManager) {
             utils::positionDialogOnParentScreen(pHost->mpModuleManager, this);
-            
+
             // Set up focus restoration for the module manager to return to this detached window
             mudletInstance->setupModuleManagerFocusRestoration(pHost->mpModuleManager);
         }
@@ -2973,13 +2956,13 @@ void TDetachedWindow::slot_profileDiscord()
     if (!mudletInstance || mCurrentProfileName.isEmpty()) {
         return;
     }
-    
+
     Host* pHost = mudletInstance->getHostManager().getHost(mCurrentProfileName);
     QString invite;
     if (pHost) {
         invite = pHost->getDiscordInviteURL();
     }
-    
+
     if (invite.isEmpty()) {
         // Fall back to Mudlet Discord - call the slot directly without profile switching
         mudletInstance->slot_mudletDiscord();
@@ -3029,7 +3012,7 @@ void TDetachedWindow::changeEvent(QEvent* event)
         QMainWindow::changeEvent(event);
         return;
     }
-    
+
     if (event->type() == QEvent::WindowStateChange) {
         // Check if window is being minimized
         if (windowState() & Qt::WindowMinimized) {
@@ -3057,7 +3040,7 @@ void TDetachedWindow::refreshTabBar()
         QString profileName = mpTabBar->tabData(i).toString();
         if (!profileName.isEmpty()) {
             QString displayText = profileName;
-            
+
             // Apply CDC identifier prefix if debug mode is active
             if (mudlet::smDebugMode) {
                 Host* pHost = mudlet::self()->getHostManager().getHost(profileName);
@@ -3068,7 +3051,7 @@ void TDetachedWindow::refreshTabBar()
                     }
                 }
             }
-            
+
             mpTabBar->setTabText(i, displayText);
         }
     }
@@ -3079,14 +3062,14 @@ void TDetachedWindow::slot_closeAllProfiles()
     // Properly close all profiles before closing the window
     // This ensures save prompts and proper cleanup
     QStringList profilesToClose = mProfileConsoleMap.keys();
-    
+
     qDebug() << "TDetachedWindow::slot_closeAllProfiles() - Closing" << profilesToClose.size() << "profiles";
-    
+
     for (const QString& profileName : profilesToClose) {
         qDebug() << "TDetachedWindow::slot_closeAllProfiles() - Closing profile:" << profileName;
         mudlet::self()->slot_closeProfileByName(profileName);
     }
-    
+
     // After all profiles are closed, close the window
     // The profiles should already be removed from mProfileConsoleMap by now,
     // but closeEvent() will handle any remaining cleanup
@@ -3097,53 +3080,53 @@ void TDetachedWindow::addTransferredDockWidget(const QString& mapKey, QDockWidge
 {
     // Add to the map
     mDockWidgetMap[mapKey] = dockWidget;
-    
+
     // Set up signal connection for visibility changes - similar to what's done for new dock widgets
     connect(dockWidget, &QDockWidget::visibilityChanged, this, [this, mapKey](bool visible) {
         auto mapDockWidget = mDockWidgetMap.value(mapKey);
         if (!mapDockWidget) {
             return;
         }
-        
+
         // Track user-initiated visibility changes - always update user preference
         // to ensure dock widget state is properly tracked regardless of which profile is active
         mDockWidgetUserPreference[mapKey] = visible;
 #if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "TDetachedWindow: User changed dock widget visibility for" << mapKey << "to" << visible;
 #endif
-        
+
         // Extract profile name from mapKey to safely look up objects
         QString profileName = mapKey;
 
         if (profileName.startsWith("map_")) {
             profileName = profileName.mid(4); // Remove "map_" prefix
         }
-        
+
         // Safely get the host and map - they might be null during shutdown
         auto mudletInstance = mudlet::self();
 
         if (!mudletInstance) {
             return;
         }
-        
+
         Host* pHost = mudletInstance->getHostManager().getHost(profileName);
 
         if (!pHost) {
             return;
         }
-        
+
         auto pMap = pHost->mpMap.data();
 
         if (!pMap) {
             return;
         }
-        
+
         if (!visible) {
             // If this is the currently active map dock, clear the global reference
             if (mpMapDockWidget == mapDockWidget) {
                 mpMapDockWidget = nullptr;
             }
-            
+
             // Restore the main window's mapper as the active one when hiding
             if (pHost->mpDockableMapWidget) {
                 auto mainMapWidget = pHost->mpDockableMapWidget->widget();
@@ -3155,7 +3138,7 @@ void TDetachedWindow::addTransferredDockWidget(const QString& mapKey, QDockWidge
         } else {
             // When showing, set this as the active mapper
             mpMapDockWidget = mapDockWidget;
-            
+
             // Ensure the map's active mapper points to our detached instance
             auto mapWidget = mapDockWidget->widget();
 
@@ -3163,7 +3146,7 @@ void TDetachedWindow::addTransferredDockWidget(const QString& mapKey, QDockWidge
                 pMap->mpMapper = detachedMapper;
             }
         }
-        
+
         // Update visibility for the current profile
         updateDockWidgetVisibilityForProfile(profileName);
     });
@@ -3182,17 +3165,17 @@ void TDetachedWindow::slot_toggleCompactInputLine()
     if (mCurrentProfileName.isEmpty()) {
         return;
     }
-    
+
     auto mudletInstance = mudlet::self();
     if (!mudletInstance) {
         return;
     }
-    
+
     auto host = mudletInstance->getHostManager().getHost(mCurrentProfileName);
     if (!host) {
         return;
     }
-    
+
     // Toggle the compact input line state for the current profile
     bool currentState = host->getCompactInputLine();
     host->setCompactInputLine(!currentState);

--- a/src/TEasyButtonBar.cpp
+++ b/src/TEasyButtonBar.cpp
@@ -149,7 +149,7 @@ void TEasyButtonBar::finalize()
 // button state to ensure the visible representation is used.
 void TEasyButtonBar::slot_pressed(const bool isChecked)
 {
-    auto * pB = dynamic_cast<TFlipButton*>(sender());
+    auto* pB = dynamic_cast<TFlipButton*>(sender());
     if (!pB) {
         return;
     }

--- a/src/TEncodingHelper.cpp
+++ b/src/TEncodingHelper.cpp
@@ -26,11 +26,7 @@
 
 bool TEncodingHelper::isCustomEncoding(const QByteArray& encoding)
 {
-    return encoding.startsWith("M_") ||
-           encoding == "CP437" ||
-           encoding == "CP667" ||
-           encoding == "CP737" ||
-           encoding == "CP869";
+    return encoding.startsWith("M_") || encoding == "CP437" || encoding == "CP667" || encoding == "CP737" || encoding == "CP869";
 }
 
 // Check if an encoding is available via Qt6's QStringDecoder
@@ -236,6 +232,6 @@ QList<QByteArray> TEncodingHelper::aliases(const QByteArray& encoding)
     } else if (encoding == "M_MEDIEVIA" || encoding == "MEDIEVIA") {
         return TTextCodec_medievia::aliases();
     }
-    
+
     return {};
 }

--- a/src/TEntityHandler.cpp
+++ b/src/TEntityHandler.cpp
@@ -25,9 +25,7 @@
 // returns true if the char is handled by the EntityHandler (i.e. it is part of an entity)
 bool TEntityHandler::handle(char c, bool resolveCustomEntities)
 {
-    const bool isLegalNamedEntityChar = isalnum(c) ||
-                                        c == '#' || c == '.' || c == '-' ||
-                                        c == '_' || c == '&' || c == ';';
+    const bool isLegalNamedEntityChar = isalnum(c) || c == '#' || c == '.' || c == '-' || c == '_' || c == '&' || c == ';';
     if (!mCurrentEntity.isEmpty() || c == '&') {
         mCurrentEntity.append(c);
         if (c == ';') {

--- a/src/TEntityResolver.cpp
+++ b/src/TEntityResolver.cpp
@@ -20,7 +20,7 @@
 #include "TEntityResolver.h"
 #include "utils.h"
 
-QString TEntityResolver::getResolution(const QString& entity, bool resolveCustomEntities, TEntityType *entityType) const
+QString TEntityResolver::getResolution(const QString& entity, bool resolveCustomEntities, TEntityType* entityType) const
 {
     if (entity.front() != '&' || entity.back() != ';') {
         if (entityType) {
@@ -82,7 +82,8 @@ bool TEntityResolver::registerEntity(const QString& entity, const QString& str)
     return true;
 }
 
-bool TEntityResolver::unregisterEntity(const QString & entity){
+bool TEntityResolver::unregisterEntity(const QString& entity)
+{
     return mEntititesMap.remove(entity.toLower()) > 0;
 }
 
@@ -126,7 +127,9 @@ QString TEntityResolver::interpolate(const QString& input, std::function<QString
 
 QString TEntityResolver::interpolate(const QString& input) const
 {
-    return interpolate(input, [this](const QString& it) { return getResolution(it); });
+    return interpolate(input, [this](const QString& it) {
+        return getResolution(it);
+    });
 }
 
 const TEntityResolver TEntityResolver::scmDefaultResolver = TEntityResolver();

--- a/src/TForkedProcess.cpp
+++ b/src/TForkedProcess.cpp
@@ -71,8 +71,7 @@ TForkedProcess::TForkedProcess(TLuaInterpreter* pInterpreter, lua_State* L)
     setProcessChannelMode(QProcess::MergedChannels);
     start(prog, args, QIODevice::ReadWrite);
     if (!waitForStarted()) {
-        const QString errorMessage = qsl("Failed to start process '%1': %2. Working directory: '%3'. PATH: '%4'")
-                                             .arg(prog, errorString(), QDir::currentPath(), qEnvironmentVariable("PATH"));
+        const QString errorMessage = qsl("Failed to start process '%1': %2. Working directory: '%3'. PATH: '%4'").arg(prog, errorString(), QDir::currentPath(), qEnvironmentVariable("PATH"));
         lua_pushstring(L, errorMessage.toUtf8().constData());
         lua_error(L);
         return;
@@ -160,7 +159,7 @@ int TForkedProcess::startProcess(TLuaInterpreter* pInterpreter, lua_State* L)
     auto process = new TForkedProcess(pInterpreter, L);
 
     // The userdata for the closures.
-    auto ** luaMemory = (QPointer<TForkedProcess>**)lua_newuserdata(L, sizeof(QPointer<TForkedProcess>*));
+    auto** luaMemory = (QPointer<TForkedProcess>**)lua_newuserdata(L, sizeof(QPointer<TForkedProcess>*));
     int userDataIndex = lua_gettop(L);
     if (lua_getmetatable(L, userDataIndex) != 0) {
         lua_pushstring(L, "Error: new user data should not have any metatable.");

--- a/src/THyperlinkCompactManager.cpp
+++ b/src/THyperlinkCompactManager.cpp
@@ -42,9 +42,7 @@ void THyperlinkCompactManager::registerShorthand(const QString& shorthand, const
 
     if (mShorthandRegistry.contains(shorthand)) {
         const ShorthandEntry& existing = mShorthandRegistry.value(shorthand);
-        qWarning() << "THyperlinkCompactManager::registerShorthand: Replacing existing shorthand"
-                   << shorthand << "→" << existing.fullName
-                   << "with new mapping:" << shorthand << "→" << fullName;
+        qWarning() << "THyperlinkCompactManager::registerShorthand: Replacing existing shorthand" << shorthand << "→" << existing.fullName << "with new mapping:" << shorthand << "→" << fullName;
     }
 
     mShorthandRegistry.insert(shorthand, ShorthandEntry(fullName));
@@ -114,8 +112,7 @@ void THyperlinkCompactManager::registerPresetProperty(const QString& propertyNam
     }
 
     if (mPresetPropertyRegistry.contains(propertyName)) {
-        qWarning() << "THyperlinkCompactManager::registerPresetProperty: Replacing existing preset property"
-                   << propertyName;
+        qWarning() << "THyperlinkCompactManager::registerPresetProperty: Replacing existing preset property" << propertyName;
     }
 
     mPresetPropertyRegistry.insert(propertyName, PresetPropertyEntry());
@@ -172,8 +169,7 @@ void THyperlinkCompactManager::registerPreset(const QString& name, const QJsonOb
     emit presetRegistered(name);
 
 #if defined(DEBUG_OSC_PROCESSING)
-    qDebug() << "[CompactSyntax] Registered preset:" << name
-             << "config:" << QJsonDocument(config).toJson(QJsonDocument::Compact);
+    qDebug() << "[CompactSyntax] Registered preset:" << name << "config:" << QJsonDocument(config).toJson(QJsonDocument::Compact);
 #endif
 }
 
@@ -206,8 +202,7 @@ QJsonObject THyperlinkCompactManager::deepMerge(const QJsonObject& base, const Q
 {
     // Check recursion depth limit to prevent stack overflow
     if (depth >= MAX_MERGE_DEPTH) {
-        qWarning() << "THyperlinkCompactManager::deepMerge: Maximum recursion depth"
-                   << MAX_MERGE_DEPTH << "reached. Stopping recursion and using overlay.";
+        qWarning() << "THyperlinkCompactManager::deepMerge: Maximum recursion depth" << MAX_MERGE_DEPTH << "reached. Stopping recursion and using overlay.";
         return overlay;
     }
 

--- a/src/THyperlinkSelectionManager.cpp
+++ b/src/THyperlinkSelectionManager.cpp
@@ -39,16 +39,16 @@ bool THyperlinkSelectionManager::isSelected(const QString& group, const QString&
 void THyperlinkSelectionManager::setSelected(const QString& group, const QString& value, bool selected)
 {
     registerGroupMember(group, value);
-    
+
     bool previousState = isSelected(group, value);
-    
+
     // If selecting and group is exclusive, clear other selections
     if (selected && isGroupExclusive(group)) {
         handleExclusiveSelection(group, value);
     }
-    
+
     mSelectionState[group][value] = selected;
-    
+
     if (previousState != selected) {
         emit selectionChanged(group, value, selected);
     }
@@ -86,7 +86,7 @@ QString THyperlinkSelectionManager::addSelectedParameter(const QString& command,
     QUrlQuery query(url);
     query.removeQueryItem(qsl("selected"));
     query.addQueryItem(qsl("selected"), isSelected ? qsl("true") : qsl("false"));
-    
+
     QString cleanCommand = url.path();
     if (!query.isEmpty()) {
         cleanCommand += qsl("?") + query.query(QUrl::FullyEncoded);
@@ -98,17 +98,17 @@ QString THyperlinkSelectionManager::modifyUriForSelection(const QString& baseUri
 {
     // Query the current selection state from our internal state
     bool isSelected = this->isSelected(group, value);
-    
+
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "modifyUriForSelection called with baseUri:" << baseUri << "group:" << group << "value:" << value << "isSelected:" << isSelected;
 #endif
-    
+
     // Check if it's a send() or sendCmdLine() call
     const QString sendPrefix = qsl("send([[");
     const QString sendSuffix = qsl("]])");
     const QString sendCmdLinePrefix = qsl("sendCmdLine([[");
     const QString sendCmdLineSuffix = qsl("]])");
-    
+
     if (baseUri.startsWith(sendPrefix) && baseUri.endsWith(sendSuffix)) {
         const int prefixLength = sendPrefix.length();
         const int suffixLength = sendSuffix.length();
@@ -130,7 +130,7 @@ QString THyperlinkSelectionManager::modifyUriForSelection(const QString& baseUri
 #endif
         return result;
     }
-    
+
     // For other URI formats (like openUrl), return as-is
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug() << "No modification - returning as-is";
@@ -143,18 +143,18 @@ void THyperlinkSelectionManager::registerGroupMember(const QString& group, const
     if (!mGroupMembers.contains(group)) {
         mGroupMembers[group] = QSet<QString>();
     }
-    
+
     mGroupMembers[group].insert(value);
 }
 
 void THyperlinkSelectionManager::setGroupExclusive(const QString& group, bool exclusive)
 {
     mGroupExclusivity[group] = exclusive;
-    
+
     if (exclusive && mSelectionState.contains(group)) {
         QStringList members = getGroupMembers(group);
         members.sort();
-        
+
         bool foundFirst = false;
         for (const QString& member : members) {
             if (isSelected(group, member)) {

--- a/src/THyperlinkVisibilityManager.cpp
+++ b/src/THyperlinkVisibilityManager.cpp
@@ -33,7 +33,7 @@ THyperlinkVisibilityManager::THyperlinkVisibilityManager(TConsole* pConsole)
 , mpConsole(pConsole)
 {
     Q_ASSERT(pConsole);
-    
+
     mpTimer = new QTimer(this);
     mpTimer->setInterval(100); // Check every 100ms for timer-based concealments
     connect(mpTimer, &QTimer::timeout, this, &THyperlinkVisibilityManager::slot_checkTimers);
@@ -49,8 +49,7 @@ THyperlinkVisibilityManager::~THyperlinkVisibilityManager()
     mpOutputGapTimer->stop();
 }
 
-bool THyperlinkVisibilityManager::registerHyperlink(int linkId, int lineNumber, int startColumn, int length,
-                                                    const QString& originalText, const Mudlet::HyperlinkStyling& styling)
+bool THyperlinkVisibilityManager::registerHyperlink(int linkId, int lineNumber, int startColumn, int length, const QString& originalText, const Mudlet::HyperlinkStyling& styling)
 {
     if (!styling.visibility.hasVisibilitySettings) {
         return false;
@@ -63,7 +62,7 @@ bool THyperlinkVisibilityManager::registerHyperlink(int linkId, int lineNumber, 
     tracked.length = length;
     tracked.originalText = originalText;
     tracked.creationTimeMs = QDateTime::currentMSecsSinceEpoch();
-    
+
     switch (styling.visibility.action) {
     case Mudlet::HyperlinkStyling::VisibilitySettings::Action::Conceal:
         tracked.action = TrackedHyperlink::Action::Conceal;
@@ -73,7 +72,7 @@ bool THyperlinkVisibilityManager::registerHyperlink(int linkId, int lineNumber, 
         break;
     case Mudlet::HyperlinkStyling::VisibilitySettings::Action::RevealThenConceal:
         tracked.action = TrackedHyperlink::Action::RevealThenConceal;
-        tracked.phase = TrackedHyperlink::Phase::Initial;  // Start in initial phase, waiting for reveal
+        tracked.phase = TrackedHyperlink::Phase::Initial; // Start in initial phase, waiting for reveal
         break;
     default:
         tracked.action = TrackedHyperlink::Action::None;
@@ -82,7 +81,7 @@ bool THyperlinkVisibilityManager::registerHyperlink(int linkId, int lineNumber, 
     tracked.delayMs = styling.visibility.delayMs;
     tracked.deletesEntireLine = styling.visibility.deletesEntireLine;
     tracked.isConcealed = styling.visibility.isConcealed;
-    
+
     // Copy expire trigger settings
     tracked.expireOnInput = styling.visibility.expireOnInput;
     tracked.expireOnPrompt = styling.visibility.expireOnPrompt;
@@ -109,22 +108,13 @@ bool THyperlinkVisibilityManager::registerHyperlink(int linkId, int lineNumber, 
         actionStr = qsl("none");
         break;
     }
-    qDebug().noquote() << "[OSC] Registered hyperlink" << linkId 
-                       << "at line" << lineNumber << "col" << startColumn
-                       << "length" << length
-                       << "action:" << actionStr
-                       << "delayMs:" << tracked.delayMs
-                       << "deletesEntireLine:" << tracked.deletesEntireLine
-                       << "isConcealed:" << tracked.isConcealed
-                       << "expireOnInput:" << tracked.expireOnInput
-                       << "expireOnPrompt:" << tracked.expireOnPrompt
-                       << "expireOnOutput:" << tracked.expireOnOutput
-                       << "outputDelayMs:" << tracked.outputDelayMs;
+    qDebug().noquote() << "[OSC] Registered hyperlink" << linkId << "at line" << lineNumber << "col" << startColumn << "length" << length << "action:" << actionStr << "delayMs:" << tracked.delayMs
+                       << "deletesEntireLine:" << tracked.deletesEntireLine << "isConcealed:" << tracked.isConcealed << "expireOnInput:" << tracked.expireOnInput
+                       << "expireOnPrompt:" << tracked.expireOnPrompt << "expireOnOutput:" << tracked.expireOnOutput << "outputDelayMs:" << tracked.outputDelayMs;
 #endif
 
     // Handle reveal with zero delay - reveal immediately (don't start concealed)
-    if (tracked.action == TrackedHyperlink::Action::Reveal && tracked.delayMs == 0 
-        && !tracked.expireOnInput && !tracked.expireOnPrompt && !tracked.expireOnOutput) {
+    if (tracked.action == TrackedHyperlink::Action::Reveal && tracked.delayMs == 0 && !tracked.expireOnInput && !tracked.expireOnPrompt && !tracked.expireOnOutput) {
 #if defined(DEBUG_OSC_PROCESSING)
         qDebug().noquote() << "[OSC] Reveal link" << linkId << "has zero delay and no expire triggers - will be visible immediately";
 #endif
@@ -150,7 +140,7 @@ bool THyperlinkVisibilityManager::registerHyperlink(int linkId, int lineNumber, 
         mHasTimerBasedLinks = true;
         startTimerIfNeeded();
     }
-    
+
     // Return true if this link should start concealed (caller should replace text with spaces)
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug().noquote() << "[OSC] registerHyperlink returning isConcealed=" << tracked.isConcealed << "for linkId" << linkId;
@@ -161,20 +151,18 @@ bool THyperlinkVisibilityManager::registerHyperlink(int linkId, int lineNumber, 
 void THyperlinkVisibilityManager::onLinkClicked(int linkId)
 {
 #if defined(DEBUG_OSC_PROCESSING)
-    qDebug().noquote() << "[OSC] onLinkClicked called with linkId:" << linkId 
-                       << "tracked links count:" << mTrackedLinks.size()
-                       << "contains linkId:" << mTrackedLinks.contains(linkId);
+    qDebug().noquote() << "[OSC] onLinkClicked called with linkId:" << linkId << "tracked links count:" << mTrackedLinks.size() << "contains linkId:" << mTrackedLinks.contains(linkId);
 #endif
     if (!mTrackedLinks.contains(linkId)) {
         return;
     }
 
     TrackedHyperlink& link = mTrackedLinks[linkId];
-    
+
     // For conceal actions, clicking activates the concealment
     if (link.action == TrackedHyperlink::Action::Conceal && !link.isConcealed) {
         const bool hasExpireTriggers = link.expireOnInput || link.expireOnPrompt || link.expireOnOutput;
-        
+
         if (link.delayMs == 0 && !hasExpireTriggers) {
             // Immediate concealment (no delay and no expire triggers)
 #if defined(DEBUG_OSC_PROCESSING)
@@ -198,19 +186,15 @@ void THyperlinkVisibilityManager::onLinkClicked(int linkId)
             link.skipFirstPrompt = link.expireOnPrompt;
             link.skipFirstOutput = link.expireOnOutput;
 #if defined(DEBUG_OSC_PROCESSING)
-            qDebug().noquote() << "[OSC] Link" << linkId << "clicked - expire triggers activated"
-                               << "input:" << link.expireOnInput
-                               << "skipPrompt:" << link.skipFirstPrompt
+            qDebug().noquote() << "[OSC] Link" << linkId << "clicked - expire triggers activated" << "input:" << link.expireOnInput << "skipPrompt:" << link.skipFirstPrompt
                                << "skipOutput:" << link.skipFirstOutput;
 #endif
         }
     }
-    
+
     // For RevealThenConceal links that have been revealed, clicking conceals immediately
     // (the delay only applies to the initial reveal phase, not the conceal)
-    if (link.action == TrackedHyperlink::Action::RevealThenConceal 
-        && link.phase == TrackedHyperlink::Phase::Revealed) {
-        
+    if (link.action == TrackedHyperlink::Action::RevealThenConceal && link.phase == TrackedHyperlink::Phase::Revealed) {
 #if defined(DEBUG_OSC_PROCESSING)
         qDebug().noquote() << "[OSC] RevealThenConceal link" << linkId << "clicked - concealing immediately";
 #endif
@@ -250,11 +234,11 @@ void THyperlinkVisibilityManager::onPromptReceived()
 void THyperlinkVisibilityManager::onDataReceived()
 {
     qint64 currentTime = QDateTime::currentMSecsSinceEpoch();
-    
+
     // Check if any tracked links have output expiry enabled
     quint32 minOutputDelay = 0;
     bool hasOutputLinks = false;
-    
+
     for (const auto& link : mTrackedLinks) {
         if (link.expireOnOutput) {
             hasOutputLinks = true;
@@ -263,12 +247,12 @@ void THyperlinkVisibilityManager::onDataReceived()
             }
         }
     }
-    
+
     if (!hasOutputLinks) {
         mLastDataReceivedMs = currentTime;
         return;
     }
-    
+
     // Sammer's "batch" approach: expire links when new data arrives AFTER a gap
     // This creates the "one batch at a time" effect - old links are hidden when
     // a new batch of output begins, not during the idle period
@@ -280,9 +264,9 @@ void THyperlinkVisibilityManager::onDataReceived()
 #endif
         processExpireTriggeredLinks(false, false, true);
     }
-    
+
     mLastDataReceivedMs = currentTime;
-    
+
     // Start/restart the output gap timer with the minimum delay
     // Clamp to INT_MAX to prevent truncation when casting to int for QTimer::start()
     if (mpOutputGapTimer && minOutputDelay > 0) {
@@ -305,18 +289,18 @@ void THyperlinkVisibilityManager::slot_outputGapExpired()
 void THyperlinkVisibilityManager::processExpireTriggeredLinks(bool input, bool prompt, bool output)
 {
     bool changed = false;
-    
+
     // First pass: collect IDs of links that should be processed for this expire trigger
     QVector<int> linksToProcess;
-    
+
     for (auto it = mTrackedLinks.begin(); it != mTrackedLinks.end(); ++it) {
         TrackedHyperlink& link = it.value();
-        
+
         // Only process links that have been activated by clicking
         if (!link.expireActivated) {
             continue;
         }
-        
+
         // Handle skipFirstPrompt - skip the immediate prompt from the click action response
         if (prompt && link.skipFirstPrompt) {
             link.skipFirstPrompt = false;
@@ -325,7 +309,7 @@ void THyperlinkVisibilityManager::processExpireTriggeredLinks(bool input, bool p
 #endif
             continue;
         }
-        
+
         // Handle skipFirstOutput - skip the immediate output from the click action response
         if (output && link.skipFirstOutput) {
             link.skipFirstOutput = false;
@@ -334,37 +318,33 @@ void THyperlinkVisibilityManager::processExpireTriggeredLinks(bool input, bool p
 #endif
             continue;
         }
-        
+
         // Check if this trigger applies to this link
-        bool shouldTrigger = (input && link.expireOnInput) ||
-                            (prompt && link.expireOnPrompt) ||
-                            (output && link.expireOnOutput);
-        
+        bool shouldTrigger = (input && link.expireOnInput) || (prompt && link.expireOnPrompt) || (output && link.expireOnOutput);
+
         if (shouldTrigger) {
             linksToProcess.append(it.key());
         }
     }
-    
+
     // Second pass: process each link by ID (safe from iterator invalidation)
     for (int linkId : linksToProcess) {
         // Look up the link - it might have been removed by previous operations
         if (!mTrackedLinks.contains(linkId)) {
             continue;
         }
-        
+
         TrackedHyperlink& link = mTrackedLinks[linkId];
 
         if (link.action == TrackedHyperlink::Action::Conceal && !link.isConcealed) {
 #if defined(DEBUG_OSC_PROCESSING)
-            qDebug().noquote() << "[OSC] Expire trigger concealing link" << link.linkId
-                               << "input:" << input << "prompt:" << prompt << "output:" << output;
+            qDebug().noquote() << "[OSC] Expire trigger concealing link" << link.linkId << "input:" << input << "prompt:" << prompt << "output:" << output;
 #endif
             performConcealment(link);
             changed = true;
         } else if (link.action == TrackedHyperlink::Action::Reveal && link.isConcealed) {
 #if defined(DEBUG_OSC_PROCESSING)
-            qDebug().noquote() << "[OSC] Expire trigger revealing link" << link.linkId
-                               << "input:" << input << "prompt:" << prompt << "output:" << output;
+            qDebug().noquote() << "[OSC] Expire trigger revealing link" << link.linkId << "input:" << input << "prompt:" << prompt << "output:" << output;
 #endif
             performReveal(link);
             changed = true;
@@ -373,8 +353,7 @@ void THyperlinkVisibilityManager::processExpireTriggeredLinks(bool input, bool p
             if (link.phase == TrackedHyperlink::Phase::Initial && link.isConcealed) {
                 // Phase 1: Reveal the link
 #if defined(DEBUG_OSC_PROCESSING)
-                qDebug().noquote() << "[OSC] RevealThenConceal link" << link.linkId 
-                                   << "- expire trigger revealing (phase: Initial -> Revealed)";
+                qDebug().noquote() << "[OSC] RevealThenConceal link" << link.linkId << "- expire trigger revealing (phase: Initial -> Revealed)";
 #endif
                 performReveal(link);
                 link.phase = TrackedHyperlink::Phase::Revealed;
@@ -383,7 +362,7 @@ void THyperlinkVisibilityManager::processExpireTriggeredLinks(bool input, bool p
             // Note: Conceal phase for RevealThenConceal is triggered by click, not by expire triggers
         }
     }
-    
+
     if (changed) {
         emit visibilityChanged();
     }
@@ -432,38 +411,38 @@ bool THyperlinkVisibilityManager::isLinkConcealed(int linkId) const
 void THyperlinkVisibilityManager::removeLinksOnLine(int lineNumber)
 {
     QList<int> toRemove;
-    
+
     for (auto it = mTrackedLinks.constBegin(); it != mTrackedLinks.constEnd(); ++it) {
         if (it.value().lineNumber == lineNumber) {
             toRemove.append(it.key());
         }
     }
-    
+
     for (int linkId : toRemove) {
         mTrackedLinks.remove(linkId);
     }
-    
+
     stopTimerIfNotNeeded();
 }
 
 void THyperlinkVisibilityManager::adjustLineNumbers(int deletedLineStart, int deletedLineCount)
 {
     QList<int> toRemove;
-    
+
     for (auto it = mTrackedLinks.begin(); it != mTrackedLinks.end(); ++it) {
         TrackedHyperlink& link = it.value();
-        
+
         if (link.lineNumber >= deletedLineStart && link.lineNumber < deletedLineStart + deletedLineCount) {
             toRemove.append(it.key());
         } else if (link.lineNumber >= deletedLineStart + deletedLineCount) {
             link.lineNumber -= deletedLineCount;
         }
     }
-    
+
     for (int linkId : toRemove) {
         mTrackedLinks.remove(linkId);
     }
-    
+
     stopTimerIfNotNeeded();
 }
 
@@ -488,11 +467,11 @@ void THyperlinkVisibilityManager::slot_checkTimers()
     qint64 currentTime = QDateTime::currentMSecsSinceEpoch();
     bool changed = false;
     bool stillHasTimerLinks = false;
-    
+
     // Collect link IDs that need action to avoid iterator invalidation
     QVector<int> linksToReveal;
     QVector<int> linksToConceal;
-    QVector<int> linksToTransition;  // For RevealThenConceal phase transitions
+    QVector<int> linksToTransition; // For RevealThenConceal phase transitions
 
     for (auto it = mTrackedLinks.begin(); it != mTrackedLinks.end(); ++it) {
         TrackedHyperlink& link = it.value();
@@ -508,26 +487,25 @@ void THyperlinkVisibilityManager::slot_checkTimers()
                 stillHasTimerLinks = true;
                 continue;
             }
-            
+
             qint64 elapsed = currentTime - link.timerActivatedMs;
             if (elapsed < link.delayMs) {
                 stillHasTimerLinks = true;
                 continue;
             }
-            
+
             linksToConceal.append(it.key());
         } else if (link.action == TrackedHyperlink::Action::Reveal && link.isConcealed) {
             // For reveal actions, timer starts immediately from creation
             qint64 elapsed = currentTime - link.creationTimeMs;
 #if defined(DEBUG_OSC_PROCESSING)
-            qDebug().noquote() << "[OSC] Checking reveal link" << it.key() 
-                               << "elapsed:" << elapsed << "delayMs:" << link.delayMs;
+            qDebug().noquote() << "[OSC] Checking reveal link" << it.key() << "elapsed:" << elapsed << "delayMs:" << link.delayMs;
 #endif
             if (elapsed < link.delayMs) {
                 stillHasTimerLinks = true;
                 continue;
             }
-            
+
             linksToReveal.append(it.key());
         } else if (link.action == TrackedHyperlink::Action::RevealThenConceal) {
             // Handle RevealThenConceal based on phase
@@ -539,8 +517,7 @@ void THyperlinkVisibilityManager::slot_checkTimers()
                     continue;
                 }
 #if defined(DEBUG_OSC_PROCESSING)
-                qDebug().noquote() << "[OSC] RevealThenConceal link" << it.key() 
-                                   << "- timer revealing (phase: Initial -> Revealed)";
+                qDebug().noquote() << "[OSC] RevealThenConceal link" << it.key() << "- timer revealing (phase: Initial -> Revealed)";
 #endif
                 // Keep timer running as link transitions to Revealed phase waiting for click
                 stillHasTimerLinks = true;
@@ -551,7 +528,7 @@ void THyperlinkVisibilityManager::slot_checkTimers()
             }
         }
     }
-    
+
     // Now process the collected links (safe because we're not iterating)
     for (int linkId : linksToReveal) {
         if (mTrackedLinks.contains(linkId)) {
@@ -559,7 +536,7 @@ void THyperlinkVisibilityManager::slot_checkTimers()
             changed = true;
         }
     }
-    
+
     for (int linkId : linksToConceal) {
         if (mTrackedLinks.contains(linkId)) {
             // For RevealThenConceal, mark phase as Concealed
@@ -570,7 +547,7 @@ void THyperlinkVisibilityManager::slot_checkTimers()
             changed = true;
         }
     }
-    
+
     for (int linkId : linksToTransition) {
         if (mTrackedLinks.contains(linkId)) {
             performReveal(mTrackedLinks[linkId]);
@@ -580,7 +557,7 @@ void THyperlinkVisibilityManager::slot_checkTimers()
     }
 
     mHasTimerBasedLinks = stillHasTimerLinks;
-    
+
     if (!mHasTimerBasedLinks) {
         stopTimerIfNotNeeded();
     }
@@ -606,8 +583,7 @@ void THyperlinkVisibilityManager::stopTimerIfNotNeeded()
             // RevealThenConceal links in certain phases still need the timer even with zero delay
             if (link.delayMs == 0) {
                 // Don't skip RevealThenConceal links that are in phases requiring the timer
-                if (link.action == TrackedHyperlink::Action::RevealThenConceal && 
-                    link.phase != TrackedHyperlink::Phase::Concealed) {
+                if (link.action == TrackedHyperlink::Action::RevealThenConceal && link.phase != TrackedHyperlink::Phase::Concealed) {
                     // These phases need the timer even with zero delay
                     hasTimerLinks = true;
                     break;
@@ -634,7 +610,7 @@ void THyperlinkVisibilityManager::stopTimerIfNotNeeded()
                 }
             }
         }
-        
+
         if (!hasTimerLinks) {
             mpTimer->stop();
             mHasTimerBasedLinks = false;
@@ -649,8 +625,7 @@ void THyperlinkVisibilityManager::performConcealment(TrackedHyperlink& link)
     }
 
 #if defined(DEBUG_OSC_PROCESSING)
-    qDebug().noquote() << "[OSC] Concealing link" << link.linkId
-                       << "deletesEntireLine:" << link.deletesEntireLine;
+    qDebug().noquote() << "[OSC] Concealing link" << link.linkId << "deletesEntireLine:" << link.deletesEntireLine;
 #endif
 
     TBuffer& buffer = mpConsole->buffer;
@@ -659,11 +634,11 @@ void THyperlinkVisibilityManager::performConcealment(TrackedHyperlink& link)
         // CRITICAL BUG FIX: Prevent cascade deletion by unregistering ALL links on the target line
         // before deleting it. This prevents other links from being adjusted to the wrong line
         // and accidentally triggering on content they shouldn't affect.
-        
+
         // Capture fields from link before removal to avoid dangling reference
         const int targetLine = link.lineNumber;
         const int currentLinkId = link.linkId;
-        
+
         if (targetLine >= 0 && targetLine < buffer.lineBuffer.size()) {
             // First, collect all link IDs that are on the same line as the one being deleted
             QList<int> linksOnTargetLine;
@@ -672,7 +647,7 @@ void THyperlinkVisibilityManager::performConcealment(TrackedHyperlink& link)
                     linksOnTargetLine.append(it.key());
                 }
             }
-            
+
             // Unregister all links on the target line to prevent interference
             for (int linkId : linksOnTargetLine) {
                 if (linkId != currentLinkId) { // Don't remove the current link yet
@@ -682,12 +657,12 @@ void THyperlinkVisibilityManager::performConcealment(TrackedHyperlink& link)
 #endif
                 }
             }
-            
+
             // Now delete the line
             buffer.deleteLine(targetLine);
-            
+
             mTrackedLinks.remove(currentLinkId);
-            
+
             // SAFE line number adjustment: Only adjust links that are on lines > targetLine
             // Update in-place to avoid copying the entire map
             for (auto it = mTrackedLinks.begin(); it != mTrackedLinks.end(); ++it) {
@@ -695,13 +670,11 @@ void THyperlinkVisibilityManager::performConcealment(TrackedHyperlink& link)
                     int originalLine = it.value().lineNumber;
                     it.value().lineNumber--;
 #if defined(DEBUG_OSC_PROCESSING)
-                    qDebug().noquote() << "[OSC] Adjusted link" << it.key() 
-                                       << "from line" << originalLine 
-                                       << "to line" << it.value().lineNumber;
+                    qDebug().noquote() << "[OSC] Adjusted link" << it.key() << "from line" << originalLine << "to line" << it.value().lineNumber;
 #endif
                 }
             }
-            
+
             // Update display
             if (mpConsole->mUpperPane) {
                 mpConsole->mUpperPane->update();
@@ -709,7 +682,7 @@ void THyperlinkVisibilityManager::performConcealment(TrackedHyperlink& link)
             if (mpConsole->mLowerPane) {
                 mpConsole->mLowerPane->update();
             }
-            
+
             // Stop timer if no more timer-based links exist
             bool hasTimers = false;
             for (const auto& remainingLink : mTrackedLinks) {
@@ -722,21 +695,21 @@ void THyperlinkVisibilityManager::performConcealment(TrackedHyperlink& link)
                 mHasTimerBasedLinks = false;
                 mpTimer->stop();
             }
-            
+
             return; // Early return - all cleanup done
         }
     } else {
         // Non-destructive concealment (replace text with spaces)
         if (link.lineNumber >= 0 && link.lineNumber < buffer.lineBuffer.size()) {
             QString& lineText = buffer.lineBuffer[link.lineNumber];
-            
+
             if (link.startColumn >= 0 && link.startColumn + link.length <= lineText.length()) {
                 // Replace text with spaces of the same character length to maintain buffer consistency
                 const QString spaces = QString(link.length, ' ');
-                
+
                 lineText.replace(link.startColumn, link.length, spaces);
                 buffer.clearLinkIndices(link.lineNumber, link.startColumn, link.length);
-                
+
                 // Only mark as concealed and update panes after successful text replacement
                 link.isConcealed = true;
 
@@ -770,13 +743,13 @@ void THyperlinkVisibilityManager::performReveal(TrackedHyperlink& link)
 
     if (link.lineNumber >= 0 && link.lineNumber < buffer.lineBuffer.size()) {
         QString& lineText = buffer.lineBuffer[link.lineNumber];
-        
+
         if (link.startColumn >= 0 && link.startColumn + link.length <= lineText.length()) {
             lineText.replace(link.startColumn, link.length, link.originalText);
             // Restore the link indices so the text is clickable again
             buffer.restoreLinkIndices(link.lineNumber, link.startColumn, link.length, link.linkId);
             link.isConcealed = false;
-            
+
             if (mpConsole->mUpperPane) {
                 mpConsole->mUpperPane->update();
             }

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -29,13 +29,13 @@
 #include "mudlet.h"
 
 TKey::TKey(TKey* parent, Host* pHost)
-: Tree<TKey>( parent )
+: Tree<TKey>(parent)
 , mpHost(pHost)
 {
 }
 
 TKey::TKey(QString name, Host* pHost)
-: Tree<TKey>( nullptr )
+: Tree<TKey>(nullptr)
 , mpHost(pHost)
 , mName(name)
 {

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -90,7 +90,7 @@ void TLabel::setText(const QString& text)
 
         for (const auto& match : matches) {
             QString fullMatch = match.captured(0);
-            QString hrefPart = match.captured(1);  // The href="..." part
+            QString hrefPart = match.captured(1);   // The href="..." part
             QString otherAttrs = match.captured(2); // Other attributes
 
             // Extract the actual URL from hrefPart (remove quotes)
@@ -249,7 +249,6 @@ void TLabel::mouseMoveEvent(QMouseEvent* event)
 
 void TLabel::wheelEvent(QWheelEvent* event)
 {
-
     if (mpHost && mWheelFunction) {
         mpHost->getLuaInterpreter()->callLabelCallbackEvent(mWheelFunction, event);
         event->accept();
@@ -386,7 +385,7 @@ void TLabel::slot_linkActivated(const QString& link)
 
     if (colonPos > 0) {
         const QString scheme = link.left(colonPos).toLower(); // RFC 3986: schemes are case-insensitive
-        const QString payload = link.mid(colonPos + 1); // Everything after the colon
+        const QString payload = link.mid(colonPos + 1);       // Everything after the colon
 
         // Handle custom Mudlet URL schemes for Lua commands
         if (scheme == qsl("send")) {

--- a/src/TLinkStore.cpp
+++ b/src/TLinkStore.cpp
@@ -20,9 +20,9 @@
 
 #include "TLinkStore.h"
 #if !defined(LinkStore_Test)
-#include "TBuffer.h"  // For Mudlet::HyperlinkStyling definition
+#include "TBuffer.h" // For Mudlet::HyperlinkStyling definition
 #include "Host.h"
-#include "utils.h"    // For qsl() macro
+#include "utils.h" // For qsl() macro
 #endif
 
 #include <QSet>
@@ -138,9 +138,9 @@ void TLinkStore::setStyling(int id, const Mudlet::HyperlinkStyling& styling)
             mSelectionGroupIndex.remove(oldKey, id);
         }
     }
-    
+
     mStylingStore[id] = styling;
-    
+
     // Add new selection group index entry if applicable
     if (styling.selection.hasSelectionSettings) {
         QPair<QString, QString> key = qMakePair(styling.selection.group, styling.selection.value);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -88,8 +88,8 @@ static bool isMain(const QString& name)
     return false;
 }
 
-static const char *bad_cmdline_type = "%s: bad argument #%d type (command line name as string expected, got %s)!";
-static const char *bad_cmdline_value = "command line \"%s\" not found";
+static const char* bad_cmdline_type = "%s: bad argument #%d type (command line name as string expected, got %s)!";
+static const char* bad_cmdline_value = "command line \"%s\" not found";
 
 const QString TLuaInterpreter::csmInvalidRoomID{qsl("number %1 is not a valid roomID")};
 const QString TLuaInterpreter::csmInvalidStopWatchID{qsl("stopwatch with ID %1 not found")};
@@ -102,28 +102,27 @@ const QString TLuaInterpreter::csmInvalidItemID{qsl("item ID as %1 does not seem
 const QString TLuaInterpreter::csmInvalidAreaID{qsl("number %1 is not a valid area id")};
 const QString TLuaInterpreter::csmInvalidAreaName{qsl("string '%1' is not a valid area name")};
 
-#define CMDLINE_NAME(ARG_L, ARG_pos)                                                                 \
-    ({                                                                                               \
-        int pos_ = (ARG_pos);                                                                        \
-        if (!lua_isstring(ARG_L, pos_)) {                                                            \
-            lua_pushfstring(ARG_L, bad_cmdline_type, __FUNCTION__, pos_, luaL_typename(ARG_L, pos_));\
-            return lua_error(ARG_L);                                                                 \
-        }                                                                                            \
-        lua_tostring(ARG_L, pos_);                                                                   \
+#define CMDLINE_NAME(ARG_L, ARG_pos)                                                                                                                                                                   \
+    ({                                                                                                                                                                                                 \
+        int pos_ = (ARG_pos);                                                                                                                                                                          \
+        if (!lua_isstring(ARG_L, pos_)) {                                                                                                                                                              \
+            lua_pushfstring(ARG_L, bad_cmdline_type, __FUNCTION__, pos_, luaL_typename(ARG_L, pos_));                                                                                                  \
+            return lua_error(ARG_L);                                                                                                                                                                   \
+        }                                                                                                                                                                                              \
+        lua_tostring(ARG_L, pos_);                                                                                                                                                                     \
     })
 
-#define COMMANDLINE(ARG_L, ARG_name)                                                           \
-    ({                                                                                         \
-        const QString& name_ = (ARG_name);                                                     \
-        auto console_ = getHostFromLua(ARG_L).mpConsole;                                       \
-        auto cmdLine_ = isMain(name_) ? &*console_->mpCommandLine                              \
-                                    : console_->mSubCommandLineMap.value(name_);               \
-        if (!cmdLine_) {                                                                       \
-            lua_pushnil(ARG_L);                                                                \
-            lua_pushfstring(ARG_L, bad_cmdline_value, name_.toUtf8().constData());             \
-            return 2;                                                                          \
-        }                                                                                      \
-        cmdLine_;                                                                              \
+#define COMMANDLINE(ARG_L, ARG_name)                                                                                                                                                                   \
+    ({                                                                                                                                                                                                 \
+        const QString& name_ = (ARG_name);                                                                                                                                                             \
+        auto console_ = getHostFromLua(ARG_L).mpConsole;                                                                                                                                               \
+        auto cmdLine_ = isMain(name_) ? &*console_->mpCommandLine : console_->mSubCommandLineMap.value(name_);                                                                                         \
+        if (!cmdLine_) {                                                                                                                                                                               \
+            lua_pushnil(ARG_L);                                                                                                                                                                        \
+            lua_pushfstring(ARG_L, bad_cmdline_value, name_.toUtf8().constData());                                                                                                                     \
+            return 2;                                                                                                                                                                                  \
+        }                                                                                                                                                                                              \
+        cmdLine_;                                                                                                                                                                                      \
     })
 
 // variable names within these macros have trailing underscores because in
@@ -237,7 +236,7 @@ float TLuaInterpreter::getVerifiedFloat(lua_State* L, const char* functionName, 
         lua_error(L);
         Q_UNREACHABLE();
     }
-    return static_cast <float> (lua_tonumber(L, pos));
+    return static_cast<float>(lua_tonumber(L, pos));
 }
 
 // No documentation available in wiki - internal function
@@ -258,11 +257,9 @@ double TLuaInterpreter::getVerifiedDouble(lua_State* L, const char* functionName
 void TLuaInterpreter::errorArgumentType(lua_State* L, const char* functionName, const int pos, const char* publicName, const char* publicType, const bool isOptional)
 {
     if (isOptional) {
-        lua_pushfstring(L, "%s: bad argument #%d type (%s as %s is optional, got %s!)",
-            functionName, pos, publicName, publicType, luaL_typename(L, pos));
+        lua_pushfstring(L, "%s: bad argument #%d type (%s as %s is optional, got %s!)", functionName, pos, publicName, publicType, luaL_typename(L, pos));
     } else {
-        lua_pushfstring(L, "%s: bad argument #%d type (%s as %s expected, got %s!)",
-            functionName, pos, publicName, publicType, luaL_typename(L, pos));
+        lua_pushfstring(L, "%s: bad argument #%d type (%s as %s expected, got %s!)", functionName, pos, publicName, publicType, luaL_typename(L, pos));
     }
 }
 
@@ -319,7 +316,7 @@ void TLuaInterpreter::slot_httpRequestFinished(QNetworkReply* reply)
     }
 
     if (reply->error() != QNetworkReply::NoError) {
-        TEvent event {};
+        TEvent event{};
         QString localFileName;
 
         switch (reply->operation()) {
@@ -343,9 +340,7 @@ void TLuaInterpreter::slot_httpRequestFinished(QNetworkReply* reply)
 
         case QNetworkAccessManager::GetOperation:
             localFileName = downloadMap.value(reply);
-            event.mArgumentList << (localFileName.isEmpty()
-                                   ? qsl("sysGetHttpError")
-                                   : qsl("sysDownloadError"));
+            event.mArgumentList << (localFileName.isEmpty() ? qsl("sysGetHttpError") : qsl("sysDownloadError"));
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
             event.mArgumentList << reply->errorString();
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
@@ -399,7 +394,7 @@ void TLuaInterpreter::slot_httpRequestFinished(QNetworkReply* reply)
 // No documentation available in wiki - internal function
 void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
 {
-    TEvent event {};
+    TEvent event{};
     Host* pHost = mpHost;
     if (!pHost) {
         return;
@@ -515,7 +510,6 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
         }
         break;
-
     }
 
     event.mArgumentList << QString::number(createHttpResponseTable(reply));
@@ -531,14 +525,14 @@ void TLuaInterpreter::raiseDownloadProgressEvent(lua_State* L, QString fileUrl, 
 {
     Host& host = getHostFromLua(L);
 
-    TEvent event {};
+    TEvent event{};
     event.mArgumentList << qsl("sysDownloadFileProgress");
     event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
     event.mArgumentList << fileUrl;
     event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
     event.mArgumentList << QString::number(bytesDownloaded);
     event.mArgumentTypeList << ARGUMENT_TYPE_NUMBER;
-    if(totalBytes >= 0) {
+    if (totalBytes >= 0) {
         event.mArgumentList << QString::number(totalBytes);
         event.mArgumentTypeList << ARGUMENT_TYPE_NUMBER;
     } else {
@@ -558,7 +552,7 @@ void TLuaInterpreter::slot_pathChanged(const QString& path)
         mpFileSystemWatcher->addPath(path);
     }
 
-    TEvent event {};
+    TEvent event{};
     event.mArgumentList << QLatin1String("sysPathChanged");
     event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
     event.mArgumentList << path;
@@ -675,7 +669,6 @@ QString TLuaInterpreter::dirToString(lua_State* L, int position)
             return QLatin1String("out");
         }
         return direction;
-
     }
     return QString();
 }
@@ -768,9 +761,8 @@ int TLuaInterpreter::resetProfile(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getWindowsCodepage
 int TLuaInterpreter::getWindowsCodepage(lua_State* L)
 {
-#if defined (Q_OS_WINDOWS)
-    QSettings registry(qsl(R"(HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Nls\CodePage)"),
-                       QSettings::NativeFormat);
+#if defined(Q_OS_WINDOWS)
+    QSettings registry(qsl(R"(HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Nls\CodePage)"), QSettings::NativeFormat);
     auto value = registry.value(qsl("ACP"));
     lua_pushstring(L, value.toString().toUtf8().constData());
     return 1;
@@ -836,190 +828,158 @@ QByteArray TLuaInterpreter::parseTelnetCodes(const QByteArray& input)
      * * ASCII character abbreviation
      * * `T_` prefix - Telnet control code
      */
-    const QHash<QByteArray, unsigned char> lookupTable = {
-        {QByteArray("<00>"), '\0'},
-        {QByteArray("<O_BINARY>"), '\0'},
-        {QByteArray("<NUL>"), '\0'},
+    const QHash<QByteArray, unsigned char> lookupTable = {{QByteArray("<00>"), '\0'},           {QByteArray("<O_BINARY>"), '\0'},   {QByteArray("<NUL>"), '\0'},
 
-        {QByteArray("<01>"), '\x01'},
-        {QByteArray("<O_ECHO>"), '\x01'},
-        {QByteArray("<SOH>"), '\x01'},
+                                                          {QByteArray("<01>"), '\x01'},         {QByteArray("<O_ECHO>"), '\x01'},   {QByteArray("<SOH>"), '\x01'},
 
-        {QByteArray("<02>"), '\x02'}, // Reconnect
-        {QByteArray("<STX>"), '\x02'},
+                                                          {QByteArray("<02>"), '\x02'}, // Reconnect
+                                                          {QByteArray("<STX>"), '\x02'},
 
-        {QByteArray("<03>"), '\x03'},
-        {QByteArray("<O_SGA>"), '\x03'},
-        {QByteArray("<ETX>"), '\x03'},
+                                                          {QByteArray("<03>"), '\x03'},         {QByteArray("<O_SGA>"), '\x03'},    {QByteArray("<ETX>"), '\x03'},
 
-        {QByteArray("<04>"), '\x04'}, // Approx Message Size Negotiation
-        {QByteArray("<EOT>"), '\x04'},
+                                                          {QByteArray("<04>"), '\x04'}, // Approx Message Size Negotiation
+                                                          {QByteArray("<EOT>"), '\x04'},
 
-        {QByteArray("<05>"), '\x05'},
-        {QByteArray("<O_STATUS>"), '\x05'},
-        {QByteArray("<ENQ>"), '\x05'},
+                                                          {QByteArray("<05>"), '\x05'},         {QByteArray("<O_STATUS>"), '\x05'}, {QByteArray("<ENQ>"), '\x05'},
 
-        {QByteArray("<06>"), '\x06'}, // Timing Mark
-        {QByteArray("<ACK>"), '\x06'},
+                                                          {QByteArray("<06>"), '\x06'}, // Timing Mark
+                                                          {QByteArray("<ACK>"), '\x06'},
 
-        {QByteArray("<07>"), '\x07'}, // Remote Controlled Trans and Echo
-        {QByteArray("<BELL>"), '\x07'},
+                                                          {QByteArray("<07>"), '\x07'}, // Remote Controlled Trans and Echo
+                                                          {QByteArray("<BELL>"), '\x07'},
 
-        {QByteArray("<08>"), '\x08'}, // Output Line Width
-        {QByteArray("<BS>"), '\x08'},
+                                                          {QByteArray("<08>"), '\x08'}, // Output Line Width
+                                                          {QByteArray("<BS>"), '\x08'},
 
-        {QByteArray("<09>"), '\x09'}, // Output Page Size
-        {QByteArray("<HTAB>"), '\x09'},
+                                                          {QByteArray("<09>"), '\x09'}, // Output Page Size
+                                                          {QByteArray("<HTAB>"), '\x09'},
 
-        {QByteArray("<0A>"), '\x0a'}, // Output Carriage-Return Disposition
-        {QByteArray("<LF>"), '\x0a'},
+                                                          {QByteArray("<0A>"), '\x0a'}, // Output Carriage-Return Disposition
+                                                          {QByteArray("<LF>"), '\x0a'},
 
-        {QByteArray("<0B>"), '\x0b'}, // Output Horizontal Tab Stops
-        {QByteArray("<VTAB>"), '\x0b'},
+                                                          {QByteArray("<0B>"), '\x0b'}, // Output Horizontal Tab Stops
+                                                          {QByteArray("<VTAB>"), '\x0b'},
 
-        {QByteArray("<0C>"), '\x0c'}, // Output Horizontal Tab Disposition
-        {QByteArray("<FF>"), '\x0c'},
+                                                          {QByteArray("<0C>"), '\x0c'}, // Output Horizontal Tab Disposition
+                                                          {QByteArray("<FF>"), '\x0c'},
 
-        {QByteArray("<0D>"), '\x0d'}, // Output Formfeed Disposition
-        {QByteArray("<CR>"), '\x0d'},
+                                                          {QByteArray("<0D>"), '\x0d'}, // Output Formfeed Disposition
+                                                          {QByteArray("<CR>"), '\x0d'},
 
-        {QByteArray("<0E>"), '\x0e'}, // Output Vertical Tab Stops
-        {QByteArray("<SO>"), '\x0e'},
+                                                          {QByteArray("<0E>"), '\x0e'}, // Output Vertical Tab Stops
+                                                          {QByteArray("<SO>"), '\x0e'},
 
-        {QByteArray("<0F>"), '\x0f'}, // Output Vertical Tab Disposition
-        {QByteArray("<SI>"), '\x0f'},
+                                                          {QByteArray("<0F>"), '\x0f'}, // Output Vertical Tab Disposition
+                                                          {QByteArray("<SI>"), '\x0f'},
 
-        {QByteArray("<10>"), '\x10'}, // Output Linefeed Disposition
-        {QByteArray("<DLE>"), '\x10'},
+                                                          {QByteArray("<10>"), '\x10'}, // Output Linefeed Disposition
+                                                          {QByteArray("<DLE>"), '\x10'},
 
-        {QByteArray("<11>"), '\x11'}, // Extended ASCII
-        {QByteArray("<DC1>"), '\x11'},
+                                                          {QByteArray("<11>"), '\x11'}, // Extended ASCII
+                                                          {QByteArray("<DC1>"), '\x11'},
 
-        {QByteArray("<12>"), '\x12'}, // Logout
-        {QByteArray("<DC2"), '\x12'},
+                                                          {QByteArray("<12>"), '\x12'}, // Logout
+                                                          {QByteArray("<DC2"), '\x12'},
 
-        {QByteArray("<13>"), '\x13'}, // Byte Macro
-        {QByteArray("<DC3>"), '\x13'},
+                                                          {QByteArray("<13>"), '\x13'}, // Byte Macro
+                                                          {QByteArray("<DC3>"), '\x13'},
 
-        {QByteArray("<14>"), '\x14'}, // Data Entry Terminal
-        {QByteArray("<DC4>"), '\x14'},
+                                                          {QByteArray("<14>"), '\x14'}, // Data Entry Terminal
+                                                          {QByteArray("<DC4>"), '\x14'},
 
-        {QByteArray("<15>"), '\x15'}, // SUPDUP
-        {QByteArray("<NAK>"), '\x15'},
+                                                          {QByteArray("<15>"), '\x15'}, // SUPDUP
+                                                          {QByteArray("<NAK>"), '\x15'},
 
-        {QByteArray("<16>"), '\x16'}, // SUPDUP Output
-        {QByteArray("<SYN>"), '\x16'},
+                                                          {QByteArray("<16>"), '\x16'}, // SUPDUP Output
+                                                          {QByteArray("<SYN>"), '\x16'},
 
-        {QByteArray("<17>"), '\x17'}, // Send location
-        {QByteArray("<ETB>"), '\x17'},
+                                                          {QByteArray("<17>"), '\x17'}, // Send location
+                                                          {QByteArray("<ETB>"), '\x17'},
 
-        {QByteArray("<18>"), '\x18'},
-        {QByteArray("<O_TERM>"), '\x18'},
-        {QByteArray("<CAN>"), '\x18'},
+                                                          {QByteArray("<18>"), '\x18'},         {QByteArray("<O_TERM>"), '\x18'},   {QByteArray("<CAN>"), '\x18'},
 
-        {QByteArray("<19>"), '\x19'},
-        {QByteArray("<O_EOR>"), '\x19'},
-        {QByteArray("<EM>"), '\x19'},
+                                                          {QByteArray("<19>"), '\x19'},         {QByteArray("<O_EOR>"), '\x19'},    {QByteArray("<EM>"), '\x19'},
 
-        {QByteArray("<1A>"), '\x1a'}, // TACACS User Identification
-        {QByteArray("<SUB>"), '\x1a'},
+                                                          {QByteArray("<1A>"), '\x1a'}, // TACACS User Identification
+                                                          {QByteArray("<SUB>"), '\x1a'},
 
-        {QByteArray("<1B>"), '\x1b'}, // Output Marking
-        {QByteArray("<ESC>"), '\x1b'},
+                                                          {QByteArray("<1B>"), '\x1b'}, // Output Marking
+                                                          {QByteArray("<ESC>"), '\x1b'},
 
-        {QByteArray("<1C>"), '\x1c'}, // Terminal Location Number
-        {QByteArray("<FS>"), '\x1c'},
+                                                          {QByteArray("<1C>"), '\x1c'}, // Terminal Location Number
+                                                          {QByteArray("<FS>"), '\x1c'},
 
-        {QByteArray("<1D>"), '\x1d'}, // Telnet 3270 Regime
-        {QByteArray("<GS>"), '\x1d'},
+                                                          {QByteArray("<1D>"), '\x1d'}, // Telnet 3270 Regime
+                                                          {QByteArray("<GS>"), '\x1d'},
 
-        {QByteArray("<1E>"), '\x1e'}, // X.3 PAD
-        {QByteArray("<RS>"), '\x1e'},
+                                                          {QByteArray("<1E>"), '\x1e'}, // X.3 PAD
+                                                          {QByteArray("<RS>"), '\x1e'},
 
-        {QByteArray("<1F>"), '\x1f'},
-        {QByteArray("<O_NAWS>"), '\x1f'},
-        {QByteArray("<US>"), '\x1f'},
+                                                          {QByteArray("<1F>"), '\x1f'},         {QByteArray("<O_NAWS>"), '\x1f'},   {QByteArray("<US>"), '\x1f'},
 
-        {QByteArray("<SP>"), '\x20'}, // 32 dec, Space
+                                                          {QByteArray("<SP>"), '\x20'}, // 32 dec, Space
 
-        {QByteArray("<O_NENV>"), '\x27'}, // 39 dec, New Environment (also MNES)
+                                                          {QByteArray("<O_NENV>"), '\x27'}, // 39 dec, New Environment (also MNES)
 
-        {QByteArray("<O_CHARS>"), '\x2a'}, // 42 dec, Character Set
+                                                          {QByteArray("<O_CHARS>"), '\x2a'}, // 42 dec, Character Set
 
-        {QByteArray("<O_KERMIT>"), '\x2f'}, // 47 dec
+                                                          {QByteArray("<O_KERMIT>"), '\x2f'}, // 47 dec
 
-        {QByteArray("<O_MSDP>"), '\x45'}, // 69 dec
+                                                          {QByteArray("<O_MSDP>"), '\x45'}, // 69 dec
 
-        {QByteArray("<O_MSSP>"), '\x46'}, // 70 dec
+                                                          {QByteArray("<O_MSSP>"), '\x46'}, // 70 dec
 
-        {QByteArray("<O_MCCP>"), '\x55'}, // 85 dec
+                                                          {QByteArray("<O_MCCP>"), '\x55'}, // 85 dec
 
-        {QByteArray("<O_MCCP2>"), '\x56'}, // 86 dec
+                                                          {QByteArray("<O_MCCP2>"), '\x56'}, // 86 dec
 
-        {QByteArray("<O_MSP>"), '\x5a'}, // 90 dec
+                                                          {QByteArray("<O_MSP>"), '\x5a'}, // 90 dec
 
-        {QByteArray("<O_MXP>"), '\x5b'}, // 91 dec
+                                                          {QByteArray("<O_MXP>"), '\x5b'}, // 91 dec
 
-        {QByteArray("<O_ZENITH>"), '\x5d'}, // 93 dec
+                                                          {QByteArray("<O_ZENITH>"), '\x5d'}, // 93 dec
 
-        {QByteArray("<O_AARDWULF>"), '\x66'}, // 102 dec
+                                                          {QByteArray("<O_AARDWULF>"), '\x66'}, // 102 dec
 
-        {QByteArray("<DEL>"), '\x7f'}, // 127 dec
+                                                          {QByteArray("<DEL>"), '\x7f'}, // 127 dec
 
-        {QByteArray("<O_ATCP>"), '\xc8'}, // 200 dec
+                                                          {QByteArray("<O_ATCP>"), '\xc8'}, // 200 dec
 
-        {QByteArray("<O_GMCP>"), '\xc9'}, // 201 dec
+                                                          {QByteArray("<O_GMCP>"), '\xc9'}, // 201 dec
 
-        {QByteArray("<T_EOR>"), '\xef'}, // 239 dec
+                                                          {QByteArray("<T_EOR>"), '\xef'}, // 239 dec
 
-        {QByteArray("<F0>"), '\xf0'},
-        {QByteArray("<T_SE>"), '\xf0'},
+                                                          {QByteArray("<F0>"), '\xf0'},         {QByteArray("<T_SE>"), '\xf0'},
 
-        {QByteArray("<F1>"), '\xf1'},
-        {QByteArray("<T_NOP>"), '\xf1'},
+                                                          {QByteArray("<F1>"), '\xf1'},         {QByteArray("<T_NOP>"), '\xf1'},
 
-        {QByteArray("<F2>"), '\xf2'},
-        {QByteArray("<T_DM>"), '\xf2'},
+                                                          {QByteArray("<F2>"), '\xf2'},         {QByteArray("<T_DM>"), '\xf2'},
 
-        {QByteArray("<F3>"), '\xf3'},
-        {QByteArray("<T_BRK>"), '\xf3'},
+                                                          {QByteArray("<F3>"), '\xf3'},         {QByteArray("<T_BRK>"), '\xf3'},
 
-        {QByteArray("<F4>"), '\xf4'},
-        {QByteArray("<T_IP>"), '\xf4'},
+                                                          {QByteArray("<F4>"), '\xf4'},         {QByteArray("<T_IP>"), '\xf4'},
 
-        {QByteArray("<F5>"), '\xf5'},
-        {QByteArray("<T_ABOP>"), '\xf5'},
+                                                          {QByteArray("<F5>"), '\xf5'},         {QByteArray("<T_ABOP>"), '\xf5'},
 
-        {QByteArray("<F6>"), '\xf6'},
-        {QByteArray("<T_AYT>"), '\xf6'},
+                                                          {QByteArray("<F6>"), '\xf6'},         {QByteArray("<T_AYT>"), '\xf6'},
 
-        {QByteArray("<F7>"), '\xf7'},
-        {QByteArray("<T_EC>"), '\xf7'},
+                                                          {QByteArray("<F7>"), '\xf7'},         {QByteArray("<T_EC>"), '\xf7'},
 
-        {QByteArray("<F8>"), '\xf8'},
-        {QByteArray("<T_EL>"), '\xf8'},
+                                                          {QByteArray("<F8>"), '\xf8'},         {QByteArray("<T_EL>"), '\xf8'},
 
-        {QByteArray("<F9>"), '\xf9'},
-        {QByteArray("<T_GA>"), '\xf9'},
+                                                          {QByteArray("<F9>"), '\xf9'},         {QByteArray("<T_GA>"), '\xf9'},
 
-        {QByteArray("<FA>"), '\xfa'},
-        {QByteArray("<T_SB>"), '\xfa'},
+                                                          {QByteArray("<FA>"), '\xfa'},         {QByteArray("<T_SB>"), '\xfa'},
 
-        {QByteArray("<FB>"), '\xfb'},
-        {QByteArray("<T_WILL>"), '\xfb'},
+                                                          {QByteArray("<FB>"), '\xfb'},         {QByteArray("<T_WILL>"), '\xfb'},
 
-        {QByteArray("<FC>"), '\xfc'},
-        {QByteArray("<T_WONT>"), '\xfc'},
+                                                          {QByteArray("<FC>"), '\xfc'},         {QByteArray("<T_WONT>"), '\xfc'},
 
-        {QByteArray("<FD>"), '\xfd'},
-        {QByteArray("<T_DO>"), '\xfd'},
+                                                          {QByteArray("<FD>"), '\xfd'},         {QByteArray("<T_DO>"), '\xfd'},
 
-        {QByteArray("<FE>"), '\xfe'},
-        {QByteArray("<T_DONT>"), '\xfe'},
+                                                          {QByteArray("<FE>"), '\xfe'},         {QByteArray("<T_DONT>"), '\xfe'},
 
-        {QByteArray("<FF>"), '\xff'},
-        {QByteArray("<T_IAC>"), '\xff'}
-    };
+                                                          {QByteArray("<FF>"), '\xff'},         {QByteArray("<T_IAC>"), '\xff'}};
 
     QByteArray bytes;
     if (input.isEmpty()) {
@@ -1136,14 +1096,15 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
         }
         const QString dataQString{data};
         // else
-            // We need to transcode it from UTF-8 into the current Game Server
-            // encoding - this can fail if it includes any characters (as UTF-8)
-            // that the game encoding cannot convey:
+        // We need to transcode it from UTF-8 into the current Game Server
+        // encoding - this can fail if it includes any characters (as UTF-8)
+        // that the game encoding cannot convey:
         if (!(currentEncoding.isEmpty() || currentEncoding == "ASCII")) {
             if (!TEncodingHelper::canEncode(dataQString, currentEncoding)) {
-                return warnArgumentValue(L, __func__, qsl(
-                    "cannot send '%1' as it contains one or more characters that cannot be conveyed in the current game server encoding of '%2'")
-                    .arg(data.constData(), currentEncoding.constData()));
+                return warnArgumentValue(L,
+                                         __func__,
+                                         qsl("cannot send '%1' as it contains one or more characters that cannot be conveyed in the current game server encoding of '%2'")
+                                                 .arg(data.constData(), currentEncoding.constData()));
             }
 
             std::string encodedText{TEncodingHelper::encode(dataQString, currentEncoding).toStdString()};
@@ -1155,9 +1116,8 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
         // else plain, raw ASCII, we hope!
         for (const QChar c : dataQString) {
             if (c.row() || c.cell() > 127) {
-                return warnArgumentValue(L, __func__, qsl(
-                    "cannot send '%1' as it contains one or more characters that cannot be conveyed in the current game server encoding of 'ASCII'")
-                    .arg(data.constData()));
+                return warnArgumentValue(
+                        L, __func__, qsl("cannot send '%1' as it contains one or more characters that cannot be conveyed in the current game server encoding of 'ASCII'").arg(data.constData()));
             }
         }
 
@@ -1207,8 +1167,7 @@ void TLuaInterpreter::generateElapsedTimeTable(lua_State* L, const QStringList& 
 {
     constexpr int expectedElements = 6;
     if (elapsedTimeSplitString.size() < expectedElements) {
-        qWarning() << "TLuaInterpreter::generateElapsedTimeTable() ERROR: expected" << expectedElements
-                   << "elements in time string but got" << elapsedTimeSplitString.size();
+        qWarning() << "TLuaInterpreter::generateElapsedTimeTable() ERROR: expected" << expectedElements << "elements in time string but got" << elapsedTimeSplitString.size();
         lua_newtable(L);
         return;
     }
@@ -1251,9 +1210,7 @@ void TLuaInterpreter::generateElapsedTimeTable(lua_State* L, const QStringList& 
 int TLuaInterpreter::holdingModifiers(lua_State* L)
 {
     Qt::KeyboardModifiers keyModifiers;
-    keyModifiers = static_cast<Qt::KeyboardModifiers>(
-        getVerifiedInt(L, __func__, 1, "key modifier", true)
-    );
+    keyModifiers = static_cast<Qt::KeyboardModifiers>(getVerifiedInt(L, __func__, 1, "key modifier", true));
     Qt::KeyboardModifiers modifiersHeld = QGuiApplication::queryKeyboardModifiers();
     lua_pushboolean(L, modifiersHeld == keyModifiers);
     return 1;
@@ -1332,9 +1289,7 @@ int TLuaInterpreter::saveProfile(lua_State* L)
         }
     }
 
-    auto [ok, filename, error] = (saveAsFile.isNull())
-                               ? host.saveProfile(saveToDir)
-                               : host.saveProfileAs(saveToDir + "/" + saveAsFile);
+    auto [ok, filename, error] = (saveAsFile.isNull()) ? host.saveProfile(saveToDir) : host.saveProfileAs(saveToDir + "/" + saveAsFile);
 
     if (ok) {
         lua_pushboolean(L, true);
@@ -1637,10 +1592,10 @@ int TLuaInterpreter::errorc(lua_State* L)
         if (!host.mpConsole->buffer.isEmpty() && !host.mpConsole->buffer.lineBuffer.at(host.mpConsole->buffer.lineBuffer.size() - 1).isEmpty()) {
             host.postMessage(qsl("\n"));
         }
-        host.mpConsole->print(qsl("[  LUA  ] - "), QColor(80,160,255), QColor(Qt::black));
+        host.mpConsole->print(qsl("[  LUA  ] - "), QColor(80, 160, 255), QColor(Qt::black));
         host.mpConsole->print(qsl("ERROR: "), QColor(Qt::blue), QColor(Qt::black));
         host.mpConsole->print(qsl("%1").arg(luaFunctionInfo), QColor(Qt::green), QColor(Qt::black));
-        host.mpConsole->print(qsl("           %1").arg(luaErrorText), QColor(200,50,42), QColor(Qt::black));
+        host.mpConsole->print(qsl("           %1").arg(luaErrorText), QColor(200, 50, 42), QColor(Qt::black));
     }
     return 0;
 }
@@ -1728,8 +1683,7 @@ std::pair<int, TAction*> TLuaInterpreter::getTActionFromIdOrName(lua_State* L, c
 
     if (!pItem) {
         // we'll get here if the (index) argument is NOT usable:
-        lua_pushfstring(L, "%s: bad argument #%d type (ID as number or name as string expected, got %s!)",
-                        func, index, luaL_typename(L, index));
+        lua_pushfstring(L, "%s: bad argument #%d type (ID as number or name as string expected, got %s!)", func, index, luaL_typename(L, index));
         lua_error(L); // Does not return!
         Q_UNREACHABLE();
     }
@@ -2229,8 +2183,7 @@ int TLuaInterpreter::getTimestamp(lua_State* L)
 
     qint64 const luaLine = getVerifiedInt(L, __func__, s, "line number");
     if (luaLine < 1) {
-        return warnArgumentValue(L, __func__, qsl(
-            "line number %1 invalid, it should be greater than zero").arg(luaLine));
+        return warnArgumentValue(L, __func__, qsl("line number %1 invalid, it should be greater than zero").arg(luaLine));
     }
 
     const Host& host = getHostFromLua(L);
@@ -2544,8 +2497,8 @@ int TLuaInterpreter::getMudletVersion(lua_State* L)
             return 4;
         } else {
             lua_pushstring(L,
-                            "getMudletVersion: takes one (optional) argument:\n"
-                            "   \"major\", \"minor\", \"revision\", \"build\", \"string\" or \"table\".");
+                           "getMudletVersion: takes one (optional) argument:\n"
+                           "   \"major\", \"minor\", \"revision\", \"build\", \"string\" or \"table\".");
             return lua_error(L);
         }
     } else if (n == 0) {
@@ -2626,7 +2579,7 @@ int TLuaInterpreter::getTime(lua_State* L)
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getEpoch
-int TLuaInterpreter::getEpoch(lua_State *L)
+int TLuaInterpreter::getEpoch(lua_State* L)
 {
     lua_pushnumber(L, static_cast<double>(QDateTime::currentDateTime().toMSecsSinceEpoch() / 1000.0));
     return 1;
@@ -2891,25 +2844,25 @@ int TLuaInterpreter::getPackageInfo(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setModuleInfo
 int TLuaInterpreter::setModuleInfo(lua_State* L)
 {
-  Host& host = getHostFromLua(L);
-  const QString moduleName = getVerifiedString(L, __func__, 1, "module name");
-  const QString info = getVerifiedString(L, __func__, 2, "info");
-  const QString value = getVerifiedString(L, __func__, 3, "value");
-  host.mModuleInfo[moduleName][info] = value;
-  lua_pushboolean(L, true);
-  return 1;
+    Host& host = getHostFromLua(L);
+    const QString moduleName = getVerifiedString(L, __func__, 1, "module name");
+    const QString info = getVerifiedString(L, __func__, 2, "info");
+    const QString value = getVerifiedString(L, __func__, 3, "value");
+    host.mModuleInfo[moduleName][info] = value;
+    lua_pushboolean(L, true);
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setPackageInfo
 int TLuaInterpreter::setPackageInfo(lua_State* L)
 {
-  Host& host = getHostFromLua(L);
-  const QString packageName = getVerifiedString(L, __func__, 1, "package name");
-  const QString info = getVerifiedString(L, __func__, 2, "info");
-  const QString value = getVerifiedString(L, __func__, 3, "value");
-  host.mPackageInfo[packageName][info] = value;
-  lua_pushboolean(L, true);
-  return 1;
+    Host& host = getHostFromLua(L);
+    const QString packageName = getVerifiedString(L, __func__, 1, "package name");
+    const QString info = getVerifiedString(L, __func__, 2, "info");
+    const QString value = getVerifiedString(L, __func__, 3, "value");
+    host.mPackageInfo[packageName][info] = value;
+    lua_pushboolean(L, true);
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setDefaultAreaVisible
@@ -3039,7 +2992,6 @@ int TLuaInterpreter::sendSocket(lua_State* L)
 }
 
 
-
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setServerEncoding
 int TLuaInterpreter::setServerEncoding(lua_State* L)
 {
@@ -3066,7 +3018,7 @@ int TLuaInterpreter::getServerEncoding(lua_State* L)
     const Host& host = getHostFromLua(L);
 
     // don't leak if we're using a Mudlet or a Qt-supplied codec to Lua
-    auto sanitizeEncoding = [] (auto encodingName) {
+    auto sanitizeEncoding = [](auto encodingName) {
         if (encodingName.startsWith("M_")) {
             encodingName.remove(0, 2);
         }
@@ -3087,7 +3039,7 @@ int TLuaInterpreter::getServerEncodingsList(lua_State* L)
     const Host& host = getHostFromLua(L);
 
     // don't leak if we're using a Mudlet or a Qt-supplied codec to Lua
-    auto sanitizeEncoding = [] (auto encodingName) {
+    auto sanitizeEncoding = [](auto encodingName) {
         if (encodingName.startsWith("M_")) {
             encodingName.remove(0, 2);
         }
@@ -3109,7 +3061,7 @@ int TLuaInterpreter::getServerEncodingsList(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getOS
 int TLuaInterpreter::getOS(lua_State* L)
 {
-    auto pushProcessor = [&] () {
+    auto pushProcessor = [&]() {
 #if defined(Q_PROCESSOR_IA64)
         lua_pushstring(L, "ia64");
         return 1;
@@ -3240,7 +3192,7 @@ bool TLuaInterpreter::compileAndExecuteScript(const QString& code)
 // No documentation available in wiki - internal function
 // reformats given Lua code. In case of any issues, returns the original code as-is
 // issues could be invalid Lua code or the formatter code bugging out
-QString TLuaInterpreter::formatLuaCode(const QString &code)
+QString TLuaInterpreter::formatLuaCode(const QString& code)
 {
     if (code.isEmpty()) {
         return code;
@@ -3292,9 +3244,7 @@ bool TLuaInterpreter::compile(const QString& code, QString& errorMsg, const QStr
 {
     lua_State* L = pGlobalLua;
 
-    const int error = (luaL_loadbuffer(L, code.toUtf8().constData(),
-                                 strlen(code.toUtf8().constData()),
-                                 name.toUtf8().constData()) || lua_pcall(L, 0, 0, 0));
+    const int error = (luaL_loadbuffer(L, code.toUtf8().constData(), strlen(code.toUtf8().constData()), name.toUtf8().constData()) || lua_pcall(L, 0, 0, 0));
 
     if (error) {
         std::string e = "Lua syntax error:";
@@ -3335,7 +3285,7 @@ std::pair<bool, QString> TLuaInterpreter::validateLuaCodeParam(int index)
 // No documentation available in wiki - internal function
 // returns pair where first is bool stating true the given Lua code is valid, false otherwise
 // second is empty if code is valid, error message if not valid
-std::pair<bool, QString> TLuaInterpreter::validLuaCode(const QString &code)
+std::pair<bool, QString> TLuaInterpreter::validLuaCode(const QString& code)
 {
     lua_State* L = pGlobalLua;
     const int error = luaL_loadbuffer(L, code.toUtf8().constData(), strlen(code.toUtf8().constData()), code.toUtf8().data());
@@ -3444,7 +3394,7 @@ void TLuaInterpreter::setAtcpTable(const QString& var, const QString& arg)
     lua_rawset(L, -3);
     lua_pop(L, 1);
 
-    TEvent event {};
+    TEvent event{};
     event.mArgumentList.append(var);
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(arg);
@@ -3454,9 +3404,9 @@ void TLuaInterpreter::setAtcpTable(const QString& var, const QString& arg)
 }
 
 // No documentation available in wiki - internal function
-void TLuaInterpreter::signalMXPEvent(const QString &type, const QMap<QString, QString> &attrs, const QStringList &actions, const QString &caption)
+void TLuaInterpreter::signalMXPEvent(const QString& type, const QMap<QString, QString>& attrs, const QStringList& actions, const QString& caption)
 {
-    lua_State *L = pGlobalLua;
+    lua_State* L = pGlobalLua;
     lua_getglobal(L, "mxp");
     if (!lua_istable(L, -1)) {
         lua_newtable(L);
@@ -3506,7 +3456,7 @@ void TLuaInterpreter::signalMXPEvent(const QString &type, const QMap<QString, QS
     event.mArgumentList.append(token);
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
 
-    Host &host = getHostFromLua(L);
+    Host& host = getHostFromLua(L);
     if (mudlet::smDebugMode) {
         const QString msg = qsl("\n%1 event <%2> display(%1) to see the full content\n").arg("mxp", token);
         host.mpConsole->printSystemMessage(msg);
@@ -3659,7 +3609,7 @@ void TLuaInterpreter::parseJSON(QString& key, const QString& string_data, const 
     }
 
     for (int k = 0, total = tokenList.size(); k < total; ++k) {
-        TEvent event {};
+        TEvent event{};
         token.append(".");
         token.append(tokenList[k]);
         event.mArgumentList.append(token);
@@ -3862,8 +3812,7 @@ void TLuaInterpreter::msdp2Lua(const char* src)
             if (last == MSDP_VAL || last == MSDP_TABLE_CLOSE || last == MSDP_ARRAY_CLOSE) {
                 script.append(',');
             }
-            if (((textLength > i + 1) && transcodedSrc.at(i + 1) && transcodedSrc.at(i + 1) != MSDP_TABLE_OPEN && transcodedSrc.at(i + 1) != MSDP_ARRAY_OPEN) ||
-                (textLength <= i + 1)) {
+            if (((textLength > i + 1) && transcodedSrc.at(i + 1) && transcodedSrc.at(i + 1) != MSDP_TABLE_OPEN && transcodedSrc.at(i + 1) != MSDP_ARRAY_OPEN) || (textLength <= i + 1)) {
                 script.append('\"');
             }
             varList.append(lastVar);
@@ -3912,7 +3861,7 @@ void TLuaInterpreter::setChannel102Table(int& var, int& arg)
     lua_rawset(L, -3);
     lua_pop(L, 1);
 
-    TEvent event {};
+    TEvent event{};
     event.mArgumentList.append(QLatin1String("channel102Message"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(QString::number(var));
@@ -3937,7 +3886,7 @@ void TLuaInterpreter::setMatches(lua_State* L)
             lua_pushstring(L, (*it).c_str());
             lua_settable(L, -3);
         }
-        for (const auto &[name, capture] : mCapturedNameGroups) {
+        for (const auto& [name, capture] : mCapturedNameGroups) {
             lua_pushstring(L, name.toUtf8().constData());
             lua_pushstring(L, capture.toUtf8().constData());
             lua_settable(L, -3);
@@ -3980,13 +3929,14 @@ bool TLuaInterpreter::call_luafunction(void* pT)
         } else {
             if (mudlet::smDebugMode) {
                 auto& host = getHostFromLua(L);
-                TDebug(Qt::white, Qt::darkGreen) << "LUA OK anonymous Lua function ran without errors" << (executionTimer.isValid() ? " in " + QString::number(executionTimer.elapsed()) + "ms.\n" : ".\n") >> &host;
+                TDebug(Qt::white, Qt::darkGreen) << "LUA OK anonymous Lua function ran without errors"
+                                                 << (executionTimer.isValid() ? " in " + QString::number(executionTimer.elapsed()) + "ms.\n" : ".\n")
+                        >> &host;
             }
         }
         lua_pop(L, lua_gettop(L));
         //lua_settop(L, 0);
         return !error;
-
     }
 
     const QString _n = "error in anonymous Lua function";
@@ -4063,11 +4013,13 @@ std::pair<bool, bool> TLuaInterpreter::callLuaFunctionReturnBool(void* pT)
 
             if (mudlet::smDebugMode) {
                 auto& host = getHostFromLua(L);
-                TDebug(Qt::white, Qt::darkGreen) << "LUA OK anonymous Lua function ran without errors" << (executionTimer.isValid() ? " in " + QString::number(executionTimer.elapsed()) + "ms.\n" : ".\n") >> &host;
+                TDebug(Qt::white, Qt::darkGreen) << "LUA OK anonymous Lua function ran without errors"
+                                                 << (executionTimer.isValid() ? " in " + QString::number(executionTimer.elapsed()) + "ms.\n" : ".\n")
+                        >> &host;
             }
         }
         lua_pop(L, lua_gettop(L));
-        return {!error , returnValue};
+        return {!error, returnValue};
     }
 
     const QString _n = "error in anonymous Lua function";
@@ -4110,7 +4062,9 @@ bool TLuaInterpreter::call(const QString& function, const QString& mName, const 
     } else {
         if (mudlet::smDebugMode && !muteDebugOutput) {
             auto& host = getHostFromLua(L);
-            TDebug(Qt::white, Qt::darkGreen) << "LUA OK: script " << mName << " (" << function << ") ran without errors" << (executionTimer.isValid() ? " in " + QString::number(executionTimer.elapsed()) + "ms.\n" : ".\n") >> &host;
+            TDebug(Qt::white, Qt::darkGreen) << "LUA OK: script " << mName << " (" << function << ") ran without errors"
+                                             << (executionTimer.isValid() ? " in " + QString::number(executionTimer.elapsed()) + "ms.\n" : ".\n")
+                    >> &host;
         }
     }
     lua_pop(L, lua_gettop(L));
@@ -4155,7 +4109,9 @@ std::pair<bool, bool> TLuaInterpreter::callReturnBool(const QString& function, c
 
         if (mudlet::smDebugMode) {
             auto& host = getHostFromLua(L);
-            TDebug(Qt::white, Qt::darkGreen) << "LUA OK script " << mName << " (" << function << ") ran without errors" << (executionTimer.isValid() ? " in " + QString::number(executionTimer.elapsed()) + "ms.\n" : ".\n") >> &host;
+            TDebug(Qt::white, Qt::darkGreen) << "LUA OK script " << mName << " (" << function << ") ran without errors"
+                                             << (executionTimer.isValid() ? " in " + QString::number(executionTimer.elapsed()) + "ms.\n" : ".\n")
+                    >> &host;
         }
     }
     lua_pop(L, lua_gettop(L));
@@ -4168,12 +4124,16 @@ void TLuaInterpreter::logError(std::string& e, const QString& name, const QStrin
     // Log error to Editor's Errors TConsole:
     if (mpHost->mpEditorDialog) {
         mpHost->mpEditorDialog->mpErrorConsole->print(qsl("[%1:]").arg(tr("ERROR")), QColor(Qt::blue), QColor(Qt::black));
-        mpHost->mpEditorDialog->mpErrorConsole->print(qsl(" %1:<%2> %3:<%4>\n").arg(
-            //: object is the Mudlet alias/trigger/script, used in this sample message: object:<Alias1> function:<cure_me>
-            tr("object"),
-            name,
-            //: function is the Lua function, used in this sample message: object:<Alias1> function:<cure_me>
-            tr("function"), function), QColor(Qt::green), QColor(Qt::black));
+        mpHost->mpEditorDialog->mpErrorConsole->print(qsl(" %1:<%2> %3:<%4>\n")
+                                                              .arg(
+                                                                      //: object is the Mudlet alias/trigger/script, used in this sample message: object:<Alias1> function:<cure_me>
+                                                                      tr("object"),
+                                                                      name,
+                                                                      //: function is the Lua function, used in this sample message: object:<Alias1> function:<cure_me>
+                                                                      tr("function"),
+                                                                      function),
+                                                      QColor(Qt::green),
+                                                      QColor(Qt::black));
         mpHost->mpEditorDialog->mpErrorConsole->print(qsl("        <%1>\n").arg(e.c_str()), QColor(Qt::red), QColor(Qt::black));
     }
 
@@ -4187,12 +4147,15 @@ void TLuaInterpreter::logError(std::string& e, const QString& name, const QStrin
             mpHost->postMessage(qsl("\n"));
         }
 
-        mpHost->postMessage(qsl("[  LUA  ] - %1: <%2> %3:<%4>\n<%5>").arg(
-            //: object is the Mudlet alias/trigger/script, used in this sample message: object:<Alias1> function:<cure_me>
-            tr("object"),
-            name,
-            //: function is the Lua function, used in this sample message: object:<Alias1> function:<cure_me>
-            tr("function"), function, e.c_str()));
+        mpHost->postMessage(qsl("[  LUA  ] - %1: <%2> %3:<%4>\n<%5>")
+                                    .arg(
+                                            //: object is the Mudlet alias/trigger/script, used in this sample message: object:<Alias1> function:<cure_me>
+                                            tr("object"),
+                                            name,
+                                            //: function is the Lua function, used in this sample message: object:<Alias1> function:<cure_me>
+                                            tr("function"),
+                                            function,
+                                            e.c_str()));
     }
 }
 
@@ -4247,7 +4210,9 @@ bool TLuaInterpreter::callConditionFunction(std::string& function, const QString
     } else {
         if (mudlet::smDebugMode) {
             auto& host = getHostFromLua(L);
-            TDebug(Qt::white, Qt::darkGreen) << "LUA OK script " << mName << " (" << function.c_str() << ") ran without errors" << (executionTimer.isValid() ? " in " + QString::number(executionTimer.elapsed()) + "ms\n" : ".\n") >> &host;
+            TDebug(Qt::white, Qt::darkGreen) << "LUA OK script " << mName << " (" << function.c_str() << ") ran without errors"
+                                             << (executionTimer.isValid() ? " in " + QString::number(executionTimer.elapsed()) + "ms\n" : ".\n")
+                    >> &host;
         }
     }
 
@@ -4286,7 +4251,7 @@ bool TLuaInterpreter::callMulti(const QString& function, const QString& mName)
                 lua_pushstring(L, (*it).c_str());
                 lua_settable(L, -3); //match in matches
             }
-            for (const auto &[name, capture] : mMultiCaptureNameGroups.value(k - 1)) {
+            for (const auto& [name, capture] : mMultiCaptureNameGroups.value(k - 1)) {
                 lua_pushstring(L, name.toUtf8().constData());
                 lua_pushstring(L, capture.toUtf8().constData());
                 lua_settable(L, -3);
@@ -4314,7 +4279,9 @@ bool TLuaInterpreter::callMulti(const QString& function, const QString& mName)
     } else {
         if (mudlet::smDebugMode) {
             auto& host = getHostFromLua(L);
-            TDebug(Qt::white, Qt::darkGreen) << "LUA OK script " << mName << " (" << function << ") ran without errors" << (executionTimer.isValid() ? " in " + QString::number(executionTimer.elapsed()) + "ms\n" : ".\n") >> &host;
+            TDebug(Qt::white, Qt::darkGreen) << "LUA OK script " << mName << " (" << function << ") ran without errors"
+                                             << (executionTimer.isValid() ? " in " + QString::number(executionTimer.elapsed()) + "ms\n" : ".\n")
+                    >> &host;
         }
     }
     lua_pop(L, lua_gettop(L));
@@ -4375,7 +4342,9 @@ std::pair<bool, bool> TLuaInterpreter::callMultiReturnBool(const QString& functi
 
         if (mudlet::smDebugMode) {
             auto& host = getHostFromLua(L);
-            TDebug(Qt::white, Qt::darkGreen) << "LUA OK script " << mName << " (" << function << ") ran without errors" << (executionTimer.isValid() ? " in " + QString::number(executionTimer.elapsed()) + "ms\n" : ".\n") >> &host;
+            TDebug(Qt::white, Qt::darkGreen) << "LUA OK script " << mName << " (" << function << ") ran without errors"
+                                             << (executionTimer.isValid() ? " in " + QString::number(executionTimer.elapsed()) + "ms\n" : ".\n")
+                    >> &host;
         }
     }
     lua_pop(L, lua_gettop(L));
@@ -4580,18 +4549,18 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
     }
 
     lua_State* L = pGlobalLua;
-    
+
     // Validate Lua state before attempting to call event handler
     if (!L) {
         qWarning() << "TLuaInterpreter::callEventHandler() - Lua state is null for function:" << function;
         return false;
     }
-    
+
     // Check if we're in emergency stop mode
     if (mpHost && mpHost->mEmergencyStop) {
         return false;
     }
-    
+
     // Record initial stack size for cleanup
     const int initialStackSize = lua_gettop(L);
 
@@ -4604,7 +4573,7 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
         }
         const QString name = "event handler function";
         logError(err, name, function);
-        
+
         // Clean up stack after error
         lua_settop(L, initialStackSize);
         return false;
@@ -4614,8 +4583,8 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
     // Use minimum of argument list size and type list size to avoid out-of-bounds access
     auto maxArguments = std::min({pE.mArgumentList.size(), pE.mArgumentTypeList.size(), static_cast<qsizetype>(LUA_FUNCTION_MAX_ARGS)});
     if (pE.mArgumentList.size() != pE.mArgumentTypeList.size()) {
-        qWarning() << "TLuaInterpreter::callEventHandler() WARNING: argument list size" << pE.mArgumentList.size()
-                   << "does not match type list size" << pE.mArgumentTypeList.size() << "for function:" << function;
+        qWarning() << "TLuaInterpreter::callEventHandler() WARNING: argument list size" << pE.mArgumentList.size() << "does not match type list size" << pE.mArgumentTypeList.size()
+                   << "for function:" << function;
     }
     for (int i = 0; i < maxArguments; i++) {
         switch (pE.mArgumentTypeList.at(i)) {
@@ -4670,7 +4639,7 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
     if (finalStackSize > initialStackSize) {
         qWarning() << "TLuaInterpreter::callEventHandler() - Stack grew during execution. Initial:" << initialStackSize << "Final:" << finalStackSize;
     }
-    
+
     lua_pop(L, lua_gettop(L));
     return !error;
 }
@@ -4708,7 +4677,8 @@ double TLuaInterpreter::condenseMapLoad()
     } else {
         if (mudlet::smDebugMode) {
             auto& host = getHostFromLua(L);
-            TDebug(Qt::white, Qt::darkGreen) << "LUA OK " << luaFunction << " ran without errors in" << (executionTimer.isValid() ? " in " + QString::number(executionTimer.elapsed()) + "ms\n" : ".\n") >> &host;
+            TDebug(Qt::white, Qt::darkGreen) << "LUA OK " << luaFunction << " ran without errors in" << (executionTimer.isValid() ? " in " + QString::number(executionTimer.elapsed()) + "ms\n" : ".\n")
+                    >> &host;
         }
     }
 
@@ -4721,7 +4691,7 @@ double TLuaInterpreter::condenseMapLoad()
 }
 
 // No documentation available in wiki - internal function
-int TLuaInterpreter::performHttpRequest(lua_State *L, const char* functionName, const int pos, QNetworkAccessManager::Operation operation, const QString& verb)
+int TLuaInterpreter::performHttpRequest(lua_State* L, const char* functionName, const int pos, QNetworkAccessManager::Operation operation, const QString& verb)
 {
     auto& host = getHostFromLua(L);
 
@@ -4792,14 +4762,14 @@ int TLuaInterpreter::performHttpRequest(lua_State *L, const char* functionName, 
 
     QNetworkReply* reply;
     switch (operation) {
-        case QNetworkAccessManager::PostOperation:
-            reply = host.mLuaInterpreter.mpFileDownloader->post(request, fileToUpload.isEmpty() ?dataToPost.toUtf8() : fileToUpload);
-            break;
-        case QNetworkAccessManager::PutOperation:
-            reply = host.mLuaInterpreter.mpFileDownloader->put(request, fileToUpload.isEmpty() ?dataToPost.toUtf8() : fileToUpload);
-            break;
-        default:
-            reply = host.mLuaInterpreter.mpFileDownloader->sendCustomRequest(request, verb.toUtf8(), fileToUpload.isEmpty() ?dataToPost.toUtf8() : fileToUpload);
+    case QNetworkAccessManager::PostOperation:
+        reply = host.mLuaInterpreter.mpFileDownloader->post(request, fileToUpload.isEmpty() ? dataToPost.toUtf8() : fileToUpload);
+        break;
+    case QNetworkAccessManager::PutOperation:
+        reply = host.mLuaInterpreter.mpFileDownloader->put(request, fileToUpload.isEmpty() ? dataToPost.toUtf8() : fileToUpload);
+        break;
+    default:
+        reply = host.mLuaInterpreter.mpFileDownloader->sendCustomRequest(request, verb.toUtf8(), fileToUpload.isEmpty() ? dataToPost.toUtf8() : fileToUpload);
     };
 
     if (mudlet::smDebugMode) {
@@ -4812,7 +4782,7 @@ int TLuaInterpreter::performHttpRequest(lua_State *L, const char* functionName, 
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Networking_Functions#unzipAsync
-int TLuaInterpreter::unzipAsync(lua_State *L)
+int TLuaInterpreter::unzipAsync(lua_State* L)
 {
     const QString zipLocation = getVerifiedString(L, __func__, 1, "zip location");
     QString extractLocation = getVerifiedString(L, __func__, 2, "extract location");
@@ -4835,7 +4805,7 @@ int TLuaInterpreter::unzipAsync(lua_State *L)
     auto future = QtConcurrent::run(mudlet::unzip, zipLocation, extractLocation, temporaryDir.path());
     auto watcher = new QFutureWatcher<bool>;
     connect(watcher, &QFutureWatcher<bool>::finished, watcher, [=]() {
-        TEvent event {};
+        TEvent event{};
         Host& host = getHostFromLua(L);
 
         if (future.result()) {
@@ -4969,9 +4939,7 @@ static void storeHostInLua(lua_State* L, Host* h);
 // with its success message, on failure will just append...
 bool TLuaInterpreter::loadLuaModule(QQueue<QString>& resultMsgsQueue, const QString& requirement, const QString& failureConsequence, const QString& description, const QString& luaModuleId)
 {
-    const int error = luaL_dostring(pGlobalLua, qsl("%1require \"%2\"")
-                              .arg(luaModuleId.isEmpty() ? QString() : qsl("%1 =").arg(luaModuleId),
-                                   requirement).toUtf8().constData());
+    const int error = luaL_dostring(pGlobalLua, qsl("%1require \"%2\"").arg(luaModuleId.isEmpty() ? QString() : qsl("%1 =").arg(luaModuleId), requirement).toUtf8().constData());
     if (error) {
         QString luaErrorMsg = tr("No error message available from Lua");
         if (lua_isstring(pGlobalLua, -1)) {
@@ -4983,11 +4951,9 @@ bool TLuaInterpreter::loadLuaModule(QQueue<QString>& resultMsgsQueue, const QStr
         %3 is the error message from the lua sub-system;
         %4 can be an additional message about the expected effect (but may be blank).
         */
-        resultMsgsQueue.enqueue(tr("[ ERROR ] - Cannot find Lua module %1.%2%3%4")
-                                .arg((description.isEmpty() ? requirement : description),
-                                     QLatin1String("\n"),
-                                     luaErrorMsg,
-                                     (failureConsequence.isEmpty() ? QString() : qsl("\n%1").arg(failureConsequence))));
+        resultMsgsQueue.enqueue(
+                tr("[ ERROR ] - Cannot find Lua module %1.%2%3%4")
+                        .arg((description.isEmpty() ? requirement : description), QLatin1String("\n"), luaErrorMsg, (failureConsequence.isEmpty() ? QString() : qsl("\n%1").arg(failureConsequence))));
         return false;
     }
 
@@ -5837,7 +5803,7 @@ void TLuaInterpreter::initIndenterGlobals()
     // macOS app bundle would like the search path for the binary modules to
     // also be set to the current binary directory:
     additionalCPaths << qsl("%1/?.so").arg(appPath);
-#elif defined (Q_OS_LINUX)
+#elif defined(Q_OS_LINUX)
     // AppInstaller on Linux would like the search path for the binary modules
     // to also be set to a lib sub-directory of the application directory:
     additionalCPaths << qsl("%1/lib/?.so").arg(appPath);
@@ -5852,7 +5818,7 @@ void TLuaInterpreter::initIndenterGlobals()
     }
     // 2 AppImage (directory of executable) - not needed for Wndows:
     //     "<applicationDirectory>/?.lua"
-#if ! defined (Q_OS_WINDOWS)
+#if !defined(Q_OS_WINDOWS)
     additionalLuaPaths << qsl("%1/?.lua").arg(appPath);
 #endif
     // 3 QMake shadow builds without CONFIG containing "debug_and_release" but
@@ -5867,11 +5833,9 @@ void TLuaInterpreter::initIndenterGlobals()
     //    "<applicationDirectory>/../../mudlet/3rdparty/?.lua"
     additionalLuaPaths << qsl("%1/../../mudlet/3rdparty/?.lua").arg(appPath);
 
-    int error = luaL_dostring(pIndenterState.get(), qsl("package.path = toNativeSeparators([[%1;]] .. package.path)")
-                              .arg(additionalLuaPaths.join(QLatin1Char(';'))).toUtf8().constData());
+    int error = luaL_dostring(pIndenterState.get(), qsl("package.path = toNativeSeparators([[%1;]] .. package.path)").arg(additionalLuaPaths.join(QLatin1Char(';'))).toUtf8().constData());
     if (!error && !additionalCPaths.isEmpty()) {
-        error = luaL_dostring(pIndenterState.get(), qsl("package.cpath = toNativeSeparators([[%1;]] .. package.cpath)")
-                              .arg(additionalCPaths.join(QLatin1Char(';'))).toUtf8().constData());
+        error = luaL_dostring(pIndenterState.get(), qsl("package.cpath = toNativeSeparators([[%1;]] .. package.cpath)").arg(additionalCPaths.join(QLatin1Char(';'))).toUtf8().constData());
     }
 
     // clang-format off
@@ -5881,7 +5845,7 @@ void TLuaInterpreter::initIndenterGlobals()
   get_ast = request('!.lua.code.get_ast')
   get_formatted_code = request('!.lua.code.ast_as_code')
 )LUA");
-// clang-format on
+        // clang-format on
     }
     if (error) {
         QString e = tr("No error message available from Lua.");
@@ -5912,39 +5876,38 @@ void TLuaInterpreter::loadGlobal()
     // getMudletLuaDefaultPaths() can report them later if asked:
     mPossiblePaths = QStringList{
 #if defined(Q_OS_MACOS)
-        // Load relatively to MacOS inside Resources when we're in a .app
-        // bundle, as mudlet-lua always gets copied in by the build script into
-        // the bundle for the Mac installer build:
-        qsl("%1/../Resources/mudlet-lua/lua/LuaGlobal.lua").arg(executablePath),
+            // Load relatively to MacOS inside Resources when we're in a .app
+            // bundle, as mudlet-lua always gets copied in by the build script into
+            // the bundle for the Mac installer build:
+            qsl("%1/../Resources/mudlet-lua/lua/LuaGlobal.lua").arg(executablePath),
 #endif
 
-        // For the installer we put the lua files under the executable's
-        // location. This is the case for the Windows install:
-        QDir::toNativeSeparators(qsl("%1/mudlet-lua/lua/LuaGlobal.lua").arg(executablePath)),
+            // For the installer we put the lua files under the executable's
+            // location. This is the case for the Windows install:
+            QDir::toNativeSeparators(qsl("%1/mudlet-lua/lua/LuaGlobal.lua").arg(executablePath)),
 
-        // Although a no-op for an in source build an additional "../src/"
-        // allows location of lua code when object code is in a directory
-        // alongside the src directory as occurs using Qt Creator "Shadow
-        // Builds":
-        QDir::toNativeSeparators(qsl("%1/../src/mudlet-lua/lua/LuaGlobal.lua").arg(executablePath)),
+            // Although a no-op for an in source build an additional "../src/"
+            // allows location of lua code when object code is in a directory
+            // alongside the src directory as occurs using Qt Creator "Shadow
+            // Builds":
+            QDir::toNativeSeparators(qsl("%1/../src/mudlet-lua/lua/LuaGlobal.lua").arg(executablePath)),
 
-        // Windows builds (or others where the qmake project file has CONFIG
-        // containing debug_and_release AND debug_and_release_target options)
-        // may be an additional sub-directory down:
-        QDir::toNativeSeparators(qsl("%1/../../src/mudlet-lua/lua/LuaGlobal.lua").arg(executablePath)),
+            // Windows builds (or others where the qmake project file has CONFIG
+            // containing debug_and_release AND debug_and_release_target options)
+            // may be an additional sub-directory down:
+            QDir::toNativeSeparators(qsl("%1/../../src/mudlet-lua/lua/LuaGlobal.lua").arg(executablePath)),
 
-        // CMake builds done from Qt Creator tend to make their build directory
-        // be in a "out-of-source" (the more common name for what Qt calls
-        // "Shadow Builds") on the same level as the top level CMakeList.txt
-        // project file - which is one level up compared to the QMake case.
-        // and in a "src" subdirectory (to match the relative source file
-        // location to that top-level project file) of the main project
-        // "mudlet" directory:
-        QDir::toNativeSeparators(qsl("%1/../../../src/mudlet-lua/lua/LuaGlobal.lua").arg(executablePath)),
+            // CMake builds done from Qt Creator tend to make their build directory
+            // be in a "out-of-source" (the more common name for what Qt calls
+            // "Shadow Builds") on the same level as the top level CMakeList.txt
+            // project file - which is one level up compared to the QMake case.
+            // and in a "src" subdirectory (to match the relative source file
+            // location to that top-level project file) of the main project
+            // "mudlet" directory:
+            QDir::toNativeSeparators(qsl("%1/../../../src/mudlet-lua/lua/LuaGlobal.lua").arg(executablePath)),
 
-        // CMake builds from Qt Creator on Windows 11 appear to use this directory:
-        QDir::toNativeSeparators(qsl("%1/../../../mudlet-lua/lua/LuaGlobal.lua").arg(executablePath))
-    };
+            // CMake builds from Qt Creator on Windows 11 appear to use this directory:
+            QDir::toNativeSeparators(qsl("%1/../../../mudlet-lua/lua/LuaGlobal.lua").arg(executablePath))};
 
     // Although it is relatively easy to detect whether something is #define d
     // it is not so easy to detect what it contains at the preprocessor stage,
@@ -5952,7 +5915,7 @@ void TLuaInterpreter::loadGlobal()
     // for Linux/FreeBSD where the read-only shared Lua files go into the
     // /usr/share part of the file-system:
     if (!qsl(LUA_DEFAULT_PATH).isEmpty()) {
-        mPossiblePaths <<  QDir::toNativeSeparators(qsl(LUA_DEFAULT_PATH "/LuaGlobal.lua"));
+        mPossiblePaths << QDir::toNativeSeparators(qsl(LUA_DEFAULT_PATH "/LuaGlobal.lua"));
     };
     QStringList failedMessages{};
 
@@ -6178,7 +6141,7 @@ std::pair<int, QString> TLuaInterpreter::startPermTimer(const QString& name, con
 // No documentation available in wiki - internal function
 QPair<int, QString> TLuaInterpreter::startTempTimer(double timeout, const QString& function, const bool repeating)
 {
-    const QTime time = QTime(0,0,0,0).addMSecs(qRound(timeout * 1000));
+    const QTime time = QTime(0, 0, 0, 0).addMSecs(qRound(timeout * 1000));
     auto* pT = new TTimer(qsl("newTempTimerWithoutAnId"), time, mpHost, repeating);
     pT->setTime(time);
     pT->setIsFolder(false);
@@ -6292,8 +6255,8 @@ int TLuaInterpreter::startTempKey(int& modifier, int& keycode, const QString& fu
 int TLuaInterpreter::startTempExactMatchTrigger(const QString& regex, const QString& function, int expiryCount)
 {
     TTrigger* pT = nullptr;
-    const QStringList sList {regex};
-    QList<int> const propertyList {REGEX_EXACT_MATCH};
+    const QStringList sList{regex};
+    QList<int> const propertyList{REGEX_EXACT_MATCH};
     pT = new TTrigger("a", sList, propertyList, false, mpHost);
     pT->setIsFolder(false);
     pT->setIsActive(true);
@@ -6310,8 +6273,8 @@ int TLuaInterpreter::startTempExactMatchTrigger(const QString& regex, const QStr
 int TLuaInterpreter::startTempBeginOfLineTrigger(const QString& regex, const QString& function, int expiryCount)
 {
     TTrigger* pT = nullptr;
-    const QStringList sList {regex};
-    QList<int> const propertyList {REGEX_BEGIN_OF_LINE_SUBSTRING};
+    const QStringList sList{regex};
+    QList<int> const propertyList{REGEX_BEGIN_OF_LINE_SUBSTRING};
     pT = new TTrigger("a", sList, propertyList, false, mpHost);
     pT->setIsFolder(false);
     pT->setIsActive(true);
@@ -6328,8 +6291,8 @@ int TLuaInterpreter::startTempBeginOfLineTrigger(const QString& regex, const QSt
 int TLuaInterpreter::startTempTrigger(const QString& regex, const QString& function, int expiryCount)
 {
     TTrigger* pT = nullptr;
-    const QStringList sList {regex};
-    QList<int> const propertyList {REGEX_SUBSTRING};
+    const QStringList sList{regex};
+    QList<int> const propertyList{REGEX_SUBSTRING};
     pT = new TTrigger("a", sList, propertyList, false, mpHost);
     pT->setIsFolder(false);
     pT->setIsActive(true);
@@ -6409,8 +6372,8 @@ int TLuaInterpreter::startTempColorTrigger(int fg, int bg, const QString& functi
 int TLuaInterpreter::startTempRegexTrigger(const QString& regex, const QString& function, int expiryCount)
 {
     TTrigger* pT = nullptr;
-    const QStringList sList {regex};
-    QList<int> const propertyList {REGEX_PERL};
+    const QStringList sList{regex};
+    QList<int> const propertyList{REGEX_PERL};
     pT = new TTrigger("a", sList, propertyList, false, mpHost);
     pT->setIsFolder(false);
     pT->setIsActive(true);
@@ -6594,10 +6557,10 @@ static void storeHostInLua(lua_State* L, Host* h)
 // No documentation available in wiki - internal function
 Host& getHostFromLua(lua_State* L)
 {
-    lua_pushlightuserdata(L, &host_key);    // 1 - push unique key
-    lua_rawget(L, LUA_REGISTRYINDEX);       // 1 - pop key, push host ptr
+    lua_pushlightuserdata(L, &host_key);                 // 1 - push unique key
+    lua_rawget(L, LUA_REGISTRYINDEX);                    // 1 - pop key, push host ptr
     auto* h = static_cast<Host*>(lua_touserdata(L, -1)); // 1 - get host ptr
-    lua_pop(L, 1);                          // 0 - pop host ptr
+    lua_pop(L, 1);                                       // 0 - pop host ptr
     assert(h);
     return *h;
 }
@@ -6616,8 +6579,7 @@ void TLuaInterpreter::freeLuaRegistryIndex(int index)
 void TLuaInterpreter::freeAllInLuaRegistry(TEvent event)
 {
     for (int i = 0; i < event.mArgumentList.size(); i++) {
-        if (event.mArgumentTypeList.at(i) == ARGUMENT_TYPE_TABLE || event.mArgumentTypeList.at(i) == ARGUMENT_TYPE_FUNCTION)
-        {
+        if (event.mArgumentTypeList.at(i) == ARGUMENT_TYPE_TABLE || event.mArgumentTypeList.at(i) == ARGUMENT_TYPE_FUNCTION) {
             freeLuaRegistryIndex(event.mArgumentList.at(i).toInt());
         }
     }
@@ -6689,8 +6651,7 @@ int TLuaInterpreter::spellCheckWord(lua_State* L)
     } else {
         handle = host.mpConsole->getHunspellHandle_system();
         if (!handle) {
-            return warnArgumentValue(L, __func__,
-                "no main dictionaries found: Mudlet has not been able to find any dictionary files to use so is unable to check your word");
+            return warnArgumentValue(L, __func__, "no main dictionaries found: Mudlet has not been able to find any dictionary files to use so is unable to check your word");
         }
 
         encodedText = TEncodingHelper::encode(text, host.mpConsole->getHunspellCodecName_system());
@@ -6718,7 +6679,7 @@ int TLuaInterpreter::spellSuggestWord(lua_State* L)
         }
     }
 
-    char **wordList;
+    char** wordList;
     size_t wordCount = 0;
     Hunhandle* handle = nullptr;
     QByteArray encodedText;
@@ -6728,8 +6689,7 @@ int TLuaInterpreter::spellSuggestWord(lua_State* L)
     } else {
         handle = host.mpConsole->getHunspellHandle_system();
         if (!handle) {
-            return warnArgumentValue(L, __func__,
-                "no main dictionaries found: Mudlet has not been able to find any dictionary files to use so is unable to make suggestions for your word");
+            return warnArgumentValue(L, __func__, "no main dictionaries found: Mudlet has not been able to find any dictionary files to use so is unable to make suggestions for your word");
         }
 
         encodedText = TEncodingHelper::encode(text, host.mpConsole->getHunspellCodecName_system());
@@ -6738,7 +6698,7 @@ int TLuaInterpreter::spellSuggestWord(lua_State* L)
     wordCount = Hunspell_suggest(handle, &wordList, encodedText.constData());
     lua_newtable(L);
     for (size_t i = 0; i < wordCount; ++i) {
-        lua_pushnumber(L, i+1);
+        lua_pushnumber(L, i + 1);
         QString suggestion;
         if (hasUserDictionary) {
             suggestion = QString::fromUtf8(wordList[i]);
@@ -6780,7 +6740,7 @@ int TLuaInterpreter::getDictionaryWordList(lua_State* L)
 
     lua_newtable(L);
     for (int i = 0; i < wordCount; ++i) {
-        lua_pushinteger(L, i+1);
+        lua_pushinteger(L, i + 1);
         lua_pushstring(L, wordList.at(i).toUtf8().constData());
         lua_settable(L, -3);
     }
@@ -6812,28 +6772,26 @@ int TLuaInterpreter::getProfileInformation(lua_State* L)
     const int params = lua_gettop(L);
 
     switch (params) {
-        case 0:
-        {
-            info = host.readProfileData(qsl("description"));
-            break;
+    case 0: {
+        info = host.readProfileData(qsl("description"));
+        break;
+    }
+    default: {
+        QString profileName = getVerifiedString(L, __func__, 1, "profile name");
+        if (profileName.isEmpty()) {
+            lua_pushnil(L);
+            lua_pushstring(L, "getProfileInformation: profile name cannot be empty");
+            return 2;
         }
-        default:
-        {
-            QString profileName = getVerifiedString(L, __func__, 1, "profile name");
-            if (profileName.isEmpty()) {
-                lua_pushnil(L);
-                lua_pushstring(L, "getProfileInformation: profile name cannot be empty");
-                return 2;
-            }
-            if (!mudlet::self()->profileExists(profileName)) {
-                lua_pushnil(L);
-                lua_pushfstring(L, "getProfileInformation: profile '%s' does not exist", profileName.toUtf8().constData());
-                return 2;
-            } else {
-                info = mudlet::self()->readProfileData(profileName, qsl("description"));
-            }
-            break;
+        if (!mudlet::self()->profileExists(profileName)) {
+            lua_pushnil(L);
+            lua_pushfstring(L, "getProfileInformation: profile '%s' does not exist", profileName.toUtf8().constData());
+            return 2;
+        } else {
+            info = mudlet::self()->readProfileData(profileName, qsl("description"));
         }
+        break;
+    }
     }
 
     lua_pushstring(L, info.toUtf8().constData());
@@ -6848,17 +6806,15 @@ int TLuaInterpreter::setProfileInformation(lua_State* L)
     const int params = lua_gettop(L);
 
     switch (params) {
-        case 1:
-        {
-            text = getVerifiedString(L, __func__, 1, "text");
-            break;
-        }
-        default:
-        {
-            profileName = getVerifiedString(L, __func__, 1, "profile name");
-            text = getVerifiedString(L, __func__, 2, "text");
-            break;
-        }
+    case 1: {
+        text = getVerifiedString(L, __func__, 1, "text");
+        break;
+    }
+    default: {
+        profileName = getVerifiedString(L, __func__, 1, "profile name");
+        text = getVerifiedString(L, __func__, 2, "text");
+        break;
+    }
     }
 
     QPair<bool, QString> result = mudlet::self()->writeProfileData(profileName, qsl("description"), text);
@@ -6942,7 +6898,7 @@ void TLuaInterpreter::updateAnsi16ColorsInTable()
     // Equivalent to Lua:
     // color_table = color_table or {}
     lua_getfield(L, LUA_GLOBALSINDEX, "color_table");
-    if (!(lua_toboolean(L,-1))) {
+    if (!(lua_toboolean(L, -1))) {
         // no it doesn't
         lua_pop(L, 1);
         // So make it
@@ -7046,7 +7002,7 @@ void TLuaInterpreter::updateExtendedAnsiColorsInTable()
     // Equivalent to Lua:
     // color_table = color_table or {}
     lua_getfield(L, LUA_GLOBALSINDEX, "color_table");
-    if (!(lua_toboolean(L,-1))) {
+    if (!(lua_toboolean(L, -1))) {
         // no it doesn't
         lua_pop(L, 1);
         // So make it
@@ -7147,7 +7103,7 @@ void TLuaInterpreter::createHttpHeadersTable(lua_State* L, QNetworkReply* reply)
         // Push header key onto stack
         lua_pushstring(L, header.constData());
         // Push header value onto stack
-        lua_pushstring(L,  reply->rawHeader(header).constData());
+        lua_pushstring(L, reply->rawHeader(header).constData());
         // Put key-value pair into table (now 3 deep in stack), pop stack twice
         lua_settable(L, -3);
     }
@@ -7179,7 +7135,7 @@ void TLuaInterpreter::createCookiesTable(lua_State* L, QNetworkReply* reply)
         // Push cookie name onto stack
         lua_pushstring(L, cookie.name().constData());
         // Push cookie value onto stack
-        lua_pushstring(L,  cookie.value().constData());
+        lua_pushstring(L, cookie.value().constData());
         // Put key-value pair into table (now 3 deep in stack), pop stack twice
         lua_settable(L, -3);
     }
@@ -7295,7 +7251,7 @@ int TLuaInterpreter::showNotification(lua_State* L)
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addFileWatch
-int TLuaInterpreter::addFileWatch(lua_State * L)
+int TLuaInterpreter::addFileWatch(lua_State* L)
 {
     auto path = getVerifiedString(L, __func__, 1, "path");
     auto& host = getHostFromLua(L);
@@ -7310,7 +7266,7 @@ int TLuaInterpreter::addFileWatch(lua_State * L)
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#removeFileWatch
-int TLuaInterpreter::removeFileWatch(lua_State * L)
+int TLuaInterpreter::removeFileWatch(lua_State* L)
 {
     auto path = getVerifiedString(L, __func__, 1, "path");
     auto& host = getHostFromLua(L);
@@ -7323,7 +7279,7 @@ int TLuaInterpreter::removeFileWatch(lua_State * L)
 // Please use same options with same names in setConfig and getConfig and keep them in sync
 // The table argument case for setting multiple properties at once is handled
 // by setConfig in Other.lua.
-int TLuaInterpreter::setConfig(lua_State * L)
+int TLuaInterpreter::setConfig(lua_State* L)
 {
     auto& host = getHostFromLua(L);
     const bool currentHost = (mudlet::self()->mpCurrentActiveHost == &host);
@@ -7332,8 +7288,7 @@ int TLuaInterpreter::setConfig(lua_State * L)
         return warnArgumentValue(L, __func__, "you must provide key");
     }
 
-    auto success = [&]()
-    {
+    auto success = [&]() {
         if (mudlet::smDebugMode) {
             TDebug(Qt::white, Qt::blue) << qsl("setConfig: a script has changed %1\n").arg(key) >> &host;
         }
@@ -7399,8 +7354,7 @@ int TLuaInterpreter::setConfig(lua_State * L)
         }
         if (key == qsl("mapInfoColor")) {
             if (!lua_istable(L, 2)) {
-                lua_pushfstring(L, "%s: bad argument #%d type (table expected for mapInfoColor, got %s!)",
-                    __func__, 2, luaL_typename(L, 2));
+                lua_pushfstring(L, "%s: bad argument #%d type (table expected for mapInfoColor, got %s!)", __func__, 2, luaL_typename(L, 2));
                 return warnArgumentValue(L, __func__, qsl("mapInfoColor requires a table {r, g, b} or {r, g, b, a}"));
             }
 
@@ -7606,8 +7560,7 @@ int TLuaInterpreter::setConfig(lua_State * L)
 
         if (!behaviours.contains(behaviour)) {
             lua_pushnil(L);
-            lua_pushfstring(L, "invalid caretShortcut string \"%s\", it should be one of \"%s\"",
-                            lua_tostring(L, 2), behaviours.join(qsl("\", \"")).toUtf8().constData());
+            lua_pushfstring(L, "invalid caretShortcut string \"%s\", it should be one of \"%s\"", lua_tostring(L, 2), behaviours.join(qsl("\", \"")).toUtf8().constData());
             return 2;
         }
 
@@ -7626,8 +7579,7 @@ int TLuaInterpreter::setConfig(lua_State * L)
 
         if (!values.contains(value)) {
             lua_pushnil(L);
-            lua_pushfstring(L, "invalid caretShortcut string \"%s\", it should be one of \"%s\"",
-                            lua_tostring(L, 2), values.join(qsl("\", \"")).toUtf8().constData());
+            lua_pushfstring(L, "invalid caretShortcut string \"%s\", it should be one of \"%s\"", lua_tostring(L, 2), values.join(qsl("\", \"")).toUtf8().constData());
             return 2;
         }
 
@@ -7653,8 +7605,7 @@ int TLuaInterpreter::setConfig(lua_State * L)
 
         if (!values.contains(value)) {
             lua_pushnil(L);
-            lua_pushfstring(L, "invalid commandLineHistorySaveSize string \"%s\", it should be one of \"%s\"",
-                            lua_tostring(L, 2), values.join(qsl("\", \"")).toUtf8().constData());
+            lua_pushfstring(L, "invalid commandLineHistorySaveSize string \"%s\", it should be one of \"%s\"", lua_tostring(L, 2), values.join(qsl("\", \"")).toUtf8().constData());
             return 2;
         }
 
@@ -7686,8 +7637,7 @@ int TLuaInterpreter::setConfig(lua_State * L)
 
         if (!values.contains(value)) {
             lua_pushnil(L);
-            lua_pushfstring(L, "invalid ambiguousEAsianWidthCharacters string \"%s\", it should be one of \"%s\"",
-                            lua_tostring(L, 2), values.join(qsl("\", \"")).toUtf8().constData());
+            lua_pushfstring(L, "invalid ambiguousEAsianWidthCharacters string \"%s\", it should be one of \"%s\"", lua_tostring(L, 2), values.join(qsl("\", \"")).toUtf8().constData());
             return 2;
         }
 
@@ -7774,7 +7724,7 @@ int TLuaInterpreter::setConfig(lua_State * L)
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#announce
-int TLuaInterpreter::announce(lua_State *L)
+int TLuaInterpreter::announce(lua_State* L)
 {
     const QString text = getVerifiedString(L, __func__, 1, "text to announce");
     static const QStringList processingKinds{"importantall", "importantmostrecent", "all", "mostrecent", "currentthenmostrecent"};
@@ -7786,8 +7736,8 @@ int TLuaInterpreter::announce(lua_State *L)
         processing = getVerifiedString(L, __func__, 2, "processing style");
 
         if (!processingKinds.contains(processing)) {
-            lua_pushfstring(L, "%s: bad argument #%d type (processing should be one of %s, got %s!)",
-                __func__, 2, processingKinds.join(qsl(", ")).toUtf8().constData(), processing.toUtf8().constData());
+            lua_pushfstring(
+                    L, "%s: bad argument #%d type (processing should be one of %s, got %s!)", __func__, 2, processingKinds.join(qsl(", ")).toUtf8().constData(), processing.toUtf8().constData());
             return lua_error(L);
         }
     }
@@ -7800,9 +7750,9 @@ int TLuaInterpreter::announce(lua_State *L)
 // Please use same options with same names in setConfig and getConfig and keep them in sync
 // The no args case that returns a table is handled by getConfig in Other.lua
 // that runs a loop with a list of these properties, please update that list.
-int TLuaInterpreter::getConfig(lua_State *L)
+int TLuaInterpreter::getConfig(lua_State* L)
 {
-    auto &host = getHostFromLua(L);
+    auto& host = getHostFromLua(L);
     const QString key = getVerifiedString(L, __func__, 1, "key");
     if (key.isEmpty()) {
         return warnArgumentValue(L, __func__, "you must provide a key");
@@ -7815,173 +7765,317 @@ int TLuaInterpreter::getConfig(lua_State *L)
     }
 
     const std::unordered_map<QString, std::function<void()>> configMap = {
-        { qsl("mapRoomSize"), [&](){ lua_pushnumber(L, host.mRoomSize); } },
-        { qsl("mapExitSize"), [&](){ lua_pushnumber(L, host.mLineSize); } },
-        { qsl("mapRoundRooms"), [&](){ lua_pushboolean(L, host.mBubbleMode); } },
-        { qsl("showRoomIdsOnMap"), [&](){ lua_pushboolean(L, host.mShowRoomID); } },
-        { qsl("show3dMapView"), [&](){
+            {qsl("mapRoomSize"),
+             [&]() {
+                 lua_pushnumber(L, host.mRoomSize);
+             }},
+            {qsl("mapExitSize"),
+             [&]() {
+                 lua_pushnumber(L, host.mLineSize);
+             }},
+            {qsl("mapRoundRooms"),
+             [&]() {
+                 lua_pushboolean(L, host.mBubbleMode);
+             }},
+            {qsl("showRoomIdsOnMap"),
+             [&]() {
+                 lua_pushboolean(L, host.mShowRoomID);
+             }},
+            {qsl("show3dMapView"),
+             [&]() {
 #if defined(INCLUDE_3DMAPPER)
-            if (host.mpMap && host.mpMap->mpMapper) {
-                auto widget = host.mpMap->mpMapper->glWidget;
-                lua_pushboolean(L, (widget && widget->isVisible()));
-                return;
-            }
+                 if (host.mpMap && host.mpMap->mpMapper) {
+                     auto widget = host.mpMap->mpMapper->glWidget;
+                     lua_pushboolean(L, (widget && widget->isVisible()));
+                     return;
+                 }
 #endif
-            lua_pushboolean(L, false);
-        }},
-        { qsl("mapperPanelVisible"), [&](){ lua_pushboolean(L, host.mShowPanel); } },
-        { qsl("mapShowRoomBorders"), [&](){ lua_pushboolean(L, host.mMapperShowRoomBorders); } },
-        { qsl("mapInfoColor"), [&](){
-            lua_newtable(L);
-            lua_pushnumber(L, host.mMapInfoBg.red());
-            lua_rawseti(L, -2, 1);
-            lua_pushnumber(L, host.mMapInfoBg.green());
-            lua_rawseti(L, -2, 2);
-            lua_pushnumber(L, host.mMapInfoBg.blue());
-            lua_rawseti(L, -2, 3);
-            lua_pushnumber(L, host.mMapInfoBg.alpha());
-            lua_rawseti(L, -2, 4);
-        } },
-        { qsl("mapShowGrid"), [&](){ lua_pushboolean(L, host.mMapperShowGrid); } },
-        { qsl("editorAutoComplete"), [&](){ lua_pushboolean(L, host.mEditorAutoComplete); } },
-        { qsl("enableGMCP"), [&](){ lua_pushboolean(L, host.mEnableGMCP); } },
-        { qsl("enableMSSP"), [&](){ lua_pushboolean(L, host.mEnableMSSP); } },
-        { qsl("enableMSDP"), [&](){ lua_pushboolean(L, host.mEnableMSDP); } },
-        { qsl("enableMSP"), [&](){ lua_pushboolean(L, host.mEnableMSP); } },
-        { qsl("enableMTTS"), [&](){ lua_pushboolean(L, host.mEnableMTTS); } },
-        { qsl("enableMNES"), [&](){ lua_pushboolean(L, host.mEnableMNES); } },
-        { qsl("enableMXP"), [&](){ lua_pushboolean(L, host.mEnableMXP); } },
-        { qsl("enableNAWS"), [&](){ lua_pushboolean(L, host.mEnableNAWS); } },
-        { qsl("logDirectory"), [&](){
-            const auto logDir = host.mLogDir;
+                 lua_pushboolean(L, false);
+             }},
+            {qsl("mapperPanelVisible"),
+             [&]() {
+                 lua_pushboolean(L, host.mShowPanel);
+             }},
+            {qsl("mapShowRoomBorders"),
+             [&]() {
+                 lua_pushboolean(L, host.mMapperShowRoomBorders);
+             }},
+            {qsl("mapInfoColor"),
+             [&]() {
+                 lua_newtable(L);
+                 lua_pushnumber(L, host.mMapInfoBg.red());
+                 lua_rawseti(L, -2, 1);
+                 lua_pushnumber(L, host.mMapInfoBg.green());
+                 lua_rawseti(L, -2, 2);
+                 lua_pushnumber(L, host.mMapInfoBg.blue());
+                 lua_rawseti(L, -2, 3);
+                 lua_pushnumber(L, host.mMapInfoBg.alpha());
+                 lua_rawseti(L, -2, 4);
+             }},
+            {qsl("mapShowGrid"),
+             [&]() {
+                 lua_pushboolean(L, host.mMapperShowGrid);
+             }},
+            {qsl("editorAutoComplete"),
+             [&]() {
+                 lua_pushboolean(L, host.mEditorAutoComplete);
+             }},
+            {qsl("enableGMCP"),
+             [&]() {
+                 lua_pushboolean(L, host.mEnableGMCP);
+             }},
+            {qsl("enableMSSP"),
+             [&]() {
+                 lua_pushboolean(L, host.mEnableMSSP);
+             }},
+            {qsl("enableMSDP"),
+             [&]() {
+                 lua_pushboolean(L, host.mEnableMSDP);
+             }},
+            {qsl("enableMSP"),
+             [&]() {
+                 lua_pushboolean(L, host.mEnableMSP);
+             }},
+            {qsl("enableMTTS"),
+             [&]() {
+                 lua_pushboolean(L, host.mEnableMTTS);
+             }},
+            {qsl("enableMNES"),
+             [&]() {
+                 lua_pushboolean(L, host.mEnableMNES);
+             }},
+            {qsl("enableMXP"),
+             [&]() {
+                 lua_pushboolean(L, host.mEnableMXP);
+             }},
+            {qsl("enableNAWS"),
+             [&]() {
+                 lua_pushboolean(L, host.mEnableNAWS);
+             }},
+            {qsl("logDirectory"),
+             [&]() {
+                 const auto logDir = host.mLogDir;
 
-            if (logDir == nullptr || logDir.isEmpty()) {
-                lua_pushstring(L, mudlet::getMudletPath(enums::profileReplayAndLogFilesPath, getHostFromLua(L).getName()).toUtf8().constData());
-            } else {
-                lua_pushstring(L, host.mLogDir.toUtf8().constData());
-            }
-        } },
-        { qsl("askTlsAvailable"), [&](){lua_pushboolean(L, host.mAskTlsAvailable); } },
-        { qsl("promptForMXPProcessorOn"), [&](){lua_pushboolean(L, host.mPromptedForMXPProcessorOn); } },
-        { qsl("specialForceMXPProcessorOn"), [&](){lua_pushboolean(L, host.getForceMXPProcessorOn()); } },
-        { qsl("promptForVersionInTTYPE"), [&](){lua_pushboolean(L, host.mPromptedForVersionInTTYPE); } },
-        { qsl("versionInTTYPE"), [&](){ lua_pushboolean(L, host.mVersionInTTYPE); } },
-        { qsl("inputLineStrictUnixEndings"), [&](){ lua_pushboolean(L, host.mUSE_UNIX_EOL); } },
-        { qsl("autoClearInputLine"), [&](){ lua_pushboolean(L, host.mAutoClearCommandLineAfterSend); } },
-        { qsl("showSentText"), [&](){
-            if (useStringFormat) {
-                // Return string representation for new enhanced API
-                switch (host.mCommandEchoMode) {
-                case Host::CommandEchoMode::Never:
-                    lua_pushstring(L, "never");
-                    break;
-                case Host::CommandEchoMode::Always:
-                    lua_pushstring(L, "always");
-                    break;
-                case Host::CommandEchoMode::ScriptControl:
-                    lua_pushstring(L, "script");
-                    break;
-                }
-            } else {
-                // For backward compatibility, return boolean for legacy scripts
-                switch (host.mCommandEchoMode) {
-                case Host::CommandEchoMode::Never:
-                    lua_pushboolean(L, false);
-                    break;
-                case Host::CommandEchoMode::Always:
-                case Host::CommandEchoMode::ScriptControl:
-                    // Both modes map to true for backward compatibility
-                    lua_pushboolean(L, true);
-                    break;
-                }
-            }
-        } },
-        { qsl("fixUnnecessaryLinebreaks"), [&](){ lua_pushboolean(L, host.mUSE_IRE_DRIVER_BUGFIX); } },
-        { qsl("specialForceCompressionOff"), [&](){ lua_pushboolean(L, host.mFORCE_NO_COMPRESSION); } },
-        { qsl("specialForceGAOff"), [&](){ lua_pushboolean(L, host.mFORCE_GA_OFF); } },
-        { qsl("specialForceMxpNegotiationOff"), [&](){
-            // specialForceMxpNegotiationOff should not be used anymore, but we support it for compatibility
-            // it will be the inverse of enableMXP
-            lua_pushboolean(L, !host.mEnableMXP);
-        } },
-        { qsl("specialForceCharsetNegotiationOff"), [&](){
-            // specialForceCharsetNegotiationOff should not be used anymore, but we support it for compatibility
-            // it will be the inverse of enableCHARSET
-            lua_pushboolean(L, !host.mEnableCHARSET);
-        } },
-        { qsl("enableCHARSET"), [&](){ lua_pushboolean(L, host.mEnableCHARSET); } },
-        { qsl("forceNewEnvironNegotiationOff"), [&](){
-            // forceNewEnvironNegotiationOff should not be used anymore, but we support it for compatibility
-            // it will be the inverse of enableNEWENVIRON
-            lua_pushboolean(L, !host.mEnableNEWENVIRON);
-        } },
-        { qsl("enableNEWENVIRON"), [&](){ lua_pushboolean(L, host.mEnableNEWENVIRON); } },
-        { qsl("compactInputLine"), [&](){ lua_pushboolean(L, host.getCompactInputLine()); } },
-        { qsl("announceIncomingText"), [&](){ lua_pushboolean(L, host.mAnnounceIncomingText); } },
-        { qsl("blankLinesBehaviour"), [&](){
-            const auto behaviour = host.mBlankLineBehaviour;
-            if (behaviour == Host::BlankLineBehaviour::Show) {
-                lua_pushstring(L, "show");
-            } else if (behaviour == Host::BlankLineBehaviour::Hide) {
-                lua_pushstring(L, "hide");
-            } else if (behaviour == Host::BlankLineBehaviour::ReplaceWithSpace) {
-                lua_pushstring(L, "replacewithspace");
-            }
-        } },
-        { qsl("caretShortcut"), [&](){
-            const auto caret = host.mCaretShortcut;
-            if (caret == Host::CaretShortcut::None) {
-                lua_pushstring(L, "none");
-            } else if (caret == Host::CaretShortcut::Tab) {
-                lua_pushstring(L, "tab");
-            } else if (caret == Host::CaretShortcut::CtrlTab) {
-                lua_pushstring(L, "ctrltab");
-            } else if (caret == Host::CaretShortcut::F6) {
-                lua_pushstring(L, "f6");
-            }
-        } },
-        { qsl("commandLineHistorySaveSize"), [&](){ lua_pushnumber(L, host.getCommandLineHistorySaveSize()); } },
-        { qsl("controlCharacterHandling"), [&](){
-            const auto controlCharacterMode = host.getControlCharacterMode();
-            switch (controlCharacterMode) {
-            case ControlCharacterMode::Picture:
-                lua_pushstring(L, "picture");
-                break;
-            case ControlCharacterMode::OEM:
-                lua_pushstring(L, "oem");
-                break;
-            default:
-                lua_pushstring(L, "asis");
-            }
-        } },
-        { qsl("logInHTML"), [&](){ lua_pushboolean(L, host.mIsNextLogFileInHtmlFormat); } },
-        { qsl("f3SearchEnabled"), [&](){ lua_pushboolean(L, host.getF3SearchEnabled()); } },
-        { qsl("showTabConnectionIndicators"), [&](){ lua_pushboolean(L, mudlet::self()->mShowTabConnectionIndicators); } },
-        { qsl("advertiseScreenReader"), [&](){ lua_pushboolean(L, host.mAdvertiseScreenReader); } },
-        { qsl("ambiguousEAsianWidthCharacters"), [&]() {
-            const auto ambiguousEAsianGlyphWidth = host.getWideAmbiguousEAsianGlyphsControlState();
-            switch (ambiguousEAsianGlyphWidth) {
-            case Qt::Unchecked:
-                lua_pushstring(L, "narrow");
-                break;
-            case Qt::Checked:
-                lua_pushstring(L, "wide");
-            break;
-            default:
-                lua_pushstring(L, "auto");
-            }
-        } },
-        { qsl("enableClosedCaption"), [&](){ lua_pushboolean(L, host.mEnableClosedCaption); } },
-        { qsl("showUpperLowerLevels"), [&](){ lua_pushboolean(L, mudlet::self()->mDrawUpperLowerLevels); } },
-        { qsl("muteMediaAPI"), [&](){ lua_pushboolean(L, mudlet::self()->muteAPI()); } },
-        { qsl("muteMediaGame"), [&](){ lua_pushboolean(L, mudlet::self()->muteGame()); } },
-        { qsl("ircHostName"), [&](){ lua_pushstring(L, dlgIRC::readIrcHostName(&host).toUtf8().constData()); } },
-        { qsl("ircHostPort"), [&](){ lua_pushnumber(L, dlgIRC::readIrcHostPort(&host)); } },
-        { qsl("ircHostSecure"), [&](){ lua_pushboolean(L, dlgIRC::readIrcHostSecure(&host)); } },
-        { qsl("ircChannels"), [&](){ lua_pushstring(L, dlgIRC::readIrcChannels(&host).join(qsl(" ")).toUtf8().constData()); } },
-        { qsl("ircNickName"), [&](){ lua_pushstring(L, dlgIRC::readIrcNickName(&host).toUtf8().constData()); } },
-        { qsl("ircPassword"), [&](){ lua_pushstring(L, dlgIRC::readIrcPassword(&host).toUtf8().constData()); } }
-    };
+                 if (logDir == nullptr || logDir.isEmpty()) {
+                     lua_pushstring(L, mudlet::getMudletPath(enums::profileReplayAndLogFilesPath, getHostFromLua(L).getName()).toUtf8().constData());
+                 } else {
+                     lua_pushstring(L, host.mLogDir.toUtf8().constData());
+                 }
+             }},
+            {qsl("askTlsAvailable"),
+             [&]() {
+                 lua_pushboolean(L, host.mAskTlsAvailable);
+             }},
+            {qsl("promptForMXPProcessorOn"),
+             [&]() {
+                 lua_pushboolean(L, host.mPromptedForMXPProcessorOn);
+             }},
+            {qsl("specialForceMXPProcessorOn"),
+             [&]() {
+                 lua_pushboolean(L, host.getForceMXPProcessorOn());
+             }},
+            {qsl("promptForVersionInTTYPE"),
+             [&]() {
+                 lua_pushboolean(L, host.mPromptedForVersionInTTYPE);
+             }},
+            {qsl("versionInTTYPE"),
+             [&]() {
+                 lua_pushboolean(L, host.mVersionInTTYPE);
+             }},
+            {qsl("inputLineStrictUnixEndings"),
+             [&]() {
+                 lua_pushboolean(L, host.mUSE_UNIX_EOL);
+             }},
+            {qsl("autoClearInputLine"),
+             [&]() {
+                 lua_pushboolean(L, host.mAutoClearCommandLineAfterSend);
+             }},
+            {qsl("showSentText"),
+             [&]() {
+                 if (useStringFormat) {
+                     // Return string representation for new enhanced API
+                     switch (host.mCommandEchoMode) {
+                     case Host::CommandEchoMode::Never:
+                         lua_pushstring(L, "never");
+                         break;
+                     case Host::CommandEchoMode::Always:
+                         lua_pushstring(L, "always");
+                         break;
+                     case Host::CommandEchoMode::ScriptControl:
+                         lua_pushstring(L, "script");
+                         break;
+                     }
+                 } else {
+                     // For backward compatibility, return boolean for legacy scripts
+                     switch (host.mCommandEchoMode) {
+                     case Host::CommandEchoMode::Never:
+                         lua_pushboolean(L, false);
+                         break;
+                     case Host::CommandEchoMode::Always:
+                     case Host::CommandEchoMode::ScriptControl:
+                         // Both modes map to true for backward compatibility
+                         lua_pushboolean(L, true);
+                         break;
+                     }
+                 }
+             }},
+            {qsl("fixUnnecessaryLinebreaks"),
+             [&]() {
+                 lua_pushboolean(L, host.mUSE_IRE_DRIVER_BUGFIX);
+             }},
+            {qsl("specialForceCompressionOff"),
+             [&]() {
+                 lua_pushboolean(L, host.mFORCE_NO_COMPRESSION);
+             }},
+            {qsl("specialForceGAOff"),
+             [&]() {
+                 lua_pushboolean(L, host.mFORCE_GA_OFF);
+             }},
+            {qsl("specialForceMxpNegotiationOff"),
+             [&]() {
+                 // specialForceMxpNegotiationOff should not be used anymore, but we support it for compatibility
+                 // it will be the inverse of enableMXP
+                 lua_pushboolean(L, !host.mEnableMXP);
+             }},
+            {qsl("specialForceCharsetNegotiationOff"),
+             [&]() {
+                 // specialForceCharsetNegotiationOff should not be used anymore, but we support it for compatibility
+                 // it will be the inverse of enableCHARSET
+                 lua_pushboolean(L, !host.mEnableCHARSET);
+             }},
+            {qsl("enableCHARSET"),
+             [&]() {
+                 lua_pushboolean(L, host.mEnableCHARSET);
+             }},
+            {qsl("forceNewEnvironNegotiationOff"),
+             [&]() {
+                 // forceNewEnvironNegotiationOff should not be used anymore, but we support it for compatibility
+                 // it will be the inverse of enableNEWENVIRON
+                 lua_pushboolean(L, !host.mEnableNEWENVIRON);
+             }},
+            {qsl("enableNEWENVIRON"),
+             [&]() {
+                 lua_pushboolean(L, host.mEnableNEWENVIRON);
+             }},
+            {qsl("compactInputLine"),
+             [&]() {
+                 lua_pushboolean(L, host.getCompactInputLine());
+             }},
+            {qsl("announceIncomingText"),
+             [&]() {
+                 lua_pushboolean(L, host.mAnnounceIncomingText);
+             }},
+            {qsl("blankLinesBehaviour"),
+             [&]() {
+                 const auto behaviour = host.mBlankLineBehaviour;
+                 if (behaviour == Host::BlankLineBehaviour::Show) {
+                     lua_pushstring(L, "show");
+                 } else if (behaviour == Host::BlankLineBehaviour::Hide) {
+                     lua_pushstring(L, "hide");
+                 } else if (behaviour == Host::BlankLineBehaviour::ReplaceWithSpace) {
+                     lua_pushstring(L, "replacewithspace");
+                 }
+             }},
+            {qsl("caretShortcut"),
+             [&]() {
+                 const auto caret = host.mCaretShortcut;
+                 if (caret == Host::CaretShortcut::None) {
+                     lua_pushstring(L, "none");
+                 } else if (caret == Host::CaretShortcut::Tab) {
+                     lua_pushstring(L, "tab");
+                 } else if (caret == Host::CaretShortcut::CtrlTab) {
+                     lua_pushstring(L, "ctrltab");
+                 } else if (caret == Host::CaretShortcut::F6) {
+                     lua_pushstring(L, "f6");
+                 }
+             }},
+            {qsl("commandLineHistorySaveSize"),
+             [&]() {
+                 lua_pushnumber(L, host.getCommandLineHistorySaveSize());
+             }},
+            {qsl("controlCharacterHandling"),
+             [&]() {
+                 const auto controlCharacterMode = host.getControlCharacterMode();
+                 switch (controlCharacterMode) {
+                 case ControlCharacterMode::Picture:
+                     lua_pushstring(L, "picture");
+                     break;
+                 case ControlCharacterMode::OEM:
+                     lua_pushstring(L, "oem");
+                     break;
+                 default:
+                     lua_pushstring(L, "asis");
+                 }
+             }},
+            {qsl("logInHTML"),
+             [&]() {
+                 lua_pushboolean(L, host.mIsNextLogFileInHtmlFormat);
+             }},
+            {qsl("f3SearchEnabled"),
+             [&]() {
+                 lua_pushboolean(L, host.getF3SearchEnabled());
+             }},
+            {qsl("showTabConnectionIndicators"),
+             [&]() {
+                 lua_pushboolean(L, mudlet::self()->mShowTabConnectionIndicators);
+             }},
+            {qsl("advertiseScreenReader"),
+             [&]() {
+                 lua_pushboolean(L, host.mAdvertiseScreenReader);
+             }},
+            {qsl("ambiguousEAsianWidthCharacters"),
+             [&]() {
+                 const auto ambiguousEAsianGlyphWidth = host.getWideAmbiguousEAsianGlyphsControlState();
+                 switch (ambiguousEAsianGlyphWidth) {
+                 case Qt::Unchecked:
+                     lua_pushstring(L, "narrow");
+                     break;
+                 case Qt::Checked:
+                     lua_pushstring(L, "wide");
+                     break;
+                 default:
+                     lua_pushstring(L, "auto");
+                 }
+             }},
+            {qsl("enableClosedCaption"),
+             [&]() {
+                 lua_pushboolean(L, host.mEnableClosedCaption);
+             }},
+            {qsl("showUpperLowerLevels"),
+             [&]() {
+                 lua_pushboolean(L, mudlet::self()->mDrawUpperLowerLevels);
+             }},
+            {qsl("muteMediaAPI"),
+             [&]() {
+                 lua_pushboolean(L, mudlet::self()->muteAPI());
+             }},
+            {qsl("muteMediaGame"),
+             [&]() {
+                 lua_pushboolean(L, mudlet::self()->muteGame());
+             }},
+            {qsl("ircHostName"),
+             [&]() {
+                 lua_pushstring(L, dlgIRC::readIrcHostName(&host).toUtf8().constData());
+             }},
+            {qsl("ircHostPort"),
+             [&]() {
+                 lua_pushnumber(L, dlgIRC::readIrcHostPort(&host));
+             }},
+            {qsl("ircHostSecure"),
+             [&]() {
+                 lua_pushboolean(L, dlgIRC::readIrcHostSecure(&host));
+             }},
+            {qsl("ircChannels"),
+             [&]() {
+                 lua_pushstring(L, dlgIRC::readIrcChannels(&host).join(qsl(" ")).toUtf8().constData());
+             }},
+            {qsl("ircNickName"),
+             [&]() {
+                 lua_pushstring(L, dlgIRC::readIrcNickName(&host).toUtf8().constData());
+             }},
+            {qsl("ircPassword"), [&]() {
+                 lua_pushstring(L, dlgIRC::readIrcPassword(&host).toUtf8().constData());
+             }}};
 
     auto it = configMap.find(key);
     if (it != configMap.end()) {
@@ -8014,7 +8108,7 @@ int TLuaInterpreter::getConfig(lua_State *L)
             if (validExperiments.contains(key)) {
                 lua_pushboolean(L, host.experimentEnabled(key));
             } else {
-                lua_pushboolean(L, false);  // Invalid experiments are always false
+                lua_pushboolean(L, false); // Invalid experiments are always false
             }
         }
         return 1;
@@ -8074,8 +8168,7 @@ int TLuaInterpreter::setSaveCommandHistory(lua_State* L)
 
         } else {
             if (lua_type(L, 1) != LUA_TBOOLEAN) {
-                lua_pushfstring(L, "%s: bad argument #1 type (command line name as string or save history as boolean is optional, got %s!)",
-                                __func__, luaL_typename(L, 1));
+                lua_pushfstring(L, "%s: bad argument #1 type (command line name as string or save history as boolean is optional, got %s!)", __func__, luaL_typename(L, 1));
                 return lua_error(L); // Dummy return!
             }
 

--- a/src/TLuaInterpreterAI.cpp
+++ b/src/TLuaInterpreterAI.cpp
@@ -119,7 +119,7 @@ int TLuaInterpreter::aiChat(lua_State* L)
 
     // Always use event-based approach (async)
     aiManager->chatCompletion(request, [&host, eventName](const LlamafileManager::ApiResponse& response) {
-        TEvent event {};
+        TEvent event{};
 
         // Add event name as first argument
         event.mArgumentList.append(eventName);
@@ -213,7 +213,7 @@ int TLuaInterpreter::aiPrompt(lua_State* L)
     auto* aiManager = pMudlet->getAIManager();
 
     aiManager->textCompletion(request, [&host, eventName](const LlamafileManager::ApiResponse& response) {
-        TEvent event {};
+        TEvent event{};
 
         // Add event name as first argument
         event.mArgumentList.append(eventName);
@@ -268,7 +268,7 @@ int TLuaInterpreter::aiPromptStream(lua_State* L)
 
     // Optional parameters
     double temperature = 0.7;
-    int maxTokens = 0; // 0 means no limit
+    int maxTokens = 0;                            // 0 means no limit
     QString eventName = "aiPromptStreamResponse"; // Default event name
 
     if (lua_gettop(L) >= 2) {
@@ -308,70 +308,70 @@ int TLuaInterpreter::aiPromptStream(lua_State* L)
 
     // For streaming, we need to handle the response differently
     // This will require modifications to LlamaFileManager to support streaming callbacks
-    aiManager->textCompletionStream(request,
-        // Chunk callback - fired for each streaming chunk
-        [&host, eventName](const QString& chunk, bool isComplete) {
-            TEvent event {};
+    aiManager->textCompletionStream(
+            request,
+            // Chunk callback - fired for each streaming chunk
+            [&host, eventName](const QString& chunk, bool isComplete) {
+                TEvent event{};
 
-            // Add event name as first argument
-            event.mArgumentList.append(eventName);
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+                // Add event name as first argument
+                event.mArgumentList.append(eventName);
+                event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
 
-            // Add chunk type
-            event.mArgumentList.append(isComplete ? QLatin1String("complete") : QLatin1String("partial"));
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+                // Add chunk type
+                event.mArgumentList.append(isComplete ? QLatin1String("complete") : QLatin1String("partial"));
+                event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
 
-            // Add success status (always true for chunks, errors handled separately)
-            event.mArgumentList.append(QLatin1String("1"));
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_BOOLEAN);
+                // Add success status (always true for chunks, errors handled separately)
+                event.mArgumentList.append(QLatin1String("1"));
+                event.mArgumentTypeList.append(ARGUMENT_TYPE_BOOLEAN);
 
-            // Add empty error message for chunks
-            event.mArgumentList.append(QString());
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+                // Add empty error message for chunks
+                event.mArgumentList.append(QString());
+                event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
 
-            // Add chunk content
-            QString content = chunk;
-            // Strip leading "\n " and trailing "</s>" for final chunk
-            if (isComplete) {
-                if (content.startsWith("\n ")) {
-                    content = content.mid(2);
+                // Add chunk content
+                QString content = chunk;
+                // Strip leading "\n " and trailing "</s>" for final chunk
+                if (isComplete) {
+                    if (content.startsWith("\n ")) {
+                        content = content.mid(2);
+                    }
+                    if (content.endsWith("</s>")) {
+                        content.chop(4);
+                    }
                 }
-                if (content.endsWith("</s>")) {
-                    content.chop(4);
-                }
-            }
-            event.mArgumentList.append(content);
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+                event.mArgumentList.append(content);
+                event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
 
-            host.raiseEvent(event);
-        },
-        // Error callback - fired on error
-        [&host, eventName](const QString& error) {
-            TEvent event {};
+                host.raiseEvent(event);
+            },
+            // Error callback - fired on error
+            [&host, eventName](const QString& error) {
+                TEvent event{};
 
-            // Add event name as first argument
-            event.mArgumentList.append(eventName);
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+                // Add event name as first argument
+                event.mArgumentList.append(eventName);
+                event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
 
-            // Add chunk type
-            event.mArgumentList.append(QLatin1String("error"));
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+                // Add chunk type
+                event.mArgumentList.append(QLatin1String("error"));
+                event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
 
-            // Add success status (false for errors)
-            event.mArgumentList.append(QLatin1String("0"));
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_BOOLEAN);
+                // Add success status (false for errors)
+                event.mArgumentList.append(QLatin1String("0"));
+                event.mArgumentTypeList.append(ARGUMENT_TYPE_BOOLEAN);
 
-            // Add error message
-            event.mArgumentList.append(error);
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+                // Add error message
+                event.mArgumentList.append(error);
+                event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
 
-            // Add empty content
-            event.mArgumentList.append(QString());
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+                // Add empty content
+                event.mArgumentList.append(QString());
+                event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
 
-            host.raiseEvent(event);
-        }
-    );
+                host.raiseEvent(event);
+            });
 
     lua_pushboolean(L, true);
     return 1;

--- a/src/TLuaInterpreterDiscord.cpp
+++ b/src/TLuaInterpreterDiscord.cpp
@@ -565,4 +565,3 @@ int TLuaInterpreter::setDiscordState(lua_State* L)
     lua_pushboolean(L, true);
     return 1;
 }
-

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -219,7 +219,7 @@ int TLuaInterpreter::getCustomLines1(lua_State* L)
             // we need to start the numbering from the Lua standard of 1 and
             // NOT the C/C++ standard of 0 - otherwise the end-user has to
             // fiddle with the zero-th entry to keep the points in order:
-            lua_pushinteger(L, k+1);
+            lua_pushinteger(L, k + 1);
             lua_newtable(L); //customLines[direction]["points"][3 x coordinates]
             lua_pushinteger(L, 1);
             lua_pushnumber(L, pointL.at(k).x());
@@ -279,8 +279,8 @@ int TLuaInterpreter::addAreaName(lua_State* L)
         return warnArgumentValue(L, __func__, "area names may not be empty strings (and spaces are trimmed from the ends)");
     } else if (host.mpMap->mpRoomDB->getAreaNamesMap().values().count(name) > 0) {
         // That name is already IN the areaNamesMap
-        return warnArgumentValue(L, __func__, qsl("area names may not be duplicated and areaID %1 already has the name '%2'")
-            .arg(QString::number(host.mpMap->mpRoomDB->getAreaNamesMap().key(name)), name));
+        return warnArgumentValue(
+                L, __func__, qsl("area names may not be duplicated and areaID %1 already has the name '%2'").arg(QString::number(host.mpMap->mpRoomDB->getAreaNamesMap().key(name)), name));
     }
 
     // Note that adding an area name implicitly creates an underlying TArea instance
@@ -331,10 +331,11 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
         const int area = pR->getArea();
         const int area_to = pR_to->getArea();
         if (area != area_to) {
-            return warnArgumentValue(L, __func__, qsl(
-                "target room is in area '%1' (ID: %2) which is not the one '%3' (ID: %4) in which this custom line is to be drawn")
-                .arg((host.mpMap->mpRoomDB->getAreaNamesMap()).value(area_to), QString::number(area_to),
-                        (host.mpMap->mpRoomDB->getAreaNamesMap()).value(area), QString::number(area)));
+            return warnArgumentValue(
+                    L,
+                    __func__,
+                    qsl("target room is in area '%1' (ID: %2) which is not the one '%3' (ID: %4) in which this custom line is to be drawn")
+                            .arg((host.mpMap->mpRoomDB->getAreaNamesMap()).value(area_to), QString::number(area_to), (host.mpMap->mpRoomDB->getAreaNamesMap()).value(area), QString::number(area)));
         }
 
         x.append(static_cast<qreal>(pR_to->x()));
@@ -406,7 +407,10 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
             return warnArgumentValue(L, __func__, "missing coordinates to create the line to");
         }
         if (x.count() != y.count() || x.count() != z.count()) {
-            return warnArgumentValue(L, __func__, "mismatch in numbers of coordinates for the points for the custom line given in table as second argument; each must contain three coordinates, i.e. x, y AND z numeric values as a sub-table");
+            return warnArgumentValue(L,
+                                     __func__,
+                                     "mismatch in numbers of coordinates for the points for the custom line given in table as second argument; each must contain three coordinates, i.e. x, y AND z "
+                                     "numeric values as a sub-table");
         }
     }
 
@@ -416,8 +420,7 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
         return lua_error(L);
     }
     if (!pR->hasExitOrSpecialExit(direction)) {
-        return warnArgumentValue(L, __func__, qsl("roomID %1 does not have an exit in a direction that can be identified from '%2'")
-            .arg(QString::number(id_from), lua_tostring(L, 3)));
+        return warnArgumentValue(L, __func__, qsl("roomID %1 does not have an exit in a direction that can be identified from '%2'").arg(QString::number(id_from), lua_tostring(L, 3)));
     }
 
     const QString lineStyleString = getVerifiedString(L, __func__, 4, "line style");
@@ -432,9 +435,7 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
     } else if (!lineStyleString.compare(QLatin1String("dash dot dot line"))) {
         line_style = Qt::DashDotDotLine;
     } else {
-        return warnArgumentValue(L, __func__, qsl(
-                "invalid line style '%1', only use one of: 'solid line', 'dot line', 'dash line', 'dash dot line' or 'dash dot dot line'")
-                .arg(lineStyleString));
+        return warnArgumentValue(L, __func__, qsl("invalid line style '%1', only use one of: 'solid line', 'dot line', 'dash line', 'dash dot line' or 'dash dot dot line'").arg(lineStyleString));
     }
 
     if (!lua_istable(L, 5)) {
@@ -456,9 +457,10 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
 
                 qint64 const component = lua_tointeger(L, -1);
                 if (component < 0 || component > 255) {
-                    return warnArgumentValue(L, __func__, qsl(
-                        "%1 color component in the table of the fifth argument is %2 which is out of the valid range (0 to 255)")
-                        .arg((tind == 1 ? "red" : (tind == 2 ? "green" : "blue")), QString::number(component)));
+                    return warnArgumentValue(L,
+                                             __func__,
+                                             qsl("%1 color component in the table of the fifth argument is %2 which is out of the valid range (0 to 255)")
+                                                     .arg((tind == 1 ? "red" : (tind == 2 ? "green" : "blue")), QString::number(component)));
                 }
                 switch (tind) {
                 case 1:
@@ -484,9 +486,7 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
     points.append(QPointF(x.at(0), y.at(0)));
     for (int i = 1, total = z.size(); i < total; ++i) {
         if (lz != z.at(i)) {
-            return warnArgumentValue(L, __func__, qsl(
-                "the z values are not all on the same level (first wrong value is %1 at index %2)")
-                .arg(QString::number(z.at(i)), QString::number(i + 1)));
+            return warnArgumentValue(L, __func__, qsl("the z values are not all on the same level (first wrong value is %1 at index %2)").arg(QString::number(z.at(i)), QString::number(i + 1)));
         }
         points.append(QPointF(x.at(i), y.at(i)));
     }
@@ -653,7 +653,7 @@ int TLuaInterpreter::shiftMapPerspective(lua_State* L)
 
     if (host.mpMap->mpM) {
         if (auto* modernWidget = dynamic_cast<ModernGLWidget*>(host.mpMap->mpM.data())) {
-        modernWidget->shiftCamera(verticalAngle, horizontalAngle, rotationAngle);
+            modernWidget->shiftCamera(verticalAngle, horizontalAngle, rotationAngle);
         }
     }
     return 0;
@@ -672,7 +672,7 @@ int TLuaInterpreter::setMapPerspective(lua_State* L)
 
     if (host.mpMap->mpM) {
         if (auto* modernWidget = dynamic_cast<ModernGLWidget*>(host.mpMap->mpM.data())) {
-        modernWidget->setCameraPosition(r, theta, phi);
+            modernWidget->setCameraPosition(r, theta, phi);
         }
     }
     return 0;
@@ -956,7 +956,10 @@ int TLuaInterpreter::connectExitStub(lua_State* L)
                 if (hasRoomWithNumberAsId) {
                     if (hasExitStubWithNumberAsDirection) {
                         return warnArgumentValue(
-                                L, __func__, qsl("%1 is too ambiguous a number to parse into a toID or a direction code as both are valid in this case. If this is a direction, try providing it as a string").arg(lua_tonumber(L, 2)));
+                                L,
+                                __func__,
+                                qsl("%1 is too ambiguous a number to parse into a toID or a direction code as both are valid in this case. If this is a direction, try providing it as a string")
+                                        .arg(lua_tonumber(L, 2)));
                     }
                     // else - usable as only one of the two flags is set:
                     hasToRoomId = true;
@@ -1081,7 +1084,21 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
     }
 
     const Host& host = getHostFromLua(L);
-    lua_pushinteger(L, host.mpMap->createMapLabel(area, text, posx, posy, posz, QColor(fgr, fgg, fgb, foregroundTransparency), QColor(bgr, bgg, bgb, backgroundTransparency), showOnTop, noScaling, temporary, zoom, fontSize, fontName, QColor(olr, olg, olb, foregroundTransparency)));
+    lua_pushinteger(L,
+                    host.mpMap->createMapLabel(area,
+                                               text,
+                                               posx,
+                                               posy,
+                                               posz,
+                                               QColor(fgr, fgg, fgb, foregroundTransparency),
+                                               QColor(bgr, bgg, bgb, backgroundTransparency),
+                                               showOnTop,
+                                               noScaling,
+                                               temporary,
+                                               zoom,
+                                               fontSize,
+                                               fontName,
+                                               QColor(olr, olg, olb, foregroundTransparency)));
     host.mpMap->updateArea(area);
     return 1;
 }
@@ -1158,8 +1175,7 @@ int TLuaInterpreter::createRoomID(lua_State* L)
     if (lua_gettop(L) > 0) {
         const int minId = getVerifiedInt(L, __func__, 1, "minimum room Id", true);
         if (minId < 1) {
-            return warnArgumentValue(L, __func__, qsl(
-                "minimum roomID %1 is an optional value but if provided it must be greater than zero").arg(minId));
+            return warnArgumentValue(L, __func__, qsl("minimum roomID %1 is an optional value but if provided it must be greater than zero").arg(minId));
         }
         lua_pushnumber(L, host.mpMap->createNewRoomID(lua_tointeger(L, 1)));
     } else {
@@ -1664,10 +1680,7 @@ int TLuaInterpreter::getExitStubs1(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getExitStubsNames
 int TLuaInterpreter::getExitStubsNames(lua_State* L)
 {
-    const QStringList stubmap = { "north", "northeast", "northwest", "east", "west",
-                                  "south", "southeast", "southwest", "up", "down", "in",
-                                  "out", "other"
-    };
+    const QStringList stubmap = {"north", "northeast", "northwest", "east", "west", "south", "southeast", "southwest", "up", "down", "in", "out", "other"};
 
     const Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
@@ -1781,8 +1794,7 @@ int TLuaInterpreter::getMapLabel(lua_State* L)
 
     if (labelId >= 0) {
         if (!pA->mMapLabels.contains(labelId)) {
-            return warnArgumentValue(L, __func__, qsl("labelID %1 does not exist in area with areaID %2")
-                .arg(QString::number(labelId), QString::number(areaId)));
+            return warnArgumentValue(L, __func__, qsl("labelID %1 does not exist in area with areaID %2").arg(QString::number(labelId), QString::number(areaId)));
         }
         lua_newtable(L);
         auto label = pA->mMapLabels.value(labelId);
@@ -1842,7 +1854,7 @@ int TLuaInterpreter::getMapMenus(lua_State* L)
         display = menuInfo[1];
         qDebug() << it.key() << parent << display;
         lua_pushstring(L, display.toUtf8().constData());
-        lua_pushstring(L, parent.isEmpty() ? "top-level" :parent.toUtf8().constData());
+        lua_pushstring(L, parent.isEmpty() ? "top-level" : parent.toUtf8().constData());
         lua_settable(L, -3);
     }
 
@@ -1858,8 +1870,7 @@ int TLuaInterpreter::getMapSelection(lua_State* L)
     }
 
     lua_newtable(L);
-    QList<int> selectionRoomsList{pHost->mpMap->mpMapper->mp2dMap->mMultiSelectionSet.begin(),
-                                  pHost->mpMap->mpMapper->mp2dMap->mMultiSelectionSet.end()};
+    QList<int> selectionRoomsList{pHost->mpMap->mpMapper->mp2dMap->mMultiSelectionSet.begin(), pHost->mpMap->mpMapper->mp2dMap->mMultiSelectionSet.end()};
     if (!selectionRoomsList.isEmpty()) {
         if (selectionRoomsList.count() > 1) {
             std::sort(selectionRoomsList.begin(), selectionRoomsList.end());
@@ -1878,7 +1889,6 @@ int TLuaInterpreter::getMapSelection(lua_State* L)
         }
 
         lua_settable(L, -3);
-
     }
 
     return 1;
@@ -2323,8 +2333,7 @@ int TLuaInterpreter::getRoomUserData(lua_State* L)
     }
     if (!pR->userData.contains(key)) {
         if (!isBackwardCompatibilityRequired) {
-            return warnArgumentValue(L, __func__, qsl(
-                "no user data with key '%1' in room with ID %2").arg(key, QString::number(roomId)));
+            return warnArgumentValue(L, __func__, qsl("no user data with key '%1' in room with ID %2").arg(key, QString::number(roomId)));
         }
         lua_pushstring(L, "");
         return 1;
@@ -2442,7 +2451,6 @@ int TLuaInterpreter::getSpecialExits(lua_State* L)
                         bestUnlockedExitIndex = j;
                         bestUnlockedExitWeight = thisExitWeight;
                     }
-
                 }
             }
 
@@ -2547,8 +2555,7 @@ int TLuaInterpreter::hasSpecialExitLock(lua_State* L)
         return warnArgumentValue(L, __func__, csmInvalidExitRoomID.arg(fromRoomID));
     }
     if (!pR->getSpecialExits().contains(dir)) {
-        return warnArgumentValue(L, __func__, qsl("the special exit name/command '%1' does not exist in roomID %2")
-            .arg(dir, QString::number(fromRoomID)));
+        return warnArgumentValue(L, __func__, qsl("the special exit name/command '%1' does not exist in roomID %2").arg(dir, QString::number(fromRoomID)));
     }
 
     lua_pushboolean(L, pR->hasSpecialExitLock(dir));
@@ -2722,8 +2729,7 @@ int TLuaInterpreter::lockSpecialExit(lua_State* L)
         return warnArgumentValue(L, __func__, csmInvalidExitRoomID.arg(fromRoomID));
     }
     if (!pR->setSpecialExitLock(dir, b)) {
-        return warnArgumentValue(L, __func__, qsl("the special exit name/command %1 does not exist in roomID %2")
-            .arg(dir, QString::number(fromRoomID)));
+        return warnArgumentValue(L, __func__, qsl("the special exit name/command %1 does not exist in roomID %2").arg(dir, QString::number(fromRoomID)));
     }
 
     lua_pushboolean(L, true);
@@ -2826,7 +2832,7 @@ int TLuaInterpreter::registerMapInfo(lua_State* L)
             color = QColor(r, g, b);
         }
         lua_pop(L, nResult);
-        return MapInfoProperties{ isBold, isItalic, text, color };
+        return MapInfoProperties{isBold, isItalic, text, color};
     });
 
     host.mpMap->updateArea(-1);
@@ -2852,15 +2858,11 @@ int TLuaInterpreter::removeCustomLine(lua_State* L)
         return lua_error(L);
     }
     if (!pR->hasExitOrSpecialExit(direction)) {
-        return warnArgumentValue(L, __func__, qsl(
-            "roomID %1 does not have an exit that can be identified from '%2'").arg(QString::number(roomId), lua_tostring(L, 2)));
+        return warnArgumentValue(L, __func__, qsl("roomID %1 does not have an exit that can be identified from '%2'").arg(QString::number(roomId), lua_tostring(L, 2)));
     }
 
-    if (0 >= (pR->customLines.remove(direction) + pR->customLinesArrow.remove(direction)
-        + pR->customLinesStyle.remove(direction) + pR->customLinesColor.remove(direction))) {
-        return warnArgumentValue(L, __func__, qsl(
-            "roomID %1 does not appear to have a custom exit line for the exit indentifed from '%2'")
-            .arg(QString::number(roomId), lua_tostring(L, 2)));
+    if (0 >= (pR->customLines.remove(direction) + pR->customLinesArrow.remove(direction) + pR->customLinesStyle.remove(direction) + pR->customLinesColor.remove(direction))) {
+        return warnArgumentValue(L, __func__, qsl("roomID %1 does not appear to have a custom exit line for the exit indentifed from '%2'").arg(QString::number(roomId), lua_tostring(L, 2)));
     }
     // Need to update the TRoom {min|max}_{x|y} settings as they are used during
     // the painting process:
@@ -2949,8 +2951,7 @@ int TLuaInterpreter::removeSpecialExit(lua_State* L)
     }
 
     if (!pR->getSpecialExits().contains(dir)) {
-        return warnArgumentValue(L, __func__, qsl(
-            "the special exit name/command '%1' does not exist in exit roomID %2").arg(dir, QString::number(fromRoomID)));
+        return warnArgumentValue(L, __func__, qsl("the special exit name/command '%1' does not exist in exit roomID %2").arg(dir, QString::number(fromRoomID)));
     }
     pR->setSpecialExit(-1, dir);
     host.mpMap->updateArea(pR->getArea());
@@ -3353,8 +3354,7 @@ int TLuaInterpreter::setAreaName(lua_State* L)
         } else if (!host.mpMap->mpRoomDB->getAreaNamesMap().values().contains(existingName)) {
             return warnArgumentValue(L, __func__, csmInvalidAreaName.arg(existingName));
         } else if (host.mpMap->mpRoomDB->getAreaNamesMap().value(-1).contains(existingName)) {
-            return warnArgumentValue(L, __func__, qsl(
-                "area name '%1' is reserved and protected - it cannot be changed").arg(existingName));
+            return warnArgumentValue(L, __func__, qsl("area name '%1' is reserved and protected - it cannot be changed").arg(existingName));
         }
     } else {
         lua_pushfstring(L,
@@ -3376,9 +3376,8 @@ int TLuaInterpreter::setAreaName(lua_State* L)
         // problem or just pointless quite easily...!
         if (host.mpMap->mpRoomDB->getAreaNamesMap().value(id) != newName) {
             // And it isn't the trivial case, where the given areaID already IS that name
-            return warnArgumentValue(L, __func__, qsl(
-                "area names may not be duplicated and areaID %1 already has the name '%2'")
-                .arg(QString::number(host.mpMap->mpRoomDB->getAreaNamesMap().key(newName)), newName));
+            return warnArgumentValue(
+                    L, __func__, qsl("area names may not be duplicated and areaID %1 already has the name '%2'").arg(QString::number(host.mpMap->mpRoomDB->getAreaNamesMap().key(newName)), newName));
         }
         // Renaming an area to the same name is pointlessly successful!
         lua_pushboolean(L, true);
@@ -3469,23 +3468,56 @@ int TLuaInterpreter::setCustomEnvColor(lua_State* L)
     Host& host = getHostFromLua(L);
     host.mpMap->mCustomEnvColors[id] = newColor;
     switch (id) { // See TMap::restore16ColorSet() for mapping of indexes:
-    case 257:   host.mRed_2 = newColor;             break;
-    case 258:   host.mGreen_2 = newColor;           break;
-    case 259:   host.mYellow_2 = newColor;          break;
-    case 260:   host.mBlue_2 = newColor;            break;
-    case 261:   host.mMagenta_2 = newColor;         break;
-    case 262:   host.mCyan_2 = newColor;            break;
-    case 263:   host.mWhite_2 = newColor;           break;
-    case 264:   host.mBlack_2 = newColor;           break;
-    case 265:   host.mLightRed_2 = newColor;        break;
-    case 266:   host.mLightGreen_2 = newColor;      break;
-    case 267:   host.mLightYellow_2 = newColor;     break;
-    case 268:   host.mLightBlue_2 = newColor;       break;
-    case 269:   host.mLightMagenta_2 = newColor;    break;
-    case 270:   host.mLightCyan_2 = newColor;       break;
-    case 271:   host.mLightWhite_2 = newColor;      break;
-    case 272:   host.mLightBlack_2 = newColor;      break;
-    default: {} // No-op
+    case 257:
+        host.mRed_2 = newColor;
+        break;
+    case 258:
+        host.mGreen_2 = newColor;
+        break;
+    case 259:
+        host.mYellow_2 = newColor;
+        break;
+    case 260:
+        host.mBlue_2 = newColor;
+        break;
+    case 261:
+        host.mMagenta_2 = newColor;
+        break;
+    case 262:
+        host.mCyan_2 = newColor;
+        break;
+    case 263:
+        host.mWhite_2 = newColor;
+        break;
+    case 264:
+        host.mBlack_2 = newColor;
+        break;
+    case 265:
+        host.mLightRed_2 = newColor;
+        break;
+    case 266:
+        host.mLightGreen_2 = newColor;
+        break;
+    case 267:
+        host.mLightYellow_2 = newColor;
+        break;
+    case 268:
+        host.mLightBlue_2 = newColor;
+        break;
+    case 269:
+        host.mLightMagenta_2 = newColor;
+        break;
+    case 270:
+        host.mLightCyan_2 = newColor;
+        break;
+    case 271:
+        host.mLightWhite_2 = newColor;
+        break;
+    case 272:
+        host.mLightBlack_2 = newColor;
+        break;
+    default: {
+    } // No-op
     }
 
     host.mpMap->setUnsaved(__func__);
@@ -3509,51 +3541,39 @@ int TLuaInterpreter::setDoor(lua_State* L)
     }
     const QString exitCmd = getVerifiedString(L, __func__, 2, "door command");
 
-    if (exitCmd.compare(qsl("n")) && exitCmd.compare(qsl("e")) && exitCmd.compare(qsl("s")) && exitCmd.compare(qsl("w"))
-        && exitCmd.compare(qsl("ne"))
-        && exitCmd.compare(qsl("se"))
-        && exitCmd.compare(qsl("sw"))
-        && exitCmd.compare(qsl("nw"))
-        && exitCmd.compare(qsl("up"))
-        && exitCmd.compare(qsl("down"))
-        && exitCmd.compare(qsl("in"))
-        && exitCmd.compare(qsl("out"))) {
+    if (exitCmd.compare(qsl("n")) && exitCmd.compare(qsl("e")) && exitCmd.compare(qsl("s")) && exitCmd.compare(qsl("w")) && exitCmd.compare(qsl("ne")) && exitCmd.compare(qsl("se"))
+        && exitCmd.compare(qsl("sw")) && exitCmd.compare(qsl("nw")) && exitCmd.compare(qsl("up")) && exitCmd.compare(qsl("down")) && exitCmd.compare(qsl("in")) && exitCmd.compare(qsl("out"))) {
         // One of the above WILL BE ZERO if the exitCmd is ONE of the above qsls
         // So the above will be TRUE if NONE of above strings match - which
         // means we must treat the exitCmd as a SPECIAL exit
         if (!(pR->getSpecialExits().contains(exitCmd))) {
             // And NOT a special one either
-            return warnArgumentValue(L, __func__, qsl(
-                "roomID %1 does not have a special exit in direction '%2'")
-                .arg(QString::number(roomId), exitCmd));
+            return warnArgumentValue(L, __func__, qsl("roomID %1 does not have a special exit in direction '%2'").arg(QString::number(roomId), exitCmd));
         }
         // else IS a valid special exit - so fall out of if and continue
     } else {
         // Is a normal exit so see if it is valid
         if (!(((!exitCmd.compare(qsl("n"))) && (pR->getExit(DIR_NORTH) > 0 || pR->exitStubs.contains(DIR_NORTH)))
-                || ((!exitCmd.compare(qsl("e"))) && (pR->getExit(DIR_EAST) > 0 || pR->exitStubs.contains(DIR_EAST)))
-                || ((!exitCmd.compare(qsl("s"))) && (pR->getExit(DIR_SOUTH) > 0 || pR->exitStubs.contains(DIR_SOUTH)))
-                || ((!exitCmd.compare(qsl("w"))) && (pR->getExit(DIR_WEST) > 0 || pR->exitStubs.contains(DIR_WEST)))
-                || ((!exitCmd.compare(qsl("ne"))) && (pR->getExit(DIR_NORTHEAST) > 0 || pR->exitStubs.contains(DIR_NORTHEAST)))
-                || ((!exitCmd.compare(qsl("se"))) && (pR->getExit(DIR_SOUTHEAST) > 0 || pR->exitStubs.contains(DIR_SOUTHEAST)))
-                || ((!exitCmd.compare(qsl("sw"))) && (pR->getExit(DIR_SOUTHWEST) > 0 || pR->exitStubs.contains(DIR_SOUTHWEST)))
-                || ((!exitCmd.compare(qsl("nw"))) && (pR->getExit(DIR_NORTHWEST) > 0 || pR->exitStubs.contains(DIR_NORTHWEST)))
-                || ((!exitCmd.compare(qsl("up"))) && (pR->getExit(DIR_UP) > 0 || pR->exitStubs.contains(DIR_UP)))
-                || ((!exitCmd.compare(qsl("down"))) && (pR->getExit(DIR_DOWN) > 0 || pR->exitStubs.contains(DIR_DOWN)))
-                || ((!exitCmd.compare(qsl("in"))) && (pR->getExit(DIR_IN) > 0 || pR->exitStubs.contains(DIR_IN)))
-                || ((!exitCmd.compare(qsl("out"))) && (pR->getExit(DIR_OUT) > 0 || pR->exitStubs.contains(DIR_OUT))))) {
+              || ((!exitCmd.compare(qsl("e"))) && (pR->getExit(DIR_EAST) > 0 || pR->exitStubs.contains(DIR_EAST)))
+              || ((!exitCmd.compare(qsl("s"))) && (pR->getExit(DIR_SOUTH) > 0 || pR->exitStubs.contains(DIR_SOUTH)))
+              || ((!exitCmd.compare(qsl("w"))) && (pR->getExit(DIR_WEST) > 0 || pR->exitStubs.contains(DIR_WEST)))
+              || ((!exitCmd.compare(qsl("ne"))) && (pR->getExit(DIR_NORTHEAST) > 0 || pR->exitStubs.contains(DIR_NORTHEAST)))
+              || ((!exitCmd.compare(qsl("se"))) && (pR->getExit(DIR_SOUTHEAST) > 0 || pR->exitStubs.contains(DIR_SOUTHEAST)))
+              || ((!exitCmd.compare(qsl("sw"))) && (pR->getExit(DIR_SOUTHWEST) > 0 || pR->exitStubs.contains(DIR_SOUTHWEST)))
+              || ((!exitCmd.compare(qsl("nw"))) && (pR->getExit(DIR_NORTHWEST) > 0 || pR->exitStubs.contains(DIR_NORTHWEST)))
+              || ((!exitCmd.compare(qsl("up"))) && (pR->getExit(DIR_UP) > 0 || pR->exitStubs.contains(DIR_UP)))
+              || ((!exitCmd.compare(qsl("down"))) && (pR->getExit(DIR_DOWN) > 0 || pR->exitStubs.contains(DIR_DOWN)))
+              || ((!exitCmd.compare(qsl("in"))) && (pR->getExit(DIR_IN) > 0 || pR->exitStubs.contains(DIR_IN)))
+              || ((!exitCmd.compare(qsl("out"))) && (pR->getExit(DIR_OUT) > 0 || pR->exitStubs.contains(DIR_OUT))))) {
             // No there IS NOT a stub or real exit in the exitCmd direction
-            return warnArgumentValue(L, __func__, qsl(
-                "roomID %1 does not have a normal exit or a stub exit in direction '%2'")
-                .arg(QString::number(roomId), exitCmd));
+            return warnArgumentValue(L, __func__, qsl("roomID %1 does not have a normal exit or a stub exit in direction '%2'").arg(QString::number(roomId), exitCmd));
         }
         // else IS a valid stub or real normal exit -fall through to continue
     }
 
     const int doorStatus = getVerifiedInt(L, __func__, 3, "door type  {0='none', 1='open', 2='closed' or 3='locked'}");
     if (doorStatus < 0 || doorStatus > 3) {
-        return warnArgumentValue(L, __func__, qsl(
-            "door type %1 is not one of 0='none', 1='open', 2='closed' or 3='locked'").arg(doorStatus));
+        return warnArgumentValue(L, __func__, qsl("door type %1 is not one of 0='none', 1='open', 2='closed' or 3='locked'").arg(doorStatus));
     }
 
     const bool result = pR->setDoor(exitCmd, doorStatus);
@@ -3635,9 +3655,7 @@ int TLuaInterpreter::setExitWeightFilter(lua_State* L)
     }
 
     if (!lua_isfunction(L, 1)) {
-        lua_pushfstring(L,
-                        "setExitWeightFilter: bad argument #1 type (callback as function expected, got %s!)",
-                        luaL_typename(L, 1));
+        lua_pushfstring(L, "setExitWeightFilter: bad argument #1 type (callback as function expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
 
@@ -3671,8 +3689,7 @@ TLuaInterpreter::ExitWeightFilterResult TLuaInterpreter::applyExitWeightFilter(i
         if (mudlet::smDebugMode && lua_isstring(L, -1)) {
             const char* errorMessage = lua_tostring(L, -1);
             if (errorMessage) {
-                TDebug(QColor(Qt::white), QColor(Qt::red))
-                    << "LUA ERROR: when running exit weight filter\nreason: " << errorMessage << "\n" >> 0;
+                TDebug(QColor(Qt::white), QColor(Qt::red)) << "LUA ERROR: when running exit weight filter\nreason: " << errorMessage << "\n" >> 0;
             }
         }
         lua_pop(L, 1);
@@ -3683,8 +3700,7 @@ TLuaInterpreter::ExitWeightFilterResult TLuaInterpreter::applyExitWeightFilter(i
         if (!lua_toboolean(L, -1)) {
             result.blocked = true;
         } else if (mudlet::smDebugMode) {
-            TDebug(QColor(Qt::white), QColor(Qt::red))
-                << "LUA WARNING: exit weight filter returned boolean 'true', expected numeric weight. Ignoring.\n" >> 0;
+            TDebug(QColor(Qt::white), QColor(Qt::red)) << "LUA WARNING: exit weight filter returned boolean 'true', expected numeric weight. Ignoring.\n" >> 0;
         }
     } else if (lua_isnil(L, -1)) {
         // nothing to do
@@ -3703,14 +3719,11 @@ TLuaInterpreter::ExitWeightFilterResult TLuaInterpreter::applyExitWeightFilter(i
         if (value.compare(qsl("block"), Qt::CaseInsensitive) == 0) {
             result.blocked = true;
         } else if (mudlet::smDebugMode) {
-            TDebug(QColor(Qt::white), QColor(Qt::red))
-                << "LUA WARNING: exit weight filter returned unexpected string '" << value
-                << "', expected numeric weight. Ignoring.\n" >> 0;
+            TDebug(QColor(Qt::white), QColor(Qt::red)) << "LUA WARNING: exit weight filter returned unexpected string '" << value << "', expected numeric weight. Ignoring.\n" >> 0;
         }
     } else {
         if (mudlet::smDebugMode) {
-            TDebug(QColor(Qt::white), QColor(Qt::red))
-                << "LUA WARNING: exit weight filter returned unexpected type '" << luaL_typename(L, -1) << "', ignoring.\n" >> 0;
+            TDebug(QColor(Qt::white), QColor(Qt::red)) << "LUA WARNING: exit weight filter returned unexpected type '" << luaL_typename(L, -1) << "', ignoring.\n" >> 0;
         }
     }
 
@@ -3760,14 +3773,15 @@ int TLuaInterpreter::setExitWeight(lua_State* L)
         return lua_error(L);
     }
     if (!pR->hasExitOrSpecialExit(direction)) {
-        return warnArgumentValue(L, __func__, qsl("roomID %1 does not have an exit that can be identified from '%2'")
-            .arg(QString::number(roomID), lua_tostring(L, 2)));
+        return warnArgumentValue(L, __func__, qsl("roomID %1 does not have an exit that can be identified from '%2'").arg(QString::number(roomID), lua_tostring(L, 2)));
     }
 
     const int weight = getVerifiedInt(L, __func__, 3, "exit weight");
     if (weight < 0) {
-        return warnArgumentValue(L, __func__, qsl("weight %1 is outside of the usable range of 0 (which resets the weight back to that of the destination room) to %2")
-            .arg(QString::number(weight), QString::number(std::numeric_limits<int>::max())));
+        return warnArgumentValue(L,
+                                 __func__,
+                                 qsl("weight %1 is outside of the usable range of 0 (which resets the weight back to that of the destination room) to %2")
+                                         .arg(QString::number(weight), QString::number(std::numeric_limits<int>::max())));
     }
 
     pR->setExitWeight(direction, weight);
@@ -3909,9 +3923,11 @@ int TLuaInterpreter::setRoomArea(lua_State* L)
     if (lua_isnumber(L, 2)) {
         areaId = static_cast<int>(lua_tonumber(L, 2));
         if (areaId < 1) {
-            return warnArgumentValue(L, __func__, qsl(
-                "number %1 is not a valid areaID greater than zero. "
-                "To remove a room's area, use resetRoomArea(roomID)").arg(areaId));
+            return warnArgumentValue(L,
+                                     __func__,
+                                     qsl("number %1 is not a valid areaID greater than zero. "
+                                         "To remove a room's area, use resetRoomArea(roomID)")
+                                             .arg(areaId));
         }
         if (!host.mpMap->mpRoomDB->getAreaNamesMap().contains(areaId)) {
             return warnArgumentValue(L, __func__, csmInvalidAreaID.arg(areaId));
@@ -4360,7 +4376,6 @@ int TLuaInterpreter::getCollisionLocationsInArea(lua_State* L)
         lua_settable(L, -3);
     }
     return 1;
-
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#exportAreaImage

--- a/src/TLuaInterpreterMedia.cpp
+++ b/src/TLuaInterpreterMedia.cpp
@@ -329,11 +329,11 @@ int TLuaInterpreter::playMusicFileAsTableArgument(lua_State* L, const char* func
             QString value = getVerifiedString(L,
                                               func,
                                               -1,
-                                              key == QLatin1String("name")  ? "value for name"
-                                              : key == QLatin1String("key") ? "value for key"
-                                              : key == QLatin1String("tag") ? "value for tag"
+                                              key == QLatin1String("name")      ? "value for name"
+                                              : key == QLatin1String("key")     ? "value for key"
+                                              : key == QLatin1String("tag")     ? "value for tag"
                                               : key == QLatin1String("caption") ? "value for caption"
-                                                                            : "value for url");
+                                                                                : "value for url");
 
             if (key == QLatin1String("name") && !value.isEmpty()) {
                 if (QDir::homePath().contains('\\')) {
@@ -352,7 +352,8 @@ int TLuaInterpreter::playMusicFileAsTableArgument(lua_State* L, const char* func
             } else if (key == QLatin1String("caption") && !value.isEmpty()) {
                 mediaData.setMediaCaption(value);
             }
-        } else if (key == QLatin1String("volume") || key == QLatin1String("fadein") || key == QLatin1String("fadeout") || key == QLatin1String("start") || key == QLatin1String("finish") || key == QLatin1String("loops")) {
+        } else if (key == QLatin1String("volume") || key == QLatin1String("fadein") || key == QLatin1String("fadeout") || key == QLatin1String("start") || key == QLatin1String("finish")
+                   || key == QLatin1String("loops")) {
             int value = getVerifiedInt(L,
                                        func,
                                        -1,
@@ -589,11 +590,11 @@ int TLuaInterpreter::playSoundFileAsTableArgument(lua_State* L, const char* func
             QString value = getVerifiedString(L,
                                               func,
                                               -1,
-                                              key == QLatin1String("name")  ? "value for name"
-                                              : key == QLatin1String("key") ? "value for key"
-                                              : key == QLatin1String("tag") ? "value for tag"
+                                              key == QLatin1String("name")      ? "value for name"
+                                              : key == QLatin1String("key")     ? "value for key"
+                                              : key == QLatin1String("tag")     ? "value for tag"
                                               : key == QLatin1String("caption") ? "value for caption"
-                                                                            : "value for url");
+                                                                                : "value for url");
 
             if (key == QLatin1String("name") && !value.isEmpty()) {
                 if (QDir::homePath().contains('\\')) {
@@ -612,8 +613,8 @@ int TLuaInterpreter::playSoundFileAsTableArgument(lua_State* L, const char* func
             } else if (key == QLatin1String("caption") && !value.isEmpty()) {
                 mediaData.setMediaCaption(value);
             }
-        } else if (key == QLatin1String("volume") || key == QLatin1String("fadein") || key == QLatin1String("fadeout") || key == QLatin1String("start") || key == QLatin1String("finish") || key == QLatin1String("loops")
-                   || key == QLatin1String("priority")) {
+        } else if (key == QLatin1String("volume") || key == QLatin1String("fadein") || key == QLatin1String("fadeout") || key == QLatin1String("start") || key == QLatin1String("finish")
+                   || key == QLatin1String("loops") || key == QLatin1String("priority")) {
             int value = getVerifiedInt(L,
                                        func,
                                        -1,
@@ -724,8 +725,8 @@ int TLuaInterpreter::playVideoFileAsTableArgument(lua_State* L, const char* func
         // key at index -2 and value at index -1
         QString key = getVerifiedString(L, func, -2, "table keys");
 
-        if (!key.compare(QLatin1String("name"), Qt::CaseInsensitive) || !key.compare(QLatin1String("url"), Qt::CaseInsensitive)
-            || !key.compare(QLatin1String("key"), Qt::CaseInsensitive) || !key.compare(QLatin1String("tag"), Qt::CaseInsensitive)) {
+        if (!key.compare(QLatin1String("name"), Qt::CaseInsensitive) || !key.compare(QLatin1String("url"), Qt::CaseInsensitive) || !key.compare(QLatin1String("key"), Qt::CaseInsensitive)
+            || !key.compare(QLatin1String("tag"), Qt::CaseInsensitive)) {
             QString value = getVerifiedString(L,
                                               func,
                                               -1,
@@ -749,13 +750,13 @@ int TLuaInterpreter::playVideoFileAsTableArgument(lua_State* L, const char* func
             } else if (!key.compare(QLatin1String("tag"), Qt::CaseInsensitive) && !value.isEmpty()) {
                 mediaData.setMediaTag(value);
             }
-        } else if (!key.compare(QLatin1String("volume"), Qt::CaseInsensitive) || !key.compare(QLatin1String("start"), Qt::CaseInsensitive)
-            || !key.compare(QLatin1String("finish"), Qt::CaseInsensitive) || !key.compare(QLatin1String("loops"), Qt::CaseInsensitive)) {
+        } else if (!key.compare(QLatin1String("volume"), Qt::CaseInsensitive) || !key.compare(QLatin1String("start"), Qt::CaseInsensitive) || !key.compare(QLatin1String("finish"), Qt::CaseInsensitive)
+                   || !key.compare(QLatin1String("loops"), Qt::CaseInsensitive)) {
             int value = getVerifiedInt(L,
                                        func,
                                        -1,
-                                       !key.compare(QLatin1String("volume"), Qt::CaseInsensitive)  ? "value for volume"
-                                       : !key.compare(QLatin1String("start"), Qt::CaseInsensitive) ? "value for start"
+                                       !key.compare(QLatin1String("volume"), Qt::CaseInsensitive)   ? "value for volume"
+                                       : !key.compare(QLatin1String("start"), Qt::CaseInsensitive)  ? "value for start"
                                        : !key.compare(QLatin1String("finish"), Qt::CaseInsensitive) ? "value for finish"
                                                                                                     : "value for loops");
 

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -77,10 +77,10 @@
 #include <QTextToSpeech>
 #endif // QT_TEXTTOSPEECH_LIB
 
-static const char *bad_window_type = "%s: bad argument #%d type (window name as string expected, got %s)!";
-static const char *bad_cmdline_type = "%s: bad argument #%d type (command line name as string expected, got %s)!";
-static const char *bad_window_value = "window \"%s\" not found";
-static const char *bad_cmdline_value = "command line \"%s\" not found";
+static const char* bad_window_type = "%s: bad argument #%d type (window name as string expected, got %s)!";
+static const char* bad_cmdline_type = "%s: bad argument #%d type (command line name as string expected, got %s)!";
+static const char* bad_window_value = "window \"%s\" not found";
+static const char* bad_cmdline_value = "command line \"%s\" not found";
 // Not used: static const char *bad_label_value = "label \"%s\" not found";
 
 // No documentation available in wiki - internal function
@@ -95,76 +95,75 @@ static bool isMain(const QString& name)
     return false;
 }
 
-#define WINDOW_NAME(ARG_L, ARG_pos)                                                                      \
-    ({                                                                                                   \
-        int pos_ = (ARG_pos);                                                                            \
-        const char *res_;                                                                                \
-        if ((lua_gettop(ARG_L) < pos_) || lua_isnil(ARG_L, pos_)) {                                      \
-            res_ = "";                                                                                   \
-        } else {                                                                                         \
-            if (!lua_isstring(ARG_L, pos_)) {                                                            \
-                lua_pushfstring(ARG_L, bad_window_type, __FUNCTION__, pos_, luaL_typename(ARG_L, pos_)); \
-                return lua_error(ARG_L);                                                                 \
-            }                                                                                            \
-            res_ = lua_tostring(ARG_L, pos_);                                                            \
-        }                                                                                                \
-        res_;                                                                                            \
+#define WINDOW_NAME(ARG_L, ARG_pos)                                                                                                                                                                    \
+    ({                                                                                                                                                                                                 \
+        int pos_ = (ARG_pos);                                                                                                                                                                          \
+        const char* res_;                                                                                                                                                                              \
+        if ((lua_gettop(ARG_L) < pos_) || lua_isnil(ARG_L, pos_)) {                                                                                                                                    \
+            res_ = "";                                                                                                                                                                                 \
+        } else {                                                                                                                                                                                       \
+            if (!lua_isstring(ARG_L, pos_)) {                                                                                                                                                          \
+                lua_pushfstring(ARG_L, bad_window_type, __FUNCTION__, pos_, luaL_typename(ARG_L, pos_));                                                                                               \
+                return lua_error(ARG_L);                                                                                                                                                               \
+            }                                                                                                                                                                                          \
+            res_ = lua_tostring(ARG_L, pos_);                                                                                                                                                          \
+        }                                                                                                                                                                                              \
+        res_;                                                                                                                                                                                          \
     })
 
-#define CMDLINE_NAME(ARG_L, ARG_pos)                                                                 \
-    ({                                                                                               \
-        int pos_ = (ARG_pos);                                                                        \
-        if (!lua_isstring(ARG_L, pos_)) {                                                            \
-            lua_pushfstring(ARG_L, bad_cmdline_type, __FUNCTION__, pos_, luaL_typename(ARG_L, pos_));\
-            return lua_error(ARG_L);                                                                 \
-        }                                                                                            \
-        lua_tostring(ARG_L, pos_);                                                                   \
+#define CMDLINE_NAME(ARG_L, ARG_pos)                                                                                                                                                                   \
+    ({                                                                                                                                                                                                 \
+        int pos_ = (ARG_pos);                                                                                                                                                                          \
+        if (!lua_isstring(ARG_L, pos_)) {                                                                                                                                                              \
+            lua_pushfstring(ARG_L, bad_cmdline_type, __FUNCTION__, pos_, luaL_typename(ARG_L, pos_));                                                                                                  \
+            return lua_error(ARG_L);                                                                                                                                                                   \
+        }                                                                                                                                                                                              \
+        lua_tostring(ARG_L, pos_);                                                                                                                                                                     \
     })
 
-#define CONSOLE_NIL(ARG_L, ARG_name)                                                           \
-    ({                                                                                         \
-        auto name_ = (ARG_name);                                                               \
-        auto console_ = getHostFromLua(ARG_L).findConsole(name_);                              \
-        console_;                                                                              \
+#define CONSOLE_NIL(ARG_L, ARG_name)                                                                                                                                                                   \
+    ({                                                                                                                                                                                                 \
+        auto name_ = (ARG_name);                                                                                                                                                                       \
+        auto console_ = getHostFromLua(ARG_L).findConsole(name_);                                                                                                                                      \
+        console_;                                                                                                                                                                                      \
     })
 
-#define CONSOLE(ARG_L, ARG_name)                                                               \
-    ({                                                                                         \
-        auto name_ = (ARG_name);                                                               \
-        auto console_ = getHostFromLua(ARG_L).findConsole(name_);                              \
-        if (!console_) {                                                                       \
-            lua_pushnil(ARG_L);                                                                \
-            lua_pushfstring(ARG_L, bad_window_value, name_.toUtf8().constData());              \
-            return 2;                                                                          \
-        }                                                                                      \
-        console_;                                                                              \
+#define CONSOLE(ARG_L, ARG_name)                                                                                                                                                                       \
+    ({                                                                                                                                                                                                 \
+        auto name_ = (ARG_name);                                                                                                                                                                       \
+        auto console_ = getHostFromLua(ARG_L).findConsole(name_);                                                                                                                                      \
+        if (!console_) {                                                                                                                                                                               \
+            lua_pushnil(ARG_L);                                                                                                                                                                        \
+            lua_pushfstring(ARG_L, bad_window_value, name_.toUtf8().constData());                                                                                                                      \
+            return 2;                                                                                                                                                                                  \
+        }                                                                                                                                                                                              \
+        console_;                                                                                                                                                                                      \
     })
 
-#define COMMANDLINE(ARG_L, ARG_name)                                                           \
-    ({                                                                                         \
-        const QString& name_ = (ARG_name);                                                     \
-        auto console_ = getHostFromLua(ARG_L).mpConsole;                                       \
-        auto cmdLine_ = isMain(name_) ? &*console_->mpCommandLine                              \
-                                    : console_->mSubCommandLineMap.value(name_);               \
-        if (!cmdLine_) {                                                                       \
-            lua_pushnil(ARG_L);                                                                \
-            lua_pushfstring(ARG_L, bad_cmdline_value, name_.toUtf8().constData());             \
-            return 2;                                                                          \
-        }                                                                                      \
-        cmdLine_;                                                                              \
+#define COMMANDLINE(ARG_L, ARG_name)                                                                                                                                                                   \
+    ({                                                                                                                                                                                                 \
+        const QString& name_ = (ARG_name);                                                                                                                                                             \
+        auto console_ = getHostFromLua(ARG_L).mpConsole;                                                                                                                                               \
+        auto cmdLine_ = isMain(name_) ? &*console_->mpCommandLine : console_->mSubCommandLineMap.value(name_);                                                                                         \
+        if (!cmdLine_) {                                                                                                                                                                               \
+            lua_pushnil(ARG_L);                                                                                                                                                                        \
+            lua_pushfstring(ARG_L, bad_cmdline_value, name_.toUtf8().constData());                                                                                                                     \
+            return 2;                                                                                                                                                                                  \
+        }                                                                                                                                                                                              \
+        cmdLine_;                                                                                                                                                                                      \
     })
 
-#define LABEL(ARG_L, ARG_name)                                                                 \
-    ({                                                                                         \
-        const QString& name_ = (ARG_name);                                                     \
-        auto console_ = getHostFromLua(ARG_L).mpConsole;                                       \
-        auto label_ = console_->mLabelMap.value(name_);                                        \
-        if (!label_) {                                                                         \
-            lua_pushnil(ARG_L);                                                                \
-            lua_pushfstring(ARG_L, bad_label_value, name_.toUtf8().constData());               \
-            return 2;                                                                          \
-        }                                                                                      \
-        label_;                                                                                \
+#define LABEL(ARG_L, ARG_name)                                                                                                                                                                         \
+    ({                                                                                                                                                                                                 \
+        const QString& name_ = (ARG_name);                                                                                                                                                             \
+        auto console_ = getHostFromLua(ARG_L).mpConsole;                                                                                                                                               \
+        auto label_ = console_->mLabelMap.value(name_);                                                                                                                                                \
+        if (!label_) {                                                                                                                                                                                 \
+            lua_pushnil(ARG_L);                                                                                                                                                                        \
+            lua_pushfstring(ARG_L, bad_label_value, name_.toUtf8().constData());                                                                                                                       \
+            return 2;                                                                                                                                                                                  \
+        }                                                                                                                                                                                              \
+        label_;                                                                                                                                                                                        \
     })
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addCmdLineSuggestion
@@ -525,8 +524,7 @@ int TLuaInterpreter::exists(lua_State* L)
 
         count = host.getScriptUnit()->findItems(nameOrId).size();
     } else {
-        return warnArgumentValue(L, __func__, qsl(
-                "invalid item type '%1' given, it should be one of: 'alias', 'button', 'script', 'keybind', 'timer' or 'trigger'").arg(type));
+        return warnArgumentValue(L, __func__, qsl("invalid item type '%1' given, it should be one of: 'alias', 'button', 'script', 'keybind', 'timer' or 'trigger'").arg(type));
     }
     // If we get here we have successfully identified a type and have looked for
     // the item type with a specific NAME - so now just return the count of
@@ -701,17 +699,17 @@ int TLuaInterpreter::getProfileStats(lua_State* L)
     lua_settable(L, -3);
 
     // Gifs
-    lua_pushstring(L,"gifs");
+    lua_pushstring(L, "gifs");
     lua_newtable(L);
 
-    lua_pushstring(L,"total");
-    lua_pushnumber(L,gifsTotal);
-    lua_settable(L,-3);
+    lua_pushstring(L, "total");
+    lua_pushnumber(L, gifsTotal);
+    lua_settable(L, -3);
 
-    lua_pushstring(L,"active");
-    lua_pushnumber(L,activeGifs);
-    lua_settable(L,-3);
-    lua_settable(L,-3);
+    lua_pushstring(L, "active");
+    lua_pushnumber(L, activeGifs);
+    lua_settable(L, -3);
+    lua_settable(L, -3);
 
     return 1;
 }
@@ -783,9 +781,8 @@ int TLuaInterpreter::getStopWatchTime(lua_State* L)
         // We have already validated the name to get the watchId - so for things
         // to fail now is, unlikely?
         if (Q_UNLIKELY(!result.first)) {
-            return warnArgumentValue(L, __func__, qsl(
-                "stopwatch with name '%1' (ID: %2) has disappeared - this should not happen, please report it to Mudlet developers")
-                .arg(name, QString::number(watchId)));
+            return warnArgumentValue(
+                    L, __func__, qsl("stopwatch with name '%1' (ID: %2) has disappeared - this should not happen, please report it to Mudlet developers").arg(name, QString::number(watchId)));
         }
     }
 
@@ -900,17 +897,13 @@ int TLuaInterpreter::isActive(lua_State* L)
     if (!type.compare(QLatin1String("timer"), Qt::CaseInsensitive)) {
         if (isId) {
             auto pT = host.getTimerUnit()->getTimer(id);
-            cnt = (static_cast<bool>(pT)
-                   && (pT->isOffsetTimer() ? pT->shouldBeActive() : pT->isActive())
-                   && (!checkAncestors || pT->shouldAncestorsBeActive())) ? 1 : 0;
+            cnt = (static_cast<bool>(pT) && (pT->isOffsetTimer() ? pT->shouldBeActive() : pT->isActive()) && (!checkAncestors || pT->shouldAncestorsBeActive())) ? 1 : 0;
         } else {
             auto itpItem = host.getTimerUnit()->mLookupTable.constFind(nameOrId);
             while (itpItem != host.getTimerUnit()->mLookupTable.cend() && itpItem.key() == nameOrId) {
                 auto pT = itpItem.value();
                 // Offset timer have their active state recorded differently
-                if ((pT->isOffsetTimer() ? pT->shouldBeActive() : pT->isActive())
-                    && (!checkAncestors || pT->shouldAncestorsBeActive())) {
-
+                if ((pT->isOffsetTimer() ? pT->shouldBeActive() : pT->isActive()) && (!checkAncestors || pT->shouldAncestorsBeActive())) {
                     ++cnt;
                 }
                 ++itpItem;
@@ -989,8 +982,7 @@ int TLuaInterpreter::isActive(lua_State* L)
         }
 
     } else {
-        return warnArgumentValue(L, __func__, qsl(
-                "invalid item type '%1' given, it should be one (case insensitive) of: 'alias', 'button', 'script', 'keybind', 'timer' or 'trigger'").arg(type));
+        return warnArgumentValue(L, __func__, qsl("invalid item type '%1' given, it should be one (case insensitive) of: 'alias', 'button', 'script', 'keybind', 'timer' or 'trigger'").arg(type));
     }
     lua_pushnumber(L, cnt);
     return 1;
@@ -1088,7 +1080,7 @@ int TLuaInterpreter::permPromptTrigger(lua_State* L)
     const QString luaFunction = lua_tostring(L, 3);
 
     auto [triggerID, message] = pLuaInterpreter->startPermPromptTrigger(triggerName, parentName, luaFunction);
-    if(triggerID == - 1) {
+    if (triggerID == -1) {
         lua_pushfstring(L, "permPromptTrigger: cannot create trigger (%s)", message.toUtf8().constData());
         return lua_error(L);
     }
@@ -1104,8 +1096,7 @@ int TLuaInterpreter::permRegexTrigger(lua_State* L)
 
     QStringList regList;
     if (!lua_istable(L, 3)) {
-        lua_pushfstring(L, "permRegexTrigger: bad argument #3 type (sub-strings list as table expected, got %s!)",
-                        luaL_typename(L, 3));
+        lua_pushfstring(L, "permRegexTrigger: bad argument #3 type (sub-strings list as table expected, got %s!)", luaL_typename(L, 3));
         return lua_error(L);
     }
     lua_pushnil(L);
@@ -1143,8 +1134,7 @@ int TLuaInterpreter::permBeginOfLineStringTrigger(lua_State* L)
 
     QStringList regList;
     if (!lua_istable(L, 3)) {
-        lua_pushfstring(L, "permBeginOfLineStringTrigger: bad argument #3 type (sub-strings list as table expected, got %s!)",
-                        luaL_typename(L, 3));
+        lua_pushfstring(L, "permBeginOfLineStringTrigger: bad argument #3 type (sub-strings list as table expected, got %s!)", luaL_typename(L, 3));
         return lua_error(L);
     }
     lua_pushnil(L);
@@ -1181,8 +1171,7 @@ int TLuaInterpreter::permSubstringTrigger(lua_State* L)
     const QString parent = getVerifiedString(L, __func__, 2, "trigger parent");
     QStringList regList;
     if (!lua_istable(L, 3)) {
-        lua_pushfstring(L, "permSubstringTrigger: bad argument #3 type (sub-strings list as table expected, got %s!)",
-                        luaL_typename(L, 3));
+        lua_pushfstring(L, "permSubstringTrigger: bad argument #3 type (sub-strings list as table expected, got %s!)", luaL_typename(L, 3));
         return lua_error(L);
     }
     lua_pushnil(L);
@@ -1204,7 +1193,7 @@ int TLuaInterpreter::permSubstringTrigger(lua_State* L)
 
     const QString script{lua_tostring(L, 4)};
     auto [triggerID, message] = pLuaInterpreter->startPermSubstringTrigger(name, parent, regList, script);
-    if(triggerID == - 1) {
+    if (triggerID == -1) {
         lua_pushfstring(L, "permSubstringTrigger: cannot create trigger (%s)", message.toUtf8().constData());
         return lua_error(L);
     }
@@ -1219,8 +1208,7 @@ int TLuaInterpreter::permExactMatchTrigger(lua_State* L)
     const QString parent = getVerifiedString(L, __func__, 2, "trigger parent");
     QStringList patternList;
     if (!lua_istable(L, 3)) {
-        lua_pushfstring(L, "permExactMatchTrigger: bad argument #3 type (exact match patterns list as table expected, got %s!)",
-                        luaL_typename(L, 3));
+        lua_pushfstring(L, "permExactMatchTrigger: bad argument #3 type (exact match patterns list as table expected, got %s!)", luaL_typename(L, 3));
         return lua_error(L);
     }
     lua_pushnil(L);
@@ -1316,7 +1304,7 @@ int TLuaInterpreter::permKey(lua_State* L)
 
     QString luaFunction{lua_tostring(L, argIndex)};
     auto [keyID, message] = pLuaInterpreter->startPermKey(keyName, parentGroup, keyCode, keyModifier, luaFunction);
-    if(keyID == - 1) {
+    if (keyID == -1) {
         lua_pushfstring(L, "permKey: cannot create key (%s)", message.toUtf8().constData());
         return lua_error(L);
     }
@@ -1348,7 +1336,7 @@ int TLuaInterpreter::raiseEvent(lua_State* L)
 {
     Host& host = getHostFromLua(L);
 
-    TEvent event {};
+    TEvent event{};
 
     const int n = lua_gettop(L);
     // We go from the top of the stack down, because luaL_ref will
@@ -1414,7 +1402,7 @@ int TLuaInterpreter::raiseGlobalEvent(lua_State* L)
         return lua_error(L);
     }
 
-    TEvent event {};
+    TEvent event{};
 
     for (int i = 1; i <= n; ++i) {
         // The sending profile of the event does not receive the event if
@@ -1811,9 +1799,8 @@ int TLuaInterpreter::stopStopWatch(lua_State* L)
         // We have already validated the name to get the watchId - so for things
         // to fail now is, unlikely?
         if (Q_UNLIKELY(!watchId)) {
-            return warnArgumentValue(L, __func__, qsl(
-                "stopwatch with name '%1' (ID: %2) has disappeared - this should not happen, please report it to Mudlet developers")
-                .arg(name, QString::number(watchId)));
+            return warnArgumentValue(
+                    L, __func__, qsl("stopwatch with name '%1' (ID: %2) has disappeared - this should not happen, please report it to Mudlet developers").arg(name, QString::number(watchId)));
         }
     }
 
@@ -1836,51 +1823,56 @@ int TLuaInterpreter::tempAnsiColorTrigger(lua_State* L)
     int s = 0;
 
     if (!lua_isnumber(L, ++s)) {
-        lua_pushfstring(L, "tempAnsiColorTrigger: bad argument #%d type (foreground color as ANSI Color number {%d = ignore foreground color, %d = default color, 0 to 255 ANSI color} expected, got %s!)",
-                        s, TTrigger::scmIgnored, TTrigger::scmDefault, luaL_typename(L, s));
+        lua_pushfstring(L,
+                        "tempAnsiColorTrigger: bad argument #%d type (foreground color as ANSI Color number {%d = ignore foreground color, %d = default color, 0 to 255 ANSI color} expected, got %s!)",
+                        s,
+                        TTrigger::scmIgnored,
+                        TTrigger::scmDefault,
+                        luaL_typename(L, s));
         return lua_error(L);
     }
-    {   // separate block so that "value" is not scoped to the whole function
+    { // separate block so that "value" is not scoped to the whole function
         const int value = lua_tointeger(L, s);
         if (value == TTrigger::scmIgnored && lua_gettop(L) < 2) {
-            return warnArgumentValue(L, __func__, qsl(
-                "invalid ANSI color number %1, it cannot be used (to ignore the foreground color) if the background color is omitted")
-                .arg(value));
+            return warnArgumentValue(L, __func__, qsl("invalid ANSI color number %1, it cannot be used (to ignore the foreground color) if the background color is omitted").arg(value));
         }
         // At present we limit the range to (Trigger::scmIgnored),
         // (Trigger::scmDefault) and 0-255 ANSI colors - in the future we could
         // extend it to other "coded" values for locally generated textual
         // content
         if (!(value == TTrigger::scmIgnored || value == TTrigger::scmDefault || (value >= 0 && value <= 255))) {
-            return warnArgumentValue(L, __func__, qsl(
-                "invalid ANSI color number %1, only %2 (ignore foreground color), %3 (default foregroud color) or 0 to 255 recognised")
-                .arg(QString::number(value), QString::number(TTrigger::scmIgnored), QString::number(TTrigger::scmDefault)));
+            return warnArgumentValue(L,
+                                     __func__,
+                                     qsl("invalid ANSI color number %1, only %2 (ignore foreground color), %3 (default foregroud color) or 0 to 255 recognised")
+                                             .arg(QString::number(value), QString::number(TTrigger::scmIgnored), QString::number(TTrigger::scmDefault)));
         }
         if (value == TTrigger::scmIgnored && lua_gettop(L) < 4) {
-            return warnArgumentValue(L, __func__, qsl(
-                "invalid ANSI color number %1, you cannot ignore both foreground and background color (omitted)").arg(value));
+            return warnArgumentValue(L, __func__, qsl("invalid ANSI color number %1, you cannot ignore both foreground and background color (omitted)").arg(value));
         }
         ansiFgColor = value;
     }
 
     // s=1 at this point. If top=4 the next argument must be the BG color number,
     // otherwise it may have been omitted.
-    if (lua_gettop(L) < s+3 && !lua_isnumber(L, s+1)) {
+    if (lua_gettop(L) < s + 3 && !lua_isnumber(L, s + 1)) {
         // BG color omitted, skip this part
     } else if (!lua_isnumber(L, ++s)) {
-        lua_pushfstring(L, "tempAnsiColorTrigger: bad argument #%d type (background color as ANSI Color number {%d = ignore foreground color, %d = default color, 0 to 255 ANSI color} expected, got %s!)",
-                        s, TTrigger::scmIgnored, TTrigger::scmDefault, luaL_typename(L, s));
+        lua_pushfstring(L,
+                        "tempAnsiColorTrigger: bad argument #%d type (background color as ANSI Color number {%d = ignore foreground color, %d = default color, 0 to 255 ANSI color} expected, got %s!)",
+                        s,
+                        TTrigger::scmIgnored,
+                        TTrigger::scmDefault,
+                        luaL_typename(L, s));
         return lua_error(L);
     } else {
         const int value = lua_tointeger(L, s);
         if (!(value == TTrigger::scmIgnored || value == TTrigger::scmDefault || (value >= 0 && value <= 255))) {
-            return warnArgumentValue(L, __func__, qsl(
-                "invalid ANSI color number %1, only %2 (ignore background color), %3 (default background color) or 0 to 255 recognised")
-                .arg(QString::number(value), QString::number(TTrigger::scmIgnored), QString::number(TTrigger::scmDefault)));
+            return warnArgumentValue(L,
+                                     __func__,
+                                     qsl("invalid ANSI color number %1, only %2 (ignore background color), %3 (default background color) or 0 to 255 recognised")
+                                             .arg(QString::number(value), QString::number(TTrigger::scmIgnored), QString::number(TTrigger::scmDefault)));
         } else if (value == TTrigger::scmIgnored && ansiFgColor == TTrigger::scmIgnored) {
-                return warnArgumentValue(L, __func__, qsl(
-                    "invalid ANSI color number %1, you cannot ignore both foreground and background color")
-                    .arg(value));
+            return warnArgumentValue(L, __func__, qsl("invalid ANSI color number %1, you cannot ignore both foreground and background color").arg(value));
         } else {
             ansiBgColor = value;
         }
@@ -1899,8 +1891,7 @@ int TLuaInterpreter::tempAnsiColorTrigger(lua_State* L)
     if (lua_isnumber(L, ++s)) {
         expiryCount = static_cast<int>(lua_tonumber(L, s));
         if (expiryCount < 1) {
-            return warnArgumentValue(L, __func__, qsl(
-                "trigger expiration count must be nil or greater than zero, got %1").arg(expiryCount));
+            return warnArgumentValue(L, __func__, qsl("trigger expiration count must be nil or greater than zero, got %1").arg(expiryCount));
         }
     } else if (!lua_isnoneornil(L, ++s)) {
         lua_pushfstring(L, "tempAnsiColorTrigger: bad argument #%d value (trigger expiration count must be a number, got %s!)", s, luaL_typename(L, s));
@@ -1919,7 +1910,7 @@ int TLuaInterpreter::tempAnsiColorTrigger(lua_State* L)
         }
         trigger->mRegisteredAnonymousLuaFunction = true;
         lua_pushlightuserdata(L, trigger);
-        lua_pushvalue(L, s-1);
+        lua_pushvalue(L, s - 1);
         lua_settable(L, LUA_REGISTRYINDEX);
     }
 
@@ -1935,7 +1926,6 @@ int TLuaInterpreter::tempAlias(lua_State* L)
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
 
     if (lua_isfunction(L, 2)) {
-
         const int result = pLuaInterpreter->startTempAlias(regex, QString());
         if (result == -1) {
             lua_pushnumber(L, -1);
@@ -1981,8 +1971,7 @@ int TLuaInterpreter::tempBeginOfLineTrigger(lua_State* L)
         expiryCount = static_cast<int>(lua_tonumber(L, 3));
 
         if (expiryCount < 1) {
-            return warnArgumentValue(L, __func__, qsl(
-                "trigger expiration count must be nil or greater than zero, got %1").arg(expiryCount));
+            return warnArgumentValue(L, __func__, qsl("trigger expiration count must be nil or greater than zero, got %1").arg(expiryCount));
         }
     } else if (!lua_isnoneornil(L, 3)) {
         lua_pushfstring(L, "tempBeginOfLineTrigger: bad argument #3 value (trigger expiration count must be nil or a number, got %s!)", luaL_typename(L, 3));
@@ -2157,7 +2146,7 @@ int TLuaInterpreter::tempColorTrigger(lua_State* L)
     // it will break the API for this lua function
     // other colours in ANSI 256 colours handled but not mentioned in Wiki
     default:    foregroundColor =  value;   break;
-    // clang-format on
+        // clang-format on
     }
 
     value = getVerifiedInt(L, __func__, 2, "background color");
@@ -2184,7 +2173,7 @@ int TLuaInterpreter::tempColorTrigger(lua_State* L)
     // The default includes case -1:    backgroundColor = TTrigger::scmIgnored
     // but this cannot be used for the foreground case at the same time:
     default:    backgroundColor =  value;   break;
-    // clang-format on
+        // clang-format on
     }
 
     if (foregroundColor == TTrigger::scmIgnored && backgroundColor == TTrigger::scmIgnored) {
@@ -2198,8 +2187,7 @@ int TLuaInterpreter::tempColorTrigger(lua_State* L)
         expiryCount = static_cast<int>(lua_tonumber(L, 4));
 
         if (expiryCount < 1) {
-            return warnArgumentValue(L, __func__, qsl(
-                "trigger expiration count must be greater than zero, got %1").arg(expiryCount));
+            return warnArgumentValue(L, __func__, qsl("trigger expiration count must be greater than zero, got %1").arg(expiryCount));
         }
     } else if (!lua_isnoneornil(L, 4)) {
         lua_pushfstring(L, "tempColorTrigger: bad argument #4 value (trigger expiration count must be nil or a number, got %s!)", luaL_typename(L, 4));
@@ -2320,8 +2308,7 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
         expiryCount = static_cast<int>(lua_tonumber(L, 14));
 
         if (expiryCount < 1) {
-            return warnArgumentValue(L, __func__, qsl(
-                "trigger expiration count must be nil or greater than zero, got %1").arg(expiryCount));
+            return warnArgumentValue(L, __func__, qsl("trigger expiration count must be nil or greater than zero, got %1").arg(expiryCount));
         }
     } else if (!lua_isnoneornil(L, 14)) {
         lua_pushfstring(L, "tempComplexRegexTrigger: bad argument #14 value (trigger expiration count must be nil or a number, got %s!)", luaL_typename(L, 14));
@@ -2391,8 +2378,7 @@ int TLuaInterpreter::tempExactMatchTrigger(lua_State* L)
         expiryCount = static_cast<int>(lua_tonumber(L, 3));
 
         if (expiryCount < 1) {
-            return warnArgumentValue(L, __func__, qsl(
-                "trigger expiration count must be nil or greater than zero, got %1").arg(expiryCount));
+            return warnArgumentValue(L, __func__, qsl("trigger expiration count must be nil or greater than zero, got %1").arg(expiryCount));
         }
     } else if (!lua_isnoneornil(L, 3)) {
         lua_pushfstring(L, "tempExactMatchTrigger: bad argument #3 value (trigger expiration count must be nil or a number, got %s!)", luaL_typename(L, 3));
@@ -2440,7 +2426,6 @@ int TLuaInterpreter::tempKey(lua_State* L)
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
 
     if (lua_isfunction(L, ++argIndex)) {
-
         const int result = pLuaInterpreter->startTempKey(keyModifier, keyCode, QString());
         if (result == -1) {
             lua_pushnumber(L, -1);
@@ -2448,9 +2433,7 @@ int TLuaInterpreter::tempKey(lua_State* L)
         }
 
         TKey* key = host.getKeyUnit()->getKey(result);
-        Q_ASSERT_X(key,
-                   "TLuaInterpreter::tempKey(...)",
-                   "Got a positive result from LuaInterpreter::startTempKey(...) but that failed to produce pointer to it from Host::mKeyUnit::getKey(...)");
+        Q_ASSERT_X(key, "TLuaInterpreter::tempKey(...)", "Got a positive result from LuaInterpreter::startTempKey(...) but that failed to produce pointer to it from Host::mKeyUnit::getKey(...)");
         if (!key) {
             lua_pushnumber(L, -1);
             return 1;
@@ -2480,7 +2463,7 @@ int TLuaInterpreter::tempLineTrigger(lua_State* L)
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
     const int from = getVerifiedInt(L, __func__, 1, "line to start matching from");
-    const int howMany  = getVerifiedInt(L, __func__, 2, "how many lines to match for");
+    const int howMany = getVerifiedInt(L, __func__, 2, "how many lines to match for");
     int triggerID;
     // temp line triggers expire naturally on their own, thus don't need the expiry mechanism applicable to all other triggers
     const int dontExpire = -1;
@@ -2524,8 +2507,7 @@ int TLuaInterpreter::tempPromptTrigger(lua_State* L)
         expiryCount = static_cast<int>(lua_tonumber(L, 2));
 
         if (expiryCount < 1) {
-            return warnArgumentValue(L, __func__, qsl(
-                "trigger expiration count must be nil or greater than zero, got %1").arg(expiryCount));
+            return warnArgumentValue(L, __func__, qsl("trigger expiration count must be nil or greater than zero, got %1").arg(expiryCount));
         }
     } else if (!lua_isnoneornil(L, 2)) {
         lua_pushfstring(L, "tempPromptTrigger: bad argument #2 value (trigger expiration count must be nil or a number, got %s!)", luaL_typename(L, 2));
@@ -2571,8 +2553,7 @@ int TLuaInterpreter::tempRegexTrigger(lua_State* L)
         expiryCount = static_cast<int>(lua_tonumber(L, 3));
 
         if (expiryCount < 1) {
-            return warnArgumentValue(L, __func__, qsl(
-                "trigger expiration count must be nil or greater than zero, got %1").arg(expiryCount));
+            return warnArgumentValue(L, __func__, qsl("trigger expiration count must be nil or greater than zero, got %1").arg(expiryCount));
         }
     } else if (!lua_isnoneornil(L, 3)) {
         lua_pushfstring(L, "tempRegexTrigger: bad argument #3 value (trigger expiration count must be nil or a number, got %s!)", luaL_typename(L, 3));
@@ -2668,8 +2649,7 @@ int TLuaInterpreter::tempTrigger(lua_State* L)
         expiryCount = static_cast<int>(lua_tonumber(L, 3));
 
         if (expiryCount < 1) {
-            return warnArgumentValue(L, __func__, qsl(
-                "trigger expiration count must be nil or greater than zero, got %1").arg(expiryCount));
+            return warnArgumentValue(L, __func__, qsl("trigger expiration count must be nil or greater than zero, got %1").arg(expiryCount));
         }
     } else if (!lua_isnoneornil(L, 3)) {
         lua_pushfstring(L, "tempTrigger: bad argument #3 value (trigger expiration count must be nil or a number, got %s!)", luaL_typename(L, 3));
@@ -2706,8 +2686,7 @@ int TLuaInterpreter::tempTrigger(lua_State* L)
 int TLuaInterpreter::getProfiles(lua_State* L)
 {
     auto& hostManager = mudlet::self()->getHostManager();
-    const QStringList profiles = QDir(mudlet::getMudletPath(enums::profilesPath))
-                                   .entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+    const QStringList profiles = QDir(mudlet::getMudletPath(enums::profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
 
     lua_newtable(L);
 
@@ -2840,7 +2819,7 @@ int TLuaInterpreter::closeProfile(lua_State* L)
 
     auto profileIndex = mudlet::self()->mpTabBar->tabIndex(profileName);
     if (profileIndex != -1) {
-        emit mudlet::self()->mpTabBar->tabCloseRequested(profileIndex);
+        emit mudlet::self() -> mpTabBar->tabCloseRequested(profileIndex);
         lua_pushboolean(L, true);
         return 1;
     }

--- a/src/TLuaInterpreterNetworking.cpp
+++ b/src/TLuaInterpreterNetworking.cpp
@@ -88,8 +88,7 @@ int TLuaInterpreter::connectToServer(lua_State* L)
     if (!lua_isnoneornil(L, 2)) {
         port = getVerifiedInt(L, __func__, 2, "port number {default = 23}", true);
         if (port > 65535 || port < 1) {
-            return warnArgumentValue(L, __func__, qsl(
-                "invalid port number %1 given, if supplied it must be in range 1 to 65535, {defaults to 23 if not provided}").arg(port));
+            return warnArgumentValue(L, __func__, qsl("invalid port number %1 given, if supplied it must be in range 1 to 65535, {defaults to 23 if not provided}").arg(port));
         }
     }
 
@@ -145,8 +144,7 @@ int TLuaInterpreter::downloadFile(lua_State* L)
         raiseDownloadProgressEvent(L, urlString, bytesDownloaded, totalBytes);
         if (mudlet::smDebugMode) {
             auto& lHost = getHostFromLua(L);
-            TDebug(Qt::white, Qt::blue) << "downloadFile: " << bytesDownloaded << "/" << totalBytes
-                                        << " bytes ready for " << reply->url().toString() << "\n" >> &lHost;
+            TDebug(Qt::white, Qt::blue) << "downloadFile: " << bytesDownloaded << "/" << totalBytes << " bytes ready for " << reply->url().toString() << "\n" >> &lHost;
         }
     });
 
@@ -160,7 +158,7 @@ int TLuaInterpreter::downloadFile(lua_State* L)
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getConnectionInfo
-int TLuaInterpreter::getConnectionInfo(lua_State *L)
+int TLuaInterpreter::getConnectionInfo(lua_State* L)
 {
     const Host& host = getHostFromLua(L);
 
@@ -424,13 +422,13 @@ int TLuaInterpreter::openIRC(lua_State* L)
     if (!pHost) {
         return warnArgumentValue(L, __func__, "no host found");
     }
-    
+
     if (!pHost->mpDlgIRC) {
         pHost->mpDlgIRC = new dlgIRC(pHost);
     }
     pHost->mpDlgIRC->raise();
     pHost->mpDlgIRC->show();
-    
+
     lua_pushboolean(L, true);
     return 1;
 }
@@ -479,15 +477,13 @@ int TLuaInterpreter::sendMSDP(lua_State* L)
 int TLuaInterpreter::sendTelnetChannel102(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
-        lua_pushfstring(L, "sendTelnetChannel102: bad argument #1 type (message bytes {2 characters} as string expected, got %s!)",
-                        luaL_typename(L, 1));
+        lua_pushfstring(L, "sendTelnetChannel102: bad argument #1 type (message bytes {2 characters} as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
     const std::string msg = lua_tostring(L, 1);
     if (msg.length() != 2) {
-        return warnArgumentValue(L, __func__, qsl(
-            "invalid message of length %1 supplied, it should be two bytes (may use lua \\### for each byte where ### is a number between 1 and 254)")
-            .arg(msg.length()));
+        return warnArgumentValue(
+                L, __func__, qsl("invalid message of length %1 supplied, it should be two bytes (may use lua \\### for each byte where ### is a number between 1 and 254)").arg(msg.length()));
     }
 
     std::string output;
@@ -588,7 +584,7 @@ int TLuaInterpreter::setIrcServer(lua_State* L)
         secure = getVerifiedBool(L, __func__, 3, "secure {default = false}", true);
     }
     if (args > 3) {
-            password = getVerifiedString(L, __func__, 4, "server password", true);
+        password = getVerifiedString(L, __func__, 4, "server password", true);
     }
 
     Host* pHost = &getHostFromLua(L);
@@ -677,7 +673,7 @@ int TLuaInterpreter::putHTTP(lua_State* L)
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Networking_Functions#deleteHTTP
-int TLuaInterpreter::deleteHTTP(lua_State *L)
+int TLuaInterpreter::deleteHTTP(lua_State* L)
 {
     auto& host = getHostFromLua(L);
     const QString urlString = getVerifiedString(L, __func__, 1, "remote url");
@@ -698,7 +694,6 @@ int TLuaInterpreter::deleteHTTP(lua_State *L)
         while (lua_next(L, 2) != 0) {
             // key at index -2 and value at index -1
             if (lua_type(L, -1) == LUA_TSTRING && lua_type(L, -2) == LUA_TSTRING) {
-
                 request.setRawHeader(QByteArray(lua_tostring(L, -2)), QByteArray(lua_tostring(L, -1)));
             } else {
                 lua_pushfstring(L,
@@ -730,4 +725,3 @@ int TLuaInterpreter::customHTTP(lua_State* L)
     auto customMethod = getVerifiedString(L, __func__, 1, "http method");
     return performHttpRequest(L, __func__, 1, QNetworkAccessManager::CustomOperation, customMethod);
 }
-

--- a/src/TLuaInterpreterTextToSpeech.cpp
+++ b/src/TLuaInterpreterTextToSpeech.cpp
@@ -117,7 +117,7 @@ void TLuaInterpreter::ttsStateChanged(QTextToSpeech::State state)
 {
     if (state != speechState) {
         speechState = state;
-        TEvent event {};
+        TEvent event{};
         switch (state) {
         case QTextToSpeech::State::Paused:
             event.mArgumentList.append(QLatin1String("ttsSpeechPaused"));
@@ -346,7 +346,7 @@ int TLuaInterpreter::ttsQueue(lua_State* L)
 
     speechQueue.insert(index, inputText);
 
-    TEvent event {};
+    TEvent event{};
     Host& host = getHostFromLua(L);
     event.mArgumentList.append(QLatin1String("ttsSpeechQueued"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
@@ -416,7 +416,7 @@ int TLuaInterpreter::ttsSetPitch(lua_State* L)
 
     speechUnit->setPitch(pitch);
 
-    TEvent event {};
+    TEvent event{};
     event.mArgumentList.append(QLatin1String("ttsPitchChanged"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(QString::number(pitch));
@@ -442,7 +442,7 @@ int TLuaInterpreter::ttsSetRate(lua_State* L)
 
     speechUnit->setRate(rate);
 
-    TEvent event {};
+    TEvent event{};
     event.mArgumentList.append(QLatin1String("ttsRateChanged"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(QString::number(rate));
@@ -468,7 +468,7 @@ int TLuaInterpreter::ttsSetVolume(lua_State* L)
 
     speechUnit->setVolume(volume);
 
-    TEvent event {};
+    TEvent event{};
     event.mArgumentList.append(QLatin1String("ttsVolumeChanged"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(QString::number(volume));
@@ -493,7 +493,7 @@ int TLuaInterpreter::ttsSetVoiceByIndex(lua_State* L)
 
     speechUnit->setVoice(speechVoices.at(index));
 
-    TEvent event {};
+    TEvent event{};
     event.mArgumentList.append(QLatin1String("ttsVoiceChanged"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(speechVoices[index].name());
@@ -516,7 +516,7 @@ int TLuaInterpreter::ttsSetVoiceByName(lua_State* L)
             speechUnit->setVoice(voice);
             lua_pushboolean(L, true);
 
-            TEvent event {};
+            TEvent event{};
             event.mArgumentList.append(QLatin1String("ttsVoiceChanged"));
             event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
             event.mArgumentList.append(voice.name());

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -74,11 +74,11 @@
 #include <QTextToSpeech>
 #endif // QT_TEXTTOSPEECH_LIB
 
-static const char *bad_window_type = "%s: bad argument #%d type (window name as string expected, got %s)!";
-static const char *bad_cmdline_type = "%s: bad argument #%d type (command line name as string expected, got %s)!";
-static const char *bad_window_value = "window \"%s\" not found";
-static const char *bad_cmdline_value = "command line \"%s\" not found";
-static const char *bad_label_value = "label \"%s\" not found";
+static const char* bad_window_type = "%s: bad argument #%d type (window name as string expected, got %s)!";
+static const char* bad_cmdline_type = "%s: bad argument #%d type (command line name as string expected, got %s)!";
+static const char* bad_window_value = "window \"%s\" not found";
+static const char* bad_cmdline_value = "command line \"%s\" not found";
+static const char* bad_label_value = "label \"%s\" not found";
 
 // No documentation available in wiki - internal function
 static bool isMain(const QString& name)
@@ -92,80 +92,79 @@ static bool isMain(const QString& name)
     return false;
 }
 
-#define WINDOW_NAME(ARG_L, ARG_pos)                                                                      \
-    ({                                                                                                   \
-        int pos_ = (ARG_pos);                                                                            \
-        const char *res_;                                                                                \
-        if ((lua_gettop(ARG_L) < pos_) || lua_isnil(ARG_L, pos_)) {                                      \
-            res_ = "";                                                                                   \
-        } else {                                                                                         \
-            if (!lua_isstring(ARG_L, pos_)) {                                                            \
-                lua_pushfstring(ARG_L, bad_window_type, __FUNCTION__, pos_, luaL_typename(ARG_L, pos_)); \
-                return lua_error(ARG_L);                                                                 \
-            }                                                                                            \
-            res_ = lua_tostring(ARG_L, pos_);                                                            \
-        }                                                                                                \
-        res_;                                                                                            \
+#define WINDOW_NAME(ARG_L, ARG_pos)                                                                                                                                                                    \
+    ({                                                                                                                                                                                                 \
+        int pos_ = (ARG_pos);                                                                                                                                                                          \
+        const char* res_;                                                                                                                                                                              \
+        if ((lua_gettop(ARG_L) < pos_) || lua_isnil(ARG_L, pos_)) {                                                                                                                                    \
+            res_ = "";                                                                                                                                                                                 \
+        } else {                                                                                                                                                                                       \
+            if (!lua_isstring(ARG_L, pos_)) {                                                                                                                                                          \
+                lua_pushfstring(ARG_L, bad_window_type, __FUNCTION__, pos_, luaL_typename(ARG_L, pos_));                                                                                               \
+                return lua_error(ARG_L);                                                                                                                                                               \
+            }                                                                                                                                                                                          \
+            res_ = lua_tostring(ARG_L, pos_);                                                                                                                                                          \
+        }                                                                                                                                                                                              \
+        res_;                                                                                                                                                                                          \
     })
 
-#define CMDLINE_NAME(ARG_L, ARG_pos)                                                                 \
-    ({                                                                                               \
-        int pos_ = (ARG_pos);                                                                        \
-        if (!lua_isstring(ARG_L, pos_)) {                                                            \
-            lua_pushfstring(ARG_L, bad_cmdline_type, __FUNCTION__, pos_, luaL_typename(ARG_L, pos_));\
-            return lua_error(ARG_L);                                                                 \
-        }                                                                                            \
-        lua_tostring(ARG_L, pos_);                                                                   \
+#define CMDLINE_NAME(ARG_L, ARG_pos)                                                                                                                                                                   \
+    ({                                                                                                                                                                                                 \
+        int pos_ = (ARG_pos);                                                                                                                                                                          \
+        if (!lua_isstring(ARG_L, pos_)) {                                                                                                                                                              \
+            lua_pushfstring(ARG_L, bad_cmdline_type, __FUNCTION__, pos_, luaL_typename(ARG_L, pos_));                                                                                                  \
+            return lua_error(ARG_L);                                                                                                                                                                   \
+        }                                                                                                                                                                                              \
+        lua_tostring(ARG_L, pos_);                                                                                                                                                                     \
     })
 
-#define CONSOLE_NIL(ARG_L, ARG_name)                                                           \
-    ({                                                                                         \
-        auto name_ = (ARG_name);                                                               \
-        auto console_ = getHostFromLua(ARG_L).findConsole(name_);                              \
-        console_;                                                                              \
+#define CONSOLE_NIL(ARG_L, ARG_name)                                                                                                                                                                   \
+    ({                                                                                                                                                                                                 \
+        auto name_ = (ARG_name);                                                                                                                                                                       \
+        auto console_ = getHostFromLua(ARG_L).findConsole(name_);                                                                                                                                      \
+        console_;                                                                                                                                                                                      \
     })
 
-#define CONSOLE(ARG_L, ARG_name)                                                               \
-    ({                                                                                         \
-        auto name_ = (ARG_name);                                                               \
-        auto console_ = getHostFromLua(ARG_L).findConsole(name_);                              \
-        if (!console_) {                                                                       \
-            lua_pushnil(ARG_L);                                                                \
-            lua_pushfstring(ARG_L, bad_window_value, name_.toUtf8().constData());              \
-            return 2;                                                                          \
-        }                                                                                      \
-        console_;                                                                              \
+#define CONSOLE(ARG_L, ARG_name)                                                                                                                                                                       \
+    ({                                                                                                                                                                                                 \
+        auto name_ = (ARG_name);                                                                                                                                                                       \
+        auto console_ = getHostFromLua(ARG_L).findConsole(name_);                                                                                                                                      \
+        if (!console_) {                                                                                                                                                                               \
+            lua_pushnil(ARG_L);                                                                                                                                                                        \
+            lua_pushfstring(ARG_L, bad_window_value, name_.toUtf8().constData());                                                                                                                      \
+            return 2;                                                                                                                                                                                  \
+        }                                                                                                                                                                                              \
+        console_;                                                                                                                                                                                      \
     })
 
-#define COMMANDLINE(ARG_L, ARG_name)                                                           \
-    ({                                                                                         \
-        const QString& name_ = (ARG_name);                                                     \
-        auto console_ = getHostFromLua(ARG_L).mpConsole;                                       \
-        auto cmdLine_ = isMain(name_) ? &*console_->mpCommandLine                              \
-                                    : console_->mSubCommandLineMap.value(name_);               \
-        if (!cmdLine_) {                                                                       \
-            lua_pushnil(ARG_L);                                                                \
-            lua_pushfstring(ARG_L, bad_cmdline_value, name_.toUtf8().constData());             \
-            return 2;                                                                          \
-        }                                                                                      \
-        cmdLine_;                                                                              \
+#define COMMANDLINE(ARG_L, ARG_name)                                                                                                                                                                   \
+    ({                                                                                                                                                                                                 \
+        const QString& name_ = (ARG_name);                                                                                                                                                             \
+        auto console_ = getHostFromLua(ARG_L).mpConsole;                                                                                                                                               \
+        auto cmdLine_ = isMain(name_) ? &*console_->mpCommandLine : console_->mSubCommandLineMap.value(name_);                                                                                         \
+        if (!cmdLine_) {                                                                                                                                                                               \
+            lua_pushnil(ARG_L);                                                                                                                                                                        \
+            lua_pushfstring(ARG_L, bad_cmdline_value, name_.toUtf8().constData());                                                                                                                     \
+            return 2;                                                                                                                                                                                  \
+        }                                                                                                                                                                                              \
+        cmdLine_;                                                                                                                                                                                      \
     })
 
-#define LABEL(ARG_L, ARG_name)                                                                 \
-    ({                                                                                         \
-        const QString& name_ = (ARG_name);                                                     \
-        auto console_ = getHostFromLua(ARG_L).mpConsole;                                       \
-        auto label_ = console_->mLabelMap.value(name_);                                        \
-        if (!label_) {                                                                         \
-            lua_pushnil(ARG_L);                                                                \
-            lua_pushfstring(ARG_L, bad_label_value, name_.toUtf8().constData());               \
-            return 2;                                                                          \
-        }                                                                                      \
-        label_;                                                                                \
+#define LABEL(ARG_L, ARG_name)                                                                                                                                                                         \
+    ({                                                                                                                                                                                                 \
+        const QString& name_ = (ARG_name);                                                                                                                                                             \
+        auto console_ = getHostFromLua(ARG_L).mpConsole;                                                                                                                                               \
+        auto label_ = console_->mLabelMap.value(name_);                                                                                                                                                \
+        if (!label_) {                                                                                                                                                                                 \
+            lua_pushnil(ARG_L);                                                                                                                                                                        \
+            lua_pushfstring(ARG_L, bad_label_value, name_.toUtf8().constData());                                                                                                                       \
+            return 2;                                                                                                                                                                                  \
+        }                                                                                                                                                                                              \
+        label_;                                                                                                                                                                                        \
     })
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addCommandLineMenuEvent
-int TLuaInterpreter::addCommandLineMenuEvent(lua_State * L)
+int TLuaInterpreter::addCommandLineMenuEvent(lua_State* L)
 {
     int args = 1;
     const int argsCount = lua_gettop(L);
@@ -187,7 +186,7 @@ int TLuaInterpreter::addCommandLineMenuEvent(lua_State * L)
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addMouseEvent
-int TLuaInterpreter::addMouseEvent(lua_State * L)
+int TLuaInterpreter::addMouseEvent(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     QStringList actionInfo;
@@ -221,7 +220,7 @@ int TLuaInterpreter::addMouseEvent(lua_State * L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#appendBuffer
 int TLuaInterpreter::appendBuffer(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->appendBuffer();
     return 0;
@@ -237,8 +236,7 @@ int TLuaInterpreter::calcFontSize(lua_State* L)
 
     // font name and size are passed in as arguments
     if (lua_gettop(L) == 2) {
-        auto font = QFont(getVerifiedString(L, __func__, 2, "font name"),
-                          getVerifiedInt(L, __func__, 1, "font size"), QFont::Normal);
+        auto font = QFont(getVerifiedString(L, __func__, 2, "font name"), getVerifiedInt(L, __func__, 1, "font size"), QFont::Normal);
         auto fontMetrics = QFontMetrics(font);
         size = QSize(fontMetrics.averageCharWidth(), fontMetrics.height());
 
@@ -527,7 +525,7 @@ int TLuaInterpreter::deleteScrollBox(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#deleteLine
 int TLuaInterpreter::deleteLine(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->skipLine();
     return 0;
@@ -536,7 +534,7 @@ int TLuaInterpreter::deleteLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#deselect
 int TLuaInterpreter::deselect(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->deselect();
     lua_pushboolean(L, true);
@@ -546,7 +544,7 @@ int TLuaInterpreter::deselect(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableClickthrough
 int TLuaInterpreter::disableClickthrough(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
 
     Host& host = getHostFromLua(L);
 
@@ -583,7 +581,7 @@ int TLuaInterpreter::disableCommandLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableHorizontalScrollBar
 int TLuaInterpreter::disableHorizontalScrollBar(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->setHorizontalScrollBar(false);
     return 0;
@@ -592,7 +590,7 @@ int TLuaInterpreter::disableHorizontalScrollBar(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableScrollBar
 int TLuaInterpreter::disableScrollBar(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->setScrollBarVisible(false);
     return 0;
@@ -601,7 +599,7 @@ int TLuaInterpreter::disableScrollBar(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableTimeStamps
 int TLuaInterpreter::disableTimeStamps(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     auto pConsole = CONSOLE(L, windowName);
     // *pConsole can be the main console as well as any user one
     if (!pConsole->showTimeStamps()) {
@@ -677,7 +675,7 @@ int TLuaInterpreter::echoLink(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#echoUserWindow
 int TLuaInterpreter::echoUserWindow(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     const QString text = getVerifiedString(L, __func__, 2, "text");
     Host& host = getHostFromLua(L);
     host.echoWindow(windowName, text);
@@ -728,7 +726,10 @@ int TLuaInterpreter::echoPopup(lua_State* L)
 
     if ((hintList.size() - commandList.size()) < 0 || (hintList.size() - commandList.size()) > 1) {
         lua_pushnil(L);
-        lua_pushfstring(L, "command table and hint table sizes do not match up (%d and %d, either they must be the same or there should be one extra hint) - cannot create popup", commandList.size(), hintList.size());
+        lua_pushfstring(L,
+                        "command table and hint table sizes do not match up (%d and %d, either they must be the same or there should be one extra hint) - cannot create popup",
+                        commandList.size(),
+                        hintList.size());
         return 2;
     }
 
@@ -741,7 +742,7 @@ int TLuaInterpreter::echoPopup(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableClickthrough
 int TLuaInterpreter::enableClickthrough(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
 
     Host& host = getHostFromLua(L);
 
@@ -826,7 +827,7 @@ int TLuaInterpreter::enableCommandLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableHorizontalScrollBar
 int TLuaInterpreter::enableHorizontalScrollBar(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->setHorizontalScrollBar(true);
     return 0;
@@ -835,7 +836,7 @@ int TLuaInterpreter::enableHorizontalScrollBar(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableScrollBar
 int TLuaInterpreter::enableScrollBar(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->setScrollBarVisible(true);
     return 0;
@@ -844,7 +845,7 @@ int TLuaInterpreter::enableScrollBar(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableTimeStamps
 int TLuaInterpreter::enableTimeStamps(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     auto pConsole = CONSOLE(L, windowName);
     // *pConsole can be the main console as well as any user one
     if (pConsole->showTimeStamps()) {
@@ -990,7 +991,7 @@ int TLuaInterpreter::getClipboardText(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getColumnCount
 int TLuaInterpreter::getColumnCount(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
 
     int columns;
     auto console = CONSOLE(L, windowName);
@@ -1015,7 +1016,7 @@ int TLuaInterpreter::getColumnNumber(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getCurrentLine
 int TLuaInterpreter::getCurrentLine(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     auto console = getHostFromLua(L).findConsole(windowName);
     if (!console) {
         // the next line should be "pushnil"; compatibility with old bugs and all that
@@ -1074,7 +1075,7 @@ int TLuaInterpreter::getFont(lua_State* L)
 int TLuaInterpreter::getFontSize(lua_State* L)
 {
     int rval = -1;
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     rval = console->mUpperPane->font().pointSize();
 
@@ -1139,7 +1140,7 @@ int TLuaInterpreter::getLabelStyleSheet(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getLastLineNumber
 int TLuaInterpreter::getLastLineNumber(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     auto console = CONSOLE_NIL(L, windowName);
     const int number = console ? console->getLastLineNumber() : -1;
     lua_pushnumber(L, number);
@@ -1212,7 +1213,7 @@ int TLuaInterpreter::getMainConsoleWidth(lua_State* L)
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMouseEvents
-int TLuaInterpreter::getMouseEvents(lua_State * L)
+int TLuaInterpreter::getMouseEvents(lua_State* L)
 {
     const Host& host = getHostFromLua(L);
     // create the result table
@@ -1276,7 +1277,7 @@ int TLuaInterpreter::getMainWindowSize(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRowCount
 int TLuaInterpreter::getRowCount(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
 
     int rows;
     auto console = CONSOLE(L, windowName);
@@ -1441,7 +1442,7 @@ int TLuaInterpreter::getTextFormat(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#timeStampsEnabled
 int TLuaInterpreter::timeStampsEnabled(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     auto pConsole = CONSOLE(L, windowName);
     // *pConsole can be the main console as well as any user one
     lua_pushboolean(L, pConsole->showTimeStamps());
@@ -1451,7 +1452,7 @@ int TLuaInterpreter::timeStampsEnabled(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getUserWindowSize
 int TLuaInterpreter::getUserWindowSize(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
 
     const Host& host = getHostFromLua(L);
     const QSize userWindowSize = host.mpConsole->getUserWindowSize(windowName);
@@ -1464,7 +1465,7 @@ int TLuaInterpreter::getUserWindowSize(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getWindowWrap
 int TLuaInterpreter::getWindowWrap(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
 
     auto console = CONSOLE(L, windowName);
     lua_pushnumber(L, console->getWrapAt());
@@ -1482,7 +1483,7 @@ int TLuaInterpreter::hasFocus(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#hideToolBar
 int TLuaInterpreter::hideToolBar(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
 
     Host& host = getHostFromLua(L);
     host.getActionUnit()->hideToolBar(windowName);
@@ -1599,7 +1600,10 @@ int TLuaInterpreter::insertPopup(lua_State* L)
 
     if ((hintList.size() - commandList.size()) < 0 || (hintList.size() - commandList.size()) > 1) {
         lua_pushnil(L);
-        lua_pushfstring(L, "command table and hint table sizes do not match up (%d and %d, either they must be the same or there should be one extra hint) - cannot create popup", commandList.size(), hintList.size());
+        lua_pushfstring(L,
+                        "command table and hint table sizes do not match up (%d and %d, either they must be the same or there should be one extra hint) - cannot create popup",
+                        commandList.size(),
+                        hintList.size());
         return 2;
     }
 
@@ -1824,7 +1828,7 @@ int TLuaInterpreter::loadWindowLayout(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#lowerWindow
 int TLuaInterpreter::lowerWindow(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     const Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.mpConsole->lowerWindow(windowName));
     return 1;
@@ -1851,7 +1855,7 @@ int TLuaInterpreter::moveCursor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#moveCursorEnd
 int TLuaInterpreter::moveCursorEnd(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->moveCursorEnd();
     return 0;
@@ -1927,14 +1931,14 @@ int TLuaInterpreter::pauseMovie(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#raiseWindow
 int TLuaInterpreter::raiseWindow(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     const Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.mpConsole->raiseWindow(windowName));
     return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#removeCommandLineMenuEvent
-int TLuaInterpreter::removeCommandLineMenuEvent(lua_State * L)
+int TLuaInterpreter::removeCommandLineMenuEvent(lua_State* L)
 {
     int args = 1;
     const int argsCount = lua_gettop(L);
@@ -1959,7 +1963,7 @@ int TLuaInterpreter::removeCommandLineMenuEvent(lua_State * L)
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#removeMouseEvent
-int TLuaInterpreter::removeMouseEvent(lua_State * L)
+int TLuaInterpreter::removeMouseEvent(lua_State* L)
 {
     const QString uniqueName = getVerifiedString(L, __func__, 1, "event name");
     Host& host = getHostFromLua(L);
@@ -1989,7 +1993,8 @@ int TLuaInterpreter::replace(lua_State* L)
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#resetCmdLineAction
-int TLuaInterpreter::resetCmdLineAction(lua_State* L){
+int TLuaInterpreter::resetCmdLineAction(lua_State* L)
+{
     Host& host = getHostFromLua(L);
     const QString name = getVerifiedString(L, __func__, 1, "command line name");
     if (name.isEmpty()) {
@@ -2025,7 +2030,7 @@ int TLuaInterpreter::resetBackgroundImage(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#resetFormat
 int TLuaInterpreter::resetFormat(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     auto console = CONSOLE(L, windowName);
     console->reset();
     lua_pushboolean(L, true);
@@ -2058,17 +2063,15 @@ int TLuaInterpreter::scaleMovie(lua_State* L)
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#selectCaptureGroup
-int TLuaInterpreter::selectCaptureGroup(lua_State *L)
+int TLuaInterpreter::selectCaptureGroup(lua_State* L)
 {
     if (!(lua_isnumber(L, 1) || lua_isstring(L, 1))) {
-        lua_pushfstring(L,
-                        "selectCaptureGroup: bad argument #1 type (capture group as number or capture group name as string expected, got %s!)",
-                        luaL_typename(L, 1));
+        lua_pushfstring(L, "selectCaptureGroup: bad argument #1 type (capture group as number or capture group name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
 
-    Host &host = getHostFromLua(L);
-    TLuaInterpreter *pL = host.getLuaInterpreter();
+    Host& host = getHostFromLua(L);
+    TLuaInterpreter* pL = host.getLuaInterpreter();
     int begin = 0;
     int length = 0;
 
@@ -2084,7 +2087,7 @@ int TLuaInterpreter::selectCaptureGroup(lua_State *L)
             auto iti = pL->mCaptureGroupPosList.begin();
             auto its = pL->mCaptureGroupList.begin();
             begin = *iti;
-            std::string &s = *its;
+            std::string& s = *its;
 
             for (int i = 0; iti != pL->mCaptureGroupPosList.end(); ++iti, ++i) {
                 begin = *iti;
@@ -2175,7 +2178,7 @@ int TLuaInterpreter::selectString(lua_State* L)
     const QString searchText = getVerifiedString(L, __func__, s++, "text to select");
     // CHECK: Do we need to qualify this for a non-blank string?
 
-    qint64 const numOfMatch = static_cast <qint64> (getVerifiedInt(L, __func__, s, "match count {1 for first}"));
+    qint64 const numOfMatch = static_cast<qint64>(getVerifiedInt(L, __func__, s, "match count {1 for first}"));
 
     auto console = CONSOLE(L, windowName);
     lua_pushnumber(L, console->select(searchText, numOfMatch));
@@ -2222,7 +2225,7 @@ int TLuaInterpreter::setAppStyleSheet(lua_State* L)
     }
 
     Host& host = getHostFromLua(L);
-    TEvent event {};
+    TEvent event{};
     event.mArgumentList.append(QLatin1String("sysAppStyleSheetChange"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(tag);
@@ -2313,8 +2316,7 @@ int TLuaInterpreter::setBackgroundImage(lua_State* L)
     }
 
     if (mode < 1 || mode > 4) {
-        return warnArgumentValue(L, __func__, qsl(
-            "%1 is not a valid mode! Valid modes are 1 'border', 2 'center', 3 'tile', 4 'style'").arg(mode));
+        return warnArgumentValue(L, __func__, qsl("%1 is not a valid mode! Valid modes are 1 'border', 2 'center', 3 'tile', 4 'style'").arg(mode));
     }
 
     Host* host = &getHostFromLua(L);
@@ -2332,7 +2334,9 @@ int TLuaInterpreter::setBgColor(lua_State* L)
     QString windowName;
     int r, g, b, alpha;
 
-    auto validRange = [](int number) { return number >= 0 && number <= 255; };
+    auto validRange = [](int number) {
+        return number >= 0 && number <= 255;
+    };
 
     int s = 1;
     if (lua_isstring(L, s) && !lua_isnumber(L, s)) {
@@ -2468,7 +2472,7 @@ int TLuaInterpreter::setBorderSizes(lua_State* L)
         auto bottom = getVerifiedInt(L, __func__, 3, "new bottom size");
         host.setBorders({width, top, width, bottom});
         break;
-        }
+    }
     default: {
         auto top = getVerifiedInt(L, __func__, 1, "new top size");
         auto right = getVerifiedInt(L, __func__, 2, "new right size");
@@ -2496,7 +2500,9 @@ int TLuaInterpreter::setFgColor(lua_State* L)
 {
     int s = 0;
     const int n = lua_gettop(L);
-    auto validRange = [](int number) { return number >= 0 && number <= 255; };
+    auto validRange = [](int number) {
+        return number >= 0 && number <= 255;
+    };
     QString windowName;
     if (n > 3) {
         windowName = WINDOW_NAME(L, ++s);
@@ -2618,7 +2624,7 @@ int TLuaInterpreter::setFont(lua_State* L)
     if (!mudlet::self()->getAvailableFonts().contains(fontName, Qt::CaseInsensitive)) {
         // Font not found - try parsing as a static font name with style
         auto [baseName, weight] = host.parseFontNameAndStyle(fontName);
-        
+
         if (mudlet::self()->getAvailableFonts().contains(baseName, Qt::CaseInsensitive)) {
             // Found the base font family, use it with the parsed weight
             effectiveFontName = baseName;
@@ -2963,7 +2969,10 @@ int TLuaInterpreter::setPopup(lua_State* L)
 
     if ((hintList.size() - commandList.size()) < 0 || (hintList.size() - commandList.size()) > 1) {
         lua_pushnil(L);
-        lua_pushfstring(L, "command table and hint table sizes do not match up (%d and %d, either they must be the same or there should be one extra hint) - cannot create popup", commandList.size(), hintList.size());
+        lua_pushfstring(L,
+                        "command table and hint table sizes do not match up (%d and %d, either they must be the same or there should be one extra hint) - cannot create popup",
+                        commandList.size(),
+                        hintList.size());
         return 2;
     }
 
@@ -3025,7 +3034,7 @@ int TLuaInterpreter::setTextFormat(lua_State* L)
 
     const int n = lua_gettop(L);
 
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
 
     QVector<int> colorComponents(6); // 0-2 RGB background, 3-5 RGB foreground
     colorComponents[0] = qRound(qBound(0.0, getVerifiedDouble(L, __func__, 2, "red background color component"), 255.0));
@@ -3042,8 +3051,7 @@ int TLuaInterpreter::setTextFormat(lua_State* L)
     } else if (lua_isnumber(L, s)) {
         bold = !qFuzzyCompare(1.0, 1.0 + lua_tonumber(L, s));
     } else {
-        lua_pushfstring(L, "setTextFormat: bad argument #%d type (bold format as boolean or number {true/non-zero to enable} expected, got %s!)",
-                        s, luaL_typename(L, s));
+        lua_pushfstring(L, "setTextFormat: bad argument #%d type (bold format as boolean or number {true/non-zero to enable} expected, got %s!)", s, luaL_typename(L, s));
         return lua_error(L);
     }
 
@@ -3053,8 +3061,7 @@ int TLuaInterpreter::setTextFormat(lua_State* L)
     } else if (lua_isnumber(L, s)) {
         underline = !qFuzzyCompare(1.0, 1.0 + lua_tonumber(L, s));
     } else {
-        lua_pushfstring(L, "setTextFormat: bad argument #%d type (underline format as boolean or number {true/non-zero to enable} expected, got %s!)",
-                        s, luaL_typename(L, s));
+        lua_pushfstring(L, "setTextFormat: bad argument #%d type (underline format as boolean or number {true/non-zero to enable} expected, got %s!)", s, luaL_typename(L, s));
         return lua_error(L);
     }
 
@@ -3064,8 +3071,7 @@ int TLuaInterpreter::setTextFormat(lua_State* L)
     } else if (lua_isnumber(L, s)) {
         italics = !qFuzzyCompare(1.0, 1.0 + lua_tonumber(L, s));
     } else {
-        lua_pushfstring(L, "setTextFormat: bad argument #%d type (italic format as boolean or number {true/non-zero to enable} expected, got %s!)",
-                        s, luaL_typename(L, s));
+        lua_pushfstring(L, "setTextFormat: bad argument #%d type (italic format as boolean or number {true/non-zero to enable} expected, got %s!)", s, luaL_typename(L, s));
         return lua_error(L);
     }
 
@@ -3078,8 +3084,7 @@ int TLuaInterpreter::setTextFormat(lua_State* L)
         } else if (lua_isnumber(L, s)) {
             strikeout = !qFuzzyCompare(1.0, 1.0 + lua_tonumber(L, s));
         } else {
-            lua_pushfstring(L, "setTextFormat: bad argument #%d type (strikeout format as boolean or number {true/non-zero to enable} is optional, got %s!)",
-                            s, luaL_typename(L, s));
+            lua_pushfstring(L, "setTextFormat: bad argument #%d type (strikeout format as boolean or number {true/non-zero to enable} is optional, got %s!)", s, luaL_typename(L, s));
             return lua_error(L);
         }
     }
@@ -3092,8 +3097,7 @@ int TLuaInterpreter::setTextFormat(lua_State* L)
         } else if (lua_isnumber(L, s)) {
             overline = !qFuzzyCompare(1.0, 1.0 + lua_tonumber(L, s));
         } else {
-            lua_pushfstring(L, "setTextFormat: bad argument #%d type (overline format as boolean or number {true/non-zero to enable} is optional, got %s!)",
-                            s, luaL_typename(L, s));
+            lua_pushfstring(L, "setTextFormat: bad argument #%d type (overline format as boolean or number {true/non-zero to enable} is optional, got %s!)", s, luaL_typename(L, s));
             return lua_error(L);
         }
     }
@@ -3106,23 +3110,16 @@ int TLuaInterpreter::setTextFormat(lua_State* L)
         } else if (lua_isnumber(L, s)) {
             reverse = !qFuzzyCompare(1.0, 1.0 + lua_tonumber(L, s));
         } else {
-            lua_pushfstring(L, "setTextFormat: bad argument #%d type (reverse format as boolean or number {true/non-zero to enable} is optional, got %s!)",
-                            s, luaL_typename(L, s));
+            lua_pushfstring(L, "setTextFormat: bad argument #%d type (reverse format as boolean or number {true/non-zero to enable} is optional, got %s!)", s, luaL_typename(L, s));
             return lua_error(L);
         }
     }
 
-    TChar::AttributeFlags const flags = (bold ? TChar::Bold : TChar::None)
-            | (italics ? TChar::Italic : TChar::None)
-            | (overline ? TChar::Overline : TChar::None)
-            | (reverse ? TChar::Reverse : TChar::None)
-            | (strikeout ? TChar::StrikeOut : TChar::None)
-            | (underline ? TChar::Underline : TChar::None);
+    TChar::AttributeFlags const flags = (bold ? TChar::Bold : TChar::None) | (italics ? TChar::Italic : TChar::None) | (overline ? TChar::Overline : TChar::None)
+                                        | (reverse ? TChar::Reverse : TChar::None) | (strikeout ? TChar::StrikeOut : TChar::None) | (underline ? TChar::Underline : TChar::None);
 
-    if (!host.mpConsole->setTextFormat(windowName,
-                                      QColor(colorComponents.at(3), colorComponents.at(4), colorComponents.at(5)),
-                                      QColor(colorComponents.at(0), colorComponents.at(1), colorComponents.at(2)),
-                                      flags)) {
+    if (!host.mpConsole->setTextFormat(
+                windowName, QColor(colorComponents.at(3), colorComponents.at(4), colorComponents.at(5)), QColor(colorComponents.at(0), colorComponents.at(1), colorComponents.at(2)), flags)) {
         return warnArgumentValue(L, __func__, qsl("window '%1' does not exist").arg(windowName), true);
     }
 
@@ -3185,7 +3182,7 @@ int TLuaInterpreter::setWindow(lua_State* L)
     int x = 0, y = 0;
     bool show = true;
 
-    const QString windowname {WINDOW_NAME(L, 1)};
+    const QString windowname{WINDOW_NAME(L, 1)};
 
     if (lua_type(L, 2) != LUA_TSTRING) {
         lua_pushfstring(L, "setWindow: bad argument #2 type (element name as string expected, got %s!)", luaL_typename(L, 2));
@@ -3224,7 +3221,7 @@ int TLuaInterpreter::setWindowWrap(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setWindowWrapIndent
 int TLuaInterpreter::setWindowWrapIndent(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     const int luaFrom = getVerifiedInt(L, __func__, 2, "wrapTo");
     auto console = CONSOLE(L, windowName);
     console->setIndentCount(luaFrom);
@@ -3234,7 +3231,7 @@ int TLuaInterpreter::setWindowWrapIndent(lua_State* L)
 //Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setWindowWrapHangingIndent
 int TLuaInterpreter::setWindowWrapHangingIndent(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     const int luaFrom = getVerifiedInt(L, __func__, 2, "wrapTo");
     auto console = CONSOLE(L, windowName);
     console->setHangingIndentCount(luaFrom);
@@ -3259,7 +3256,7 @@ int TLuaInterpreter::startMovie(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#showToolBar
 int TLuaInterpreter::showToolBar(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
 
     Host& host = getHostFromLua(L);
     host.getActionUnit()->showToolBar(windowName);
@@ -3474,7 +3471,7 @@ int TLuaInterpreter::pasteWindow(lua_State* L)
         lua_pushfstring(L, "pasteWindow: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     Host& host = getHostFromLua(L);
     host.pasteWindow(windowName);
     return 0;
@@ -3483,7 +3480,7 @@ int TLuaInterpreter::pasteWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableScrolling
 int TLuaInterpreter::enableScrolling(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     if (windowName.compare(qsl("main"), Qt::CaseSensitive) == 0) {
         lua_pushnil(L);
         lua_pushfstring(L, "scrolling cannot be enabled/disabled for the 'main' window", windowName.toUtf8().constData());
@@ -3499,7 +3496,7 @@ int TLuaInterpreter::enableScrolling(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableScrolling
 int TLuaInterpreter::disableScrolling(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     if (windowName.compare(qsl("main"), Qt::CaseSensitive) == 0) {
         lua_pushnil(L);
         lua_pushfstring(L, "scrolling cannot be enabled/disabled for the 'main' window", windowName.toUtf8().constData());
@@ -3515,7 +3512,7 @@ int TLuaInterpreter::disableScrolling(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#scrollingActive
 int TLuaInterpreter::scrollingActive(lua_State* L)
 {
-    const QString windowName {WINDOW_NAME(L, 1)};
+    const QString windowName{WINDOW_NAME(L, 1)};
     if (windowName.compare(qsl("main"), Qt::CaseSensitive) == 0) {
         // Handle the main console case:
         lua_pushboolean(L, true);
@@ -3559,7 +3556,9 @@ int TLuaInterpreter::movieFunc(lua_State* L, const QString& funcName)
         }
         movie->setScaledSize(pN->size());
         if (autoScale) {
-            connect(pN, &TLabel::resized, pN, [=] { movie->setScaledSize(pN->size()); });
+            connect(pN, &TLabel::resized, pN, [=] {
+                movie->setScaledSize(pN->size());
+            });
         } else {
             pN->disconnect(SIGNAL(resized()));
         }

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -270,10 +270,9 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
             logStream << "  <title>" << tr("Mudlet, log from %1 profile").arg(mProfileName) << "</title>\n";
             // Web-page title
             logStream << "  <style type='text/css'>\n";
-            logStream << "   <!-- body { font-family: '" << fontsList.join("', '") << "'; font-size: 100%; line-height: 1.125em; white-space: nowrap; color:rgb("
-                      << mpHost->mFgColor.red() << "," << mpHost->mFgColor.green() << "," << mpHost->mFgColor.blue()
-                      << "); background-color:rgb("
-                      << mpHost->mBgColor.red() << "," << mpHost->mBgColor.green() << "," << mpHost->mBgColor.blue() << ");}\n";
+            logStream << "   <!-- body { font-family: '" << fontsList.join("', '") << "'; font-size: 100%; line-height: 1.125em; white-space: nowrap; color:rgb(" << mpHost->mFgColor.red() << ","
+                      << mpHost->mFgColor.green() << "," << mpHost->mFgColor.blue() << "); background-color:rgb(" << mpHost->mBgColor.red() << "," << mpHost->mBgColor.green() << ","
+                      << mpHost->mBgColor.blue() << ");}\n";
             logStream << "        span { white-space: pre-wrap; } -->\n";
             logStream << "  </style>\n";
             logStream << "  </head>\n";
@@ -302,9 +301,10 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
                 // Put a horizontal line between separate log sessions
                 logStream << "  </div><hr><div>\n";
             }
-            logStream << qsl("<p>%1</p>\n")
-                         //: This is the format argument to QDateTime::toString(...) and needs to follow the rules for that function {literal text must be single quoted} as well as being suitable for the translation locale
-                         .arg(logDateTime.toString(tr("'Log session starting at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'.")));
+            logStream
+                    << qsl("<p>%1</p>\n")
+                               //: This is the format argument to QDateTime::toString(...) and needs to follow the rules for that function {literal text must be single quoted} as well as being suitable for the translation locale
+                               .arg(logDateTime.toString(tr("'Log session starting at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'.")));
             // <div></div> tags required around outside of the body <span></spans> for
             // strict HTML 4 as we do not use <p></p>s or anything else
 
@@ -324,10 +324,10 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
                 // file to not trigger the insertion of this line:
                 mLogStream << qsl("⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯").repeated(8).append(QChar::LineFeed);
             }
-            mLogStream << qsl("%1\n")
-                         //: This is the format argument to QDateTime::toString(...) and needs to follow the rules for that function {literal text must be single quoted} as well as being suitable for the translation locale
-                         .arg(logDateTime.toString(tr("'Log session starting at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'.")));
-
+            mLogStream
+                    << qsl("%1\n")
+                               //: This is the format argument to QDateTime::toString(...) and needs to follow the rules for that function {literal text must be single quoted} as well as being suitable for the translation locale
+                               .arg(logDateTime.toString(tr("'Log session starting at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'.")));
         }
         logButton->setToolTip(utils::richText(tr("Stop logging game output to log file.")));
     } else {
@@ -583,7 +583,6 @@ std::pair<bool, QString> TMainConsole::deleteLabel(const QString& name)
 
     auto pL = mLabelMap.take(name);
     if (pL) {
-
         if (pL->mpMovie) {
             mpHost->getGifTracker()->unregisterGif(pL->mpMovie);
         }
@@ -1008,7 +1007,7 @@ bool TMainConsole::printWindow(const QString& name, const QString& text)
 QSize TMainConsole::getUserWindowSize(const QString& windowname) const
 {
     auto pW = mDockWidgetMap.value(windowname);
-    if (pW){
+    if (pW) {
         const QSize windowSize = pW->widget()->size();
         QSize userWindowSize(windowSize.width(), windowSize.height());
         return userWindowSize;
@@ -1121,7 +1120,8 @@ void TMainConsole::setSystemSpellDictionary(const QString& newDict)
     mpHunspell_system = Hunspell_create(spell_aff.toUtf8().constData(), spell_dic.toUtf8().constData());
     if (mpHunspell_system) {
         mHunspellCodecName_system = QByteArray(Hunspell_get_dic_encoding(mpHunspell_system));
-        qDebug().noquote().nospace() << "TMainConsole::setSystemSpellDictionary(\"" << newDict << "\") INFO - System Hunspell dictionary loaded for profile, it uses a \"" << Hunspell_get_dic_encoding(mpHunspell_system) << "\" encoding...";
+        qDebug().noquote().nospace() << "TMainConsole::setSystemSpellDictionary(\"" << newDict << "\") INFO - System Hunspell dictionary loaded for profile, it uses a \""
+                                     << Hunspell_get_dic_encoding(mpHunspell_system) << "\" encoding...";
     }
 }
 
@@ -1266,17 +1266,14 @@ void TMainConsole::printOnDisplay(std::string& incomingSocketData, const bool is
         The first argument 'N' represents the 'N'etwork latency; the second 'S' the
         'S'ystem (processing) time
         */
-        mpLineEdit_networkLatency->setText(tr("N:%1 S:%2")
-                                                   .arg(mpHost->mTelnet.networkLatencyTime, 0, 'f', 3)
-                                                   .arg(processT, 0, 'f', 3));
+        mpLineEdit_networkLatency->setText(tr("N:%1 S:%2").arg(mpHost->mTelnet.networkLatencyTime, 0, 'f', 3).arg(processT, 0, 'f', 3));
     } else {
         /*:
         The argument 'S' represents the 'S'ystem (processing) time, in this situation
         the Game Server is not sending \"GoAhead\" signals so we cannot deduce the
         network latency...
         */
-        mpLineEdit_networkLatency->setText(tr("<no GA> S:%1")
-                                                   .arg(processT, 0, 'f', 3));
+        mpLineEdit_networkLatency->setText(tr("<no GA> S:%1").arg(processT, 0, 'f', 3));
     }
     // Modify the tab text if this is not the currently active host - this
     // method is only used on the "main" console so no need to filter depending
@@ -1320,9 +1317,8 @@ void TMainConsole::finalize()
 // to the TMap class...?
 bool TMainConsole::saveMap(const QString& location, int saveVersion)
 {
-    const QString filename_map = location.isEmpty() ?
-        mudlet::getMudletPath(enums::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss"))) :
-        location;
+    const QString filename_map =
+            location.isEmpty() ? mudlet::getMudletPath(enums::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss"))) : location;
 
     const QDir dir_map(mudlet::getMudletPath(enums::profileMapsPath, mProfileName));
     if (!dir_map.exists() && !dir_map.mkpath(dir_map.path())) {
@@ -1468,8 +1464,8 @@ bool TMainConsole::importMap(const QString& location, QString* errMsg)
     if (!file.exists()) {
         if (!errMsg) {
             const QString infoMsg = tr("[ ERROR ]  - Map file not found, path and name used was:\n"
-                                 "%1.")
-                                      .arg(filePathNameString);
+                                       "%1.")
+                                            .arg(filePathNameString);
             pHost->postMessage(infoMsg);
         } else {
             // error message for lua loadMap()
@@ -1553,11 +1549,10 @@ void TMainConsole::showStatistics()
         return;
     }
 
-    const QString header = qsl("%1\n").arg(tr(
-        "+--------------------------------------------------------------+\n"
-        "|                      system statistics                       |\n"
-        "+--------------------------------------------------------------+",
-        "Header for the system's statistics information displayed in the console, it is 64 'narrow' characters wide"));
+    const QString header = qsl("%1\n").arg(tr("+--------------------------------------------------------------+\n"
+                                              "|                      system statistics                       |\n"
+                                              "+--------------------------------------------------------------+",
+                                              "Header for the system's statistics information displayed in the console, it is 64 'narrow' characters wide"));
     print(header, QColor(150, 120, 0), Qt::black);
 
     QStringList subjects;
@@ -1596,8 +1591,8 @@ void TMainConsole::showStatistics()
 
     Q_ASSERT_X(subjects.count() == tables.count(), "TMainConsole::showStatistics()", "mismatch in titles and built-in tables to show");
     for (int i = 0, total = subjects.count(); i < total; ++i) {
-        mpHost->mLuaInterpreter.compileAndExecuteScript(qsl("setFgColor(190,150,0); setUnderline(true); echo([[\n\n%1\n]]);setUnderline(false);setFgColor(150,120,0);display( %2 );")
-                                                        .arg(subjects.at(i), tables.at(i)));
+        mpHost->mLuaInterpreter.compileAndExecuteScript(
+                qsl("setFgColor(190,150,0); setUnderline(true); echo([[\n\n%1\n]]);setUnderline(false);setFgColor(150,120,0);display( %2 );").arg(subjects.at(i), tables.at(i)));
     }
 
     const QString itemScript = "setFgColor(190,150,0); setUnderline(true); echo([[\n\n%1\n]]); setBold(false);setUnderline(false);setFgColor(150,120,0)";
@@ -1608,7 +1603,8 @@ void TMainConsole::showStatistics()
 
     //: Heading for the system's statistics information displayed in the console
     mpHost->mLuaInterpreter.compileAndExecuteScript(itemScript.arg(tr("Timer Report:")));
-    itemMsg = std::get<0>(mpHost->getTimerUnit()->assembleReport());;
+    itemMsg = std::get<0>(mpHost->getTimerUnit()->assembleReport());
+    ;
     print(itemMsg, QColor(150, 120, 0), Qt::black);
 
     //: Heading for the system's statistics information displayed in the console
@@ -1690,11 +1686,8 @@ void TMainConsole::closeEvent(QCloseEvent* event)
             auto [ok, filename, error] = mpHost->saveProfile();
 
             if (!ok) {
-                QMessageBox::critical(this,
-                                      tr("Could not save profile"),
-                                      tr("Sorry, could not save your profile as \"%1\" - got the following error: \"%2\".")
-                                              .arg(filename, error),
-                                      QMessageBox::Retry);
+                QMessageBox::critical(
+                        this, tr("Could not save profile"), tr("Sorry, could not save your profile as \"%1\" - got the following error: \"%2\".").arg(filename, error), QMessageBox::Retry);
                 goto ASK_PROFILE;
             }
 
@@ -1703,9 +1696,9 @@ void TMainConsole::closeEvent(QCloseEvent* event)
             ASK_MAP:
                 if (!saveMap(QString())) {
                     const int mapChoice = QMessageBox::warning(this,
-                                          tr("Could not save map"),
-                                          tr("Sorry, could not save the map. Would you like to retry or close without saving the map?"),
-                                          QMessageBox::Retry | QMessageBox::Ignore | QMessageBox::Cancel);
+                                                               tr("Could not save map"),
+                                                               tr("Sorry, could not save the map. Would you like to retry or close without saving the map?"),
+                                                               QMessageBox::Retry | QMessageBox::Ignore | QMessageBox::Cancel);
                     if (mapChoice == QMessageBox::Retry) {
                         goto ASK_MAP;
                     }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -57,8 +57,7 @@ void restoreLabelFontFromUserData(TMapLabel& label, int labelId, QMap<QString, Q
     if (userData.contains(fontKey)) {
         const QStringList fontParts = userData.take(fontKey).split(QLatin1Char('|'));
         if (fontParts.size() == 4) {
-            label.font = QFont(fontParts.at(0), fontParts.at(1).toInt(),
-                               fontParts.at(2).toInt(), fontParts.at(3).toInt() != 0);
+            label.font = QFont(fontParts.at(0), fontParts.at(1).toInt(), fontParts.at(2).toInt(), fontParts.at(3).toInt() != 0);
         } else {
             qWarning("TMap: Failed to parse font data for label %d, expected 4 parts but got %lld", labelId, fontParts.size());
         }
@@ -242,8 +241,7 @@ QString TMap::connectExitStubByDirection(const int fromRoomId, const int dirType
     int meanSquareDistance = 0;
 
     if (!pFromR->exitStubs.contains(dirType)) {
-        return qsl("fromID (%1) does not have an exit stub in the given direction '%2' (%3)")
-                .arg(QString::number(fromRoomId), TRoom::dirCodeToString(dirType), QString::number(dirType));
+        return qsl("fromID (%1) does not have an exit stub in the given direction '%2' (%3)").arg(QString::number(fromRoomId), TRoom::dirCodeToString(dirType), QString::number(dirType));
     }
 
     const int reverseDir = scmReverseDirections.value(dirType);
@@ -341,7 +339,8 @@ QString TMap::connectExitStubByDirection(const int fromRoomId, const int dirType
         return {};
     }
 
-    return qsl("fromID (%1) does not have another room in the indicated direction '%2' (%3) with an exit stub in the reverse direction to connect to in its area").arg(QString::number(fromRoomId), TRoom::dirCodeToString(dirType), QString::number(dirType));
+    return qsl("fromID (%1) does not have another room in the indicated direction '%2' (%3) with an exit stub in the reverse direction to connect to in its area")
+            .arg(QString::number(fromRoomId), TRoom::dirCodeToString(dirType), QString::number(dirType));
 }
 
 // Will connect an exit stub from the fromRoomId numbered room to the toRoomId
@@ -437,8 +436,7 @@ QString TMap::connectExitStubByDirectionAndToId(const int fromRoomId, const int 
     }
 
     if (!pFromR->exitStubs.contains(dirType)) {
-        return qsl("fromID (%1) does not have an exit stub in the given direction '%2' (%3)")
-                .arg(QString::number(fromRoomId), TRoom::dirCodeToString(dirType), QString::number(dirType));
+        return qsl("fromID (%1) does not have an exit stub in the given direction '%2' (%3)").arg(QString::number(fromRoomId), TRoom::dirCodeToString(dirType), QString::number(dirType));
     }
 
     auto pToR = mpRoomDB->getRoom(toRoomId);
@@ -841,14 +839,7 @@ void TMap::initGraph()
         while (itSpecialExit.hasNext()) {
             itSpecialExit.next();
 
-            addDirectionalRoute(bestRoutes,
-                                exitWeights,
-                                source,
-                                pSourceR,
-                                itSpecialExit.value(),
-                                DIR_OTHER,
-                                itSpecialExit.key(),
-                                unUsableRoomSet);
+            addDirectionalRoute(bestRoutes, exitWeights, source, pSourceR, itSpecialExit.value(), DIR_OTHER, itSpecialExit.key(), unUsableRoomSet);
         } // End of while(itSpecialExit.hasNext())
 
         // Now we have eliminated possible duplicate and useless edges we can create and
@@ -977,9 +968,7 @@ bool TMap::findPath(int from, int to)
     }
 
     if (static_cast<std::size_t>(start) >= vertexCount || static_cast<std::size_t>(goal) >= vertexCount) {
-        qWarning().nospace().noquote() << "TMap::findPath(" << from << "," << to
-                                       << ") FAIL: start or target vertex outside of graph range (vertexCount=" << vertexCount
-                                       << ").";
+        qWarning().nospace().noquote() << "TMap::findPath(" << from << "," << to << ") FAIL: start or target vertex outside of graph range (vertexCount=" << vertexCount << ").";
         return false;
     }
 
@@ -1035,20 +1024,48 @@ bool TMap::findPath(int from, int to)
                  * accommodate all the possible languages the GUI of Mudlet was
                  * configured to support!
                  */
-            case DIR_NORTH:        mDirList.prepend(qsl("n"));             break;
-            case DIR_NORTHEAST:    mDirList.prepend(qsl("ne"));            break;
-            case DIR_EAST:         mDirList.prepend(qsl("e"));             break;
-            case DIR_SOUTHEAST:    mDirList.prepend(qsl("se"));            break;
-            case DIR_SOUTH:        mDirList.prepend(qsl("s"));             break;
-            case DIR_SOUTHWEST:    mDirList.prepend(qsl("sw"));            break;
-            case DIR_WEST:         mDirList.prepend(qsl("w"));             break;
-            case DIR_NORTHWEST:    mDirList.prepend(qsl("nw"));            break;
-            case DIR_UP:           mDirList.prepend(qsl("up"));            break;
-            case DIR_DOWN:         mDirList.prepend(qsl("down"));          break;
-            case DIR_IN:           mDirList.prepend(qsl("in"));            break;
-            case DIR_OUT:          mDirList.prepend(qsl("out"));           break;
-            case DIR_OTHER:        mDirList.prepend(r.specialExitName);    break;
-            default:            qWarning().nospace().noquote() << "TMap::findPath(" << from << ", " << to << ") WARNING - found route between rooms (from id: " << previousRoomId << ", to id: " << currentRoomId << ") with an invalid DIR_xxxx code: " << r.direction << " - the path will not be valid!";
+            case DIR_NORTH:
+                mDirList.prepend(qsl("n"));
+                break;
+            case DIR_NORTHEAST:
+                mDirList.prepend(qsl("ne"));
+                break;
+            case DIR_EAST:
+                mDirList.prepend(qsl("e"));
+                break;
+            case DIR_SOUTHEAST:
+                mDirList.prepend(qsl("se"));
+                break;
+            case DIR_SOUTH:
+                mDirList.prepend(qsl("s"));
+                break;
+            case DIR_SOUTHWEST:
+                mDirList.prepend(qsl("sw"));
+                break;
+            case DIR_WEST:
+                mDirList.prepend(qsl("w"));
+                break;
+            case DIR_NORTHWEST:
+                mDirList.prepend(qsl("nw"));
+                break;
+            case DIR_UP:
+                mDirList.prepend(qsl("up"));
+                break;
+            case DIR_DOWN:
+                mDirList.prepend(qsl("down"));
+                break;
+            case DIR_IN:
+                mDirList.prepend(qsl("in"));
+                break;
+            case DIR_OUT:
+                mDirList.prepend(qsl("out"));
+                break;
+            case DIR_OTHER:
+                mDirList.prepend(r.specialExitName);
+                break;
+            default:
+                qWarning().nospace().noquote() << "TMap::findPath(" << from << ", " << to << ") WARNING - found route between rooms (from id: " << previousRoomId << ", to id: " << currentRoomId
+                                               << ") with an invalid DIR_xxxx code: " << r.direction << " - the path will not be valid!";
             }
             currentVertex = previousVertex;
             currentRoomId = previousRoomId;
@@ -1070,8 +1087,8 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
     } else if (saveVersion > mMaxVersion) {
         saveVersion = mMaxVersion;
         const QString errMsg = tr("[ ERROR ] - The format version \"%1\" you are trying to save the map with is too new\n"
-                             "for this version of Mudlet. Supported are only formats up to version %2.")
-                                 .arg(QString::number(saveVersion), QString::number(mMaxVersion));
+                                  "for this version of Mudlet. Supported are only formats up to version %2.")
+                                       .arg(QString::number(saveVersion), QString::number(mMaxVersion));
         appendErrorMsgWithNoLf(errMsg, false);
         postMessage(errMsg);
         return false;
@@ -1086,19 +1103,19 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
 
     if (mSaveVersion != mVersion) {
         const QString message = tr("[ ALERT ] - Saving map in format version \"%1\" that is different than \"%2\" which\n"
-                             "it was loaded as. This may be an issue if you want to share the resulting\n"
-                             "map with others relying on the original format.")
-                                  .arg(mSaveVersion)
-                                  .arg(mVersion);
+                                   "it was loaded as. This may be an issue if you want to share the resulting\n"
+                                   "map with others relying on the original format.")
+                                        .arg(mSaveVersion)
+                                        .arg(mVersion);
         appendErrorMsgWithNoLf(message, false);
         mpHost->mTelnet.postMessage(message);
     }
 
     if (mSaveVersion != mDefaultVersion) {
         const QString message = tr("[ WARN ]  - Saving map in format version \"%1\" different from the\n"
-                             "recommended map version %2 for this version of Mudlet.")
-                                  .arg(mSaveVersion)
-                                  .arg(mDefaultVersion);
+                                   "recommended map version %2 for this version of Mudlet.")
+                                        .arg(mSaveVersion)
+                                        .arg(mDefaultVersion);
         appendErrorMsgWithNoLf(message, false);
         postMessage(message);
     }
@@ -1170,15 +1187,10 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
             const auto label = pA->mMapLabels.value(labelID);
             if (!label.font.family().isEmpty()) {
                 if (label.font.family().contains(QLatin1Char('|'))) {
-                    qWarning("TMap::serialize() - Font family '%s' for label %d contains pipe character, font may not deserialize correctly",
-                             qUtf8Printable(label.font.family()), labelID);
+                    qWarning("TMap::serialize() - Font family '%s' for label %d contains pipe character, font may not deserialize correctly", qUtf8Printable(label.font.family()), labelID);
                 }
                 const QString fontKey = qsl("system.labelFont_%1").arg(labelID);
-                const QString fontValue = qsl("%1|%2|%3|%4")
-                    .arg(label.font.family())
-                    .arg(label.font.pointSize())
-                    .arg(label.font.weight())
-                    .arg(label.font.italic() ? 1 : 0);
+                const QString fontValue = qsl("%1|%2|%3|%4").arg(label.font.family()).arg(label.font.pointSize()).arg(label.font.weight()).arg(label.font.italic() ? 1 : 0);
                 pA->mUserData.insert(fontKey, fontValue);
             }
         }
@@ -1221,7 +1233,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
         QMap<int, TArea*> areasWithPermanentLabels;
         // Need to count the areas that have mapLabels:
         QMapIterator<int, TArea*> itArea(mpRoomDB->getAreaMap());
-        while (itArea.hasNext()){
+        while (itArea.hasNext()) {
             // Now we have temporary labels we need to identify areas with
             // permanent ones:
             itArea.next();
@@ -1301,11 +1313,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
             QMapIterator<QString, int> itSpecialExit(pR->getSpecialExits());
             while (itSpecialExit.hasNext()) {
                 itSpecialExit.next();
-                oldSpecialExits.insert(itSpecialExit.value(),
-                                       (pR->hasSpecialExitLock(itSpecialExit.key())
-                                                ? QLatin1Char('1')
-                                                : QLatin1Char('0'))
-                                               % itSpecialExit.key());
+                oldSpecialExits.insert(itSpecialExit.value(), (pR->hasSpecialExitLock(itSpecialExit.key()) ? QLatin1Char('1') : QLatin1Char('0')) % itSpecialExit.key());
             }
             ofs << oldSpecialExits;
         }
@@ -1365,13 +1373,8 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
                 itCustomLine.next();
                 const QString direction(itCustomLine.key());
                 if (direction == QLatin1String("n") || direction == QLatin1String("e") || direction == QLatin1String("s") || direction == QLatin1String("w") || direction == QLatin1String("up")
-                    || direction == QLatin1String("down")
-                    || direction == QLatin1String("ne")
-                    || direction == QLatin1String("se")
-                    || direction == QLatin1String("sw")
-                    || direction == QLatin1String("nw")
-                    || direction == QLatin1String("in")
-                    || direction == QLatin1String("out")) {
+                    || direction == QLatin1String("down") || direction == QLatin1String("ne") || direction == QLatin1String("se") || direction == QLatin1String("sw")
+                    || direction == QLatin1String("nw") || direction == QLatin1String("in") || direction == QLatin1String("out")) {
                     oldLinesData.insert(itCustomLine.key().toUpper(), itCustomLine.value());
                 } else {
                     oldLinesData.insert(itCustomLine.key(), itCustomLine.value());
@@ -1385,13 +1388,8 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
                 itCustomLineArrow.next();
                 const QString direction(itCustomLineArrow.key());
                 if (direction == QLatin1String("n") || direction == QLatin1String("e") || direction == QLatin1String("s") || direction == QLatin1String("w") || direction == QLatin1String("up")
-                    || direction == QLatin1String("down")
-                    || direction == QLatin1String("ne")
-                    || direction == QLatin1String("se")
-                    || direction == QLatin1String("sw")
-                    || direction == QLatin1String("nw")
-                    || direction == QLatin1String("in")
-                    || direction == QLatin1String("out")) {
+                    || direction == QLatin1String("down") || direction == QLatin1String("ne") || direction == QLatin1String("se") || direction == QLatin1String("sw")
+                    || direction == QLatin1String("nw") || direction == QLatin1String("in") || direction == QLatin1String("out")) {
                     oldLinesArrowData.insert(itCustomLineArrow.key().toUpper(), itCustomLineArrow.value());
                 } else {
                     oldLinesArrowData.insert(itCustomLineArrow.key(), itCustomLineArrow.value());
@@ -1407,13 +1405,8 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
                 QList<int> colorComponents;
                 colorComponents << itCustomLineColor.value().red() << itCustomLineColor.value().green() << itCustomLineColor.value().blue();
                 if (direction == QLatin1String("n") || direction == QLatin1String("e") || direction == QLatin1String("s") || direction == QLatin1String("w") || direction == QLatin1String("up")
-                    || direction == QLatin1String("down")
-                    || direction == QLatin1String("ne")
-                    || direction == QLatin1String("se")
-                    || direction == QLatin1String("sw")
-                    || direction == QLatin1String("nw")
-                    || direction == QLatin1String("in")
-                    || direction == QLatin1String("out")) {
+                    || direction == QLatin1String("down") || direction == QLatin1String("ne") || direction == QLatin1String("se") || direction == QLatin1String("sw")
+                    || direction == QLatin1String("nw") || direction == QLatin1String("in") || direction == QLatin1String("out")) {
                     oldLinesColorData.insert(itCustomLineColor.key().toUpper(), colorComponents);
                 } else {
                     oldLinesColorData.insert(itCustomLineColor.key(), colorComponents);
@@ -1427,13 +1420,8 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
                 itCustomLineStyle.next();
                 QString direction(itCustomLineStyle.key());
                 if (direction == QLatin1String("n") || direction == QLatin1String("e") || direction == QLatin1String("s") || direction == QLatin1String("w") || direction == QLatin1String("up")
-                    || direction == QLatin1String("down")
-                    || direction == QLatin1String("ne")
-                    || direction == QLatin1String("se")
-                    || direction == QLatin1String("sw")
-                    || direction == QLatin1String("nw")
-                    || direction == QLatin1String("in")
-                    || direction == QLatin1String("out")) {
+                    || direction == QLatin1String("down") || direction == QLatin1String("ne") || direction == QLatin1String("se") || direction == QLatin1String("sw")
+                    || direction == QLatin1String("nw") || direction == QLatin1String("in") || direction == QLatin1String("out")) {
                     direction = direction.toUpper();
                 }
                 switch (itCustomLineStyle.value()) {
@@ -1502,10 +1490,10 @@ bool TMap::validatePotentialMapFile(QFile& file, QDataStream& ifs)
     ifs >> version;
     if ((version < 1) || (version > 127)) {
         const QString errMsg = tr("[ ALERT ] - File does not seem to be a Mudlet Map file. The part that indicates\n"
-                            "its format version seems to be \"%1\" and that doesn't make sense. The file is:\n"
-                            "\"%2\".")
-                                 .arg(version)
-                                 .arg(file.fileName());
+                                  "its format version seems to be \"%1\" and that doesn't make sense. The file is:\n"
+                                  "\"%2\".")
+                                       .arg(version)
+                                       .arg(file.fileName());
         appendErrorMsgWithNoLf(errMsg);
         postMessage(errMsg);
         const QString infoMsg = tr("[ INFO ]  - Ignoring this unlikely map file.");
@@ -1517,10 +1505,10 @@ bool TMap::validatePotentialMapFile(QFile& file, QDataStream& ifs)
     }
     if (version > mMaxVersion) {
         const QString errMsg = tr("[ ALERT ] - Map file is too new. Its format version \"%1\" is higher than this version of\n"
-                            "Mudlet can handle (%2)! The file is:\n\"%3\".")
-                                 .arg(version)
-                                 .arg(mMaxVersion)
-                                 .arg(file.fileName());
+                                  "Mudlet can handle (%2)! The file is:\n\"%3\".")
+                                       .arg(version)
+                                       .arg(mMaxVersion)
+                                       .arg(file.fileName());
         appendErrorMsgWithNoLf(errMsg);
         postMessage(errMsg);
         const QString infoMsg = tr("[ INFO ]  - You will need to update your Mudlet to read the map file.");
@@ -1533,22 +1521,24 @@ bool TMap::validatePotentialMapFile(QFile& file, QDataStream& ifs)
 
     if (version < 4) {
         const QString alertMsg = tr("[ ALERT ] - Map file is really old. Its format version \"%1\" is so ancient that\n"
-                              "this version of Mudlet may not gain enough information from\n"
-                              "it but it will try! The file is: \"%2\".")
-                                   .arg(version)
-                                   .arg(file.fileName());
+                                    "this version of Mudlet may not gain enough information from\n"
+                                    "it but it will try! The file is: \"%2\".")
+                                         .arg(version)
+                                         .arg(file.fileName());
         appendErrorMsgWithNoLf(alertMsg, false);
         postMessage(alertMsg);
         const QString infoMsg = tr("[ INFO ]  - You might wish to donate THIS map file to the Mudlet Museum!\n"
-                             "There is so much data that it DOES NOT have that you could be\n"
-                             "better off starting again...");
+                                   "There is so much data that it DOES NOT have that you could be\n"
+                                   "better off starting again...");
         appendErrorMsgWithNoLf(infoMsg, false);
         postMessage(infoMsg);
     } else {
         // Less than (but not less than 4) or equal to default version
         const QString infoMsg = tr("[ INFO ]  - Reading map. Format version: %1. File:\n"
-                             "\"%2\",\n"
-                             "please wait...").arg(version).arg(file.fileName());
+                                   "\"%2\",\n"
+                                   "please wait...")
+                                        .arg(version)
+                                        .arg(file.fileName());
         appendErrorMsg(tr(R"([ INFO ]  - Reading map. Format version: %1. File: "%2".)").arg(version).arg(file.fileName()), false);
         postMessage(infoMsg);
     }
@@ -1601,23 +1591,24 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
 
             } else {
                 if (auto [isOk, message] = readJsonMapFile(fileName, true); !isOk) {
-                   // Failed to read the JSON file
-                   const QString errMsg = tr("[ ALERT ] - Failed to load a Mudlet JSON Map file, reason:\n"
-                                       "%1; the file is:\n"
-                                       "\"%2\".").arg(message, fileName);
-                   appendErrorMsgWithNoLf(errMsg);
-                   postMessage(errMsg);
-                   const QString infoMsg = tr("[ INFO ]  - Ignoring this map file.");
-                   appendErrorMsgWithNoLf(infoMsg);
-                   postMessage(infoMsg);
-               } else {
-                   // immediately leave on success:
-                   return true;
-               }
-           }
+                    // Failed to read the JSON file
+                    const QString errMsg = tr("[ ALERT ] - Failed to load a Mudlet JSON Map file, reason:\n"
+                                              "%1; the file is:\n"
+                                              "\"%2\".")
+                                                   .arg(message, fileName);
+                    appendErrorMsgWithNoLf(errMsg);
+                    postMessage(errMsg);
+                    const QString infoMsg = tr("[ INFO ]  - Ignoring this map file.");
+                    appendErrorMsgWithNoLf(infoMsg);
+                    postMessage(infoMsg);
+                } else {
+                    // immediately leave on success:
+                    return true;
+                }
+            }
 
-           // Allow for somethings to be updated - especially on Windows?
-           qApp->processEvents();
+            // Allow for somethings to be updated - especially on Windows?
+            qApp->processEvents();
         } else {
             file.setFileName(location);
             if (validatePotentialMapFile(file, ifs)) {
@@ -1695,10 +1686,8 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
             }
         }
 
-        mMapSymbolFont.setStyleStrategy(static_cast<QFont::StyleStrategy>((mIsOnlyMapSymbolFontToBeUsed ? QFont::NoFontMerging : 0)
-                                                                          |QFont::PreferOutline | QFont::PreferAntialias | QFont::PreferQuality
-                                                                          |QFont::PreferNoShaping
-                                                                          ));
+        mMapSymbolFont.setStyleStrategy(static_cast<QFont::StyleStrategy>((mIsOnlyMapSymbolFontToBeUsed ? QFont::NoFontMerging : 0) | QFont::PreferOutline | QFont::PreferAntialias
+                                                                          | QFont::PreferQuality | QFont::PreferNoShaping));
         if (mVersion >= 14) {
             int areaSize = 0;
             ifs >> areaSize;
@@ -1781,7 +1770,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
             auto pDefaultA = new TArea(this, mpRoomDB);
             mpRoomDB->restoreSingleArea(-1, pDefaultA);
             const QString defaultAreaInsertionMsg = tr("[ INFO ]  - Default (reset) area (for rooms that have not been assigned to an\n"
-                                                 "area) not found, adding reserved -1 id.");
+                                                       "area) not found, adding reserved -1 id.");
             appendErrorMsgWithNoLf(defaultAreaInsertionMsg, false);
             if (mudlet::self()->showMapAuditErrors()) {
                 postMessage(defaultAreaInsertionMsg);
@@ -1861,8 +1850,8 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
         restore16ColorSet();
 
         const QString okMsg = tr("[ INFO ]  - Successfully read the map file (%1s), checking some\n"
-                           "consistency details..." )
-                                .arg(_time.nsecsElapsed() * 1.0e-9, 0, 'f', 2);
+                                 "consistency details...")
+                                      .arg(_time.nsecsElapsed() * 1.0e-9, 0, 'f', 2);
 
         postMessage(okMsg);
         appendErrorMsgWithNoLf(okMsg);
@@ -2144,7 +2133,20 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
 }
 
 //NOLINT(readability-make-member-function-const)
-int TMap::createMapLabel(int area, const QString& text, float x, float y, float z, QColor fg, QColor bg, bool showOnTop, bool noScaling, bool temporary, qreal zoom, int fontSize, std::optional<QString> fontName, QColor outline)
+int TMap::createMapLabel(int area,
+                         const QString& text,
+                         float x,
+                         float y,
+                         float z,
+                         QColor fg,
+                         QColor bg,
+                         bool showOnTop,
+                         bool noScaling,
+                         bool temporary,
+                         qreal zoom,
+                         int fontSize,
+                         std::optional<QString> fontName,
+                         QColor outline)
 {
     auto pA = mpRoomDB->getArea(area);
     if (!pA) {
@@ -2240,7 +2242,7 @@ int TMap::createMapImageLabel(int area, QString imagePath, float x, float y, flo
     label.pix = pix;
 
     const int labelId = pA->createLabelId();
-    if (Q_LIKELY(labelId >=0)) {
+    if (Q_LIKELY(labelId >= 0)) {
         pA->mMapLabels.insert(labelId, label);
         if (mpMapper) {
             mpMapper->mp2dMap->update();
@@ -2425,7 +2427,7 @@ void TMap::pushErrorMessagesToFile(const QString title, const bool isACleanup)
                        "\"%1\"\n"
                        "- look for the (last) report with the title:\n"
                        "\"%2\".")
-                    .arg(mudlet::getMudletPath(enums::profileLogErrorsFilePath, mProfileName), title));
+                            .arg(mudlet::getMudletPath(enums::profileLogErrorsFilePath, mProfileName), title));
     } else if (mIsFileViewingRecommended && mudlet::self()->showMapAuditErrors()) {
         postMessage(tr("[ INFO ]  - The equivalent to the above information about that last map\n"
                        "operation has been saved for review as the most recent report in\n"
@@ -2433,7 +2435,7 @@ void TMap::pushErrorMessagesToFile(const QString title, const bool isACleanup)
                        "\"%1\"\n"
                        "- look for the (last) report with the title:\n"
                        "\"%2\".")
-                    .arg(mudlet::getMudletPath(enums::profileLogErrorsFilePath, mProfileName), title));
+                            .arg(mudlet::getMudletPath(enums::profileLogErrorsFilePath, mProfileName), title));
     }
 
     mIsFileViewingRecommended = false;
@@ -2449,8 +2451,8 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     // Incidentally this should address: https://bugs.launchpad.net/mudlet/+bug/852861
     if (mImportRunning) {
         const QString warnMsg = tr("[ WARN ]  - Attempt made to download an XML map when one has already been\n"
-                                         "requested or is being imported from a local file - wait for that\n"
-                                         "operation to complete (if it cannot be canceled) before retrying!");
+                                   "requested or is being imported from a local file - wait for that\n"
+                                   "operation to complete (if it cannot be canceled) before retrying!");
         postMessage(warnMsg);
         return;
     }
@@ -2470,10 +2472,10 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
 
     if (!url.isValid()) {
         const QString errMsg = tr("[ WARN ]  - Attempt made to download an XML from an invalid URL.  The URL was:\n"
-                                        "%1\n"
-                                        "and the error message (may contain technical details) was:"
-                                        "\"%2\".")
-                                 .arg(url.toString(), url.errorString());
+                                  "%1\n"
+                                  "and the error message (may contain technical details) was:"
+                                  "\"%2\".")
+                                       .arg(url.toString(), url.errorString());
         postMessage(errMsg);
         mImportRunning = false;
         return;
@@ -2484,10 +2486,10 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     const QString toProfileDirPathString = mudlet::getMudletPath(enums::profileMapsPath, mProfileName);
     if (!toProfileDir.mkpath(toProfileDirPathString)) {
         const QString errMsg = tr("[ ERROR ] - Unable to use or create directory to store map.\n"
-                            "Please check that you have permissions/access to:\n"
-                            "\"%1\"\n"
-                            "and there is enough space. The download operation has failed.")
-                                    .arg(toProfileDirPathString);
+                                  "Please check that you have permissions/access to:\n"
+                                  "\"%1\"\n"
+                                  "and there is enough space. The download operation has failed.")
+                                       .arg(toProfileDirPathString);
         pHost->postMessage(errMsg);
         mImportRunning = false;
         return;
@@ -2518,8 +2520,7 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     // Using zero for both min and max values should cause the bar to oscillate
     // until the first update
     //: %1 is the name of the current Mudlet profile
-    mpProgressDialog = new QProgressDialog(tr("Downloading map file for use in %1...")
-                                              .arg(mProfileName), tr("Abort"), 0, 0);
+    mpProgressDialog = new QProgressDialog(tr("Downloading map file for use in %1...").arg(mProfileName), tr("Abort"), 0, 0);
     //: This is a title of a progress window.
     mpProgressDialog->setWindowTitle(tr("Map download"));
     mpProgressDialog->setWindowIcon(QIcon(qsl(":/icons/mudlet_map_download.png")));
@@ -2550,8 +2551,8 @@ bool TMap::importMap(QFile& file, QString* errMsg)
                          "imported at user request.");
         } else {
             const QString warnMsg = qsl("[ WARN ]  - Attempt made to import an XML map when one is already being\n"
-                                             "downloaded or is being imported from a local file - wait for that\n"
-                                             "operation to complete (if it cannot be canceled) before retrying!");
+                                        "downloaded or is being imported from a local file - wait for that\n"
+                                        "operation to complete (if it cannot be canceled) before retrying!");
             postMessage(warnMsg);
         }
         return false;
@@ -2625,7 +2626,7 @@ bool TMap::readXmlMapFile(QFile& file, QString* errMsg)
     }
 
     if (!mpMapper.isNull()) {
-         mpMapper->show();
+        mpMapper->show();
     }
 
     return success;
@@ -2677,7 +2678,7 @@ void TMap::slot_downloadError(QNetworkReply::NetworkError error)
 
 void TMap::slot_replyFinished(QNetworkReply* reply)
 {
-    auto cleanup = [this, reply](){
+    auto cleanup = [this, reply]() {
         reply->deleteLater();
         mpNetworkReply = nullptr;
 
@@ -2762,7 +2763,7 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
     }
 
     if (parsingWasSuccessful) {
-        TEvent mapDownloadEvent {};
+        TEvent mapDownloadEvent{};
         mapDownloadEvent.mArgumentList.append(qsl("sysMapDownloadEvent"));
         mapDownloadEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         pHost->raiseEvent(mapDownloadEvent);
@@ -2815,7 +2816,7 @@ QHash<QString, QSet<int>> TMap::roomSymbolsHash()
     return results;
 }
 
-void TMap::setMmpMapLocation(const QString &location)
+void TMap::setMmpMapLocation(const QString& location)
 {
     mMmpMapLocation = location;
 
@@ -2890,13 +2891,13 @@ std::pair<bool, QString> TMap::writeJsonMapFile(const QString& dest)
 
     mpProgressDialog = new QProgressDialog(tr("Exporting JSON map data from %1\n"
                                               "Areas: %2 of: %3   Rooms: %4 of: %5   Labels: %6 of: %7...")
-                                           .arg(mProfileName,
-                                                QLatin1String("0"),
-                                                QString::number(mProgressDialogAreasTotal),
-                                                QLatin1String("0"),
-                                                QString::number(mProgressDialogRoomsTotal),
-                                                QLatin1String("0"),
-                                                QString::number(mProgressDialogLabelsTotal)),
+                                                   .arg(mProfileName,
+                                                        QLatin1String("0"),
+                                                        QString::number(mProgressDialogAreasTotal),
+                                                        QLatin1String("0"),
+                                                        QString::number(mProgressDialogRoomsTotal),
+                                                        QLatin1String("0"),
+                                                        QString::number(mProgressDialogLabelsTotal)),
                                            tr("Abort"),
                                            0,
                                            mProgressDialogRoomsTotal,
@@ -2912,7 +2913,7 @@ std::pair<bool, QString> TMap::writeJsonMapFile(const QString& dest)
     mpProgressDialog->setMinimumDuration(1); // Normally waits for 4 seconds before showing
     qApp->processEvents();
     QSaveFile file(destination);
-    if (!file.open(QFile::OpenMode(QFile::Text|QFile::WriteOnly))) {
+    if (!file.open(QFile::OpenMode(QFile::Text | QFile::WriteOnly))) {
         qWarning().noquote().nospace() << "TMap::writeJsonMapFile(...) WARNING - Could not open save file \"" << destination << "\".";
         mpProgressDialog->setAttribute(Qt::WA_DeleteOnClose, true);
         mpProgressDialog->close();
@@ -3034,7 +3035,8 @@ std::pair<bool, QString> TMap::writeJsonMapFile(const QString& dest)
     mapObj.insert(QLatin1String("playerRoomInnerDiameterPercentage"), static_cast<double>(mPlayerRoomInnerDiameterPercentage));
 
     mpProgressDialog->setLabelText(tr("Exporting JSON map file from %1 - writing data to file:\n"
-                                      "%2 ...").arg(mProfileName, destination));
+                                      "%2 ...")
+                                           .arg(mProfileName, destination));
     mpProgressDialog->setValue(0);
     // Hide the cancel button as we can't stop now:
     mpProgressDialog->setCancelButton(nullptr);
@@ -3047,8 +3049,7 @@ std::pair<bool, QString> TMap::writeJsonMapFile(const QString& dest)
     mpProgressDialog->close();
     mpProgressDialog = nullptr;
 
-    return {file.error() == QFileDevice::NoError,
-                ((file.error() == QFileDevice::NoError) ? QString() : qsl("could not export file, reason: %1").arg(file.errorString()))};
+    return {file.error() == QFileDevice::NoError, ((file.error() == QFileDevice::NoError) ? QString() : qsl("could not export file, reason: %1").arg(file.errorString()))};
 }
 
 // The translatable messages are used within this file and do not need to
@@ -3060,17 +3061,13 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
     const QString oldUnnamedName{mUnnamedAreaName};
 
     if (mpProgressDialog) {
-        return {false, (translatableTexts
-                    ? tr("import or export already in progress")
-                    : qsl("import or export already in progress"))};
+        return {false, (translatableTexts ? tr("import or export already in progress") : qsl("import or export already in progress"))};
     }
 
     QFile file(source);
     if (!file.open(QFile::ReadOnly)) {
         qWarning().noquote().nospace() << "TMap::readJsonMapFile(...) WARNING - Could not open JSON file \"" << source << "\".";
-        return {false, (translatableTexts
-                    ? tr("could not open file")
-                    : qsl("could not open file \"%1\"").arg(source))};
+        return {false, (translatableTexts ? tr("could not open file") : qsl("could not open file \"%1\"").arg(source))};
     }
 
     const QByteArray mapData = file.readAll();
@@ -3078,18 +3075,14 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
     QJsonParseError jsonErr;
     const QJsonDocument doc(QJsonDocument::fromJson(mapData, &jsonErr));
     if (jsonErr.error != QJsonParseError::NoError) {
-        return {false, (translatableTexts
-                    ? tr("could not parse file, reason: \"%1\" at offset %2")
-                      .arg(jsonErr.errorString(), QString::number(jsonErr.offset))
-                    : qsl("could not parse file \"%1\", reason: \"%2\" at offset %3")
-                      .arg(source, jsonErr.errorString(), QString::number(jsonErr.offset)))};
+        return {false,
+                (translatableTexts ? tr("could not parse file, reason: \"%1\" at offset %2").arg(jsonErr.errorString(), QString::number(jsonErr.offset))
+                                   : qsl("could not parse file \"%1\", reason: \"%2\" at offset %3").arg(source, jsonErr.errorString(), QString::number(jsonErr.offset)))};
     }
 
     if (doc.isEmpty()) {
         qDebug().nospace().noquote() << "TMap::readJsonMapFile(\"" << source << "\") INFO - no Json file data detected, this is not a Mudlet JSON map file.";
-        return {false, (translatableTexts
-                    ? tr("empty Json file, no map data detected")
-                    : qsl("empty Json file, no map data detected"))};
+        return {false, (translatableTexts ? tr("empty Json file, no map data detected") : qsl("empty Json file, no map data detected"))};
     }
 
     // Read all the base level stuff:
@@ -3102,21 +3095,17 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
             // didn't include room symbol color, 0.003 is the same as 1.000
             // but the numbered was changed for release into the wild):
             qDebug().nospace().noquote() << "TMap::readJsonMapFile(\"" << source << "\") INFO - Version information \"" << formatVersion << "\" was found, and it is not okay.";
-            return {false, (translatableTexts
-                        ? tr("invalid format version \"%1\" detected").arg(formatVersion, 0, 'f', 3, QLatin1Char('0'))
-                        : qsl("invalid format version \"%1\" detected").arg(formatVersion, 0, 'f', 3, QLatin1Char('0')))};
+            return {false,
+                    (translatableTexts ? tr("invalid format version \"%1\" detected").arg(formatVersion, 0, 'f', 3, QLatin1Char('0'))
+                                       : qsl("invalid format version \"%1\" detected").arg(formatVersion, 0, 'f', 3, QLatin1Char('0')))};
         }
     } else {
         qDebug().nospace().noquote() << "TMap::readJsonMapFile(\"" << source << "\") INFO - Version information was not found. This is not likely to be a Mudlet JSON map file.";
-        return {false, (translatableTexts
-                    ? tr("no format version detected")
-                    : qsl("no format version detected"))};
+        return {false, (translatableTexts ? tr("no format version detected") : qsl("no format version detected"))};
     }
 
     if (!mapObj.contains(QLatin1String("areas")) || !mapObj.value(QLatin1String("areas")).isArray()) {
-        return {false, (translatableTexts
-                    ? tr("no areas detected")
-                    : qsl("no areas detected"))};
+        return {false, (translatableTexts ? tr("no areas detected") : qsl("no areas detected"))};
     }
 
     mProgressDialogAreasTotal = qRound(mapObj[QLatin1String("areaCount")].toDouble());
@@ -3194,9 +3183,8 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
                 const QJsonObject customEnvColorObj{customEnvColorValue.toObject()};
                 if (customEnvColorObj.contains(QLatin1String("id"))
                     && ((customEnvColorObj.contains(QLatin1String("color32RGBA")) && customEnvColorObj.value(QLatin1String("color32RGBA")).isArray())
-                        ||(customEnvColorObj.contains(QLatin1String("color24RGB")) && customEnvColorObj.value(QLatin1String("color24RGB")).isArray()))
+                        || (customEnvColorObj.contains(QLatin1String("color24RGB")) && customEnvColorObj.value(QLatin1String("color24RGB")).isArray()))
                     && customEnvColorObj.value(QLatin1String("id")).isDouble()) {
-
                     const int id{customEnvColorObj.value(QLatin1String("id")).toInt()};
                     const QColor color{readJsonColor(customEnvColorObj)};
                     customEnvColors.insert(id, color);
@@ -3239,9 +3227,7 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
         mDefaultAreaName = oldDefaultAreaName;
         mUnnamedAreaName = oldUnnamedName;
         delete pNewRoomDB;
-        return {false, (translatableTexts
-                    ? tr("aborted by user")
-                    : qsl("aborted by user"))};
+        return {false, (translatableTexts ? tr("aborted by user") : qsl("aborted by user"))};
     }
 
     mCustomEnvColors.swap(customEnvColors);
@@ -3249,9 +3235,8 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
     mIsOnlyMapSymbolFontToBeUsed = isOnlyMapSymbolFontToBeUsed;
     QFont mapSymbolFont;
     mapSymbolFont.fromString(mapSymbolFontText);
-    mapSymbolFont.setStyleStrategy(static_cast<QFont::StyleStrategy>((isOnlyMapSymbolFontToBeUsed ? QFont::NoFontMerging : 0)
-                                                                     |QFont::PreferOutline | QFont::PreferAntialias | QFont::PreferQuality
-                                                                     |QFont::PreferNoShaping));
+    mapSymbolFont.setStyleStrategy(static_cast<QFont::StyleStrategy>((isOnlyMapSymbolFontToBeUsed ? QFont::NoFontMerging : 0) | QFont::PreferOutline | QFont::PreferAntialias | QFont::PreferQuality
+                                                                     | QFont::PreferNoShaping));
 
     mMapSymbolFont.swap(mapSymbolFont);
     mMapSymbolFontFudgeFactor = mapSymbolFontFudgeFactor;
@@ -3331,7 +3316,7 @@ void TMap::writeJsonColor(QJsonObject& obj, const QColor& color)
 
 QColor TMap::readJsonColor(const QJsonObject& obj)
 {
-    if (!(   (obj.contains(QLatin1String("color32RGBA")) && obj.value(QLatin1String("color32RGBA")).isArray())
+    if (!((obj.contains(QLatin1String("color32RGBA")) && obj.value(QLatin1String("color32RGBA")).isArray())
           || (obj.contains(QLatin1String("color24RGB")) && obj.value(QLatin1String("color24RGB")).isArray()))) {
         // Return a null color if one was not found
         return QColor();
@@ -3350,11 +3335,7 @@ QColor TMap::readJsonColor(const QJsonObject& obj)
         colorRGBAArray = obj.value(QLatin1String("color24RGB")).toArray();
     }
     const int size = colorRGBAArray.size();
-    if ((size == 3 || size == 4)
-        && colorRGBAArray.at(0).isDouble()
-        && colorRGBAArray.at(1).isDouble()
-        && colorRGBAArray.at(2).isDouble()) {
-
+    if ((size == 3 || size == 4) && colorRGBAArray.at(0).isDouble() && colorRGBAArray.at(1).isDouble() && colorRGBAArray.at(2).isDouble()) {
         red = qRound(colorRGBAArray.at(0).toDouble());
         green = qRound(colorRGBAArray.at(1).toDouble());
         blue = qRound(colorRGBAArray.at(2).toDouble());
@@ -3382,23 +3363,23 @@ bool TMap::incrementJsonProgressDialog(const bool isExportNotImport, const bool 
     if (isExportNotImport) {
         mpProgressDialog->setLabelText(tr("Exporting JSON map data from %1\n"
                                           "Areas: %2 of: %3   Rooms: %4 of: %5   Labels: %6 of: %7...")
-                                       .arg(mProfileName,
-                                            QString::number(mProgressDialogAreasCount),
-                                            QString::number(mProgressDialogAreasTotal),
-                                            QString::number(mProgressDialogRoomsCount),
-                                            QString::number(mProgressDialogRoomsTotal),
-                                            QString::number(mProgressDialogLabelsCount),
-                                            QString::number(mProgressDialogLabelsTotal)));
+                                               .arg(mProfileName,
+                                                    QString::number(mProgressDialogAreasCount),
+                                                    QString::number(mProgressDialogAreasTotal),
+                                                    QString::number(mProgressDialogRoomsCount),
+                                                    QString::number(mProgressDialogRoomsTotal),
+                                                    QString::number(mProgressDialogLabelsCount),
+                                                    QString::number(mProgressDialogLabelsTotal)));
     } else {
         mpProgressDialog->setLabelText(tr("Importing JSON map data to %1\n"
                                           "Areas: %2 of: %3   Rooms: %4 of: %5   Labels: %6 of: %7...")
-                                       .arg(mProfileName,
-                                            QString::number(mProgressDialogAreasCount),
-                                            QString::number(mProgressDialogAreasTotal),
-                                            QString::number(mProgressDialogRoomsCount),
-                                            QString::number(mProgressDialogRoomsTotal),
-                                            QString::number(mProgressDialogLabelsCount),
-                                            QString::number(mProgressDialogLabelsTotal)));
+                                               .arg(mProfileName,
+                                                    QString::number(mProgressDialogAreasCount),
+                                                    QString::number(mProgressDialogAreasTotal),
+                                                    QString::number(mProgressDialogRoomsCount),
+                                                    QString::number(mProgressDialogRoomsTotal),
+                                                    QString::number(mProgressDialogLabelsCount),
+                                                    QString::number(mProgressDialogLabelsTotal)));
     }
     qApp->processEvents();
     return mpProgressDialog->wasCanceled();
@@ -3418,7 +3399,6 @@ void TMap::updateArea(int areaId)
             }
 #endif
             if (mpMapper) {
-
                 if (mpMapper->mp2dMap) {
                     mpMapper->mp2dMap->mNewMoveAction = true;
                     mpMapper->mp2dMap->update();
@@ -3448,22 +3428,54 @@ QColor TMap::getColor(int id)
         }
     }
     switch (env) {
-    case 1:     color = mpHost->mRed_2;             break;
-    case 2:     color = mpHost->mGreen_2;           break;
-    case 3:     color = mpHost->mYellow_2;          break;
-    case 4:     color = mpHost->mBlue_2;            break;
-    case 5:     color = mpHost->mMagenta_2;         break;
-    case 6:     color = mpHost->mCyan_2;            break;
-    case 7:     color = mpHost->mWhite_2;           break;
-    case 8:     color = mpHost->mBlack_2;           break;
-    case 9:     color = mpHost->mLightRed_2;        break;
-    case 10:    color = mpHost->mLightGreen_2;      break;
-    case 11:    color = mpHost->mLightYellow_2;     break;
-    case 12:    color = mpHost->mLightBlue_2;       break;
-    case 13:    color = mpHost->mLightMagenta_2;    break;
-    case 14:    color = mpHost->mLightCyan_2;       break;
-    case 15:    color = mpHost->mLightWhite_2;      break;
-    case 16:    color = mpHost->mLightBlack_2;      break;
+    case 1:
+        color = mpHost->mRed_2;
+        break;
+    case 2:
+        color = mpHost->mGreen_2;
+        break;
+    case 3:
+        color = mpHost->mYellow_2;
+        break;
+    case 4:
+        color = mpHost->mBlue_2;
+        break;
+    case 5:
+        color = mpHost->mMagenta_2;
+        break;
+    case 6:
+        color = mpHost->mCyan_2;
+        break;
+    case 7:
+        color = mpHost->mWhite_2;
+        break;
+    case 8:
+        color = mpHost->mBlack_2;
+        break;
+    case 9:
+        color = mpHost->mLightRed_2;
+        break;
+    case 10:
+        color = mpHost->mLightGreen_2;
+        break;
+    case 11:
+        color = mpHost->mLightYellow_2;
+        break;
+    case 12:
+        color = mpHost->mLightBlue_2;
+        break;
+    case 13:
+        color = mpHost->mLightMagenta_2;
+        break;
+    case 14:
+        color = mpHost->mLightCyan_2;
+        break;
+    case 15:
+        color = mpHost->mLightWhite_2;
+        break;
+    case 16:
+        color = mpHost->mLightBlack_2;
+        break;
     default: //user defined room color
         if (!mCustomEnvColors.contains(env)) {
             if (16 < env && env < 232) {

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -77,8 +77,7 @@ void TMedia::playMedia(TMediaData& mediaData)
             return; // MSP and GMCP files should not have absolute paths.
         }
 
-        if (!mediaData.mediaFileName().contains(QLatin1Char('*')) &&
-            !mediaData.mediaFileName().contains(QLatin1Char('?'))) { // File path wildcards are * and ?
+        if (!mediaData.mediaFileName().contains(QLatin1Char('*')) && !mediaData.mediaFileName().contains(QLatin1Char('?'))) { // File path wildcards are * and ?
             // Append appropriate file extension for MSP files
             if (mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP && !mediaData.mediaFileName().contains(QLatin1Char('.'))) {
                 switch (mediaData.mediaType()) {
@@ -137,8 +136,7 @@ QList<TMediaData> TMedia::playingMedia(TMediaData& mediaData)
     if (!mediaData.mediaFileName().isEmpty()) {
         const bool fileRelative = TMedia::isFileRelative(mediaData);
 
-        if (!fileRelative && (mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP ||
-                              mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP)) {
+        if (!fileRelative && (mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP || mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP)) {
             return mMatchingTMediaDataList; // MSP and GMCP files should not have absolute paths.
         }
 
@@ -153,8 +151,7 @@ QList<TMediaData> TMedia::playingMedia(TMediaData& mediaData)
             continue;
         }
 
-        if (pPlayer->getPlaybackState() != QMediaPlayer::PlayingState &&
-            pPlayer->mediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
+        if (pPlayer->getPlaybackState() != QMediaPlayer::PlayingState && pPlayer->mediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
             continue;
         }
 
@@ -162,9 +159,8 @@ QList<TMediaData> TMedia::playingMedia(TMediaData& mediaData)
             continue;
         }
 
-        if (mediaData.mediaPriority() != TMediaData::MediaPriorityNotSet &&
-            pPlayer->mediaData().mediaPriority() != TMediaData::MediaPriorityNotSet &&
-            pPlayer->mediaData().mediaPriority() > mediaData.mediaPriority()) {
+        if (mediaData.mediaPriority() != TMediaData::MediaPriorityNotSet && pPlayer->mediaData().mediaPriority() != TMediaData::MediaPriorityNotSet
+            && pPlayer->mediaData().mediaPriority() > mediaData.mediaPriority()) {
             continue;
         }
 
@@ -191,8 +187,7 @@ QList<TMediaData> TMedia::pausedMedia(TMediaData& mediaData)
     if (!mediaData.mediaFileName().isEmpty()) {
         const bool fileRelative = TMedia::isFileRelative(mediaData);
 
-        if (!fileRelative && (mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP ||
-                              mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP)) {
+        if (!fileRelative && (mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP || mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP)) {
             return mMatchingTMediaDataList; // MSP and GMCP files should not have absolute paths.
         }
 
@@ -215,9 +210,8 @@ QList<TMediaData> TMedia::pausedMedia(TMediaData& mediaData)
             continue;
         }
 
-        if (mediaData.mediaPriority() != TMediaData::MediaPriorityNotSet &&
-            pPlayer->mediaData().mediaPriority() != TMediaData::MediaPriorityNotSet &&
-            pPlayer->mediaData().mediaPriority() > mediaData.mediaPriority()) {
+        if (mediaData.mediaPriority() != TMediaData::MediaPriorityNotSet && pPlayer->mediaData().mediaPriority() != TMediaData::MediaPriorityNotSet
+            && pPlayer->mediaData().mediaPriority() > mediaData.mediaPriority()) {
             continue;
         }
 
@@ -242,8 +236,7 @@ void TMedia::pauseMedia(TMediaData& mediaData)
     if (!mediaData.mediaFileName().isEmpty() && mediaData.mediaInput() == TMediaData::MediaInputFile) {
         const bool fileRelative = TMedia::isFileRelative(mediaData);
 
-        if (!fileRelative && (mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP ||
-                              mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP)) {
+        if (!fileRelative && (mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP || mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP)) {
             return; // MSP and GMCP files should not have absolute paths.
         }
 
@@ -266,9 +259,8 @@ void TMedia::pauseMedia(TMediaData& mediaData)
             continue;
         }
 
-        if (mediaData.mediaPriority() != TMediaData::MediaPriorityNotSet &&
-            pPlayer->mediaData().mediaPriority() != TMediaData::MediaPriorityNotSet &&
-            pPlayer->mediaData().mediaPriority() >= mediaData.mediaPriority()) {
+        if (mediaData.mediaPriority() != TMediaData::MediaPriorityNotSet && pPlayer->mediaData().mediaPriority() != TMediaData::MediaPriorityNotSet
+            && pPlayer->mediaData().mediaPriority() >= mediaData.mediaPriority()) {
             continue;
         }
 
@@ -291,8 +283,7 @@ void TMedia::stopMedia(TMediaData& mediaData)
     if (!mediaData.mediaFileName().isEmpty() && mediaData.mediaInput() == TMediaData::MediaInputFile) {
         const bool fileRelative = TMedia::isFileRelative(mediaData);
 
-        if (!fileRelative && (mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP ||
-                              mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP)) {
+        if (!fileRelative && (mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP || mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP)) {
             return; // MSP and GMCP files should not have absolute paths.
         }
 
@@ -311,14 +302,13 @@ void TMedia::stopMedia(TMediaData& mediaData)
             continue;
         }
 
-        if (mediaData.mediaPriority() != TMediaData::MediaPriorityNotSet &&
-            pPlayer->mediaData().mediaPriority() != TMediaData::MediaPriorityNotSet &&
-            pPlayer->mediaData().mediaPriority() >= mediaData.mediaPriority()) {
+        if (mediaData.mediaPriority() != TMediaData::MediaPriorityNotSet && pPlayer->mediaData().mediaPriority() != TMediaData::MediaPriorityNotSet
+            && pPlayer->mediaData().mediaPriority() >= mediaData.mediaPriority()) {
             continue;
         }
 
-        if ((mediaData.mediaFadeAway() == TMediaData::MediaFadeAwayEnabled || mediaData.mediaFadeOut() != TMediaData::MediaFadeNotSet) &&
-            pPlayer->mediaData().mediaEnd() == TMediaData::MediaEndNotSet) {
+        if ((mediaData.mediaFadeAway() == TMediaData::MediaFadeAwayEnabled || mediaData.mediaFadeOut() != TMediaData::MediaFadeNotSet)
+            && pPlayer->mediaData().mediaEnd() == TMediaData::MediaEndNotSet) {
             const int finishPosition = pPlayer->mediaData().mediaFinish();
             const int duration = pPlayer->mediaPlayer()->duration();
             const int currentPosition = pPlayer->mediaPlayer()->position();
@@ -412,8 +402,7 @@ void TMedia::unmuteMedia(const TMediaData::MediaProtocol mediaProtocol)
 // Private
 bool TMedia::isMediaProtocolAllowed(const TMediaData& mediaData) const
 {
-    if ((mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP && !mpHost->mEnableMSP) ||
-        (mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP && !mpHost->mAcceptServerMedia)) {
+    if ((mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP && !mpHost->mEnableMSP) || (mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP && !mpHost->mAcceptServerMedia)) {
         return false;
     }
     return true;
@@ -422,50 +411,46 @@ bool TMedia::isMediaProtocolAllowed(const TMediaData& mediaData) const
 QList<std::shared_ptr<TMediaPlayer>> TMedia::findMediaPlayersByCriteria(const TMediaData& mediaData)
 {
     switch (mediaData.mediaProtocol()) {
-        case TMediaData::MediaProtocolMSP:
-            return (mediaData.mediaType() == TMediaData::MediaTypeSound) ? mMSPSoundList : mMSPMusicList;
+    case TMediaData::MediaProtocolMSP:
+        return (mediaData.mediaType() == TMediaData::MediaTypeSound) ? mMSPSoundList : mMSPMusicList;
 
-        case TMediaData::MediaProtocolGMCP:
-            if (mediaData.mediaType() == TMediaData::MediaTypeNotSet) {
-                QList<std::shared_ptr<TMediaPlayer>> combinedList;
-                combinedList.append(mGMCPSoundList);
-                combinedList.append(mGMCPMusicList);
-                combinedList.append(mGMCPVideoList);
-                return combinedList;
-            }
-            return (mediaData.mediaType() == TMediaData::MediaTypeSound) ? mGMCPSoundList :
-                   (mediaData.mediaType() == TMediaData::MediaTypeMusic) ? mGMCPMusicList :
-                   mGMCPVideoList;
+    case TMediaData::MediaProtocolGMCP:
+        if (mediaData.mediaType() == TMediaData::MediaTypeNotSet) {
+            QList<std::shared_ptr<TMediaPlayer>> combinedList;
+            combinedList.append(mGMCPSoundList);
+            combinedList.append(mGMCPMusicList);
+            combinedList.append(mGMCPVideoList);
+            return combinedList;
+        }
+        return (mediaData.mediaType() == TMediaData::MediaTypeSound) ? mGMCPSoundList : (mediaData.mediaType() == TMediaData::MediaTypeMusic) ? mGMCPMusicList : mGMCPVideoList;
 
-        case TMediaData::MediaProtocolAPI:
-            if (mediaData.mediaType() == TMediaData::MediaTypeNotSet) {
-                QList<std::shared_ptr<TMediaPlayer>> combinedList;
-                combinedList.append(mAPISoundList);
-                combinedList.append(mAPIMusicList);
-                combinedList.append(mAPIVideoList);
-                return combinedList;
-            }
-            return (mediaData.mediaType() == TMediaData::MediaTypeSound) ? mAPISoundList :
-                   (mediaData.mediaType() == TMediaData::MediaTypeMusic) ? mAPIMusicList :
-                   mAPIVideoList;
+    case TMediaData::MediaProtocolAPI:
+        if (mediaData.mediaType() == TMediaData::MediaTypeNotSet) {
+            QList<std::shared_ptr<TMediaPlayer>> combinedList;
+            combinedList.append(mAPISoundList);
+            combinedList.append(mAPIMusicList);
+            combinedList.append(mAPIVideoList);
+            return combinedList;
+        }
+        return (mediaData.mediaType() == TMediaData::MediaTypeSound) ? mAPISoundList : (mediaData.mediaType() == TMediaData::MediaTypeMusic) ? mAPIMusicList : mAPIVideoList;
 
-        case TMediaData::MediaProtocolNotSet:
-            if (mediaData.mediaType() == TMediaData::MediaTypeNotSet) {
-                QList<std::shared_ptr<TMediaPlayer>> combinedList;
-                combinedList.append(mMSPSoundList);
-                combinedList.append(mMSPMusicList);
-                combinedList.append(mGMCPSoundList);
-                combinedList.append(mGMCPMusicList);
-                combinedList.append(mGMCPVideoList);
-                combinedList.append(mAPISoundList);
-                combinedList.append(mAPIMusicList);
-                combinedList.append(mAPIVideoList);
-                return combinedList;
-            }
-            return (mediaData.mediaType() == TMediaData::MediaTypeSound) ? mMSPSoundList :
-                   (mediaData.mediaType() == TMediaData::MediaTypeMusic) ? mMSPMusicList :
-                   (mediaData.mediaType() == TMediaData::MediaTypeVideo) ? mGMCPVideoList :
-                   QList<std::shared_ptr<TMediaPlayer>>(); // Return empty list
+    case TMediaData::MediaProtocolNotSet:
+        if (mediaData.mediaType() == TMediaData::MediaTypeNotSet) {
+            QList<std::shared_ptr<TMediaPlayer>> combinedList;
+            combinedList.append(mMSPSoundList);
+            combinedList.append(mMSPMusicList);
+            combinedList.append(mGMCPSoundList);
+            combinedList.append(mGMCPMusicList);
+            combinedList.append(mGMCPVideoList);
+            combinedList.append(mAPISoundList);
+            combinedList.append(mAPIMusicList);
+            combinedList.append(mAPIVideoList);
+            return combinedList;
+        }
+        return (mediaData.mediaType() == TMediaData::MediaTypeSound)   ? mMSPSoundList
+               : (mediaData.mediaType() == TMediaData::MediaTypeMusic) ? mMSPMusicList
+               : (mediaData.mediaType() == TMediaData::MediaTypeVideo) ? mGMCPVideoList
+                                                                       : QList<std::shared_ptr<TMediaPlayer>>(); // Return empty list
     }
 
     return {}; // Default empty list fallback
@@ -477,18 +462,15 @@ bool TMedia::isMediaMatch(const std::shared_ptr<TMediaPlayer>& player, const TMe
         return false;
     }
 
-    if (!mediaData.mediaKey().isEmpty() && !player->mediaData().mediaKey().isEmpty() &&
-        player->mediaData().mediaKey() != mediaData.mediaKey()) {
+    if (!mediaData.mediaKey().isEmpty() && !player->mediaData().mediaKey().isEmpty() && player->mediaData().mediaKey() != mediaData.mediaKey()) {
         return false;
     }
 
-    if (!mediaData.mediaFileName().isEmpty() && !player->mediaData().mediaFileName().isEmpty() &&
-        player->mediaData().mediaFileName() != mediaData.mediaFileName()) {
+    if (!mediaData.mediaFileName().isEmpty() && !player->mediaData().mediaFileName().isEmpty() && player->mediaData().mediaFileName() != mediaData.mediaFileName()) {
         return false;
     }
 
-    if (!mediaData.mediaTag().isEmpty() && !player->mediaData().mediaTag().isEmpty() &&
-        player->mediaData().mediaTag() != mediaData.mediaTag()) {
+    if (!mediaData.mediaTag().isEmpty() && !player->mediaData().mediaTag().isEmpty() && player->mediaData().mediaTag() != mediaData.mediaTag()) {
         return false;
     }
 
@@ -646,8 +628,7 @@ bool TMedia::isFileRelative(TMediaData& mediaData)
 
     if (!QFileInfo(mediaData.mediaFileName()).isRelative()) {
         if (mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP || mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP) {
-            qWarning()
-                    << qsl("TMedia::isFileRelative() WARNING - attempt made to send an absolute path as a media file name: %1.  Only relative paths are permitted.").arg(mediaData.mediaFileName());
+            qWarning() << qsl("TMedia::isFileRelative() WARNING - attempt made to send an absolute path as a media file name: %1.  Only relative paths are permitted.").arg(mediaData.mediaFileName());
         }
     } else {
         isFileRelative = true;
@@ -714,7 +695,7 @@ QStringList TMedia::getFileNameList(TMediaData& mediaData)
 
             if (!mediaSubDir.mkpath(mediaSubPath)) {
                 qWarning() << qsl("TMedia::getFileNameList() WARNING - attempt made to create a directory failed: %1")
-                                    .arg(mudlet::getMudletPath(enums::profileMediaPath, mpHost->getName()), mediaData.mediaFileName().section(QLatin1Char('/'), 0, -2));
+                                      .arg(mudlet::getMudletPath(enums::profileMediaPath, mpHost->getName()), mediaData.mediaFileName().section(QLatin1Char('/'), 0, -2));
                 return fileNameList;
             }
 
@@ -1001,12 +982,11 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
 
     // Playback state changed connection
     disconnect(player->mediaPlayer(), &QMediaPlayer::playbackStateChanged, nullptr, nullptr);
-    connect(player->mediaPlayer(), &QMediaPlayer::playbackStateChanged, this,
-            [this, weakPlayer](QMediaPlayerPlaybackState playbackState) {
-                if (auto lockedPlayer = weakPlayer.lock()) {
-                    handlePlayerPlaybackStateChanged(playbackState, lockedPlayer);
-                }
-            });
+    connect(player->mediaPlayer(), &QMediaPlayer::playbackStateChanged, this, [this, weakPlayer](QMediaPlayerPlaybackState playbackState) {
+        if (auto lockedPlayer = weakPlayer.lock()) {
+            handlePlayerPlaybackStateChanged(playbackState, lockedPlayer);
+        }
+    });
 
     // Position changed connection (handles fade-in/fade-out effects)
     disconnect(player->mediaPlayer(), &QMediaPlayer::positionChanged, nullptr, nullptr);
@@ -1033,8 +1013,7 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
             } else {
                 if (fadeInUsed) {
                     if (progress < relativeFadeInPosition) {
-                        const double fadeInVolume = static_cast<double>(volume * (progress - startPosition)) /
-                                                    static_cast<double>(relativeFadeInPosition - startPosition);
+                        const double fadeInVolume = static_cast<double>(volume * (progress - startPosition)) / static_cast<double>(relativeFadeInPosition - startPosition);
                         lockedPlayer->setVolume(qRound(fadeInVolume));
                         actionTaken = true;
                     } else if (progress == relativeFadeInPosition) {
@@ -1045,8 +1024,7 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
 
                 if (!actionTaken && fadeOutUsed && progress > 0) {
                     if (progress > relativeFadeOutPosition) {
-                        const double fadeOutVolume = static_cast<double>(volume * (relativeDuration - progress)) /
-                                                     static_cast<double>(fadeOutDuration);
+                        const double fadeOutVolume = static_cast<double>(volume * (relativeDuration - progress)) / static_cast<double>(fadeOutDuration);
                         lockedPlayer->setVolume(qRound(fadeOutVolume));
                         actionTaken = true;
                     }
@@ -1062,7 +1040,8 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
 
 void TMedia::purgeStoppedMediaPlayers(QList<std::shared_ptr<TMediaPlayer>>& mediaList)
 {
-    mediaList.erase(std::remove_if(mediaList.begin(), mediaList.end(),
+    mediaList.erase(std::remove_if(mediaList.begin(),
+                                   mediaList.end(),
                                    [](const std::shared_ptr<TMediaPlayer>& player) {
                                        return player->getPlaybackState() == QMediaPlayer::StoppedState;
                                    }),
@@ -1070,7 +1049,7 @@ void TMedia::purgeStoppedMediaPlayers(QList<std::shared_ptr<TMediaPlayer>>& medi
 }
 
 // Helper for updating media player lists (now a static TMedia method)
-template<typename T>
+template <typename T>
 void TMedia::updateList(QList<std::shared_ptr<T>>& list, int index, std::shared_ptr<T> player, TMedia* mediaInstance)
 {
     if (index == -1) {
@@ -1080,8 +1059,7 @@ void TMedia::updateList(QList<std::shared_ptr<T>>& list, int index, std::shared_
         qDebug() << "TMedia::updateList() - Replacing existing player at index:" << index;
         list[index] = std::move(player);
     } else {
-        qWarning() << "TMedia::updateList() - Invalid index:" << index
-                   << " for list size:" << list.size() << ". Appending instead.";
+        qWarning() << "TMedia::updateList() - Invalid index:" << index << " for list size:" << list.size() << ". Appending instead.";
         list.append(std::move(player));
     }
 
@@ -1134,20 +1112,16 @@ void TMedia::updateMediaPlayerList(std::shared_ptr<TMediaPlayer> player)
 
     QList<std::shared_ptr<TMediaPlayer>>* list = nullptr;
 
-    qDebug() << "TMedia::updateMediaPlayerList() - Updating list for protocol:"
-             << mediaData.mediaProtocol()
-             << "and type:" << mediaData.mediaType();
+    qDebug() << "TMedia::updateMediaPlayerList() - Updating list for protocol:" << mediaData.mediaProtocol() << "and type:" << mediaData.mediaType();
     switch (mediaData.mediaProtocol()) {
     case TMediaData::MediaProtocolMSP:
         list = (mediaData.mediaType() == TMediaData::MediaTypeMusic) ? &mMSPMusicList : &mMSPSoundList;
         break;
     case TMediaData::MediaProtocolGMCP:
-        list = (mediaData.mediaType() == TMediaData::MediaTypeMusic) ? &mGMCPMusicList :
-               (mediaData.mediaType() == TMediaData::MediaTypeVideo) ? &mGMCPVideoList : &mGMCPSoundList;
+        list = (mediaData.mediaType() == TMediaData::MediaTypeMusic) ? &mGMCPMusicList : (mediaData.mediaType() == TMediaData::MediaTypeVideo) ? &mGMCPVideoList : &mGMCPSoundList;
         break;
     case TMediaData::MediaProtocolAPI:
-        list = (mediaData.mediaType() == TMediaData::MediaTypeMusic) ? &mAPIMusicList :
-               (mediaData.mediaType() == TMediaData::MediaTypeVideo) ? &mAPIVideoList : &mAPISoundList;
+        list = (mediaData.mediaType() == TMediaData::MediaTypeMusic) ? &mAPIMusicList : (mediaData.mediaType() == TMediaData::MediaTypeVideo) ? &mAPIVideoList : &mAPISoundList;
         break;
     }
 
@@ -1168,10 +1142,9 @@ std::shared_ptr<TMediaPlayer> TMedia::getMediaPlayer(TMediaData& mediaData)
             continue;
         }
 
-        if (existingPlayer->getPlaybackState() != QMediaPlayer::PlayingState &&
-            existingPlayer->mediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
+        if (existingPlayer->getPlaybackState() != QMediaPlayer::PlayingState && existingPlayer->mediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
             existingPlayer->setMediaData(mediaData);
-            return existingPlayer;  // Reuse existing player
+            return existingPlayer; // Reuse existing player
         }
     }
 
@@ -1179,16 +1152,16 @@ std::shared_ptr<TMediaPlayer> TMedia::getMediaPlayer(TMediaData& mediaData)
     int maxAllowed = getMaxAllowedSoundPlayers(); // Default fallback
 
     switch (mediaData.mediaType()) {
-        case TMediaData::MediaTypeMusic:
-            maxAllowed = getMaxAllowedMusicPlayers();
-            break;
-        case TMediaData::MediaTypeVideo:
-            maxAllowed = getMaxAllowedVideoPlayers();
-            break;
-        case TMediaData::MediaTypeSound:
-        default:
-            maxAllowed = getMaxAllowedSoundPlayers();
-            break;
+    case TMediaData::MediaTypeMusic:
+        maxAllowed = getMaxAllowedMusicPlayers();
+        break;
+    case TMediaData::MediaTypeVideo:
+        maxAllowed = getMaxAllowedVideoPlayers();
+        break;
+    case TMediaData::MediaTypeSound:
+    default:
+        maxAllowed = getMaxAllowedSoundPlayers();
+        break;
     }
 
     if (mediaPlayerList.size() >= maxAllowed) {
@@ -1217,22 +1190,26 @@ std::shared_ptr<TMediaPlayer> TMedia::getMediaPlayer(TMediaData& mediaData)
 }
 
 // Dynamic limits for media players, based on host count
-int TMedia::getMaxUnprunedPlayers() const {
+int TMedia::getMaxUnprunedPlayers() const
+{
     int hostCount = std::max(1, mudlet::self()->getHostManager().getHostCount());
     return std::max(10, 25 / hostCount);
 }
 
-int TMedia::getMaxAllowedSoundPlayers() const {
+int TMedia::getMaxAllowedSoundPlayers() const
+{
     int hostCount = std::max(1, mudlet::self()->getHostManager().getHostCount());
     return std::max(16, 65 / hostCount);
 }
 
-int TMedia::getMaxAllowedMusicPlayers() const {
+int TMedia::getMaxAllowedMusicPlayers() const
+{
     int hostCount = std::max(1, mudlet::self()->getHostManager().getHostCount());
     return std::max(4, 20 / hostCount);
 }
 
-int TMedia::getMaxAllowedVideoPlayers() const {
+int TMedia::getMaxAllowedVideoPlayers() const
+{
     int hostCount = std::max(1, mudlet::self()->getHostManager().getHostCount());
     return std::max(2, 10 / hostCount);
 }
@@ -1258,9 +1235,7 @@ void TMedia::handlePlayerPlaybackStateChanged(QMediaPlayerPlaybackState playback
             mpHost->raiseEvent(mediaFinished);
         }
 
-        if (player->mediaData().mediaWidget() == TMediaData::MediaWidgetLabel &&
-            player->mediaData().mediaClose() == TMediaData::MediaCloseEnabled &&
-            player->mediaPlayer()->videoOutput() != nullptr) {
+        if (player->mediaData().mediaWidget() == TMediaData::MediaWidgetLabel && player->mediaData().mediaClose() == TMediaData::MediaCloseEnabled && player->mediaPlayer()->videoOutput() != nullptr) {
             QVideoWidget* videoOutput = qobject_cast<QVideoWidget*>(player->mediaPlayer()->videoOutput());
 
             if (videoOutput != nullptr) {
@@ -1322,25 +1297,24 @@ std::shared_ptr<TMediaPlayer> TMedia::matchMediaPlayer(TMediaData& mediaData)
             continue;
         }
 
-        if (pTestPlayer->getPlaybackState() == QMediaPlayer::PlayingState &&
-            pTestPlayer->mediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
+        if (pTestPlayer->getPlaybackState() == QMediaPlayer::PlayingState && pTestPlayer->mediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
             if (pTestPlayer->mediaData().mediaAbsolutePathFileName().endsWith(mediaData.mediaAbsolutePathFileName())) {
                 // Is the same sound or music playing?
                 pTestPlayer->setMediaData(mediaData);
                 pTestPlayer->setVolume(mediaData.mediaFadeIn() != TMediaData::MediaFadeNotSet ? 1 : mediaData.mediaVolume());
-                return pTestPlayer;  // Return a pointer to the matched player
+                return pTestPlayer; // Return a pointer to the matched player
             }
         }
     }
 
-    return nullptr;  // No matching player found
+    return nullptr; // No matching player found
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Scripting#priority:_1_to_100
 bool TMedia::doesMediaHavePriorityToPlay(TMediaData& mediaData, const QString& absolutePathFileName)
 {
     if (mediaData.mediaPriority() == TMediaData::MediaPriorityNotSet) {
-        return true;  // Default behavior: assume priority if not set
+        return true; // Default behavior: assume priority if not set
     }
 
     int maxMediaPriority = 0;
@@ -1352,12 +1326,10 @@ bool TMedia::doesMediaHavePriorityToPlay(TMediaData& mediaData, const QString& a
             continue;
         }
 
-        if (pTestPlayer->getPlaybackState() == QMediaPlayer::PlayingState &&
-            pTestPlayer->mediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
+        if (pTestPlayer->getPlaybackState() == QMediaPlayer::PlayingState && pTestPlayer->mediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
             if (!pTestPlayer->mediaData().mediaAbsolutePathFileName().endsWith(absolutePathFileName)) {
                 // Is it a different sound or music than specified?
-                if (pTestPlayer->mediaData().mediaPriority() != TMediaData::MediaPriorityNotSet &&
-                    pTestPlayer->mediaData().mediaPriority() > maxMediaPriority) {
+                if (pTestPlayer->mediaData().mediaPriority() != TMediaData::MediaPriorityNotSet && pTestPlayer->mediaData().mediaPriority() > maxMediaPriority) {
                     maxMediaPriority = pTestPlayer->mediaData().mediaPriority();
                 }
             }
@@ -1388,15 +1360,11 @@ void TMedia::matchMediaKeyAndStopMediaVariants(TMediaData& mediaData, const QStr
             continue;
         }
 
-        if (pTestPlayer->getPlaybackState() == QMediaPlayer::PlayingState &&
-            pTestPlayer->mediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
-
-            if (!mediaData.mediaKey().isEmpty() && !pTestPlayer->mediaData().mediaKey().isEmpty()
-                && mediaData.mediaKey() == pTestPlayer->mediaData().mediaKey()) {
+        if (pTestPlayer->getPlaybackState() == QMediaPlayer::PlayingState && pTestPlayer->mediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
+            if (!mediaData.mediaKey().isEmpty() && !pTestPlayer->mediaData().mediaKey().isEmpty() && mediaData.mediaKey() == pTestPlayer->mediaData().mediaKey()) {
                 // Does it have the same key?
                 if (!pTestPlayer->mediaData().mediaAbsolutePathFileName().endsWith(absolutePathFileName)
-                    || (!mediaData.mediaUrl().isEmpty() && !pTestPlayer->mediaData().mediaUrl().isEmpty()
-                        && mediaData.mediaUrl() != pTestPlayer->mediaData().mediaUrl())) {
+                    || (!mediaData.mediaUrl().isEmpty() && !pTestPlayer->mediaData().mediaUrl().isEmpty() && mediaData.mediaUrl() != pTestPlayer->mediaData().mediaUrl())) {
                     // Is it a different sound or music than specified?
                     TMediaData stopMediaData = pTestPlayer->mediaData();
                     mpHost->mpMedia->stopMedia(stopMediaData); // Stop it!
@@ -1523,7 +1491,7 @@ void TMedia::play(TMediaData& mediaData)
     }
 
     // Ensure the player has a valid playlist
-    TMediaPlaylist *playlist = pPlayer->playlist();
+    TMediaPlaylist* playlist = pPlayer->playlist();
 
     if (!sameMediaIsPlaying) {
         if (!playlist) {
@@ -1552,24 +1520,18 @@ void TMedia::play(TMediaData& mediaData)
             }
         }
 
-        absolutePathFileName = fileNameList.size() > 1
-                                   ? fileNameList.at(QRandomGenerator::global()->bounded(fileNameList.size()))
-                                   : (mediaData.mediaInput() == TMediaData::MediaInputStream
-                                          ? TMedia::getStreamUrl(mediaData)
-                                          : fileNameList.at(0));
+        absolutePathFileName = fileNameList.size() > 1 ? fileNameList.at(QRandomGenerator::global()->bounded(fileNameList.size()))
+                                                       : (mediaData.mediaInput() == TMediaData::MediaInputStream ? TMedia::getStreamUrl(mediaData) : fileNameList.at(0));
 
         if (!TMedia::doesMediaHavePriorityToPlay(mediaData, absolutePathFileName)) {
             return;
         }
 
-        if (!mediaData.mediaKey().isEmpty() && (mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP ||
-                                                mediaData.mediaProtocol() == TMediaData::MediaProtocolAPI)) {
+        if (!mediaData.mediaKey().isEmpty() && (mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP || mediaData.mediaProtocol() == TMediaData::MediaProtocolAPI)) {
             TMedia::matchMediaKeyAndStopMediaVariants(mediaData, absolutePathFileName);
         }
 
-        const QUrl mediaSource = mediaData.mediaInput() == TMediaData::MediaInputFile
-                                     ? QUrl::fromLocalFile(absolutePathFileName)
-                                     : QUrl(absolutePathFileName);
+        const QUrl mediaSource = mediaData.mediaInput() == TMediaData::MediaInputFile ? QUrl::fromLocalFile(absolutePathFileName) : QUrl(absolutePathFileName);
         pPlayer->mediaPlayer()->setSource(mediaSource);
     } else {
         if (mediaData.mediaLoops() == TMediaData::MediaLoopsRepeat) { // Repeat indefinitely
@@ -1584,24 +1546,18 @@ void TMedia::play(TMediaData& mediaData)
                 }
             }
 
-            absolutePathFileName = fileNameList.size() > 1
-                                       ? fileNameList.at(QRandomGenerator::global()->bounded(fileNameList.size()))
-                                       : (mediaData.mediaInput() == TMediaData::MediaInputStream
-                                              ? TMedia::getStreamUrl(mediaData)
-                                              : fileNameList.at(0));
+            absolutePathFileName = fileNameList.size() > 1 ? fileNameList.at(QRandomGenerator::global()->bounded(fileNameList.size()))
+                                                           : (mediaData.mediaInput() == TMediaData::MediaInputStream ? TMedia::getStreamUrl(mediaData) : fileNameList.at(0));
 
             if (!TMedia::doesMediaHavePriorityToPlay(mediaData, absolutePathFileName)) {
                 return;
             }
 
-            if (!mediaData.mediaKey().isEmpty() && (mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP ||
-                                                    mediaData.mediaProtocol() == TMediaData::MediaProtocolAPI)) {
+            if (!mediaData.mediaKey().isEmpty() && (mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP || mediaData.mediaProtocol() == TMediaData::MediaProtocolAPI)) {
                 TMedia::matchMediaKeyAndStopMediaVariants(mediaData, absolutePathFileName);
             }
 
-            const QUrl mediaSource = mediaData.mediaInput() == TMediaData::MediaInputFile
-                                         ? QUrl::fromLocalFile(absolutePathFileName)
-                                         : QUrl(absolutePathFileName);
+            const QUrl mediaSource = mediaData.mediaInput() == TMediaData::MediaInputFile ? QUrl::fromLocalFile(absolutePathFileName) : QUrl(absolutePathFileName);
             playlist->addMedia(mediaSource);
         } else { // Play a finite number of times
             playlist->setPlaybackMode(TMediaPlaylist::Sequential);
@@ -1620,25 +1576,18 @@ void TMedia::play(TMediaData& mediaData)
             }
 
             for (int k = 0; k < mediaData.mediaLoops(); k++) {
-                absolutePathFileName = fileNameList.size() > 1
-                                           ? fileNameList.at(QRandomGenerator::global()->bounded(fileNameList.size()))
-                                           : (mediaData.mediaInput() == TMediaData::MediaInputStream
-                                                  ? TMedia::getStreamUrl(mediaData)
-                                                  : fileNameList.at(0));
+                absolutePathFileName = fileNameList.size() > 1 ? fileNameList.at(QRandomGenerator::global()->bounded(fileNameList.size()))
+                                                               : (mediaData.mediaInput() == TMediaData::MediaInputStream ? TMedia::getStreamUrl(mediaData) : fileNameList.at(0));
 
                 if (k == 0 && !TMedia::doesMediaHavePriorityToPlay(mediaData, absolutePathFileName)) {
                     return;
                 }
 
-                if (k == 0 && !mediaData.mediaKey().isEmpty() &&
-                    (mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP ||
-                     mediaData.mediaProtocol() == TMediaData::MediaProtocolAPI)) {
+                if (k == 0 && !mediaData.mediaKey().isEmpty() && (mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP || mediaData.mediaProtocol() == TMediaData::MediaProtocolAPI)) {
                     TMedia::matchMediaKeyAndStopMediaVariants(mediaData, absolutePathFileName);
                 }
 
-                const QUrl mediaSource = mediaData.mediaInput() == TMediaData::MediaInputFile
-                                             ? QUrl::fromLocalFile(absolutePathFileName)
-                                             : QUrl(absolutePathFileName);
+                const QUrl mediaSource = mediaData.mediaInput() == TMediaData::MediaInputFile ? QUrl::fromLocalFile(absolutePathFileName) : QUrl(absolutePathFileName);
                 playlist->addMedia(mediaSource);
             }
         }
@@ -1658,13 +1607,13 @@ void TMedia::play(TMediaData& mediaData)
 
     // Set mute state based on protocol
     switch (mediaData.mediaProtocol()) {
-        case TMediaData::MediaProtocolAPI:
-            pPlayer->mediaPlayer()->audioOutput()->setMuted(mudlet::self()->muteAPI());
-            break;
-        case TMediaData::MediaProtocolGMCP:
-        case TMediaData::MediaProtocolMSP:
-            pPlayer->mediaPlayer()->audioOutput()->setMuted(mudlet::self()->muteGame());
-            break;
+    case TMediaData::MediaProtocolAPI:
+        pPlayer->mediaPlayer()->audioOutput()->setMuted(mudlet::self()->muteAPI());
+        break;
+    case TMediaData::MediaProtocolGMCP:
+    case TMediaData::MediaProtocolMSP:
+        pPlayer->mediaPlayer()->audioOutput()->setMuted(mudlet::self()->muteGame());
+        break;
     }
 
     // Handle video setup if applicable
@@ -2064,10 +2013,10 @@ void TMedia::printClosedCaption(const TMediaData& mediaData, const QString& acti
     } else {
         //: This word is part of a sentence like "Music stops" when Mudlet handles a piece of music.
         const QString mediaType = mediaData.mediaType() == TMediaData::MediaTypeMusic ? tr("music") :
-        //: This word is part of a sentence like "Video stops" when Mudlet handles a video.
-                                  mediaData.mediaType() == TMediaData::MediaTypeVideo ? tr("video")
-        //: This word is part of a sentence like "Sound stops" when Mudlet handles neither music nor video.
-                                                                                      : tr("sound");
+                                                                                      //: This word is part of a sentence like "Video stops" when Mudlet handles a video.
+                                          mediaData.mediaType() == TMediaData::MediaTypeVideo ? tr("video")
+                                                                                              //: This word is part of a sentence like "Sound stops" when Mudlet handles neither music nor video.
+                                                                                              : tr("sound");
         const QString mediaKey = mediaData.mediaKey();
         const QString mediaFileName = mediaData.mediaFileName();
         if (mediaKey.isEmpty()) {

--- a/src/TMediaPlaylist.cpp
+++ b/src/TMediaPlaylist.cpp
@@ -24,12 +24,12 @@
 TMediaPlaylist::TMediaPlaylist()
 : mCurrentIndex(0)
 , mPlaybackMode(Sequential)
-{}
+{
+}
 
-TMediaPlaylist::~TMediaPlaylist()
-{}
+TMediaPlaylist::~TMediaPlaylist() {}
 
-void TMediaPlaylist::addMedia(const QUrl &url)
+void TMediaPlaylist::addMedia(const QUrl& url)
 {
     mMediaList.append(url);
 }
@@ -53,7 +53,8 @@ int TMediaPlaylist::mediaCount() const
     return mMediaList.count();
 }
 
-bool TMediaPlaylist::isEmpty() const {
+bool TMediaPlaylist::isEmpty() const
+{
     return mMediaList.isEmpty();
 }
 

--- a/src/TMxpCustomElementTagHandler.cpp
+++ b/src/TMxpCustomElementTagHandler.cpp
@@ -96,13 +96,13 @@ MxpStartTag TMxpCustomElementTagHandler::resolveElementDefinition(const TMxpElem
 
     // Transform the definition tag's attributes with mapped values
     auto result = definitionTag->transform(mapping);
-    
+
     // Collect all attributes from the transformed result
     QList<MxpTagAttribute> allAttrs;
     for (int i = 0; i < result.getAttributesCount(); ++i) {
         allAttrs.append(result.getAttribute(i));
     }
-    
+
     // Add any attributes from the custom tag that aren't already present
     for (int i = 0; i < customTag->getAttributesCount(); ++i) {
         const auto& attr = customTag->getAttribute(i);
@@ -110,7 +110,7 @@ MxpStartTag TMxpCustomElementTagHandler::resolveElementDefinition(const TMxpElem
             allAttrs.append(attr);
         }
     }
-    
+
     // Return a new tag with all combined attributes
     return MxpStartTag(result.getName(), allAttrs, result.isEmpty());
 }

--- a/src/TMxpDestTagHandler.cpp
+++ b/src/TMxpDestTagHandler.cpp
@@ -30,33 +30,30 @@ bool TMxpDestTagHandler::supports(TMxpContext& ctx, TMxpClient& client, MxpTag* 
 TMxpTagHandlerResult TMxpDestTagHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
 {
     Q_UNUSED(ctx)
-    
+
     QString frameName = extractFrameName(tag);
-    
+
 #ifdef DEBUG_MXP_PROCESSING
-    qDebug() << "TMxpDestTagHandler::handleStartTag: DEST tag received"
-             << "frameName:" << frameName
-             << "EOL:" << hasEOL(tag)
-             << "EOF:" << hasEOF(tag);
+    qDebug() << "TMxpDestTagHandler::handleStartTag: DEST tag received" << "frameName:" << frameName << "EOL:" << hasEOL(tag) << "EOF:" << hasEOF(tag);
 #endif
-    
+
     if (frameName.isEmpty()) {
 #ifdef DEBUG_MXP_PROCESSING
         qDebug() << "TMxpDestTagHandler::handleStartTag: Empty frame name, not handled";
 #endif
         return MXP_TAG_NOT_HANDLED;
     }
-    
+
     bool eol = hasEOL(tag);
     bool eof = hasEOF(tag);
-    
+
     if (client.setMxpDestination(frameName, eol, eof)) {
 #ifdef DEBUG_MXP_PROCESSING
         qDebug() << "TMxpDestTagHandler::handleStartTag: Destination set to:" << frameName;
 #endif
         return MXP_TAG_HANDLED;
     }
-    
+
 #ifdef DEBUG_MXP_PROCESSING
     qDebug() << "TMxpDestTagHandler::handleStartTag: Failed to set destination:" << frameName;
 #endif
@@ -67,12 +64,12 @@ TMxpTagHandlerResult TMxpDestTagHandler::handleEndTag(TMxpContext& ctx, TMxpClie
 {
     Q_UNUSED(ctx)
     Q_UNUSED(tag)
-    
+
 #ifdef DEBUG_MXP_PROCESSING
     qDebug() << "TMxpDestTagHandler::handleEndTag: Clearing destination";
 #endif
     client.clearMxpDestination();
-    
+
     return MXP_TAG_HANDLED;
 }
 
@@ -80,16 +77,14 @@ QString TMxpDestTagHandler::extractFrameName(MxpStartTag* tag)
 {
     // Frame name can be first positional argument or NAME attribute
     QString frameName = tag->getAttributeByNameOrIndex(qsl("NAME"), 0);
-    
+
     // If empty, check if any attribute without a value (flag-style)
     if (frameName.isEmpty()) {
         const auto& attrNames = tag->getAttributesNames();
 
         for (const auto& attrName : attrNames) {
             // Skip known flags
-            if (attrName.compare(qsl("EOL"), Qt::CaseInsensitive) != 0 &&
-                attrName.compare(qsl("EOF"), Qt::CaseInsensitive) != 0 &&
-                attrName.compare(qsl("NAME"), Qt::CaseInsensitive) != 0) {
+            if (attrName.compare(qsl("EOL"), Qt::CaseInsensitive) != 0 && attrName.compare(qsl("EOF"), Qt::CaseInsensitive) != 0 && attrName.compare(qsl("NAME"), Qt::CaseInsensitive) != 0) {
                 const auto& attr = tag->getAttribute(attrName);
                 // Assume this is the frame name
                 if (!attr.hasValue()) {
@@ -99,7 +94,7 @@ QString TMxpDestTagHandler::extractFrameName(MxpStartTag* tag)
             }
         }
     }
-    
+
     return frameName;
 }
 

--- a/src/TMxpFormattingTagsHandler.cpp
+++ b/src/TMxpFormattingTagsHandler.cpp
@@ -26,15 +26,11 @@ bool TMxpFormattingTagsHandler::supports(TMxpContext& ctx, TMxpClient& client, M
     Q_UNUSED(ctx)
     Q_UNUSED(client)
 
-    return tag->isNamed(qsl("B")) || tag->isNamed(qsl("BOLD")) || tag->isNamed(qsl("STRONG")) ||
-           tag->isNamed(qsl("H")) || tag->isNamed(qsl("HIGH")) ||
-           tag->isNamed(qsl("I")) || tag->isNamed(qsl("ITALIC")) || tag->isNamed(qsl("EM")) ||
-           tag->isNamed(qsl("U")) || tag->isNamed(qsl("UNDERLINE")) ||
-           tag->isNamed(qsl("S")) || tag->isNamed(qsl("STRIKEOUT")) ||
+    return tag->isNamed(qsl("B")) || tag->isNamed(qsl("BOLD")) || tag->isNamed(qsl("STRONG")) || tag->isNamed(qsl("H")) || tag->isNamed(qsl("HIGH")) || tag->isNamed(qsl("I"))
+           || tag->isNamed(qsl("ITALIC")) || tag->isNamed(qsl("EM")) || tag->isNamed(qsl("U")) || tag->isNamed(qsl("UNDERLINE")) || tag->isNamed(qsl("S")) || tag->isNamed(qsl("STRIKEOUT")) ||
            // Additional HTML tags - recognized but not styled differently:
-           tag->isNamed(qsl("H1")) || tag->isNamed(qsl("H2")) || tag->isNamed(qsl("H3")) ||
-           tag->isNamed(qsl("H4")) || tag->isNamed(qsl("H5")) || tag->isNamed(qsl("H6")) ||
-           tag->isNamed(qsl("SMALL")) || tag->isNamed(qsl("TT"));
+           tag->isNamed(qsl("H1")) || tag->isNamed(qsl("H2")) || tag->isNamed(qsl("H3")) || tag->isNamed(qsl("H4")) || tag->isNamed(qsl("H5")) || tag->isNamed(qsl("H6")) || tag->isNamed(qsl("SMALL"))
+           || tag->isNamed(qsl("TT"));
 }
 
 TMxpTagHandlerResult TMxpFormattingTagsHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
@@ -65,9 +61,7 @@ void TMxpFormattingTagsHandler::setAttribute(TMxpClient& client, MxpTag* tag, bo
         client.setUnderline(value);
     } else if (tag->isNamed("S") || tag->isNamed("STRIKEOUT")) {
         client.setStrikeOut(value);
-    } else if (tag->isNamed("H1") || tag->isNamed("H2") || tag->isNamed("H3") ||
-               tag->isNamed("H4") || tag->isNamed("H5") || tag->isNamed("H6") ||
-               tag->isNamed("SMALL") || tag->isNamed("TT")) {
+    } else if (tag->isNamed("H1") || tag->isNamed("H2") || tag->isNamed("H3") || tag->isNamed("H4") || tag->isNamed("H5") || tag->isNamed("H6") || tag->isNamed("SMALL") || tag->isNamed("TT")) {
         // Recognized but no styling applied
     } else {
         // do nothing

--- a/src/TMxpFrameManager.cpp
+++ b/src/TMxpFrameManager.cpp
@@ -37,12 +37,12 @@
 TMxpFrame::~TMxpFrame()
 {
     mBeingDestroyed = true;
-    
+
     if (parentFrame && !parentFrame->mBeingDestroyed) {
         parentFrame->childFrames.removeOne(this);
     }
     parentFrame = nullptr;
-    
+
     // Orphan children - we do NOT delete them since TMxpFrameManager owns all frames
     for (TMxpFrame* child : childFrames) {
         if (child && !child->mBeingDestroyed) {
@@ -50,7 +50,7 @@ TMxpFrame::~TMxpFrame()
         }
     }
     childFrames.clear();
-    
+
     if (dockWidget) {
         delete dockWidget.data();
     } else if (widget) {
@@ -74,22 +74,22 @@ bool TMxpFrameManager::createFrame(const QString& name, const QMap<QString, QStr
     if (!mpHost->mMxpProcessor.isEnabled()) {
         return false;
     }
-    
+
     if (!validateFrameName(name)) {
         qWarning() << "TMxpFrameManager::createFrame: Invalid frame name:" << name;
         return false;
     }
-    
+
     // Parse action first - avoids unnecessary TMxpFrame allocation for close/focus
     // Per Zugg/CMUD behavior: action determines what to do with the frame
     QString action = attributes.value(qsl("ACTION"), qsl("open")).toLower();
-    
+
     if (action == qsl("close")) {
         return closeFrame(name);
     } else if (action == qsl("focus")) {
         return focusFrame(name);
     }
-    
+
     // action="open" (default) - show existing frame or create new one
     if (frameExists(name)) {
         // Frame already exists - per CMUD 2.30 behavior, don't recreate or resize.
@@ -97,15 +97,15 @@ bool TMxpFrameManager::createFrame(const QString& name, const QMap<QString, QStr
         // Just ensure the frame is visible and return success.
         return showFrame(name);
     }
-    
+
     if (!canCreateFrame()) {
         qWarning() << "TMxpFrameManager::createFrame: Maximum frame limit reached";
         return false;
     }
-    
+
     auto* frame = new TMxpFrame();
     frame->name = name;
-    
+
     // Parse attributes
     frame->isInternal = attributes.contains(qsl("INTERNAL")) || !attributes.contains(qsl("EXTERNAL"));
     frame->align = attributes.value(qsl("ALIGN"), qsl("left")).toLower();
@@ -118,14 +118,11 @@ bool TMxpFrameManager::createFrame(const QString& name, const QMap<QString, QStr
     frame->scrolling = attributes.value(qsl("SCROLLING"), qsl("YES")).toUpper() == qsl("YES");
     frame->floating = attributes.contains(qsl("FLOATING"));
     frame->dockFrame = attributes.value(qsl("DOCK"));
-    
+
 #ifdef DEBUG_MXP_PROCESSING
-    qDebug() << "TMxpFrameManager::createFrame:" << name 
-             << "TITLE attr:" << attributes.value(qsl("TITLE"))
-             << "title:" << frame->title
-             << "floating:" << frame->floating;
+    qDebug() << "TMxpFrameManager::createFrame:" << name << "TITLE attr:" << attributes.value(qsl("TITLE")) << "title:" << frame->title << "floating:" << frame->floating;
 #endif
-    
+
     // Create the appropriate UI layout
     if (frame->isInternal) {
         if (!frame->dockFrame.isEmpty() && frame->align == qsl("client")) {
@@ -136,10 +133,10 @@ bool TMxpFrameManager::createFrame(const QString& name, const QMap<QString, QStr
     } else {
         layoutExternalFrame(frame);
     }
-    
+
     // Store the frame
     mFrames[name] = frame;
-    
+
     return true;
 }
 
@@ -149,40 +146,40 @@ bool TMxpFrameManager::closeFrame(const QString& name)
     if (!frame) {
         return false;
     }
-    
+
     if (mCurrentDestination == name) {
         clearDestination();
     }
-    
+
     // Special handling for frames that are tabs in a parent frame
     if (frame->parentFrame && frame->parentFrame->tabWidget && frame->widget) {
         QTabWidget* parentTabWidget = frame->parentFrame->tabWidget;
         QWidget* tabWidget = frame->widget;
-        
+
         // Find the tab index for this frame's widget
         int tabIndex = parentTabWidget->indexOf(tabWidget);
         if (tabIndex >= 0) {
             // Remove the tab from the parent's tab widget
             parentTabWidget->removeTab(tabIndex);
-            
+
             // Clean up console registration
             if (mpHost && mpHost->mpConsole) {
                 mpHost->mpConsole->mSubConsoleMap.remove(name);
                 mpHost->mpConsole->mDockWidgetMap.remove(name);
             }
-            
+
             // Remove from hierarchy
             removeFrameFromHierarchy(frame);
-            
+
             // Remove from frames map and delete
             mFrames.remove(name);
             delete frame;
-            
+
             // No need to recalculate borders for tab frames since they don't affect main window borders
             return true;
         }
     }
-    
+
     // Close children first - make a copy since closeFrame modifies the list
     QList<TMxpFrame*> childrenCopy = frame->childFrames;
 
@@ -191,20 +188,20 @@ bool TMxpFrameManager::closeFrame(const QString& name)
             closeFrame(child->name);
         }
     }
-    
+
     if (mpHost && mpHost->mpConsole) {
         mpHost->mpConsole->mSubConsoleMap.remove(name);
         mpHost->mpConsole->mDockWidgetMap.remove(name);
     }
-    
+
     removeFrameFromHierarchy(frame);
-    
+
     mFrames.remove(name);
     delete frame;
-    
+
     // Recalculate borders after frame removal to reclaim space
     recalculateBorders();
-    
+
     return true;
 }
 
@@ -215,7 +212,7 @@ bool TMxpFrameManager::focusFrame(const QString& name)
     if (!frame) {
         return false;
     }
-    
+
     if (frame->dockWidget) {
         frame->dockWidget->raise();
         frame->dockWidget->setFocus();
@@ -223,7 +220,7 @@ bool TMxpFrameManager::focusFrame(const QString& name)
         frame->widget->raise();
         frame->widget->setFocus();
     }
-    
+
     return true;
 }
 
@@ -234,7 +231,7 @@ bool TMxpFrameManager::showFrame(const QString& name)
     if (!frame) {
         return false;
     }
-    
+
     // Make the frame visible - per CMUD 2.30 behavior, action="open" on existing
     // frame should just show it without changing size/position
     if (frame->dockWidget) {
@@ -244,7 +241,7 @@ bool TMxpFrameManager::showFrame(const QString& name)
         frame->widget->show();
         frame->widget->raise();
     }
-    
+
     return true;
 }
 
@@ -256,13 +253,13 @@ void TMxpFrameManager::resetAllFrames()
     for (const QString& name : frameNames) {
         closeFrame(name);
     }
-    
+
     mMxpBorders = QMargins();
-    
+
     if (mpHost) {
         mpHost->setBorders(QMargins());
     }
-    
+
     clearDestination();
 }
 
@@ -274,7 +271,7 @@ void TMxpFrameManager::setDestination(const QString& frameName, bool eol, bool e
 #endif
         return;
     }
-    
+
     if (frameName.isEmpty()) {
 #ifdef DEBUG_MXP_PROCESSING
         qDebug() << "TMxpFrameManager::setDestination: Empty frame name, clearing destination";
@@ -282,7 +279,7 @@ void TMxpFrameManager::setDestination(const QString& frameName, bool eol, bool e
         clearDestination();
         return;
     }
-    
+
     auto* frame = getFrame(frameName);
 
     if (!frame) {
@@ -292,15 +289,13 @@ void TMxpFrameManager::setDestination(const QString& frameName, bool eol, bool e
 #endif
         return;
     }
-    
+
 #ifdef DEBUG_MXP_PROCESSING
-    qDebug() << "TMxpFrameManager::setDestination: Setting destination to" << frameName
-             << "frame->console:" << (frame->console ? "valid" : "null")
-             << "eol:" << eol << "eof:" << eof;
+    qDebug() << "TMxpFrameManager::setDestination: Setting destination to" << frameName << "frame->console:" << (frame->console ? "valid" : "null") << "eol:" << eol << "eof:" << eof;
 #endif
-    
+
     mCurrentDestination = frameName;
-    
+
     auto* console = getCurrentDestinationConsole();
 
     if (console) {
@@ -322,7 +317,7 @@ QWidget* TMxpFrameManager::getCurrentDestinationWidget() const
     if (mCurrentDestination.isEmpty()) {
         return mpHost->mpConsole;
     }
-    
+
     const auto* frame = getFrame(mCurrentDestination);
     return frame ? frame->widget.data() : nullptr;
 }
@@ -332,7 +327,7 @@ TConsole* TMxpFrameManager::getCurrentDestinationConsole() const
     if (mCurrentDestination.isEmpty()) {
         return qobject_cast<TConsole*>(mpHost->mpConsole);
     }
-    
+
     const auto* frame = getFrame(mCurrentDestination);
     return frame ? frame->console.data() : nullptr;
 }
@@ -358,30 +353,30 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
         qWarning() << "TMxpFrameManager::layoutInternalFrame: No console available";
         return;
     }
-    
+
     TMainConsole* mainConsole = mpHost->mpConsole.data();
-    
+
     // Note: DOCK tabbing is handled in createFrame() when ALIGN=CLIENT is set.
     // Per CMUD, ALIGN=CLIENT + DOCK creates tabbed frames.
     // This is a CMUD extension, not part of the official MXP 1.0 specification.
-    
+
     // Check if we're inside a DEST - if so, nest this frame inside the destination
     TMxpFrame* parentFrame = nullptr;
     if (!mCurrentDestination.isEmpty()) {
         parentFrame = getFrame(mCurrentDestination);
     }
-    
+
     // Determine the container for this frame
     QSize containerSize;
     int containerX = 0;
     int containerY = 0;
-    
+
     if (parentFrame && parentFrame->widget) {
         // Nested frame - position relative to parent
         containerSize = parentFrame->widget->size();
         containerX = parentFrame->widget->x();
         containerY = parentFrame->widget->y();
-        
+
         // Track used space in parent for VBox-style stacking
         containerY += parentFrame->usedHeight;
         containerSize.setHeight(containerSize.height() - parentFrame->usedHeight);
@@ -393,31 +388,32 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
         containerSize.setWidth(containerSize.width() - mMxpBorders.left() - mMxpBorders.right());
         containerSize.setHeight(containerSize.height() - mMxpBorders.top() - mMxpBorders.bottom());
     }
-    
+
     // Calculate frame dimensions relative to container
     QSize widthSize = calculateFrameSize(frame->width, containerSize, false);
     QSize heightSize = calculateFrameSize(frame->height, containerSize, true);
     int frameWidth = widthSize.width();
     int frameHeight = heightSize.height();
-    
+
     // For "100%" height in a nested context, use remaining space
     if (frame->height.trimmed() == qsl("100%") && parentFrame) {
         frameHeight = containerSize.height();
     }
-    
+
     // Ensure minimum size for visibility
-    if (frameWidth < 50) frameWidth = 100;
-    
+    if (frameWidth < 50)
+        frameWidth = 100;
+
     // For character-based height specs, handle minimum size more carefully
     bool isCharacterHeight = frame->height.trimmed().endsWith('c', Qt::CaseInsensitive);
     bool isCharacterWidth = frame->width.trimmed().endsWith('c', Qt::CaseInsensitive);
     bool willHaveTitle = !frame->floating && frame->hasExplicitTitle;
-    
+
     // Apply minimum size for visibility to non-character-based frames
     if (frameHeight < 20 && !isCharacterHeight) {
         frameHeight = 50;
     }
-    
+
     // For character-based frames, ensure adequate space regardless of title
     if (isCharacterHeight) {
         int minFrameSize;
@@ -428,36 +424,36 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
             // No title: just ensure adequate content space (30px minimum)
             minFrameSize = 30;
         }
-        
+
         if (frameHeight < minFrameSize) {
             frameHeight = minFrameSize;
         }
-        
+
         // IMPORTANT: If this frame will have a tab header, add extra height
-        // to the character-based calculation so the final console area (after 
+        // to the character-based calculation so the final console area (after
         // subtracting tab widget overhead) matches the requested character count
         if (willHaveTitle) {
             // Tab widget overhead includes: tab bar (24px) + content margins/padding (~6px)
             frameHeight += 30; // More accurate tab widget overhead
         }
     }
-    
+
     // Add small padding compensation for character-based frames to ensure full character visibility
     // This accounts for any internal widget padding or text rendering margins
     if (isCharacterHeight || isCharacterWidth) {
         if (isCharacterWidth && frameWidth > 0) {
-            frameWidth += 4;  // Add 4px horizontal padding for character visibility
+            frameWidth += 4; // Add 4px horizontal padding for character visibility
         }
         if (isCharacterHeight && frameHeight > 0) {
-            frameHeight += 4; // Add 4px vertical padding for character visibility  
+            frameHeight += 4; // Add 4px vertical padding for character visibility
         }
     }
-    
+
     // Calculate position based on alignment
     int x = containerX;
     int y = containerY;
     QString align = frame->align.toLower();
-    
+
     if (parentFrame) {
         // Nested frame - position within parent's bounds using VBox/HBox logic
         if (align == qsl("left") || align.isEmpty()) {
@@ -477,10 +473,10 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
     } else {
         // Top-level frame - position at window edges and update MXP borders
         QSize windowSize = mainConsole->size();
-        
+
         // Check for LEFT/TOP absolute positioning first - these take precedence over alignment
         bool hasAbsolutePosition = !frame->left.isEmpty() || !frame->top.isEmpty();
-        
+
         if (hasAbsolutePosition) {
             // Absolute positioning via LEFT/TOP attributes
             if (!frame->left.isEmpty()) {
@@ -526,48 +522,43 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
             x = containerX;
             y = containerY;
         }
-        
+
         mpHost->setBorders(mMxpBorders);
     }
-    
+
     // FLOATING attribute, no explicit title, or very small height = borderless frame without header
     // Exception: character-based frames with explicit titles always show headers
-    bool showHeader = !frame->floating && frame->hasExplicitTitle && 
-                      (frameHeight >= 50 || (isCharacterHeight && willHaveTitle));
+    bool showHeader = !frame->floating && frame->hasExplicitTitle && (frameHeight >= 50 || (isCharacterHeight && willHaveTitle));
     const int tabBarHeight = showHeader ? 30 : 0; // Tab widget overhead including margins
-    
+
 #ifdef DEBUG_MXP_PROCESSING
-    qDebug() << "TMxpFrameManager::layoutInternalFrame: Creating frame" << frame->name 
-             << "at" << x << y << "size" << frameWidth << "x" << frameHeight
-             << "showHeader:" << showHeader;
+    qDebug() << "TMxpFrameManager::layoutInternalFrame: Creating frame" << frame->name << "at" << x << y << "size" << frameWidth << "x" << frameHeight << "showHeader:" << showHeader;
 #endif
-    
+
     // Create the container widget for the frame - use WA_DontShowOnScreen to prevent any rendering
     auto* containerWidget = new QFrame(mainConsole->mpMainFrame);
     containerWidget->setAttribute(Qt::WA_DontShowOnScreen, true);
     containerWidget->setObjectName(frame->name + qsl("_container"));
     containerWidget->setGeometry(x, y, frameWidth, frameHeight);
-    
+
     if (showHeader) {
         containerWidget->setFrameStyle(QFrame::Panel | QFrame::Raised);
         containerWidget->setLineWidth(1);
-        containerWidget->setStyleSheet(
-            qsl("QFrame { background-color: #1a1a1a; border: 1px solid #444444; }"));
+        containerWidget->setStyleSheet(qsl("QFrame { background-color: #1a1a1a; border: 1px solid #444444; }"));
     } else {
         containerWidget->setFrameStyle(QFrame::NoFrame);
         containerWidget->setLineWidth(0);
-        containerWidget->setStyleSheet(
-            qsl("QFrame { background-color: transparent; border: none; }"));
+        containerWidget->setStyleSheet(qsl("QFrame { background-color: transparent; border: none; }"));
     }
-    
+
     // Create a layout for the container
     auto* containerLayout = new QVBoxLayout(containerWidget);
     containerLayout->setContentsMargins(0, 0, 0, 0);
     containerLayout->setSpacing(0);
-    
+
     QTabWidget* tabWidget = nullptr;
     TConsole* console = nullptr;
-    
+
     if (showHeader) {
         // Create TabWidget as the header - allows future tab additions
         tabWidget = new QTabWidget(containerWidget);
@@ -575,13 +566,12 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
         tabWidget->setTabPosition(QTabWidget::North);
         tabWidget->setDocumentMode(true);
         tabWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-        tabWidget->setStyleSheet(qsl(
-            "QTabWidget::pane { border: none; background-color: transparent; }"
-            "QTabBar::tab { background-color: #2a2a2a; color: #cccccc; padding: 4px 12px; "
-            "              border: 1px solid #444444; border-bottom: none; margin-right: 2px; }"
-            "QTabBar::tab:selected { background-color: #3a3a3a; color: #ffffff; }"
-            "QTabBar::tab:hover { background-color: #333333; }"));
-        
+        tabWidget->setStyleSheet(qsl("QTabWidget::pane { border: none; background-color: transparent; }"
+                                     "QTabBar::tab { background-color: #2a2a2a; color: #cccccc; padding: 4px 12px; "
+                                     "              border: 1px solid #444444; border-bottom: none; margin-right: 2px; }"
+                                     "QTabBar::tab:selected { background-color: #3a3a3a; color: #ffffff; }"
+                                     "QTabBar::tab:hover { background-color: #333333; }"));
+
         // Create a page widget to hold the console
         auto* tabPage = new QWidget();
         tabPage->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -589,7 +579,7 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
         tabPage->setStyleSheet(qsl("background-color: transparent;"));
         auto* tabPageLayout = new QVBoxLayout(tabPage);
         tabPageLayout->setContentsMargins(0, 0, 0, 0);
-        
+
         // Create console directly with tabPage as parent to avoid flash on mpMainFrame
         // (createMiniConsole parents to mpMainFrame and calls show() before we can intervene)
         console = new TConsole(mpHost, frame->name, TConsole::SubConsole, tabPage);
@@ -598,7 +588,7 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
             delete containerWidget;
             return;
         }
-        
+
         // Setup console properties (mirroring what createMiniConsole does)
         console->setObjectName(frame->name);
         const auto& hostCommandLine = mpHost->mpConsole->mpCommandLine;
@@ -614,22 +604,22 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
         console->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
         // Don't show yet - wait until frame is fully set up
         console->hide();
-        
+
         tabPageLayout->addWidget(console);
         int tabIndex = tabWidget->addTab(tabPage, frame->title);
-        tabWidget->setCurrentIndex(tabIndex);  // Make this tab active
+        tabWidget->setCurrentIndex(tabIndex); // Make this tab active
         containerLayout->addWidget(tabWidget);
     } else {
         // Floating/borderless: console directly in container, no tab header
         // Create console directly with containerWidget as parent to avoid flash
         console = new TConsole(mpHost, frame->name, TConsole::SubConsole, containerWidget);
-        
+
         if (!console) {
             qWarning() << "TMxpFrameManager::layoutInternalFrame: Failed to create console for" << frame->name;
             delete containerWidget;
             return;
         }
-        
+
         // Setup console properties (mirroring what createMiniConsole does)
         console->setObjectName(frame->name);
         const auto& hostCommandLine = mpHost->mpConsole->mpCommandLine;
@@ -644,44 +634,44 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
         console->setFontSize(fontSize > 0 ? fontSize : 12);
         console->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
         console->hide();
-        
+
         containerLayout->addWidget(console);
     }
-    
+
     // Store the container, TabWidget (may be null), and console
     frame->widget = containerWidget;
     frame->tabWidget = tabWidget;
     frame->console = console;
     frame->dockWidget = nullptr;
     frame->usedHeight = 0;
-    
+
     // Track parent-child relationship
     if (parentFrame) {
         frame->parentFrame = parentFrame;
         parentFrame->childFrames.append(frame);
     }
-    
+
     // Configure scrolling
     if (!frame->scrolling) {
         console->setScrolling(false);
     }
-    
+
     // Set console colors - slightly different background for visual distinction
     console->setFgColor(mainConsole->mFgColor);
     // Use a slightly lighter background for frames to distinguish from main console
     QColor frameBgColor = mainConsole->mBgColor;
-    frameBgColor = frameBgColor.lighter(115);  // 15% lighter than main console
+    frameBgColor = frameBgColor.lighter(115); // 15% lighter than main console
     console->setBgColor(frameBgColor);
-    
+
     // Only add border for borderless/floating frames (no tab header)
     // Tabbed frames already have visual separation from the tab widget
     if (!showHeader) {
         console->setStyleSheet(qsl("QWidget { border: 1px solid #444444; }"));
     }
-    
+
     // Register console
     mainConsole->mSubConsoleMap.insert(frame->name, console);
-    
+
     // Force layout to calculate sizes
     containerWidget->layout()->activate();
     if (tabWidget) {
@@ -691,13 +681,13 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
             tabWidget->currentWidget()->resize(tabWidget->size());
         }
     }
-    
+
     // Clear the WA_DontShowOnScreen attribute and show immediately
     containerWidget->setAttribute(Qt::WA_DontShowOnScreen, false);
     console->show();
     containerWidget->show();
     containerWidget->raise();
-    
+
     // Force immediate repaint to prevent visual artifacts
     containerWidget->update();
     QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
@@ -709,35 +699,30 @@ void TMxpFrameManager::layoutExternalFrame(TMxpFrame* frame)
         qWarning() << "TMxpFrameManager::layoutExternalFrame: No console available";
         return;
     }
-    
+
     // Calculate size
     QSize mainSize = mpHost->mpConsole->size();
     QSize widthSize = calculateFrameSize(frame->width, mainSize, false);
     QSize heightSize = calculateFrameSize(frame->height, mainSize, true);
     int frameWidth = widthSize.width();
     int frameHeight = heightSize.height();
-    
+
     // Create standalone window with mini console
-    auto* console = mpHost->mpConsole->createMiniConsole(
-        qsl("main"),
-        frame->name,
-        0, 0,
-        frameWidth,
-        frameHeight);
-    
+    auto* console = mpHost->mpConsole->createMiniConsole(qsl("main"), frame->name, 0, 0, frameWidth, frameHeight);
+
     if (!console) {
         qWarning() << "TMxpFrameManager::layoutExternalFrame: Failed to create console";
         return;
     }
-    
+
     frame->widget = console;
     frame->console = console;
-    
+
     // Configure scrolling
     if (!frame->scrolling) {
         console->setScrolling(false);
     }
-    
+
     // Set window title and show as floating
     console->setWindowTitle(frame->title);
     console->setWindowFlags(Qt::Window);
@@ -750,7 +735,7 @@ void TMxpFrameManager::layoutTabFrame(TMxpFrame* frame)
         qWarning() << "TMxpFrameManager::layoutTabFrame: No console available";
         return;
     }
-    
+
     // Find parent frame for tab docking
     auto* parentFrame = getFrame(frame->dockFrame);
 
@@ -759,52 +744,50 @@ void TMxpFrameManager::layoutTabFrame(TMxpFrame* frame)
         layoutInternalFrame(frame);
         return;
     }
-    
+
     // Ensure parent has a tab widget
     if (!parentFrame->tabWidget && parentFrame->dockWidget) {
         // Create tab widget to replace single widget
         auto* tabWidget = new QTabWidget();
-        
+
         // Move existing widget to first tab
         if (parentFrame->widget) {
             tabWidget->addTab(parentFrame->widget, parentFrame->title);
         }
-        
+
         parentFrame->tabWidget = tabWidget;
         parentFrame->dockWidget->setWidget(tabWidget);
     }
-    
+
     if (!parentFrame->tabWidget) {
         qWarning() << "TMxpFrameManager::layoutTabFrame: Failed to create tab widget";
         layoutInternalFrame(frame);
         return;
     }
-    
+
     // Calculate size
     QSize tabSize = parentFrame->tabWidget->size();
-    QSize frameSize = calculateFrameSize(frame->width, tabSize, false) + 
-                      calculateFrameSize(frame->height, tabSize, true);
-    
+    QSize frameSize = calculateFrameSize(frame->width, tabSize, false) + calculateFrameSize(frame->height, tabSize, true);
+
 #ifdef DEBUG_MXP_PROCESSING
-    qDebug() << "TMxpFrameManager::layoutTabFrame: Adding tab" << frame->name 
-             << "to parent" << frame->dockFrame << "size" << frameSize;
+    qDebug() << "TMxpFrameManager::layoutTabFrame: Adding tab" << frame->name << "to parent" << frame->dockFrame << "size" << frameSize;
 #endif
-    
+
     // Create a page widget to hold the console (avoids flash on mpMainFrame)
     auto* tabPage = new QWidget();
     tabPage->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     auto* tabPageLayout = new QVBoxLayout(tabPage);
     tabPageLayout->setContentsMargins(0, 0, 0, 0);
-    
+
     // Create console directly with tabPage as parent
     auto* console = new TConsole(mpHost, frame->name, TConsole::SubConsole, tabPage);
-    
+
     if (!console) {
         qWarning() << "TMxpFrameManager::layoutTabFrame: Failed to create console";
         delete tabPage;
         return;
     }
-    
+
     // Setup console properties
     TMainConsole* mainConsole = mpHost->mpConsole;
     console->setObjectName(frame->name);
@@ -819,22 +802,22 @@ void TMxpFrameManager::layoutTabFrame(TMxpFrame* frame)
     int fontSize = mpHost->getDisplayFont().pointSize();
     console->setFontSize(fontSize > 0 ? fontSize : 12);
     console->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    
+
     tabPageLayout->addWidget(console);
-    
+
     frame->widget = tabPage;
     frame->console = console;
     frame->parentFrame = parentFrame;
     parentFrame->childFrames.append(frame);
-    
+
     // Configure scrolling
     if (!frame->scrolling) {
         console->setScrolling(false);
     }
-    
+
     // Register console in map
     mainConsole->mSubConsoleMap.insert(frame->name, console);
-    
+
     // Add as new tab - if this is the first child tab, select it
     // (The parent frame's own tab at index 0 is typically unused for content)
     int newTabIndex = parentFrame->tabWidget->addTab(tabPage, frame->title);
@@ -850,9 +833,9 @@ QSize TMxpFrameManager::calculateFrameSize(const QString& spec, const QSize& con
     if (spec.isEmpty()) {
         return QSize(0, 0);
     }
-    
+
     QString trimmed = spec.trimmed();
-    
+
     // Character-based size (e.g., "40c")
     if (trimmed.endsWith('c', Qt::CaseInsensitive)) {
         bool ok;
@@ -860,24 +843,24 @@ QSize TMxpFrameManager::calculateFrameSize(const QString& spec, const QSize& con
         if (!ok || chars <= 0) {
             return QSize(0, 0);
         }
-        
+
         // Get font metrics from main console
         QFont font = mpHost->getDisplayFont();
         QFontMetrics fm(font);
-        
+
         if (isHeight) {
             // Use height() instead of lineSpacing() to match Host::calcFontSize()
             // and avoid extra line spacing that reduces actual character count
             int result = chars * fm.height();
             return QSize(0, result);
         } else {
-            // Use horizontalAdvance('W') instead of averageCharWidth() for consistency 
+            // Use horizontalAdvance('W') instead of averageCharWidth() for consistency
             // with Host::calcFontSize() which uses this for more accurate character width
             int result = chars * fm.horizontalAdvance(QChar('W'));
             return QSize(result, 0);
         }
     }
-    
+
     // Percentage-based size (e.g., "25%")
     if (trimmed.endsWith('%')) {
         bool ok;
@@ -886,27 +869,27 @@ QSize TMxpFrameManager::calculateFrameSize(const QString& spec, const QSize& con
         if (!ok || percent <= 0 || percent > 100) {
             return QSize(0, 0);
         }
-        
+
         int dimension = isHeight ? containerSize.height() : containerSize.width();
         int size = (dimension * percent) / 100;
-        
+
         return isHeight ? QSize(0, size) : QSize(size, 0);
     }
-    
+
     // Pixel-based size (e.g., "350px" or just "350")
     QString pixelStr = trimmed;
 
     if (pixelStr.endsWith(qsl("px"), Qt::CaseInsensitive)) {
         pixelStr = pixelStr.left(pixelStr.length() - 2);
     }
-    
+
     bool ok;
     int pixels = pixelStr.toInt(&ok);
 
     if (!ok || pixels <= 0) {
         return QSize(0, 0);
     }
-    
+
     return isHeight ? QSize(0, pixels) : QSize(pixels, 0);
 }
 
@@ -930,7 +913,7 @@ bool TMxpFrameManager::validateFrameName(const QString& name) const
     if (name.isEmpty()) {
         return false;
     }
-    
+
     // Basic validation - alphanumeric, underscore, hyphen
     static QRegularExpression validNamePattern(qsl("^[a-zA-Z0-9_-]+$"));
     return validNamePattern.match(name).hasMatch();
@@ -946,13 +929,13 @@ void TMxpFrameManager::removeFrameFromHierarchy(TMxpFrame* frame)
     if (!frame || frame->mBeingDestroyed) {
         return;
     }
-    
+
     // Remove from parent's child list (if parent is valid)
     if (frame->parentFrame && !frame->parentFrame->mBeingDestroyed) {
         frame->parentFrame->childFrames.removeOne(frame);
     }
     frame->parentFrame = nullptr;
-    
+
     // Orphan children (set their parentFrame to nullptr)
     for (TMxpFrame* child : frame->childFrames) {
         if (child && !child->mBeingDestroyed) {
@@ -968,69 +951,69 @@ void TMxpFrameManager::layoutTabIntoExistingFrame(TMxpFrame* frame, TMxpFrame* t
         qWarning() << "TMxpFrameManager::layoutTabIntoExistingFrame: No console available";
         return;
     }
-    
+
     if (!targetFrame->tabWidget) {
         qWarning() << "TMxpFrameManager::layoutTabIntoExistingFrame: Target frame has no TabWidget:" << targetFrame->name;
         return;
     }
-    
+
     TMainConsole* mainConsole = mpHost->mpConsole.data();
     QTabWidget* tabWidget = targetFrame->tabWidget;
-    
+
     auto* tabPage = new QWidget();
     auto* tabPageLayout = new QVBoxLayout(tabPage);
     tabPageLayout->setContentsMargins(0, 0, 0, 0);
-    
+
     // Get size from target frame's container
     QSize containerSize = targetFrame->widget ? targetFrame->widget->size() : QSize(200, 200);
-    
+
     // Create mini console for this tab
-    auto* console = mainConsole->createMiniConsole(
-        qsl("main"), 
-        frame->name, 
-        0, 0,  // Position managed by layout
-        containerSize.width(), 
-        containerSize.height() - 30);  // Account for tab bar
-    
+    auto* console = mainConsole->createMiniConsole(qsl("main"),
+                                                   frame->name,
+                                                   0,
+                                                   0, // Position managed by layout
+                                                   containerSize.width(),
+                                                   containerSize.height() - 30); // Account for tab bar
+
     if (!console) {
         qWarning() << "TMxpFrameManager::layoutTabIntoExistingFrame: Failed to create console for" << frame->name;
         delete tabPage;
         return;
     }
-    
+
     // Ensure console expands to fill available space in the tab
     console->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    
+
     // Add console to tab page layout
     tabPageLayout->addWidget(console);
-    
+
     // Add the new tab
     int tabIndex = tabWidget->addTab(tabPage, frame->title);
-    
+
     // Store references
     frame->widget = tabPage;
-    frame->tabWidget = tabWidget;  // Share the TabWidget reference
+    frame->tabWidget = tabWidget; // Share the TabWidget reference
     frame->console = console;
     frame->parentFrame = targetFrame;
     targetFrame->childFrames.append(frame);
-    
+
     // Configure scrolling
     if (!frame->scrolling) {
         console->setScrolling(false);
     }
-    
+
     // Set console colors
     console->setFgColor(mainConsole->mFgColor);
     QColor frameBgColor = mainConsole->mBgColor;
     frameBgColor = frameBgColor.lighter(115);
     console->setBgColor(frameBgColor);
-    
+
     // Register console
     mainConsole->mSubConsoleMap.insert(frame->name, console);
-    
+
     // Optionally switch to the new tab
     tabWidget->setCurrentIndex(tabIndex);
-    
+
     console->show();
 }
 
@@ -1039,35 +1022,35 @@ void TMxpFrameManager::recalculateBorders()
     if (!mpHost) {
         return;
     }
-    
+
     // Reset borders and recalculate based on remaining frames
     mMxpBorders = QMargins();
-    
+
     if (!mpHost->mpConsole) {
         mpHost->setBorders(mMxpBorders);
         return;
     }
-    
+
     QSize windowSize = mpHost->mpConsole->size();
-    
+
     // Recalculate borders by examining all remaining top-level frames
     // (frames without parents that affect the main window borders)
     for (auto* frame : mFrames.values()) {
         if (!frame || frame->parentFrame) {
             continue; // Skip child frames, only process top-level frames
         }
-        
+
         // Only frames that were positioned using alignment (not absolute positioning)
         // contribute to MXP borders
         bool hasAbsolutePosition = !frame->left.isEmpty() || !frame->top.isEmpty();
         if (hasAbsolutePosition) {
             continue;
         }
-        
+
         QString align = frame->align.toLower();
         QSize widthSize = calculateFrameSize(frame->width, windowSize, false);
         QSize heightSize = calculateFrameSize(frame->height, windowSize, true);
-        
+
         if (align == qsl("left")) {
             mMxpBorders.setLeft(mMxpBorders.left() + widthSize.width());
         } else if (align == qsl("right")) {
@@ -1078,7 +1061,7 @@ void TMxpFrameManager::recalculateBorders()
             mMxpBorders.setBottom(mMxpBorders.bottom() + heightSize.height());
         }
     }
-    
+
     // Apply the recalculated borders
     mpHost->setBorders(mMxpBorders);
 }

--- a/src/TMxpFrameTagHandler.cpp
+++ b/src/TMxpFrameTagHandler.cpp
@@ -30,30 +30,28 @@ bool TMxpFrameTagHandler::supports(TMxpContext& ctx, TMxpClient& client, MxpTag*
 TMxpTagHandlerResult TMxpFrameTagHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
 {
     Q_UNUSED(ctx)
-    
+
     QMap<QString, QString> attributes = extractAttributes(tag);
     QString frameName = attributes.value(qsl("NAME"));
-    
+
 #ifdef DEBUG_MXP_PROCESSING
-    qDebug() << "TMxpFrameTagHandler::handleStartTag: FRAME tag received"
-             << "name:" << frameName
-             << "attributes:" << attributes;
+    qDebug() << "TMxpFrameTagHandler::handleStartTag: FRAME tag received" << "name:" << frameName << "attributes:" << attributes;
 #endif
-    
+
     if (frameName.isEmpty()) {
 #ifdef DEBUG_MXP_PROCESSING
         qDebug() << "TMxpFrameTagHandler::handleStartTag: Empty frame name, not handled";
 #endif
         return MXP_TAG_NOT_HANDLED;
     }
-    
+
     if (client.createMxpFrame(frameName, attributes)) {
 #ifdef DEBUG_MXP_PROCESSING
         qDebug() << "TMxpFrameTagHandler::handleStartTag: Frame created successfully:" << frameName;
 #endif
         return MXP_TAG_HANDLED;
     }
-    
+
 #ifdef DEBUG_MXP_PROCESSING
     qDebug() << "TMxpFrameTagHandler::handleStartTag: Frame creation failed:" << frameName;
 #endif
@@ -63,21 +61,21 @@ TMxpTagHandlerResult TMxpFrameTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
 QMap<QString, QString> TMxpFrameTagHandler::extractAttributes(MxpStartTag* tag)
 {
     QMap<QString, QString> attributes;
-    
+
     // Get the NAME attribute (can be first positional argument or named)
     QString name = tag->getAttributeByNameOrIndex(qsl("NAME"), 0);
 
     if (!name.isEmpty()) {
         attributes[qsl("NAME")] = name;
     }
-    
+
     // Extract all other attributes
     const auto& attrNames = tag->getAttributesNames();
 
     for (const auto& attrName : attrNames) {
         QString upperName = attrName.toUpper();
         const auto& attr = tag->getAttribute(attrName);
-        
+
         // Common attributes
         if (upperName == qsl("INTERNAL")) {
             attributes[qsl("INTERNAL")] = qsl("true");
@@ -110,6 +108,6 @@ QMap<QString, QString> TMxpFrameTagHandler::extractAttributes(MxpStartTag* tag)
             attributes[qsl("FLOATING")] = qsl("true");
         }
     }
-    
+
     return attributes;
 }

--- a/src/TMxpHRTagHandler.cpp
+++ b/src/TMxpHRTagHandler.cpp
@@ -24,10 +24,10 @@ TMxpTagHandlerResult TMxpHRTagHandler::handleStartTag(TMxpContext& ctx, TMxpClie
 {
     Q_UNUSED(ctx)
     Q_UNUSED(tag)
-    
+
     // Get the console wrap width to determine HR length
     const int width = client.getWrapWidth();
-    
+
     // Build HR with newlines: the first \n commits the current buffered line,
     // then the dashes form the HR line, and the final \n starts a new line.
     // We inject this through insertText() which feeds it back through the MXP
@@ -35,6 +35,6 @@ TMxpTagHandlerResult TMxpHRTagHandler::handleStartTag(TMxpContext& ctx, TMxpClie
     // the current line buffer state.
     const QString horizontalRule = qsl("\n") + QString(width, '-') + qsl("\n");
     client.insertText(horizontalRule);
-    
+
     return MXP_TAG_HANDLED;
 }

--- a/src/TMxpImageTagHandler.cpp
+++ b/src/TMxpImageTagHandler.cpp
@@ -24,7 +24,7 @@ TMxpTagHandlerResult TMxpImageTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
     Q_UNUSED(ctx)
     Q_UNUSED(client)
     Q_UNUSED(tag)
-    
+
     // IMAGE tag is not yet supported in Mudlet, but we swallow it
     // to prevent it from appearing in the output
     return MXP_TAG_HANDLED;

--- a/src/TMxpLinkTagHandler.cpp
+++ b/src/TMxpLinkTagHandler.cpp
@@ -25,7 +25,7 @@
 TMxpTagHandlerResult TMxpLinkTagHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
 {
     Q_UNUSED(ctx)
-    
+
     // Extract expire name if present
     QString expireName;
     if (tag->hasAttribute(qsl("expire"))) {
@@ -47,7 +47,7 @@ TMxpTagHandlerResult TMxpLinkTagHandler::handleStartTag(TMxpContext& ctx, TMxpCl
     } else {
         mLinkId = client.setLink(QStringList(href), QStringList(hint));
     }
-    
+
     client.setLinkMode(true);
     return MXP_TAG_HANDLED;
 }

--- a/src/TMxpMudlet.cpp
+++ b/src/TMxpMudlet.cpp
@@ -218,17 +218,17 @@ bool TMxpMudlet::startTagReceived(MxpStartTag* startTag)
     // Get the current MXP mode from the processor
     TMXPMode currentMode = mpHost->mMxpProcessor.mode();
     const QString tagName = startTag->getName().toUpper();
-    
+
     // In LOCKED mode, no tags are allowed
     if (currentMode == MXP_MODE_LOCKED) {
         return false;
     }
-    
+
     // Check if this tag is allowed in the current mode
     if (!isTagAllowedInMode(tagName, currentMode)) {
         return false;
     }
-    
+
     return true;
 }
 
@@ -238,29 +238,36 @@ bool TMxpMudlet::isTagAllowedInMode(const QString& tagName, TMXPMode mode) const
     if (mode == MXP_MODE_SECURE || mode == MXP_MODE_TEMP_SECURE) {
         return true;
     }
-    
+
     // In LOCKED mode, no tags are allowed (handled in startTagReceived)
     if (mode == MXP_MODE_LOCKED) {
         return false;
     }
-    
+
     // In OPEN mode, only specific formatting tags are allowed
     // According to MXP spec: https://www.zuggsoft.com/zmud/mxp.htm
     // OPEN tags are: B, I, U, S, C (color), H (high), FONT, NOBR, P, BR, SBR
     // Plus their variations: BOLD, ITALIC, UNDERLINE, STRIKEOUT, EM, STRONG, HIGH
-    static const QSet<QString> openModeTags = {
-        qsl("B"), qsl("BOLD"), qsl("STRONG"),
-        qsl("I"), qsl("ITALIC"), qsl("EM"),
-        qsl("U"), qsl("UNDERLINE"),
-        qsl("S"), qsl("STRIKEOUT"),
-        qsl("C"), qsl("COLOR"),
-        qsl("H"), qsl("HIGH"),
-        qsl("FONT"),
-        qsl("NOBR"),
-        qsl("P"),
-        qsl("BR"), qsl("SBR")
-    };
-    
+    static const QSet<QString> openModeTags = {qsl("B"),
+                                               qsl("BOLD"),
+                                               qsl("STRONG"),
+                                               qsl("I"),
+                                               qsl("ITALIC"),
+                                               qsl("EM"),
+                                               qsl("U"),
+                                               qsl("UNDERLINE"),
+                                               qsl("S"),
+                                               qsl("STRIKEOUT"),
+                                               qsl("C"),
+                                               qsl("COLOR"),
+                                               qsl("H"),
+                                               qsl("HIGH"),
+                                               qsl("FONT"),
+                                               qsl("NOBR"),
+                                               qsl("P"),
+                                               qsl("BR"),
+                                               qsl("SBR")};
+
     return openModeTags.contains(tagName);
 }
 

--- a/src/TMxpMusicTagHandler.cpp
+++ b/src/TMxpMusicTagHandler.cpp
@@ -35,7 +35,7 @@ TMxpTagHandlerResult TMxpMusicTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
         const QString type = extractType(tag);
         const QString url = extractUrl(tag);
 
-        TMediaData mediaData {};
+        TMediaData mediaData{};
 
         mediaData.setMediaProtocol(TMediaData::MediaProtocolMSP);
         mediaData.setMediaType(TMediaData::MediaTypeMusic);

--- a/src/TMxpNodeBuilder.cpp
+++ b/src/TMxpNodeBuilder.cpp
@@ -82,7 +82,7 @@ bool TMxpNodeBuilder::acceptTag(char ch)
 
     if (ch == '<') { // reset
         if (!mIsInsideTag) {
-        resetCurrentTag();
+            resetCurrentTag();
         }
         if (!mRawTagContent.empty() && mRawTagContent.back() == '<') {
             mRawTagContent.pop_back();

--- a/src/TMxpProcessor.cpp
+++ b/src/TMxpProcessor.cpp
@@ -71,7 +71,7 @@ bool TMxpProcessor::setMode(int modeCode)
     // MXP line modes - comments are from http://www.zuggsoft.com/zmud/mxp.htm#MXP%20Line%20TagsmMXP = true; // some servers don't negotiate, they assume!
 
     mMXP = true;
-    
+
     switch (modeCode) {
     case 0: // open line - only MXP commands in the "open" category are allowed.  When a newline is received from the MUD, the mode reverts back to the Default mode.  OPEN MODE starts as the Default mode until changes with one of the "lock mode" tags listed below.
         mMXP_MODE = MXP_MODE_OPEN;
@@ -160,16 +160,13 @@ void TMxpProcessor::disable()
 
 TMxpProcessingResult TMxpProcessor::processMxpInput(char& ch, bool resolveCustomEntities)
 {
-    if (ch == '<'
-    && mMxpTagBuilder.isInsideTag()
-    && !mMxpTagBuilder.isQuotedSequence()
-    && !mMxpTagBuilder.isInsideComment()) {
+    if (ch == '<' && mMxpTagBuilder.isInsideTag() && !mMxpTagBuilder.isQuotedSequence() && !mMxpTagBuilder.isInsideComment()) {
         // Error recovery: nested '<' inside a tag
         // Output the incomplete tag as text and prepare to process the new '<' as a tag start
         const std::string rawBytes = mMxpTagBuilder.getRawTagContent();
         const QByteArray encoding = mpMxpClient->getEncoding();
         QString decoded;
-        
+
         if (encoding == qsl("UTF-8")) {
             decoded = QString::fromStdString(rawBytes);
         } else if (encoding == qsl("ISO 8859-1")) {
@@ -177,7 +174,7 @@ TMxpProcessingResult TMxpProcessor::processMxpInput(char& ch, bool resolveCustom
         } else {
             decoded = TEncodingHelper::decode(QByteArray::fromRawData(rawBytes.c_str(), rawBytes.length()), encoding);
         }
-        
+
         lastEntityValue = qsl("<") + decoded;
         // resetForNewTag() puts the builder in "inside tag" state, as if we just processed '<'
         // This allows the next character to be processed as part of the new tag
@@ -193,10 +190,10 @@ TMxpProcessingResult TMxpProcessor::processMxpInput(char& ch, bool resolveCustom
         // Note: getRawTagContent() returns content INCLUDING the closing '>'
         const std::string rawTagBytes = mMxpTagBuilder.getRawTagContent();
         const QByteArray encoding = mpMxpClient->getEncoding();
-        
+
         // Build the tag content string with proper encoding
         QString rawTagContent = qsl("<");
-        
+
         // Decode the raw bytes using the proper encoding
         if (encoding == qsl("UTF-8")) {
             rawTagContent += QString::fromStdString(rawTagBytes);
@@ -206,7 +203,7 @@ TMxpProcessingResult TMxpProcessor::processMxpInput(char& ch, bool resolveCustom
             // For other encodings (GBK, BIG5, EUC-KR, etc.), use TEncodingHelper
             rawTagContent += TEncodingHelper::decode(QByteArray::fromRawData(rawTagBytes.c_str(), rawTagBytes.length()), encoding);
         }
-        
+
         QScopedPointer<MxpTag> const tag(mMxpTagBuilder.buildTag());
 
         if (mMXP_MODE == MXP_MODE_TEMP_SECURE) {
@@ -226,17 +223,17 @@ TMxpProcessingResult TMxpProcessor::processMxpInput(char& ch, bool resolveCustom
         return result == MXP_TAG_COMMIT_LINE ? HANDLER_COMMIT_LINE : HANDLER_NEXT_CHAR;
     }
 
-    if (mEntityHandler.handle(ch, resolveCustomEntities)) {             // ch is part of an entity
-        if (mEntityHandler.isEntityResolved()) { // entity has been mapped (i.e. ch == ';')
+    if (mEntityHandler.handle(ch, resolveCustomEntities)) { // ch is part of an entity
+        if (mEntityHandler.isEntityResolved()) {            // entity has been mapped (i.e. ch == ';')
             lastEntityValue = mEntityHandler.getResultAndReset();
             switch (mEntityHandler.getEntityType()) {
-                case ENTITY_TYPE_CUSTOM:
-                    return HANDLER_INSERT_ENTITY_CUST;
-                case ENTITY_TYPE_SYSTEM:
-                    // Note special handling for '\n' as a result of &newline;
-                    return lastEntityValue == qsl("\n") ? HANDLER_COMMIT_LINE : HANDLER_INSERT_ENTITY_SYS;
-                default:
-                    return HANDLER_INSERT_ENTITY_LIT;
+            case ENTITY_TYPE_CUSTOM:
+                return HANDLER_INSERT_ENTITY_CUST;
+            case ENTITY_TYPE_SYSTEM:
+                // Note special handling for '\n' as a result of &newline;
+                return lastEntityValue == qsl("\n") ? HANDLER_COMMIT_LINE : HANDLER_INSERT_ENTITY_SYS;
+            default:
+                return HANDLER_INSERT_ENTITY_LIT;
             }
         } else { // ask for the next char
             return HANDLER_NEXT_CHAR;

--- a/src/TMxpSendTagHandler.cpp
+++ b/src/TMxpSendTagHandler.cpp
@@ -29,7 +29,7 @@ TMxpTagHandlerResult TMxpSendTagHandler::handleStartTag(TMxpContext& ctx, TMxpCl
     QString href = extractHref(tag);
     QString hint = extractHint(tag);
     QString expireName;
-    
+
     // Extract expire name if present
     if (tag->hasAttribute(ATTR_EXPIRE)) {
         expireName = tag->getAttributeValue(ATTR_EXPIRE);
@@ -126,7 +126,7 @@ TMxpTagHandlerResult TMxpSendTagHandler::handleEndTag(TMxpContext& ctx, TMxpClie
 {
     Q_UNUSED(ctx)
     Q_UNUSED(tag)
-    
+
     // Only process link-related logic if a link was actually created
     if (mLinkId != 0) {
         if (mIsHrefInContent) {

--- a/src/TMxpSoundTagHandler.cpp
+++ b/src/TMxpSoundTagHandler.cpp
@@ -35,7 +35,7 @@ TMxpTagHandlerResult TMxpSoundTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
         const QString type = extractType(tag);
         const QString url = extractUrl(tag);
 
-        TMediaData mediaData {};
+        TMediaData mediaData{};
 
         mediaData.setMediaProtocol(TMediaData::MediaProtocolMSP);
         mediaData.setMediaType(TMediaData::MediaTypeSound);
@@ -105,7 +105,6 @@ QString TMxpSoundTagHandler::extractLoops(MxpStartTag* tag)
 
 QString TMxpSoundTagHandler::extractPriority(MxpStartTag* tag)
 {
-
     return tag->getAttributeByNameOrIndex(qsl("p"), 3);
 }
 

--- a/src/TMxpTagProcessor.cpp
+++ b/src/TMxpTagProcessor.cpp
@@ -53,7 +53,7 @@ TMxpTagHandlerResult TMxpTagProcessor::handleTag(TMxpContext& ctx, TMxpClient& c
 #ifdef DEBUG_MXP_PROCESSING
     qDebug() << "TMxpTagProcessor::handleTag() processing tag:" << tag->getName();
 #endif
-    
+
     if (!client.tagReceived(tag)) {
 #ifdef DEBUG_MXP_PROCESSING
         qDebug() << "  client.tagReceived() returned false, not handling";
@@ -97,20 +97,20 @@ TMxpTagProcessor::TMxpTagProcessor()
     // Variable and entity tags
     registerHandler(TMxpFeatureOptions({"var", {"publish"}}), new TMxpVarTagHandler());
     registerHandler(TMxpFeatureOptions({"entity", {"name", "value", "desc", "private", "publish", "delete", "add", "remove"}}), new TMxpEntityTagHandler());
-    
+
     // Line spacing tags
     registerHandler(TMxpFeatureOptions({"br", {}}), new TMxpBRTagHandler());
     registerHandler(TMxpFeatureOptions({"hr", {}}), new TMxpHRTagHandler());
-    
+
     // Link tags
     registerHandler(TMxpFeatureOptions({"send", {"href", "hint", "prompt", "expire"}}), new TMxpSendTagHandler());
     registerHandler(TMxpFeatureOptions({"a", {"href", "hint", "expire"}}), new TMxpLinkTagHandler());
     registerHandler(TMxpFeatureOptions({"expire", {"name"}}), new TMxpExpireTagHandler());
-    
+
     // Color and font tags
     registerHandler(TMxpFeatureOptions({"color", {"fore", "back"}}), new TMxpColorTagHandler());
     registerHandler(TMxpFeatureOptions({"font", {"color", "back"}}), new TMxpFontTagHandler());
-    
+
     // Media tags (MSP compatibility)
     registerHandler(TMxpFeatureOptions({"sound", {"fname", "v", "l", "p", "t", "u"}}), new TMxpSoundTagHandler());
     registerHandler(TMxpFeatureOptions({"music", {"fname", "v", "l", "p", "c", "t", "u"}}), new TMxpMusicTagHandler());
@@ -120,7 +120,8 @@ TMxpTagProcessor::TMxpTagProcessor()
     registerHandler(new TMxpImageTagHandler());
 
     // Frame and destination tags
-    registerHandler(TMxpFeatureOptions({"frame", {"name", "action", "internal", "external", "align", "left", "right", "top", "bottom", "width", "height", "scrolling", "floating", "title"}}), new TMxpFrameTagHandler());
+    registerHandler(TMxpFeatureOptions({"frame", {"name", "action", "internal", "external", "align", "left", "right", "top", "bottom", "width", "height", "scrolling", "floating", "title"}}),
+                    new TMxpFrameTagHandler());
     registerHandler(TMxpFeatureOptions({"dest", {"name", "eol", "eof"}}), new TMxpDestTagHandler());
 
     // Formatting tags (text style)

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -40,7 +40,7 @@
 // Helper needed to allow Qt::PenStyle enum to be unserialised (read from file)
 // in Qt5 - the compilation errors that result in not having this are really
 // confusing!
-QDataStream &operator>>(QDataStream& ds, Qt::PenStyle& value)
+QDataStream& operator>>(QDataStream& ds, Qt::PenStyle& value)
 {
     int temporary;
     ds >> temporary;
@@ -57,7 +57,7 @@ QDataStream &operator>>(QDataStream& ds, Qt::PenStyle& value)
     case Qt::SolidLine:
         [[fallthrough]];
     default:
-    // Force anything else to be a solidline
+        // Force anything else to be a solidline
         value = Qt::SolidLine;
     }
     return ds;
@@ -83,38 +83,64 @@ TRoom::~TRoom()
 QString TRoom::dirCodeToDisplayName(const int dirCode) const
 {
     switch (dirCode) {
-    case DIR_NORTH:     return tr("North");
-    case DIR_NORTHEAST: return tr("North-east");
-    case DIR_NORTHWEST: return tr("North-west");
-    case DIR_SOUTH:     return tr("South");
-    case DIR_SOUTHEAST: return tr("South-east");
-    case DIR_SOUTHWEST: return tr("South-west");
-    case DIR_EAST:      return tr("East");
-    case DIR_WEST:      return tr("West");
-    case DIR_UP:        return tr("Up");
-    case DIR_DOWN:      return tr("Down");
-    case DIR_IN:        return tr("In");
-    case DIR_OUT:       return tr("Out");
-    case DIR_OTHER:     return tr("Other");
-    default:            return tr("Unknown");
+    case DIR_NORTH:
+        return tr("North");
+    case DIR_NORTHEAST:
+        return tr("North-east");
+    case DIR_NORTHWEST:
+        return tr("North-west");
+    case DIR_SOUTH:
+        return tr("South");
+    case DIR_SOUTHEAST:
+        return tr("South-east");
+    case DIR_SOUTHWEST:
+        return tr("South-west");
+    case DIR_EAST:
+        return tr("East");
+    case DIR_WEST:
+        return tr("West");
+    case DIR_UP:
+        return tr("Up");
+    case DIR_DOWN:
+        return tr("Down");
+    case DIR_IN:
+        return tr("In");
+    case DIR_OUT:
+        return tr("Out");
+    case DIR_OTHER:
+        return tr("Other");
+    default:
+        return tr("Unknown");
     }
 }
 
 /* static */ QString TRoom::dirCodeToShortString(const int dirCode)
 {
     switch (dirCode) {
-    case DIR_NORTH:     return QLatin1String("n");
-    case DIR_NORTHEAST: return QLatin1String("ne");
-    case DIR_NORTHWEST: return QLatin1String("nw");
-    case DIR_EAST:      return QLatin1String("e");
-    case DIR_WEST:      return QLatin1String("w");
-    case DIR_SOUTH:     return QLatin1String("s");
-    case DIR_SOUTHEAST: return QLatin1String("se");
-    case DIR_SOUTHWEST: return QLatin1String("sw");
-    case DIR_UP:        return QLatin1String("up");
-    case DIR_DOWN:      return QLatin1String("down");
-    case DIR_IN:        return QLatin1String("in");
-    case DIR_OUT:       return QLatin1String("out");
+    case DIR_NORTH:
+        return QLatin1String("n");
+    case DIR_NORTHEAST:
+        return QLatin1String("ne");
+    case DIR_NORTHWEST:
+        return QLatin1String("nw");
+    case DIR_EAST:
+        return QLatin1String("e");
+    case DIR_WEST:
+        return QLatin1String("w");
+    case DIR_SOUTH:
+        return QLatin1String("s");
+    case DIR_SOUTHEAST:
+        return QLatin1String("se");
+    case DIR_SOUTHWEST:
+        return QLatin1String("sw");
+    case DIR_UP:
+        return QLatin1String("up");
+    case DIR_DOWN:
+        return QLatin1String("down");
+    case DIR_IN:
+        return QLatin1String("in");
+    case DIR_OUT:
+        return QLatin1String("out");
     default:
         Q_UNREACHABLE();
     }
@@ -123,19 +149,32 @@ QString TRoom::dirCodeToDisplayName(const int dirCode) const
 /* static */ QString TRoom::dirCodeToString(const int dirCode)
 {
     switch (dirCode) {
-    case DIR_NORTH:     return QLatin1String("north");
-    case DIR_NORTHEAST: return QLatin1String("northeast");
-    case DIR_NORTHWEST: return QLatin1String("northwest");
-    case DIR_EAST:      return QLatin1String("east");
-    case DIR_WEST:      return QLatin1String("west");
-    case DIR_SOUTH:     return QLatin1String("south");
-    case DIR_SOUTHEAST: return QLatin1String("southeast");
-    case DIR_SOUTHWEST: return QLatin1String("southwest");
-    case DIR_UP:        return QLatin1String("up");
-    case DIR_DOWN:      return QLatin1String("down");
-    case DIR_IN:        return QLatin1String("in");
-    case DIR_OUT:       return QLatin1String("out");
-    default:            Q_UNREACHABLE();
+    case DIR_NORTH:
+        return QLatin1String("north");
+    case DIR_NORTHEAST:
+        return QLatin1String("northeast");
+    case DIR_NORTHWEST:
+        return QLatin1String("northwest");
+    case DIR_EAST:
+        return QLatin1String("east");
+    case DIR_WEST:
+        return QLatin1String("west");
+    case DIR_SOUTH:
+        return QLatin1String("south");
+    case DIR_SOUTHEAST:
+        return QLatin1String("southeast");
+    case DIR_SOUTHWEST:
+        return QLatin1String("southwest");
+    case DIR_UP:
+        return QLatin1String("up");
+    case DIR_DOWN:
+        return QLatin1String("down");
+    case DIR_IN:
+        return QLatin1String("in");
+    case DIR_OUT:
+        return QLatin1String("out");
+    default:
+        Q_UNREACHABLE();
     }
 }
 
@@ -353,18 +392,42 @@ bool TRoom::setExit(const int to, const int direction)
 {
     // FIXME: This along with TRoom->setExit need to be unified to a controller.
     switch (direction) {
-    case DIR_NORTH:     north     = to; break;
-    case DIR_NORTHEAST: northeast = to; break;
-    case DIR_NORTHWEST: northwest = to; break;
-    case DIR_EAST:      east      = to; break;
-    case DIR_WEST:      west      = to; break;
-    case DIR_SOUTH:     south     = to; break;
-    case DIR_SOUTHEAST: southeast = to; break;
-    case DIR_SOUTHWEST: southwest = to; break;
-    case DIR_UP:        up        = to; break;
-    case DIR_DOWN:      down      = to; break;
-    case DIR_IN:        in        = to; break;
-    case DIR_OUT:       out       = to; break;
+    case DIR_NORTH:
+        north = to;
+        break;
+    case DIR_NORTHEAST:
+        northeast = to;
+        break;
+    case DIR_NORTHWEST:
+        northwest = to;
+        break;
+    case DIR_EAST:
+        east = to;
+        break;
+    case DIR_WEST:
+        west = to;
+        break;
+    case DIR_SOUTH:
+        south = to;
+        break;
+    case DIR_SOUTHEAST:
+        southeast = to;
+        break;
+    case DIR_SOUTHWEST:
+        southwest = to;
+        break;
+    case DIR_UP:
+        up = to;
+        break;
+    case DIR_DOWN:
+        down = to;
+        break;
+    case DIR_IN:
+        in = to;
+        break;
+    case DIR_OUT:
+        out = to;
+        break;
     default:
         return false;
     }
@@ -376,18 +439,66 @@ bool TRoom::setExit(const int to, const int direction)
 bool TRoom::hasExit(const int direction) const
 {
     switch (direction) {
-    case DIR_NORTH:     if (north     != -1) { return true; } break;
-    case DIR_NORTHEAST: if (northeast != -1) { return true; } break;
-    case DIR_NORTHWEST: if (northwest != -1) { return true; } break;
-    case DIR_EAST:      if (east      != -1) { return true; } break;
-    case DIR_WEST:      if (west      != -1) { return true; } break;
-    case DIR_SOUTH:     if (south     != -1) { return true; } break;
-    case DIR_SOUTHEAST: if (southeast != -1) { return true; } break;
-    case DIR_SOUTHWEST: if (southwest != -1) { return true; } break;
-    case DIR_UP:        if (up        != -1) { return true; } break;
-    case DIR_DOWN:      if (down      != -1) { return true; } break;
-    case DIR_IN:        if (in        != -1) { return true; } break;
-    case DIR_OUT:       if (out       != -1) { return true; } break;
+    case DIR_NORTH:
+        if (north != -1) {
+            return true;
+        }
+        break;
+    case DIR_NORTHEAST:
+        if (northeast != -1) {
+            return true;
+        }
+        break;
+    case DIR_NORTHWEST:
+        if (northwest != -1) {
+            return true;
+        }
+        break;
+    case DIR_EAST:
+        if (east != -1) {
+            return true;
+        }
+        break;
+    case DIR_WEST:
+        if (west != -1) {
+            return true;
+        }
+        break;
+    case DIR_SOUTH:
+        if (south != -1) {
+            return true;
+        }
+        break;
+    case DIR_SOUTHEAST:
+        if (southeast != -1) {
+            return true;
+        }
+        break;
+    case DIR_SOUTHWEST:
+        if (southwest != -1) {
+            return true;
+        }
+        break;
+    case DIR_UP:
+        if (up != -1) {
+            return true;
+        }
+        break;
+    case DIR_DOWN:
+        if (down != -1) {
+            return true;
+        }
+        break;
+    case DIR_IN:
+        if (in != -1) {
+            return true;
+        }
+        break;
+    case DIR_OUT:
+        if (out != -1) {
+            return true;
+        }
+        break;
     }
     return false;
 }
@@ -809,13 +920,8 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
                 itCustomLine.next();
                 const QString direction(itCustomLine.key());
                 if (direction == QLatin1String("N") || direction == QLatin1String("E") || direction == QLatin1String("S") || direction == QLatin1String("W") || direction == QLatin1String("UP")
-                    || direction == QLatin1String("DOWN")
-                    || direction == QLatin1String("NE")
-                    || direction == QLatin1String("SE")
-                    || direction == QLatin1String("SW")
-                    || direction == QLatin1String("NW")
-                    || direction == QLatin1String("IN")
-                    || direction == QLatin1String("OUT")) {
+                    || direction == QLatin1String("DOWN") || direction == QLatin1String("NE") || direction == QLatin1String("SE") || direction == QLatin1String("SW")
+                    || direction == QLatin1String("NW") || direction == QLatin1String("IN") || direction == QLatin1String("OUT")) {
                     customLines.insert(itCustomLine.key().toLower(), itCustomLine.value());
                 } else {
                     customLines.insert(itCustomLine.key(), itCustomLine.value());
@@ -829,13 +935,8 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
                 itCustomLineArrow.next();
                 const QString direction(itCustomLineArrow.key());
                 if (direction == QLatin1String("N") || direction == QLatin1String("E") || direction == QLatin1String("S") || direction == QLatin1String("W") || direction == QLatin1String("UP")
-                    || direction == QLatin1String("DOWN")
-                    || direction == QLatin1String("NE")
-                    || direction == QLatin1String("SE")
-                    || direction == QLatin1String("SW")
-                    || direction == QLatin1String("NW")
-                    || direction == QLatin1String("IN")
-                    || direction == QLatin1String("OUT")) {
+                    || direction == QLatin1String("DOWN") || direction == QLatin1String("NE") || direction == QLatin1String("SE") || direction == QLatin1String("SW")
+                    || direction == QLatin1String("NW") || direction == QLatin1String("IN") || direction == QLatin1String("OUT")) {
                     customLinesArrow.insert(itCustomLineArrow.key().toLower(), itCustomLineArrow.value());
                 } else {
                     customLinesArrow.insert(itCustomLineArrow.key(), itCustomLineArrow.value());
@@ -849,14 +950,8 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
                 itCustomLineColor.next();
                 const QString direction(itCustomLineColor.key());
                 if (direction == QLatin1String("N") || direction == QLatin1String("E") || direction == QLatin1String("S") || direction == QLatin1String("W") || direction == QLatin1String("UP")
-                    || direction == QLatin1String("DOWN")
-                    || direction == QLatin1String("NE")
-                    || direction == QLatin1String("SE")
-                    || direction == QLatin1String("SW")
-                    || direction == QLatin1String("NW")
-                    || direction == QLatin1String("IN")
-                    || direction == QLatin1String("OUT")) {
-
+                    || direction == QLatin1String("DOWN") || direction == QLatin1String("NE") || direction == QLatin1String("SE") || direction == QLatin1String("SW")
+                    || direction == QLatin1String("NW") || direction == QLatin1String("IN") || direction == QLatin1String("OUT")) {
                     // Fixup broken custom lines caused by maps saved prior to
                     // https://github.com/Mudlet/Mudlet/pull/2559 going into the
                     // code by only adding the value if it contains enough
@@ -901,13 +996,8 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
                 itCustomLineStyle.next();
                 QString direction(itCustomLineStyle.key());
                 if (direction == QLatin1String("N") || direction == QLatin1String("E") || direction == QLatin1String("S") || direction == QLatin1String("W") || direction == QLatin1String("UP")
-                    || direction == QLatin1String("DOWN")
-                    || direction == QLatin1String("NE")
-                    || direction == QLatin1String("SE")
-                    || direction == QLatin1String("SW")
-                    || direction == QLatin1String("NW")
-                    || direction == QLatin1String("IN")
-                    || direction == QLatin1String("OUT")) {
+                    || direction == QLatin1String("DOWN") || direction == QLatin1String("NE") || direction == QLatin1String("SE") || direction == QLatin1String("SW")
+                    || direction == QLatin1String("NW") || direction == QLatin1String("IN") || direction == QLatin1String("OUT")) {
                     direction = direction.toLower();
                 }
 
@@ -1149,7 +1239,8 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
             const int exitRoomId = it.value();
             if (exitName.isEmpty()) {
                 //: %1 is the room ID, %2 is the destination room ID
-                const QString warnMsg = tr("[ WARN ]  - In room ID: %1 removing invalid (special) exit to %2 (with no name!)").arg(id, 6, 10, QLatin1Char('0')).arg(exitRoomId, 6, 10, QLatin1Char('0'));
+                const QString warnMsg =
+                        tr("[ WARN ]  - In room ID: %1 removing invalid (special) exit to %2 (with no name!)").arg(id, 6, 10, QLatin1Char('0')).arg(exitRoomId, 6, 10, QLatin1Char('0'));
                 if (mudlet::self()->showMapAuditErrors()) {
                     mpRoomDB->mpMap->postMessage(warnMsg);
                 }
@@ -1163,10 +1254,10 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
                 userData.insert(auditKey, QString::number(exitRoomId));
                 //: %1 is the room ID, %2 is the exit name, %3 is the old destination room ID, %4 is the new destination room ID
                 const QString infoMsg = tr(R"([ INFO ]  - In room with ID: %1 correcting special exit "%2" that was to room with an exit to invalid room: %3 to now go to: %4.)")
-                                              .arg(id)
-                                              .arg(exitName)
-                                              .arg(exitRoomId)
-                                              .arg(roomRemapping.value(exitRoomId));
+                                                .arg(id)
+                                                .arg(exitName)
+                                                .arg(exitRoomId)
+                                                .arg(roomRemapping.value(exitRoomId));
                 if (mudlet::self()->showMapAuditErrors()) {
                     mpRoomDB->mpMap->postMessage(infoMsg);
                 }
@@ -1192,11 +1283,12 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
                     // But it doesn't exist
                     const QString auditKey = qsl("audit.removed_valid_but_missing_special_exit.%1").arg(exitName);
                     //: %1 is the room ID, %2 is the exit name, %3 is the destination room ID, %4 is the audit key
-                    const QString warnMsg = tr(R"([ WARN ]  - Room with ID: %1 has a special exit "%2" with an exit to: %3 but that room does not exist.  The exit will be removed (but the destination room ID will be stored in the room user data under a key: "%4").)")
-                                                  .arg(id)
-                                                  .arg(exitName)
-                                                  .arg(exitRoomId)
-                                                  .arg(auditKey);
+                    const QString warnMsg =
+                            tr(R"([ WARN ]  - Room with ID: %1 has a special exit "%2" with an exit to: %3 but that room does not exist.  The exit will be removed (but the destination room ID will be stored in the room user data under a key: "%4").)")
+                                    .arg(id)
+                                    .arg(exitName)
+                                    .arg(exitRoomId)
+                                    .arg(auditKey);
                     if (mudlet::self()->showMapAuditErrors()) {
                         mpRoomDB->mpMap->postMessage(warnMsg);
                     }
@@ -1235,11 +1327,12 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
                 const QString auditKey = qsl("audit.removed_invalid_special_exit.%1").arg(exitName);
                 userData.insert(auditKey, QString::number(exitRoomId));
                 //: %1 is the room ID, %2 is the exit name, %3 is the invalid destination room ID, %4 is the audit key
-                const QString infoMsg = tr(R"([ INFO ]  - In room with ID: %1 special exit "%2" that was to room with an invalid ID: %3 that does not exist.  The exit will be removed (the bad destination room ID will be stored in the room user data under a key: "%4").)")
-                                              .arg(id)
-                                              .arg(exitName)
-                                              .arg(exitRoomId)
-                                              .arg(auditKey);
+                const QString infoMsg =
+                        tr(R"([ INFO ]  - In room with ID: %1 special exit "%2" that was to room with an invalid ID: %3 that does not exist.  The exit will be removed (the bad destination room ID will be stored in the room user data under a key: "%4").)")
+                                .arg(id)
+                                .arg(exitName)
+                                .arg(exitRoomId)
+                                .arg(auditKey);
                 if (mudlet::self()->showMapAuditErrors()) {
                     mpRoomDB->mpMap->postMessage(infoMsg);
                 }
@@ -1288,9 +1381,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
             }
         }
         //: %1 is the room ID, %2 is a list of door items
-        const QString infoMsg = tr("[ INFO ]  - In room with ID: %1 found one or more surplus door items that were removed: %2.")
-                                      .arg(id)
-                                      .arg(extras.join(QLatin1String(", ")));
+        const QString infoMsg = tr("[ INFO ]  - In room with ID: %1 found one or more surplus door items that were removed: %2.").arg(id).arg(extras.join(QLatin1String(", ")));
         if (mudlet::self()->showMapAuditErrors()) {
             mpRoomDB->mpMap->postMessage(infoMsg);
         }
@@ -1307,9 +1398,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
             extras << qsl("\"%1\"(%2)").arg(itSpareExitWeight.key()).arg(itSpareExitWeight.value());
         }
         //: %1 is the room ID, %2 is a list of weight items
-        const QString infoMsg = tr("[ INFO ]  - In room with ID: %1 found one or more surplus weight items that were removed: %2.")
-                                      .arg(id)
-                                      .arg(extras.join(QLatin1String(", ")));
+        const QString infoMsg = tr("[ INFO ]  - In room with ID: %1 found one or more surplus weight items that were removed: %2.").arg(id).arg(extras.join(QLatin1String(", ")));
         if (mudlet::self()->showMapAuditErrors()) {
             mpRoomDB->mpMap->postMessage(infoMsg);
         }
@@ -1326,9 +1415,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
             exitLocks.removeAll(dirCode);
         }
         //: %1 is the room ID, %2 is a list of exit lock items
-        const QString infoMsg = tr("[ INFO ]  - In room with ID: %1 found one or more surplus exit lock items that were removed: %2.")
-                                      .arg(id)
-                                      .arg(extras.join(QLatin1String(", ")));
+        const QString infoMsg = tr("[ INFO ]  - In room with ID: %1 found one or more surplus exit lock items that were removed: %2.").arg(id).arg(extras.join(QLatin1String(", ")));
         if (mudlet::self()->showMapAuditErrors()) {
             mpRoomDB->mpMap->postMessage(infoMsg);
         }
@@ -1408,9 +1495,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
 
         if (!extras.isEmpty()) {
             //: %1 is the room ID, %2 is a list of custom line elements
-            const QString infoMsg = tr("[ INFO ]  - In room with ID: %1 found one or more surplus custom line elements that were removed: %2.")
-                                          .arg(id)
-                                          .arg(extras.join(QLatin1String(", ")));
+            const QString infoMsg = tr("[ INFO ]  - In room with ID: %1 found one or more surplus custom line elements that were removed: %2.").arg(id).arg(extras.join(QLatin1String(", ")));
             if (mudlet::self()->showMapAuditErrors()) {
                 mpRoomDB->mpMap->postMessage(infoMsg);
             }
@@ -1438,10 +1523,10 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
         userData.insert(auditKey, QString::number(exitRoomId));
         //: %1 is the room ID, %2 is the exit direction, %3 is the old destination room ID, %4 is the new destination room ID
         const QString infoMsg = tr(R"([ INFO ]  - In room with ID: %1 correcting exit "%2" that was to room with an exit to invalid room: %3 to now go to: %4.)")
-                                      .arg(id)
-                                      .arg(displayName)
-                                      .arg(exitRoomId)
-                                      .arg(roomRemapping.value(exitRoomId));
+                                        .arg(id)
+                                        .arg(displayName)
+                                        .arg(exitRoomId)
+                                        .arg(roomRemapping.value(exitRoomId));
         if (mudlet::self()->showMapAuditErrors()) {
             mpRoomDB->mpMap->postMessage(infoMsg);
         }
@@ -1456,11 +1541,12 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
             // But it doesn't exist
             const QString auditKey = qsl("audit.made_stub_of_valid_but_missing_exit.%1").arg(dirCode);
             //: %1 is the room ID, %2 is the exit direction, %3 is the destination room ID that doesn't exist, %4 is the audit key
-            const QString warnMsg = tr(R"([ WARN ]  - Room with ID: %1 has an exit "%2" to: %3 but that room does not exist.  The exit will be removed (but the destination room ID will be stored in the room user data under a key: "%4") and the exit will be turned into a stub.)")
-                                          .arg(id)
-                                          .arg(displayName)
-                                          .arg(exitRoomId)
-                                          .arg(auditKey);
+            const QString warnMsg =
+                    tr(R"([ WARN ]  - Room with ID: %1 has an exit "%2" to: %3 but that room does not exist.  The exit will be removed (but the destination room ID will be stored in the room user data under a key: "%4") and the exit will be turned into a stub.)")
+                            .arg(id)
+                            .arg(displayName)
+                            .arg(exitRoomId)
+                            .arg(auditKey);
             if (mudlet::self()->showMapAuditErrors()) {
                 mpRoomDB->mpMap->postMessage(warnMsg);
             }
@@ -1504,10 +1590,11 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
             // We cannot allow a stub exit at the same time as a real exit:
             if (exitStubs.contains(dirCode)) {
                 //: %1 is the room ID, %2 is the exit direction, %3 is the destination room ID
-                const QString warnMsg = tr(R"([ ALERT ] - Room with ID: %1 has an exit "%2" to: %3 but also has a stub exit in the same direction!  As a real exit precludes a stub, the latter will be removed.)")
-                                              .arg(id)
-                                              .arg(displayName)
-                                              .arg(exitRoomId);
+                const QString warnMsg =
+                        tr(R"([ ALERT ] - Room with ID: %1 has an exit "%2" to: %3 but also has a stub exit in the same direction!  As a real exit precludes a stub, the latter will be removed.)")
+                                .arg(id)
+                                .arg(displayName)
+                                .arg(exitRoomId);
                 if (mudlet::self()->showMapAuditErrors()) {
                     mpRoomDB->mpMap->postMessage(warnMsg);
                 }
@@ -1563,11 +1650,12 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
         const QString auditKey = qsl("audit.made_stub_of_invalid_exit.%1").arg(dirCode);
         userData.insert(auditKey, QString::number(exitRoomId));
         //: %1 is the room ID, %2 is the exit direction, %3 is the invalid destination room ID, %4 is the audit key
-        QString infoMsg = tr(R"([ INFO ]  - In room with ID: %1 exit "%2" that was to room with an invalid ID: %3 that does not exist.  The exit will be removed (the bad destination room ID will be stored in the room user data under a key: "%4") and the exit will be turned into a stub.)")
-                              .arg(id)
-                              .arg(displayName)
-                              .arg(exitRoomId)
-                              .arg(auditKey);
+        QString infoMsg =
+                tr(R"([ INFO ]  - In room with ID: %1 exit "%2" that was to room with an invalid ID: %3 that does not exist.  The exit will be removed (the bad destination room ID will be stored in the room user data under a key: "%4") and the exit will be turned into a stub.)")
+                        .arg(id)
+                        .arg(displayName)
+                        .arg(exitRoomId)
+                        .arg(auditKey);
         exitRoomId = -1;
 
         if (!exitStubs.contains(dirCode)) {
@@ -1994,9 +2082,15 @@ void TRoom::writeJsonDoor(QJsonObject& obj, const QString& key) const
         // We won't bother to include this item for exits without doors but we
         // will check that it is one of these values (and not "none") when
         // reading in case the file gets edited:
-    case 1: door = QLatin1String("open");    break;
-    case 2: door = QLatin1String("closed");  break;
-    case 3: door = QLatin1String("locked");  break;
+    case 1:
+        door = QLatin1String("open");
+        break;
+    case 2:
+        door = QLatin1String("closed");
+        break;
+    case 3:
+        door = QLatin1String("locked");
+        break;
     default:
         return;
     }
@@ -2060,12 +2154,20 @@ void TRoom::writeJsonCustomExitLine(QJsonObject& exitObj, const QString& directi
 
     QString lineStyle;
     switch (customLinesStyle.value(directionString)) {
-    case Qt::DotLine:           lineStyle = QLatin1String("dot line");           break;
-    case Qt::DashDotLine:       lineStyle = QLatin1String("dash dot line");      break;
-    case Qt::DashDotDotLine:    lineStyle = QLatin1String("dash dot dot line");  break;
-    case Qt::DashLine:          lineStyle = QLatin1String("dash line");          break;
-    default:
-        {} // Use this (nothing) for Solid but will also convert anything else we do not handle to it as well
+    case Qt::DotLine:
+        lineStyle = QLatin1String("dot line");
+        break;
+    case Qt::DashDotLine:
+        lineStyle = QLatin1String("dash dot line");
+        break;
+    case Qt::DashDotDotLine:
+        lineStyle = QLatin1String("dash dot dot line");
+        break;
+    case Qt::DashLine:
+        lineStyle = QLatin1String("dash line");
+        break;
+    default: {
+    } // Use this (nothing) for Solid but will also convert anything else we do not handle to it as well
     }
     if (!lineStyle.isEmpty()) {
         const QJsonValue customLineStyleValue{lineStyle};
@@ -2340,4 +2442,3 @@ void TRoom::readJsonBorder(const QJsonObject& roomObj)
         }
     }
 }
-

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -70,7 +70,6 @@ TRoomDB::~TRoomDB()
     for (auto area : areaList) {
         delete area;
     }
-
 }
 
 TRoom* TRoomDB::getRoom(int id)
@@ -660,10 +659,10 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             if (!pR) {
                 if (mudlet::self()->showMapAuditErrors()) {
                     const QString warnMsg = tr("[ WARN ]  - Problem with data structure associated with room id: %1 - that\n"
-                                         "room's data has been lost so the id is now being deleted.  This\n"
-                                         "suggests serious problems with the currently running version of\n"
-                                         "Mudlet - is your system running out of memory?")
-                                              .arg(itRoom.key());
+                                               "room's data has been lost so the id is now being deleted.  This\n"
+                                               "suggests serious problems with the currently running version of\n"
+                                               "Mudlet - is your system running out of memory?")
+                                                    .arg(itRoom.key());
                     mpMap->postMessage(warnMsg);
                 }
                 mpMap->appendRoomErrorMsg(itRoom.key(),
@@ -749,10 +748,10 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
     if (!missingAreasNeeded.isEmpty()) {
         if (mudlet::self()->showMapAuditErrors()) {
             const QString alertMsg = tr("[ ALERT ] - %n area(s) detected as missing in map: adding it/them in.\n"
-                                  "Look for further messages related to the rooms that are supposed\n"
-                                  "to be in this/these area(s)...",
-                                  "Making use of %n to allow quantity dependent message form 8-) !",
-                                  missingAreasNeeded.count());
+                                        "Look for further messages related to the rooms that are supposed\n"
+                                        "to be in this/these area(s)...",
+                                        "Making use of %n to allow quantity dependent message form 8-) !",
+                                        missingAreasNeeded.count());
             mpMap->postMessage(alertMsg);
         }
         mpMap->appendErrorMsgWithNoLf(tr("[ ALERT ] - %n area(s) detected as missing in map: adding it/them in.\n"
@@ -800,8 +799,8 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
     if (!areaRemapping.isEmpty()) {
         if (mudlet::self()->showMapAuditErrors()) {
             const QString alertMsg = tr("[ ALERT ] - Bad, (less than +1 and not the reserved -1) area ids found (count: %1)\n"
-                                  "in map, now working out what new id numbers to use...")
-                                       .arg(areaRemapping.count());
+                                        "in map, now working out what new id numbers to use...")
+                                             .arg(areaRemapping.count());
             mpMap->postMessage(alertMsg);
         }
         mpMap->appendErrorMsg(tr("[ ALERT ] - Bad, (less than +1 and not the reserved -1) area ids found (count: %1) in map!"
@@ -879,8 +878,8 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
     if (!roomRemapping.isEmpty()) {
         if (mudlet::self()->showMapAuditErrors()) {
             const QString alertMsg = tr("[ ALERT ] - Bad, (less than +1) room ids found (count: %1) in map, now working\n"
-                                  "out what new id numbers to use.")
-                                       .arg(roomRemapping.count());
+                                        "out what new id numbers to use.")
+                                             .arg(roomRemapping.count());
             mpMap->postMessage(alertMsg);
         }
         mpMap->appendErrorMsg(tr("[ ALERT ] - Bad, (less than +1) room ids found (count: %1) in map!"
@@ -967,8 +966,8 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             if (_set.count() < _listCount) {
                 if (mudlet::self()->showMapAuditErrors()) {
                     const QString infoMsg = tr("[ INFO ]  - Duplicate exit stub identifiers found in room id: %1, this is an\n"
-                                         "anomaly but has been cleaned up easily.")
-                                              .arg(itRoom.key());
+                                               "anomaly but has been cleaned up easily.")
+                                                    .arg(itRoom.key());
                     mpMap->postMessage(infoMsg);
                 }
                 mpMap->appendRoomErrorMsg(itRoom.key(), tr("[ INFO ]  - Duplicate exit stub identifiers found in room, this is an anomaly but has been cleaned up easily."), false);
@@ -981,8 +980,8 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             if (_set.count() < _listCount) {
                 if (mudlet::self()->showMapAuditErrors()) {
                     const QString infoMsg = tr("[ INFO ]  - Duplicate exit lock identifiers found in room id: %1, this is an\n"
-                                         "anomaly but has been cleaned up easily.")
-                                              .arg(itRoom.key());
+                                               "anomaly but has been cleaned up easily.")
+                                                    .arg(itRoom.key());
                     mpMap->postMessage(infoMsg);
                 }
                 mpMap->appendRoomErrorMsg(itRoom.key(), tr("[ INFO ]  - Duplicate exit lock identifiers found in room, this is an anomaly but has been cleaned up easily."), false);
@@ -1065,10 +1064,10 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                 }
                 if (mudlet::self()->showMapAuditErrors()) {
                     const QString infoMsg = tr("[ INFO ]  - In area with id: %1 there were %2 rooms missing from those it\n"
-                                         "should be recording as possessing, they were:\n%3\nthey have been added.")
-                                              .arg(itArea.key())
-                                              .arg(missingRooms.count())
-                                              .arg(roomList.join(qsl(", ")));
+                                               "should be recording as possessing, they were:\n%3\nthey have been added.")
+                                                    .arg(itArea.key())
+                                                    .arg(missingRooms.count())
+                                                    .arg(roomList.join(qsl(", ")));
                     mpMap->postMessage(infoMsg);
                 }
                 mpMap->appendAreaErrorMsg(itArea.key(),
@@ -1100,10 +1099,10 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                 }
                 if (mudlet::self()->showMapAuditErrors()) {
                     const QString infoMsg = tr("[ INFO ]  - In area with id: %1 there were %2 extra rooms compared to those it\n"
-                                         "should be recording as possessing, they were:\n%3\nthey have been removed.")
-                                              .arg(itArea.key())
-                                              .arg(extraRooms.count())
-                                              .arg(roomList.join(qsl(", ")));
+                                               "should be recording as possessing, they were:\n%3\nthey have been removed.")
+                                                    .arg(itArea.key())
+                                                    .arg(extraRooms.count())
+                                                    .arg(roomList.join(qsl(", ")));
                     mpMap->postMessage(infoMsg);
                 }
                 mpMap->appendAreaErrorMsg(itArea.key(),
@@ -1243,11 +1242,12 @@ void TRoomDB::restoreAreaMap(QDataStream& ifs)
             // - may be the same items
             alertText = tr("[ ALERT ] - Empty and duplicate area names detected in Map file!");
             informativeText = tr("[ INFO ]  - Mudlet had previously allowed the map to have more than one area\n"
-                                  "with the same or no name. To resolve these cases, an area without a name\n"
-                                  "here (or created in the future) will automatically be assigned the name \"%1\".\n"
-                                  "Duplicated area names will cause all but the first encountered one to gain a\n"
-                                  "\"_###\" style suffix.\n"
-                                 "%2").arg(mpMap->getUnnamedAreaName(), extraTextForMatchingSuffixAlreadyUsed);
+                                 "with the same or no name. To resolve these cases, an area without a name\n"
+                                 "here (or created in the future) will automatically be assigned the name \"%1\".\n"
+                                 "Duplicated area names will cause all but the first encountered one to gain a\n"
+                                 "\"_###\" style suffix.\n"
+                                 "%2")
+                                      .arg(mpMap->getUnnamedAreaName(), extraTextForMatchingSuffixAlreadyUsed);
         } else if (!renamedMap.empty()) {
             // Duplicates but no unnnamed area
             alertText = tr("[ ALERT ] - Duplicate area names detected in the Map file!");
@@ -1294,8 +1294,8 @@ void TRoomDB::restoreAreaMap(QDataStream& ifs)
     if (!areaNamesMap.contains(-1)) {
         areaNamesMap.insert(-1, mpMap->getDefaultAreaName());
         const QString defaultAreaNameInsertionMsg = tr("[ INFO ]  - Default (reset) area name (for rooms that have not been assigned to an\n"
-                                                 "area) not found, adding \"%1\" against the reserved -1 id.")
-                                                      .arg(mpMap->getDefaultAreaName());
+                                                       "area) not found, adding \"%1\" against the reserved -1 id.")
+                                                            .arg(mpMap->getDefaultAreaName());
         mpMap->mpHost->postMessage(defaultAreaNameInsertionMsg);
         mpMap->appendErrorMsgWithNoLf(defaultAreaNameInsertionMsg, false);
     }
@@ -1338,15 +1338,19 @@ bool getUserDataBool(const QMap<QString, QString>& userData, const QString& key,
         return defaultValue;
     }
     switch (value[0].unicode()) {
-      case 'y': case 'Y':
-      case 't': case 'T':
-      case '1':
+    case 'y':
+    case 'Y':
+    case 't':
+    case 'T':
+    case '1':
         return true;
-      case 'n': case 'N':
-      case 'f': case 'F':
-      case '0':
+    case 'n':
+    case 'N':
+    case 'f':
+    case 'F':
+    case '0':
         return false;
-      default:
+    default:
         return defaultValue;
     }
 }

--- a/src/TScript.cpp
+++ b/src/TScript.cpp
@@ -28,13 +28,13 @@
 #include "TDebug.h"
 #include "mudlet.h"
 
-TScript::TScript( TScript * parent, Host * pHost )
-: Tree<TScript>( parent )
+TScript::TScript(TScript* parent, Host* pHost)
+: Tree<TScript>(parent)
 , mpHost(pHost)
 {
 }
 
-TScript::TScript(const QString& name, Host * pHost )
+TScript::TScript(const QString& name, Host* pHost)
 : Tree<TScript>(nullptr)
 , mName(name)
 , mpHost(pHost)

--- a/src/TScrollBox.cpp
+++ b/src/TScrollBox.cpp
@@ -36,20 +36,18 @@ TScrollBox::TScrollBox(Host* pH, QWidget* pW)
 
 TScrollBoxWidget::TScrollBoxWidget(QWidget* pW)
 : QWidget(pW)
-{}
+{
+}
 
-TScrollBoxWidget::~TScrollBoxWidget()
-{}
+TScrollBoxWidget::~TScrollBoxWidget() {}
 
 void TScrollBoxWidget::childEvent(QChildEvent* event)
 {
     auto child = event->child();
-    if (event->added())
-    {
+    if (event->added()) {
         child->installEventFilter(this);
     }
-    if (event->removed())
-    {
+    if (event->removed()) {
         child->removeEventFilter(this);
     }
 }
@@ -58,9 +56,8 @@ bool TScrollBoxWidget::eventFilter(QObject* object, QEvent* event)
 {
     Q_UNUSED(object)
 
-    if (event->type() == QMoveEvent::Move || event->type() == QResizeEvent::Resize || event->type() == QHideEvent::Hide || event->type() == QShowEvent::Show)
-    {
-      adjustSize();
+    if (event->type() == QMoveEvent::Move || event->type() == QResizeEvent::Resize || event->type() == QHideEvent::Hide || event->type() == QShowEvent::Show) {
+        adjustSize();
     }
 
     return false;

--- a/src/TStringUtils.cpp
+++ b/src/TStringUtils.cpp
@@ -34,5 +34,3 @@ bool TStringUtils::isOneOf(QChar inputCharacter, const QString& characterSet)
 
     return false;
 }
-
-

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -39,12 +39,12 @@
 #include <QDateTime>
 
 // Constants for improved drag detection
-static const int DETACH_DISTANCE_THRESHOLD = 80;  // Pixels to drag before tab detaches
-static const int DETACH_PIXEL_BUFFER = 20;        // Drag tolerance buffer
-static const int VERTICAL_MOVEMENT_RATIO_THRESHOLD = 60;  // Percentage of movement that must be vertical
-static const int TAB_REORDER_DELAY_MS = 150;  // Delay before allowing tab detachment
+static const int DETACH_DISTANCE_THRESHOLD = 80;         // Pixels to drag before tab detaches
+static const int DETACH_PIXEL_BUFFER = 20;               // Drag tolerance buffer
+static const int VERTICAL_MOVEMENT_RATIO_THRESHOLD = 60; // Percentage of movement that must be vertical
+static const int TAB_REORDER_DELAY_MS = 150;             // Delay before allowing tab detachment
 
-void TStyle::drawControl(ControlElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget) const
+void TStyle::drawControl(ControlElement element, const QStyleOption* option, QPainter* painter, const QWidget* widget) const
 {
     if (element == QStyle::CE_TabBarTab) {
         QString tabName = mpTabBar->tabData(mpTabBar->tabAt(option->rect.center())).toString();

--- a/src/TTextCodec.cpp
+++ b/src/TTextCodec.cpp
@@ -245,7 +245,7 @@ QString TTextCodec_437::toUnicode(const QByteArray& bytes)
 {
     QString result;
     result.reserve(bytes.size());
-    
+
     for (unsigned char byte : bytes) {
         if (byte < 0x80) {
             result += QLatin1Char(byte);
@@ -260,7 +260,7 @@ QString TTextCodec_667::toUnicode(const QByteArray& bytes)
 {
     QString result;
     result.reserve(bytes.size());
-    
+
     for (unsigned char byte : bytes) {
         if (byte < 0x80) {
             result += QLatin1Char(byte);
@@ -275,7 +275,7 @@ QString TTextCodec_737::toUnicode(const QByteArray& bytes)
 {
     QString result;
     result.reserve(bytes.size());
-    
+
     for (unsigned char byte : bytes) {
         if (byte < 0x80) {
             result += QLatin1Char(byte);
@@ -290,7 +290,7 @@ QString TTextCodec_869::toUnicode(const QByteArray& bytes)
 {
     QString result;
     result.reserve(bytes.size());
-    
+
     for (unsigned char byte : bytes) {
         if (byte < 0x80) {
             result += QLatin1Char(byte);
@@ -305,7 +305,7 @@ QString TTextCodec_medievia::toUnicode(const QByteArray& bytes)
 {
     QString result;
     result.reserve(bytes.size());
-    
+
     for (unsigned char byte : bytes) {
         if (byte < 0x80) {
             result += QLatin1Char(byte);
@@ -321,7 +321,7 @@ QByteArray TTextCodec_437::fromUnicode(const QString& str)
 {
     QByteArray result;
     result.reserve(str.size());
-    
+
     for (const QChar& ch : str) {
         if (ch < QLatin1Char('\x80')) {
             result += ch.cell();
@@ -341,7 +341,7 @@ QByteArray TTextCodec_667::fromUnicode(const QString& str)
 {
     QByteArray result;
     result.reserve(str.size());
-    
+
     for (const QChar& ch : str) {
         if (ch < QLatin1Char('\x80')) {
             result += ch.cell();
@@ -361,7 +361,7 @@ QByteArray TTextCodec_737::fromUnicode(const QString& str)
 {
     QByteArray result;
     result.reserve(str.size());
-    
+
     for (const QChar& ch : str) {
         if (ch < QLatin1Char('\x80')) {
             result += ch.cell();
@@ -381,7 +381,7 @@ QByteArray TTextCodec_869::fromUnicode(const QString& str)
 {
     QByteArray result;
     result.reserve(str.size());
-    
+
     for (const QChar& ch : str) {
         if (ch < QLatin1Char('\x80')) {
             result += ch.cell();
@@ -401,7 +401,7 @@ QByteArray TTextCodec_medievia::fromUnicode(const QString& str)
 {
     QByteArray result;
     result.reserve(str.size());
-    
+
     for (const QChar& ch : str) {
         if (ch < QLatin1Char('\x80')) {
             result += ch.cell();

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -313,8 +313,7 @@ void TTextEdit::showNewLines()
     update();
 
 
-    if (mpHost && QAccessible::isActive() && mpConsole->getType() == TConsole::MainConsole
-        && mpHost->mAnnounceIncomingText && mudlet::self()->getActiveHost() == mpHost) {
+    if (mpHost && QAccessible::isActive() && mpConsole->getType() == TConsole::MainConsole && mpHost->mAnnounceIncomingText && mudlet::self()->getActiveHost() == mpHost) {
         QString newLines;
 
         // content has been deleted
@@ -444,7 +443,8 @@ void TTextEdit::drawLine(QPainter& painter, int lineNumber, int lineOfScreen, in
         int nextBoundary = boundaryFinder.toNextBoundary();
 
         TChar& charStyle = mpBuffer->buffer.at(lineNumber).at(indexOfChar);
-        int graphemeWidth = drawGraphemeBackground(painter, fgColors, textRects, graphemes, charWidths, cursor, lineText.mid(indexOfChar, nextBoundary - indexOfChar), columnWithOutTimestamp, lineNumber, charStyle);
+        int graphemeWidth = drawGraphemeBackground(
+                painter, fgColors, textRects, graphemes, charWidths, cursor, lineText.mid(indexOfChar, nextBoundary - indexOfChar), columnWithOutTimestamp, lineNumber, charStyle);
         cursor.setX(cursor.x() + graphemeWidth);
         indexOfChar = nextBoundary;
         columnWithOutTimestamp += graphemeWidth;
@@ -470,44 +470,140 @@ void TTextEdit::drawLine(QPainter& painter, int lineNumber, int lineOfScreen, in
 /* inline */ void TTextEdit::replaceControlCharacterWith_Picture(const uint unicode, const QString& grapheme, const int column, QVector<QString>& graphemes, int& charWidth) const
 {
     switch (unicode) {
-    case 0:     graphemes.append(QChar(0x2400)); charWidth = 1; break; // NUL - not sure that this can appear
-    case 1:     graphemes.append(QChar(0x2401)); charWidth = 1; break; // SOH
-    case 2:     graphemes.append(QChar(0x2402)); charWidth = 1; break; // STX
-    case 3:     graphemes.append(QChar(0x2403)); charWidth = 1; break; // ETX
-    case 4:     graphemes.append(QChar(0x2404)); charWidth = 1; break; // EOT
-    case 5:     graphemes.append(QChar(0x2405)); charWidth = 1; break; // ENQ
-    case 6:     graphemes.append(QChar(0x2406)); charWidth = 1; break; // ACK
-    case 7:     graphemes.append(QChar(0x2407)); charWidth = 1; break; // BEL - the (audio) handling of this gets done when it is received, not when it is displayed here:
-    case 8:     graphemes.append(QChar(0x2408)); charWidth = 1; break; // BS
-    case 9: // HT
+    case 0:
+        graphemes.append(QChar(0x2400));
+        charWidth = 1;
+        break; // NUL - not sure that this can appear
+    case 1:
+        graphemes.append(QChar(0x2401));
+        charWidth = 1;
+        break; // SOH
+    case 2:
+        graphemes.append(QChar(0x2402));
+        charWidth = 1;
+        break; // STX
+    case 3:
+        graphemes.append(QChar(0x2403));
+        charWidth = 1;
+        break; // ETX
+    case 4:
+        graphemes.append(QChar(0x2404));
+        charWidth = 1;
+        break; // EOT
+    case 5:
+        graphemes.append(QChar(0x2405));
+        charWidth = 1;
+        break; // ENQ
+    case 6:
+        graphemes.append(QChar(0x2406));
+        charWidth = 1;
+        break; // ACK
+    case 7:
+        graphemes.append(QChar(0x2407));
+        charWidth = 1;
+        break; // BEL - the (audio) handling of this gets done when it is received, not when it is displayed here:
+    case 8:
+        graphemes.append(QChar(0x2408));
+        charWidth = 1;
+        break; // BS
+    case 9:    // HT
         // Makes the spacing behave like a tab
         charWidth = mTabStopwidth - (column % mTabStopwidth);
         // But print the "control picture" on top
         graphemes.append(QChar(0x2409));
         break;
-    case 10:    graphemes.append(QChar(0x240A)); charWidth = 1; break; // LF - may not ever appear!
-    case 11:    graphemes.append(QChar(0x240B)); charWidth = 1; break; // VT
-    case 12:    graphemes.append(QChar(0x240C)); charWidth = 1; break; // FF
-    case 13:    graphemes.append(QChar(0x240D)); charWidth = 1; break; // CR - shouldn't appear but does seem to crop up somehow!
-    case 14:    graphemes.append(QChar(0x240E)); charWidth = 1; break; // SO
-    case 15:    graphemes.append(QChar(0x240F)); charWidth = 1; break; // SI
-    case 16:    graphemes.append(QChar(0x2410)); charWidth = 1; break; // DLE
-    case 17:    graphemes.append(QChar(0x2411)); charWidth = 1; break; // DC1
-    case 18:    graphemes.append(QChar(0x2412)); charWidth = 1; break; // DC2
-    case 19:    graphemes.append(QChar(0x2413)); charWidth = 1; break; // DC3
-    case 20:    graphemes.append(QChar(0x2414)); charWidth = 1; break; // DC4
-    case 21:    graphemes.append(QChar(0x2415)); charWidth = 1; break; // NAK
-    case 22:    graphemes.append(QChar(0x2416)); charWidth = 1; break; // SYN
-    case 23:    graphemes.append(QChar(0x2417)); charWidth = 1; break; // ETB
-    case 24:    graphemes.append(QChar(0x2418)); charWidth = 1; break; // CAN
-    case 25:    graphemes.append(QChar(0x2419)); charWidth = 1; break; // EM
-    case 26:    graphemes.append(QChar(0x241A)); charWidth = 1; break; // SUB
-    case 27:    graphemes.append(QChar(0x241B)); charWidth = 1; break; // ESC - shouldn't appear as will have been intercepted previously
-    case 28:    graphemes.append(QChar(0x241C)); charWidth = 1; break; // FS
-    case 29:    graphemes.append(QChar(0x241D)); charWidth = 1; break; // GS
-    case 30:    graphemes.append(QChar(0x241E)); charWidth = 1; break; // RS
-    case 31:    graphemes.append(QChar(0x241F)); charWidth = 1; break; // US
-    case 127:   graphemes.append(QChar(0x2421)); charWidth = 1; break; // DEL
+    case 10:
+        graphemes.append(QChar(0x240A));
+        charWidth = 1;
+        break; // LF - may not ever appear!
+    case 11:
+        graphemes.append(QChar(0x240B));
+        charWidth = 1;
+        break; // VT
+    case 12:
+        graphemes.append(QChar(0x240C));
+        charWidth = 1;
+        break; // FF
+    case 13:
+        graphemes.append(QChar(0x240D));
+        charWidth = 1;
+        break; // CR - shouldn't appear but does seem to crop up somehow!
+    case 14:
+        graphemes.append(QChar(0x240E));
+        charWidth = 1;
+        break; // SO
+    case 15:
+        graphemes.append(QChar(0x240F));
+        charWidth = 1;
+        break; // SI
+    case 16:
+        graphemes.append(QChar(0x2410));
+        charWidth = 1;
+        break; // DLE
+    case 17:
+        graphemes.append(QChar(0x2411));
+        charWidth = 1;
+        break; // DC1
+    case 18:
+        graphemes.append(QChar(0x2412));
+        charWidth = 1;
+        break; // DC2
+    case 19:
+        graphemes.append(QChar(0x2413));
+        charWidth = 1;
+        break; // DC3
+    case 20:
+        graphemes.append(QChar(0x2414));
+        charWidth = 1;
+        break; // DC4
+    case 21:
+        graphemes.append(QChar(0x2415));
+        charWidth = 1;
+        break; // NAK
+    case 22:
+        graphemes.append(QChar(0x2416));
+        charWidth = 1;
+        break; // SYN
+    case 23:
+        graphemes.append(QChar(0x2417));
+        charWidth = 1;
+        break; // ETB
+    case 24:
+        graphemes.append(QChar(0x2418));
+        charWidth = 1;
+        break; // CAN
+    case 25:
+        graphemes.append(QChar(0x2419));
+        charWidth = 1;
+        break; // EM
+    case 26:
+        graphemes.append(QChar(0x241A));
+        charWidth = 1;
+        break; // SUB
+    case 27:
+        graphemes.append(QChar(0x241B));
+        charWidth = 1;
+        break; // ESC - shouldn't appear as will have been intercepted previously
+    case 28:
+        graphemes.append(QChar(0x241C));
+        charWidth = 1;
+        break; // FS
+    case 29:
+        graphemes.append(QChar(0x241D));
+        charWidth = 1;
+        break; // GS
+    case 30:
+        graphemes.append(QChar(0x241E));
+        charWidth = 1;
+        break; // RS
+    case 31:
+        graphemes.append(QChar(0x241F));
+        charWidth = 1;
+        break; // US
+    case 127:
+        graphemes.append(QChar(0x2421));
+        charWidth = 1;
+        break; // DEL
     default:
         charWidth = getGraphemeWidth(unicode);
         graphemes.append((charWidth < 1) ? QChar() : grapheme);
@@ -518,48 +614,155 @@ void TTextEdit::drawLine(QPainter& painter, int lineNumber, int lineOfScreen, in
 {
     Q_UNUSED(column)
     switch (unicode) {
-    case 0:     graphemes.append(QString(QChar::Space)); charWidth = 1; break; // NUL - not sure that this can appear and the OEM font treats it as a space
-    case 1:     graphemes.append(QChar(0x263A)); charWidth = 1; break; // SOH - White Smiling Face
-    case 2:     graphemes.append(QChar(0x263B)); charWidth = 1; break; // STX - Black Smiling Face
-    case 3:     graphemes.append(QChar(0x2665)); charWidth = 1; break; // ETX - Black Heart Suite
-    case 4:     graphemes.append(QChar(0x2666)); charWidth = 1; break; // EOT - Black Diamond Suite
-    case 5:     graphemes.append(QChar(0x2663)); charWidth = 1; break; // ENQ - Black ClubsSuite
-    case 6:     graphemes.append(QChar(0x2660)); charWidth = 1; break; // ACK - Black Spade Suite
-    case 7:     graphemes.append(QChar(0x2022)); charWidth = 1; break; // BEL - Bullet - the handling of this gets done when it is received, not when it is displayed here:
-    case 8:     graphemes.append(QChar(0x25D8)); charWidth = 1; break; // BS  - Inverse Bullet
+    case 0:
+        graphemes.append(QString(QChar::Space));
+        charWidth = 1;
+        break; // NUL - not sure that this can appear and the OEM font treats it as a space
+    case 1:
+        graphemes.append(QChar(0x263A));
+        charWidth = 1;
+        break; // SOH - White Smiling Face
+    case 2:
+        graphemes.append(QChar(0x263B));
+        charWidth = 1;
+        break; // STX - Black Smiling Face
+    case 3:
+        graphemes.append(QChar(0x2665));
+        charWidth = 1;
+        break; // ETX - Black Heart Suite
+    case 4:
+        graphemes.append(QChar(0x2666));
+        charWidth = 1;
+        break; // EOT - Black Diamond Suite
+    case 5:
+        graphemes.append(QChar(0x2663));
+        charWidth = 1;
+        break; // ENQ - Black ClubsSuite
+    case 6:
+        graphemes.append(QChar(0x2660));
+        charWidth = 1;
+        break; // ACK - Black Spade Suite
+    case 7:
+        graphemes.append(QChar(0x2022));
+        charWidth = 1;
+        break; // BEL - Bullet - the handling of this gets done when it is received, not when it is displayed here:
+    case 8:
+        graphemes.append(QChar(0x25D8));
+        charWidth = 1;
+        break; // BS  - Inverse Bullet
     case 9:
         // NOTE THAT WE DO NOT USE TAB SPACING FOR THIS MODE:
-                graphemes.append(QChar(0x25CB)); charWidth = 1; break; // HT  - Circle
-    case 10:    graphemes.append(QChar(0x25D9)); charWidth = 1; break; // LF  - Inverse Circle
-    case 11:    graphemes.append(QChar(0x2642)); charWidth = 1; break; // VT  - Male Sign
-    case 12:    graphemes.append(QChar(0x2640)); charWidth = 1; break; // FF  - Female Sign
-    case 13:    graphemes.append(QChar(0x266A)); charWidth = 1; break; // CR  - Single Quaver - shouldn't appear but does seem to crop up somehow!
-    case 14:    graphemes.append(QChar(0x266B)); charWidth = 1; break; // SO  - Double Quaver
-    case 15:    graphemes.append(QChar(0x263C)); charWidth = 1; break; // SI  - White Sun with Rays
-    case 16:    graphemes.append(QChar(0x25BA)); charWidth = 1; break; // DLE - Black Right-Pointing Pointer
-    case 17:    graphemes.append(QChar(0x25C4)); charWidth = 1; break; // DC1 - Black Left-Pointing Pointer
-    case 18:    graphemes.append(QChar(0x2195)); charWidth = 1; break; // DC2 - Up Down ArroW
-    case 19:    graphemes.append(QChar(0x203C)); charWidth = 1; break; // DC3 - Double Exclaimation Mark
-    case 20:    graphemes.append(QChar(0x00B6)); charWidth = 1; break; // DC4 - Pilcrow
-    case 21:    graphemes.append(QChar(0x00A7)); charWidth = 1; break; // NAK - Section Sign
-    case 22:    graphemes.append(QChar(0x25AC)); charWidth = 1; break; // SYN - Black Rectangle
-    case 23:    graphemes.append(QChar(0x21A8)); charWidth = 1; break; // ETB - Up Down Arrow With Base
-    case 24:    graphemes.append(QChar(0x2191)); charWidth = 1; break; // CAN - Up Arrow
-    case 25:    graphemes.append(QChar(0x2193)); charWidth = 1; break; // EM  - Down Arrow
-    case 26:    graphemes.append(QChar(0x2192)); charWidth = 1; break; // SUB - Right Arrow
-    case 27:    graphemes.append(QChar(0x2190)); charWidth = 1; break; // ESC - Left Arrow - shouldn't appear as will have been intercepted previously
-    case 28:    graphemes.append(QChar(0x221F)); charWidth = 1; break; // FS  - Right Angle
-    case 29:    graphemes.append(QChar(0x2194)); charWidth = 1; break; // GS  - Left Right Arrow
-    case 30:    graphemes.append(QChar(0x25B2)); charWidth = 1; break; // RS  - Black Up-Pointing Pointer
-    case 31:    graphemes.append(QChar(0x25BC)); charWidth = 1; break; // US  - Black Down-Pointing Pointer
-    case 127:   graphemes.append(QChar(0x2302)); charWidth = 1; break; // DEL - House
+        graphemes.append(QChar(0x25CB));
+        charWidth = 1;
+        break; // HT  - Circle
+    case 10:
+        graphemes.append(QChar(0x25D9));
+        charWidth = 1;
+        break; // LF  - Inverse Circle
+    case 11:
+        graphemes.append(QChar(0x2642));
+        charWidth = 1;
+        break; // VT  - Male Sign
+    case 12:
+        graphemes.append(QChar(0x2640));
+        charWidth = 1;
+        break; // FF  - Female Sign
+    case 13:
+        graphemes.append(QChar(0x266A));
+        charWidth = 1;
+        break; // CR  - Single Quaver - shouldn't appear but does seem to crop up somehow!
+    case 14:
+        graphemes.append(QChar(0x266B));
+        charWidth = 1;
+        break; // SO  - Double Quaver
+    case 15:
+        graphemes.append(QChar(0x263C));
+        charWidth = 1;
+        break; // SI  - White Sun with Rays
+    case 16:
+        graphemes.append(QChar(0x25BA));
+        charWidth = 1;
+        break; // DLE - Black Right-Pointing Pointer
+    case 17:
+        graphemes.append(QChar(0x25C4));
+        charWidth = 1;
+        break; // DC1 - Black Left-Pointing Pointer
+    case 18:
+        graphemes.append(QChar(0x2195));
+        charWidth = 1;
+        break; // DC2 - Up Down ArroW
+    case 19:
+        graphemes.append(QChar(0x203C));
+        charWidth = 1;
+        break; // DC3 - Double Exclaimation Mark
+    case 20:
+        graphemes.append(QChar(0x00B6));
+        charWidth = 1;
+        break; // DC4 - Pilcrow
+    case 21:
+        graphemes.append(QChar(0x00A7));
+        charWidth = 1;
+        break; // NAK - Section Sign
+    case 22:
+        graphemes.append(QChar(0x25AC));
+        charWidth = 1;
+        break; // SYN - Black Rectangle
+    case 23:
+        graphemes.append(QChar(0x21A8));
+        charWidth = 1;
+        break; // ETB - Up Down Arrow With Base
+    case 24:
+        graphemes.append(QChar(0x2191));
+        charWidth = 1;
+        break; // CAN - Up Arrow
+    case 25:
+        graphemes.append(QChar(0x2193));
+        charWidth = 1;
+        break; // EM  - Down Arrow
+    case 26:
+        graphemes.append(QChar(0x2192));
+        charWidth = 1;
+        break; // SUB - Right Arrow
+    case 27:
+        graphemes.append(QChar(0x2190));
+        charWidth = 1;
+        break; // ESC - Left Arrow - shouldn't appear as will have been intercepted previously
+    case 28:
+        graphemes.append(QChar(0x221F));
+        charWidth = 1;
+        break; // FS  - Right Angle
+    case 29:
+        graphemes.append(QChar(0x2194));
+        charWidth = 1;
+        break; // GS  - Left Right Arrow
+    case 30:
+        graphemes.append(QChar(0x25B2));
+        charWidth = 1;
+        break; // RS  - Black Up-Pointing Pointer
+    case 31:
+        graphemes.append(QChar(0x25BC));
+        charWidth = 1;
+        break; // US  - Black Down-Pointing Pointer
+    case 127:
+        graphemes.append(QChar(0x2302));
+        charWidth = 1;
+        break; // DEL - House
     default:
         charWidth = getGraphemeWidth(unicode);
         graphemes.append((charWidth < 1) ? QChar() : grapheme);
     }
 }
 
-int TTextEdit::drawGraphemeBackground(QPainter& painter, QVector<QColor>& fgColors, QVector<QRect>& textRects, QVector<QString>& graphemes, QVector<int>& charWidths, QPoint& cursor, const QString& grapheme, const int column, const int line, TChar& charStyle) const
+int TTextEdit::drawGraphemeBackground(QPainter& painter,
+                                      QVector<QColor>& fgColors,
+                                      QVector<QRect>& textRects,
+                                      QVector<QString>& graphemes,
+                                      QVector<int>& charWidths,
+                                      QPoint& cursor,
+                                      const QString& grapheme,
+                                      const int column,
+                                      const int line,
+                                      TChar& charStyle) const
 {
     uint unicode = graphemeInfo::getBaseCharacter(grapheme);
     int charWidth = 0;
@@ -653,12 +856,8 @@ void TTextEdit::drawGraphemeForeground(QPainter& painter, const QColor& fgColor,
 
     // const bool isConcealed = attributes & TChar::Concealed;
     // const int altFontIndex = charStyle.alternateFont();
-    if ((painter.font().bold() != isBold)
-            || (painter.font().italic() != isItalics)
-            || (painter.font().overline() != useQtOverline)
-            || (painter.font().strikeOut() != useQtStrikeOut)
-            || (painter.font().underline() != useQtUnderline)) {
-
+    if ((painter.font().bold() != isBold) || (painter.font().italic() != isItalics) || (painter.font().overline() != useQtOverline) || (painter.font().strikeOut() != useQtStrikeOut)
+        || (painter.font().underline() != useQtUnderline)) {
         QFont font = painter.font();
         font.setBold(isBold);
         font.setItalic(isItalics);
@@ -675,7 +874,7 @@ void TTextEdit::drawGraphemeForeground(QPainter& painter, const QColor& fgColor,
     if (painter.pen().color() != fgColor) {
         painter.setPen(fgColor);
     }
-    painter.drawText(textRect, Qt::AlignCenter|Qt::TextDontClip|Qt::TextSingleLine, grapheme);
+    painter.drawText(textRect, Qt::AlignCenter | Qt::TextDontClip | Qt::TextSingleLine, grapheme);
 
     // Draw custom decorations (colored underlines, overlines, strikethrough)
     drawCustomDecorations(painter, fgColor, textRect, charStyle);
@@ -794,8 +993,9 @@ int TTextEdit::getGraphemeWidth(uint unicode) const
         if (!mIsLowerPane) {
             bool newCodePointToWarnAbout = !mProblemCodepoints.contains(unicode);
             if (mShowAllCodepointIssues && newCodePointToWarnAbout) {
-                qWarning().nospace().noquote() << "TTextEdit::getGraphemeWidth(...) WARN - trying to get width of a Unicode character which is a non-character that Mudlet is not itself using, codepoint number: U+"
-                                             << qsl("%1").arg(unicode, 4, 16, QLatin1Char('0')).toUtf8().constData() << ".";
+                qWarning().nospace().noquote()
+                        << "TTextEdit::getGraphemeWidth(...) WARN - trying to get width of a Unicode character which is a non-character that Mudlet is not itself using, codepoint number: U+"
+                        << qsl("%1").arg(unicode, 4, 16, QLatin1Char('0')).toUtf8().constData() << ".";
             }
             if (Q_UNLIKELY(newCodePointToWarnAbout)) {
                 mProblemCodepoints.insert(unicode, std::tuple{1, std::string{"Non-character"}});
@@ -813,7 +1013,7 @@ int TTextEdit::getGraphemeWidth(uint unicode) const
             bool newCodePointToWarnAbout = !mProblemCodepoints.contains(unicode);
             if (mShowAllCodepointIssues && newCodePointToWarnAbout) {
                 qWarning().nospace().noquote() << "TTextEdit::getGraphemeWidth(...) WARN - trying to get width of a Unicode character which is a zero width combiner, codepoint number: U+"
-                                             << qsl("%1").arg(unicode, 4, 16, QLatin1Char('0')).toUtf8().constData() << ".";
+                                               << qsl("%1").arg(unicode, 4, 16, QLatin1Char('0')).toUtf8().constData() << ".";
             }
             if (Q_UNLIKELY(newCodePointToWarnAbout)) {
                 mProblemCodepoints.insert(unicode, std::tuple{1, std::string{"Zero Width Combiner"}});
@@ -846,7 +1046,8 @@ int TTextEdit::getGraphemeWidth(uint unicode) const
         if (!mIsLowerPane) {
             bool newCodePointToWarnAbout = !mProblemCodepoints.contains(unicode);
             if (mShowAllCodepointIssues && newCodePointToWarnAbout) {
-                qWarning().nospace().noquote() << "TTextEdit::getGraphemeWidth(...) WARN - trying to get width of a Unicode character which was not previously assigned and we do not know how wide it is, codepoint number: U+"
+                qWarning().nospace().noquote() << "TTextEdit::getGraphemeWidth(...) WARN - trying to get width of a Unicode character which was not previously assigned and we do not know how wide it "
+                                                  "is, codepoint number: U+"
                                                << qsl("%1").arg(unicode, 4, 16, QLatin1Char('0')).toUtf8().constData() << ".";
             }
             if (Q_UNLIKELY(newCodePointToWarnAbout)) {
@@ -875,7 +1076,7 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
     p.setCompositionMode(QPainter::CompositionMode_SourceOver);
 
     int y_top = r.top() / mFontHeight;
-    int y_bottom = r.bottom()/ mFontHeight;
+    int y_bottom = r.bottom() / mFontHeight;
     int x_right = std::min(r.right(), (mScreenWidth * mFontWidth)) / mFontWidth;
 
     int lineOffset = imageTopLine();
@@ -1105,8 +1306,7 @@ void TTextEdit::expandSelectionToWords()
                 break; // xind is out of bounds, break the loop
             }
             const QChar currentChar = mpBuffer->lineBuffer.at(yind).at(xind);
-            if (currentChar == QChar::Space
-                || mpHost->mDoubleClickIgnore.contains(currentChar)) {
+            if (currentChar == QChar::Space || mpHost->mDoubleClickIgnore.contains(currentChar)) {
                 break;
             }
         }
@@ -1121,8 +1321,7 @@ void TTextEdit::expandSelectionToWords()
     if (yind >= 0 && yind < static_cast<int>(mpBuffer->lineBuffer.size())) {
         for (; xind < static_cast<int>(mpBuffer->lineBuffer.at(yind).size()); ++xind) {
             const QChar currentChar = mpBuffer->lineBuffer.at(yind).at(xind);
-            if (currentChar == QChar::Space
-                || mpHost->mDoubleClickIgnore.contains(currentChar)) {
+            if (currentChar == QChar::Space || mpHost->mDoubleClickIgnore.contains(currentChar)) {
                 break;
             }
         }
@@ -1130,7 +1329,6 @@ void TTextEdit::expandSelectionToWords()
     mDragSelectionEnd.setX(xind - 1);
     mPB.setX(xind - 1);
 }
-
 
 
 void TTextEdit::expandSelectionToLine(int y)
@@ -1246,8 +1444,7 @@ void TTextEdit::updateTextCursor(const QMouseEvent* event, int lineIndex, int tC
                 // Also don't set hover if this link was just clicked - wait for mouse to leave first
                 if (mpBuffer->getHoveredLink() != linkIndex) {
                     auto currentState = mpBuffer->getLinkState(linkIndex);
-                    if (currentState != Mudlet::HyperlinkStyling::StateDisabled 
-                        && linkIndex != mpBuffer->getLastClickedLinkIndex()) {
+                    if (currentState != Mudlet::HyperlinkStyling::StateDisabled && linkIndex != mpBuffer->getLastClickedLinkIndex()) {
                         mpBuffer->setHoveredLink(linkIndex);
                         forceUpdate(); // Trigger re-render with new hover state
                     }
@@ -1261,7 +1458,7 @@ void TTextEdit::updateTextCursor(const QMouseEvent* event, int lineIndex, int tC
                     mpBuffer->setHoveredLink(0);
                     forceUpdate(); // Trigger re-render
                 }
-                
+
                 // Clear last clicked link when mouse leaves - allows hover to work again
                 if (mpBuffer->getLastClickedLinkIndex() != 0) {
                     mpBuffer->clearLastClickedLinkIndex();
@@ -1440,17 +1637,18 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
                         mpBuffer->setActiveLink(linkIndex);
 
                         Mudlet::HyperlinkStyling hyperlinkStyling = mpBuffer->getEffectiveHyperlinkStyling(linkIndex);
-                        
+
 #if defined(DEBUG_OSC_PROCESSING)
-                        qDebug() << "TTextEdit::mousePressEvent - Link" << linkIndex << "disabled:" << hyperlinkStyling.selection.disabled << "hasSelectionSettings:" << hyperlinkStyling.selection.hasSelectionSettings << "isSpoiler:" << hyperlinkStyling.isSpoiler;
+                        qDebug() << "TTextEdit::mousePressEvent - Link" << linkIndex << "disabled:" << hyperlinkStyling.selection.disabled
+                                 << "hasSelectionSettings:" << hyperlinkStyling.selection.hasSelectionSettings << "isSpoiler:" << hyperlinkStyling.isSpoiler;
 #endif
-                        
+
                         // Handle spoiler revealing first (even for disabled links)
                         if (hyperlinkStyling.isSpoiler) {
                             // Check if this spoiler hasn't been revealed yet
                             bool wasUnrevealed = mpBuffer->isSpoilerUnrevealed(linkIndex);
                             mpBuffer->revealSpoilerLink(linkIndex);
-                            
+
                             // For unrevealed spoilers, the first click should ONLY reveal, not execute the function
                             if (wasUnrevealed && !hyperlinkStyling.selection.disabled) {
 #if defined(DEBUG_OSC_PROCESSING)
@@ -1459,11 +1657,11 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
                                 forceUpdate();
                                 return;
                             }
-                            
+
                             // Update styling after spoiler reveal
                             hyperlinkStyling = mpBuffer->getEffectiveHyperlinkStyling(linkIndex);
                         }
-                        
+
                         // Check for disabled links - they can reveal spoilers but can't execute functions
                         if (hyperlinkStyling.selection.disabled) {
 #if defined(DEBUG_OSC_PROCESSING)
@@ -1474,7 +1672,7 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
                             forceUpdate();
                             return;
                         }
-                        
+
                         if (hyperlinkStyling.selection.hasSelectionSettings) {
                             auto* mgr = mpConsole ? &mpConsole->getHyperlinkSelectionManager() : nullptr;
                             if (!mgr) {
@@ -1482,10 +1680,10 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
                             } else {
                                 const QString& group = hyperlinkStyling.selection.group;
                                 const QString& value = hyperlinkStyling.selection.value;
-                                
+
                                 // Configure group exclusivity mode if needed
                                 mgr->setGroupExclusive(group, hyperlinkStyling.selection.exclusive);
-                                
+
                                 bool currentlySelected = mgr->isSelected(group, value);
 
                                 if (hyperlinkStyling.selection.toggle) {
@@ -1514,7 +1712,7 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
                                     mpBuffer->setLinkState(linkIndex, Mudlet::HyperlinkStyling::StateDefault);
                                 }
                                 mpBuffer->updateLinkCharacters(linkIndex);
-                                
+
                                 // For exclusive groups, update visual state of all other members that may have been deselected
                                 if (mgr->isGroupExclusive(group)) {
                                     QStringList groupMembers = mgr->getGroupMembers(group);
@@ -1523,11 +1721,10 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
                                             // Get all link IDs with this group/value combination using the reverse index
                                             bool memberSelected = mgr->isSelected(group, member);
                                             QList<int> matchingLinkIds = mpBuffer->mLinkStore.getLinkIdsByGroupValue(group, member);
-                                            
+
                                             for (int otherLinkId : matchingLinkIds) {
                                                 mpBuffer->setLinkSelected(otherLinkId, memberSelected);
-                                                mpBuffer->setLinkState(otherLinkId, memberSelected ? 
-                                                    Mudlet::HyperlinkStyling::StateSelected : Mudlet::HyperlinkStyling::StateDefault);
+                                                mpBuffer->setLinkState(otherLinkId, memberSelected ? Mudlet::HyperlinkStyling::StateSelected : Mudlet::HyperlinkStyling::StateDefault);
                                                 mpBuffer->updateLinkCharacters(otherLinkId);
 #if defined(DEBUG_OSC_PROCESSING)
                                                 qDebug() << "TTextEdit::mousePressEvent - Updated exclusive group member link" << otherLinkId << "to selected=" << memberSelected;
@@ -1538,13 +1735,13 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
                                 }
                             }
                         }
-                        
+
                         // Clear hover to show selection immediately; mouse move will restore it
                         mpBuffer->setHoveredLink(0);
-                        
+
                         // Remember this link was just clicked - suppress hover until mouse leaves
                         mpBuffer->setLastClickedLinkIndex(linkIndex);
-                        
+
                         forceUpdate();
 
                         // Notify visibility manager that link was clicked (activates timers)
@@ -1987,8 +2184,9 @@ QString TTextEdit::getSelectedText(const QChar& newlineChar, const bool showTime
     if (showTimestamps) {
         QStringList timestamps = mpBuffer->timeBuffer.mid(startLine, endLine - startLine + 1);
         QStringList result;
-        std::transform(textLines.cbegin(), textLines.cend(), timestamps.cbegin(), std::back_inserter(result),
-                               [](const QString& text, const QString& timestamp) { return timestamp + text; });
+        std::transform(textLines.cbegin(), textLines.cend(), timestamps.cbegin(), std::back_inserter(result), [](const QString& text, const QString& timestamp) {
+            return timestamp + text;
+        });
         textLines = result;
     }
 
@@ -2019,7 +2217,7 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
             if (x < static_cast<int>(mpBuffer->buffer.at(static_cast<size_t>(y)).size()) && !isOutOfbounds) {
                 if (mpBuffer->buffer.at(static_cast<size_t>(y)).at(static_cast<size_t>(x)).linkIndex()) {
                     int linkIndex = mpBuffer->buffer.at(static_cast<size_t>(y)).at(static_cast<size_t>(x)).linkIndex();
-                    
+
                     // Check if link is disabled - disabled links don't show context menus
                     Mudlet::HyperlinkStyling hyperlinkStyling = mpBuffer->getEffectiveHyperlinkStyling(linkIndex);
                     if (hyperlinkStyling.selection.disabled) {
@@ -2029,7 +2227,7 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
                         mIsCommandPopup = false;
                         return;
                     }
-                    
+
                     QStringList command = mpBuffer->mLinkStore.getLinks(linkIndex);
                     QStringList hint = mpBuffer->mLinkStore.getHints(linkIndex);
                     QVector<int> luaReference = mpBuffer->mLinkStore.getReference(linkIndex);
@@ -2176,7 +2374,9 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
                 QAction* mouseAction = new QAction(actionName, this);
                 mouseAction->setToolTip(actionInfo.at(2));
                 popup->addAction(mouseAction);
-                connect(mouseAction, &QAction::triggered, this, [this, uniqueName] { slot_mouseAction(uniqueName); });
+                connect(mouseAction, &QAction::triggered, this, [this, uniqueName] {
+                    slot_mouseAction(uniqueName);
+                });
             }
         }
 
@@ -2232,9 +2432,7 @@ void TTextEdit::resizeEvent(QResizeEvent* event)
 
     QWidget::resizeEvent(event);
 
-    if (mpConsole && !mIsLowerPane
-        && (mpConsole->getType() & (TConsole::MainConsole | TConsole::UserWindow | TConsole::SubConsole))) {
-
+    if (mpConsole && !mIsLowerPane && (mpConsole->getType() & (TConsole::MainConsole | TConsole::UserWindow | TConsole::SubConsole))) {
         mpConsole->raiseMudletResizeEvent();
     }
 }
@@ -2667,21 +2865,15 @@ void TTextEdit::slot_analyseSelection()
                         qsl("<td colspan=\"%1\" style=\"white-space:no-wrap vertical-align:top\"><center>%2</center>&#8232;<center>(0x%3:0x%4)</center></td>")
                                 .arg(QString::number(columnsToUse))
 #if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
-                                .arg(qsl("%1").arg(static_cast<uint32_t>(QChar::surrogateToUcs4(mpBuffer->lineBuffer.at(line).at(index),
-                                                                                                mpBuffer->lineBuffer.at(line).at(index + 1))),
-                                                   4, 16, zero).toUpper())
-                                .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index).unicode()),
-                                     4, 16, zero)
-                                .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index + 1).unicode()),
-                                     4, 16, zero));
+                                .arg(qsl("%1")
+                                             .arg(static_cast<uint32_t>(QChar::surrogateToUcs4(mpBuffer->lineBuffer.at(line).at(index), mpBuffer->lineBuffer.at(line).at(index + 1))), 4, 16, zero)
+                                             .toUpper())
+                                .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index).unicode()), 4, 16, zero)
+                                .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index + 1).unicode()), 4, 16, zero));
 #else
-                                .arg(qsl("%1").arg(QChar::surrogateToUcs4(mpBuffer->lineBuffer.at(line).at(index),
-                                                                          mpBuffer->lineBuffer.at(line).at(index + 1)),
-                                                   4, 16, zero).toUpper())
-                                .arg(mpBuffer->lineBuffer.at(line).at(index).unicode(),
-                                     4, 16, zero)
-                                .arg(mpBuffer->lineBuffer.at(line).at(index + 1).unicode(),
-                                     4, 16, zero));
+                                .arg(qsl("%1").arg(QChar::surrogateToUcs4(mpBuffer->lineBuffer.at(line).at(index), mpBuffer->lineBuffer.at(line).at(index + 1)), 4, 16, zero).toUpper())
+                                .arg(mpBuffer->lineBuffer.at(line).at(index).unicode(), 4, 16, zero)
+                                .arg(mpBuffer->lineBuffer.at(line).at(index + 1).unicode(), 4, 16, zero));
 #endif
 
                 // Note the addition to the index here to jump over the low-surrogate:
@@ -2755,12 +2947,10 @@ void TTextEdit::slot_analyseSelection()
                 utf16Vals.append(qsl("<td colspan=\"%1\" style=\"white-space:no-wrap vertical-align:top\"><center>%2</center></td>")
                                          .arg(QString::number(columnsToUse))
 #if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
-                                         .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index).unicode()),
-                                              4, 16, QChar('0'))
+                                         .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index).unicode()), 4, 16, QChar('0'))
                                          .toUpper());
 #else
-                                         .arg(mpBuffer->lineBuffer.at(line).at(index).unicode(),
-                                              4, 16, QChar('0'))
+                                         .arg(mpBuffer->lineBuffer.at(line).at(index).unicode(), 4, 16, QChar('0'))
                                          .toUpper());
 #endif
 
@@ -2831,54 +3021,53 @@ void TTextEdit::slot_analyseSelection()
 
         if (rowItems > rowLimit) {
             if (isFirstRow) {
-                completedRows =
-                        qsl("<small><table border=\"1\" style=\"margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;\" width=\"100%\" cellspacing=\"2\" cellpadding=\"0\">"
-                                       "<tr><th>%1</th>%2</tr>"
-                                       "<tr><th>%3</th>%4</tr>"
-                                       "<tr><th>%5</th>%6</tr>"
-                                       "<tr><th>%7</th>%8</tr>"
-                                       "<tr><th>%9</th>%10</tr>"
-                                       "<tr><th>%11</th>%12</tr>"
-                                       "</table></small><br>")
-                                //: 1st Row heading for Text analyser output, table item is the count into the QChars/TChars that make up the text {this translation used 2 times}
-                                .arg(tr("Index (UTF-16)"), utf16indexes)
-                                /*:
+                completedRows = qsl("<small><table border=\"1\" style=\"margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;\" width=\"100%\" cellspacing=\"2\" cellpadding=\"0\">"
+                                    "<tr><th>%1</th>%2</tr>"
+                                    "<tr><th>%3</th>%4</tr>"
+                                    "<tr><th>%5</th>%6</tr>"
+                                    "<tr><th>%7</th>%8</tr>"
+                                    "<tr><th>%9</th>%10</tr>"
+                                    "<tr><th>%11</th>%12</tr>"
+                                    "</table></small><br>")
+                                        //: 1st Row heading for Text analyser output, table item is the count into the QChars/TChars that make up the text {this translation used 2 times}
+                                        .arg(tr("Index (UTF-16)"), utf16indexes)
+                                        /*:
                                 2nd Row heading for Text analyser output, table item is the unicode code point (will be
                                 between 000001 and 10FFFF in hexadecimal) {this translation used 2 times}
                                 */
-                                .arg(tr("U+<i>####</i> Unicode Code-point <i>(High:Low Surrogates)</i>"), utf16Vals)
-                                /*:
+                                        .arg(tr("U+<i>####</i> Unicode Code-point <i>(High:Low Surrogates)</i>"), utf16Vals)
+                                        /*:
                                 3rd Row heading for Text analyser output, table item is a visual representation of the character/part of the character or a '{'...'}' wrapped
                                 letter code if the character is whitespace or otherwise unshowable {this translation used 2 times}
                                 */
-                                .arg(tr("Visual"), graphemes)
-                                /*:
+                                        .arg(tr("Visual"), graphemes)
+                                        /*:
                                 4th Row heading for Text analyser output, table item is the count into the bytes that make up the UTF-8 form of the text that the Lua system
                                 uses {this translation used 2 times}
                                 */
-                                .arg(tr("Index (UTF-8)"), utf8Indexes)
-                                /*:
+                                        .arg(tr("Index (UTF-8)"), utf8Indexes)
+                                        /*:
                                 5th Row heading for Text analyser output, table item is the unsigned 8-bit integer for the particular byte in the UTF-8 form of the text that the Lua
                                 system uses {this translation used 2 times}
                                 */
-                                .arg(tr("Byte"), utf8Vals)
-                                /*:
+                                        .arg(tr("Byte"), utf8Vals)
+                                        /*:
                                 6th Row heading for Text analyser output, table item is either the ASCII character or the numeric code for the byte in the row about
                                 this item in the table, as displayed the thing shown can be used in a Lua string entry to reproduce this byte {this translation used
                                 2 times}"
                                 */
-                                .arg(tr("Lua character or code"), luaCodes);
+                                        .arg(tr("Lua character or code"), luaCodes);
                 isFirstRow = false;
             } else {
                 completedRows.append(
                         qsl("<small><table border=\"1\" style=\"margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;\" width=\"100%\" cellspacing=\"2\" cellpadding=\"0\">"
-                                       "<tr>%1</tr>"
-                                       "<tr>%2</tr>"
-                                       "<tr>%3</tr>"
-                                       "<tr>%4</tr>"
-                                       "<tr>%5</tr>"
-                                       "<tr>%6</tr>"
-                                       "</table></small><br>")
+                            "<tr>%1</tr>"
+                            "<tr>%2</tr>"
+                            "<tr>%3</tr>"
+                            "<tr>%4</tr>"
+                            "<tr>%5</tr>"
+                            "<tr>%6</tr>"
+                            "</table></small><br>")
                                 .arg(utf16indexes, utf16Vals, graphemes, utf8Indexes, utf8Vals, luaCodes));
             }
             rowItems = 0;
@@ -2905,47 +3094,47 @@ void TTextEdit::slot_analyseSelection()
                         "<tr><th>%10</th>%11</tr>"
                         "<tr><th>%12</th>%13</tr>"
                         "</table></small>")
-                        .arg(completedRows)
-                        //: 1st Row heading for Text analyser output, table item is the count into the QChars/TChars that make up the text {this translation used 2 times}
-                        .arg(tr("Index (UTF-16)"), utf16indexes)
-                        /*:
+                            .arg(completedRows)
+                            //: 1st Row heading for Text analyser output, table item is the count into the QChars/TChars that make up the text {this translation used 2 times}
+                            .arg(tr("Index (UTF-16)"), utf16indexes)
+                            /*:
                         2nd Row heading for Text analyser output, table item is the unicode code point (will be between
                         000001 and 10FFFF in hexadecimal) {this translation used 2 times}
                         */
-                        .arg(tr("U+<i>####</i> Unicode Code-point <i>(High:Low Surrogates)</i>"), utf16Vals)
-                        /*:
+                            .arg(tr("U+<i>####</i> Unicode Code-point <i>(High:Low Surrogates)</i>"), utf16Vals)
+                            /*:
                         3rd Row heading for Text analyser output, table item is a visual representation of the character/part of the character or a '{'...'}' wrapped letter
                         code if the character is whitespace or otherwise unshowable {this translation used 2 times}
                         */
-                        .arg(tr("Visual"), graphemes)
-                        /*:
+                            .arg(tr("Visual"), graphemes)
+                            /*:
                         4th Row heading for Text analyser output, table item is the count into the bytes that make up the UTF-8 form of the text that the Lua system
                         uses {this translation used 2 times}
                         */
-                        .arg(tr("Index (UTF-8)"), utf8Indexes)
-                        /*:
+                            .arg(tr("Index (UTF-8)"), utf8Indexes)
+                            /*:
                         5th Row heading for Text analyser output, table item is the unsigned 8-bit integer for the particular byte in the UTF-8 form of the text that the Lua
                         system uses {this translation used 2 times}
                         */
-                        .arg(tr("Byte"), utf8Vals)
-                        /*:
+                            .arg(tr("Byte"), utf8Vals)
+                            /*:
                         6th Row heading for Text analyser output, table item is either the ASCII character or the numeric code for the byte in the row about
                         this item in the table, as displayed the thing shown can be used in a Lua string entry to reproduce this byte {this translation used 2
                         times}
                         */
-                        .arg(tr("Lua character or code"), luaCodes));
+                            .arg(tr("Lua character or code"), luaCodes));
         } else {
             mpContextMenuAnalyser->setToolTip(
-                        qsl("%1"
-                            "<small><table border=\"1\" style=\"margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;\" width=\"100%\" cellspacing=\"2\" cellpadding=\"0\">"
-                            "<tr>%2</tr>"
-                            "<tr>%3</tr>"
-                            "<tr>%4</tr>"
-                            "<tr>%5</tr>"
-                            "<tr>%6</tr>"
-                            "<tr>%7</tr>"
-                            "</table></small>")
-                        .arg(completedRows, utf16indexes, utf16Vals, graphemes, utf8Indexes, utf8Vals, luaCodes));
+                    qsl("%1"
+                        "<small><table border=\"1\" style=\"margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;\" width=\"100%\" cellspacing=\"2\" cellpadding=\"0\">"
+                        "<tr>%2</tr>"
+                        "<tr>%3</tr>"
+                        "<tr>%4</tr>"
+                        "<tr>%5</tr>"
+                        "<tr>%6</tr>"
+                        "<tr>%7</tr>"
+                        "</table></small>")
+                            .arg(completedRows, utf16indexes, utf16Vals, graphemes, utf8Indexes, utf8Vals, luaCodes));
         }
     }
 }
@@ -2967,13 +3156,13 @@ void TTextEdit::slot_changeDebugShowAllProblemCodepoints(const bool state)
 }
 #endif
 
-void TTextEdit::slot_mouseAction(const QString &uniqueName)
+void TTextEdit::slot_mouseAction(const QString& uniqueName)
 {
     if (!mpHost) {
         return;
     }
 
-    TEvent event {};
+    TEvent event{};
     QStringList mouseEvent = mpHost->mConsoleActions[uniqueName];
     event.mArgumentList.append(mouseEvent[0]);
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
@@ -3186,181 +3375,177 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
     };
 
     switch (event->key()) {
-        case Qt::Key_Up: {
-            if (mCaretLine == 0) {
-                newCaretLine = mCaretLine;
-                newCaretColumn = 0;
-            } else {
-                newCaretLine = mCaretLine - 1;
-                newCaretColumn = mCaretColumn;
-            }
-
-            adjustCaretColumn();
-            updateSelection(true);
-        }
-            break;
-        case Qt::Key_Down: {
-            int emptyLastLine = mpBuffer->lineBuffer.last().isEmpty();
-            if (mCaretLine >= mpBuffer->lineBuffer.length() - 1 - emptyLastLine) {
-                newCaretLine = mCaretLine;
-                newCaretColumn = mpBuffer->line(mCaretLine).length() - 1;
-            } else {
-                newCaretLine = mCaretLine + 1;
-                newCaretColumn = mCaretColumn;
-            }
-
-            adjustCaretColumn();
-            updateSelection(true);
-        }
-            break;
-        case Qt::Key_Left: {
-            bool jumpedLines = false;
-            if (mCaretColumn > 0) {
-                if (QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
-                    const auto& line = mpBuffer->line(mCaretLine);
-                    QTextBoundaryFinder finder(QTextBoundaryFinder::Word, line);
-                    finder.setPosition(mCaretColumn);
-                    int nextBoundary {};
-                    QString currentLetter {};
-
-                    do {
-                        nextBoundary = finder.toPreviousBoundary();
-                        currentLetter = line.mid(nextBoundary, 1);
-                    } while (nextBoundary != 0 && mCtrlSelectionIgnores.contains(currentLetter));
-
-                    newCaretLine = mCaretLine;
-                    newCaretColumn = nextBoundary;
-                } else {
-                    newCaretLine = mCaretLine;
-                    newCaretColumn = mCaretColumn - 1;
-                }
-            } else if (mCaretLine > 0) {
-                newCaretLine = mCaretLine - 1;
-                newCaretColumn = mpBuffer->lineBuffer.at(newCaretLine).length() - 1;
-                jumpedLines = true;
-            }
-
-            // use newCaretColumn if we jumped lines or the selection extends to the left of the cursor
-            const bool selectionBehindCursor = newCaretColumn < mCaretColumn;
-
-            updateSelection(jumpedLines || selectionBehindCursor);
-        }
-            break;
-        case Qt::Key_Right: {
-            bool jumpedLines = false;
-            if (mCaretColumn < (mpBuffer->lineBuffer.at(mCaretLine).length() - 1)) {
-                if (QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
-                    const auto& line = mpBuffer->line(mCaretLine);
-                    QTextBoundaryFinder finder(QTextBoundaryFinder::Word, line);
-                    finder.setPosition(mCaretColumn);
-                    int nextBoundary {};
-                    QString currentLetter {};
-
-                    do {
-                        nextBoundary = finder.toNextBoundary();
-                        currentLetter = line.mid(nextBoundary, 1);
-                    } while (nextBoundary != line.length() && mCtrlSelectionIgnores.contains(currentLetter));
-
-                    nextBoundary = std::min<qsizetype>(nextBoundary, line.length() - 1);
-                    newCaretColumn = nextBoundary;
-                    newCaretLine = mCaretLine;
-                } else {
-                    newCaretColumn = mCaretColumn + 1;
-                    newCaretLine = mCaretLine;
-                }
-                // last line of the buffer is empty, so we need to check for that:
-            } else if (mCaretLine < (mpBuffer->lineBuffer.length() - 2)) {
-                newCaretLine = mCaretLine + 1;
-                newCaretColumn = 0;
-                jumpedLines = true;
-            } else {
-                // last line, last character in the buffer
-                newCaretLine = mCaretLine;
-                newCaretColumn = mCaretColumn;
-            }
-
-            // use newCaretColumn if we jumped lines or the selection extends to the right of the cursor
-            const bool selectionBehindCursor = newCaretColumn > mCaretColumn;
-
-            updateSelection(jumpedLines || selectionBehindCursor);
-        }
-            break;
-        case Qt::Key_Home:
-            if (QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
-                newCaretLine = 0;
-                newCaretColumn = 0;
-            } else {
-                newCaretColumn = 0;
-            }
+    case Qt::Key_Up: {
+        if (mCaretLine == 0) {
+            newCaretLine = mCaretLine;
             newCaretColumn = 0;
-            break;
-        case Qt::Key_End:
+        } else {
+            newCaretLine = mCaretLine - 1;
+            newCaretColumn = mCaretColumn;
+        }
+
+        adjustCaretColumn();
+        updateSelection(true);
+    } break;
+    case Qt::Key_Down: {
+        int emptyLastLine = mpBuffer->lineBuffer.last().isEmpty();
+        if (mCaretLine >= mpBuffer->lineBuffer.length() - 1 - emptyLastLine) {
+            newCaretLine = mCaretLine;
+            newCaretColumn = mpBuffer->line(mCaretLine).length() - 1;
+        } else {
+            newCaretLine = mCaretLine + 1;
+            newCaretColumn = mCaretColumn;
+        }
+
+        adjustCaretColumn();
+        updateSelection(true);
+    } break;
+    case Qt::Key_Left: {
+        bool jumpedLines = false;
+        if (mCaretColumn > 0) {
             if (QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
-                newCaretLine = mpBuffer->lineBuffer.length() - 1;
-                newCaretColumn = mpBuffer->lineBuffer[mCaretLine].length() - 1;
+                const auto& line = mpBuffer->line(mCaretLine);
+                QTextBoundaryFinder finder(QTextBoundaryFinder::Word, line);
+                finder.setPosition(mCaretColumn);
+                int nextBoundary{};
+                QString currentLetter{};
+
+                do {
+                    nextBoundary = finder.toPreviousBoundary();
+                    currentLetter = line.mid(nextBoundary, 1);
+                } while (nextBoundary != 0 && mCtrlSelectionIgnores.contains(currentLetter));
+
+                newCaretLine = mCaretLine;
+                newCaretColumn = nextBoundary;
             } else {
-                newCaretColumn = mpBuffer->lineBuffer.at(mCaretLine).length() - 1;
+                newCaretLine = mCaretLine;
+                newCaretColumn = mCaretColumn - 1;
             }
-            break;
-        case Qt::Key_PageUp:
-            newCaretLine = std::max(mCaretLine - mScreenHeight, 0);
-            break;
-        case Qt::Key_PageDown:
-            newCaretLine = std::min<qsizetype>(mCaretLine + mScreenHeight, mpBuffer->lineBuffer.length() - 2);
-            break;
-        case Qt::Key_Return:
-        case Qt::Key_Enter:
-        case Qt::Key_Space: {
-            // Activate the focused link when Enter or Space is pressed in caret mode
-            int focusedLink = mpBuffer->getFocusedLink();
-            if (focusedLink > 0) {
-                // Get the link commands and execute them
-                QStringList commands = mpBuffer->mLinkStore.getLinksConst(focusedLink);
-                if (!commands.isEmpty()) {
-                    // Notify visibility manager that link was clicked (activates timers)
-                    if (mpConsole) {
-                        mpConsole->getHyperlinkVisibilityManager().onLinkClicked(focusedLink);
-                    }
-
-                    // Mark the link as visited
-                    mpBuffer->markLinkAsVisited(focusedLink);
-
-                    // Execute the command(s)
-                    for (const auto& cmd : commands) {
-                        mpHost->send(cmd);
-                    }
-
-                    // Don't move the caret for this key press
-                    QWidget::keyPressEvent(event);
-                    return;
-                }
-            }
-            // If no link is focused or it has no command, handle normally
-            break;
+        } else if (mCaretLine > 0) {
+            newCaretLine = mCaretLine - 1;
+            newCaretColumn = mpBuffer->lineBuffer.at(newCaretLine).length() - 1;
+            jumpedLines = true;
         }
-        case Qt::Key_C:
+
+        // use newCaretColumn if we jumped lines or the selection extends to the left of the cursor
+        const bool selectionBehindCursor = newCaretColumn < mCaretColumn;
+
+        updateSelection(jumpedLines || selectionBehindCursor);
+    } break;
+    case Qt::Key_Right: {
+        bool jumpedLines = false;
+        if (mCaretColumn < (mpBuffer->lineBuffer.at(mCaretLine).length() - 1)) {
             if (QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
-                if (!QGuiApplication::keyboardModifiers().testFlag(Qt::ShiftModifier)) {
-                    slot_copySelectionToClipboard();
-                } else {
-                    slot_copySelectionToClipboardHTML();
-                }
+                const auto& line = mpBuffer->line(mCaretLine);
+                QTextBoundaryFinder finder(QTextBoundaryFinder::Word, line);
+                finder.setPosition(mCaretColumn);
+                int nextBoundary{};
+                QString currentLetter{};
+
+                do {
+                    nextBoundary = finder.toNextBoundary();
+                    currentLetter = line.mid(nextBoundary, 1);
+                } while (nextBoundary != line.length() && mCtrlSelectionIgnores.contains(currentLetter));
+
+                nextBoundary = std::min<qsizetype>(nextBoundary, line.length() - 1);
+                newCaretColumn = nextBoundary;
+                newCaretLine = mCaretLine;
+            } else {
+                newCaretColumn = mCaretColumn + 1;
+                newCaretLine = mCaretLine;
             }
-            break;
-        case Qt::Key_Tab: {
-            if ((mpHost->mCaretShortcut == Host::CaretShortcut::Tab && !(event->modifiers() & Qt::ControlModifier))
-                || (mpHost->mCaretShortcut == Host::CaretShortcut::CtrlTab && (event->modifiers() & Qt::ControlModifier))) {
-                mpHost->setCaretEnabled(false);
-            }
-            break;
+            // last line of the buffer is empty, so we need to check for that:
+        } else if (mCaretLine < (mpBuffer->lineBuffer.length() - 2)) {
+            newCaretLine = mCaretLine + 1;
+            newCaretColumn = 0;
+            jumpedLines = true;
+        } else {
+            // last line, last character in the buffer
+            newCaretLine = mCaretLine;
+            newCaretColumn = mCaretColumn;
         }
 
-        case Qt::Key_F6: {
-            if (mpHost->mCaretShortcut == Host::CaretShortcut::F6) {
-                mpHost->setCaretEnabled(false);
-            }
-            break;
+        // use newCaretColumn if we jumped lines or the selection extends to the right of the cursor
+        const bool selectionBehindCursor = newCaretColumn > mCaretColumn;
+
+        updateSelection(jumpedLines || selectionBehindCursor);
+    } break;
+    case Qt::Key_Home:
+        if (QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
+            newCaretLine = 0;
+            newCaretColumn = 0;
+        } else {
+            newCaretColumn = 0;
         }
+        newCaretColumn = 0;
+        break;
+    case Qt::Key_End:
+        if (QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
+            newCaretLine = mpBuffer->lineBuffer.length() - 1;
+            newCaretColumn = mpBuffer->lineBuffer[mCaretLine].length() - 1;
+        } else {
+            newCaretColumn = mpBuffer->lineBuffer.at(mCaretLine).length() - 1;
+        }
+        break;
+    case Qt::Key_PageUp:
+        newCaretLine = std::max(mCaretLine - mScreenHeight, 0);
+        break;
+    case Qt::Key_PageDown:
+        newCaretLine = std::min<qsizetype>(mCaretLine + mScreenHeight, mpBuffer->lineBuffer.length() - 2);
+        break;
+    case Qt::Key_Return:
+    case Qt::Key_Enter:
+    case Qt::Key_Space: {
+        // Activate the focused link when Enter or Space is pressed in caret mode
+        int focusedLink = mpBuffer->getFocusedLink();
+        if (focusedLink > 0) {
+            // Get the link commands and execute them
+            QStringList commands = mpBuffer->mLinkStore.getLinksConst(focusedLink);
+            if (!commands.isEmpty()) {
+                // Notify visibility manager that link was clicked (activates timers)
+                if (mpConsole) {
+                    mpConsole->getHyperlinkVisibilityManager().onLinkClicked(focusedLink);
+                }
+
+                // Mark the link as visited
+                mpBuffer->markLinkAsVisited(focusedLink);
+
+                // Execute the command(s)
+                for (const auto& cmd : commands) {
+                    mpHost->send(cmd);
+                }
+
+                // Don't move the caret for this key press
+                QWidget::keyPressEvent(event);
+                return;
+            }
+        }
+        // If no link is focused or it has no command, handle normally
+        break;
+    }
+    case Qt::Key_C:
+        if (QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
+            if (!QGuiApplication::keyboardModifiers().testFlag(Qt::ShiftModifier)) {
+                slot_copySelectionToClipboard();
+            } else {
+                slot_copySelectionToClipboardHTML();
+            }
+        }
+        break;
+    case Qt::Key_Tab: {
+        if ((mpHost->mCaretShortcut == Host::CaretShortcut::Tab && !(event->modifiers() & Qt::ControlModifier))
+            || (mpHost->mCaretShortcut == Host::CaretShortcut::CtrlTab && (event->modifiers() & Qt::ControlModifier))) {
+            mpHost->setCaretEnabled(false);
+        }
+        break;
+    }
+
+    case Qt::Key_F6: {
+        if (mpHost->mCaretShortcut == Host::CaretShortcut::F6) {
+            mpHost->setCaretEnabled(false);
+        }
+        break;
+    }
     }
 
     // Did the key press change the caret position?
@@ -3380,7 +3565,8 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
     setCaretPosition(newCaretLine, newCaretColumn);
 }
 
-int TTextEdit::offsetForPosition(int line, int column) const {
+int TTextEdit::offsetForPosition(int line, int column) const
+{
     int ret = 0;
 
     for (int i = 0; i < line; i++) {

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -241,7 +241,6 @@ void TTimer::execute()
         }
 
         if (!mpHost->mLuaInterpreter.call(mFuncName, mName, (mTime < mpHost->mTimerDebugOutputSuppressionInterval))) {
-
             mpQTimer->stop();
         }
     }

--- a/src/TToolBar.cpp
+++ b/src/TToolBar.cpp
@@ -33,7 +33,7 @@
 TToolBar::TToolBar(Host* pHost, TAction* pA, const QString& name, QWidget* pW)
 : QDockWidget(pW)
 , mpTAction(pA)
-, mpWidget( new QWidget( this ) )
+, mpWidget(new QWidget(this))
 , mpHost(pHost)
 {
     setFeatures(QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
@@ -76,7 +76,7 @@ void TToolBar::setName(const QString& name)
 
 void TToolBar::moveEvent(QMoveEvent* e)
 {
-    if (!mpTAction||mpHost.isNull()) {
+    if (!mpTAction || mpHost.isNull()) {
         return;
     }
 
@@ -184,7 +184,7 @@ void TToolBar::finalize()
 // now retrieve the button state to ensure the visible representation is used.
 void TToolBar::slot_pressed(const bool isChecked)
 {
-    auto * pB = dynamic_cast<TFlipButton*>(sender());
+    auto* pB = dynamic_cast<TFlipButton*>(sender());
     if (!pB) {
         return;
     }
@@ -203,7 +203,7 @@ void TToolBar::slot_pressed(const bool isChecked)
         mpHost->mpConsole->mButtonState = (pA->mButtonState ? 2 : 1); // Was using 1 and 0 but that was wrong
     } else {
         pA->mButtonState = false;
-        pB->setChecked(false);                   // This does NOT invoke the clicked()!
+        pB->setChecked(false);               // This does NOT invoke the clicked()!
         mpHost->mpConsole->mButtonState = 1; // Was effectively 0 but that is wrong
     }
 

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -42,8 +42,8 @@
 const int TTrigger::scmDefault = -2;
 const int TTrigger::scmIgnored = -1;
 
-TTrigger::TTrigger( TTrigger * parent, Host * pHost )
-: Tree<TTrigger>( parent )
+TTrigger::TTrigger(TTrigger* parent, Host* pHost)
+: Tree<TTrigger>(parent)
 , mpHost(pHost)
 , mpLua(mpHost->getLuaInterpreter())
 {
@@ -66,19 +66,19 @@ TTrigger::~TTrigger()
     QMutableListIterator<TColorTable*> itColorTable(mColorPatternList);
     while (itColorTable.hasNext()) {
         if (itColorTable.next()) {
-//            qDebug() << "TTrigger::~TTrigger() INFO: removing TColorTable from mColorPatternList: (ansiFg:"
-//                     << itColorTable.peekPrevious()->ansiFg
-//                     << itColorTable.peekPrevious()->mFgColor
-//                     << "ansiBg:"
-//                     << itColorTable.peekPrevious()->ansiBg
-//                     << itColorTable.peekPrevious()->mBgColor
-//                     << ").";
+            //            qDebug() << "TTrigger::~TTrigger() INFO: removing TColorTable from mColorPatternList: (ansiFg:"
+            //                     << itColorTable.peekPrevious()->ansiFg
+            //                     << itColorTable.peekPrevious()->mFgColor
+            //                     << "ansiBg:"
+            //                     << itColorTable.peekPrevious()->ansiBg
+            //                     << itColorTable.peekPrevious()->mBgColor
+            //                     << ").";
             delete itColorTable.peekPrevious();
         }
         itColorTable.remove();
     }
 
-    for (auto && [key, value] : mConditionMap) {
+    for (auto&& [key, value] : mConditionMap) {
         delete value;
     }
 
@@ -99,7 +99,7 @@ TTrigger::~TTrigger()
 void TTrigger::setName(const QString& name)
 {
     if (!isTemporary()) {
-        mpHost->getTriggerUnit()->mLookupTable.remove( mName, this );
+        mpHost->getTriggerUnit()->mLookupTable.remove(mName, this);
     }
     mName = name;
     mpHost->getTriggerUnit()->mLookupTable.insert(name, this);
@@ -123,13 +123,13 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds, b
     QMutableListIterator<TColorTable*> itColorTable(mColorPatternList);
     while (itColorTable.hasNext()) {
         if (itColorTable.next()) {
-//            qDebug() << "TTrigger::setRegexCodeList() INFO: removing TColorTable from mColorPatternList: (ansiFg:"
-//                     << itColorTable.peekPrevious()->ansiFg
-//                     << itColorTable.peekPrevious()->mFgColor
-//                     << "ansiBg:"
-//                     << itColorTable.peekPrevious()->ansiBg
-//                     << itColorTable.peekPrevious()->mBgColor
-//                     << ").";
+            //            qDebug() << "TTrigger::setRegexCodeList() INFO: removing TColorTable from mColorPatternList: (ansiFg:"
+            //                     << itColorTable.peekPrevious()->ansiFg
+            //                     << itColorTable.peekPrevious()->mFgColor
+            //                     << "ansiBg:"
+            //                     << itColorTable.peekPrevious()->ansiBg
+            //                     << itColorTable.peekPrevious()->mBgColor
+            //                     << ").";
             delete itColorTable.peekPrevious();
         }
         itColorTable.remove();
@@ -166,13 +166,8 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds, b
 
                 // PCRE2_UTF needed to run compile in UTF-8 mode
                 // PCRE2_UCP needed for \d, \w etc. to use Unicode properties:
-                QSharedPointer<pcre2_code> const re(pcre2_compile(
-                    reinterpret_cast<PCRE2_SPTR>(regexp.constData()),
-                    PCRE2_ZERO_TERMINATED,
-                    PCRE2_UTF | PCRE2_UCP,
-                    &errorcode,
-                    &erroffset,
-                    nullptr), pcre2_code_deleter);
+                QSharedPointer<pcre2_code> const re(pcre2_compile(reinterpret_cast<PCRE2_SPTR>(regexp.constData()), PCRE2_ZERO_TERMINATED, PCRE2_UTF | PCRE2_UCP, &errorcode, &erroffset, nullptr),
+                                                    pcre2_code_deleter);
 
                 if (!re) {
                     PCRE2_UCHAR errorBuffer[256];
@@ -183,8 +178,8 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds, b
                         TDebug(Qt::red, Qt::gray) << TDebug::csmContinue << R"(in: ")" << regexp.constData() << "\"\n" >> mpHost;
                     }
                     setError(qsl("<b><font color='blue'>%1</font></b>")
-                             .arg(tr(R"(Error: in item %1, perl regex "%2" failed to compile, reason: "%3".)")
-                             .arg(QString::number(i + 1), QString(regexp.constData()).toHtmlEscaped(), QString(error).toHtmlEscaped())));
+                                     .arg(tr(R"(Error: in item %1, perl regex "%2" failed to compile, reason: "%3".)")
+                                                  .arg(QString::number(i + 1), QString(regexp.constData()).toHtmlEscaped(), QString(error).toHtmlEscaped())));
                     state = false;
                 } else {
                     pcre2_jit_compile(re.data(), PCRE2_JIT_COMPLETE);
@@ -205,8 +200,7 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds, b
                 QString error;
                 if (!mpLua->compile(code, error, QString::fromStdString(funcName))) {
                     setError(qsl("<b><font color='blue'>%1</font></b>")
-                             .arg(tr(R"(Error: in item %1, lua function "%2" failed to compile, reason: "%3".)")
-                             .arg(QString::number(i + 1), patterns.at(i).toHtmlEscaped(), QString(error))));
+                                     .arg(tr(R"(Error: in item %1, lua function "%2" failed to compile, reason: "%3".)").arg(QString::number(i + 1), patterns.at(i).toHtmlEscaped(), QString(error))));
                     state = false;
                     if (mudlet::smDebugMode) {
                         TDebug(Qt::white, Qt::red) << "LUA ERROR: failed to compile, reason:\n" << error << "\n" >> mpHost;
@@ -226,7 +220,7 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds, b
                 if (textAnsiBg == scmIgnored && textAnsiFg == scmIgnored) {
                     setError(qsl("<b><font color='blue'>%1</font></b>")
                                      .arg(tr("Error: in item %1, no colors to match were set - at least <i>one</i> of the foreground or background must not be <i>ignored</i>.")
-                                          .arg(QString::number(i+1))));
+                                                  .arg(QString::number(i + 1))));
                     state = false;
                     continue;
                 }
@@ -284,8 +278,8 @@ bool TTrigger::match_perl(char* haystackC, const QString& haystack, int patternN
     return true;
 }
 
-void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack, int patternNumber, int posOffset,
-                                 const QSharedPointer<pcre2_code>& re, int haystackCLength, pcre2_match_data* match_data, int rc)
+void TTrigger::processRegexMatch(
+        const char* haystackC, const QString& haystack, int patternNumber, int posOffset, const QSharedPointer<pcre2_code>& re, int haystackCLength, pcre2_match_data* match_data, int rc)
 {
     PCRE2_SIZE* ovector = pcre2_get_ovector_pointer(match_data);
 
@@ -300,7 +294,7 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
     QMap<QString, QPair<int, int>> namePositions;
     NameGroupMatches nameGroups;
     for (i = 0; i < rc; i++) {
-        const char *substring_start = haystackC + ovector[2 * i];
+        const char* substring_start = haystackC + ovector[2 * i];
         const int substring_length = ovector[2 * i + 1] - ovector[2 * i];
         const int utf16_pos = haystack.indexOf(QString::fromUtf8(substring_start, substring_length));
         std::string match;
@@ -331,9 +325,10 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
         pcre2_pattern_info(re.data(), PCRE2_INFO_NAMEENTRYSIZE, &name_entry_size);
         for (uint32_t j = 0; j < namecount; ++j) {
             const int n = (tabptr[0] << 8) | tabptr[1];
-            auto name = QString::fromUtf8(reinterpret_cast<const char*>(&tabptr[2])).trimmed(); //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)
-            auto* substring_start = haystackC + ovector[2*n]; //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)
-            auto substring_length = ovector[2*n+1] - ovector[2*n]; //NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+            auto name =
+                    QString::fromUtf8(reinterpret_cast<const char*>(&tabptr[2])).trimmed(); //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)
+            auto* substring_start = haystackC + ovector[2 * n];                             //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)
+            auto substring_length = ovector[2 * n + 1] - ovector[2 * n];                    //NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
             auto utf16_pos = haystack.indexOf(QString::fromUtf8(substring_start, substring_length));
             auto capture = QString::fromUtf8(substring_start, substring_length);
             nameGroups << qMakePair(name, capture);
@@ -368,7 +363,7 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
         }
 
         for (i = 0; i < rc; i++) {
-            const char *substring_start = haystackC + ovector[2 * i];
+            const char* substring_start = haystackC + ovector[2 * i];
             const int substring_length = ovector[2 * i + 1] - ovector[2 * i];
             const int utf16_pos = haystack.indexOf(QString::fromUtf8(substring_start, substring_length));
 
@@ -388,40 +383,31 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
         }
     }
 
-    END : {
-        if (mIsColorizerTrigger) {
-            const int r1 = mBgColor.red();
-            const int g1 = mBgColor.green();
-            const int b1 = mBgColor.blue();
-            const int r2 = mFgColor.red();
-            const int g2 = mFgColor.green();
-            const int b2 = mFgColor.blue();
-            const int total = captureList.size();
-            TConsole* pC = mpHost->mpConsole;
-            if (Q_UNLIKELY(!pC)) {
-                return;
-            }
-            pC->deselect();
-            auto its = captureList.begin();
-            auto iti = posList.begin();
-            for (int position = 1; iti != posList.end(); ++iti, ++its, position++) {
-                const int begin = *iti;
-                const std::string& s = *its;
-                const int length = QString::fromStdString(s).size();
-                if (total > 1) {
-                    // skip complete match in Perl /g option type of triggers
-                    // to enable people to highlight capture groups if there are any
-                    // otherwise highlight complete expression match
-                    if (position % numberOfCaptureGroups != 1) {
-                        pC->selectSection(begin, length);
-                        if (mBgColor != QColorConstants::Transparent) {
-                            pC->setBgColor(r1, g1, b1, 255);
-                        }
-                        if (mFgColor != QColorConstants::Transparent) {
-                            pC->setFgColor(r2, g2, b2);
-                        }
-                    }
-                } else {
+END: {
+    if (mIsColorizerTrigger) {
+        const int r1 = mBgColor.red();
+        const int g1 = mBgColor.green();
+        const int b1 = mBgColor.blue();
+        const int r2 = mFgColor.red();
+        const int g2 = mFgColor.green();
+        const int b2 = mFgColor.blue();
+        const int total = captureList.size();
+        TConsole* pC = mpHost->mpConsole;
+        if (Q_UNLIKELY(!pC)) {
+            return;
+        }
+        pC->deselect();
+        auto its = captureList.begin();
+        auto iti = posList.begin();
+        for (int position = 1; iti != posList.end(); ++iti, ++its, position++) {
+            const int begin = *iti;
+            const std::string& s = *its;
+            const int length = QString::fromStdString(s).size();
+            if (total > 1) {
+                // skip complete match in Perl /g option type of triggers
+                // to enable people to highlight capture groups if there are any
+                // otherwise highlight complete expression match
+                if (position % numberOfCaptureGroups != 1) {
                     pC->selectSection(begin, length);
                     if (mBgColor != QColorConstants::Transparent) {
                         pC->setBgColor(r1, g1, b1, 255);
@@ -430,42 +416,51 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
                         pC->setFgColor(r2, g2, b2);
                     }
                 }
+            } else {
+                pC->selectSection(begin, length);
+                if (mBgColor != QColorConstants::Transparent) {
+                    pC->setBgColor(r1, g1, b1, 255);
+                }
+                if (mFgColor != QColorConstants::Transparent) {
+                    pC->setFgColor(r2, g2, b2);
+                }
             }
-            pC->reset();
         }
-        if (mIsMultiline) {
-            updateMultistates(patternNumber, captureList, posList, &nameGroups);
-            return;
-        } else {
-            TLuaInterpreter* pL = mpHost->getLuaInterpreter();
-            pL->setCaptureGroups(captureList, posList);
-            pL->setCaptureNameGroups(nameGroups, namePositions);
-            execute();
-            pL->clearCaptureGroups();
-            if (mFilterTrigger) {
-                if (captureList.size() > 1) {
-                    const int total = captureList.size();
-                    auto its = captureList.begin();
-                    auto iti = posList.begin();
-                    for (int filterPosition = 1; iti != posList.end(); ++iti, ++its, filterPosition++) {
-                        int begin = *iti;
-                        std::string& s = *its;
-                        if (total > 1 && numberOfCaptureGroups > 0) {
-                            // skip complete match in Perl /g option type of triggers
-                            // to enable people to highlight capture groups if there are any
-                            // otherwise highlight complete expression match
-                            if (filterPosition % numberOfCaptureGroups != 1) {
-                                filter(s, begin);
-                            }
-                        } else {
+        pC->reset();
+    }
+    if (mIsMultiline) {
+        updateMultistates(patternNumber, captureList, posList, &nameGroups);
+        return;
+    } else {
+        TLuaInterpreter* pL = mpHost->getLuaInterpreter();
+        pL->setCaptureGroups(captureList, posList);
+        pL->setCaptureNameGroups(nameGroups, namePositions);
+        execute();
+        pL->clearCaptureGroups();
+        if (mFilterTrigger) {
+            if (captureList.size() > 1) {
+                const int total = captureList.size();
+                auto its = captureList.begin();
+                auto iti = posList.begin();
+                for (int filterPosition = 1; iti != posList.end(); ++iti, ++its, filterPosition++) {
+                    int begin = *iti;
+                    std::string& s = *its;
+                    if (total > 1 && numberOfCaptureGroups > 0) {
+                        // skip complete match in Perl /g option type of triggers
+                        // to enable people to highlight capture groups if there are any
+                        // otherwise highlight complete expression match
+                        if (filterPosition % numberOfCaptureGroups != 1) {
                             filter(s, begin);
                         }
+                    } else {
+                        filter(s, begin);
                     }
                 }
             }
-            return;
         }
+        return;
     }
+}
 }
 
 bool TTrigger::match_begin_of_line_substring(const QString& haystack, const QString& needle, int patternNumber, int posOffset)
@@ -544,8 +539,8 @@ inline void TTrigger::updateMultistates(int regexNumber, std::list<std::string>&
             pCondition->nameCaptures.push_back(QVector<QPair<QString, QString>>());
         }
         if (mudlet::smDebugMode) {
-            TDebug(Qt::darkYellow, Qt::black) << "match state " << mConditionMap.size() << "/" << mConditionMap.size() << " condition #" << regexNumber << "=true (" << regexNumber
-                                              << "/" << mPatterns.size() << ") regex=" << mPatterns[regexNumber] << "\n"
+            TDebug(Qt::darkYellow, Qt::black) << "match state " << mConditionMap.size() << "/" << mConditionMap.size() << " condition #" << regexNumber << "=true (" << regexNumber << "/"
+                                              << mPatterns.size() << ") regex=" << mPatterns[regexNumber] << "\n"
                     >> mpHost;
         }
     } else {
@@ -554,8 +549,8 @@ inline void TTrigger::updateMultistates(int regexNumber, std::list<std::string>&
             k++;
             if (matchStatePair.second->nextCondition() == regexNumber) {
                 if (mudlet::smDebugMode) {
-                    TDebug(Qt::darkYellow, Qt::black) << "match state " << k << "/" << mConditionMap.size() << " condition #" << regexNumber << "=true (" << regexNumber << "/"
-                                                      << mPatterns.size() << ") regex=" << mPatterns[regexNumber] << "\n"
+                    TDebug(Qt::darkYellow, Qt::black) << "match state " << k << "/" << mConditionMap.size() << " condition #" << regexNumber << "=true (" << regexNumber << "/" << mPatterns.size()
+                                                      << ") regex=" << mPatterns[regexNumber] << "\n"
                             >> mpHost;
                 }
                 matchStatePair.second->conditionMatched();
@@ -602,8 +597,7 @@ bool TTrigger::match_substring(const QString& haystack, const QString& needle, i
     return false;
 }
 
-void TTrigger::processSubstringMatch(const QString& haystack, const QString& needle, int regexNumber, int posOffset,
-                                     int where)
+void TTrigger::processSubstringMatch(const QString& haystack, const QString& needle, int regexNumber, int posOffset, int where)
 {
     std::list<std::string> captureList;
     std::list<int> posList;
@@ -702,7 +696,6 @@ bool TTrigger::match_color_pattern(int line, int patternNumber)
         // have come from a decoded ANSI code number:
         if (((pCT->ansiFg == scmIgnored) || ((pCT->ansiFg == scmDefault) && mpHost->mpConsole->mFgColor == (*it).foreground()) || (pCT->mFgColor == (*it).foreground()))
             && ((pCT->ansiBg == scmIgnored) || ((pCT->ansiBg == scmDefault) && mpHost->mpConsole->mBgColor == (*it).background()) || (pCT->mBgColor == (*it).background()))) {
-
             if (matchBegin == -1) {
                 matchBegin = pos;
             }
@@ -797,9 +790,9 @@ bool TTrigger::match_line_spacer(int patternNumber)
                 if (matchStatePair.second->lineSpacerMatch(mPatterns.value(patternNumber).toInt())) {
                     if (mudlet::smDebugMode) {
                         TDebug(Qt::yellow, Qt::black) << "Trigger name=" << mName << "(" << mPatterns.value(patternNumber) << ") condition #" << patternNumber << "=true " >> mpHost;
-                        TDebug(Qt::darkYellow, Qt::black) << TDebug::csmContinue << "match state " << k << "/" << mConditionMap.size() << " condition #" << patternNumber << "=true (" << patternNumber + 1 << "/"
-                                                          << mPatterns.size() << ") line spacer=" << mPatterns.value(patternNumber) << "lines\n"
-                                                          >> mpHost;
+                        TDebug(Qt::darkYellow, Qt::black) << TDebug::csmContinue << "match state " << k << "/" << mConditionMap.size() << " condition #" << patternNumber << "=true ("
+                                                          << patternNumber + 1 << "/" << mPatterns.size() << ") line spacer=" << mPatterns.value(patternNumber) << "lines\n"
+                                >> mpHost;
                     }
                     matchStatePair.second->conditionMatched();
                     std::list<std::string> const captureList;
@@ -1198,16 +1191,16 @@ bool TTrigger::setupColorTrigger(int ansiFg, int ansiBg)
         // This can be caused by both ansiFg and ansiBg being scmIgnored
         return false;
     }
-//    qDebug() << "TTrigger::setupColorTrigger(" << ansiFg
-//             << ", "
-//             << ansiBg
-//             << ") INFO: adding TColorTable to mColorPatternList: (ansiFg:"
-//             << pCT->ansiFg
-//             << pCT->mFgColor
-//             << "ansiBg:"
-//             << pCT->ansiBg
-//             << pCT->mBgColor
-//             << ").";
+    //    qDebug() << "TTrigger::setupColorTrigger(" << ansiFg
+    //             << ", "
+    //             << ansiBg
+    //             << ") INFO: adding TColorTable to mColorPatternList: (ansiFg:"
+    //             << pCT->ansiFg
+    //             << pCT->mFgColor
+    //             << "ansiBg:"
+    //             << pCT->ansiBg
+    //             << pCT->mBgColor
+    //             << ").";
     mColorPatternList.push_back(pCT);
     return true;
 }

--- a/src/TVar.cpp
+++ b/src/TVar.cpp
@@ -36,9 +36,7 @@
  * LUA_TTHREAD          8
  */
 
-TVar::TVar()
-{
-}
+TVar::TVar() {}
 
 TVar::TVar(TVar* p)
 : parent(p)

--- a/src/TimerUnit.cpp
+++ b/src/TimerUnit.cpp
@@ -389,7 +389,7 @@ bool TimerUnit::killTimer(const QString& name)
 int TimerUnit::remainingTime(const QString& name) const
 {
     auto pTimer = findFirstTimer(name);
-    if (pTimer){
+    if (pTimer) {
         return pTimer->remainingTime();
     }
 
@@ -457,16 +457,10 @@ std::tuple<QString, int, int, int> TimerUnit::assembleReport()
         assembleReport(pItem);
     }
     QStringList msg;
-    msg << QLatin1String("Timers current total: ") << QString::number(statsItemsTotal) << QLatin1String("\n")
-        << QLatin1String("tempTimers current total: ") << QString::number(statsTempItems) << QLatin1String("\n")
-        << QLatin1String("active Timers: ") << QString::number(statsActiveItems) << QLatin1String("\n");
+    msg << QLatin1String("Timers current total: ") << QString::number(statsItemsTotal) << QLatin1String("\n") << QLatin1String("tempTimers current total: ") << QString::number(statsTempItems)
+        << QLatin1String("\n") << QLatin1String("active Timers: ") << QString::number(statsActiveItems) << QLatin1String("\n");
 
-    return {
-        msg.join(QString()),
-        statsItemsTotal,
-        statsTempItems,
-        statsActiveItems
-    };
+    return {msg.join(QString()), statsItemsTotal, statsTempItems, statsActiveItems};
 }
 
 void TimerUnit::changeHostName(const QString& newName)

--- a/src/TrailingWhitespaceMarker.cpp
+++ b/src/TrailingWhitespaceMarker.cpp
@@ -40,20 +40,23 @@ void markQString(QString* text)
 
     // Mark leading spaces before ^ with a middle dot
     if (trimmedText.front() == '^') {
-        auto firstNonSpace = std::find_if_not(text->begin(), text->end(), [](QChar c) {return c == QChar(' '); });
+        auto firstNonSpace = std::find_if_not(text->begin(), text->end(), [](QChar c) {
+            return c == QChar(' ');
+        });
         std::replace(text->begin(), firstNonSpace, QChar(' '), middleDot);
     }
 
     // Mark trailing spaces after $ with a middle dot
     if (trimmedText.back() == '$') {
-        auto lastNonSpace = std::find_if_not(text->rbegin(), text->rend(), [](QChar c) {return c == QChar(' '); });
+        auto lastNonSpace = std::find_if_not(text->rbegin(), text->rend(), [](QChar c) {
+            return c == QChar(' ');
+        });
         std::replace(lastNonSpace, text->rend(), QChar(' '), middleDot);
     }
 }
 
 void markQLineEdit(QLineEdit* lineEdit)
 {
-
     QString text = lineEdit->text();
 
     unmarkQString(&text);
@@ -69,7 +72,6 @@ void markQLineEdit(QLineEdit* lineEdit)
 
 void unmarkQLineEdit(QLineEdit* lineEdit)
 {
-
     QString text = lineEdit->text();
 
     unmarkQString(&text);

--- a/src/TriggerHighlighter.cpp
+++ b/src/TriggerHighlighter.cpp
@@ -21,8 +21,8 @@
 #include "edbee/views/texttheme.h"
 #include "edbee/models/textdocumentscopes.h"
 
-TriggerHighlighter::TriggerHighlighter(QTextDocument *parent)
-    : QSyntaxHighlighter(parent)
+TriggerHighlighter::TriggerHighlighter(QTextDocument* parent)
+: QSyntaxHighlighter(parent)
 {
     setTheme("Mudlet"); // start with the default theme
 }
@@ -33,13 +33,13 @@ void TriggerHighlighter::setHighlightingEnabled(bool enabled)
     rehighlight();
 }
 
-void TriggerHighlighter::highlightBlock(const QString &text)
+void TriggerHighlighter::highlightBlock(const QString& text)
 {
     if (!highlightingEnabled) {
         return;
     }
 
-    for (const HighlightingRule &rule : highlightingRules) {
+    for (const HighlightingRule& rule : highlightingRules) {
         QRegularExpressionMatchIterator matchIterator = rule.pattern.globalMatch(text);
         while (matchIterator.hasNext()) {
             QRegularExpressionMatch match = matchIterator.next();
@@ -68,21 +68,19 @@ void TriggerHighlighter::setTheme(const QString& themeName)
 
     // override defaults in theme using scopes which map to regex formats
     // check a few as some themes don't provide all of them
-    std::map<QString, QTextCharFormat&> scopeMap = {
-        {"comment", anchorFormat},
-        {"keyword", charClassFormat},
-        {"keyword.control", charClassFormat},
-        {"keyword.operator", charClassFormat},
-        {"constant", escapeCharFormat},
-        {"constant.numeric", escapeCharFormat},
-        {"constant.language", escapeCharFormat},
-        {"constant.character.escape", escapeCharFormat},
-        {"string", groupFormat},
-        {"variable", quantifierFormat},
-        {"variable.language", quantifierFormat},
-        {"variable.parameter", quantifierFormat},
-        {"variable.function", quantifierFormat}
-    };
+    std::map<QString, QTextCharFormat&> scopeMap = {{"comment", anchorFormat},
+                                                    {"keyword", charClassFormat},
+                                                    {"keyword.control", charClassFormat},
+                                                    {"keyword.operator", charClassFormat},
+                                                    {"constant", escapeCharFormat},
+                                                    {"constant.numeric", escapeCharFormat},
+                                                    {"constant.language", escapeCharFormat},
+                                                    {"constant.character.escape", escapeCharFormat},
+                                                    {"string", groupFormat},
+                                                    {"variable", quantifierFormat},
+                                                    {"variable.language", quantifierFormat},
+                                                    {"variable.parameter", quantifierFormat},
+                                                    {"variable.function", quantifierFormat}};
 
     for (auto& rule : rules) {
         QString scope = rule->scopeSelector()->toString();

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -438,19 +438,10 @@ std::tuple<QString, int, int, int, int, int> TriggerUnit::assembleReport()
         assembleReport(pItem);
     }
     QStringList msg;
-    msg << QLatin1String("triggers current total: ") << QString::number(statsItemsTotal) << QLatin1String("\n")
-        << QLatin1String("tempTriggers current total: ") << QString::number(statsTempItems) << QLatin1String("\n")
-        << QLatin1String("active triggers: ") << QString::number(statsActiveItems) << QLatin1String("\n")
-        << QLatin1String("trigger patterns total: ") << QString::number(statsPatternsTotal) << QLatin1String("\n")
-        << QLatin1String("active patterns total: ") << QString::number(statsPatternsActive) << QLatin1String("\n");
-    return {
-        msg.join(QString()),
-        statsItemsTotal,
-        statsPatternsTotal,
-        statsTempItems,
-        statsActiveItems,
-        statsPatternsActive
-    };
+    msg << QLatin1String("triggers current total: ") << QString::number(statsItemsTotal) << QLatin1String("\n") << QLatin1String("tempTriggers current total: ") << QString::number(statsTempItems)
+        << QLatin1String("\n") << QLatin1String("active triggers: ") << QString::number(statsActiveItems) << QLatin1String("\n") << QLatin1String("trigger patterns total: ")
+        << QString::number(statsPatternsTotal) << QLatin1String("\n") << QLatin1String("active patterns total: ") << QString::number(statsPatternsActive) << QLatin1String("\n");
+    return {msg.join(QString()), statsItemsTotal, statsPatternsTotal, statsTempItems, statsActiveItems, statsPatternsActive};
 }
 
 void TriggerUnit::doCleanup()

--- a/src/VarUnit.cpp
+++ b/src/VarUnit.cpp
@@ -127,7 +127,7 @@ QString VarUnit::getUnsaveableReason(TVar* var)
             //: Tooltip explaining why a large table cannot be saved, recommending alternative methods
             return tr("This table has %1 items, exceeding the 10,000 item limit for saved variables. "
                       "Use <b>table.save()</b> and <b>table.load()</b> instead for better performance with large tables.")
-                .arg(QLocale::system().toString(itemCount));
+                    .arg(QLocale::system().toString(itemCount));
         }
     }
 

--- a/src/WideComboBox.cpp
+++ b/src/WideComboBox.cpp
@@ -22,7 +22,8 @@
 #include <QScrollBar>
 #include <QAbstractItemView>
 
-void WideComboBox::showPopup() {
+void WideComboBox::showPopup()
+{
     // compute width of widest content.
     int maxWidth = view()->sizeHintForColumn(0);
     if (maxWidth > 0) {

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -43,37 +43,37 @@
 #include <QFile>
 #include <sstream>
 
-XMLexport::XMLexport( Host * pH )
+XMLexport::XMLexport(Host* pH)
 : mpHost(pH)
 {
 }
 
-XMLexport::XMLexport( TTrigger * pT )
+XMLexport::XMLexport(TTrigger* pT)
 : mpTrigger(pT)
 {
 }
 
-XMLexport::XMLexport( TTimer * pT )
+XMLexport::XMLexport(TTimer* pT)
 : mpTimer(pT)
 {
 }
 
-XMLexport::XMLexport( TAlias * pT )
+XMLexport::XMLexport(TAlias* pT)
 : mpAlias(pT)
 {
 }
 
-XMLexport::XMLexport( TAction * pT )
+XMLexport::XMLexport(TAction* pT)
 : mpAction(pT)
 {
 }
 
-XMLexport::XMLexport( TScript * pT )
+XMLexport::XMLexport(TScript* pT)
 : mpScript(pT)
 {
 }
 
-XMLexport::XMLexport( TKey * pT )
+XMLexport::XMLexport(TKey* pT)
 : mpKey(pT)
 {
 }
@@ -185,8 +185,8 @@ void XMLexport::runAsyncSave(const QString& fileName, const QString& xmlSavedKey
     for (pugi::xml_node child = mExportDoc.first_child(); child; child = child.next_sibling()) {
         docClone.append_copy(child);
     }
-    auto future = QtConcurrent::run([fileName, docClone = std::move(docClone)]() mutable { 
-        return XMLexport::saveXmlDocToFile(fileName, docClone); 
+    auto future = QtConcurrent::run([fileName, docClone = std::move(docClone)]() mutable {
+        return XMLexport::saveXmlDocToFile(fileName, docClone);
     });
     auto watcher = new QFutureWatcher<bool>;
     connect(watcher, &QFutureWatcher<bool>::finished, host, [host, xmlSavedKey]() {
@@ -228,21 +228,21 @@ void XMLexport::sanitizeForQxml(std::string& output)
 {
     QMap<std::string, std::string> replacements{
             {"&#1;", "\uFFFC\u2401"},   // SOH
-            {"&#01;", "\uFFFC\u2401"},   // SOH
+            {"&#01;", "\uFFFC\u2401"},  // SOH
             {"&#2;", "\uFFFC\u2402"},   // STX
-            {"&#02;", "\uFFFC\u2402"},   // STX
+            {"&#02;", "\uFFFC\u2402"},  // STX
             {"&#3;", "\uFFFC\u2403"},   // ETX
-            {"&#03;", "\uFFFC\u2403"},   // ETX
+            {"&#03;", "\uFFFC\u2403"},  // ETX
             {"&#4;", "\uFFFC\u2404"},   // EOT
-            {"&#04;", "\uFFFC\u2404"},   // EOT
+            {"&#04;", "\uFFFC\u2404"},  // EOT
             {"&#5;", "\uFFFC\u2405"},   // ENQ
-            {"&#05;", "\uFFFC\u2405"},   // ENQ
+            {"&#05;", "\uFFFC\u2405"},  // ENQ
             {"&#6;", "\uFFFC\u2406"},   // ACK
-            {"&#06;", "\uFFFC\u2406"},   // ACK
+            {"&#06;", "\uFFFC\u2406"},  // ACK
             {"&#7;", "\uFFFC\u2407"},   // BEL
-            {"&#07;", "\uFFFC\u2407"},   // BEL
+            {"&#07;", "\uFFFC\u2407"},  // BEL
             {"&#8;", "\uFFFC\u2408"},   // BS
-            {"&#08;", "\uFFFC\u2408"},   // BS
+            {"&#08;", "\uFFFC\u2408"},  // BS
             {"&#11;", "\uFFFC\u240B"},  // VT
             {"&#12;", "\uFFFC\u240C"},  // FF
             {"&#14;", "\uFFFC\u240E"},  // SS
@@ -334,13 +334,13 @@ bool XMLexport::saveXmlDocToFile(const QString& fileName, const pugi::xml_docume
     std::stringstream saveStringStream(std::ios::out);
     doc.save(saveStringStream);
     std::string output(saveStringStream.str());
-    
+
     // Apply sanitization for control characters
     sanitizeForQxml(output);
 
     file.write(output.data(), output.size());
     bool success = file.error() == QFileDevice::NoError;
-    
+
     if (!success) {
         printErrorMessage(file.errorString());
     } else if (!file.commit()) {
@@ -533,10 +533,8 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("advertiseScreenReader") = pHost->mAdvertiseScreenReader ? "yes" : "no";
     host.append_attribute("f3SearchEnabled") = pHost->mF3SearchEnabled ? "yes" : "no";
     host.append_attribute("enableClosedCaption") = pHost->mEnableClosedCaption ? "yes" : "no";
-    host.append_attribute("caretShortcut") = QMetaEnum::fromType<Host::CaretShortcut>().valueToKey(
-            static_cast<int>(pHost->mCaretShortcut));
-    host.append_attribute("blankLineBehaviour") = QMetaEnum::fromType<Host::BlankLineBehaviour>().valueToKey(
-            static_cast<int>(pHost->mBlankLineBehaviour));
+    host.append_attribute("caretShortcut") = QMetaEnum::fromType<Host::CaretShortcut>().valueToKey(static_cast<int>(pHost->mCaretShortcut));
+    host.append_attribute("blankLineBehaviour") = QMetaEnum::fromType<Host::BlankLineBehaviour>().valueToKey(static_cast<int>(pHost->mBlankLineBehaviour));
     host.append_attribute("NetworkPacketTimeout") = pHost->mTelnet.getPostingTimeout();
     host.append_attribute("ShowIDsInEditor") = pHost->showIdsInEditor() ? "yes" : "no";
     if (const int mode = static_cast<int>(pHost->getControlCharacterMode()); mode) {
@@ -960,8 +958,8 @@ void XMLexport::writeTrigger(TTrigger* pT, pugi::xml_node xmlParent)
             trigger.append_child("mStayOpen").text().set(QString::number(pT->mStayOpen).toUtf8().constData());
             trigger.append_child("mCommand").text().set(pT->mCommand.toUtf8().constData());
             trigger.append_child("packageName").text().set(pT->mPackageName.toUtf8().constData());
-            trigger.append_child("mFgColor").text().set(pT->mFgColor == QColorConstants::Transparent ? "transparent": pT->mFgColor.name().toUtf8().constData());
-            trigger.append_child("mBgColor").text().set(pT->mBgColor == QColorConstants::Transparent ? "transparent": pT->mBgColor.name().toUtf8().constData());
+            trigger.append_child("mFgColor").text().set(pT->mFgColor == QColorConstants::Transparent ? "transparent" : pT->mFgColor.name().toUtf8().constData());
+            trigger.append_child("mBgColor").text().set(pT->mBgColor == QColorConstants::Transparent ? "transparent" : pT->mBgColor.name().toUtf8().constData());
             trigger.append_child("mSoundFile").text().set(pT->mSoundFile.toUtf8().constData());
             trigger.append_child("colorTriggerFgColor").text().set(pT->mColorTriggerFgColor.name().toUtf8().constData());
             trigger.append_child("colorTriggerBgColor").text().set(pT->mColorTriggerBgColor.name().toUtf8().constData());
@@ -1278,9 +1276,8 @@ void XMLexport::writeScriptElement(const QString& script, pugi::xml_node xmlElem
 }
 
 // Unlike the reverse operation in XMLimport we cannot modify the supplied patternlist
-QStringList XMLexport::remapAnsiToColorNumber(const QStringList & patternList, const QList<int> & typeList)
+QStringList XMLexport::remapAnsiToColorNumber(const QStringList& patternList, const QList<int>& typeList)
 {
-
     QStringList results;
     const QRegularExpression regex = QRegularExpression(qsl("^ANSI_COLORS_F{(\\d+|IGNORE|DEFAULT)}_B{(\\d+|IGNORE|DEFAULT)}$"));
     QStringListIterator itPattern(patternList);
@@ -1377,10 +1374,12 @@ QStringList XMLexport::remapAnsiToColorNumber(const QStringList & patternList, c
                     }
 
                     if (!isFgOk) {
-                        qDebug() << "XMLexport::remapAnsiToColorNumber(...) ERROR - failed to extract FG color code from pattern text:" << itPattern.peekPrevious() << " setting colour to default foreground";
+                        qDebug() << "XMLexport::remapAnsiToColorNumber(...) ERROR - failed to extract FG color code from pattern text:" << itPattern.peekPrevious()
+                                 << " setting colour to default foreground";
                     }
                     if (!isBgOk) {
-                        qDebug() << "XMLexport::remapAnsiToColorNumber(...) ERROR - failed to extract BG color code from pattern text:" << itPattern.peekPrevious() << " setting colour to default background";
+                        qDebug() << "XMLexport::remapAnsiToColorNumber(...) ERROR - failed to extract BG color code from pattern text:" << itPattern.peekPrevious()
+                                 << " setting colour to default background";
                     }
 
                     results << qsl("FG%1BG%2").arg(QString::number(fg), QString::number(bg));

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -147,10 +147,10 @@ std::pair<bool, QString> XMLimport::importPackage(QFile* pfile, QString packName
                     // Minor check is not currently relevant, just abort on 2.000f or more
 
                     const QString moanMsg = tr("[ ALERT ] - Sorry, the file being read:\n"
-                                         "\"%1\"\n"
-                                         "reports it has a version (%2) it must have come from a later Mudlet version,\n"
-                                         "and this one cannot read it, you need a newer Mudlet!")
-                                              .arg(pfile->fileName(), versionString);
+                                               "\"%1\"\n"
+                                               "reports it has a version (%2) it must have come from a later Mudlet version,\n"
+                                               "and this one cannot read it, you need a newer Mudlet!")
+                                                    .arg(pfile->fileName(), versionString);
                     mpHost->postMessage(moanMsg);
                     return {false, moanMsg};
                 }
@@ -491,11 +491,10 @@ void XMLimport::readRoom(QMultiHash<int, int>& areamRoomMultiHash, unsigned int*
             // depending on the value (I.R.E. MUD maps always uses "1" for "door"
             // and/or "hidden" - though the latter does not always appear with
             // former):
-            const int door = (attributes().hasAttribute(qsl("hidden")) && attributes().value(qsl("hidden")).toString().toInt() == 1)
-                    ? 3
-                    : (attributes().hasAttribute(qsl("door")) && attributes().value(qsl("door")).toString().toInt() >= 0 && attributes().value(qsl("door")).toString().toInt() <= 3)
-                      ? attributes().value(qsl("door")).toString().toInt()
-                      : 0;
+            const int door = (attributes().hasAttribute(qsl("hidden")) && attributes().value(qsl("hidden")).toString().toInt() == 1) ? 3
+                             : (attributes().hasAttribute(qsl("door")) && attributes().value(qsl("door")).toString().toInt() >= 0 && attributes().value(qsl("door")).toString().toInt() <= 3)
+                                     ? attributes().value(qsl("door")).toString().toInt()
+                                     : 0;
             if (dir.isEmpty()) {
                 if (attributes().value(qsl("special")).toString().toInt() == 1 && !attributes().value(qsl("command")).toString().isEmpty()) {
                     // This is how IRE XML maps mark special exits, rather than
@@ -548,9 +547,7 @@ void XMLimport::readRoom(QMultiHash<int, int>& areamRoomMultiHash, unsigned int*
                 continue;
             }
 
-            pT->setCoordinates(attributes().value(qsl("x")).toString().toInt(),
-                               attributes().value(qsl("y")).toString().toInt(),
-                               attributes().value(qsl("z")).toString().toInt());
+            pT->setCoordinates(attributes().value(qsl("x")).toString().toInt(), attributes().value(qsl("y")).toString().toInt(), attributes().value(qsl("z")).toString().toInt());
             continue;
         } else if (name() == qsl("features")) {
             readRoomFeatures(pT);
@@ -1177,56 +1174,56 @@ bool XMLimport::readHostColorElement(Host* pHost, QStringView elementName)
 {
     // Simple colors (no alpha channel)
     static const QHash<QString, QColor Host::*> simpleColors = {
-        {qsl("mCommandLineFgColor"), &Host::mCommandLineFgColor},
-        {qsl("mCommandLineBgColor"), &Host::mCommandLineBgColor},
-        {qsl("mFgColor"), &Host::mFgColor},
-        {qsl("mBgColor"), &Host::mBgColor},
-        {qsl("mCommandFgColor"), &Host::mCommandFgColor},
-        {qsl("mCommandBgColor"), &Host::mCommandBgColor},
-        {qsl("mBlack"), &Host::mBlack},
-        {qsl("mLightBlack"), &Host::mLightBlack},
-        {qsl("mRed"), &Host::mRed},
-        {qsl("mLightRed"), &Host::mLightRed},
-        {qsl("mBlue"), &Host::mBlue},
-        {qsl("mLightBlue"), &Host::mLightBlue},
-        {qsl("mGreen"), &Host::mGreen},
-        {qsl("mLightGreen"), &Host::mLightGreen},
-        {qsl("mYellow"), &Host::mYellow},
-        {qsl("mLightYellow"), &Host::mLightYellow},
-        {qsl("mCyan"), &Host::mCyan},
-        {qsl("mLightCyan"), &Host::mLightCyan},
-        {qsl("mMagenta"), &Host::mMagenta},
-        {qsl("mLightMagenta"), &Host::mLightMagenta},
-        {qsl("mWhite"), &Host::mWhite},
-        {qsl("mLightWhite"), &Host::mLightWhite},
-        {qsl("mFgColor2"), &Host::mFgColor_2},
-        {qsl("mLowerLevelColor"), &Host::mLowerLevelColor},
-        {qsl("mUpperLevelColor"), &Host::mUpperLevelColor},
-        {qsl("mRoomBorderColor"), &Host::mRoomBorderColor},
-        {qsl("mRoomCollisionBorderColor"), &Host::mRoomCollisionBorderColor},
-        {qsl("mBlack2"), &Host::mBlack_2},
-        {qsl("mLightBlack2"), &Host::mLightBlack_2},
-        {qsl("mRed2"), &Host::mRed_2},
-        {qsl("mLightRed2"), &Host::mLightRed_2},
-        {qsl("mBlue2"), &Host::mBlue_2},
-        {qsl("mLightBlue2"), &Host::mLightBlue_2},
-        {qsl("mGreen2"), &Host::mGreen_2},
-        {qsl("mLightGreen2"), &Host::mLightGreen_2},
-        {qsl("mYellow2"), &Host::mYellow_2},
-        {qsl("mLightYellow2"), &Host::mLightYellow_2},
-        {qsl("mCyan2"), &Host::mCyan_2},
-        {qsl("mLightCyan2"), &Host::mLightCyan_2},
-        {qsl("mMagenta2"), &Host::mMagenta_2},
-        {qsl("mLightMagenta2"), &Host::mLightMagenta_2},
-        {qsl("mWhite2"), &Host::mWhite_2},
-        {qsl("mLightWhite2"), &Host::mLightWhite_2},
+            {qsl("mCommandLineFgColor"), &Host::mCommandLineFgColor},
+            {qsl("mCommandLineBgColor"), &Host::mCommandLineBgColor},
+            {qsl("mFgColor"), &Host::mFgColor},
+            {qsl("mBgColor"), &Host::mBgColor},
+            {qsl("mCommandFgColor"), &Host::mCommandFgColor},
+            {qsl("mCommandBgColor"), &Host::mCommandBgColor},
+            {qsl("mBlack"), &Host::mBlack},
+            {qsl("mLightBlack"), &Host::mLightBlack},
+            {qsl("mRed"), &Host::mRed},
+            {qsl("mLightRed"), &Host::mLightRed},
+            {qsl("mBlue"), &Host::mBlue},
+            {qsl("mLightBlue"), &Host::mLightBlue},
+            {qsl("mGreen"), &Host::mGreen},
+            {qsl("mLightGreen"), &Host::mLightGreen},
+            {qsl("mYellow"), &Host::mYellow},
+            {qsl("mLightYellow"), &Host::mLightYellow},
+            {qsl("mCyan"), &Host::mCyan},
+            {qsl("mLightCyan"), &Host::mLightCyan},
+            {qsl("mMagenta"), &Host::mMagenta},
+            {qsl("mLightMagenta"), &Host::mLightMagenta},
+            {qsl("mWhite"), &Host::mWhite},
+            {qsl("mLightWhite"), &Host::mLightWhite},
+            {qsl("mFgColor2"), &Host::mFgColor_2},
+            {qsl("mLowerLevelColor"), &Host::mLowerLevelColor},
+            {qsl("mUpperLevelColor"), &Host::mUpperLevelColor},
+            {qsl("mRoomBorderColor"), &Host::mRoomBorderColor},
+            {qsl("mRoomCollisionBorderColor"), &Host::mRoomCollisionBorderColor},
+            {qsl("mBlack2"), &Host::mBlack_2},
+            {qsl("mLightBlack2"), &Host::mLightBlack_2},
+            {qsl("mRed2"), &Host::mRed_2},
+            {qsl("mLightRed2"), &Host::mLightRed_2},
+            {qsl("mBlue2"), &Host::mBlue_2},
+            {qsl("mLightBlue2"), &Host::mLightBlue_2},
+            {qsl("mGreen2"), &Host::mGreen_2},
+            {qsl("mLightGreen2"), &Host::mLightGreen_2},
+            {qsl("mYellow2"), &Host::mYellow_2},
+            {qsl("mLightYellow2"), &Host::mLightYellow_2},
+            {qsl("mCyan2"), &Host::mCyan_2},
+            {qsl("mLightCyan2"), &Host::mLightCyan_2},
+            {qsl("mMagenta2"), &Host::mMagenta_2},
+            {qsl("mLightMagenta2"), &Host::mLightMagenta_2},
+            {qsl("mWhite2"), &Host::mWhite_2},
+            {qsl("mLightWhite2"), &Host::mLightWhite_2},
     };
 
     // Colors that support alpha channel
     static const QHash<QString, QColor Host::*> alphaColors = {
-        {qsl("mBgColor2"), &Host::mBgColor_2},
-        {qsl("mMapGridColor"), &Host::mMapGridColor},
-        {qsl("mMapInfoBg"), &Host::mMapInfoBg},
+            {qsl("mBgColor2"), &Host::mBgColor_2},
+            {qsl("mMapGridColor"), &Host::mMapGridColor},
+            {qsl("mMapInfoBg"), &Host::mMapInfoBg},
     };
 
     const QString elemName = elementName.toString();
@@ -1843,15 +1840,20 @@ void XMLimport::readIntegerList(QList<int>& list, const QString& parentName, con
                         list << num;
                         break;
                     default:
-                        mpHost->postMessage(qsl("[ ERROR ] - \"%1\" as a number when reading the 'regexCodePropertyList' element of the 'Trigger' or 'TriggerGroup' element \"%2\" cannot be understood by this version of Mudlet, is it from a later version? Converting it to a SUBSTRING type so the data can be shown but it will probably not work as expected.").arg(numberText, parentName));
+                        mpHost->postMessage(
+                                qsl("[ ERROR ] - \"%1\" as a number when reading the 'regexCodePropertyList' element of the 'Trigger' or 'TriggerGroup' element \"%2\" cannot be understood by this "
+                                    "version of Mudlet, is it from a later version? Converting it to a SUBSTRING type so the data can be shown but it will probably not work as expected.")
+                                        .arg(numberText, parentName));
                         list << REGEX_SUBSTRING; //Set it to the default type
                     }
 
                 } else {
-                    qWarning(R"(XMLimport::readIntegerList(...) ERROR: unable to convert: "%s" to a number when reading the 'regexCodePropertyList' element of the 'Trigger' or 'TriggerGroup' element "%s"!)",
-                           numberText.toUtf8().constData(),
-                           parentName.toUtf8().constData());
-                    mpHost->postMessage(qsl("[ ERROR ] - Unable to convert: \"%1\" to a number when reading the 'regexCodePropertyList' element of the 'Trigger' or 'TriggerGroup' element \"%2\"!").arg(numberText, parentName));
+                    qWarning(
+                            R"(XMLimport::readIntegerList(...) ERROR: unable to convert: "%s" to a number when reading the 'regexCodePropertyList' element of the 'Trigger' or 'TriggerGroup' element "%s"!)",
+                            numberText.toUtf8().constData(),
+                            parentName.toUtf8().constData());
+                    mpHost->postMessage(qsl("[ ERROR ] - Unable to convert: \"%1\" to a number when reading the 'regexCodePropertyList' element of the 'Trigger' or 'TriggerGroup' element \"%2\"!")
+                                                .arg(numberText, parentName));
                     list << REGEX_SUBSTRING; //Just assume most common one
                 }
             } else {
@@ -1913,7 +1915,7 @@ QString XMLimport::readScriptElement()
 }
 
 // Unlike the reverse operation in the XMLexport this can modify the supplied patternList:
-void XMLimport::remapColorsToAnsiNumber(QStringList & patternList, const QList<int> & typeList)
+void XMLimport::remapColorsToAnsiNumber(QStringList& patternList, const QList<int>& typeList)
 {
     // The regexp is slightly modified compared to the one we once used to allow
     // it to capture a '-' sign as part of the color numbers as we use -2 for
@@ -1934,7 +1936,8 @@ void XMLimport::remapColorsToAnsiNumber(QStringList & patternList, const QList<i
                 int ansibg = TTrigger::scmIgnored;
                 int fg = match.captured(1).toInt(&isFgOk);
                 if (!isFgOk) {
-                    qDebug() << "XMLimport::remapColorsToAnsiNumber(...) ERROR - failed to extract FG color code from pattern text:" << itPattern.peekPrevious() << " setting colour to default foreground";
+                    qDebug() << "XMLimport::remapColorsToAnsiNumber(...) ERROR - failed to extract FG color code from pattern text:" << itPattern.peekPrevious()
+                             << " setting colour to default foreground";
                     fg = TTrigger::scmDefault;
                 } else {
                     // clang-format off
@@ -1965,7 +1968,8 @@ void XMLimport::remapColorsToAnsiNumber(QStringList & patternList, const QList<i
 
                 int bg = match.captured(2).toInt(&isBgOk);
                 if (!isBgOk) {
-                    qDebug() << "XMLimport::remapColorsToAnsiNumber(...) ERROR - failed to extract BG color code from pattern text:" << itPattern.peekPrevious() << " setting colour to default background";
+                    qDebug() << "XMLimport::remapColorsToAnsiNumber(...) ERROR - failed to extract BG color code from pattern text:" << itPattern.peekPrevious()
+                             << " setting colour to default background";
                     bg = TTrigger::scmDefault;
                 } else {
                     // clang-format off
@@ -2039,7 +2043,6 @@ void XMLimport::readStopWatchMap()
             }
         }
     }
-
 }
 
 void XMLimport::readMapInfoContributor()

--- a/src/crash_reporter/main.cpp
+++ b/src/crash_reporter/main.cpp
@@ -38,7 +38,7 @@ extern "C" {
 // Windows: in the registry at HKEY_CURRENT_USER\Software\mudlet\CrashReporter
 // Linux: in a file at ~/.config/Mudlet/CrashReporter.conf
 // macOS: in a file at ~/Library/Preferences/com.Mudlet.CrashReporter.plist
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
     if (argc < 2) {
         qWarning() << "Error: This program requires the path to a .envelope file as an argument.";
@@ -58,7 +58,8 @@ int main(int argc, char *argv[])
     return 0;
 }
 
-void showCrashDialogAndSend(const char *envelopePath, QSettings &settings) {
+void showCrashDialogAndSend(const char* envelopePath, QSettings& settings)
+{
     TCrashSendOption result = createCrashDialog();
 
     if (result == AlwaysSend) {
@@ -69,22 +70,22 @@ void showCrashDialogAndSend(const char *envelopePath, QSettings &settings) {
     }
 }
 
-TCrashSendOption createCrashDialog() {
+TCrashSendOption createCrashDialog()
+{
     QDialog dialog;
     dialog.setWindowTitle(QCoreApplication::translate("CrashReporter", "Mudlet Crash"));
 
-    QVBoxLayout *vLayout = new QVBoxLayout(&dialog);
-    QLabel *label = new QLabel(QCoreApplication::translate(
-        "CrashReporter",
-        "<div align='center'><b>Mudlet has encountered a problem.</b><br><br>"
-        "You can choose to send a crash report to help us improve the application.</div>"));
+    QVBoxLayout* vLayout = new QVBoxLayout(&dialog);
+    QLabel* label = new QLabel(QCoreApplication::translate("CrashReporter",
+                                                           "<div align='center'><b>Mudlet has encountered a problem.</b><br><br>"
+                                                           "You can choose to send a crash report to help us improve the application.</div>"));
     label->setAlignment(Qt::AlignCenter);
     vLayout->addWidget(label);
 
-    QHBoxLayout *hLayout = new QHBoxLayout();
-    QPushButton *sendBtn   = new QPushButton(QCoreApplication::translate("CrashReporter", "Send this time"));
-    QPushButton *alwaysBtn = new QPushButton(QCoreApplication::translate("CrashReporter", "Always send"));
-    QPushButton *dontBtn   = new QPushButton(QCoreApplication::translate("CrashReporter", "Don't send"));
+    QHBoxLayout* hLayout = new QHBoxLayout();
+    QPushButton* sendBtn = new QPushButton(QCoreApplication::translate("CrashReporter", "Send this time"));
+    QPushButton* alwaysBtn = new QPushButton(QCoreApplication::translate("CrashReporter", "Always send"));
+    QPushButton* dontBtn = new QPushButton(QCoreApplication::translate("CrashReporter", "Don't send"));
 
     hLayout->addStretch();
     hLayout->addWidget(sendBtn);
@@ -93,21 +94,27 @@ TCrashSendOption createCrashDialog() {
     hLayout->addStretch();
     vLayout->addLayout(hLayout);
 
-    QObject::connect(sendBtn,   &QPushButton::clicked, [&dialog](){ dialog.done(static_cast<int>(SendThisTime)); });
-    QObject::connect(alwaysBtn, &QPushButton::clicked, [&dialog](){ dialog.done(static_cast<int>(AlwaysSend)); });
-    QObject::connect(dontBtn,   &QPushButton::clicked, [&dialog](){ dialog.done(static_cast<int>(DontSend)); });
+    QObject::connect(sendBtn, &QPushButton::clicked, [&dialog]() {
+        dialog.done(static_cast<int>(SendThisTime));
+    });
+    QObject::connect(alwaysBtn, &QPushButton::clicked, [&dialog]() {
+        dialog.done(static_cast<int>(AlwaysSend));
+    });
+    QObject::connect(dontBtn, &QPushButton::clicked, [&dialog]() {
+        dialog.done(static_cast<int>(DontSend));
+    });
 
     sendBtn->setDefault(true);
 
     return static_cast<TCrashSendOption>(dialog.exec());
 }
 
-void sendCrashReport(const char *envelopePath)
+void sendCrashReport(const char* envelopePath)
 {
-    sentry_options_t*  opts = sentry_options_new();
+    sentry_options_t* opts = sentry_options_new();
     sentry_envelope_t* envelope = sentry_envelope_read_from_file(envelopePath);
-    const char*        effectiveDsn = nullptr;
-    const char*        sentry_dsn_from_environment = std::getenv("SENTRY_DSN");
+    const char* effectiveDsn = nullptr;
+    const char* sentry_dsn_from_environment = std::getenv("SENTRY_DSN");
 
     if (!opts || !envelope) {
         return;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -68,16 +68,14 @@ int loadedBytes;
 QDataStream replayStream;
 QFile replayFile;
 
-static const QVector<unsigned char> expectedOrderForKaVirHandler = {
-    static_cast<unsigned char>(OPT_TERMINAL_TYPE),
-    static_cast<unsigned char>(OPT_NAWS),
-    static_cast<unsigned char>(OPT_CHARSET),
-    static_cast<unsigned char>(OPT_MSDP),
-    static_cast<unsigned char>(OPT_MSSP),
-    static_cast<unsigned char>(OPT_ATCP),
-    static_cast<unsigned char>(OPT_MSP),
-    static_cast<unsigned char>(OPT_MXP)
-};
+static const QVector<unsigned char> expectedOrderForKaVirHandler = {static_cast<unsigned char>(OPT_TERMINAL_TYPE),
+                                                                    static_cast<unsigned char>(OPT_NAWS),
+                                                                    static_cast<unsigned char>(OPT_CHARSET),
+                                                                    static_cast<unsigned char>(OPT_MSDP),
+                                                                    static_cast<unsigned char>(OPT_MSSP),
+                                                                    static_cast<unsigned char>(OPT_ATCP),
+                                                                    static_cast<unsigned char>(OPT_MSP),
+                                                                    static_cast<unsigned char>(OPT_MXP)};
 
 cTelnet::cTelnet(Host* pH, const QString& profileName)
 : mProfileName(profileName)
@@ -203,7 +201,7 @@ cTelnet::~cTelnet()
     }
 
     if (!messageStack.empty()) {
-#if defined (Q_OS_WINDOWS)
+#if defined(Q_OS_WINDOWS)
         // Windows does not seem to accept line-feeds in these strings:
         qWarning("cTelnet::~cTelnet() Instance being destroyed before it could display some messages,");
         qWarning("messages are:");
@@ -212,7 +210,7 @@ cTelnet::~cTelnet()
         qWarning("cTelnet::~cTelnet() Instance being destroyed before it could display some messages,\nmessages are:\n------------");
 #endif
         for (const auto& message : messageStack) {
-#if defined (Q_OS_WINDOWS)
+#if defined(Q_OS_WINDOWS)
             qWarning("%s", qPrintable(message));
             qWarning("------------");
 #else
@@ -352,8 +350,7 @@ QPair<bool, QString> cTelnet::setEncoding(const QByteArray& newEncoding, const b
             }
         }
         return qMakePair(false,
-                         QLatin1String(R"(Encoding ")") % newEncoding % QLatin1String("\" does not exist;\nuse one of the following:\n\"ASCII\", \"")
-                                 % QLatin1String(fixedUpEncodings.join(R"(", ")"))
+                         QLatin1String(R"(Encoding ")") % newEncoding % QLatin1String("\" does not exist;\nuse one of the following:\n\"ASCII\", \"") % QLatin1String(fixedUpEncodings.join(R"(", ")"))
                                  % QLatin1String(R"(".)"));
     } else if (mEncoding != newEncoding && ("M_" + mEncoding) != newEncoding) {
         encodingChanged(newEncoding);
@@ -419,13 +416,13 @@ void cTelnet::connectIt(const QString& address, int port)
         // CHECKME: do we also need to block the sockets from emitting signals here?
         if (mSocket_ipV4.state() != QAbstractSocket::UnconnectedState) {
 #if defined(DEBUG_TELNET) && (DEBUG_TELNET & 4)
-            qDebug().noquote().nospace() << "cTelnet::cTelnet::connectIt(" <<  address << ", " << port << ") INFO - IPv4 socket not disconnected, aborting exisiting connection.";
+            qDebug().noquote().nospace() << "cTelnet::cTelnet::connectIt(" << address << ", " << port << ") INFO - IPv4 socket not disconnected, aborting exisiting connection.";
 #endif
             mSocket_ipV4.abort();
         }
         if (mSocket_ipV6.state() != QAbstractSocket::UnconnectedState) {
 #if defined(DEBUG_TELNET) && (DEBUG_TELNET & 4)
-            qDebug().noquote().nospace() << "cTelnet::cTelnet::connectIt(" <<  address << ", " << port << ") INFO - IPv6 socket not disconnected, aborting exisiting connection.";
+            qDebug().noquote().nospace() << "cTelnet::cTelnet::connectIt(" << address << ", " << port << ") INFO - IPv6 socket not disconnected, aborting exisiting connection.";
 #endif
             mSocket_ipV6.abort();
         }
@@ -454,10 +451,7 @@ void cTelnet::connectIt(const QString& address, int port)
     /*: %1 is the URL or an IP address (suitably wrapped if it is an IPv6 one)
      * of the Game Server (or Proxy); %2 is the port number.
      */
-    TDebug(QColorConstants::Blue, QColorConstants::White) << tr("Looking up the details of server: %1:%2 ...")
-                                                             .arg(displayAddress, QString::number(port))
-                                                             .append(QChar::LineFeed)
-                                                          >> mpHost;
+    TDebug(QColorConstants::Blue, QColorConstants::White) << tr("Looking up the details of server: %1:%2 ...").arg(displayAddress, QString::number(port)).append(QChar::LineFeed) >> mpHost;
     // We can now use a compile-time slot for this as:
     // https://bugreports.qt.io/browse/QTBUG-67646 was (finally) fixed in
     // Qt 5.12.5:
@@ -616,7 +610,7 @@ void cTelnet::slot_socketConnected()
 
     emit signal_connected(mpHost);
 
-    TEvent event {};
+    TEvent event{};
     event.mArgumentList.append(qsl("sysConnectionEvent"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     mpHost->raiseEvent(event);
@@ -627,7 +621,7 @@ void cTelnet::slot_socketDisconnected()
 #if defined(DEBUG_TELNET) && (DEBUG_TELNET & 4)
     qDebug().noquote() << "cTelnet::slot_socketDisconnected() INFO - called.";
 #endif
-    TEvent event {};
+    TEvent event{};
 #if !defined(QT_NO_SSL)
     bool sslerr = false;
 #endif
@@ -654,7 +648,7 @@ void cTelnet::slot_socketDisconnected()
     const auto timeOffset = mConnectionTimer.isValid() ? mConnectionTimer.elapsed() : 0;
     const QString msg = tr("[ INFO ]  - Connection time: %1.")
                                 .arg(timeDiff.addMSecs(timeOffset)
-                                /*: This is the format to be used to show the profile connection time, it follows
+                                             /*: This is the format to be used to show the profile connection time, it follows
                                  * the rules of the "QDateTime::toString(...)" function and may need
                                  * modification for some locales, e.g. France, Spain.
                                  */
@@ -752,7 +746,7 @@ void cTelnet::slot_socketDisconnected()
                  * ensure the same text is used in both.
                  */
                 reason = tr("Connection/login attempt rejected by server");
-            } else if (!mpSocket->errorString().isEmpty()){
+            } else if (!mpSocket->errorString().isEmpty()) {
                 reason = mpSocket->errorString();
             }
 
@@ -776,7 +770,8 @@ void cTelnet::slot_socketDisconnected()
                  * of connection.
                  */
                 postMessage(tr("[ ALERT ] - Socket got disconnected, for reason:\n"
-                                           "%1").arg(reason));
+                               "%1")
+                                    .arg(reason));
             }
 #if !defined(QT_NO_SSL)
         }
@@ -854,12 +849,7 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
     QStringList addressList_ipV6;
     for (const QHostAddress& address : hostInfo.addresses()) {
         // Handle (or not) some special cases:
-        if (QHostAddress::Null == address
-            || QHostAddress::Broadcast == address
-            || QHostAddress::Any == address
-            || QHostAddress::AnyIPv4 == address
-            || QHostAddress::AnyIPv6 == address) {
-
+        if (QHostAddress::Null == address || QHostAddress::Broadcast == address || QHostAddress::Any == address || QHostAddress::AnyIPv4 == address || QHostAddress::AnyIPv6 == address) {
             continue;
         }
 
@@ -882,16 +872,15 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
             break;
         case QAbstractSocket::AnyIPProtocol:
             [[fallthrough]];
-        case QAbstractSocket::UnknownNetworkLayerProtocol:
-            {} // No-op
+        case QAbstractSocket::UnknownNetworkLayerProtocol: {
+        } // No-op
         }
     }
 
     bool hasIPv4_address = (addressList_ipV4.count());
     bool hasIPv6_address = (addressList_ipV6.count());
 
-    const bool onlyLocalhost = (addressList_ipV4.isEmpty() || addressList_ipV4 == QStringList{qsl("127.0.0.1")})
-                            && (addressList_ipV6.isEmpty() || addressList_ipV6 == QStringList{qsl("::1")});
+    const bool onlyLocalhost = (addressList_ipV4.isEmpty() || addressList_ipV4 == QStringList{qsl("127.0.0.1")}) && (addressList_ipV6.isEmpty() || addressList_ipV6 == QStringList{qsl("::1")});
     if (onlyLocalhost && hasIPv4_address && hasIPv6_address) {
         hasIPv6_address = false;
     }
@@ -905,11 +894,11 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
         TDebug(QColorConstants::Red, QColorConstants::White) << tr("Host name lookup Failure! A connection cannot be established.\n"
                                                                    "The server name is not correct, or your nameservers are not\n"
                                                                    "working properly.\n")
-                                                             >> mpHost;
+                >> mpHost;
         //: %1 is the URL of the Game Server
         postMessage(tr("[ ERROR ] - Unable to connect to \"%1\".\n"
                        "Check your internet connection and the details entered for the game server.")
-                    .arg(mHostUrl));
+                            .arg(mHostUrl));
         return;
     }
 
@@ -942,9 +931,7 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
              * perform a "reverse-lookup" to see if we can identify the URL that
              * matches it - but nothing useful was found.
              */
-            TDebug(QColorConstants::Svg::orange, QColorConstants::White) << tr("A host name could not be found for the given IP address.")
-                                                                            .append(QChar::LineFeed)
-                                                                         >> mpHost;
+            TDebug(QColorConstants::Svg::orange, QColorConstants::White) << tr("A host name could not be found for the given IP address.").append(QChar::LineFeed) >> mpHost;
         } else {
             /*: This text is used when the user has provided a raw IP address
              * for the Game Server rather than a URL. In this case we try to
@@ -954,8 +941,8 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
              */
             TDebug(QColorConstants::Blue, QColorConstants::White) << tr("A host name for the IP address has been found.\n"
                                                                         "It is: \"%1\"\n")
-                                                                     .arg(hostInfo.hostName())
-                                                                  >> mpHost;
+                                                                             .arg(hostInfo.hostName())
+                    >> mpHost;
         }
     } else {
         /*: This text is used in the (expected) case when the user has provided
@@ -968,13 +955,10 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
                                                                     // Intentional comment to separate arguments
                                                                     "",
                                                                     addressesToReport.count())
-                                                                 .arg(hostInfo.hostName())
-                                                                 .append(QChar::LineFeed)
-                                                              >> mpHost;
-        TDebug(QColorConstants::Green, QColorConstants::White) << addressesToReport.join(QChar::LineFeed)
-                                                                  .prepend(TDebug::csmContinue)
-                                                                  .append(QChar::LineFeed)
-                                                               >> mpHost;
+                                                                         .arg(hostInfo.hostName())
+                                                                         .append(QChar::LineFeed)
+                >> mpHost;
+        TDebug(QColorConstants::Green, QColorConstants::White) << addressesToReport.join(QChar::LineFeed).prepend(TDebug::csmContinue).append(QChar::LineFeed) >> mpHost;
     }
 
 #if !defined(QT_NO_SSL)
@@ -1004,31 +988,27 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
                  * case. %1 is the URL for the server and %2 is the port number
                  * (on BOTH addresses) for the connection.
                  */
-                TDebug(QColorConstants::Blue, QColorConstants::White) << tr("Trying secure (IPv4 and IPv6) connections to proxy %1:%2 ...")
-                                                                         .arg(hostInfo.hostName(), QString::number(mHostPort))
-                                                                         .append(QChar::LineFeed)
-                                                                      >> mpHost;
+                TDebug(QColorConstants::Blue, QColorConstants::White)
+                                << tr("Trying secure (IPv4 and IPv6) connections to proxy %1:%2 ...").arg(hostInfo.hostName(), QString::number(mHostPort)).append(QChar::LineFeed)
+                        >> mpHost;
                 /* We don't need to worry about %1 being a raw IPv6 address here
                  * as we prohibit IP addresses for secure connections so it is
                  * a URL; %2 is the port number.
                  */
-                postMessage(tr("[ INFO ]  - Attempting a secure connection to %1:%2 via proxy...")
-                            .arg(hostInfo.hostName(), QString::number(mHostPort)));
+                postMessage(tr("[ INFO ]  - Attempting a secure connection to %1:%2 via proxy...").arg(hostInfo.hostName(), QString::number(mHostPort)));
             } else {
                 /*: Happy-Eyeballs (both IPv4 and IPv6 addresses available)
                  * case. %1 is the URL for the Server and %2 is the port number
                  * (on BOTH addresses) for the connection.
                  */
-                TDebug(QColorConstants::Blue, QColorConstants::White) << tr("Trying secure (IPv4 and IPv6) connections to %1:%2 ...")
-                                                                         .arg(hostInfo.hostName(), QString::number(mHostPort))
-                                                                         .append(QChar::LineFeed)
-                                                                      >> mpHost;
+                TDebug(QColorConstants::Blue, QColorConstants::White)
+                                << tr("Trying secure (IPv4 and IPv6) connections to %1:%2 ...").arg(hostInfo.hostName(), QString::number(mHostPort)).append(QChar::LineFeed)
+                        >> mpHost;
                 /* We don't need to worry about %1 being a raw IPv6 address here
                  * as we prohibit IP addresses for secure connections so it is
                  * a URL; %2 is the port number.
                  */
-                postMessage(tr("[ INFO ]  - Attempting a secure connection to %1:%2 ...")
-                            .arg(hostInfo.hostName(), QString::number(mHostPort)));
+                postMessage(tr("[ INFO ]  - Attempting a secure connection to %1:%2 ...").arg(hostInfo.hostName(), QString::number(mHostPort)));
             }
 
             mSocket_ipV6.connectToHostEncrypted(hostInfo.hostName(), mHostPort, QIODevice::ReadWrite, QAbstractSocket::IPv6Protocol);
@@ -1045,30 +1025,26 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
                     /*: %1 is the URL for the Server and %2 is the port number
                      * for the connection.
                      */
-                    TDebug(QColorConstants::Blue, QColorConstants::White) << tr("Trying secure (IPv6) connection to %1:%2 via proxy...")
-                                                                             .arg(hostInfo.hostName(), QString::number(mHostPort))
-                                                                             .append(QChar::LineFeed)
-                                                                          >> mpHost;
+                    TDebug(QColorConstants::Blue, QColorConstants::White)
+                                    << tr("Trying secure (IPv6) connection to %1:%2 via proxy...").arg(hostInfo.hostName(), QString::number(mHostPort)).append(QChar::LineFeed)
+                            >> mpHost;
                     /* We don't need to worry about %1 being a raw IPv6 address here
                      * as we prohibit IP addresses for secure connections so it is
                      * a URL; %2 is the port number.
                      */
-                    postMessage(tr("[ INFO ]  - Attempting a secure connection to %1:%2 via proxy...")
-                                .arg(hostInfo.hostName(), QString::number(mHostPort)));
+                    postMessage(tr("[ INFO ]  - Attempting a secure connection to %1:%2 via proxy...").arg(hostInfo.hostName(), QString::number(mHostPort)));
                 } else {
                     /*: %1 is the URL for the Server and %2 is the port number
                      * for the connection.
                      */
-                    TDebug(QColorConstants::Blue, QColorConstants::White) << tr("Trying secure (IPv4 and IPv6) connections to %1:%2 ...")
-                                                                             .arg(hostInfo.hostName(), QString::number(mHostPort))
-                                                                             .append(QChar::LineFeed)
-                                                                          >> mpHost;
+                    TDebug(QColorConstants::Blue, QColorConstants::White)
+                                    << tr("Trying secure (IPv4 and IPv6) connections to %1:%2 ...").arg(hostInfo.hostName(), QString::number(mHostPort)).append(QChar::LineFeed)
+                            >> mpHost;
                     /* We don't need to worry about %1 being a raw IPv6 address here
                      * as we prohibit IP addresses for secure connections so it is
                      * a URL; %2 is the port number.
                      */
-                    postMessage(tr("[ INFO ]  - Attempting a secure connection to %1:%2 ...")
-                                .arg(hostInfo.hostName(), QString::number(mHostPort)));
+                    postMessage(tr("[ INFO ]  - Attempting a secure connection to %1:%2 ...").arg(hostInfo.hostName(), QString::number(mHostPort)));
                 }
                 mSocket_ipV6.connectToHostEncrypted(hostInfo.hostName(), mHostPort, QIODevice::ReadWrite, QAbstractSocket::IPv6Protocol);
             }
@@ -1082,24 +1058,20 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
                     /*: %1 is the URL for the Server and %2 is the port number
                      * for the connection.
                      */
-                    TDebug(QColorConstants::Blue, QColorConstants::White) << tr("Trying secure (IPv4) connection to %1:%2 via proxy...")
-                                                                             .arg(hostInfo.hostName(), QString::number(mHostPort))
-                                                                             .append(QChar::LineFeed)
-                                                                          >> mpHost;
+                    TDebug(QColorConstants::Blue, QColorConstants::White)
+                                    << tr("Trying secure (IPv4) connection to %1:%2 via proxy...").arg(hostInfo.hostName(), QString::number(mHostPort)).append(QChar::LineFeed)
+                            >> mpHost;
                     //: %1 is a URL for the Game Server; %2 is the port number.
-                    postMessage(tr("[ INFO ]  - Attempting a secure connection to %1:%2 via proxy...")
-                                .arg(hostInfo.hostName(), QString::number(mHostPort)));
+                    postMessage(tr("[ INFO ]  - Attempting a secure connection to %1:%2 via proxy...").arg(hostInfo.hostName(), QString::number(mHostPort)));
                 } else {
                     /*: %1 is the URL for the Server and %2 is the port number
                      * for the connection.
                      */
-                    TDebug(QColorConstants::Blue, QColorConstants::White) << tr("Trying secure (IPv4) connection to %1:%2 ...")
-                                                                             .arg(hostInfo.hostName(), QString::number(mHostPort))
-                                                                             .append(QChar::LineFeed)
-                                                                          >> mpHost;
+                    TDebug(QColorConstants::Blue, QColorConstants::White)
+                                    << tr("Trying secure (IPv4) connection to %1:%2 ...").arg(hostInfo.hostName(), QString::number(mHostPort)).append(QChar::LineFeed)
+                            >> mpHost;
                     //: %1 is a URL for the Game Server; %2 is the port number.
-                    postMessage(tr("[ INFO ]  - Attempting a secure connection to %1:%2 ...")
-                                .arg(hostInfo.hostName(), QString::number(mHostPort)));
+                    postMessage(tr("[ INFO ]  - Attempting a secure connection to %1:%2 ...").arg(hostInfo.hostName(), QString::number(mHostPort)));
                 }
                 mSocket_ipV4.connectToHostEncrypted(hostInfo.hostName(), mHostPort, QIODevice::ReadWrite, QAbstractSocket::IPv4Protocol);
             }
@@ -1120,25 +1092,21 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
                  * case. %1 is the URL for the proxy and %2 is the port number
                  * (on BOTH addresses) for the connection.
                  */
-                TDebug(QColorConstants::Blue, QColorConstants::White) << tr("Trying open (IPv4 and IPv6) connections to %1:%2 via proxy...")
-                                                                         .arg(hostInfo.hostName(), QString::number(mHostPort))
-                                                                         .append(QChar::LineFeed)
-                                                                      >> mpHost;
+                TDebug(QColorConstants::Blue, QColorConstants::White)
+                                << tr("Trying open (IPv4 and IPv6) connections to %1:%2 via proxy...").arg(hostInfo.hostName(), QString::number(mHostPort)).append(QChar::LineFeed)
+                        >> mpHost;
                 //: %1 is a URL for the Game Server; %2 is the port number.
-                postMessage(tr("[ INFO ]  - Attempting an open connection to %1:%2 via proxy...")
-                            .arg(hostInfo.hostName(), QString::number(mHostPort)));
+                postMessage(tr("[ INFO ]  - Attempting an open connection to %1:%2 via proxy...").arg(hostInfo.hostName(), QString::number(mHostPort)));
             } else {
                 /*: Happy-Eyeballs (both IPv4 and IPv6 addresses available)
                  * case. %1 is the URL for the Server and %2 is the port number
                  * (on BOTH addresses) for the connection.
                  */
-                TDebug(QColorConstants::Blue, QColorConstants::White) << tr("Trying open (IPv4 and IPv6) connections to %1:%2 ...")
-                                                                         .arg(hostInfo.hostName(), QString::number(mHostPort))
-                                                                         .append(QChar::LineFeed)
-                                                                      >> mpHost;
+                TDebug(QColorConstants::Blue, QColorConstants::White)
+                                << tr("Trying open (IPv4 and IPv6) connections to %1:%2 ...").arg(hostInfo.hostName(), QString::number(mHostPort)).append(QChar::LineFeed)
+                        >> mpHost;
                 //: %1 is a URL for the Game Server; %2 is the port number.
-                postMessage(tr("[ INFO ]  - Attempting an open connection to %1:%2 ...")
-                            .arg(hostInfo.hostName(), QString::number(mHostPort)));
+                postMessage(tr("[ INFO ]  - Attempting an open connection to %1:%2 ...").arg(hostInfo.hostName(), QString::number(mHostPort)));
             }
 
             mSocket_ipV6.connectToHost(hostInfo.hostName(), mHostPort, QIODevice::ReadWrite, QAbstractSocket::IPv6Protocol);
@@ -1155,28 +1123,23 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
                     /*: %1 is the URL or IPv6 address (suitably wrapped) for the
                      * Game Server and %2 is the port number for the connection.
                      */
-                    TDebug(QColorConstants::Blue, QColorConstants::White) << tr("Trying open (IPv6) connection to %1:%2 via proxy...")
-                                                                             .arg(displayAddress, QString::number(mHostPort))
-                                                                             .append(QChar::LineFeed)
-                                                                          >> mpHost;
+                    TDebug(QColorConstants::Blue, QColorConstants::White)
+                                    << tr("Trying open (IPv6) connection to %1:%2 via proxy...").arg(displayAddress, QString::number(mHostPort)).append(QChar::LineFeed)
+                            >> mpHost;
                     /*: %1 is the URL or IPv6 address (suitably wrapped) for the
                      * Game Server and %2 is the port number.
                      */
-                    postMessage(tr("[ INFO ]  - Attempting an open connection to %1:%2 via proxy...")
-                                .arg(displayAddress, QString::number(mHostPort)));
+                    postMessage(tr("[ INFO ]  - Attempting an open connection to %1:%2 via proxy...").arg(displayAddress, QString::number(mHostPort)));
                 } else {
                     /*: %1 is the URL or IPv6 address (suitably wrapped) for the
                      * Game Server and %2 is the port number for the connection.
                      */
-                    TDebug(QColorConstants::Blue, QColorConstants::White) << tr("Trying open (IPv6) connection to %1:%2 ...")
-                                                                             .arg(displayAddress, QString::number(mHostPort))
-                                                                             .append(QChar::LineFeed)
-                                                                          >> mpHost;
+                    TDebug(QColorConstants::Blue, QColorConstants::White) << tr("Trying open (IPv6) connection to %1:%2 ...").arg(displayAddress, QString::number(mHostPort)).append(QChar::LineFeed)
+                            >> mpHost;
                     /*: %1 is the URL or IPv6 address (suitably wrapped) for the
                      * Game Server and %2 is the port number for the connection.
                      */
-                    postMessage(tr("[ INFO ]  - Attempting an open connection to %1:%2 ...")
-                                .arg(displayAddress, QString::number(mHostPort)));
+                    postMessage(tr("[ INFO ]  - Attempting an open connection to %1:%2 ...").arg(displayAddress, QString::number(mHostPort)));
                 }
 
                 mSocket_ipV6.connectToHost(hostInfo.hostName(), mHostPort, QIODevice::ReadWrite, QAbstractSocket::IPv6Protocol);
@@ -1190,29 +1153,25 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
                     /*: %1 is the URL or IPv4 address for the Game Server and %2
                      * is the port number for the connection.
                      */
-                    TDebug(QColorConstants::Blue, QColorConstants::White) << tr("Trying open (IPv4) connection to %1:%2 via proxy...")
-                                                                             .arg(hostInfo.hostName(), QString::number(mHostPort))
-                                                                             .append(QChar::LineFeed)
-                                                                          >> mpHost;
+                    TDebug(QColorConstants::Blue, QColorConstants::White)
+                                    << tr("Trying open (IPv4) connection to %1:%2 via proxy...").arg(hostInfo.hostName(), QString::number(mHostPort)).append(QChar::LineFeed)
+                            >> mpHost;
                     /*: %1 is the URL or IPv4 address for the Game Server and %2
                      * is the port number for the connection.
                      */
-                    postMessage(tr("[ INFO ]  - Attempting an open connection to %1:%2 via proxy...")
-                                .arg(hostInfo.hostName(), QString::number(mHostPort)));
+                    postMessage(tr("[ INFO ]  - Attempting an open connection to %1:%2 via proxy...").arg(hostInfo.hostName(), QString::number(mHostPort)));
 
                 } else {
                     /*: %1 is the URL or IPv4 address for the Game Server and %2
                      * is the port number for the connection.
                      */
-                    TDebug(QColorConstants::Blue, QColorConstants::White) << tr("Trying open (IPv4) connection to %1:%2 ...")
-                                                                             .arg(hostInfo.hostName(), QString::number(mHostPort))
-                                                                             .append(QChar::LineFeed)
-                                                                          >> mpHost;
+                    TDebug(QColorConstants::Blue, QColorConstants::White)
+                                    << tr("Trying open (IPv4) connection to %1:%2 ...").arg(hostInfo.hostName(), QString::number(mHostPort)).append(QChar::LineFeed)
+                            >> mpHost;
                     /*: %1 is the URL or IPv4 address for the Game Server and %2
                      * is the port number for the connection.
                      */
-                    postMessage(tr("[ INFO ]  - Attempting an open connection to %1:%2 ...")
-                                .arg(hostInfo.hostName(), QString::number(mHostPort)));
+                    postMessage(tr("[ INFO ]  - Attempting an open connection to %1:%2 ...").arg(hostInfo.hostName(), QString::number(mHostPort)));
                 }
 
                 mSocket_ipV4.connectToHost(hostInfo.hostName(), mHostPort, QIODevice::ReadWrite, QAbstractSocket::IPv4Protocol);
@@ -1245,8 +1204,7 @@ bool cTelnet::sendData(QString& data, const bool permitDataSendRequestEvent)
         if (!mEncoding.isEmpty()) {
             if (TEncodingHelper::isEncodingAvailable(mEncoding)) {
                 if ((!mEncodingWarningIssued) && (!TEncodingHelper::canEncode(data, mEncoding))) {
-                    QString errorMsg = tr(errorMsgTemplate,
-                                          "%1 is the command that was sent to the game.").arg(data);
+                    QString errorMsg = tr(errorMsgTemplate, "%1 is the command that was sent to the game.").arg(data);
                     postMessage(errorMsg);
                     mEncodingWarningIssued = true;
                 }
@@ -1260,7 +1218,8 @@ bool cTelnet::sendData(QString& data, const bool permitDataSendRequestEvent)
                                    "use. Mudlet will attempt to send the data using the ASCII encoding\n"
                                    "but will be limited to only unaccented characters of basic English.\n"
                                    "Note: this warning will only be issued once, until the encoding is\n"
-                                   "changed.").arg(QLatin1String(mEncoding)));
+                                   "changed.")
+                                        .arg(QLatin1String(mEncoding)));
                     mEncoderFailureNoticeIssued = true;
                 }
                 // Even if there are unusable characters - try to send it as ASCII ...
@@ -1269,9 +1228,8 @@ bool cTelnet::sendData(QString& data, const bool permitDataSendRequestEvent)
         } else {
             // Plain, raw ASCII, we hope!
             for (const auto c : data) {
-                if ((!mEncodingWarningIssued) && (c.row() || c.cell() > 127)){
-                    QString errorMsg = tr(errorMsgTemplate,
-                                          "%1 is the command that was sent to the game.").arg(data);
+                if ((!mEncodingWarningIssued) && (c.row() || c.cell() > 127)) {
+                    QString errorMsg = tr(errorMsgTemplate, "%1 is the command that was sent to the game.").arg(data);
                     postMessage(errorMsg);
                     mEncodingWarningIssued = true;
                     break;
@@ -1292,7 +1250,6 @@ bool cTelnet::sendData(QString& data, const bool permitDataSendRequestEvent)
         outData = mudlet::replaceString(outData, "\xff", "\xff\xff");
         return socketOutRaw(outData);
     } else {
-
         mpHost->mAllowToSendCommand = true;
         return false;
     }
@@ -1343,7 +1300,7 @@ bool cTelnet::socketOutRaw(std::string& data)
 void cTelnet::checkNAWS()
 {
     Host* pHost = mpHost;
-    if (!pHost ||!pHost->mpConsole) {
+    if (!pHost || !pHost->mpConsole) {
         return;
     }
     // Use the smaller of the screen width or the wrapAt, then subtract the
@@ -1365,8 +1322,8 @@ void cTelnet::sendNAWS(int width, int height)
     }
 
     std::string message;
-    message += TN_IAC; // Interpret As Command
-    message += TN_SB;  // Sub-negotiation begins
+    message += TN_IAC;   // Interpret As Command
+    message += TN_SB;    // Sub-negotiation begins
     message += OPT_NAWS; // NAWS - Negotiate About Window Size
     char widthHighByte = static_cast<char>(width / 256);
     char widthLowByte = static_cast<char>(width % 256);
@@ -1444,17 +1401,17 @@ void cTelnet::slot_replyFinished(QNetworkReply* reply)
                 errorMsg = tr("[ INFO ]  - Package download cancelled.");
             } else {
                 //: %1 is the URL, %2 is the error message
-                errorMsg = tr("[ WARN ]  - Package download failed from '%1', reason: %2")
-                    .arg(reply->url().toString(), reply->errorString());
-                
+                errorMsg = tr("[ WARN ]  - Package download failed from '%1', reason: %2").arg(reply->url().toString(), reply->errorString());
+
                 // Provide specific guidance for SSL errors
                 if (reply->error() == QNetworkReply::SslHandshakeFailedError) {
-                    errorMsg += tr("\nThe package is hosted on a server with an SSL certificate problem. The URL may be using HTTPS when it should use HTTP, or the server's security certificate is not trusted by your system.");
+                    errorMsg += tr("\nThe package is hosted on a server with an SSL certificate problem. The URL may be using HTTPS when it should use HTTP, or the server's security certificate is "
+                                   "not trusted by your system.");
                 }
             }
 
             postMessage(errorMsg);
-            
+
             reply->deleteLater();
             mpPackageDownloadReply = nullptr;
             return;
@@ -1464,8 +1421,7 @@ void cTelnet::slot_replyFinished(QNetworkReply* reply)
 
         if (!file.open(QFile::WriteOnly)) {
             //: %1 is the file path, %2 is the error message
-            postMessage(tr("[ WARN ]  - Package download failed: could not open file '%1' for writing, reason: %2")
-                .arg(mServerPackage, file.errorString()));
+            postMessage(tr("[ WARN ]  - Package download failed: could not open file '%1' for writing, reason: %2").arg(mServerPackage, file.errorString()));
             qWarning() << "ctelnet: failed to open file for writing:" << file.errorString();
             return;
         }
@@ -1474,23 +1430,21 @@ void cTelnet::slot_replyFinished(QNetworkReply* reply)
 
         if (!file.commit()) {
             //: %1 is the error message
-            postMessage(tr("[ WARN ]  - Package download failed: could not save file, reason: %1")
-                .arg(file.errorString()));
+            postMessage(tr("[ WARN ]  - Package download failed: could not save file, reason: %1").arg(file.errorString()));
             qDebug() << "cTelnet::slot_replyFinished: error downloading package: " << file.errorString();
             return;
         }
 
         reply->deleteLater();
         mpPackageDownloadReply = nullptr;
-        
+
         // Install the package and handle any installation errors
         if (auto [success, message] = mpHost->installPackage(mServerPackage, enums::PackageModuleType::Package); !success) {
             //: %1 is the package file path, %2 is the error message
-            postMessage(tr("[ WARN ]  - Package installation failed for '%1', reason: %2")
-                .arg(mServerPackage, message));
+            postMessage(tr("[ WARN ]  - Package installation failed for '%1', reason: %2").arg(mServerPackage, message));
             return;
         }
-        
+
         QString packageName = mServerPackage.section("/", -1);
         packageName.remove(QLatin1String(".zip"), Qt::CaseInsensitive);
         packageName.remove(QLatin1String(".trigger"), Qt::CaseInsensitive);
@@ -1531,82 +1485,146 @@ QString cTelnet::decodeOption(const unsigned char ch) const
     // and other places:
     switch (ch) {
     // Official:
-    case 0:     return QLatin1String("BINARY (0)");
-    case 1:     return QLatin1String("ECHO (1)");
-    case 2:     return QLatin1String("RECONNECTION (2)");
-    case 3:     return QLatin1String("SUPPRESS_GO_AHEAD (3)");
-    case 4:     return QLatin1String("APROX_MSG_SIZE (4)");
-    case 5:     return QLatin1String("STATUS (5)");
-    case 6:     return QLatin1String("TIMING_MARK (6)");
-    case 7:     return QLatin1String("REMOTE_CTRL_TRANS_AND_ECHO (7)");
-    case 8:     return QLatin1String("OUTPUT_L_WIDTH (8)");
-    case 9:     return QLatin1String("OUTPUT_P_SIZE (9)");
-    case 10:    return QLatin1String("OUTPUT_CR_DISPOSITION (10)");
-    case 11:    return QLatin1String("OUTPUT_HTAB_STOPS (11)");
-    case 12:    return QLatin1String("OUTPUT_HTAB_DISPOSITION (12)");
-    case 13:    return QLatin1String("OUTPUT_FF_DISPOSITION (13)");
-    case 14:    return QLatin1String("OUTPUT_VTAB_STOPS (14)");
-    case 15:    return QLatin1String("OUTPUT_VTAB_DISPOSITION (15)");
-    case 16:    return QLatin1String("OUTPUT_LF_DISPOSITION (16)");
-    case 17:    return QLatin1String("EXTENDED_ASCII (17)");
-    case 18:    return QLatin1String("LOGOUT (18)");
-    case 19:    return QLatin1String("BYTE_MACRO (19)");
-    case 20:    return QLatin1String("DATA_ENTRY_TERMINAL (20)");
-    case 21:    return QLatin1String("SUPDUP (21)");
-    case 22:    return QLatin1String("SUPDUP_OUTPUT (22)");
-    case 23:    return QLatin1String("SEND_LOCATION (23)");
-    case 24:    return QLatin1String("TTYPE (24)");
-    case 25:    return QLatin1String("EOR (25)");
-    case 26:    return QLatin1String("TACACS_USER_ID (26)");
-    case 27:    return QLatin1String("OUTPUT_MARKING (27)");
-    case 28:    return QLatin1String("TERMINAL_LOCATION_NUMBER (28)");
-    case 29:    return QLatin1String("TELNET_3270_REGIME (29)");
-    case 30:    return QLatin1String("X3_PAD (30)");
-    case 31:    return QLatin1String("NAWS (31)");
-    case 32:    return QLatin1String("TERMINAL_SPEED (32)");
-    case 33:    return QLatin1String("REMOTE_FLOW_CONTROL (33)");
-    case 34:    return QLatin1String("LINEMODE (34)");
-    case 35:    return QLatin1String("X_DISPLAY_LOCATION (35)");
-    case 36:    return QLatin1String("ENVIRONMENT_OPTION (36)");
-    case 37:    return QLatin1String("AUTHENTICATION_OPTIOM (37)");
-    case 38:    return QLatin1String("ENCRYPTION_OPTION (38)");
-    case 39:    return QLatin1String("NEW_ENVIRONMENT_OPTION (39)");
-    case 40:    return QLatin1String("TN3270E (40)");
-    case 41:    return QLatin1String("XAUTH (41)");
-    case 42:    return QLatin1String("CHARSET (42)");
-    case 43:    return QLatin1String("TELNET_REMOTE_SERIAL_PORT (43)");
-    case 44:    return QLatin1String("COM_PORT_CONTROL_OPTION (44)");
-    case 45:    return QLatin1String("TELNET_SUPPRESS_LOCAL_ECHO (45)");
-    case 46:    return QLatin1String("TELNET_START_TLS (46)");
-    case 47:    return QLatin1String("KERMIT (47)");
-    case 48:    return QLatin1String("SEND_URL (48)");
-    case 49:    return QLatin1String("FORWARD_X (49)");
+    case 0:
+        return QLatin1String("BINARY (0)");
+    case 1:
+        return QLatin1String("ECHO (1)");
+    case 2:
+        return QLatin1String("RECONNECTION (2)");
+    case 3:
+        return QLatin1String("SUPPRESS_GO_AHEAD (3)");
+    case 4:
+        return QLatin1String("APROX_MSG_SIZE (4)");
+    case 5:
+        return QLatin1String("STATUS (5)");
+    case 6:
+        return QLatin1String("TIMING_MARK (6)");
+    case 7:
+        return QLatin1String("REMOTE_CTRL_TRANS_AND_ECHO (7)");
+    case 8:
+        return QLatin1String("OUTPUT_L_WIDTH (8)");
+    case 9:
+        return QLatin1String("OUTPUT_P_SIZE (9)");
+    case 10:
+        return QLatin1String("OUTPUT_CR_DISPOSITION (10)");
+    case 11:
+        return QLatin1String("OUTPUT_HTAB_STOPS (11)");
+    case 12:
+        return QLatin1String("OUTPUT_HTAB_DISPOSITION (12)");
+    case 13:
+        return QLatin1String("OUTPUT_FF_DISPOSITION (13)");
+    case 14:
+        return QLatin1String("OUTPUT_VTAB_STOPS (14)");
+    case 15:
+        return QLatin1String("OUTPUT_VTAB_DISPOSITION (15)");
+    case 16:
+        return QLatin1String("OUTPUT_LF_DISPOSITION (16)");
+    case 17:
+        return QLatin1String("EXTENDED_ASCII (17)");
+    case 18:
+        return QLatin1String("LOGOUT (18)");
+    case 19:
+        return QLatin1String("BYTE_MACRO (19)");
+    case 20:
+        return QLatin1String("DATA_ENTRY_TERMINAL (20)");
+    case 21:
+        return QLatin1String("SUPDUP (21)");
+    case 22:
+        return QLatin1String("SUPDUP_OUTPUT (22)");
+    case 23:
+        return QLatin1String("SEND_LOCATION (23)");
+    case 24:
+        return QLatin1String("TTYPE (24)");
+    case 25:
+        return QLatin1String("EOR (25)");
+    case 26:
+        return QLatin1String("TACACS_USER_ID (26)");
+    case 27:
+        return QLatin1String("OUTPUT_MARKING (27)");
+    case 28:
+        return QLatin1String("TERMINAL_LOCATION_NUMBER (28)");
+    case 29:
+        return QLatin1String("TELNET_3270_REGIME (29)");
+    case 30:
+        return QLatin1String("X3_PAD (30)");
+    case 31:
+        return QLatin1String("NAWS (31)");
+    case 32:
+        return QLatin1String("TERMINAL_SPEED (32)");
+    case 33:
+        return QLatin1String("REMOTE_FLOW_CONTROL (33)");
+    case 34:
+        return QLatin1String("LINEMODE (34)");
+    case 35:
+        return QLatin1String("X_DISPLAY_LOCATION (35)");
+    case 36:
+        return QLatin1String("ENVIRONMENT_OPTION (36)");
+    case 37:
+        return QLatin1String("AUTHENTICATION_OPTIOM (37)");
+    case 38:
+        return QLatin1String("ENCRYPTION_OPTION (38)");
+    case 39:
+        return QLatin1String("NEW_ENVIRONMENT_OPTION (39)");
+    case 40:
+        return QLatin1String("TN3270E (40)");
+    case 41:
+        return QLatin1String("XAUTH (41)");
+    case 42:
+        return QLatin1String("CHARSET (42)");
+    case 43:
+        return QLatin1String("TELNET_REMOTE_SERIAL_PORT (43)");
+    case 44:
+        return QLatin1String("COM_PORT_CONTROL_OPTION (44)");
+    case 45:
+        return QLatin1String("TELNET_SUPPRESS_LOCAL_ECHO (45)");
+    case 46:
+        return QLatin1String("TELNET_START_TLS (46)");
+    case 47:
+        return QLatin1String("KERMIT (47)");
+    case 48:
+        return QLatin1String("SEND_URL (48)");
+    case 49:
+        return QLatin1String("FORWARD_X (49)");
 
     // Unofficial:
-    case 69:    return QLatin1String("MSDP (69)");
-    case 70:    return QLatin1String("MSSP (70)");
+    case 69:
+        return QLatin1String("MSDP (69)");
+    case 70:
+        return QLatin1String("MSSP (70)");
 
-    case 85:    return QLatin1String("MCCP (85)");
-    case 86:    return QLatin1String("MCCP2 (86)");
+    case 85:
+        return QLatin1String("MCCP (85)");
+    case 86:
+        return QLatin1String("MCCP2 (86)");
 
-    case 90:    return QLatin1String("MSP (90)");
-    case 91:    return QLatin1String("MXP (91)");
+    case 90:
+        return QLatin1String("MSP (90)");
+    case 91:
+        return QLatin1String("MXP (91)");
 
-    case 93:    return QLatin1String("ZENITH (93)");
+    case 93:
+        return QLatin1String("ZENITH (93)");
 
-    case 102:   return QLatin1String("AARDWULF (102)");
+    case 102:
+        return QLatin1String("AARDWULF (102)");
 
     // Official:
-    case 138:   return QLatin1String("TELOPT_PRAGRMA_LOGON (138)");
-    case 139:   return QLatin1String("TELOPT_SSPI_LOGON (139)");
-    case 140:   return QLatin1String("TELOPT_PRAGMA_HEARTBEAT (140)");
+    case 138:
+        return QLatin1String("TELOPT_PRAGRMA_LOGON (138)");
+    case 139:
+        return QLatin1String("TELOPT_SSPI_LOGON (139)");
+    case 140:
+        return QLatin1String("TELOPT_PRAGMA_HEARTBEAT (140)");
 
     // Unofficial:
-    case 200:   return QLatin1String("ATCP (200)");
-    case 201:   return QLatin1String("GMCP (201)");
+    case 200:
+        return QLatin1String("ATCP (200)");
+    case 201:
+        return QLatin1String("GMCP (201)");
 
     // Official:
-    case 255:   return QLatin1String("EXTENDED_OPTIONS_LIST (255)");
+    case 255:
+        return QLatin1String("EXTENDED_OPTIONS_LIST (255)");
     default:
         return qsl("UNKNOWN (%1)").arg(ch, 3);
     }
@@ -1625,7 +1643,7 @@ std::tuple<QString, int, bool> cTelnet::getConnectionInfo() const
 }
 
 // escapes data to be send over NEW ENVIRON and MNES
-QByteArray cTelnet::prepareNewEnvironData(const QString &arg)
+QByteArray cTelnet::prepareNewEnvironData(const QString& arg)
 {
     QString ret = arg;
 
@@ -1685,7 +1703,7 @@ QString cTelnet::getNewEnvironValueSystemType()
     systemType = qsl("UNIX");
 #endif
 
-    return systemType.isEmpty() ? QString(): systemType;
+    return systemType.isEmpty() ? QString() : systemType;
 }
 
 QString cTelnet::getNewEnvironCharset()
@@ -1717,12 +1735,7 @@ QString cTelnet::getNewEnvironClientVersion()
     * letters, digits, and the two punctuation characters hyphen and slash.  It must
     * start with a letter, and end with a letter or digit."
     */
-    clientVersion = clientVersion.toUpper()
-                                        .replace(QChar('.'), QChar('/'))
-                                        .replace(QChar::Space, QChar('-'))
-                                        .replace(allInvalidCharacters, QChar('-'))
-                                        .replace(multipleHyphens, QChar('-'))
-                                        .left(40);
+    clientVersion = clientVersion.toUpper().replace(QChar('.'), QChar('/')).replace(QChar::Space, QChar('-')).replace(allInvalidCharacters, QChar('-')).replace(multipleHyphens, QChar('-')).left(40);
 
     for (int i = clientVersion.size() - 1; i >= 0; --i) {
         if (clientVersion.at(i).isLetterOrNumber()) {
@@ -1741,7 +1754,7 @@ QString cTelnet::getNewEnvironTerminalType()
 
 QString cTelnet::getNewEnvironMTTS()
 {
-    int terminalStandards = MTTS_STD_ANSI|MTTS_STD_256_COLORS|MTTS_STD_OSC_COLOR_PALETTE|MTTS_STD_TRUECOLOR;
+    int terminalStandards = MTTS_STD_ANSI | MTTS_STD_256_COLORS | MTTS_STD_OSC_COLOR_PALETTE | MTTS_STD_TRUECOLOR;
 
     if (getEncoding() == "UTF-8") {
         terminalStandards |= MTTS_STD_UTF_8;
@@ -1933,7 +1946,7 @@ QMap<QString, QPair<bool, QString>> cTelnet::getNewEnvironDataMap()
 }
 
 // SEND INFO per https://www.rfc-editor.org/rfc/rfc1572
-void cTelnet::sendInfoNewEnvironValue(const QString &var)
+void cTelnet::sendInfoNewEnvironValue(const QString& var)
 {
     if (!enableNewEnviron || !mpHost->mEnableNEWENVIRON) {
         return;
@@ -1997,7 +2010,7 @@ void cTelnet::sendInfoNewEnvironValue(const QString &var)
     }
 }
 
-void cTelnet::appendAllNewEnvironValues(std::string &output, const bool isUserVar, const QMap<QString, QPair<bool, QString>> &newEnvironDataMap)
+void cTelnet::appendAllNewEnvironValues(std::string& output, const bool isUserVar, const QMap<QString, QPair<bool, QString>>& newEnvironDataMap)
 {
     for (auto it = newEnvironDataMap.begin(); it != newEnvironDataMap.end(); ++it) {
         // QPair first: NEW_ENVIRON_USERVAR indicator, second: data
@@ -2034,7 +2047,7 @@ void cTelnet::appendAllNewEnvironValues(std::string &output, const bool isUserVa
     }
 }
 
-void cTelnet::appendNewEnvironValue(std::string &output, const QString &var, const bool isUserVar, const QMap<QString, QPair<bool, QString>> &newEnvironDataMap)
+void cTelnet::appendNewEnvironValue(std::string& output, const QString& var, const bool isUserVar, const QMap<QString, QPair<bool, QString>>& newEnvironDataMap)
 {
     if (newEnvironDataMap.contains(var)) {
         // QPair first: NEW_ENVIRON_USERVAR indicator, second: data
@@ -2150,7 +2163,7 @@ void cTelnet::sendIsNewEnvironValues(const QByteArray& payload)
     socketOutRaw(output);
 }
 
-bool cTelnet::isMNESVariable(const QString &var)
+bool cTelnet::isMNESVariable(const QString& var)
 {
     static const QStringList validValues = {"CHARSET", "CLIENT_NAME", "CLIENT_VERSION", "MTTS", "TERMINAL_TYPE", "IPADDRESS"};
 
@@ -2196,7 +2209,7 @@ void cTelnet::sendAllMNESValues()
     socketOutRaw(output);
 }
 
-void cTelnet::sendMNESValue(const QString &var, const QMap<QString, QPair<bool, QString>> &newEnvironDataMap)
+void cTelnet::sendMNESValue(const QString& var, const QMap<QString, QPair<bool, QString>>& newEnvironDataMap)
 {
     if (!mpHost->mEnableMNES) {
         return;
@@ -2298,13 +2311,13 @@ void cTelnet::trackKaVirNegotiation(unsigned char option)
     // Check for match
     if (mNegotiationOrder == expectedOrderForKaVirHandler) {
 #if defined(DEBUG_TELNET) && (DEBUG_TELNET & 1)
-    QStringList optList;
+        QStringList optList;
 
-    for (unsigned char opt : mNegotiationOrder) {
-        optList << QString("%1 (%2)").arg(static_cast<int>(opt)).arg(decodeOption(opt));
-    }
+        for (unsigned char opt : mNegotiationOrder) {
+            optList << QString("%1 (%2)").arg(static_cast<int>(opt)).arg(decodeOption(opt));
+        }
 
-    qDebug().nospace() << "Matched KaVir protocol handling negotiation order: [" << optList.join(", ") << "]";
+        qDebug().nospace() << "Matched KaVir protocol handling negotiation order: [" << optList.join(", ") << "]";
 #endif
         autoEnableTTYPEVersion();
     }
@@ -2318,7 +2331,8 @@ void cTelnet::autoEnableTTYPEVersion()
     // Automatically enable TTYPE version compatibility
     disconnectIt();
     mpHost->mVersionInTTYPE = true;
-    postMessage(tr("[ INFO ]  - This game appears to use KaVir's protocol handler, which works best when Mudlet reports its version number during connection. Version reporting in terminal type has been automatically enabled for improved color support. Reconnecting..."));
+    postMessage(tr("[ INFO ]  - This game appears to use KaVir's protocol handler, which works best when Mudlet reports its version number during connection. Version reporting in terminal type has "
+                   "been automatically enabled for improved color support. Reconnecting..."));
     reconnect();
 }
 
@@ -2336,7 +2350,8 @@ void cTelnet::autoEnableMXPProcessor()
     // secure tags. Lock to secure mode for compatibility.
     // Properly-negotiated MXP games will use mode switches as needed.
     mpHost->mMxpProcessor.setMode(6); // Lock secure mode
-    postMessage(tr("[ INFO ]  - This game appears to support MXP (Mud eXtension Protocol), but has not turned it on properly. MXP processing has been automatically enabled for clickable links, room info, and richer interactions. You can disable this setting in Settings > Special Options."));
+    postMessage(tr("[ INFO ]  - This game appears to support MXP (Mud eXtension Protocol), but has not turned it on properly. MXP processing has been automatically enabled for clickable links, room "
+                   "info, and richer interactions. You can disable this setting in Settings > Special Options."));
 }
 
 void cTelnet::processTelnetCommand(const std::string& telnetCommand)
@@ -2565,7 +2580,8 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             output += TN_IAC;
             output += TN_SB;
             output += OPT_ATCP;
-            std::string atcpOptions = std::string("hello Mudlet ") + std::string(APP_VERSION) + mudlet::self()->mAppBuild.toUtf8().constData() + "\ncomposer 1\nchar_vitals 1\nroom_brief 1\nroom_exits 1\nmap_display 1\n";
+            std::string atcpOptions = std::string("hello Mudlet ") + std::string(APP_VERSION) + mudlet::self()->mAppBuild.toUtf8().constData()
+                                      + "\ncomposer 1\nchar_vitals 1\nroom_brief 1\nroom_exits 1\nmap_display 1\n";
             output += encodeAndCookBytes(atcpOptions);
             output += TN_IAC;
             output += TN_SE;
@@ -2720,9 +2736,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                     // Skip this if the user has disabled password masking entirely.
                     constexpr auto LOGIN_PHASE_MS = 5min;
                     constexpr auto PASSWORD_TIMEOUT_MS = 60s;
-                    if (!mpHost->mDisablePasswordMasking
-                        && mConnectionTimer.isValid()
-                        && mConnectionTimer.elapsed() < LOGIN_PHASE_MS.count()) {
+                    if (!mpHost->mDisablePasswordMasking && mConnectionTimer.isValid() && mConnectionTimer.elapsed() < LOGIN_PHASE_MS.count()) {
                         if (!mTimerPasswordModeTimeout) {
                             mTimerPasswordModeTimeout = new QTimer(this);
                             mTimerPasswordModeTimeout->setSingleShot(true);
@@ -2932,7 +2946,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 }
 
                 enableCHARSET = false;
-            } else  { // We have already negotiated the use of the option by us (We WILL welcome the DO)
+            } else { // We have already negotiated the use of the option by us (We WILL welcome the DO)
                 sendTelnetOption(TN_WILL, OPT_CHARSET);
                 enableCHARSET = true; // We negotiated, the game server is welcome to REQUEST now
                 qDebug() << "CHARSET enabled";
@@ -3237,21 +3251,19 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                     for (QByteArray characterSet : characterSetList) {
                         characterSet = characterSet.toUpper();
 
-                        if (mAcceptableEncodings.contains(characterSet) ||
-                            mAcceptableEncodings.contains(("M_" + characterSet)) ||
-                            characterSet.contains(QByteArray("ASCII"))) { // Accept variants of ASCII
+                        if (mAcceptableEncodings.contains(characterSet) || mAcceptableEncodings.contains(("M_" + characterSet))
+                            || characterSet.contains(QByteArray("ASCII"))) { // Accept variants of ASCII
                             acceptedCharacterSet = characterSet;
                             break;
                         }
 
-                        if (characterSet.startsWith("ISO-") &&  // Accept "ISO-####-#" variant of "ISO ####-#"
+                        if (characterSet.startsWith("ISO-") && // Accept "ISO-####-#" variant of "ISO ####-#"
                             mAcceptableEncodings.contains(QByteArray("ISO " + characterSet.mid(4)))) {
                             acceptedCharacterSet = characterSet;
                             break;
                         }
 
-                        if (!characterSet.startsWith("ISO ") &&
-                            characterSet.startsWith("ISO") &&  // Accept "ISO####-#" variant of "ISO ####-#"
+                        if (!characterSet.startsWith("ISO ") && characterSet.startsWith("ISO") && // Accept "ISO####-#" variant of "ISO ####-#"
                             mAcceptableEncodings.contains(QByteArray("ISO " + characterSet.mid(3)))) {
                             acceptedCharacterSet = characterSet;
                             break;
@@ -3348,7 +3360,8 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 output += TN_SB;
                 output += OPT_ATCP;
                 // mudlet::self()->mAppBuild *could* be a non-ASCII UTF-8 string:
-                std::string atcpOptions = std::string("hello Mudlet ") + std::string(APP_VERSION) + mudlet::self()->mAppBuild.toUtf8().constData() + "\ncomposer 1\nchar_vitals 1\nroom_brief 1\nroom_exits 1\nmap_display 1\n";
+                std::string atcpOptions = std::string("hello Mudlet ") + std::string(APP_VERSION) + mudlet::self()->mAppBuild.toUtf8().constData()
+                                          + "\ncomposer 1\nchar_vitals 1\nroom_brief 1\nroom_exits 1\nmap_display 1\n";
                 output += encodeAndCookBytes(atcpOptions);
                 output += TN_IAC;
                 output += TN_SE;
@@ -3390,7 +3403,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                     // Check if the version is different and handle the upgrade
                     postMessage(tr("[ INFO ]  - Upgrading the GUI to new version '%1' from version '%2'\n"
                                    "(url='%3').")
-                                .arg(version, mpHost->mServerGUI_Package_version, url));
+                                        .arg(version, mpHost->mServerGUI_Package_version, url));
 
                     // Uninstall the old version
                     mpHost->uninstallPackage(mpHost->mServerGUI_Package_name != qsl("nothing") ? mpHost->mServerGUI_Package_name : packageName, enums::PackageModuleType::Package);
@@ -3520,52 +3533,52 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                     cmd += TNSB_IS;
 
                     switch (mCycleCountMTTS) {
-                        case 0: {
-                            QString terminalType = getNewEnvironClientName();
+                    case 0: {
+                        QString terminalType = getNewEnvironClientName();
 
-                            // Some servers use KaVir’s protocol snippet, which expects the client to provide both its name and a decimal
-                            // version number during Telnet TTYPE negotiation. However, including a version number is not in accordance with
-                            // the relevant RFCs as the period character is not permitted therein; so since 2024, Mudlet has stopped sending
-                            // it by default. As a result, servers that rely on this information may assume Mudlet is version 1.0 or earlier,
-                            // and consequently restrict color support to 16 colors instead of enabling 256-color mode. Hence, users can add
-                            // the version number to the terminal type via a setting in Special Options.
-                            if (mpHost->mVersionInTTYPE) {
-                                terminalType += qsl(" %1").arg(APP_VERSION);
-                            }
-
-                            cmd += terminalType.toStdString();
-
-                            if (mpHost->mEnableMTTS) { // If we don't MTTS, remainder of the cases do not execute.
-                                mCycleCountMTTS++;
-                                qDebug() << "MTTS enabled";
-                                qDebug() << "WE send TERMINAL_TYPE (MTTS) terminal type is" << terminalType;
-                            } else {
-                                qDebug() << "WE send TERMINAL_TYPE is" << terminalType;
-                            }
-
-                            break;
+                        // Some servers use KaVir’s protocol snippet, which expects the client to provide both its name and a decimal
+                        // version number during Telnet TTYPE negotiation. However, including a version number is not in accordance with
+                        // the relevant RFCs as the period character is not permitted therein; so since 2024, Mudlet has stopped sending
+                        // it by default. As a result, servers that rely on this information may assume Mudlet is version 1.0 or earlier,
+                        // and consequently restrict color support to 16 colors instead of enabling 256-color mode. Hence, users can add
+                        // the version number to the terminal type via a setting in Special Options.
+                        if (mpHost->mVersionInTTYPE) {
+                            terminalType += qsl(" %1").arg(APP_VERSION);
                         }
 
-                        case 1: {
-                            const QString mttsTerminalType = getNewEnvironTerminalType();
-                            cmd += mttsTerminalType.toStdString(); // Example: ANSI-TRUECOLOR
+                        cmd += terminalType.toStdString();
+
+                        if (mpHost->mEnableMTTS) { // If we don't MTTS, remainder of the cases do not execute.
                             mCycleCountMTTS++;
-                            qDebug() << "WE send TERMINAL_TYPE (MTTS) terminal type is" << mttsTerminalType;
-                            break;
+                            qDebug() << "MTTS enabled";
+                            qDebug() << "WE send TERMINAL_TYPE (MTTS) terminal type is" << terminalType;
+                        } else {
+                            qDebug() << "WE send TERMINAL_TYPE is" << terminalType;
                         }
 
-                        default: {
-                            const QString mttsTerminalStandards = getNewEnvironMTTS();
-                            cmd += qsl("MTTS %1").arg(mttsTerminalStandards).toStdString(); // Example: MTTS 2349
+                        break;
+                    }
 
-                            if (mCycleCountMTTS == 2) {
-                                mCycleCountMTTS++;
-                                qDebug() << "WE send TERMINAL_TYPE (MTTS) bitvector is" << mttsTerminalStandards;
-                            } else {
-                                mCycleCountMTTS = 0; // Send the bitvector twice, then reset (0) to finish MTTS negotiation
-                                qDebug() << "WE send TERMINAL_TYPE (MTTS) bitvector is" << mttsTerminalStandards << "(repeated)";
-                            }
+                    case 1: {
+                        const QString mttsTerminalType = getNewEnvironTerminalType();
+                        cmd += mttsTerminalType.toStdString(); // Example: ANSI-TRUECOLOR
+                        mCycleCountMTTS++;
+                        qDebug() << "WE send TERMINAL_TYPE (MTTS) terminal type is" << mttsTerminalType;
+                        break;
+                    }
+
+                    default: {
+                        const QString mttsTerminalStandards = getNewEnvironMTTS();
+                        cmd += qsl("MTTS %1").arg(mttsTerminalStandards).toStdString(); // Example: MTTS 2349
+
+                        if (mCycleCountMTTS == 2) {
+                            mCycleCountMTTS++;
+                            qDebug() << "WE send TERMINAL_TYPE (MTTS) bitvector is" << mttsTerminalStandards;
+                        } else {
+                            mCycleCountMTTS = 0; // Send the bitvector twice, then reset (0) to finish MTTS negotiation
+                            qDebug() << "WE send TERMINAL_TYPE (MTTS) bitvector is" << mttsTerminalStandards << "(repeated)";
                         }
+                    }
                     }
 
                     cmd += TN_IAC;
@@ -3574,8 +3587,8 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 }
             }
         }
-        //other cmds should not arrive, as they were not negotiated.
-        //if they do, they are merely ignored
+            //other cmds should not arrive, as they were not negotiated.
+            //if they do, they are merely ignored
         } //end switch 2
         //other commands are simply ignored (NOP and such, see .h file for list)
     }
@@ -3594,7 +3607,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 msg = msg.mid(3, telnetCommand.size() - 5);
             }
 
-            TEvent event {};
+            TEvent event{};
             event.mArgumentList.append(qsl("sysTelnetEvent"));
             event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
             event.mArgumentList.append(QString::number(type));
@@ -3605,7 +3618,6 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
             mpHost->raiseEvent(event);
         }
-
     }
 }
 
@@ -3714,7 +3726,8 @@ QString cTelnet::parseGUIUrlFromJSON(const QJsonObject& json)
 void cTelnet::downloadAndInstallGUIPackage(const QString& packageName, const QString& fileName, const QString& url)
 {
     postMessage(tr("[ INFO ]  - Downloading and installing package '%1'\n"
-                   "(url='%2').").arg(packageName, url));
+                   "(url='%2').")
+                        .arg(packageName, url));
 
     mServerPackage = mudlet::getMudletPath(enums::profileDataItemPath, mProfileName, fileName);
     mpHost->updateProxySettings(mpDownloader);
@@ -3744,7 +3757,7 @@ void cTelnet::handleGUIPackageInstallationAndUpgrade(QJsonDocument document)
     QString url = parseGUIUrlFromJSON(json);
 
     if (version.isEmpty() || url.isEmpty()) {
-        return;  // Exit if version or URL is missing
+        return; // Exit if version or URL is missing
     }
 
     // Clean up package name from URL
@@ -3768,7 +3781,7 @@ void cTelnet::handleGUIPackageInstallationAndUpgrade(QJsonDocument document)
         // Check if the version is different and handle the upgrade
         postMessage(tr("[ INFO ]  - Upgrading the GUI to new version '%1' from version '%2'\n"
                        "(url='%3').")
-                    .arg(version, mpHost->mServerGUI_Package_version, url));
+                            .arg(version, mpHost->mServerGUI_Package_version, url));
 
         // Uninstall the old version
         mpHost->uninstallPackage(mpHost->mServerGUI_Package_name != qsl("nothing") ? mpHost->mServerGUI_Package_name : packageName, enums::PackageModuleType::Package);
@@ -3855,8 +3868,7 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
     // remove \r's from the data, as yajl doesn't like it
     data.remove(QChar::CarriageReturn);
 
-    if (packageMessage.startsWith(QLatin1String("External.Discord.Status"), Qt::CaseInsensitive)
-        || packageMessage.startsWith(QLatin1String("External.Discord.Info"), Qt::CaseInsensitive)) {
+    if (packageMessage.startsWith(QLatin1String("External.Discord.Status"), Qt::CaseInsensitive) || packageMessage.startsWith(QLatin1String("External.Discord.Info"), Qt::CaseInsensitive)) {
         mpHost->processDiscordGMCP(packageMessage, data);
     }
 
@@ -3924,7 +3936,7 @@ void cTelnet::setMSPVariables(const QByteArray& msg)
         transcodedMsg.chop(1);
     }
 
-    TMediaData mediaData {};
+    TMediaData mediaData{};
 
     mediaData.setMediaProtocol(TMediaData::MediaProtocolMSP);
 
@@ -4028,15 +4040,9 @@ void cTelnet::promptTlsConnectionAvailable()
     // If an SSL port is detected by MSSP and we're not using it, prompt to use
     // on future connections; note that it is unlikely that a literal IP address
     // will be included in a TLS/SSL cert so we can include that in the tests:
-    if (mpHost->mMSSPTlsPort
-        && QSslSocket::UnencryptedMode == mpSocket->mode()
-        && mpHost->mAskTlsAvailable
-        && !isIPAddress(mHostUrl)
-        && (mpHost->mMSSPHostName.isEmpty()
-            || mpHost->mMSSPHostName.compare(mHostUrl, Qt::CaseInsensitive) == 0)) {
-
-        postMessage(tr("[ INFO ]  - A more secure connection on port %1 is available.")
-                    .arg(QString::number(mpHost->mMSSPTlsPort)));
+    if (mpHost->mMSSPTlsPort && QSslSocket::UnencryptedMode == mpSocket->mode() && mpHost->mAskTlsAvailable && !isIPAddress(mHostUrl)
+        && (mpHost->mMSSPHostName.isEmpty() || mpHost->mMSSPHostName.compare(mHostUrl, Qt::CaseInsensitive) == 0)) {
+        postMessage(tr("[ INFO ]  - A more secure connection on port %1 is available.").arg(QString::number(mpHost->mMSSPTlsPort)));
 
         // This QMessageBox is application modal and because we use ::exec() it
         // spins up it's own event loop - this is not recommended by the Qt
@@ -4066,7 +4072,7 @@ void cTelnet::promptTlsConnectionAvailable()
         case QMessageBox::No:
             disconnectIt();
             mpHost->mAskTlsAvailable = false; // Don't ask next time
-            reconnect();             // A no-op (;) is desired, but read buffer does not flush
+            reconnect();                      // A no-op (;) is desired, but read buffer does not flush
             break;
         default:
             Q_UNREACHABLE(); // should never be reached
@@ -4208,7 +4214,7 @@ void cTelnet::postMessage(QString msg)
                 if (!body.empty()) {
                     mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(255, 255, 50), mpHost->mBgColor); // Bright Yellow
                 }
-            //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
+                //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
             } else if (prefix.contains(tr("LUA")) || prefix.contains(QLatin1String("LUA"))) {
                 mpHost->mpConsole->print(prefix, QColor(80, 160, 255), mpHost->mBgColor);                    // Light blue
                 mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(50, 200, 50), mpHost->mBgColor); // Light green
@@ -4220,7 +4226,7 @@ void cTelnet::postMessage(QString msg)
                 if (!body.empty()) {
                     mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(200, 50, 50), mpHost->mBgColor); // Red
                 }
-            //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
+                //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
             } else if (prefix.contains(tr("WARN")) || prefix.contains(QLatin1String("WARN"))) {
                 mpHost->mpConsole->print(prefix, QColor(0, 150, 190), mpHost->mBgColor);                     // Cyan
                 mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(190, 150, 0), mpHost->mBgColor); // Orange
@@ -4232,7 +4238,7 @@ void cTelnet::postMessage(QString msg)
                 if (!body.empty()) {
                     mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(190, 150, 0), mpHost->mBgColor);
                 }
-            //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
+                //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
             } else if (prefix.contains(tr("ALERT")) || prefix.contains(QLatin1String("ALERT"))) {
                 mpHost->mpConsole->print(prefix, QColor(190, 100, 50), mpHost->mBgColor);                     // Orange-ish
                 mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(190, 190, 50), mpHost->mBgColor); // Yellow
@@ -4244,7 +4250,7 @@ void cTelnet::postMessage(QString msg)
                 if (!body.empty()) {
                     mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(190, 190, 50), mpHost->mBgColor); // Yellow
                 }
-            //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
+                //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
             } else if (prefix.contains(tr("INFO")) || prefix.contains(QLatin1String("INFO"))) {
                 mpHost->mpConsole->print(prefix, QColor(0, 150, 190), mpHost->mBgColor);                   // Cyan
                 mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(0, 160, 0), mpHost->mBgColor); // Light Green
@@ -4256,7 +4262,7 @@ void cTelnet::postMessage(QString msg)
                 if (!body.empty()) {
                     mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(0, 160, 0), mpHost->mBgColor); // Light Green
                 }
-            //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
+                //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
             } else if (prefix.contains(tr("OK")) || prefix.contains(QLatin1String("OK"))) {
                 mpHost->mpConsole->print(prefix, QColor(0, 160, 0), mpHost->mBgColor);                        // Light Green
                 mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(190, 100, 50), mpHost->mBgColor); // Orange-ish
@@ -4355,10 +4361,7 @@ void cTelnet::trackMXPElementDetection(const std::string& line)
     // an escape sequence, similar to ANSI or VT100 is used: ESC[#z"
     // Valid modes: 0=open, 1=secure, 2=locked, 3=reset, 4=temp secure,
     //              5=lock open, 6=lock secure, 7=lock locked
-    static const std::vector<std::string> mxpEscapes = {
-        "\x1B[0z", "\x1B[1z", "\x1B[2z", "\x1B[3z",
-        "\x1B[4z", "\x1B[5z", "\x1B[6z", "\x1B[7z"
-    };
+    static const std::vector<std::string> mxpEscapes = {"\x1B[0z", "\x1B[1z", "\x1B[2z", "\x1B[3z", "\x1B[4z", "\x1B[5z", "\x1B[6z", "\x1B[7z"};
 
     for (const auto& esc : mxpEscapes) {
         if (line.find(esc) != std::string::npos) {
@@ -4451,7 +4454,7 @@ void cTelnet::postData()
     if (!mpHost || mpHost->isClosingDown() || !mpHost->mpConsole) {
         return;
     }
-    
+
     // All data goes through main console's printOnDisplay which calls
     // translateToPlainText - MXP DEST routing happens inside that process
     mpHost->mpConsole->printOnDisplay(mMudData, true);
@@ -4519,7 +4522,7 @@ bool cTelnet::loadReplay(const QString& name, QString* pErrMsg)
             // Only post an information menu if initiated from GUI controls
             postMessage(tr("[ INFO ]  - Loading replay file:\n"
                            "\"%1\".")
-                        .arg(name));
+                                .arg(name));
             mIsReplayRunFromLua = false;
         } else {
             mIsReplayRunFromLua = true;
@@ -4562,12 +4565,11 @@ bool cTelnet::loadReplay(const QString& name, QString* pErrMsg)
     } else {
         if (pErrMsg) {
             // Call from lua case:
-            *pErrMsg = tr("Cannot read file \"%1\", error message was: \"%2\".")
-                    .arg(name, replayFile.errorString());
+            *pErrMsg = tr("Cannot read file \"%1\", error message was: \"%2\".").arg(name, replayFile.errorString());
         } else {
             postMessage(tr("[ ERROR ] - Cannot read file \"%1\",\n"
                            "error message was: \"%2\".")
-                        .arg(name, replayFile.errorString()));
+                                .arg(name, replayFile.errorString()));
         }
         return false;
     }
@@ -4767,7 +4769,7 @@ void cTelnet::processSocketData(char* in_buffer, int amount, const bool loopback
         mpHost->mpConsole->mReplayStream.writeRawData(buffer, datalen);
 #if defined(DEBUG_RECORDING)
         qDebug().noquote().nospace() << "cTelnet::processSocketData(...) INFO - recording chunk: " << mRecordingChunkCount << " is " << datalen
-                                        << " bytes and has an interval of: " << recordingChunkInterval << " mSecond since the previous chunk.";
+                                     << " bytes and has an interval of: " << recordingChunkInterval << " mSecond since the previous chunk.";
 #endif
     }
 
@@ -4876,7 +4878,8 @@ void cTelnet::processSocketData(char* in_buffer, int amount, const bool loopback
                     if (!mIncompleteSB) {
                         mIncompleteSB = true;
                         qWarning(R"("TELNET: the server did not properly complete a subnegotiation (code %02x).
-Some data loss is likely - please mention this problem to the game admins.)", command[2]);
+Some data loss is likely - please mention this problem to the game admins.)",
+                                 command[2]);
                     }
 
                     // Re-enter the state machine.
@@ -4950,7 +4953,7 @@ Some data loss is likely - please mention this problem to the game admins.)", co
 
 void cTelnet::raiseProtocolEvent(const QString& name, const QString& protocol)
 {
-    TEvent event {};
+    TEvent event{};
     event.mArgumentList.append(name);
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(protocol);
@@ -4987,8 +4990,8 @@ void cTelnet::setKeepAlive(int socketHandle)
     Q_UNUSED(init)
     struct tcp_keepalive
     {
-        u_long onoff; // off = 0; on = not 0; default off
-        u_long keepalivetime; // milliseconds, default = 7,200,000 = 2 hours
+        u_long onoff;             // off = 0; on = not 0; default off
+        u_long keepalivetime;     // milliseconds, default = 7,200,000 = 2 hours
         u_long keepaliveinterval; // milliseconds, default = 1000 = 1 second
     } alive;
     alive.onoff = on;
@@ -5095,7 +5098,7 @@ void cTelnet::setPostingTimeout(const int timeout)
 /*static*/ std::pair<bool, bool> cTelnet::testReadReplayFile()
 {
     // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (5 of 7) - investigate switching from using `char[]` to `std::array<char>`
-    char replayBuffer[BUFFER_SIZE+1];
+    char replayBuffer[BUFFER_SIZE + 1];
 
     quint64 totalElapsed = 0;
     int replayChunks = 0;
@@ -5188,8 +5191,12 @@ QAbstractSocket::SocketState cTelnet::getConnectionState() const
     }
 
     // These two other states should not be possible!
-    Q_ASSERT_X(mSocket_ipV4.state() != QAbstractSocket::ListeningState && mSocket_ipV4.state() != QAbstractSocket::BoundState, "cTelnet::getConnectionState()", "The IPv4 socket is not in an expected state.");
-    Q_ASSERT_X(mSocket_ipV6.state() != QAbstractSocket::ListeningState && mSocket_ipV6.state() != QAbstractSocket::BoundState, "cTelnet::getConnectionState()", "The IPv6 socket is not in an expected state.");
+    Q_ASSERT_X(mSocket_ipV4.state() != QAbstractSocket::ListeningState && mSocket_ipV4.state() != QAbstractSocket::BoundState,
+               "cTelnet::getConnectionState()",
+               "The IPv4 socket is not in an expected state.");
+    Q_ASSERT_X(mSocket_ipV6.state() != QAbstractSocket::ListeningState && mSocket_ipV6.state() != QAbstractSocket::BoundState,
+               "cTelnet::getConnectionState()",
+               "The IPv6 socket is not in an expected state.");
 
     return QAbstractSocket::UnconnectedState;
 }

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -43,22 +43,22 @@ Discord::Discord(QObject* parent)
 // "midmud"  is "460618737712889858", has "server-icon", "exventure" and "mudlet" icons
 // "carinus" is "438335628942376960", has "server-icon" and "mudlet" icons
 // "wotmud"  is "464945517156106240", has "mudlet", "ajar_(red|green|yellow|blue|white|grey|brown)"
-, mHostApplicationIDs{{nullptr, mMudletApplicationId}}
-// lowercase list of known games
+, mHostApplicationIDs{{nullptr, mMudletApplicationId}} // lowercase list of known games
 // {game name, {game addresses}}
-, mKnownGames{{"midmud", {"midmud.com"}},
-              {"wotmud", {"game.wotmud.org"}},
-              {"luminari", {"luminarimud.com"}},
-              {"achaea", {"achaea.com", "iron-ach.ironrealms.com"}},
-              {"aetolia", {"aetolia.com", "iron-aet.ironrealms.com"}},
-              {"imperian", {"imperian.com", "iron-imp.ironrealms.com"}},
-              {"lusternia", {"lusternia.com", "iron-lus.ironrealms.com"}},
-              {"starmourn", {"starmourn.com"}},
-              {"stickmud", {"stickmud.com"}},
-              {"clessidra", {"clessidra.it", "mud.clessidra.it"}},
-              {"mume", {"mume.org"}},
-              {"asteria", {"asteriamud.com"}},
-            }
+, mKnownGames{
+          {"midmud", {"midmud.com"}},
+          {"wotmud", {"game.wotmud.org"}},
+          {"luminari", {"luminarimud.com"}},
+          {"achaea", {"achaea.com", "iron-ach.ironrealms.com"}},
+          {"aetolia", {"aetolia.com", "iron-aet.ironrealms.com"}},
+          {"imperian", {"imperian.com", "iron-imp.ironrealms.com"}},
+          {"lusternia", {"lusternia.com", "iron-lus.ironrealms.com"}},
+          {"starmourn", {"starmourn.com"}},
+          {"stickmud", {"stickmud.com"}},
+          {"clessidra", {"clessidra.it", "mud.clessidra.it"}},
+          {"mume", {"mume.org"}},
+          {"asteria", {"asteriamud.com"}},
+  }
 {
 #if defined(Q_OS_WIN64)
     // Only defined on 64 bit Windows
@@ -378,7 +378,8 @@ void Discord::UpdatePresence()
         // It has changed - must shutdown and reopen the library instance with
         // the alternate application id:
 #if defined(DEBUG_DISCORD)
-        qDebug().nospace().noquote() << "Discord::UpdatePresence() INFO - mCurrentApplicationId (\"" << mCurrentApplicationId << "\") does not match the one for this Host instance (\"" << applicationID << "\"), restarting RPC library with the latter.";
+        qDebug().nospace().noquote() << "Discord::UpdatePresence() INFO - mCurrentApplicationId (\"" << mCurrentApplicationId << "\") does not match the one for this Host instance (\""
+                                     << applicationID << "\"), restarting RPC library with the latter.";
 #endif
         Discord_Shutdown();
 
@@ -588,7 +589,8 @@ bool Discord::setApplicationID(Host* pHost, const QString& text)
     return false;
 }
 
-void Discord::resetData(Host* pHost){
+void Discord::resetData(Host* pHost)
+{
     mStartTimes.remove(pHost);
     mEndTimes.remove(pHost);
     mDetailTexts[pHost] = qsl("www.mudlet.org");

--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -137,7 +137,7 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent)
 }
 
 void dlgAboutDialog::setAboutTab(const QString& htmlHead) const
-{   // TAB 1 - "About Mudlet"
+{ // TAB 1 - "About Mudlet"
     // clang-format off
     QString aboutMudletHeader(
         tr("<tr><td><span style=\"color:#bc8942;\"><b>Homepage</b></span></td><td><a href=\"http://www.mudlet.org/\">www.mudlet.org</a></td></tr>\n"
@@ -274,15 +274,13 @@ QString dlgAboutDialog::createMakerHTML(const aboutMaker& maker) const
     }
 
     return qsl("<p>%1%2 %3</p>\n") // name (big?), contacts (if any?), description
-        .arg(coloredText.arg(qsl("bc8942"), qsl("<b>%1</b>")
-             .arg((maker.big) ? qsl("<big>%1</big>").arg(maker.name) : maker.name)),
-        (contactDetails.isEmpty()) ? QString() :
-             qsl(" (%1)").arg(contactDetails.join(QChar::Space)),
-        maker.description);
+            .arg(coloredText.arg(qsl("bc8942"), qsl("<b>%1</b>").arg((maker.big) ? qsl("<big>%1</big>").arg(maker.name) : maker.name)),
+                 (contactDetails.isEmpty()) ? QString() : qsl(" (%1)").arg(contactDetails.join(QChar::Space)),
+                 maker.description);
 }
 
 void dlgAboutDialog::setLicenseTab(const QString& htmlHead) const
-{   // TAB 2 - "License"
+{ // TAB 2 - "License"
     // clang-format off
     // Only the introductory text at the top is to be translated - the Licence
     // itself MUST NOT be translated as only the English Language version is
@@ -579,7 +577,7 @@ void dlgAboutDialog::setLicenseTab(const QString& htmlHead) const
 }
 
 void dlgAboutDialog::setThirdPartyTab(const QString& htmlHead) const
-{   // TAB 3 - Third party items
+{ // TAB 3 - Third party items
     // clang-format off
     // Only the introductory text at the top and interspersed between items are
     // to be translated - the Licences themselves MUST NOT be translated:
@@ -1053,7 +1051,7 @@ void dlgAboutDialog::setThirdPartyTab(const QString& htmlHead) const
 void dlgAboutDialog::setSupportersTab(const QString& htmlHead)
 {
     // see https://www.patreon.com/mudlet if you'd like to be added!
-    QStringList mightier_than_swords = {/* active */"Joshua C. Burt", "StickMUD", "Medievia", /* inactive */ "Qwindor Rousseau", "Maiyannah Bishop", "Stick In the MUD 🎙"};
+    QStringList mightier_than_swords = {/* active */ "Joshua C. Burt", "StickMUD", "Medievia", /* inactive */ "Qwindor Rousseau", "Maiyannah Bishop", "Stick In the MUD 🎙"};
     QStringList on_a_plaque = {"demonnic", "Henry Hsiao"};
     int image_counter{1};
 
@@ -1065,7 +1063,7 @@ void dlgAboutDialog::setSupportersTab(const QString& htmlHead)
     nameFont.setPixelSize(32);
     nameFont.setFamily(qsl("Bitstream Vera Sans"));
 
-    for (const auto& name: std::as_const(mightier_than_swords)) {
+    for (const auto& name : std::as_const(mightier_than_swords)) {
         QImage background(qsl(":/icons/frame_swords.png"));
         QPainter painter(&background);
         painter.setFont(nameFont);
@@ -1074,7 +1072,7 @@ void dlgAboutDialog::setSupportersTab(const QString& htmlHead)
         image_counter++;
     }
 
-    for (const auto& name: std::as_const(on_a_plaque)) {
+    for (const auto& name : std::as_const(on_a_plaque)) {
         QImage background(qsl(":/icons/frame_plaque.png"));
         QPainter painter(&background);
         painter.setFont(nameFont);
@@ -1101,17 +1099,19 @@ void dlgAboutDialog::setSupportersTab(const QString& htmlHead)
                 <p align="center"><br>%1<br></p>
                 %2
                 )")
-                    .arg(tr(R"(
+                                  .arg(tr(R"(
                             These formidable folks will be fondly remembered forever<br>for their generous financial support on Mudlet's patreon:
-                            )"), supporters_image_html);
+                            )"),
+                                       supporters_image_html);
     } else {
         supporters_text = qsl(R"(
                 <p align="center"><br>%1<br></p>
                 %2
                 )")
-                    .arg(tr(R"(
+                                  .arg(tr(R"(
                             These formidable folks will be fondly remembered forever<br>for their generous financial support on <a href="https://www.patreon.com/mudlet">Mudlet's patreon</a>:
-                            )"), supporters_image_html);
+                            )"),
+                                       supporters_image_html);
     }
 
     supportersDocument->setHtml(qsl("<html>%1<body>%2</body></html>").arg(htmlHead, supporters_text));
@@ -1161,41 +1161,41 @@ QString dlgAboutDialog::createBuildInfo() const
                    "<tr><td style=\"padding-right: 10px;\">%10</td><td>%11</td></tr>\n"
                    "%12"
                    "</table>")
-                .arg(tr("Technical information:"), // %1
-                     tr("Version"), // %2
-                     mudlet::self()->scmVersion, // %3
-                     tr("OS"), // %4
+                .arg(tr("Technical information:"),  // %1
+                     tr("Version"),                 // %2
+                     mudlet::self()->scmVersion,    // %3
+                     tr("OS"),                      // %4
                      QSysInfo::prettyProductName(), // %5
                      /*: This is shown for 32-Bit Windows builds when run on a
                       *64-Bit OS. \"WoW64\" stands for WindowOnWindows64.
                       */
                      isWow64Process.has_value() ? (isWow64Process.value() ? tr("CPU (WoW64)")
-                     /*: This is shown for 32-Bit or 64-Bit Windows builds when
+                                                                          /*: This is shown for 32-Bit or 64-Bit Windows builds when
                       *run on a Windows OS of the same bitness. It is the
                       *opposite case to that when \"WoW64\" is included - in
                       *those cases a 32-Bit application is run on 64-Bit
                       *hardware via an extra WindowOnWindows64 software layer.
                       */
                                                                           : tr("CPU (%1-bits)").arg(is64BitBuild ? 64 : 32))
-                     /*: This is shown for 32-Bit or 64-Bit Windows builds if
+                                                /*: This is shown for 32-Bit or 64-Bit Windows builds if
                       *the Windows API call to detect whether the WoW64 system
                       *is in use fails to work.
                       */
                                                 : tr("CPU"), // %6
-                     QSysInfo::currentCpuArchitecture(), // %7
+                     QSysInfo::currentCpuArchitecture(),     // %7
                      /*: This is shown when the Qt version used at run-time
                       *is different to that used during compilation - it not
                       *the usual case.
                       */
                      tr("Qt version (compilation)"), // %8
-                     QLatin1String(QT_VERSION_STR)) // %9
-                     /*: This is shown when the Qt version used at run-time
+                     QLatin1String(QT_VERSION_STR))  // %9
+                                                     /*: This is shown when the Qt version used at run-time
                       *is different to that used during compilation - it not
                       *the usual case.
                       */
-                .arg(tr("Qt version (run-time)"), // %10
-                     qVersion(), // %11
-                     upgradeTo64Bits); // %12
+                .arg(tr("Qt version (run-time)"),    // %10
+                     qVersion(),                     // %11
+                     upgradeTo64Bits);               // %12
     }
 
     // Else they are the same:
@@ -1207,35 +1207,35 @@ QString dlgAboutDialog::createBuildInfo() const
                "<tr><td style=\"padding-right: 10px;\">%8</td><td>%9</td></tr>\n"
                "%10"
                "</table>")
-            .arg(tr("Technical information:"), // %1
-                 tr("Version"), // %2
-                 mudlet::self()->scmVersion, // %3
-                 tr("OS"), // %4
+            .arg(tr("Technical information:"),  // %1
+                 tr("Version"),                 // %2
+                 mudlet::self()->scmVersion,    // %3
+                 tr("OS"),                      // %4
                  QSysInfo::prettyProductName(), // %5
                  /*: This is shown for 32-Bit Windows builds when run on a
                   *64-Bit OS. \"WoW64\" stands for WindowOnWindows64.
                   */
                  isWow64Process.has_value() ? (isWow64Process.value() ? tr("CPU (WoW64)")
-                 /*: This is shown for 32-Bit or 64-Bit Windows builds when
+                                                                      /*: This is shown for 32-Bit or 64-Bit Windows builds when
                   *a Windows OS of the same size. It is the opposite case
                   *to that when \"WoW64\" is included - in those cases a
                   *32-Bit application is run on 64-Bit hardware via an
                   *extra WindowOnWindows64 software layer.
                   */
                                                                       : tr("CPU (%1-bits)").arg(is64BitBuild ? 64 : 32))
-                 /*: This is shown when something has gone wrong and it is not
+                                            /*: This is shown when something has gone wrong and it is not
                   *possible to correctly determine whether there is an extra
                   *software layer being used to run a 32-Bit Windows build
                   *on 64-Bit hardware/OS.
                   */
                                             : tr("CPU"), // %6
-                 QSysInfo::currentCpuArchitecture(), // %7
+                 QSysInfo::currentCpuArchitecture(),     // %7
                  /*: This is shown when the same Qt version is used at run-time
                   *as was used during compilation - it is the usual case.
                   */
-                 tr("Qt version"), // %8
+                 tr("Qt version"),              // %8
                  QLatin1String(QT_VERSION_STR), // %9
-                 upgradeTo64Bits); // %10
+                 upgradeTo64Bits);              // %10
 #else
 
     // Anything else
@@ -1248,26 +1248,26 @@ QString dlgAboutDialog::createBuildInfo() const
                    "<tr><td style=\"padding-right: 10px;\">%8</td><td>%9</td></tr>\n"
                    "<tr><td style=\"padding-right: 10px;\">%10</td><td>%11</td></tr>\n"
                    "</table>")
-                .arg(tr("Technical information:"), // %1
-                     tr("Version"), // %2
-                     mudlet::self()->scmVersion, // %3
-                     tr("OS"), // %4
+                .arg(tr("Technical information:"),  // %1
+                     tr("Version"),                 // %2
+                     mudlet::self()->scmVersion,    // %3
+                     tr("OS"),                      // %4
                      QSysInfo::prettyProductName(), // %5
                      //: This is shown for all other OSes than Windows.
-                     tr("CPU"), // %6
+                     tr("CPU"),                          // %6
                      QSysInfo::currentCpuArchitecture(), // %7
                      /*: This is shown when the Qt version used at run-time
                       *is different to that used during compilation - it not
                       *the usual case.
                       */
                      tr("Qt version (compilation)"), // %8
-                     QLatin1String(QT_VERSION_STR)) // %9
-                     /*: This is shown when the Qt version used at run-time
+                     QLatin1String(QT_VERSION_STR))  // %9
+                                                     /*: This is shown when the Qt version used at run-time
                       *is different to that used during compilation - it not
                       *the usual case.
                       */
-                .arg(tr("Qt version (run-time)"), // %10
-                     qVersion()); // %11
+                .arg(tr("Qt version (run-time)"),    // %10
+                     qVersion());                    // %11
     }
 
     // Else they are the same:
@@ -1278,18 +1278,18 @@ QString dlgAboutDialog::createBuildInfo() const
                "<tr><td style=\"padding-right: 10px;\">%6</td><td>%7</td></tr>\n"
                "<tr><td style=\"padding-right: 10px;\">%8</td><td>%9</td></tr>\n"
                "</table>")
-            .arg(tr("Technical information:"), // %1
-                 tr("Version"), // %2
-                 mudlet::self()->scmVersion, // %3
-                 tr("OS"), // %4
+            .arg(tr("Technical information:"),  // %1
+                 tr("Version"),                 // %2
+                 mudlet::self()->scmVersion,    // %3
+                 tr("OS"),                      // %4
                  QSysInfo::prettyProductName(), // %5
                  //: This is shown for all other OSes than Windows.
-                 tr("CPU"), // %6
+                 tr("CPU"),                          // %6
                  QSysInfo::currentCpuArchitecture(), // %7
                  /*: This is shown when the same Qt version is used at run-time
                   *as was used during compilation - it is the usual case.
                   */
-                 tr("Qt version"), // %8
+                 tr("Qt version"),               // %8
                  QLatin1String(QT_VERSION_STR)); // %9
 #endif
 }

--- a/src/dlgColorTrigger.cpp
+++ b/src/dlgColorTrigger.cpp
@@ -53,18 +53,19 @@ dlgColorTrigger::dlgColorTrigger(QWidget* pParentWidget, TTrigger* pT, const boo
     connect(buttonBox->button(QDialogButtonBox::Apply), &QAbstractButton::clicked, this, &dlgColorTrigger::slot_moreColorsClicked);
 
     connect(buttonBox->button(QDialogButtonBox::Ignore), &QAbstractButton::clicked, this, &dlgColorTrigger::slot_resetColorClicked);
-    buttonBox->button(QDialogButtonBox::Ignore)->setToolTip(utils::richText(mIsBackground
-                                                                            ? tr("Click to make the color trigger ignore the text's background color - however choosing this for both foreground and background is an error.")
-                                                                            : tr("Click to make the color trigger ignore the text's foreground color - however choosing this for both foreground and background is an error.")));
+    buttonBox->button(QDialogButtonBox::Ignore)
+            ->setToolTip(utils::richText(mIsBackground
+                                                 ? tr("Click to make the color trigger ignore the text's background color - however choosing this for both foreground and background is an error.")
+                                                 : tr("Click to make the color trigger ignore the text's foreground color - however choosing this for both foreground and background is an error.")));
     // The Reset button means trigger only if the text is not set to anything
     // so is in the "default" colour - what ever THAT is:
     connect(buttonBox->button(QDialogButtonBox::Reset), &QAbstractButton::clicked, this, &dlgColorTrigger::slot_defaultColorClicked);
     buttonBox->button(QDialogButtonBox::Reset)->setText(tr("Default"));
-    buttonBox->button(QDialogButtonBox::Reset)->setToolTip(utils::richText(mIsBackground
-                                                                                ? tr("Click to make the color trigger when the text's background color has not been modified from its normal value.")                                                                          : tr("Click to make the color trigger when the text's foreground color has not been modified from its normal value.")));
-    groupBox_basicColors->setToolTip(utils::richText(mIsBackground
-                                                     ? tr("Click a color to make the trigger fire only when the text's background color matches the color number indicated.")
-                                                     : tr("Click a color to make the trigger fire only when the text's foreground color matches the color number indicated.")));
+    buttonBox->button(QDialogButtonBox::Reset)
+            ->setToolTip(utils::richText(mIsBackground ? tr("Click to make the color trigger when the text's background color has not been modified from its normal value.")
+                                                       : tr("Click to make the color trigger when the text's foreground color has not been modified from its normal value.")));
+    groupBox_basicColors->setToolTip(utils::richText(mIsBackground ? tr("Click a color to make the trigger fire only when the text's background color matches the color number indicated.")
+                                                                   : tr("Click a color to make the trigger fire only when the text's foreground color matches the color number indicated.")));
 
     connect(pushButton_setUsingRgbValue, &QAbstractButton::clicked, this, &dlgColorTrigger::slot_rgbColorClicked);
     connect(pushButton_setUsingGrayValue, &QAbstractButton::clicked, this, &dlgColorTrigger::slot_grayColorClicked);
@@ -188,13 +189,10 @@ dlgColorTrigger::dlgColorTrigger(QWidget* pParentWidget, TTrigger* pT, const boo
 
     // If the current is ignored or default set the focus onto them:
     if ((mIsBackground && mpTrigger->mColorTriggerBgAnsi == TTrigger::scmDefault) || (!mIsBackground && mpTrigger->mColorTriggerFgAnsi == TTrigger::scmDefault)) {
-
         buttonBox->button(QDialogButtonBox::Reset)->setFocus();
 
     } else if ((mIsBackground && mpTrigger->mColorTriggerBgAnsi == TTrigger::scmIgnored) || (!mIsBackground && mpTrigger->mColorTriggerFgAnsi == TTrigger::scmIgnored)) {
-
         buttonBox->button(QDialogButtonBox::Ignore)->setFocus();
-
     }
 }
 
@@ -204,9 +202,7 @@ void dlgColorTrigger::setupBasicButton(QPushButton* pButton, const int ansiColor
         slot_basicColorClicked(ansiColor);
     });
 
-    if ((mIsBackground && (mpTrigger->mColorTriggerBgAnsi == ansiColor))
-     || (!mIsBackground && (mpTrigger->mColorTriggerFgAnsi == ansiColor))) {
-
+    if ((mIsBackground && (mpTrigger->mColorTriggerBgAnsi == ansiColor)) || (!mIsBackground && (mpTrigger->mColorTriggerFgAnsi == ansiColor))) {
         pButton->setFocus();
     }
 
@@ -223,8 +219,7 @@ void dlgColorTrigger::slot_rgbColorChanged()
     // Use the same stylesheet code as in the main editor and for the basic 16
     // color buttons but because this is a QLabel we need to replace one word in
     // the generated stylesheet:
-    label_rgbValue->setStyleSheet(dlgTriggerEditor::generateButtonStyleSheet(mRgbAnsiColor)
-                                  .replace(QLatin1String("QPushButton"), QLatin1String("QLabel")));
+    label_rgbValue->setStyleSheet(dlgTriggerEditor::generateButtonStyleSheet(mRgbAnsiColor).replace(QLatin1String("QPushButton"), QLatin1String("QLabel")));
 }
 
 void dlgColorTrigger::slot_setRBGButtonFocus()
@@ -242,8 +237,7 @@ void dlgColorTrigger::slot_grayColorChanged(int sliderValue)
     // Use the same stylesheet code as in the main editor and for the basic 16
     // color buttons but because this is a QLabel we need to replace one word in
     // the generated stylesheet:
-    label_grayValue->setStyleSheet(dlgTriggerEditor::generateButtonStyleSheet(mGrayAnsiColor)
-                                   .replace(QLatin1String("QPushButton"), QLatin1String("QLabel")));
+    label_grayValue->setStyleSheet(dlgTriggerEditor::generateButtonStyleSheet(mGrayAnsiColor).replace(QLatin1String("QPushButton"), QLatin1String("QLabel")));
 
     if (horizontalSlider_gray->value() != sliderValue) {
         // This slot is also used to set the value so it may need to reposition

--- a/src/dlgComposer.cpp
+++ b/src/dlgComposer.cpp
@@ -64,7 +64,7 @@ void dlgComposer::slot_save()
     this->hide();
 }
 
-void dlgComposer::init(const QString &newTitle, const QString &newText)
+void dlgComposer::init(const QString& newTitle, const QString& newText)
 {
     title->setText(newTitle);
     edit->setPlainText(newText);
@@ -229,8 +229,7 @@ void dlgComposer::slot_contextMenu(const QPoint& pos)
     if (mpHost && mpHost->mEnableSpellCheck) {
         // Convert from widget coordinates to viewport coordinates
         QPoint viewportPos = edit->viewport()->mapFromParent(pos);
-        QMouseEvent mouseEvent(QEvent::MouseButtonPress, viewportPos, edit->mapToGlobal(pos),
-                               Qt::RightButton, Qt::RightButton, Qt::NoModifier);
+        QMouseEvent mouseEvent(QEvent::MouseButtonPress, viewportPos, edit->mapToGlobal(pos), Qt::RightButton, Qt::RightButton, Qt::NoModifier);
         fillSpellCheckList(&mouseEvent, popup);
     }
 

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -392,10 +392,10 @@ void dlgConnectionProfiles::indicatePackagesInstallOnConnect(QStringList package
     packageInfoLayout->setContentsMargins(8, 8, 8, 8);
     packageGroupBox->setStyleSheet("QGroupBox:title { padding-left: 8px; }");
 
-    for (const QString &package : packages) {
+    for (const QString& package : packages) {
         QFileInfo fileInfo(package);
         QString packageName = fileInfo.baseName();
-        QLabel *packageLabel = new QLabel(packageName);
+        QLabel* packageLabel = new QLabel(packageName);
         packageInfoLayout->addWidget(packageLabel);
     }
 
@@ -447,17 +447,16 @@ void dlgConnectionProfiles::writeSecurePassword(const QString& profile, const QS
     // Use async API for QtKeychain integration with file fallback
     auto* credManager = new CredentialManager();
 
-    credManager->storePassword(profile, "character", pass,
-        [credManager, profile](bool success, const QString& errorMessage) {
-            if (success) {
-                qDebug() << "dlgConnectionProfiles: Successfully stored password for profile" << profile;
-            } else {
-                qWarning() << "dlgConnectionProfiles: Failed to store password for profile" << profile << ":" << errorMessage;
-            }
+    credManager->storePassword(profile, "character", pass, [credManager, profile](bool success, const QString& errorMessage) {
+        if (success) {
+            qDebug() << "dlgConnectionProfiles: Successfully stored password for profile" << profile;
+        } else {
+            qWarning() << "dlgConnectionProfiles: Failed to store password for profile" << profile << ":" << errorMessage;
+        }
 
-            // Clean up the credential manager
-            credManager->deleteLater();
-        });
+        // Clean up the credential manager
+        credManager->deleteLater();
+    });
 }
 
 void dlgConnectionProfiles::deleteSecurePassword(const QString& profile) const
@@ -465,17 +464,16 @@ void dlgConnectionProfiles::deleteSecurePassword(const QString& profile) const
     // Use async API for QtKeychain integration with file fallback
     auto* credManager = new CredentialManager();
 
-    credManager->removePassword(profile, "character",
-        [credManager, profile](bool success, const QString& errorMessage) {
-            if (success) {
-                qDebug() << "dlgConnectionProfiles: Successfully removed password for profile" << profile;
-            } else {
-                qWarning() << "dlgConnectionProfiles: Failed to remove password for profile" << profile << ":" << errorMessage;
-            }
+    credManager->removePassword(profile, "character", [credManager, profile](bool success, const QString& errorMessage) {
+        if (success) {
+            qDebug() << "dlgConnectionProfiles: Successfully removed password for profile" << profile;
+        } else {
+            qWarning() << "dlgConnectionProfiles: Failed to remove password for profile" << profile << ":" << errorMessage;
+        }
 
-            // Clean up the credential manager
-            credManager->deleteLater();
-        });
+        // Clean up the credential manager
+        credManager->deleteLater();
+    });
 }
 
 void dlgConnectionProfiles::slot_updateLogin(const QString& login)
@@ -620,51 +618,49 @@ void dlgConnectionProfiles::slot_saveName()
     // Check for orphaned keychain entries when creating a new profile with a name
     // that doesn't exist as a directory but might have keychain entries from
     // a previously deleted profile (deleted outside Mudlet interface)
-    if (mudlet::self()->storingPasswordsSecurely() &&
-        currentProfileEditName == tr("new profile name") &&
-        !QDir(mudlet::getMudletPath(enums::profileHomePath, newProfileName)).exists()) {
-
+    if (mudlet::self()->storingPasswordsSecurely() && currentProfileEditName == tr("new profile name") && !QDir(mudlet::getMudletPath(enums::profileHomePath, newProfileName)).exists()) {
         // Check if there are orphaned keychain entries for this profile name
         auto* credManager = new CredentialManager(this);
-        credManager->retrievePassword(newProfileName, "character",
-            [this, credManager, newProfileName, pItem, newProfileHost, newProfilePort, newProfileSslTsl]
-            (bool foundCharacterEntry, const QString& characterPassword, const QString& errorMessage) {
-                Q_UNUSED(characterPassword)
-                Q_UNUSED(errorMessage)
+        credManager->retrievePassword(
+                newProfileName,
+                "character",
+                [this, credManager, newProfileName, pItem, newProfileHost, newProfilePort, newProfileSslTsl](bool foundCharacterEntry, const QString& characterPassword, const QString& errorMessage) {
+                    Q_UNUSED(characterPassword)
+                    Q_UNUSED(errorMessage)
 
-                credManager->retrievePassword(newProfileName, "proxy",
-                    [this, credManager, newProfileName, pItem, newProfileHost, newProfilePort, newProfileSslTsl, foundCharacterEntry]
-                    (bool foundProxyEntry, const QString& proxyPassword, const QString& errorMessage) {
-                        Q_UNUSED(proxyPassword)
-                        Q_UNUSED(errorMessage)
+                    credManager->retrievePassword(newProfileName,
+                                                  "proxy",
+                                                  [this, credManager, newProfileName, pItem, newProfileHost, newProfilePort, newProfileSslTsl, foundCharacterEntry](
+                                                          bool foundProxyEntry, const QString& proxyPassword, const QString& errorMessage) {
+                                                      Q_UNUSED(proxyPassword)
+                                                      Q_UNUSED(errorMessage)
 
-                        // If we found any orphaned entries, clean them up
-                        if (foundCharacterEntry || foundProxyEntry) {
-                            if (foundCharacterEntry) {
-                                credManager->removeCredential(newProfileName, "character",
-                                    [newProfileName](bool success, const QString& errorMessage) {
-                                        if (!success) {
-                                            qWarning() << "dlgConnectionProfiles: Failed to clean up orphaned character password for" << newProfileName << ":" << errorMessage;
-                                        }
-                                    });
-                            }
+                                                      // If we found any orphaned entries, clean them up
+                                                      if (foundCharacterEntry || foundProxyEntry) {
+                                                          if (foundCharacterEntry) {
+                                                              credManager->removeCredential(newProfileName, "character", [newProfileName](bool success, const QString& errorMessage) {
+                                                                  if (!success) {
+                                                                      qWarning()
+                                                                              << "dlgConnectionProfiles: Failed to clean up orphaned character password for" << newProfileName << ":" << errorMessage;
+                                                                  }
+                                                              });
+                                                          }
 
-                            if (foundProxyEntry) {
-                                credManager->removeCredential(newProfileName, "proxy",
-                                    [newProfileName](bool success, const QString& errorMessage) {
-                                        if (!success) {
-                                            qWarning() << "dlgConnectionProfiles: Failed to clean up orphaned proxy password for" << newProfileName << ":" << errorMessage;
-                                        }
-                                    });
-                            }
-                        }
+                                                          if (foundProxyEntry) {
+                                                              credManager->removeCredential(newProfileName, "proxy", [newProfileName](bool success, const QString& errorMessage) {
+                                                                  if (!success) {
+                                                                      qWarning() << "dlgConnectionProfiles: Failed to clean up orphaned proxy password for" << newProfileName << ":" << errorMessage;
+                                                                  }
+                                                              });
+                                                          }
+                                                      }
 
-                        credManager->deleteLater();
+                                                      credManager->deleteLater();
 
-                        // Continue with normal profile creation flow
-                        continueProfileSave(pItem, newProfileName, newProfileHost, newProfilePort, newProfileSslTsl);
-                    });
-            });
+                                                      // Continue with normal profile creation flow
+                                                      continueProfileSave(pItem, newProfileName, newProfileHost, newProfilePort, newProfileSslTsl);
+                                                  });
+                });
 
         return; // Exit here - continueProfileSave will be called from the callback
     }
@@ -676,9 +672,7 @@ void dlgConnectionProfiles::slot_saveName()
     continueProfileSave(pItem, newProfileName, newProfileHost, newProfilePort, newProfileSslTsl);
 }
 
-void dlgConnectionProfiles::continueProfileSave(QListWidgetItem* pItem, const QString& newProfileName,
-                                               const QString& newProfileHost, const QString& newProfilePort,
-                                               const int newProfileSslTsl)
+void dlgConnectionProfiles::continueProfileSave(QListWidgetItem* pItem, const QString& newProfileName, const QString& newProfileHost, const QString& newProfilePort, const int newProfileSslTsl)
 {
     const QString currentProfileEditName = pItem->data(csmNameRole).toString();
     setItemName(pItem, newProfileName);
@@ -812,23 +806,21 @@ void dlgConnectionProfiles::reallyDeleteProfile(const QString& profile)
         auto* credManager = new CredentialManager(this);
 
         // Clean up character password entry
-        credManager->removeCredential(profile, "character",
-            [profile](bool success, const QString& errorMessage) {
-                if (!success) {
-                    qWarning() << "dlgConnectionProfiles: Failed to clean up character password for deleted profile" << profile << ":" << errorMessage;
-                }
-            });
+        credManager->removeCredential(profile, "character", [profile](bool success, const QString& errorMessage) {
+            if (!success) {
+                qWarning() << "dlgConnectionProfiles: Failed to clean up character password for deleted profile" << profile << ":" << errorMessage;
+            }
+        });
 
         // Clean up proxy password entry (if any)
-        credManager->removeCredential(profile, "proxy",
-            [credManager, profile](bool success, const QString& errorMessage) {
-                if (!success) {
-                    qWarning() << "dlgConnectionProfiles: Failed to clean up proxy password for deleted profile" << profile << ":" << errorMessage;
-                }
+        credManager->removeCredential(profile, "proxy", [credManager, profile](bool success, const QString& errorMessage) {
+            if (!success) {
+                qWarning() << "dlgConnectionProfiles: Failed to clean up proxy password for deleted profile" << profile << ":" << errorMessage;
+            }
 
-                // Clean up the credential manager after both operations
-                credManager->deleteLater();
-            });
+            // Clean up the credential manager after both operations
+            credManager->deleteLater();
+        });
     }
 
     // record the deleted default profile so it does not get re-created in the future
@@ -928,7 +920,8 @@ QPair<bool, QString> dlgConnectionProfiles::writeProfileData(const QString& prof
         }
         ofs << what;
         if (!file.commit()) {
-            qDebug().noquote().nospace() << "dlgConnectionProfiles::writeProfileData(...) ERROR - writing profile: \"" << profile << "\", item: \"" << item << "\", reason: \"" << file.errorString() << "\".";
+            qDebug().noquote().nospace() << "dlgConnectionProfiles::writeProfileData(...) ERROR - writing profile: \"" << profile << "\", item: \"" << item << "\", reason: \"" << file.errorString()
+                                         << "\".";
         }
     }
 
@@ -1101,9 +1094,8 @@ void dlgConnectionProfiles::slot_itemClicked(QListWidgetItem* pItem)
         } else if (entry == QLatin1String("autosave.xml")) {
             const QFileInfo fileInfo(dir, entry);
             auto lastModified = fileInfo.lastModified();
-            profile_history->addItem(QIcon::fromTheme(qsl("document-save"), QIcon(qsl(":/icons/document-save.png"))),
-                                     mudlet::self()->getUserLocale().toString(lastModified, mDateTimeFormat),
-                                     QVariant(entry));
+            profile_history->addItem(
+                    QIcon::fromTheme(qsl("document-save"), QIcon(qsl(":/icons/document-save.png"))), mudlet::self()->getUserLocale().toString(lastModified, mDateTimeFormat), QVariant(entry));
         } else if (entry.endsWith(QLatin1String(".xml"), Qt::CaseInsensitive)) {
             profile_history->addItem(entry, QVariant(entry)); // if it has a custom name, use it as it is
         }
@@ -1373,22 +1365,21 @@ void dlgConnectionProfiles::loadSecuredPassword(const QString& profile, L callba
     // Use async API for QtKeychain integration with file fallback
     auto* credManager = new CredentialManager();
 
-    credManager->retrievePassword(profile, "character",
-        [credManager, callback = std::move(callback)](bool success, const QString& password, const QString& errorMessage) {
-            if (success) {
-                callback(password);
-                QString passwordCopy = password; // Make a copy for secure clearing
-                SecureStringUtils::secureStringClear(passwordCopy);
-            } else {
-                if (!errorMessage.isEmpty()) {
-                    qDebug() << "dlgConnectionProfiles: Failed to retrieve password:" << errorMessage;
-                }
-                callback(QString()); // Call with empty string on failure
+    credManager->retrievePassword(profile, "character", [credManager, callback = std::move(callback)](bool success, const QString& password, const QString& errorMessage) {
+        if (success) {
+            callback(password);
+            QString passwordCopy = password; // Make a copy for secure clearing
+            SecureStringUtils::secureStringClear(passwordCopy);
+        } else {
+            if (!errorMessage.isEmpty()) {
+                qDebug() << "dlgConnectionProfiles: Failed to retrieve password:" << errorMessage;
             }
+            callback(QString()); // Call with empty string on failure
+        }
 
-            // Clean up the credential manager
-            credManager->deleteLater();
-        });
+        // Clean up the credential manager
+        credManager->deleteLater();
+    });
 }
 
 std::optional<QColor> getCustomColor(const QString& profileName)
@@ -1450,8 +1441,7 @@ void dlgConnectionProfiles::slot_setCustomIcon()
     QSettings& settings = *mudlet::getQSettings();
     QString lastDir = settings.value("lastFileDialogLocation", QDir::homePath()).toString();
 
-    const QString imageLocation = QFileDialog::getOpenFileName(
-            this, tr("Select custom image for profile (should be 120x30)"), lastDir, tr("Images (%1)").arg(qsl("*.png *.gif *.jpg")));
+    const QString imageLocation = QFileDialog::getOpenFileName(this, tr("Select custom image for profile (should be 120x30)"), lastDir, tr("Images (%1)").arg(qsl("*.png *.gif *.jpg")));
     if (imageLocation.isEmpty()) {
         return;
     }
@@ -1720,11 +1710,10 @@ void dlgConnectionProfiles::loadProfile(bool alsoConnect)
     Host* pHostBeforeLoad = mudlet::self()->getHostManager().getHost(profile_name);
     bool hostExistedBefore = (pHostBeforeLoad != nullptr);
 
-    Host *pHost = mudlet::self()->loadProfile(profile_name, alsoConnect, profile_history->currentData().toString());
+    Host* pHost = mudlet::self()->loadProfile(profile_name, alsoConnect, profile_history->currentData().toString());
 
     // overwrite the generic profile with user supplied name, url and login information
     if (pHost) {
-
         Host* pActiveHost = mudlet::self()->getActiveHost();
 
         if (pActiveHost && pActiveHost->getName() == profile_name) {
@@ -1908,11 +1897,12 @@ bool dlgConnectionProfiles::validateProfile()
              *  line can be italicised and spaced out - if appropriate for
              *  the locale.
              */
-            notificationAreaMessageBox->setText(qsl("%1%2\n\n%3").arg(!notificationAreaMessageBox->text().isEmpty() ? notificationAreaMessageBox->text().append(QChar::LineFeed) : QString(),
-                                                                      tr("Please enter the URL of the Game server.\n\n"
-                                                                         "<i>SSL/TLS connections require a URL, as an IP address is not a suitable "
-                                                                         "identifier for the certification of the Game Server.</i>"),
-                                                                      check.errorString()));
+            notificationAreaMessageBox->setText(qsl("%1%2\n\n%3")
+                                                        .arg(!notificationAreaMessageBox->text().isEmpty() ? notificationAreaMessageBox->text().append(QChar::LineFeed) : QString(),
+                                                             tr("Please enter the URL of the Game server.\n\n"
+                                                                "<i>SSL/TLS connections require a URL, as an IP address is not a suitable "
+                                                                "identifier for the certification of the Game Server.</i>"),
+                                                             check.errorString()));
             host_name_entry->setPalette(mErrorPalette);
             validUrl = false;
             valid = false;
@@ -2283,52 +2273,49 @@ void dlgConnectionProfiles::slot_loadPasswordAsync()
     if (mudlet::self()->storingPasswordsSecurely()) {
         mKeychainOperationInProgress = true;
         auto* credManager = new CredentialManager(this);
-        credManager->retrievePassword(profile_name, "character",
-            [this, credManager, profile_name](bool success, const QString& retrievedPassword, const QString& errorMessage) {
-                // Clear the operation flag first
-                mKeychainOperationInProgress = false;
+        credManager->retrievePassword(profile_name, "character", [this, credManager, profile_name](bool success, const QString& retrievedPassword, const QString& errorMessage) {
+            // Clear the operation flag first
+            mKeychainOperationInProgress = false;
 
-                // Check if profile selection has changed while we were waiting
-                if (listWidget_profiles->currentItem() &&
-                    listWidget_profiles->currentItem()->data(csmNameRole).toString() == profile_name) {
-
-                    if (success) {
-                        // Keychain operation succeeded - set the password (even if empty)
-                        // Temporarily block textChanged signal to avoid triggering save on programmatic setText
-                        {
-                            const QSignalBlocker blocker(character_password_entry);
-                            character_password_entry->setText(retrievedPassword);
-                        }
-
-                        if (retrievedPassword.isEmpty()) {
-                            qDebug() << "dlgConnectionProfiles: Keychain returned empty password for" << profile_name;
-                        } else {
-                            qDebug() << "dlgConnectionProfiles: Successfully loaded password from keychain for" << profile_name;
-                        }
-                    } else {
-                        // Fallback to QSettings only if credential retrieval failed
-                        loadPasswordFromSettings(profile_name);
-                        qDebug() << "dlgConnectionProfiles: Credential retrieval unsuccessful for" << profile_name << "-" << errorMessage;
+            // Check if profile selection has changed while we were waiting
+            if (listWidget_profiles->currentItem() && listWidget_profiles->currentItem()->data(csmNameRole).toString() == profile_name) {
+                if (success) {
+                    // Keychain operation succeeded - set the password (even if empty)
+                    // Temporarily block textChanged signal to avoid triggering save on programmatic setText
+                    {
+                        const QSignalBlocker blocker(character_password_entry);
+                        character_password_entry->setText(retrievedPassword);
                     }
+
+                    if (retrievedPassword.isEmpty()) {
+                        qDebug() << "dlgConnectionProfiles: Keychain returned empty password for" << profile_name;
+                    } else {
+                        qDebug() << "dlgConnectionProfiles: Successfully loaded password from keychain for" << profile_name;
+                    }
+                } else {
+                    // Fallback to QSettings only if credential retrieval failed
+                    loadPasswordFromSettings(profile_name);
+                    qDebug() << "dlgConnectionProfiles: Credential retrieval unsuccessful for" << profile_name << "-" << errorMessage;
                 }
+            }
 
-                // Check if there's a pending connection waiting for this password load
-                // (do this regardless of profile selection state to avoid hanging)
-                if (!mPendingProfileLoad.isEmpty() && mPendingProfileLoad == profile_name) {
-                    qDebug() << "dlgConnectionProfiles: Password load completed, proceeding with pending connection for" << profile_name;
+            // Check if there's a pending connection waiting for this password load
+            // (do this regardless of profile selection state to avoid hanging)
+            if (!mPendingProfileLoad.isEmpty() && mPendingProfileLoad == profile_name) {
+                qDebug() << "dlgConnectionProfiles: Password load completed, proceeding with pending connection for" << profile_name;
 
-                    // Clear pending state
-                    QString profileToLoad = mPendingProfileLoad;
-                    bool shouldConnect = mPendingConnect;
-                    mPendingProfileLoad.clear();
+                // Clear pending state
+                QString profileToLoad = mPendingProfileLoad;
+                bool shouldConnect = mPendingConnect;
+                mPendingProfileLoad.clear();
 
-                    // Proceed with the connection
-                    loadProfile(shouldConnect);
-                    QDialog::accept();
-                }
+                // Proceed with the connection
+                loadProfile(shouldConnect);
+                QDialog::accept();
+            }
 
-                credManager->deleteLater();
-            });
+            credManager->deleteLater();
+        });
     } else {
         // Secure storage disabled, use QSettings directly
         loadPasswordFromSettings(profile_name);

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -273,12 +273,12 @@ void dlgIRC::setupCommandParser()
     commandParser->addCommand(IrcCommand::Whois, qsl("WHOIS <user>"));
     commandParser->addCommand(IrcCommand::Whowas, qsl("WHOWAS <user>"));
 
-    commandParser->addCommand(IrcCommand::Custom, qsl("MSG <target> <message...>")); // replaces the old /msg command.
-    commandParser->addCommand(IrcCommand::Custom, qsl("CLEAR (<buffer>)"));          // clears the given buffer, or the current active if none are given.
-    commandParser->addCommand(IrcCommand::Custom, qsl("CLOSE (<buffer>)"));          // closes the buffer and removes it from the list, uses current active buffer if none are given.
-    commandParser->addCommand(IrcCommand::Custom, qsl("RECONNECT"));                 // Issues a Quit command and closes the IRC connection then reconnects to the IRC server.
-    commandParser->addCommand(IrcCommand::Custom, qsl("HELP (<command>)"));          // displays some help information about a given command or lists all available commands.
-    commandParser->addCommand(IrcCommand::Custom, qsl("MSGLIMIT <limit> (<buffer>)"));  // sets buffer limit on all buffers and updates settings, or sets buffer limit on given buffer.
+    commandParser->addCommand(IrcCommand::Custom, qsl("MSG <target> <message...>"));   // replaces the old /msg command.
+    commandParser->addCommand(IrcCommand::Custom, qsl("CLEAR (<buffer>)"));            // clears the given buffer, or the current active if none are given.
+    commandParser->addCommand(IrcCommand::Custom, qsl("CLOSE (<buffer>)"));            // closes the buffer and removes it from the list, uses current active buffer if none are given.
+    commandParser->addCommand(IrcCommand::Custom, qsl("RECONNECT"));                   // Issues a Quit command and closes the IRC connection then reconnects to the IRC server.
+    commandParser->addCommand(IrcCommand::Custom, qsl("HELP (<command>)"));            // displays some help information about a given command or lists all available commands.
+    commandParser->addCommand(IrcCommand::Custom, qsl("MSGLIMIT <limit> (<buffer>)")); // sets buffer limit on all buffers and updates settings, or sets buffer limit on given buffer.
 }
 
 void dlgIRC::setupBuffers()
@@ -305,7 +305,7 @@ bool dlgIRC::processCustomCommand(IrcCommand* cmd)
 
     const QString cmdName = QString(cmd->parameters().at(0)).toUpper();
     if (cmdName == "CLEAR") {
-        auto * buffer = bufferList->currentIndex().data(Irc::BufferRole).value<IrcBuffer*>();
+        auto* buffer = bufferList->currentIndex().data(Irc::BufferRole).value<IrcBuffer*>();
         if (cmd->parameters().count() > 1) {
             const QString bufferName = cmd->parameters().at(1);
             //QString cBufferName = buffer->title();
@@ -319,7 +319,7 @@ bool dlgIRC::processCustomCommand(IrcCommand* cmd)
         return true;
     }
     if (cmdName == "CLOSE") {
-        auto * buffer = bufferList->currentIndex().data(Irc::BufferRole).value<IrcBuffer*>();
+        auto* buffer = bufferList->currentIndex().data(Irc::BufferRole).value<IrcBuffer*>();
         if (cmd->parameters().count() > 1) {
             const QString bufferName = cmd->parameters().at(1);
             if (!bufferName.isEmpty()) {
@@ -547,7 +547,7 @@ void dlgIRC::slot_onBufferRemoved(IrcBuffer* buffer)
 
 void dlgIRC::slot_onBufferActivated(const QModelIndex& index)
 {
-    auto * buffer = index.data(Irc::BufferRole).value<IrcBuffer*>();
+    auto* buffer = index.data(Irc::BufferRole).value<IrcBuffer*>();
     // document, user list and nick completion for the current buffer
     ircBrowser->setDocument(bufferTexts.value(buffer));
     ircBrowser->verticalScrollBar()->triggerAction(QScrollBar::SliderToMaximum);
@@ -561,7 +561,7 @@ void dlgIRC::slot_onBufferActivated(const QModelIndex& index)
 
 void dlgIRC::slot_onUserActivated(const QModelIndex& index)
 {
-    auto * user = index.data(Irc::UserRole).value<IrcUser*>();
+    auto* user = index.data(Irc::UserRole).value<IrcUser*>();
     if (user) {
         // ensure the "user" isn't our own client, can only do this by name.
         if (user->name() == mNickName) {
@@ -596,7 +596,7 @@ void dlgIRC::slot_receiveMessage(IrcMessage* message)
         mPingStarted = 0;
     }
 
-    auto * buffer = qobject_cast<IrcBuffer*>(sender());
+    auto* buffer = qobject_cast<IrcBuffer*>(sender());
     if (!buffer) {
         buffer = bufferList->currentIndex().data(Irc::BufferRole).value<IrcBuffer*>();
     }
@@ -708,21 +708,18 @@ QString dlgIRC::getMessageTarget(IrcMessage* msg, const QString& bufferName)
     QString target = bufferName;
     switch (msg->type()) {
     case IrcMessage::Notice: {
-        auto * msgNotice = static_cast<IrcNoticeMessage*>(msg);
+        auto* msgNotice = static_cast<IrcNoticeMessage*>(msg);
         target = msgNotice->target();
         break;
     }
     case IrcMessage::Private: {
-        auto * msgPrivate = static_cast<IrcPrivateMessage*>(msg);
+        auto* msgPrivate = static_cast<IrcPrivateMessage*>(msg);
         target = msgPrivate->target();
         break;
     }
     default:
         // Other message types are not expected - I hope - SlySven
-        qWarning().noquote().nospace() << "dlgIRC::getMessageTarget(..., \""
-                                       << bufferName
-                                       << "\") WARNING - message of type: "
-                                       << msg->type()
+        qWarning().noquote().nospace() << "dlgIRC::getMessageTarget(..., \"" << bufferName << "\") WARNING - message of type: " << msg->type()
                                        << " not explicitly handled, this needs fixing by Mudlet Makers...";
     }
     return target;

--- a/src/dlgMapLabel.cpp
+++ b/src/dlgMapLabel.cpp
@@ -246,7 +246,8 @@ void dlgMapLabel::slot_updateControls()
     lineEdit_font->setText(tr("%1 %2").arg(font.family(), font.styleName()));
     pushButton_fgColor->setStyleSheet(BUTTON_STYLESHEET.arg(QString::number(fgColor.red()), QString::number(fgColor.green()), QString::number(fgColor.blue()), QString::number(fgColor.alpha())));
     pushButton_bgColor->setStyleSheet(BUTTON_STYLESHEET.arg(QString::number(bgColor.red()), QString::number(bgColor.green()), QString::number(bgColor.blue()), QString::number(bgColor.alpha())));
-    pushButton_outlineColor->setStyleSheet(BUTTON_STYLESHEET.arg(QString::number(outlineColor.red()), QString::number(outlineColor.green()), QString::number(outlineColor.blue()), QString::number(outlineColor.alpha())));
+    pushButton_outlineColor->setStyleSheet(
+            BUTTON_STYLESHEET.arg(QString::number(outlineColor.red()), QString::number(outlineColor.green()), QString::number(outlineColor.blue()), QString::number(outlineColor.alpha())));
     lineEdit_image->setText(imagePath);
 }
 

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -39,7 +39,7 @@
 
 using namespace std::chrono_literals;
 
-dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
+dlgMapper::dlgMapper(QWidget* parent, Host* pH, TMap* pM)
 : QWidget(parent)
 , mpMap(pM)
 , mpHost(pH)
@@ -120,7 +120,6 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
 
     connect(mpMap->mMapInfoContributorManager, &MapInfoContributorManager::signal_contributorsUpdated, this, &dlgMapper::slot_updateInfoContributors);
     slot_updateInfoContributors();
-
 }
 
 int dlgMapper::getCurrentShownAreaIndex()
@@ -253,7 +252,7 @@ void dlgMapper::slot_toggle3DView(const bool is3DMode)
         connect(slider_xRot, SIGNAL(valueChanged(int)), glWidget, SLOT(slot_setCameraPositionX(int)));
         connect(slider_yRot, SIGNAL(valueChanged(int)), glWidget, SLOT(slot_setCameraPositionY(int)));
         connect(slider_zRot, SIGNAL(valueChanged(int)), glWidget, SLOT(slot_setCameraPositionZ(int)));
-        
+
         // Player icon adjustment controls
         connect(slider_playerIconHeight, SIGNAL(valueChanged(int)), glWidget, SLOT(slot_setPlayerIconHeight(int)));
         connect(slider_playerIconRotX, SIGNAL(valueChanged(int)), glWidget, SLOT(slot_setPlayerIconRotationX(int)));
@@ -261,7 +260,7 @@ void dlgMapper::slot_toggle3DView(const bool is3DMode)
         connect(slider_playerIconRotZ, SIGNAL(valueChanged(int)), glWidget, SLOT(slot_setPlayerIconRotationZ(int)));
         connect(slider_playerIconScale, SIGNAL(valueChanged(int)), glWidget, SLOT(slot_setPlayerIconScale(int)));
         connect(pushButton_resetPlayerIcon, SIGNAL(clicked()), glWidget, SLOT(slot_resetPlayerIcon()));
-        
+
         // Connect reset signal from glWidget back to sliders (cast to ModernGLWidget*)
         if (ModernGLWidget* modernWidget = qobject_cast<ModernGLWidget*>(glWidget)) {
             connect(modernWidget, &ModernGLWidget::resetPlayerIconSliders, this, [this](int height, int rotX, int rotY, int rotZ, int scale) {
@@ -281,11 +280,11 @@ void dlgMapper::slot_toggle3DView(const bool is3DMode)
         widget_3DControls->setVisible(true);
         widget_playerIconControls->setVisible(mpHost && mpHost->experimentEnabled("experiment.3d-player-icon")
 #ifdef DEBUG_PLAYER_ICON_CONTROLS
-                                               && true
+                                              && true
 #else
-                                               && false
+                                              && false
 #endif
-                                               );
+        );
     } else {
         // workaround for buttons reloading oddly
         QTimer::singleShot(100ms, this, [this]() {
@@ -462,9 +461,18 @@ void dlgMapper::recreate3DWidget()
 #endif
 }
 
-void dlgMapper::paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, Host* pHost, TMap* pMap,
-                            int roomID, int displayAreaId, int selectionSize, QColor& infoColor,
-                            int xOffset, int yOffset, int widgetWidth, int fontHeight)
+void dlgMapper::paintMapInfo(const QElapsedTimer& renderTimer,
+                             QPainter& painter,
+                             Host* pHost,
+                             TMap* pMap,
+                             int roomID,
+                             int displayAreaId,
+                             int selectionSize,
+                             QColor& infoColor,
+                             int xOffset,
+                             int yOffset,
+                             int widgetWidth,
+                             int fontHeight)
 {
     if (!pMap || !pMap->mMapInfoContributorManager || !pHost) {
         return;
@@ -497,17 +505,8 @@ void dlgMapper::paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter
     }
 
 #ifdef QT_DEBUG
-    yOffset += paintMapInfoContributor(painter,
-                         xOffset,
-                         yOffset,
-                         {false,
-                          false,
-                          QObject::tr("render time: %1S")
-                                  .arg(renderTimer.nsecsElapsed() * 1.0e-9, 0, 'f', 3),
-                          infoColor},
-                         pHost->mMapInfoBg,
-                         fontHeight,
-                         widgetWidth);
+    yOffset += paintMapInfoContributor(
+            painter, xOffset, yOffset, {false, false, QObject::tr("render time: %1S").arg(renderTimer.nsecsElapsed() * 1.0e-9, 0, 'f', 3), infoColor}, pHost->mMapInfoBg, fontHeight, widgetWidth);
 #else
     Q_UNUSED(renderTimer)
 #endif
@@ -519,9 +518,7 @@ void dlgMapper::paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter
     }
 }
 
-int dlgMapper::paintMapInfoContributor(QPainter& painter, int xOffset, int yOffset,
-                                      const MapInfoProperties& properties, QColor bgColor, int fontHeight,
-                                      int widgetWidth)
+int dlgMapper::paintMapInfoContributor(QPainter& painter, int xOffset, int yOffset, const MapInfoProperties& properties, QColor bgColor, int fontHeight, int widgetWidth)
 {
     if (properties.text.isEmpty()) {
         return 0;
@@ -536,15 +533,21 @@ int dlgMapper::paintMapInfoContributor(QPainter& painter, int xOffset, int yOffs
     const int infoHeight = fontHeight;
     QRect testRect;
     QRect mapInfoRect = QRect(xOffset, yOffset, widgetWidth - 10 - xOffset, infoHeight);
-    testRect = painter.boundingRect(mapInfoRect.left() + 10, mapInfoRect.top(), mapInfoRect.width() - 20, mapInfoRect.height() - 20,
-                                   Qt::Alignment(Qt::AlignTop | Qt::AlignLeft) | Qt::TextFlag(Qt::TextWordWrap | Qt::TextIncludeTrailingSpaces),
-                                   infoText);
+    testRect = painter.boundingRect(mapInfoRect.left() + 10,
+                                    mapInfoRect.top(),
+                                    mapInfoRect.width() - 20,
+                                    mapInfoRect.height() - 20,
+                                    Qt::Alignment(Qt::AlignTop | Qt::AlignLeft) | Qt::TextFlag(Qt::TextWordWrap | Qt::TextIncludeTrailingSpaces),
+                                    infoText);
     mapInfoRect.setHeight(testRect.height() + 10);
     painter.fillRect(mapInfoRect, bgColor);
     painter.setPen(properties.color);
-    painter.drawText(mapInfoRect.left() + 10, mapInfoRect.top(), mapInfoRect.width() - 20, mapInfoRect.height() - 10,
-                    Qt::Alignment(Qt::AlignTop | Qt::AlignLeft) | Qt::TextFlag(Qt::TextWordWrap | Qt::TextIncludeTrailingSpaces),
-                    infoText);
+    painter.drawText(mapInfoRect.left() + 10,
+                     mapInfoRect.top(),
+                     mapInfoRect.width() - 20,
+                     mapInfoRect.height() - 10,
+                     Qt::Alignment(Qt::AlignTop | Qt::AlignLeft) | Qt::TextFlag(Qt::TextWordWrap | Qt::TextIncludeTrailingSpaces),
+                     infoText);
     painter.restore();
     return mapInfoRect.height();
 }

--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -46,9 +46,7 @@ dlgModuleManager::dlgModuleManager(QWidget* parent, Host* pHost)
     setAttribute(Qt::WA_DeleteOnClose);
 }
 
-dlgModuleManager::~dlgModuleManager()
-{
-}
+dlgModuleManager::~dlgModuleManager() {}
 
 void dlgModuleManager::layoutModules()
 {
@@ -110,7 +108,7 @@ void dlgModuleManager::layoutModules()
             itemEntry->setText(moduleName);
             itemEntry->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
             itemLocation->setText(moduleInfo[0]);
-            itemLocation->setToolTip(utils::richText(moduleInfo[0]));     // show the full path in a tooltip, in case it doesn't fit in the table
+            itemLocation->setToolTip(utils::richText(moduleInfo[0]));         // show the full path in a tooltip, in case it doesn't fit in the table
             itemLocation->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled); // disallow editing of module path, because that is not saved
             itemPriority->setData(Qt::EditRole, mpHost->mModulePriorities[moduleName]);
             moduleTable->setItem(row, 0, itemEntry);
@@ -192,8 +190,7 @@ void dlgModuleManager::slot_moduleClicked(QTableWidgetItem* pItem)
     }
 
     if (mpHost->moduleHelp.contains(entry->text())) {
-        helpButton->setDisabled((!mpHost->moduleHelp.value(entry->text()).contains(qsl("helpURL"))
-                                || mpHost->moduleHelp.value(entry->text()).value(qsl("helpURL")).isEmpty()));
+        helpButton->setDisabled((!mpHost->moduleHelp.value(entry->text()).contains(qsl("helpURL")) || mpHost->moduleHelp.value(entry->text()).value(qsl("helpURL")).isEmpty()));
     } else {
         helpButton->setDisabled(true);
     }

--- a/src/dlgNotepad.cpp
+++ b/src/dlgNotepad.cpp
@@ -231,10 +231,13 @@ void dlgNotepad::renameTab(int index)
     const QString currentName = tabWidget->tabText(index);
     bool ok = false;
     //: Dialog title for renaming a note tab
-    const QString newName = QInputDialog::getText(this, tr("Rename Note Tab"),
-                                                   //: Label for the input field when renaming a note tab
-                                                   tr("New name:"), QLineEdit::Normal,
-                                                   currentName, &ok);
+    const QString newName = QInputDialog::getText(this,
+                                                  tr("Rename Note Tab"),
+                                                  //: Label for the input field when renaming a note tab
+                                                  tr("New name:"),
+                                                  QLineEdit::Normal,
+                                                  currentName,
+                                                  &ok);
     if (ok && !newName.isEmpty() && newName != currentName) {
         tabWidget->setTabText(index, newName);
         mNeedToSave = true;
@@ -559,10 +562,8 @@ void dlgNotepad::saveSettings()
         return;
     }
 
-    mpHost->writeProfileIniData(qsl("Notepad/SendControlsVisible"),
-                                 action_toggleSendControls->isChecked() ? qsl("true") : qsl("false"));
-    mpHost->writeProfileIniData(qsl("Notepad/WindowState"),
-                                 QString::fromLatin1(saveState().toBase64()));
+    mpHost->writeProfileIniData(qsl("Notepad/SendControlsVisible"), action_toggleSendControls->isChecked() ? qsl("true") : qsl("false"));
+    mpHost->writeProfileIniData(qsl("Notepad/WindowState"), QString::fromLatin1(saveState().toBase64()));
 }
 
 void dlgNotepad::restoreSettings()
@@ -587,7 +588,7 @@ void dlgNotepad::restoreSettings()
     }
 }
 
-void dlgNotepad::closeEvent(QCloseEvent *event)
+void dlgNotepad::closeEvent(QCloseEvent* event)
 {
     saveSettings();
     QMainWindow::closeEvent(event);
@@ -710,8 +711,7 @@ void dlgNotepad::highlightAllMatches()
             QTextEdit::ExtraSelection selection;
             selection.cursor = cursor;
 
-            if (cursor.selectionStart() == currentCursor.selectionStart() &&
-                cursor.selectionEnd() == currentCursor.selectionEnd()) {
+            if (cursor.selectionStart() == currentCursor.selectionStart() && cursor.selectionEnd() == currentCursor.selectionEnd()) {
                 selection.format.setBackground(currentMatchColor);
             } else {
                 selection.format.setBackground(highlightColor);

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -51,7 +51,7 @@
 #error Mudlet requires a version of libzip of at least 1.0
 #endif
 
-dlgPackageExporter::dlgPackageExporter(QWidget *parent, Host* pHost)
+dlgPackageExporter::dlgPackageExporter(QWidget* parent, Host* pHost)
 : QDialog(parent)
 , ui(new Ui::dlgPackageExporter)
 , mpHost(pHost)
@@ -218,17 +218,17 @@ void dlgPackageExporter::setModuleCreationMode(bool isModule)
         // Clear the default package template text and set module-specific template
         ui->textEdit_description->clear();
         ui->textEdit_description->setPlainText(tr("(optional)\n\n"
-            "This module description is shown in the Module Manager. The editor supports Commonmark markdown.\n\n"
-            "### Description\n\n"
-            "A full description of what this module does. If the module is game-specific, mention that here.\n\n"
-            "### Usage\n\n"
-            "If this module uses aliases, show a few examples and expected output.\n\n"
-            "`> alias_1`\n\n"
-            "    output of alias_1  -- indent by four spaces\n"
-            "    more output        -- for code blocks\n\n"
-            "### See Also\n\n"
-            "Further reading material, e.g., links to documentation or forum posts.\n\n"
-            "* https://wiki.mudlet.org/w/Manual:Modules"));
+                                                  "This module description is shown in the Module Manager. The editor supports Commonmark markdown.\n\n"
+                                                  "### Description\n\n"
+                                                  "A full description of what this module does. If the module is game-specific, mention that here.\n\n"
+                                                  "### Usage\n\n"
+                                                  "If this module uses aliases, show a few examples and expected output.\n\n"
+                                                  "`> alias_1`\n\n"
+                                                  "    output of alias_1  -- indent by four spaces\n"
+                                                  "    more output        -- for code blocks\n\n"
+                                                  "### See Also\n\n"
+                                                  "Further reading material, e.g., links to documentation or forum posts.\n\n"
+                                                  "* https://wiki.mudlet.org/w/Manual:Modules"));
 
         // Focus on the module name input
         ui->lineEdit_packageName->setFocus();
@@ -410,8 +410,7 @@ std::pair<bool, QString> dlgPackageExporter::writeFileToZip(const QString& archi
     if (s == nullptr) {
         return {false,
                 //: This error message will appear when a file is to be placed into the package but the code cannot open it.
-                tr("Failed to open file \"%1\" to place into package. Error message was: \"%2\".")
-                        .arg(fileSystemFileName.toHtmlEscaped(), zip_strerror(archive))};
+                tr("Failed to open file \"%1\" to place into package. Error message was: \"%2\".").arg(fileSystemFileName.toHtmlEscaped(), zip_strerror(archive))};
     }
 
     if (zip_file_add(archive, archiveFileName.toUtf8().constData(), s, ZIP_FL_ENC_UTF_8 | ZIP_FL_OVERWRITE) == -1) {
@@ -419,8 +418,7 @@ std::pair<bool, QString> dlgPackageExporter::writeFileToZip(const QString& archi
         s = nullptr;
         return {false,
                 //: This error message will appear when a file is to be placed into the package but cannot be done for some reason.
-                tr("Failed to add file \"%1\" to package. Error message was: \"%3\".")
-                        .arg(archiveFileName.toHtmlEscaped(), zip_strerror(archive))};
+                tr("Failed to add file \"%1\" to package. Error message was: \"%3\".").arg(archiveFileName.toHtmlEscaped(), zip_strerror(archive))};
     }
 
     return {true, QString()};
@@ -909,7 +907,8 @@ void dlgPackageExporter::slot_exportPackage()
     QFile checkWriteability(mXmlPathFileName);
     if (!checkWriteability.open(QIODevice::WriteOnly)) {
         displayResultMessage(tr("Failed to export. Could not open the folder \"%1\" for writing. Do you have the necessary permissions and free disk-space to write to that folder?")
-                             .arg(mXmlPathFileName.toHtmlEscaped()), false);
+                                     .arg(mXmlPathFileName.toHtmlEscaped()),
+                             false);
         assetsFuture.cancel();
         mExportingPackage = false;
         checkToEnableExportButton();
@@ -955,9 +954,7 @@ void dlgPackageExporter::slot_exportPackage()
                         auto [installSuccess, installMessage] = mpHost->installPackage(mPackagePathFileName, enums::PackageModuleType::ModuleFromUI);
                         if (installSuccess) {
                             // Show embedded success message (better UX than popup)
-                            displayResultMessage(tr("Module \"%1\" created and installed successfully! You can now close this dialog.")
-                                                         .arg(mPackageName.toHtmlEscaped()),
-                                                 true);
+                            displayResultMessage(tr("Module \"%1\" created and installed successfully! You can now close this dialog.").arg(mPackageName.toHtmlEscaped()), true);
 
                             // Clear the form to allow creating another module
                             ui->lineEdit_packageName->clear();
@@ -990,32 +987,21 @@ void dlgPackageExporter::slot_exportPackage()
                                             // Close the dialog after successful module overwrite to prevent duplicates
                                             this->accept();
                                         } else {
-                                            displayResultMessage(tr("Module \"%1\" exported but installation failed: %2")
-                                                                         .arg(mPackageName.toHtmlEscaped(), retryMessage.toHtmlEscaped()),
-                                                                 false);
+                                            displayResultMessage(tr("Module \"%1\" exported but installation failed: %2").arg(mPackageName.toHtmlEscaped(), retryMessage.toHtmlEscaped()), false);
                                         }
                                     } else {
-                                        displayResultMessage(tr("Module \"%1\" exported but failed to uninstall existing version")
-                                                                     .arg(mPackageName.toHtmlEscaped()),
-                                                             false);
+                                        displayResultMessage(tr("Module \"%1\" exported but failed to uninstall existing version").arg(mPackageName.toHtmlEscaped()), false);
                                     }
                                 } else {
                                     // User chose not to overwrite
-                                    displayResultMessage(tr("Module \"%1\" exported successfully but not installed (already exists)")
-                                                                 .arg(mPackageName.toHtmlEscaped()),
-                                                         true);
+                                    displayResultMessage(tr("Module \"%1\" exported successfully but not installed (already exists)").arg(mPackageName.toHtmlEscaped()), true);
                                 }
                             } else {
-                                displayResultMessage(tr("Module \"%1\" exported but installation failed: %2")
-                                                             .arg(mPackageName.toHtmlEscaped(), installMessage.toHtmlEscaped()),
-                                                     false);
+                                displayResultMessage(tr("Module \"%1\" exported but installation failed: %2").arg(mPackageName.toHtmlEscaped(), installMessage.toHtmlEscaped()), false);
                             }
                         }
                     } else {
-                        displayResultMessage(tr("Package \"%1\" exported to: %2")
-                                                     .arg(mPackageName.toHtmlEscaped(), qsl("<a href=\"file:///%1\">%1</a>")
-                                                                                .arg(getActualPath().toHtmlEscaped())),
-                                             true);
+                        displayResultMessage(tr("Package \"%1\" exported to: %2").arg(mPackageName.toHtmlEscaped(), qsl("<a href=\"file:///%1\">%1</a>").arg(getActualPath().toHtmlEscaped())), true);
                     }
                 }
                 mCancelButton->setVisible(false);
@@ -1234,8 +1220,7 @@ void dlgPackageExporter::exportXml(bool& isOk,
 
     if (!writer.exportPackage(mXmlPathFileName, false, true)) {
         //: This error message is shown when all the Mudlet items cannot be written to the 'packageName'.xml file in the base directory of the place where all the files are staged before being compressed into the package file. The full path and filename are shown in %1 to help the user diagnose what might have happened
-        displayResultMessage(tr("Failed to export. Could not write Mudlet items to the file \"%1\".")
-                             .arg(mXmlPathFileName.toHtmlEscaped()), false);
+        displayResultMessage(tr("Failed to export. Could not write Mudlet items to the file \"%1\".").arg(mXmlPathFileName.toHtmlEscaped()), false);
         // Although we have failed, we must not just abort here. We need to reset
         // the selected "for export or not"-flags first. So note that we have failed:
         isOk = false;
@@ -1313,7 +1298,8 @@ std::pair<bool, QString> dlgPackageExporter::copyAssetsToTmp(const QStringList& 
     return {true, QString{}};
 }
 
-std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDirName, const QString& packagePathFileName, const QString& xmlPathFileName, const QString& packageName, const QString& packageComment)
+std::pair<bool, QString>
+dlgPackageExporter::zipPackage(const QString& stagingDirName, const QString& packagePathFileName, const QString& xmlPathFileName, const QString& packageName, const QString& packageComment)
 {
     bool isOk = true;
     QString error;
@@ -1335,8 +1321,7 @@ std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDi
          * existing file that is to be overwritten may be a source of problems
          * here.
         */
-        const QString errMsg = tr("Failed to open package file. Error is: \"%1\".")
-                                 .arg(zip_error_strerror(&zipError));
+        const QString errMsg = tr("Failed to open package file. Error is: \"%1\".").arg(zip_error_strerror(&zipError));
         zip_error_fini(&zipError);
         return {false, errMsg};
     }
@@ -1461,13 +1446,13 @@ std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDi
 
         } else {
             return {false,
-                        tr("Required file \"%1\" was not found in the staging area. "
-                           "This area contains the Mudlet items chosen for the package, "
-                           "which you selected to be included in the package file. "
-                           "This suggests there may be a problem with that directory: "
-                           "\"%2\" - "
-                           "Do you have the necessary permissions and free disk-space?")
-                                .arg(xmlPathFileName, QDir(stagingDirName).canonicalPath())};
+                    tr("Required file \"%1\" was not found in the staging area. "
+                       "This area contains the Mudlet items chosen for the package, "
+                       "which you selected to be included in the package file. "
+                       "This suggests there may be a problem with that directory: "
+                       "\"%2\" - "
+                       "Do you have the necessary permissions and free disk-space?")
+                            .arg(xmlPathFileName, QDir(stagingDirName).canonicalPath())};
         }
     }
 
@@ -1475,7 +1460,9 @@ std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDi
         zip_set_archive_comment(archive, packageComment.toUtf8().constData(), static_cast<zip_uint16_t>(packageComment.toUtf8().length()));
 
 #if defined(LIBZIP_SUPPORTS_CANCELLING)
-        auto cancel_callback = [](zip*, void*) -> int { return !mExportingPackage; };
+        auto cancel_callback = [](zip*, void*) -> int {
+            return !mExportingPackage;
+        };
         zip_register_cancel_callback_with_state(archive, cancel_callback, nullptr, nullptr);
 #endif
 
@@ -1535,14 +1522,20 @@ void dlgPackageExporter::slot_addFiles()
     if (dialogListView) {
         dialogListView->setSelectionMode(QAbstractItemView::ExtendedSelection);
         //button would be disabled if no folder is selected
-        connect(dialogListView, &QListView::clicked, this, [=] { button->setEnabled(true); });
+        connect(dialogListView, &QListView::clicked, this, [=] {
+            button->setEnabled(true);
+        });
     }
     QTreeView* dialogTreeView = fDialog->findChild<QTreeView*>();
     if (dialogTreeView) {
         dialogTreeView->setSelectionMode(QAbstractItemView::ExtendedSelection);
-        connect(dialogTreeView, &QTreeView::clicked, this, [=] { button->setEnabled(true); });
+        connect(dialogTreeView, &QTreeView::clicked, this, [=] {
+            button->setEnabled(true);
+        });
     }
-    connect(button, &QPushButton::clicked, this, [=] { fDialog->QDialog::accept(); });
+    connect(button, &QPushButton::clicked, this, [=] {
+        fDialog->QDialog::accept();
+    });
     if (fDialog->exec()) {
         selectedFiles = fDialog->selectedFiles();
     }
@@ -1562,8 +1555,7 @@ void dlgPackageExporter::slot_openPackageLocation()
     QSettings& settings = *mudlet::getQSettings();
     QString lastDir = settings.value("lastFileDialogLocation", QDir::homePath()).toString();
 
-    mPackagePath = QFileDialog::getExistingDirectory(
-            nullptr, tr("Where do you want to save the package?"), lastDir, QFileDialog::DontUseNativeDialog | QFileDialog::ShowDirsOnly);
+    mPackagePath = QFileDialog::getExistingDirectory(nullptr, tr("Where do you want to save the package?"), lastDir, QFileDialog::DontUseNativeDialog | QFileDialog::ShowDirsOnly);
 
     if (mPackagePath.isEmpty()) {
         return;
@@ -1693,7 +1685,7 @@ void dlgPackageExporter::recurseAliases(TAlias* item, QTreeWidgetItem* qItem)
         QStringList sl;
         sl << pChild->getName();
         auto pItem = new QTreeWidgetItem(sl);
-        pItem->setFlags(Qt::ItemIsUserCheckable  | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+        pItem->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         pItem->setCheckState(0, Qt::Unchecked);
         qItem->addChild(pItem);
         aliasMap.insert(pItem, pChild);
@@ -1715,7 +1707,7 @@ void dlgPackageExporter::listAliases()
         QStringList sl;
         sl << pChild->getName();
         auto pItem = new QTreeWidgetItem(sl);
-        pItem->setFlags(Qt::ItemIsUserCheckable  | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+        pItem->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         pItem->setCheckState(0, Qt::Unchecked);
         if (pChild->isFolder() && pChild->getScript().isEmpty()) {
             pItem->setData(0, Qt::UserRole, isTopFolder);
@@ -1783,7 +1775,7 @@ void dlgPackageExporter::recurseKeys(TKey* item, QTreeWidgetItem* qItem)
         QStringList sl;
         sl << pChild->getName();
         auto pItem = new QTreeWidgetItem(sl);
-        pItem->setFlags(Qt::ItemIsUserCheckable  | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+        pItem->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         pItem->setCheckState(0, Qt::Unchecked);
         keyMap.insert(pItem, pChild);
         qItem->addChild(pItem);
@@ -1805,7 +1797,7 @@ void dlgPackageExporter::listKeys()
         QStringList sl;
         sl << pChild->getName();
         auto pItem = new QTreeWidgetItem(sl);
-        pItem->setFlags(Qt::ItemIsUserCheckable  | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+        pItem->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         pItem->setCheckState(0, Qt::Unchecked);
         if (pChild->isFolder() && pChild->getScript().isEmpty()) {
             pItem->setData(0, Qt::UserRole, isTopFolder);
@@ -1828,7 +1820,7 @@ void dlgPackageExporter::recurseActions(TAction* item, QTreeWidgetItem* qItem)
         QStringList sl;
         sl << pChild->getName();
         auto pItem = new QTreeWidgetItem(sl);
-        pItem->setFlags(Qt::ItemIsUserCheckable  | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+        pItem->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         pItem->setCheckState(0, Qt::Unchecked);
         actionMap.insert(pItem, pChild);
         qItem->addChild(pItem);
@@ -1847,7 +1839,7 @@ void dlgPackageExporter::listActions()
         QStringList sl;
         sl << pChild->getName();
         auto pItem = new QTreeWidgetItem(sl);
-        pItem->setFlags(Qt::ItemIsUserCheckable  | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+        pItem->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         pItem->setCheckState(0, Qt::Unchecked);
         if (pChild->isFolder() && pChild->getScript().isEmpty()) {
             pItem->setData(0, Qt::UserRole, isTopFolder);
@@ -1873,7 +1865,7 @@ void dlgPackageExporter::recurseTimers(TTimer* item, QTreeWidgetItem* qItem)
         QStringList sl;
         sl << pChild->getName();
         auto pItem = new QTreeWidgetItem(sl);
-        pItem->setFlags(Qt::ItemIsUserCheckable  | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+        pItem->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         pItem->setCheckState(0, Qt::Unchecked);
         timerMap.insert(pItem, pChild);
         qItem->addChild(pItem);
@@ -1895,7 +1887,7 @@ void dlgPackageExporter::listTimers()
         QStringList sl;
         sl << pChild->getName();
         auto pItem = new QTreeWidgetItem(sl);
-        pItem->setFlags(Qt::ItemIsUserCheckable  | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+        pItem->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         pItem->setCheckState(0, Qt::Unchecked);
         if (pChild->isFolder() && pChild->getScript().isEmpty()) {
             pItem->setData(0, Qt::UserRole, isTopFolder);
@@ -1917,21 +1909,20 @@ void dlgPackageExporter::displayResultMessage(const QString& html, const bool is
     // Big BLACK (Green would be hard for most common colour blind people to
     // tell from Red, and Blue would likely hide the URL) success message:
     ui->infoLabel->setText(qsl("<p><b><big>%1</big><b></p>"
-                                          "<p>%2</p>")
-                           .arg(html,
-                            /*:
+                               "<p>%2</p>")
+                                   .arg(html,
+                                        /*:
                             Only the text outside of the 'a' (HTML anchor) tags PLUS the verb
                             'upload' in between them in the source text, (associated with uploading
                             the resulting package to the Mudlet forums) should be translated.
                             */
-                                tr("Why not <a href=\"https://packages.mudlet.org/upload\">upload</a> your package for other Mudlet users?")));
+                                        tr("Why not <a href=\"https://packages.mudlet.org/upload\">upload</a> your package for other Mudlet users?")));
     ui->infoLabel->setTextInteractionFlags(Qt::TextBrowserInteraction);
     ui->infoLabel->setOpenExternalLinks(true);
 }
 
-void dlgPackageExporter::slot_recountItems(QTreeWidgetItem *item)
+void dlgPackageExporter::slot_recountItems(QTreeWidgetItem* item)
 {
-
     checkChildren(item);
     static bool debounce;
     if (!debounce) {
@@ -1988,10 +1979,10 @@ void dlgPackageExporter::slot_cancelExport()
 //Description Class TextEdit
 dlgPackageExporterDescription::dlgPackageExporterDescription(QWidget* pW)
 : QTextEdit(pW)
-{}
+{
+}
 
-dlgPackageExporterDescription::~dlgPackageExporterDescription()
-{}
+dlgPackageExporterDescription::~dlgPackageExporterDescription() {}
 
 bool dlgPackageExporterDescription::canInsertFromMimeData(const QMimeData* source) const
 {
@@ -2014,12 +2005,7 @@ void dlgPackageExporterDescription::insertFromMimeData(const QMimeData* source)
             setPlainText(my_parent->mPlainDescription);
         }
         QStringList accepted_types;
-        accepted_types << "jpeg"
-                       << "jpg"
-                       << "png"
-                       << "gif"
-                       << "bmp"
-                       << "svg";
+        accepted_types << "jpeg" << "jpg" << "png" << "gif" << "bmp" << "svg";
         for (const auto& url : source->urls()) {
             const QString fname = url.toLocalFile();
             const QFileInfo info(fname);

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -93,7 +93,7 @@ void dlgPackageManager::clearPackageDetails()
     pushButton_report->hide();
 }
 
-void dlgPackageManager::downloadIcon(const QString &packageName)
+void dlgPackageManager::downloadIcon(const QString& packageName)
 {
     QString iconPath;
 
@@ -109,22 +109,24 @@ void dlgPackageManager::downloadIcon(const QString &packageName)
         }
     }
 
-    QNetworkAccessManager *manager = new QNetworkAccessManager(this);
+    QNetworkAccessManager* manager = new QNetworkAccessManager(this);
     QNetworkRequest request(QUrl(qsl("https://github.com/Mudlet/mudlet-package-repository/raw/refs/heads/main/") + iconPath));
     request.setTransferTimeout(10000);
-    QNetworkReply *reply = manager->get(request);
+    QNetworkReply* reply = manager->get(request);
     reply->setProperty("packageName", packageName);
-    connect(reply, &QNetworkReply::finished, this, [this, reply](){ slot_onIconDownloaded(reply); });
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        slot_onIconDownloaded(reply);
+    });
 }
 
 void dlgPackageManager::downloadRepositoryIndex()
 {
     const QString outputPath = mudlet::getMudletPath(enums::profileHomePath, mpHost->getName() + QDir::separator() + qsl("mpkg.packages.json"));
-    QNetworkAccessManager *manager = new QNetworkAccessManager(this);
+    QNetworkAccessManager* manager = new QNetworkAccessManager(this);
     QNetworkRequest request(QUrl(qsl("https://raw.githubusercontent.com/Mudlet/mudlet-package-repository/refs/heads/main/packages/mpkg.packages.json")));
     request.setTransferTimeout(20000);
-    QNetworkReply *reply = manager->get(request);
-    QFile *file = new QFile(outputPath);
+    QNetworkReply* reply = manager->get(request);
+    QFile* file = new QFile(outputPath);
 
     if (!file->open(QIODevice::WriteOnly)) {
         file->deleteLater();
@@ -158,7 +160,7 @@ void dlgPackageManager::downloadRepositoryIndex()
     });
 }
 
-void dlgPackageManager::fillPackageDetails(const QString &name, const QString &title, const QString &author, const QString &version)
+void dlgPackageManager::fillPackageDetails(const QString& name, const QString& title, const QString& author, const QString& version)
 {
     const QFontMetrics metrics(label_packageName->font());
     const QString elidedText = metrics.elidedText(name, Qt::ElideRight, label_packageName->width());
@@ -196,7 +198,7 @@ bool dlgPackageManager::readPackageRepositoryFile()
 
     repositoryPackages = obj[qsl("packages")].toArray();
     packageLookup.clear();
-    for (const QJsonValue &val : repositoryPackages) {
+    for (const QJsonValue& val : repositoryPackages) {
         QJsonObject pkg = val.toObject();
         packageLookup.insert(pkg["mpackage"].toString(), pkg);
     }
@@ -283,7 +285,7 @@ void dlgPackageManager::slot_installPackageFromRepository()
     progress->setMinimumDuration(0);
     progress->show();
 
-    QNetworkAccessManager *manager = new QNetworkAccessManager(this);
+    QNetworkAccessManager* manager = new QNetworkAccessManager(this);
     auto pendingDownloads = std::make_shared<QHash<QString, QString>>();
     auto remainingDownloads = std::make_shared<int>(selected.size());
     auto activeReplies = std::make_shared<QList<QNetworkReply*>>();
@@ -336,10 +338,10 @@ void dlgPackageManager::slot_installPackageFromRepository()
         const QString outPath = outDir + QDir::separator() + remoteFileName;
         QNetworkRequest request(QUrl(qsl("https://github.com/Mudlet/mudlet-package-repository/raw/refs/heads/main/packages/%1").arg(QString::fromUtf8(encoded))));
         request.setTransferTimeout(30000);
-        QNetworkReply *reply = manager->get(request);
+        QNetworkReply* reply = manager->get(request);
         activeReplies->append(reply);
 
-        QFile *file = new QFile(outPath);
+        QFile* file = new QFile(outPath);
         if (!file->open(QIODevice::WriteOnly)) {
             (*remainingDownloads.get())--;
             file->deleteLater();
@@ -384,8 +386,8 @@ void dlgPackageManager::slot_installPackageFromRepository()
 
             if (--(*remainingDownloads.get()) == 0) {
                 for (auto it = pendingDownloads->begin(); it != pendingDownloads->end(); ++it) {
-                    const QString &pkgName = it.key();
-                    const QString &filePath = it.value();
+                    const QString& pkgName = it.key();
+                    const QString& filePath = it.value();
 
                     if (mpHost) {
                         mpHost->installPackage(filePath, enums::PackageModuleType::Package);
@@ -449,10 +451,7 @@ void dlgPackageManager::slot_itemChanged(QListWidgetItem* pItem)
             label_icon->setPixmap(pixmap.scaled(96, 96, Qt::KeepAspectRatio, Qt::SmoothTransformation));
         }
 
-        fillPackageDetails(packageName,
-                           packageInfo.value(qsl("title")),
-                           packageInfo.value(qsl("author")),
-                           packageInfo.value(qsl("version")));
+        fillPackageDetails(packageName, packageInfo.value(qsl("title")), packageInfo.value(qsl("author")), packageInfo.value(qsl("version")));
 
     } else if (status == statusAvailable) {
         pushButton_website->show();
@@ -461,16 +460,14 @@ void dlgPackageManager::slot_itemChanged(QListWidgetItem* pItem)
 
         if (packageLookup.contains(packageName)) {
             QJsonObject packageObj = packageLookup.value(packageName);
-            fillPackageDetails(packageObj.value(qsl("mpackage")).toString(),
-                               packageObj.value(qsl("title")).toString(),
-                               packageObj.value(qsl("author")).toString(),
-                               packageObj.value(qsl("version")).toString());
+            fillPackageDetails(
+                    packageObj.value(qsl("mpackage")).toString(), packageObj.value(qsl("title")).toString(), packageObj.value(qsl("author")).toString(), packageObj.value(qsl("version")).toString());
             packageDescription->setMarkdown(packageObj.value(qsl("description")).toString());
         }
     }
 }
 
-void dlgPackageManager::slot_onIconDownloaded(QNetworkReply *reply)
+void dlgPackageManager::slot_onIconDownloaded(QNetworkReply* reply)
 {
     if (!reply) {
         return;
@@ -532,24 +529,21 @@ void dlgPackageManager::slot_removePackages()
     }
 }
 
-void dlgPackageManager::slot_searchTextChanged(const QString &searchText)
+void dlgPackageManager::slot_searchTextChanged(const QString& searchText)
 {
     const auto status = packageStatusList->currentItem();
     packageList->clear();
 
     if (status == statusInstalled) {
-        for (const auto &value : mpHost->mPackageInfo) {
+        for (const auto& value : mpHost->mPackageInfo) {
             const QString name = value.value(qsl("mpackage"));
             const QString title = value.value(qsl("title"));
             const QString description = value.value(qsl("description"));
             const QString author = value.value(qsl("author"));
 
-            if (name.contains(searchText, Qt::CaseInsensitive) ||
-                title.contains(searchText, Qt::CaseInsensitive) ||
-                description.contains(searchText, Qt::CaseInsensitive) ||
-                author.contains(searchText, Qt::CaseInsensitive)) {
-
-                QListWidgetItem *item = new QListWidgetItem(name);
+            if (name.contains(searchText, Qt::CaseInsensitive) || title.contains(searchText, Qt::CaseInsensitive) || description.contains(searchText, Qt::CaseInsensitive)
+                || author.contains(searchText, Qt::CaseInsensitive)) {
+                QListWidgetItem* item = new QListWidgetItem(name);
                 if (!title.isEmpty()) {
                     item->setData(Qt::UserRole, title);
                 }
@@ -567,19 +561,16 @@ void dlgPackageManager::slot_searchTextChanged(const QString &searchText)
             }
         }
     } else if (status == statusAvailable) {
-        for (const QJsonValue &value : repositoryPackages) {
+        for (const QJsonValue& value : repositoryPackages) {
             const QJsonObject pkg = value.toObject();
             const QString name = pkg[qsl("mpackage")].toString();
             const QString title = pkg[qsl("title")].toString();
             const QString description = pkg[qsl("description")].toString();
             const QString author = pkg[qsl("author")].toString();
 
-            if (name.contains(searchText, Qt::CaseInsensitive) ||
-                title.contains(searchText, Qt::CaseInsensitive) ||
-                description.contains(searchText, Qt::CaseInsensitive) ||
-                author.contains(searchText, Qt::CaseInsensitive)) {
-
-                QListWidgetItem *item = new QListWidgetItem(name);
+            if (name.contains(searchText, Qt::CaseInsensitive) || title.contains(searchText, Qt::CaseInsensitive) || description.contains(searchText, Qt::CaseInsensitive)
+                || author.contains(searchText, Qt::CaseInsensitive)) {
+                QListWidgetItem* item = new QListWidgetItem(name);
                 if (!title.isEmpty()) {
                     item->setData(Qt::UserRole, title);
                 }
@@ -631,7 +622,6 @@ void dlgPackageManager::slot_setPackageList()
             packageList->addItem(item);
         }
     } else if (status == statusAvailable) {
-
         if (!readPackageRepositoryFile()) {
             return;
         }

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -134,7 +134,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
     }
 
     checkBox_showTabConnectionIndicators->setChecked(pMudlet->mShowTabConnectionIndicators);
-    connect(checkBox_showTabConnectionIndicators, &QCheckBox::toggled, this, [=](bool checked){
+    connect(checkBox_showTabConnectionIndicators, &QCheckBox::toggled, this, [=](bool checked) {
         mudlet::self()->setShowTabConnectionIndicators(checked);
     });
 
@@ -208,7 +208,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
                                                              "cannot be displayed; also, up to the first thirty two rooms that are using "
                                                              "that symbol are listed, which may help to identify any unexpected or odd cases.")));
     fontComboBox_mapSymbols->setToolTip(utils::richText(tr("Select the only or the primary font used (depending on <i>Only use symbols "
-                                                               "(glyphs) from chosen font</i> setting) to produce the 2D mapper room symbols.")));
+                                                           "(glyphs) from chosen font</i> setting) to produce the 2D mapper room symbols.")));
     checkBox_isOnlyMapSymbolFontToBeUsed->setToolTip(utils::richText(tr("Using a single font is likely to produce a more consistent style but may "
                                                                         "cause the <i>font replacement character</i> '<b>�</b>' to show if the font "
                                                                         "does not have a needed glyph (a font's individual character/symbol) to represent "
@@ -278,7 +278,9 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
     connect(pMudlet, &mudlet::signal_guiLanguageChanged, this, &dlgProfilePreferences::slot_guiLanguageChanged);
     connect(pMudlet, &mudlet::signal_appearanceChanged, this, &dlgProfilePreferences::slot_setAppearance);
     connect(pMudlet, &mudlet::signal_showTabConnectionIndicatorsChanged, this, &dlgProfilePreferences::slot_changeShowTabConnectionIndicators);
-    connect(comboBox_appearance, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this](int index) { dlgProfilePreferences::slot_setAppearance(enums::Appearance(index)); });
+    connect(comboBox_appearance, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this](int index) {
+        dlgProfilePreferences::slot_setAppearance(enums::Appearance(index));
+    });
     connect(toolButton_resetMainWindowShortcuts, &QPushButton::released, this, [=, this]() {
         emit signal_resetMainWindowShortcutsToDefaults();
     });
@@ -296,9 +298,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
         if (translation.fromResourceFile()) {
             auto& translatedPc = translation.getTranslatedPercentage();
             if (translatedPc >= pMudlet->scmTranslationGoldStar) {
-                comboBox_guiLanguage->addItem(QIcon(":/icons/rating.png"),
-                                              nativeName,
-                                              code);
+                comboBox_guiLanguage->addItem(QIcon(":/icons/rating.png"), nativeName, code);
             } else {
                 // This will also be used if the percentage is set to zero
                 // because it was not found in the translation statistics file
@@ -308,7 +308,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
                                               tr("%1 (%2% done)",
                                                  // Intentional argument to separate arguments
                                                  "%1 is the (not-translated so users of the language can read it!) language name, %2 is percentage done.")
-                                              .arg(nativeName, QString::number(translatedPc)),
+                                                      .arg(nativeName, QString::number(translatedPc)),
                                               code);
             }
         } else {
@@ -328,8 +328,8 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
     } else {
         currentIndex = comboBox_guiLanguage->findData(qsl("en_US"));
         if (Q_LIKELY(currentIndex != -1)) {
-           // The default code has been found in the UserData role for one of
-           // the entries - so select it as a fallback
+            // The default code has been found in the UserData role for one of
+            // the entries - so select it as a fallback
             comboBox_guiLanguage->setCurrentIndex(currentIndex);
             connect(comboBox_guiLanguage, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_changeGuiLanguage);
         } else if (comboBox_guiLanguage->count()) {
@@ -354,10 +354,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
         option = storedOption.toInt() - 1;
     }
     comboBox_crashReportPolicy->setCurrentIndex(option);
-    connect(comboBox_crashReportPolicy,
-        qOverload<int>(&QComboBox::currentIndexChanged),
-        this,
-        &dlgProfilePreferences::slot_crashReportPolicyChanged);
+    connect(comboBox_crashReportPolicy, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_crashReportPolicyChanged);
 
     setupPasswordsMigration();
 
@@ -733,9 +730,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
             auto key = entries.at(i).toLower();
             key.replace(QLatin1String("-"), QLatin1String("_"));
 
-            QString displayText = mudlet::self()->mDictionaryLanguageCodeMap.contains(key)
-                    ? mudlet::self()->mDictionaryLanguageCodeMap.value(key)
-                    : tr("%1 - not recognised").arg(entries.at(i));
+            QString displayText = mudlet::self()->mDictionaryLanguageCodeMap.contains(key) ? mudlet::self()->mDictionaryLanguageCodeMap.value(key) : tr("%1 - not recognised").arg(entries.at(i));
             translatedNameToEntriesMap.insert(displayText, i);
         }
 
@@ -748,9 +743,10 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
             key.replace(QLatin1String("-"), QLatin1String("_"));
 
             QString toolTip = mudlet::self()->mDictionaryLanguageCodeMap.contains(key)
-                    ? utils::richText(tr("From the dictionary file <tt>%1.dic</tt> (and its companion affix <tt>.aff</tt> file).").arg(dir.absoluteFilePath(entries.at(i))))
-                    : tr("<p>Mudlet does not recognise the code \"%1\", please report it to the Mudlet developers so we can describe it properly in future Mudlet versions!</p>"
-                         "<p>The file <tt>%2.dic</tt> (and its companion affix <tt>.aff</tt> file) is still usable.</p>").arg(entries.at(i), dir.absoluteFilePath(entries.at(i)));
+                                      ? utils::richText(tr("From the dictionary file <tt>%1.dic</tt> (and its companion affix <tt>.aff</tt> file).").arg(dir.absoluteFilePath(entries.at(i))))
+                                      : tr("<p>Mudlet does not recognise the code \"%1\", please report it to the Mudlet developers so we can describe it properly in future Mudlet versions!</p>"
+                                           "<p>The file <tt>%2.dic</tt> (and its companion affix <tt>.aff</tt> file) is still usable.</p>")
+                                                .arg(entries.at(i), dir.absoluteFilePath(entries.at(i)));
 
             comboBox_dictionary->addItem(displayText, entries.at(i));
             comboBox_dictionary->setItemData(comboBox_dictionary->count() - 1, toolTip, Qt::ToolTipRole);
@@ -1049,13 +1045,14 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         mpDoubleSpinBox_mapSymbolFontFudge->setPrefix(qsl("×"));
         mpDoubleSpinBox_mapSymbolFontFudge->setRange(0.50, 2.00);
         mpDoubleSpinBox_mapSymbolFontFudge->setSingleStep(0.01);
-        auto * pSymbolsLayout = qobject_cast<QGridLayout*>(groupBox_mapSymbols->layout());
+        auto* pSymbolsLayout = qobject_cast<QGridLayout*>(groupBox_mapSymbols->layout());
         if (pSymbolsLayout) {
             const int existingRows = pSymbolsLayout->rowCount();
             pSymbolsLayout->addWidget(pLabel_mapSymbolFontFudge, existingRows, 0);
             pSymbolsLayout->addWidget(mpDoubleSpinBox_mapSymbolFontFudge, existingRows, 1);
         } else {
-            qWarning() << "dlgProfilePreferences::initWithHost(...) WARNING - Unable to cast groupBox_mapSymbols layout to expected QGridLayout - someone has messed with the profile_preferences.ui file and the contents of the groupBox can not be shown...!";
+            qWarning() << "dlgProfilePreferences::initWithHost(...) WARNING - Unable to cast groupBox_mapSymbols layout to expected QGridLayout - someone has messed with the profile_preferences.ui "
+                          "file and the contents of the groupBox can not be shown...!";
         }
 
         label_mapSymbolsFont->setEnabled(true);
@@ -1110,11 +1107,13 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     }
 
     comboBox_encoding->addItem(mudlet::self()->getEncodingNamesMap().value(QByteArray("ASCII")), QByteArray("ASCII"));
-    for (const auto &encoding : pHost->mTelnet.getEncodingsList()) {
-        auto encodingTitle = mudlet::self()->getEncodingNamesMap().value(encoding, tr("%1 (*Error, report to Mudlet Makers*)",
-                                                                                      // Intentional comment to separate arguments
-                                                                                      "The encoder code name is not in the mudlet class mEncodingNamesMap when it should be and the Mudlet Makers need to fix it!")
-                                                                         .arg(QLatin1String(encoding)));
+    for (const auto& encoding : pHost->mTelnet.getEncodingsList()) {
+        auto encodingTitle =
+                mudlet::self()->getEncodingNamesMap().value(encoding,
+                                                            tr("%1 (*Error, report to Mudlet Makers*)",
+                                                               // Intentional comment to separate arguments
+                                                               "The encoder code name is not in the mudlet class mEncodingNamesMap when it should be and the Mudlet Makers need to fix it!")
+                                                                    .arg(QLatin1String(encoding)));
         comboBox_encoding->addItem(encodingTitle, encoding);
     }
     if (pHost->mTelnet.getEncoding().isEmpty()) {
@@ -1124,7 +1123,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         comboBox_encoding->setCurrentIndex(0);
     } else {
         const int currentIndex = comboBox_encoding->findData(pHost->mTelnet.getEncoding());
-        if (currentIndex >=0) {
+        if (currentIndex >= 0) {
             comboBox_encoding->setCurrentIndex(currentIndex);
         } else {
             // invalid or not found - so reset to ASCII:
@@ -1207,9 +1206,9 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
                         notificationAreaMessageBox->show();
                         notificationAreaMessageBox->setText(pHost->mTelnet.errorString());
                         break;
-                    default:
-                        {} // There are a significant number of other errors
-                           // that are not handled here!
+                    default: {
+                    } // There are a significant number of other errors
+                      // that are not handled here!
                     }
                 }
             }
@@ -1221,12 +1220,11 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         notificationAreaIconLabelWarning->show();
         frame_notificationArea->show();
         notificationAreaMessageBox->show();
-        QString errorDetails = pHost->mProfileLoadError.isEmpty()
-            ? tr("unknown error")
-            : pHost->mProfileLoadError;
+        QString errorDetails = pHost->mProfileLoadError.isEmpty() ? tr("unknown error") : pHost->mProfileLoadError;
         notificationAreaMessageBox->setText(tr("This profile could not be loaded correctly (%1). "
                                                "Settings cannot be saved. Close the profile and try loading an older version from "
-                                               "'Connect - Options - Profile history'.").arg(errorDetails));
+                                               "'Connect - Options - Profile history'.")
+                                                    .arg(errorDetails));
     }
 
     groupBox_ssl->setChecked(pHost->mSslTsl);
@@ -1361,8 +1359,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         shortcutsRow++;
         connect(sequenceEdit, &QKeySequenceEdit::editingFinished, this, [=]() {
             QKeySequence* newSequence = nullptr;
-            if (sequenceEdit->keySequence().isEmpty()
-                    || sequenceEdit->keySequence().matches(QKeySequence(Qt::Key_Escape))) {
+            if (sequenceEdit->keySequence().isEmpty() || sequenceEdit->keySequence().matches(QKeySequence(Qt::Key_Escape))) {
                 newSequence = new QKeySequence();
             } else {
                 newSequence = new QKeySequence(sequenceEdit->keySequence());
@@ -1378,7 +1375,6 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
             delete newSequence;
         });
     }
-
 }
 
 void dlgProfilePreferences::disconnectHostRelatedControls()
@@ -1606,9 +1602,7 @@ void dlgProfilePreferences::loadEditorTab()
     config->setIndentSize(2);
     config->setThemeName(pHost->mEditorTheme);
     config->setCaretWidth(1);
-    config->setShowWhitespaceMode((mudlet::self()->mEditorTextOptions & QTextOption::ShowTabsAndSpaces)
-                                  ? edbee::TextEditorConfig::ShowWhitespaces
-                                  : edbee::TextEditorConfig::HideWhitespaces);
+    config->setShowWhitespaceMode((mudlet::self()->mEditorTextOptions & QTextOption::ShowTabsAndSpaces) ? edbee::TextEditorConfig::ShowWhitespaces : edbee::TextEditorConfig::HideWhitespaces);
     config->setUseLineSeparator(mudlet::self()->mEditorTextOptions & QTextOption::ShowLineAndParagraphSeparators);
     config->setFont(pHost->getDisplayFont());
     config->setAutocompleteAutoShow(pHost->mEditorAutoComplete);
@@ -1882,8 +1876,7 @@ void dlgProfilePreferences::setButtonAndProfileColor(QPushButton* button, QColor
     }
 
     //: Generic pick color dialog title
-    auto color = QColorDialog::getColor(presentColor, this, tr("Pick color"),
-                                        allowAlpha ? QColorDialog::ShowAlphaChannel : QColorDialog::ColorDialogOptions());
+    auto color = QColorDialog::getColor(presentColor, this, tr("Pick color"), allowAlpha ? QColorDialog::ShowAlphaChannel : QColorDialog::ColorDialogOptions());
     if (color.isValid()) {
         presentColor = color;
 
@@ -1900,36 +1893,19 @@ void dlgProfilePreferences::setButtonAndProfileColor(QPushButton* button, QColor
             }
         }
 
-        if (button == pushButton_black || button == pushButton_lBlack
-            || button == pushButton_red || button == pushButton_lRed
-            || button == pushButton_green || button == pushButton_lGreen
-            || button == pushButton_yellow || button == pushButton_lYellow
-            || button == pushButton_blue || button == pushButton_lBlue
-            || button == pushButton_magenta || button == pushButton_lMagenta
-            || button == pushButton_cyan || button == pushButton_lCyan
-            || button == pushButton_white || button == pushButton_lWhite) {
-
+        if (button == pushButton_black || button == pushButton_lBlack || button == pushButton_red || button == pushButton_lRed || button == pushButton_green || button == pushButton_lGreen
+            || button == pushButton_yellow || button == pushButton_lYellow || button == pushButton_blue || button == pushButton_lBlue || button == pushButton_magenta || button == pushButton_lMagenta
+            || button == pushButton_cyan || button == pushButton_lCyan || button == pushButton_white || button == pushButton_lWhite) {
             pHost->updateAnsi16ColorsInTable();
         }
 
-        const bool isAMapEnvColor = (button == pushButton_black_2 || button == pushButton_Lblack_2
-                                     || button == pushButton_red_2 || button == pushButton_Lred_2
-                                     || button == pushButton_green_2 || button == pushButton_Lgreen_2
-                                     || button == pushButton_yellow_2 || button == pushButton_Lyellow_2
-                                     || button == pushButton_blue_2 || button == pushButton_Lblue_2
-                                     || button == pushButton_magenta_2 || button == pushButton_Lmagenta_2
-                                     || button == pushButton_cyan_2 || button == pushButton_Lcyan_2
-                                     || button == pushButton_white_2 || button == pushButton_Lwhite_2);
+        const bool isAMapEnvColor = (button == pushButton_black_2 || button == pushButton_Lblack_2 || button == pushButton_red_2 || button == pushButton_Lred_2 || button == pushButton_green_2
+                                     || button == pushButton_Lgreen_2 || button == pushButton_yellow_2 || button == pushButton_Lyellow_2 || button == pushButton_blue_2 || button == pushButton_Lblue_2
+                                     || button == pushButton_magenta_2 || button == pushButton_Lmagenta_2 || button == pushButton_cyan_2 || button == pushButton_Lcyan_2 || button == pushButton_white_2
+                                     || button == pushButton_Lwhite_2);
 
-        if (isAMapEnvColor
-                || button == pushButton_foreground_color_2
-                || button == pushButton_background_color_2
-                || button == pushButton_lowerLevelColor
-                || button == pushButton_upperLevelColor
-                || button == pushButton_mapInfoBg
-                || button == pushButton_roomBorderColor
-                || button == pushButton_roomCollisionBorderColor) {
-
+        if (isAMapEnvColor || button == pushButton_foreground_color_2 || button == pushButton_background_color_2 || button == pushButton_lowerLevelColor || button == pushButton_upperLevelColor
+            || button == pushButton_mapInfoBg || button == pushButton_roomBorderColor || button == pushButton_roomCollisionBorderColor) {
             if (pHost->mpMap) {
                 // Update the custom environment (room colors)
                 if (isAMapEnvColor) {
@@ -2143,11 +2119,11 @@ void dlgProfilePreferences::slot_setMapBgColor()
         if (pHost->mpMap->mpMapper->glWidget) {
             QOpenGLWidget* map = pHost->mpMap->mpMapper->glWidget;
             if (pHost->mBgColor_2.alpha() < 255) {
-            map->setAttribute(Qt::WA_OpaquePaintEvent, false);
-            map->setAttribute(Qt::WA_AlwaysStackOnTop, true);
+                map->setAttribute(Qt::WA_OpaquePaintEvent, false);
+                map->setAttribute(Qt::WA_AlwaysStackOnTop, true);
             } else {
-            map->setAttribute(Qt::WA_OpaquePaintEvent, true);
-            map->setAttribute(Qt::WA_AlwaysStackOnTop, false);
+                map->setAttribute(Qt::WA_OpaquePaintEvent, true);
+                map->setAttribute(Qt::WA_AlwaysStackOnTop, false);
             }
         }
 #endif
@@ -2499,12 +2475,11 @@ void dlgProfilePreferences::slot_loadMap()
         return;
     }
 
-    auto loadExtensions(QStringList()
-        <<   tr("Any map file (*.dat *.json *.xml)", "Do not change extensions (in braces) as they are used programmatically")
-        <<   tr("Mudlet binary map (*.dat)", "Do not change extensions (in braces) as they are used programmatically")
-        <<   tr("Mudlet JSON map (*.json)", "Do not change extensions (in braces) as they are used programmatically")
-        <<   tr("Mudlet XML map (*.xml)", "Do not change extensions (in braces) as they are used programmatically")
-        <<   tr("Any file (*)", "Do not change extensions (in braces) as they are used programmatically"));
+    auto loadExtensions(QStringList() << tr("Any map file (*.dat *.json *.xml)", "Do not change extensions (in braces) as they are used programmatically")
+                                      << tr("Mudlet binary map (*.dat)", "Do not change extensions (in braces) as they are used programmatically")
+                                      << tr("Mudlet JSON map (*.json)", "Do not change extensions (in braces) as they are used programmatically")
+                                      << tr("Mudlet XML map (*.xml)", "Do not change extensions (in braces) as they are used programmatically")
+                                      << tr("Any file (*)", "Do not change extensions (in braces) as they are used programmatically"));
 
 
     QFileDialog* dialog = new QFileDialog(this);
@@ -2546,7 +2521,7 @@ void dlgProfilePreferences::slot_saveMap()
     dialog->setNameFilter(saveExtensions.join(qsl(";;")));
     dialog->setAcceptMode(QFileDialog::AcceptSave);
     dialog->setDefaultSuffix(qsl("dat"));
-    connect(dialog,  &QFileDialog::filterSelected, this, [=](const QString& filter) {
+    connect(dialog, &QFileDialog::filterSelected, this, [=](const QString& filter) {
         if (filter == datFilter) {
             dialog->setDefaultSuffix(qsl("dat"));
         }
@@ -2657,10 +2632,10 @@ void dlgProfilePreferences::slot_copyMap()
             if (!toProfileDir.exists(toProfileDirPathString)) {
                 if (!toProfileDir.mkpath(toProfileDirPathString)) {
                     const QString errMsg = tr("[ ERROR ] - Unable to use or create directory to store map for other profile \"%1\".\n"
-                                        "Please check that you have permissions/access to:\n"
-                                        "\"%2\"\n"
-                                        "and there is enough space. The copying operation has failed.")
-                                             .arg(toProfileName, toProfileDirPathString);
+                                              "Please check that you have permissions/access to:\n"
+                                              "\"%2\"\n"
+                                              "and there is enough space. The copying operation has failed.")
+                                                   .arg(toProfileName, toProfileDirPathString);
                     pHost->postMessage(errMsg);
                     label_mapFileActionResult->show();
                     label_mapFileActionResult->setText(tr("Creating a destination directory failed..."));
@@ -2715,25 +2690,10 @@ void dlgProfilePreferences::slot_copyMap()
         qsizetype otherProfileAreaCount;
         int otherProfileVersion;
         int otherProfileCurrentRoomId; // What we are looking for!
-        if (pHost->mpMap->retrieveMapFileStats(itOtherProfile.key(),
-                                               &otherProfileFileUsed,
-                                               &otherProfileVersion,
-                                               &otherProfileCurrentRoomId,
-                                               &otherProfileAreaCount,
-                                               &otherProfileRoomCount)) {
-
-            qDebug() << "dlgProfilePreference::slot_copyMap() in other INACTIVE profile:"
-                     << itOtherProfile.key()
-                     << "\n    the file examined was:"
-                     << otherProfileFileUsed
-                     << "\n    it was of version:"
-                     << otherProfileVersion
-                     << "\n    it had an area count of:"
-                     << otherProfileAreaCount
-                     << "\n    it had a room count of:"
-                     << otherProfileRoomCount
-                     << "\n    the player was located in:"
-                     << otherProfileCurrentRoomId;
+        if (pHost->mpMap->retrieveMapFileStats(itOtherProfile.key(), &otherProfileFileUsed, &otherProfileVersion, &otherProfileCurrentRoomId, &otherProfileAreaCount, &otherProfileRoomCount)) {
+            qDebug() << "dlgProfilePreference::slot_copyMap() in other INACTIVE profile:" << itOtherProfile.key() << "\n    the file examined was:" << otherProfileFileUsed
+                     << "\n    it was of version:" << otherProfileVersion << "\n    it had an area count of:" << otherProfileAreaCount << "\n    it had a room count of:" << otherProfileRoomCount
+                     << "\n    the player was located in:" << otherProfileCurrentRoomId;
             itOtherProfile.setValue(otherProfileCurrentRoomId);
             // Using a mutable iterator we must modify (mutate) the data through
             // the iterator!
@@ -2854,8 +2814,7 @@ void dlgProfilePreferences::slot_setLogDir()
      * dialog while the directory selector is open...!
      */
     // Seems to return "." when Cancel is hit:
-    const QString currentLogDir = QFileDialog::getExistingDirectory(
-            this, tr("Where should Mudlet save log files?"), (mLogDirPath.isEmpty() ? lastDir : mLogDirPath), QFileDialog::DontUseNativeDialog);
+    const QString currentLogDir = QFileDialog::getExistingDirectory(this, tr("Where should Mudlet save log files?"), (mLogDirPath.isEmpty() ? lastDir : mLogDirPath), QFileDialog::DontUseNativeDialog);
 
     if (!currentLogDir.isEmpty() && currentLogDir != nullptr) {
         settings.setValue("lastFileDialogLocation", currentLogDir);
@@ -3115,15 +3074,13 @@ void dlgProfilePreferences::slot_saveAndClose()
         }
 
         pHost->mDiscordAccessFlags = static_cast<Host::DiscordOptionFlags>(
-                                         (hideLargeIcon ? Host::DiscordNoOption : Host::DiscordSetLargeIcon)
-                                         | (hideLargeIconText ? Host::DiscordNoOption : Host::DiscordSetLargeIconText)
-                                         | (hideSmallIcon ? Host::DiscordNoOption : Host::DiscordSetSmallIcon)
-                                         | (hideSmallIconText ? Host::DiscordNoOption : Host::DiscordSetSmallIconText)
-                                         | (checkBox_discordServerAccessToDetail->isChecked() ? Host::DiscordNoOption : Host::DiscordSetDetail)
-                                         | (checkBox_discordServerAccessToState->isChecked() ? Host::DiscordNoOption : Host::DiscordSetState)
-                                         | (checkBox_discordServerAccessToPartyInfo->isChecked() ? Host::DiscordNoOption : Host::DiscordSetPartyInfo)
-                                         | (checkBox_discordServerAccessToTimerInfo->isChecked() ? Host::DiscordNoOption : Host::DiscordSetTimeInfo)
-                                         | (checkBox_discordLuaAPI->isChecked() ? Host::DiscordLuaAccessEnabled : Host::DiscordNoOption));
+                (hideLargeIcon ? Host::DiscordNoOption : Host::DiscordSetLargeIcon) | (hideLargeIconText ? Host::DiscordNoOption : Host::DiscordSetLargeIconText)
+                | (hideSmallIcon ? Host::DiscordNoOption : Host::DiscordSetSmallIcon) | (hideSmallIconText ? Host::DiscordNoOption : Host::DiscordSetSmallIconText)
+                | (checkBox_discordServerAccessToDetail->isChecked() ? Host::DiscordNoOption : Host::DiscordSetDetail)
+                | (checkBox_discordServerAccessToState->isChecked() ? Host::DiscordNoOption : Host::DiscordSetState)
+                | (checkBox_discordServerAccessToPartyInfo->isChecked() ? Host::DiscordNoOption : Host::DiscordSetPartyInfo)
+                | (checkBox_discordServerAccessToTimerInfo->isChecked() ? Host::DiscordNoOption : Host::DiscordSetTimeInfo)
+                | (checkBox_discordLuaAPI->isChecked() ? Host::DiscordLuaAccessEnabled : Host::DiscordNoOption));
 
         pHost->mRequiredDiscordUserName = lineEdit_discordUserName->text().trimmed();
         if (lineEdit_discordUserDiscriminator->hasAcceptableInput()) {
@@ -3330,7 +3287,7 @@ void dlgProfilePreferences::populateScriptsList()
     combobox->setUpdatesEnabled(false);
     combobox->clear();
 
-    for (const auto &[name, type, id] : items) {
+    for (const auto& [name, type, id] : items) {
         combobox->addItem(qsl("%1 (%2)").arg(name, type),
                           // store the item type and ID in data so we can pull up the script for it later
                           QVariant::fromValue(QPair<QString, int>(type, id)));
@@ -3562,7 +3519,9 @@ void dlgProfilePreferences::populateThemesList()
     }
     sortedThemes << std::make_pair(qsl("Mudlet"), qsl("Mudlet.tmTheme"));
 
-    std::sort(sortedThemes.begin(), sortedThemes.end(), [](const auto& a, const auto& b) { return QString::localeAwareCompare(a.first, b.first) < 0; });
+    std::sort(sortedThemes.begin(), sortedThemes.end(), [](const auto& a, const auto& b) {
+        return QString::localeAwareCompare(a.first, b.first) < 0;
+    });
 
     // temporary disable painting and event updates while we refill the list
     code_editor_theme_selection_combobox->setUpdatesEnabled(false);
@@ -3570,7 +3529,7 @@ void dlgProfilePreferences::populateThemesList()
 
     auto currentSelection = code_editor_theme_selection_combobox->currentText();
     code_editor_theme_selection_combobox->clear();
-    for (const auto &key : std::as_const(sortedThemes)) {
+    for (const auto& key : std::as_const(sortedThemes)) {
         // store the actual theme file as data because edbee needs that,
         // not the name, for choosing the theme even after the theme file was loaded
         code_editor_theme_selection_combobox->addItem(key.first, key.second);
@@ -3643,9 +3602,7 @@ void dlgProfilePreferences::slot_changeShowSpacesAndTabs(const bool state)
 {
     auto config = edbeePreviewWidget->config();
     config->beginChanges();
-    config->setShowWhitespaceMode(state
-                                  ? edbee::TextEditorConfig::ShowWhitespaces
-                                  : edbee::TextEditorConfig::HideWhitespaces);
+    config->setShowWhitespaceMode(state ? edbee::TextEditorConfig::ShowWhitespaces : edbee::TextEditorConfig::HideWhitespaces);
     config->endChanges();
 }
 
@@ -3749,12 +3706,12 @@ void dlgProfilePreferences::generateMapGlyphDisplay()
         if (roomsWithSymbol.count() > 1) {
             std::sort(roomsWithSymbol.begin(), roomsWithSymbol.end());
         }
-        auto * pSymbolInFont = new QTableWidgetItem();
+        auto* pSymbolInFont = new QTableWidgetItem();
         pSymbolInFont->setTextAlignment(Qt::AlignCenter);
         pSymbolInFont->setToolTip(utils::richText(tr("The room symbol will appear like this if only symbols (glyphs) from the specific font are used.")));
         pSymbolInFont->setFont(selectedFont);
 
-        auto * pSymbolAnyFont = new QTableWidgetItem();
+        auto* pSymbolAnyFont = new QTableWidgetItem();
         pSymbolAnyFont->setTextAlignment(Qt::AlignCenter);
         pSymbolAnyFont->setToolTip(utils::richText(tr("The room symbol will appear like this if symbols (glyphs) from any font can be used.")));
         pSymbolAnyFont->setFont(anyFont);
@@ -3817,7 +3774,7 @@ void dlgProfilePreferences::generateMapGlyphDisplay()
         pRoomNumbers->setToolTip(utils::richText(tr("The rooms with this symbol, up to a maximum of thirty-two, if there are more "
                                                     "than this, it is indicated but they are not shown.")));
 
-        auto * pDummyButton = new QToolButton();
+        auto* pDummyButton = new QToolButton();
         if (isSingleFontUsable) {
             pSymbolInFont->setText(symbol);
             pSymbolAnyFont->setText(symbol);
@@ -3931,23 +3888,23 @@ void dlgProfilePreferences::generateDiscordTooltips()
     </tr>
   </table>
       )")
-                                  .arg(highlight,
-                                       //: Discord Rich Presence large icon
-                                       tr("Large icon"),
-                                       //: Discord Rich Presence detail
-                                       tr("Detail"),
-                                       detail,
-                                       //: Discord Rich Presence small icon"
-                                       tr("Small icon"),
-                                       //: Discord Rich Presence state
-                                       tr("State"),
-                                       state,
-                                       //: Discord Rich Presence party size
-                                       tr("Party size"),
-                                       //: Discord Rich Presence maximum party size
-                                       tr("Party max"))
-                                  //: Discord Rich Presence time until or time elapsed
-                                  .arg(tr("Time"));
+                                        .arg(highlight,
+                                             //: Discord Rich Presence large icon
+                                             tr("Large icon"),
+                                             //: Discord Rich Presence detail
+                                             tr("Detail"),
+                                             detail,
+                                             //: Discord Rich Presence small icon"
+                                             tr("Small icon"),
+                                             //: Discord Rich Presence state
+                                             tr("State"),
+                                             state,
+                                             //: Discord Rich Presence party size
+                                             tr("Party size"),
+                                             //: Discord Rich Presence maximum party size
+                                             tr("Party max"))
+                                        //: Discord Rich Presence time until or time elapsed
+                                        .arg(tr("Time"));
         widget->setToolTip(tooltip);
     };
 
@@ -3993,7 +3950,7 @@ void dlgProfilePreferences::slot_showMapGlyphUsage()
 void dlgProfilePreferences::slot_setMapSymbolFontStrategy(const bool isToOnlyUseSelectedFont)
 {
     Host* pHost = mpHost;
-    if (!pHost ||!pHost->mpMap) {
+    if (!pHost || !pHost->mpMap) {
         return;
     }
 
@@ -4002,7 +3959,7 @@ void dlgProfilePreferences::slot_setMapSymbolFontStrategy(const bool isToOnlyUse
         if (isToOnlyUseSelectedFont) {
             pHost->mpMap->mMapSymbolFont.setStyleStrategy(static_cast<QFont::StyleStrategy>(pHost->mpMap->mMapSymbolFont.styleStrategy() | QFont::NoFontMerging));
         } else {
-            pHost->mpMap->mMapSymbolFont.setStyleStrategy(static_cast<QFont::StyleStrategy>(pHost->mpMap->mMapSymbolFont.styleStrategy() &~(QFont::NoFontMerging)));
+            pHost->mpMap->mMapSymbolFont.setStyleStrategy(static_cast<QFont::StyleStrategy>(pHost->mpMap->mMapSymbolFont.styleStrategy() & ~(QFont::NoFontMerging)));
         }
         // Clear the existing cache of room symbol pixmaps - if there is a mapper:
         if (pHost->mpMap->mpMapper) {
@@ -4017,10 +3974,10 @@ void dlgProfilePreferences::slot_setMapSymbolFontStrategy(const bool isToOnlyUse
     }
 }
 
-void dlgProfilePreferences::slot_setMapSymbolFont(const QFont & font)
+void dlgProfilePreferences::slot_setMapSymbolFont(const QFont& font)
 {
     Host* pHost = mpHost;
-    if (!pHost ||!pHost->mpMap) {
+    if (!pHost || !pHost->mpMap) {
         return;
     }
 
@@ -4085,7 +4042,6 @@ void dlgProfilePreferences::setButtonColor(QPushButton* button, const QColor& co
     if (color.isValid()) {
         if (button->isEnabled()) {
             if (hasAlpha) {
-
                 // This is for buttons that show a color that may have
                 // transparency; so,instead of colouring the background, we
                 // include a generated black/white checkerboard pattern overlaid
@@ -4102,20 +4058,17 @@ void dlgProfilePreferences::setButtonColor(QPushButton* button, const QColor& co
                 labelBackground.fill(Qt::black);
                 QPainter painter(&labelBackground);
                 painter.drawImage(QRect(0, 0, labelBackground.width(), labelBackground.height()),
-                                  QImage(qsl(":/icons/black_white_transparent_check_1x3_ratio.png"))
-                                          .scaled(labelBackground.width(), labelBackground.height(), Qt::KeepAspectRatioByExpanding));
+                                  QImage(qsl(":/icons/black_white_transparent_check_1x3_ratio.png")).scaled(labelBackground.width(), labelBackground.height(), Qt::KeepAspectRatioByExpanding));
                 painter.fillRect(0, 0, labelBackground.width(), labelBackground.height(), color);
                 painter.end();
                 button->setIcon(QIcon(labelBackground));
             } else {
-                button->setStyleSheet(mudlet::self()->mTEXT_ON_BG_STYLESHEET
-                                              .arg(color.lightness() > 127 ? QLatin1String("black") : QLatin1String("white"),
-                                                   color.name()));
+                button->setStyleSheet(mudlet::self()->mTEXT_ON_BG_STYLESHEET.arg(color.lightness() > 127 ? QLatin1String("black") : QLatin1String("white"), color.name()));
             }
             return;
         }
 
-        const QColor disabledColor = QColor::fromHsl(color.hslHue(), color.hslSaturation()/4, color.lightness(), color.alpha());
+        const QColor disabledColor = QColor::fromHsl(color.hslHue(), color.hslSaturation() / 4, color.lightness(), color.alpha());
         if (hasAlpha) {
             // As above for buttons showing a potentially transparent color:
             if (auto iconWidth{button->iconSize().width()}, iconHeight{button->iconSize().height()}; iconWidth != iconHeight * 3) {
@@ -4126,8 +4079,7 @@ void dlgProfilePreferences::setButtonColor(QPushButton* button, const QColor& co
             iconBackground.fill(Qt::black);
             QPainter painter(&iconBackground);
             painter.drawImage(QRect(0, 0, iconBackground.width(), iconBackground.height()),
-                              QImage(qsl(":/icons/black_white_transparent_check_1x3_ratio.png"))
-                                      .scaled(iconBackground.width(), iconBackground.height(), Qt::KeepAspectRatioByExpanding));
+                              QImage(qsl(":/icons/black_white_transparent_check_1x3_ratio.png")).scaled(iconBackground.width(), iconBackground.height(), Qt::KeepAspectRatioByExpanding));
             painter.fillRect(0, 0, iconBackground.width(), iconBackground.height(), disabledColor);
             painter.end();
             // Because the button is disabled we have to explicitly force our
@@ -4139,8 +4091,7 @@ void dlgProfilePreferences::setButtonColor(QPushButton* button, const QColor& co
             icon.addPixmap(iconBackground, QIcon::Disabled, QIcon::Off);
             button->setIcon(icon);
         } else {
-            button->setStyleSheet(mudlet::self()->mTEXT_ON_BG_STYLESHEET
-                              .arg(QLatin1String("darkGray"), disabledColor.name()));
+            button->setStyleSheet(mudlet::self()->mTEXT_ON_BG_STYLESHEET.arg(QLatin1String("darkGray"), disabledColor.name()));
         }
         return;
     }
@@ -4439,10 +4390,8 @@ void dlgProfilePreferences::setPlayerRoomColor(QPushButton* b, QColor& c)
         return;
     }
 
-    auto color = QColorDialog::getColor(c, this, (b == pushButton_playerRoomPrimaryColor
-                                                          ? tr("Set outer color of player room mark.")
-                                                          : tr("Set inner color of player room mark.")),
-                                        QColorDialog::ShowAlphaChannel);
+    auto color = QColorDialog::getColor(
+            c, this, (b == pushButton_playerRoomPrimaryColor ? tr("Set outer color of player room mark.") : tr("Set inner color of player room mark.")), QColorDialog::ShowAlphaChannel);
     if (color.isValid()) {
         c = color;
 
@@ -4523,7 +4472,6 @@ void dlgProfilePreferences::slot_toggleEnableClosedCaption(const bool state)
         mpHost->mEnableClosedCaption = state;
     }
 }
-
 
 
 void dlgProfilePreferences::slot_changeWrapAt()
@@ -4613,9 +4561,9 @@ bool dlgProfilePreferences::updateDisplayFont()
 
     QFont displayFont = fontComboBox_displayFont->currentFont();
     displayFont.setPointSize(spinBox_displayFontSize->value());
-    displayFont.setStyleHint(QFont::AnyStyle, checkBox_antiAlias->isChecked()
-                              ? static_cast<QFont::StyleStrategy>(QFont::PreferAntialias | QFont::PreferQuality)
-                              : static_cast<QFont::StyleStrategy>(QFont::NoAntialias | QFont::PreferQuality));
+    displayFont.setStyleHint(QFont::AnyStyle,
+                             checkBox_antiAlias->isChecked() ? static_cast<QFont::StyleStrategy>(QFont::PreferAntialias | QFont::PreferQuality)
+                                                             : static_cast<QFont::StyleStrategy>(QFont::NoAntialias | QFont::PreferQuality));
 
     if (TFontAttributes(mpHost->getDisplayFont()) == TFontAttributes(displayFont)) {
         // No change!

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -40,7 +40,8 @@ const QString doubleParagraph{qsl("<p>%1</p><p>%2</p>")};
 
 WeightSpinBoxDelegate::WeightSpinBoxDelegate(QObject* parent)
 : QStyledItemDelegate(parent)
-{}
+{
+}
 
 QWidget* WeightSpinBoxDelegate::createEditor(QWidget* parent, const QStyleOptionViewItem& /* option */, const QModelIndex& /* index */) const
 {
@@ -77,7 +78,8 @@ void WeightSpinBoxDelegate::updateEditorGeometry(QWidget* pEditor, const QStyleO
 
 RoomIdLineEditDelegate::RoomIdLineEditDelegate(QObject* parent)
 : QStyledItemDelegate(parent)
-{}
+{
+}
 
 QWidget* RoomIdLineEditDelegate::createEditor(QWidget* parent, const QStyleOptionViewItem& /* option */, const QModelIndex& index) const
 {
@@ -127,11 +129,10 @@ QWidget* RoomIdLineEditDelegate::createEditor(QWidget* parent, const QStyleOptio
                 const int exitAreaID = exitToRoom->getArea();
                 const bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
                 const bool exitRoomLocked = exitToRoom->isLocked;
-                mpDlgRoomExits->setActionOnExit(mpEditor, exitRoomLocked
-                                                ? mpDlgRoomExits->mpAction_exitRoomLocked
-                                                : outOfAreaExit
-                                                  ? mpDlgRoomExits->mpAction_otherAreaExit
-                                                  : mpDlgRoomExits->mpAction_inAreaExit);
+                mpDlgRoomExits->setActionOnExit(mpEditor,
+                                                exitRoomLocked  ? mpDlgRoomExits->mpAction_exitRoomLocked
+                                                : outOfAreaExit ? mpDlgRoomExits->mpAction_otherAreaExit
+                                                                : mpDlgRoomExits->mpAction_inAreaExit);
                 QString exitAreaName;
                 if (outOfAreaExit) {
                     exitAreaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(exitAreaID);
@@ -211,11 +212,10 @@ void RoomIdLineEditDelegate::slot_specialRoomExitIdEdited(const QString& text) c
             exitAreaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(exitAreaID);
         }
 
-        mpDlgRoomExits->setActionOnExit(mpEditor, exitRoomLocked
-                                        ? mpDlgRoomExits->mpAction_exitRoomLocked
-                                        : outOfAreaExit
-                                          ? mpDlgRoomExits->mpAction_otherAreaExit
-                                          : mpDlgRoomExits->mpAction_inAreaExit);
+        mpDlgRoomExits->setActionOnExit(mpEditor,
+                                        exitRoomLocked  ? mpDlgRoomExits->mpAction_exitRoomLocked
+                                        : outOfAreaExit ? mpDlgRoomExits->mpAction_otherAreaExit
+                                                        : mpDlgRoomExits->mpAction_inAreaExit);
         roomIdToolTipText = mpDlgRoomExits->generateToolTip(pExitToRoom->name, exitAreaName, exitRoomLocked, outOfAreaExit, pExitToRoom->getWeight());
     } else if (text.toInt() > 0) {
         // A number but not valid
@@ -329,7 +329,10 @@ void dlgRoomExits::slot_editSpecialExit(QTreeWidgetItem* pI, int column)
             break;
 
         case ExitsTreeWidget::colIndex_exitWeight:
-            mpEditItem->setText(ExitsTreeWidget::colIndex_exitWeight, QString::number((mpEditItem->text(ExitsTreeWidget::colIndex_exitWeight).toInt() < 0) ? (-1 * mpEditItem->text(ExitsTreeWidget::colIndex_exitWeight).toInt()) : mpEditItem->text(ExitsTreeWidget::colIndex_exitWeight).toInt())); //Force result to be non-negative integer
+            mpEditItem->setText(ExitsTreeWidget::colIndex_exitWeight,
+                                QString::number((mpEditItem->text(ExitsTreeWidget::colIndex_exitWeight).toInt() < 0)
+                                                        ? (-1 * mpEditItem->text(ExitsTreeWidget::colIndex_exitWeight).toInt())
+                                                        : mpEditItem->text(ExitsTreeWidget::colIndex_exitWeight).toInt())); //Force result to be non-negative integer
             specialExits->closePersistentEditor(mpEditItem, mEditColumn);
             break;
 
@@ -369,8 +372,8 @@ void dlgRoomExits::slot_editSpecialExit(QTreeWidgetItem* pI, int column)
             specialExits->closePersistentEditor(mpEditItem, mEditColumn);
             //            qDebug().nospace().noquote() << "dlgRoomExits::slot_editSpecialExit(...) INFO - Closed PE on item: \"" << mpEditItem->text(ExitsTreeWidget::colIndex_command) << "\" column: " << mEditColumn;
             break;
-        default:
-            {} //noop for other column (ExitsTreeWidget::colIndex_lockExit)
+        default: {
+        } //noop for other column (ExitsTreeWidget::colIndex_lockExit)
         }
         setIconAndToolTipsOnSpecialExit(mpEditItem, true);
 
@@ -399,7 +402,9 @@ void dlgRoomExits::slot_editSpecialExit(QTreeWidgetItem* pI, int column)
     //    qDebug().nospace().noquote() << "dlgRoomExits::slot_editSpecialExit(...) INFO - A Special Exit is been edited, it has the command: \"" << pI->text(ExitsTreeWidget::colIndex_command) << "\" and the editing is on column:" << column;
     switch (column) {
     case ExitsTreeWidget::colIndex_exitWeight:
-        pI->setText(ExitsTreeWidget::colIndex_exitWeight, QString::number((pI->text(ExitsTreeWidget::colIndex_exitWeight).toInt() < 0) ? (-1 * pI->text(ExitsTreeWidget::colIndex_exitWeight).toInt()) : pI->text(ExitsTreeWidget::colIndex_exitWeight).toInt())); //Force result to be non-negative
+        pI->setText(ExitsTreeWidget::colIndex_exitWeight,
+                    QString::number((pI->text(ExitsTreeWidget::colIndex_exitWeight).toInt() < 0) ? (-1 * pI->text(ExitsTreeWidget::colIndex_exitWeight).toInt())
+                                                                                                 : pI->text(ExitsTreeWidget::colIndex_exitWeight).toInt())); //Force result to be non-negative
         break;
 
     case ExitsTreeWidget::colIndex_doorNone: // Enforce exclusive Radio Button type behaviour on the checkboxes in these four columns
@@ -449,7 +454,8 @@ void dlgRoomExits::slot_addSpecialExit()
 
     pI->setText(ExitsTreeWidget::colIndex_exitWeight, qsl("0")); //Exit Weight
     pI->setTextAlignment(ExitsTreeWidget::colIndex_exitWeight, Qt::AlignRight);
-    pI->setToolTip(ExitsTreeWidget::colIndex_exitWeight, utils::richText(tr("Set to a positive value to override the default (Room) Weight for using this Exit route, zero value assigns the default.")));
+    pI->setToolTip(ExitsTreeWidget::colIndex_exitWeight,
+                   utils::richText(tr("Set to a positive value to override the default (Room) Weight for using this Exit route, zero value assigns the default.")));
 
     pI->setCheckState(ExitsTreeWidget::colIndex_doorNone, Qt::Checked); //Doortype: none
     pI->setToolTip(ExitsTreeWidget::colIndex_doorNone, utils::richText(tr("No door symbol is drawn on 2D Map for this exit (only functional choice currently).")));
@@ -497,8 +503,7 @@ void dlgRoomExits::save()
             door = 0;
         }
         const QString key = pI->text(ExitsTreeWidget::colIndex_command);
-        if (key != mSpecialExitCommandPlaceholder
-            && value != 0 && mpHost->mpMap->mpRoomDB->getRoom(value) != nullptr) {
+        if (key != mSpecialExitCommandPlaceholder && value != 0 && mpHost->mpMap->mpRoomDB->getRoom(value) != nullptr) {
             originalExitCmds.remove(key);
             locked = (pI->checkState(ExitsTreeWidget::colIndex_lockExit) != Qt::Unchecked);
             pR->setSpecialExit(value, key); // Now can overwrite an existing exit with a different destination
@@ -966,24 +971,20 @@ void dlgRoomExits::setIconAndToolTipsOnSpecialExit(QTreeWidgetItem* pSpecialExit
         // This is the toolTip text for the roomID number column (and the
         // status icons)
         const QString roomIdToolTipText{generateToolTip(pExitToRoom->name, exitAreaName, exitRoomLocked, outOfAreaExit, pExitToRoom->getWeight())};
-        pSpecialExit->setToolTip(ExitsTreeWidget::colIndex_exitStatus, utils::richText(tr("The roomID of the room that this special exit leads to is expected here. "
-                                                                                          "If left like this, this exit will be deleted when <tt>save</tt> is clicked.")));
+        pSpecialExit->setToolTip(ExitsTreeWidget::colIndex_exitStatus,
+                                 utils::richText(tr("The roomID of the room that this special exit leads to is expected here. "
+                                                    "If left like this, this exit will be deleted when <tt>save</tt> is clicked.")));
 
-        pSpecialExit->setIcon(ExitsTreeWidget::colIndex_exitStatus, !showIconOnExitStatus
-                              ? QIcon()
-                              : exitRoomLocked
-                                ? mIcon_exitRoomLocked
-                                : outOfAreaExit
-                                  ? mIcon_otherAreaExit
-                                  : mIcon_inAreaExit);
+        pSpecialExit->setIcon(ExitsTreeWidget::colIndex_exitStatus, !showIconOnExitStatus ? QIcon() : exitRoomLocked ? mIcon_exitRoomLocked : outOfAreaExit ? mIcon_otherAreaExit : mIcon_inAreaExit);
         pSpecialExit->setToolTip(ExitsTreeWidget::colIndex_exitRoomId, roomIdToolTipText);
         pSpecialExit->setToolTip(ExitsTreeWidget::colIndex_exitStatus, roomIdToolTipText);
 
     } else if (pSpecialExit->text(ExitsTreeWidget::colIndex_exitRoomId).toInt() > 0) {
         // A number but not valid:
         pSpecialExit->setIcon(ExitsTreeWidget::colIndex_exitStatus, showIconOnExitStatus ? mIcon_invalidExit : QIcon());
-        pSpecialExit->setToolTip(ExitsTreeWidget::colIndex_exitRoomId, doubleParagraph.arg(tr("Entered number is invalid. If left like this, this exit will be deleted when <tt>save</tt> is clicked."),
-                                                                                           tr("Set the number of the room that this special exit leads to.")));
+        pSpecialExit->setToolTip(ExitsTreeWidget::colIndex_exitRoomId,
+                                 doubleParagraph.arg(tr("Entered number is invalid. If left like this, this exit will be deleted when <tt>save</tt> is clicked."),
+                                                     tr("Set the number of the room that this special exit leads to.")));
     } else if (pSpecialExit->text(ExitsTreeWidget::colIndex_exitRoomId).isEmpty() || pSpecialExit->text(ExitsTreeWidget::colIndex_exitRoomId) == mSpecialExitRoomIdPlaceholder) {
         // Nothing:
         pSpecialExit->setIcon(ExitsTreeWidget::colIndex_exitStatus, QIcon());
@@ -991,12 +992,14 @@ void dlgRoomExits::setIconAndToolTipsOnSpecialExit(QTreeWidgetItem* pSpecialExit
     } else {
         // Something else that isn't a positive number:
         pSpecialExit->setIcon(ExitsTreeWidget::colIndex_exitStatus, showIconOnExitStatus ? mIcon_invalidExit : QIcon());
-        pSpecialExit->setToolTip(ExitsTreeWidget::colIndex_exitRoomId, utils::richText(tr("The roomID of the room that this special exit leads to is expected here. "
-                                                                                          "If left like this, this exit will be deleted when <tt>save</tt> is clicked.")));
+        pSpecialExit->setToolTip(ExitsTreeWidget::colIndex_exitRoomId,
+                                 utils::richText(tr("The roomID of the room that this special exit leads to is expected here. "
+                                                    "If left like this, this exit will be deleted when <tt>save</tt> is clicked.")));
     }
 
     if (pSpecialExit->text(ExitsTreeWidget::colIndex_command) == mSpecialExitCommandPlaceholder) {
-        pSpecialExit->setToolTip(ExitsTreeWidget::colIndex_command, utils::richText(tr("No command or Lua script entered, if left like this, this exit will be deleted when <tt>save</tt> is clicked.")));
+        pSpecialExit->setToolTip(ExitsTreeWidget::colIndex_command,
+                                 utils::richText(tr("No command or Lua script entered, if left like this, this exit will be deleted when <tt>save</tt> is clicked.")));
     } else {
         pSpecialExit->setToolTip(ExitsTreeWidget::colIndex_command, utils::richText(tr("Some mapper scripts may require prefixing the keyword \"script:\").")));
     }
@@ -1043,33 +1046,27 @@ QAction* dlgRoomExits::getActionOnExit(QLineEdit* pExitLineEdit) const
     if (exitRoomName.trimmed().length()) {
         if (exitRoomLocked) {
             if (outOfAreaExit) {
-                return doubleParagraph.arg(tr("Exit to \"%1\" in area: \"%2\".")
-                                               .arg(exitRoomName.toHtmlEscaped(), exitAreaName.toHtmlEscaped()),
+                return doubleParagraph.arg(tr("Exit to \"%1\" in area: \"%2\".").arg(exitRoomName.toHtmlEscaped(), exitAreaName.toHtmlEscaped()),
                                            //: Bold HTML tags are used to emphasis that destination room locked status overrides any weight or lock ("No route") setting of any exit that goes to it.
                                            tr("<b>Room is locked</b>, it will not be used for speed-walks for any exit that leads to it."));
             }
-            return doubleParagraph.arg(tr("Exit to \"%1\".")
-                                           .arg(exitRoomName.toHtmlEscaped()),
+            return doubleParagraph.arg(tr("Exit to \"%1\".").arg(exitRoomName.toHtmlEscaped()),
                                        //: Bold HTML tags are used to emphasis that destination room locked status overrides any weight or lock ("No route") setting of any exit that goes to it.
                                        tr("<b>Room is locked</b>, it will not be used for speed-walks for any exit that leads to it."));
-
         }
         if (outOfAreaExit) {
-            return doubleParagraph.arg(tr("Exit to \"%1\" in area: \"%2\".")
-                                           .arg(exitRoomName.toHtmlEscaped(), exitAreaName.toHtmlEscaped()),
+            return doubleParagraph.arg(tr("Exit to \"%1\" in area: \"%2\".").arg(exitRoomName.toHtmlEscaped(), exitAreaName.toHtmlEscaped()),
                                        //: Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not
                                        tr("<b>Room</b> Weight of destination: %1.").arg(exitRoomWeight));
         }
-        return doubleParagraph.arg(tr("Exit to \"%1\".")
-                                       .arg(exitRoomName.toHtmlEscaped()),
+        return doubleParagraph.arg(tr("Exit to \"%1\".").arg(exitRoomName.toHtmlEscaped()),
                                    //: Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not
                                    tr("<b>Room</b> Weight of destination: %1.").arg(exitRoomWeight));
     }
 
     if (exitRoomLocked) {
         if (outOfAreaExit) {
-            return doubleParagraph.arg(tr("Exit to unnamed room in area: \"%1\", is valid.")
-                                           .arg(exitAreaName.toHtmlEscaped()),
+            return doubleParagraph.arg(tr("Exit to unnamed room in area: \"%1\", is valid.").arg(exitAreaName.toHtmlEscaped()),
                                        //: Bold HTML tags are used to emphasis that destination room locked status overrides any weight or lock ("No route") setting of any exit that goes to it.
                                        tr("<b>Room is locked</b>, it will not be used for speed-walks for any exit that leads to it."));
         }
@@ -1080,8 +1077,7 @@ QAction* dlgRoomExits::getActionOnExit(QLineEdit* pExitLineEdit) const
     }
 
     if (outOfAreaExit) {
-        return doubleParagraph.arg(tr("Exit to unnamed room in area: \"%1\", is valid.")
-                                       .arg(exitAreaName.toHtmlEscaped()),
+        return doubleParagraph.arg(tr("Exit to unnamed room in area: \"%1\", is valid.").arg(exitAreaName.toHtmlEscaped()),
                                    //: Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.
                                    tr("<b>Room</b> Weight of destination: %1.").arg(exitRoomWeight));
     }
@@ -1091,7 +1087,17 @@ QAction* dlgRoomExits::getActionOnExit(QLineEdit* pExitLineEdit) const
                                tr("<b>Room</b> Weight of destination: %1.").arg(exitRoomWeight));
 }
 
-void dlgRoomExits::normalExitEdited(const QString& roomExitIdText, QLineEdit* pExit, QCheckBox* pNoRoute, QCheckBox* pStub, QSpinBox* pWeight, QRadioButton* pDoorType_none, QRadioButton* pDoorType_open, QRadioButton* pDoorType_closed, QRadioButton* pDoorType_locked, const QString& invalidExitToolTipText, const QString& noExitToolTipText)
+void dlgRoomExits::normalExitEdited(const QString& roomExitIdText,
+                                    QLineEdit* pExit,
+                                    QCheckBox* pNoRoute,
+                                    QCheckBox* pStub,
+                                    QSpinBox* pWeight,
+                                    QRadioButton* pDoorType_none,
+                                    QRadioButton* pDoorType_open,
+                                    QRadioButton* pDoorType_closed,
+                                    QRadioButton* pDoorType_locked,
+                                    const QString& invalidExitToolTipText,
+                                    const QString& noExitToolTipText)
 {
     TRoom* exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(roomExitIdText.toInt());
     if (exitToRoom) {
@@ -1111,11 +1117,7 @@ void dlgRoomExits::normalExitEdited(const QString& roomExitIdText, QLineEdit* pE
         pDoorType_open->setEnabled(true);
         pDoorType_closed->setEnabled(true);
         pDoorType_locked->setEnabled(true);
-        setActionOnExit(pExit, exitRoomLocked
-                        ? mpAction_exitRoomLocked
-                        : outOfAreaExit
-                          ? mpAction_otherAreaExit
-                          : mpAction_inAreaExit);
+        setActionOnExit(pExit, exitRoomLocked ? mpAction_exitRoomLocked : outOfAreaExit ? mpAction_otherAreaExit : mpAction_inAreaExit);
         pExit->setToolTip(generateToolTip(exitToRoom->name, exitAreaName, exitRoomLocked, outOfAreaExit, exitToRoom->getWeight()));
     } else {
         if (!roomExitIdText.isEmpty()) {
@@ -1138,10 +1140,17 @@ void dlgRoomExits::normalExitEdited(const QString& roomExitIdText, QLineEdit* pE
         pDoorType_locked->setEnabled(false);
         pStub->setEnabled(true);
     }
- }
+}
 
-void dlgRoomExits::normalStubExitChanged(const int state, QLineEdit* pExit, QCheckBox* pNoRoute, QSpinBox* pWeight,
-                                         QRadioButton* pDoorType_none, QRadioButton* pDoorType_open, QRadioButton* pDoorType_closed, QRadioButton* pDoorType_locked, const QString& noExitToolTipText) const
+void dlgRoomExits::normalStubExitChanged(const int state,
+                                         QLineEdit* pExit,
+                                         QCheckBox* pNoRoute,
+                                         QSpinBox* pWeight,
+                                         QRadioButton* pDoorType_none,
+                                         QRadioButton* pDoorType_open,
+                                         QRadioButton* pDoorType_closed,
+                                         QRadioButton* pDoorType_locked,
+                                         const QString& noExitToolTipText) const
 {
     if (state == Qt::Checked) {
         if (!pExit->text().isEmpty()) {
@@ -1153,7 +1162,7 @@ void dlgRoomExits::normalStubExitChanged(const int state, QLineEdit* pExit, QChe
             pNoRoute->setChecked(false); // nor a "lock"
         }
         pNoRoute->setEnabled(false); // Disable "lock" on this exit
-        pExit->setEnabled(false);         // Prevent entry of an exit roomID
+        pExit->setEnabled(false);    // Prevent entry of an exit roomID
         pExit->setToolTip(utils::richText(tr("Clear the stub exit for this exit to enter an exit roomID.")));
         pDoorType_none->setEnabled(true);
         pDoorType_open->setEnabled(true);
@@ -1180,8 +1189,15 @@ void dlgRoomExits::normalStubExitChanged(const int state, QLineEdit* pExit, QChe
 // These slots are called as the text for the exitID is edited
 void dlgRoomExits::slot_nw_textEdited(const QString& text)
 {
-    normalExitEdited(text, nw, noroute_nw, stub_nw, weight_nw,
-                     doortype_none_nw, doortype_open_nw, doortype_closed_nw, doortype_locked_nw,
+    normalExitEdited(text,
+                     nw,
+                     noroute_nw,
+                     stub_nw,
+                     weight_nw,
+                     doortype_none_nw,
+                     doortype_open_nw,
+                     doortype_closed_nw,
+                     doortype_locked_nw,
                      doubleParagraph.arg(tr("Entered number is invalid."), tr("Set the number of the room northwest of this one.")),
                      utils::richText(tr("Set the number of the room northwest of this one.")));
     slot_checkModified();
@@ -1189,8 +1205,15 @@ void dlgRoomExits::slot_nw_textEdited(const QString& text)
 
 void dlgRoomExits::slot_n_textEdited(const QString& text)
 {
-    normalExitEdited(text, n, noroute_n, stub_n, weight_n,
-                     doortype_none_n, doortype_open_n, doortype_closed_n, doortype_locked_n,
+    normalExitEdited(text,
+                     n,
+                     noroute_n,
+                     stub_n,
+                     weight_n,
+                     doortype_none_n,
+                     doortype_open_n,
+                     doortype_closed_n,
+                     doortype_locked_n,
                      doubleParagraph.arg(tr("Entered number is invalid."), tr("Set the number of the room north of this one.")),
                      utils::richText(tr("Set the number of the room north of this one.")));
     slot_checkModified();
@@ -1198,8 +1221,15 @@ void dlgRoomExits::slot_n_textEdited(const QString& text)
 
 void dlgRoomExits::slot_ne_textEdited(const QString& text)
 {
-    normalExitEdited(text, ne, noroute_ne, stub_ne, weight_ne,
-                     doortype_none_ne, doortype_open_ne, doortype_closed_ne, doortype_locked_ne,
+    normalExitEdited(text,
+                     ne,
+                     noroute_ne,
+                     stub_ne,
+                     weight_ne,
+                     doortype_none_ne,
+                     doortype_open_ne,
+                     doortype_closed_ne,
+                     doortype_locked_ne,
                      doubleParagraph.arg(tr("Entered number is invalid."), tr("Set the number of the room northeast of this one.")),
                      utils::richText(tr("Set the number of the room northeast of this one.")));
     slot_checkModified();
@@ -1207,8 +1237,15 @@ void dlgRoomExits::slot_ne_textEdited(const QString& text)
 
 void dlgRoomExits::slot_up_textEdited(const QString& text)
 {
-    normalExitEdited(text, up, noroute_up, stub_up, weight_up,
-                     doortype_none_up, doortype_open_up, doortype_closed_up, doortype_locked_up,
+    normalExitEdited(text,
+                     up,
+                     noroute_up,
+                     stub_up,
+                     weight_up,
+                     doortype_none_up,
+                     doortype_open_up,
+                     doortype_closed_up,
+                     doortype_locked_up,
                      doubleParagraph.arg(tr("Entered number is invalid."), tr("Set the number of the room up from this one.")),
                      utils::richText(tr("Set the number of the room up from this one.")));
     slot_checkModified();
@@ -1216,8 +1253,15 @@ void dlgRoomExits::slot_up_textEdited(const QString& text)
 
 void dlgRoomExits::slot_w_textEdited(const QString& text)
 {
-    normalExitEdited(text, w, noroute_w, stub_w, weight_w,
-                     doortype_none_w, doortype_open_w, doortype_closed_w, doortype_locked_w,
+    normalExitEdited(text,
+                     w,
+                     noroute_w,
+                     stub_w,
+                     weight_w,
+                     doortype_none_w,
+                     doortype_open_w,
+                     doortype_closed_w,
+                     doortype_locked_w,
                      doubleParagraph.arg(tr("Entered number is invalid."), tr("Set the number of the room west of this one.")),
                      utils::richText(tr("Set the number of the room west of this one.")));
     slot_checkModified();
@@ -1225,8 +1269,15 @@ void dlgRoomExits::slot_w_textEdited(const QString& text)
 
 void dlgRoomExits::slot_e_textEdited(const QString& text)
 {
-    normalExitEdited(text, e, noroute_e, stub_e, weight_e,
-                     doortype_none_e, doortype_open_e, doortype_closed_e, doortype_locked_e,
+    normalExitEdited(text,
+                     e,
+                     noroute_e,
+                     stub_e,
+                     weight_e,
+                     doortype_none_e,
+                     doortype_open_e,
+                     doortype_closed_e,
+                     doortype_locked_e,
                      doubleParagraph.arg(tr("Entered number is invalid."), tr("Set the number of the room east of this one.")),
                      utils::richText(tr("Set the number of the room east of this one.")));
     slot_checkModified();
@@ -1234,8 +1285,15 @@ void dlgRoomExits::slot_e_textEdited(const QString& text)
 
 void dlgRoomExits::slot_down_textEdited(const QString& text)
 {
-    normalExitEdited(text, down, noroute_down, stub_down, weight_down,
-                     doortype_none_down, doortype_open_down, doortype_closed_down, doortype_locked_down,
+    normalExitEdited(text,
+                     down,
+                     noroute_down,
+                     stub_down,
+                     weight_down,
+                     doortype_none_down,
+                     doortype_open_down,
+                     doortype_closed_down,
+                     doortype_locked_down,
                      doubleParagraph.arg(tr("Entered number is invalid."), tr("Set the number of the room down from this one.")),
                      utils::richText(tr("Set the number of the room down from this one.")));
     slot_checkModified();
@@ -1243,8 +1301,15 @@ void dlgRoomExits::slot_down_textEdited(const QString& text)
 
 void dlgRoomExits::slot_sw_textEdited(const QString& text)
 {
-    normalExitEdited(text, sw, noroute_sw, stub_sw, weight_sw,
-                     doortype_none_sw, doortype_open_sw, doortype_closed_sw, doortype_locked_sw,
+    normalExitEdited(text,
+                     sw,
+                     noroute_sw,
+                     stub_sw,
+                     weight_sw,
+                     doortype_none_sw,
+                     doortype_open_sw,
+                     doortype_closed_sw,
+                     doortype_locked_sw,
                      doubleParagraph.arg(tr("Entered number is invalid."), tr("Set the number of the room southwest of this one.")),
                      utils::richText(tr("Set the number of the room southwest of this one.")));
     slot_checkModified();
@@ -1252,8 +1317,15 @@ void dlgRoomExits::slot_sw_textEdited(const QString& text)
 
 void dlgRoomExits::slot_s_textEdited(const QString& text)
 {
-    normalExitEdited(text, s, noroute_s, stub_s, weight_s,
-                     doortype_none_s, doortype_open_s, doortype_closed_s, doortype_locked_s,
+    normalExitEdited(text,
+                     s,
+                     noroute_s,
+                     stub_s,
+                     weight_s,
+                     doortype_none_s,
+                     doortype_open_s,
+                     doortype_closed_s,
+                     doortype_locked_s,
                      doubleParagraph.arg(tr("Entered number is invalid."), tr("Set the number of the room south of this one.")),
                      utils::richText(tr("Set the number of the room south of this one.")));
     slot_checkModified();
@@ -1261,8 +1333,15 @@ void dlgRoomExits::slot_s_textEdited(const QString& text)
 
 void dlgRoomExits::slot_se_textEdited(const QString& text)
 {
-    normalExitEdited(text, se, noroute_se, stub_se, weight_se,
-                     doortype_none_se, doortype_open_se, doortype_closed_se, doortype_locked_se,
+    normalExitEdited(text,
+                     se,
+                     noroute_se,
+                     stub_se,
+                     weight_se,
+                     doortype_none_se,
+                     doortype_open_se,
+                     doortype_closed_se,
+                     doortype_locked_se,
                      doubleParagraph.arg(tr("Entered number is invalid."), tr("Set the number of the room southeast of this one.")),
                      utils::richText(tr("Set the number of the room southeast of this one.")));
     slot_checkModified();
@@ -1270,8 +1349,15 @@ void dlgRoomExits::slot_se_textEdited(const QString& text)
 
 void dlgRoomExits::slot_in_textEdited(const QString& text)
 {
-    normalExitEdited(text, in, noroute_in, stub_in, weight_in,
-                     doortype_none_in, doortype_open_in, doortype_closed_in, doortype_locked_in,
+    normalExitEdited(text,
+                     in,
+                     noroute_in,
+                     stub_in,
+                     weight_in,
+                     doortype_none_in,
+                     doortype_open_in,
+                     doortype_closed_in,
+                     doortype_locked_in,
                      doubleParagraph.arg(tr("Entered number is invalid."), tr("Set the number of the room in from this one.")),
                      utils::richText(tr("Set the number of the room in from this one.")));
     slot_checkModified();
@@ -1279,8 +1365,15 @@ void dlgRoomExits::slot_in_textEdited(const QString& text)
 
 void dlgRoomExits::slot_out_textEdited(const QString& text)
 {
-    normalExitEdited(text, out, noroute_out, stub_out, weight_out,
-                     doortype_none_out, doortype_open_out, doortype_closed_out, doortype_locked_out,
+    normalExitEdited(text,
+                     out,
+                     noroute_out,
+                     stub_out,
+                     weight_out,
+                     doortype_none_out,
+                     doortype_open_out,
+                     doortype_closed_out,
+                     doortype_locked_out,
                      doubleParagraph.arg(tr("Entered number is invalid."), tr("Set the number of the room out from this one.")),
                      utils::richText(tr("Set the number of the room out from this one.")));
     slot_checkModified();
@@ -1289,97 +1382,88 @@ void dlgRoomExits::slot_out_textEdited(const QString& text)
 // These slots are called as the stub exit checkboxes are clicked
 void dlgRoomExits::slot_stub_nw_stateChanged(int state)
 {
-    normalStubExitChanged(state, nw, noroute_nw, weight_nw,
-                          doortype_none_nw, doortype_open_nw, doortype_closed_nw, doortype_locked_n,
-                          utils::richText(tr("Set the number of the room northwest of this one.")));
+    normalStubExitChanged(
+            state, nw, noroute_nw, weight_nw, doortype_none_nw, doortype_open_nw, doortype_closed_nw, doortype_locked_n, utils::richText(tr("Set the number of the room northwest of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_n_stateChanged(int state)
 {
-    normalStubExitChanged(state, n, noroute_n, weight_n,
-                          doortype_none_n, doortype_open_n, doortype_closed_n, doortype_locked_n,
-                          utils::richText(tr("Set the number of the room north of this one.")));
+    normalStubExitChanged(state, n, noroute_n, weight_n, doortype_none_n, doortype_open_n, doortype_closed_n, doortype_locked_n, utils::richText(tr("Set the number of the room north of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_ne_stateChanged(int state)
 {
-    normalStubExitChanged(state, ne, noroute_ne, weight_ne,
-                          doortype_none_ne, doortype_open_ne, doortype_closed_ne, doortype_locked_ne,
-                          utils::richText(tr("Set the number of the room northeast of this one.")));
+    normalStubExitChanged(
+            state, ne, noroute_ne, weight_ne, doortype_none_ne, doortype_open_ne, doortype_closed_ne, doortype_locked_ne, utils::richText(tr("Set the number of the room northeast of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_up_stateChanged(int state)
 {
-    normalStubExitChanged(state, up, noroute_up, weight_up,
-                          doortype_none_up, doortype_open_up, doortype_closed_up, doortype_locked_up,
-                          utils::richText(tr("Set the number of the room up from this one.")));
+    normalStubExitChanged(
+            state, up, noroute_up, weight_up, doortype_none_up, doortype_open_up, doortype_closed_up, doortype_locked_up, utils::richText(tr("Set the number of the room up from this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_w_stateChanged(int state)
 {
-    normalStubExitChanged(state, w, noroute_w, weight_w,
-                          doortype_none_w, doortype_open_w, doortype_closed_w, doortype_locked_w,
-                          utils::richText(tr("Set the number of the room west of this one.")));
+    normalStubExitChanged(state, w, noroute_w, weight_w, doortype_none_w, doortype_open_w, doortype_closed_w, doortype_locked_w, utils::richText(tr("Set the number of the room west of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_e_stateChanged(int state)
 {
-    normalStubExitChanged(state, e, noroute_e, weight_e,
-                          doortype_none_e, doortype_open_e, doortype_closed_e, doortype_locked_e,
-                          utils::richText(tr("Set the number of the room east of this one.")));
+    normalStubExitChanged(state, e, noroute_e, weight_e, doortype_none_e, doortype_open_e, doortype_closed_e, doortype_locked_e, utils::richText(tr("Set the number of the room east of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_down_stateChanged(int state)
 {
-    normalStubExitChanged(state, down, noroute_down, weight_down,
-                          doortype_none_down, doortype_open_down, doortype_closed_down, doortype_locked_down,
+    normalStubExitChanged(state,
+                          down,
+                          noroute_down,
+                          weight_down,
+                          doortype_none_down,
+                          doortype_open_down,
+                          doortype_closed_down,
+                          doortype_locked_down,
                           utils::richText(tr("Set the number of the room down from this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_sw_stateChanged(int state)
 {
-    normalStubExitChanged(state, sw, noroute_sw, weight_sw,
-                          doortype_none_sw, doortype_open_sw, doortype_closed_sw, doortype_locked_sw,
-                          utils::richText(tr("Set the number of the room southwest of this one.")));
+    normalStubExitChanged(
+            state, sw, noroute_sw, weight_sw, doortype_none_sw, doortype_open_sw, doortype_closed_sw, doortype_locked_sw, utils::richText(tr("Set the number of the room southwest of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_s_stateChanged(int state)
 {
-    normalStubExitChanged(state, s, noroute_s, weight_s,
-                          doortype_none_s, doortype_open_s, doortype_closed_s, doortype_locked_s,
-                          utils::richText(tr("Set the number of the room south of this one.")));
+    normalStubExitChanged(state, s, noroute_s, weight_s, doortype_none_s, doortype_open_s, doortype_closed_s, doortype_locked_s, utils::richText(tr("Set the number of the room south of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_se_stateChanged(int state)
 {
-    normalStubExitChanged(state, se, noroute_se, weight_se,
-                          doortype_none_se, doortype_open_se, doortype_closed_se, doortype_locked_se,
-                          utils::richText(tr("Set the number of the room southeast of this one.")));
+    normalStubExitChanged(
+            state, se, noroute_se, weight_se, doortype_none_se, doortype_open_se, doortype_closed_se, doortype_locked_se, utils::richText(tr("Set the number of the room southeast of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_in_stateChanged(int state)
 {
-    normalStubExitChanged(state, in, noroute_in, weight_in,
-                          doortype_none_in, doortype_open_in, doortype_closed_in, doortype_locked_in,
-                          utils::richText(tr("Set the number of the room in from this one.")));
+    normalStubExitChanged(
+            state, in, noroute_in, weight_in, doortype_none_in, doortype_open_in, doortype_closed_in, doortype_locked_in, utils::richText(tr("Set the number of the room in from this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_out_stateChanged(int state)
 {
-    normalStubExitChanged(state, out, noroute_out, weight_out,
-                          doortype_none_out, doortype_open_out, doortype_closed_out, doortype_locked_out,
-                          utils::richText(tr("Set the number of the room out from this one.")));
+    normalStubExitChanged(
+            state, out, noroute_out, weight_out, doortype_none_out, doortype_open_out, doortype_closed_out, doortype_locked_out, utils::richText(tr("Set the number of the room out from this one.")));
     slot_checkModified();
 }
 
@@ -1397,18 +1481,42 @@ void dlgRoomExits::initExit(int direction,
 {
     QString doorAndWeightText; // lowercase, initials for XY-plane, words for others
     switch (direction) {
-        case DIR_NORTHWEST: doorAndWeightText = qsl("nw");   break;
-        case DIR_NORTH    : doorAndWeightText = qsl("n");    break;
-        case DIR_NORTHEAST: doorAndWeightText = qsl("ne");   break;
-        case DIR_UP       : doorAndWeightText = qsl("up");   break;
-        case DIR_WEST     : doorAndWeightText = qsl("w");    break;
-        case DIR_EAST     : doorAndWeightText = qsl("e");    break;
-        case DIR_DOWN     : doorAndWeightText = qsl("down"); break;
-        case DIR_SOUTHWEST: doorAndWeightText = qsl("sw");   break;
-        case DIR_SOUTH    : doorAndWeightText = qsl("s");    break;
-        case DIR_SOUTHEAST: doorAndWeightText = qsl("se");   break;
-        case DIR_IN       : doorAndWeightText = qsl("in");   break;
-        case DIR_OUT      : doorAndWeightText = qsl("out");  break;
+    case DIR_NORTHWEST:
+        doorAndWeightText = qsl("nw");
+        break;
+    case DIR_NORTH:
+        doorAndWeightText = qsl("n");
+        break;
+    case DIR_NORTHEAST:
+        doorAndWeightText = qsl("ne");
+        break;
+    case DIR_UP:
+        doorAndWeightText = qsl("up");
+        break;
+    case DIR_WEST:
+        doorAndWeightText = qsl("w");
+        break;
+    case DIR_EAST:
+        doorAndWeightText = qsl("e");
+        break;
+    case DIR_DOWN:
+        doorAndWeightText = qsl("down");
+        break;
+    case DIR_SOUTHWEST:
+        doorAndWeightText = qsl("sw");
+        break;
+    case DIR_SOUTH:
+        doorAndWeightText = qsl("s");
+        break;
+    case DIR_SOUTHEAST:
+        doorAndWeightText = qsl("se");
+        break;
+    case DIR_IN:
+        doorAndWeightText = qsl("in");
+        break;
+    case DIR_OUT:
+        doorAndWeightText = qsl("out");
+        break;
     }
 
     weight->setValue(pR->hasExitWeight(doorAndWeightText) ? pR->getExitWeight(doorAndWeightText) : 0);
@@ -1450,11 +1558,7 @@ void dlgRoomExits::initExit(int direction,
         if (outOfAreaExit) {
             exitAreaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(exitAreaID);
         }
-        setActionOnExit(exitLineEdit, exitRoomLocked
-                        ? mpAction_exitRoomLocked
-                        : outOfAreaExit
-                          ? mpAction_otherAreaExit
-                          : mpAction_inAreaExit);
+        setActionOnExit(exitLineEdit, exitRoomLocked ? mpAction_exitRoomLocked : outOfAreaExit ? mpAction_otherAreaExit : mpAction_inAreaExit);
         exitLineEdit->setToolTip(generateToolTip(pExitR->name, exitAreaName, exitRoomLocked, outOfAreaExit, pExitR->getWeight()));
         noRoute->setEnabled(true); //Enable speedwalk lock control
         none->setEnabled(true);    //Enable door type controls...
@@ -1526,29 +1630,149 @@ void dlgRoomExits::init()
     // Because we are manipulating the settings for the exit we need to know
     // explicitly where the weight comes from, pR->getExitWeight() hides that
     // detail deliberately for normal usage
-    initExit(DIR_NORTHWEST, pR->getExit(DIR_NORTHWEST), nw, noroute_nw, stub_nw, doortype_none_nw, doortype_open_nw, doortype_closed_nw, doortype_locked_nw, weight_nw, utils::richText(tr("Set the number of the room northwest of this one.")));
+    initExit(DIR_NORTHWEST,
+             pR->getExit(DIR_NORTHWEST),
+             nw,
+             noroute_nw,
+             stub_nw,
+             doortype_none_nw,
+             doortype_open_nw,
+             doortype_closed_nw,
+             doortype_locked_nw,
+             weight_nw,
+             utils::richText(tr("Set the number of the room northwest of this one.")));
 
-    initExit(DIR_NORTH, pR->getExit(DIR_NORTH), n, noroute_n, stub_n, doortype_none_n, doortype_open_n, doortype_closed_n, doortype_locked_n, weight_n, utils::richText(tr("Set the number of the room north of this one.")));
+    initExit(DIR_NORTH,
+             pR->getExit(DIR_NORTH),
+             n,
+             noroute_n,
+             stub_n,
+             doortype_none_n,
+             doortype_open_n,
+             doortype_closed_n,
+             doortype_locked_n,
+             weight_n,
+             utils::richText(tr("Set the number of the room north of this one.")));
 
-    initExit(DIR_NORTHEAST, pR->getExit(DIR_NORTHEAST), ne, noroute_ne, stub_ne, doortype_none_ne, doortype_open_ne, doortype_closed_ne, doortype_locked_ne, weight_ne, utils::richText(tr("Set the number of the room northeast of this one.")));
+    initExit(DIR_NORTHEAST,
+             pR->getExit(DIR_NORTHEAST),
+             ne,
+             noroute_ne,
+             stub_ne,
+             doortype_none_ne,
+             doortype_open_ne,
+             doortype_closed_ne,
+             doortype_locked_ne,
+             weight_ne,
+             utils::richText(tr("Set the number of the room northeast of this one.")));
 
-    initExit(DIR_UP, pR->getExit(DIR_UP), up, noroute_up, stub_up, doortype_none_up, doortype_open_up, doortype_closed_up, doortype_locked_up, weight_up, utils::richText(tr("Set the number of the room up from this one.")));
+    initExit(DIR_UP,
+             pR->getExit(DIR_UP),
+             up,
+             noroute_up,
+             stub_up,
+             doortype_none_up,
+             doortype_open_up,
+             doortype_closed_up,
+             doortype_locked_up,
+             weight_up,
+             utils::richText(tr("Set the number of the room up from this one.")));
 
-    initExit(DIR_WEST, pR->getExit(DIR_WEST), w, noroute_w, stub_w, doortype_none_w, doortype_open_w, doortype_closed_w, doortype_locked_w, weight_w, utils::richText(tr("Set the number of the room west of this one.")));
+    initExit(DIR_WEST,
+             pR->getExit(DIR_WEST),
+             w,
+             noroute_w,
+             stub_w,
+             doortype_none_w,
+             doortype_open_w,
+             doortype_closed_w,
+             doortype_locked_w,
+             weight_w,
+             utils::richText(tr("Set the number of the room west of this one.")));
 
-    initExit(DIR_EAST, pR->getExit(DIR_EAST), e, noroute_e, stub_e, doortype_none_e, doortype_open_e, doortype_closed_e, doortype_locked_e, weight_e, utils::richText(tr("Set the number of the room east of this one.")));
+    initExit(DIR_EAST,
+             pR->getExit(DIR_EAST),
+             e,
+             noroute_e,
+             stub_e,
+             doortype_none_e,
+             doortype_open_e,
+             doortype_closed_e,
+             doortype_locked_e,
+             weight_e,
+             utils::richText(tr("Set the number of the room east of this one.")));
 
-    initExit(DIR_DOWN, pR->getExit(DIR_DOWN), down, noroute_down, stub_down, doortype_none_down, doortype_open_down, doortype_closed_down, doortype_locked_down, weight_down, utils::richText(tr("Set the number of the room down from this one.")));
+    initExit(DIR_DOWN,
+             pR->getExit(DIR_DOWN),
+             down,
+             noroute_down,
+             stub_down,
+             doortype_none_down,
+             doortype_open_down,
+             doortype_closed_down,
+             doortype_locked_down,
+             weight_down,
+             utils::richText(tr("Set the number of the room down from this one.")));
 
-    initExit(DIR_SOUTHWEST, pR->getExit(DIR_SOUTHWEST), sw, noroute_sw, stub_sw, doortype_none_sw, doortype_open_sw, doortype_closed_sw, doortype_locked_sw, weight_sw, utils::richText(tr("Set the number of the room southwest of this one.")));
+    initExit(DIR_SOUTHWEST,
+             pR->getExit(DIR_SOUTHWEST),
+             sw,
+             noroute_sw,
+             stub_sw,
+             doortype_none_sw,
+             doortype_open_sw,
+             doortype_closed_sw,
+             doortype_locked_sw,
+             weight_sw,
+             utils::richText(tr("Set the number of the room southwest of this one.")));
 
-    initExit(DIR_SOUTH, pR->getExit(DIR_SOUTH), s, noroute_s, stub_s, doortype_none_s, doortype_open_s, doortype_closed_s, doortype_locked_s, weight_s, utils::richText(tr("Set the number of the room south of this one.")));
+    initExit(DIR_SOUTH,
+             pR->getExit(DIR_SOUTH),
+             s,
+             noroute_s,
+             stub_s,
+             doortype_none_s,
+             doortype_open_s,
+             doortype_closed_s,
+             doortype_locked_s,
+             weight_s,
+             utils::richText(tr("Set the number of the room south of this one.")));
 
-    initExit(DIR_SOUTHEAST, pR->getExit(DIR_SOUTHEAST), se, noroute_se, stub_se, doortype_none_se, doortype_open_se, doortype_closed_se, doortype_locked_se, weight_se, utils::richText(tr("Set the number of the room southeast of this one.")));
+    initExit(DIR_SOUTHEAST,
+             pR->getExit(DIR_SOUTHEAST),
+             se,
+             noroute_se,
+             stub_se,
+             doortype_none_se,
+             doortype_open_se,
+             doortype_closed_se,
+             doortype_locked_se,
+             weight_se,
+             utils::richText(tr("Set the number of the room southeast of this one.")));
 
-    initExit(DIR_IN, pR->getExit(DIR_IN), in, noroute_in, stub_in, doortype_none_in, doortype_open_in, doortype_closed_in, doortype_locked_in, weight_in, utils::richText(tr("Set the number of the room in from this one.")));
+    initExit(DIR_IN,
+             pR->getExit(DIR_IN),
+             in,
+             noroute_in,
+             stub_in,
+             doortype_none_in,
+             doortype_open_in,
+             doortype_closed_in,
+             doortype_locked_in,
+             weight_in,
+             utils::richText(tr("Set the number of the room in from this one.")));
 
-    initExit(DIR_OUT, pR->getExit(DIR_OUT), out, noroute_out, stub_out, doortype_none_out, doortype_open_out, doortype_closed_out, doortype_locked_out, weight_out, utils::richText(tr("Set the number of the room out from this one.")));
+    initExit(DIR_OUT,
+             pR->getExit(DIR_OUT),
+             out,
+             noroute_out,
+             stub_out,
+             doortype_none_out,
+             doortype_open_out,
+             doortype_closed_out,
+             doortype_locked_out,
+             weight_out,
+             utils::richText(tr("Set the number of the room out from this one.")));
 
     QMapIterator<QString, int> it(pR->getSpecialExits());
     while (it.hasNext()) {
@@ -1588,7 +1812,8 @@ void dlgRoomExits::init()
         pI->setData(ExitsTreeWidget::colIndex_exitWeight, Qt::EditRole, pR->hasExitWeight(dir) ? pR->getExitWeight(dir) : 0);
         pI->setTextAlignment(ExitsTreeWidget::colIndex_exitWeight, Qt::AlignLeft);
         pSpecialExit->weight = pI->data(ExitsTreeWidget::colIndex_exitWeight, Qt::EditRole).toInt();
-        pI->setToolTip(ExitsTreeWidget::colIndex_exitWeight, utils::richText(tr("Set to a positive value to override the default (Room) Weight for using this Exit route, zero value assigns the default.")));
+        pI->setToolTip(ExitsTreeWidget::colIndex_exitWeight,
+                       utils::richText(tr("Set to a positive value to override the default (Room) Weight for using this Exit route, zero value assigns the default.")));
 
         //ExitsTreeWidget::colIndex_doorNone-ExitsTreeWidget::colIndex_doorLocked
         //hold a buttongroup of 4, ideally QRadioButtons, to select a door type
@@ -1964,13 +2189,12 @@ void dlgRoomExits::slot_checkModified()
             if (!pI) {
                 continue;
             }
-/*            qDebug("dlgRoomExits::slot_checkModified() considering specialExit (item %i, pass 1) to:%i, command:%s",
+            /*            qDebug("dlgRoomExits::slot_checkModified() considering specialExit (item %i, pass 1) to:%i, command:%s",
  *                   i,
  *                   pI->text(ExitsTreeWidget::colIndex_exitRoomId).toInt(),
  *                   qPrintable(pI->text(ExitsTreeWidget::colIndex_command)));
  */
-            if (pI->text(ExitsTreeWidget::colIndex_command) == mSpecialExitCommandPlaceholder
-                || pI->text(ExitsTreeWidget::colIndex_exitRoomId).toInt() <= 0) {
+            if (pI->text(ExitsTreeWidget::colIndex_command) == mSpecialExitCommandPlaceholder || pI->text(ExitsTreeWidget::colIndex_exitRoomId).toInt() <= 0) {
                 continue;
             } // Ignore new or to be deleted entries
             currentCount++;
@@ -1989,31 +2213,26 @@ void dlgRoomExits::slot_checkModified()
                     if (!pI) {
                         continue;
                     }
-/*                    qDebug("dlgRoomExits::slot_checkModified() considering specialExit (item %i, pass 2) to:%i, command:%s",
+                    /*                    qDebug("dlgRoomExits::slot_checkModified() considering specialExit (item %i, pass 2) to:%i, command:%s",
  *                           i,
  *                           pI->text(ExitsTreeWidget::colIndex_exitRoomId).toInt(),
  *                           qPrintable(pI->text(ExitsTreeWidget::colIndex_command)));
  */
-                    if (pI->text(ExitsTreeWidget::colIndex_command) == mSpecialExitCommandPlaceholder
-                        || pI->text(ExitsTreeWidget::colIndex_exitRoomId).toInt() <= 0) {
+                    if (pI->text(ExitsTreeWidget::colIndex_command) == mSpecialExitCommandPlaceholder || pI->text(ExitsTreeWidget::colIndex_exitRoomId).toInt() <= 0) {
                         continue; // Ignore new or to be deleted entries
                     }
                     const QString currentCmd = pI->text(ExitsTreeWidget::colIndex_command);
                     TExit currentExit;
                     currentExit.destination = pI->text(ExitsTreeWidget::colIndex_exitRoomId).toInt();
                     currentExit.hasNoRoute = pI->checkState(ExitsTreeWidget::colIndex_lockExit) == Qt::Checked;
-                    currentExit.door = pI->checkState(ExitsTreeWidget::colIndex_doorLocked) == Qt::Checked
-                            ? 3 : pI->checkState(ExitsTreeWidget::colIndex_doorClosed) == Qt::Checked
-                              ? 2 : pI->checkState(ExitsTreeWidget::colIndex_doorOpen) == Qt::Checked
-                                ? 1 : 0;
+                    currentExit.door = pI->checkState(ExitsTreeWidget::colIndex_doorLocked) == Qt::Checked   ? 3
+                                       : pI->checkState(ExitsTreeWidget::colIndex_doorClosed) == Qt::Checked ? 2
+                                       : pI->checkState(ExitsTreeWidget::colIndex_doorOpen) == Qt::Checked   ? 1
+                                                                                                             : 0;
                     currentExit.weight = pI->text(ExitsTreeWidget::colIndex_exitWeight).toInt();
                     currentExit.hasStub = false;
                     auto exit = foundMap.value(currentCmd);
-                    if (exit
-                        && exit->destination == currentExit.destination
-                        && exit->door        == currentExit.door
-                        && exit->hasNoRoute  == currentExit.hasNoRoute
-                        && exit->weight      == currentExit.weight      ) {
+                    if (exit && exit->destination == currentExit.destination && exit->door == currentExit.door && exit->hasNoRoute == currentExit.hasNoRoute && exit->weight == currentExit.weight) {
                         foundMap.remove(currentCmd);
                     } else {
                         isModified = true;

--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -52,13 +52,7 @@ dlgRoomProperties::dlgRoomProperties(Host* pHost, QWidget* pParentWidget)
     setAttribute(Qt::WA_DeleteOnClose);
 }
 
-void dlgRoomProperties::init(
-    QHash<QString, int> usedNames,
-    QHash<int, int>& pColors,
-    QHash<QString, int>& pSymbols,
-    QHash<int, int>& pWeights,
-    QHash<bool, int> lockStatus,
-    QSet<TRoom*>& pRooms)
+void dlgRoomProperties::init(QHash<QString, int> usedNames, QHash<int, int>& pColors, QHash<QString, int>& pSymbols, QHash<int, int>& pWeights, QHash<bool, int> lockStatus, QSet<TRoom*>& pRooms)
 {
     // Configure name display
     if (usedNames.size() > 1) {
@@ -178,9 +172,9 @@ void dlgRoomProperties::init(
 void dlgRoomProperties::initLockInstructions()
 {
     const QString instructions = tr("Lock room(s), so it/they will never be used for speedwalking",
-                           // Intentional comment to separate arguments!
-                           "This text will be shown at a checkbox, where you can set/unset a number of room's lock.",
-                           mpRooms.size());
+                                    // Intentional comment to separate arguments!
+                                    "This text will be shown at a checkbox, where you can set/unset a number of room's lock.",
+                                    mpRooms.size());
     checkBox_locked->setText(instructions);
 }
 
@@ -206,7 +200,8 @@ void dlgRoomProperties::initWeightInstructions()
                           // Intentional comment to separate arguments!
                           "This is for when applying a new room weight to one or more rooms "
                           "and some have different weights at present. "
-                          "%n is the total number of rooms involved.", mpRooms.size());
+                          "%n is the total number of rooms involved.",
+                          mpRooms.size());
     }
     label_weightInstructions->setText(instructions);
     label_weightInstructions->setWordWrap(true);
@@ -236,7 +231,8 @@ void dlgRoomProperties::initSymbolInstructions()
                           // Intentional comment to separate arguments!
                           "This is for when applying a new room symbol to one or more rooms "
                           "and some have different symbols or no symbol at present. "
-                          "%n is the total number of rooms involved.", mpRooms.size());
+                          "%n is the total number of rooms involved.",
+                          mpRooms.size());
     }
     label_symbolInstructions->setText(instructions);
     label_symbolInstructions->setWordWrap(true);
@@ -272,8 +268,7 @@ QStringList dlgRoomProperties::getComboBoxSymbolItems()
                 %2 is the number of rooms using this symbol. Example output: "★ (count: 5)" or "! (count: 12)".
                 The word "count" and the format can be translated, but ensure the numbers remain clearly associated.
                 */
-                displayStrings.append(tr("%1 (count: %2)")
-                    .arg(itSymbolUsed.key(), QString::number(itSymbolUsed.value())));
+                displayStrings.append(tr("%1 (count: %2)").arg(itSymbolUsed.key(), QString::number(itSymbolUsed.value())));
             }
         }
     }
@@ -310,8 +305,7 @@ QStringList dlgRoomProperties::getComboBoxWeightItems()
                 %2 is the number of rooms with this weight. Example output: "5 (count: 3)" or "100 (count: 7)".
                 The word "count" and the format can be translated, but ensure the numbers remain clearly associated.
                 */
-                displayStrings.append(tr("%1 (count: %2)")
-                    .arg(QString::number(itWeightUsed.key()), QString::number(itWeightUsed.value())));
+                displayStrings.append(tr("%1 (count: %2)").arg(QString::number(itWeightUsed.key()), QString::number(itWeightUsed.value())));
             }
         }
     }
@@ -376,16 +370,23 @@ void dlgRoomProperties::accept()
     bool changeBorderThickness = mBorderThicknessWasChanged;
     int newBorderThickness = mBorderThickness;
 
-    emit signal_save_symbol(
-        changeName, newName,
-        mChangeRoomColor, mRoomColorNumber,
-        changeSymbol, newSymbol,
-        changeSymbolColor, newSymbolColor,
-        changeWeight, newWeight,
-        changeLockStatus, newLockStatus,
-        changeBorderColor, newBorderColor,
-        changeBorderThickness, newBorderThickness,
-        mpRooms);
+    emit signal_save_symbol(changeName,
+                            newName,
+                            mChangeRoomColor,
+                            mRoomColorNumber,
+                            changeSymbol,
+                            newSymbol,
+                            changeSymbolColor,
+                            newSymbolColor,
+                            changeWeight,
+                            newWeight,
+                            changeLockStatus,
+                            newLockStatus,
+                            changeBorderColor,
+                            newBorderColor,
+                            changeBorderThickness,
+                            newBorderThickness,
+                            mpRooms);
 }
 
 
@@ -436,15 +437,12 @@ void dlgRoomProperties::slot_updatePreview()
         pushButton_setSymbolColor->setStyleSheet(QString());
     } else {
         pushButton_setSymbolColor->setStyleSheet(
-        qsl("background-color: %1; color: %2; border: 1px solid; border-radius: 1px;")
-            .arg(realSymbolColor.name(), backgroundBasedColor(realSymbolColor).name()));
+                qsl("background-color: %1; color: %2; border: 1px solid; border-radius: 1px;").arg(realSymbolColor.name(), backgroundBasedColor(realSymbolColor).name()));
     }
     label_preview->setFont(getFontForPreview(newSymbol));
     label_preview->setText(newSymbol);
-    label_preview->setStyleSheet(
-        qsl("color: %1; background-color: %2; border: %3;")
-            .arg(realSymbolColor.name(), mRoomColor.name(), mpHost->mMapperShowRoomBorders ? qsl("1px solid %1").arg(mpHost->mRoomBorderColor.name()) : qsl("none")));
-
+    label_preview->setStyleSheet(qsl("color: %1; background-color: %2; border: %3;")
+                                         .arg(realSymbolColor.name(), mRoomColor.name(), mpHost->mMapperShowRoomBorders ? qsl("1px solid %1").arg(mpHost->mRoomBorderColor.name()) : qsl("none")));
 }
 
 

--- a/src/dlgSourceEditorArea.cpp
+++ b/src/dlgSourceEditorArea.cpp
@@ -44,7 +44,7 @@ dlgSourceEditorArea::dlgSourceEditorArea(QWidget* pParentWidget)
 
     config->beginChanges();
 
-    config->setSmartTab(true); // enable the automatic addition of indents when inserting a newline
+    config->setSmartTab(true);    // enable the automatic addition of indents when inserting a newline
     config->setUseTabChar(false); // when you press Enter for a newline, pad with spaces and not tabs
     config->setCaretBlinkRate(200);
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -86,8 +86,7 @@
 void runUndoRedoTestSuite(dlgTriggerEditor* editor);
 
 // Forward declaration for per-property undo helper (defined later in this file)
-static void pushKeyPropertyCommand(EditorUndoStack* undoStack, Host* host, int keyID, const QString& keyName,
-                                   const QString& propertyName, const QString& oldStateXML, const QString& newStateXML);
+static void pushKeyPropertyCommand(EditorUndoStack* undoStack, Host* host, int keyID, const QString& keyName, const QString& propertyName, const QString& oldStateXML, const QString& newStateXML);
 
 using namespace std::chrono_literals;
 
@@ -335,7 +334,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     statusBar->show();
 
     mpNonCodeWidgets = new QWidget(this);
-    auto *layoutColumn = new QVBoxLayout(mpNonCodeWidgets);
+    auto* layoutColumn = new QVBoxLayout(mpNonCodeWidgets);
     splitter_right->addWidget(mpNonCodeWidgets);
 
     // system message area
@@ -509,189 +508,189 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
         auto* provider = new edbee::StringTextAutoCompleteProvider();
 
         // Add lua functions and reserved lua terms to an AutoComplete provider
-    for (const QString& key : mudlet::smLuaFunctionNames.keys()) {
-        provider->add(key, 3, mudlet::smLuaFunctionNames.value(key).toString());
-    }
+        for (const QString& key : mudlet::smLuaFunctionNames.keys()) {
+            provider->add(key, 3, mudlet::smLuaFunctionNames.value(key).toString());
+        }
 
-    // Lua reserved keywords (highest priority for basic syntax)
-    provider->add(qsl("and"), 14);
-    provider->add(qsl("break"), 14);
-    provider->add(qsl("else"), 14);
-    provider->add(qsl("elseif"), 14);
-    provider->add(qsl("end"), 14);
-    provider->add(qsl("false"), 14);
-    provider->add(qsl("for"), 14);
-    provider->add(qsl("function"), 14);
-    provider->add(qsl("goto"), 14);
-    provider->add(qsl("local"), 14);
-    provider->add(qsl("nil"), 14);
-    provider->add(qsl("not"), 14);
-    provider->add(qsl("repeat"), 14);
-    provider->add(qsl("return"), 14);
-    provider->add(qsl("then"), 14);
-    provider->add(qsl("true"), 14);
-    provider->add(qsl("until"), 14);
-    provider->add(qsl("while"), 14);
+        // Lua reserved keywords (highest priority for basic syntax)
+        provider->add(qsl("and"), 14);
+        provider->add(qsl("break"), 14);
+        provider->add(qsl("else"), 14);
+        provider->add(qsl("elseif"), 14);
+        provider->add(qsl("end"), 14);
+        provider->add(qsl("false"), 14);
+        provider->add(qsl("for"), 14);
+        provider->add(qsl("function"), 14);
+        provider->add(qsl("goto"), 14);
+        provider->add(qsl("local"), 14);
+        provider->add(qsl("nil"), 14);
+        provider->add(qsl("not"), 14);
+        provider->add(qsl("repeat"), 14);
+        provider->add(qsl("return"), 14);
+        provider->add(qsl("then"), 14);
+        provider->add(qsl("true"), 14);
+        provider->add(qsl("until"), 14);
+        provider->add(qsl("while"), 14);
 
-    // Standard Lua library functions (priority 4 - between Mudlet functions and keywords)
-    // String library
-    provider->add(qsl("string.byte"), 4, qsl("string.byte(s [, i [, j]])"));
-    provider->add(qsl("string.char"), 4, qsl("string.char(...)"));
-    provider->add(qsl("string.dump"), 4, qsl("string.dump(function)"));
-    provider->add(qsl("string.find"), 4, qsl("string.find(s, pattern [, init [, plain]])"));
-    provider->add(qsl("string.format"), 4, qsl("string.format(formatstring, ...)"));
-    provider->add(qsl("string.gmatch"), 4, qsl("string.gmatch(s, pattern)"));
-    provider->add(qsl("string.gsub"), 4, qsl("string.gsub(s, pattern, repl [, n])"));
-    provider->add(qsl("string.len"), 4, qsl("string.len(s)"));
-    provider->add(qsl("string.lower"), 4, qsl("string.lower(s)"));
-    provider->add(qsl("string.match"), 4, qsl("string.match(s, pattern [, init])"));
-    provider->add(qsl("string.rep"), 4, qsl("string.rep(s, n)"));
-    provider->add(qsl("string.reverse"), 4, qsl("string.reverse(s)"));
-    provider->add(qsl("string.sub"), 4, qsl("string.sub(s, i [, j])"));
-    provider->add(qsl("string.upper"), 4, qsl("string.upper(s)"));
+        // Standard Lua library functions (priority 4 - between Mudlet functions and keywords)
+        // String library
+        provider->add(qsl("string.byte"), 4, qsl("string.byte(s [, i [, j]])"));
+        provider->add(qsl("string.char"), 4, qsl("string.char(...)"));
+        provider->add(qsl("string.dump"), 4, qsl("string.dump(function)"));
+        provider->add(qsl("string.find"), 4, qsl("string.find(s, pattern [, init [, plain]])"));
+        provider->add(qsl("string.format"), 4, qsl("string.format(formatstring, ...)"));
+        provider->add(qsl("string.gmatch"), 4, qsl("string.gmatch(s, pattern)"));
+        provider->add(qsl("string.gsub"), 4, qsl("string.gsub(s, pattern, repl [, n])"));
+        provider->add(qsl("string.len"), 4, qsl("string.len(s)"));
+        provider->add(qsl("string.lower"), 4, qsl("string.lower(s)"));
+        provider->add(qsl("string.match"), 4, qsl("string.match(s, pattern [, init])"));
+        provider->add(qsl("string.rep"), 4, qsl("string.rep(s, n)"));
+        provider->add(qsl("string.reverse"), 4, qsl("string.reverse(s)"));
+        provider->add(qsl("string.sub"), 4, qsl("string.sub(s, i [, j])"));
+        provider->add(qsl("string.upper"), 4, qsl("string.upper(s)"));
 
-    // Table library
-    provider->add(qsl("table.concat"), 4, qsl("table.concat(list [, sep [, i [, j]]])"));
-    provider->add(qsl("table.insert"), 4, qsl("table.insert(list, [pos,] value)"));
-    provider->add(qsl("table.pack"), 4, qsl("table.pack(...)"));
-    provider->add(qsl("table.remove"), 4, qsl("table.remove(list [, pos])"));
-    provider->add(qsl("table.sort"), 4, qsl("table.sort(list [, comp])"));
-    provider->add(qsl("table.unpack"), 4, qsl("table.unpack(list [, i [, j]])"));
+        // Table library
+        provider->add(qsl("table.concat"), 4, qsl("table.concat(list [, sep [, i [, j]]])"));
+        provider->add(qsl("table.insert"), 4, qsl("table.insert(list, [pos,] value)"));
+        provider->add(qsl("table.pack"), 4, qsl("table.pack(...)"));
+        provider->add(qsl("table.remove"), 4, qsl("table.remove(list [, pos])"));
+        provider->add(qsl("table.sort"), 4, qsl("table.sort(list [, comp])"));
+        provider->add(qsl("table.unpack"), 4, qsl("table.unpack(list [, i [, j]])"));
 
-    // Math library
-    provider->add(qsl("math.abs"), 4, qsl("math.abs(x)"));
-    provider->add(qsl("math.acos"), 4, qsl("math.acos(x)"));
-    provider->add(qsl("math.asin"), 4, qsl("math.asin(x)"));
-    provider->add(qsl("math.atan"), 4, qsl("math.atan(x)"));
-    provider->add(qsl("math.atan2"), 4, qsl("math.atan2(y, x)"));
-    provider->add(qsl("math.ceil"), 4, qsl("math.ceil(x)"));
-    provider->add(qsl("math.cos"), 4, qsl("math.cos(x)"));
-    provider->add(qsl("math.cosh"), 4, qsl("math.cosh(x)"));
-    provider->add(qsl("math.deg"), 4, qsl("math.deg(x)"));
-    provider->add(qsl("math.exp"), 4, qsl("math.exp(x)"));
-    provider->add(qsl("math.floor"), 4, qsl("math.floor(x)"));
-    provider->add(qsl("math.fmod"), 4, qsl("math.fmod(x, y)"));
-    provider->add(qsl("math.frexp"), 4, qsl("math.frexp(x)"));
-    provider->add(qsl("math.huge"), 4, qsl("math.huge"));
-    provider->add(qsl("math.ldexp"), 4, qsl("math.ldexp(m, e)"));
-    provider->add(qsl("math.log"), 4, qsl("math.log(x [, base])"));
-    provider->add(qsl("math.log10"), 4, qsl("math.log10(x)"));
-    provider->add(qsl("math.max"), 4, qsl("math.max(x, ...)"));
-    provider->add(qsl("math.min"), 4, qsl("math.min(x, ...)"));
-    provider->add(qsl("math.modf"), 4, qsl("math.modf(x)"));
-    provider->add(qsl("math.pi"), 4, qsl("math.pi"));
-    provider->add(qsl("math.pow"), 4, qsl("math.pow(x, y)"));
-    provider->add(qsl("math.rad"), 4, qsl("math.rad(x)"));
-    provider->add(qsl("math.random"), 4, qsl("math.random([m [, n]])"));
-    provider->add(qsl("math.randomseed"), 4, qsl("math.randomseed(x)"));
-    provider->add(qsl("math.sin"), 4, qsl("math.sin(x)"));
-    provider->add(qsl("math.sinh"), 4, qsl("math.sinh(x)"));
-    provider->add(qsl("math.sqrt"), 4, qsl("math.sqrt(x)"));
-    provider->add(qsl("math.tan"), 4, qsl("math.tan(x)"));
-    provider->add(qsl("math.tanh"), 4, qsl("math.tanh(x)"));
+        // Math library
+        provider->add(qsl("math.abs"), 4, qsl("math.abs(x)"));
+        provider->add(qsl("math.acos"), 4, qsl("math.acos(x)"));
+        provider->add(qsl("math.asin"), 4, qsl("math.asin(x)"));
+        provider->add(qsl("math.atan"), 4, qsl("math.atan(x)"));
+        provider->add(qsl("math.atan2"), 4, qsl("math.atan2(y, x)"));
+        provider->add(qsl("math.ceil"), 4, qsl("math.ceil(x)"));
+        provider->add(qsl("math.cos"), 4, qsl("math.cos(x)"));
+        provider->add(qsl("math.cosh"), 4, qsl("math.cosh(x)"));
+        provider->add(qsl("math.deg"), 4, qsl("math.deg(x)"));
+        provider->add(qsl("math.exp"), 4, qsl("math.exp(x)"));
+        provider->add(qsl("math.floor"), 4, qsl("math.floor(x)"));
+        provider->add(qsl("math.fmod"), 4, qsl("math.fmod(x, y)"));
+        provider->add(qsl("math.frexp"), 4, qsl("math.frexp(x)"));
+        provider->add(qsl("math.huge"), 4, qsl("math.huge"));
+        provider->add(qsl("math.ldexp"), 4, qsl("math.ldexp(m, e)"));
+        provider->add(qsl("math.log"), 4, qsl("math.log(x [, base])"));
+        provider->add(qsl("math.log10"), 4, qsl("math.log10(x)"));
+        provider->add(qsl("math.max"), 4, qsl("math.max(x, ...)"));
+        provider->add(qsl("math.min"), 4, qsl("math.min(x, ...)"));
+        provider->add(qsl("math.modf"), 4, qsl("math.modf(x)"));
+        provider->add(qsl("math.pi"), 4, qsl("math.pi"));
+        provider->add(qsl("math.pow"), 4, qsl("math.pow(x, y)"));
+        provider->add(qsl("math.rad"), 4, qsl("math.rad(x)"));
+        provider->add(qsl("math.random"), 4, qsl("math.random([m [, n]])"));
+        provider->add(qsl("math.randomseed"), 4, qsl("math.randomseed(x)"));
+        provider->add(qsl("math.sin"), 4, qsl("math.sin(x)"));
+        provider->add(qsl("math.sinh"), 4, qsl("math.sinh(x)"));
+        provider->add(qsl("math.sqrt"), 4, qsl("math.sqrt(x)"));
+        provider->add(qsl("math.tan"), 4, qsl("math.tan(x)"));
+        provider->add(qsl("math.tanh"), 4, qsl("math.tanh(x)"));
 
-    // IO library
-    provider->add(qsl("io.close"), 4, qsl("io.close([file])"));
-    provider->add(qsl("io.flush"), 4, qsl("io.flush()"));
-    provider->add(qsl("io.input"), 4, qsl("io.input([file])"));
-    provider->add(qsl("io.lines"), 4, qsl("io.lines([filename, ...])"));
-    provider->add(qsl("io.open"), 4, qsl("io.open(filename [, mode])"));
-    provider->add(qsl("io.output"), 4, qsl("io.output([file])"));
-    provider->add(qsl("io.popen"), 4, qsl("io.popen(prog [, mode])"));
-    provider->add(qsl("io.read"), 4, qsl("io.read(...)"));
-    provider->add(qsl("io.tmpfile"), 4, qsl("io.tmpfile()"));
-    provider->add(qsl("io.type"), 4, qsl("io.type(obj)"));
-    provider->add(qsl("io.write"), 4, qsl("io.write(...)"));
+        // IO library
+        provider->add(qsl("io.close"), 4, qsl("io.close([file])"));
+        provider->add(qsl("io.flush"), 4, qsl("io.flush()"));
+        provider->add(qsl("io.input"), 4, qsl("io.input([file])"));
+        provider->add(qsl("io.lines"), 4, qsl("io.lines([filename, ...])"));
+        provider->add(qsl("io.open"), 4, qsl("io.open(filename [, mode])"));
+        provider->add(qsl("io.output"), 4, qsl("io.output([file])"));
+        provider->add(qsl("io.popen"), 4, qsl("io.popen(prog [, mode])"));
+        provider->add(qsl("io.read"), 4, qsl("io.read(...)"));
+        provider->add(qsl("io.tmpfile"), 4, qsl("io.tmpfile()"));
+        provider->add(qsl("io.type"), 4, qsl("io.type(obj)"));
+        provider->add(qsl("io.write"), 4, qsl("io.write(...)"));
 
-    // OS library
-    provider->add(qsl("os.clock"), 4, qsl("os.clock()"));
-    provider->add(qsl("os.date"), 4, qsl("os.date([format [, time]])"));
-    provider->add(qsl("os.difftime"), 4, qsl("os.difftime(t2, t1)"));
-    provider->add(qsl("os.execute"), 4, qsl("os.execute([command])"));
-    provider->add(qsl("os.exit"), 4, qsl("os.exit([code [, close]])"));
-    provider->add(qsl("os.getenv"), 4, qsl("os.getenv(varname)"));
-    provider->add(qsl("os.remove"), 4, qsl("os.remove(filename)"));
-    provider->add(qsl("os.rename"), 4, qsl("os.rename(oldname, newname)"));
-    provider->add(qsl("os.setlocale"), 4, qsl("os.setlocale(locale [, category])"));
-    provider->add(qsl("os.time"), 4, qsl("os.time([table])"));
-    provider->add(qsl("os.tmpname"), 4, qsl("os.tmpname()"));
+        // OS library
+        provider->add(qsl("os.clock"), 4, qsl("os.clock()"));
+        provider->add(qsl("os.date"), 4, qsl("os.date([format [, time]])"));
+        provider->add(qsl("os.difftime"), 4, qsl("os.difftime(t2, t1)"));
+        provider->add(qsl("os.execute"), 4, qsl("os.execute([command])"));
+        provider->add(qsl("os.exit"), 4, qsl("os.exit([code [, close]])"));
+        provider->add(qsl("os.getenv"), 4, qsl("os.getenv(varname)"));
+        provider->add(qsl("os.remove"), 4, qsl("os.remove(filename)"));
+        provider->add(qsl("os.rename"), 4, qsl("os.rename(oldname, newname)"));
+        provider->add(qsl("os.setlocale"), 4, qsl("os.setlocale(locale [, category])"));
+        provider->add(qsl("os.time"), 4, qsl("os.time([table])"));
+        provider->add(qsl("os.tmpname"), 4, qsl("os.tmpname()"));
 
-    // Coroutine library
-    provider->add(qsl("coroutine.create"), 4, qsl("coroutine.create(f)"));
-    provider->add(qsl("coroutine.resume"), 4, qsl("coroutine.resume(co [, val1, ...])"));
-    provider->add(qsl("coroutine.running"), 4, qsl("coroutine.running()"));
-    provider->add(qsl("coroutine.status"), 4, qsl("coroutine.status(co)"));
-    provider->add(qsl("coroutine.wrap"), 4, qsl("coroutine.wrap(f)"));
-    provider->add(qsl("coroutine.yield"), 4, qsl("coroutine.yield(...)"));
+        // Coroutine library
+        provider->add(qsl("coroutine.create"), 4, qsl("coroutine.create(f)"));
+        provider->add(qsl("coroutine.resume"), 4, qsl("coroutine.resume(co [, val1, ...])"));
+        provider->add(qsl("coroutine.running"), 4, qsl("coroutine.running()"));
+        provider->add(qsl("coroutine.status"), 4, qsl("coroutine.status(co)"));
+        provider->add(qsl("coroutine.wrap"), 4, qsl("coroutine.wrap(f)"));
+        provider->add(qsl("coroutine.yield"), 4, qsl("coroutine.yield(...)"));
 
-    // Debug library
-    provider->add(qsl("debug.debug"), 4, qsl("debug.debug()"));
-    provider->add(qsl("debug.gethook"), 4, qsl("debug.gethook([thread])"));
-    provider->add(qsl("debug.getinfo"), 4, qsl("debug.getinfo([thread,] f [, what])"));
-    provider->add(qsl("debug.getlocal"), 4, qsl("debug.getlocal([thread,] f, local)"));
-    provider->add(qsl("debug.getmetatable"), 4, qsl("debug.getmetatable(value)"));
-    provider->add(qsl("debug.getregistry"), 4, qsl("debug.getregistry()"));
-    provider->add(qsl("debug.getupvalue"), 4, qsl("debug.getupvalue(f, up)"));
-    provider->add(qsl("debug.getuservalue"), 4, qsl("debug.getuservalue(u)"));
-    provider->add(qsl("debug.sethook"), 4, qsl("debug.sethook([thread,] hook, mask [, count])"));
-    provider->add(qsl("debug.setlocal"), 4, qsl("debug.setlocal([thread,] level, local, value)"));
-    provider->add(qsl("debug.setmetatable"), 4, qsl("debug.setmetatable(value, table)"));
-    provider->add(qsl("debug.setupvalue"), 4, qsl("debug.setupvalue(f, up, value)"));
-    provider->add(qsl("debug.setuservalue"), 4, qsl("debug.setuservalue(udata, value)"));
-    provider->add(qsl("debug.traceback"), 4, qsl("debug.traceback([thread,] [message [, level]])"));
-    provider->add(qsl("debug.upvalueid"), 4, qsl("debug.upvalueid(f, n)"));
-    provider->add(qsl("debug.upvaluejoin"), 4, qsl("debug.upvaluejoin(f1, n1, f2, n2)"));
+        // Debug library
+        provider->add(qsl("debug.debug"), 4, qsl("debug.debug()"));
+        provider->add(qsl("debug.gethook"), 4, qsl("debug.gethook([thread])"));
+        provider->add(qsl("debug.getinfo"), 4, qsl("debug.getinfo([thread,] f [, what])"));
+        provider->add(qsl("debug.getlocal"), 4, qsl("debug.getlocal([thread,] f, local)"));
+        provider->add(qsl("debug.getmetatable"), 4, qsl("debug.getmetatable(value)"));
+        provider->add(qsl("debug.getregistry"), 4, qsl("debug.getregistry()"));
+        provider->add(qsl("debug.getupvalue"), 4, qsl("debug.getupvalue(f, up)"));
+        provider->add(qsl("debug.getuservalue"), 4, qsl("debug.getuservalue(u)"));
+        provider->add(qsl("debug.sethook"), 4, qsl("debug.sethook([thread,] hook, mask [, count])"));
+        provider->add(qsl("debug.setlocal"), 4, qsl("debug.setlocal([thread,] level, local, value)"));
+        provider->add(qsl("debug.setmetatable"), 4, qsl("debug.setmetatable(value, table)"));
+        provider->add(qsl("debug.setupvalue"), 4, qsl("debug.setupvalue(f, up, value)"));
+        provider->add(qsl("debug.setuservalue"), 4, qsl("debug.setuservalue(udata, value)"));
+        provider->add(qsl("debug.traceback"), 4, qsl("debug.traceback([thread,] [message [, level]])"));
+        provider->add(qsl("debug.upvalueid"), 4, qsl("debug.upvalueid(f, n)"));
+        provider->add(qsl("debug.upvaluejoin"), 4, qsl("debug.upvaluejoin(f1, n1, f2, n2)"));
 
-    // Package library
-    provider->add(qsl("package.config"), 4, qsl("package.config"));
-    provider->add(qsl("package.cpath"), 4, qsl("package.cpath"));
-    provider->add(qsl("package.loaded"), 4, qsl("package.loaded"));
-    provider->add(qsl("package.loadlib"), 4, qsl("package.loadlib(libname, funcname)"));
-    provider->add(qsl("package.path"), 4, qsl("package.path"));
-    provider->add(qsl("package.preload"), 4, qsl("package.preload"));
-    provider->add(qsl("package.searchers"), 4, qsl("package.searchers"));
-    provider->add(qsl("package.searchpath"), 4, qsl("package.searchpath(name, path [, sep [, rep]])"));
+        // Package library
+        provider->add(qsl("package.config"), 4, qsl("package.config"));
+        provider->add(qsl("package.cpath"), 4, qsl("package.cpath"));
+        provider->add(qsl("package.loaded"), 4, qsl("package.loaded"));
+        provider->add(qsl("package.loadlib"), 4, qsl("package.loadlib(libname, funcname)"));
+        provider->add(qsl("package.path"), 4, qsl("package.path"));
+        provider->add(qsl("package.preload"), 4, qsl("package.preload"));
+        provider->add(qsl("package.searchers"), 4, qsl("package.searchers"));
+        provider->add(qsl("package.searchpath"), 4, qsl("package.searchpath(name, path [, sep [, rep]])"));
 
-    // Mudlet framework namespaced functions (priority 4 - same as Lua stdlib)
-    // Geyser UI Framework
-    provider->add(qsl("Geyser.Container:new"), 4, qsl("Geyser.Container:new(cons, container)"));
-    provider->add(qsl("Geyser.Window:new"), 4, qsl("Geyser.Window:new(cons, container)"));
-    provider->add(qsl("Geyser.Label:new"), 4, qsl("Geyser.Label:new(cons, container)"));
-    provider->add(qsl("Geyser.MiniConsole:new"), 4, qsl("Geyser.MiniConsole:new(cons, container)"));
-    provider->add(qsl("Geyser.Button:new"), 4, qsl("Geyser.Button:new(cons, container)"));
-    provider->add(qsl("Geyser.Gauge:new"), 4, qsl("Geyser.Gauge:new(cons, container)"));
-    provider->add(qsl("Geyser.Mapper:new"), 4, qsl("Geyser.Mapper:new(cons, container)"));
-    provider->add(qsl("Geyser.UserWindow:new"), 4, qsl("Geyser.UserWindow:new(cons)"));
-    provider->add(qsl("Geyser.CommandLine:new"), 4, qsl("Geyser.CommandLine:new(cons, container)"));
-    provider->add(qsl("Geyser.HBox:new"), 4, qsl("Geyser.HBox:new(cons, container)"));
-    provider->add(qsl("Geyser.VBox:new"), 4, qsl("Geyser.VBox:new(cons, container)"));
-    provider->add(qsl("Geyser.ScrollBox:new"), 4, qsl("Geyser.ScrollBox:new(cons, container)"));
-    provider->add(qsl("Geyser.ScrollBox:new2"), 4, qsl("Geyser.ScrollBox:new2()"));
-    provider->add(qsl("Geyser.StyleSheet:new"), 4, qsl("Geyser.StyleSheet:new(stylesheet, parent, target)"));
+        // Mudlet framework namespaced functions (priority 4 - same as Lua stdlib)
+        // Geyser UI Framework
+        provider->add(qsl("Geyser.Container:new"), 4, qsl("Geyser.Container:new(cons, container)"));
+        provider->add(qsl("Geyser.Window:new"), 4, qsl("Geyser.Window:new(cons, container)"));
+        provider->add(qsl("Geyser.Label:new"), 4, qsl("Geyser.Label:new(cons, container)"));
+        provider->add(qsl("Geyser.MiniConsole:new"), 4, qsl("Geyser.MiniConsole:new(cons, container)"));
+        provider->add(qsl("Geyser.Button:new"), 4, qsl("Geyser.Button:new(cons, container)"));
+        provider->add(qsl("Geyser.Gauge:new"), 4, qsl("Geyser.Gauge:new(cons, container)"));
+        provider->add(qsl("Geyser.Mapper:new"), 4, qsl("Geyser.Mapper:new(cons, container)"));
+        provider->add(qsl("Geyser.UserWindow:new"), 4, qsl("Geyser.UserWindow:new(cons)"));
+        provider->add(qsl("Geyser.CommandLine:new"), 4, qsl("Geyser.CommandLine:new(cons, container)"));
+        provider->add(qsl("Geyser.HBox:new"), 4, qsl("Geyser.HBox:new(cons, container)"));
+        provider->add(qsl("Geyser.VBox:new"), 4, qsl("Geyser.VBox:new(cons, container)"));
+        provider->add(qsl("Geyser.ScrollBox:new"), 4, qsl("Geyser.ScrollBox:new(cons, container)"));
+        provider->add(qsl("Geyser.ScrollBox:new2"), 4, qsl("Geyser.ScrollBox:new2()"));
+        provider->add(qsl("Geyser.StyleSheet:new"), 4, qsl("Geyser.StyleSheet:new(stylesheet, parent, target)"));
 
-    // Geyser namespace functions
-    provider->add(qsl("Geyser.Color.parse"), 4, qsl("Geyser.Color.parse(color)"));
-    provider->add(qsl("Geyser.Color.hex"), 4, qsl("Geyser.Color.hex(color)"));
-    provider->add(qsl("Geyser.Color.hexa"), 4, qsl("Geyser.Color.hexa(color)"));
-    provider->add(qsl("Geyser.Color.hhex"), 4, qsl("Geyser.Color.hhex(color)"));
-    provider->add(qsl("Geyser.Color.hhexa"), 4, qsl("Geyser.Color.hhexa(color)"));
-    provider->add(qsl("Geyser.Color.hdec"), 4, qsl("Geyser.Color.hdec(color)"));
-    provider->add(qsl("Geyser.Color.hdeca"), 4, qsl("Geyser.Color.hdeca(color)"));
+        // Geyser namespace functions
+        provider->add(qsl("Geyser.Color.parse"), 4, qsl("Geyser.Color.parse(color)"));
+        provider->add(qsl("Geyser.Color.hex"), 4, qsl("Geyser.Color.hex(color)"));
+        provider->add(qsl("Geyser.Color.hexa"), 4, qsl("Geyser.Color.hexa(color)"));
+        provider->add(qsl("Geyser.Color.hhex"), 4, qsl("Geyser.Color.hhex(color)"));
+        provider->add(qsl("Geyser.Color.hhexa"), 4, qsl("Geyser.Color.hhexa(color)"));
+        provider->add(qsl("Geyser.Color.hdec"), 4, qsl("Geyser.Color.hdec(color)"));
+        provider->add(qsl("Geyser.Color.hdeca"), 4, qsl("Geyser.Color.hdeca(color)"));
 
-    // Adjustable Container Framework
-    provider->add(qsl("Adjustable.Container:new"), 4, qsl("Adjustable.Container:new(cons, container)"));
+        // Adjustable Container Framework
+        provider->add(qsl("Adjustable.Container:new"), 4, qsl("Adjustable.Container:new(cons, container)"));
 
-    // Database Framework
-    provider->add(qsl("db.create"), 4, qsl("db.create(db_name, schema)"));
-    provider->add(qsl("db.query"), 4, qsl("db.query(db_name, query, ...)"));
-    provider->add(qsl("db.insert"), 4, qsl("db.insert(db_name, sheet_name, values)"));
-    provider->add(qsl("db.update"), 4, qsl("db.update(db_name, sheet_name, values, query)"));
-    provider->add(qsl("db.delete"), 4, qsl("db.delete(db_name, sheet_name, query)"));
-    provider->add(qsl("db.fetch"), 4, qsl("db.fetch(db_name, query, ...)"));
-    provider->add(qsl("db.aggregate"), 4, qsl("db.aggregate(db_name, query, ...)"));
+        // Database Framework
+        provider->add(qsl("db.create"), 4, qsl("db.create(db_name, schema)"));
+        provider->add(qsl("db.query"), 4, qsl("db.query(db_name, query, ...)"));
+        provider->add(qsl("db.insert"), 4, qsl("db.insert(db_name, sheet_name, values)"));
+        provider->add(qsl("db.update"), 4, qsl("db.update(db_name, sheet_name, values, query)"));
+        provider->add(qsl("db.delete"), 4, qsl("db.delete(db_name, sheet_name, query)"));
+        provider->add(qsl("db.fetch"), 4, qsl("db.fetch(db_name, query, ...)"));
+        provider->add(qsl("db.aggregate"), 4, qsl("db.aggregate(db_name, query, ...)"));
 
-    // DateTime utilities
-    provider->add(qsl("datetime.parse"), 4, qsl("datetime.parse(format, date_string)"));
+        // DateTime utilities
+        provider->add(qsl("datetime.parse"), 4, qsl("datetime.parse(format, date_string)"));
 
         // Transfer ownership to Edbee - deleted automatically at app shutdown
         edbee::Edbee::instance()->autoCompleteProviderList()->giveProvider(provider);
@@ -836,7 +835,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     QAction* showDebugAreaAction = new QAction(QIcon(qsl(":/icons/tools-report-bug.png")), tr("Debug"), this);
     showDebugAreaAction->setStatusTip(tr("Show/Hide the separate Central Debug Console - when being displayed the system will be slower."));
     //: %1 is a keyboard shortcut, e.g. 'Ctrl+0' on Windows/Linux or '⌘0' on macOS
-    showDebugAreaAction->setToolTip(utils::richText(tr("Show/Hide Debug Console (%1) -> system will be <b><i>slower</i></b>.").arg(QKeySequence(Qt::CTRL | Qt::Key_0).toString(QKeySequence::NativeText))));
+    showDebugAreaAction->setToolTip(
+            utils::richText(tr("Show/Hide Debug Console (%1) -> system will be <b><i>slower</i></b>.").arg(QKeySequence(Qt::CTRL | Qt::Key_0).toString(QKeySequence::NativeText))));
     connect(showDebugAreaAction, &QAction::triggered, this, &dlgTriggerEditor::slot_toggleCentralDebugConsole);
 
     // Only show undo/redo test button in "Mudlet self-test" profile (tests are destructive)
@@ -885,8 +885,9 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mSaveItem = new QAction(QIcon(qsl(":/icons/document-save-as.png")), qsl("Save Item"), this);
     //: %1 is a keyboard shortcut, e.g. 'Ctrl+S' on Windows/Linux or '⌘S' on macOS
     mSaveItem->setToolTip(tr("<p>Saves the selected item. (%1)</p>"
-                              "<p>Saving causes any changes to the item to take effect. It will not save to disk, "
-                              "so changes will be lost in case of a computer/program crash (but Save Profile to the right will be secure.)</p>").arg(QKeySequence(QKeySequence::Save).toString(QKeySequence::NativeText)));
+                             "<p>Saving causes any changes to the item to take effect. It will not save to disk, "
+                             "so changes will be lost in case of a computer/program crash (but Save Profile to the right will be secure.)</p>")
+                                  .arg(QKeySequence(QKeySequence::Save).toString(QKeySequence::NativeText)));
     connect(mSaveItem, &QAction::triggered, this, &dlgTriggerEditor::slot_saveEdits);
 
     QAction* copyAction = new QAction(tr("Copy"), this);
@@ -933,8 +934,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     separator2->setSeparator(true);
 
     // Add context menu actions to all tree widgets
-    QList<QTreeWidget*> treeWidgets = {treeWidget_triggers, treeWidget_aliases, treeWidget_timers,
-                                       treeWidget_scripts, treeWidget_actions, treeWidget_keys, treeWidget_variables};
+    QList<QTreeWidget*> treeWidgets = {treeWidget_triggers, treeWidget_aliases, treeWidget_timers, treeWidget_scripts, treeWidget_actions, treeWidget_keys, treeWidget_variables};
 
     for (QTreeWidget* widget : treeWidgets) {
         widget->addAction(mAddItem);
@@ -973,8 +973,10 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                                       "when connecting.</p>"
                                       "<p>Should there be any modules that are marked to be \"<i>synced</i>\" this will "
                                       "also cause them to be saved and reloaded into other profiles if they too are "
-                                      "active.</p>").arg(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_S).toString(QKeySequence::NativeText)));
-    mProfileSaveAction->setStatusTip(tr(R"(Saves your entire profile (triggers, aliases, scripts, timers, buttons and keys, but not the map or script-specific settings); also "synchronizes" modules that are so marked.)"));
+                                      "active.</p>")
+                                           .arg(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_S).toString(QKeySequence::NativeText)));
+    mProfileSaveAction->setStatusTip(
+            tr(R"(Saves your entire profile (triggers, aliases, scripts, timers, buttons and keys, but not the map or script-specific settings); also "synchronizes" modules that are so marked.)"));
 
     mProfileSaveAsAction = new QAction(QIcon(qsl(":/icons/utilities-file-archiver.png")), tr("Save Profile As"), this);
 
@@ -985,18 +987,18 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
         mProfileSaveAction->setDisabled(true);
         mProfileSaveAsAction->setDisabled(true);
         auto disabledSaving = tr("Something went wrong loading your Mudlet profile and it could not be loaded. "
-            "Try loading an older version in 'Connect - Options - Profile history'");
+                                 "Try loading an older version in 'Connect - Options - Profile history'");
         mProfileSaveAction->setToolTip(disabledSaving);
         mProfileSaveAsAction->setToolTip(disabledSaving);
     }
 
-    auto *nextSectionShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Tab), this);
+    auto* nextSectionShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Tab), this);
     QObject::connect(nextSectionShortcut, &QShortcut::activated, this, &dlgTriggerEditor::slot_nextSection);
 
-    QShortcut *previousSectionShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Tab), this);
+    QShortcut* previousSectionShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Tab), this);
     connect(previousSectionShortcut, &QShortcut::activated, this, &dlgTriggerEditor::slot_previousSection);
 
-    QShortcut *activateMainWindowAction = new QShortcut(QKeySequence((Qt::ALT | Qt::Key_E)), this);
+    QShortcut* activateMainWindowAction = new QShortcut(QKeySequence((Qt::ALT | Qt::Key_E)), this);
     connect(activateMainWindowAction, &QShortcut::activated, this, &dlgTriggerEditor::slot_activateMainWindow);
 
     toolBar = new QToolBar();
@@ -1102,9 +1104,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     config->beginChanges();
     config->setThemeName(mpHost->mEditorTheme);
     config->setFont(mpHost->getDisplayFont());
-    config->setShowWhitespaceMode((mudlet::self()->mEditorTextOptions & QTextOption::ShowTabsAndSpaces)
-                                  ? edbee::TextEditorConfig::ShowWhitespaces
-                                  : edbee::TextEditorConfig::HideWhitespaces);
+    config->setShowWhitespaceMode((mudlet::self()->mEditorTextOptions & QTextOption::ShowTabsAndSpaces) ? edbee::TextEditorConfig::ShowWhitespaces : edbee::TextEditorConfig::HideWhitespaces);
     config->setUseLineSeparator(mudlet::self()->mEditorTextOptions & QTextOption::ShowLineAndParagraphSeparators);
     config->setAutocompleteAutoShow(mpHost->mEditorAutoComplete);
     config->setRenderBidiContolCharacters(mpHost->getEditorShowBidi());
@@ -1224,14 +1224,12 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     // see https://bugreports.qt.io/browse/QTBUG-36257 for problem
     // credit to Albert for the workaround
     for (auto child : pLineEdit_searchTerm->children()) {
-        auto *pAction_clear(qobject_cast<QAction *>(child));
+        auto* pAction_clear(qobject_cast<QAction*>(child));
 
         // The name was found by inspection - but as it is a QT internal it
         // might change in the future:
         if (pAction_clear && pAction_clear->objectName() == QLatin1String("_q_qlineeditclearaction")) {
-            connect(pAction_clear, &QAction::triggered,
-                    this, &dlgTriggerEditor::slot_clearSearchResults,
-                    Qt::QueuedConnection);
+            connect(pAction_clear, &QAction::triggered, this, &dlgTriggerEditor::slot_clearSearchResults, Qt::QueuedConnection);
             break;
         }
     }
@@ -1313,8 +1311,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     comboBox_searchTerms->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
-    QFrame *searchContainer = new QFrame();
-    QVBoxLayout *searchLayout = new QVBoxLayout(searchContainer);
+    QFrame* searchContainer = new QFrame();
+    QVBoxLayout* searchLayout = new QVBoxLayout(searchContainer);
     searchLayout->addWidget(checkBox_displayAllVariables);
     searchLayout->addWidget(comboBox_searchTerms);
     searchLayout->addWidget(treeWidget_searchResults);
@@ -1323,8 +1321,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     connect(searchSplitter, &QSplitter::splitterMoved, this, &dlgTriggerEditor::slot_searchSplitterMoved);
 
-    QFrame *itemContainer = new QFrame();
-    QVBoxLayout *itemLayout = new QVBoxLayout(itemContainer);
+    QFrame* itemContainer = new QFrame();
+    QVBoxLayout* itemLayout = new QVBoxLayout(itemContainer);
 
     itemLayout->addWidget(treeWidget_triggers);
     itemLayout->addWidget(treeWidget_aliases);
@@ -1386,23 +1384,9 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     pixMap_prompt.fill(Qt::yellow);
     const QIcon icon_prompt(pixMap_prompt);
 
-    mPatternList << tr("substring")
-                 << tr("perl regex")
-                 << tr("start of line")
-                 << tr("exact match")
-                 << tr("lua function")
-                 << tr("line spacer")
-                 << tr("color trigger")
-                 << tr("prompt");
+    mPatternList << tr("substring") << tr("perl regex") << tr("start of line") << tr("exact match") << tr("lua function") << tr("line spacer") << tr("color trigger") << tr("prompt");
 
-    mPatternIcons = {icon_subString,
-                     icon_perl_regex,
-                     icon_begin_of_line_substring,
-                     icon_exact_match,
-                     icon_lua_function,
-                     icon_line_spacer,
-                     icon_color_trigger,
-                     icon_prompt};
+    mPatternIcons = {icon_subString, icon_perl_regex, icon_begin_of_line_substring, icon_exact_match, icon_lua_function, icon_line_spacer, icon_color_trigger, icon_prompt};
 
 
     showPatternItems(2);
@@ -1424,7 +1408,6 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     if (mAutosaveInterval > 0) {
         startTimer(mAutosaveInterval * 1min);
     }
-
 }
 
 void dlgTriggerEditor::slot_searchSplitterMoved(const int pos, const int index)
@@ -1975,14 +1958,13 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
         // These searches are to be case sensitive and recursive and find an
         // exact match - we are trying to find the "Name" of the item and then,
         // in case of duplicates we do a match on exact ID number
-        foundItemsList = treeWidget_triggers->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString| Qt::MatchRecursive, 0);
+        foundItemsList = treeWidget_triggers->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString | Qt::MatchRecursive, 0);
 
         // This was inside the loop but it is a constant value for the duration
         // of this method!
         const int idSearch = pItem->data(0, IdRole).toInt();
 
         for (auto treeWidgetItem : std::as_const(foundItemsList)) {
-
             if (treeWidgetItem->data(0, IdRole).toInt() == idSearch) {
                 slot_showTriggers();
                 slot_triggerSelected(treeWidgetItem);
@@ -2006,13 +1988,12 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
                     mpTriggersMainArea->lineEdit_trigger_name->setCursorPosition(pItem->data(0, PositionRole).toInt());
                     break;
                 case SearchResultIsPattern: {
-                    dlgTriggerPatternEdit * pTriggerPattern = mTriggerPatternEdit.at(pItem->data(0, PatternOrLineRole).toInt());
+                    dlgTriggerPatternEdit* pTriggerPattern = mTriggerPatternEdit.at(pItem->data(0, PatternOrLineRole).toInt());
                     mpScrollArea->ensureWidgetVisible(pTriggerPattern);
                     if (pTriggerPattern->singleLineTextEdit_pattern->isVisible()) {
                         // If is a colour trigger the singleLineTextEdit_pattern is not shown
                         pTriggerPattern->singleLineTextEdit_pattern->setFocus();
                         pTriggerPattern->singleLineTextEdit_pattern->textCursor().setPosition(pItem->data(0, PositionRole).toInt());
-
                     }
                     break;
                 }
@@ -2021,8 +2002,8 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
                     mpTriggersMainArea->lineEdit_trigger_command->setCursorPosition(pItem->data(0, PositionRole).toInt());
                     break;
                 default:
-                    qDebug() << "dlgTriggerEditor::slot_item_selected_list(...) Called for a TRIGGER type item but handler for element of type:"
-                             << treeWidgetItem->data(0, TypeRole).toInt() << "not yet done/applicable...!";
+                    qDebug() << "dlgTriggerEditor::slot_item_selected_list(...) Called for a TRIGGER type item but handler for element of type:" << treeWidgetItem->data(0, TypeRole).toInt()
+                             << "not yet done/applicable...!";
                 }
                 return;
             }
@@ -2031,12 +2012,11 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
     }
 
     case EditorViewType::cmAliasView: {
-        foundItemsList = treeWidget_aliases->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString| Qt::MatchRecursive, 0);
+        foundItemsList = treeWidget_aliases->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString | Qt::MatchRecursive, 0);
 
         const int idSearch = pItem->data(0, IdRole).toInt();
 
         for (auto treeWidgetItem : std::as_const(foundItemsList)) {
-
             if (treeWidgetItem->data(0, IdRole).toInt() == idSearch) {
                 slot_showAliases();
                 slot_aliasSelected(treeWidgetItem);
@@ -2069,8 +2049,8 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
                     mpAliasMainArea->lineEdit_alias_command->setCursorPosition(pItem->data(0, PositionRole).toInt());
                     break;
                 default:
-                    qDebug() << "dlgTriggerEditor::slot_item_selected_list(...) Called for a ALIAS type item but handler for element of type:"
-                             << treeWidgetItem->data(0, TypeRole).toInt() << "not yet done/applicable...!";
+                    qDebug() << "dlgTriggerEditor::slot_item_selected_list(...) Called for a ALIAS type item but handler for element of type:" << treeWidgetItem->data(0, TypeRole).toInt()
+                             << "not yet done/applicable...!";
                 }
                 return;
             }
@@ -2079,12 +2059,11 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
     }
 
     case EditorViewType::cmScriptView: {
-        foundItemsList = treeWidget_scripts->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString| Qt::MatchRecursive, 0);
+        foundItemsList = treeWidget_scripts->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString | Qt::MatchRecursive, 0);
 
         const int idSearch = pItem->data(0, IdRole).toInt();
 
         for (auto treeWidgetItem : std::as_const(foundItemsList)) {
-
             if (treeWidgetItem->data(0, IdRole).toInt() == idSearch) {
                 slot_showScripts();
                 slot_scriptsSelected(treeWidgetItem);
@@ -2122,8 +2101,8 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
                     mIsScriptsMainAreaEditHandler = true;
                     break;
                 default:
-                    qDebug() << "dlgTriggerEditor::slot_item_selected_list(...) Called for a SCRIPT type item but handler for element of type:"
-                             << treeWidgetItem->data(0, TypeRole).toInt() << "not yet done/applicable...!";
+                    qDebug() << "dlgTriggerEditor::slot_item_selected_list(...) Called for a SCRIPT type item but handler for element of type:" << treeWidgetItem->data(0, TypeRole).toInt()
+                             << "not yet done/applicable...!";
                 }
 
                 return;
@@ -2133,12 +2112,11 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
     }
 
     case EditorViewType::cmActionView: {
-        foundItemsList = treeWidget_actions->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString| Qt::MatchRecursive, 0);
+        foundItemsList = treeWidget_actions->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString | Qt::MatchRecursive, 0);
 
         const int idSearch = pItem->data(0, IdRole).toInt();
 
         for (auto treeWidgetitem : std::as_const(foundItemsList)) {
-
             if (treeWidgetitem->data(0, IdRole).toInt() == idSearch) {
                 slot_showActions();
                 slot_actionSelected(treeWidgetitem);
@@ -2162,7 +2140,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
                     mpActionsMainArea->lineEdit_action_name->setCursorPosition(pItem->data(0, PositionRole).toInt());
                     break;
                 case SearchResultIsCommand:
-                    mpActionsMainArea->lineEdit_action_button_command_down ->setFocus(Qt::OtherFocusReason);
+                    mpActionsMainArea->lineEdit_action_button_command_down->setFocus(Qt::OtherFocusReason);
                     mpActionsMainArea->lineEdit_action_button_command_down->setCursorPosition(pItem->data(0, PositionRole).toInt());
                     break;
                 case SearchResultIsExtraCommand:
@@ -2185,10 +2163,10 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
                     }
                     mpActionsMainArea->plainTextEdit_action_css->setTextCursor(cssCursor);
                 } // End case SearchResultsIsCss
-                    break;
+                break;
                 default:
-                    qDebug() << "dlgTriggerEditor::slot_item_selected_list(...) Called for a BUTTON type item but handler for element of type:"
-                             << treeWidgetitem->data(0, TypeRole).toInt() << "not yet done/applicable...!";
+                    qDebug() << "dlgTriggerEditor::slot_item_selected_list(...) Called for a BUTTON type item but handler for element of type:" << treeWidgetitem->data(0, TypeRole).toInt()
+                             << "not yet done/applicable...!";
                 } // End or switch()
                 return;
             } // End of if()
@@ -2197,12 +2175,11 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
     } // End of case EditorViewType::cmActionView
 
     case EditorViewType::cmTimerView: {
-        foundItemsList = treeWidget_timers->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString| Qt::MatchRecursive, 0);
+        foundItemsList = treeWidget_timers->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString | Qt::MatchRecursive, 0);
 
         const int idSearch = pItem->data(0, IdRole).toInt();
 
         for (auto treeWidgetItem : std::as_const(foundItemsList)) {
-
             if (treeWidgetItem->data(0, IdRole).toInt() == idSearch) {
                 slot_showTimers();
                 slot_timerSelected(treeWidgetItem);
@@ -2230,8 +2207,8 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
                     mpTimersMainArea->lineEdit_timer_command->setCursorPosition(pItem->data(0, PositionRole).toInt());
                     break;
                 default:
-                    qDebug() << "dlgTriggerEditor::slot_item_selected_list(...) Called for a TIMER type item but handler for element of type:"
-                             << treeWidgetItem->data(0, TypeRole).toInt() << "not yet done/applicable...!";
+                    qDebug() << "dlgTriggerEditor::slot_item_selected_list(...) Called for a TIMER type item but handler for element of type:" << treeWidgetItem->data(0, TypeRole).toInt()
+                             << "not yet done/applicable...!";
                 } // End of switch()
                 return;
             } // End of if()
@@ -2240,7 +2217,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
     } // End of case EditorViewType::cmTimerView
 
     case EditorViewType::cmKeysView: {
-        foundItemsList = treeWidget_keys->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString| Qt::MatchRecursive, 0);
+        foundItemsList = treeWidget_keys->findItems(pItem->data(0, NameRole).toString(), Qt::MatchCaseSensitive | Qt::MatchFixedString | Qt::MatchRecursive, 0);
 
         for (auto treeWidgetItem : std::as_const(foundItemsList)) {
             const int idTree = treeWidgetItem->data(0, IdRole).toInt();
@@ -2268,7 +2245,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
                     mpTriggersMainArea->lineEdit_trigger_name->setCursorPosition(pItem->data(0, PositionRole).toInt());
                     break;
                 case SearchResultIsPattern: {
-                    dlgTriggerPatternEdit * pTriggerPattern = mTriggerPatternEdit.at(pItem->data(0, PatternOrLineRole).toInt());
+                    dlgTriggerPatternEdit* pTriggerPattern = mTriggerPatternEdit.at(pItem->data(0, PatternOrLineRole).toInt());
                     mpScrollArea->ensureWidgetVisible(pTriggerPattern);
                     if (pTriggerPattern->singleLineTextEdit_pattern->isVisible()) {
                         // If is a colour trigger the singleLineTextEdit_pattern is not shown
@@ -2282,8 +2259,8 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
                     mpTriggersMainArea->lineEdit_trigger_command->setCursorPosition(pItem->data(0, PositionRole).toInt());
                     break;
                 default:
-                    qDebug() << "dlgTriggerEditor::slot_item_selected_list(...) Called for a KEY type item but handler for element of type:"
-                             << treeWidgetItem->data(0, TypeRole).toInt() << "not yet done/applicable...!";
+                    qDebug() << "dlgTriggerEditor::slot_item_selected_list(...) Called for a KEY type item but handler for element of type:" << treeWidgetItem->data(0, TypeRole).toInt()
+                             << "not yet done/applicable...!";
                 } // End of switch()
                 return;
             } // End of if
@@ -2323,16 +2300,15 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
                     controller->moveCaretTo(static_cast<size_t>(pItem->data(0, PatternOrLineRole).toInt()), static_cast<size_t>(pItem->data(0, PositionRole).toInt()), false);
                     break;
                 default:
-                    qDebug() << "dlgTriggerEditor::slot_item_selected_list(...) Called for a VAR type item but handler for element of type:"
-                             << treeWidgetItem->data(0, TypeRole).toInt() << "not yet done/applicable...!";
+                    qDebug() << "dlgTriggerEditor::slot_item_selected_list(...) Called for a VAR type item but handler for element of type:" << treeWidgetItem->data(0, TypeRole).toInt()
+                             << "not yet done/applicable...!";
                 }
                 return;
             }
         }
-    }  // End of case static_cast<int>(EditorViewType::cmVarsView)
-        break;
-    default:
-        ; // No-op
+    } // End of case static_cast<int>(EditorViewType::cmVarsView)
+    break;
+    default:; // No-op
     } // End of switch()
 }
 
@@ -2504,8 +2480,7 @@ void dlgTriggerEditor::searchKeys(const QString& text)
         const int total = textList.count();
         for (int index = 0; index < total; ++index) {
             // CHECK: This may NOT be an optimisation...!
-            if (textList.at(index).isEmpty() ||
-               !containsSearchMatch(textList.at(index), text)) {
+            if (textList.at(index).isEmpty() || !containsSearchMatch(textList.at(index), text)) {
                 // Short-cuts that mean we do not have to examine the line in more detail
                 continue;
             }
@@ -3088,12 +3063,12 @@ void dlgTriggerEditor::recursiveSearchTriggers(TTrigger* pTriggerParent, const Q
                 whatText.replace(QString(QChar::SpecialCharacter::Tabulation), QString(QChar::Space).repeated(2));
                 QStringList sl;
                 if (!parent) {
-                    sl << tr("Trigger") << name << tr("Lua code (%1:%2)").arg(index+1).arg(startPos+1) << whatText;
+                    sl << tr("Trigger") << name << tr("Lua code (%1:%2)").arg(index + 1).arg(startPos + 1) << whatText;
                     parent = new QTreeWidgetItem(sl);
                     setAllSearchData(parent, EditorViewType::cmTriggerView, name, trigger->getID(), SearchResultIsScript, startPos, index, instance++);
                     treeWidget_searchResults->addTopLevelItem(parent);
                 } else {
-                    sl << QString() << QString() << tr("Lua code (%1:%2)").arg(index+1).arg(startPos+1) << whatText;
+                    sl << QString() << QString() << tr("Lua code (%1:%2)").arg(index + 1).arg(startPos + 1) << whatText;
                     pItem = new QTreeWidgetItem(parent, sl);
                     setAllSearchData(pItem, EditorViewType::cmTriggerView, name, trigger->getID(), SearchResultIsScript, startPos, index, instance++);
                     parent->addChild(pItem);
@@ -3584,9 +3559,7 @@ void dlgTriggerEditor::delete_alias()
     if (aliasesToDelete.size() == 1) {
         message = tr("Do you really want to delete alias \"%1\"?").arg(itemNames.first());
     } else {
-        message = tr("Do you really want to delete %1 aliases?\n\nItems to be deleted:\n%2")
-                    .arg(aliasesToDelete.size())
-                    .arg(itemNames.join(", "));
+        message = tr("Do you really want to delete %1 aliases?\n\nItems to be deleted:\n%2").arg(aliasesToDelete.size()).arg(itemNames.join(", "));
     }
 
     // Capture state of all items BEFORE deletion for undo
@@ -3712,10 +3685,7 @@ void dlgTriggerEditor::delete_alias()
     }
 
     if (!deletedItems.isEmpty()) {
-        auto* qtCmd = new EditorDeleteItemCommand(
-            EditorViewType::cmAliasView,
-            deletedItems,
-            mpHost);
+        auto* qtCmd = new EditorDeleteItemCommand(EditorViewType::cmAliasView, deletedItems, mpHost);
         mpUndoStack->pushCommand(qtCmd);
     }
 
@@ -3757,9 +3727,7 @@ void dlgTriggerEditor::delete_action()
     if (actionsToDelete.size() == 1) {
         message = tr("Do you really want to delete button \"%1\"?").arg(itemNames.first());
     } else {
-        message = tr("Do you really want to delete %1 buttons?\n\nItems to be deleted:\n%2")
-                    .arg(actionsToDelete.size())
-                    .arg(itemNames.join(", "));
+        message = tr("Do you really want to delete %1 buttons?\n\nItems to be deleted:\n%2").arg(actionsToDelete.size()).arg(itemNames.join(", "));
     }
 
     // Capture state of all items BEFORE deletion for undo
@@ -3864,10 +3832,7 @@ void dlgTriggerEditor::delete_action()
     }
 
     if (!deletedItems.isEmpty()) {
-        auto* qtCmd = new EditorDeleteItemCommand(
-            EditorViewType::cmActionView,
-            deletedItems,
-            mpHost);
+        auto* qtCmd = new EditorDeleteItemCommand(EditorViewType::cmActionView, deletedItems, mpHost);
         mpUndoStack->pushCommand(qtCmd);
     }
 
@@ -3913,9 +3878,7 @@ void dlgTriggerEditor::delete_variable()
     if (varsToDelete.size() == 1) {
         message = tr("Do you really want to delete variable \"%1\"?").arg(itemNames.first());
     } else {
-        message = tr("Do you really want to delete %1 variables?\n\nItems to be deleted:\n%2")
-                    .arg(varsToDelete.size())
-                    .arg(itemNames.join(", "));
+        message = tr("Do you really want to delete %1 variables?\n\nItems to be deleted:\n%2").arg(varsToDelete.size()).arg(itemNames.join(", "));
     }
 
     // Sort items by their position in tree (top to bottom) to delete correctly
@@ -3989,9 +3952,7 @@ void dlgTriggerEditor::delete_script()
     if (scriptsToDelete.size() == 1) {
         message = tr("Do you really want to delete script \"%1\"?").arg(itemNames.first());
     } else {
-        message = tr("Do you really want to delete %1 scripts?\n\nItems to be deleted:\n%2")
-                    .arg(scriptsToDelete.size())
-                    .arg(itemNames.join(", "));
+        message = tr("Do you really want to delete %1 scripts?\n\nItems to be deleted:\n%2").arg(scriptsToDelete.size()).arg(itemNames.join(", "));
     }
 
     // Capture state of all items BEFORE deletion for undo
@@ -4089,10 +4050,7 @@ void dlgTriggerEditor::delete_script()
     }
 
     if (!deletedItems.isEmpty()) {
-        auto* qtCmd = new EditorDeleteItemCommand(
-            EditorViewType::cmScriptView,
-            deletedItems,
-            mpHost);
+        auto* qtCmd = new EditorDeleteItemCommand(EditorViewType::cmScriptView, deletedItems, mpHost);
         mpUndoStack->pushCommand(qtCmd);
     }
 
@@ -4134,9 +4092,7 @@ void dlgTriggerEditor::delete_key()
     if (keysToDelete.size() == 1) {
         message = tr("Do you really want to delete key \"%1\"?").arg(itemNames.first());
     } else {
-        message = tr("Do you really want to delete %1 keys?\n\nItems to be deleted:\n%2")
-                    .arg(keysToDelete.size())
-                    .arg(itemNames.join(", "));
+        message = tr("Do you really want to delete %1 keys?\n\nItems to be deleted:\n%2").arg(keysToDelete.size()).arg(itemNames.join(", "));
     }
 
     // Capture state of all items BEFORE deletion for undo
@@ -4234,10 +4190,7 @@ void dlgTriggerEditor::delete_key()
     }
 
     if (!deletedItems.isEmpty()) {
-        auto* qtCmd = new EditorDeleteItemCommand(
-            EditorViewType::cmKeysView,
-            deletedItems,
-            mpHost);
+        auto* qtCmd = new EditorDeleteItemCommand(EditorViewType::cmKeysView, deletedItems, mpHost);
         mpUndoStack->pushCommand(qtCmd);
     }
 
@@ -4279,9 +4232,7 @@ void dlgTriggerEditor::delete_trigger()
     if (triggersToDelete.size() == 1) {
         message = tr("Do you really want to delete trigger \"%1\"?").arg(itemNames.first());
     } else {
-        message = tr("Do you really want to delete %1 triggers?\n\nItems to be deleted:\n%2")
-                    .arg(triggersToDelete.size())
-                    .arg(itemNames.join(", "));
+        message = tr("Do you really want to delete %1 triggers?\n\nItems to be deleted:\n%2").arg(triggersToDelete.size()).arg(itemNames.join(", "));
     }
 
     // Capture state of all items BEFORE deletion for undo
@@ -4384,10 +4335,7 @@ void dlgTriggerEditor::delete_trigger()
     }
 
     if (!deletedItems.isEmpty()) {
-        auto* qtCmd = new EditorDeleteItemCommand(
-            EditorViewType::cmTriggerView,
-            deletedItems,
-            mpHost);
+        auto* qtCmd = new EditorDeleteItemCommand(EditorViewType::cmTriggerView, deletedItems, mpHost);
         mpUndoStack->pushCommand(qtCmd);
     }
 
@@ -4429,9 +4377,7 @@ void dlgTriggerEditor::delete_timer()
     if (timersToDelete.size() == 1) {
         message = tr("Do you really want to delete timer \"%1\"?").arg(itemNames.first());
     } else {
-        message = tr("Do you really want to delete %1 timers?\n\nItems to be deleted:\n%2")
-                    .arg(timersToDelete.size())
-                    .arg(itemNames.join(", "));
+        message = tr("Do you really want to delete %1 timers?\n\nItems to be deleted:\n%2").arg(timersToDelete.size()).arg(itemNames.join(", "));
     }
 
     // Capture state of all items BEFORE deletion for undo
@@ -4529,10 +4475,7 @@ void dlgTriggerEditor::delete_timer()
     }
 
     if (!deletedItems.isEmpty()) {
-        auto* qtCmd = new EditorDeleteItemCommand(
-            EditorViewType::cmTimerView,
-            deletedItems,
-            mpHost);
+        auto* qtCmd = new EditorDeleteItemCommand(EditorViewType::cmTimerView, deletedItems, mpHost);
         mpUndoStack->pushCommand(qtCmd);
     }
 
@@ -4623,7 +4566,8 @@ void dlgTriggerEditor::activeToggle_trigger()
     if (!pT->state()) {
         pT->setIsActive(false);
         showError(tr(R"(<p>Unable to activate "<tt>%1</tt>": %2</p>
-                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)").arg(pT->getName().toHtmlEscaped(), pT->getError()));
+                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)")
+                          .arg(pT->getName().toHtmlEscaped(), pT->getError()));
         icon.addPixmap(QPixmap(qsl(":/icons/tools-report-bug.png")), QIcon::Normal, QIcon::Off);
         itemDescription = descError;
     }
@@ -4636,13 +4580,7 @@ void dlgTriggerEditor::activeToggle_trigger()
     }
 
     if (mpUndoStack && oldState != newState) {
-        auto* qtCmd = new EditorToggleActiveCommand(
-            EditorViewType::cmTriggerView,
-            pT->getID(),
-            oldState,
-            newState,
-            pT->getName(),
-            mpHost);
+        auto* qtCmd = new EditorToggleActiveCommand(EditorViewType::cmTriggerView, pT->getID(), oldState, newState, pT->getName(), mpHost);
         mpUndoStack->pushCommand(qtCmd);
     }
 }
@@ -4724,15 +4662,7 @@ void dlgTriggerEditor::slot_itemMoved(int itemID, int oldParentID, int newParent
     }
 
     // Push move command to undo system
-    auto* qtCmd = new EditorMoveItemCommand(
-        viewType,
-        itemID,
-        oldParentID,
-        newParentID,
-        oldPosition,
-        newPosition,
-        itemName,
-        mpHost);
+    auto* qtCmd = new EditorMoveItemCommand(viewType, itemID, oldParentID, newParentID, oldPosition, newPosition, itemName, mpHost);
     mpUndoStack->pushCommand(qtCmd);
 }
 
@@ -4814,7 +4744,7 @@ void dlgTriggerEditor::children_icon_triggers(QTreeWidgetItem* pWidgetItemParent
                     }
 
                 } else {
-                        itemDescription = descInactive;
+                    itemDescription = descInactive;
                     if (pT->ancestorsActive()) {
                         icon.addPixmap(QPixmap(qsl(":/icons/tag_checkbox.png")), QIcon::Normal, QIcon::Off);
                     } else {
@@ -4936,7 +4866,8 @@ void dlgTriggerEditor::activeToggle_timer()
     if (!pT->state()) {
         pT->setIsActive(false);
         showError(tr(R"(<p><b>Unable to activate "<tt>%1</tt>": %2.</b></p>
-                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)").arg(pT->getName().toHtmlEscaped(), pT->getError()));
+                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)")
+                          .arg(pT->getName().toHtmlEscaped(), pT->getError()));
         icon.addPixmap(QPixmap(qsl(":/icons/tools-report-bug.png")), QIcon::Normal, QIcon::Off);
         itemDescription = descError;
     }
@@ -4949,13 +4880,7 @@ void dlgTriggerEditor::activeToggle_timer()
     }
 
     if (mpUndoStack && oldState != newState) {
-        auto* qtCmd = new EditorToggleActiveCommand(
-            EditorViewType::cmTimerView,
-            pT->getID(),
-            oldState,
-            newState,
-            pT->getName(),
-            mpHost);
+        auto* qtCmd = new EditorToggleActiveCommand(EditorViewType::cmTimerView, pT->getID(), oldState, newState, pT->getName(), mpHost);
         mpUndoStack->pushCommand(qtCmd);
     }
 }
@@ -5089,7 +5014,8 @@ void dlgTriggerEditor::activeToggle_alias()
     if (!pT->state()) {
         pT->setIsActive(false);
         showError(tr(R"(<p><b>Unable to activate "<tt>%1</tt>"; %2.</b></p>
-                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)").arg(pT->getName().toHtmlEscaped(), pT->getError()));
+                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)")
+                          .arg(pT->getName().toHtmlEscaped(), pT->getError()));
         icon.addPixmap(QPixmap(qsl(":/icons/tools-report-bug.png")), QIcon::Normal, QIcon::Off);
         itemDescription = descError;
     }
@@ -5102,13 +5028,7 @@ void dlgTriggerEditor::activeToggle_alias()
     }
 
     if (mpUndoStack && oldState != newState) {
-        auto* qtCmd = new EditorToggleActiveCommand(
-            EditorViewType::cmAliasView,
-            pT->getID(),
-            oldState,
-            newState,
-            pT->getName(),
-            mpHost);
+        auto* qtCmd = new EditorToggleActiveCommand(EditorViewType::cmAliasView, pT->getID(), oldState, newState, pT->getName(), mpHost);
         mpUndoStack->pushCommand(qtCmd);
     }
 }
@@ -5223,7 +5143,8 @@ void dlgTriggerEditor::activeToggle_script()
     if (!pT->state()) {
         pT->setIsActive(false);
         showError(tr(R"(<p><b>Unable to activate "<tt>%1</tt>"; %2.</b></p>
-                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)").arg(pT->getName().toHtmlEscaped(), pT->getError()));
+                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)")
+                          .arg(pT->getName().toHtmlEscaped(), pT->getError()));
         icon.addPixmap(QPixmap(qsl(":/icons/tools-report-bug.png")), QIcon::Normal, QIcon::Off);
         itemDescription = descError;
     }
@@ -5235,13 +5156,7 @@ void dlgTriggerEditor::activeToggle_script()
     }
 
     if (mpUndoStack && oldState != newState) {
-        auto* qtCmd = new EditorToggleActiveCommand(
-            EditorViewType::cmScriptView,
-            pT->getID(),
-            oldState,
-            newState,
-            pT->getName(),
-            mpHost);
+        auto* qtCmd = new EditorToggleActiveCommand(EditorViewType::cmScriptView, pT->getID(), oldState, newState, pT->getName(), mpHost);
         mpUndoStack->pushCommand(qtCmd);
     }
 }
@@ -5391,7 +5306,8 @@ void dlgTriggerEditor::activeToggle_action()
     if (!pT->state()) {
         pT->setIsActive(false);
         showError(tr(R"(<p><b>Unable to activate "<tt>%1</tt>"; %2.</b></p>
-                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)").arg(pT->getName().toHtmlEscaped(), pT->getError()));
+                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)")
+                          .arg(pT->getName().toHtmlEscaped(), pT->getError()));
         icon.addPixmap(QPixmap(qsl(":/icons/tools-report-bug.png")), QIcon::Normal, QIcon::Off);
         itemDescription = descError;
     }
@@ -5405,13 +5321,7 @@ void dlgTriggerEditor::activeToggle_action()
     }
 
     if (mpUndoStack && oldState != newState) {
-        auto* qtCmd = new EditorToggleActiveCommand(
-            EditorViewType::cmActionView,
-            pT->getID(),
-            oldState,
-            newState,
-            pT->getName(),
-            mpHost);
+        auto* qtCmd = new EditorToggleActiveCommand(EditorViewType::cmActionView, pT->getID(), oldState, newState, pT->getName(), mpHost);
         mpUndoStack->pushCommand(qtCmd);
     }
 }
@@ -5568,7 +5478,8 @@ void dlgTriggerEditor::activeToggle_key()
     if (!pT->state()) {
         pT->setIsActive(false);
         showError(tr(R"(<p><b>Unable to activate "<tt>%1</tt>"; %2.</b></p>
-                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)").arg(pT->getName().toHtmlEscaped(), pT->getError()));
+                     <p><i>You will need to reactivate this after the problem has been corrected.</i></p>)")
+                          .arg(pT->getName().toHtmlEscaped(), pT->getError()));
         icon.addPixmap(QPixmap(qsl(":/icons/tools-report-bug.png")), QIcon::Normal, QIcon::Off);
         itemDescription = descError;
     }
@@ -5578,13 +5489,7 @@ void dlgTriggerEditor::activeToggle_key()
     }
 
     if (mpUndoStack && oldState != newState) {
-        auto* qtCmd = new EditorToggleActiveCommand(
-            EditorViewType::cmKeysView,
-            pT->getID(),
-            oldState,
-            newState,
-            pT->getName(),
-            mpHost);
+        auto* qtCmd = new EditorToggleActiveCommand(EditorViewType::cmKeysView, pT->getID(), oldState, newState, pT->getName(), mpHost);
         mpUndoStack->pushCommand(qtCmd);
     }
 }
@@ -5658,7 +5563,7 @@ void dlgTriggerEditor::addTrigger(bool isFolder)
     saveTrigger();
 
     QString name = isFolder ? tr("New trigger group") : tr("New trigger");
-    QStringList nameList { name };
+    QStringList nameList{name};
     const QStringList patterns;
     QList<int> const patternKinds;
     const QString script = "";
@@ -5711,9 +5616,7 @@ void dlgTriggerEditor::addTrigger(bool isFolder)
 
     // Initialize tree item properties
     pNewItem->setData(0, Qt::UserRole, pNewTrigger->getID());
-    pNewItem->setIcon(0, QIcon(QPixmap(isFolder ?
-        qsl(":/icons/folder-red.png") :
-        qsl(":/icons/document-save-as.png"))));
+    pNewItem->setIcon(0, QIcon(QPixmap(isFolder ? qsl(":/icons/folder-red.png") : qsl(":/icons/document-save-as.png"))));
     pNewItem->setData(0, Qt::AccessibleDescriptionRole, isFolder ? descNewFolder : descNewItem);
 
     // Expand parent if applicable
@@ -5740,9 +5643,7 @@ void dlgTriggerEditor::addTrigger(bool isFolder)
     slot_triggerSelected(treeWidget_triggers->currentItem());
 
     QTreeWidgetItem* actualParent = pNewItem->parent();
-    int parentID = (actualParent && actualParent != mpTriggerBaseItem)
-                   ? actualParent->data(0, Qt::UserRole).toInt()
-                   : -1;
+    int parentID = (actualParent && actualParent != mpTriggerBaseItem) ? actualParent->data(0, Qt::UserRole).toInt() : -1;
 
     int positionInParent = 0;
     if (actualParent) {
@@ -5751,14 +5652,7 @@ void dlgTriggerEditor::addTrigger(bool isFolder)
         positionInParent = treeWidget_triggers->indexOfTopLevelItem(pNewItem);
     }
 
-    auto* qtCmd = new EditorAddItemCommand(
-        EditorViewType::cmTriggerView,
-        pNewTrigger->getID(),
-        parentID,
-        positionInParent,
-        isFolder,
-        name,
-        mpHost);
+    auto* qtCmd = new EditorAddItemCommand(EditorViewType::cmTriggerView, pNewTrigger->getID(), parentID, positionInParent, isFolder, name, mpHost);
     mpUndoStack->pushCommand(qtCmd);
 
     // Note: Subsequent modify commands will automatically merge with this Add command
@@ -5771,7 +5665,7 @@ void dlgTriggerEditor::addTimer(bool isFolder)
     saveTimer();
 
     QString name = isFolder ? tr("New timer group") : tr("New timer");
-    QStringList nameList = { name };
+    QStringList nameList = {name};
     const QString command = "";
     const QTime time;
     const QString script = "";
@@ -5819,9 +5713,7 @@ void dlgTriggerEditor::addTimer(bool isFolder)
 
     // Initialize tree item properties
     pNewItem->setData(0, Qt::UserRole, pNewTimer->getID());
-    pNewItem->setIcon(0, QIcon(QPixmap(isFolder ?
-        qsl(":/icons/folder-red.png") :
-        qsl(":/icons/document-save-as.png"))));
+    pNewItem->setIcon(0, QIcon(QPixmap(isFolder ? qsl(":/icons/folder-red.png") : qsl(":/icons/document-save-as.png"))));
     pNewItem->setData(0, Qt::AccessibleDescriptionRole, isFolder ? descNewFolder : descNewItem);
 
     // Expand parent if applicable
@@ -5841,9 +5733,7 @@ void dlgTriggerEditor::addTimer(bool isFolder)
     slot_timerSelected(treeWidget_timers->currentItem());
 
     QTreeWidgetItem* actualParent = pNewItem->parent();
-    int parentID = (actualParent && actualParent != mpTimerBaseItem)
-                   ? actualParent->data(0, Qt::UserRole).toInt()
-                   : -1;
+    int parentID = (actualParent && actualParent != mpTimerBaseItem) ? actualParent->data(0, Qt::UserRole).toInt() : -1;
 
     int positionInParent = 0;
     if (actualParent) {
@@ -5852,14 +5742,7 @@ void dlgTriggerEditor::addTimer(bool isFolder)
         positionInParent = treeWidget_timers->indexOfTopLevelItem(pNewItem);
     }
 
-    auto* qtCmd = new EditorAddItemCommand(
-        EditorViewType::cmTimerView,
-        pNewTimer->getID(),
-        parentID,
-        positionInParent,
-        isFolder,
-        name,
-        mpHost);
+    auto* qtCmd = new EditorAddItemCommand(EditorViewType::cmTimerView, pNewTimer->getID(), parentID, positionInParent, isFolder, name, mpHost);
     mpUndoStack->pushCommand(qtCmd);
 
     // Note: Subsequent modify commands will automatically merge with this Add command
@@ -5886,7 +5769,7 @@ void dlgTriggerEditor::addVar(bool isFolder)
     LuaInterface* lI = mpHost->getLuaInterface();
     VarUnit* vu = lI->getVarUnit();
 
-    QStringList nameList = { QString(isFolder ? tr("table_variable") : tr("variable_name")) };
+    QStringList nameList = {QString(isFolder ? tr("table_variable") : tr("variable_name"))};
     mpVarsMainArea->lineEdit_var_name->setText(nameList[0]);
     QTreeWidgetItem* pParentItem = nullptr;
     QTreeWidgetItem* pNewItem;
@@ -5936,8 +5819,8 @@ void dlgTriggerEditor::addKey(bool isFolder)
 {
     saveKey();
 
-    QString name = isFolder? tr("New key group") : tr("New key");
-    QStringList nameList = { name };
+    QString name = isFolder ? tr("New key group") : tr("New key");
+    QStringList nameList = {name};
     const QString script = "";
 
     QTreeWidgetItem* pParentItem = treeWidget_keys->currentItem();
@@ -5985,9 +5868,7 @@ void dlgTriggerEditor::addKey(bool isFolder)
 
     // Initialize tree item properties
     pNewItem->setData(0, Qt::UserRole, pNewKey->getID());
-    pNewItem->setIcon(0, QIcon(QPixmap(isFolder ?
-        qsl(":/icons/folder-red.png") :
-        qsl(":/icons/document-save-as.png"))));
+    pNewItem->setIcon(0, QIcon(QPixmap(isFolder ? qsl(":/icons/folder-red.png") : qsl(":/icons/document-save-as.png"))));
     pNewItem->setData(0, Qt::AccessibleDescriptionRole, isFolder ? descNewFolder : descNewItem);
 
     // Expand parent if applicable
@@ -6006,9 +5887,7 @@ void dlgTriggerEditor::addKey(bool isFolder)
     slot_keySelected(treeWidget_keys->currentItem());
 
     QTreeWidgetItem* actualParent = pNewItem->parent();
-    int parentID = (actualParent && actualParent != mpKeyBaseItem)
-                   ? actualParent->data(0, Qt::UserRole).toInt()
-                   : -1;
+    int parentID = (actualParent && actualParent != mpKeyBaseItem) ? actualParent->data(0, Qt::UserRole).toInt() : -1;
 
     int positionInParent = 0;
     if (actualParent) {
@@ -6017,14 +5896,7 @@ void dlgTriggerEditor::addKey(bool isFolder)
         positionInParent = treeWidget_keys->indexOfTopLevelItem(pNewItem);
     }
 
-    auto* qtCmd = new EditorAddItemCommand(
-        EditorViewType::cmKeysView,
-        pNewKey->getID(),
-        parentID,
-        positionInParent,
-        isFolder,
-        name,
-        mpHost);
+    auto* qtCmd = new EditorAddItemCommand(EditorViewType::cmKeysView, pNewKey->getID(), parentID, positionInParent, isFolder, name, mpHost);
     mpUndoStack->pushCommand(qtCmd);
 
     // Note: Subsequent modify commands will automatically merge with this Add command
@@ -6037,7 +5909,7 @@ void dlgTriggerEditor::addAlias(bool isFolder)
     saveAlias();
 
     QString name = isFolder ? tr("New alias group") : tr("New alias");
-    QStringList nameList = { name };
+    QStringList nameList = {name};
     const QString regex = "";
     const QString command = "";
     const QString script = "";
@@ -6088,9 +5960,7 @@ void dlgTriggerEditor::addAlias(bool isFolder)
 
     // Initialize tree item properties
     pNewItem->setData(0, Qt::UserRole, pNewAlias->getID());
-    pNewItem->setIcon(0, QIcon(QPixmap(isFolder ?
-        qsl(":/icons/folder-red.png") :
-        qsl(":/icons/document-save-as.png"))));
+    pNewItem->setIcon(0, QIcon(QPixmap(isFolder ? qsl(":/icons/folder-red.png") : qsl(":/icons/document-save-as.png"))));
     pNewItem->setData(0, Qt::AccessibleDescriptionRole, isFolder ? descNewFolder : descNewItem);
 
     // Expand parent if applicable
@@ -6113,9 +5983,7 @@ void dlgTriggerEditor::addAlias(bool isFolder)
     slot_aliasSelected(treeWidget_aliases->currentItem());
 
     QTreeWidgetItem* actualParent = pNewItem->parent();
-    int parentID = (actualParent && actualParent != mpAliasBaseItem)
-                   ? actualParent->data(0, Qt::UserRole).toInt()
-                   : -1;
+    int parentID = (actualParent && actualParent != mpAliasBaseItem) ? actualParent->data(0, Qt::UserRole).toInt() : -1;
 
     int positionInParent = 0;
     if (actualParent) {
@@ -6124,14 +5992,7 @@ void dlgTriggerEditor::addAlias(bool isFolder)
         positionInParent = treeWidget_aliases->indexOfTopLevelItem(pNewItem);
     }
 
-    auto* qtCmd = new EditorAddItemCommand(
-        EditorViewType::cmAliasView,
-        pNewAlias->getID(),
-        parentID,
-        positionInParent,
-        isFolder,
-        name,
-        mpHost);
+    auto* qtCmd = new EditorAddItemCommand(EditorViewType::cmAliasView, pNewAlias->getID(), parentID, positionInParent, isFolder, name, mpHost);
     mpUndoStack->pushCommand(qtCmd);
 
     // Note: Subsequent modify commands will automatically merge with this Add command
@@ -6143,7 +6004,7 @@ void dlgTriggerEditor::addAction(bool isFolder)
     saveAction();
 
     QString name = isFolder ? tr("New menu") : tr("New button");
-    QStringList nameList = { name };
+    QStringList nameList = {name};
     const QString cmdButtonUp = "";
     const QString cmdButtonDown = "";
     const QString script = "";
@@ -6194,9 +6055,7 @@ void dlgTriggerEditor::addAction(bool isFolder)
 
     // Initialize tree item properties
     pNewItem->setData(0, Qt::UserRole, pNewAction->getID());
-    pNewItem->setIcon(0, QIcon(QPixmap(isFolder ?
-        qsl(":/icons/folder-red.png") :
-        qsl(":/icons/document-save-as.png"))));
+    pNewItem->setIcon(0, QIcon(QPixmap(isFolder ? qsl(":/icons/folder-red.png") : qsl(":/icons/document-save-as.png"))));
     pNewItem->setData(0, Qt::AccessibleDescriptionRole, isFolder ? descNewFolder : descNewItem);
 
     // Expand parent if applicable
@@ -6221,9 +6080,7 @@ void dlgTriggerEditor::addAction(bool isFolder)
     slot_actionSelected(treeWidget_actions->currentItem());
 
     QTreeWidgetItem* actualParent = pNewItem->parent();
-    int parentID = (actualParent && actualParent != mpActionBaseItem)
-                   ? actualParent->data(0, Qt::UserRole).toInt()
-                   : -1;
+    int parentID = (actualParent && actualParent != mpActionBaseItem) ? actualParent->data(0, Qt::UserRole).toInt() : -1;
 
     int positionInParent = 0;
     if (actualParent) {
@@ -6232,14 +6089,7 @@ void dlgTriggerEditor::addAction(bool isFolder)
         positionInParent = treeWidget_actions->indexOfTopLevelItem(pNewItem);
     }
 
-    auto* qtCmd = new EditorAddItemCommand(
-        EditorViewType::cmActionView,
-        pNewAction->getID(),
-        parentID,
-        positionInParent,
-        isFolder,
-        name,
-        mpHost);
+    auto* qtCmd = new EditorAddItemCommand(EditorViewType::cmActionView, pNewAction->getID(), parentID, positionInParent, isFolder, name, mpHost);
     mpUndoStack->pushCommand(qtCmd);
 
     // Note: Subsequent modify commands will automatically merge with this Add command
@@ -6252,7 +6102,7 @@ void dlgTriggerEditor::addScript(bool isFolder)
     saveScript();
 
     QString name = isFolder ? tr("New script group") : tr("New script");
-    QStringList nameList = { name };
+    QStringList nameList = {name};
     const QString script;
 
     QTreeWidgetItem* pParentItem = treeWidget_scripts->currentItem();
@@ -6298,9 +6148,7 @@ void dlgTriggerEditor::addScript(bool isFolder)
 
     // Initialize tree item properties
     pNewItem->setData(0, Qt::UserRole, pNewScript->getID());
-    pNewItem->setIcon(0, QIcon(QPixmap(isFolder ?
-        qsl(":/icons/folder-red.png") :
-        qsl(":/icons/document-save-as.png"))));
+    pNewItem->setIcon(0, QIcon(QPixmap(isFolder ? qsl(":/icons/folder-red.png") : qsl(":/icons/document-save-as.png"))));
     pNewItem->setData(0, Qt::AccessibleDescriptionRole, isFolder ? descNewFolder : descNewItem);
 
     // Expand parent if applicable
@@ -6320,9 +6168,7 @@ void dlgTriggerEditor::addScript(bool isFolder)
     slot_scriptsSelected(treeWidget_scripts->currentItem());
 
     QTreeWidgetItem* actualParent = pNewItem->parent();
-    int parentID = (actualParent && actualParent != mpScriptsBaseItem)
-                   ? actualParent->data(0, Qt::UserRole).toInt()
-                   : -1;
+    int parentID = (actualParent && actualParent != mpScriptsBaseItem) ? actualParent->data(0, Qt::UserRole).toInt() : -1;
 
     int positionInParent = 0;
     if (actualParent) {
@@ -6331,14 +6177,7 @@ void dlgTriggerEditor::addScript(bool isFolder)
         positionInParent = treeWidget_scripts->indexOfTopLevelItem(pNewItem);
     }
 
-    auto* qtCmd = new EditorAddItemCommand(
-        EditorViewType::cmScriptView,
-        pNewScript->getID(),
-        parentID,
-        positionInParent,
-        isFolder,
-        name,
-        mpHost);
+    auto* qtCmd = new EditorAddItemCommand(EditorViewType::cmScriptView, pNewScript->getID(), parentID, positionInParent, isFolder, name, mpHost);
     mpUndoStack->pushCommand(qtCmd);
 
     // Note: Subsequent modify commands will automatically merge with this Add command
@@ -6779,13 +6618,7 @@ void dlgTriggerEditor::saveTrigger()
 
         // Only push undo command if something actually changed
         if (oldStateXML != newStateXML) {
-            auto* qtCmd = new EditorModifyPropertyCommand(
-                EditorViewType::cmTriggerView,
-                triggerID,
-                name,
-                oldStateXML,
-                newStateXML,
-                mpHost);
+            auto* qtCmd = new EditorModifyPropertyCommand(EditorViewType::cmTriggerView, triggerID, name, oldStateXML, newStateXML, mpHost);
             mpUndoStack->pushCommand(qtCmd);
 
             // Clear edbee undo stack after save to make Save a commit point
@@ -6924,13 +6757,7 @@ void dlgTriggerEditor::saveTimer()
 
         // Only push undo command if something actually changed
         if (oldStateXML != newStateXML) {
-            auto* qtCmd = new EditorModifyPropertyCommand(
-                EditorViewType::cmTimerView,
-                timerID,
-                name,
-                oldStateXML,
-                newStateXML,
-                mpHost);
+            auto* qtCmd = new EditorModifyPropertyCommand(EditorViewType::cmTimerView, timerID, name, oldStateXML, newStateXML, mpHost);
             mpUndoStack->pushCommand(qtCmd);
 
             // Clear edbee undo stack after save to make Save a commit point
@@ -7101,13 +6928,7 @@ void dlgTriggerEditor::saveAlias()
 
         // Only push undo command if something actually changed
         if (oldStateXML != newStateXML) {
-            auto* qtCmd = new EditorModifyPropertyCommand(
-                EditorViewType::cmAliasView,
-                triggerID,
-                name,
-                oldStateXML,
-                newStateXML,
-                mpHost);
+            auto* qtCmd = new EditorModifyPropertyCommand(EditorViewType::cmAliasView, triggerID, name, oldStateXML, newStateXML, mpHost);
             mpUndoStack->pushCommand(qtCmd);
 
             // Clear edbee undo stack after save to make Save a commit point
@@ -7277,13 +7098,7 @@ void dlgTriggerEditor::saveAction()
 
         // Only push undo command if something actually changed
         if (oldStateXML != newStateXML) {
-            auto* qtCmd = new EditorModifyPropertyCommand(
-                EditorViewType::cmActionView,
-                actionID,
-                name,
-                oldStateXML,
-                newStateXML,
-                mpHost);
+            auto* qtCmd = new EditorModifyPropertyCommand(EditorViewType::cmActionView, actionID, name, oldStateXML, newStateXML, mpHost);
             mpUndoStack->pushCommand(qtCmd);
 
             // Clear edbee undo stack after save to make Save a commit point
@@ -7469,13 +7284,7 @@ void dlgTriggerEditor::saveScript()
 
     // Only push undo command if something actually changed
     if (oldStateXML != newStateXML) {
-        auto* qtCmd = new EditorModifyPropertyCommand(
-            EditorViewType::cmScriptView,
-            scriptID,
-            name,
-            oldStateXML,
-            newStateXML,
-            mpHost);
+        auto* qtCmd = new EditorModifyPropertyCommand(EditorViewType::cmScriptView, scriptID, name, oldStateXML, newStateXML, mpHost);
         mpUndoStack->pushCommand(qtCmd);
 
         // Clear edbee undo stack after save to make Save a commit point
@@ -7880,13 +7689,7 @@ void dlgTriggerEditor::saveKey()
 
         // Only push undo command if something actually changed
         if (oldStateXML != newStateXML) {
-            auto* qtCmd = new EditorModifyPropertyCommand(
-                EditorViewType::cmKeysView,
-                triggerID,
-                name,
-                oldStateXML,
-                newStateXML,
-                mpHost);
+            auto* qtCmd = new EditorModifyPropertyCommand(EditorViewType::cmKeysView, triggerID, name, oldStateXML, newStateXML, mpHost);
             mpUndoStack->pushCommand(qtCmd);
 
             // Clear edbee undo stack after save to make Save a commit point
@@ -7995,8 +7798,7 @@ void dlgTriggerEditor::handlePatternChange(dlgTriggerPatternEdit* patternItem, b
         if (type == REGEX_PROMPT) {
             itemHasContent = true;
         } else if (type == REGEX_LINE_SPACER) {
-            itemHasContent = item->spinBox_lineSpacer->value() > 0
-                             || item->spinBox_lineSpacer->isVisible();
+            itemHasContent = item->spinBox_lineSpacer->value() > 0 || item->spinBox_lineSpacer->isVisible();
             if (forceLineSpacerActive && item == patternItem) {
                 itemHasContent = true;
             }
@@ -8164,7 +7966,6 @@ void dlgTriggerEditor::updatePatternTabOrder()
     addToChain(mpTriggersMainArea->pushButtonFgColor);
     addToChain(mpTriggersMainArea->pushButtonBgColor);
     addToChain(mpSourceEditorEdbee);
-
 }
 
 void dlgTriggerEditor::slot_changedPattern()
@@ -8228,9 +8029,7 @@ void dlgTriggerEditor::slot_setupPatternControls(int type)
 
         // Only process the text if it looks like it should:
         if ((pPatternItem->singleLineTextEdit_pattern->toPlainText().startsWith(QLatin1String("ANSI_COLORS_F{"))
-              && pPatternItem->singleLineTextEdit_pattern->toPlainText().contains(QLatin1String("}_B{"))
-              && pPatternItem->singleLineTextEdit_pattern->toPlainText().endsWith(QLatin1String("}")))) {
-
+             && pPatternItem->singleLineTextEdit_pattern->toPlainText().contains(QLatin1String("}_B{")) && pPatternItem->singleLineTextEdit_pattern->toPlainText().endsWith(QLatin1String("}")))) {
             // It looks as though there IS a valid color pattern string in the
             // lineEdit, so, in case it has been edited by hand, regenerate the
             // colors that are used:
@@ -8377,13 +8176,9 @@ void dlgTriggerEditor::slot_triggerSelected(QTreeWidgetItem* pItem)
                         pPatternItem->pushButton_bgColor->setStyleSheet(generateButtonStyleSheet(pT->mColorPatternList.at(i)->mBgColor));
                         //: Color trigger ANSI background color button, ensure all three instances have the same text
                         pPatternItem->pushButton_bgColor->setText(tr("Background color [ANSI %1]").arg(QString::number(pT->mColorPatternList.at(i)->ansiBg)));
-
                     }
                 } else {
-                    qWarning() << "dlgTriggerEditor::slot_triggerSelected(...) ERROR: TTrigger instance has an mColorPattern of size:"
-                               << pT->mColorPatternList.size()
-                               << "but array element:"
-                               << i
+                    qWarning() << "dlgTriggerEditor::slot_triggerSelected(...) ERROR: TTrigger instance has an mColorPattern of size:" << pT->mColorPatternList.size() << "but array element:" << i
                                << "is a nullptr";
                     pPatternItem->pushButton_fgColor->setStyleSheet(QString());
                     pPatternItem->pushButton_fgColor->setText(tr("fault"));
@@ -8728,7 +8523,7 @@ void dlgTriggerEditor::slot_variableChanged(QTreeWidgetItem* pItem)
 
 void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
 {
-    if (!pItem ||treeWidget_variables->indexOfTopLevelItem(pItem) == 0) {
+    if (!pItem || treeWidget_variables->indexOfTopLevelItem(pItem) == 0) {
         // Null item or it is for the first row of the tree
         clearVarForm();
         return;
@@ -8821,10 +8616,10 @@ void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
     QIcon icon;
 
     switch (keyType) {
-//    case LUA_TNONE: // -1
-//    case LUA_TNIL: // 0
-//    case LUA_TBOOLEAN: // 1
-//    case LUA_TLIGHTUSERDATA: // 2
+        //    case LUA_TNONE: // -1
+        //    case LUA_TNIL: // 0
+        //    case LUA_TBOOLEAN: // 1
+        //    case LUA_TLIGHTUSERDATA: // 2
     case LUA_TNUMBER: // 3
         // index 2 = "index (integer number)"
         mpVarsMainArea->comboBox_variable_key_type->setCurrentIndex(2);
@@ -8845,8 +8640,8 @@ void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
         mpVarsMainArea->comboBox_variable_key_type->setCurrentIndex(4);
         mpVarsMainArea->comboBox_variable_key_type->setEnabled(false);
         break;
-//    case LUA_TUSERDATA: // 7
-//    case LUA_TTHREAD: // 8
+        //    case LUA_TUSERDATA: // 7
+        //    case LUA_TTHREAD: // 8
     }
 
     switch (varType) {
@@ -8899,8 +8694,7 @@ void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
         [[fallthrough]];
     case LUA_TUSERDATA:
         [[fallthrough]];
-    case LUA_TTHREAD:
-        ; // No-op
+    case LUA_TTHREAD:; // No-op
     }
 
     mpVarsMainArea->checkBox_variable_hidden->setChecked(vu->isHidden(var));
@@ -9068,7 +8862,7 @@ void dlgTriggerEditor::slot_actionSelected(QTreeWidgetItem* pItem)
 
 void dlgTriggerEditor::slot_treeSelectionChanged()
 {
-    auto * sender = qobject_cast<TTreeWidget*>(QObject::sender());
+    auto* sender = qobject_cast<TTreeWidget*>(QObject::sender());
     if (sender) {
         QTreeWidgetItem* item = sender->currentItem();
         if (!item) {
@@ -9144,7 +8938,8 @@ void dlgTriggerEditor::slot_scriptsSelected(QTreeWidgetItem* pItem)
         mpScriptsMainArea->label_idNumber->setText(QString::number(ID));
         if (auto error = pT->getLoadingError(); error) {
             showWarning(tr("While loading the profile, this script had an error that has since been fixed, "
-                           "possibly by another script. The error was:%2%3").arg(qsl("<br>"), error.value()));
+                           "possibly by another script. The error was:%2%3")
+                                .arg(qsl("<br>"), error.value()));
         } else if (!pT->state()) {
             showError(pT->getError());
         } else {
@@ -9617,7 +9412,7 @@ void dlgTriggerEditor::populateScripts()
 }
 void dlgTriggerEditor::populateTimers()
 {
-    std::list<TTimer *> const baseNodeList_timers = mpHost->getTimerUnit()->getTimerRootNodeList();
+    std::list<TTimer*> const baseNodeList_timers = mpHost->getTimerUnit()->getTimerRootNodeList();
     for (auto timer : baseNodeList_timers) {
         if (timer->isTemporary()) {
             continue;
@@ -9707,7 +9502,7 @@ void dlgTriggerEditor::populateTimers()
 }
 void dlgTriggerEditor::populateTriggers()
 {
-    std::list<TTrigger *> const baseNodeList = mpHost->getTriggerUnit()->getTriggerRootNodeList();
+    std::list<TTrigger*> const baseNodeList = mpHost->getTriggerUnit()->getTriggerRootNodeList();
     for (auto trigger : baseNodeList) {
         if (trigger->isTemporary()) {
             continue;
@@ -9737,7 +9532,7 @@ void dlgTriggerEditor::populateTriggers()
                         itemDescription = descInactiveParent.arg(itemDescription);
                     }
                 } else {
-                        itemDescription = descInactiveFilterChain;
+                    itemDescription = descInactiveFilterChain;
                     if (trigger->ancestorsActive()) {
                         icon.addPixmap(QPixmap(qsl(":/icons/filter-locked.png")), QIcon::Normal, QIcon::Off);
                     } else {
@@ -9813,7 +9608,6 @@ void dlgTriggerEditor::repopulateVars()
     mpVarBaseItem->setExpanded(true);
     treeWidget_variables->setUpdatesEnabled(true);
     treeWidget_variables->setCurrentItem(mpVarBaseItem);
-
 }
 
 void dlgTriggerEditor::expand_child_triggers(TTrigger* pTriggerParent, QTreeWidgetItem* pWidgetItemParent)
@@ -10265,7 +10059,7 @@ void dlgTriggerEditor::saveOpenChanges()
     }
 }
 
-void dlgTriggerEditor::timerEvent(QTimerEvent *event)
+void dlgTriggerEditor::timerEvent(QTimerEvent* event)
 {
     Q_UNUSED(event)
 
@@ -10766,15 +10560,12 @@ void dlgTriggerEditor::showIntro(const QString& desiredOption)
 
     introTextParts introAddCurrentItem = introAddItem.value(mCurrentView);
     QString introTextOptions;
-    for (const auto &[name, headline, contents] : introAddCurrentItem.options) {
-        introTextOptions.append(
-            (name != desiredOption)
-            ? qsl("<li><a href='%1' style='color: inherit; text-decoration: underline;'>%2</a></li>").arg(name, headline)
-            : qsl("<li><strong>%1</strong>%2</li>").arg(headline, contents));
+    for (const auto& [name, headline, contents] : introAddCurrentItem.options) {
+        introTextOptions.append((name != desiredOption) ? qsl("<li><a href='%1' style='color: inherit; text-decoration: underline;'>%2</a></li>").arg(name, headline)
+                                                        : qsl("<li><strong>%1</strong>%2</li>").arg(headline, contents));
     }
 
-    QString content = qsl("<p>%1</p><ul>%2</ul>")
-        .arg(introAddCurrentItem.summary, introTextOptions);
+    QString content = qsl("<p>%1</p><ul>%2</ul>").arg(introAddCurrentItem.summary, introTextOptions);
 
     showHideableBanner(content, bannerKey);
 }
@@ -10807,13 +10598,11 @@ void dlgTriggerEditor::showHideableBanner(const QString& content, const QString&
         return;
     }
 
-    if (mpSystemMessageArea->isVisible() && mCurrentBannerKey != bannerKey
-        && !mpSystemMessageArea->notificationAreaMessageBox->text().isEmpty()) {
+    if (mpSystemMessageArea->isVisible() && mCurrentBannerKey != bannerKey && !mpSystemMessageArea->notificationAreaMessageBox->text().isEmpty()) {
         return;
     }
 
-    if (mpSystemMessageArea->isVisible() && mCurrentBannerKey == bannerKey
-        && mpSystemMessageArea->notificationAreaMessageBox->text() == content) {
+    if (mpSystemMessageArea->isVisible() && mCurrentBannerKey == bannerKey && mpSystemMessageArea->notificationAreaMessageBox->text() == content) {
         return;
     }
 
@@ -11084,7 +10873,7 @@ void dlgTriggerEditor::slot_sourceReplace()
     auto controller = mpSourceEditorEdbee->controller();
     auto replaceText = mpSourceEditorFindArea->lineEdit_replaceText->text();
     for (size_t i = 0; i < controller->textSelection()->rangeCount(); i++) {
-        auto &range = controller->textSelection()->range(i);
+        auto& range = controller->textSelection()->range(i);
         if (mpSourceEditorEdbee->textDocument()->text().mid(range.anchor(), range.length()) == replaceText) {
             slot_sourceFindNext();
             continue;
@@ -11234,7 +11023,7 @@ void dlgTriggerEditor::slot_scriptMainAreaDeleteHandler()
 
 void dlgTriggerEditor::slot_scriptMainAreaAddHandler()
 {
-    auto addEventHandler = [&] () {
+    auto addEventHandler = [&]() {
         if (mpScriptsMainArea->lineEdit_script_event_handler_entry->text().isEmpty()) {
             return;
         }
@@ -11260,7 +11049,7 @@ void dlgTriggerEditor::slot_scriptMainAreaAddHandler()
             addEventHandler();
         } else {
             if (mpScriptsMainAreaEditHandlerItem->text() == mpScriptsMainArea->lineEdit_script_event_handler_entry->text()
-            || mpScriptsMainArea->lineEdit_script_event_handler_entry->text().isEmpty()) {
+                || mpScriptsMainArea->lineEdit_script_event_handler_entry->text().isEmpty()) {
                 return;
             }
             mpScriptsMainAreaEditHandlerItem->setText(mpScriptsMainArea->lineEdit_script_event_handler_entry->text());
@@ -11430,14 +11219,14 @@ void dlgTriggerEditor::slot_previousSection()
             mpSourceEditorEdbee->setFocus();
             return;
         }
-        for (auto child : mpTriggersMainArea->scrollArea->findChildren<QWidget *>()) {
-            if (child->hasFocus()){
+        for (auto child : mpTriggersMainArea->scrollArea->findChildren<QWidget*>()) {
+            if (child->hasFocus()) {
                 mpTriggersMainArea->lineEdit_trigger_name->setFocus();
                 return;
             }
         }
-        for (auto child : mpTriggersMainArea->findChildren<QWidget *>()) {
-            if (child->hasFocus()){
+        for (auto child : mpTriggersMainArea->findChildren<QWidget*>()) {
+            if (child->hasFocus()) {
                 treeWidget_triggers->setFocus();
                 return;
             }
@@ -11452,8 +11241,8 @@ void dlgTriggerEditor::slot_previousSection()
             mpSourceEditorEdbee->setFocus();
             return;
         }
-        for (auto child : mpTimersMainArea->findChildren<QWidget *>()) {
-            if (child->hasFocus()){
+        for (auto child : mpTimersMainArea->findChildren<QWidget*>()) {
+            if (child->hasFocus()) {
                 treeWidget_timers->setFocus();
                 return;
             }
@@ -11468,8 +11257,8 @@ void dlgTriggerEditor::slot_previousSection()
             mpSourceEditorEdbee->setFocus();
             return;
         }
-        for (auto child : mpAliasMainArea->findChildren<QWidget *>()) {
-            if (child->hasFocus()){
+        for (auto child : mpAliasMainArea->findChildren<QWidget*>()) {
+            if (child->hasFocus()) {
                 treeWidget_aliases->setFocus();
                 return;
             }
@@ -11484,8 +11273,8 @@ void dlgTriggerEditor::slot_previousSection()
             mpSourceEditorEdbee->setFocus();
             return;
         }
-        for (auto child : mpScriptsMainArea->findChildren<QWidget *>()) {
-            if (child->hasFocus()){
+        for (auto child : mpScriptsMainArea->findChildren<QWidget*>()) {
+            if (child->hasFocus()) {
                 treeWidget_scripts->setFocus();
                 return;
             }
@@ -11500,8 +11289,8 @@ void dlgTriggerEditor::slot_previousSection()
             mpSourceEditorEdbee->setFocus();
             return;
         }
-        for (auto child : mpActionsMainArea->findChildren<QWidget *>()) {
-            if (child->hasFocus()){
+        for (auto child : mpActionsMainArea->findChildren<QWidget*>()) {
+            if (child->hasFocus()) {
                 treeWidget_actions->setFocus();
                 return;
             }
@@ -11516,8 +11305,8 @@ void dlgTriggerEditor::slot_previousSection()
             mpSourceEditorEdbee->setFocus();
             return;
         }
-        for (auto child : mpKeysMainArea->findChildren<QWidget *>()) {
-            if (child->hasFocus()){
+        for (auto child : mpKeysMainArea->findChildren<QWidget*>()) {
+            if (child->hasFocus()) {
                 treeWidget_keys->setFocus();
                 return;
             }
@@ -11532,8 +11321,8 @@ void dlgTriggerEditor::slot_previousSection()
             mpSourceEditorEdbee->setFocus();
             return;
         }
-        for (auto child : mpVarsMainArea->findChildren<QWidget *>()) {
-            if (child->hasFocus()){
+        for (auto child : mpVarsMainArea->findChildren<QWidget*>()) {
+            if (child->hasFocus()) {
                 treeWidget_variables->setFocus();
                 return;
             }
@@ -12266,8 +12055,7 @@ void dlgTriggerEditor::slot_pasteXml()
                     int targetId = targetIndex.data(Qt::UserRole).toInt();
                     TTrigger* targetTrigger = mpHost->getTriggerUnit()->getTrigger(targetId);
 
-                    bool isGroup = (targetItem && targetItem->childCount() > 0) ||
-                                  (targetTrigger && targetTrigger->isFolder());
+                    bool isGroup = (targetItem && targetItem->childCount() > 0) || (targetTrigger && targetTrigger->isFolder());
 
                     for (int itemID : importedIDs) {
                         if (isGroup) {
@@ -12330,8 +12118,7 @@ void dlgTriggerEditor::slot_pasteXml()
             TTrigger* targetTrigger = mpHost->getTriggerUnit()->getTrigger(targetId);
 
             // Check if target is a group/folder (has children OR is a group trigger)
-            bool isGroup = (targetItem && targetItem->childCount() > 0) ||
-                          (targetTrigger && targetTrigger->isFolder());
+            bool isGroup = (targetItem && targetItem->childCount() > 0) || (targetTrigger && targetTrigger->isFolder());
 
             if (isGroup) {
                 // Paste INSIDE the selected group/folder
@@ -12646,14 +12433,7 @@ void dlgTriggerEditor::slot_pasteXml()
             }
 
             if (!itemName.isEmpty()) {
-                auto* qtCmd = new EditorAddItemCommand(
-                    viewType,
-                    itemID,
-                    parentID,
-                    positionInParent,
-                    isFolder,
-                    itemName,
-                    mpHost);
+                auto* qtCmd = new EditorAddItemCommand(viewType, itemID, parentID, positionInParent, isFolder, itemName, mpHost);
                 mpUndoStack->pushCommand(qtCmd);
             }
         };
@@ -12952,7 +12732,7 @@ bool dlgTriggerEditor::event(QEvent* event)
 {
     if (mIsGrabKey) {
         if (event->type() == QEvent::KeyPress) {
-            auto * ke = static_cast<QKeyEvent*>(event);
+            auto* ke = static_cast<QKeyEvent*>(event);
             switch (ke->key()) {
             case Qt::Key_Escape:
                 mIsGrabKey = false;
@@ -13075,9 +12855,7 @@ void dlgTriggerEditor::slot_colorizeTriggerSetFgColor()
         return;
     }
 
-    auto color = QColorDialog::getColor(QColor(mpTriggersMainArea->pushButtonFgColor->property(cButtonBaseColor).toString()),
-                                        this,
-                                        tr("Select foreground color to apply to matches"));
+    auto color = QColorDialog::getColor(QColor(mpTriggersMainArea->pushButtonFgColor->property(cButtonBaseColor).toString()), this, tr("Select foreground color to apply to matches"));
     color = color.isValid() ? color : QColorConstants::Transparent;
     const bool keepColor = color == QColorConstants::Transparent;
     mpTriggersMainArea->pushButtonFgColor->setStyleSheet(generateButtonStyleSheet(color));
@@ -13097,9 +12875,7 @@ void dlgTriggerEditor::slot_colorizeTriggerSetBgColor()
         return;
     }
 
-    auto color = QColorDialog::getColor(QColor(mpTriggersMainArea->pushButtonBgColor->property(cButtonBaseColor).toString()),
-                                        this,
-                                        tr("Select background color to apply to matches"));
+    auto color = QColorDialog::getColor(QColor(mpTriggersMainArea->pushButtonBgColor->property(cButtonBaseColor).toString()), this, tr("Select background color to apply to matches"));
     color = color.isValid() ? color : QColorConstants::Transparent;
     const bool keepColor = color == QColorConstants::Transparent;
     mpTriggersMainArea->pushButtonBgColor->setStyleSheet(generateButtonStyleSheet(color));
@@ -13114,21 +12890,20 @@ void dlgTriggerEditor::slot_soundTrigger()
     QSettings& settings = *mudlet::getQSettings();
     QString lastDir = settings.value("lastFileDialogLocation", QDir::homePath()).toString();
 
-    const QString fileName = QFileDialog::getOpenFileName(this,
-                                                    tr("Choose sound file"),
-                                                    mpTriggersMainArea->lineEdit_soundFile->text().isEmpty()
-                                                    ? lastDir
-                                                    : mpTriggersMainArea->lineEdit_soundFile->text(),
-                                                    //: This the list of file extensions that are considered for sounds from triggers, the terms inside of the '('...')' and the ";;" are used programmatically and should not be changed.
-                                                    tr("Audio files(*.aac *.mp3 *.mp4a *.oga *.ogg *.pcm *.wav *.wma);;"
-                                                       "Advanced Audio Coding-stream(*.aac);;"
-                                                       "MPEG-2 Audio Layer 3(*.mp3);;"
-                                                       "MPEG-4 Audio(*.mp4a);;"
-                                                       "Ogg Vorbis(*.oga *.ogg);;"
-                                                       "PCM Audio(*.pcm);;"
-                                                       "Wave(*.wav);;"
-                                                       "Windows Media Audio(*.wma);;"
-                                                       "All files(*.*)"));
+    const QString fileName = QFileDialog::getOpenFileName(
+            this,
+            tr("Choose sound file"),
+            mpTriggersMainArea->lineEdit_soundFile->text().isEmpty() ? lastDir : mpTriggersMainArea->lineEdit_soundFile->text(),
+            //: This the list of file extensions that are considered for sounds from triggers, the terms inside of the '('...')' and the ";;" are used programmatically and should not be changed.
+            tr("Audio files(*.aac *.mp3 *.mp4a *.oga *.ogg *.pcm *.wav *.wma);;"
+               "Advanced Audio Coding-stream(*.aac);;"
+               "MPEG-2 Audio Layer 3(*.mp3);;"
+               "MPEG-4 Audio(*.mp4a);;"
+               "Ogg Vorbis(*.oga *.ogg);;"
+               "PCM Audio(*.pcm);;"
+               "Wave(*.wav);;"
+               "Windows Media Audio(*.wma);;"
+               "All files(*.*)"));
     if (!fileName.isEmpty()) {
         // This will only be executed if the user did not press cancel
         mpTriggersMainArea->lineEdit_soundFile->setToolTip(fileName);
@@ -13154,7 +12929,7 @@ void dlgTriggerEditor::slot_colorTriggerFg()
         return;
     }
 
-    auto * pB = qobject_cast<QPushButton*>(sender());
+    auto* pB = qobject_cast<QPushButton*>(sender());
     if (!pB) {
         return;
     }
@@ -13173,7 +12948,7 @@ void dlgTriggerEditor::slot_colorTriggerFg()
     // it will select the appropriate as a result of the third argument and it
     // uses both to determine whether the result to return is valid considering
     // the other, non used (background in this method) part:
-    auto pD = new dlgColorTrigger(this, pT, false, tr("Select foreground trigger color for item %1").arg(QString::number(pPatternItem->mRow+1)));
+    auto pD = new dlgColorTrigger(this, pT, false, tr("Select foreground trigger color for item %1").arg(QString::number(pPatternItem->mRow + 1)));
     pD->setModal(true);
     // This sounds a bit iffy - prevent access to other application windows
     // while we get a colour setting:
@@ -13217,7 +12992,7 @@ void dlgTriggerEditor::slot_colorTriggerBg()
         return;
     }
 
-    auto * pB = qobject_cast<QPushButton*>(sender());
+    auto* pB = qobject_cast<QPushButton*>(sender());
     if (!pB) {
         return;
     }
@@ -13236,7 +13011,7 @@ void dlgTriggerEditor::slot_colorTriggerBg()
     // it will select the appropriate as a result of the third argument and it
     // uses both to determine whether the result to return is valid considering
     // the other, non used (background in this method) part:
-    auto pD = new dlgColorTrigger(this, pT, true, tr("Select background trigger color for item %1").arg(QString::number(pPatternItem->mRow+1)));
+    auto pD = new dlgColorTrigger(this, pT, true, tr("Select background trigger color for item %1").arg(QString::number(pPatternItem->mRow + 1)));
     pD->setModal(true);
     // This sounds a bit iffy - prevent access to other application windows
     // while we get a colour setting:
@@ -13299,9 +13074,7 @@ void dlgTriggerEditor::slot_changeEditorTextOptions(QTextOption::Flags state)
     edbee::TextEditorConfig* config = mpSourceEditorEdbee->config();
 
     config->beginChanges();
-    config->setShowWhitespaceMode((state & QTextOption::ShowTabsAndSpaces)
-                                  ? edbee::TextEditorConfig::ShowWhitespaces
-                                  : edbee::TextEditorConfig::HideWhitespaces);
+    config->setShowWhitespaceMode((state & QTextOption::ShowTabsAndSpaces) ? edbee::TextEditorConfig::ShowWhitespaces : edbee::TextEditorConfig::HideWhitespaces);
     config->setUseLineSeparator(state & QTextOption::ShowLineAndParagraphSeparators);
     config->endChanges();
 }
@@ -13332,20 +13105,15 @@ void dlgTriggerEditor::clearDocument(edbee::TextEditorWidget* pEditorWidget, con
     }
     // Connect to the new document's undo stack
     mpTextUndoStack = mpSourceEditorEdbeeDocument->textUndoStack();
-    connect(mpTextUndoStack, &edbee::TextUndoStack::undoExecuted,
-            this, &dlgTriggerEditor::slot_updateUndoRedoButtonStates);
-    connect(mpTextUndoStack, &edbee::TextUndoStack::redoExecuted,
-            this, &dlgTriggerEditor::slot_updateUndoRedoButtonStates);
-    connect(mpTextUndoStack, &edbee::TextUndoStack::changeAdded,
-            this, &dlgTriggerEditor::slot_updateUndoRedoButtonStates);
+    connect(mpTextUndoStack, &edbee::TextUndoStack::undoExecuted, this, &dlgTriggerEditor::slot_updateUndoRedoButtonStates);
+    connect(mpTextUndoStack, &edbee::TextUndoStack::redoExecuted, this, &dlgTriggerEditor::slot_updateUndoRedoButtonStates);
+    connect(mpTextUndoStack, &edbee::TextUndoStack::changeAdded, this, &dlgTriggerEditor::slot_updateUndoRedoButtonStates);
 
     auto config = mpSourceEditorEdbee->config();
     config->beginChanges();
     config->setThemeName(mpHost->mEditorTheme);
     config->setFont(mpHost->getDisplayFont());
-    config->setShowWhitespaceMode((mudlet::self()->mEditorTextOptions & QTextOption::ShowTabsAndSpaces)
-                                  ? edbee::TextEditorConfig::ShowWhitespaces
-                                  : edbee::TextEditorConfig::HideWhitespaces);
+    config->setShowWhitespaceMode((mudlet::self()->mEditorTextOptions & QTextOption::ShowTabsAndSpaces) ? edbee::TextEditorConfig::ShowWhitespaces : edbee::TextEditorConfig::HideWhitespaces);
     config->setUseLineSeparator(mudlet::self()->mEditorTextOptions & QTextOption::ShowLineAndParagraphSeparators);
     config->setSmartTab(true);
     config->setUseTabChar(false); // when you press Enter for a newline, pad with spaces and not tabs
@@ -13373,9 +13141,7 @@ void dlgTriggerEditor::setThemeAndOtherSettings(const QString& theme)
     localConfig->setThemeName(theme);
     mpHost->editorThemeChanged();
     localConfig->setFont(mpHost->getDisplayFont());
-    localConfig->setShowWhitespaceMode((mudlet::self()->mEditorTextOptions & QTextOption::ShowTabsAndSpaces)
-                                               ? edbee::TextEditorConfig::ShowWhitespaces
-                                               : edbee::TextEditorConfig::HideWhitespaces);
+    localConfig->setShowWhitespaceMode((mudlet::self()->mEditorTextOptions & QTextOption::ShowTabsAndSpaces) ? edbee::TextEditorConfig::ShowWhitespaces : edbee::TextEditorConfig::HideWhitespaces);
     localConfig->setUseLineSeparator(mudlet::self()->mEditorTextOptions & QTextOption::ShowLineAndParagraphSeparators);
     localConfig->setAutocompleteAutoShow(mpHost->mEditorAutoComplete);
     localConfig->setRenderBidiContolCharacters(mpHost->getEditorShowBidi());
@@ -13391,15 +13157,15 @@ void dlgTriggerEditor::createSearchOptionIcon()
     QIcon newIcon;
     switch (mSearchOptions) {
     // Each combination must be handled here
-    case SearchOptionCaseSensitive|SearchOptionIncludeVariables|SearchOptionWholeWord:
+    case SearchOptionCaseSensitive | SearchOptionIncludeVariables | SearchOptionWholeWord:
         newIcon.addPixmap(QPixmap(":/icons/searchOptions-caseSensitive+withVariables+wholeWords.png"));
         break;
 
-    case SearchOptionIncludeVariables|SearchOptionWholeWord:
+    case SearchOptionIncludeVariables | SearchOptionWholeWord:
         newIcon.addPixmap(QPixmap(":/icons/searchOptions-withVariables+wholeWords.png"));
         break;
 
-    case SearchOptionCaseSensitive|SearchOptionWholeWord:
+    case SearchOptionCaseSensitive | SearchOptionWholeWord:
         newIcon.addPixmap(QPixmap(":/icons/searchOptions-caseSensitive+wholeWords.png"));
         break;
 
@@ -13407,7 +13173,7 @@ void dlgTriggerEditor::createSearchOptionIcon()
         newIcon.addPixmap(QPixmap(":/icons/searchOptions-wholeWords.png"));
         break;
 
-    case SearchOptionCaseSensitive|SearchOptionIncludeVariables:
+    case SearchOptionCaseSensitive | SearchOptionIncludeVariables:
         newIcon.addPixmap(QPixmap(":/icons/searchOptions-caseSensitive+withVariables.png"));
         break;
 
@@ -13559,14 +13325,11 @@ QString dlgTriggerEditor::generateButtonStyleSheet(const QColor& color, const bo
 {
     if (color != QColorConstants::Transparent && color.isValid()) {
         if (isEnabled) {
-            return mudlet::self()->mTEXT_ON_BG_STYLESHEET
-                    .arg(color.lightness() > 127 ? QLatin1String("black") : QLatin1String("white"),
-                         color.name());
+            return mudlet::self()->mTEXT_ON_BG_STYLESHEET.arg(color.lightness() > 127 ? QLatin1String("black") : QLatin1String("white"), color.name());
         }
 
-        const QColor disabledColor = QColor::fromHsl(color.hslHue(), color.hslSaturation()/4, color.lightness());
-        return mudlet::self()->mTEXT_ON_BG_STYLESHEET
-                .arg(QLatin1String("darkGray"), disabledColor.name());
+        const QColor disabledColor = QColor::fromHsl(color.hslHue(), color.hslSaturation() / 4, color.lightness());
+        return mudlet::self()->mTEXT_ON_BG_STYLESHEET.arg(QLatin1String("darkGray"), disabledColor.name());
     }
     return QString();
 }
@@ -13603,8 +13366,9 @@ QColor dlgTriggerEditor::parseButtonStyleSheetColors(const QString& styleSheetTe
                 return QColor(match.captured(1).prepend(QLatin1Char('#')));
 
             default:
-            // case 8: // AARRGGBB - Invalid here
-                qDebug().noquote().nospace() << "dlgTriggerEditor::parseButtonStyleSheetColors(\"" << styleSheetText << "\", " << isToGetForeground << ") ERROR - Invalid hex string as foreground color!";
+                // case 8: // AARRGGBB - Invalid here
+                qDebug().noquote().nospace() << "dlgTriggerEditor::parseButtonStyleSheetColors(\"" << styleSheetText << "\", " << isToGetForeground
+                                             << ") ERROR - Invalid hex string as foreground color!";
                 return QColor();
             }
         } else {
@@ -13618,11 +13382,13 @@ QColor dlgTriggerEditor::parseButtonStyleSheetColors(const QString& styleSheetTe
 #endif
                     return QColor(match.captured(1));
                 } else {
-                    qDebug().noquote().nospace() << "dlgTriggerEditor::parseButtonStyleSheetColors(\"" << styleSheetText << "\", " << isToGetForeground << ") ERROR - Invalid string \"" <<  match.captured(1) << "\" found as name of foreground color!";
+                    qDebug().noquote().nospace() << "dlgTriggerEditor::parseButtonStyleSheetColors(\"" << styleSheetText << "\", " << isToGetForeground << ") ERROR - Invalid string \""
+                                                 << match.captured(1) << "\" found as name of foreground color!";
                     return QColor();
                 }
             } else {
-                qDebug().noquote().nospace() << "dlgTriggerEditor::parseButtonStyleSheetColors(\"" << styleSheetText << "\", " << isToGetForeground << ") ERROR - No string as name of foreground color found!";
+                qDebug().noquote().nospace() << "dlgTriggerEditor::parseButtonStyleSheetColors(\"" << styleSheetText << "\", " << isToGetForeground
+                                             << ") ERROR - No string as name of foreground color found!";
                 return QColor();
             }
         }
@@ -13641,8 +13407,9 @@ QColor dlgTriggerEditor::parseButtonStyleSheetColors(const QString& styleSheetTe
                 return QColor(match.captured(1).prepend(QLatin1Char('#')));
 
             default:
-            // case 8: // AARRGGBB - Invalid here
-                qDebug().noquote().nospace() << "dlgTriggerEditor::parseButtonStyleSheetColors(\"" << styleSheetText << "\", " << isToGetForeground << ") ERROR - Invalid hex string as background color!";
+                // case 8: // AARRGGBB - Invalid here
+                qDebug().noquote().nospace() << "dlgTriggerEditor::parseButtonStyleSheetColors(\"" << styleSheetText << "\", " << isToGetForeground
+                                             << ") ERROR - Invalid hex string as background color!";
                 return QColor();
             }
         } else {
@@ -13656,11 +13423,13 @@ QColor dlgTriggerEditor::parseButtonStyleSheetColors(const QString& styleSheetTe
 #endif
                     return QColor(match.captured(1));
                 } else {
-                    qDebug().noquote().nospace() << "dlgTriggerEditor::parseButtonStyleSheetColors(\"" << styleSheetText << "\", " << isToGetForeground << ") ERROR - Invalid string \"" <<  match.captured(1) << "\" found as name of background color!";
+                    qDebug().noquote().nospace() << "dlgTriggerEditor::parseButtonStyleSheetColors(\"" << styleSheetText << "\", " << isToGetForeground << ") ERROR - Invalid string \""
+                                                 << match.captured(1) << "\" found as name of background color!";
                     return QColor();
                 }
             } else {
-                qDebug().noquote().nospace() << "dlgTriggerEditor::parseButtonStyleSheetColors(\"" << styleSheetText << "\", " << isToGetForeground << ") ERROR - No string as name of background color found!";
+                qDebug().noquote().nospace() << "dlgTriggerEditor::parseButtonStyleSheetColors(\"" << styleSheetText << "\", " << isToGetForeground
+                                             << ") ERROR - No string as name of background color found!";
                 return QColor();
             }
         }
@@ -13751,7 +13520,6 @@ void dlgTriggerEditor::slot_rightSplitterMoved(const int, const int)
             if (mTriggerMainAreaMinimumHeightToShowAll > 0 && mpTriggersMainArea->widget_left->height() > mTriggerMainAreaMinimumHeightToShowAll) {
                 slot_showAllTriggerControls(true);
             }
-
         }
     } else if (mpActionsMainArea->isVisible()) {
         mActionEditorSplitterState = splitter_right->saveState();
@@ -13786,9 +13554,8 @@ void dlgTriggerEditor::setSearchOptions(const SearchOptions optionsState)
 
 void dlgTriggerEditor::showOrHideRestoreEditorActionsToolbarAction()
 {
-    if ((!toolBar->isVisible())
-        || toolBar->isFloating()
-        || (QMainWindow::toolBarArea(toolBar) & (Qt::ToolBarArea::LeftToolBarArea|Qt::ToolBarArea::RightToolBarArea|Qt::ToolBarArea::BottomToolBarArea))) {
+    if ((!toolBar->isVisible()) || toolBar->isFloating()
+        || (QMainWindow::toolBarArea(toolBar) & (Qt::ToolBarArea::LeftToolBarArea | Qt::ToolBarArea::RightToolBarArea | Qt::ToolBarArea::BottomToolBarArea))) {
         // If it is NOT visible
         // OR If the toolbar is floating
         // OR it is docked in an area other than the top one
@@ -13803,10 +13570,8 @@ void dlgTriggerEditor::showOrHideRestoreEditorActionsToolbarAction()
 
 void dlgTriggerEditor::showOrHideRestoreEditorItemsToolbarAction()
 {
-    if ((!toolBar2->isVisible())
-        || toolBar2->isFloating()
-        || (QMainWindow::toolBarArea(toolBar2) & (Qt::ToolBarArea::TopToolBarArea|Qt::ToolBarArea::RightToolBarArea|Qt::ToolBarArea::BottomToolBarArea))) {
-
+    if ((!toolBar2->isVisible()) || toolBar2->isFloating()
+        || (QMainWindow::toolBarArea(toolBar2) & (Qt::ToolBarArea::TopToolBarArea | Qt::ToolBarArea::RightToolBarArea | Qt::ToolBarArea::BottomToolBarArea))) {
         mpAction_restoreEditorItemsToolbar->setVisible(true);
     } else {
         mpAction_restoreEditorItemsToolbar->setVisible(false);
@@ -14106,7 +13871,7 @@ QSet<int> collectExpandedItemIDs(QTreeWidgetItem* parent)
     // If this item is expanded, record its ID
     if (parent->isExpanded()) {
         int itemID = parent->data(0, Qt::UserRole).toInt();
-        if (itemID > 0) {  // Valid ID
+        if (itemID > 0) { // Valid ID
             expandedIDs.insert(itemID);
         }
     }
@@ -14648,7 +14413,8 @@ void dlgTriggerEditor::showBannerUndoToast()
     mpBannerUndoTimer->setInterval(std::chrono::seconds(5));
 
     //: Toast notification shown when user dismisses an editor tip banner. Allows them to undo or permanently hide the tips for this editor view type.
-    QString toastMessage = tr("Banner hidden. <a href='undo' style='color: inherit; text-decoration: underline;'>Undo</a> | <a href='hide-permanently' style='color: inherit; text-decoration: underline;'>Hide permanently</a>");
+    QString toastMessage = tr("Banner hidden. <a href='undo' style='color: inherit; text-decoration: underline;'>Undo</a> | <a href='hide-permanently' style='color: inherit; text-decoration: "
+                              "underline;'>Hide permanently</a>");
 
     mpSystemMessageArea->notificationAreaIconLabelError->hide();
     mpSystemMessageArea->notificationAreaIconLabelWarning->hide();
@@ -14768,20 +14534,14 @@ void dlgTriggerEditor::setBannerPermanentlyHidden(EditorViewType viewType, const
 
 // Helper function for per-property trigger saves
 // Creates an undo command for a single property change with time-based merging support
-static void pushTriggerPropertyCommand(EditorUndoStack* undoStack, Host* host, int triggerID, const QString& triggerName,
-                                        const QString& propertyName, const QString& oldStateXML, const QString& newStateXML)
+static void
+pushTriggerPropertyCommand(EditorUndoStack* undoStack, Host* host, int triggerID, const QString& triggerName, const QString& propertyName, const QString& oldStateXML, const QString& newStateXML)
 {
     if (oldStateXML == newStateXML) {
         return; // No change
     }
 
-    auto* cmd = new EditorModifyPropertyCommand(
-        EditorViewType::cmTriggerView,
-        triggerID,
-        triggerName,
-        oldStateXML,
-        newStateXML,
-        host);
+    auto* cmd = new EditorModifyPropertyCommand(EditorViewType::cmTriggerView, triggerID, triggerName, oldStateXML, newStateXML, host);
     cmd->setPropertyId(qsl("trigger:%1:%2").arg(triggerID).arg(propertyName));
     undoStack->pushCommand(cmd);
 }
@@ -14880,8 +14640,7 @@ void dlgTriggerEditor::slot_saveProperty_TriggerLineMargin()
     const bool newIsMultiline = newValue >= 0;
 
     // Check if anything actually changed
-    if (pT->isMultiline() == newIsMultiline &&
-        (!newIsMultiline || pT->getConditionLineDelta() == newValue)) {
+    if (pT->isMultiline() == newIsMultiline && (!newIsMultiline || pT->getConditionLineDelta() == newValue)) {
         return;
     }
 
@@ -15061,20 +14820,13 @@ void dlgTriggerEditor::slot_saveProperty_TriggerPatternType(int patternIndex)
 // =============================================================================
 
 // Helper function for per-property alias saves
-static void pushAliasPropertyCommand(EditorUndoStack* undoStack, Host* host, int aliasID, const QString& aliasName,
-                                      const QString& propertyName, const QString& oldStateXML, const QString& newStateXML)
+static void pushAliasPropertyCommand(EditorUndoStack* undoStack, Host* host, int aliasID, const QString& aliasName, const QString& propertyName, const QString& oldStateXML, const QString& newStateXML)
 {
     if (oldStateXML == newStateXML) {
         return;
     }
 
-    auto* cmd = new EditorModifyPropertyCommand(
-        EditorViewType::cmAliasView,
-        aliasID,
-        aliasName,
-        oldStateXML,
-        newStateXML,
-        host);
+    auto* cmd = new EditorModifyPropertyCommand(EditorViewType::cmAliasView, aliasID, aliasName, oldStateXML, newStateXML, host);
     cmd->setPropertyId(qsl("alias:%1:%2").arg(aliasID).arg(propertyName));
     undoStack->pushCommand(cmd);
 }
@@ -15161,20 +14913,13 @@ void dlgTriggerEditor::slot_saveProperty_AliasCommand()
 // =============================================================================
 
 // Helper function for per-property timer saves
-static void pushTimerPropertyCommand(EditorUndoStack* undoStack, Host* host, int timerID, const QString& timerName,
-                                      const QString& propertyName, const QString& oldStateXML, const QString& newStateXML)
+static void pushTimerPropertyCommand(EditorUndoStack* undoStack, Host* host, int timerID, const QString& timerName, const QString& propertyName, const QString& oldStateXML, const QString& newStateXML)
 {
     if (oldStateXML == newStateXML) {
         return;
     }
 
-    auto* cmd = new EditorModifyPropertyCommand(
-        EditorViewType::cmTimerView,
-        timerID,
-        timerName,
-        oldStateXML,
-        newStateXML,
-        host);
+    auto* cmd = new EditorModifyPropertyCommand(EditorViewType::cmTimerView, timerID, timerName, oldStateXML, newStateXML, host);
     cmd->setPropertyId(qsl("timer:%1:%2").arg(timerID).arg(propertyName));
     undoStack->pushCommand(cmd);
 }
@@ -15264,20 +15009,14 @@ void dlgTriggerEditor::slot_saveProperty_TimerTime()
 // =============================================================================
 
 // Helper function for per-property script saves
-static void pushScriptPropertyCommand(EditorUndoStack* undoStack, Host* host, int scriptID, const QString& scriptName,
-                                       const QString& propertyName, const QString& oldStateXML, const QString& newStateXML)
+static void
+pushScriptPropertyCommand(EditorUndoStack* undoStack, Host* host, int scriptID, const QString& scriptName, const QString& propertyName, const QString& oldStateXML, const QString& newStateXML)
 {
     if (oldStateXML == newStateXML) {
         return;
     }
 
-    auto* cmd = new EditorModifyPropertyCommand(
-        EditorViewType::cmScriptView,
-        scriptID,
-        scriptName,
-        oldStateXML,
-        newStateXML,
-        host);
+    auto* cmd = new EditorModifyPropertyCommand(EditorViewType::cmScriptView, scriptID, scriptName, oldStateXML, newStateXML, host);
     cmd->setPropertyId(qsl("script:%1:%2").arg(scriptID).arg(propertyName));
     undoStack->pushCommand(cmd);
 }
@@ -15343,20 +15082,13 @@ void dlgTriggerEditor::slot_saveProperty_ScriptEventHandlers()
 // =============================================================================
 
 // Helper function for per-property key saves
-static void pushKeyPropertyCommand(EditorUndoStack* undoStack, Host* host, int keyID, const QString& keyName,
-                                    const QString& propertyName, const QString& oldStateXML, const QString& newStateXML)
+static void pushKeyPropertyCommand(EditorUndoStack* undoStack, Host* host, int keyID, const QString& keyName, const QString& propertyName, const QString& oldStateXML, const QString& newStateXML)
 {
     if (oldStateXML == newStateXML) {
         return;
     }
 
-    auto* cmd = new EditorModifyPropertyCommand(
-        EditorViewType::cmKeysView,
-        keyID,
-        keyName,
-        oldStateXML,
-        newStateXML,
-        host);
+    auto* cmd = new EditorModifyPropertyCommand(EditorViewType::cmKeysView, keyID, keyName, oldStateXML, newStateXML, host);
     cmd->setPropertyId(qsl("key:%1:%2").arg(keyID).arg(propertyName));
     undoStack->pushCommand(cmd);
 }
@@ -15418,20 +15150,14 @@ void dlgTriggerEditor::slot_saveProperty_KeyCommand()
 // =============================================================================
 
 // Helper function for per-property action saves
-static void pushActionPropertyCommand(EditorUndoStack* undoStack, Host* host, int actionID, const QString& actionName,
-                                       const QString& propertyName, const QString& oldStateXML, const QString& newStateXML)
+static void
+pushActionPropertyCommand(EditorUndoStack* undoStack, Host* host, int actionID, const QString& actionName, const QString& propertyName, const QString& oldStateXML, const QString& newStateXML)
 {
     if (oldStateXML == newStateXML) {
         return;
     }
 
-    auto* cmd = new EditorModifyPropertyCommand(
-        EditorViewType::cmActionView,
-        actionID,
-        actionName,
-        oldStateXML,
-        newStateXML,
-        host);
+    auto* cmd = new EditorModifyPropertyCommand(EditorViewType::cmActionView, actionID, actionName, oldStateXML, newStateXML, host);
     cmd->setPropertyId(qsl("action:%1:%2").arg(actionID).arg(propertyName));
     undoStack->pushCommand(cmd);
 }

--- a/src/dlgTriggerPatternEdit.cpp
+++ b/src/dlgTriggerPatternEdit.cpp
@@ -61,7 +61,6 @@ dlgTriggerPatternEdit::dlgTriggerPatternEdit(QWidget* pParentWidget)
 void dlgTriggerPatternEdit::slot_triggerTypeComboBoxChanged(const int index)
 {
     label_colorIcon->setPixmap(comboBox_patternType->itemIcon(index).pixmap(15, 15));
-
 }
 
 void dlgTriggerPatternEdit::applyThemePalette(const QPalette& editorPalette)

--- a/src/dlgVarsMainArea.cpp
+++ b/src/dlgVarsMainArea.cpp
@@ -44,24 +44,24 @@ dlgVarsMainArea::dlgVarsMainArea(QWidget* pParentWidget)
     // Key type widget:
 
     // Magic - part 1 set up a replacement data model:
-    auto *contents = new QListWidget(comboBox_variable_key_type);
+    auto* contents = new QListWidget(comboBox_variable_key_type);
     contents->hide();
     comboBox_variable_key_type->setModel(contents->model());
 
     // Now populate the widget - throw away stuff entered from form design
     // before substitute model was attached:
     comboBox_variable_key_type->clear();
-    comboBox_variable_key_type->insertItem(0, tr("Auto-Type"), -1); // LUA_TNONE
-    comboBox_variable_key_type->insertItem(1, tr("key (string)"), 4);  // LUA_TSTRING
-    comboBox_variable_key_type->insertItem(2, tr("index (integer number)"), 3);  // LUA_TNUMBER
-    comboBox_variable_key_type->insertItem(3, tr("table (use \"Add Group\" to create)"), 5);  // LUA_TTABLE
-    comboBox_variable_key_type->insertItem(4, tr("function (cannot create from GUI)"), 6);  // LUA_TFUNCTION
+    comboBox_variable_key_type->insertItem(0, tr("Auto-Type"), -1);                          // LUA_TNONE
+    comboBox_variable_key_type->insertItem(1, tr("key (string)"), 4);                        // LUA_TSTRING
+    comboBox_variable_key_type->insertItem(2, tr("index (integer number)"), 3);              // LUA_TNUMBER
+    comboBox_variable_key_type->insertItem(3, tr("table (use \"Add Group\" to create)"), 5); // LUA_TTABLE
+    comboBox_variable_key_type->insertItem(4, tr("function (cannot create from GUI)"), 6);   // LUA_TFUNCTION
 
     // Magic - part 2 use the features of the substitute data model to disable
     // the required entries - they can still be set programmatically for display
     // purposes:
     // Disable table type:
-    QListWidgetItem *item = contents->item(3);
+    QListWidgetItem* item = contents->item(3);
     item->setFlags(item->flags() & ~Qt::ItemIsEnabled);
 
     // Disable function type:

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -43,16 +43,16 @@
 #endif
 
 
-GLWidget::GLWidget(TMap* pMap, Host* pHost, QWidget *parent)
+GLWidget::GLWidget(TMap* pMap, Host* pHost, QWidget* parent)
 : QOpenGLWidget(parent)
 , mpMap(pMap)
 , mpHost(pHost)
 {
     if (mpHost->mBgColor_2.alpha() < 255) {
-    setAttribute(Qt::WA_OpaquePaintEvent, false);
-    setAttribute(Qt::WA_AlwaysStackOnTop);
+        setAttribute(Qt::WA_OpaquePaintEvent, false);
+        setAttribute(Qt::WA_AlwaysStackOnTop);
     } else {
-    setAttribute(Qt::WA_OpaquePaintEvent);
+        setAttribute(Qt::WA_OpaquePaintEvent);
     }
 }
 
@@ -290,7 +290,7 @@ void GLWidget::paintGL()
             } else {
                 message = tr("You do not have a map yet - load one, or start mapping from scratch to begin.");
             }
-            painter.drawText(0, 0, (width() -1), (height() -1), Qt::AlignCenter | Qt::TextWordWrap, message);
+            painter.drawText(0, 0, (width() - 1), (height() - 1), Qt::AlignCenter | Qt::TextWordWrap, message);
             painter.end();
 
             glLoadIdentity();
@@ -371,59 +371,59 @@ void GLWidget::paintGL()
     glEnable(GL_LINE_STIPPLE);
     glLineWidth(1.0);
     float planeColor2[][4] = {{0.9, 0.5, 0.0, 1.0},
-                               {165.0 / 255.0, 102.0 / 255.0, 167.0 / 255.0, 1.0},
-                               {170.0 / 255.0, 10.0 / 255.0, 127.0 / 255.0, 1.0},
-                               {203.0 / 255.0, 135.0 / 255.0, 101.0 / 255.0, 1.0},
-                               {154.0 / 255.0, 154.0 / 255.0, 115.0 / 255.0, 1.0},
-                               {107.0 / 255.0, 154.0 / 255.0, 100.0 / 255.0, 1.0},
-                               {154.0 / 255.0, 184.0 / 255.0, 111.0 / 255.0, 1.0},
-                               {67.0 / 255.0, 154.0 / 255.0, 148.0 / 255.0, 1.0},
-                               {154.0 / 255.0, 118.0 / 255.0, 151.0 / 255.0, 1.0},
-                               {208.0 / 255.0, 213.0 / 255.0, 164.0 / 255.0, 1.0},
-                               {213.0 / 255.0, 169.0 / 255.0, 158.0 / 255.0, 1.0},
-                               {139.0 / 255.0, 209.0 / 255.0, 0, 1.0},
-                               {163.0 / 255.0, 209.0 / 255.0, 202.0 / 255.0, 1.0},
-                               {158.0 / 255.0, 156.0 / 255.0, 209.0 / 255.0, 1.0},
-                               {209.0 / 255.0, 144.0 / 255.0, 162.0 / 255.0, 1.0},
-                               {209.0 / 255.0, 183.0 / 255.0, 78.0 / 255.0, 1.0},
-                               {111.0 / 255.0, 209.0 / 255.0, 88.0 / 255.0, 1.0},
-                               {95.0 / 255.0, 120.0 / 255.0, 209.0 / 255.0, 1.0},
-                               {31.0 / 255.0, 209.0 / 255.0, 126.0 / 255.0, 1.0},
-                               {1.0, 170.0 / 255.0, 1.0, 1.0},
-                               {158.0 / 255.0, 105.0 / 255.0, 158.0 / 255.0, 1.0},
-                               {68.0 / 255.0, 189.0 / 255.0, 189.0 / 255.0, 1.0},
-                               {0.1, 0.69, 0.49, 1.0},
-                               {0.0, 0.15, 1.0, 1.0},
-                               {0.12, 0.02, 0.20, 1.0},
-                               {0.0, 0.3, 0.1, 1.0}};
+                              {165.0 / 255.0, 102.0 / 255.0, 167.0 / 255.0, 1.0},
+                              {170.0 / 255.0, 10.0 / 255.0, 127.0 / 255.0, 1.0},
+                              {203.0 / 255.0, 135.0 / 255.0, 101.0 / 255.0, 1.0},
+                              {154.0 / 255.0, 154.0 / 255.0, 115.0 / 255.0, 1.0},
+                              {107.0 / 255.0, 154.0 / 255.0, 100.0 / 255.0, 1.0},
+                              {154.0 / 255.0, 184.0 / 255.0, 111.0 / 255.0, 1.0},
+                              {67.0 / 255.0, 154.0 / 255.0, 148.0 / 255.0, 1.0},
+                              {154.0 / 255.0, 118.0 / 255.0, 151.0 / 255.0, 1.0},
+                              {208.0 / 255.0, 213.0 / 255.0, 164.0 / 255.0, 1.0},
+                              {213.0 / 255.0, 169.0 / 255.0, 158.0 / 255.0, 1.0},
+                              {139.0 / 255.0, 209.0 / 255.0, 0, 1.0},
+                              {163.0 / 255.0, 209.0 / 255.0, 202.0 / 255.0, 1.0},
+                              {158.0 / 255.0, 156.0 / 255.0, 209.0 / 255.0, 1.0},
+                              {209.0 / 255.0, 144.0 / 255.0, 162.0 / 255.0, 1.0},
+                              {209.0 / 255.0, 183.0 / 255.0, 78.0 / 255.0, 1.0},
+                              {111.0 / 255.0, 209.0 / 255.0, 88.0 / 255.0, 1.0},
+                              {95.0 / 255.0, 120.0 / 255.0, 209.0 / 255.0, 1.0},
+                              {31.0 / 255.0, 209.0 / 255.0, 126.0 / 255.0, 1.0},
+                              {1.0, 170.0 / 255.0, 1.0, 1.0},
+                              {158.0 / 255.0, 105.0 / 255.0, 158.0 / 255.0, 1.0},
+                              {68.0 / 255.0, 189.0 / 255.0, 189.0 / 255.0, 1.0},
+                              {0.1, 0.69, 0.49, 1.0},
+                              {0.0, 0.15, 1.0, 1.0},
+                              {0.12, 0.02, 0.20, 1.0},
+                              {0.0, 0.3, 0.1, 1.0}};
 
 
     float planeColor[][4] = {{0.5, 0.6, 0.5, 0.2},
-                              {0.233, 0.498, 0.113, 0.2},
-                              {0.666, 0.333, 0.498, 0.2},
-                              {0.5, 0.333, 0.666, 0.2},
-                              {0.69, 0.458, 0.0, 0.2},
-                              {0.333, 0.0, 0.49, 0.2},
-                              {133.0 / 255.0, 65.0 / 255.0, 98.0 / 255.0, 0.2},
-                              {0.3, 0.3, 0.0, 0.2},
-                              {0.6, 0.2, 0.6, 0.2},
-                              {0.6, 0.6, 0.2, 0.2},
-                              {0.4, 0.1, 0.4, 0.2},
-                              {0.4, 0.4, 0.1, 0.2},
-                              {0.3, 0.1, 0.3, 0.2},
-                              {0.3, 0.3, 0.1, 0.2},
-                              {0.2, 0.1, 0.2, 0.2},
-                              {0.2, 0.2, 0.1, 0.2},
-                              {0.24, 0.1, 0.5, 0.2},
-                              {0.1, 0.1, 0.0, 0.2},
-                              {0.54, 0.6, 0.2, 0.2},
-                              {0.2, 0.2, 0.5, 0.2},
-                              {0.6, 0.6, 0.2, 0.2},
-                              {0.6, 0.4, 0.6, 0.2},
-                              {0.4, 0.4, 0.1, 0.2},
-                              {0.4, 0.2, 0.4, 0.2},
-                              {0.2, 0.2, 0.0, 0.2},
-                              {0.2, 0.1, 0.3, 0.2}};
+                             {0.233, 0.498, 0.113, 0.2},
+                             {0.666, 0.333, 0.498, 0.2},
+                             {0.5, 0.333, 0.666, 0.2},
+                             {0.69, 0.458, 0.0, 0.2},
+                             {0.333, 0.0, 0.49, 0.2},
+                             {133.0 / 255.0, 65.0 / 255.0, 98.0 / 255.0, 0.2},
+                             {0.3, 0.3, 0.0, 0.2},
+                             {0.6, 0.2, 0.6, 0.2},
+                             {0.6, 0.6, 0.2, 0.2},
+                             {0.4, 0.1, 0.4, 0.2},
+                             {0.4, 0.4, 0.1, 0.2},
+                             {0.3, 0.1, 0.3, 0.2},
+                             {0.3, 0.3, 0.1, 0.2},
+                             {0.2, 0.1, 0.2, 0.2},
+                             {0.2, 0.2, 0.1, 0.2},
+                             {0.24, 0.1, 0.5, 0.2},
+                             {0.1, 0.1, 0.0, 0.2},
+                             {0.54, 0.6, 0.2, 0.2},
+                             {0.2, 0.2, 0.5, 0.2},
+                             {0.6, 0.6, 0.2, 0.2},
+                             {0.6, 0.4, 0.6, 0.2},
+                             {0.4, 0.4, 0.1, 0.2},
+                             {0.4, 0.2, 0.4, 0.2},
+                             {0.2, 0.2, 0.0, 0.2},
+                             {0.2, 0.1, 0.3, 0.2}};
 
     while (true) {
         if (zRot <= 0) {
@@ -516,7 +516,7 @@ void GLWidget::paintGL()
                     // if (areaExit) {
                     //    glLineWidth(1); //1/mScale+2);
                     // } else {
-                        glLineWidth(1); //1/mScale);
+                    glLineWidth(1); //1/mScale);
                     // }
                     if (k == mRID || ((rz == pz) && (rx == px) && (ry == py))) {
                         glDisable(GL_BLEND);
@@ -782,8 +782,7 @@ void GLWidget::paintGL()
                             break;
                         default: //user defined room color
                             if (!mpMap->mCustomEnvColors.contains(env)) {
-                                if (16 < env && env < 232)
-                                {
+                                if (16 < env && env < 232) {
                                     quint8 const base = env - 16;
                                     quint8 r = base / 36;
                                     quint8 g = (base - (r * 36)) / 6;
@@ -926,7 +925,7 @@ void GLWidget::paintGL()
                     // if (areaExit) {
                     //    glLineWidth(1); //1/mScale+2);
                     // } else {
-                        glLineWidth(1); //1/mScale);
+                    glLineWidth(1); //1/mScale);
                     // }
                     if (k == mRID || ((rz == pz) && (rx == px) && (ry == py))) {
                         glDisable(GL_BLEND);
@@ -941,7 +940,7 @@ void GLWidget::paintGL()
                         glEnable(GL_LIGHT1);
                         glMaterialfv(GL_FRONT, GL_AMBIENT_AND_DIFFUSE, planeColor2[ef]);
                         glMateriali(GL_FRONT, GL_SHININESS, 1); //gut:36
-                        glColor4f(0.3, 0.3, 0.3, 1.0); /*planeColor2[ef][0],
+                        glColor4f(0.3, 0.3, 0.3, 1.0);          /*planeColor2[ef][0],
                                   planeColor2[ef][1],
                                   planeColor2[ef][2],
                                   planeColor2[ef][3])*/
@@ -1190,8 +1189,7 @@ void GLWidget::paintGL()
                             break;
                         default: //user defined room color
                             if (!mpMap->mCustomEnvColors.contains(env)) {
-                                if (16 < env && env < 232)
-                                {
+                                if (16 < env && env < 232) {
                                     quint8 const base = env - 16;
                                     quint8 r = base / 36;
                                     quint8 g = (base - (r * 36)) / 6;
@@ -1583,8 +1581,7 @@ void GLWidget::paintGL()
                     break;
                 default: //user defined room color
                     if (!mpMap->mCustomEnvColors.contains(env)) {
-                        if (16 < env && env < 232)
-                        {
+                        if (16 < env && env < 232) {
                             quint8 const base = env - 16;
                             quint8 r = base / 36;
                             quint8 g = (base - (r * 36)) / 6;
@@ -1885,8 +1882,7 @@ void GLWidget::paintGL()
                 break;
             default: //user defined room color
                 if (!mpMap->mCustomEnvColors.contains(env)) {
-                    if (16 < env && env < 232)
-                    {
+                    if (16 < env && env < 232) {
                         quint8 const base = env - 16;
                         quint8 r = base / 36;
                         quint8 g = (base - (r * 36)) / 6;
@@ -2013,23 +2009,23 @@ void GLWidget::paintGL()
             }
             glEnd();
 
-//            if (mpMap->rooms[pArea->rooms[i]]->out > -1) {
-//                glBegin( GL_LINE_LOOP );
-//                for (int angle=0; angle<360; angle += 1 ) {
-//                    glVertex3f((0.5 + sin((float)angle) * 0.25)/scale, ( cos((float)angle) * 0.25)/scale, 0.0);
-//                }
-//                glEnd();
-//            }
+            //            if (mpMap->rooms[pArea->rooms[i]]->out > -1) {
+            //                glBegin( GL_LINE_LOOP );
+            //                for (int angle=0; angle<360; angle += 1 ) {
+            //                    glVertex3f((0.5 + sin((float)angle) * 0.25)/scale, ( cos((float)angle) * 0.25)/scale, 0.0);
+            //                }
+            //                glEnd();
+            //            }
 
-//            glTranslatef(-0.1, 0.0, 0.0);
-//            if (mpMap->rooms[pArea->rooms[i]]->in > -1) {
-//                glBegin(GL_TRIANGLE_FAN);
-//                glVertex3f(0.0, 0.0, 0.0);
-//                for (int angle=0; angle<=360; angle += 5) {
-//                    glVertex3f((sin((float)angle)*0.25)/scale, (cos((float)angle)*0.25)/scale, 0.0);
-//                }
-//                glEnd();
-//            }
+            //            glTranslatef(-0.1, 0.0, 0.0);
+            //            if (mpMap->rooms[pArea->rooms[i]]->in > -1) {
+            //                glBegin(GL_TRIANGLE_FAN);
+            //                glVertex3f(0.0, 0.0, 0.0);
+            //                for (int angle=0; angle<=360; angle += 5) {
+            //                    glVertex3f((sin((float)angle)*0.25)/scale, (cos((float)angle)*0.25)/scale, 0.0);
+            //                }
+            //                glEnd();
+            //            }
         }
 
 
@@ -2055,7 +2051,7 @@ void GLWidget::resizeGL(int w, int h)
 void GLWidget::mousePressEvent(QMouseEvent* event)
 {
     mudlet::self()->activateProfile(mpHost);
-    if (!mpMap||!mpMap->mpRoomDB) {
+    if (!mpMap || !mpMap->mpRoomDB) {
         return;
     }
     if (event->buttons() & Qt::LeftButton) {
@@ -2107,9 +2103,8 @@ void GLWidget::mousePressEvent(QMouseEvent* event)
             } else if (mpMap->findPath(mpMap->mRoomIdHash.value(mpMap->mProfileName), mpMap->mTargetID)) {
                 mpMap->mpHost->startSpeedWalk();
             } else {
-                mpMap->mpHost->mpConsole->printSystemMessage(qsl("%1\n").arg(tr("Mapper: Cannot find a path from %1 to %2 using known exits.")
-                                                          .arg(QString::number(mpMap->mRoomIdHash.value(mpMap->mProfileName)),
-                                                               QString::number(mpMap->mTargetID))));
+                mpMap->mpHost->mpConsole->printSystemMessage(qsl("%1\n").arg(
+                        tr("Mapper: Cannot find a path from %1 to %2 using known exits.").arg(QString::number(mpMap->mRoomIdHash.value(mpMap->mProfileName)), QString::number(mpMap->mTargetID))));
             }
             //            else
             //            {
@@ -2133,7 +2128,7 @@ void GLWidget::mousePressEvent(QMouseEvent* event)
 
 void GLWidget::mouseMoveEvent(QMouseEvent* event)
 {
-    if (!mpMap||!mpMap->mpRoomDB) {
+    if (!mpMap || !mpMap->mpRoomDB) {
         return;
     }
     if (mPanMode) {

--- a/src/glwidget_integration.cpp
+++ b/src/glwidget_integration.cpp
@@ -33,10 +33,10 @@ bool GLWidgetFactory::isCorrectWidgetType(QOpenGLWidget* widget, Host* pHost)
     if (!widget || !pHost) {
         return false;
     }
-    
+
     bool shouldUseModern = pHost->getUseModern3DMapper();
     bool isModern = dynamic_cast<ModernGLWidget*>(widget) != nullptr;
-    
+
     return shouldUseModern == isModern;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,7 +57,7 @@ extern void qInitResources_qm();
 extern void qInitResources_additional_splash_screens();
 extern void qInitResources_mudlet_fonts_common();
 extern void qInitResources_mudlet_fonts_posix();
-void        initializeQRCResources();
+void initializeQRCResources();
 
 #if defined(Q_OS_WINDOWS) && defined(INCLUDE_UPDATER)
 bool runUpdate();
@@ -183,10 +183,12 @@ int main(int argc, char* argv[])
     }
 #endif
 
-    #ifdef WITH_SENTRY
-        initSentry();
-        auto sentryClose = qScopeGuard([] { sentry_close(); });
-    #endif
+#ifdef WITH_SENTRY
+    initSentry();
+    auto sentryClose = qScopeGuard([] {
+        sentry_close();
+    });
+#endif
 
 #ifdef Q_OS_WINDOWS
     if (AttachConsole(ATTACH_PARENT_PROCESS)) {
@@ -287,9 +289,8 @@ int main(int argc, char* argv[])
     beQuiet.setFlags(QCommandLineOption::HiddenFromHelp);
     parser.addOption(beQuiet);
 
-    const QCommandLineOption onlyPredefinedProfileToShow(QStringList() << qsl("o") << qsl("only"),
-                                                   qsl("Set Mudlet to only show this predefined MUD profile and hide all other predefined ones."),
-                                                   qsl("predefined_game"));
+    const QCommandLineOption onlyPredefinedProfileToShow(
+            QStringList() << qsl("o") << qsl("only"), qsl("Set Mudlet to only show this predefined MUD profile and hide all other predefined ones."), qsl("predefined_game"));
     parser.addOption(onlyPredefinedProfileToShow);
 
     const QCommandLineOption steamMode(QStringList() << qsl("steammode"), qsl("Adjusts Mudlet settings to match Steam's requirements."));
@@ -320,64 +321,77 @@ int main(int argc, char* argv[])
 
     if (parser.isSet(showHelp)) {
         // Do "help" action
-        texts << appendLF.arg(QCoreApplication::translate("main", "Usage: %1 [OPTION...] [FILE] ",
+        texts << appendLF.arg(QCoreApplication::translate("main",
+                                                          "Usage: %1 [OPTION...] [FILE] ",
                                                           // Comment to separate arguments
                                                           "%1 is the name of the executable as it is on this OS.")
-                                         .arg(QLatin1String(APP_TARGET)));
+                                      .arg(QLatin1String(APP_TARGET)));
         texts << appendLF.arg(QCoreApplication::translate("main", "Options:"));
         texts << appendLF.arg(QCoreApplication::translate("main", "       -h, --help                   displays this message."));
         texts << appendLF.arg(QCoreApplication::translate("main", "       -v, --version                displays version information."));
         texts << appendLF.arg(QCoreApplication::translate("main", "       -s, --splashscreen           show splashscreen on startup."));
-        texts << appendLF.arg(QCoreApplication::translate("main", "       -p, --profile=<profile>      additional profile to open, may be\n"
-                                                                  "                                    repeated."));
-        texts << appendLF.arg(QCoreApplication::translate("main", "       -o, --only=<predefined>      make Mudlet only show the specific\n"
-                                                                  "                                    predefined game, may be repeated."));
+        texts << appendLF.arg(QCoreApplication::translate("main",
+                                                          "       -p, --profile=<profile>      additional profile to open, may be\n"
+                                                          "                                    repeated."));
+        texts << appendLF.arg(QCoreApplication::translate("main",
+                                                          "       -o, --only=<predefined>      make Mudlet only show the specific\n"
+                                                          "                                    predefined game, may be repeated."));
         texts << appendLF.arg(QCoreApplication::translate("main", "       -f, --fullscreen             start Mudlet in fullscreen mode."));
-        texts << appendLF.arg(QCoreApplication::translate("main", "       --steammode                  adjusts Mudlet settings to match\n"
-                                                                  "                                    Steam's requirements."));
-        texts << appendLF.arg(QCoreApplication::translate("main", "There are other inherited options that arise from the Qt Libraries which are\n"
-                                                                  "less likely to be useful for normal use of this application:"));
+        texts << appendLF.arg(QCoreApplication::translate("main",
+                                                          "       --steammode                  adjusts Mudlet settings to match\n"
+                                                          "                                    Steam's requirements."));
+        texts << appendLF.arg(QCoreApplication::translate("main",
+                                                          "There are other inherited options that arise from the Qt Libraries which are\n"
+                                                          "less likely to be useful for normal use of this application:"));
         // From documentation and from http://qt-project.org/doc/qt-5/qapplication.html:
-        texts << appendLF.arg(QCoreApplication::translate("main", "       --dograb                     ignore any implicit or explicit -nograb.\n"
-                                                                  "                                    --dograb wins over --nograb even when --nograb is last on\n"
-                                                                  "                                    the command line."));
+        texts << appendLF.arg(QCoreApplication::translate("main",
+                                                          "       --dograb                     ignore any implicit or explicit -nograb.\n"
+                                                          "                                    --dograb wins over --nograb even when --nograb is last on\n"
+                                                          "                                    the command line."));
 #if defined(Q_OS_LINUX)
-        texts << appendLF.arg(QCoreApplication::translate("main", "       --nograb                     the application should never grab the mouse or the\n"
-                                                                  "                                    keyboard. This option is set by default when Mudlet is\n"
-                                                                  "                                    running in the gdb debugger under Linux."));
-#else // ! defined(Q_OS_LINUX)
-        texts << appendLF.arg(QCoreApplication::translate("main", "       --nograb                     the application should never grab the mouse or the\n"
-                                                                  "                                    keyboard."));
+        texts << appendLF.arg(QCoreApplication::translate("main",
+                                                          "       --nograb                     the application should never grab the mouse or the\n"
+                                                          "                                    keyboard. This option is set by default when Mudlet is\n"
+                                                          "                                    running in the gdb debugger under Linux."));
+#else  // ! defined(Q_OS_LINUX)
+        texts << appendLF.arg(QCoreApplication::translate("main",
+                                                          "       --nograb                     the application should never grab the mouse or the\n"
+                                                          "                                    keyboard."));
 #endif // ! defined(Q_OS_LINUX)
         texts << appendLF.arg(QCoreApplication::translate("main", "       --reverse                    sets the application's layout direction to right to left."));
-        texts << appendLF.arg(QCoreApplication::translate("main", "       --style=style                sets the application GUI style. Possible values depend on\n"
-                                                                  "                                    your system configuration. If Qt was compiled with\n"
-                                                                  "                                    additional styles or has additional styles as plugins\n"
-                                                                  "                                    these will be available to the -style command line\n"
-                                                                  "                                    option. You can also set the style for all Qt\n"
-                                                                  "                                    applications by setting the QT_STYLE_OVERRIDE environment\n"
-                                                                  "                                    variable."));
+        texts << appendLF.arg(QCoreApplication::translate("main",
+                                                          "       --style=style                sets the application GUI style. Possible values depend on\n"
+                                                          "                                    your system configuration. If Qt was compiled with\n"
+                                                          "                                    additional styles or has additional styles as plugins\n"
+                                                          "                                    these will be available to the -style command line\n"
+                                                          "                                    option. You can also set the style for all Qt\n"
+                                                          "                                    applications by setting the QT_STYLE_OVERRIDE environment\n"
+                                                          "                                    variable."));
         texts << appendLF.arg(QCoreApplication::translate("main", "       --style style                is the same as listed above."));
-        texts << appendLF.arg(QCoreApplication::translate("main", "       --stylesheet=stylesheet      sets the application styleSheet.\n"
-                                                                  "                                    The value must be a path to a file that contains the\n"
-                                                                  "                                    Style Sheet. Note: Relative URLs in the Style Sheet file\n"
-                                                                  "                                    are relative to the Style Sheet file's path."));
+        texts << appendLF.arg(QCoreApplication::translate("main",
+                                                          "       --stylesheet=stylesheet      sets the application styleSheet.\n"
+                                                          "                                    The value must be a path to a file that contains the\n"
+                                                          "                                    Style Sheet. Note: Relative URLs in the Style Sheet file\n"
+                                                          "                                    are relative to the Style Sheet file's path."));
 
         texts << appendLF.arg(QCoreApplication::translate("main", "       --stylesheet stylesheet      is the same as listed above."));
 // Not sure about MacOS case as that does not use X
-#if defined(Q_OS_UNIX) && (! defined(Q_OS_MACOS))
-        texts << appendLF.arg(QCoreApplication::translate("main", "       --sync                       forces the X server to perform each X client request\n"
-                                                                  "                                    immediately and not use buffer optimization. It makes the\n"
-                                                                  "                                    program easier to debug and often much slower. The --sync\n"
-                                                                  "                                    option is only valid for the X11 version of Qt."));
+#if defined(Q_OS_UNIX) && (!defined(Q_OS_MACOS))
+        texts << appendLF.arg(QCoreApplication::translate("main",
+                                                          "       --sync                       forces the X server to perform each X client request\n"
+                                                          "                                    immediately and not use buffer optimization. It makes the\n"
+                                                          "                                    program easier to debug and often much slower. The --sync\n"
+                                                          "                                    option is only valid for the X11 version of Qt."));
 #endif // defined(Q_OS_UNIX) and not defined(Q_OS_MACOS)
-        texts << appendLF.arg(QCoreApplication::translate("main", "       --widgetcount                prints debug message at the end about number of widgets\n"
-                                                                  "                                    left undestroyed and maximum number of widgets existing\n"
-                                                                  "                                    at the same time."));
-        texts << append2LF.arg(QCoreApplication::translate("main", "       --qmljsdebugger=1234[,block] activates the QML/JS debugger with a\n"
-                                                                   "                                    specified port. The number is the port value and block is\n"
-                                                                   "                                    optional and will make the application wait until a\n"
-                                                                   "                                    debugger connects to it."));
+        texts << appendLF.arg(QCoreApplication::translate("main",
+                                                          "       --widgetcount                prints debug message at the end about number of widgets\n"
+                                                          "                                    left undestroyed and maximum number of widgets existing\n"
+                                                          "                                    at the same time."));
+        texts << append2LF.arg(QCoreApplication::translate("main",
+                                                           "       --qmljsdebugger=1234[,block] activates the QML/JS debugger with a\n"
+                                                           "                                    specified port. The number is the port value and block is\n"
+                                                           "                                    optional and will make the application wait until a\n"
+                                                           "                                    debugger connects to it."));
         texts << appendLF.arg(QCoreApplication::translate("main", "Arguments:"));
         texts << appendLF.arg(QCoreApplication::translate("main", "        [FILE]                       File to install as a package"));
         texts << appendLF.arg(QCoreApplication::translate("main", "Report bugs to: https://github.com/Mudlet/Mudlet/issues"));
@@ -389,19 +403,20 @@ int main(int argc, char* argv[])
     if (parser.isSet(showVersion)) {
         // Do "version" action - wording and format is quite tightly specified by the coding standards
 #if defined(QT_DEBUG)
-        texts << appendLF.arg(QCoreApplication::translate("main", "%1 %2%3 (with debug symbols, without optimisations)",
+        texts << appendLF.arg(QCoreApplication::translate("main",
+                                                          "%1 %2%3 (with debug symbols, without optimisations)",
                                                           "%1 is the name of the application like mudlet or Mudlet.exe, %2 is the version number like 3.20 and %3 is a build suffix like -dev")
-                 .arg(QLatin1String(APP_TARGET), QLatin1String(APP_VERSION), appBuild));
-#else // ! defined(QT_DEBUG)
+                                      .arg(QLatin1String(APP_TARGET), QLatin1String(APP_VERSION), appBuild));
+#else  // ! defined(QT_DEBUG)
         texts << QString::fromStdString(APP_TARGET " " APP_VERSION " " + appBuild.toStdString() + " \n");
 #endif // ! defined(QT_DEBUG)
-        texts << appendLF.arg(QCoreApplication::translate("main", "Qt libraries %1 (compilation) %2 (runtime)",
-             "%1 and %2 are version numbers").arg(QLatin1String(QT_VERSION_STR), qVersion()));
+        texts << appendLF.arg(QCoreApplication::translate("main", "Qt libraries %1 (compilation) %2 (runtime)", "%1 and %2 are version numbers").arg(QLatin1String(QT_VERSION_STR), qVersion()));
         // PLACEMARKER: Date-stamp needing annual update
         texts << appendLF.arg(QCoreApplication::translate("main", "Copyright © 2008-2026  Mudlet developers"));
         texts << appendLF.arg(QCoreApplication::translate("main", "Licence GPLv2+: GNU GPL version 2 or later - http://gnu.org/licenses/gpl.html"));
-        texts << appendLF.arg(QCoreApplication::translate("main", "This is free software: you are free to change and redistribute it.\n"
-                                                                  "There is NO WARRANTY, to the extent permitted by law."));
+        texts << appendLF.arg(QCoreApplication::translate("main",
+                                                          "This is free software: you are free to change and redistribute it.\n"
+                                                          "There is NO WARRANTY, to the extent permitted by law."));
         std::cout << texts.join(QString()).toStdString();
         return 0;
     }
@@ -782,14 +797,13 @@ int main(int argc, char* argv[])
 static bool isFileAccessible(const QString& filePath)
 {
     // Try opening file with exclusive write access
-    HANDLE hFile = CreateFileW(
-        reinterpret_cast<const wchar_t*>(filePath.utf16()),
-        GENERIC_WRITE,
-        0, // No sharing - exclusive access
-        nullptr,
-        OPEN_EXISTING,
-        FILE_ATTRIBUTE_NORMAL,
-        nullptr);
+    HANDLE hFile = CreateFileW(reinterpret_cast<const wchar_t*>(filePath.utf16()),
+                               GENERIC_WRITE,
+                               0, // No sharing - exclusive access
+                               nullptr,
+                               OPEN_EXISTING,
+                               FILE_ATTRIBUTE_NORMAL,
+                               nullptr);
 
     if (hFile == INVALID_HANDLE_VALUE) {
         DWORD error = GetLastError();
@@ -813,8 +827,7 @@ static bool tryFileOperationWithRetry(const std::function<bool()>& operation, co
 
     for (int attempt = 0; attempt < maxAttempts; ++attempt) {
         if (attempt > 0) {
-            qWarning() << operationName << "- Attempt" << (attempt + 1) << "of" << maxAttempts
-                      << "after" << retryDelays[attempt - 1].count() << "ms delay";
+            qWarning() << operationName << "- Attempt" << (attempt + 1) << "of" << maxAttempts << "after" << retryDelays[attempt - 1].count() << "ms delay";
             QThread::msleep(retryDelays[attempt - 1].count());
         }
 
@@ -862,10 +875,11 @@ bool runUpdate()
 
         // Try to remove old installer if it exists
         if (seenUpdatedInstaller.exists()) {
-            bool removed = tryFileOperationWithRetry([&]() {
-                return isFileAccessible(seenUpdatedInstaller.absoluteFilePath()) &&
-                       updateDir.remove(seenUpdatedInstaller.absoluteFilePath());
-            }, qsl("Delete previous installer"));
+            bool removed = tryFileOperationWithRetry(
+                    [&]() {
+                        return isFileAccessible(seenUpdatedInstaller.absoluteFilePath()) && updateDir.remove(seenUpdatedInstaller.absoluteFilePath());
+                    },
+                    qsl("Delete previous installer"));
 
             if (!removed) {
                 qWarning() << "Couldn't delete previous installer after retries:" << seenUpdatedInstaller;
@@ -875,14 +889,14 @@ bool runUpdate()
         }
 
         // Try to move the installer with retry logic
-        bool moved = tryFileOperationWithRetry([&]() {
-            return isFileAccessible(updatedInstaller.absoluteFilePath()) &&
-                   updateDir.rename(updatedInstaller.absoluteFilePath(), seenUpdatedInstaller.absoluteFilePath());
-        }, qsl("Rename installer to mark as ready"));
+        bool moved = tryFileOperationWithRetry(
+                [&]() {
+                    return isFileAccessible(updatedInstaller.absoluteFilePath()) && updateDir.rename(updatedInstaller.absoluteFilePath(), seenUpdatedInstaller.absoluteFilePath());
+                },
+                qsl("Rename installer to mark as ready"));
 
         if (!moved) {
-            qWarning() << "Failed to prep installer: couldn't move" << updatedInstaller.absoluteFilePath()
-                      << "to" << seenUpdatedInstaller.absoluteFilePath() << "after all retries";
+            qWarning() << "Failed to prep installer: couldn't move" << updatedInstaller.absoluteFilePath() << "to" << seenUpdatedInstaller.absoluteFilePath() << "after all retries";
             qWarning() << "Update will be attempted on next Mudlet restart";
             return false;
         }

--- a/src/mapInfoContributorManager.cpp
+++ b/src/mapInfoContributorManager.cpp
@@ -53,7 +53,7 @@ bool MapInfoContributorManager::removeContributor(const QString& name)
     return contributors.remove(name) > 0;
 }
 
-bool MapInfoContributorManager::enableContributor(const QString &name)
+bool MapInfoContributorManager::enableContributor(const QString& name)
 {
     if (!contributors.contains(name)) {
         return false;
@@ -64,7 +64,7 @@ bool MapInfoContributorManager::enableContributor(const QString &name)
     return true;
 }
 
-bool MapInfoContributorManager::disableContributor(const QString &name)
+bool MapInfoContributorManager::disableContributor(const QString& name)
 {
     if (!contributors.contains(name)) {
         return false;
@@ -80,7 +80,7 @@ MapInfoCallback MapInfoContributorManager::getContributor(const QString& name)
     return contributors.value(name);
 }
 
-QList<QString> &MapInfoContributorManager::getContributorKeys()
+QList<QString>& MapInfoContributorManager::getContributorKeys()
 {
     return ordering;
 }
@@ -99,8 +99,7 @@ MapInfoProperties MapInfoContributorManager::shortInfo(int roomID, int selection
         if (mpHost->mMapViewOnly) {
             roomName = roomName.remove(trailingPunctuation).trimmed();
         }
-        auto roomFragment = !roomName.isEmpty() && roomName != QString::number(room->getId()) ?
-            qsl("%1 / %2").arg(roomName, QString::number(room->getId())) : QString::number(room->getId());
+        auto roomFragment = !roomName.isEmpty() && roomName != QString::number(room->getId()) ? qsl("%1 / %2").arg(roomName, QString::number(room->getId())) : QString::number(room->getId());
         infoText = qsl("%1 (%2)\n").arg(roomFragment, areaName);
     }
     return MapInfoProperties{false, false, infoText, infoColor};
@@ -119,7 +118,7 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
         const QString areaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(areaId);
         if (area) {
             infoText = qsl("%1\n").arg(
-                /*:
+                    /*:
                 %1 is the (text) name of the area, %2 is the area ID number,
                 %3 and %4 are the minimum and maximum x coordinates, %5 and %6 for y, and %7 and %8 for z.
                 This text uses non-breaking spaces (Unicode U+00A0) and non-breaking hyphens
@@ -127,15 +126,15 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
                 When translating, please consider at which points the text may be divided to fit
                 onto more than one line. 
                 */
-                           tr("Area:\u00A0%1 ID:\u00A0%2 x:\u00A0%3\u00A0<‑>\u00A0%4 y:\u00A0%5\u00A0<‑>\u00A0%6 z:\u00A0%7\u00A0<‑>\u00A0%8")
-                               .arg(areaName,
-                                    QString::number(areaId),
-                                    QString::number(area->min_x),
-                                    QString::number(area->max_x),
-                                    QString::number(area->min_y),
-                                    QString::number(area->max_y),
-                                    QString::number(area->min_z),
-                                    QString::number(area->max_z)));
+                    tr("Area:\u00A0%1 ID:\u00A0%2 x:\u00A0%3\u00A0<‑>\u00A0%4 y:\u00A0%5\u00A0<‑>\u00A0%6 z:\u00A0%7\u00A0<‑>\u00A0%8")
+                            .arg(areaName,
+                                 QString::number(areaId),
+                                 QString::number(area->min_x),
+                                 QString::number(area->max_x),
+                                 QString::number(area->min_y),
+                                 QString::number(area->max_y),
+                                 QString::number(area->min_z),
+                                 QString::number(area->max_z)));
         } else {
             infoText = QChar::LineFeed;
         }
@@ -166,12 +165,12 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
             please consider at which points the text may be divided to fit onto more than one line.
             */
             infoText.append(tr("Room\u00A0ID:\u00A0%1 Position\u00A0on\u00A0Map: (%2,%3,%4) \u2011\u00A0%5")
-                            .arg(QString::number(roomID),
-                                 QString::number(room->x()),
-                                 QString::number(room->y()),
-                                 QString::number(room->z()),
-            //: This description is shown when NO room is selected.
-                                 tr("Current player location")))
+                                    .arg(QString::number(roomID),
+                                         QString::number(room->x()),
+                                         QString::number(room->y()),
+                                         QString::number(room->z()),
+                                         //: This description is shown when NO room is selected.
+                                         tr("Current player location")))
                     .append(QChar::LineFeed);
             if (areaId != displayAreaId) {
                 isItalic = true;
@@ -189,12 +188,12 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
             please consider at which points the text may be divided to fit onto more than one line.
             */
             infoText.append(tr("Room\u00A0ID:\u00A0%1 Position\u00A0on\u00A0Map: (%2,%3,%4) \u2011\u00A0%5")
-                            .arg(QString::number(roomID),
-                                 QString::number(room->x()),
-                                 QString::number(room->y()),
-                                 QString::number(room->z()),
-            //: This description is shown when EXACTLY ONE room is selected.
-                                 tr("Selected room")))
+                                    .arg(QString::number(roomID),
+                                         QString::number(room->x()),
+                                         QString::number(room->y()),
+                                         QString::number(room->z()),
+                                         //: This description is shown when EXACTLY ONE room is selected.
+                                         tr("Selected room")))
                     .append(QChar::LineFeed);
             isBold = true;
             if (infoColor.lightness() > 127) {
@@ -213,12 +212,12 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
             please consider at which points the text may be divided to fit onto more than one line.
             */
             infoText.append(tr("Room\u00A0ID:\u00A0%1 Position\u00A0on\u00A0Map: (%2,%3,%4) \u2011\u00A0%5")
-                            .arg(QString::number(roomID),
-                                 QString::number(room->x()),
-                                 QString::number(room->y()),
-                                 QString::number(room->z()),
-            //: This description is shown when MORE THAN ONE room is selected.
-                                 tr("Center of %n selected rooms", nullptr, selectionSize)))
+                                    .arg(QString::number(roomID),
+                                         QString::number(room->x()),
+                                         QString::number(room->y()),
+                                         QString::number(room->z()),
+                                         //: This description is shown when MORE THAN ONE room is selected.
+                                         tr("Center of %n selected rooms", nullptr, selectionSize)))
                     .append(QChar::LineFeed);
             isBold = true;
             if (infoColor.lightness() > 127) {

--- a/src/modern_glwidget.cpp
+++ b/src/modern_glwidget.cpp
@@ -102,8 +102,7 @@ void ModernGLWidget::initializeGL()
     if (context) {
         QSurfaceFormat format = context->format();
         qDebug() << "OpenGL Version:" << format.majorVersion() << "." << format.minorVersion();
-        qDebug() << "OpenGL Profile:" << (format.profile() == QSurfaceFormat::CoreProfile ? "Core" :
-                                         format.profile() == QSurfaceFormat::CompatibilityProfile ? "Compatibility" : "NoProfile");
+        qDebug() << "OpenGL Profile:" << (format.profile() == QSurfaceFormat::CoreProfile ? "Core" : format.profile() == QSurfaceFormat::CompatibilityProfile ? "Compatibility" : "NoProfile");
         qDebug() << "Debug Context:" << (format.testOption(QSurfaceFormat::DebugContext) ? "Enabled" : "Disabled");
     }
 
@@ -346,8 +345,7 @@ void ModernGLWidget::paintGL()
     } else {
         infoColor = QColor(Qt::white);
     }
-    dlgMapper::paintMapInfo(mFrameTimer, painter, mpHost, mpMap,
-                           mRID, mAID, 0, infoColor, 10, 10, width(), mFontHeight);
+    dlgMapper::paintMapInfo(mFrameTimer, painter, mpHost, mpMap, mRID, mAID, 0, infoColor, 10, 10, width(), mFontHeight);
 
     painter.end();
 }
@@ -413,12 +411,11 @@ void ModernGLWidget::renderRooms()
             // Current room: red
             QMatrix4x4 transform = QMatrix4x4();
             transform.translate(rx, ry, rz);
-            transform.scale(1.0f/scale, 1.0f/scale, 1.0f/scale/zFlattening);
+            transform.scale(1.0f / scale, 1.0f / scale, 1.0f / scale / zFlattening);
             currentRoomInstances.append(CubeInstanceData(transform, 1.0f, 0.0f, 0.0f, 1.0f));
 
             if (mpHost && mpHost->experimentEnabled("experiment.3d-player-icon")) {
-                GeometryData playerIcon = mGeometryManager.generatePlayerIconGeometry(
-                    mPlayerIconScale, mPlayerIconRotationX, mPlayerIconRotationY, mPlayerIconRotationZ);
+                GeometryData playerIcon = mGeometryManager.generatePlayerIconGeometry(mPlayerIconScale, mPlayerIconRotationX, mPlayerIconRotationY, mPlayerIconRotationZ);
                 if (!playerIcon.isEmpty()) {
                     // Create modified geometry positioned slightly above the current room
                     GeometryData positionedIcon = playerIcon;
@@ -456,7 +453,7 @@ void ModernGLWidget::renderRooms()
             // Target room: green
             QMatrix4x4 transform = QMatrix4x4();
             transform.translate(rx, ry, rz);
-            transform.scale(1.0f/scale, 1.0f/scale, 1.0f/scale/zFlattening);
+            transform.scale(1.0f / scale, 1.0f / scale, 1.0f / scale / zFlattening);
             targetRoomInstances.append(CubeInstanceData(transform, 0.0f, 1.0f, 0.0f, 1.0f));
         } else {
             // Normal room: use planeColor logic based on z-level relationship
@@ -492,8 +489,7 @@ void ModernGLWidget::renderRooms()
                 roomAlpha = 1.0f; // Full opacity
 
                 if (levelDistance > 0) {
-                    qDebug() << "[Sliding Darkness] Room Z:" << rz << "Player Z:" << pz
-                             << "Distance:" << levelDistance << "Darkness factor:" << darknessFactor;
+                    qDebug() << "[Sliding Darkness] Room Z:" << rz << "Player Z:" << pz << "Distance:" << levelDistance << "Darkness factor:" << darknessFactor;
                 }
             } else {
                 // Original rendering: rooms above are dark and transparent
@@ -510,13 +506,13 @@ void ModernGLWidget::renderRooms()
 
             QMatrix4x4 transform = QMatrix4x4();
             transform.translate(rx, ry, rz);
-            transform.scale(1.0f/scale, 1.0f/scale, 1.0f/scale/zFlattening);
+            transform.scale(1.0f / scale, 1.0f / scale, 1.0f / scale / zFlattening);
             mainRoomInstances.append(CubeInstanceData(transform, redComponent, greenComponent, blueComponent, roomAlpha));
         }
 
         // 2. Collect environment color overlay data
         QColor envColor = getEnvironmentColor(pR);
-        float overlayZ = rz + 0.25f/zFlattening; // Slightly above the main cube
+        float overlayZ = rz + 0.25f / zFlattening; // Slightly above the main cube
         float envRed = envColor.redF();
         float envGreen = envColor.greenF();
         float envBlue = envColor.blueF();
@@ -560,44 +556,34 @@ void ModernGLWidget::renderRooms()
         overlayInstances.append(CubeInstanceData(transform, envRed, envGreen, envBlue, overlayAlpha));
 
         // 3. Render up/down exit indicators on the overlay (keep individual rendering for now)
-        renderUpDownIndicators(pR, rx, ry, overlayZ + (1.0f / scale / zFlattening) + 0.1f/zFlattening);
+        renderUpDownIndicators(pR, rx, ry, overlayZ + (1.0f / scale / zFlattening) + 0.1f / zFlattening);
 
         // 4. Render in/out exit indicators on the overlay (keep individual rendering for now)
-        renderInOutIndicators(pR, rx, ry, overlayZ + (1.0f / scale / zFlattening) + 0.1f/zFlattening);
+        renderInOutIndicators(pR, rx, ry, overlayZ + (1.0f / scale / zFlattening) + 0.1f / zFlattening);
     }
 
     // Create instanced render commands for each batch
     if (!mainRoomInstances.isEmpty()) {
-        auto command = std::make_unique<RenderInstancedCubesCommand>(mainRoomInstances,
-                                                                    mCameraController.getProjectionMatrix(),
-                                                                    mCameraController.getViewMatrix(),
-                                                                    mCameraController.getModelMatrix());
+        auto command = std::make_unique<RenderInstancedCubesCommand>(mainRoomInstances, mCameraController.getProjectionMatrix(), mCameraController.getViewMatrix(), mCameraController.getModelMatrix());
         mRenderCommandQueue.addCommand(std::move(command));
     }
 
     if (!currentRoomInstances.isEmpty()) {
-        auto command = std::make_unique<RenderInstancedCubesCommand>(currentRoomInstances,
-                                                                    mCameraController.getProjectionMatrix(),
-                                                                    mCameraController.getViewMatrix(),
-                                                                    mCameraController.getModelMatrix());
+        auto command =
+                std::make_unique<RenderInstancedCubesCommand>(currentRoomInstances, mCameraController.getProjectionMatrix(), mCameraController.getViewMatrix(), mCameraController.getModelMatrix());
         mRenderCommandQueue.addCommand(std::move(command));
     }
 
     if (!targetRoomInstances.isEmpty()) {
-        auto command = std::make_unique<RenderInstancedCubesCommand>(targetRoomInstances,
-                                                                    mCameraController.getProjectionMatrix(),
-                                                                    mCameraController.getViewMatrix(),
-                                                                    mCameraController.getModelMatrix());
+        auto command =
+                std::make_unique<RenderInstancedCubesCommand>(targetRoomInstances, mCameraController.getProjectionMatrix(), mCameraController.getViewMatrix(), mCameraController.getModelMatrix());
         mRenderCommandQueue.addCommand(std::move(command));
     }
 
     if (!overlayInstances.isEmpty()) {
         // Keep depth testing enabled for overlays (was conditional with experiment.always-depth-test)
 
-        auto command = std::make_unique<RenderInstancedCubesCommand>(overlayInstances,
-                                                                    mCameraController.getProjectionMatrix(),
-                                                                    mCameraController.getViewMatrix(),
-                                                                    mCameraController.getModelMatrix());
+        auto command = std::make_unique<RenderInstancedCubesCommand>(overlayInstances, mCameraController.getProjectionMatrix(), mCameraController.getViewMatrix(), mCameraController.getModelMatrix());
         mRenderCommandQueue.addCommand(std::move(command));
 
         // Re-enable depth testing for subsequent rendering
@@ -715,20 +701,20 @@ void ModernGLWidget::renderConnections()
                 lineColors << r << g << b << connectionAlpha; // End color
 
                 // for volume exits we calculate the cube transformation we need
-                const QVector3D exitVector = QVector3D(ex-rx, ey-ry, ez-rz);
+                const QVector3D exitVector = QVector3D(ex - rx, ey - ry, ez - rz);
                 const QQuaternion alignmentQuat = QQuaternion::rotationTo(zVector, exitVector);
                 QMatrix4x4 transform = QMatrix4x4();
                 if (inOut) {
-                    transform.translate(3.0f*exitVector/8.0f);
+                    transform.translate(3.0f * exitVector / 8.0f);
                     transform.translate(rx, ry, rz);
                     transform.rotate(alignmentQuat);
-                    transform.scale(0.02f, 0.02f, exitVector.length()/16.0f);
+                    transform.scale(0.02f, 0.02f, exitVector.length() / 16.0f);
                     roomConnectionInstances.append(CubeInstanceData(transform, r, g, b, connectionAlpha));
                 } else {
-                    transform.translate(exitVector/4.0f);
+                    transform.translate(exitVector / 4.0f);
                     transform.translate(rx, ry, rz);
                     transform.rotate(alignmentQuat);
-                    transform.scale(0.02f, 0.02f, exitVector.length()/4.0f);
+                    transform.scale(0.02f, 0.02f, exitVector.length() / 4.0f);
                     roomConnectionInstances.append(CubeInstanceData(transform, r, g, b, connectionAlpha));
                 }
             } else {
@@ -794,39 +780,39 @@ void ModernGLWidget::renderConnections()
                 lineColors << exitRed << exitGreen << exitBlue << exitAlpha; // End color
 
                 // for volume exits we calculate the cube transformation we need
-                const QVector3D exitVector = QVector3D(dx-rx, dy-ry, dz-rz);
+                const QVector3D exitVector = QVector3D(dx - rx, dy - ry, dz - rz);
                 const QQuaternion alignmentQuat = QQuaternion::rotationTo(zVector, exitVector);
                 // double length of normal exits since this exit is one sided
                 QMatrix4x4 transform = QMatrix4x4();
                 if (inOut) {
-                    transform.translate(3.0f*exitVector/8.0f);
+                    transform.translate(3.0f * exitVector / 8.0f);
                     transform.translate(rx, ry, rz);
                     transform.rotate(alignmentQuat);
-                    transform.scale(0.02f, 0.02f, exitVector.length()/16.0f);
+                    transform.scale(0.02f, 0.02f, exitVector.length() / 16.0f);
                     roomConnectionInstances.append(CubeInstanceData(transform, exitRed, exitGreen, exitBlue, exitAlpha));
                     transform.setToIdentity();
-                    transform.translate(5.0f*exitVector/8.0f);
+                    transform.translate(5.0f * exitVector / 8.0f);
                     transform.translate(rx, ry, rz);
                     transform.rotate(alignmentQuat);
-                    transform.scale(0.02f, 0.02f, exitVector.length()/16.0f);
+                    transform.scale(0.02f, 0.02f, exitVector.length() / 16.0f);
                     roomConnectionInstances.append(CubeInstanceData(transform, exitRed, exitGreen, exitBlue, exitAlpha));
                 } else {
-                    transform.translate(exitVector/2.0f);
+                    transform.translate(exitVector / 2.0f);
                     transform.translate(rx, ry, rz);
                     transform.rotate(alignmentQuat);
-                    transform.scale(0.02f, 0.02f, exitVector.length()/2.0f);
+                    transform.scale(0.02f, 0.02f, exitVector.length() / 2.0f);
                     roomConnectionInstances.append(CubeInstanceData(transform, exitRed, exitGreen, exitBlue, exitAlpha));
                 }
 
                 // Render green area exit cube at the destination position with translucency and darkening
                 transform.setToIdentity();
                 transform.translate(dx, dy, dz);
-                transform.scale(1.0f/scale, 1.0f/scale, 1.0f/scale/zFlattening);
+                transform.scale(1.0f / scale, 1.0f / scale, 1.0f / scale / zFlattening);
                 areaExitInstances.append(CubeInstanceData(transform, exitRed, exitGreen, exitBlue, exitAlpha));
 
                 // Render smaller environment overlay rectangle on top with translucency and darkening
                 QColor envColor = getEnvironmentColor(pExit);
-                float overlayZ = dz + 0.25f/zFlattening;
+                float overlayZ = dz + 0.25f / zFlattening;
                 float overlayAlpha = exitAboveCurrentLevel ? 0.16f : 0.8f; // 0.2 * 0.8 for above level
 
                 // Darken area exit environment overlay if above current level
@@ -844,7 +830,7 @@ void ModernGLWidget::renderConnections()
 
                 transform.setToIdentity();
                 transform.translate(dx, dy, overlayZ);
-                transform.scale(0.5f/scale, 0.5f/scale, 1.0f/scale/zFlattening);
+                transform.scale(0.5f / scale, 0.5f / scale, 1.0f / scale / zFlattening);
                 areaExitInstances.append(CubeInstanceData(transform, exitEnvRed, exitEnvGreen, exitEnvBlue, overlayAlpha));
             }
         }
@@ -856,10 +842,8 @@ void ModernGLWidget::renderConnections()
 
     // Always render room connection volumes
     if (!roomConnectionInstances.isEmpty()) {
-        auto command = std::make_unique<RenderInstancedCubesCommand>(roomConnectionInstances,
-                                                                    mCameraController.getProjectionMatrix(),
-                                                                    mCameraController.getViewMatrix(),
-                                                                    mCameraController.getModelMatrix());
+        auto command =
+                std::make_unique<RenderInstancedCubesCommand>(roomConnectionInstances, mCameraController.getProjectionMatrix(), mCameraController.getViewMatrix(), mCameraController.getModelMatrix());
         mRenderCommandQueue.addCommand(std::move(command));
 
     } else {
@@ -870,22 +854,15 @@ void ModernGLWidget::renderConnections()
     }
 
     if (!areaExitInstances.isEmpty()) {
-        auto command = std::make_unique<RenderInstancedCubesCommand>(areaExitInstances,
-                                                                    mCameraController.getProjectionMatrix(),
-                                                                    mCameraController.getViewMatrix(),
-                                                                    mCameraController.getModelMatrix());
+        auto command = std::make_unique<RenderInstancedCubesCommand>(areaExitInstances, mCameraController.getProjectionMatrix(), mCameraController.getViewMatrix(), mCameraController.getModelMatrix());
         mRenderCommandQueue.addCommand(std::move(command));
     }
-
 }
 
 void ModernGLWidget::renderCube(float x, float y, float z, float size, float r, float g, float b, float a)
 {
     // Create render command and queue it
-    auto command = std::make_unique<RenderCubeCommand>(x, y, z, size, r, g, b, a,
-                                                      mCameraController.getProjectionMatrix(),
-                                                      mCameraController.getViewMatrix(),
-                                                      mCameraController.getModelMatrix());
+    auto command = std::make_unique<RenderCubeCommand>(x, y, z, size, r, g, b, a, mCameraController.getProjectionMatrix(), mCameraController.getViewMatrix(), mCameraController.getModelMatrix());
     mRenderCommandQueue.addCommand(std::move(command));
 }
 
@@ -1048,7 +1025,7 @@ void ModernGLWidget::slot_shiftCameraDown()
 {
     const float angle = 3.0f;
     QVector3D currentPosition = mCameraController.getPosition();
-    mCameraController.setPosition(currentPosition[0], currentPosition[1]+angle, currentPosition[2]);
+    mCameraController.setPosition(currentPosition[0], currentPosition[1] + angle, currentPosition[2]);
     is2DView = false;
     update();
 }
@@ -1057,7 +1034,7 @@ void ModernGLWidget::slot_shiftCameraUp()
 {
     const float angle = 3.0f;
     QVector3D currentPosition = mCameraController.getPosition();
-    mCameraController.setPosition(currentPosition[0], currentPosition[1]-angle, currentPosition[2]);
+    mCameraController.setPosition(currentPosition[0], currentPosition[1] - angle, currentPosition[2]);
     is2DView = false;
     update();
 }
@@ -1066,7 +1043,7 @@ void ModernGLWidget::slot_shiftCameraLeft()
 {
     const float angle = 3.0f;
     QVector3D currentPosition = mCameraController.getPosition();
-    mCameraController.setPosition(currentPosition[0], currentPosition[1], currentPosition[2]-angle);
+    mCameraController.setPosition(currentPosition[0], currentPosition[1], currentPosition[2] - angle);
     is2DView = false;
     update();
 }
@@ -1075,7 +1052,7 @@ void ModernGLWidget::slot_shiftCameraRight()
 {
     const float angle = 3.0f;
     QVector3D currentPosition = mCameraController.getPosition();
-    mCameraController.setPosition(currentPosition[0], currentPosition[1], currentPosition[2]+angle);
+    mCameraController.setPosition(currentPosition[0], currentPosition[1], currentPosition[2] + angle);
     is2DView = false;
     update();
 }
@@ -1106,11 +1083,11 @@ void ModernGLWidget::mousePressEvent(QMouseEvent* event)
 {
     // Implement mouse handling (placeholder)
     mudlet::self()->activateProfile(mpHost);
-    if (!mpMap||!mpMap->mpRoomDB) {
+    if (!mpMap || !mpMap->mpRoomDB) {
         return;
     }
 
-    if (event->buttons() & Qt::LeftButton) {        // translation on xy-plane
+    if (event->buttons() & Qt::LeftButton) { // translation on xy-plane
         auto eventPos = event->position().toPoint();
         const int x = eventPos.x();
         const int y = height() - eventPos.y(); // the opengl origin is at bottom left
@@ -1122,7 +1099,7 @@ void ModernGLWidget::mousePressEvent(QMouseEvent* event)
 
 void ModernGLWidget::mouseMoveEvent(QMouseEvent* event)
 {
-    if (!mpMap||!mpMap->mpRoomDB) {
+    if (!mpMap || !mpMap->mpRoomDB) {
         return;
     }
     if (mPanMode) {
@@ -1234,15 +1211,16 @@ void ModernGLWidget::slot_resetPlayerIcon()
     mPlayerIconScale = 0.0055f;
 
 #ifdef DEBUG_PLAYER_ICON_CONTROLS
-    qDebug() << "Player Icon RESET - Height:" << mPlayerIconHeight << "RotX:" << mPlayerIconRotationX << "RotY:" << mPlayerIconRotationY << "RotZ:" << mPlayerIconRotationZ << "Scale:" << mPlayerIconScale;
+    qDebug() << "Player Icon RESET - Height:" << mPlayerIconHeight << "RotX:" << mPlayerIconRotationX << "RotY:" << mPlayerIconRotationY << "RotZ:" << mPlayerIconRotationZ
+             << "Scale:" << mPlayerIconScale;
 #endif
 
     // Reset the slider values to their defaults (need to emit signals to update UI)
     // Convert back to slider values
-    emit resetPlayerIconSliders(static_cast<int>(mPlayerIconHeight * 100.0f), // height: 51
-                                static_cast<int>(mPlayerIconRotationX),        // rotX: 1
-                                static_cast<int>(mPlayerIconRotationY),        // rotY: -56
-                                static_cast<int>(mPlayerIconRotationZ),        // rotZ: 20
+    emit resetPlayerIconSliders(static_cast<int>(mPlayerIconHeight * 100.0f),   // height: 51
+                                static_cast<int>(mPlayerIconRotationX),         // rotX: 1
+                                static_cast<int>(mPlayerIconRotationY),         // rotY: -56
+                                static_cast<int>(mPlayerIconRotationZ),         // rotZ: 20
                                 static_cast<int>(mPlayerIconScale * 10000.0f)); // scale: 55
 
     update();
@@ -1255,10 +1233,7 @@ void ModernGLWidget::renderLines(const QVector<float>& vertices, const QVector<f
     }
 
     // Create render command and queue it
-    auto command = std::make_unique<RenderLinesCommand>(vertices, colors,
-                                                       mCameraController.getProjectionMatrix(),
-                                                       mCameraController.getViewMatrix(),
-                                                       mCameraController.getModelMatrix());
+    auto command = std::make_unique<RenderLinesCommand>(vertices, colors, mCameraController.getProjectionMatrix(), mCameraController.getViewMatrix(), mCameraController.getModelMatrix());
     mRenderCommandQueue.addCommand(std::move(command));
 }
 
@@ -1269,10 +1244,7 @@ void ModernGLWidget::renderTriangles(const QVector<float>& vertices, const QVect
     }
 
     // Create render command and queue it
-    auto command = std::make_unique<RenderTrianglesCommand>(vertices, colors,
-                                                           mCameraController.getProjectionMatrix(),
-                                                           mCameraController.getViewMatrix(),
-                                                           mCameraController.getModelMatrix());
+    auto command = std::make_unique<RenderTrianglesCommand>(vertices, colors, mCameraController.getProjectionMatrix(), mCameraController.getViewMatrix(), mCameraController.getModelMatrix());
     mRenderCommandQueue.addCommand(std::move(command));
 }
 
@@ -1345,11 +1317,11 @@ void ModernGLWidget::renderInOutIndicators(TRoom* pRoom, float x, float y, float
         // triangle pointing inwards: top-left, bottom-left, mid-center
         triangleVertices << (x - width) << (y + halfHeight) << z; // Top-left
         triangleVertices << (x - width) << (y - halfHeight) << z; // Bottom-left
-        triangleVertices << x << y << z;              // Mid-center
+        triangleVertices << x << y << z;                          // Mid-center
         // triangle pointing inwards: top-right, bottom-right, mid-center
         triangleVertices << (x + width) << (y + halfHeight) << z; // Top-right
         triangleVertices << (x + width) << (y - halfHeight) << z; // Bottom-right
-        triangleVertices << x << y << z;              // Mid-center
+        triangleVertices << x << y << z;                          // Mid-center
 
         // Add gray color for all six vertices
         for (int i = 0; i < 6; ++i) {
@@ -1362,11 +1334,11 @@ void ModernGLWidget::renderInOutIndicators(TRoom* pRoom, float x, float y, float
         // triangle pointing outwards: top-left, bottom-left, out-center
         triangleVertices << (x - width) << (y + halfHeight) << z; // Top-left
         triangleVertices << (x - width) << (y - halfHeight) << z; // Bottom-left
-        triangleVertices << x - 1.0f/scale << y << z;              // Outside-center
+        triangleVertices << x - 1.0f / scale << y << z;           // Outside-center
         // triangle pointing outwards: top-right, bottom-right, out-center
         triangleVertices << (x + width) << (y + halfHeight) << z; // Top-right
         triangleVertices << (x + width) << (y - halfHeight) << z; // Bottom-right
-        triangleVertices << x + 1.0f/scale << y << z;              // Outside-center
+        triangleVertices << x + 1.0f / scale << y << z;           // Outside-center
 
         // Add gray color for all six vertices
         for (int i = 0; i < 6; ++i) {
@@ -1452,9 +1424,7 @@ QColor ModernGLWidget::getPlaneColor(int zLevel, bool belowOrAtLevel)
         // qDebug() << "Using planeColor[" << ef << "] for room above level";
     }
 
-    return QColor(static_cast<int>(color[0] * 255),
-                  static_cast<int>(color[1] * 255),
-                  static_cast<int>(color[2] * 255),
+    return QColor(static_cast<int>(color[0] * 255), static_cast<int>(color[1] * 255), static_cast<int>(color[2] * 255),
                   255); // Use full alpha for room colors
 }
 
@@ -1553,7 +1523,6 @@ QColor ModernGLWidget::getEnvironmentColor(TRoom* pRoom)
 
 void ModernGLWidget::startSmoothTransition(int targetAID, int targetX, int targetY, int targetZ)
 {
-
     // Set up animation parameters
     mTargetAID = targetAID;
     mTargetMapCenterX = static_cast<float>(targetX);
@@ -1620,7 +1589,6 @@ void ModernGLWidget::onCameraAnimationTick()
         mCurrentAnimationX = mStartMapCenterX + (mTargetMapCenterX - mStartMapCenterX) * easedProgress;
         mCurrentAnimationY = mStartMapCenterY + (mTargetMapCenterY - mStartMapCenterY) * easedProgress;
         mCurrentAnimationZ = mStartMapCenterZ + (mTargetMapCenterZ - mStartMapCenterZ) * easedProgress;
-
     }
 
     // Update camera controller with current floating-point position

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -231,7 +231,7 @@ void mudlet::init()
     setupUi(this);
     setUnifiedTitleAndToolBarOnMac(true);
     setContentsMargins(0, 0, 0, 0);
-    setAcceptDrops(true);  // Enable drag and drop for profile tabs
+    setAcceptDrops(true); // Enable drag and drop for profile tabs
     menuGames->setToolTipsVisible(true);
     menuEditor->setToolTipsVisible(true);
     menuOptions->setToolTipsVisible(true);
@@ -257,8 +257,7 @@ void mudlet::init()
 
     // Add context menu to toolbar for show/hide functionality
     mpMainToolBar->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(mpMainToolBar, &QWidget::customContextMenuRequested,
-            this, &mudlet::slot_showMainToolBarContextMenu);
+    connect(mpMainToolBar, &QWidget::customContextMenuRequested, this, &mudlet::slot_showMainToolBarContextMenu);
     addToolBarBreak();
     auto frame = new QWidget(this);
     setCentralWidget(frame);
@@ -273,16 +272,13 @@ void mudlet::init()
     connect(mpTabBar, &QTabBar::currentChanged, this, &mudlet::slot_tabChanged);
     connect(mpTabBar, &QTabBar::tabMoved, this, &mudlet::slot_tabMoved);
     // Connect the tab bar's detach signal
-    connect(mpTabBar, &TTabBar::tabDetachRequested,
-            this, &mudlet::slot_tabDetachRequested);
+    connect(mpTabBar, &TTabBar::tabDetachRequested, this, &mudlet::slot_tabDetachRequested);
     // Connect the tab bar's reattach signal (for drag and drop reattachment)
-    connect(mpTabBar, &TTabBar::tabReattachRequested,
-            this, &mudlet::slot_tabReattachRequested);
+    connect(mpTabBar, &TTabBar::tabReattachRequested, this, &mudlet::slot_tabReattachRequested);
 
     // Add context menu to tab bar for toolbar visibility options
     mpTabBar->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(mpTabBar, &QWidget::customContextMenuRequested,
-            this, &mudlet::slot_showTabContextMenu);
+    connect(mpTabBar, &QWidget::customContextMenuRequested, this, &mudlet::slot_showTabContextMenu);
     auto layoutTopLevel = new QVBoxLayout(frame);
     layoutTopLevel->setContentsMargins(0, 0, 0, 0);
     layoutTopLevel->addWidget(mpTabBar);
@@ -518,10 +514,11 @@ void mudlet::init()
 #if defined(INCLUDE_UPDATER)
     if (publicTestVersion) {
         mpActionReportIssue = new QAction(tr("Report issue"), this);
-        const QStringList issueReportIcons {"face-uncertain.png", "face-surprise.png", "face-smile.png", "face-sad.png", "face-plain.png"};
+        const QStringList issueReportIcons{"face-uncertain.png", "face-surprise.png", "face-smile.png", "face-sad.png", "face-plain.png"};
         auto randomIcon = QRandomGenerator::global()->bounded(issueReportIcons.size());
         mpActionReportIssue->setIcon(QIcon(qsl(":/icons/%1").arg(issueReportIcons.at(randomIcon))));
-        mpActionReportIssue->setToolTip(utils::richText(tr("The public test build gets newer features to you quicker, and you help us find issues in them quicker. Spotted something odd? Let us know asap!")));
+        mpActionReportIssue->setToolTip(
+                utils::richText(tr("The public test build gets newer features to you quicker, and you help us find issues in them quicker. Spotted something odd? Let us know asap!")));
         mpMainToolBar->addAction(mpActionReportIssue);
         mpActionReportIssue->setObjectName(qsl("reportissue_action"));
         mpMainToolBar->widgetForAction(mpActionReportIssue)->setObjectName(mpActionReportIssue->objectName());
@@ -798,21 +795,21 @@ void mudlet::init()
     // PLACEMARKER: sample benchmarking code
     // looking to benchmark old/new code? Use this example
     // full docs at https://nanobench.ankerl.com
-//    ankerl::nanobench::Bench benchmark;
-//    benchmark.title("Example benchmark")
-//            .minEpochIterations(2000)
-//            .warmup(100)
-//            .relative(true);
+    //    ankerl::nanobench::Bench benchmark;
+    //    benchmark.title("Example benchmark")
+    //            .minEpochIterations(2000)
+    //            .warmup(100)
+    //            .relative(true);
 
-//    benchmark.run("old code", [this] {
-//        loadMaps();
-//    });
+    //    benchmark.run("old code", [this] {
+    //        loadMaps();
+    //    });
 
-//    benchmark.run("new code", [this] {
-//        for (int i = 0; i < 2; i++) {
-//            loadMaps();
-//        }
-//    });
+    //    benchmark.run("new code", [this] {
+    //        for (int i = 0; i < 2; i++) {
+    //            loadMaps();
+    //        }
+    //    });
 }
 
 static QString findExecutableDir()
@@ -951,380 +948,381 @@ void mudlet::loadMaps()
     // Initially populated from the dictionaries provided within the Debian
     // GNU/Linux distribution:
     //: In the translation source texts the language is the leading term, with, generally, the (primary) country(ies) in the brackets, with a trailing language disabiguation after a '-' Chinese is an exception!
-    mDictionaryLanguageCodeMap = {{qsl("af"), tr("Afrikaans")},
-                                  {qsl("af_za"), tr("Afrikaans (South Africa)")},
-                                  {qsl("an"), tr("Aragonese")},
-                                  {qsl("an_es"), tr("Aragonese (Spain)")},
-                                  {qsl("ar"), tr("Arabic")},
-                                  {qsl("ar_ae"), tr("Arabic (United Arab Emirates)")},
-                                  {qsl("ar_bh"), tr("Arabic (Bahrain)")},
-                                  {qsl("ar_dz"), tr("Arabic (Algeria)")},
-                                  {qsl("ar_eg"), tr("Arabic (Egypt)")},
-                                  {qsl("ar_in"), tr("Arabic (India)")},
-                                  {qsl("ar_iq"), tr("Arabic (Iraq)")},
-                                  {qsl("ar_jo"), tr("Arabic (Jordan)")},
-                                  {qsl("ar_kw"), tr("Arabic (Kuwait)")},
-                                  {qsl("ar_lb"), tr("Arabic (Lebanon)")},
-                                  {qsl("ar_ly"), tr("Arabic (Libya)")},
-                                  {qsl("ar_ma"), tr("Arabic (Morocco)")},
-                                  {qsl("ar_om"), tr("Arabic (Oman)")},
-                                  {qsl("ar_qa"), tr("Arabic (Qatar)")},
-                                  {qsl("ar_sa"), tr("Arabic (Saudi Arabia)")},
-                                  {qsl("ar_sd"), tr("Arabic (Sudan)")},
-                                  {qsl("ar_sy"), tr("Arabic (Syria)")},
-                                  {qsl("ar_tn"), tr("Arabic (Tunisia)")},
-                                  {qsl("ar_ye"), tr("Arabic (Yemen)")},
-                                  {qsl("be"), tr("Belarusian")},
-                                  {qsl("be_by"), tr("Belarusian (Belarus)")},
-                                  {qsl("be_ru"), tr("Belarusian (Russia)")},
-                                  {qsl("bg"), tr("Bulgarian")},
-                                  {qsl("bg_bg"), tr("Bulgarian (Bulgaria)")},
-                                  {qsl("bn"), tr("Bangla")},
-                                  {qsl("bn_bd"), tr("Bangla (Bangladesh)")},
-                                  {qsl("bn_in"), tr("Bangla (India)")},
-                                  {qsl("bo"), tr("Tibetan")},
-                                  {qsl("bo_cn"), tr("Tibetan (China)")},
-                                  {qsl("bo_in"), tr("Tibetan (India)")},
-                                  {qsl("br"), tr("Breton")},
-                                  {qsl("br_fr"), tr("Breton (France)")},
-                                  {qsl("bs"), tr("Bosnian")},
-                                  {qsl("bs_ba"), tr("Bosnian (Bosnia/Herzegovina)")},
-                                  {qsl("bs_ba_cyrl"), tr("Bosnian (Bosnia/Herzegovina - Cyrillic alphabet)")},
-                                  {qsl("ca"), tr("Catalan")},
-                                  {qsl("ca_es"), tr("Catalan (Spain)")},
-                                  {qsl("ca_es_valencia"), tr("Catalan (Spain - Valencian)")},
-                                  {qsl("ckb"), tr("Central Kurdish")},
-                                  {qsl("ckb_iq"), tr("Central Kurdish (Iraq)")},
-                                  {qsl("cs"), tr("Czech")},
-                                  {qsl("cs_cz"), tr("Czech (Czechia)")},
-                                  {qsl("cy"), tr("Welsh")},
-                                  {qsl("cy_gb"), tr("Welsh (United Kingdom {Wales})")},
-                                  {qsl("da"), tr("Danish")},
-                                  {qsl("da_dk"), tr("Danish (Denmark)")},
-                                  {qsl("de"), tr("German")},
-                                  {qsl("de_at"), tr("German (Austria)")},
-                                  {qsl("de_at_frami"), tr("German (Austria, revised by F M Baumann)")},
-                                  {qsl("de_be"), tr("German (Belgium)")},
-                                  {qsl("de_ch"), tr("German (Switzerland)")},
-                                  {qsl("de_ch_frami"), tr("German (Switzerland, revised by F M Baumann)")},
-                                  {qsl("de_de"), tr("German (Germany/Belgium/Luxemburg)")},
-                                  {qsl("de_de_frami"), tr("German (Germany/Belgium/Luxemburg, revised by F M Baumann)")},
-                                  {qsl("de_li"), tr("German (Liechtenstein)")},
-                                  {qsl("de_lu"), tr("German (Luxembourg)")},
-                                  {qsl("dz"), tr("Dzongkha")},
-                                  {qsl("dz_bt"), tr("Dzongkha (Bhutan)")},
-                                  {qsl("el"), tr("Greek")},
-                                  {qsl("el_gr"), tr("Greek (Greece)")},
-                                  {qsl("en"), tr("English")},
-                                  {qsl("en_ag"), tr("English (Antigua/Barbuda)")},
-                                  {qsl("en_au"), tr("English (Australia)")},
-                                  {qsl("en_au_large"), tr("English (Australia, Large)", "This dictionary contains larger vocabulary.")},
-                                  {qsl("en_bs"), tr("English (Bahamas)")},
-                                  {qsl("en_bw"), tr("English (Botswana)")},
-                                  {qsl("en_bz"), tr("English (Belize)")},
-                                  {qsl("en_ca"), tr("English (Canada)")},
-                                  {qsl("en_ca_large"), tr("English (Canada, Large)", "This dictionary contains larger vocabulary.")},
-                                  {qsl("en_dk"), tr("English (Denmark)")},
-                                  {qsl("en_gb"), tr("English (United Kingdom)")},
-                                  {qsl("en_gb_large"), tr("English (United Kingdom, Large)", "This dictionary contains larger vocabulary.")},
-                                  {qsl("en_gb_ise"), tr("English (United Kingdom - 'ise' not 'ize')", "This dictionary prefers the British 'ise' form over the American 'ize' one.")},
-                                  {qsl("en_gh"), tr("English (Ghana)")},
-                                  {qsl("en_hk"), tr("English (Hong Kong SAR China)")},
-                                  {qsl("en_ie"), tr("English (Ireland)")},
-                                  {qsl("en_in"), tr("English (India)")},
-                                  {qsl("en_jm"), tr("English (Jamaica)")},
-                                  {qsl("en_na"), tr("English (Namibia)")},
-                                  {qsl("en_ng"), tr("English (Nigeria)")},
-                                  {qsl("en_nz"), tr("English (New Zealand)")},
-                                  {qsl("en_ph"), tr("English (Philippines)")},
-                                  {qsl("en_sg"), tr("English (Singapore)")},
-                                  {qsl("en_tt"), tr("English (Trinidad/Tobago)")},
-                                  {qsl("en_us"), tr("English (United States)")},
-                                  {qsl("en_us_large"), tr("English (United States, Large)", "This dictionary contains larger vocabulary.")},
-                                  {qsl("en_za"), tr("English (South Africa)")},
-                                  {qsl("en_zw"), tr("English (Zimbabwe)")},
-                                  {qsl("eo"), tr("Esperanto")},
-                                  {qsl("es"), tr("Spanish")},
-                                  {qsl("es_ar"), tr("Spanish (Argentina)")},
-                                  {qsl("es_bo"), tr("Spanish (Bolivia)")},
-                                  {qsl("es_cl"), tr("Spanish (Chile)")},
-                                  {qsl("es_co"), tr("Spanish (Colombia)")},
-                                  {qsl("es_cr"), tr("Spanish (Costa Rica)")},
-                                  {qsl("es_cu"), tr("Spanish (Cuba)")},
-                                  {qsl("es_do"), tr("Spanish (Dominican Republic)")},
-                                  {qsl("es_ec"), tr("Spanish (Ecuador)")},
-                                  {qsl("es_es"), tr("Spanish (Spain)")},
-                                  {qsl("es_gt"), tr("Spanish (Guatemala)")},
-                                  {qsl("es_hn"), tr("Spanish (Honduras)")},
-                                  {qsl("es_mx"), tr("Spanish (Mexico)")},
-                                  {qsl("es_ni"), tr("Spanish (Nicaragua)")},
-                                  {qsl("es_pa"), tr("Spanish (Panama)")},
-                                  {qsl("es_pe"), tr("Spanish (Peru)")},
-                                  {qsl("es_pr"), tr("Spanish (Puerto Rico)")},
-                                  {qsl("es_py"), tr("Spanish (Paraguay)")},
-                                  {qsl("es_sv"), tr("Spanish (El Savador)")},
-                                  {qsl("es_us"), tr("Spanish (United States)")},
-                                  {qsl("es_uy"), tr("Spanish (Uruguay)")},
-                                  {qsl("es_ve"), tr("Spanish (Venezuela)")},
-                                  {qsl("et"), tr("Estonian")},
-                                  {qsl("et_ee"), tr("Estonian (Estonia)")},
-                                  {qsl("eu"), tr("Basque")},
-                                  {qsl("eu_es"), tr("Basque (Spain)")},
-                                  {qsl("eu_fr"), tr("Basque (France)")},
-                                  {qsl("fi"), tr("Finnish")},
-                                  {qsl("fi_fi"), tr("Finnish")},
-                                  {qsl("fo"), tr("Faroese")},
-                                  {qsl("fo_fo"), tr("Faroese (Faroe Islands)")},
-                                  {qsl("fr"), tr("French")},
-                                  // On OpenBSD this seems to be the "usual spellings of French,
-                                  // with, in addition, some new spellings rectifying past
-                                  // inconsistencies":
-                                  {qsl("fr_xx_classique"), tr("French")},
-                                  {qsl("fr_be"), tr("French (Belgium)")},
-                                  {qsl("fr_ca"), tr("French (Catalan)")},
-                                  {qsl("fr_ch"), tr("French (Switzerland)")},
-                                  {qsl("fr_fr"), tr("French (France)")},
-                                  {qsl("fr_lu"), tr("French (Luxemburg)")},
-                                  {qsl("fr_mc"), tr("French (Monaco)")},
-                                  {qsl("ga"), tr("Irish")},
-                                  {qsl("gd"), tr("Gaelic")},
-                                  {qsl("gd_gb"), tr("Gaelic (United Kingdom {Scots})")},
-                                  {qsl("gl"), tr("Galician")},
-                                  {qsl("gl_es"), tr("Galician (Spain)")},
-                                  {qsl("gn"), tr("Guarani")},
-                                  {qsl("gn_py"), tr("Guarani (Paraguay)")},
-                                  {qsl("gu"), tr("Gujarati")},
-                                  {qsl("gu_in"), tr("Gujarati (India)")},
-                                  // Debian uses gug instead of gn for some reason:
-                                  {qsl("gug"), tr("Guarani")},
-                                  {qsl("gug_py"), tr("Guarani (Paraguay)")},
-                                  {qsl("he"), tr("Hebrew")},
-                                  {qsl("he_il"), tr("Hebrew (Israel)")},
-                                  {qsl("hi"), tr("Hindi")},
-                                  {qsl("hi_in"), tr("Hindi (India)")},
-                                  {qsl("hr"), tr("Croatian")},
-                                  {qsl("hr_hr"), tr("Croatian (Croatia)")},
-                                  {qsl("hu"), tr("Hungarian")},
-                                  {qsl("hu_hu"), tr("Hungarian (Hungary)")},
-                                  {qsl("hy"), tr("Armenian")},
-                                  {qsl("hy_am"), tr("Armenian (Armenia)")},
-                                  {qsl("id"), tr("Indonesian")},
-                                  {qsl("id_id"), tr("Indonesian (Indonesia)")},
-                                  //: , formerly known as Occidental, and not to be mistaken for Interlingua
-                                  {qsl("ie"), tr("Interlingue")},
-                                  {qsl("is"), tr("Icelandic")},
-                                  {qsl("is_is"), tr("Icelandic (Iceland)")},
-                                  {qsl("it"), tr("Italian")},
-                                  {qsl("it_ch"), tr("Italian (Switzerland)")},
-                                  {qsl("it_it"), tr("Italian (Italy)")},
-                                  {qsl("kk"), tr("Kazakh")},
-                                  {qsl("kk_kz"), tr("Kazakh (Kazakhstan)")},
-                                  {qsl("kmr"), tr("Kurmanji")},
-                                  {qsl("kmr_latn"), tr("Kurmanji {Latin-alphabet Kurdish}")},
-                                  {qsl("ko"), tr("Korean")},
-                                  {qsl("ko_kr"), tr("Korean (South Korea)")},
-                                  {qsl("ku"), tr("Kurdish")},
-                                  {qsl("ku_sy"), tr("Kurdish (Syria)")},
-                                  {qsl("ku_tr"), tr("Kurdish (Turkey)")},
-                                  {qsl("la"), tr("Latin")},
-                                  {qsl("lb"), tr("Luxembourgish")},
-                                  {qsl("lb_lu"), tr("Luxembourgish (Luxembourg)")},
-                                  {qsl("lo"), tr("Lao")},
-                                  {qsl("lo_la"), tr("Lao (Laos)")},
-                                  {qsl("lt"), tr("Lithuanian")},
-                                  {qsl("lt_lt"), tr("Lithuanian (Lithuania)")},
-                                  {qsl("lv"), tr("Latvian")},
-                                  {qsl("lv_lv"), tr("Latvian (Latvia)")},
-                                  {qsl("ml"), tr("Malayalam")},
-                                  {qsl("ml_in"), tr("Malayalam (India)")},
-                                  {qsl("mn"), tr("Mongolian")},
-                                  {qsl("mn_mn"), tr("Mongolian (Mongolia)")},
-                                  {qsl("nb"), tr("Norwegian Bokmål")},
-                                  {qsl("nb_no"), tr("Norwegian Bokmål (Norway)")},
-                                  {qsl("ne"), tr("Nepali")},
-                                  {qsl("ne_np"), tr("Nepali (Nepal)")},
-                                  {qsl("nl"), tr("Dutch")},
-                                  {qsl("nl_an"), tr("Dutch (Netherlands Antilles)")},
-                                  {qsl("nl_aw"), tr("Dutch (Aruba)")},
-                                  {qsl("nl_be"), tr("Dutch (Belgium)")},
-                                  {qsl("nl_nl"), tr("Dutch (Netherlands)")},
-                                  {qsl("nl_sr"), tr("Dutch (Suriname)")},
-                                  {qsl("nn"), tr("Norwegian Nynorsk")},
-                                  {qsl("nn_no"), tr("Norwegian Nynorsk (Norway)")},
-                                  {qsl("oc"), tr("Occitan")},
-                                  {qsl("oc_fr"), tr("Occitan (France)")},
-                                  {qsl("pl"), tr("Polish")},
-                                  {qsl("pl_pl"), tr("Polish (Poland)")},
-                                  {qsl("pt"), tr("Portuguese")},
-                                  {qsl("pt_br"), tr("Portuguese (Brazil)")},
-                                  {qsl("pt_pt"), tr("Portuguese (Portugal)")},
-                                  {qsl("ro"), tr("Romanian")},
-                                  {qsl("ro_ro"), tr("Romanian (Romania)")},
-                                  {qsl("ru"), tr("Russian")},
-                                  {qsl("ru_ru"), tr("Russian (Russia)")},
-                                  {qsl("se"), tr("Northern Sami")},
-                                  {qsl("se_fi"), tr("Northern Sami (Finland)")},
-                                  {qsl("se_no"), tr("Northern Sami (Norway)")},
-                                  {qsl("se_se"), tr("Northern Sami (Sweden)")},
-                                  //: This code seems to be the identifier for the prestige dialect for several languages used in the region of the former Yugoslavia state without a state indication
-                                  {qsl("sh"), tr("Shtokavian")},
-                                  //: This code seems to be the identifier for the prestige dialect for several languages used in the region of the former Yugoslavia state with a (withdrawn from ISO 3166) state indication
-                                  {qsl("sh_yu"), tr("Shtokavian (former state of Yugoslavia)")},
-                                  {qsl("si"), tr("Sinhala")},
-                                  {qsl("si_lk"), tr("Sinhala (Sri Lanka)")},
-                                  {qsl("sk"), tr("Slovak")},
-                                  {qsl("sk_sk"), tr("Slovak (Slovakia)")},
-                                  {qsl("sl"), tr("Slovenian")},
-                                  {qsl("sl_si"), tr("Slovenian (Slovenia)")},
-                                  {qsl("so"), tr("Somali")},
-                                  {qsl("so_so"), tr("Somali (Somalia)")},
-                                  {qsl("sq"), tr("Albanian")},
-                                  {qsl("sq_al"), tr("Albanian (Albania)")},
-                                  {qsl("sr"), tr("Serbian")},
-                                  {qsl("sr_me"), tr("Serbian (Montenegro)")},
-                                  {qsl("sr_rs"), tr("Serbian (Serbia)")},
-                                  {qsl("sr_latn_rs"), tr("Serbian (Serbia - Latin-alphabet)")},
-                                  {qsl("sr_yu"), tr("Serbian (former state of Yugoslavia)")},
-                                  {qsl("ss"), tr("Swati")},
-                                  {qsl("ss_sz"), tr("Swati (Swaziland)")},
-                                  {qsl("ss_za"), tr("Swati (South Africa)")},
-                                  {qsl("sv"), tr("Swedish")},
-                                  {qsl("sv_se"), tr("Swedish (Sweden)")},
-                                  {qsl("sv_fi"), tr("Swedish (Finland)")},
-                                  {qsl("sw"), tr("Swahili")},
-                                  {qsl("sw_ke"), tr("Swahili (Kenya)")},
-                                  {qsl("sw_tz"), tr("Swahili (Tanzania)")},
-                                  {qsl("te"), tr("Telugu")},
-                                  {qsl("te_in"), tr("Telugu (India)")},
-                                  {qsl("th"), tr("Thai")},
-                                  {qsl("th_th"), tr("Thai (Thailand)")},
-                                  {qsl("ti"), tr("Tigrinya")},
-                                  {qsl("ti_er"), tr("Tigrinya (Eritrea)")},
-                                  {qsl("ti_et"), tr("Tigrinya (Ethiopia)")},
-                                  {qsl("tk"), tr("Turkmen")},
-                                  {qsl("tk_tm"), tr("Turkmen (Turkmenistan)")},
-                                  {qsl("tl"), tr("Tagalog")},
-                                  {qsl("tn"), tr("Tswana")},
-                                  {qsl("tn_bw"), tr("Tswana (Botswana)")},
-                                  {qsl("tn_za"), tr("Tswana (South Africa)")},
-                                  {qsl("tr"), tr("Turkish")},
-                                  {qsl("tr_tr"), tr("Turkish (Turkey)")},
-                                  {qsl("ts"), tr("Tsonga")},
-                                  {qsl("ts_za"), tr("Tsonga (South Africa)")},
-                                  {qsl("uk"), tr("Ukrainian")},
-                                  {qsl("uk_ua"), tr("Ukrainian (Ukraine)")},
-                                  {qsl("uz"), tr("Uzbek")},
-                                  {qsl("uz_uz"), tr("Uzbek (Uzbekistan)")},
-                                  {qsl("ve"), tr("Venda")},
-                                  {qsl("vi"), tr("Vietnamese")},
-                                  {qsl("vi_vn"), tr("Vietnamese (Vietnam)")},
-                                  {qsl("vi_daucu"), tr("Vietnamese (DauCu variant - old-style diacritics)")},
-                                  {qsl("vi_daumoi"), tr("Vietnamese (DauMoi variant - new-style diacritics)")},
-                                  // OpenBSD has the old names, see:
-                                  // https://github.com/1ec5/hunspell-vi/commit/fecdb355e7c114e1d5ca22fe5b301b2d54af84c9
-                                  {qsl("vi_x_old"), tr("Vietnamese (DauCu variant - old-style diacritics)")},
-                                  {qsl("vi_x_new"), tr("Vietnamese (DauMoi variant - new-style diacritics)")},
-                                  {qsl("wa"), tr("Walloon")},
-                                  {qsl("xh"), tr("Xhosa")},
-                                  {qsl("yi"), tr("Yiddish")},
-                                  {qsl("zh"), tr("Chinese")},
-                                  {qsl("zh_cn"), tr("Chinese (China - simplified)")},
-                                  {qsl("zh_tw"), tr("Chinese (Taiwan - traditional)")},
-                                  {qsl("zu"), tr("Zulu")}};
+    mDictionaryLanguageCodeMap = {
+            {qsl("af"), tr("Afrikaans")},
+            {qsl("af_za"), tr("Afrikaans (South Africa)")},
+            {qsl("an"), tr("Aragonese")},
+            {qsl("an_es"), tr("Aragonese (Spain)")},
+            {qsl("ar"), tr("Arabic")},
+            {qsl("ar_ae"), tr("Arabic (United Arab Emirates)")},
+            {qsl("ar_bh"), tr("Arabic (Bahrain)")},
+            {qsl("ar_dz"), tr("Arabic (Algeria)")},
+            {qsl("ar_eg"), tr("Arabic (Egypt)")},
+            {qsl("ar_in"), tr("Arabic (India)")},
+            {qsl("ar_iq"), tr("Arabic (Iraq)")},
+            {qsl("ar_jo"), tr("Arabic (Jordan)")},
+            {qsl("ar_kw"), tr("Arabic (Kuwait)")},
+            {qsl("ar_lb"), tr("Arabic (Lebanon)")},
+            {qsl("ar_ly"), tr("Arabic (Libya)")},
+            {qsl("ar_ma"), tr("Arabic (Morocco)")},
+            {qsl("ar_om"), tr("Arabic (Oman)")},
+            {qsl("ar_qa"), tr("Arabic (Qatar)")},
+            {qsl("ar_sa"), tr("Arabic (Saudi Arabia)")},
+            {qsl("ar_sd"), tr("Arabic (Sudan)")},
+            {qsl("ar_sy"), tr("Arabic (Syria)")},
+            {qsl("ar_tn"), tr("Arabic (Tunisia)")},
+            {qsl("ar_ye"), tr("Arabic (Yemen)")},
+            {qsl("be"), tr("Belarusian")},
+            {qsl("be_by"), tr("Belarusian (Belarus)")},
+            {qsl("be_ru"), tr("Belarusian (Russia)")},
+            {qsl("bg"), tr("Bulgarian")},
+            {qsl("bg_bg"), tr("Bulgarian (Bulgaria)")},
+            {qsl("bn"), tr("Bangla")},
+            {qsl("bn_bd"), tr("Bangla (Bangladesh)")},
+            {qsl("bn_in"), tr("Bangla (India)")},
+            {qsl("bo"), tr("Tibetan")},
+            {qsl("bo_cn"), tr("Tibetan (China)")},
+            {qsl("bo_in"), tr("Tibetan (India)")},
+            {qsl("br"), tr("Breton")},
+            {qsl("br_fr"), tr("Breton (France)")},
+            {qsl("bs"), tr("Bosnian")},
+            {qsl("bs_ba"), tr("Bosnian (Bosnia/Herzegovina)")},
+            {qsl("bs_ba_cyrl"), tr("Bosnian (Bosnia/Herzegovina - Cyrillic alphabet)")},
+            {qsl("ca"), tr("Catalan")},
+            {qsl("ca_es"), tr("Catalan (Spain)")},
+            {qsl("ca_es_valencia"), tr("Catalan (Spain - Valencian)")},
+            {qsl("ckb"), tr("Central Kurdish")},
+            {qsl("ckb_iq"), tr("Central Kurdish (Iraq)")},
+            {qsl("cs"), tr("Czech")},
+            {qsl("cs_cz"), tr("Czech (Czechia)")},
+            {qsl("cy"), tr("Welsh")},
+            {qsl("cy_gb"), tr("Welsh (United Kingdom {Wales})")},
+            {qsl("da"), tr("Danish")},
+            {qsl("da_dk"), tr("Danish (Denmark)")},
+            {qsl("de"), tr("German")},
+            {qsl("de_at"), tr("German (Austria)")},
+            {qsl("de_at_frami"), tr("German (Austria, revised by F M Baumann)")},
+            {qsl("de_be"), tr("German (Belgium)")},
+            {qsl("de_ch"), tr("German (Switzerland)")},
+            {qsl("de_ch_frami"), tr("German (Switzerland, revised by F M Baumann)")},
+            {qsl("de_de"), tr("German (Germany/Belgium/Luxemburg)")},
+            {qsl("de_de_frami"), tr("German (Germany/Belgium/Luxemburg, revised by F M Baumann)")},
+            {qsl("de_li"), tr("German (Liechtenstein)")},
+            {qsl("de_lu"), tr("German (Luxembourg)")},
+            {qsl("dz"), tr("Dzongkha")},
+            {qsl("dz_bt"), tr("Dzongkha (Bhutan)")},
+            {qsl("el"), tr("Greek")},
+            {qsl("el_gr"), tr("Greek (Greece)")},
+            {qsl("en"), tr("English")},
+            {qsl("en_ag"), tr("English (Antigua/Barbuda)")},
+            {qsl("en_au"), tr("English (Australia)")},
+            {qsl("en_au_large"), tr("English (Australia, Large)", "This dictionary contains larger vocabulary.")},
+            {qsl("en_bs"), tr("English (Bahamas)")},
+            {qsl("en_bw"), tr("English (Botswana)")},
+            {qsl("en_bz"), tr("English (Belize)")},
+            {qsl("en_ca"), tr("English (Canada)")},
+            {qsl("en_ca_large"), tr("English (Canada, Large)", "This dictionary contains larger vocabulary.")},
+            {qsl("en_dk"), tr("English (Denmark)")},
+            {qsl("en_gb"), tr("English (United Kingdom)")},
+            {qsl("en_gb_large"), tr("English (United Kingdom, Large)", "This dictionary contains larger vocabulary.")},
+            {qsl("en_gb_ise"), tr("English (United Kingdom - 'ise' not 'ize')", "This dictionary prefers the British 'ise' form over the American 'ize' one.")},
+            {qsl("en_gh"), tr("English (Ghana)")},
+            {qsl("en_hk"), tr("English (Hong Kong SAR China)")},
+            {qsl("en_ie"), tr("English (Ireland)")},
+            {qsl("en_in"), tr("English (India)")},
+            {qsl("en_jm"), tr("English (Jamaica)")},
+            {qsl("en_na"), tr("English (Namibia)")},
+            {qsl("en_ng"), tr("English (Nigeria)")},
+            {qsl("en_nz"), tr("English (New Zealand)")},
+            {qsl("en_ph"), tr("English (Philippines)")},
+            {qsl("en_sg"), tr("English (Singapore)")},
+            {qsl("en_tt"), tr("English (Trinidad/Tobago)")},
+            {qsl("en_us"), tr("English (United States)")},
+            {qsl("en_us_large"), tr("English (United States, Large)", "This dictionary contains larger vocabulary.")},
+            {qsl("en_za"), tr("English (South Africa)")},
+            {qsl("en_zw"), tr("English (Zimbabwe)")},
+            {qsl("eo"), tr("Esperanto")},
+            {qsl("es"), tr("Spanish")},
+            {qsl("es_ar"), tr("Spanish (Argentina)")},
+            {qsl("es_bo"), tr("Spanish (Bolivia)")},
+            {qsl("es_cl"), tr("Spanish (Chile)")},
+            {qsl("es_co"), tr("Spanish (Colombia)")},
+            {qsl("es_cr"), tr("Spanish (Costa Rica)")},
+            {qsl("es_cu"), tr("Spanish (Cuba)")},
+            {qsl("es_do"), tr("Spanish (Dominican Republic)")},
+            {qsl("es_ec"), tr("Spanish (Ecuador)")},
+            {qsl("es_es"), tr("Spanish (Spain)")},
+            {qsl("es_gt"), tr("Spanish (Guatemala)")},
+            {qsl("es_hn"), tr("Spanish (Honduras)")},
+            {qsl("es_mx"), tr("Spanish (Mexico)")},
+            {qsl("es_ni"), tr("Spanish (Nicaragua)")},
+            {qsl("es_pa"), tr("Spanish (Panama)")},
+            {qsl("es_pe"), tr("Spanish (Peru)")},
+            {qsl("es_pr"), tr("Spanish (Puerto Rico)")},
+            {qsl("es_py"), tr("Spanish (Paraguay)")},
+            {qsl("es_sv"), tr("Spanish (El Savador)")},
+            {qsl("es_us"), tr("Spanish (United States)")},
+            {qsl("es_uy"), tr("Spanish (Uruguay)")},
+            {qsl("es_ve"), tr("Spanish (Venezuela)")},
+            {qsl("et"), tr("Estonian")},
+            {qsl("et_ee"), tr("Estonian (Estonia)")},
+            {qsl("eu"), tr("Basque")},
+            {qsl("eu_es"), tr("Basque (Spain)")},
+            {qsl("eu_fr"), tr("Basque (France)")},
+            {qsl("fi"), tr("Finnish")},
+            {qsl("fi_fi"), tr("Finnish")},
+            {qsl("fo"), tr("Faroese")},
+            {qsl("fo_fo"), tr("Faroese (Faroe Islands)")},
+            {qsl("fr"), tr("French")},
+            // On OpenBSD this seems to be the "usual spellings of French,
+            // with, in addition, some new spellings rectifying past
+            // inconsistencies":
+            {qsl("fr_xx_classique"), tr("French")},
+            {qsl("fr_be"), tr("French (Belgium)")},
+            {qsl("fr_ca"), tr("French (Catalan)")},
+            {qsl("fr_ch"), tr("French (Switzerland)")},
+            {qsl("fr_fr"), tr("French (France)")},
+            {qsl("fr_lu"), tr("French (Luxemburg)")},
+            {qsl("fr_mc"), tr("French (Monaco)")},
+            {qsl("ga"), tr("Irish")},
+            {qsl("gd"), tr("Gaelic")},
+            {qsl("gd_gb"), tr("Gaelic (United Kingdom {Scots})")},
+            {qsl("gl"), tr("Galician")},
+            {qsl("gl_es"), tr("Galician (Spain)")},
+            {qsl("gn"), tr("Guarani")},
+            {qsl("gn_py"), tr("Guarani (Paraguay)")},
+            {qsl("gu"), tr("Gujarati")},
+            {qsl("gu_in"), tr("Gujarati (India)")},
+            // Debian uses gug instead of gn for some reason:
+            {qsl("gug"), tr("Guarani")},
+            {qsl("gug_py"), tr("Guarani (Paraguay)")},
+            {qsl("he"), tr("Hebrew")},
+            {qsl("he_il"), tr("Hebrew (Israel)")},
+            {qsl("hi"), tr("Hindi")},
+            {qsl("hi_in"), tr("Hindi (India)")},
+            {qsl("hr"), tr("Croatian")},
+            {qsl("hr_hr"), tr("Croatian (Croatia)")},
+            {qsl("hu"), tr("Hungarian")},
+            {qsl("hu_hu"), tr("Hungarian (Hungary)")},
+            {qsl("hy"), tr("Armenian")},
+            {qsl("hy_am"), tr("Armenian (Armenia)")},
+            {qsl("id"), tr("Indonesian")},
+            {qsl("id_id"), tr("Indonesian (Indonesia)")},
+            //: , formerly known as Occidental, and not to be mistaken for Interlingua
+            {qsl("ie"), tr("Interlingue")},
+            {qsl("is"), tr("Icelandic")},
+            {qsl("is_is"), tr("Icelandic (Iceland)")},
+            {qsl("it"), tr("Italian")},
+            {qsl("it_ch"), tr("Italian (Switzerland)")},
+            {qsl("it_it"), tr("Italian (Italy)")},
+            {qsl("kk"), tr("Kazakh")},
+            {qsl("kk_kz"), tr("Kazakh (Kazakhstan)")},
+            {qsl("kmr"), tr("Kurmanji")},
+            {qsl("kmr_latn"), tr("Kurmanji {Latin-alphabet Kurdish}")},
+            {qsl("ko"), tr("Korean")},
+            {qsl("ko_kr"), tr("Korean (South Korea)")},
+            {qsl("ku"), tr("Kurdish")},
+            {qsl("ku_sy"), tr("Kurdish (Syria)")},
+            {qsl("ku_tr"), tr("Kurdish (Turkey)")},
+            {qsl("la"), tr("Latin")},
+            {qsl("lb"), tr("Luxembourgish")},
+            {qsl("lb_lu"), tr("Luxembourgish (Luxembourg)")},
+            {qsl("lo"), tr("Lao")},
+            {qsl("lo_la"), tr("Lao (Laos)")},
+            {qsl("lt"), tr("Lithuanian")},
+            {qsl("lt_lt"), tr("Lithuanian (Lithuania)")},
+            {qsl("lv"), tr("Latvian")},
+            {qsl("lv_lv"), tr("Latvian (Latvia)")},
+            {qsl("ml"), tr("Malayalam")},
+            {qsl("ml_in"), tr("Malayalam (India)")},
+            {qsl("mn"), tr("Mongolian")},
+            {qsl("mn_mn"), tr("Mongolian (Mongolia)")},
+            {qsl("nb"), tr("Norwegian Bokmål")},
+            {qsl("nb_no"), tr("Norwegian Bokmål (Norway)")},
+            {qsl("ne"), tr("Nepali")},
+            {qsl("ne_np"), tr("Nepali (Nepal)")},
+            {qsl("nl"), tr("Dutch")},
+            {qsl("nl_an"), tr("Dutch (Netherlands Antilles)")},
+            {qsl("nl_aw"), tr("Dutch (Aruba)")},
+            {qsl("nl_be"), tr("Dutch (Belgium)")},
+            {qsl("nl_nl"), tr("Dutch (Netherlands)")},
+            {qsl("nl_sr"), tr("Dutch (Suriname)")},
+            {qsl("nn"), tr("Norwegian Nynorsk")},
+            {qsl("nn_no"), tr("Norwegian Nynorsk (Norway)")},
+            {qsl("oc"), tr("Occitan")},
+            {qsl("oc_fr"), tr("Occitan (France)")},
+            {qsl("pl"), tr("Polish")},
+            {qsl("pl_pl"), tr("Polish (Poland)")},
+            {qsl("pt"), tr("Portuguese")},
+            {qsl("pt_br"), tr("Portuguese (Brazil)")},
+            {qsl("pt_pt"), tr("Portuguese (Portugal)")},
+            {qsl("ro"), tr("Romanian")},
+            {qsl("ro_ro"), tr("Romanian (Romania)")},
+            {qsl("ru"), tr("Russian")},
+            {qsl("ru_ru"), tr("Russian (Russia)")},
+            {qsl("se"), tr("Northern Sami")},
+            {qsl("se_fi"), tr("Northern Sami (Finland)")},
+            {qsl("se_no"), tr("Northern Sami (Norway)")},
+            {qsl("se_se"), tr("Northern Sami (Sweden)")},
+            //: This code seems to be the identifier for the prestige dialect for several languages used in the region of the former Yugoslavia state without a state indication
+            {qsl("sh"), tr("Shtokavian")},
+            //: This code seems to be the identifier for the prestige dialect for several languages used in the region of the former Yugoslavia state with a (withdrawn from ISO 3166) state indication
+            {qsl("sh_yu"), tr("Shtokavian (former state of Yugoslavia)")},
+            {qsl("si"), tr("Sinhala")},
+            {qsl("si_lk"), tr("Sinhala (Sri Lanka)")},
+            {qsl("sk"), tr("Slovak")},
+            {qsl("sk_sk"), tr("Slovak (Slovakia)")},
+            {qsl("sl"), tr("Slovenian")},
+            {qsl("sl_si"), tr("Slovenian (Slovenia)")},
+            {qsl("so"), tr("Somali")},
+            {qsl("so_so"), tr("Somali (Somalia)")},
+            {qsl("sq"), tr("Albanian")},
+            {qsl("sq_al"), tr("Albanian (Albania)")},
+            {qsl("sr"), tr("Serbian")},
+            {qsl("sr_me"), tr("Serbian (Montenegro)")},
+            {qsl("sr_rs"), tr("Serbian (Serbia)")},
+            {qsl("sr_latn_rs"), tr("Serbian (Serbia - Latin-alphabet)")},
+            {qsl("sr_yu"), tr("Serbian (former state of Yugoslavia)")},
+            {qsl("ss"), tr("Swati")},
+            {qsl("ss_sz"), tr("Swati (Swaziland)")},
+            {qsl("ss_za"), tr("Swati (South Africa)")},
+            {qsl("sv"), tr("Swedish")},
+            {qsl("sv_se"), tr("Swedish (Sweden)")},
+            {qsl("sv_fi"), tr("Swedish (Finland)")},
+            {qsl("sw"), tr("Swahili")},
+            {qsl("sw_ke"), tr("Swahili (Kenya)")},
+            {qsl("sw_tz"), tr("Swahili (Tanzania)")},
+            {qsl("te"), tr("Telugu")},
+            {qsl("te_in"), tr("Telugu (India)")},
+            {qsl("th"), tr("Thai")},
+            {qsl("th_th"), tr("Thai (Thailand)")},
+            {qsl("ti"), tr("Tigrinya")},
+            {qsl("ti_er"), tr("Tigrinya (Eritrea)")},
+            {qsl("ti_et"), tr("Tigrinya (Ethiopia)")},
+            {qsl("tk"), tr("Turkmen")},
+            {qsl("tk_tm"), tr("Turkmen (Turkmenistan)")},
+            {qsl("tl"), tr("Tagalog")},
+            {qsl("tn"), tr("Tswana")},
+            {qsl("tn_bw"), tr("Tswana (Botswana)")},
+            {qsl("tn_za"), tr("Tswana (South Africa)")},
+            {qsl("tr"), tr("Turkish")},
+            {qsl("tr_tr"), tr("Turkish (Turkey)")},
+            {qsl("ts"), tr("Tsonga")},
+            {qsl("ts_za"), tr("Tsonga (South Africa)")},
+            {qsl("uk"), tr("Ukrainian")},
+            {qsl("uk_ua"), tr("Ukrainian (Ukraine)")},
+            {qsl("uz"), tr("Uzbek")},
+            {qsl("uz_uz"), tr("Uzbek (Uzbekistan)")},
+            {qsl("ve"), tr("Venda")},
+            {qsl("vi"), tr("Vietnamese")},
+            {qsl("vi_vn"), tr("Vietnamese (Vietnam)")},
+            {qsl("vi_daucu"), tr("Vietnamese (DauCu variant - old-style diacritics)")},
+            {qsl("vi_daumoi"), tr("Vietnamese (DauMoi variant - new-style diacritics)")},
+            // OpenBSD has the old names, see:
+            // https://github.com/1ec5/hunspell-vi/commit/fecdb355e7c114e1d5ca22fe5b301b2d54af84c9
+            {qsl("vi_x_old"), tr("Vietnamese (DauCu variant - old-style diacritics)")},
+            {qsl("vi_x_new"), tr("Vietnamese (DauMoi variant - new-style diacritics)")},
+            {qsl("wa"), tr("Walloon")},
+            {qsl("xh"), tr("Xhosa")},
+            {qsl("yi"), tr("Yiddish")},
+            {qsl("zh"), tr("Chinese")},
+            {qsl("zh_cn"), tr("Chinese (China - simplified)")},
+            {qsl("zh_tw"), tr("Chinese (Taiwan - traditional)")},
+            {qsl("zu"), tr("Zulu")}};
 
     mEncodingNameMap = {
-        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-        {"ASCII", tr("ASCII (Basic)")},
-        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"UTF-8", tr("UTF-8 (Recommended)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"EUC-KR", tr("EUC-KR (Korean)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"GBK", tr("GBK (Chinese)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"GB18030", tr("GB18030 (Chinese)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"BIG5", tr("Big5-ETen (Taiwan)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"BIG5-HKSCS", tr("Big5-HKSCS (Hong Kong)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"ISO 8859-1", tr("ISO 8859-1 (Western European)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"ISO 8859-2", tr("ISO 8859-2 (Central European)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"ISO 8859-3", tr("ISO 8859-3 (South European)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"ISO 8859-4", tr("ISO 8859-4 (Baltic)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"ISO 8859-5", tr("ISO 8859-5 (Cyrillic)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"ISO 8859-6", tr("ISO 8859-6 (Arabic)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"ISO 8859-7", tr("ISO 8859-7 (Greek)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"ISO 8859-8", tr("ISO 8859-8 (Hebrew Visual)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"ISO 8859-9", tr("ISO 8859-9 (Turkish)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"ISO 8859-10", tr("ISO 8859-10 (Nordic)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"ISO 8859-11", tr("ISO 8859-11 (Latin/Thai)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"ISO 8859-13", tr("ISO 8859-13 (Baltic)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"ISO 8859-14", tr("ISO 8859-14 (Celtic)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"ISO 8859-15", tr("ISO 8859-15 (Western)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"ISO 8859-16", tr("ISO 8859-16 (Romanian)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"CP437", tr("CP437 (OEM Font)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"M_CP437", qsl("m ") % tr("CP437 (OEM Font)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"CP667", tr("CP667 (Mazovia)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"M_CP667", qsl("m ") % tr("CP667 (Mazovia)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"CP737", tr("CP737 (DOS Greek)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"M_CP737", qsl("m ") % tr("CP737 (DOS Greek)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"CP850", tr("CP850 (Western Europe)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"CP866", tr("CP866 (Cyrillic/Russian)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"CP869", tr("CP869 (DOS Greek 2)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"M_CP869",  qsl("m ") % tr("CP869 (DOS Greek 2)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"CP1161", tr("CP1161 (Latin/Thai)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"KOI8-R", tr("KOI8-R (Cyrillic)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"KOI8-U", tr("KOI8-U (Cyrillic/Ukrainian)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"MACINTOSH", tr("MACINTOSH")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"M_MEDIEVIA",  qsl("m ") % tr("Medievia {Custom codec for that MUD}")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"WINDOWS-1250", tr("WINDOWS-1250 (Central European)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"WINDOWS-1251", tr("WINDOWS-1251 (Cyrillic)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"WINDOWS-1252", tr("WINDOWS-1252 (Western)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"WINDOWS-1253", tr("WINDOWS-1253 (Greek)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"WINDOWS-1254", tr("WINDOWS-1254 (Turkish)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"WINDOWS-1255", tr("WINDOWS-1255 (Hebrew)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"WINDOWS-1256", tr("WINDOWS-1256 (Arabic)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"WINDOWS-1257", tr("WINDOWS-1257 (Baltic)")},
-                        //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
-                        {"WINDOWS-1258", tr("WINDOWS-1258 (Vietnamese)")}};
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"ASCII", tr("ASCII (Basic)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"UTF-8", tr("UTF-8 (Recommended)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"EUC-KR", tr("EUC-KR (Korean)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"GBK", tr("GBK (Chinese)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"GB18030", tr("GB18030 (Chinese)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"BIG5", tr("Big5-ETen (Taiwan)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"BIG5-HKSCS", tr("Big5-HKSCS (Hong Kong)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"ISO 8859-1", tr("ISO 8859-1 (Western European)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"ISO 8859-2", tr("ISO 8859-2 (Central European)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"ISO 8859-3", tr("ISO 8859-3 (South European)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"ISO 8859-4", tr("ISO 8859-4 (Baltic)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"ISO 8859-5", tr("ISO 8859-5 (Cyrillic)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"ISO 8859-6", tr("ISO 8859-6 (Arabic)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"ISO 8859-7", tr("ISO 8859-7 (Greek)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"ISO 8859-8", tr("ISO 8859-8 (Hebrew Visual)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"ISO 8859-9", tr("ISO 8859-9 (Turkish)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"ISO 8859-10", tr("ISO 8859-10 (Nordic)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"ISO 8859-11", tr("ISO 8859-11 (Latin/Thai)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"ISO 8859-13", tr("ISO 8859-13 (Baltic)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"ISO 8859-14", tr("ISO 8859-14 (Celtic)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"ISO 8859-15", tr("ISO 8859-15 (Western)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"ISO 8859-16", tr("ISO 8859-16 (Romanian)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"CP437", tr("CP437 (OEM Font)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"M_CP437", qsl("m ") % tr("CP437 (OEM Font)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"CP667", tr("CP667 (Mazovia)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"M_CP667", qsl("m ") % tr("CP667 (Mazovia)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"CP737", tr("CP737 (DOS Greek)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"M_CP737", qsl("m ") % tr("CP737 (DOS Greek)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"CP850", tr("CP850 (Western Europe)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"CP866", tr("CP866 (Cyrillic/Russian)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"CP869", tr("CP869 (DOS Greek 2)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"M_CP869", qsl("m ") % tr("CP869 (DOS Greek 2)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"CP1161", tr("CP1161 (Latin/Thai)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"KOI8-R", tr("KOI8-R (Cyrillic)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"KOI8-U", tr("KOI8-U (Cyrillic/Ukrainian)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"MACINTOSH", tr("MACINTOSH")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"M_MEDIEVIA", qsl("m ") % tr("Medievia {Custom codec for that MUD}")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"WINDOWS-1250", tr("WINDOWS-1250 (Central European)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"WINDOWS-1251", tr("WINDOWS-1251 (Cyrillic)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"WINDOWS-1252", tr("WINDOWS-1252 (Western)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"WINDOWS-1253", tr("WINDOWS-1253 (Greek)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"WINDOWS-1254", tr("WINDOWS-1254 (Turkish)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"WINDOWS-1255", tr("WINDOWS-1255 (Hebrew)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"WINDOWS-1256", tr("WINDOWS-1256 (Arabic)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"WINDOWS-1257", tr("WINDOWS-1257 (Baltic)")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"WINDOWS-1258", tr("WINDOWS-1258 (Vietnamese)")}};
 
     /*: This represents the format of the timestamps shown alongside the texts
      * in a console and might require translation for a few locales; the content
@@ -1534,8 +1532,8 @@ void mudlet::loadTranslators(const QString& languageCode)
     if (!mudletTranslatorFileName.isEmpty()) {
         const bool isOk = pMudletTranslator->load(mudletTranslatorFileName, mPathNameMudletTranslations);
         if (isOk && !pMudletTranslator->isEmpty()) {
-//            qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - installing Mudlet translation from: \"" << mPathNameMudletTranslations << "/"
-//                                         << mudletTranslatorFileName << "\"...";
+            //            qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - installing Mudlet translation from: \"" << mPathNameMudletTranslations << "/"
+            //                                         << mudletTranslatorFileName << "\"...";
             qApp->installTranslator(pMudletTranslator);
             mTranslatorsLoadedList.append(pMudletTranslator);
         }
@@ -1549,7 +1547,7 @@ void mudlet::slot_moduleManager()
         return;
     }
     auto moduleManager = pH->mpModuleManager;
-    if (!moduleManager){
+    if (!moduleManager) {
         moduleManager = new dlgModuleManager(this, pH);
         pH->mpModuleManager = moduleManager;
 
@@ -1746,7 +1744,7 @@ void mudlet::slot_toggleAlwaysOnTop()
         setWindowFlags(flags | Qt::WindowStaysOnTopHint);
         dactionToggleAlwaysOnTop->setChecked(true);
     }
-    show();  // Required after changing window flags
+    show(); // Required after changing window flags
 }
 
 void mudlet::slot_minimize()
@@ -1863,7 +1861,7 @@ void mudlet::slot_activateMainWindow()
 {
     raise();
     activateWindow();
-    show(); // Ensure it's not minimized
+    show();             // Ensure it's not minimized
     updateWindowMenu(); // Refresh checkmarks
 }
 
@@ -1883,7 +1881,7 @@ void mudlet::slot_activateDetachedWindow()
             detachedWindow->raise();
             detachedWindow->activateWindow();
             detachedWindow->show(); // Ensure it's not minimized
-            updateWindowMenu(); // Refresh checkmarks
+            updateWindowMenu();     // Refresh checkmarks
         }
     }
 }
@@ -2014,7 +2012,7 @@ void mudlet::updateMultiViewControls()
 {
     const bool isEnabled = (mHostManager.getHostCount() > 1);
 
-    if (mpActionMultiView->isEnabled() != isEnabled){
+    if (mpActionMultiView->isEnabled() != isEnabled) {
         mpActionMultiView->setEnabled(isEnabled);
     }
 
@@ -2033,7 +2031,7 @@ void mudlet::updateMultiViewControls()
 void mudlet::reshowRequiredMainConsoles()
 {
     if (mpTabBar->count() > 1 && mMultiView) {
-        for (const auto& host: mHostManager) {
+        for (const auto& host : mHostManager) {
             if (host->mpConsole) {
                 // Only show consoles that are in the main window, not detached ones
                 const QString profileName = host->getName();
@@ -2149,8 +2147,8 @@ void mudlet::addConsoleForNewHost(Host* pH)
 
     auto pEditor = new dlgTriggerEditor(pH);
     pH->mpEditorDialog = pEditor;
-    connect(pH, &Host::profileSaveStarted,  pH->mpEditorDialog, &dlgTriggerEditor::slot_profileSaveStarted);
-    connect(pH, &Host::profileSaveFinished,  pH->mpEditorDialog, &dlgTriggerEditor::slot_profileSaveFinished);
+    connect(pH, &Host::profileSaveStarted, pH->mpEditorDialog, &dlgTriggerEditor::slot_profileSaveStarted);
+    connect(pH, &Host::profileSaveFinished, pH->mpEditorDialog, &dlgTriggerEditor::slot_profileSaveFinished);
     pEditor->fillout_form();
 
     pH->getActionUnit()->updateToolbar();
@@ -2208,10 +2206,10 @@ void mudlet::slot_timerFires()
     }
     TTimer* pTT = pHost->getTimerUnit()->getTimer(id);
     if (Q_LIKELY(pTT)) {
-// commented out as it will be spammy in normal situations but saved as useful
-// during timer debugging... 8-)
-//        qDebug().nospace().noquote() << "mudlet::slot_timerFires() INFO - Host: \"" << hostName << "\" QTimer firing for TTimer Id:" << id;
-//        qDebug().nospace().noquote() << "    (objectName:\"" << pQT->objectName() << "\")";
+        // commented out as it will be spammy in normal situations but saved as useful
+        // during timer debugging... 8-)
+        //        qDebug().nospace().noquote() << "mudlet::slot_timerFires() INFO - Host: \"" << hostName << "\" QTimer firing for TTimer Id:" << id;
+        //        qDebug().nospace().noquote() << "    (objectName:\"" << pQT->objectName() << "\")";
         pTT->execute();
         if (pTT->checkRestart()) {
             pTT->start();
@@ -2743,15 +2741,16 @@ void mudlet::readEarlySettings(const QSettings& settings)
     mInterfaceLanguage = settings.value("interfaceLanguage", autodetectPreferredLanguage()).toString();
     mUserLocale = QLocale(mInterfaceLanguage);
     if (mUserLocale == QLocale::c()) {
-        qWarning().nospace().noquote() << "mudlet::readEarlySettings(...) WARNING - Unable to convert language code \"" << mInterfaceLanguage << "\" to a recognised locale, reverting to the POSIX 'C' one.";
+        qWarning().nospace().noquote() << "mudlet::readEarlySettings(...) WARNING - Unable to convert language code \"" << mInterfaceLanguage
+                                       << "\" to a recognised locale, reverting to the POSIX 'C' one.";
         return;
     }
 
-// #if QT_VERSION < QT_VERSION_CHECK(6, 2, 0)
-//     qDebug().nospace().noquote() << "mudlet::readEarlySettings(...) INFO - Using language code \"" << mInterfaceLanguage << "\" to switch to \"" << QLocale::languageToString(mUserLocale.language()) << " (" << QLocale::countryToString(mUserLocale.country()) << ")\" locale.";
-// #else
-//     qDebug().nospace().noquote() << "mudlet::readEarlySettings(...) INFO - Using language code \"" << mInterfaceLanguage << "\" to switch to \"" << QLocale::languageToString(mUserLocale.language()) << " (" << QLocale::territoryToString(mUserLocale.territory()) << ")\" locale.";
-// #endif
+    // #if QT_VERSION < QT_VERSION_CHECK(6, 2, 0)
+    //     qDebug().nospace().noquote() << "mudlet::readEarlySettings(...) INFO - Using language code \"" << mInterfaceLanguage << "\" to switch to \"" << QLocale::languageToString(mUserLocale.language()) << " (" << QLocale::countryToString(mUserLocale.country()) << ")\" locale.";
+    // #else
+    //     qDebug().nospace().noquote() << "mudlet::readEarlySettings(...) INFO - Using language code \"" << mInterfaceLanguage << "\" to switch to \"" << QLocale::languageToString(mUserLocale.language()) << " (" << QLocale::territoryToString(mUserLocale.territory()) << ")\" locale.";
+    // #endif
 }
 
 void mudlet::readLateSettings(const QSettings& settings)
@@ -2787,9 +2786,9 @@ void mudlet::readLateSettings(const QSettings& settings)
     // Qt::WindowActive from the state and then apply the result of combining
     // the stored state - if we are full-screen then the maximised does not have
     // any effect until we leave that:
-    auto state = windowState() & ~(Qt::WindowMaximized|Qt::WindowFullScreen|Qt::WindowActive);
+    auto state = windowState() & ~(Qt::WindowMaximized | Qt::WindowFullScreen | Qt::WindowActive);
     state |= (settings.value(qsl("fullScreen"), false).toBool() ? Qt::WindowFullScreen : Qt::WindowNoState)
-            |(settings.value(qsl("maximized"), false).toBool() ? Qt::WindowMaximized : Qt::WindowNoState);
+             | (settings.value(qsl("maximized"), false).toBool() ? Qt::WindowMaximized : Qt::WindowNoState);
     setWindowState(state);
 
     mCopyAsImageTimeout = settings.value(qsl("copyAsImageTimeout"), mCopyAsImageTimeout).toInt();
@@ -2996,7 +2995,9 @@ void mudlet::slot_showConnectionDialog()
     QStringList packagesToInstall = mInstanceCoordinator->readPackageQueue();
     mpConnectionDialog->indicatePackagesInstallOnConnect(packagesToInstall);
 
-    connect(mpConnectionDialog, &QDialog::accepted, this, [=, this]() { enableToolbarButtons(); });
+    connect(mpConnectionDialog, &QDialog::accepted, this, [=, this]() {
+        enableToolbarButtons();
+    });
     mpConnectionDialog->setAttribute(Qt::WA_DeleteOnClose);
 
     // Use a timer to ensure the main window is ready before showing the dialog
@@ -3516,10 +3517,7 @@ void mudlet::slot_assignShortcutsFromProfile(Host* pHost)
 void mudlet::slot_updateShortcuts()
 {
     if (Q_LIKELY(mMenuVisibleState.has_value())) {
-        if ((mMenuBarVisibility == enums::visibleNever
-            || (mMenuBarVisibility == enums::visibleOnlyWithoutLoadedProfile && mHostManager.getHostCount()))
-           && (!mMenuVisibleState.value()) ) {
-
+        if ((mMenuBarVisibility == enums::visibleNever || (mMenuBarVisibility == enums::visibleOnlyWithoutLoadedProfile && mHostManager.getHostCount())) && (!mMenuVisibleState.value())) {
             /*
              * IF   EITHER the menu is NOT to be shown
              *      OR the menu is only to be show when there is no profiles AND there IS one
@@ -3532,10 +3530,7 @@ void mudlet::slot_updateShortcuts()
             return;
         }
 
-        if ((mMenuBarVisibility == enums::visibleAlways
-            || (mMenuBarVisibility == enums::visibleOnlyWithoutLoadedProfile && !mHostManager.getHostCount()))
-           && (mMenuVisibleState.value()) ) {
-
+        if ((mMenuBarVisibility == enums::visibleAlways || (mMenuBarVisibility == enums::visibleOnlyWithoutLoadedProfile && !mHostManager.getHostCount())) && (mMenuVisibleState.value())) {
             /*
              * IF   EITHER the menu IS to be shown
              *      OR the menu is only to be show when there is no profiles AND there is NOT one
@@ -3827,11 +3822,8 @@ void mudlet::slot_showMapperDialog()
 
     // Create a new mapper instance for the main window's per-profile dock widget
     // We need to copy player room style details first
-    pHost->getPlayerRoomStyleDetails(pMap->mPlayerRoomStyle,
-                                   pMap->mPlayerRoomOuterDiameterPercentage,
-                                   pMap->mPlayerRoomInnerDiameterPercentage,
-                                   pMap->mPlayerRoomOuterColor,
-                                   pMap->mPlayerRoomInnerColor);
+    pHost->getPlayerRoomStyleDetails(
+            pMap->mPlayerRoomStyle, pMap->mPlayerRoomOuterDiameterPercentage, pMap->mPlayerRoomInnerDiameterPercentage, pMap->mPlayerRoomOuterColor, pMap->mPlayerRoomInnerColor);
 
     // Create the mapper dialog
     auto mainMapper = new dlgMapper(newMapDockWidget, pHost, pMap);
@@ -4106,9 +4098,7 @@ void mudlet::slot_replay()
     QString lastDir = settings.value("lastFileDialogLocation", mudlet::getMudletPath(enums::profileHomePath, pHost->getName())).toString();
 
 
-    const QString fileName = QFileDialog::getOpenFileName(this, tr("Select Replay"),
-                                                    lastDir,
-                                                    tr("*.dat"));
+    const QString fileName = QFileDialog::getOpenFileName(this, tr("Select Replay"), lastDir, tr("*.dat"));
     if (fileName.isEmpty()) {
         // Cancel was hit in QFileDialog::getOpenFileName(...)
         return;
@@ -4187,14 +4177,14 @@ void mudlet::startAutoLogin(const QStringList& cliProfiles)
     hostList.removeDuplicates();
     int loadedProfiles = 0;
 
-    for (auto& hostName : cliProfiles){
+    for (auto& hostName : cliProfiles) {
         if (hostList.contains(hostName)) {
             QElapsedTimer timer;
             timer.start();
             doAutoLogin(hostName);
             hostList.removeOne(hostName);
             loadedProfiles++;
-            qDebug() << "Profile" << hostName << "loaded in" << timer.elapsed()/1000.0 << "seconds";
+            qDebug() << "Profile" << hostName << "loaded in" << timer.elapsed() / 1000.0 << "seconds";
         }
     }
 
@@ -4205,14 +4195,14 @@ void mudlet::startAutoLogin(const QStringList& cliProfiles)
             timer.start();
             doAutoLogin(hostName);
             loadedProfiles++;
-            qDebug() << "Profile" << hostName << "loaded in" << timer.elapsed()/1000.0 << "seconds";
+            qDebug() << "Profile" << hostName << "loaded in" << timer.elapsed() / 1000.0 << "seconds";
         }
     }
 
     if (loadedProfiles == 0) {
         slot_showConnectionDialog();
     } else {
-        qDebug() << "All" << loadedProfiles << "profiles loaded in" << timer.elapsed()/1000.0 << "seconds";
+        qDebug() << "All" << loadedProfiles << "profiles loaded in" << timer.elapsed() / 1000.0 << "seconds";
     }
 }
 
@@ -4424,7 +4414,7 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
         activateWindow();
     }
 
-    TEvent event {};
+    TEvent event{};
     event.mArgumentList.append(QLatin1String("sysLoadEvent"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     // A non-zero value is how we send a "true" value - which indicates that
@@ -4473,7 +4463,7 @@ void mudlet::slot_multiView(const bool state)
     }
     mMultiView = state;
     bool foundActiveHost = false;
-    for (const auto &pHost : mHostManager) {
+    for (const auto& pHost : mHostManager) {
         auto console = pHost->mpConsole;
         if (!console) {
             continue;
@@ -4512,7 +4502,7 @@ void mudlet::toggleMute(bool state, QAction* toolbarAction, QAction* menuAction,
         menuAction->setChecked(state);
     }
 
-    for (const auto &pHost : mHostManager) {
+    for (const auto& pHost : mHostManager) {
         if (state) {
             if (isAPINotGame) {
                 pHost->mpMedia->muteMedia(TMediaData::MediaProtocolAPI);
@@ -4560,13 +4550,10 @@ void mudlet::toggleMute(bool state, QAction* toolbarAction, QAction* menuAction,
 
                 if (sequence && !sequence->toString().isEmpty()) {
                     const QString seq = sequence->toString(QKeySequence::NativeText);
-                    message = isMediaMuted
-                        ? tr("[ INFO ]  - Mudlet and game sounds are muted. Use \"%1\" to unmute.").arg(seq)
-                        : tr("[ INFO ]  - Mudlet and game sounds are unmuted. Use \"%1\" to mute.").arg(seq);
+                    message = isMediaMuted ? tr("[ INFO ]  - Mudlet and game sounds are muted. Use \"%1\" to unmute.").arg(seq)
+                                           : tr("[ INFO ]  - Mudlet and game sounds are unmuted. Use \"%1\" to mute.").arg(seq);
                 } else {
-                    message = isMediaMuted
-                        ? tr("[ INFO ]  - Mudlet and game sounds are muted.")
-                        : tr("[ INFO ]  - Mudlet and game sounds are unmuted.");
+                    message = isMediaMuted ? tr("[ INFO ]  - Mudlet and game sounds are muted.") : tr("[ INFO ]  - Mudlet and game sounds are unmuted.");
                 }
 
                 pHost->postMessage(message);
@@ -4621,8 +4608,7 @@ void mudlet::slot_compactInputLine(const bool state)
         mpCurrentActiveHost->setCompactInputLine(state);
         // Make sure players don't get confused when accidentally hiding buttons.
         if (QKeySequence* shortcut = mpShortcutsManager->getSequence(qsl("Compact input line"));
-                state && !mpCurrentActiveHost->mTutorialForCompactLineAlreadyShown && shortcut && !shortcut->isEmpty()) {
-
+            state && !mpCurrentActiveHost->mTutorialForCompactLineAlreadyShown && shortcut && !shortcut->isEmpty()) {
             //: Here %1 will be replaced with the keyboard shortcut, default is ALT+L.
             const QString infoMsg = tr("[ INFO ]  - Compact input line set. Press \"%1\" to show bottom-right buttons again.").arg(shortcut->toString(QKeySequence::NativeText));
             mpCurrentActiveHost->postMessage(infoMsg);
@@ -4675,11 +4661,11 @@ void mudlet::slot_toggleFullScreenView()
     if (state & Qt::WindowFullScreen) {
         // Need to remove the Qt::WindowFullScreen AND Qt::WindowActive from the
         // state and then apply the result
-        setWindowState(state & ~(Qt::WindowFullScreen|Qt::WindowActive));
+        setWindowState(state & ~(Qt::WindowFullScreen | Qt::WindowActive));
     } else {
         // Need to apply the Qt::WindowFullScreen state after removing
         // Qt::WindowActive from the flags we might read:
-        setWindowState((state & ~(Qt::WindowActive))|Qt::WindowFullScreen);
+        setWindowState((state & ~(Qt::WindowActive)) | Qt::WindowFullScreen);
     }
     // Update the controls to reflect the actual state - note that
     // QAction::setChecked(bool) won't cause excution loops as it doesn't
@@ -4874,8 +4860,7 @@ void mudlet::slot_replayTimeChanged()
 {
     // This can get called by a QTimer after mpLabelReplayTime has been destroyed:
     if (mpLabelReplayTime) {
-        mpLabelReplayTime->setText(qsl("<font size=25><b>%1</b></font>")
-                                   .arg(tr("Time: %1").arg(mReplayTime.toString(mTimeFormat))));
+        mpLabelReplayTime->setText(qsl("<font size=25><b>%1</b></font>").arg(tr("Time: %1").arg(mReplayTime.toString(mTimeFormat))));
         mpLabelReplayTime->show();
     }
 }
@@ -4937,7 +4922,7 @@ void mudlet::slot_replaySpeedDown()
 void mudlet::setEditorTextoptions(const bool isTabsAndSpacesToBeShown, const bool isLinesAndParagraphsToBeShown)
 {
     mEditorTextOptions = QTextOption::Flags((isTabsAndSpacesToBeShown ? QTextOption::ShowTabsAndSpaces : QTextOption::Flag())
-                                           |(isLinesAndParagraphsToBeShown ? QTextOption::ShowLineAndParagraphSeparators : QTextOption::Flag()));
+                                            | (isLinesAndParagraphsToBeShown ? QTextOption::ShowLineAndParagraphSeparators : QTextOption::Flag()));
     emit signal_editorTextOptionsChanged(mEditorTextOptions);
 }
 
@@ -4958,7 +4943,8 @@ bool mudlet::unzip(const QString& archivePath, const QString& destination, const
     if (!archive) {
         zip_error_t error;
         zip_error_init_with_code(&error, err);
-        qWarning().noquote().nospace() << "mudlet::unzip(\"" << archivePath << "\", \"" << destination << "\", \"" << tmpDir.absolutePath() << "\") WARNING - failed to unzip file, error: \"" << zip_error_strerror(&error) << "\"";
+        qWarning().noquote().nospace() << "mudlet::unzip(\"" << archivePath << "\", \"" << destination << "\", \"" << tmpDir.absolutePath() << "\") WARNING - failed to unzip file, error: \""
+                                       << zip_error_strerror(&error) << "\"";
         zip_error_fini(&error);
         return false;
     }
@@ -5051,7 +5037,7 @@ bool mudlet::unzip(const QString& archivePath, const QString& destination, const
 
     err = zip_close(archive);
     if (err) {
-        zip_error_t *error = zip_get_error(archive);
+        zip_error_t* error = zip_get_error(archive);
         qWarning().noquote().nospace() << "mudlet::unzip(\"" << archivePath << "\", \"" << destination << "\", \"" << tmpDir.absolutePath() << "\") Warning - " << zip_error_strerror(error);
         zip_error_fini(error);
         zip_discard(archive);
@@ -5390,8 +5376,7 @@ void mudlet::slot_updateAvailable(const int updateCount)
     pUpdateMenu->insertAction(nullptr, mpActionAbout);
     // We can then add in the new item to give access the update(s)
     //: Review update(s) menu item, %n is the count of how many updates are available
-    auto pActionReview = pUpdateMenu->addAction(tr("Review %n update(s)...", nullptr, updateCount),
-                                                this, &mudlet::slot_manualUpdateCheck);
+    auto pActionReview = pUpdateMenu->addAction(tr("Review %n update(s)...", nullptr, updateCount), this, &mudlet::slot_manualUpdateCheck);
     //: Tool-tip for review update(s) menu item, given that the count of how many updates are available is already shown in the menu, the %n parameter that is that number need not be used here
     pActionReview->setToolTip(utils::richText(tr("Review the update(s) available...", nullptr, updateCount)));
     // Override the default hide tooltips state:
@@ -5483,7 +5468,8 @@ Host* mudlet::loadProfile(const QString& profile_name, const bool playOnline, co
             pHost->mProfileLoadError = message;
             //: %1 is the path and file name (i.e. the location) of the problem fil
             pHost->postMessage(tr("[ ERROR ] - Something went wrong loading your Mudlet profile and it could not be loaded.\n"
-            "Try loading an older version in 'Connect - Options - Profile history' or double-check that %1 looks correct.").arg(file.fileName()));
+                                  "Try loading an older version in 'Connect - Options - Profile history' or double-check that %1 looks correct.")
+                                       .arg(file.fileName()));
 
             qDebug().nospace().noquote() << "mudlet::loadProfile(" << profile_name << ", " << playOnline << ") ERROR - loading \"" << file.fileName() << "\" failed, reason: \"" << message << "\".";
         } else {
@@ -5582,8 +5568,8 @@ std::string mudlet::replaceString(std::string subject, const std::string& search
 {
     size_t pos = 0;
     while ((pos = subject.find(search, pos)) != std::string::npos) {
-         subject.replace(pos, search.length(), replace);
-         pos += replace.length();
+        subject.replace(pos, search.length(), replace);
+        pos += replace.length();
     }
     return subject;
 }
@@ -5631,8 +5617,7 @@ bool mudlet::migratePasswordsToSecureStorage()
 
     mStorePasswordsSecurely = true;
 
-    const QStringList profiles = QDir(mudlet::getMudletPath(enums::profilesPath))
-                                   .entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+    const QStringList profiles = QDir(mudlet::getMudletPath(enums::profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
 
     bool anyMigrationNeeded = false;
 
@@ -5646,9 +5631,11 @@ bool mudlet::migratePasswordsToSecureStorage()
                 // that users may still have installed alongside development builds
                 if (isVersionAtLeast(qsl("4.20.0"))) {
                     deleteProfileData(profile, qsl("password"));
-                    qDebug().nospace().noquote() << "mudlet::migratePasswordsToSecureStorage() INFO - migrated password for profile \"" << profile << "\" from old format and cleaned up legacy storage.";
+                    qDebug().nospace().noquote() << "mudlet::migratePasswordsToSecureStorage() INFO - migrated password for profile \"" << profile
+                                                 << "\" from old format and cleaned up legacy storage.";
                 } else {
-                    qDebug().nospace().noquote() << "mudlet::migratePasswordsToSecureStorage() INFO - migrated password for profile \"" << profile << "\" from old format (legacy storage preserved for compatibility).";
+                    qDebug().nospace().noquote() << "mudlet::migratePasswordsToSecureStorage() INFO - migrated password for profile \"" << profile
+                                                 << "\" from old format (legacy storage preserved for compatibility).";
                 }
                 anyMigrationNeeded = true;
             } else {
@@ -5693,9 +5680,11 @@ bool mudlet::migratePasswordsToProfileStorage()
             // This prevents breaking compatibility with older Mudlet versions
             if (isVersionAtLeast(qsl("4.20.0"))) {
                 CredentialManager::removeCredential(profile, "character");
-                qDebug().nospace().noquote() << "mudlet::migratePasswordsToProfileStorage() INFO - migrated password for profile \"" << profile << "\" to profile storage and cleaned up secure storage.";
+                qDebug().nospace().noquote() << "mudlet::migratePasswordsToProfileStorage() INFO - migrated password for profile \"" << profile
+                                             << "\" to profile storage and cleaned up secure storage.";
             } else {
-                qDebug().nospace().noquote() << "mudlet::migratePasswordsToProfileStorage() INFO - migrated password for profile \"" << profile << "\" to profile storage (secure storage preserved for compatibility).";
+                qDebug().nospace().noquote() << "mudlet::migratePasswordsToProfileStorage() INFO - migrated password for profile \"" << profile
+                                             << "\" to profile storage (secure storage preserved for compatibility).";
             }
         }
 
@@ -5739,14 +5728,15 @@ void mudlet::slot_passwordMigratedToPortableStorage(QKeychain::Job* job)
         // Only delete from secure storage if this version is >= 4.20.0
         // This prevents breaking compatibility with older Mudlet versions
         if (isVersionAtLeast(qsl("4.20.0"))) {
-            auto *deleteJob = new QKeychain::DeletePasswordJob(qsl("Mudlet profile"));
+            auto* deleteJob = new QKeychain::DeletePasswordJob(qsl("Mudlet profile"));
             deleteJob->setAutoDelete(true);
             deleteJob->setKey(profileName);
             deleteJob->setProperty("profile", profileName);
             deleteJob->start();
             qDebug().nospace().noquote() << "mudlet::slot_passwordMigratedToPortableStorage() INFO - migrated password for profile \"" << profileName << "\" and cleaned up legacy keychain storage.";
         } else {
-            qDebug().nospace().noquote() << "mudlet::slot_passwordMigratedToPortableStorage() INFO - migrated password for profile \"" << profileName << "\" (legacy keychain storage preserved for compatibility).";
+            qDebug().nospace().noquote() << "mudlet::slot_passwordMigratedToPortableStorage() INFO - migrated password for profile \"" << profileName
+                                         << "\" (legacy keychain storage preserved for compatibility).";
         }
     }
     mProfilePasswordsToMigrate.removeAll(profileName);
@@ -5766,7 +5756,8 @@ void mudlet::slot_passwordMigratedToSecureStorage(QKeychain::Job* job)
     if (job->error()) {
         const auto error = job->errorString();
         if (error != qsl("Entry not found") && error != qsl("No match")) {
-            qWarning().nospace().noquote() << "mudlet::slot_passwordMigratedToSecureStorage(...) ERROR - could not migrate character password for \"" << characterName << "\" in profile \"" << profileName << "\"; error was: " << error << ".";
+            qWarning().nospace().noquote() << "mudlet::slot_passwordMigratedToSecureStorage(...) ERROR - could not migrate character password for \"" << characterName << "\" in profile \""
+                                           << profileName << "\"; error was: " << error << ".";
         }
     } else {
         auto readJob = static_cast<QKeychain::ReadPasswordJob*>(job);
@@ -5778,15 +5769,17 @@ void mudlet::slot_passwordMigratedToSecureStorage(QKeychain::Job* job)
         // Only delete from QtKeychain if this version is >= 4.20.0
         // This prevents breaking compatibility with older Mudlet versions
         if (isVersionAtLeast(qsl("4.20.0"))) {
-            auto *deleteJob = new QKeychain::DeletePasswordJob(qsl("Mudlet profile"));
+            auto* deleteJob = new QKeychain::DeletePasswordJob(qsl("Mudlet profile"));
             deleteJob->setAutoDelete(true);
             deleteJob->setKey(characterName);
             deleteJob->setProperty("profile", profileName);
             deleteJob->setProperty("character", characterName);
             deleteJob->start();
-            qDebug().nospace().noquote() << "mudlet::slot_passwordMigratedToSecureStorage() INFO - migrated character password for \"" << characterName << "\" in profile \"" << profileName << "\" and cleaned up legacy keychain storage.";
+            qDebug().nospace().noquote() << "mudlet::slot_passwordMigratedToSecureStorage() INFO - migrated character password for \"" << characterName << "\" in profile \"" << profileName
+                                         << "\" and cleaned up legacy keychain storage.";
         } else {
-            qDebug().nospace().noquote() << "mudlet::slot_passwordMigratedToSecureStorage() INFO - migrated character password for \"" << characterName << "\" in profile \"" << profileName << "\" (legacy keychain storage preserved for compatibility).";
+            qDebug().nospace().noquote() << "mudlet::slot_passwordMigratedToSecureStorage() INFO - migrated character password for \"" << characterName << "\" in profile \"" << profileName
+                                         << "\" (legacy keychain storage preserved for compatibility).";
         }
     }
 
@@ -5913,11 +5906,11 @@ void mudlet::setInterfaceLanguage(const QString& languageCode)
                                            << "\") WARNING - Unable to convert given language code to a recognised locale, reverting to the POSIX 'C' one.";
         } else {
 #if QT_VERSION < QT_VERSION_CHECK(6, 2, 0)
-            qDebug().nospace().noquote() << "mudlet::setInterfaceLanguage(\"" << languageCode
-                                         << "\") INFO - switching to \"" << QLocale::languageToString(mUserLocale.language()) << " (" << QLocale::countryToString(mUserLocale.country()) << ")\" locale.";
+            qDebug().nospace().noquote() << "mudlet::setInterfaceLanguage(\"" << languageCode << "\") INFO - switching to \"" << QLocale::languageToString(mUserLocale.language()) << " ("
+                                         << QLocale::countryToString(mUserLocale.country()) << ")\" locale.";
 #else
-            qDebug().nospace().noquote() << "mudlet::setInterfaceLanguage(\"" << languageCode
-                                         << "\") INFO - switching to \"" << QLocale::languageToString(mUserLocale.language()) << " (" << QLocale::territoryToString(mUserLocale.territory()) << ")\" locale.";
+            qDebug().nospace().noquote() << "mudlet::setInterfaceLanguage(\"" << languageCode << "\") INFO - switching to \"" << QLocale::languageToString(mUserLocale.language()) << " ("
+                                         << QLocale::territoryToString(mUserLocale.territory()) << ")\" locale.";
 #endif
         }
         loadTranslators(languageCode);
@@ -5936,7 +5929,7 @@ QString mudlet::autodetectPreferredLanguage()
 {
     // en_GB is a temporary special exception due to its likeness to en_US, while its
     // translation is still only at 20%
-    QVector<QString> availableQualityTranslations {qsl("en_GB")};
+    QVector<QString> availableQualityTranslations{qsl("en_GB")};
     for (auto& code : getAvailableTranslationCodes()) {
         auto& translation = mTranslationsMap[code];
         if (translation.fromResourceFile()) {
@@ -5961,7 +5954,7 @@ QString mudlet::autodetectPreferredLanguage()
 }
 
 // Returns false on significant failure (where the caller will have to bail out)
-bool mudlet::scanDictionaryFile(const QString& dictionaryPath, int& oldWC, QHash<QString, unsigned int>&gc, QStringList& wl)
+bool mudlet::scanDictionaryFile(const QString& dictionaryPath, int& oldWC, QHash<QString, unsigned int>& gc, QStringList& wl)
 {
     QFile dict(dictionaryPath);
     if (!dict.exists()) {
@@ -5969,7 +5962,7 @@ bool mudlet::scanDictionaryFile(const QString& dictionaryPath, int& oldWC, QHash
     }
 
     // First update the line count in the list of words
-    if (!dict.open(QFile::ReadOnly|QFile::Text)) {
+    if (!dict.open(QFile::ReadOnly | QFile::Text)) {
         qWarning().nospace().noquote() << "mudlet::scanDictionaryFile(...) ERROR - failed to open dictionary file (for reading): \"" << dict.fileName() << "\" reason: " << dict.errorString();
         return false;
     }
@@ -6037,7 +6030,7 @@ bool mudlet::overwriteDictionaryFile(const QString& dictionaryPath, const QStrin
     // QFile::WriteOnly automatically implies QFile::Truncate in the absence of
     // certain other flags:
     QSaveFile dict(dictionaryPath);
-    if (!dict.open(QFile::WriteOnly|QFile::Text)) {
+    if (!dict.open(QFile::WriteOnly | QFile::Text)) {
         qWarning().nospace().noquote() << "mudlet::overwriteDictionaryFile(...) ERROR - failed to open dictionary file (for writing): \"" << dict.fileName() << "\" reason: " << dict.errorString();
         return false;
     }
@@ -6045,8 +6038,8 @@ bool mudlet::overwriteDictionaryFile(const QString& dictionaryPath, const QStrin
     QTextStream ds(&dict);
     ds << qMax(0, wl.count());
     if (!wl.isEmpty()) {
-      ds << QChar(QChar::LineFeed);
-      ds << wl.join(QChar::LineFeed).toUtf8();
+        ds << QChar(QChar::LineFeed);
+        ds << wl.join(QChar::LineFeed).toUtf8();
     }
     ds.flush();
     dict.commit();
@@ -6059,10 +6052,10 @@ bool mudlet::overwriteDictionaryFile(const QString& dictionaryPath, const QStrin
 }
 
 // Returns -1 on significant failure (where the caller will have to bail out)
-int mudlet::getDictionaryWordCount(const QString &dictionaryPath)
+int mudlet::getDictionaryWordCount(const QString& dictionaryPath)
 {
     QFile dict(dictionaryPath);
-    if (!dict.open(QFile::ReadOnly|QFile::Text)) {
+    if (!dict.open(QFile::ReadOnly | QFile::Text)) {
         qWarning().nospace().noquote() << "mudlet::saveDictionary(...) ERROR - failed to open dictionary file (for reading): \"" << dict.fileName() << "\" reason: " << dict.errorString();
         return -1;
     }
@@ -6109,7 +6102,7 @@ bool mudlet::overwriteAffixFile(const QString& affixPath, const QHash<QString, u
 
     QSaveFile aff(affixPath);
     // Finally, having got the needed content, write it out:
-    if (!aff.open(QFile::WriteOnly|QFile::Text)) {
+    if (!aff.open(QFile::WriteOnly | QFile::Text)) {
         qWarning().nospace().noquote() << "mudlet::overwriteAffixFile(...) ERROR - failed to open affix file (for writing): \"" << aff.fileName() << "\" reason: " << aff.errorString();
         return false;
     }
@@ -6295,7 +6288,7 @@ bool mudlet::saveDictionary(const QString& pathFileBaseName, QSet<QString>& word
     if (wordCount > oldWordCount) {
         qDebug().nospace().noquote() << "  Saved an extra " << wordCount - oldWordCount << " words in dictionary.";
     } else if (wordCount < oldWordCount) {
-        qDebug().nospace().noquote() << "  Saved " << oldWordCount - wordCount  << " fewer words in dictionary.";
+        qDebug().nospace().noquote() << "  Saved " << oldWordCount - wordCount << " fewer words in dictionary.";
     } else {
         qDebug().nospace().noquote() << "  No change in the number of words saved in dictionary.";
     }
@@ -6356,7 +6349,7 @@ std::pair<bool, QString> mudlet::setProfileIcon(const QString& profile, const QS
     }
 
     if (!QFile::copy(newIconPath, profileIconPath)) {
-        qWarning() << "mudlet::setProfileIcon() ERROR: couldn't copy new icon" << newIconPath<< " to" << profileIconPath;
+        qWarning() << "mudlet::setProfileIcon() ERROR: couldn't copy new icon" << newIconPath << " to" << profileIconPath;
         return {false, qsl("couldn't copy icon file into new location")};
     }
 
@@ -6468,7 +6461,7 @@ void mudlet::activateProfile(Host* pHost)
 
     if (mpCurrentActiveHost && mpCurrentActiveHost->mpConsole) {
         // Tell the old profile that it is losing focus:
-        TEvent focusLostEvent {};
+        TEvent focusLostEvent{};
         focusLostEvent.mArgumentList << QLatin1String("sysProfileFocusChangeEvent");
         // Boolean arguments are carried as "0" for false or "1" for true,
         // This is for the profile that is losing focus:
@@ -6542,7 +6535,7 @@ void mudlet::activateProfile(Host* pHost)
     menuBar()->setStyleSheet(mpCurrentActiveHost->mProfileStyleSheet);
 
     // Tell the new profile that it is gaining focus via a Mudlet event:
-    TEvent focusGainedEvent {};
+    TEvent focusGainedEvent{};
     focusGainedEvent.mArgumentList << QLatin1String("sysProfileFocusChangeEvent");
     focusGainedEvent.mArgumentList << QLatin1String("1");
     focusGainedEvent.mArgumentTypeList << ARGUMENT_TYPE_STRING << ARGUMENT_TYPE_BOOLEAN;
@@ -6598,7 +6591,7 @@ void mudlet::setupTrayIcon()
     auto menu = new QMenu(this);
     auto hideTrayAction = new QAction(tr("Hide tray icon"), this);
     connect(hideTrayAction, &QAction::triggered, this, [=, this]() {
-       mTrayIcon.hide();
+        mTrayIcon.hide();
     });
     menu->addAction(hideTrayAction);
     auto exitAction = new QAction(tr("Quit Mudlet"), this);
@@ -6621,7 +6614,7 @@ void mudlet::slot_tabMoved(const int oldPos, const int newPos)
             auto name = pWidget->property("HostName").toString();
             widgetMap.insert(name, pWidget);
         } else {
-            qWarning().nospace().noquote() << "mudlet::slot_tabMoved(" << oldPos<< ", " << newPos << ") WARNING - nullptr for pointer to TMainConsole at 'profileIndex': " << profileIndex << ".";
+            qWarning().nospace().noquote() << "mudlet::slot_tabMoved(" << oldPos << ", " << newPos << ") WARNING - nullptr for pointer to TMainConsole at 'profileIndex': " << profileIndex << ".";
         }
     }
     // Now go through all the names, pull the associated TMainConsoles from the
@@ -6658,7 +6651,7 @@ void mudlet::refreshTabBar()
 void mudlet::setupPreInstallPackages(const QString& gameUrl, const QString& profileName)
 {
     const QHash<QString, QStringList> defaultScripts = {
-        // clang-format off
+            // clang-format off
         // scripts to pre-install for a profile      games this applies to, * means all games
         {qsl(":/run-lua-code.mpackage"),             {qsl("*")}},
         {qsl(":/echo.mpackage"),                     {qsl("*")}},
@@ -6680,7 +6673,7 @@ void mudlet::setupPreInstallPackages(const QString& gameUrl, const QString& prof
                                                       qsl("starmourn.com"),
                                                       qsl("stickmud.com")}},
         {qsl(":/MedBootstrap.xml"),                  {qsl("medievia.com")}}
-        // clang-format on
+            // clang-format on
     };
 
     QHashIterator<QString, QStringList> i(defaultScripts);
@@ -6753,8 +6746,8 @@ void mudlet::onlyShowProfiles(const QStringList& predefinedProfiles)
 #else
     if (const bool layEasterEgg = (now.date().month() == 4
                         && now.date().day() == 1); layEasterEgg) {
-#endif // ! DEBUG_EASTER_EGGS
-        // clang-format on
+#endif // ! DEBUG_EASTER_EGGS                                                                                                                                                                                \
+        // clang-format on                                                                                                                                                                             \
         // Set to one more than the highest number Mudlet_splashscreen_other_NN.png:
         auto egg = QRandomGenerator::global()->bounded(24);
         if (egg) {
@@ -6762,21 +6755,17 @@ void mudlet::onlyShowProfiles(const QStringList& predefinedProfiles)
             return QImage(eggFileName);
         }
         // For the zeroth case just rotate the picture 180 degrees:
-        const QImage original(releaseVersion
-                                ? qsl(":/splash/Mudlet_splashscreen_main.png")
-                                : testVersion ? qsl(":/splash/Mudlet_splashscreen_ptb.png")
-                                                                 : qsl(":/splash/Mudlet_splashscreen_development.png"));
+        const QImage original(releaseVersion ? qsl(":/splash/Mudlet_splashscreen_main.png")
+                              : testVersion  ? qsl(":/splash/Mudlet_splashscreen_ptb.png")
+                                             : qsl(":/splash/Mudlet_splashscreen_development.png"));
 #if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
-        return original.flipped(Qt::Horizontal|Qt::Vertical);
+        return original.flipped(Qt::Horizontal | Qt::Vertical);
 #else
         // Deprecated in 6.9 and due for removal in 6.13:
         return original.mirrored(true, true);
 #endif
     }
-    return QImage(releaseVersion
-                              ? qsl(":/splash/Mudlet_splashscreen_main.png")
-                              : testVersion ? qsl(":/splash/Mudlet_splashscreen_ptb.png")
-                                                               : qsl(":/splash/Mudlet_splashscreen_development.png"));
+    return QImage(releaseVersion ? qsl(":/splash/Mudlet_splashscreen_main.png") : testVersion ? qsl(":/splash/Mudlet_splashscreen_ptb.png") : qsl(":/splash/Mudlet_splashscreen_development.png"));
 #else
     return QImage(qsl(":/splash/Mudlet_splashscreen_main.png"));
 #endif // INCLUDE_VARIABLE_SPLASH_SCREEN
@@ -6827,7 +6816,7 @@ bool mudlet::experiencedMudletPlayer()
     QFileInfoList entries = profilesDir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
     QDateTime sixMonthsAgo = QDateTime::currentDateTime().addMonths(-6);
 
-    for (const QFileInfo &entry : entries) {
+    for (const QFileInfo& entry : entries) {
         if (entry.lastModified() < sixMonthsAgo) {
             cachedResult = true;
             return true;
@@ -6884,8 +6873,7 @@ void mudlet::changeEvent(QEvent* event)
 
 bool mudlet::profileExists(const QString& profileName)
 {
-    const QStringList profiles = QDir(mudlet::getMudletPath(enums::profilesPath))
-                                 .entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+    const QStringList profiles = QDir(mudlet::getMudletPath(enums::profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
 
     if (profiles.contains(profileName, Qt::CaseInsensitive)) {
         return true;
@@ -6901,10 +6889,8 @@ void mudlet::initializeAI()
     mpLlamafileManager = std::make_unique<LlamafileManager>(this);
 
     // Connect signals
-    connect(mpLlamafileManager.get(), &LlamafileManager::statusChanged,
-            this, &mudlet::slot_aiStatusChanged);
-    connect(mpLlamafileManager.get(), &LlamafileManager::processError,
-            this, &mudlet::slot_aiError);
+    connect(mpLlamafileManager.get(), &LlamafileManager::statusChanged, this, &mudlet::slot_aiStatusChanged);
+    connect(mpLlamafileManager.get(), &LlamafileManager::processError, this, &mudlet::slot_aiError);
 
     // Try to find and configure AI model
     if (findAIModel()) {
@@ -6979,13 +6965,8 @@ bool mudlet::findAIModel()
 
     // Search for llamafile executables in common locations
     QStringList searchPaths;
-    searchPaths << QCoreApplication::applicationDirPath()
-                << QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
-                << QStandardPaths::writableLocation(QStandardPaths::DownloadLocation)
-                << getMudletPath(enums::profilesPath)
-                << (getMudletPath(enums::profilesPath) + "/ai")
-                << "/usr/local/bin"
-                << "/opt/llamafile";
+    searchPaths << QCoreApplication::applicationDirPath() << QStandardPaths::writableLocation(QStandardPaths::HomeLocation) << QStandardPaths::writableLocation(QStandardPaths::DownloadLocation)
+                << getMudletPath(enums::profilesPath) << (getMudletPath(enums::profilesPath) + "/ai") << "/usr/local/bin" << "/opt/llamafile";
 
     QString foundPath = LlamafileManager::findLlamafileExecutable(searchPaths);
     if (!foundPath.isEmpty()) {
@@ -7168,14 +7149,11 @@ void mudlet::detachTab(int tabIndex, const QPoint& position)
     transferDockWidgetToDetachedWindow(profileName, detachedWindow);
 
     // Connect signals
-    connect(detachedWindow, &TDetachedWindow::reattachRequested,
-            this, [this](const QString& profileName) {
-                slot_tabReattachRequested(profileName, -1); // Use default insert index
-            });
-    connect(detachedWindow, &TDetachedWindow::windowClosed,
-            this, &mudlet::slot_detachedWindowClosed);
-    connect(detachedWindow, &TDetachedWindow::profileDetachToWindowRequested,
-            this, &mudlet::slot_profileDetachToWindow);
+    connect(detachedWindow, &TDetachedWindow::reattachRequested, this, [this](const QString& profileName) {
+        slot_tabReattachRequested(profileName, -1); // Use default insert index
+    });
+    connect(detachedWindow, &TDetachedWindow::windowClosed, this, &mudlet::slot_detachedWindowClosed);
+    connect(detachedWindow, &TDetachedWindow::profileDetachToWindowRequested, this, &mudlet::slot_profileDetachToWindow);
 
     // Initialize the toolbar for this profile
     if (pHost) {
@@ -7269,8 +7247,7 @@ void mudlet::reattachTab(const QString& profileName, int insertIndex)
 
         if (auto* existingConsole = qobject_cast<TMainConsole*>(widget)) {
             if (existingConsole->objectName() == safeProfileName) {
-                qWarning() << "reattachTab: CONFLICT! Main window already has console for" << safeProfileName
-                          << "existing:" << existingConsole << "moving:" << console;
+                qWarning() << "reattachTab: CONFLICT! Main window already has console for" << safeProfileName << "existing:" << existingConsole << "moving:" << console;
                 // Remove the conflicting console
                 existingConsole->setParent(nullptr);
                 existingConsole->hide();
@@ -7437,8 +7414,7 @@ void mudlet::addConsoleToSplitter(TMainConsole* console, int index)
 
     // Safety check: make sure console doesn't have a conflicting parent
     if (console->parentWidget() && console->parentWidget() != mpSplitter_profileContainer) {
-        qWarning() << "addConsoleToSplitter: Console has unexpected parent" << console->parentWidget()
-                   << ", removing from current parent first";
+        qWarning() << "addConsoleToSplitter: Console has unexpected parent" << console->parentWidget() << ", removing from current parent first";
         // Remove from current parent without setting to nullptr
         if (auto* layout = console->parentWidget()->layout()) {
             layout->removeWidget(console);
@@ -7526,9 +7502,7 @@ QIcon mudlet::createConnectionStatusIcon(bool isConnected, bool isConnecting, bo
         painter.setBrush(QColor(220, 50, 50));
         painter.setPen(QPen(QColor(180, 40, 40), 1));
         QPolygon triangle;
-        triangle << QPoint(centerX, centerY - 4)
-                 << QPoint(centerX - 4, centerY + 3)
-                 << QPoint(centerX + 4, centerY + 3);
+        triangle << QPoint(centerX, centerY - 4) << QPoint(centerX - 4, centerY + 3) << QPoint(centerX + 4, centerY + 3);
         painter.drawPolygon(triangle);
     } else if (isConnected) {
         // Green filled circle for connected
@@ -7721,10 +7695,10 @@ void mudlet::moveProfileBetweenDetachedWindows(const QString& profileName, TDeta
     sourceWindow->removeProfile(profileName);
 
     // Important: Reset console properties before moving to ensure proper sizing
-    console->setParent(nullptr);  // Temporarily unparent
+    console->setParent(nullptr); // Temporarily unparent
     console->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     console->setMinimumSize(0, 0);
-    console->setMaximumSize(16777215, 16777215);  // Qt's maximum size
+    console->setMaximumSize(16777215, 16777215); // Qt's maximum size
 
     // Ensure console is in a clean state before adding to new window
     console->hide();
@@ -7889,8 +7863,7 @@ void mudlet::moveProfileFromDetachedToMainWindow(const QString& profileName, TDe
         QWidget* widget = mpSplitter_profileContainer->widget(i);
         if (auto* existingConsole = qobject_cast<TMainConsole*>(widget)) {
             if (existingConsole->objectName() == profileName) {
-                qWarning() << "moveProfileFromDetachedToMainWindow: CONFLICT! Main window already has console for" << profileName
-                          << "existing:" << existingConsole << "moving:" << console;
+                qWarning() << "moveProfileFromDetachedToMainWindow: CONFLICT! Main window already has console for" << profileName << "existing:" << existingConsole << "moving:" << console;
                 // Remove the conflicting console - need to use setParent for splitter widgets
                 existingConsole->setParent(nullptr);
                 existingConsole->hide();
@@ -7970,8 +7943,7 @@ void mudlet::moveProfileFromDetachedToMainWindow(const QString& profileName, TDe
     // Make sure the moved profile becomes the current active one
     if (pHost && mpCurrentActiveHost != pHost) {
 #if defined(DEBUG_WINDOW_HANDLING)
-        qDebug() << "moveProfileFromDetachedToMainWindow: Current active host is" << (mpCurrentActiveHost ? mpCurrentActiveHost->getName() : "null")
-                 << ", forcing switch to" << pHost->getName();
+        qDebug() << "moveProfileFromDetachedToMainWindow: Current active host is" << (mpCurrentActiveHost ? mpCurrentActiveHost->getName() : "null") << ", forcing switch to" << pHost->getName();
 #endif
         mpCurrentActiveHost = pHost;
     }
@@ -8064,8 +8036,7 @@ void mudlet::updateMainWindowDockWidgetVisibilityForProfile(const QString& profi
     mpCurrentMapDockWidget = nullptr;
 
 #if defined(DEBUG_WINDOW_HANDLING)
-    qDebug() << "mudlet::updateMainWindowDockWidgetVisibilityForProfile: Starting for profile" << profileName
-             << "- mMainWindowDockWidgetMap.size():" << mMainWindowDockWidgetMap.size();
+    qDebug() << "mudlet::updateMainWindowDockWidgetVisibilityForProfile: Starting for profile" << profileName << "- mMainWindowDockWidgetMap.size():" << mMainWindowDockWidgetMap.size();
 #endif
 
     // Collect dock widgets to process to avoid iterator invalidation
@@ -8097,8 +8068,7 @@ void mudlet::updateMainWindowDockWidgetVisibilityForProfile(const QString& profi
         // Check if the dock widget still exists and is in our map
         if (!dockWidget || !mMainWindowDockWidgetMap.contains(dockKey)) {
 #if defined(DEBUG_WINDOW_HANDLING)
-            qDebug() << "mudlet: Skipping main window dock widget" << dockKey << "- widget exists:" << (dockWidget != nullptr)
-                     << "in map:" << mMainWindowDockWidgetMap.contains(dockKey);
+            qDebug() << "mudlet: Skipping main window dock widget" << dockKey << "- widget exists:" << (dockWidget != nullptr) << "in map:" << mMainWindowDockWidgetMap.contains(dockKey);
 #endif
             continue;
         }
@@ -8115,9 +8085,7 @@ void mudlet::updateMainWindowDockWidgetVisibilityForProfile(const QString& profi
                 // Check the user's preference for dock widget visibility
                 bool shouldBeVisible = mMainWindowDockWidgetUserPreference.value(dockKey, false);
 #if defined(DEBUG_WINDOW_HANDLING)
-                qDebug() << "mudlet: Found main window dock widget for current profile" << profileName
-                         << "currently visible:" << dockWidget->isVisible()
-                         << "should be visible:" << shouldBeVisible;
+                qDebug() << "mudlet: Found main window dock widget for current profile" << profileName << "currently visible:" << dockWidget->isVisible() << "should be visible:" << shouldBeVisible;
 #endif
 
                 // Show or hide based on user preference
@@ -8189,10 +8157,8 @@ void mudlet::updateMainWindowDockWidgetVisibilityForProfile(const QString& profi
 
 #if defined(DEBUG_WINDOW_HANDLING)
     // Debug output to help track dock widget visibility changes
-    qDebug() << "mudlet::updateMainWindowDockWidgetVisibilityForProfile:" << profileName
-             << "- Found visible dock widget:" << currentProfileHasVisibleDockWidget
-             << "- Total dock widgets:" << dockWidgetsToProcess.size()
-             << "- mpCurrentMapDockWidget set:" << (mpCurrentMapDockWidget != nullptr);
+    qDebug() << "mudlet::updateMainWindowDockWidgetVisibilityForProfile:" << profileName << "- Found visible dock widget:" << currentProfileHasVisibleDockWidget
+             << "- Total dock widgets:" << dockWidgetsToProcess.size() << "- mpCurrentMapDockWidget set:" << (mpCurrentMapDockWidget != nullptr);
 #endif
 }
 

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -67,8 +67,7 @@ static void cleanupSquirrelTempFiles()
     }
 
     if (removedCount > 0) {
-        qWarning() << "Cleaned up" << removedCount << "Mudlet .nupkg files from SquirrelTemp, freed"
-                  << (freedSpace / 1024 / 1024) << "MB of disk space";
+        qWarning() << "Cleaned up" << removedCount << "Mudlet .nupkg files from SquirrelTemp, freed" << (freedSpace / 1024 / 1024) << "MB of disk space";
     }
 }
 #endif // Q_OS_WINDOWS
@@ -81,7 +80,8 @@ static void cleanupSquirrelTempFiles()
 //   and promptly quits. Installer updates Mudlet and launches Mudlet when its done
 // mac: handled completely outside of Mudlet by Sparkle
 
-Updater::Updater(QObject* parent, QSettings* settings, bool testVersion) : QObject(parent)
+Updater::Updater(QObject* parent, QSettings* settings, bool testVersion)
+: QObject(parent)
 , mpInstallOrRestart(new QPushButton(tr("Update")))
 , mUpdateInstalled(false)
 {
@@ -204,7 +204,9 @@ void Updater::showChangelog() const
 void Updater::showFullChangelog() const
 {
     if (!feed->isReady()) {
-        KDToolBox::connectSingleShot(feed, &dblsqd::Feed::ready, feed, [=, this]() { showChangelog(); });
+        KDToolBox::connectSingleShot(feed, &dblsqd::Feed::ready, feed, [=, this]() {
+            showChangelog();
+        });
         feed->load();
         return;
     }
@@ -341,7 +343,9 @@ void Updater::setupOnLinux()
         }
         const QString fileName = downloadFile->fileName();
 
-        QFuture<void> future = QtConcurrent::run([=, this]() { untarOnLinux(fileName); });
+        QFuture<void> future = QtConcurrent::run([=, this]() {
+            untarOnLinux(fileName);
+        });
 
         // replace current binary with the unzipped one
         auto watcher = new QFutureWatcher<void>;
@@ -380,9 +384,7 @@ void Updater::slot_updateLinuxBinary()
 
     QFileInfo unzippedBinary(QStandardPaths::writableLocation(QStandardPaths::TempLocation) + "/" + unzippedBinaryName);
     auto systemEnvironment = QProcessEnvironment::systemEnvironment();
-    auto appimageLocation = systemEnvironment.contains(qsl("APPIMAGE")) ?
-                systemEnvironment.value(qsl("APPIMAGE"), QString()) :
-                QCoreApplication::applicationFilePath();
+    auto appimageLocation = systemEnvironment.contains(qsl("APPIMAGE")) ? systemEnvironment.value(qsl("APPIMAGE"), QString()) : QCoreApplication::applicationFilePath();
 
     const QString& installedBinaryPath(appimageLocation);
 
@@ -431,8 +433,7 @@ void Updater::slot_installOrRestartClicked(QAbstractButton* button, const QStrin
         // The installer will relaunch Mudlet after the update completes.
         if (mDownloadedInstallerPath.isEmpty() || !QFile::exists(mDownloadedInstallerPath)) {
             qWarning() << "Installer not found at:" << mDownloadedInstallerPath;
-            QMessageBox::warning(nullptr, tr("Update Error"),
-                tr("The update installer could not be found. Please try checking for updates again."));
+            QMessageBox::warning(nullptr, tr("Update Error"), tr("The update installer could not be found. Please try checking for updates again."));
             return;
         }
 
@@ -440,13 +441,10 @@ void Updater::slot_installOrRestartClicked(QAbstractButton* button, const QStrin
         // that will be deleted when Mudlet exits. We copy (not move) because AV
         // may still have a lock on the file, and copy only needs read access.
         // Use a unique filename with timestamp to avoid conflicts with locked files.
-        QString installerPath = qsl("%1/mudlet-setup-%2.exe")
-            .arg(QStandardPaths::writableLocation(QStandardPaths::TempLocation))
-            .arg(QDateTime::currentSecsSinceEpoch());
+        QString installerPath = qsl("%1/mudlet-setup-%2.exe").arg(QStandardPaths::writableLocation(QStandardPaths::TempLocation)).arg(QDateTime::currentSecsSinceEpoch());
         if (!QFile::copy(mDownloadedInstallerPath, installerPath)) {
             qWarning() << "Failed to copy installer from" << mDownloadedInstallerPath << "to" << installerPath;
-            QMessageBox::warning(nullptr, tr("Update Error"),
-                tr("Could not prepare the update installer. Please try again or download the update manually from https://www.mudlet.org/download/"));
+            QMessageBox::warning(nullptr, tr("Update Error"), tr("Could not prepare the update installer. Please try again or download the update manually from https://www.mudlet.org/download/"));
             return;
         }
 
@@ -458,23 +456,23 @@ void Updater::slot_installOrRestartClicked(QAbstractButton* button, const QStrin
             QString exeName = QFileInfo(QCoreApplication::applicationFilePath()).fileName();
             // Uses ping for delay instead of timeout.exe because timeout doesn't work when stdin is redirected.
             // Change to temp directory immediately to release handle on Mudlet's app folder.
-            QString batchContent = qsl(
-                "@echo off\r\n"
-                "cd /d %TEMP%\r\n"
-                "echo Mudlet updater: waiting for %1 to exit...\r\n"
-                ":wait_mudlet\r\n"
-                "tasklist /FI \"IMAGENAME eq %1\" 2>NUL | C:\\Windows\\System32\\find.exe /I \"%1\" >NUL\r\n"
-                "if %ERRORLEVEL%==0 (\r\n"
-                "    echo Mudlet updater: %1 still running, waiting...\r\n"
-                "    ping -n 2 127.0.0.1 > nul\r\n"
-                "    goto wait_mudlet\r\n"
-                ")\r\n"
-                "echo Mudlet updater: %1 exited, waiting for cleanup...\r\n"
-                "ping -n 4 127.0.0.1 > nul\r\n"
-                "echo Mudlet updater: launching installer...\r\n"
-                "echo Mudlet updater: running %2\r\n"
-                "\"%2\"\r\n"
-                "echo Mudlet updater: installer finished with exit code %ERRORLEVEL%\r\n").arg(exeName, QDir::toNativeSeparators(installerPath));
+            QString batchContent = qsl("@echo off\r\n"
+                                       "cd /d %TEMP%\r\n"
+                                       "echo Mudlet updater: waiting for %1 to exit...\r\n"
+                                       ":wait_mudlet\r\n"
+                                       "tasklist /FI \"IMAGENAME eq %1\" 2>NUL | C:\\Windows\\System32\\find.exe /I \"%1\" >NUL\r\n"
+                                       "if %ERRORLEVEL%==0 (\r\n"
+                                       "    echo Mudlet updater: %1 still running, waiting...\r\n"
+                                       "    ping -n 2 127.0.0.1 > nul\r\n"
+                                       "    goto wait_mudlet\r\n"
+                                       ")\r\n"
+                                       "echo Mudlet updater: %1 exited, waiting for cleanup...\r\n"
+                                       "ping -n 4 127.0.0.1 > nul\r\n"
+                                       "echo Mudlet updater: launching installer...\r\n"
+                                       "echo Mudlet updater: running %2\r\n"
+                                       "\"%2\"\r\n"
+                                       "echo Mudlet updater: installer finished with exit code %ERRORLEVEL%\r\n")
+                                           .arg(exeName, QDir::toNativeSeparators(installerPath));
             batchFile.write(batchContent.toLocal8Bit());
             batchFile.close();
 
@@ -503,9 +501,13 @@ void Updater::slot_installOrRestartClicked(QAbstractButton* button, const QStrin
 
 // otherwise the button says 'Install', so install the update
 #if defined(Q_OS_LINUX)
-    QFuture<void> future = QtConcurrent::run([&, filePath]() { untarOnLinux(filePath); });
+    QFuture<void> future = QtConcurrent::run([&, filePath]() {
+        untarOnLinux(filePath);
+    });
 #elif defined(Q_OS_WINDOWS)
-    QFuture<void> future = QtConcurrent::run([&, filePath]() { prepareSetupOnWindows(filePath); });
+    QFuture<void> future = QtConcurrent::run([&, filePath]() {
+        prepareSetupOnWindows(filePath);
+    });
 #endif
 
     // replace current binary with the unzipped one
@@ -637,9 +639,8 @@ bool Updater::is64BitCompatible() const
 #endif
 
     BOOL isWow64 = FALSE;
-    typedef BOOL (WINAPI *LPFN_ISWOW64PROCESS)(HANDLE, PBOOL);
-    LPFN_ISWOW64PROCESS fnIsWow64Process = (LPFN_ISWOW64PROCESS)
-        GetProcAddress(GetModuleHandle(TEXT("kernel32")), "IsWow64Process");
+    typedef BOOL(WINAPI * LPFN_ISWOW64PROCESS)(HANDLE, PBOOL);
+    LPFN_ISWOW64PROCESS fnIsWow64Process = (LPFN_ISWOW64PROCESS)GetProcAddress(GetModuleHandle(TEXT("kernel32")), "IsWow64Process");
 
     if (fnIsWow64Process) {
         if (fnIsWow64Process(GetCurrentProcess(), &isWow64)) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Ran clang-format on all 134 CPP files in src/ using the project's .clang-format config

#### Motivation for adding to Mudlet
Ensures consistent code formatting across the codebase.

#### Other info (issues closed, discussion etc)
None

**Test case:** Build the project and verify it compiles successfully.