### PR TITLE
infrastructure: fix unintended ccache collisions

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -74,6 +74,7 @@ jobs:
       run: ccache --zero-stats --show-stats
 
     - name: Get sentry-native commit hash
+      shell: msys2 {0}
       id: sentry-hash
       run: echo "SENTRY_HASH=$(git -C 3rdparty/sentry-native rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -75,7 +75,7 @@ jobs:
 
     - name: Get sentry-native commit hash
       id: sentry-hash
-      run: echo "hash=$(git -C 3rdparty/sentry-native rev-parse HEAD)" >> $GITHUB_OUTPUT
+      run: echo "SENTRY_HASH=$(git -C 3rdparty/sentry-native rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
     - name: Cache sentry-native
       id: cache-sentry
@@ -84,7 +84,7 @@ jobs:
         path: |
           3rdparty/sentry-native/install_without_transport
           3rdparty/sentry-native/install_with_transport
-        key: sentry-${{ runner.os }}-${{ runner.arch }}-${{ steps.sentry-hash.outputs.hash }}
+        key: sentry-${{ runner.os }}-${{ runner.arch }}-${{ steps.sentry-hash.outputs.SENTRY_HASH }}
 
     - name: (Windows) Build
       shell: msys2 {0}

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -239,8 +239,8 @@ jobs:
       uses: actions/cache/restore@v5
       with:
         path: ${{runner.workspace}}/ccache
-        key: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version)}}-${{matrix.qt}}-${{ github.sha }}
-        restore-keys: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version)}}-${{matrix.qt}}
+        key: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version) || ''}}-${{matrix.qt}}-${{ github.sha }}
+        restore-keys: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version) || ''}}-${{matrix.qt}}
 
     - name: (Linux) Set build info
       if: runner.os == 'Linux'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -239,8 +239,8 @@ jobs:
       uses: actions/cache/restore@v5
       with:
         path: ${{runner.workspace}}/ccache
-        key: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}{{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version)}}-${{matrix.qt}}-${{ github.sha }}
-        restore-keys: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}{{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version)}}-${{matrix.qt}}
+        key: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version)}}-${{matrix.qt}}-${{ github.sha }}
+        restore-keys: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version)}}-${{matrix.qt}}
 
     - name: (Linux) Set build info
       if: runner.os == 'Linux'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -239,8 +239,8 @@ jobs:
       uses: actions/cache/restore@v5
       with:
         path: ${{runner.workspace}}/ccache
-        key: ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.qt}}-${{ github.sha }}
-        restore-keys: ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.qt}}
+        key: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}{{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version)}}-${{matrix.qt}}-${{ github.sha }}
+        restore-keys: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}{{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version)}}-${{matrix.qt}}
 
     - name: (Linux) Set build info
       if: runner.os == 'Linux'
@@ -268,7 +268,7 @@ jobs:
 
     - name: Get sentry-native commit hash
       id: sentry-hash
-      run: echo "hash=$(git -C 3rdparty/sentry-native rev-parse HEAD)" >> $GITHUB_OUTPUT
+      run: echo "SENTRY_HASH=$(git -C 3rdparty/sentry-native rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
     - name: Cache sentry-native
       id: cache-sentry
@@ -277,7 +277,7 @@ jobs:
         path: |
           3rdparty/sentry-native/install_without_transport
           3rdparty/sentry-native/install_with_transport
-        key: sentry-${{ runner.os }}-${{ runner.arch }}-${{ steps.sentry-hash.outputs.hash }}
+        key: sentry-${{ runner.os }}-${{ runner.arch }}-${{ steps.sentry-hash.outputs.SENTRY_HASH }}
 
     - name: Build Mudlet
       uses: lukka/run-cmake@v3


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
## Brief overview of PR changes/additions
* fixed missing sentry hash within sentry cache
* made linux/mac ccache keys more specific to each workflow so they do not collide accidently

## Motivation for adding to Mudlet
Faster build times with correct cache keys.

## Other info (issues closed, discussion etc)

### Missing Sentry hash
In the wild: https://github.com/Mudlet/Mudlet/actions/runs/22512716140/job/65224933016

<img width="441" height="447" alt="image" src="https://github.com/user-attachments/assets/48f52495-6852-42a7-9b15-d0e7f9be25e7" />

### Cache collision
In the wild: https://github.com/Mudlet/Mudlet/actions/runs/22512822243
**`ubuntu / gcc...`**: `ccache-ubuntu-22.04-gcc_64-6.9.0-7d032b3000f396828b5d9869464e866728a6a76d`
**`ubuntu (x64_84)`**: `ccache-ubuntu-22.04-gcc_64-6.9.0-7d032b3000f396828b5d9869464e866728a6a76d`

These use different versions of GCC.  v10 and v12 respectively.  Additionally, the former has additional env and compilation flags that the latter does not have.  IE. asan, lsan, and detect_leaks.