### PR TITLE
Fix: MXP FRAME close tags appearing as literal text

### DIFF
--- a/src/TMxpFrameManager.cpp
+++ b/src/TMxpFrameManager.cpp
@@ -144,7 +144,9 @@ bool TMxpFrameManager::closeFrame(const QString& name)
 {
     auto* frame = getFrame(name);
     if (!frame) {
-        return false;
+        // Frame doesn't exist - treat as success since it's already "closed"
+        // This prevents literal MXP tags from appearing when closing non-existent frames
+        return true;
     }
 
     if (mCurrentDestination == name) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions

When a game server sends MXP tags to close frames that don't exist or were already closed, those tags were appearing as literal text in the game output. This fix makes closing non-existent frames succeed silently instead of failing, preventing the unwanted text from showing up.

#### Motivation for adding to Mudlet

Players were seeing confusing MXP escape sequences like `<FRAME action='close' name='RoomDesc'>` displayed in their game output when interacting with NPCs on certain MUDs. This made the game harder to read and broke immersion.

#### Other info (issues closed, discussion etc)

Closes #8775

Technical details: Changed `TMxpFrameManager::closeFrame()` to return `true` when attempting to close a non-existent frame (treating it as already closed) rather than returning `false` which caused the MXP tag handler to display the tag as literal text.

---

This video confirms the tags are no longer showing.

https://github.com/user-attachments/assets/1e1b632e-d077-46bb-811e-128c5d070d9e