### PR TITLE
improve: luarocks busted install instructions version flag

### DIFF
--- a/src/mudlet-lua/tests/README.md
+++ b/src/mudlet-lua/tests/README.md
@@ -6,14 +6,14 @@ Have Mudlet and [Busted](https://lunarmodules.github.io/busted/) installed:
 
 ```sh
   sudo apt-get install luarocks
-  sudo luarocks install busted
+  sudo luarocks --lua-version 5.1 install busted
 ```
 
 ## macOS
 
 ```sh
   brew install luarocks
-  luarocks install busted
+  luarocks --lua-version 5.1 install busted
 ```
 
 ## Windows
@@ -32,7 +32,7 @@ Have Mudlet and [Busted](https://lunarmodules.github.io/busted/) installed:
 
 ### Install Busted
 
-- Open a command prompt and enter `luarocks install busted`
+- Open a command prompt and enter `luarocks --lua-version 5.1 install busted`
 - If you get a `'luarocks' is not recognized...` message:
   - You may need to add the LuaRocks directory to your `Path` system environment variable and restart
   - Alternatively, navigate the command prompt to the LuaRocks directory to run LuaRocks commands


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds `--lua-version 5.1` to lua busted install instructions

#### Motivation for adding to Mudlet
If a user is not aware that the difference in versions can be a problem, they will install busted for lua 5.4 when Mudlet needs busted for lua 5.1

By adding this flag to the readme instructions, we explicitly avoid this confusion for new testers.

#### Other info (issues closed, discussion etc)
Raised by `.Iol` on discord:
> oooh, I see that for luarocks I'm getting lua ver 5.4:
> ```
> Configuration:
>    Lua:
>       Version    : 5.4
>       Interpreter: /usr/bin/lua (ok)
>       LUA_DIR    : /usr (ok)
>       LUA_BINDIR : /usr/bin (ok)
>       LUA_INCDIR : /usr/include (ok)
>       LUA_LIBDIR : /usr/lib64 (ok)
> 
>    Configuration files:
>       System  : /etc/luarocks/config-5.4.lua (ok)
>       User    : /home/teeg/.luarocks/config-5.4.lua (not found)
> 
>    Rocks trees in use:
>       /home/teeg/.luarocks ("user")
>       /usr ("system")
> 
> ```
> Perhaps this is the issue...

https://discord.com/channels/283581582550237184/283582439002210305/1472042720829902859