### PR TITLE
infra: Refactor geyser doc upload workflow

### DIFF
--- a/.github/workflows/update-geyser-docs.yml
+++ b/.github/workflows/update-geyser-docs.yml
@@ -38,5 +38,5 @@ jobs:
         username: ${{secrets.UPLOAD_USERNAME}}
         key: ${{secrets.UPLOAD_PRIVATEKEY}}
         source: "${{github.workspace}}/src/mudlet-lua/mudlet-lua-doc/files/*"
-        target: "/home/${{secrets.UPLOAD_USERNAME}}/geyser/"
+        target: "/home/${{secrets.UPLOAD_USERNAME}}/geyser/files/"
         rm: true

--- a/.github/workflows/update-geyser-docs.yml
+++ b/.github/workflows/update-geyser-docs.yml
@@ -31,20 +31,12 @@ jobs:
       env:
         WORKSPACE: ${{github.workspace}}
 
-    - name: Remove previous docs
-      uses: appleboy/ssh-action@master
-      with:
-        host: 45.33.14.76
-        username: ${{secrets.UPLOAD_USERNAME}}
-        key: ${{secrets.UPLOAD_PRIVATEKEY}}
-        script: "rm -rf /home/${{secrets.UPLOAD_USERNAME}}/geyser/"
-
     - name: Upload docs
       uses: appleboy/scp-action@master
       with:
         host: 45.33.14.76
         username: ${{secrets.UPLOAD_USERNAME}}
         key: ${{secrets.UPLOAD_PRIVATEKEY}}
-        source: "${{github.workspace}}/src/mudlet-lua/mudlet-lua-doc/files/"
+        source: "${{github.workspace}}/src/mudlet-lua/mudlet-lua-doc/files/*"
         target: "/home/${{secrets.UPLOAD_USERNAME}}/geyser/"
-        strip_components: 5
+        rm: true


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Geyser doc dir is extracted to the wrong location;
`~/geyser/src/mudlet-lua/mudlet-lua-doc/files`
vs just
`~/geyser/files`

resulting in 404's.

#### Motivation for adding to Mudlet
scp-action supports removing of target dir before upload, use that option and remove previous obsolete step
scp-action was using strip-components but this is brittle and was failing to strip the correct amount of directories, switch to just tar'ing up the correct sub-dir (files)

#### Other info (issues closed, discussion etc)
fixes #8951 