### PR TITLE
fix: Use custom dark theme on all Windows versions

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -5848,9 +5848,7 @@ void mudlet::setShowIconsOnMenu(const Qt::CheckState state)
 
 bool mudlet::needsCustomDarkTheme()
 {
-#if defined(Q_OS_WINDOWS)
-    return QSysInfo::productVersion() == qsl("10");
-#elif defined(Q_OS_LINUX)
+#if defined(Q_OS_WINDOWS) || defined(Q_OS_LINUX)
     return true;
 #else
     return false;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Always use custom Fusion-based dark theme on Windows instead of only on Windows 10.

#### Motivation for adding to Mudlet
The built-in Qt dark theme on Windows 11 hasn't received praise but has received some criticism.

#### Other info (issues closed, discussion etc)
Mudlet 4.19.1 used the custom dark theme on all platforms - the switch to native Qt theming for macOS and Windows 11 was introduced after 4.19.1.

**Test case:** Enable dark mode on Windows 11, verify the custom Fusion dark theme is applied instead of the native Qt theme.