### PR TITLE
Infrastructure: switch qtkeychain submodule to upstream

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -100,7 +100,7 @@ jobs:
         HOMEBREW_NO_INSTALL_CLEANUP: "ON"
       run: |
         # Install all required dependencies
-        brew install libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost
+        brew install libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost qtkeychain
 
         echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
 
@@ -166,6 +166,7 @@ jobs:
           libpugixml-dev \
           libsecret-1-dev \
           libsqlite3-dev \
+          qtkeychain-qt6-dev \
           libxkbcommon-x11-0 \
           libyajl-dev \
           libzip-dev \

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -118,7 +118,8 @@ jobs:
 
         # Set CMAKE_PREFIX_PATH to include both Qt and Homebrew directories
         # Qt is installed by install-qt-action, Homebrew has qtkeychain
-        echo "CMAKE_PREFIX_PATH=${QT_ROOT_DIR};${HOMEBREW_PREFIX}" >> $GITHUB_ENV
+        # Use : as separator (Unix) not ; (Windows)
+        echo "CMAKE_PREFIX_PATH=${QT_ROOT_DIR}:${HOMEBREW_PREFIX}" >> $GITHUB_ENV
 
         # Help CMake find Lua installed by gh-actions-lua
         # The action installs to .lua/ and .luarocks/ in the runner home

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -116,6 +116,10 @@ jobs:
         fi
         echo "HOMEBREW_PREFIX=$HOMEBREW_PREFIX" >> $GITHUB_ENV
 
+        # Set CMAKE_PREFIX_PATH to include both Qt and Homebrew directories
+        # Qt is installed by install-qt-action, Homebrew has qtkeychain
+        echo "CMAKE_PREFIX_PATH=${QT_ROOT_DIR};${HOMEBREW_PREFIX}" >> $GITHUB_ENV
+
         # Help CMake find Lua installed by gh-actions-lua
         # The action installs to .lua/ and .luarocks/ in the runner home
         echo "LUA_DIR=$HOME/.lua" >> $GITHUB_ENV
@@ -255,7 +259,7 @@ jobs:
         buildDirectory: '${{runner.workspace}}/b/ninja'
         cmakeAppendedArgs: >-
           -G Ninja
-          -DCMAKE_PREFIX_PATH=${{ env.QT_PREFIX != '' && env.QT_PREFIX || env.MINGW_BASE_DIR }}
+          -DCMAKE_PREFIX_PATH=${{ env.CMAKE_PREFIX_PATH != '' && env.CMAKE_PREFIX_PATH || (env.QT_PREFIX != '' && env.QT_PREFIX || env.MINGW_BASE_DIR) }}
           -DUSE_SANITIZER=${{ matrix.enable_asan == 'true' && !startsWith(github.ref, 'refs/tags/Mudlet-') && 'Address' || '' }}
           ${{ runner.os == 'macOS' && format('-DLUA_INCLUDE_DIR={0}/.lua/include -DLUA_LIBRARY={0}/.lua/lib/liblua.a', github.workspace) || '' }}
           -DWITH_SENTRY=ON

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -100,7 +100,7 @@ jobs:
         HOMEBREW_NO_INSTALL_CLEANUP: "ON"
       run: |
         # Install all required dependencies
-        brew install libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost qtkeychain
+        brew install libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost
 
         echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,9 @@
 [submodule "3rdparty/qt-tags-widget"]
 	path = 3rdparty/qt-tags-widget
 	url = https://github.com/julian-go/qt-tags-widget.git
+[submodule "3rdparty/qtkeychain"]
+	path = 3rdparty/qtkeychain
+	url = https://github.com/frankosterfeld/qtkeychain.git
 [submodule "3rdparty/sentry-native"]
 	path = 3rdparty/sentry-native
 	url = https://github.com/getsentry/sentry-native.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "3rdparty/qt-tags-widget"]
 	path = 3rdparty/qt-tags-widget
 	url = https://github.com/julian-go/qt-tags-widget.git
-[submodule "3rdparty/qtkeychain"]
-	path = 3rdparty/qtkeychain
-	url = https://github.com/Mudlet/qtkeychain.git
 [submodule "3rdparty/sentry-native"]
 	path = 3rdparty/sentry-native
 	url = https://github.com/getsentry/sentry-native.git

--- a/CI/build-mudlet-for-windows.sh
+++ b/CI/build-mudlet-for-windows.sh
@@ -124,10 +124,6 @@ echo ""
 echo "Running CMake to configure project ..."
 echo ""
 
-# Since we have this already installed as a package there is no need to build
-# it from a submodule - set as environment variable for CMake
-export WITH_OWN_QTKEYCHAIN=NO
-
 # Set Ninja status format for consistent build output
 export NINJA_STATUS='[%f/%t %o/sec] '
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ find_package(Lua 5.1 EXACT)
 
 # Set Qt version for edbee-lib and dblsqd
 option(BUILD_WITH_QT5 "" OFF)
+option(BUILD_WITH_QT6 "" ON)
 
 include(InitGitSubmodule)
 
@@ -156,6 +157,19 @@ git_submodule_init(
   git_submodule_init(
     CHECK_FILE "3rdparty/qt-tags-widget/CMakeLists.txt" SUBMODULE_PATH
     "3rdparty/qt-tags-widget" READABLE_NAME "qt-tags-widget widget")
+
+# TODO: On macOS, we need to build qtkeychain from source because Homebrew's
+# qtkeychain package is built against Homebrew's Qt, which is incompatible with
+# the Qt installed by jurplel/install-qt-action in CI.
+# See: https://github.com/Mudlet/Mudlet/issues/8875
+if(APPLE)
+  set(USE_OWN_QTKEYCHAIN ON)
+  git_submodule_init(
+    CHECK_FILE "3rdparty/qtkeychain/CMakeLists.txt"
+    SUBMODULE_PATH "3rdparty/qtkeychain"
+    READABLE_NAME "QtKeychain")
+  add_subdirectory(3rdparty/qtkeychain)
+endif()
 
 git_submodule_init(
   CHECK_FILE "3rdparty/lcf/lcf-scm-1.rockspec" SUBMODULE_PATH "3rdparty/lcf"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,9 +136,6 @@ include_optional_module(ENVIRONMENT_VARIABLE WITH_SHADER_HOT_RELOAD
 include_optional_module(ENVIRONMENT_VARIABLE WITH_VARIABLE_SPLASH_SCREEN
                         OPTION_VARIABLE USE_VARIABLE_SPLASH_SCREEN
                         READABLE_NAME "build-type splash screen")
-include_optional_module(ENVIRONMENT_VARIABLE WITH_OWN_QTKEYCHAIN
-                        OPTION_VARIABLE USE_OWN_QTKEYCHAIN
-                        READABLE_NAME "own QtKeychain library")
 
 find_package(Qt6 6.8.2 REQUIRED)
 
@@ -149,8 +146,6 @@ find_package(Lua 5.1 EXACT)
 
 # Set Qt version for edbee-lib and dblsqd
 option(BUILD_WITH_QT5 "" OFF)
-# Set Qt version for qtkeychain
-option(BUILD_WITH_QT6 "" ON)
 
 include(InitGitSubmodule)
 
@@ -161,21 +156,6 @@ git_submodule_init(
   git_submodule_init(
     CHECK_FILE "3rdparty/qt-tags-widget/CMakeLists.txt" SUBMODULE_PATH
     "3rdparty/qt-tags-widget" READABLE_NAME "qt-tags-widget widget")
-
-if(USE_OWN_QTKEYCHAIN)
-  git_submodule_init(
-    CHECK_FILE "3rdparty/qtkeychain/CMakeLists.txt"
-    SUBMODULE_PATH "3rdparty/qtkeychain"
-    READABLE_NAME "QtKeychain")
-  add_subdirectory(3rdparty/qtkeychain)
-
-  # Handle both old (files in qtkeychain/) and new (files in qtkeychain/qtkeychain/) directory structures
-  # so includes via <qtkeychain/keychain.h> work in both cases
-  if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/qtkeychain/qtkeychain/keychain.h")
-    # Old structure: add 3rdparty to include path so <qtkeychain/keychain.h> resolves correctly
-    target_include_directories(qt6keychain PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/3rdparty>)
-  endif()
-endif()
 
 git_submodule_init(
   CHECK_FILE "3rdparty/lcf/lcf-scm-1.rockspec" SUBMODULE_PATH "3rdparty/lcf"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -528,8 +528,10 @@ if (CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
   find_library(KVM_LIBRARY NAMES kvm)
 endif()
 
-find_package(Qt${QT_MAJOR_VERSION}Keychain REQUIRED)
-message(STATUS "Using system QtKeyChain (Qt${QT_MAJOR_VERSION}) library (found version \"${Qt${QT_MAJOR_VERSION}Keychain_VERSION}\").")
+if(NOT USE_OWN_QTKEYCHAIN)
+  find_package(Qt${QT_MAJOR_VERSION}Keychain REQUIRED)
+  message(STATUS "Using system QtKeyChain (Qt${QT_MAJOR_VERSION}) library (found version \"${Qt${QT_MAJOR_VERSION}Keychain_VERSION}\").")
+endif()
 
 if(USE_3DMAPPER)
   if(POLICY CMP0072)
@@ -640,6 +642,11 @@ target_compile_definitions(${LIB_MUDLET_TARGET}
     APP_VERSION="${APP_VERSION}"
     APP_TARGET="${APP_TARGET}"
     LUA_DEFAULT_PATH="${LUA_DEFAULT_DIR}")
+
+if(USE_OWN_QTKEYCHAIN)
+    target_compile_definitions(${LIB_MUDLET_TARGET} PUBLIC INCLUDE_OWN_QT6_KEYCHAIN QTKEYCHAIN_NO_EXPORT)
+    target_include_directories(${LIB_MUDLET_TARGET} PRIVATE ${CMAKE_SOURCE_DIR}/3rdparty/qtkeychain)
+endif()
 
 # Define shader hot-reloading if enabled
 if(USE_SHADER_HOT_RELOAD AND USE_3DMAPPER)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -528,14 +528,8 @@ if (CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
   find_library(KVM_LIBRARY NAMES kvm)
 endif()
 
-if(NOT USE_OWN_QTKEYCHAIN)
-  # Only use this when we are using a system package and NOT our own local build
-  find_package(Qt${QT_MAJOR_VERSION}Keychain REQUIRED)
-
-  # No need to test for it being found as the REQUIRED will make it error out
-  # if it is NOT found!
-  message(STATUS "Using system QtKeyChain (Qt${QT_MAJOR_VERSION}) library (found version \"${Qt${QT_MAJOR_VERSION}Keychain_VERSION}\").")
-endif()
+find_package(Qt${QT_MAJOR_VERSION}Keychain REQUIRED)
+message(STATUS "Using system QtKeyChain (Qt${QT_MAJOR_VERSION}) library (found version \"${Qt${QT_MAJOR_VERSION}Keychain_VERSION}\").")
 
 if(USE_3DMAPPER)
   if(POLICY CMP0072)
@@ -646,11 +640,6 @@ target_compile_definitions(${LIB_MUDLET_TARGET}
     APP_VERSION="${APP_VERSION}"
     APP_TARGET="${APP_TARGET}"
     LUA_DEFAULT_PATH="${LUA_DEFAULT_DIR}")
-
-if(USE_OWN_QTKEYCHAIN)
-    target_compile_definitions(${LIB_MUDLET_TARGET} PUBLIC INCLUDE_OWN_QT6_KEYCHAIN QTKEYCHAIN_NO_EXPORT)
-    target_include_directories(${LIB_MUDLET_TARGET} PRIVATE ${CMAKE_SOURCE_DIR}/3rdparty/qtkeychain)
-endif()
 
 # Define shader hot-reloading if enabled
 if(USE_SHADER_HOT_RELOAD AND USE_3DMAPPER)

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -33,7 +33,11 @@
 #include <QStandardPaths>
 #include <QTimer>
 #include <QVersionNumber>
+#if defined(INCLUDE_OWN_QT6_KEYCHAIN)
+#include <qtkeychain/keychain.h>
+#else
 #include <qt6keychain/keychain.h>
+#endif
 
 // Forward declaration to avoid including mudlet.h
 class mudlet;

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -33,11 +33,7 @@
 #include <QStandardPaths>
 #include <QTimer>
 #include <QVersionNumber>
-#if defined(INCLUDE_OWN_QT6_KEYCHAIN)
-#include <qtkeychain/keychain.h>
-#else
 #include <qt6keychain/keychain.h>
-#endif
 
 // Forward declaration to avoid including mudlet.h
 class mudlet;

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -53,7 +53,11 @@
 #include <QTime>
 #include <QVersionNumber>
 #include <QWindow>
+#if defined(INCLUDE_OWN_QT6_KEYCHAIN)
+#include <qtkeychain/keychain.h>
+#else
 #include <qt6keychain/keychain.h>
+#endif
 #include <optional>
 #include <hunspell/hunspell.hxx>
 #include <hunspell/hunspell.h>

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -53,11 +53,7 @@
 #include <QTime>
 #include <QVersionNumber>
 #include <QWindow>
-#if defined(INCLUDE_OWN_QT6_KEYCHAIN)
-#include <qtkeychain/keychain.h>
-#else
 #include <qt6keychain/keychain.h>
-#endif
 #include <optional>
 #include <hunspell/hunspell.hxx>
 #include <hunspell/hunspell.h>
@@ -206,7 +202,7 @@ public:
     void attachDebugArea(const QString&);
     void checkUpdatesOnStart();
     void commitLayoutUpdates(bool flush = false);
-    void deleteProfileData(const QString &profile, const QString &item);
+    void deleteProfileData(const QString& profile, const QString& item);
     void disableToolbarButtons();
     void doAutoLogin(const QString&);
     void enableToolbarButtons();
@@ -333,7 +329,7 @@ public:
     // entries in their system if they do not appear in this and thus get
     // reported in the dictionary selection as the hunspell dictionary/affix
     // filename (e.g. a "xx" or "xx_YY" form rather than "words"):
-    QHash<QString, QString>mDictionaryLanguageCodeMap;
+    QHash<QString, QString> mDictionaryLanguageCodeMap;
     Discord mDiscord;
     // Used for editor area, but
     // only ::ShowTabsAndSpaces
@@ -468,7 +464,7 @@ public slots:
     static QIcon createConnectionStatusIcon(bool isConnected, bool isConnecting, bool hasError);
     void updateMainWindowTabIndicators();
     void updateMainWindowTabBarAutoHide();
-    void updateTabIndicators(); // Update all tab indicators (main window)
+    void updateTabIndicators();               // Update all tab indicators (main window)
     void updateDetachedWindowTabIndicators(); // Update all detached window tab indicators
     void slot_showActionDialog();
     void slot_showAliasDialog();
@@ -513,7 +509,7 @@ signals:
     void signal_passwordsMigratedToProfiles();
     void signal_passwordsMigratedToSecure();
     void signal_characterPasswordsMigrated();
-    void signal_profileActivated(Host *, quint8);
+    void signal_profileActivated(Host*, quint8);
     void signal_profileMapReloadRequested(QList<QString>);
     void signal_setToolBarIconSize(int);
     void signal_setTreeIconSize(int);
@@ -550,13 +546,11 @@ private slots:
 
 
 private:
-
-
     void assignKeySequences();
     QString autodetectPreferredLanguage();
     static bool needsCustomDarkTheme();
     void closeHost(const QString&);
-    int getDictionaryWordCount(const QString &dictionaryPath);
+    int getDictionaryWordCount(const QString& dictionaryPath);
     void goingDown() { mIsGoingDown = true; }
     void initEdbee();
     void installModulesList(Host*, QStringList);
@@ -720,10 +714,10 @@ private:
     QAction* mWindowListSeparator = nullptr;
 
     // amount of times the shortcut has been shown help educate new users
-    int mScrollbackTutorialsShown = 0; // Cancel split screen
+    int mScrollbackTutorialsShown = 0;   // Cancel split screen
     int mMuteAllMediaTutorialsShown = 0; // Mute all media
     // show the tutorial maximum 3 times on a new Mudlet
-    static const int mScrollbackTutorialsMax = 3; // Split screen
+    static const int mScrollbackTutorialsMax = 3;   // Split screen
     static const int mMuteAllMediaTutorialsMax = 3; // Mute all media
 
     // AI/LlamaFile integration
@@ -762,7 +756,6 @@ private:
 };
 
 
-
 class TConsoleMonitor : public QObject
 {
     Q_OBJECT
@@ -771,7 +764,8 @@ public:
     Q_DISABLE_COPY(TConsoleMonitor)
     explicit TConsoleMonitor(QObject* parent)
     : QObject(parent)
-    {}
+    {
+    }
 
 protected:
     bool eventFilter(QObject*, QEvent*) override;
@@ -790,7 +784,8 @@ class translation
 public:
     explicit translation(const int translationPercent = -1)
     : mTranslatedPercentage(translationPercent)
-    {}
+    {
+    }
 
     const QString& getNativeName() const { return mNativeName; }
     const QString& getMudletTranslationFileName() const { return mMudletTranslationFileName; }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,7 +35,9 @@ link_libraries(
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake ${CMAKE_MODULE_PATH})
 
 # Configure QtKeychain linking
-find_package(Qt6Keychain REQUIRED)
+if(NOT USE_OWN_QTKEYCHAIN)
+    find_package(Qt6Keychain REQUIRED)
+endif()
 set(KEYCHAIN_LIBRARY qt6keychain)
 
 
@@ -92,10 +94,16 @@ target_link_libraries(
 
 add_executable(SecureStringUtilsTest SecureStringUtilsTest.cpp ../src/SecureStringUtils.cpp)
 target_link_libraries(SecureStringUtilsTest ${KEYCHAIN_LIBRARY})
+if(USE_OWN_QTKEYCHAIN)
+    target_compile_definitions(SecureStringUtilsTest PRIVATE INCLUDE_OWN_QT6_KEYCHAIN QTKEYCHAIN_NO_EXPORT)
+endif()
 add_test(NAME SecureStringUtilsTest COMMAND SecureStringUtilsTest)
 
 add_executable(CredentialManagerTest CredentialManagerTest.cpp ../src/CredentialManager.cpp ../src/SecureStringUtils.cpp)
 target_link_libraries(CredentialManagerTest ${KEYCHAIN_LIBRARY})
+if(USE_OWN_QTKEYCHAIN)
+    target_compile_definitions(CredentialManagerTest PRIVATE INCLUDE_OWN_QT6_KEYCHAIN QTKEYCHAIN_NO_EXPORT)
+endif()
 add_test(NAME CredentialManagerTest COMMAND CredentialManagerTest)
 
 add_subdirectory(functional_tests)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,28 +34,9 @@ link_libraries(
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake ${CMAKE_MODULE_PATH})
 
-# Include the same keychain configuration as main project
-include(IncludeOptionalModule)
-include_optional_module(ENVIRONMENT_VARIABLE WITH_OWN_QTKEYCHAIN
-                        OPTION_VARIABLE USE_OWN_QTKEYCHAIN
-                        READABLE_NAME "own QtKeychain library")
-
-if(NOT DEFINED USE_OWN_QTKEYCHAIN)
-    # Check the parent project's setting
-    get_directory_property(parent_USE_OWN_QTKEYCHAIN PARENT_DIRECTORY USE_OWN_QTKEYCHAIN)
-    if(DEFINED parent_USE_OWN_QTKEYCHAIN)
-        set(USE_OWN_QTKEYCHAIN ${parent_USE_OWN_QTKEYCHAIN})
-    endif()
-endif()
-
 # Configure QtKeychain linking
-if(USE_OWN_QTKEYCHAIN)
-    # Link to the already built qt6keychain target from parent
-    set(KEYCHAIN_LIBRARY qt6keychain)
-else()
-    find_package(Qt6Keychain REQUIRED)
-    set(KEYCHAIN_LIBRARY qt6keychain)
-endif()
+find_package(Qt6Keychain REQUIRED)
+set(KEYCHAIN_LIBRARY qt6keychain)
 
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../src")
@@ -111,16 +92,10 @@ target_link_libraries(
 
 add_executable(SecureStringUtilsTest SecureStringUtilsTest.cpp ../src/SecureStringUtils.cpp)
 target_link_libraries(SecureStringUtilsTest ${KEYCHAIN_LIBRARY})
-if(USE_OWN_QTKEYCHAIN)
-    target_compile_definitions(SecureStringUtilsTest PRIVATE INCLUDE_OWN_QT6_KEYCHAIN QTKEYCHAIN_NO_EXPORT)
-endif()
 add_test(NAME SecureStringUtilsTest COMMAND SecureStringUtilsTest)
 
 add_executable(CredentialManagerTest CredentialManagerTest.cpp ../src/CredentialManager.cpp ../src/SecureStringUtils.cpp)
 target_link_libraries(CredentialManagerTest ${KEYCHAIN_LIBRARY})
-if(USE_OWN_QTKEYCHAIN)
-    target_compile_definitions(CredentialManagerTest PRIVATE INCLUDE_OWN_QT6_KEYCHAIN QTKEYCHAIN_NO_EXPORT)
-endif()
 add_test(NAME CredentialManagerTest COMMAND CredentialManagerTest)
 
 add_subdirectory(functional_tests)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove our own qtkeychain submodule and switch to upstream
#### Motivation for adding to Mudlet
We haven't update it in the last 6 years
#### Other info (issues closed, discussion etc)
Completely removing it was not possible, see https://github.com/Mudlet/Mudlet/issues/8875