### PR TITLE
Improve: macOS build instructions use absolute path

### DIFF
--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -198,8 +198,8 @@ cd /path/to/Mudlet/build
 cmake ../../Mudlet -DCMAKE_PREFIX_PATH=`brew --prefix qt6`
 make -j `sysctl -n hw.ncpu`
 
-# Run
-cd /path/to/Mudlet/build && ./src/mudlet.app/Contents/MacOS/mudlet
+# Run Mudlet - use absolute path to avoid directory confusion
+/path/to/Mudlet/build/src/mudlet.app/Contents/MacOS/mudlet
 ```
 
 ### Building on Linux


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Updated the macOS build instructions to use an absolute path when running Mudlet, making it clearer and more reliable.

#### Motivation for adding to Mudlet

Using a relative path requires being in the correct directory, which can cause confusion. An absolute path works from anywhere and matches the pattern that has been successful in practice.

#### Other info (issues closed, discussion etc)

This is a documentation-only change that improves clarity for developers building on macOS.