### PR TITLE
infrastructure: detect Lua test failures on macOS CI

### DIFF
--- a/src/run-tests.xml
+++ b/src/run-tests.xml
@@ -567,17 +567,18 @@ local errorLogged = false
 function logTestError()
   if errorLogged then return end
 
-  if getOS() == "linux" then
+  local os_name = getOS()
+  if os_name == "linux" or os_name == "mac" then
     file = io.open("/tmp/busted-tests-failed", "w")
     file:write("Lua busted tests failed")
     file:close()
-  elseif getOS() == "windows" then
+  elseif os_name == "windows" then
     temp_directory = os.getenv("TEMP")
     file = io.open(temp_directory.."\\busted-tests-failed", "w")
     file:write("Lua busted tests failed")
     file:close()
   else
-    ioprint("Tests failed, but did not know how to log the error for "..getOS())
+    ioprint("Tests failed, but did not know how to log the error for "..os_name)
   end
   errorLogged = true
 end</script>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add macOS ("mac") to the OS check when creating the test failure marker file.

#### Motivation for adding to Mudlet
macOS CI jobs were passing even when Lua tests failed because `getOS()` returns "mac" which wasn't handled, so `/tmp/busted-tests-failed` was never created.

#### Other info (issues closed, discussion etc)
Discovered via https://github.com/Mudlet/Mudlet/actions/runs/21546849813/job/62089471648

**Test case:** Lua test failures on macOS CI should now correctly fail the job.