### PR TITLE
Infrastructure: add qtkeychain-qt6-dev to Linux workflows

### DIFF
--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -104,7 +104,7 @@ jobs:
         # Install all required dependencies
         # liblua5.1-0-dev is needed for CMake to find Lua headers/library
         sudo apt-get install libsecret-1-dev ccache pkg-config libzip-dev libglu1-mesa-dev libpulse-dev \
-          libassimp-dev libpcre2-dev libpugixml-dev libsqlite3-dev libyajl-dev libhunspell-dev liblua5.1-0-dev libboost-dev -y
+          libassimp-dev libpcre2-dev libpugixml-dev libsqlite3-dev libyajl-dev libhunspell-dev liblua5.1-0-dev libboost-dev qtkeychain-qt6-dev -y
 
         # Install lua-yajl early to generate translation statistics
         luarocks install --local lua-yajl
@@ -138,7 +138,7 @@ jobs:
         exclude: '3rdparty'
         config_file: '.clang-tidy'
         # the action doesn't see system-level libraries, need to replicate them here
-        apt_packages: 'gettext, pkg-config, libzip-dev, libglu1-mesa-dev, libpulse-dev, libpcre3-dev, liblua5.1-0-dev, libassimp-dev, libboost-dev, libhunspell-dev, libpugixml-dev, libsecret-1-dev, libsqlite3-dev, libyajl-dev'
+        apt_packages: 'gettext, pkg-config, libzip-dev, libglu1-mesa-dev, libpulse-dev, libpcre3-dev, liblua5.1-0-dev, libassimp-dev, libboost-dev, libhunspell-dev, libpugixml-dev, libsecret-1-dev, libsqlite3-dev, libyajl-dev, qtkeychain-qt6-dev'
         # workaround for https://github.com/ZedThree/clang-tidy-review/issues/157
         extra_arguments: '--allow-no-checks'
         split_workflow: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -119,7 +119,7 @@ jobs:
         # Install all required dependencies
         # liblua5.1-0-dev is needed for CMake to find Lua headers/library
         sudo apt-get install libsecret-1-dev ccache pkg-config pcre2-utils expect libzip-dev libglu1-mesa-dev libpulse-dev g++-${{matrix.gcc_compiler_version}} \
-          libassimp-dev libpcre2-dev libpugixml-dev libsqlite3-dev libyajl-dev libhunspell-dev liblua5.1-0-dev libboost-dev -y
+          libassimp-dev libpcre2-dev libpugixml-dev libsqlite3-dev libyajl-dev libhunspell-dev liblua5.1-0-dev libboost-dev qtkeychain-qt6-dev -y
 
         # switch to GCC that supports C++20 while retaining support for older OS's
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{matrix.gcc_compiler_version}} ${{matrix.gcc_compiler_version}}

--- a/.github/workflows/performance-analysis.yml
+++ b/.github/workflows/performance-analysis.yml
@@ -36,7 +36,7 @@ jobs:
         sudo apt-get install build-essential git liblua5.1-dev zlib1g-dev libhunspell-dev libpcre2-dev \
           libzip-dev libboost-graph-dev libyajl-dev libpulse-dev lua-filesystem lua-zip \
           lua-sql-sqlite3 qt6-multimedia-dev qt6-tools-dev luarocks ccache libpugixml-dev cmake ninja-build \
-          xvfb libassimp-dev -y
+          xvfb libassimp-dev qtkeychain-qt6-dev -y
 
         sudo luarocks install lrexlib-pcre2
 


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
After switching qtkeychain to build from source only on macOS, Linux workflows need the system package installed.
#### Motivation for adding to Mudlet
Fix CodeQL and other builds.
#### Other info (issues closed, discussion etc)
