### PR TITLE
infrastructure: Fix Windows code signing by adding SignPath v2 policy file

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -192,6 +192,7 @@ jobs:
         wait-for-completion: true
         output-artifact-directory: ${{steps.prepare-signing.outputs.signing_dir}}
         wait-for-completion-timeout-in-seconds: 600
+        github-policies-file: '.signpath/github-policies.yaml'
 
     - name: (Windows) Replace binaries with signed versions
       if: steps.sign-binaries.outcome == 'success'
@@ -262,6 +263,7 @@ jobs:
         wait-for-completion: true
         output-artifact-directory: ${{github.workspace}}/signed-installer
         wait-for-completion-timeout-in-seconds: 600
+        github-policies-file: '.signpath/github-policies.yaml'
 
     - name: (Windows) Replace installer with signed version
       if: steps.sign-installer.outcome == 'success'

--- a/.signpath/github-policies.yaml
+++ b/.signpath/github-policies.yaml
@@ -1,0 +1,9 @@
+github-policies:
+  - organization: "Mudlet"
+    repository: "Mudlet"
+    branches:
+      - "development"
+      - "master"
+      - "release-*"
+    tags:
+      - "Mudlet-*"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds required github-policies.yaml configuration file for SignPath v2 action.

#### Motivation for adding to Mudlet
SignPath v2 action requires a github-policies section to specify which branches/tags can trigger code signing.

#### Other info (issues closed, discussion etc)
Fixes https://github.com/Mudlet/Mudlet/actions/runs/21383651237/job/61555494943

**Test case:** Windows scheduled build should complete binary signing step without errors.