### PR TITLE
Fix: Correct TestMask to exclude internal flags

### DIFF
--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -251,7 +251,7 @@ public:
         // Mask for "any alternate font" - only the most significant one should
         // be used if more than one is set:
         AltFontMask = 0x1ff00,        // 0000 0000 0000 0001 1111 1111 0000 0000
-        TestMask = 0x1f3ffff,         // 0000 0001 1111 0011 1111 1111 1111 1111 (includes extended underline styles)
+        TestMask = 0x1c3ffff,         // 0000 0001 1100 0011 1111 1111 1111 1111 (includes extended underline styles)
         // The remainder are internal use ones that do not related to SGR codes
         // that have been parsed from the incoming text.
         // Has been found in a search operation (currently Main Console only)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Corrects `TChar::AttributeFlag::TestMask` from `0x1f3ffff` to `0x1c3ffff` to properly exclude the `Found` and `Echo` internal flags.

#### Motivation for adding to Mudlet

PR #8262 inadvertently included two extra bits in the `TestMask` when adding extended underline styles. These bits correspond to `Found` (search highlighting) and `Echo` (echo state) — internal flags that should not be part of the display attributes mask.

This could cause unexpected behavior when copying or setting display attributes, potentially affecting search result highlighting and echo functionality.

#### Other info (issues closed, discussion etc)

Bug spotted by @Slysven in the PR #8262 diff and Discorded [here](https://discord.com/channels/283581582550237184/283582439002210305/1472400880769830964).