### PR TITLE
Fix: Input bar height changes unexpectedly when switching profiles

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -6548,6 +6548,12 @@ void mudlet::activateProfile(Host* pHost)
     QResizeEvent event(s, s);
     QApplication::sendEvent(mpCurrentActiveHost->mpConsole, &event);
 
+    // Defer command line height adjustment to ensure geometry is correct after profile switch.
+    // When switching profiles, Qt widget geometry isn't updated until the event loop processes
+    // show/hide events. Calling adjustHeight() immediately would use incorrect document width,
+    // causing the input bar to have the wrong height.
+    QTimer::singleShot(0, mpCurrentActiveHost->mpConsole->mpCommandLine, &TCommandLine::adjustHeight);
+
     // Update the main application window title based on active profiles in main window
     updateMainWindowTitle();
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes the input bar height growing unexpectedly when switching between open profiles.

#### Motivation for adding to Mudlet

When switching between multiple connections with text entered in the input bar, the input bar height would become larger than expected until the user started typing again. This creates a jarring visual experience when using Ctrl+Tab to switch profiles.

#### Other info (issues closed, discussion etc)

Fixes #8922

**Root cause:** When switching profiles, Qt widget geometry isn't updated until the event loop processes show/hide events. The input bar's `adjustHeight()` method was being called (via the resize event) before the geometry was correct, causing incorrect height calculations.

**Solution:** Defer the `adjustHeight()` call using `QTimer::singleShot(0, ...)` so Qt can fully process visibility changes and update geometry first. This is the same pattern used in PR #8853 for miniconsole text cutoff.