### PR TITLE
Infrastructure: CI concurrency logic

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{matrix.os}}
     if: ${{ github.repository_owner == 'Mudlet' }}
     concurrency:
-      group: ${{github.workflow}}-${{matrix.buildname}}-${{ github.event.pull_request.number || github.ref_name }}
+      group: ${{github.workflow}}-${{matrix.buildname}}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
     env:
       SIGNPATH_SIGNING_ENABLED: ${{ secrets.SIGNPATH_API_TOKEN != '' }}

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -24,6 +24,9 @@ jobs:
     name: ${{matrix.buildname}}
     runs-on: ${{matrix.os}}
     if: ${{ github.repository_owner == 'Mudlet' }}
+    concurrency:
+      group: ${{github.workflow}}-${{matrix.buildname}}-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     env:
       SIGNPATH_SIGNING_ENABLED: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
     strategy:

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{matrix.os}}
     if: ${{ github.repository_owner == 'Mudlet' }}
     concurrency:
-      group: ${{github.workflow}}-${{matrix.buildname}}-${{ github.event.pull_request.number || github.ref }}
+      group: ${{github.workflow}}-${{matrix.buildname}}-${{ github.event.pull_request.number || github.ref_name }}
       cancel-in-progress: true
     env:
       SIGNPATH_SIGNING_ENABLED: ${{ secrets.SIGNPATH_API_TOKEN != '' }}

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -18,6 +18,9 @@ jobs:
     name: ${{matrix.buildname}}
     runs-on: ${{matrix.os}}
     if: ${{ github.repository_owner == 'Mudlet' }}
+    concurrency:
+      group: ${{github.workflow}}-${{matrix.buildname}}-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     env:
       LUA_VERSION: '5.1.5'
     strategy:

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{matrix.os}}
     if: ${{ github.repository_owner == 'Mudlet' }}
     concurrency:
-      group: ${{github.workflow}}-${{matrix.buildname}}-${{ github.event.pull_request.number || github.ref }}
+      group: ${{github.workflow}}-${{matrix.buildname}}-${{ github.event.pull_request.number || github.ref_name }}
       cancel-in-progress: true
     env:
       LUA_VERSION: '5.1.5'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{matrix.os}}
     if: ${{ github.repository_owner == 'Mudlet' }}
     concurrency:
-      group: ${{github.workflow}}-${{matrix.buildname}}-${{ github.event.pull_request.number || github.ref_name }}
+      group: ${{github.workflow}}-${{matrix.buildname}}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
     env:
       LUA_VERSION: '5.1.5'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     concurrency:
-      group: ${{github.workflow}}-${{matrix.buildname}}-${{github.ref_name}}
+      group: ${{github.workflow}}-${{matrix.buildname}}-${{github.ref}}
       cancel-in-progress: true
 
     permissions:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     concurrency:
-      group: ${{github.workflow}}-${{matrix.buildname}}
+      group: ${{github.workflow}}-${{matrix.buildname}}-${{github.ref_name}}
       cancel-in-progress: true
 
     permissions:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,9 +16,6 @@ jobs:
   analyze:
     name: ${{matrix.buildname}}
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{github.workflow}}-${{matrix.buildname}}-${{ github.ref }}
-      cancel-in-progress: true
 
     permissions:
       security-events: write

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,6 +16,9 @@ jobs:
   analyze:
     name: ${{matrix.buildname}}
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{github.workflow}}-${{matrix.buildname}}-${{ github.ref }}
+      cancel-in-progress: true
 
     permissions:
       security-events: write

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,10 @@ jobs:
     name: ${{matrix.buildname}}
     runs-on: ubuntu-latest
 
+    concurrency:
+      group: ${{github.workflow}}-${{matrix.buildname}}
+      cancel-in-progress: true
+
     permissions:
       security-events: write
 

--- a/.github/workflows/dangerjs.yml
+++ b/.github/workflows/dangerjs.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, edited]
 
+concurrency:
+  group: ${{github.workflow}}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   danger:
     runs-on: ubuntu-latest

--- a/.github/workflows/dangerjs.yml
+++ b/.github/workflows/dangerjs.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened, edited]
 
 concurrency:
-  group: ${{github.workflow}}-${{ github.event.pull_request.number || github.ref_name }}
+  group: ${{github.workflow}}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/dangerjs.yml
+++ b/.github/workflows/dangerjs.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened, edited]
 
 concurrency:
-  group: ${{github.workflow}}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{github.workflow}}-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### Brief overview of PR changes/additions
Adds concurrency logic to cancel ongoing CI workflow runs if a new run starts.

### Motivation for adding to Mudlet
If a person pushes multiple commits to a Pull Request, multiple runs will begin.  As we limit the number of runners allowed (as one should), this can prevent new runners from starting on other PRs.  It can also waste time building and testing obsolete code, while the fresher code is waiting in the queue for the old workflow to finish.

### Other info (issues closed, discussion etc)
We could add this logic to the rest of the workflows, but I did not think it necessary.  Instead, I added the concurrency logic only to those workflows that run frequently or run for several minutes.

#### Github's Documentation
https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency

#### Workflows run most frequently
<img width="906" height="639" alt="image" src="https://github.com/user-attachments/assets/5039c23e-b919-4ace-b6ed-74690b67fb49" />

