### PR TITLE
Fix: Command history not working when password masking is disabled

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1009,7 +1009,9 @@ void TCommandLine::enterCommand(QKeyEvent* event)
         }
     }
 
-    if (!toPlainText().isEmpty() && !mpHost->isRemoteEchoingActive()) {
+    // Save to history if not empty, unless we're in password mode (remote echo suppression)
+    // Exception: when password masking is disabled, history should work normally
+    if (!toPlainText().isEmpty() && (!mpHost->isRemoteEchoingActive() || mpHost->mDisablePasswordMasking)) {
         if (mpHost->mAutoClearCommandLineAfterSend) {
             mHistoryBuffer = 0;
         } else {


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Command history (up/down arrow keys) now works correctly when the "Disable password masking" option is enabled in Settings → Input.

#### Motivation for adding to Mudlet

Users who disable password masking expect the command line to behave normally, including saving and recalling previous commands. Previously, command history was disabled whenever the server requested echo suppression (password mode), even if the user had opted out of password masking.

#### Other info (issues closed, discussion etc)

Reported on [Discord by a MUD2 player](https://discord.com/channels/283581582550237184/427919962561052673/1469063040539558020) who couldn't use input history despite disabling password masking.

---

MUD2 - mudii.co.uk, port 23

https://github.com/user-attachments/assets/23341749-3444-4c77-b5a7-b8fd1e1c5130
