### PR TITLE
Fix: Profiles with similar names no longer share or lose passwords

### DIFF
--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -30,6 +30,7 @@
 #include <QDataStream>
 #include <QProcessEnvironment>
 #include <QRegularExpression>
+#include <QCryptographicHash>
 #include <QStandardPaths>
 #include <QTimer>
 #include <QVersionNumber>
@@ -263,95 +264,107 @@ void CredentialManager::retrievePassword(const QString& profileName, const QStri
     }
 
     if (shouldUseKeychain(profileName)) {
-        // Use keychain storage - but also try SecureStringUtils as fallback
+        // Use keychain storage with fallback chain:
+        // 1. New hash-based format (unique per profile name)
+        // 2. Old colliding format (profiles with similar names may share passwords)
+        // 3. Legacy keychain format (pre-4.20.0)
+        // 4. Encrypted file storage
         QString service = generateServiceName(profileName, key);
+        QString legacyService = generateLegacyServiceName(profileName, key);
 
-        // First try keychain
-        auto fallbackCallback = [this, profileName, key, callback](bool keychainSuccess, const QString& keychainPassword, const QString& keychainError) {
-            qDebug() << "CredentialManager: Keychain result for profile" << profileName << "- success:" << keychainSuccess << "password empty:" << keychainPassword.isEmpty();
+        // Helper to try old colliding format and migrate if found
+        auto tryCollidingFormat = [this, profileName, key, legacyService, callback]() {
+            retrieveCredential(legacyService, key, [this, profileName, key, legacyService, callback](bool oldSuccess, const QString& oldPassword, const QString& oldError) {
+                if (oldSuccess && !oldPassword.isEmpty()) {
+                    qDebug() << "CredentialManager: Migrating password from colliding format for" << profileName;
+                    // Migrate to new format
+                    storePassword(profileName, key, oldPassword, [this, legacyService, key, callback, oldPassword](bool migrationSuccess, const QString& migrationError) {
+                        if (migrationSuccess) {
+                            // Only clean up old colliding entry if version > 4.20.1
+                            // The colliding format bug existed in 4.20.0 and 4.20.1
+                            // Preserving the entry allows users to switch back to those versions
+#ifdef APP_VERSION
+                            const QString currentVersion = QString(APP_VERSION);
+                            const QVersionNumber appVersion = QVersionNumber::fromString(currentVersion);
+                            const QVersionNumber collidingFormatVersion = QVersionNumber(4, 20, 1);
+
+                            if (appVersion > collidingFormatVersion) {
+                                removeCredential(legacyService, key, [](bool, const QString&) {});
+                            }
+#endif
+                        } else {
+                            qWarning() << "CredentialManager: Migration failed:" << migrationError;
+                        }
+                        if (callback) {
+                            callback(true, oldPassword, QString());
+                        }
+                    });
+                } else {
+                    // Old format not found, try legacy keychain format
+                    if (key == "password" || key == "character") {
+                        checkLegacyKeychainFormat(profileName, [this, profileName, key, callback](bool legacySuccess, const QString& legacyPassword) {
+                            if (legacySuccess && !legacyPassword.isEmpty()) {
+                                qDebug() << "CredentialManager: Migrating password from legacy format for" << profileName;
+                                storePassword(profileName, key, legacyPassword, [this, profileName, callback, legacyPassword](bool migrationSuccess, const QString& migrationError) {
+                                    if (!migrationSuccess) {
+                                        qWarning() << "CredentialManager: Migration failed:" << migrationError;
+                                    } else {
+                                        // Only clean up legacy entry after successful migration if this version is >= 4.20.0
+                                        // This prevents breaking compatibility with older Mudlet versions
+#ifdef APP_VERSION
+                                        const QString currentVersion = QString(APP_VERSION);
+                                        const QVersionNumber appVersion = QVersionNumber::fromString(currentVersion);
+                                        const QVersionNumber secureStorageVersion = QVersionNumber(4, 20, 0);
+                                        if (appVersion >= secureStorageVersion) {
+                                            deleteLegacyKeychainEntry(profileName);
+                                        }
+#endif
+                                    }
+                                    if (callback) {
+                                        callback(true, legacyPassword, QString());
+                                    }
+                                });
+                            } else {
+                                // Try encrypted file storage as final fallback
+                                QString fallbackPassword = retrieveCredentialFromFile(profileName, key);
+                                if (callback) {
+                                    if (!fallbackPassword.isEmpty()) {
+                                        callback(true, fallbackPassword, QString());
+                                    } else {
+                                        callback(false, QString(), qsl("No stored credentials found for profile %1").arg(profileName));
+                                    }
+                                }
+                            }
+                        });
+                    } else {
+                        // Not a password request, use encrypted file storage directly
+                        QString fallbackPassword = retrieveCredentialFromFile(profileName, key);
+                        if (callback) {
+                            if (!fallbackPassword.isEmpty()) {
+                                callback(true, fallbackPassword, QString());
+                            } else {
+                                callback(false, QString(), qsl("No stored credentials found for profile %1").arg(profileName));
+                            }
+                        }
+                    }
+                }
+            });
+        };
+
+        // First try new hash-based format
+        auto newFormatCallback = [this, profileName, key, callback, tryCollidingFormat](bool keychainSuccess, const QString& keychainPassword, const QString& keychainError) {
 
             if (keychainSuccess && !keychainPassword.isEmpty()) {
-                // Keychain succeeded
                 if (callback) {
                     callback(true, keychainPassword, QString());
                 }
             } else {
-                // Keychain failed, try legacy keychain format if this is a password request
-                if (key == "password" || key == "character") {
-                    qDebug() << "CredentialManager: Checking for legacy keychain format for profile" << profileName;
-                    checkLegacyKeychainFormat(profileName, [this, profileName, key, callback, keychainError](bool legacySuccess, const QString& legacyPassword) {
-                        if (legacySuccess && !legacyPassword.isEmpty()) {
-                            qDebug() << "CredentialManager: Migrating legacy password for profile" << profileName;
-                            // Store in new format and remove from legacy
-                            storePassword(profileName, key, legacyPassword, [callback, legacyPassword](bool migrationSuccess, const QString& migrationError) {
-                                if (migrationSuccess) {
-                                    qDebug() << "CredentialManager: Legacy migration successful";
-                                } else {
-                                    qWarning() << "CredentialManager: Legacy migration failed:" << migrationError;
-                                }
-                                // Return the password regardless of migration result
-                                if (callback) {
-                                    callback(true, legacyPassword, QString());
-                                }
-                            });
-
-                            // Only clean up legacy entry if this version is >= 4.20.0
-                            // This prevents breaking compatibility with older Mudlet versions
-#ifdef APP_VERSION
-                            const QString currentVersion = QString(APP_VERSION);
-                            const QVersionNumber appVersion = QVersionNumber::fromString(currentVersion);
-                            const QVersionNumber secureStorageVersion = QVersionNumber(4, 20, 0);
-
-                            if (appVersion >= secureStorageVersion) {
-                                // Clean up legacy entry asynchronously (don't wait for result)
-                                deleteLegacyKeychainEntry(profileName);
-                                qDebug() << "CredentialManager: Legacy cleanup enabled for version" << currentVersion;
-                            } else {
-                                qDebug() << "CredentialManager: Legacy cleanup skipped for version" << currentVersion;
-                            }
-#else
-                            // In test environment, preserve legacy entries for safety
-                            qDebug() << "CredentialManager: Legacy cleanup skipped (test mode)";
-#endif
-                        } else {
-                            // No legacy password found, try encrypted file storage
-                            qDebug() << "CredentialManager: No legacy password found, using encrypted file storage for profile" << profileName;
-                            QString fallbackPassword = retrieveCredentialFromFile(profileName, key);
-
-                            if (!fallbackPassword.isEmpty()) {
-                                qDebug() << "CredentialManager: Password retrieved from encrypted file storage";
-
-                                if (callback) {
-                                    callback(true, fallbackPassword, QString());
-                                }
-                            } else {
-                                if (callback) {
-                                    callback(false, QString(), qsl("No stored credentials found for profile %1 (keychain, legacy, and encrypted file storage all empty)").arg(profileName));
-                                }
-                            }
-                        }
-                    });
-                } else {
-                    // Not a password request, use encrypted file storage directly
-                    qDebug() << "CredentialManager: Using encrypted file storage for credential" << key << "for profile" << profileName;
-                    QString fallbackPassword = retrieveCredentialFromFile(profileName, key);
-
-                    if (!fallbackPassword.isEmpty()) {
-                        qDebug() << "CredentialManager: Retrieved credential from encrypted file storage";
-
-                        if (callback) {
-                            callback(true, fallbackPassword, QString());
-                        }
-                    } else {
-                        if (callback) {
-                            callback(false, QString(), qsl("No stored credentials found for profile %1 (keychain and encrypted file storage both empty)").arg(profileName));
-                        }
-                    }
-                }
+                // New format not found, try old colliding format
+                tryCollidingFormat();
             }
         };
 
-        retrieveCredential(service, key, fallbackCallback);
+        retrieveCredential(service, key, newFormatCallback);
     } else {
         // Use SecureStringUtils directly (portable/test mode)
         QString password = retrieveCredentialFromFile(profileName, key);
@@ -385,20 +398,24 @@ void CredentialManager::removePassword(const QString& profileName, const QString
     }
 
     if (shouldUseKeychain(profileName)) {
-        // Remove from both keychain and SecureStringUtils to ensure complete cleanup
+        // Remove from both new and old keychain formats, plus SecureStringUtils for complete cleanup
         QString service = generateServiceName(profileName, key);
+        QString legacyService = generateLegacyServiceName(profileName, key);
 
-        auto combinedCallback = [this, profileName, key, callback](bool keychainSuccess, const QString& keychainError) {
-            // Also remove from SecureStringUtils (ignore result as it might not exist there)
-            bool fileSuccess = removeCredentialFromFile(profileName, key);
+        auto combinedCallback = [this, profileName, key, legacyService, callback](bool keychainSuccess, const QString& keychainError) {
+            // Also remove from old colliding format (ignore result as it might not exist)
+            removeCredential(legacyService, key, [this, profileName, key, callback, keychainSuccess, keychainError](bool oldSuccess, const QString&) {
+                // Also remove from SecureStringUtils (ignore result as it might not exist there)
+                bool fileSuccess = removeCredentialFromFile(profileName, key);
 
-            if (callback) {
-                if (keychainSuccess || fileSuccess) {
-                    callback(true, QString());
-                } else {
-                    callback(false, qsl("Failed to remove from keychain: %1").arg(keychainError));
+                if (callback) {
+                    if (keychainSuccess || oldSuccess || fileSuccess) {
+                        callback(true, QString());
+                    } else {
+                        callback(false, qsl("Failed to remove from keychain: %1").arg(keychainError));
+                    }
                 }
-            }
+            });
         };
 
         removeCredential(service, key, combinedCallback);
@@ -1084,16 +1101,37 @@ bool CredentialManager::removeCredentialFromFile(const QString& profileName, con
 
 QString CredentialManager::generateServiceName(const QString& profileName, const QString& key)
 {
-    // Sanitize inputs to prevent keychain service name conflicts
+    // Use SHA-256 hash to generate unique service names that won't collide
+    // even when profile names differ only in special characters
+    QByteArray data = (profileName + qsl(":") + key).toUtf8();
+    QByteArray hash = QCryptographicHash::hash(data, QCryptographicHash::Sha256);
+    QString hashHex = QString::fromLatin1(hash.toHex()).left(16);
+
+    // Include a readable prefix with sanitized profile name and key for easier keychain debugging
+    auto sanitizeForDisplay = [](const QString& input) -> QString {
+        QString sanitized = input;
+        sanitized.replace(QRegularExpression(R"([^\w\-\.])"), "_");
+        if (sanitized.length() > 20) {
+            sanitized = sanitized.left(20);
+        }
+        return sanitized;
+    };
+
+    QString sanitizedProfile = sanitizeForDisplay(profileName);
+    QString sanitizedKey = sanitizeForDisplay(key);
+    return qsl("Mudlet-%1-%2-%3").arg(sanitizedProfile, sanitizedKey, hashHex);
+}
+
+QString CredentialManager::generateLegacyServiceName(const QString& profileName, const QString& key)
+{
+    // Original service name generation that caused collisions
+    // Kept for backwards compatibility to migrate existing passwords
     auto sanitizeForService = [](const QString& input) -> QString {
         QString sanitized = input;
-        // Replace invalid characters with underscores
         sanitized.replace(QRegularExpression(R"([^\w\-\.])"), "_");
-        // Limit length to prevent overly long service names
         if (sanitized.length() > 50) {
             sanitized = sanitized.left(50);
         }
-
         return sanitized;
     };
 

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -231,7 +231,7 @@ void CredentialManager::storePassword(const QString& profileName, const QString&
     if (shouldUseKeychain(profileName)) {
         // Use keychain storage
         QString service = generateServiceName(profileName, key);
-        storeCredential(service, key, password, callback);
+        storeCredential(service, key, password, profileName, callback);
     } else {
         // Use SecureStringUtils for portable/test environments
         bool success = storeCredentialToFile(profileName, key, password);
@@ -274,11 +274,11 @@ void CredentialManager::retrievePassword(const QString& profileName, const QStri
 
         // Helper to try old colliding format and migrate if found
         auto tryCollidingFormat = [this, profileName, key, legacyService, callback]() {
-            retrieveCredential(legacyService, key, [this, profileName, key, legacyService, callback](bool oldSuccess, const QString& oldPassword, const QString& oldError) {
+            retrieveCredential(legacyService, key, profileName, [this, profileName, key, legacyService, callback](bool oldSuccess, const QString& oldPassword, const QString& oldError) {
                 if (oldSuccess && !oldPassword.isEmpty()) {
                     qDebug() << "CredentialManager: Migrating password from colliding format for" << profileName;
                     // Migrate to new format
-                    storePassword(profileName, key, oldPassword, [this, legacyService, key, callback, oldPassword](bool migrationSuccess, const QString& migrationError) {
+                    storePassword(profileName, key, oldPassword, [this, legacyService, key, profileName, callback, oldPassword](bool migrationSuccess, const QString& migrationError) {
                         if (migrationSuccess) {
                             // Only clean up old colliding entry if version > 4.20.1
                             // The colliding format bug existed in 4.20.0 and 4.20.1
@@ -289,7 +289,7 @@ void CredentialManager::retrievePassword(const QString& profileName, const QStri
                             const QVersionNumber collidingFormatVersion = QVersionNumber(4, 20, 1);
 
                             if (appVersion > collidingFormatVersion) {
-                                removeCredential(legacyService, key, [](bool, const QString&) {});
+                                removeCredential(legacyService, key, profileName, [](bool, const QString&) {});
                             }
 #endif
                         } else {
@@ -364,7 +364,7 @@ void CredentialManager::retrievePassword(const QString& profileName, const QStri
             }
         };
 
-        retrieveCredential(service, key, newFormatCallback);
+        retrieveCredential(service, key, profileName, newFormatCallback);
     } else {
         // Use SecureStringUtils directly (portable/test mode)
         QString password = retrieveCredentialFromFile(profileName, key);
@@ -404,7 +404,7 @@ void CredentialManager::removePassword(const QString& profileName, const QString
 
         auto combinedCallback = [this, profileName, key, legacyService, callback](bool keychainSuccess, const QString& keychainError) {
             // Also remove from old colliding format (ignore result as it might not exist)
-            removeCredential(legacyService, key, [this, profileName, key, callback, keychainSuccess, keychainError](bool oldSuccess, const QString&) {
+            removeCredential(legacyService, key, profileName, [this, profileName, key, callback, keychainSuccess, keychainError](bool oldSuccess, const QString&) {
                 // Also remove from SecureStringUtils (ignore result as it might not exist there)
                 bool fileSuccess = removeCredentialFromFile(profileName, key);
 
@@ -418,7 +418,7 @@ void CredentialManager::removePassword(const QString& profileName, const QString
             });
         };
 
-        removeCredential(service, key, combinedCallback);
+        removeCredential(service, key, profileName, combinedCallback);
     } else {
         // Use SecureStringUtils
         bool success = removeCredentialFromFile(profileName, key);
@@ -455,11 +455,11 @@ void CredentialManager::migratePassword(const QString& profileName, const QStrin
     storePassword(profileName, key, plaintextPassword, callback);
 }
 
-void CredentialManager::storeCredential(const QString& service, const QString& account, const QString& password, CredentialCallback callback)
+void CredentialManager::storeCredential(const QString& service, const QString& account, const QString& password, const QString& profileName, CredentialCallback callback)
 {
-    if (service.isEmpty() || account.isEmpty()) {
+    if (service.isEmpty() || account.isEmpty() || profileName.isEmpty()) {
         if (callback) {
-            callback(false, qsl("Service and account cannot be empty"));
+            callback(false, qsl("Service, account, and profile name cannot be empty"));
         }
 
         return;
@@ -497,7 +497,7 @@ void CredentialManager::storeCredential(const QString& service, const QString& a
             writeJob,
             &QKeychain::WritePasswordJob::finished,
             this,
-            [this, writeJob, service, account, password]() {
+            [this, writeJob, service, account, password, profileName]() {
                 // Early exit if operation is no longer valid
                 if (!isOperationValid()) {
                     qWarning() << "CredentialManager: Ignoring keychain callback - operation no longer valid";
@@ -514,8 +514,8 @@ void CredentialManager::storeCredential(const QString& service, const QString& a
                 if (!success) {
                     qDebug() << "CredentialManager: Keychain storage failed, using encrypted file storage:" << errorMessage;
 
-                    // Use service as profile name and account as key for file storage
-                    bool fileSuccess = storeCredentialToFile(service, account, password);
+                    // Use actual profile name (not service name) for file storage
+                    bool fileSuccess = storeCredentialToFile(profileName, account, password);
 
                     if (fileSuccess) {
                         success = true;
@@ -544,11 +544,11 @@ void CredentialManager::storeCredential(const QString& service, const QString& a
     writeJob->start();
 }
 
-void CredentialManager::retrieveCredential(const QString& service, const QString& account, CredentialRetrievalCallback callback)
+void CredentialManager::retrieveCredential(const QString& service, const QString& account, const QString& profileName, CredentialRetrievalCallback callback)
 {
-    if (service.isEmpty() || account.isEmpty()) {
+    if (service.isEmpty() || account.isEmpty() || profileName.isEmpty()) {
         if (callback) {
-            callback(false, QString(), qsl("Service and account cannot be empty"));
+            callback(false, QString(), qsl("Service, account, and profile name cannot be empty"));
         }
 
         return;
@@ -583,7 +583,7 @@ void CredentialManager::retrieveCredential(const QString& service, const QString
             readJob,
             &QKeychain::ReadPasswordJob::finished,
             this,
-            [this, readJob, service, account]() {
+            [this, readJob, service, account, profileName]() {
                 // Early exit if operation is no longer valid
                 if (!isOperationValid()) {
                     qWarning() << "CredentialManager: Ignoring keychain callback - operation no longer valid";
@@ -702,8 +702,8 @@ void CredentialManager::retrieveCredential(const QString& service, const QString
                             } else {
                                 qDebug() << "CredentialManager: No legacy password found for profile" << profileName;
 
-                                // No legacy password, try file storage
-                                QString filePassword = retrieveCredentialFromFile(service, account);
+                                // No legacy password, try file storage using actual profile name
+                                QString filePassword = retrieveCredentialFromFile(profileName, account);
                                 bool fileSuccess = !filePassword.isNull();
                                 QString finalError = fileSuccess ? QString() : qsl("Both keychain and encrypted file storage failed for credentials. Keychain: %1").arg(keychainError);
 
@@ -727,7 +727,8 @@ void CredentialManager::retrieveCredential(const QString& service, const QString
                     }
 
                     // Not a character password or not new format, try file storage directly
-                    password = retrieveCredentialFromFile(service, account);
+                    // Use actual profile name (not service name) for file storage path
+                    password = retrieveCredentialFromFile(profileName, account);
 
                     if (!password.isNull()) {
                         success = true;
@@ -754,11 +755,11 @@ void CredentialManager::retrieveCredential(const QString& service, const QString
     readJob->start();
 }
 
-void CredentialManager::removeCredential(const QString& service, const QString& account, CredentialCallback callback)
+void CredentialManager::removeCredential(const QString& service, const QString& account, const QString& profileName, CredentialCallback callback)
 {
-    if (service.isEmpty() || account.isEmpty()) {
+    if (service.isEmpty() || account.isEmpty() || profileName.isEmpty()) {
         if (callback) {
-            callback(false, "Service and account cannot be empty");
+            callback(false, "Service, account, and profile name cannot be empty");
         }
 
         return;
@@ -793,7 +794,7 @@ void CredentialManager::removeCredential(const QString& service, const QString& 
             deleteJob,
             &QKeychain::DeletePasswordJob::finished,
             this,
-            [this, deleteJob, service, account]() {
+            [this, deleteJob, service, account, profileName]() {
                 // Early exit if operation is no longer valid
                 if (!isOperationValid()) {
                     qWarning() << "CredentialManager: Ignoring keychain callback - operation no longer valid";
@@ -806,7 +807,8 @@ void CredentialManager::removeCredential(const QString& service, const QString& 
                 bool keychainSuccess = (deleteJob->error() == QKeychain::NoError || deleteJob->error() == QKeychain::EntryNotFound);
 
                 // Always try to remove from file storage as well (for cleanup)
-                bool fileSuccess = removeCredentialFromFile(service, account);
+                // Use actual profile name (not service name) for file storage path
+                bool fileSuccess = removeCredentialFromFile(profileName, account);
 
                 // Consider success if either method succeeded
                 bool success = keychainSuccess || fileSuccess;

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -276,76 +276,14 @@ void CredentialManager::retrievePassword(const QString& profileName, const QStri
         auto tryCollidingFormat = [this, profileName, key, legacyService, callback]() {
             retrieveCredential(legacyService, key, profileName, [this, profileName, key, legacyService, callback](bool oldSuccess, const QString& oldPassword, const QString& oldError) {
                 if (oldSuccess && !oldPassword.isEmpty()) {
-                    qDebug() << "CredentialManager: Migrating password from colliding format for" << profileName;
-                    // Migrate to new format
-                    storePassword(profileName, key, oldPassword, [this, legacyService, key, profileName, callback, oldPassword](bool migrationSuccess, const QString& migrationError) {
-                        if (migrationSuccess) {
-                            // Only clean up old colliding entry if version > 4.20.1
-                            // The colliding format bug existed in 4.20.0 and 4.20.1
-                            // Preserving the entry allows users to switch back to those versions
-#ifdef APP_VERSION
-                            const QString currentVersion = QString(APP_VERSION);
-                            const QVersionNumber appVersion = QVersionNumber::fromString(currentVersion);
-                            const QVersionNumber collidingFormatVersion = QVersionNumber(4, 20, 1);
-
-                            if (appVersion > collidingFormatVersion) {
-                                removeCredential(legacyService, key, profileName, [](bool, const QString&) {});
-                            }
-#endif
-                        } else {
-                            qWarning() << "CredentialManager: Migration failed:" << migrationError;
-                        }
-                        if (callback) {
-                            callback(true, oldPassword, QString());
-                        }
-                    });
+                    attemptCollidingMigration(profileName, key, legacyService, oldPassword, callback);
                 } else {
                     // Old format not found, try legacy keychain format
                     if (key == "password" || key == "character") {
-                        checkLegacyKeychainFormat(profileName, [this, profileName, key, callback](bool legacySuccess, const QString& legacyPassword) {
-                            if (legacySuccess && !legacyPassword.isEmpty()) {
-                                qDebug() << "CredentialManager: Migrating password from legacy format for" << profileName;
-                                storePassword(profileName, key, legacyPassword, [this, profileName, callback, legacyPassword](bool migrationSuccess, const QString& migrationError) {
-                                    if (!migrationSuccess) {
-                                        qWarning() << "CredentialManager: Migration failed:" << migrationError;
-                                    } else {
-                                        // Only clean up legacy entry after successful migration if this version is >= 4.20.0
-                                        // This prevents breaking compatibility with older Mudlet versions
-#ifdef APP_VERSION
-                                        const QString currentVersion = QString(APP_VERSION);
-                                        const QVersionNumber appVersion = QVersionNumber::fromString(currentVersion);
-                                        const QVersionNumber secureStorageVersion = QVersionNumber(4, 20, 0);
-                                        if (appVersion >= secureStorageVersion) {
-                                            deleteLegacyKeychainEntry(profileName);
-                                        }
-#endif
-                                    }
-                                    if (callback) {
-                                        callback(true, legacyPassword, QString());
-                                    }
-                                });
-                            } else {
-                                // Try encrypted file storage as final fallback
-                                QString fallbackPassword = retrieveCredentialFromFile(profileName, key);
-                                if (callback) {
-                                    if (!fallbackPassword.isEmpty()) {
-                                        callback(true, fallbackPassword, QString());
-                                    } else {
-                                        callback(false, QString(), qsl("No stored credentials found for profile %1").arg(profileName));
-                                    }
-                                }
-                            }
-                        });
+                        attemptLegacyKeychainMigration(profileName, key, callback);
                     } else {
                         // Not a password request, use encrypted file storage directly
-                        QString fallbackPassword = retrieveCredentialFromFile(profileName, key);
-                        if (callback) {
-                            if (!fallbackPassword.isEmpty()) {
-                                callback(true, fallbackPassword, QString());
-                            } else {
-                                callback(false, QString(), qsl("No stored credentials found for profile %1").arg(profileName));
-                            }
-                        }
+                        fallbackFileRetrieval(profileName, key, callback);
                     }
                 }
             });
@@ -353,7 +291,6 @@ void CredentialManager::retrievePassword(const QString& profileName, const QStri
 
         // First try new hash-based format
         auto newFormatCallback = [this, profileName, key, callback, tryCollidingFormat](bool keychainSuccess, const QString& keychainPassword, const QString& keychainError) {
-
             if (keychainSuccess && !keychainPassword.isEmpty()) {
                 if (callback) {
                     callback(true, keychainPassword, QString());
@@ -373,6 +310,84 @@ void CredentialManager::retrievePassword(const QString& profileName, const QStri
         if (callback) {
             // Empty password is normal for first-time profiles - not an error
             callback(success, password, success ? QString() : qsl("No password stored in encrypted file storage"));
+        }
+    }
+}
+
+void CredentialManager::attemptCollidingMigration(const QString& profileName, const QString& key, const QString& legacyService, const QString& password, CredentialRetrievalCallback callback)
+{
+    qDebug() << "CredentialManager: Migrating password from colliding format for" << profileName;
+
+    // Migrate to new format
+    storePassword(profileName, key, password, [this, legacyService, key, profileName, callback, password](bool migrationSuccess, const QString& migrationError) {
+        if (migrationSuccess) {
+            // Only clean up old colliding entry if version > 4.20.1
+            // The colliding format bug existed in 4.20.0 and 4.20.1
+            // Preserving the entry allows users to switch back to those versions
+#ifdef APP_VERSION
+            const QString currentVersion = QString(APP_VERSION);
+            const QVersionNumber appVersion = QVersionNumber::fromString(currentVersion);
+            const QVersionNumber collidingFormatVersion = QVersionNumber(4, 20, 1);
+
+            if (appVersion > collidingFormatVersion) {
+                removeCredential(legacyService, key, profileName, [](bool, const QString&) {});
+            }
+#endif
+        } else {
+            qWarning() << "CredentialManager: Migration failed:" << migrationError;
+        }
+
+        // Return the recovered password even if migration failed
+        if (callback) {
+            callback(true, password, QString());
+        }
+    });
+}
+
+void CredentialManager::attemptLegacyKeychainMigration(const QString& profileName, const QString& key, CredentialRetrievalCallback callback)
+{
+    checkLegacyKeychainFormat(profileName, [this, profileName, key, callback](bool legacySuccess, const QString& legacyPassword) {
+        if (legacySuccess && !legacyPassword.isEmpty()) {
+            qDebug() << "CredentialManager: Migrating password from legacy format for" << profileName;
+
+            storePassword(profileName, key, legacyPassword, [this, profileName, callback, legacyPassword](bool migrationSuccess, const QString& migrationError) {
+                if (!migrationSuccess) {
+                    qWarning() << "CredentialManager: Migration failed:" << migrationError;
+                } else {
+                    // Only clean up legacy entry after successful migration if this version is >= 4.20.0
+                    // This prevents breaking compatibility with older Mudlet versions
+#ifdef APP_VERSION
+                    const QString currentVersion = QString(APP_VERSION);
+                    const QVersionNumber appVersion = QVersionNumber::fromString(currentVersion);
+                    const QVersionNumber secureStorageVersion = QVersionNumber(4, 20, 0);
+
+                    if (appVersion >= secureStorageVersion) {
+                        deleteLegacyKeychainEntry(profileName);
+                    }
+#endif
+                }
+
+                // Return the recovered password even if migration failed
+                if (callback) {
+                    callback(true, legacyPassword, QString());
+                }
+            });
+        } else {
+            // Try encrypted file storage as final fallback
+            fallbackFileRetrieval(profileName, key, callback);
+        }
+    });
+}
+
+void CredentialManager::fallbackFileRetrieval(const QString& profileName, const QString& key, CredentialRetrievalCallback callback)
+{
+    QString fallbackPassword = retrieveCredentialFromFile(profileName, key);
+
+    if (callback) {
+        if (!fallbackPassword.isEmpty()) {
+            callback(true, fallbackPassword, QString());
+        } else {
+            callback(false, QString(), qsl("No stored credentials found for profile %1").arg(profileName));
         }
     }
 }

--- a/src/CredentialManager.h
+++ b/src/CredentialManager.h
@@ -119,6 +119,11 @@ private:
     void checkLegacyKeychainFormat(const QString& profileName, std::function<void(bool, const QString&)> callback);
     void deleteLegacyKeychainEntry(const QString& profileName);
 
+    // Password retrieval fallback helpers (extracted from retrievePassword for readability)
+    void attemptCollidingMigration(const QString& profileName, const QString& key, const QString& legacyService, const QString& password, CredentialRetrievalCallback callback);
+    void attemptLegacyKeychainMigration(const QString& profileName, const QString& key, CredentialRetrievalCallback callback);
+    void fallbackFileRetrieval(const QString& profileName, const QString& key, CredentialRetrievalCallback callback);
+
     // Current operation state
     QPointer<QKeychain::Job> mCurrentJob{nullptr};
     QTimer* mTimeoutTimer{nullptr};

--- a/src/CredentialManager.h
+++ b/src/CredentialManager.h
@@ -81,9 +81,10 @@ public:
 
 private:
     // Low-level async keychain methods (internal use only - use hybrid *Password methods instead)
-    void storeCredential(const QString& service, const QString& account, const QString& password, CredentialCallback callback);
-    void retrieveCredential(const QString& service, const QString& account, CredentialRetrievalCallback callback);
-    void removeCredential(const QString& service, const QString& account, CredentialCallback callback);
+    // profileName is used for file storage fallback (the service name is a hash that can't be reversed)
+    void storeCredential(const QString& service, const QString& account, const QString& password, const QString& profileName, CredentialCallback callback);
+    void retrieveCredential(const QString& service, const QString& account, const QString& profileName, CredentialRetrievalCallback callback);
+    void removeCredential(const QString& service, const QString& account, const QString& profileName, CredentialCallback callback);
 
     // Check if QtKeychain is available and working (asynchronous)
     void isKeychainAvailable(AvailabilityCallback callback);

--- a/src/CredentialManager.h
+++ b/src/CredentialManager.h
@@ -108,6 +108,7 @@ private:
     // Static utility methods for fallback storage
     static QString generateFilePath(const QString& profileName, const QString& key);
     static QString generateServiceName(const QString& profileName, const QString& key);
+    static QString generateLegacyServiceName(const QString& profileName, const QString& key);
     static bool isValidKeyName(const QString& key);
     static bool storeCredentialToFile(const QString& profileName, const QString& key, const QString& credential);
     static QString retrieveCredentialFromFile(const QString& profileName, const QString& key);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -308,6 +308,12 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
 
 dlgConnectionProfiles::~dlgConnectionProfiles()
 {
+    // Stop any pending password save timer to prevent late updates
+    if (mPasswordSaveTimer) {
+        mPasswordSaveTimer->stop();
+    }
+    mPendingPasswordSaveProfile.clear();
+
     // Clear any pending operation flags
     mKeychainOperationInProgress = false;
     mPendingProfileLoad.clear();
@@ -1839,9 +1845,11 @@ void dlgConnectionProfiles::loadProfile(bool alsoConnect)
 
         if (!character_password_entry->text().trimmed().isEmpty()) {
             pHost->setPass(character_password_entry->text().trimmed());
-        } else {
-            slot_updatePassword(pHost->getPass());
         }
+        // Note: If password field is empty, we don't call slot_updatePassword() because:
+        // 1. The host's password was already loaded via Host::loadSecuredPassword()
+        // 2. Calling slot_updatePassword with empty password would delete the stored password
+        // 3. slot_updatePassword reads profile from list widget which could mismatch
 
         if (!login_entry->text().trimmed().isEmpty()) {
             pHost->setLogin(login_entry->text().trimmed());
@@ -2452,6 +2460,13 @@ void dlgConnectionProfiles::loadPasswordFromSettings(const QString& profile_name
 
 void dlgConnectionProfiles::slot_passwordTextChanged()
 {
+    // Capture the current profile name - this is the profile we want to save the password for
+    QListWidgetItem* pItem = listWidget_profiles->currentItem();
+    if (!pItem) {
+        return;
+    }
+    mPendingPasswordSaveProfile = pItem->data(csmNameRole).toString();
+
     // Cancel any pending password save
     if (mPasswordSaveTimer) {
         mPasswordSaveTimer->stop();
@@ -2460,9 +2475,14 @@ void dlgConnectionProfiles::slot_passwordTextChanged()
         mPasswordSaveTimer->setSingleShot(true);
         mPasswordSaveTimer->setInterval(500); // 500ms debounce
         connect(mPasswordSaveTimer, &QTimer::timeout, this, [this]() {
-            QListWidgetItem* pItem = listWidget_profiles->currentItem();
-            if (pItem) {
-                slot_updatePassword(character_password_entry->text());
+            // Use the captured profile name, not the current selection
+            if (!mPendingPasswordSaveProfile.isEmpty()) {
+                // Check if this profile is STILL selected - if not, don't save
+                // (user switched away, so the password field content is for a different profile)
+                QListWidgetItem* currentItem = listWidget_profiles->currentItem();
+                if (currentItem && currentItem->data(csmNameRole).toString() == mPendingPasswordSaveProfile) {
+                    slot_updatePassword(character_password_entry->text());
+                }
             }
         });
     }

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -153,6 +153,7 @@ private:
     QTimer mSearchTextTimer;
     QString mSearchText;
     QTimer* mPasswordSaveTimer = nullptr;
+    QString mPendingPasswordSaveProfile;  // Profile name for pending password save
 
     // Async connection handling
     QString mPendingProfileLoad;  // Profile name waiting for password load

--- a/test/CredentialManagerTest.cpp
+++ b/test/CredentialManagerTest.cpp
@@ -27,6 +27,7 @@ private slots:
     void initTestCase();
     void testStoreAndRetrieve();
     void testProfileIsolation();
+    void testSpecialCharacterProfileIsolation();
     void testKeyIsolation();
     void testEmptyPassword();
     void testRemovePassword();
@@ -72,6 +73,47 @@ void CredentialManagerTest::testProfileIsolation()
     // Verify isolation
     QCOMPARE(CredentialManager::retrieveCredential(profile1, key), password1);
     QCOMPARE(CredentialManager::retrieveCredential(profile2, key), password2);
+}
+
+void CredentialManagerTest::testSpecialCharacterProfileIsolation()
+{
+    // Test for issue #8933: Profiles with similar names sharing passwords
+    // Profile names that differ only in special characters should NOT collide.
+    // Using only characters allowed by the UI validation in dlgConnectionProfiles.cpp:
+    // ". _0123456789-#&" plus letters. All these would collide to "Game_Server"
+    // under the old sanitization logic.
+    QString profileDot = "Game.Server";
+    QString profileHash = "Game#Server";
+    QString profileAmp = "Game&Server";
+    QString profileSpace = "Game Server";
+    QString profileDash = "Game-Server";
+    QString key = "password";
+    QString passwordDot = "password_dot";
+    QString passwordHash = "password_hash";
+    QString passwordAmp = "password_amp";
+    QString passwordSpace = "password_space";
+    QString passwordDash = "password_dash";
+
+    // Store different passwords for profiles that differ only in special characters
+    QVERIFY(CredentialManager::storeCredential(profileDot, key, passwordDot));
+    QVERIFY(CredentialManager::storeCredential(profileHash, key, passwordHash));
+    QVERIFY(CredentialManager::storeCredential(profileAmp, key, passwordAmp));
+    QVERIFY(CredentialManager::storeCredential(profileSpace, key, passwordSpace));
+    QVERIFY(CredentialManager::storeCredential(profileDash, key, passwordDash));
+
+    // Verify each profile retrieves its own password (not the last stored one)
+    QCOMPARE(CredentialManager::retrieveCredential(profileDot, key), passwordDot);
+    QCOMPARE(CredentialManager::retrieveCredential(profileHash, key), passwordHash);
+    QCOMPARE(CredentialManager::retrieveCredential(profileAmp, key), passwordAmp);
+    QCOMPARE(CredentialManager::retrieveCredential(profileSpace, key), passwordSpace);
+    QCOMPARE(CredentialManager::retrieveCredential(profileDash, key), passwordDash);
+
+    // Cleanup
+    CredentialManager::removeCredential(profileDot, key);
+    CredentialManager::removeCredential(profileHash, key);
+    CredentialManager::removeCredential(profileAmp, key);
+    CredentialManager::removeCredential(profileSpace, key);
+    CredentialManager::removeCredential(profileDash, key);
 }
 
 void CredentialManagerTest::testKeyIsolation()
@@ -236,6 +278,14 @@ void CredentialManagerTest::cleanupTestCase()
     CredentialManager::removeCredential("SanitizationTestProfile", "normal_key");
     CredentialManager::removeCredential("PathTraversalTestProfile", "test_key");
     CredentialManager::removeCredential("ConcurrentTestProfile", "concurrent_key");
+    
+    // Defensive cleanup for special character profile isolation test
+    // (ensures cleanup even if test fails early)
+    CredentialManager::removeCredential("Game.Server", "password");
+    CredentialManager::removeCredential("Game#Server", "password");
+    CredentialManager::removeCredential("Game&Server", "password");
+    CredentialManager::removeCredential("Game Server", "password");
+    CredentialManager::removeCredential("Game-Server", "password");
 }
 
 #include "CredentialManagerTest.moc"


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes password storage issues where profiles with similar names could share passwords, and where passwords could be accidentally deleted when switching between profiles.

#### Motivation for adding to Mudlet

Since Mudlet 4.20.0, users reported passwords being lost or shared between profiles with similar names. This was caused by:

1. **Path mismatch in file fallback storage** - When keychain storage fails, the encrypted file fallback was using the keychain service name (which includes a hash) instead of the actual profile name for the file path. This caused passwords to be stored in one location but looked for in another.

2. **Accidental password deletion on profile switch** - The password save debounce timer didn't track which profile it was saving for. If a user switched profiles while a save was pending, the empty password field could trigger deletion of the wrong profile's password.

#### Other info (issues closed, discussion etc)

**Key changes:**
- Private keychain methods now receive the profile name separately to ensure file fallback paths are correct
- Password save timer now tracks the intended profile and only saves if that profile is still selected
- Removed problematic `slot_updatePassword` call in `loadProfile` that could delete passwords
- Added unit test for profile isolation
- Refactored nested lambdas in `retrievePassword()` into helper methods for readability

Closes #8922 (related password issues)