### PR TITLE
Fix: Medievia encoding showing error in preferences dropdown

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1304,6 +1304,8 @@ void mudlet::loadMaps()
             //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
             {"MACINTOSH", tr("MACINTOSH")},
             //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
+            {"MEDIEVIA", tr("Medievia {Custom codec for that MUD}")},
+            //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
             {"M_MEDIEVIA", qsl("m ") % tr("Medievia {Custom codec for that MUD}")},
             //: Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)
             {"WINDOWS-1250", tr("WINDOWS-1250 (Central European)")},


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Added the "MEDIEVIA" encoding name to the encoding names map so it displays correctly in the Server data encoding dropdown.

#### Motivation for adding to Mudlet

Users selecting the Medievia encoding from the preferences dropdown were seeing an error message "*Error, report to Mudlet Makers*" instead of the proper encoding description. This fix ensures the encoding option displays correctly.

#### Other info (issues closed, discussion etc)

Follow-up to #8608 which partially addressed this issue. The encoding list returns "MEDIEVIA" but the display map only had "M_MEDIEVIA" as a key, causing the lookup to fail.

---

before

<img width="1050" height="251" alt="Screenshot 2026-01-21 at 9 27 54 PM" src="https://github.com/user-attachments/assets/cd9eb831-82e3-42d8-968f-af47ecf1756b" />

after

<img width="1068" height="256" alt="Screenshot 2026-01-21 at 9 43 45 PM" src="https://github.com/user-attachments/assets/87b46d35-3bec-4e9a-bc0e-6b008a27d4ec" />
