### PR TITLE
fix: Move linefeed handling out of appendLine and into getWrapInfo

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -4241,7 +4241,9 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
         return;
     }
 
-    bool firstChar = (lineBuffer.back().isEmpty());
+    if (lineBuffer.back().isEmpty()) {
+        timeBuffer.back() = QTime::currentTime().toString(mudlet::smTimeStampFormat);
+    }
     const int length = std::min(static_cast<int>(text.size()), MAX_CHARACTERS_PER_ECHO);
     int lineEndPos = sub_end;
 
@@ -4252,12 +4254,6 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
     for (int i = sub_start; i <= (sub_start + lineEndPos); i++) {
         const QChar thisChar = text.at(i);
 
-        if (thisChar == QChar::LineFeed) {
-            firstChar = true;
-            appendEmptyLine();
-            continue;
-        }
-
         lineBuffer.back().append(thisChar);
         const TChar styling(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags), linkID);
         buffer.back().push_back(styling);
@@ -4266,10 +4262,6 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
         // translateToPlainText() where the TChar is created with ANSI formatting
         // before JSON styling is applied
 
-        if (firstChar) {
-            timeBuffer.back() = QTime::currentTime().toString(mudlet::smTimeStampFormat);
-            firstChar = false;
-        }
     }
 }
 
@@ -4481,6 +4473,7 @@ inline QList<WrapInfo> TBuffer::getWrapInfo(const QString& lineText, bool isNewl
     int totalWidth = 0;
     int firstChar = 0;
     bool needsIndent = isNewline;
+    bool hasLineFeed = false;
 
     // find all the appropriate wrap points assuming (hanging-)indentation prepended to each line
     for (int indexOfChar = 0, total = lineText.size(); indexOfChar < total and indexOfChar >= 0;) {
@@ -4494,6 +4487,7 @@ inline QList<WrapInfo> TBuffer::getWrapInfo(const QString& lineText, bool isNewl
         }
         // handle embedded linefeed
         if (c == QChar::LineFeed) {
+            hasLineFeed = true;
             output.append(WrapInfo(isNewline, needsIndent, firstChar, indexOfChar));
             indexOfChar++;
             boundaryFinder.setPosition(indexOfChar);
@@ -4538,7 +4532,7 @@ inline QList<WrapInfo> TBuffer::getWrapInfo(const QString& lineText, bool isNewl
         indexOfChar = nextBoundary;
     }
     // it's possible that no wrapping is needed
-    if (totalWidth <= mWrapAt) {
+    if (!hasLineFeed && totalWidth <= mWrapAt) {
         output.clear();
         return output;
     }

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1436,9 +1436,10 @@ bool TBuffer::commitLine(char ch, size_t& localBufferPosition)
             mpHost->mpConsole->runTriggers(line);
         }
 
-        // Only use of TBuffer::wrap(), breaks up new text
+        // Only use of TBuffer::wrapLine(), breaks up new text
         // NOTE: it MAY have been clobbered by the trigger engine!
-        const int addedLines = wrapLine(line, mWrapAt, mWrapIndent, mWrapHangingIndent);
+        // If deleteLine shrinks the buffer, wrap last line
+        const int addedLines = wrapLine(std::min(line, static_cast<int>(lineBuffer.size()) - 1), mWrapAt, mWrapIndent, mWrapHangingIndent);
 
         // Start a new, but empty line in the various buffers
         log(lineBuffer.size() - 1, lineBuffer.size() - 1);

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -4486,15 +4486,15 @@ inline QList<WrapInfo> TBuffer::getWrapInfo(const QString& lineText, bool isNewl
             boundaryFinder.setPosition(indexOfChar);
             continue;
         }
-        // handle embedded linefeed
+        // handle embedded linefeed, hitting this before passing maxWidth -> no indent needed
         if (c == QChar::LineFeed) {
             hasLineFeed = true;
+            needsIndent = false;
             output.append(WrapInfo(isNewline, needsIndent, firstChar, indexOfChar));
             indexOfChar++;
             boundaryFinder.setPosition(indexOfChar);
             firstChar = indexOfChar;
             isNewline = true;
-            needsIndent = false;
             continue;
         }
         int nextBoundary = boundaryFinder.toNextBoundary();

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1818,7 +1818,6 @@ void TConsole::printCommand(QString& msg)
     }
 
     if (mTriggerEngineMode) {
-        msg.append(QChar::LineFeed);
         const int lineBeforeNewContent = buffer.getLastLineNumber();
         if (lineBeforeNewContent >= 0 && !buffer.lineBuffer.back().isEmpty()) {
             msg.prepend(QChar::LineFeed);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1834,7 +1834,7 @@ void TConsole::printCommand(QString& msg)
                 QPoint P(promptEnd, lineBeforeNewContent);
                 const TChar format(mCommandFgColor, mCommandBgColor);
                 buffer.insertInLine(P, msg, format);
-                const int down = buffer.wrapLine(lineBeforeNewContent, mpHost->mScreenWidth, mpHost->mWrapIndentCount, mpHost->mWrapHangingIndentCount);
+                const int down = buffer.wrapLine(lineBeforeNewContent, mpHost->mWrapAt, mpHost->mWrapIndentCount, mpHost->mWrapHangingIndentCount);
 
                 mUpperPane->needUpdate(lineBeforeNewContent, lineBeforeNewContent + 1 + down);
                 mLowerPane->needUpdate(lineBeforeNewContent, lineBeforeNewContent + 1 + down);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Changes the order of detecting LineFeed characters and appending newlines.

Moves from detecting at appendLine to getWrapInfo.

#### Motivation for adding to Mudlet
Addressing some changes in behavior from the wrap overhaul (#8824)

#### Other info (issues closed, discussion etc)
This PR is marked as a draft because it introduces changes in the behavior of other linebreak situations - but I think this is an approach can be built upon to hopefully reconcile 4.19 wrapping behavior with future versions.