### PR TITLE
Fix: Disable AddressSanitizer for release builds

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -35,6 +35,8 @@ jobs:
             qt: '6.9.0'
             deploy: 'deploy'
             run_tests: 'true'
+            # Enable AddressSanitizer for PTB and testing builds, but not release
+            # builds (tagged Mudlet-*) - ASAN adds significant runtime overhead
             enable_asan: 'true'
           - os: ubuntu-22.04
             # Another try to use GCC12
@@ -253,7 +255,7 @@ jobs:
         cmakeAppendedArgs: >-
           -G Ninja
           -DCMAKE_PREFIX_PATH=${{ env.QT_PREFIX != '' && env.QT_PREFIX || env.MINGW_BASE_DIR }}
-          -DUSE_SANITIZER=${{ matrix.enable_asan == 'true' && 'Address' || '' }}
+          -DUSE_SANITIZER=${{ matrix.enable_asan == 'true' && !startsWith(github.ref, 'refs/tags/Mudlet-') && 'Address' || '' }}
           ${{ runner.os == 'macOS' && format('-DLUA_INCLUDE_DIR={0}/.lua/include -DLUA_LIBRARY={0}/.lua/lib/liblua.a', github.workspace) || '' }}
           -DWITH_SENTRY=ON
           -DSENTRY_SEND_DEBUG=${{ (startsWith(github.ref, 'refs/tags/') || github.event_name == 'schedule' || github.event.inputs.scheduled == 'true') && '1' || '0' }}


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
AddressSanitizer was enabled for all Linux builds including tagged releases (Mudlet-*). 

This change keeps ASAN enabled for:
- Pull request builds (testing)
- Development/master branch pushes
- PTB (Public Test Build) scheduled builds

But disables it for tagged release builds (refs/tags/Mudlet-*).
#### Motivation for adding to Mudlet
ASAN adds significant runtime overhead (2-3x slowdown, 2x+ memory usage) which is inappropriate for production releases.
#### Other info (issues closed, discussion etc)
