### PR TITLE
Improve: only mark map as dirty if room hidden status is changed

### DIFF
--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -277,10 +277,12 @@ void TRoom::setWeight(int w)
     mpRoomDB->mpMap->setUnsaved(__func__);
 }
 
-void TRoom::setHidden(bool isHidden)
+void TRoom::setHidden(const bool isHidden)
 {
-    hidden = isHidden;
-    mpRoomDB->mpMap->setUnsaved(__func__);
+    if (hidden != isHidden) {
+        hidden = isHidden;
+        mpRoomDB->mpMap->setUnsaved(__func__);
+    }
 }
 
 void TRoom::setExitWeight(const QString& cmd, int w)

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -87,7 +87,7 @@ public:
     }
     int getWeight() const { return weight; }
     bool isHidden() const { return hidden; }
-    void setHidden(bool isHidden);
+    void setHidden(const bool);
     int getNorth() const { return north; }
     void setNorth(int id) { north = id; }
     int getNorthwest() const { return northwest; }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Checks for the `hidden` flag of a room to actually be changed before flagging the map as needed to be resaved.

#### Motivation for adding to Mudlet
Eliminate pointless saves of a map.

#### Other info (issues closed, discussion etc)
Split off from #8930 to reduced the cognative load for reviewers.