### PR TITLE
infrastructure: Add .git-blame-ignore-revs for formatting commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# 2026-01-19: Clang-format all CPP files
+b6738dd8c


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds .git-blame-ignore-revs file listing the clang-format commit (b6738dd8c) so git blame skips it.

#### Motivation for adding to Mudlet
Prevents formatting-only commits from polluting git blame history.

#### Other info (issues closed, discussion etc)
Follow-up to #8804

**Test case:** After merging this, view blame for any file in `src/` on GitHub - the clang-format commit should be skipped. For local usage, run `git config blame.ignoreRevsFile .git-blame-ignore-revs` first.