### PR TITLE
fix: Revert map rendering optimization causing issues

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1872,11 +1872,6 @@ void T2DMap::paintEvent(QPaintEvent* e)
     painter.setRenderHint(QPainter::Antialiasing, mMapperUseAntiAlias);
     painter.setPen(pen);
 
-    const qreal visibleMinX = mMapCenterX - xspan / 2.0;
-    const qreal visibleMaxX = mMapCenterX + xspan / 2.0;
-    const qreal visibleMinY = -((yspan / 2.0) + mMapCenterY);
-    const qreal visibleMaxY = (yspan / 2.0) - mMapCenterY;
-
     if (mShowGrid && mRoomWidth > 0.0f && mRoomHeight > 0.0f) {
         painter.save();
 
@@ -1886,6 +1881,11 @@ void T2DMap::paintEvent(QPaintEvent* e)
         const qreal gridWidth = static_cast<qreal>(mpHost->mMapGridLineSize);
         gridPen.setWidthF(gridWidth);
         painter.setPen(gridPen);
+
+        const qreal visibleMinX = mMapCenterX - xspan / 2.0;
+        const qreal visibleMaxX = mMapCenterX + xspan / 2.0;
+        const qreal visibleMinY = -((yspan / 2.0) + mMapCenterY);
+        const qreal visibleMaxY = (yspan / 2.0) - mMapCenterY;
 
         const int startX = static_cast<int>(std::floor(visibleMinX));
         const int endX = static_cast<int>(std::ceil(visibleMaxX));
@@ -1920,8 +1920,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
 
     if (mudlet::self()->mDrawUpperLowerLevels) {
         // draw room on lower z-levels
-        const bool isLowerLevelVisible = pDrawnArea->isZLevelVisibleInViewport(zLevel - 1, visibleMinX, visibleMaxX, visibleMinY, visibleMaxY);
-        while (isLowerLevelVisible && itRoom.hasNext()) {
+        while (itRoom.hasNext()) {
             const int currentAreaRoom = itRoom.next();
             TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
             if (!room) {
@@ -1951,8 +1950,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
         itRoom.toFront();
 
         // draw rooms on upper z-levels
-        const bool isUpperLevelVisible = pDrawnArea->isZLevelVisibleInViewport(zLevel + 1, visibleMinX, visibleMaxX, visibleMinY, visibleMaxY);
-        while (isUpperLevelVisible && itRoom.hasNext()) {
+        while (itRoom.hasNext()) {
             const int currentAreaRoom = itRoom.next();
             TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
             if (!room) {
@@ -2029,12 +2027,11 @@ void T2DMap::paintEvent(QPaintEvent* e)
 
     // draw room exits
     if (!pDrawnArea->gridMode) {
-        paintRoomExits(painter, pen, exitList, oneWayExits, pDrawnArea, zLevel, exitWidth, areaExitsMap, visibleMinX, visibleMaxX, visibleMinY, visibleMaxY);
+        paintRoomExits(painter, pen, exitList, oneWayExits, pDrawnArea, zLevel, exitWidth, areaExitsMap);
     }
 
     // now draw rooms on selected z-level
-    const bool isCurrentLevelVisible = pDrawnArea->isZLevelVisibleInViewport(zLevel, visibleMinX, visibleMaxX, visibleMinY, visibleMaxY);
-    while (isCurrentLevelVisible && itRoom.hasNext()) {
+    while (itRoom.hasNext()) {
         const int currentAreaRoom = itRoom.next();
         TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
         if (!room) {
@@ -2334,12 +2331,8 @@ void T2DMap::drawDoor(QPainter& painter, const TRoom& room, const QString& dirKe
     painter.restore();
 }
 
-void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, QList<int>& oneWayExits, const TArea* pArea, int zLevel, float exitWidth, QMap<int, QPointF>& areaExitsMap, qreal visibleMinX, qreal visibleMaxX, qreal visibleMinY, qreal visibleMaxY)
+void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, QList<int>& oneWayExits, const TArea* pArea, int zLevel, float exitWidth, QMap<int, QPointF>& areaExitsMap)
 {
-    if (!pArea->isZLevelVisibleInViewport(zLevel, visibleMinX, visibleMaxX, visibleMinY, visibleMaxY)) {
-        return;
-    }
-
     const float exitArrowScale = (mLargeAreaExitArrows ? 2.0f : 1.0f);
     const float widgetWidth = width();
     const float widgetHeight = height();

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -401,7 +401,7 @@ private:
     bool checkButtonIsForGivenDirection(const QPushButton*, const QString&, const int&);
     bool sizeFontToFitTextInRect(QFont&, const QRectF&, const QString&, const quint8 percentageMargin = 10, const qreal minFontSize = 7.0);
     inline void drawRoom(QPainter&, QFont&, QFont&, QPen&, TRoom*, const bool isGridMode, const bool areRoomIdsLegible, const bool showRoomNames, const int, const float, const float, const QMap<int, QPointF>&, const bool showRoomCollision);
-    void paintRoomExits(QPainter&, QPen&, QList<int>& exitList, QList<int>& oneWayExits, const TArea*, int, float, QMap<int, QPointF>&, qreal visibleMinX, qreal visibleMaxX, qreal visibleMinY, qreal visibleMaxY);
+    void paintRoomExits(QPainter&, QPen&, QList<int>& exitList, QList<int>& oneWayExits, const TArea*, int, float, QMap<int, QPointF>&);
     void initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWalkTargetRoomId);
     inline void drawDoor(QPainter&, const TRoom&, const QString&, const QLineF&);
     void updateMapLabel(QRectF labelRectangle, int labelId, TArea* pArea);

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -1028,20 +1028,6 @@ void TArea::set2DMapZoom(const qreal zoom)
     }
 }
 
-bool TArea::isZLevelVisibleInViewport(int z, qreal viewMinX, qreal viewMaxX, qreal viewMinY, qreal viewMaxY) const
-{
-    if (!xminForZ.contains(z)) {
-        return false;
-    }
-
-    const qreal zMinX = xminForZ.value(z);
-    const qreal zMaxX = xmaxForZ.value(z);
-    const qreal zMinY = yminForZ.value(z);
-    const qreal zMaxY = ymaxForZ.value(z);
-
-    return !(zMaxX < viewMinX || zMinX > viewMaxX || zMaxY < viewMinY || zMinY > viewMaxY);
-}
-
 void TArea::clean()
 {
     if (mIsDirty) {

--- a/src/TArea.h
+++ b/src/TArea.h
@@ -74,7 +74,6 @@ public:
     qreal get2DMapZoom() const { return mLast2DMapZoom; }
     void set2DMapZoom(const qreal zoom);
     void clean();
-    bool isZLevelVisibleInViewport(int z, qreal viewMinX, qreal viewMaxX, qreal viewMinY, qreal viewMaxY) const;
 
 
     QSet<int> rooms; // rooms of this area

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -435,14 +435,6 @@ void GLWidget::paintGL()
                 break;
             }
         }
-        if (!pArea->zLevels.contains(static_cast<int>(zPlane))) {
-            if (zRot <= 0) {
-                zPlane -= 1.0;
-            } else {
-                zPlane += 1.0;
-            }
-            continue;
-        }
         QSetIterator<int> itRoom(pArea->getAreaRooms());
         while (itRoom.hasNext()) {
             TRoom* pR = mpMap->mpRoomDB->getRoom(itRoom.next());
@@ -1332,10 +1324,6 @@ void GLWidget::paintGL()
     while (true) {
         if (zPlane > zmax) {
             break;
-        }
-        if (!pArea->zLevels.contains(static_cast<int>(zPlane))) {
-            zPlane += 1.0;
-            continue;
         }
         QSetIterator<int> itRoom(pArea->getAreaRooms());
         while (itRoom.hasNext()) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Reverts #8797 which introduced faster map rendering by skipping off-screen rooms.

#### Motivation for adding to Mudlet
The optimization is causing the map to be hidden from drawing when zooming or panning around.

#### Other info (issues closed, discussion etc)
Reverts commit a576626428da908f5fd4843cf353058734e75a06

**Test case:** Open the mapper and verify all rooms render correctly when panning and zooming.