### PR TITLE
Infrastructure: disable signing MudletCrashReporter.exe temporarily

### DIFF
--- a/.signpath/artifact-configuration-binaries.xml
+++ b/.signpath/artifact-configuration-binaries.xml
@@ -5,7 +5,7 @@
     <pe-file path="mudlet.exe">
       <authenticode-sign/>
     </pe-file>
-    <pe-file path="MudletCrashReporter.exe">
+    <!-- <pe-file path="MudletCrashReporter.exe">
       <authenticode-sign/>
     </pe-file>
     <pe-file path="crashpad_handler.exe">
@@ -13,6 +13,6 @@
     </pe-file>
     <pe-file path="crashpad_wer.dll">
       <authenticode-sign/>
-    </pe-file>
+    </pe-file> -->
   </zip-file>
 </artifact-configuration>


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
disable signing MudletCrashReporter.exe temporarily
#### Motivation for adding to Mudlet
Crash reporter is not part of the 4.20 update.
#### Other info (issues closed, discussion etc)
