### PR TITLE
fix: custom map events not firing when placed in submenus

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -333,11 +333,20 @@ bool T2DMap::eventFilter(QObject* watched, QEvent* event)
             if (button == Qt::LeftButton || button == Qt::RightButton) {
                 const QPoint globalPos = mouseEvent->globalPosition().toPoint();
 
-                // Check if the click is on the menu itself using global coordinates
+                // Check if the click is on the menu or any of its visible submenus
                 if (auto* activeMenu = mActiveContextMenu.data()) {
                     const QRect menuGlobalGeometry(activeMenu->mapToGlobal(QPoint(0, 0)), activeMenu->size());
                     if (menuGlobalGeometry.contains(globalPos)) {
                         return QObject::eventFilter(watched, event);
+                    }
+
+                    for (const auto* action : activeMenu->actions()) {
+                        if (auto* subMenu = action->menu(); subMenu && subMenu->isVisible()) {
+                            const QRect subMenuGeometry(subMenu->mapToGlobal(QPoint(0, 0)), subMenu->size());
+                            if (subMenuGeometry.contains(globalPos)) {
+                                return QObject::eventFilter(watched, event);
+                            }
+                        }
                     }
                 }
 

--- a/src/mudlet-lua/tests/Mapper_spec.lua
+++ b/src/mudlet-lua/tests/Mapper_spec.lua
@@ -1,3 +1,87 @@
+describe("Tests custom map event and menu functions", function()
+
+  setup(function()
+    openMapWidget()
+  end)
+
+  after_each(function()
+    removeMapEvent("testEvent1")
+    removeMapEvent("testEvent2")
+    removeMapMenu("TestMenu")
+    removeMapMenu("TestSubMenu")
+  end)
+
+  describe("Tests addMapEvent and getMapEvents", function()
+    it("should add a top-level map event", function()
+      addMapEvent("testEvent1", "myEvent", "", "Test Event 1")
+
+      local events = getMapEvents()
+      assert.is_not_nil(events.testEvent1)
+      assert.are.equal("myEvent", events.testEvent1["event name"])
+      assert.are.equal("", events.testEvent1["parent"])
+      assert.are.equal("Test Event 1", events.testEvent1["display name"])
+    end)
+
+    it("should add a map event under a menu", function()
+      addMapMenu("TestMenu")
+      addMapEvent("testEvent1", "myEvent", "TestMenu", "Test Event 1")
+
+      local events = getMapEvents()
+      assert.is_not_nil(events.testEvent1)
+      assert.are.equal("TestMenu", events.testEvent1["parent"])
+    end)
+
+    it("should use unique name as display text when not provided", function()
+      addMapEvent("testEvent1", "myEvent")
+
+      local events = getMapEvents()
+      assert.is_not_nil(events.testEvent1)
+      assert.are.equal("testEvent1", events.testEvent1["display name"])
+    end)
+  end)
+
+  describe("Tests addMapMenu and getMapMenus", function()
+    it("should add a top-level menu", function()
+      addMapMenu("TestMenu")
+
+      local menus = getMapMenus()
+      assert.are.equal("top-level", menus["TestMenu"])
+    end)
+
+    it("should add a nested submenu", function()
+      addMapMenu("TestMenu")
+      addMapMenu("TestSubMenu", "TestMenu")
+
+      local menus = getMapMenus()
+      assert.are.equal("top-level", menus["TestMenu"])
+      assert.are.equal("TestMenu", menus["TestSubMenu"])
+    end)
+  end)
+
+  describe("Tests removeMapEvent", function()
+    it("should remove an event", function()
+      addMapEvent("testEvent1", "myEvent", "", "Test Event 1")
+      removeMapEvent("testEvent1")
+
+      local events = getMapEvents()
+      assert.is_nil(events.testEvent1)
+    end)
+  end)
+
+  describe("Tests removeMapMenu", function()
+    it("should remove a menu and its children", function()
+      addMapMenu("TestMenu")
+      addMapMenu("TestSubMenu", "TestMenu")
+      removeMapMenu("TestMenu")
+
+      local menus = getMapMenus()
+      assert.is_nil(menus["TestMenu"])
+      assert.is_nil(menus["TestSubMenu"])
+    end)
+  end)
+
+end)
+
 describe("Tests per-room border functions", function()
 
   local testRoomId


### PR DESCRIPTION
## Summary
- Fix the event filter in `T2DMap::eventFilter()` swallowing clicks on context menu submenus, which prevented custom map events (via `addMapEvent`/`addMapMenu`) from firing
- Add Lua tests for the map event/menu API

## Details

The `QApplication` event filter (added by #8399, partially fixed by #8492) intercepts `MouseButtonPress` events while a context menu is open to allow one-click map interactions. Its geometry check only covered the top-level popup menu - not submenus. When a user clicked an item inside a submenu (e.g. "My Events" > "Event 1"), the submenu is positioned outside the main menu's bounds, so the check failed. The filter then saw the click overlapping the T2DMap widget, closed the menu, and swallowed the event before `QAction::triggered` could fire.

The fix extends the existing geometry check to also iterate the menu's actions and test any visible submenu geometries.

## Test plan
- [x] Builds without warnings
- [x] Verify in Mudlet: right-click map, click a custom event in a submenu - event fires
- [x] CI Lua tests pass for new `addMapEvent`/`addMapMenu`/`getMapEvents`/`getMapMenus`/`removeMapEvent`/`removeMapMenu` coverage

closes #8994

🤖 Generated with [Claude Code](https://claude.com/claude-code)