### PR TITLE
fix: Crash when drawing map labels at small zoom levels

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -921,6 +921,7 @@ void T2DMap::addTextLabelToCache(const QString& key, const TMapLabel& label, con
     QRectF targetRect(0, 0, targetSize.width(), targetSize.height());
     if (!sizeFontToFitTextInRect(scaledFont, targetRect, label.text, 5, 4.0)) {
         // Font too small to be legible - fall back to smooth-scaled original pixmap
+        painter.end();
         pixmap = std::make_unique<QPixmap>(label.pix.scaled(targetSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
         if (!mTextLabelPixmapCache.insert(key, pixmap.release())) {
             qWarning("T2DMap::addTextLabelToCache() ALERT: Text Label Pixmap cache is full for key: %s", qUtf8Printable(key));


### PR DESCRIPTION
#### Brief overview of PR changes/additions
End the QPainter before reassigning the pixmap in the early return path of `addTextLabelToCache()` to fix a use-after-free.

#### Motivation for adding to Mudlet
Prevents a crash when viewing maps with text labels at certain zoom levels.

#### Other info (issues closed, discussion etc)
Fixes #8835

**Test case:** Create a text label on a map, zoom out until the label becomes very small - verify no crash occurs.