### PR TITLE
Improve: Add macOS clang-format path to AI instructions

### DIFF
--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -163,6 +163,11 @@ After editing any C++ files (`.cpp`, `.h`), run clang-format before committing:
 clang-format -i path/to/edited/file.cpp path/to/edited/file.h
 ```
 
+On macOS, use the Homebrew-installed LLVM version to ensure compatibility:
+```bash
+$(brew --prefix llvm)/bin/clang-format -i path/to/edited/file.cpp path/to/edited/file.h
+```
+
 The project uses the `.clang-format` configuration in `src/`. This ensures consistent code style across the codebase.
 
 ### Static analysis


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds macOS-specific guidance for running clang-format using the Homebrew-installed LLVM version.

#### Motivation for adding to Mudlet

On macOS, the system `clang-format` command may not be available or may be an older version. This update helps AI assistants and developers use the correct full path to the Homebrew LLVM clang-format, ensuring consistent code formatting.

#### Other info (issues closed, discussion etc)

Documentation-only change to `docs/ai-instructions.md` (symlinked to `AGENTS.md` and `.github/copilot-instructions.md`).