### PR TITLE
Fix: Clear package list before repopulating in Package Exporter

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -426,9 +426,6 @@ void dlgPackageExporter::populateDependencies()
 {
     ui->DependencyList->clear();
     ui->DependencyList->addItem(tr("add dependencies"));
-
-    // Block signals to prevent re-entrant slot_packageChanged calls while
-    // we clear and repopulate the combobox
     const QSignalBlocker blocker(ui->packageList);
     const QString previousSelection = ui->packageList->currentText();
     ui->packageList->clear();

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -426,15 +426,26 @@ void dlgPackageExporter::populateDependencies()
 {
     ui->DependencyList->clear();
     ui->DependencyList->addItem(tr("add dependencies"));
+
+    // Block signals to prevent re-entrant slot_packageChanged calls while
+    // we clear and repopulate the combobox
+    const QSignalBlocker blocker(ui->packageList);
+    const QString previousSelection = ui->packageList->currentText();
     ui->packageList->clear();
     //: First item in package selection dropdown - when selected, allows updating an existing installed package
     ui->packageList->addItem(tr("update installed package"));
     ui->packageList->addItems(mpHost->mInstalledPackages);
+
     ui->DependencyList->addItems(mpHost->mInstalledPackages);
     auto modules = mpHost->mInstalledModules;
     for (const auto& [moduleName, moduleData] : modules.asKeyValueRange()) {
         ui->packageList->addItem(moduleName);
         ui->DependencyList->addItem(moduleName);
+    }
+
+    const int previousIndex = ui->packageList->findText(previousSelection);
+    if (previousIndex >= 0) {
+        ui->packageList->setCurrentIndex(previousIndex);
     }
 }
 

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -122,8 +122,6 @@ dlgPackageExporter::dlgPackageExporter(QWidget* parent, Host* pHost)
     dlgPackageExporter* te_parent = static_cast<dlgPackageExporter*>(topLevelWidget());
     te_parent->mPlainDescription = ui->textEdit_description->toPlainText();
 
-    ui->packageList->addItem(tr("update installed package"));
-
     populateDependencies();
 
     listTriggers();
@@ -428,6 +426,9 @@ void dlgPackageExporter::populateDependencies()
 {
     ui->DependencyList->clear();
     ui->DependencyList->addItem(tr("add dependencies"));
+    ui->packageList->clear();
+    //: First item in package selection dropdown - when selected, allows updating an existing installed package
+    ui->packageList->addItem(tr("update installed package"));
     ui->packageList->addItems(mpHost->mInstalledPackages);
     ui->DependencyList->addItems(mpHost->mInstalledPackages);
     auto modules = mpHost->mInstalledModules;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Don't duplicate package lists in package manager when exporting packages
#### Motivation for adding to Mudlet
Bugfix
#### Other info (issues closed, discussion etc)
Reported in https://discord.com/channels/283581582550237184/427919962561052673/1468908943345717370