### PR TITLE
infrastructure: run undo/redo tests in test mode

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -472,6 +472,7 @@ jobs:
       run: ~/Desktop/Mudlet.app/Contents/MacOS/mudlet --profile "Mudlet self-test" --run-undo-tests
       env:
         ASAN_OPTIONS: detect_leaks=0
+        MUDLET_TEST_MODE: 1
 
     - name: Passed C++ undo/redo tests
       if: matrix.run_tests == 'true'
@@ -481,3 +482,5 @@ jobs:
           echo "C++ undo/redo tests failed - see the action called 'Run C++ undo/redo tests' above for detailed output."
           exit 1
         fi
+      env:
+        MUDLET_TEST_MODE: 1

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -465,6 +465,7 @@ jobs:
       run: xvfb-run --auto-servernum ${{github.workspace}}/src/mudlet --profile "Mudlet self-test" --run-undo-tests
       env:
         ASAN_OPTIONS: detect_leaks=0
+        MUDLET_TEST_MODE: 1
 
     - name: (macOS) Run C++ undo/redo tests
       if: matrix.run_tests == 'true' && runner.os == 'macOS'
@@ -482,5 +483,3 @@ jobs:
           echo "C++ undo/redo tests failed - see the action called 'Run C++ undo/redo tests' above for detailed output."
           exit 1
         fi
-      env:
-        MUDLET_TEST_MODE: 1


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
### Brief overview of PR changes/additions
Sets `MUDLET_TEST_MODE` for undo/redo tests.

### Motivation for adding to Mudlet
So MacOS PTB builds run properly.

### Other info (issues closed, discussion etc)
Did not know I decided to play whack-a-mole this week.

Just like how the lua tests would hang because of the updater, the c++ undo/redo tests are hanging for the same reason.

See:
https://github.com/Mudlet/Mudlet/actions/runs/22535840503/job/65283004817