### PR TITLE
add: GNOME Software-style navigation in Package Manager

### DIFF
--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -829,11 +829,11 @@ void dlgPackageManager::slot_toggleRemoveButton()
         const QList selection = packageList->selectedItems();
         const int selectionCount = selection.size();
         pushButton_remove->setEnabled(selectionCount);
-        if (selectionCount) {
-            //: Message on button in package manager to remove one or more (%n is the count of) selected package(s).
+        if (selectionCount > 1) {
+            //: Message on button in package manager to remove multiple (%n is the count of) selected packages.
             pushButton_remove->setText(tr("Remove (%n)", nullptr, selectionCount));
         } else {
-            //: Message on button in package manager initially and when there is no packages to remove
+            //: Message on button in package manager initially and when zero or one package is selected
             pushButton_remove->setText(tr("Remove"));
         }
     } else {

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -794,21 +794,21 @@ void dlgPackageManager::slot_toggleInstallRepoButton()
         pushButton_installRepo->setEnabled(selectionCount);
 
         if (mCurrentView == NavigationView::Updates) {
-            if (selectionCount) {
-                //: Message on button in package manager to update one or more (%n is the count of) selected package(s).
+            if (selectionCount > 1) {
+                //: Message on button in package manager to update multiple (%n is the count of) selected packages.
                 pushButton_installRepo->setText(tr("Update (%n)", nullptr, selectionCount));
             } else {
-                //: Message on button in package manager for updates view when no packages are selected
+                //: Message on button in package manager for updates view when zero or one package is selected
                 pushButton_installRepo->setText(tr("Update"));
             }
             //: Tooltip for button in package manager when in Updates view
             pushButton_installRepo->setToolTip(tr("Update selected packages"));
         } else {
-            if (selectionCount) {
-                //: Message on button in package manager to install one or more (%n is the count of) selected package(s).
+            if (selectionCount > 1) {
+                //: Message on button in package manager to install multiple (%n is the count of) selected packages.
                 pushButton_installRepo->setText(tr("Install (%n)", nullptr, selectionCount));
             } else {
-                //: Message on button in package manager initially and when there is no packages to install
+                //: Message on button in package manager initially and when zero or one package is selected
                 pushButton_installRepo->setText(tr("Install"));
             }
             //: Tooltip for button in package manager when in Explore view

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -455,9 +455,14 @@ void dlgPackageManager::slot_installPackageFromRepository()
 
             if (--(*remainingDownloads.get()) == 0) {
                 for (auto it = pendingDownloads->begin(); it != pendingDownloads->end(); ++it) {
+                    const QString& packageName = it.key();
                     const QString& filePath = it.value();
 
                     if (mpHost) {
+                        // Uninstall existing package first if this is an update
+                        if (mpHost->mInstalledPackages.contains(packageName)) {
+                            mpHost->uninstallPackage(packageName, enums::PackageModuleType::Package);
+                        }
                         mpHost->installPackage(filePath, enums::PackageModuleType::Package);
                     }
                     QFile::remove(filePath);
@@ -796,6 +801,8 @@ void dlgPackageManager::slot_toggleInstallRepoButton()
                 //: Message on button in package manager for updates view when no packages are selected
                 pushButton_installRepo->setText(tr("Update"));
             }
+            //: Tooltip for button in package manager when in Updates view
+            pushButton_installRepo->setToolTip(tr("Update selected packages"));
         } else {
             if (selectionCount) {
                 //: Message on button in package manager to install one or more (%n is the count of) selected package(s).
@@ -804,11 +811,15 @@ void dlgPackageManager::slot_toggleInstallRepoButton()
                 //: Message on button in package manager initially and when there is no packages to install
                 pushButton_installRepo->setText(tr("Install"));
             }
+            //: Tooltip for button in package manager when in Explore view
+            pushButton_installRepo->setToolTip(tr("Install package from repository"));
         }
     } else {
         //: Message on button in package manager initially and when there is no packages to install
         pushButton_installRepo->setText(tr("Install"));
         pushButton_installRepo->setEnabled(false);
+        //: Tooltip for button in package manager when in Explore view
+        pushButton_installRepo->setToolTip(tr("Install package from repository"));
     }
 }
 

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -31,6 +31,7 @@
 #include <QNetworkAccessManager>
 #include <QProgressDialog>
 #include <QTimer>
+#include <QVersionNumber>
 
 using namespace std::chrono_literals;
 
@@ -45,7 +46,6 @@ dlgPackageManager::dlgPackageManager(QWidget* parent, Host* pHost)
     connect(packageList, &QListWidget::currentItemChanged, this, &dlgPackageManager::slot_itemChanged);
     connect(packageList, &QListWidget::itemSelectionChanged, this, &dlgPackageManager::slot_toggleInstallRepoButton);
     connect(packageList, &QListWidget::itemSelectionChanged, this, &dlgPackageManager::slot_toggleRemoveButton);
-    connect(packageStatusList, &QListWidget::currentItemChanged, this, &dlgPackageManager::slot_setPackageList);
     connect(pushButton_installFile, &QAbstractButton::clicked, this, &dlgPackageManager::slot_installPackageFromFile);
     connect(pushButton_installRepo, &QAbstractButton::clicked, this, &dlgPackageManager::slot_installPackageFromRepository);
     connect(pushButton_remove, &QAbstractButton::clicked, this, &dlgPackageManager::slot_removePackages);
@@ -60,16 +60,11 @@ dlgPackageManager::dlgPackageManager(QWidget* parent, Host* pHost)
     pushButton_report->setIcon(QIcon(qsl(":/icons/flag-red.png")));
     pushButton_report->hide();
 
-    packageStatusList->setSortingEnabled(false);
-    //: Package manager - status item showing installed packages
-    statusInstalled = new QListWidgetItem(tr("Installed") + QString(" (%1)").arg(mpHost->mInstalledPackages.size()), packageStatusList);
-    //: Package manager - status item showing available packages
-    statusAvailable = new QListWidgetItem(tr("Available") + QString(" (%1)").arg(repositoryPackages.size()), packageStatusList);
-    packageStatusList->setCurrentItem(statusInstalled);
+    setupNavigationButtons();
+    applyNavigationStyles();
 
     packageList->setSortingEnabled(true);
 
-    // Set up custom delegate for package list to show name and description
     mpPackageItemDelegate = new PackageItemDelegate(this);
     packageList->setItemDelegate(mpPackageItemDelegate);
 
@@ -79,9 +74,32 @@ dlgPackageManager::dlgPackageManager(QWidget* parent, Host* pHost)
     }
 
     pushButton_installRepo->setEnabled(false);
-    packageList->setCurrentRow(0);
+    mCurrentView = NavigationView::Installed;
+    slot_setPackageList();
 
     setAttribute(Qt::WA_DeleteOnClose);
+}
+
+void dlgPackageManager::applyNavigationStyles()
+{
+    navigationFrame->setStyleSheet(qsl("QFrame#navigationFrame {"
+                                       "  border: 1px solid palette(mid);"
+                                       "  border-radius: 6px;"
+                                       "  background-color: palette(window);"
+                                       "}"
+                                       "QPushButton {"
+                                       "  border: none;"
+                                       "  border-radius: 4px;"
+                                       "  padding: 6px 16px;"
+                                       "  background-color: transparent;"
+                                       "}"
+                                       "QPushButton:checked {"
+                                       "  background-color: palette(highlight);"
+                                       "  color: palette(highlighted-text);"
+                                       "}"
+                                       "QPushButton:hover:!checked {"
+                                       "  background-color: palette(midlight);"
+                                       "}"));
 }
 
 void dlgPackageManager::clearPackageDetails()
@@ -160,6 +178,8 @@ void dlgPackageManager::downloadRepositoryIndex()
         file->deleteLater();
         manager->deleteLater();
         readPackageRepositoryFile();
+        populatePackagesWithUpdates();
+        updateUpdatesBadge();
     });
 }
 
@@ -172,6 +192,33 @@ void dlgPackageManager::fillPackageDetails(const QString& name, const QString& t
     label_author->setText(author);
     //: Package manager - label showing package version
     label_version->setText(tr("Version ") + version);
+}
+
+bool dlgPackageManager::hasNewerVersion(const QString& installed, const QString& repo) const
+{
+    const QVersionNumber installedVersion = QVersionNumber::fromString(installed);
+    const QVersionNumber repoVersion = QVersionNumber::fromString(repo);
+    return repoVersion > installedVersion;
+}
+
+void dlgPackageManager::populatePackagesWithUpdates()
+{
+    mPackagesWithUpdates.clear();
+
+    for (const QString& packageName : mpHost->mInstalledPackages) {
+        if (!packageLookup.contains(packageName)) {
+            continue;
+        }
+
+        const QJsonObject repoPackage = packageLookup.value(packageName);
+        const QString repoVersion = repoPackage.value(qsl("version")).toString();
+        const auto packageInfo = mpHost->mPackageInfo.value(packageName);
+        const QString installedVersion = packageInfo.value(qsl("version"));
+
+        if (!installedVersion.isEmpty() && !repoVersion.isEmpty() && hasNewerVersion(installedVersion, repoVersion)) {
+            mPackagesWithUpdates.append(packageName);
+        }
+    }
 }
 
 bool dlgPackageManager::readPackageRepositoryFile()
@@ -205,8 +252,10 @@ bool dlgPackageManager::readPackageRepositoryFile()
         QJsonObject pkg = val.toObject();
         packageLookup.insert(pkg["mpackage"].toString(), pkg);
     }
-    //: Package manager - status item showing number of available packages
-    statusAvailable->setText(tr("Available") + QString(" (%1)").arg(repositoryPackages.size()));
+
+    populatePackagesWithUpdates();
+    updateUpdatesBadge();
+
     return true;
 }
 
@@ -217,7 +266,8 @@ void dlgPackageManager::resetPackageList()
     }
 
     clearPackageDetails();
-    packageStatusList->setCurrentItem(statusInstalled);
+    mCurrentView = NavigationView::Installed;
+    mpNavigationGroup->button(static_cast<int>(NavigationView::Installed))->setChecked(true);
     packageList->clear();
 
     for (int i = 0; i < mpHost->mInstalledPackages.size(); i++) {
@@ -234,7 +284,6 @@ void dlgPackageManager::resetPackageList()
             const auto iconDir = mudlet::getMudletPath(enums::profileDataItemPath, mpHost->getName(), qsl("%1/.mudlet/Icon/%2").arg(mpHost->mInstalledPackages.at(i), iconName));
             item->setIcon(QIcon(iconDir));
         } else {
-            // for alignment purposes in the package list
             QPixmap emptyPixmap(16, 16);
             emptyPixmap.fill(Qt::transparent);
             item->setIcon(QIcon(emptyPixmap));
@@ -242,9 +291,21 @@ void dlgPackageManager::resetPackageList()
         packageList->addItem(item);
     }
 
-    //: Package manager - status item showing number of installed packages
-    statusInstalled->setText(tr("Installed") + QString(" (%1)").arg(mpHost->mInstalledPackages.size()));
+    populatePackagesWithUpdates();
+    updateUpdatesBadge();
     packageList->setCurrentRow(0);
+}
+
+void dlgPackageManager::setupNavigationButtons()
+{
+    mpNavigationGroup = new QButtonGroup(this);
+    mpNavigationGroup->setExclusive(true);
+
+    mpNavigationGroup->addButton(pushButton_explore, static_cast<int>(NavigationView::Explore));
+    mpNavigationGroup->addButton(pushButton_installed, static_cast<int>(NavigationView::Installed));
+    mpNavigationGroup->addButton(pushButton_updates, static_cast<int>(NavigationView::Updates));
+
+    connect(mpNavigationGroup, &QButtonGroup::idClicked, this, &dlgPackageManager::slot_navigationButtonClicked);
 }
 
 void dlgPackageManager::slot_installPackageFromFile()
@@ -304,7 +365,6 @@ void dlgPackageManager::slot_installPackageFromRepository()
     auto cancelled = std::make_shared<bool>(false);
     bool repoError = false;
 
-    // Handle cancellation
     QObject::connect(progress, &QProgressDialog::canceled, [activeReplies, pendingDownloads, manager, progress, cancelled]() {
         *cancelled = true;
         for (QNetworkReply* reply : *activeReplies) {
@@ -312,7 +372,6 @@ void dlgPackageManager::slot_installPackageFromRepository()
                 reply->abort();
             }
         }
-        // Clean up any partially downloaded files
         for (const QString& filePath : pendingDownloads->values()) {
             QFile::remove(filePath);
         }
@@ -380,10 +439,8 @@ void dlgPackageManager::slot_installPackageFromRepository()
             reply->deleteLater();
             file->deleteLater();
 
-            // Remove this reply from active list
             activeReplies->removeOne(reply);
 
-            // If cancelled, just clean up and return
             if (*cancelled) {
                 QFile::remove(outPath);
                 return;
@@ -398,7 +455,6 @@ void dlgPackageManager::slot_installPackageFromRepository()
 
             if (--(*remainingDownloads.get()) == 0) {
                 for (auto it = pendingDownloads->begin(); it != pendingDownloads->end(); ++it) {
-                    const QString& pkgName = it.key();
                     const QString& filePath = it.value();
 
                     if (mpHost) {
@@ -412,13 +468,11 @@ void dlgPackageManager::slot_installPackageFromRepository()
                 progress->deleteLater();
                 manager->deleteLater();
 
-                // Refresh the package list to show newly installed packages
                 resetPackageList();
             }
         });
     }
 
-    // package listing must have been corrupted, re-download
     if (repoError) {
         downloadRepositoryIndex();
     }
@@ -432,10 +486,9 @@ void dlgPackageManager::slot_itemChanged(QListWidgetItem* pItem)
 
     clearPackageDetails();
 
-    const auto status = packageStatusList->currentItem();
     QString packageName = pItem->text();
 
-    if (status == statusInstalled) {
+    if (mCurrentView == NavigationView::Installed) {
         auto packageInfo{mpHost->mPackageInfo.value(packageName)};
         if (packageInfo.isEmpty()) {
             packageDescription->clear();
@@ -465,7 +518,7 @@ void dlgPackageManager::slot_itemChanged(QListWidgetItem* pItem)
 
         fillPackageDetails(packageName, packageInfo.value(qsl("title")), packageInfo.value(qsl("author")), packageInfo.value(qsl("version")));
 
-    } else if (status == statusAvailable) {
+    } else if (mCurrentView == NavigationView::Explore) {
         pushButton_website->show();
         pushButton_report->show();
         downloadIcon(packageName);
@@ -476,7 +529,32 @@ void dlgPackageManager::slot_itemChanged(QListWidgetItem* pItem)
                     packageObj.value(qsl("mpackage")).toString(), packageObj.value(qsl("title")).toString(), packageObj.value(qsl("author")).toString(), packageObj.value(qsl("version")).toString());
             packageDescription->setMarkdown(packageObj.value(qsl("description")).toString());
         }
+    } else if (mCurrentView == NavigationView::Updates) {
+        pushButton_website->show();
+        pushButton_report->show();
+        downloadIcon(packageName);
+
+        if (packageLookup.contains(packageName)) {
+            QJsonObject packageObj = packageLookup.value(packageName);
+            const auto packageInfo = mpHost->mPackageInfo.value(packageName);
+            const QString installedVersion = packageInfo.value(qsl("version"));
+            const QString repoVersion = packageObj.value(qsl("version")).toString();
+
+            fillPackageDetails(packageObj.value(qsl("mpackage")).toString(), packageObj.value(qsl("title")).toString(), packageObj.value(qsl("author")).toString(), repoVersion);
+
+            //: Package manager - version update indicator showing old and new versions
+            label_version->setText(tr("Version %1 → %2").arg(installedVersion, repoVersion));
+
+            packageDescription->setMarkdown(packageObj.value(qsl("description")).toString());
+        }
     }
+}
+
+void dlgPackageManager::slot_navigationButtonClicked(int buttonId)
+{
+    mCurrentView = static_cast<NavigationView>(buttonId);
+    lineEdit_searchBar->clear();
+    slot_setPackageList();
 }
 
 void dlgPackageManager::slot_onIconDownloaded(QNetworkReply* reply)
@@ -539,14 +617,16 @@ void dlgPackageManager::slot_removePackages()
     for (const QString& package : removePackages) {
         mpHost->uninstallPackage(package, enums::PackageModuleType::Package);
     }
+
+    populatePackagesWithUpdates();
+    updateUpdatesBadge();
 }
 
 void dlgPackageManager::slot_searchTextChanged(const QString& searchText)
 {
-    const auto status = packageStatusList->currentItem();
     packageList->clear();
 
-    if (status == statusInstalled) {
+    if (mCurrentView == NavigationView::Installed) {
         for (const auto& value : mpHost->mPackageInfo) {
             const QString name = value.value(qsl("mpackage"));
             const QString title = value.value(qsl("title"));
@@ -564,7 +644,6 @@ void dlgPackageManager::slot_searchTextChanged(const QString& searchText)
                     const auto iconDir = mudlet::getMudletPath(enums::profileDataItemPath, mpHost->getName(), qsl("%1/.mudlet/Icon/%2").arg(name, iconName));
                     item->setIcon(QIcon(iconDir));
                 } else {
-                    // for alignment purposes in the package list
                     QPixmap emptyPixmap(16, 16);
                     emptyPixmap.fill(Qt::transparent);
                     item->setIcon(QIcon(emptyPixmap));
@@ -572,7 +651,7 @@ void dlgPackageManager::slot_searchTextChanged(const QString& searchText)
                 packageList->addItem(item);
             }
         }
-    } else if (status == statusAvailable) {
+    } else if (mCurrentView == NavigationView::Explore) {
         for (const QJsonValue& value : repositoryPackages) {
             const QJsonObject pkg = value.toObject();
             const QString name = pkg[qsl("mpackage")].toString();
@@ -589,6 +668,31 @@ void dlgPackageManager::slot_searchTextChanged(const QString& searchText)
                 if (pkg.contains(qsl("icon"))) {
                     const QPixmap pixmap(pkg[qsl("icon")].toString());
                     item->setIcon(QIcon(pixmap));
+                }
+                packageList->addItem(item);
+            }
+        }
+    } else if (mCurrentView == NavigationView::Updates) {
+        for (const QString& packageName : mPackagesWithUpdates) {
+            const auto packageInfo = mpHost->mPackageInfo.value(packageName);
+            const QString title = packageInfo.value(qsl("title"));
+            const QString description = packageInfo.value(qsl("description"));
+            const QString author = packageInfo.value(qsl("author"));
+
+            if (packageName.contains(searchText, Qt::CaseInsensitive) || title.contains(searchText, Qt::CaseInsensitive) || description.contains(searchText, Qt::CaseInsensitive)
+                || author.contains(searchText, Qt::CaseInsensitive)) {
+                QListWidgetItem* item = new QListWidgetItem(packageName);
+                if (!title.isEmpty()) {
+                    item->setData(Qt::UserRole, title);
+                }
+                const auto iconName = packageInfo.value(qsl("icon"));
+                if (!iconName.isEmpty()) {
+                    const auto iconDir = mudlet::getMudletPath(enums::profileDataItemPath, mpHost->getName(), qsl("%1/.mudlet/Icon/%2").arg(packageName, iconName));
+                    item->setIcon(QIcon(iconDir));
+                } else {
+                    QPixmap emptyPixmap(16, 16);
+                    emptyPixmap.fill(Qt::transparent);
+                    item->setIcon(QIcon(emptyPixmap));
                 }
                 packageList->addItem(item);
             }
@@ -610,9 +714,7 @@ void dlgPackageManager::slot_setPackageList()
     packageList->clear();
     clearPackageDetails();
 
-    const auto status = packageStatusList->currentItem();
-
-    if (status == statusInstalled) {
+    if (mCurrentView == NavigationView::Installed) {
         for (int i = 0; i < mpHost->mInstalledPackages.size(); i++) {
             auto item = new QListWidgetItem();
             item->setText(mpHost->mInstalledPackages.at(i));
@@ -626,14 +728,13 @@ void dlgPackageManager::slot_setPackageList()
                 const auto iconDir = mudlet::getMudletPath(enums::profileDataItemPath, mpHost->getName(), qsl("%1/.mudlet/Icon/%2").arg(mpHost->mInstalledPackages.at(i), iconName));
                 item->setIcon(QIcon(iconDir));
             } else {
-                // for alignment purposes in the package list
                 QPixmap emptyPixmap(16, 16);
                 emptyPixmap.fill(Qt::transparent);
                 item->setIcon(QIcon(emptyPixmap));
             }
             packageList->addItem(item);
         }
-    } else if (status == statusAvailable) {
+    } else if (mCurrentView == NavigationView::Explore) {
         if (!readPackageRepositoryFile()) {
             return;
         }
@@ -648,6 +749,33 @@ void dlgPackageManager::slot_setPackageList()
             }
             packageList->addItem(item);
         }
+    } else if (mCurrentView == NavigationView::Updates) {
+        populatePackagesWithUpdates();
+
+        if (mPackagesWithUpdates.isEmpty()) {
+            //: Package manager - message shown in description area when no updates are available
+            packageDescription->setPlainText(tr("All packages are up to date."));
+        }
+
+        for (const QString& packageName : mPackagesWithUpdates) {
+            auto item = new QListWidgetItem();
+            item->setText(packageName);
+            const auto packageInfo{mpHost->mPackageInfo.value(packageName)};
+            const auto iconName = packageInfo.value(qsl("icon"));
+            const auto title = packageInfo.value(qsl("title"));
+            if (!title.isEmpty()) {
+                item->setData(Qt::UserRole, title);
+            }
+            if (!iconName.isEmpty()) {
+                const auto iconDir = mudlet::getMudletPath(enums::profileDataItemPath, mpHost->getName(), qsl("%1/.mudlet/Icon/%2").arg(packageName, iconName));
+                item->setIcon(QIcon(iconDir));
+            } else {
+                QPixmap emptyPixmap(16, 16);
+                emptyPixmap.fill(Qt::transparent);
+                item->setIcon(QIcon(emptyPixmap));
+            }
+            packageList->addItem(item);
+        }
     }
 
     packageList->setCurrentRow(0);
@@ -655,18 +783,27 @@ void dlgPackageManager::slot_setPackageList()
 
 void dlgPackageManager::slot_toggleInstallRepoButton()
 {
-    const auto status = packageStatusList->currentItem();
-
-    if (status == statusAvailable) {
+    if (mCurrentView == NavigationView::Explore || mCurrentView == NavigationView::Updates) {
         const QList selection = packageList->selectedItems();
         const int selectionCount = selection.size();
         pushButton_installRepo->setEnabled(selectionCount);
-        if (selectionCount) {
-            //: Message on button in package manager to install one or more (%n is the count of) selected package(s).
-            pushButton_installRepo->setText(tr("Install (%n)", nullptr, selectionCount));
+
+        if (mCurrentView == NavigationView::Updates) {
+            if (selectionCount) {
+                //: Message on button in package manager to update one or more (%n is the count of) selected package(s).
+                pushButton_installRepo->setText(tr("Update (%n)", nullptr, selectionCount));
+            } else {
+                //: Message on button in package manager for updates view when no packages are selected
+                pushButton_installRepo->setText(tr("Update"));
+            }
         } else {
-            //: Message on button in package manager initially and when there is no packages to install
-            pushButton_installRepo->setText(tr("Install"));
+            if (selectionCount) {
+                //: Message on button in package manager to install one or more (%n is the count of) selected package(s).
+                pushButton_installRepo->setText(tr("Install (%n)", nullptr, selectionCount));
+            } else {
+                //: Message on button in package manager initially and when there is no packages to install
+                pushButton_installRepo->setText(tr("Install"));
+            }
         }
     } else {
         //: Message on button in package manager initially and when there is no packages to install
@@ -677,9 +814,7 @@ void dlgPackageManager::slot_toggleInstallRepoButton()
 
 void dlgPackageManager::slot_toggleRemoveButton()
 {
-    const auto status = packageStatusList->currentItem();
-
-    if (status == statusInstalled) {
+    if (mCurrentView == NavigationView::Installed) {
         const QList selection = packageList->selectedItems();
         const int selectionCount = selection.size();
         pushButton_remove->setEnabled(selectionCount);
@@ -705,9 +840,20 @@ void dlgPackageManager::showImportStatus(const QString& message)
     QTimer::singleShot(4s, label_importStatus, &QWidget::hide);
 }
 
+void dlgPackageManager::updateUpdatesBadge()
+{
+    const int count = mPackagesWithUpdates.size();
+    if (count > 0) {
+        //: Package manager - navigation button showing number of available updates
+        pushButton_updates->setText(tr("Updates (%1)").arg(count));
+    } else {
+        //: Package manager - navigation button for updates view
+        pushButton_updates->setText(tr("Updates"));
+    }
+}
+
 void dlgPackageManager::closeEvent(QCloseEvent* event)
 {
-    // Only emit signal to restore focus if we're not shutting down
     if (mudlet::self() && !mudlet::self()->isGoingDown() && mpHost && !mpHost->isClosingDown()) {
         emit packageManagerClosing(mpHost->getName());
     }

--- a/src/dlgPackageManager.h
+++ b/src/dlgPackageManager.h
@@ -26,6 +26,7 @@
 #include "PackageItemDelegate.h"
 
 #include "ui_package_manager.h"
+#include <QButtonGroup>
 #include <QDialog>
 #include <QJsonArray>
 #include <QListWidget>
@@ -34,6 +35,7 @@
 class Host;
 class QNetworkReply;
 
+enum class NavigationView { Explore, Installed, Updates };
 
 class dlgPackageManager : public QDialog, public Ui::package_manager
 {
@@ -52,29 +54,36 @@ private slots:
     void slot_installPackageFromFile();
     void slot_installPackageFromRepository();
     void slot_itemChanged(QListWidgetItem*);
+    void slot_navigationButtonClicked(int buttonId);
     void slot_openBugWebsite();
     void slot_openPackageWebsite();
-    void slot_onIconDownloaded(QNetworkReply *reply);
+    void slot_onIconDownloaded(QNetworkReply* reply);
     void slot_removePackages();
-    void slot_searchTextChanged(const QString &searchText);
+    void slot_searchTextChanged(const QString& searchText);
     void slot_setPackageList();
     void slot_toggleInstallRepoButton();
     void slot_toggleRemoveButton();
 
 private:
+    void applyNavigationStyles();
     void clearPackageDetails();
     void closeEvent(QCloseEvent* event) override;
-    void downloadIcon(const QString &packageName);
+    void downloadIcon(const QString& packageName);
     void downloadRepositoryIndex();
-    void fillPackageDetails(const QString &name, const QString &title, const QString &author, const QString &version);
+    void fillPackageDetails(const QString& name, const QString& title, const QString& author, const QString& version);
+    bool hasNewerVersion(const QString& installed, const QString& repo) const;
+    void populatePackagesWithUpdates();
+    void setupNavigationButtons();
     void showImportStatus(const QString& message);
+    void updateUpdatesBadge();
 
     Host* mpHost = nullptr;
+    QButtonGroup* mpNavigationGroup = nullptr;
+    NavigationView mCurrentView = NavigationView::Installed;
+    QList<QString> mPackagesWithUpdates;
     PackageItemDelegate* mpPackageItemDelegate = nullptr;
     QHash<QString, QJsonObject> packageLookup;
     QJsonArray repositoryPackages;
-    QListWidgetItem* statusAvailable;
-    QListWidgetItem* statusInstalled;
 };
 
 #endif

--- a/src/ui/package_manager.ui
+++ b/src/ui/package_manager.ui
@@ -22,243 +22,316 @@
     <height>600</height>
    </size>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout_2">
+  <layout class="QVBoxLayout" name="mainVerticalLayout">
    <item>
-    <widget class="QWidget" name="leftPanel" native="true">
+    <widget class="QWidget" name="headerBar" native="true">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="minimumSize">
-      <size>
-       <width>300</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>400</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_left">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
+     <layout class="QHBoxLayout" name="headerLayout">
       <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
+       <number>4</number>
       </property>
       <property name="bottomMargin">
-       <number>0</number>
+       <number>4</number>
       </property>
       <item>
-       <widget class="QLineEdit" name="lineEdit_searchBar">
-       <property name="toolTip">
-        <string>Search packages</string>
-       </property>
-       <property name="placeholderText">
-        <string>Search packages</string>
-       </property>
-       <property name="clearButtonEnabled">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QListWidget" name="packageStatusList">
-       <property name="focusPolicy">
-        <enum>Qt::FocusPolicy::ClickFocus</enum>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>80</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QListWidget" name="packageList">
-       <property name="focusPolicy">
-        <enum>Qt::FocusPolicy::StrongFocus</enum>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::Shape::NoFrame</enum>
-       </property>
-       <property name="alternatingRowColors">
-        <bool>true</bool>
-       </property>
-       <property name="selectionMode">
-        <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
-       </property>
-       <property name="selectionBehavior">
-        <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>16</width>
-         <height>16</height>
-        </size>
-       </property>
-       <property name="sortingEnabled">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_importStatus">
-       <property name="visible">
-        <bool>false</bool>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string notr="true"/>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QPushButton" name="pushButton_installRepo">
-         <property name="toolTip">
-          <string>Install package from repository</string>
+       <spacer name="leftSpacer">
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QFrame" name="navigationFrame">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Shadow::Raised</enum>
+        </property>
+        <layout class="QHBoxLayout" name="navigationLayout">
+         <property name="spacing">
+          <number>0</number>
          </property>
-         <property name="text">
-          <string>Install</string>
+         <property name="leftMargin">
+          <number>2</number>
          </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="pushButton_installFile">
-         <property name="focusPolicy">
-          <enum>Qt::FocusPolicy::TabFocus</enum>
+         <property name="topMargin">
+          <number>2</number>
          </property>
-         <property name="toolTip">
-          <string>Install package from file</string>
+         <property name="rightMargin">
+          <number>2</number>
          </property>
-         <property name="text">
-          <string>Install from file</string>
+         <property name="bottomMargin">
+          <number>2</number>
          </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="pushButton_remove">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="focusPolicy">
-          <enum>Qt::FocusPolicy::TabFocus</enum>
-         </property>
-         <property name="toolTip">
-          <string>Remove package from installed packages</string>
-         </property>
-         <property name="text">
-          <string comment="Message on button in package manager initially and when there is no packages to remove.">Remove</string>
-         </property>
-        </widget>
-       </item>
-       </layout>
+         <item>
+          <widget class="QPushButton" name="pushButton_explore">
+           <property name="text">
+            <string>Explore</string>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButton_installed">
+           <property name="text">
+            <string>Installed</string>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButton_updates">
+           <property name="text">
+            <string>Updates</string>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <spacer name="rightSpacer">
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="rightPanel" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>1</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_right">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_details">
-       <item>
-        <widget class="QLabel" name="label_icon">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+      <widget class="QWidget" name="leftPanel" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>300</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>400</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_left">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_searchBar">
+         <property name="toolTip">
+          <string>Search packages</string>
          </property>
-         <property name="minimumSize">
-          <size>
-           <width>96</width>
-           <height>96</height>
-          </size>
+         <property name="placeholderText">
+          <string>Search packages</string>
          </property>
-         <property name="maximumSize">
-          <size>
-           <width>96</width>
-           <height>96</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>TextLabel</string>
-         </property>
-         <property name="scaledContents">
+         <property name="clearButtonEnabled">
           <bool>true</bool>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignCenter</set>
          </property>
         </widget>
        </item>
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout_details">
+        <widget class="QListWidget" name="packageList">
+         <property name="focusPolicy">
+          <enum>Qt::FocusPolicy::StrongFocus</enum>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::Shape::NoFrame</enum>
+         </property>
+         <property name="alternatingRowColors">
+          <bool>true</bool>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+         </property>
+         <property name="selectionBehavior">
+          <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>16</width>
+           <height>16</height>
+          </size>
+         </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_importStatus">
+         <property name="visible">
+          <bool>false</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string notr="true"/>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
-          <widget class="QLabel" name="label_packageName">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>28</pointsize>
-            </font>
+          <widget class="QPushButton" name="pushButton_installRepo">
+           <property name="toolTip">
+            <string>Install package from repository</string>
            </property>
            <property name="text">
-            <string/>
+            <string>Install</string>
            </property>
           </widget>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <widget class="QPushButton" name="pushButton_installFile">
+           <property name="focusPolicy">
+            <enum>Qt::FocusPolicy::TabFocus</enum>
+           </property>
+           <property name="toolTip">
+            <string>Install package from file</string>
+           </property>
+           <property name="text">
+            <string>Install from file</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButton_remove">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="focusPolicy">
+            <enum>Qt::FocusPolicy::TabFocus</enum>
+           </property>
+           <property name="toolTip">
+            <string>Remove package from installed packages</string>
+           </property>
+           <property name="text">
+            <string comment="Message on button in package manager initially and when there is no packages to remove.">Remove</string>
+           </property>
+          </widget>
+         </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QWidget" name="rightPanel" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_right">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_details">
+         <item>
+          <widget class="QLabel" name="label_icon">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>96</width>
+             <height>96</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>96</width>
+             <height>96</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>TextLabel</string>
+           </property>
+           <property name="scaledContents">
+            <bool>true</bool>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_details">
            <item>
-            <widget class="QLabel" name="label_author">
+            <widget class="QLabel" name="label_packageName">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -267,7 +340,7 @@
              </property>
              <property name="font">
               <font>
-               <bold>true</bold>
+               <pointsize>28</pointsize>
               </font>
              </property>
              <property name="text">
@@ -276,126 +349,148 @@
             </widget>
            </item>
            <item>
-            <widget class="QLabel" name="label_version">
+            <layout class="QHBoxLayout" name="horizontalLayout_3">
+             <item>
+              <widget class="QLabel" name="label_author">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="font">
+                <font>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="label_version">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>100</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_title">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>100</width>
-               <height>0</height>
-              </size>
              </property>
              <property name="text">
               <string/>
              </property>
              <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
              </property>
             </widget>
            </item>
           </layout>
          </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
-          <widget class="QLabel" name="label_title">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
+          <widget class="QPushButton" name="pushButton_website">
+           <property name="toolTip">
+            <string>Open package repository website</string>
            </property>
            <property name="text">
             <string/>
            </property>
-           <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
-           </property>
-           <property name="wordWrap">
+           <property name="flat">
             <bool>true</bool>
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QPushButton" name="pushButton_report">
+           <property name="toolTip">
+            <string>Report an issue with this package</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
         </layout>
        </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_4">
        <item>
-        <widget class="QPushButton" name="pushButton_website">
-         <property name="toolTip">
-          <string>Open package repository website</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="flat">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="pushButton_report">
-         <property name="toolTip">
-          <string>Report an issue with this package</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="flat">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer">
+        <widget class="Line" name="line">
          <property name="orientation">
           <enum>Qt::Orientation::Horizontal</enum>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
+        </widget>
        </item>
-      </layout>
-     </item>
-     <item>
-      <widget class="Line" name="line">
-       <property name="orientation">
-        <enum>Qt::Orientation::Horizontal</enum>
-       </property>
+       <item>
+        <widget class="QTextBrowser" name="packageDescription">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="focusPolicy">
+          <enum>Qt::FocusPolicy::NoFocus</enum>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+         <property name="openLinks">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       </layout>
       </widget>
      </item>
-     <item>
-      <widget class="QTextBrowser" name="packageDescription">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="focusPolicy">
-        <enum>Qt::FocusPolicy::NoFocus</enum>
-       </property>
-       <property name="readOnly">
-        <bool>true</bool>
-       </property>
-       <property name="openExternalLinks">
-        <bool>true</bool>
-       </property>
-       <property name="openLinks">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     </layout>
-    </widget>
+    </layout>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Replace sidebar toggle with centered Explore/Installed/Updates navigation buttons
- Add Updates view showing packages with newer versions available in repository
- Show version diff (e.g. "Version 1.0 → 1.1") when viewing updatable packages
- Fix package updates to work
- Change `Install (1)` to just be `Install` for better friendliness, 2+ installs will still show the count

#### Motivation for adding to Mudlet
Modern app store-style navigation makes package management more intuitive and adds visibility for available updates, also user feedback.

#### Other info (issues closed, discussion etc)
None

**Test case:** Open Package Manager, click each navigation button, verify Explore shows repo packages, Installed shows local packages, Updates shows packages with newer versions.

<img width="1093" height="813" alt="image" src="https://github.com/user-attachments/assets/ec8df224-e462-4610-8706-5ad3c42dd06b" />

