### PR TITLE
fix: Player shown on far side of map when mapper window is wide

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1801,12 +1801,11 @@ void T2DMap::paintEvent(QPaintEvent* e)
         const qreal areaMinY = -pDrawnArea->ymaxForZ.value(zLevel, pDrawnArea->max_y);
         const qreal areaMaxY = -pDrawnArea->yminForZ.value(zLevel, pDrawnArea->min_y);
 
-        if (areaMaxX - areaMinX <= xspan) {
-            mMapCenterX = (areaMinX + areaMaxX) / 2.0;
-        }
+        const qreal areaWidth = areaMaxX - areaMinX;
+        const qreal areaHeight = areaMaxY - areaMinY;
 
-        if (areaMaxY - areaMinY <= yspan) {
-            // Negate because areaMinY/areaMaxY are in room coords, but mMapCenterY uses screen coords (-room.y())
+        if (areaWidth <= xspan && areaHeight <= yspan) {
+            mMapCenterX = (areaMinX + areaMaxX) / 2.0;
             mMapCenterY = -((areaMinY + areaMaxY) / 2.0);
         }
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Only center on area when both dimensions fit in viewport, not independently.

#### Motivation for adding to Mudlet
When the mapper was wider than tall and the area didn't fully fit, the player would appear on the far right instead of centered.

#### Other info (issues closed, discussion etc)
None

**Test case:** Open mapper, resize to be noticeably wider than tall, move to an area larger than the viewport - player should stay centered.