### PR TITLE
infrastructure: Remove x64 from Windows PTB desktop shortcut name

### DIFF
--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -254,7 +254,7 @@ else
     NAME_SUFFIX='_64_-PublicTestBuild'
     INSTALLER_ICON_WINFILE=$(cygpath -aw "${GITHUB_WORKSPACE}/src/icons/mudlet_ptb.ico")
     ID='Mudlet_64_-PublicTestBuild'
-    TITLE='Mudlet x64 (Public Test Build)'
+    TITLE='Mudlet (Public Test Build)'
     LOADING_GIF="$(cygpath -aw "${GITHUB_WORKSPACE}/installers/windows/splash-installing-ptb-2x.png")"
     # Because the packaging tools use "Semantic Versioning" it makes sense
     # use the date in a number year-first form rather than the SHA1 as


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Remove "x64" from the Public Test Build desktop shortcut name on Windows

#### Motivation for adding to Mudlet
The x64 suffix is unnecessary since Mudlet no longer ships 32-bit Windows builds.

#### Other info (issues closed, discussion etc)
Cosmetic change only - does not affect package ID or update paths.

**Test case:** Install a PTB on Windows and verify the desktop shortcut is named "Mudlet (Public Test Build)" instead of "Mudlet x64 (Public Test Build)"