### PR TITLE
infrastructure: add clang-format instructions to AI guidelines

### DIFF
--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -152,9 +152,18 @@ if (!file.open(QIODevice::ReadOnly)) {
 ## Build system notes
 
 - **Build system**: CMake (handles platform-specific configurations). See https://wiki.mudlet.org/w/Compiling_Mudlet for instructions.
-- Use `.clang-format` configuration in `src/` for C++ code style
 - Check code quality with clang-tidy using `.clang-tidy` configuration file
 - Allow up to 10mins for a build - it can take a while
+
+### Code formatting
+
+After editing any C++ files (`.cpp`, `.h`), run clang-format before committing:
+
+```bash
+clang-format -i path/to/edited/file.cpp path/to/edited/file.h
+```
+
+The project uses the `.clang-format` configuration in `src/`. This ensures consistent code style across the codebase.
 
 ### Static analysis
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add instructions for running clang-format after editing C++ files.

#### Motivation for adding to Mudlet
After the recent clang-format pass, AI assistants need clear guidance on when to format code to avoid future merge conflicts.

#### Other info (issues closed, discussion etc)
N/A