### PR TITLE
Fix: Restore sound playback on macOS

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -459,24 +459,27 @@ int main(int argc, char* argv[])
         commandLineTranslator.clear();
     }
 
-    // Needed for Qt6 on Windows (at least) - and does not work in mudlet class c'tor
-#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+    // Configure the media backend - does not work in mudlet class c'tor.
+    // On Windows, use FFmpeg which supports .ogg/.opus (native backend doesn't).
+    // On macOS, use darwin (AVFoundation) which works better than FFmpeg.
 #if defined(Q_OS_WINDOWS)
-    if (qEnvironmentVariableIsEmpty("QT_MEDIA_BACKEND")) {
-        // This variable is not set - and later versions of Qt 6.x need it for
-        // sound to work - the alternative to "ffmpeg" is "windows" but that
-        // is a less capable backend (it doesn't support ".ogg" or ".opus"
-        // audio files):
-        if (qputenv("QT_MEDIA_BACKEND", QByteArray("ffmpeg"))) {
-            qDebug().noquote() << "main(...) INFO - setting QT_MEDIA_BACKEND enviromental variable to: \"ffmpeg\".";
+    const QByteArray defaultMediaBackend("ffmpeg");
+#elif defined(Q_OS_MACOS)
+    const QByteArray defaultMediaBackend("darwin");
+#else
+    const QByteArray defaultMediaBackend;
+#endif
+    if (!defaultMediaBackend.isEmpty()) {
+        if (qEnvironmentVariableIsEmpty("QT_MEDIA_BACKEND")) {
+            if (qputenv("QT_MEDIA_BACKEND", defaultMediaBackend)) {
+                qDebug().noquote() << "main(...) INFO - setting QT_MEDIA_BACKEND enviromental variable to:" << defaultMediaBackend;
+            } else {
+                qWarning().noquote() << "main(...) WARNING - failed to set QT_MEDIA_BACKEND enviromental variable to:" << defaultMediaBackend << ", sound may not work.";
+            }
         } else {
-            qWarning().noquote() << "main(...) WARNING - failed to set QT_MEDIA_BACKEND enviromental variable to: \"ffmpeg\", sound may not work.";
+            qDebug().noquote().nospace() << "main(...) INFO - QT_MEDIA_BACKEND enviromental variable is set to: \"" << qgetenv("QT_MEDIA_BACKEND") << "\".";
         }
-    } else {
-        qDebug().noquote().nospace() << "main(...) INFO - QT_MEDIA_BACKEND enviromental variable is set to: \"" << qgetenv("QT_MEDIA_BACKEND") << "\".";
     }
-#endif
-#endif
 
     QStringList cliProfiles = parser.values(profileToOpen);
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Restores *all* sound playback functionality on macOS by using the native audio backend instead of FFmpeg.

#### Motivation for adding to Mudlet

Sound playback stopped working for certain sounds for macOS users after upgrading from version 4.19.1 to 4.20.0. This fix ensures macOS uses the native Darwin (AVFoundation) audio backend which worked correctly in previous releases.

#### Other info (issues closed, discussion etc)

Closes #8911

This change only affects macOS - Windows and Linux are unchanged.

**Testing**

- [x] Mac
- [x] Windows 

---

One can test by going to trying the difference between 4.20.0 and this change via a logon to StickMUD.

1. Login
2. Type "music on"
3. Type "media" to go to the media test room
4. Click all of the links
5. Heard sound? Let us know!

4.20.0 on Mac (turn volume up to hear *some* sounds)

https://github.com/user-attachments/assets/b9fab270-6a93-4f21-8fc2-db82b5937fd3

Running the testing build created by the CI/CD process:

https://github.com/user-attachments/assets/7c88976e-ce6c-4e7e-bd42-ad2fef4a6e00