### PR TITLE
fix: Crash when nested alias/trigger processing runs cleanup prematurely

### DIFF
--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -261,8 +261,6 @@ bool AliasUnit::processDataStream(const QString& data)
     //Using copy fixes https://github.com/Mudlet/Mudlet/issues/4297
     auto copyOfNodeList = mAliasRootNodeList;
 
-    // Increment processing depth to prevent re-entrant cleanup during alias execution
-    // Using a counter instead of bool handles nested calls from expandAlias()/send()
     mProcessingDepth++;
 
     for (auto alias : copyOfNodeList) {
@@ -272,7 +270,6 @@ bool AliasUnit::processDataStream(const QString& data)
         }
     }
 
-    // Decrement processing depth and perform cleanup only when all processing is complete
     mProcessingDepth--;
     if (mProcessingDepth == 0) {
         doCleanup();
@@ -410,8 +407,6 @@ std::tuple<QString, int, int, int> AliasUnit::assembleReport()
 
 void AliasUnit::doCleanup()
 {
-    // Skip cleanup if we're currently processing aliases to prevent iterator invalidation
-    // Cleanup will be performed when all nested processDataStream() calls complete
     if (mProcessingDepth > 0) {
         return;
     }

--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -261,8 +261,9 @@ bool AliasUnit::processDataStream(const QString& data)
     //Using copy fixes https://github.com/Mudlet/Mudlet/issues/4297
     auto copyOfNodeList = mAliasRootNodeList;
 
-    // Set processing flag to prevent re-entrant cleanup during alias execution
-    mIsProcessing = true;
+    // Increment processing depth to prevent re-entrant cleanup during alias execution
+    // Using a counter instead of bool handles nested calls from expandAlias()/send()
+    mProcessingDepth++;
 
     for (auto alias : copyOfNodeList) {
         // = data.replace( "\n", "" );
@@ -271,9 +272,11 @@ bool AliasUnit::processDataStream(const QString& data)
         }
     }
 
-    // Clear processing flag and perform any deferred cleanup
-    mIsProcessing = false;
-    doCleanup();
+    // Decrement processing depth and perform cleanup only when all processing is complete
+    mProcessingDepth--;
+    if (mProcessingDepth == 0) {
+        doCleanup();
+    }
 
     // the idea to get "command" after alias processing is finished and send its value
     // was too difficult for users because if multiple alias change the value of command it becomes too difficult to handle for many users
@@ -408,8 +411,8 @@ std::tuple<QString, int, int, int> AliasUnit::assembleReport()
 void AliasUnit::doCleanup()
 {
     // Skip cleanup if we're currently processing aliases to prevent iterator invalidation
-    // Cleanup will be performed when processDataStream() completes
-    if (mIsProcessing) {
+    // Cleanup will be performed when all nested processDataStream() calls complete
+    if (mProcessingDepth > 0) {
         return;
     }
 

--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -271,6 +271,7 @@ bool AliasUnit::processDataStream(const QString& data)
     }
 
     mProcessingDepth--;
+    Q_ASSERT(mProcessingDepth >= 0);
     if (mProcessingDepth == 0) {
         doCleanup();
     }

--- a/src/AliasUnit.h
+++ b/src/AliasUnit.h
@@ -43,7 +43,8 @@ class AliasUnit
 public:
     explicit AliasUnit(Host* pHost)
     : mpHost(pHost)
-    {}
+    {
+    }
     ~AliasUnit();
 
     std::list<TAlias*> getAliasRootNodeList() { return mAliasRootNodeList; }
@@ -93,7 +94,7 @@ private:
     int statsItemsTotal = 0;
     int statsTempItems = 0;
     int statsActiveItems = 0;
-    bool mIsProcessing = false;
+    int mProcessingDepth = 0;
 };
 
 #endif // MUDLET_ALIASUNIT_H

--- a/src/AliasUnit.h
+++ b/src/AliasUnit.h
@@ -94,6 +94,7 @@ private:
     int statsItemsTotal = 0;
     int statsTempItems = 0;
     int statsActiveItems = 0;
+    // Counter for nested processing; cleanup deferred until 0
     int mProcessingDepth = 0;
 };
 

--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -94,8 +94,9 @@ bool KeyUnit::processDataStream(const Qt::Key key, const Qt::KeyboardModifiers m
 {
     bool isMatchFound = false;
 
-    // Set processing flag to prevent re-entrant cleanup during key execution
-    mIsProcessing = true;
+    // Increment processing depth to prevent re-entrant cleanup during key execution
+    // Using a counter instead of bool handles nested calls from Lua scripts
+    mProcessingDepth++;
 
     for (auto keyObject : mKeyRootNodeList) {
         // Skip null or invalid key objects during profile closing/destruction
@@ -106,18 +107,22 @@ bool KeyUnit::processDataStream(const Qt::Key key, const Qt::KeyboardModifiers m
 
         if (keyObject->match(key, modifiers, mRunAllKeyMatches)) {
             if (!mRunAllKeyMatches) {
-                // Clear processing flag and perform any deferred cleanup before returning
-                mIsProcessing = false;
-                doCleanup();
+                // Decrement processing depth and perform cleanup only when all processing is complete
+                mProcessingDepth--;
+                if (mProcessingDepth == 0) {
+                    doCleanup();
+                }
                 return true;
             }
             isMatchFound = true;
         }
     }
 
-    // Clear processing flag and perform any deferred cleanup
-    mIsProcessing = false;
-    doCleanup();
+    // Decrement processing depth and perform cleanup only when all processing is complete
+    mProcessingDepth--;
+    if (mProcessingDepth == 0) {
+        doCleanup();
+    }
 
     return isMatchFound;
 }
@@ -448,8 +453,8 @@ void KeyUnit::markCleanup(TKey* pT)
 void KeyUnit::doCleanup()
 {
     // Skip cleanup if we're currently processing keys to prevent iterator invalidation
-    // Cleanup will be performed when processDataStream() completes
-    if (mIsProcessing) {
+    // Cleanup will be performed when all nested processDataStream() calls complete
+    if (mProcessingDepth > 0) {
         return;
     }
 

--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -94,8 +94,6 @@ bool KeyUnit::processDataStream(const Qt::Key key, const Qt::KeyboardModifiers m
 {
     bool isMatchFound = false;
 
-    // Increment processing depth to prevent re-entrant cleanup during key execution
-    // Using a counter instead of bool handles nested calls from Lua scripts
     mProcessingDepth++;
 
     for (auto keyObject : mKeyRootNodeList) {
@@ -107,7 +105,6 @@ bool KeyUnit::processDataStream(const Qt::Key key, const Qt::KeyboardModifiers m
 
         if (keyObject->match(key, modifiers, mRunAllKeyMatches)) {
             if (!mRunAllKeyMatches) {
-                // Decrement processing depth and perform cleanup only when all processing is complete
                 mProcessingDepth--;
                 if (mProcessingDepth == 0) {
                     doCleanup();
@@ -118,7 +115,6 @@ bool KeyUnit::processDataStream(const Qt::Key key, const Qt::KeyboardModifiers m
         }
     }
 
-    // Decrement processing depth and perform cleanup only when all processing is complete
     mProcessingDepth--;
     if (mProcessingDepth == 0) {
         doCleanup();
@@ -452,8 +448,6 @@ void KeyUnit::markCleanup(TKey* pT)
 
 void KeyUnit::doCleanup()
 {
-    // Skip cleanup if we're currently processing keys to prevent iterator invalidation
-    // Cleanup will be performed when all nested processDataStream() calls complete
     if (mProcessingDepth > 0) {
         return;
     }

--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -98,7 +98,6 @@ bool KeyUnit::processDataStream(const Qt::Key key, const Qt::KeyboardModifiers m
 
     for (auto keyObject : mKeyRootNodeList) {
         // Skip null or invalid key objects during profile closing/destruction
-        // Skip null or invalid key objects during profile closing/destruction
         if (!keyObject || !keyObject->isActive() || (keyObject->mpHost && keyObject->mpHost->isClosingDown())) {
             continue;
         }
@@ -106,6 +105,7 @@ bool KeyUnit::processDataStream(const Qt::Key key, const Qt::KeyboardModifiers m
         if (keyObject->match(key, modifiers, mRunAllKeyMatches)) {
             if (!mRunAllKeyMatches) {
                 mProcessingDepth--;
+                Q_ASSERT(mProcessingDepth >= 0);
                 if (mProcessingDepth == 0) {
                     doCleanup();
                 }
@@ -116,6 +116,7 @@ bool KeyUnit::processDataStream(const Qt::Key key, const Qt::KeyboardModifiers m
     }
 
     mProcessingDepth--;
+    Q_ASSERT(mProcessingDepth >= 0);
     if (mProcessingDepth == 0) {
         doCleanup();
     }

--- a/src/KeyUnit.h
+++ b/src/KeyUnit.h
@@ -41,22 +41,19 @@ class KeyUnit : public QObject
 {
     Q_OBJECT // Needed for a couple of translations
 
-    friend class XMLexport;
+            friend class XMLexport;
     friend class XMLimport;
 
 public:
     explicit KeyUnit(Host* pHost);
     ~KeyUnit();
 
-    std::list<TKey*> getKeyRootNodeList()
-    {
-        return mKeyRootNodeList;
-    }
+    std::list<TKey*> getKeyRootNodeList() { return mKeyRootNodeList; }
 
     TKey* getKey(int id);
     void removeAllTempKeys();
     void compileAll();
-    TKey* findFirstKey(QString & name);
+    TKey* findFirstKey(QString& name);
     std::vector<int> findItems(const QString& name, const bool exactMatch, const bool caseSensitive);
     bool enableKey(const QString& name);
     bool disableKey(const QString& name);
@@ -72,7 +69,7 @@ public:
     void uninstall(const QString&);
     void _uninstall(TKey* pChild, const QString& packageName);
     bool processDataStream(const Qt::Key, const Qt::KeyboardModifiers);
-    void markCleanup( TKey * pT );
+    void markCleanup(TKey* pT);
     void doCleanup();
     void stopAllTriggers();
     void reenableAllTriggers();
@@ -108,7 +105,7 @@ private:
     int statsItemsTotal = 0;
     int statsTempItems = 0;
     int statsActiveItems = 0;
-    bool mIsProcessing = false;
+    int mProcessingDepth = 0;
 };
 
 #endif // MUDLET_KEYUNIT_H

--- a/src/KeyUnit.h
+++ b/src/KeyUnit.h
@@ -105,6 +105,7 @@ private:
     int statsItemsTotal = 0;
     int statsTempItems = 0;
     int statsActiveItems = 0;
+    // Counter for nested processing; cleanup deferred until 0
     int mProcessingDepth = 0;
 };
 

--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -69,6 +69,12 @@ void TAlias::setName(const QString& name)
 
 bool TAlias::match(const QString& haystack)
 {
+    // Guard against accessing a partially destroyed object - if mpMyChildrenList
+    // is null, the destructor has run and this object is no longer valid
+    if (!mpMyChildrenList) {
+        return false;
+    }
+
     bool matchCondition = false;
     if (!isActive()) {
         if (isFolder()) {

--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -69,9 +69,10 @@ void TAlias::setName(const QString& name)
 
 bool TAlias::match(const QString& haystack)
 {
-    // Guard against accessing a partially destroyed object - if mpMyChildrenList
-    // is null, the destructor has run and this object is no longer valid
+    // Guard against re-entrancy: cleanup may have deleted this alias while
+    // match() was still on the call stack
     if (!mpMyChildrenList) {
+        qWarning() << "TAlias::match() called on destroyed alias - ID:" << mID << "Name:" << mName;
         return false;
     }
 

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -68,6 +68,13 @@ void TKey::setName(const QString& name)
 
 bool TKey::match(const Qt::Key key, const Qt::KeyboardModifiers modifier, const bool isToMatchAll)
 {
+    // Guard against re-entrancy: cleanup may have deleted this key while
+    // match() was still on the call stack
+    if (!mpMyChildrenList) {
+        qWarning() << "TKey::match() called on destroyed key - ID:" << mID << "Name:" << mName;
+        return false;
+    }
+
     bool isAMatch = false;
     if (isActive()) {
         if (!isFolder()) {

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -197,6 +197,13 @@ bool TTimer::checkRestart()
 
 void TTimer::execute()
 {
+    // Guard against re-entrancy: cleanup may have deleted this timer while
+    // execute() was still on the call stack
+    if (!mpMyChildrenList) {
+        qWarning() << "TTimer::execute() called on destroyed timer - ID:" << mID << "Name:" << mName;
+        return;
+    }
+
     if (!isActive() || isFolder()) {
         mpQTimer->stop();
         return;

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -925,6 +925,13 @@ void TTrigger::processExactMatch(const QString& line, int patternNumber, int pos
 // posOffset: position in the line to start matching from; used by child triggers
 bool TTrigger::match(char* haystackC, const QString& haystack, int line, int posOffset)
 {
+    // Guard against re-entrancy: cleanup may have deleted this trigger while
+    // match() was still on the call stack
+    if (!mpMyChildrenList) {
+        qWarning() << "TTrigger::match() called on destroyed trigger - ID:" << mID << "Name:" << mName;
+        return false;
+    }
+
     bool ret = false;
     if (isActive()) {
         if (mIsLineTrigger) {

--- a/src/TimerUnit.h
+++ b/src/TimerUnit.h
@@ -37,6 +37,10 @@ class Host;
 class TTimer;
 class QTimer;
 
+// Note: Unlike AliasUnit/TriggerUnit/KeyUnit, TimerUnit does not use mProcessingDepth
+// because timers execute via Qt's event loop (QTimer signals), not synchronous loops.
+// Protection against re-entrancy is provided by the guard in TTimer::execute() and
+// by re-verifying timer existence after execute() in mudlet::slot_timerFires().
 class TimerUnit
 {
     friend class XMLexport;
@@ -45,7 +49,8 @@ class TimerUnit
 public:
     explicit TimerUnit(Host* pHost)
     : mpHost(pHost)
-    {}
+    {
+    }
     ~TimerUnit();
 
     void resetStats();

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -287,17 +287,20 @@ void TriggerUnit::processDataStream(const QString& data, int line)
     memcpy(subject, utf8Ptr, utf8Length);
     subject[utf8Length] = '\0';
 
-    // Set processing flag to prevent re-entrant cleanup during trigger execution
-    mIsProcessing = true;
+    // Increment processing depth to prevent re-entrant cleanup during trigger execution
+    // Using a counter instead of bool handles nested calls from Lua scripts
+    mProcessingDepth++;
 
     for (auto trigger : mTriggerRootNodeList) {
         trigger->match(subject, data, line);
     }
     free(subject);
 
-    // Clear processing flag and perform any deferred cleanup
-    mIsProcessing = false;
-    doCleanup();
+    // Decrement processing depth and perform cleanup only when all processing is complete
+    mProcessingDepth--;
+    if (mProcessingDepth == 0) {
+        doCleanup();
+    }
 }
 
 void TriggerUnit::compileAll()
@@ -447,8 +450,8 @@ std::tuple<QString, int, int, int, int, int> TriggerUnit::assembleReport()
 void TriggerUnit::doCleanup()
 {
     // Skip cleanup if we're currently processing triggers to prevent iterator invalidation
-    // Cleanup will be performed when processDataStream() completes
-    if (mIsProcessing) {
+    // Cleanup will be performed when all nested processDataStream() calls complete
+    if (mProcessingDepth > 0) {
         return;
     }
 

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -295,6 +295,7 @@ void TriggerUnit::processDataStream(const QString& data, int line)
     free(subject);
 
     mProcessingDepth--;
+    Q_ASSERT(mProcessingDepth >= 0);
     if (mProcessingDepth == 0) {
         doCleanup();
     }

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -287,8 +287,6 @@ void TriggerUnit::processDataStream(const QString& data, int line)
     memcpy(subject, utf8Ptr, utf8Length);
     subject[utf8Length] = '\0';
 
-    // Increment processing depth to prevent re-entrant cleanup during trigger execution
-    // Using a counter instead of bool handles nested calls from Lua scripts
     mProcessingDepth++;
 
     for (auto trigger : mTriggerRootNodeList) {
@@ -296,7 +294,6 @@ void TriggerUnit::processDataStream(const QString& data, int line)
     }
     free(subject);
 
-    // Decrement processing depth and perform cleanup only when all processing is complete
     mProcessingDepth--;
     if (mProcessingDepth == 0) {
         doCleanup();
@@ -449,8 +446,6 @@ std::tuple<QString, int, int, int, int, int> TriggerUnit::assembleReport()
 
 void TriggerUnit::doCleanup()
 {
-    // Skip cleanup if we're currently processing triggers to prevent iterator invalidation
-    // Cleanup will be performed when all nested processDataStream() calls complete
     if (mProcessingDepth > 0) {
         return;
     }

--- a/src/TriggerUnit.h
+++ b/src/TriggerUnit.h
@@ -101,6 +101,7 @@ private:
     int statsActiveItems = 0;
     int statsPatternsTotal = 0;
     int statsPatternsActive = 0;
+    // Counter for nested processing; cleanup deferred until 0
     int mProcessingDepth = 0;
 };
 

--- a/src/TriggerUnit.h
+++ b/src/TriggerUnit.h
@@ -45,13 +45,11 @@ public:
     : mpHost(pHost)
     , mMaxID(0)
     , mModuleMember()
-    {}
+    {
+    }
     ~TriggerUnit();
 
-    std::list<TTrigger*> getTriggerRootNodeList()
-    {
-        return mTriggerRootNodeList;
-    }
+    std::list<TTrigger*> getTriggerRootNodeList() { return mTriggerRootNodeList; }
 
     void resetStats();
     TTrigger* getTrigger(int id);
@@ -103,7 +101,7 @@ private:
     int statsActiveItems = 0;
     int statsPatternsTotal = 0;
     int statsPatternsActive = 0;
-    bool mIsProcessing = false;
+    int mProcessingDepth = 0;
 };
 
 #endif // MUDLET_TRIGGERUNIT_H

--- a/src/mudlet-lua/tests/Alias_spec.lua
+++ b/src/mudlet-lua/tests/Alias_spec.lua
@@ -1,0 +1,143 @@
+describe("Alias processing", function()
+
+    -- Test for nested alias processing with self-deletion (GitHub issue #8817)
+    -- This verifies the fix that uses mProcessingDepth counter instead of a bool flag
+    --
+    -- The original bug: when using a bool mIsProcessing flag, nested alias calls
+    -- via expandAlias() would set the flag to false when the inner call completed,
+    -- causing doCleanup() to run while the outer alias was still processing.
+    -- This led to crashes when the outer alias tried to access deleted objects.
+    --
+    -- The fix uses an integer mProcessingDepth counter that increments on entry
+    -- and decrements on exit, only running cleanup when it reaches zero.
+    describe("nested processing", function()
+
+        it("should not crash when inner alias kills itself during nested expandAlias", function()
+            local inner_id
+            local outer_executed = false
+            local inner_executed = false
+
+            local outer_id = tempAlias("^test_outer$", function()
+                outer_executed = true
+                expandAlias("test_inner")
+            end)
+
+            inner_id = tempAlias("^test_inner$", function()
+                inner_executed = true
+                killAlias(inner_id)
+            end)
+
+            -- Verify both aliases exist before the test
+            assert.are.equal(1, exists(outer_id, "alias"), "Outer alias should exist before test")
+            assert.are.equal(1, exists(inner_id, "alias"), "Inner alias should exist before test")
+
+            -- This should not crash - the fix defers cleanup until all processing completes
+            -- Without the fix, this would crash because:
+            -- 1. outer alias matches, mProcessingDepth becomes 1
+            -- 2. inner alias matches (nested), mProcessingDepth becomes 2
+            -- 3. inner alias calls killAlias() -> markCleanup()
+            -- 4. inner processing ends, mProcessingDepth becomes 1, no cleanup (depth > 0)
+            -- 5. outer processing ends, mProcessingDepth becomes 0, cleanup runs safely
+            expandAlias("test_outer")
+
+            assert.is_true(outer_executed, "Outer alias should have executed")
+            assert.is_true(inner_executed, "Inner alias should have executed")
+
+            -- Verify cleanup ran correctly: inner alias should be deleted
+            assert.are.equal(0, exists(inner_id, "alias"), "Inner alias should have been cleaned up")
+
+            -- Verify outer alias still exists (wasn't incorrectly deleted)
+            assert.are.equal(1, exists(outer_id, "alias"), "Outer alias should still exist")
+
+            -- Cleanup
+            killAlias(outer_id)
+        end)
+
+        it("should handle double-nested alias processing with cleanup", function()
+            local level3_id
+            local executions = {}
+
+            local level1_id = tempAlias("^test_level1$", function()
+                table.insert(executions, "level1_start")
+                expandAlias("test_level2")
+                table.insert(executions, "level1_end")
+            end)
+
+            local level2_id = tempAlias("^test_level2$", function()
+                table.insert(executions, "level2_start")
+                expandAlias("test_level3")
+                table.insert(executions, "level2_end")
+            end)
+
+            level3_id = tempAlias("^test_level3$", function()
+                table.insert(executions, "level3")
+                killAlias(level3_id)
+            end)
+
+            -- Verify all aliases exist before the test
+            assert.are.equal(1, exists(level1_id, "alias"), "Level 1 alias should exist")
+            assert.are.equal(1, exists(level2_id, "alias"), "Level 2 alias should exist")
+            assert.are.equal(1, exists(level3_id, "alias"), "Level 3 alias should exist")
+
+            -- This tests 3 levels of nesting with cleanup at the deepest level
+            -- mProcessingDepth goes: 0 -> 1 -> 2 -> 3 -> 2 -> 1 -> 0, then cleanup
+            expandAlias("test_level1")
+
+            -- Verify all levels executed in correct order (depth-first)
+            assert.are.equal(5, #executions, "All execution points should have been reached")
+            assert.are.equal("level1_start", executions[1])
+            assert.are.equal("level2_start", executions[2])
+            assert.are.equal("level3", executions[3])
+            assert.are.equal("level2_end", executions[4])
+            assert.are.equal("level1_end", executions[5])
+
+            -- Verify level3 was cleaned up, others still exist
+            assert.are.equal(0, exists(level3_id, "alias"), "Level 3 alias should have been cleaned up")
+            assert.are.equal(1, exists(level1_id, "alias"), "Level 1 alias should still exist")
+            assert.are.equal(1, exists(level2_id, "alias"), "Level 2 alias should still exist")
+
+            -- Cleanup
+            killAlias(level1_id)
+            killAlias(level2_id)
+        end)
+
+        it("should handle multiple aliases being killed in nested processing", function()
+            local inner1_id, inner2_id
+            local execution_order = {}
+
+            local outer_id = tempAlias("^test_multi_outer$", function()
+                table.insert(execution_order, "outer_start")
+                expandAlias("test_multi_inner1")
+                expandAlias("test_multi_inner2")
+                table.insert(execution_order, "outer_end")
+            end)
+
+            inner1_id = tempAlias("^test_multi_inner1$", function()
+                table.insert(execution_order, "inner1")
+                killAlias(inner1_id)
+            end)
+
+            inner2_id = tempAlias("^test_multi_inner2$", function()
+                table.insert(execution_order, "inner2")
+                killAlias(inner2_id)
+            end)
+
+            expandAlias("test_multi_outer")
+
+            -- Verify execution order
+            assert.are.equal(4, #execution_order)
+            assert.are.equal("outer_start", execution_order[1])
+            assert.are.equal("inner1", execution_order[2])
+            assert.are.equal("inner2", execution_order[3])
+            assert.are.equal("outer_end", execution_order[4])
+
+            -- Both inner aliases should be cleaned up
+            assert.are.equal(0, exists(inner1_id, "alias"), "Inner1 should be cleaned up")
+            assert.are.equal(0, exists(inner2_id, "alias"), "Inner2 should be cleaned up")
+            assert.are.equal(1, exists(outer_id, "alias"), "Outer should still exist")
+
+            killAlias(outer_id)
+        end)
+
+    end)
+end)

--- a/src/mudlet-lua/tests/Trigger_spec.lua
+++ b/src/mudlet-lua/tests/Trigger_spec.lua
@@ -1,0 +1,129 @@
+describe("Trigger processing", function()
+
+    -- Test for nested trigger processing with self-deletion
+    -- This verifies the fix that uses mProcessingDepth counter instead of a bool flag
+    -- (same fix as for aliases - see Alias_spec.lua for detailed explanation)
+    describe("nested processing", function()
+
+        it("should not crash when inner trigger kills itself during nested feedTriggers", function()
+            local inner_id
+            local outer_executed = false
+            local inner_executed = false
+
+            local outer_id = tempRegexTrigger("^outer_trigger_test$", function()
+                outer_executed = true
+                feedTriggers("\nouter_trigger_test_inner\n")
+            end)
+
+            inner_id = tempRegexTrigger("^outer_trigger_test_inner$", function()
+                inner_executed = true
+                killTrigger(inner_id)
+            end)
+
+            -- Verify both triggers exist before the test
+            assert.are.equal(1, exists(outer_id, "trigger"), "Outer trigger should exist before test")
+            assert.are.equal(1, exists(inner_id, "trigger"), "Inner trigger should exist before test")
+
+            -- This should not crash - the fix defers cleanup until all processing completes
+            feedTriggers("\nouter_trigger_test\n")
+
+            assert.is_true(outer_executed, "Outer trigger should have executed")
+            assert.is_true(inner_executed, "Inner trigger should have executed")
+
+            -- Verify cleanup ran correctly: inner trigger should be deleted
+            assert.are.equal(0, exists(inner_id, "trigger"), "Inner trigger should have been cleaned up")
+
+            -- Verify outer trigger still exists (wasn't incorrectly deleted)
+            assert.are.equal(1, exists(outer_id, "trigger"), "Outer trigger should still exist")
+
+            -- Cleanup
+            killTrigger(outer_id)
+        end)
+
+        it("should handle double-nested trigger processing with cleanup", function()
+            local level3_id
+            local executions = {}
+
+            local level1_id = tempRegexTrigger("^trigger_level1$", function()
+                table.insert(executions, "level1_start")
+                feedTriggers("\ntrigger_level2\n")
+                table.insert(executions, "level1_end")
+            end)
+
+            local level2_id = tempRegexTrigger("^trigger_level2$", function()
+                table.insert(executions, "level2_start")
+                feedTriggers("\ntrigger_level3\n")
+                table.insert(executions, "level2_end")
+            end)
+
+            level3_id = tempRegexTrigger("^trigger_level3$", function()
+                table.insert(executions, "level3")
+                killTrigger(level3_id)
+            end)
+
+            -- Verify all triggers exist before the test
+            assert.are.equal(1, exists(level1_id, "trigger"), "Level 1 trigger should exist")
+            assert.are.equal(1, exists(level2_id, "trigger"), "Level 2 trigger should exist")
+            assert.are.equal(1, exists(level3_id, "trigger"), "Level 3 trigger should exist")
+
+            -- This tests 3 levels of nesting with cleanup at the deepest level
+            feedTriggers("\ntrigger_level1\n")
+
+            -- Verify all levels executed in correct order (depth-first)
+            assert.are.equal(5, #executions, "All execution points should have been reached")
+            assert.are.equal("level1_start", executions[1])
+            assert.are.equal("level2_start", executions[2])
+            assert.are.equal("level3", executions[3])
+            assert.are.equal("level2_end", executions[4])
+            assert.are.equal("level1_end", executions[5])
+
+            -- Verify level3 was cleaned up, others still exist
+            assert.are.equal(0, exists(level3_id, "trigger"), "Level 3 trigger should have been cleaned up")
+            assert.are.equal(1, exists(level1_id, "trigger"), "Level 1 trigger should still exist")
+            assert.are.equal(1, exists(level2_id, "trigger"), "Level 2 trigger should still exist")
+
+            -- Cleanup
+            killTrigger(level1_id)
+            killTrigger(level2_id)
+        end)
+
+        it("should handle multiple triggers being killed in nested processing", function()
+            local inner1_id, inner2_id
+            local execution_order = {}
+
+            local outer_id = tempRegexTrigger("^trigger_multi_outer$", function()
+                table.insert(execution_order, "outer_start")
+                feedTriggers("\ntrigger_multi_inner1\n")
+                feedTriggers("\ntrigger_multi_inner2\n")
+                table.insert(execution_order, "outer_end")
+            end)
+
+            inner1_id = tempRegexTrigger("^trigger_multi_inner1$", function()
+                table.insert(execution_order, "inner1")
+                killTrigger(inner1_id)
+            end)
+
+            inner2_id = tempRegexTrigger("^trigger_multi_inner2$", function()
+                table.insert(execution_order, "inner2")
+                killTrigger(inner2_id)
+            end)
+
+            feedTriggers("\ntrigger_multi_outer\n")
+
+            -- Verify execution order
+            assert.are.equal(4, #execution_order)
+            assert.are.equal("outer_start", execution_order[1])
+            assert.are.equal("inner1", execution_order[2])
+            assert.are.equal("inner2", execution_order[3])
+            assert.are.equal("outer_end", execution_order[4])
+
+            -- Both inner triggers should be cleaned up
+            assert.are.equal(0, exists(inner1_id, "trigger"), "Inner1 should be cleaned up")
+            assert.are.equal(0, exists(inner2_id, "trigger"), "Inner2 should be cleaned up")
+            assert.are.equal(1, exists(outer_id, "trigger"), "Outer should still exist")
+
+            killTrigger(outer_id)
+        end)
+
+    end)
+end)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2213,7 +2213,9 @@ void mudlet::slot_timerFires()
         //        qDebug().nospace().noquote() << "mudlet::slot_timerFires() INFO - Host: \"" << hostName << "\" QTimer firing for TTimer Id:" << id;
         //        qDebug().nospace().noquote() << "    (objectName:\"" << pQT->objectName() << "\")";
         pTT->execute();
-        if (pTT->checkRestart()) {
+        // Re-verify timer still exists after execute (script may have killed it)
+        pTT = pHost->getTimerUnit()->getTimer(id);
+        if (pTT && pTT->checkRestart()) {
             pTT->start();
         }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Change `mIsProcessing` from bool to counter (`mProcessingDepth`) in AliasUnit, TriggerUnit, and KeyUnit to properly handle nested Lua script calls via `expandAlias()`/`send()`.

#### Motivation for adding to Mudlet
Fixes crash caused by cleanup running during nested processing when inner call sets `mIsProcessing = false`.

#### Other info (issues closed, discussion etc)
Fixes #8817

**Test case:** Create an alias that calls `expandAlias()` which triggers another alias that calls `killAlias()` on itself - should no longer crash.