### PR TITLE
infrastructure: Remove dead CMake code in Sentry configuration

### DIFF
--- a/src/cmake/WithSentry.cmake
+++ b/src/cmake/WithSentry.cmake
@@ -25,10 +25,6 @@ set(SENTRY_COMMON_ARGS
     -G Ninja
 )
 
-if(UNIX AND NOT APPLE)
-    list(APPEND SENTRY_CMAKE_ARGS -DSENTRY_TRANSPORT=none)
-endif()
-
 if(APPLE)
     execute_process(
         COMMAND xcrun --sdk macosx --show-sdk-path


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Remove unused SENTRY_CMAKE_ARGS variable that was set but never read

#### Motivation for adding to Mudlet
Cleans up dead code that had no effect on the build.

#### Other info (issues closed, discussion etc)
None

**Test case:** Build with `-DWITH_SENTRY=ON` and verify Sentry integration still works