### PR TITLE
Fix: Make main console default to opaque text background, allow user to customize

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -823,7 +823,7 @@ int TTextEdit::drawGraphemeBackground(QPainter& painter,
     if (caretIsHere) {
         bgColor = mCaretColor;
     }
-    if (!textRect.isNull() && bgColor != mpConsole->getConsoleBgColor()) {
+    if (!textRect.isNull() && (mpConsole->getType() == TConsole::MainConsole) || bgColor != mpConsole->getConsoleBgColor()) {
         painter.fillRect(textRect, bgColor);
     }
     return charWidth;

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -595,7 +595,10 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
         host.append_child("consoleBufferSize").text().set(QString::number(pHost->mConsoleBufferSize).toUtf8().constData());
         host.append_child("useMaxConsoleBufferSize").text().set(pHost->mUseMaxConsoleBufferSize ? "yes" : "no");
         host.append_child("mFgColor").text().set(pHost->mFgColor.name().toUtf8().constData());
-        host.append_child("mBgColor").text().set(pHost->mBgColor.name().toUtf8().constData());
+
+        auto consoleBgColorNode = host.append_child("mBgColor");
+        consoleBgColorNode.text().set(pHost->mBgColor.name().toUtf8().constData());
+        consoleBgColorNode.append_attribute("alpha").set_value(pHost->mBgColor.alpha());
         host.append_child("mCommandFgColor").text().set(pHost->mCommandFgColor.name().toUtf8().constData());
         host.append_child("mCommandBgColor").text().set(pHost->mCommandBgColor.name().toUtf8().constData());
         host.append_child("mCommandLineFgColor").text().set(pHost->mCommandLineFgColor.name().toUtf8().constData());

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1177,7 +1177,6 @@ bool XMLimport::readHostColorElement(Host* pHost, QStringView elementName)
             {qsl("mCommandLineFgColor"), &Host::mCommandLineFgColor},
             {qsl("mCommandLineBgColor"), &Host::mCommandLineBgColor},
             {qsl("mFgColor"), &Host::mFgColor},
-            {qsl("mBgColor"), &Host::mBgColor},
             {qsl("mCommandFgColor"), &Host::mCommandFgColor},
             {qsl("mCommandBgColor"), &Host::mCommandBgColor},
             {qsl("mBlack"), &Host::mBlack},
@@ -1221,6 +1220,7 @@ bool XMLimport::readHostColorElement(Host* pHost, QStringView elementName)
 
     // Colors that support alpha channel
     static const QHash<QString, QColor Host::*> alphaColors = {
+            {qsl("mBgColor"), &Host::mBgColor},
             {qsl("mBgColor2"), &Host::mBgColor_2},
             {qsl("mMapGridColor"), &Host::mMapGridColor},
             {qsl("mMapInfoBg"), &Host::mMapInfoBg},

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1934,7 +1934,7 @@ void dlgProfilePreferences::slot_setBgColor()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setButtonAndProfileColor(pushButton_background_color, pHost->mBgColor);
+        setButtonAndProfileColor(pushButton_background_color, pHost->mBgColor, true);
     }
 }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Reverts the change from PR #7917 to omit drawing the background color of text when it matches the console's BG (the reversion is applied exclusively to the Main console).

Expose custom opacity in the color picker of [Color view] > [Background].

Text with a matching background  in the main console will now use the opacity as set in the color palette in settings (default opaque).

#### Motivation for adding to Mudlet
Keeps the functionality added in PR #7917 for good looking transparent miniconsoles while reverting to the prior (4.19.1) Main console text background behavior. Allow users users to choose if they'd prefer transparent text background or something in between.

#### Other info (issues closed, discussion etc)
Resolves #8885

End effect of custom-opacity background use can look like this:
<img width="1159" height="859" alt="image" src="https://github.com/user-attachments/assets/07bff055-e12a-4c0e-be3a-7c1df482e0da" />
