### PR TITLE
Infrastructure: Remove unused QKeychain forward declarations from CredentialManager.h

### DIFF
--- a/src/CredentialManager.h
+++ b/src/CredentialManager.h
@@ -29,9 +29,6 @@ class QTimer;
 
 namespace QKeychain {
 class Job;
-class ReadPasswordJob;
-class WritePasswordJob;
-class DeletePasswordJob;
 }
 
 /**


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
These forward declarations (ReadPasswordJob, WritePasswordJob, DeletePasswordJob) are not used in the header file - only Job is used for QPointer<QKeychain::Job>. The .cpp file includes the actual headers where these classes are instantiated.

#### Motivation for adding to Mudlet
Slightly leaner code.
#### Other info (issues closed, discussion etc)
Found using [include-what-you-use](https://include-what-you-use.org/) with Qt6 mapping file. We don't have that many unused includes at all, according to the tool.