### PR TITLE
Fix: Revert default map format to 20 in PTB / `development`

### DIFF
--- a/src/TMap.h
+++ b/src/TMap.h
@@ -266,8 +266,10 @@ public:
     bool mMapGraphNeedsUpdate = true;
     bool mNewMove = true;
 
-    // Replaced CURRENT_MAP_VERSION, default map version that new maps will get:
-    const int mDefaultVersion = 22;
+    // WARNING: Do not change this value without careful consideration - increasing
+    // the default map format makes it difficult for players to share maps with
+    // others who may be using older Mudlet versions.
+    const int mDefaultVersion = 20;
 
     // Normally the same as mDefaultVersion but can be higher for development
     // builds and is the maximum version the development build can parse, it is
@@ -291,7 +293,7 @@ public:
      * * Version 22 adds the 'hidden' property to rooms, allowing rooms and their
      *   exits to be hidden from display in the mapper.
      */
-    const int mMaxVersion = 22;
+    const int mMaxVersion = 20;
 
     // Ideally would be the same as mDefaultVersion but we have it lower,
     // particularly for release builds and is the minimum version allowed for


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Revert default map format to 20
#### Motivation for adding to Mudlet
Changing it to 22 in `development` was an error, and makes map sharing harder than it needs to be among Mudlet players.
#### Other info (issues closed, discussion etc)
