### PR TITLE
fix: Map area centering displaying areas off-screen

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1802,7 +1802,8 @@ void T2DMap::paintEvent(QPaintEvent* e)
         }
 
         if (areaMaxY - areaMinY <= yspan) {
-            mMapCenterY = (areaMinY + areaMaxY) / 2.0;
+            // Negate because areaMinY/areaMaxY are in room coords, but mMapCenterY uses screen coords (-room.y())
+            mMapCenterY = -((areaMinY + areaMaxY) / 2.0);
         }
     }
 

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -399,8 +399,8 @@ void TArea::calcSpan()
             zLevels.push_back(pR->z());
             xminForZ.insert(pR->z(), pR->x());
             xmaxForZ.insert(pR->z(), pR->x());
-            yminForZ.insert(pR->z(), pR->y());
-            ymaxForZ.insert(pR->z(), pR->y());
+            yminForZ.insert(pR->z(), (-1 * pR->y()));
+            ymaxForZ.insert(pR->z(), (-1 * pR->y()));
             isFirstDone = true;
             continue;
         } else {

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1849,6 +1849,16 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
 
         restore16ColorSet();
 
+        // Recalculate area bounds to fix any corrupted yminForZ/ymaxForZ values
+        // from older map files (bug where first room's Y wasn't negated)
+        const QList<int> areaIds = mpRoomDB->getAreaIDList();
+        for (int areaId : areaIds) {
+            TArea* pA = mpRoomDB->getArea(areaId);
+            if (pA) {
+                pA->calcSpan();
+            }
+        }
+
         const QString okMsg = tr("[ INFO ]  - Successfully read the map file (%1s), checking some\n"
                                  "consistency details...")
                                       .arg(_time.nsecsElapsed() * 1.0e-9, 0, 'f', 2);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixes bugs in the small area centering feature (#8766) that caused maps not centered around 0,0 to display incorrectly.

#### Motivation for adding to Mudlet
The centering feature from #8766 had two bugs: Y coordinates weren't negated for the first room in area bounds calculation, and the center Y calculation had wrong sign, causing areas to appear off-screen when zoomed out.

#### Other info (issues closed, discussion etc)
Fixes the issues that led to #8813. This PR can replace that revert once verified.

**Test case:** Load a map with areas not centered around 0,0, zoom out past the point where the area fits in viewport - map should stay centered correctly.