### PR TITLE
fix: Restore desktop shortcut creation on Windows install

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,7 +174,7 @@ int main(int argc, char* argv[])
             const QString exeName = appInfo.fileName();
 
             if (arg.startsWith(qsl("--squirrel-install")) || arg.startsWith(qsl("--squirrel-updated"))) {
-                QProcess::execute(updateExe, {qsl("--createShortcut"), exeName, qsl("--shortcut-locations"), qsl("StartMenu")});
+                QProcess::execute(updateExe, {qsl("--createShortcut"), exeName, qsl("--shortcut-locations"), qsl("StartMenu,Desktop")});
             } else if (arg.startsWith(qsl("--squirrel-uninstall"))) {
                 QProcess::execute(updateExe, {qsl("--removeShortcut"), exeName});
             }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add Desktop to the shortcut locations when handling Squirrel install/update events on Windows.

#### Motivation for adding to Mudlet
Desktop shortcuts stopped being created after PR #8672 switched to explicit shortcut creation with only StartMenu specified.

#### Other info (issues closed, discussion etc)
Follow-up to #8672.

**Test case:** Install Mudlet PTB on Windows and verify a desktop shortcut is created alongside the Start Menu entry.