### PR TITLE
Fix: clean up comments and related translation things

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -686,11 +686,11 @@ void Host::updateModuleZips(const QString& zipName, const QString& moduleName)
         zip_error_t zipError;
         zip_error_init_with_code(&zipError, err);
         /*: This zipError message is shown when the libzip library code is unable
-         * to open the file that was to be the end result of the export process.
-         * As this may be an existing file anywhere in the computer's
-         * file-system(s) it is possible that permissions on the directory or an
-         * existing file that is to be overwritten may be a source of problems
-         * here.
+ to open the file that was to be the end result of the export process.
+ As this may be an existing file anywhere in the computer's
+ file-system(s) it is possible that permissions on the directory or an
+ existing file that is to be overwritten may be a source of problems
+ here.
         */
         qWarning().noquote().nospace() << "Host::updateModuleZips(\"" << zipName << "\", \"" << moduleName << "\") WARNING - failed to open module to update it, error: \""
                                        << zip_error_strerror(&zipError) << "\"";

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1720,7 +1720,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
             if (mpMap->mpRoomDB->isEmpty()) {
                 message = tr("No rooms in the map - load another one, or start mapping from scratch to begin.");
             } else {
-                message = tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size());
+                message = tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", nullptr, mpMap->mpRoomDB->size());
             }
         } else {
             message = tr("You do not have a map yet - load one, or start mapping from scratch to begin.");

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -1119,7 +1119,7 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
 
             } else if (mudlet::smDebugMode) {
                 // FIXME: This message is translated - but most other TDebug ones are not!
-                TDebug(Qt::yellow, Qt::darkMagenta) << qsl("%1\n").arg(tr("Trigger name=%1 will fire %n more time(s).", "", mExpiryCount).arg(mName)) >> mpHost;
+                TDebug(Qt::yellow, Qt::darkMagenta) << qsl("%1\n").arg(tr("Trigger name=%1 will fire %n more time(s).", nullptr, mExpiryCount).arg(mName)) >> mpHost;
             }
         }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -442,15 +442,13 @@ void cTelnet::connectIt(const QString& address, int port)
     // Detect raw IPv6 addresses - as they need to be wrapped in '['...']'
 
     /*: For an IPv6 address (which is composed of hex-digits and colons) if we
-     * want to show it with a port number appended (as a colon and then an
-     * integer between 1 and 65535) we need to wrap it with '['...']' to
-     * separate the latter from the former, however some Far-East locales may
-     * expect to use the wide versions of these character here.
-     */
+ want to show it with a port number appended (as a colon and then an
+ integer between 1 and 65535) we need to wrap it with '['...']' to
+ separate the latter from the former, however some Far-East locales may
+ expect to use the wide versions of these character here.*/
     const QString displayAddress = isRawIPv6Address(mHostUrl) ? tr("[%1]").arg(mHostUrl) : mHostUrl;
     /*: %1 is the URL or an IP address (suitably wrapped if it is an IPv6 one)
-     * of the Game Server (or Proxy); %2 is the port number.
-     */
+ of the Game Server (or Proxy); %2 is the port number.*/
     TDebug(QColorConstants::Blue, QColorConstants::White) << tr("Looking up the details of server: %1:%2 ...").arg(displayAddress, QString::number(port)).append(QChar::LineFeed) >> mpHost;
     // We can now use a compile-time slot for this as:
     // https://bugreports.qt.io/browse/QTBUG-67646 was (finally) fixed in
@@ -649,9 +647,8 @@ void cTelnet::slot_socketDisconnected()
     const QString msg = tr("[ INFO ]  - Connection time: %1.")
                                 .arg(timeDiff.addMSecs(timeOffset)
                                              /*: This is the format to be used to show the profile connection time, it follows
-                                 * the rules of the "QDateTime::toString(...)" function and may need
-                                 * modification for some locales, e.g. France, Spain.
-                                 */
+ the rules of the "QDateTime::toString(...)" function and may need
+ modification for some locales, e.g. France, Spain.*/
                                              .toString(tr("hh:mm:ss.zzz")));
     mNeedDecompression = false;
     reset();
@@ -675,15 +672,13 @@ void cTelnet::slot_socketDisconnected()
             QStringList reasons;
             if (mDontReconnect) {
                 /*: A reason why a connection to a game server ended, could be
-                 * one of several to be listed. This text used in two places,
-                 * ensure the same text is used in both.
-                 */
+ one of several to be listed. This text used in two places,
+ ensure the same text is used in both.*/
                 reasons.append(tr("User Disconnected"));
             } else if (timeOffset >= 0 && timeOffset < 5000) {
                 /*: A reason why a connection to a game server ended, could be
-                 * one of several to be listed. This text used in two places,
-                 * ensure the same text is used in both.
-                 */
+ one of several to be listed. This text used in two places,
+ ensure the same text is used in both.*/
                 reasons.append(tr("Connection/login attempt rejected by server"));
             }
 
@@ -700,16 +695,15 @@ void cTelnet::slot_socketDisconnected()
 
             if (reasons.count()) {
                 /*: This message is used when we have been trying to connect or
-                 * we were connected securely, but the connection has been lost.
-                 * It is possible with a secure connection that there is MORE
-                 * than one error message to show, but for English or other
-                 * locales where the singular case (%n==1) is distinct it would
-                 * be perfectly feasible to replace "for %n reason(s)" with
-                 * "because" for that number (1) of errors - however the text
-                 * should then be repeated in the corresponding situation for
-                 * an "open" connection which is different in that it only ever
-                 * has one "reason" to report.
-                 */
+ we were connected securely, but the connection has been lost.
+ It is possible with a secure connection that there is MORE
+ than one error message to show, but for English or other
+ locales where the singular case (%n==1) is distinct it would
+ be perfectly feasible to replace "for %n reason(s)" with
+ "because" for that number (1) of errors - however the text
+ should then be repeated in the corresponding situation for
+ an "open" connection which is different in that it only ever
+ has one "reason" to report.*/
                 postMessage(tr("[ ALERT ] - Socket got disconnected, for %n reason(s):\n"
                                "%1",
                                // Intentional comment to separate arguments
@@ -718,12 +712,11 @@ void cTelnet::slot_socketDisconnected()
                                     .arg(reasons.join(QChar::LineFeed)));
             } else {
                 /*: This message is used when we have been trying to connect or
-                 * we were connected securely or in an open manner, but the
-                 * connection has been lost and we do not have any explaination
-                 * to give to the user as to why. Anyhow, in this case we do not
-                 * have anything more to say about it. This text used in two
-                 * places, ensure the same translation is used in both of them.
-                 */
+ we were connected securely or in an open manner, but the
+ connection has been lost and we do not have any explaination
+ to give to the user as to why. Anyhow, in this case we do not
+ have anything more to say about it. This text used in two
+ places, ensure the same translation is used in both of them.*/
                 postMessage(tr("[ ALERT ] - Socket got disconnected."));
             }
 
@@ -733,18 +726,16 @@ void cTelnet::slot_socketDisconnected()
             QString reason;
             if (mDontReconnect) {
                 /*: A reason why a connection to a game server ended, could be
-                 * one of several to be listed. This text used in two places,
-                 * ensure the same text is used in both.
-                 */
+ one of several to be listed. This text used in two places,
+ ensure the same text is used in both.*/
                 reason = tr("User Disconnected");
             } else if (QAbstractSocket::SslHandshakeFailedError == mpSocket->error()) {
                 //: A reason why a connection to a game server ended.
                 reason = tr("Secure connections not supported by this game on this port; try turning the option off");
             } else if (timeOffset >= 0 && timeOffset < 5000) {
                 /*: A reason why a connection to a game server ended, could be
-                 * one of several to be listed. This text used in two places,
-                 * ensure the same text is used in both.
-                 */
+ one of several to be listed. This text used in two places,
+ ensure the same text is used in both.*/
                 reason = tr("Connection/login attempt rejected by server");
             } else if (!mpSocket->errorString().isEmpty()) {
                 reason = mpSocket->errorString();
@@ -752,23 +743,21 @@ void cTelnet::slot_socketDisconnected()
 
             if (reason.isEmpty()) {
                 /*: This message is used when we have been trying to connect or
-                 * we were connected securely or in an open manner, but the
-                 * connection has been lost and we do not have any explaination
-                 * to give to the user as to why. Anyhow, in this case we do not
-                 * have anything more to say about it. This text used in two
-                 * places, ensure the same translation is used in both of them.
-                 */
+ we were connected securely or in an open manner, but the
+ connection has been lost and we do not have any explaination
+ to give to the user as to why. Anyhow, in this case we do not
+ have anything more to say about it. This text used in two
+ places, ensure the same translation is used in both of them.*/
                 postMessage(tr("[ ALERT ] - Socket got disconnected."));
             } else {
                 /*: This message is used when we have been trying to connect or
-                 * we were connected in an open, insecure manner, but the
-                 * connection has been lost. Unlike the secure connection case
-                 * there is only one error message to show; it would be
-                 * desirable to use the same text for this message as the "one
-                 * reason" (%n==1) situation for locales such as English (with
-                 * a distinct form for the singular) use for the secure type
-                 * of connection.
-                 */
+ we were connected in an open, insecure manner, but the
+ connection has been lost. Unlike the secure connection case
+ there is only one error message to show; it would be
+ desirable to use the same text for this message as the "one
+ reason" (%n==1) situation for locales such as English (with
+ a distinct form for the singular) use for the secure type
+ of connection.*/
                 postMessage(tr("[ ALERT ] - Socket got disconnected, for reason:\n"
                                "%1")
                                     .arg(reason));
@@ -887,10 +876,9 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
 
     if (!(hasIPv4_address || hasIPv6_address)) {
         /*: This text is used in the (expected) case when the user has provided
-         * a URL for the Game Server rather than (unusually) an IP address.
-         * After a DNS lookup however, we have NOT found any IP addresses which
-         * means that we cannot proceed further to connect to the Game server.
-         */
+ a URL for the Game Server rather than (unusually) an IP address.
+ After a DNS lookup however, we have NOT found any IP addresses which
+ means that we cannot proceed further to connect to the Game server.*/
         TDebug(QColorConstants::Red, QColorConstants::White) << tr("Host name lookup Failure! A connection cannot be established.\n"
                                                                    "The server name is not correct, or your nameservers are not\n"
                                                                    "working properly.\n")
@@ -906,16 +894,14 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
     QStringList addressesToReport;
     for (const auto& address : addressList_ipV6) {
         /*: Used to add an IPv6 address line to the list displayed during
-         * connecting to a Host. Some, e.g. Far Eastern locales may require a
-         * different text here if they do not use spaces, or need "wide" '(' ')'s
-         */
+ connecting to a Host. Some, e.g. Far Eastern locales may require a
+ different text here if they do not use spaces, or need "wide" '(' ')'s*/
         addressesToReport << tr("%1 (IPv6)").arg(address);
     }
     for (const auto& address : addressList_ipV4) {
         /*: Used to add an IPv4 address line to the list displayed during
-         * connecting to a Host. Some, e.g. Far Eastern locales may require a
-         * different text here if they do not use spaces, or "wide" '('...')'
-         */
+ connecting to a Host. Some, e.g. Far Eastern locales may require a
+ different text here if they do not use spaces, or "wide" '('...')'*/
         addressesToReport << tr("%1 (IPv4)").arg(address);
     }
     if (addressesToReport.count() > 1) {
@@ -927,18 +913,16 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
         // there isn't much we can say
         if (!mHostUrl.compare(hostInfo.hostName())) {
             /*: This text is used when the user has provided a raw IP address
-             * for the Game Server rather than a URL. In this case we try to
-             * perform a "reverse-lookup" to see if we can identify the URL that
-             * matches it - but nothing useful was found.
-             */
+ for the Game Server rather than a URL. In this case we try to
+ perform a "reverse-lookup" to see if we can identify the URL that
+ matches it - but nothing useful was found.*/
             TDebug(QColorConstants::Svg::orange, QColorConstants::White) << tr("A host name could not be found for the given IP address.").append(QChar::LineFeed) >> mpHost;
         } else {
             /*: This text is used when the user has provided a raw IP address
-             * for the Game Server rather than a URL. In this case we try to
-             * perform a "reverse-lookup" to see if we can identify the URL that
-             * matches it - and this is used when we have something (%1) to
-             * show.
-             */
+ for the Game Server rather than a URL. In this case we try to
+ perform a "reverse-lookup" to see if we can identify the URL that
+ matches it - and this is used when we have something (%1) to
+ show.*/
             TDebug(QColorConstants::Blue, QColorConstants::White) << tr("A host name for the IP address has been found.\n"
                                                                         "It is: \"%1\"\n")
                                                                              .arg(hostInfo.hostName())
@@ -946,11 +930,10 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
         }
     } else {
         /*: This text is used in the (expected) case when the user has provided
-         * a URL (%1) for the Game Server rather than (unusually) an IP address.
-         * After a DNS lookup we have found at least one but possibly more (%n)
-         * IP addresses, which will be listed (one per line) immediately
-         * afterwards.
-         */
+ a URL (%1) for the Game Server rather than (unusually) an IP address.
+ After a DNS lookup we have found at least one but possibly more (%n)
+ IP addresses, which will be listed (one per line) immediately
+ afterwards.*/
         TDebug(QColorConstants::Blue, QColorConstants::White) << tr("The %n IP address(es) of %1 has/have been found. It/They are:",
                                                                     // Intentional comment to separate arguments
                                                                     "",
@@ -985,29 +968,25 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
 
             if (mConnectViaProxy) {
                 /*: Happy-Eyeballs (both IPv4 and IPv6 addresses available)
-                 * case. %1 is the URL for the server and %2 is the port number
-                 * (on BOTH addresses) for the connection.
-                 */
+ case. %1 is the URL for the server and %2 is the port number
+ (on BOTH addresses) for the connection.*/
                 TDebug(QColorConstants::Blue, QColorConstants::White)
                                 << tr("Trying secure (IPv4 and IPv6) connections to proxy %1:%2 ...").arg(hostInfo.hostName(), QString::number(mHostPort)).append(QChar::LineFeed)
                         >> mpHost;
-                /* We don't need to worry about %1 being a raw IPv6 address here
-                 * as we prohibit IP addresses for secure connections so it is
-                 * a URL; %2 is the port number.
-                 */
+                /*: We don't need to worry about %1 being a raw IPv6 address here
+ as we prohibit IP addresses for secure connections so it is
+ a URL; %2 is the port number.*/
                 postMessage(tr("[ INFO ]  - Attempting a secure connection to %1:%2 via proxy...").arg(hostInfo.hostName(), QString::number(mHostPort)));
             } else {
                 /*: Happy-Eyeballs (both IPv4 and IPv6 addresses available)
-                 * case. %1 is the URL for the Server and %2 is the port number
-                 * (on BOTH addresses) for the connection.
-                 */
+ case. %1 is the URL for the Server and %2 is the port number
+ (on BOTH addresses) for the connection.*/
                 TDebug(QColorConstants::Blue, QColorConstants::White)
                                 << tr("Trying secure (IPv4 and IPv6) connections to %1:%2 ...").arg(hostInfo.hostName(), QString::number(mHostPort)).append(QChar::LineFeed)
                         >> mpHost;
-                /* We don't need to worry about %1 being a raw IPv6 address here
-                 * as we prohibit IP addresses for secure connections so it is
-                 * a URL; %2 is the port number.
-                 */
+                /*: We don't need to worry about %1 being a raw IPv6 address here
+ as we prohibit IP addresses for secure connections so it is
+ a URL; %2 is the port number.*/
                 postMessage(tr("[ INFO ]  - Attempting a secure connection to %1:%2 ...").arg(hostInfo.hostName(), QString::number(mHostPort)));
             }
 
@@ -1023,27 +1002,23 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
 
                 if (mConnectViaProxy) {
                     /*: %1 is the URL for the Server and %2 is the port number
-                     * for the connection.
-                     */
+ for the connection.*/
                     TDebug(QColorConstants::Blue, QColorConstants::White)
                                     << tr("Trying secure (IPv6) connection to %1:%2 via proxy...").arg(hostInfo.hostName(), QString::number(mHostPort)).append(QChar::LineFeed)
                             >> mpHost;
-                    /* We don't need to worry about %1 being a raw IPv6 address here
-                     * as we prohibit IP addresses for secure connections so it is
-                     * a URL; %2 is the port number.
-                     */
+                    /*: We don't need to worry about %1 being a raw IPv6 address here
+ as we prohibit IP addresses for secure connections so it is
+ a URL; %2 is the port number.*/
                     postMessage(tr("[ INFO ]  - Attempting a secure connection to %1:%2 via proxy...").arg(hostInfo.hostName(), QString::number(mHostPort)));
                 } else {
                     /*: %1 is the URL for the Server and %2 is the port number
-                     * for the connection.
-                     */
+ for the connection.*/
                     TDebug(QColorConstants::Blue, QColorConstants::White)
                                     << tr("Trying secure (IPv4 and IPv6) connections to %1:%2 ...").arg(hostInfo.hostName(), QString::number(mHostPort)).append(QChar::LineFeed)
                             >> mpHost;
-                    /* We don't need to worry about %1 being a raw IPv6 address here
-                     * as we prohibit IP addresses for secure connections so it is
-                     * a URL; %2 is the port number.
-                     */
+                    /*: We don't need to worry about %1 being a raw IPv6 address here
+ as we prohibit IP addresses for secure connections so it is
+ a URL; %2 is the port number.*/
                     postMessage(tr("[ INFO ]  - Attempting a secure connection to %1:%2 ...").arg(hostInfo.hostName(), QString::number(mHostPort)));
                 }
                 mSocket_ipV6.connectToHostEncrypted(hostInfo.hostName(), mHostPort, QIODevice::ReadWrite, QAbstractSocket::IPv6Protocol);
@@ -1056,8 +1031,7 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
 
                 if (mConnectViaProxy) {
                     /*: %1 is the URL for the Server and %2 is the port number
-                     * for the connection.
-                     */
+ for the connection.*/
                     TDebug(QColorConstants::Blue, QColorConstants::White)
                                     << tr("Trying secure (IPv4) connection to %1:%2 via proxy...").arg(hostInfo.hostName(), QString::number(mHostPort)).append(QChar::LineFeed)
                             >> mpHost;
@@ -1065,8 +1039,7 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
                     postMessage(tr("[ INFO ]  - Attempting a secure connection to %1:%2 via proxy...").arg(hostInfo.hostName(), QString::number(mHostPort)));
                 } else {
                     /*: %1 is the URL for the Server and %2 is the port number
-                     * for the connection.
-                     */
+ for the connection.*/
                     TDebug(QColorConstants::Blue, QColorConstants::White)
                                     << tr("Trying secure (IPv4) connection to %1:%2 ...").arg(hostInfo.hostName(), QString::number(mHostPort)).append(QChar::LineFeed)
                             >> mpHost;
@@ -1089,9 +1062,8 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
 
             if (mConnectViaProxy) {
                 /*: Happy-Eyeballs (both IPv4 and IPv6 addresses available)
-                 * case. %1 is the URL for the proxy and %2 is the port number
-                 * (on BOTH addresses) for the connection.
-                 */
+ case. %1 is the URL for the proxy and %2 is the port number
+ (on BOTH addresses) for the connection.*/
                 TDebug(QColorConstants::Blue, QColorConstants::White)
                                 << tr("Trying open (IPv4 and IPv6) connections to %1:%2 via proxy...").arg(hostInfo.hostName(), QString::number(mHostPort)).append(QChar::LineFeed)
                         >> mpHost;
@@ -1099,9 +1071,8 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
                 postMessage(tr("[ INFO ]  - Attempting an open connection to %1:%2 via proxy...").arg(hostInfo.hostName(), QString::number(mHostPort)));
             } else {
                 /*: Happy-Eyeballs (both IPv4 and IPv6 addresses available)
-                 * case. %1 is the URL for the Server and %2 is the port number
-                 * (on BOTH addresses) for the connection.
-                 */
+ case. %1 is the URL for the Server and %2 is the port number
+ (on BOTH addresses) for the connection.*/
                 TDebug(QColorConstants::Blue, QColorConstants::White)
                                 << tr("Trying open (IPv4 and IPv6) connections to %1:%2 ...").arg(hostInfo.hostName(), QString::number(mHostPort)).append(QChar::LineFeed)
                         >> mpHost;
@@ -1121,24 +1092,20 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
                 const QString displayAddress = isRawIPv6Address(hostInfo.hostName()) ? tr("[%1]").arg(hostInfo.hostName()) : hostInfo.hostName();
                 if (mConnectViaProxy) {
                     /*: %1 is the URL or IPv6 address (suitably wrapped) for the
-                     * Game Server and %2 is the port number for the connection.
-                     */
+ Game Server and %2 is the port number for the connection.*/
                     TDebug(QColorConstants::Blue, QColorConstants::White)
                                     << tr("Trying open (IPv6) connection to %1:%2 via proxy...").arg(displayAddress, QString::number(mHostPort)).append(QChar::LineFeed)
                             >> mpHost;
                     /*: %1 is the URL or IPv6 address (suitably wrapped) for the
-                     * Game Server and %2 is the port number.
-                     */
+ Game Server and %2 is the port number.*/
                     postMessage(tr("[ INFO ]  - Attempting an open connection to %1:%2 via proxy...").arg(displayAddress, QString::number(mHostPort)));
                 } else {
                     /*: %1 is the URL or IPv6 address (suitably wrapped) for the
-                     * Game Server and %2 is the port number for the connection.
-                     */
+ Game Server and %2 is the port number for the connection.*/
                     TDebug(QColorConstants::Blue, QColorConstants::White) << tr("Trying open (IPv6) connection to %1:%2 ...").arg(displayAddress, QString::number(mHostPort)).append(QChar::LineFeed)
                             >> mpHost;
                     /*: %1 is the URL or IPv6 address (suitably wrapped) for the
-                     * Game Server and %2 is the port number for the connection.
-                     */
+ Game Server and %2 is the port number for the connection.*/
                     postMessage(tr("[ INFO ]  - Attempting an open connection to %1:%2 ...").arg(displayAddress, QString::number(mHostPort)));
                 }
 
@@ -1151,26 +1118,22 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
 
                 if (mConnectViaProxy) {
                     /*: %1 is the URL or IPv4 address for the Game Server and %2
-                     * is the port number for the connection.
-                     */
+ is the port number for the connection.*/
                     TDebug(QColorConstants::Blue, QColorConstants::White)
                                     << tr("Trying open (IPv4) connection to %1:%2 via proxy...").arg(hostInfo.hostName(), QString::number(mHostPort)).append(QChar::LineFeed)
                             >> mpHost;
                     /*: %1 is the URL or IPv4 address for the Game Server and %2
-                     * is the port number for the connection.
-                     */
+ is the port number for the connection.*/
                     postMessage(tr("[ INFO ]  - Attempting an open connection to %1:%2 via proxy...").arg(hostInfo.hostName(), QString::number(mHostPort)));
 
                 } else {
                     /*: %1 is the URL or IPv4 address for the Game Server and %2
-                     * is the port number for the connection.
-                     */
+ is the port number for the connection.*/
                     TDebug(QColorConstants::Blue, QColorConstants::White)
                                     << tr("Trying open (IPv4) connection to %1:%2 ...").arg(hostInfo.hostName(), QString::number(mHostPort)).append(QChar::LineFeed)
                             >> mpHost;
                     /*: %1 is the URL or IPv4 address for the Game Server and %2
-                     * is the port number for the connection.
-                     */
+ is the port number for the connection.*/
                     postMessage(tr("[ INFO ]  - Attempting an open connection to %1:%2 ...").arg(hostInfo.hostName(), QString::number(mHostPort)));
                 }
 

--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -1122,35 +1122,6 @@ void dlgAboutDialog::setSupportersTab(const QString& htmlHead)
 QString dlgAboutDialog::createBuildInfo() const
 {
 #if defined(Q_OS_WINDOWS)
-    // The build environment is for Windows one - which could be run
-    // native on a 32-bit or 64-bit CPU or inside the WOW64 sub-system on a
-    // 64-bit one:
-
-    auto hProcess = GetCurrentProcess();
-    BOOL value = false;
-    std::optional<bool> isWow64Process;
-    auto result = IsWow64Process(hProcess, &value); // hProcess is a "HANDLE"
-    if (!result) {
-        // Failed to work - so there is no value to assign to isWow64Process:
-        qWarning().nospace().noquote() << "dlgAboutDialog::createBuildInfo() WARNING - IsWow64Process(...) failed, WOW64 status unknown.";
-    } else {
-        isWow64Process = static_cast<bool>(value);
-    }
-#if defined(Q_OS_WIN64)
-    const bool is64BitBuild = true;
-#else
-    const bool is64BitBuild = false;
-#endif
-    const QString upgradeTo64Bits = (isWow64Process.has_value() && isWow64Process.value())
-                                            ? qsl("<tr><td colspan=\"2\" style=\"padding-right: 10px; padding-top: 10px;\"><b>%1</b></td></tr>\n")
-                                                      .arg(mudlet::self()->releaseVersion
-                                                                   //: This text is shown on 32-Bit builds of Mudlet of release builds only when run on 64-Bit Windows
-                                                                   ? tr("You are using the 32-Bit version of Mudlet on a 64-Bit version of Windows. "
-                                                                        "You may wish to upgrade (by downloading and then installing the 64-Bit version now available from Mudlet's website).")
-                                                                   //: This text is shown on 32-Bit builds of Mudlet of all but release builds when run on 64-Bit Windows
-                                                                   : tr("This is a 32-Bit build of Mudlet running on a 64-Bit version of Windows."))
-                                            : QString();
-
     if (Q_UNLIKELY(QLatin1String(qVersion()) != QLatin1String(QT_VERSION_STR))) {
         return qsl("<table border=\"0\" style=\"margin-bottom:18px; margin-left:36px; margin-right:36px;\" width=\"100%\" cellspacing=\"2\" cellpadding=\"0\">\n"
                    "<tr><td colspan=\"2\" style=\"font-weight: 800\">%1</td></tr>\n"
@@ -1166,36 +1137,19 @@ QString dlgAboutDialog::createBuildInfo() const
                      mudlet::self()->scmVersion,    // %3
                      tr("OS"),                      // %4
                      QSysInfo::prettyProductName(), // %5
-                     /*: This is shown for 32-Bit Windows builds when run on a
-                      *64-Bit OS. \"WoW64\" stands for WindowOnWindows64.
-                      */
-                     isWow64Process.has_value() ? (isWow64Process.value() ? tr("CPU (WoW64)")
-                                                                          /*: This is shown for 32-Bit or 64-Bit Windows builds when
-                      *run on a Windows OS of the same bitness. It is the
-                      *opposite case to that when \"WoW64\" is included - in
-                      *those cases a 32-Bit application is run on 64-Bit
-                      *hardware via an extra WindowOnWindows64 software layer.
-                      */
-                                                                          : tr("CPU (%1-bits)").arg(is64BitBuild ? 64 : 32))
-                                                /*: This is shown for 32-Bit or 64-Bit Windows builds if
-                      *the Windows API call to detect whether the WoW64 system
-                      *is in use fails to work.
-                      */
-                                                : tr("CPU"), // %6
+                     tr("CPU (64-bits)"),           // %6 - We only support 64-bit now on Windows but retain what we
+                                                    // used to use when we did 32 as well for consistency
                      QSysInfo::currentCpuArchitecture(),     // %7
                      /*: This is shown when the Qt version used at run-time
-                      *is different to that used during compilation - it not
-                      *the usual case.
-                      */
+ is different to that used during compilation - it not
+ the usual case.*/
                      tr("Qt version (compilation)"), // %8
                      QLatin1String(QT_VERSION_STR))  // %9
-                                                     /*: This is shown when the Qt version used at run-time
-                      *is different to that used during compilation - it not
-                      *the usual case.
-                      */
+                     /*: This is shown when the Qt version used at run-time
+ is different to that used during compilation - it not
+ the usual case.*/
                 .arg(tr("Qt version (run-time)"),    // %10
-                     qVersion(),                     // %11
-                     upgradeTo64Bits);               // %12
+                     qVersion());                    // %11
     }
 
     // Else they are the same:
@@ -1212,32 +1166,15 @@ QString dlgAboutDialog::createBuildInfo() const
                  mudlet::self()->scmVersion,    // %3
                  tr("OS"),                      // %4
                  QSysInfo::prettyProductName(), // %5
-                 /*: This is shown for 32-Bit Windows builds when run on a
-                  *64-Bit OS. \"WoW64\" stands for WindowOnWindows64.
-                  */
-                 isWow64Process.has_value() ? (isWow64Process.value() ? tr("CPU (WoW64)")
-                                                                      /*: This is shown for 32-Bit or 64-Bit Windows builds when
-                  *a Windows OS of the same size. It is the opposite case
-                  *to that when \"WoW64\" is included - in those cases a
-                  *32-Bit application is run on 64-Bit hardware via an
-                  *extra WindowOnWindows64 software layer.
-                  */
-                                                                      : tr("CPU (%1-bits)").arg(is64BitBuild ? 64 : 32))
-                                            /*: This is shown when something has gone wrong and it is not
-                  *possible to correctly determine whether there is an extra
-                  *software layer being used to run a 32-Bit Windows build
-                  *on 64-Bit hardware/OS.
-                  */
-                                            : tr("CPU"), // %6
+                 tr("CPU (64-bits)"),           // %6 - We only support 64-bit now on Windows but retain what we
+                                                // used to use when we did 32 as well for consistency
                  QSysInfo::currentCpuArchitecture(),     // %7
                  /*: This is shown when the same Qt version is used at run-time
-                  *as was used during compilation - it is the usual case.
-                  */
+ as was used during compilation - it is the usual case.*/
                  tr("Qt version"),              // %8
                  QLatin1String(QT_VERSION_STR), // %9
                  upgradeTo64Bits);              // %10
 #else
-
     // Anything else
     if (Q_UNLIKELY(QLatin1String(qVersion()) != QLatin1String(QT_VERSION_STR))) {
         return qsl("<table border=\"0\" style=\"margin-bottom:18px; margin-left:36px; margin-right:36px;\" width=\"100%\" cellspacing=\"2\" cellpadding=\"0\">\n"
@@ -1257,15 +1194,13 @@ QString dlgAboutDialog::createBuildInfo() const
                      tr("CPU"),                          // %6
                      QSysInfo::currentCpuArchitecture(), // %7
                      /*: This is shown when the Qt version used at run-time
-                      *is different to that used during compilation - it not
-                      *the usual case.
-                      */
+ is different to that used during compilation - it not
+the usual case.*/
                      tr("Qt version (compilation)"), // %8
                      QLatin1String(QT_VERSION_STR))  // %9
-                                                     /*: This is shown when the Qt version used at run-time
-                      *is different to that used during compilation - it not
-                      *the usual case.
-                      */
+                     /*: This is shown when the Qt version used at run-time
+ is different to that used during compilation - it not
+ the usual case.*/
                 .arg(tr("Qt version (run-time)"),    // %10
                      qVersion());                    // %11
     }
@@ -1287,8 +1222,7 @@ QString dlgAboutDialog::createBuildInfo() const
                  tr("CPU"),                          // %6
                  QSysInfo::currentCpuArchitecture(), // %7
                  /*: This is shown when the same Qt version is used at run-time
-                  *as was used during compilation - it is the usual case.
-                  */
+ as was used during compilation - it is the usual case.*/
                  tr("Qt version"),               // %8
                  QLatin1String(QT_VERSION_STR)); // %9
 #endif

--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -1130,7 +1130,6 @@ QString dlgAboutDialog::createBuildInfo() const
                    "<tr><td style=\"padding-right: 10px;\">%6</td><td>%7</td></tr>\n"
                    "<tr><td style=\"padding-right: 10px;\">%8</td><td>%9</td></tr>\n"
                    "<tr><td style=\"padding-right: 10px;\">%10</td><td>%11</td></tr>\n"
-                   "%12"
                    "</table>")
                 .arg(tr("Technical information:"),  // %1
                      tr("Version"),                 // %2
@@ -1139,14 +1138,14 @@ QString dlgAboutDialog::createBuildInfo() const
                      QSysInfo::prettyProductName(), // %5
                      tr("CPU (64-bits)"),           // %6 - We only support 64-bit now on Windows but retain what we
                                                     // used to use when we did 32 as well for consistency
-                     QSysInfo::currentCpuArchitecture(),     // %7
+                     QSysInfo::currentCpuArchitecture(), // %7
                      /*: This is shown when the Qt version used at run-time
- is different to that used during compilation - it not
+ is different to that used during compilation - it is not
  the usual case.*/
                      tr("Qt version (compilation)"), // %8
                      QLatin1String(QT_VERSION_STR))  // %9
                      /*: This is shown when the Qt version used at run-time
- is different to that used during compilation - it not
+ is different to that used during compilation - it is not
  the usual case.*/
                 .arg(tr("Qt version (run-time)"),    // %10
                      qVersion());                    // %11
@@ -1159,7 +1158,6 @@ QString dlgAboutDialog::createBuildInfo() const
                "<tr><td style=\"padding-right: 10px;\">%4</td><td>%5</td></tr>\n"
                "<tr><td style=\"padding-right: 10px;\">%6</td><td>%7</td></tr>\n"
                "<tr><td style=\"padding-right: 10px;\">%8</td><td>%9</td></tr>\n"
-               "%10"
                "</table>")
             .arg(tr("Technical information:"),  // %1
                  tr("Version"),                 // %2
@@ -1172,8 +1170,7 @@ QString dlgAboutDialog::createBuildInfo() const
                  /*: This is shown when the same Qt version is used at run-time
  as was used during compilation - it is the usual case.*/
                  tr("Qt version"),              // %8
-                 QLatin1String(QT_VERSION_STR), // %9
-                 upgradeTo64Bits);              // %10
+                 QLatin1String(QT_VERSION_STR)); // %9
 #else
     // Anything else
     if (Q_UNLIKELY(QLatin1String(qVersion()) != QLatin1String(QT_VERSION_STR))) {
@@ -1194,12 +1191,12 @@ QString dlgAboutDialog::createBuildInfo() const
                      tr("CPU"),                          // %6
                      QSysInfo::currentCpuArchitecture(), // %7
                      /*: This is shown when the Qt version used at run-time
- is different to that used during compilation - it not
+ is different to that used during compilation - it is not
 the usual case.*/
                      tr("Qt version (compilation)"), // %8
                      QLatin1String(QT_VERSION_STR))  // %9
                      /*: This is shown when the Qt version used at run-time
- is different to that used during compilation - it not
+ is different to that used during compilation - it is not
  the usual case.*/
                 .arg(tr("Qt version (run-time)"),    // %10
                      qVersion());                    // %11

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1894,9 +1894,8 @@ bool dlgConnectionProfiles::validateProfile()
             // Qt::AutoFormat won't detect that rich-text is present in this text!
             notificationAreaMessageBox->setTextFormat(Qt::RichText);
             /*: Please use two line-feeds after the first line so the second
-             *  line can be italicised and spaced out - if appropriate for
-             *  the locale.
-             */
+ line can be italicised and spaced out - if appropriate for
+ the locale.*/
             notificationAreaMessageBox->setText(qsl("%1%2\n\n%3")
                                                         .arg(!notificationAreaMessageBox->text().isEmpty() ? notificationAreaMessageBox->text().append(QChar::LineFeed) : QString(),
                                                              tr("Please enter the URL of the Game server.\n\n"

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -1315,12 +1315,11 @@ dlgPackageExporter::zipPackage(const QString& stagingDirName, const QString& pac
         zip_error_t zipError;
         zip_error_init_with_code(&zipError, ze);
         /*: This zipError message is shown when the libzip library code is unable
-         * to open the file that was to be the end result of the export process.
-         * As this may be an existing file anywhere in the computer's
-         * file-system(s) it is possible that permissions on the directory or an
-         * existing file that is to be overwritten may be a source of problems
-         * here.
-        */
+ to open the file that was to be the end result of the export process.
+ As this may be an existing file anywhere in the computer's
+ file-system(s) it is possible that permissions on the directory or an
+ existing file that is to be overwritten may be a source of problems
+ here.*/
         const QString errMsg = tr("Failed to open package file. Error is: \"%1\".").arg(zip_error_strerror(&zipError));
         zip_error_fini(&zipError);
         return {false, errMsg};
@@ -1481,11 +1480,10 @@ dlgPackageExporter::zipPackage(const QString& stagingDirName, const QString& pac
             }
 
             /*: This error message is displayed at the final stage of exporting
-             * a package when all the sourced files are finally put into the
-             * archive. Unfortunately this may be the point at which something
-             * breaks because a problem was not spotted/detected in the process
-             * earlier...
-             */
+ a package when all the sourced files are finally put into the
+ archive. Unfortunately this may be the point at which something
+ breaks because a problem was not spotted/detected in the process
+ earlier...*/
             const QString errorMsg = tr("Failed to zip up the package. Error is: \"%1\".").arg(zipError);
             zip_discard(archive);
             // In libzip 0.11 a function was added to clean up

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -711,7 +711,7 @@ void dlgPackageManager::slot_setPackageList()
         return;
     }
 
-    if (lineEdit_searchBar->text().length() > 0) {
+    if (!lineEdit_searchBar->text().isEmpty()) {
         slot_searchTextChanged(lineEdit_searchBar->text());
         return;
     }
@@ -794,28 +794,28 @@ void dlgPackageManager::slot_toggleInstallRepoButton()
         pushButton_installRepo->setEnabled(selectionCount);
 
         if (mCurrentView == NavigationView::Updates) {
-            if (selectionCount > 1) {
-                //: Message on button in package manager to update multiple (%n is the count of) selected packages.
+            if (selectionCount) {
+                //: Message on button in package manager to update one or multiple (%n is the count) selected packages.
                 pushButton_installRepo->setText(tr("Update (%n)", nullptr, selectionCount));
             } else {
-                //: Message on button in package manager for updates view when zero or one package is selected
+                //: Message on button in package manager when there are no selected packages - button will also be disabled.
                 pushButton_installRepo->setText(tr("Update"));
             }
             //: Tooltip for button in package manager when in Updates view
             pushButton_installRepo->setToolTip(tr("Update selected packages"));
         } else {
-            if (selectionCount > 1) {
-                //: Message on button in package manager to install multiple (%n is the count of) selected packages.
+            if (selectionCount) {
+                //: Message on button in package manager to install one or multiple (%n is the count) selected packages.
                 pushButton_installRepo->setText(tr("Install (%n)", nullptr, selectionCount));
             } else {
-                //: Message on button in package manager initially and when zero or one package is selected
+                //: Message on button in package manager when there are no selected packages - button will also be disabled.
                 pushButton_installRepo->setText(tr("Install"));
             }
             //: Tooltip for button in package manager when in Explore view
             pushButton_installRepo->setToolTip(tr("Install package from repository"));
         }
     } else {
-        //: Message on button in package manager initially and when there is no packages to install
+        //: Message on button in package manager initially and when the view is the "Installed" one
         pushButton_installRepo->setText(tr("Install"));
         pushButton_installRepo->setEnabled(false);
         //: Tooltip for button in package manager when in Explore view
@@ -829,15 +829,15 @@ void dlgPackageManager::slot_toggleRemoveButton()
         const QList selection = packageList->selectedItems();
         const int selectionCount = selection.size();
         pushButton_remove->setEnabled(selectionCount);
-        if (selectionCount > 1) {
-            //: Message on button in package manager to remove multiple (%n is the count of) selected packages.
+        if (selectionCount) {
+            //: Message on button in package manager to remove one or multiple (%n is the count) selected packages.
             pushButton_remove->setText(tr("Remove (%n)", nullptr, selectionCount));
         } else {
-            //: Message on button in package manager initially and when zero or one package is selected
+            //: Message on button in package manager when there are no selected packages - button will also be disabled.
             pushButton_remove->setText(tr("Remove"));
         }
     } else {
-        //: Message on button in package manager initially and when there is no packages to remove
+        //: Message on button in package manager initially and when the view is NOT the "Installed" one
         pushButton_remove->setText(tr("Remove"));
         pushButton_remove->setEnabled(false);
     }
@@ -854,11 +854,11 @@ void dlgPackageManager::showImportStatus(const QString& message)
 void dlgPackageManager::updateUpdatesBadge()
 {
     const int count = mPackagesWithUpdates.size();
-    if (count > 0) {
-        //: Package manager - navigation button showing number of available updates
+    if (count) {
+        //: Package manager - navigation button showing one or more available updates
         pushButton_updates->setText(tr("Updates (%1)").arg(count));
     } else {
-        //: Package manager - navigation button for updates view
+        //: Package manager - navigation button for when there are no updates
         pushButton_updates->setText(tr("Updates"));
     }
 }

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -3191,17 +3191,13 @@ void dlgProfilePreferences::slot_chosenProfilesChanged(QAction* _action)
     pushButton_copyMap->setText(tr("copy to %n destination(s)", nullptr, selectionCount));
     if (selectionCount) {
         pushButton_copyMap->setEnabled(true);
-        /*:
-        text on button to select other profiles to receive the map from this profile,
-        %n is the number of other profiles that have already been selected to receive it and will always be 1 or more
-        */
+        /*: text on button to select other profiles to receive the map from this profile,
+ %n is the number of other profiles that have already been selected to receive it and will always be 1 or more*/
         pushButton_chooseProfiles->setText(tr("%n selected - change destinations...", nullptr, selectionCount));
     } else {
         pushButton_copyMap->setEnabled(false);
-        /*:
-        text on button to select other profiles to receive the map from this profile,
-        this is used when no profiles have been selected
-        */
+        /*: text on button to select other profiles to receive the map from this profile,
+ this is used when no profiles have been selected*/
         pushButton_chooseProfiles->setText(tr("pick destinations..."));
     }
 }

--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -294,11 +294,9 @@ QStringList dlgRoomProperties::getComboBoxSymbolItems()
         while (itSymbolUsed.hasNext()) {
             itSymbolUsed.next();
             if (itSymbolUsed.value() == symbolCountsList.at(i)) {
-                /*:
-                Format for showing a room symbol with its usage count. %1 is the symbol itself (e.g., "★" or "!"),
-                %2 is the number of rooms using this symbol. Example output: "★ (count: 5)" or "! (count: 12)".
-                The word "count" and the format can be translated, but ensure the numbers remain clearly associated.
-                */
+                /*: Format for showing a room symbol with its usage count. %1 is the symbol itself (e.g., "★" or "!"),
+%2 is the number of rooms using this symbol. Example output: "★ (count: 5)" or "! (count: 12)".
+The word "count" and the format can be translated, but ensure the numbers remain clearly associated.*/
                 displayStrings.append(tr("%1 (count: %2)").arg(itSymbolUsed.key(), QString::number(itSymbolUsed.value())));
             }
         }
@@ -331,11 +329,9 @@ QStringList dlgRoomProperties::getComboBoxWeightItems()
         while (itWeightUsed.hasNext()) {
             itWeightUsed.next();
             if (itWeightUsed.value() == weightCountsList.at(i)) {
-                /*:
-                Format for showing a room weight with its usage count. %1 is the weight value (e.g., "1" or "50"),
-                %2 is the number of rooms with this weight. Example output: "5 (count: 3)" or "100 (count: 7)".
-                The word "count" and the format can be translated, but ensure the numbers remain clearly associated.
-                */
+                /*: Format for showing a room weight with its usage count. %1 is the weight value (e.g., "1" or "50"),
+ %2 is the number of rooms with this weight. Example output: "5 (count: 3)" or "100 (count: 7)".
+ The word "count" and the format can be translated, but ensure the numbers remain clearly associated.*/
                 displayStrings.append(tr("%1 (count: %2)").arg(QString::number(itWeightUsed.key()), QString::number(itWeightUsed.value())));
             }
         }

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -285,7 +285,7 @@ void GLWidget::paintGL()
                 if (mpMap->mpRoomDB->isEmpty()) {
                     message = tr("No rooms in the map - load another one, or start mapping from scratch to begin.");
                 } else {
-                    message = tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size());
+                    message = tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", nullptr, mpMap->mpRoomDB->size());
                 }
             } else {
                 message = tr("You do not have a map yet - load one, or start mapping from scratch to begin.");

--- a/src/mapInfoContributorManager.cpp
+++ b/src/mapInfoContributorManager.cpp
@@ -118,14 +118,12 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
         const QString areaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(areaId);
         if (area) {
             infoText = qsl("%1\n").arg(
-                    /*:
-                %1 is the (text) name of the area, %2 is the area ID number,
-                %3 and %4 are the minimum and maximum x coordinates, %5 and %6 for y, and %7 and %8 for z.
-                This text uses non-breaking spaces (Unicode U+00A0) and non-breaking hyphens
-                which are used to prevent the line being split at some places it might otherwise be.
-                When translating, please consider at which points the text may be divided to fit
-                onto more than one line. 
-                */
+                    /*: %1 is the (text) name of the area, %2 is the area ID number,
+ %3 and %4 are the minimum and maximum x coordinates, %5 and %6 for y, and %7 and %8 for z.
+ This text uses non-breaking spaces (Unicode U+00A0) and non-breaking hyphens
+ which are used to prevent the line being split at some places it might otherwise be.
+ When translating, please consider at which points the text may be divided to fit
+ onto more than one line.*/
                     tr("Area:\u00A0%1 ID:\u00A0%2 x:\u00A0%3\u00A0<‑>\u00A0%4 y:\u00A0%5\u00A0<‑>\u00A0%6 z:\u00A0%7\u00A0<‑>\u00A0%8")
                             .arg(areaName,
                                  QString::number(areaId),
@@ -156,14 +154,12 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
         case 0:
             // The following multi-line comments for translators are deliberately vague to cover all
             // three same strings in these cases with a same comment, so translators only see them once.
-            /*:
-            This text is shown when room(s) are (not) selected in mapper. %1 is the room ID number, 
-            and %2, %3, %4 are the x, y, and z coordinates of the current/selected room, or a room
-            near the middle of the selection. %5 is a description like: Current player room.
-            This text uses non-breaking spaces (Unicode \u00A0) and a non-breaking hyphen (\u2011). 
-            They are used to prevent the line being split at unexpected places. When translating, 
-            please consider at which points the text may be divided to fit onto more than one line.
-            */
+            /*: This text is shown when room(s) are (not) selected in mapper. %1 is the room ID number,
+ and %2, %3, %4 are the x, y, and z coordinates of the current/selected room, or a room
+ near the middle of the selection. %5 is a description like: Current player room.
+ This text uses non-breaking spaces (Unicode \u00A0) and a non-breaking hyphen (\u2011).
+ They are used to prevent the line being split at unexpected places. When translating,
+ please consider at which points the text may be divided to fit onto more than one line.*/
             infoText.append(tr("Room\u00A0ID:\u00A0%1 Position\u00A0on\u00A0Map: (%2,%3,%4) \u2011\u00A0%5")
                                     .arg(QString::number(roomID),
                                          QString::number(room->x()),
@@ -179,14 +175,12 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
             }
             break;
         case 1:
-            /*:
-            This text is shown when room(s) are (not) selected in mapper. %1 is the room ID number, 
-            and %2, %3, %4 are the x, y, and z coordinates of the current/selected room, or a room
-            near the middle of the selection. %5 is a description like: Current player room.
-            This text uses non-breaking spaces (Unicode \u00A0) and a non-breaking hyphen (\u2011). 
-            They are used to prevent the line being split at unexpected places. When translating, 
-            please consider at which points the text may be divided to fit onto more than one line.
-            */
+            /*: This text is shown when room(s) are (not) selected in mapper. %1 is the room ID number,
+ and %2, %3, %4 are the x, y, and z coordinates of the current/selected room, or a room
+ near the middle of the selection. %5 is a description like: Current player room.
+ This text uses non-breaking spaces (Unicode \u00A0) and a non-breaking hyphen (\u2011).
+ They are used to prevent the line being split at unexpected places. When translating,
+ please consider at which points the text may be divided to fit onto more than one line.*/
             infoText.append(tr("Room\u00A0ID:\u00A0%1 Position\u00A0on\u00A0Map: (%2,%3,%4) \u2011\u00A0%5")
                                     .arg(QString::number(roomID),
                                          QString::number(room->x()),
@@ -203,14 +197,12 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
             }
             break;
         default:
-            /*:
-            This text is shown when room(s) are (not) selected in mapper. %1 is the room ID number, 
-            and %2, %3, %4 are the x, y, and z coordinates of the current/selected room, or a room
-            near the middle of the selection. %5 is a description like: Current player room.
-            This text uses non-breaking spaces (Unicode U+00A0) and a non-breaking hyphen (U+2011). 
-            They are used to prevent the line being split at unexpected places. When translating, 
-            please consider at which points the text may be divided to fit onto more than one line.
-            */
+            /*: This text is shown when room(s) are (not) selected in mapper. %1 is the room ID number,
+ and %2, %3, %4 are the x, y, and z coordinates of the current/selected room, or a room
+ near the middle of the selection. %5 is a description like: Current player room.
+ This text uses non-breaking spaces (Unicode U+00A0) and a non-breaking hyphen (U+2011).
+ They are used to prevent the line being split at unexpected places. When translating,
+ please consider at which points the text may be divided to fit onto more than one line.*/
             infoText.append(tr("Room\u00A0ID:\u00A0%1 Position\u00A0on\u00A0Map: (%2,%3,%4) \u2011\u00A0%5")
                                     .arg(QString::number(roomID),
                                          QString::number(room->x()),

--- a/src/modern_glwidget.cpp
+++ b/src/modern_glwidget.cpp
@@ -252,7 +252,7 @@ void ModernGLWidget::paintGL()
                 if (mpMap->mpRoomDB->isEmpty()) {
                     message = tr("No rooms in the map - load another one, or start mapping from scratch to begin.");
                 } else {
-                    message = tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size());
+                    message = tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", nullptr, mpMap->mpRoomDB->size());
                 }
             } else {
                 message = tr("You do not have a map yet - load one, or start mapping from scratch to begin.");

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1327,15 +1327,13 @@ void mudlet::loadMaps()
             {"WINDOWS-1258", tr("WINDOWS-1258 (Vietnamese)")}};
 
     /*: This represents the format of the timestamps shown alongside the texts
-     * in a console and might require translation for a few locales; the content
-     * is as per QDateTime::toString(...) and needs to follow the rules for that
-     * function as well as being suitable for the translation locale.
-     */
+ in a console and might require translation for a few locales; the content
+ is as per QDateTime::toString(...) and needs to follow the rules for that
+ function as well as being suitable for the translation locale.*/
     smTimeStampFormat = tr("hh:mm:ss.zzz ");
     /*: This represents the format of the timestamps shown for lines that do not
-     * have a timestamp in a console that is showing them. If localised this
-     * should be set to the same format and length as the smTimeStampFormat:
-     */
+ have a timestamp in a console that is showing them. If localised this
+ should be set to the same format and length as the smTimeStampFormat:*/
     smBlankTimeStamp = tr("------------ ");
 }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Removes the `*`s in all but the first line of a multi-line translation comment that explains to the translators details of the Engineering English text in the source code. Whilst beginning each new line with an `*` can happen automagically in the Qt Creator as a result of the "Enable Doxygen Blocks" and "Add leading asterisks" options (in "Preferences" -> "Text Editor" -> "Documentation Comments") these are not always stripped out by the `lupdate` utility that generates the `mudlet.ts` file.

Removes remaining `""` and replaces with `nullptr` any second arguments to `QObject::tr(...)` where a third argument is needed for the quantity for "numerus" (quantity dependent) translatable texts.

Removes some, now obsolete, Windows specific code that identified if a 32-Bit version of Mudlet was being run in a 64-Bit Operating System. Since we no longer can produce such 32-Bit code it is now just cruft.

Revises some quantity dependent code in `./src/dlgPackManager.cpp` so that only the zero cases are handled differently - in one place this means the conversion of a `.length() > 0` to an inverted `.isEmpty()` - and in three other places where a zero or one case was handled differently to the more than one case.

#### Motivation for adding to Mudlet
Improve the code quality and/or the situation for our translators.

#### Other info (issues closed, discussion etc)
~~This should (also) be merged into the the next release of the 4.20.x branch.~~

