### PR TITLE
Improve: Add more context to media playback events

### DIFF
--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -1222,11 +1222,17 @@ void TMedia::handlePlayerPlaybackStateChanged(QMediaPlayerPlaybackState playback
 
     if (playbackState == QMediaPlayer::StoppedState) {
         TEvent mediaFinished{};
-        mediaFinished.mArgumentList.append("sysMediaFinished");
+        mediaFinished.mArgumentList.append(qsl("sysMediaFinished"));
 
         const QUrl mediaUrl = player->mediaPlayer()->source();
         mediaFinished.mArgumentList.append(mediaUrl.fileName());
         mediaFinished.mArgumentList.append(mediaUrl.path());
+        mediaFinished.mArgumentList.append(mediaTypeToString(player->mediaData().mediaType()));
+        mediaFinished.mArgumentList.append(player->mediaData().mediaKey());
+        mediaFinished.mArgumentList.append(player->mediaData().mediaTag());
+        mediaFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        mediaFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        mediaFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         mediaFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         mediaFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         mediaFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
@@ -1252,11 +1258,17 @@ void TMedia::handlePlayerPlaybackStateChanged(QMediaPlayerPlaybackState playback
         return;
     } else if (playbackState == QMediaPlayer::PlayingState && player->mediaData().mediaVolume() != TMediaData::MediaVolumePreload) {
         TEvent mediaStarted{};
-        mediaStarted.mArgumentList.append("sysMediaStarted");
+        mediaStarted.mArgumentList.append(qsl("sysMediaStarted"));
 
         const QUrl mediaUrl = player->mediaPlayer()->source();
         mediaStarted.mArgumentList.append(mediaUrl.fileName());
         mediaStarted.mArgumentList.append(mediaUrl.path());
+        mediaStarted.mArgumentList.append(mediaTypeToString(player->mediaData().mediaType()));
+        mediaStarted.mArgumentList.append(player->mediaData().mediaKey());
+        mediaStarted.mArgumentList.append(player->mediaData().mediaTag());
+        mediaStarted.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        mediaStarted.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        mediaStarted.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         mediaStarted.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         mediaStarted.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         mediaStarted.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
@@ -1270,11 +1282,17 @@ void TMedia::handlePlayerPlaybackStateChanged(QMediaPlayerPlaybackState playback
         return;
     } else if (playbackState == QMediaPlayer::PausedState) {
         TEvent mediaPaused{};
-        mediaPaused.mArgumentList.append("sysMediaPaused");
+        mediaPaused.mArgumentList.append(qsl("sysMediaPaused"));
 
         const QUrl mediaUrl = player->mediaPlayer()->source();
         mediaPaused.mArgumentList.append(mediaUrl.fileName());
         mediaPaused.mArgumentList.append(mediaUrl.path());
+        mediaPaused.mArgumentList.append(mediaTypeToString(player->mediaData().mediaType()));
+        mediaPaused.mArgumentList.append(player->mediaData().mediaKey());
+        mediaPaused.mArgumentList.append(player->mediaData().mediaTag());
+        mediaPaused.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        mediaPaused.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        mediaPaused.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         mediaPaused.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         mediaPaused.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         mediaPaused.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
@@ -1643,6 +1661,20 @@ TMediaData::MediaType TMedia::parseJSONByMediaType(QJsonObject& json)
     }
 
     return mediaType;
+}
+
+QString TMedia::mediaTypeToString(int mediaType)
+{
+    switch (mediaType) {
+    case TMediaData::MediaTypeSound:
+        return qsl("sound");
+    case TMediaData::MediaTypeMusic:
+        return qsl("music");
+    case TMediaData::MediaTypeVideo:
+        return qsl("video");
+    default:
+        return QString();
+    }
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Scripting#input

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -41,11 +41,11 @@ class TMediaPlayer
 public:
     TMediaPlayer() = default;
     TMediaPlayer(Host* pHost, TMediaData& mediaData)
-    : mpHost(pHost),
-      mMediaData(mediaData),
-      mMediaPlayer(new QMediaPlayer(pHost)),
-      mPlaylist(new TMediaPlaylist),
-      initialized(true)
+    : mpHost(pHost)
+    , mMediaData(mediaData)
+    , mMediaPlayer(new QMediaPlayer(pHost))
+    , mPlaylist(new TMediaPlaylist)
+    , initialized(true)
     {
         mMediaPlayer->setAudioOutput(new QAudioOutput());
     }
@@ -55,22 +55,21 @@ public:
     void setMediaData(TMediaData& mediaData) { mMediaData = mediaData; }
     QMediaPlayer* mediaPlayer() const { return mMediaPlayer; }
     bool isInitialized() const { return initialized; }
-    QMediaPlayer::PlaybackState getPlaybackState() const {
+    QMediaPlayer::PlaybackState getPlaybackState() const
+    {
         if (!mMediaPlayer) {
             qWarning() << "TMediaPlayer::getPlaybackState() - mMediaPlayer is nullptr!";
             return QMediaPlayer::StoppedState; // Safe default state
         }
         return mMediaPlayer->playbackState();
     }
-    void setVolume(int volume) const {
-        return mMediaPlayer->audioOutput()->setVolume(volume / 100.0f);
-    }
-    TMediaPlaylist* playlist() const {
-        return mPlaylist;
-    }
-    void setPlaylist(TMediaPlaylist* playlist) {
+    void setVolume(int volume) const { return mMediaPlayer->audioOutput()->setVolume(volume / 100.0f); }
+    TMediaPlaylist* playlist() const { return mPlaylist; }
+    void setPlaylist(TMediaPlaylist* playlist)
+    {
         if (mPlaylist != playlist) {
-            if (mPlaylist) delete mPlaylist;
+            if (mPlaylist)
+                delete mPlaylist;
             mPlaylist = playlist;
         }
     }
@@ -131,7 +130,7 @@ private:
     QString setupMediaAbsolutePathFileName(TMediaData& mediaData);
     void connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player);
     static void purgeStoppedMediaPlayers(QList<std::shared_ptr<TMediaPlayer>>& mediaList);
-    template<typename T>
+    template <typename T>
     static void updateList(QList<std::shared_ptr<T>>& list, int index, std::shared_ptr<T> player, TMedia* mediaInstance);
     void updateMediaPlayerList(std::shared_ptr<TMediaPlayer> player);
     std::shared_ptr<TMediaPlayer> getMediaPlayer(TMediaData& mediaData);
@@ -140,6 +139,7 @@ private:
     void matchMediaKeyAndStopMediaVariants(TMediaData& mediaData, const QString& absolutePathFileName);
     void handlePlayerPlaybackStateChanged(QMediaPlayerPlaybackState playbackState, const std::shared_ptr<TMediaPlayer>& player);
     bool setupVideo(const std::shared_ptr<TMediaPlayer>& player);
+    static QString mediaTypeToString(int mediaType);
 
     void play(TMediaData& mediaData);
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds type, key, and tag information to media events (`sysMediaStarted`, `sysMediaPaused`, `sysMediaFinished`) so scripts can better identify which media triggered the event.

#### Motivation for adding to Mudlet

With the addition of video playback on labels and windows, scripts need a way to know which specific media finished playing. Previously, only the filename and path were provided. Now the key (widget name), type (sound/music/video), and tag are included, making it easy to react to specific media events.

#### Other info (issues closed, discussion etc)

Event arguments are now:
1. Event name
2. File name  
3. File path
4. Media type (`sound`, `music`, or `video`)
5. Key
6. Tag

Example usage:
```lua
function onVideoFinished(event, fileName, filePath, mediaType, key, tag)
    if key == "introLabel" then
        hideWindow("introLabel")
    end
end

registerAnonymousEventHandler("sysMediaFinished", onVideoFinished)
```
---

Example where GMCP Client.Media.Play event starts a video. The event switches focus from the Mapper to the playing label in the user interface. When the video stops playing, focus returns to the prior window with the Mapper.

https://github.com/user-attachments/assets/bc842ef3-5309-43bc-8afe-6a1870c6dcc1