### PR TITLE
Fix: Delay MXP TEMP_SECURE mode reset to allow tag handling

### DIFF
--- a/src/TMxpProcessor.cpp
+++ b/src/TMxpProcessor.cpp
@@ -206,11 +206,11 @@ TMxpProcessingResult TMxpProcessor::processMxpInput(char& ch, bool resolveCustom
 
         QScopedPointer<MxpTag> const tag(mMxpTagBuilder.buildTag());
 
+        TMxpTagHandlerResult const result = mMxpTagProcessor.handleTag(mMxpTagProcessor, *mpMxpClient, tag.get());
+
         if (mMXP_MODE == MXP_MODE_TEMP_SECURE) {
             mMXP_MODE = mMXP_DEFAULT;
         }
-
-        TMxpTagHandlerResult const result = mMxpTagProcessor.handleTag(mMxpTagProcessor, *mpMxpClient, tag.get());
 
         // If tag was not handled (not valid MXP and not a custom element), display it as-is
         // Use HANDLER_INSERT_ENTITY_SYS so the Unicode content is inserted directly


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes error in `processMxpInput` where TEMP_SECURE mode is reset to DEFAULT before tags were handled. This caused startTagReceived to validate tags against OPEN mode instead of intended TEMP_SECURE. The reset now occurs after `handleTag`.

#### Motivation for adding to Mudlet

This bug broke MXP compatibility with Evennia without force-enabling MXP.
