### PR TITLE
fix: Update ssh IP for Geyser upload workflow

### DIFF
--- a/.github/workflows/update-geyser-docs.yml
+++ b/.github/workflows/update-geyser-docs.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Remove previous docs
       uses: appleboy/ssh-action@master
       with:
-        host: mudlet.org
+        host: 45.33.14.76
         username: ${{secrets.UPLOAD_USERNAME}}
         key: ${{secrets.UPLOAD_PRIVATEKEY}}
         script: "rm -rf /home/${{secrets.UPLOAD_USERNAME}}/geyser/"
@@ -42,7 +42,7 @@ jobs:
     - name: Upload docs
       uses: appleboy/scp-action@master
       with:
-        host: mudlet.org
+        host: 45.33.14.76
         username: ${{secrets.UPLOAD_USERNAME}}
         key: ${{secrets.UPLOAD_PRIVATEKEY}}
         source: "${{github.workspace}}/src/mudlet-lua/mudlet-lua-doc/files/"


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
ssh server doesn't resolve to mudlet.org, so use IP instead

#### Motivation for adding to Mudlet
get the autodocs regenerating again

#### Other info (issues closed, discussion etc)
fixes #8951