### PR TITLE
fix: db:_coerce_sheet backwards compatibility

### DIFF
--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -921,7 +921,7 @@ function db:fetch_sql(sheet, sql)
     local row = cur:fetch({}, "a")
 
     while row do
-      results[#results + 1] = db:_coerce_sheet(columns, sheet, row)
+      results[#results + 1] = db:_coerce_sheet(sheet, row, columns)
       row = cur:fetch({}, "a")
     end
     cur:close()
@@ -1358,8 +1358,9 @@ end
 -- After a table so retrieved from the database, this function coerces values to
 -- their proper types. Specifically, numbers and datetimes become the proper
 -- types.
-function db:_coerce_sheet(columns, sheet, tbl)
+function db:_coerce_sheet(sheet, tbl, columns)
   if tbl then
+    columns = columns or table.keys(tbl)
     tbl._row_id = tonumber(tbl._row_id)
 
     for _, k in pairs(columns) do


### PR DESCRIPTION
### Brief overview of PR changes/additions

Moves the function parameter `columns` for `db:_coerce_sheet` to the end so the function is backwards compatible.

### Motivation for adding to Mudlet

While `db:_coerce_sheet` is internal, some have re-defined it.  These re-definitions use the old function definition, which is not compatible with the current definition.

### Other info (issues closed, discussion etc)

An example of a redefinition in the wild:
https://github.com/tjurczyk/arkadia/blob/2e6e5d5ef103a3302a4b5c3bff0694f7e2afd672/skrypty/db_fix.lua#L89