### PR TITLE
Infrastructure: use pcre2grep in CI validation

### DIFF
--- a/CI/validate-deployment-for-windows.sh
+++ b/CI/validate-deployment-for-windows.sh
@@ -13,13 +13,13 @@ error() {
 
 function validate_cmake() {
   local VALID_CMAKE VALID_BUILD
-  VALID_CMAKE=$(pcregrep --only-matching=1 "set\(APP_VERSION (\d+\.\d+\.\d+)\)$" < CMakeLists.txt)
+  VALID_CMAKE=$(pcre2grep --only-matching=1 "set\(APP_VERSION (\d+\.\d+\.\d+)\)$" < CMakeLists.txt)
 
   if [ -z "${VALID_CMAKE}" ]; then
     error "CMakeLists.txt VERSION variable isn't formatted following the semantic versioning rules in a release build."
   fi
 
-  VALID_BUILD=$(pcregrep --only-matching=1 'set\(APP_BUILD ("")' < CMakeLists.txt)
+  VALID_BUILD=$(pcre2grep --only-matching=1 'set\(APP_BUILD ("")' < CMakeLists.txt)
   if [ "${VALID_BUILD}" != '""' ]; then
     error "CMakeLists.txt APP_BUILD variable isn't set to \"\" as it should be in a release build."
   fi

--- a/CI/validate_deployment.sh
+++ b/CI/validate_deployment.sh
@@ -14,13 +14,13 @@ else
 
   function validate_cmake() {
     local VALID_CMAKE VALID_BUILD
-    VALID_CMAKE=$(pcregrep --only-matching=1 "set\(APP_VERSION (\d+\.\d+\.\d+)\)$" < CMakeLists.txt)
+    VALID_CMAKE=$(pcre2grep --only-matching=1 "set\(APP_VERSION (\d+\.\d+\.\d+)\)$" < CMakeLists.txt)
 
     if [ -z "${VALID_CMAKE}" ]; then
       error "CMakeLists.txt VERSION variable isn't formatted following the semantic versioning rules in a release build."
     fi
 
-    VALID_BUILD=$(pcregrep --only-matching=1 'set\(APP_BUILD ("")' < CMakeLists.txt)
+    VALID_BUILD=$(pcre2grep --only-matching=1 'set\(APP_BUILD ("")' < CMakeLists.txt)
     if [ "${VALID_BUILD}" != '""' ]; then
       error "CMakeLists.txt APP_BUILD variable isn't set to \"\" as it should be in a release build."
     fi


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Use pcre2grep in CI validation
#### Motivation for adding to Mudlet
We switched over to pcre2 from pcre, but didn't update all scripts everywhere.
#### Other info (issues closed, discussion etc)
