### PR TITLE
fix: PTB crash on some Linux systems due to libxcb-cursor bug

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -167,6 +167,8 @@ jobs:
           libsecret-1-dev \
           libsqlite3-dev \
           libxkbcommon-x11-0 \
+          libxcb-render-util0-dev \
+          libxcb-image0-dev \
           libyajl-dev \
           libzip-dev \
           pcre2-utils \
@@ -191,6 +193,26 @@ jobs:
         eval "$(luarocks path --local --lua-version "5.1")"
         echo "LUA_PATH=$LUA_PATH" >> $GITHUB_ENV
         echo "LUA_CPATH=$LUA_CPATH" >> $GITHUB_ENV
+
+    - name: (Linux) Build xcb-util-cursor 0.1.5
+      if: runner.os == 'Linux'
+      run: |
+        # Download and extract xcb-util-cursor 0.1.5
+        # This version fixes the off-by-one heap buffer overflow in _XcursorThemeInherits
+        # that causes PTB builds to crash with AddressSanitizer
+        wget -q https://xorg.freedesktop.org/archive/individual/lib/xcb-util-cursor-0.1.5.tar.xz
+        tar xf xcb-util-cursor-0.1.5.tar.xz
+        cd xcb-util-cursor-0.1.5
+
+        # Configure and build
+        ./configure --prefix=/usr
+        make -j$(nproc)
+
+        # Install system-wide (replaces Ubuntu 22.04's buggy 0.1.1)
+        sudo make install
+
+        # Update library cache so linker finds new version
+        sudo ldconfig
 
     - name: (Linux Clang) change compiler & disable optional components
       if: runner.os == 'Linux' && matrix.compiler == 'clang_64'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -205,7 +205,7 @@ jobs:
         cd xcb-util-cursor-0.1.5
 
         # Configure and build
-        ./configure --prefix=/usr
+        ./configure --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu
         make -j$(nproc)
 
         # Install system-wide (replaces Ubuntu 22.04's buggy 0.1.1)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Build xcb-util-cursor 0.1.5 from source during CI to bundle the fixed version in the AppImage.

#### Motivation for adding to Mudlet
Ubuntu 22.04 ships libxcb-cursor 0.1.1 which has a heap-buffer-overflow bug that causes PTB builds to crash on some Linux systems (e.g., Linux Mint).

#### Other info (issues closed, discussion etc)
Fixes #8858

**Test case:** Run PTB on Linux Mint - should no longer crash with AddressSanitizer error in `_XcursorThemeInherits`