### PR TITLE
[Fix] Set main console default text background opaque and allow custom opacity.

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -621,7 +621,7 @@ int TTextEdit::drawGraphemeBackground(QPainter& painter, QVector<QColor>& fgColo
     if (caretIsHere) {
         bgColor = mCaretColor;
     }
-    if (!textRect.isNull() && bgColor != mpConsole->getConsoleBgColor()) {
+    if (!textRect.isNull() && (mpConsole->getType() == TConsole::MainConsole) || bgColor != mpConsole->getConsoleBgColor()) {
         painter.fillRect(textRect, bgColor);
     }
     return charWidth;

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -571,6 +571,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
         host.append_child("wrapHangingIndentCount").text().set(QString::number(pHost->mWrapHangingIndentCount).toUtf8().constData());
         host.append_child("mFgColor").text().set(pHost->mFgColor.name().toUtf8().constData());
         host.append_child("mBgColor").text().set(pHost->mBgColor.name().toUtf8().constData());
+        host.append_child("mBgColor").append_attribute("alpha").set_value(pHost->mBgColor.alpha());
         host.append_child("mCommandFgColor").text().set(pHost->mCommandFgColor.name().toUtf8().constData());
         host.append_child("mCommandBgColor").text().set(pHost->mCommandBgColor.name().toUtf8().constData());
         host.append_child("mCommandLineFgColor").text().set(pHost->mCommandLineFgColor.name().toUtf8().constData());

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1182,7 +1182,9 @@ void XMLimport::readHost(Host* pHost)
             } else if (name() == qsl("mFgColor")) {
                 pHost->mFgColor = QColor::fromString(readElementText());
             } else if (name() == qsl("mBgColor")) {
+                auto alpha = (attributes().hasAttribute(qsl("alpha"))) ? attributes().value(qsl("alpha")).toInt() : 255;
                 pHost->mBgColor = QColor::fromString(readElementText());
+                pHost->mBgColor.setAlpha(alpha);
             } else if (name() == qsl("mCommandFgColor")) {
                 pHost->mCommandFgColor = QColor::fromString(readElementText());
             } else if (name() == qsl("mCommandBgColor")) {

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1854,7 +1854,7 @@ void dlgProfilePreferences::slot_setBgColor()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_background_color, pHost->mBgColor);
+        setButtonAndProfileColor(pushButton_background_color, pHost->mBgColor, true);
     }
 }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Reverts the change from PR #7917 to omit drawing the background color of text when it matches the console's BG (exclusively for the Main console).

Expose custom opacity in the color picker of [Color view] > [Background].

Text with a matching background  in the main console will now use the opacity as set in the color palette in settings (default opaque).

#### Motivation for adding to Mudlet
Keeps the functionality added in PR #7917 for good looking transparent miniconsoles while reverting to the prior (4.19.1) Main console text background behavior. Allow users users to choose if they'd prefer transparent text background or something in between.

#### Other info (issues closed, discussion etc)
Resolves #8885

End effect of custom-opacity background use can look like this:
<img width="1159" height="859" alt="image" src="https://github.com/user-attachments/assets/07bff055-e12a-4c0e-be3a-7c1df482e0da" />
