### PR TITLE
Fix: macOS color buttons not showing colors in settings

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1208,7 +1208,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
                         break;
                     default: {
                     } // There are a significant number of other errors
-                      // that are not handled here!
+                    // that are not handled here!
                     }
                 }
             }
@@ -1710,22 +1710,22 @@ void dlgProfilePreferences::setColors2()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonColor(pushButton_black_2, pHost->mBlack_2, true);
-        setButtonColor(pushButton_Lblack_2, pHost->mLightBlack_2, true);
-        setButtonColor(pushButton_green_2, pHost->mGreen_2, true);
-        setButtonColor(pushButton_Lgreen_2, pHost->mLightGreen_2, true);
-        setButtonColor(pushButton_red_2, pHost->mRed_2, true);
-        setButtonColor(pushButton_Lred_2, pHost->mLightRed_2, true);
-        setButtonColor(pushButton_blue_2, pHost->mBlue_2, true);
-        setButtonColor(pushButton_Lblue_2, pHost->mLightBlue_2, true);
-        setButtonColor(pushButton_yellow_2, pHost->mYellow_2, true);
-        setButtonColor(pushButton_Lyellow_2, pHost->mLightYellow_2, true);
-        setButtonColor(pushButton_cyan_2, pHost->mCyan_2, true);
-        setButtonColor(pushButton_Lcyan_2, pHost->mLightCyan_2, true);
-        setButtonColor(pushButton_magenta_2, pHost->mMagenta_2, true);
-        setButtonColor(pushButton_Lmagenta_2, pHost->mLightMagenta_2, true);
-        setButtonColor(pushButton_white_2, pHost->mWhite_2, true);
-        setButtonColor(pushButton_Lwhite_2, pHost->mLightWhite_2, true);
+        setButtonColor(pushButton_black_2, pHost->mBlack_2);
+        setButtonColor(pushButton_Lblack_2, pHost->mLightBlack_2);
+        setButtonColor(pushButton_green_2, pHost->mGreen_2);
+        setButtonColor(pushButton_Lgreen_2, pHost->mLightGreen_2);
+        setButtonColor(pushButton_red_2, pHost->mRed_2);
+        setButtonColor(pushButton_Lred_2, pHost->mLightRed_2);
+        setButtonColor(pushButton_blue_2, pHost->mBlue_2);
+        setButtonColor(pushButton_Lblue_2, pHost->mLightBlue_2);
+        setButtonColor(pushButton_yellow_2, pHost->mYellow_2);
+        setButtonColor(pushButton_Lyellow_2, pHost->mLightYellow_2);
+        setButtonColor(pushButton_cyan_2, pHost->mCyan_2);
+        setButtonColor(pushButton_Lcyan_2, pHost->mLightCyan_2);
+        setButtonColor(pushButton_magenta_2, pHost->mMagenta_2);
+        setButtonColor(pushButton_Lmagenta_2, pHost->mLightMagenta_2);
+        setButtonColor(pushButton_white_2, pHost->mWhite_2);
+        setButtonColor(pushButton_Lwhite_2, pHost->mLightWhite_2);
 
         setButtonColor(pushButton_foreground_color_2, pHost->mFgColor_2);
         setButtonColor(pushButton_background_color_2, pHost->mBgColor_2);
@@ -2182,7 +2182,7 @@ void dlgProfilePreferences::slot_setMapColorBlack()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_black_2, pHost->mBlack_2, true);
+        setButtonAndProfileColor(pushButton_black_2, pHost->mBlack_2);
     }
 }
 
@@ -2190,7 +2190,7 @@ void dlgProfilePreferences::slot_setMapColorLightBlack()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_Lblack_2, pHost->mLightBlack_2, true);
+        setButtonAndProfileColor(pushButton_Lblack_2, pHost->mLightBlack_2);
     }
 }
 
@@ -2198,7 +2198,7 @@ void dlgProfilePreferences::slot_setMapColorRed()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_red_2, pHost->mRed_2, true);
+        setButtonAndProfileColor(pushButton_red_2, pHost->mRed_2);
     }
 }
 
@@ -2206,7 +2206,7 @@ void dlgProfilePreferences::slot_setMapColorLightRed()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_Lred_2, pHost->mLightRed_2, true);
+        setButtonAndProfileColor(pushButton_Lred_2, pHost->mLightRed_2);
     }
 }
 
@@ -2214,7 +2214,7 @@ void dlgProfilePreferences::slot_setMapColorGreen()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_green_2, pHost->mGreen_2, true);
+        setButtonAndProfileColor(pushButton_green_2, pHost->mGreen_2);
     }
 }
 
@@ -2222,7 +2222,7 @@ void dlgProfilePreferences::slot_setMapColorLightGreen()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_Lgreen_2, pHost->mLightGreen_2, true);
+        setButtonAndProfileColor(pushButton_Lgreen_2, pHost->mLightGreen_2);
     }
 }
 
@@ -2230,7 +2230,7 @@ void dlgProfilePreferences::slot_setMapColorBlue()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_blue_2, pHost->mBlue_2, true);
+        setButtonAndProfileColor(pushButton_blue_2, pHost->mBlue_2);
     }
 }
 
@@ -2238,7 +2238,7 @@ void dlgProfilePreferences::slot_setMapColorLightBlue()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_Lblue_2, pHost->mLightBlue_2, true);
+        setButtonAndProfileColor(pushButton_Lblue_2, pHost->mLightBlue_2);
     }
 }
 
@@ -2246,7 +2246,7 @@ void dlgProfilePreferences::slot_setMapColorYellow()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_yellow_2, pHost->mYellow_2, true);
+        setButtonAndProfileColor(pushButton_yellow_2, pHost->mYellow_2);
     }
 }
 
@@ -2254,7 +2254,7 @@ void dlgProfilePreferences::slot_setMapColorLightYellow()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_Lyellow_2, pHost->mLightYellow_2, true);
+        setButtonAndProfileColor(pushButton_Lyellow_2, pHost->mLightYellow_2);
     }
 }
 
@@ -2262,7 +2262,7 @@ void dlgProfilePreferences::slot_setMapColorCyan()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_cyan_2, pHost->mCyan_2, true);
+        setButtonAndProfileColor(pushButton_cyan_2, pHost->mCyan_2);
     }
 }
 
@@ -2270,7 +2270,7 @@ void dlgProfilePreferences::slot_setMapColorLightCyan()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_Lcyan_2, pHost->mLightCyan_2, true);
+        setButtonAndProfileColor(pushButton_Lcyan_2, pHost->mLightCyan_2);
     }
 }
 
@@ -2278,7 +2278,7 @@ void dlgProfilePreferences::slot_setMapColorMagenta()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_magenta_2, pHost->mMagenta_2, true);
+        setButtonAndProfileColor(pushButton_magenta_2, pHost->mMagenta_2);
     }
 }
 
@@ -2286,7 +2286,7 @@ void dlgProfilePreferences::slot_setMapColorLightMagenta()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_Lmagenta_2, pHost->mLightMagenta_2, true);
+        setButtonAndProfileColor(pushButton_Lmagenta_2, pHost->mLightMagenta_2);
     }
 }
 
@@ -2294,7 +2294,7 @@ void dlgProfilePreferences::slot_setMapColorWhite()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_white_2, pHost->mWhite_2, true);
+        setButtonAndProfileColor(pushButton_white_2, pHost->mWhite_2);
     }
 }
 
@@ -2302,7 +2302,7 @@ void dlgProfilePreferences::slot_setMapColorLightWhite()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_Lwhite_2, pHost->mLightWhite_2, true);
+        setButtonAndProfileColor(pushButton_Lwhite_2, pHost->mLightWhite_2);
     }
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -5850,7 +5850,7 @@ void mudlet::setShowIconsOnMenu(const Qt::CheckState state)
 
 bool mudlet::needsCustomDarkTheme()
 {
-#if defined(Q_OS_WINDOWS) || defined(Q_OS_LINUX)
+#if defined(Q_OS_WINDOWS) || defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
     return true;
 #else
     return false;


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Use custom Fusion-based theming on macOS like Windows and Linux, restoring 4.19.1 behavior where QPushButton stylesheets work correctly.
#### Motivation for adding to Mudlet
https://discord.com/channels/283581582550237184/427919962561052673/1462801752246976533
#### Other info (issues closed, discussion etc)
