### PR TITLE
Fix: restore cecho newline behavior with creplaceLine

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -4205,7 +4205,8 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
     }
 }
 
-void TBuffer::appendLine(const QString& text, const int sub_start, const int sub_end, const QColor& fgColor, const QColor& bgColor, const TChar::AttributeFlags flags, const int linkID)
+void TBuffer::appendLine(
+        const QString& text, const int sub_start, const int sub_end, const QColor& fgColor, const QColor& bgColor, const TChar::AttributeFlags flags, const int linkID, const bool handleNewlines)
 {
     if (sub_end < 0) {
         return;
@@ -4252,7 +4253,7 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
     for (int i = sub_start; i <= (sub_start + lineEndPos); i++) {
         const QChar thisChar = text.at(i);
 
-        if (thisChar == QChar::LineFeed) {
+        if (handleNewlines && thisChar == QChar::LineFeed) {
             firstChar = true;
             appendEmptyLine();
             continue;

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -51,7 +51,8 @@ class TConsole;
 // Defined in Mudlet namespace to avoid circular dependencies
 namespace Mudlet {
 
-struct HyperlinkStyling {
+struct HyperlinkStyling
+{
     // Base styling properties
     QColor foregroundColor;
     QColor backgroundColor;
@@ -62,16 +63,16 @@ struct HyperlinkStyling {
     bool isUnderlined = false; // OSC 8 hyperlinks default to no underline (unlike other Mudlet hyperlinks)
     bool isStrikeOut = false;
     bool isOverlined = false;
-    bool hasCustomStyling = false; // Tracks if any custom styling was provided
+    bool hasCustomStyling = false;     // Tracks if any custom styling was provided
     bool hasBaseCustomStyling = false; // Tracks if base (non-pseudo-class) styling was provided
 
     // Extended text decoration support
     enum UnderlineStyle {
         UnderlineNone,
-        UnderlineSolid,     // Standard underline
-        UnderlineWavy,      // Squiggly/wavy underline
-        UnderlineDotted,    // Dotted underline
-        UnderlineDashed     // Dashed underline
+        UnderlineSolid,  // Standard underline
+        UnderlineWavy,   // Squiggly/wavy underline
+        UnderlineDotted, // Dotted underline
+        UnderlineDashed  // Dashed underline
     };
     UnderlineStyle underlineStyle = UnderlineSolid;
     QColor underlineColor;
@@ -83,18 +84,19 @@ struct HyperlinkStyling {
 
     // CSS Link State Support with Accessibility
     enum LinkState {
-        StateDefault,       // Default/unvisited (:link)
-        StateVisited,       // Visited link (:visited)
-        StateHover,         // Mouse hover (:hover)
-        StateActive,        // Mouse down/active (:active)
-        StateFocus,         // Keyboard focus (:focus)
-        StateFocusVisible,  // Visible keyboard focus (:focus-visible)
-        StateSelected,      // Selected state (from selection object)
-        StateDisabled       // Disabled state (from selection object)
+        StateDefault,      // Default/unvisited (:link)
+        StateVisited,      // Visited link (:visited)
+        StateHover,        // Mouse hover (:hover)
+        StateActive,       // Mouse down/active (:active)
+        StateFocus,        // Keyboard focus (:focus)
+        StateFocusVisible, // Visible keyboard focus (:focus-visible)
+        StateSelected,     // Selected state (from selection object)
+        StateDisabled      // Disabled state (from selection object)
     };
 
     // State-specific styling containers
-    struct StateStyle {
+    struct StateStyle
+    {
         QColor foregroundColor;
         QColor backgroundColor;
         QColor underlineColor;
@@ -115,15 +117,15 @@ struct HyperlinkStyling {
     };
 
     // State-specific styles
-    StateStyle linkStyle;           // :link (unvisited)
-    StateStyle visitedStyle;        // :visited
-    StateStyle hoverStyle;          // :hover
-    StateStyle activeStyle;         // :active
-    StateStyle focusStyle;          // :focus
-    StateStyle focusVisibleStyle;   // :focus-visible
-    StateStyle anyLinkStyle;        // :any-link (applies to both :link and :visited)
-    StateStyle selectedStyle;       // :selected (from selection object)
-    StateStyle disabledStyle;       // :disabled (from selection object)
+    StateStyle linkStyle;         // :link (unvisited)
+    StateStyle visitedStyle;      // :visited
+    StateStyle hoverStyle;        // :hover
+    StateStyle activeStyle;       // :active
+    StateStyle focusStyle;        // :focus
+    StateStyle focusVisibleStyle; // :focus-visible
+    StateStyle anyLinkStyle;      // :any-link (applies to both :link and :visited)
+    StateStyle selectedStyle;     // :selected (from selection object)
+    StateStyle disabledStyle;     // :disabled (from selection object)
 
     // State tracking
     LinkState currentState = StateDefault;
@@ -135,13 +137,14 @@ struct HyperlinkStyling {
     // JSON: {"group": "string", "value": "string", "toggle": bool, "selected": bool, "exclusive": bool, "disabled": bool}
     // When exclusive=true: radio button behavior (only one selected per group)
     // When exclusive=false: checkbox behavior (multiple selections per group)
-    struct SelectionSettings {
-        QString group;              // Group identifier for related selections
-        QString value;              // Unique value within the group
-        bool toggle = true;         // Allow deselecting when already selected
-        bool selected = false;      // Initial selection state
-        bool exclusive = true;      // Radio (true) vs checkbox (false) mode
-        bool disabled = false;      // Cannot be clicked when disabled
+    struct SelectionSettings
+    {
+        QString group;         // Group identifier for related selections
+        QString value;         // Unique value within the group
+        bool toggle = true;    // Allow deselecting when already selected
+        bool selected = false; // Initial selection state
+        bool exclusive = true; // Radio (true) vs checkbox (false) mode
+        bool disabled = false; // Cannot be clicked when disabled
         bool hasSelectionSettings = false;
     };
 
@@ -151,7 +154,8 @@ struct HyperlinkStyling {
     // JSON: {"action": "conceal"|"reveal"|["reveal","conceal"], "delay": ms, "wholeline": bool, "expire": {...}}
     // expire object: {"input": bool, "prompt": bool, "output": bool, "outputDelay": ms}
     // When action is ["reveal","conceal"]: starts hidden, reveals on trigger, then conceals on click
-    struct VisibilitySettings {
+    struct VisibilitySettings
+    {
         // Maximum allowed delay value (24 hours in milliseconds)
         static constexpr quint32 MaxDelayMs = 86400000;
         // Default output delay for batch detection (500ms)
@@ -161,7 +165,7 @@ struct HyperlinkStyling {
             None,
             Conceal,
             Reveal,
-            RevealThenConceal  // Combined: reveal first, then conceal after click
+            RevealThenConceal // Combined: reveal first, then conceal after click
         };
 
         Action action = Action::None;
@@ -171,10 +175,10 @@ struct HyperlinkStyling {
         bool hasVisibilitySettings = false;
 
         // Expire triggers - when visibility action should occur
-        bool expireOnInput = false;    // User types/submits something
-        bool expireOnPrompt = false;   // GA/EOR telnet signal received
-        bool expireOnOutput = false;   // New output after idle gap
-        quint32 outputDelayMs = DefaultOutputDelayMs;  // Idle gap for output trigger
+        bool expireOnInput = false;                   // User types/submits something
+        bool expireOnPrompt = false;                  // GA/EOR telnet signal received
+        bool expireOnOutput = false;                  // New output after idle gap
+        quint32 outputDelayMs = DefaultOutputDelayMs; // Idle gap for output trigger
     };
 
     VisibilitySettings visibility;
@@ -193,7 +197,13 @@ public:
     const bool needsIndent;
     const int firstChar;
     const int lastChar;
-    WrapInfo(bool isNewline, bool needsIndent, int firstChar, int lastChar) : isNewline(isNewline), needsIndent(needsIndent), firstChar(firstChar), lastChar(lastChar) {}
+    WrapInfo(bool isNewline, bool needsIndent, int firstChar, int lastChar)
+    : isNewline(isNewline)
+    , needsIndent(needsIndent)
+    , firstChar(firstChar)
+    , lastChar(lastChar)
+    {
+    }
 };
 
 class TChar
@@ -204,27 +214,27 @@ public:
     enum AttributeFlag {
         None = 0x0,
         // Replaces TCHAR_BOLD 2
-        Bold = 0x1,                   // 0000 0000 0000 0000 0000 0000 0000 0001
+        Bold = 0x1, // 0000 0000 0000 0000 0000 0000 0000 0001
         // Replaces TCHAR_ITALICS 1
-        Italic = 0x2,                 // 0000 0000 0000 0000 0000 0000 0000 0010
+        Italic = 0x2, // 0000 0000 0000 0000 0000 0000 0000 0010
         // Replaces TCHAR_UNDERLINE 4
-        Underline = 0x4,              // 0000 0000 0000 0000 0000 0000 0000 0100
+        Underline = 0x4, // 0000 0000 0000 0000 0000 0000 0000 0100
         // ANSI CSI SGR Overline (53 on, 55 off)
-        Overline = 0x8,               // 0000 0000 0000 0000 0000 0000 0000 1000
+        Overline = 0x8, // 0000 0000 0000 0000 0000 0000 0000 1000
         // Replaces TCHAR_STRIKEOUT 32
-        StrikeOut = 0x10,             // 0000 0000 0000 0000 0000 0000 0001 0000
+        StrikeOut = 0x10, // 0000 0000 0000 0000 0000 0000 0001 0000
         // Extended underline styles for enhanced OSC 8 hyperlink support
-        UnderlineWavy = 0x400000,     // 0000 0000 0100 0000 0000 0000 0000 0000
-        UnderlineDotted = 0x800000,   // 0000 0000 1000 0000 0000 0000 0000 0000
-        UnderlineDashed = 0x1000000,  // 0000 0001 0000 0000 0000 0000 0000 0000
+        UnderlineWavy = 0x400000,    // 0000 0000 0100 0000 0000 0000 0000 0000
+        UnderlineDotted = 0x800000,  // 0000 0000 1000 0000 0000 0000 0000 0000
+        UnderlineDashed = 0x1000000, // 0000 0001 0000 0000 0000 0000 0000 0000
         // NOT a replacement for TCHAR_INVERSE, that is now covered by the
         // separate isSelected bool but they must be EX-ORed at the point of
         // painting the Character
-        Reverse = 0x20,               // 0000 0000 0000 0000 0000 0000 0010 0000
+        Reverse = 0x20, // 0000 0000 0000 0000 0000 0000 0010 0000
         // Flashing less than 150 times a minute:
-        Blink = 0x40,                 // 0000 0000 0000 0000 0000 0000 0100 0000
+        Blink = 0x40, // 0000 0000 0000 0000 0000 0000 0100 0000
         // Flashing at least 150 times a minute:
-        FastBlink = 0x80,             // 0000 0000 0000 0000 0000 0000 1000 0000
+        FastBlink = 0x80, // 0000 0000 0000 0000 0000 0000 1000 0000
         // Alternate fonts 1 to 9 from SGR 11 m to SGR 19 m; we flag each one
         // separately so that trigger processing can select them individually
         // which could not be done should they be rolled up into just 4 bits.
@@ -232,33 +242,33 @@ public:
         // used if/when we can actually paint different fonts in a TConsole at
         // the same time; currently there is no MUD standard to specify what the
         // alternatives are:
-        AltFont1 = 0x00100,           // 0000 0000 0000 0000 0000 0001 0000 0000
-        AltFont2 = 0x00200,           // 0000 0000 0000 0000 0000 0010 0000 0000
-        AltFont3 = 0x00400,           // 0000 0000 0000 0000 0000 0100 0000 0000
-        AltFont4 = 0x00800,           // 0000 0000 0000 0000 0000 1000 0000 0000
-        AltFont5 = 0x01000,           // 0000 0000 0000 0000 0001 0000 0000 0000
-        AltFont6 = 0x02000,           // 0000 0000 0000 0000 0010 0000 0000 0000
-        AltFont7 = 0x04000,           // 0000 0000 0000 0000 0100 0000 0000 0000
-        AltFont8 = 0x08000,           // 0000 0000 0000 0000 1000 0000 0000 0000
-        AltFont9 = 0x10000,           // 0000 0000 0000 0001 0000 0000 0000 0000
+        AltFont1 = 0x00100, // 0000 0000 0000 0000 0000 0001 0000 0000
+        AltFont2 = 0x00200, // 0000 0000 0000 0000 0000 0010 0000 0000
+        AltFont3 = 0x00400, // 0000 0000 0000 0000 0000 0100 0000 0000
+        AltFont4 = 0x00800, // 0000 0000 0000 0000 0000 1000 0000 0000
+        AltFont5 = 0x01000, // 0000 0000 0000 0000 0001 0000 0000 0000
+        AltFont6 = 0x02000, // 0000 0000 0000 0000 0010 0000 0000 0000
+        AltFont7 = 0x04000, // 0000 0000 0000 0000 0100 0000 0000 0000
+        AltFont8 = 0x08000, // 0000 0000 0000 0000 1000 0000 0000 0000
+        AltFont9 = 0x10000, // 0000 0000 0000 0001 0000 0000 0000 0000
         // From SGR 8 m; however there is no MUD standard protocol to control
         // when we should show concealed text.
-        Concealed = 0x20000,          // 0000 0000 0000 0010 0000 0000 0000 0000
+        Concealed = 0x20000, // 0000 0000 0000 0010 0000 0000 0000 0000
         // Mask for "is flashing" at any rate - will return a logical true
         // should either of the above be set - should both be set then FastBlink
         // should take preference over Blink:
-        BlinkMask = 0xC0,             // 0000 0000 0000 0000 0000 0000 1100 0000
+        BlinkMask = 0xC0, // 0000 0000 0000 0000 0000 0000 1100 0000
         // Mask for "any alternate font" - only the most significant one should
         // be used if more than one is set:
-        AltFontMask = 0x1ff00,        // 0000 0000 0000 0001 1111 1111 0000 0000
-        TestMask = 0x1f3ffff,         // 0000 0001 1111 0011 1111 1111 1111 1111 (includes extended underline styles)
+        AltFontMask = 0x1ff00, // 0000 0000 0000 0001 1111 1111 0000 0000
+        TestMask = 0x1f3ffff,  // 0000 0001 1111 0011 1111 1111 1111 1111 (includes extended underline styles)
         // The remainder are internal use ones that do not related to SGR codes
         // that have been parsed from the incoming text.
         // Has been found in a search operation (currently Main Console only)
         // and has been given a highlight to indicate that:
-        Found = 0x100000,             // 0000 0000 0001 0000 0000 0000 0000 0000
+        Found = 0x100000, // 0000 0000 0001 0000 0000 0000 0000 0000
         // Replaces TCHAR_ECHO 16
-        Echo = 0x200000               // 0000 0000 0010 0000 0000 0000 0000 0000
+        Echo = 0x200000 // 0000 0000 0010 0000 0000 0000 0000 0000
     };
     Q_DECLARE_FLAGS(AttributeFlags, AttributeFlag)
 
@@ -277,7 +287,8 @@ public:
     ~TChar() = default;
 
     bool operator==(const TChar&);
-    void setColors(const QColor& newForeGroundColor, const QColor& newBackGroundColor) {
+    void setColors(const QColor& newForeGroundColor, const QColor& newBackGroundColor)
+    {
         mFgColor = newForeGroundColor;
         mBgColor = newBackGroundColor;
     }
@@ -287,7 +298,8 @@ public:
     void setAllDisplayAttributes(const AttributeFlags newDisplayAttributes) { mFlags = (mFlags & ~TestMask) | (newDisplayAttributes & TestMask); }
     void setForeground(const QColor& newColor) { mFgColor = newColor; }
     void setBackground(const QColor& newColor) { mBgColor = newColor; }
-    void setTextFormat(const QColor& newFgColor, const QColor& newBgColor, const AttributeFlags newDisplayAttributes) {
+    void setTextFormat(const QColor& newFgColor, const QColor& newBgColor, const AttributeFlags newDisplayAttributes)
+    {
         setColors(newFgColor, newBgColor);
         setAllDisplayAttributes(newDisplayAttributes);
     }
@@ -298,7 +310,7 @@ public:
     void select() { mIsSelected = true; }
     void deselect() { mIsSelected = false; }
     bool isSelected() const { return mIsSelected; }
-    int linkIndex () const { return mLinkIndex; }
+    int linkIndex() const { return mLinkIndex; }
     bool isBold() const { return mFlags & Bold; }
     bool isItalic() const { return mFlags & Italic; }
     bool isUnderlined() const { return mFlags & Underline; }
@@ -321,9 +333,21 @@ public:
     bool hasCustomStrikeoutColor() const { return mHasCustomStrikeoutColor; }
 
     // Decoration color setters
-    void setUnderlineColor(const QColor& color) { mUnderlineColor = color; mHasCustomUnderlineColor = true; }
-    void setOverlineColor(const QColor& color) { mOverlineColor = color; mHasCustomOverlineColor = true; }
-    void setStrikeoutColor(const QColor& color) { mStrikeoutColor = color; mHasCustomStrikeoutColor = true; }
+    void setUnderlineColor(const QColor& color)
+    {
+        mUnderlineColor = color;
+        mHasCustomUnderlineColor = true;
+    }
+    void setOverlineColor(const QColor& color)
+    {
+        mOverlineColor = color;
+        mHasCustomOverlineColor = true;
+    }
+    void setStrikeoutColor(const QColor& color)
+    {
+        mStrikeoutColor = color;
+        mHasCustomStrikeoutColor = true;
+    }
     void clearCustomUnderlineColor() { mHasCustomUnderlineColor = false; }
     void clearCustomOverlineColor() { mHasCustomOverlineColor = false; }
     void clearCustomStrikeoutColor() { mHasCustomStrikeoutColor = false; }
@@ -332,23 +356,34 @@ public:
     bool isBlinking() const { return (mFlags & FastBlink) ? false : (mFlags & Blink); }
     bool isFastBlinking() const { return mFlags & FastBlink; }
     quint8 alternateFont() const;
-    static TChar::AttributeFlag alternateFontFlag(const quint8 altFontNumber) {
+    static TChar::AttributeFlag alternateFontFlag(const quint8 altFontNumber)
+    {
         switch (altFontNumber) {
-        case 1: return AltFont1;
-        case 2: return AltFont2;
-        case 3: return AltFont3;
-        case 4: return AltFont4;
-        case 5: return AltFont5;
-        case 6: return AltFont6;
-        case 7: return AltFont7;
-        case 8: return AltFont8;
-        case 9: return AltFont9;
+        case 1:
+            return AltFont1;
+        case 2:
+            return AltFont2;
+        case 3:
+            return AltFont3;
+        case 4:
+            return AltFont4;
+        case 5:
+            return AltFont5;
+        case 6:
+            return AltFont6;
+        case 7:
+            return AltFont7;
+        case 8:
+            return AltFont8;
+        case 9:
+            return AltFont9;
         default:
             Q_ASSERT_X(altFontNumber < 10, "alternateFontFlag", "value out of range 0 to 9");
             return None;
         }
     }
-    static QString attributeType(const AttributeFlag flag) {
+    static QString attributeType(const AttributeFlag flag)
+    {
         switch (flag) {
         case None:
             return qsl("None");
@@ -418,11 +453,9 @@ private:
 Q_DECLARE_OPERATORS_FOR_FLAGS(TChar::AttributeFlags)
 
 
-
-
 class TBuffer
 {
-    inline static const TEncodingTable &csmEncodingTable = TEncodingTable::csmDefaultInstance;
+    inline static const TEncodingTable& csmEncodingTable = TEncodingTable::csmDefaultInstance;
 
     inline static const int TCHAR_IN_BYTES = sizeof(TChar);
 
@@ -441,7 +474,7 @@ public:
     void log(int, int);
     int skipSpacesAtBeginOfLine(const int row, const int column);
     void addLink(bool, const QString& text, QStringList& command, QStringList& hint, TChar format, QVector<int> luaReference = QVector<int>());
-    QString bufferToHtml(const bool showTimeStamp = false, const int row = -1, const int endColumn = -1, const int startColumn = 0,  int spacePadding = 0);
+    QString bufferToHtml(const bool showTimeStamp = false, const int row = -1, const int endColumn = -1, const int startColumn = 0, int spacePadding = 0);
     int size() { return static_cast<int>(buffer.size()); }
     bool isEmpty() const { return buffer.size() == 0; }
     QString& line(int lineNumber);
@@ -471,7 +504,14 @@ public:
     // Only the bits within TChar::TestMask are considered for formatting:
     void append(const QString& chunk, const int sub_start, const int sub_end, const TChar format, const int linkID = 0);
     void appendFormatted(const QString& text, const std::deque<TChar>& formatting, const TLinkStore& sourceLinkStore);
-    void appendLine(const QString& chunk, const int sub_start, const int sub_end, const QColor& fg, const QColor& bg, TChar::AttributeFlags flags = TChar::None, const int linkID = 0);
+    void appendLine(const QString& chunk,
+                    const int sub_start,
+                    const int sub_end,
+                    const QColor& fg,
+                    const QColor& bg,
+                    TChar::AttributeFlags flags = TChar::None,
+                    const int linkID = 0,
+                    const bool handleNewlines = true);
     void appendEmptyLine();
     void setWrapAt(int i) { mWrapAt = i; }
     void setWrapIndent(int i) { mWrapIndent = i; }
@@ -487,14 +527,14 @@ public:
     void clearLastClickedLinkIndex() { mLastClickedLinkIndex = 0; }
     static const QList<QByteArray> getEncodingNames();
     void logRemainingOutput();
-    void appendLog(const QString &text);
+    void appendLog(const QString& text);
 
     // OSC 8 hyperlink documentation examples - triggered by secret phrase
     void injectOSC8DocumentationExamples();
 
     // It would have been nice to do this with Qt's signals and slots but that
     // is apparently incompatible with using a default constructor - sigh!
-    void encodingChanged(const QByteArray &);
+    void encodingChanged(const QByteArray&);
     void clearSearchHighlights();
 
     static int lengthInGraphemes(const QString& text);
@@ -646,15 +686,11 @@ private:
     int mCurrentHyperlinkStartColumn = 0;
     QString mCurrentHyperlinkText;
 
-    enum class WatchdogPhase {
-        Phase1_Snapshot,
-        Phase2_Unfreeze,
-        None
-    };
-    static constexpr int    MAX_TAG_TIMEOUT_MS = 1300;
-    WatchdogPhase           mWatchdogPhase = WatchdogPhase::None;
+    enum class WatchdogPhase { Phase1_Snapshot, Phase2_Unfreeze, None };
+    static constexpr int MAX_TAG_TIMEOUT_MS = 1300;
+    WatchdogPhase mWatchdogPhase = WatchdogPhase::None;
     std::unique_ptr<QTimer> mTagWatchdog;
-    std::string             mWatchdogTagSnapshot;
+    std::string mWatchdogTagSnapshot;
 
     // Enhanced OSC 8 hyperlink styling and menu support
     Mudlet::HyperlinkStyling mCurrentHyperlinkStyling;
@@ -667,10 +703,10 @@ private:
     QMap<int, QColor> mLinkOriginalBackgrounds;
     QMap<int, TChar> mLinkOriginalCharacters;
     QMap<int, QString> mLinkOriginalText;
-    int mCurrentHoveredLinkIndex = 0;  // Which link is currently hovered (0 = none)
-    int mCurrentActiveLinkIndex = 0;   // Which link is currently being clicked (0 = none)
-    int mCurrentFocusedLinkIndex = 0;  // Which link has keyboard focus (0 = none)
-    int mLastClickedLinkIndex = 0;     // Last clicked link - suppresses hover until mouse leaves
+    int mCurrentHoveredLinkIndex = 0; // Which link is currently hovered (0 = none)
+    int mCurrentActiveLinkIndex = 0;  // Which link is currently being clicked (0 = none)
+    int mCurrentFocusedLinkIndex = 0; // Which link has keyboard focus (0 = none)
+    int mLastClickedLinkIndex = 0;    // Last clicked link - suppresses hover until mouse leaves
 
     // Flag to skip trigger processing during documentation injection
     bool mSkipTriggerProcessing = false;
@@ -701,8 +737,8 @@ public:
     int getHoveredLink() const { return mCurrentHoveredLinkIndex; }
     int getActiveLink() const { return mCurrentActiveLinkIndex; }
     int getFocusedLink() const { return mCurrentFocusedLinkIndex; }
-    int getLinkIndexAt(int line, int column) const; // Get link index at specific position
-    void clearLinkIndices(int lineNumber, int startColumn, int count); // Clear link indices in a range
+    int getLinkIndexAt(int line, int column) const;                                     // Get link index at specific position
+    void clearLinkIndices(int lineNumber, int startColumn, int count);                  // Clear link indices in a range
     void restoreLinkIndices(int lineNumber, int startColumn, int count, int linkIndex); // Restore link indices in a range
 
 private:

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1912,7 +1912,7 @@ void TConsole::printSystemMessage(const QString& msg)
 void TConsole::echo(const QString& msg)
 {
     if (mTriggerEngineMode) {
-        buffer.appendLine(msg, 0, msg.size() - 1, mFormatCurrent.foreground(), mFormatCurrent.background(), mFormatCurrent.allDisplayAttributes());
+        buffer.appendLine(msg, 0, msg.size() - 1, mFormatCurrent.foreground(), mFormatCurrent.background(), mFormatCurrent.allDisplayAttributes(), 0, false);
     } else {
         print(msg);
     }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1912,7 +1912,13 @@ void TConsole::printSystemMessage(const QString& msg)
 void TConsole::echo(const QString& msg)
 {
     if (mTriggerEngineMode) {
-        buffer.appendLine(msg, 0, msg.size() - 1, mFormatCurrent.foreground(), mFormatCurrent.background(), mFormatCurrent.allDisplayAttributes(), 0, false);
+        // Only convert \n to new lines when the message contains actual text.
+        // Pure-newline messages (e.g. cecho("\n")) are kept literal so that
+        // a subsequent creplaceLine can replace them along with the line content
+        // (see issue #8824). Messages with text (e.g. cecho("\n text")) still
+        // get proper newline handling (see PR #8896 discussion).
+        const bool handleNewlines = (msg.count(QChar::LineFeed) != msg.size());
+        buffer.appendLine(msg, 0, msg.size() - 1, mFormatCurrent.foreground(), mFormatCurrent.background(), mFormatCurrent.allDisplayAttributes(), 0, handleNewlines);
     } else {
         print(msg);
     }

--- a/src/mudlet-lua/tests/Trigger_spec.lua
+++ b/src/mudlet-lua/tests/Trigger_spec.lua
@@ -180,5 +180,27 @@ describe("Trigger processing", function()
             killTrigger(trigger_id)
         end)
 
+        it("should create new lines when cecho contains text after newline", function()
+            local next_line = nil
+            local trigger_id = tempRegexTrigger("^NEWLINE_ECHO_TEST_8896$", function()
+                -- cecho with text after \n should create a new line and display
+                -- the text on it (reported in PR #8896 discussion)
+                cecho("\n newline echo")
+
+                -- Move to the line after the trigger line to check the echoed text
+                moveCursor(0, getLineNumber() + 1)
+                selectCurrentLine()
+                next_line = getSelection()
+            end)
+
+            feedTriggers("\nNEWLINE_ECHO_TEST_8896\n")
+
+            assert.is_not_nil(next_line, "Should have captured the next line")
+            assert.are.equal(" newline echo", next_line,
+                "cecho with \\n and text should create a new line with the text")
+
+            killTrigger(trigger_id)
+        end)
+
     end)
 end)

--- a/src/mudlet-lua/tests/Trigger_spec.lua
+++ b/src/mudlet-lua/tests/Trigger_spec.lua
@@ -126,4 +126,59 @@ describe("Trigger processing", function()
         end)
 
     end)
+
+    -- Test for issue #8824: cecho behavior with newlines and creplaceLine
+    -- Previously, cecho("\n") followed by creplaceLine and then another cecho
+    -- would place the second cecho on a different line than expected
+    describe("cecho with newlines and creplaceLine (issue #8824)", function()
+
+        it("should append text on same line after creplaceLine", function()
+            local result_line = nil
+            local trigger_id = tempRegexTrigger("^REPLACE_ME_TEST_8824$", function()
+                -- This is the exact sequence from the bug report
+                cecho("\n")
+                selectCurrentLine()
+                creplaceLine("<red>REPLACED")
+                cecho("(cecho)")
+
+                -- Get the current line to verify the result
+                selectCurrentLine()
+                result_line = getSelection()
+            end)
+
+            -- Trigger the pattern
+            feedTriggers("\nREPLACE_ME_TEST_8824\n")
+
+            -- The text should be on the same line: "REPLACED(cecho)"
+            -- Before the fix, "(cecho)" would be on a separate line
+            assert.is_not_nil(result_line, "Should have captured the result line")
+            assert.are.equal("REPLACED(cecho)", result_line,
+                "cecho text should appear on same line as creplaceLine text")
+
+            killTrigger(trigger_id)
+        end)
+
+        it("should handle multiple cecho calls after creplaceLine", function()
+            local result_line = nil
+            local trigger_id = tempRegexTrigger("^MULTI_ECHO_TEST_8824$", function()
+                cecho("\n")
+                selectCurrentLine()
+                creplaceLine("<green>START")
+                cecho("<yellow>-MIDDLE")
+                cecho("<blue>-END")
+
+                selectCurrentLine()
+                result_line = getSelection()
+            end)
+
+            feedTriggers("\nMULTI_ECHO_TEST_8824\n")
+
+            assert.is_not_nil(result_line, "Should have captured the result line")
+            assert.are.equal("START-MIDDLE-END", result_line,
+                "All cecho text should appear on same line")
+
+            killTrigger(trigger_id)
+        end)
+
+    end)
 end)


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
In trigger mode, appendLine() now skips newline-to-new-line conversion to restore pre-#7714 behavior where \n was treated as a literal character that could be replaced by creplaceLine.


#### Motivation for adding to Mudlet
Backwards compatibility with existing scripts

Fixes #8824
#### Other info (issues closed, discussion etc)
Unfortunately the behaviour we restored is technically broken, but it can be worked around by doing the replace first and echoing the \n afterwards.