### PR TITLE
Improve: show feedback when manually checking for updates fails

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -737,6 +737,7 @@ void mudlet::init()
 #if defined(INCLUDE_UPDATER)
     pUpdater = new Updater(this, mpSettings, publicTestVersion);
     connect(pUpdater, &Updater::signal_updateAvailable, this, &mudlet::slot_updateAvailable);
+    connect(pUpdater, &Updater::signal_updateCheckFailed, this, &mudlet::slot_updateCheckFailed);
     connect(dactionUpdate, &QAction::triggered, this, &mudlet::slot_manualUpdateCheck);
     connect(dactionChangelog, &QAction::triggered, this, &mudlet::slot_showFullChangelog);
 #if defined(Q_OS_MACOS)
@@ -5325,6 +5326,14 @@ void mudlet::checkUpdatesOnStart()
 void mudlet::slot_manualUpdateCheck()
 {
     pUpdater->manuallyCheckUpdates();
+}
+
+void mudlet::slot_updateCheckFailed(const QString& error)
+{
+    auto* pHost = getActiveHost();
+    if (pHost && pHost->mpConsole) {
+        pHost->mpConsole->printSystemMessage(tr("Update check failed - please check your internet connection. Error: %1\n").arg(error));
+    }
 }
 
 void mudlet::slot_showFullChangelog()

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -428,6 +428,7 @@ public slots:
     void slot_handleToolbarVisibilityChanged(bool);
 #if defined(INCLUDE_UPDATER)
     void slot_manualUpdateCheck();
+    void slot_updateCheckFailed(const QString& error);
     void slot_showFullChangelog();
 #endif
     void slot_mapper();

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -181,12 +181,18 @@ void Updater::manuallyCheckUpdates()
 #if defined(Q_OS_MACOS)
     msparkleUpdater->checkForUpdates();
 #else
-    disconnect(feed, &dblsqd::Feed::ready, this, nullptr);
-    disconnect(feed, &dblsqd::Feed::loadError, this, nullptr);
+    if (mManualCheckInProgress) {
+        return;
+    }
+    mManualCheckInProgress = true;
 
     feed->load();
-    KDToolBox::connectSingleShot(feed, &dblsqd::Feed::ready, this, &Updater::showDialogManually);
+    KDToolBox::connectSingleShot(feed, &dblsqd::Feed::ready, this, [this]() {
+        mManualCheckInProgress = false;
+        showDialogManually();
+    });
     KDToolBox::connectSingleShot(feed, &dblsqd::Feed::loadError, this, [this](const QString& error) {
+        mManualCheckInProgress = false;
         emit signal_updateCheckFailed(error);
     });
 #endif
@@ -195,7 +201,6 @@ void Updater::manuallyCheckUpdates()
 void Updater::showDialogManually() const
 {
     updateDialog->show();
-    QObject::disconnect(feed, &dblsqd::Feed::ready, this, &Updater::showDialogManually);
 }
 
 // only shows the changelog since the last version

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -181,6 +181,9 @@ void Updater::manuallyCheckUpdates()
 #if defined(Q_OS_MACOS)
     msparkleUpdater->checkForUpdates();
 #else
+    disconnect(feed, &dblsqd::Feed::ready, this, nullptr);
+    disconnect(feed, &dblsqd::Feed::loadError, this, nullptr);
+
     feed->load();
     KDToolBox::connectSingleShot(feed, &dblsqd::Feed::ready, this, &Updater::showDialogManually);
     KDToolBox::connectSingleShot(feed, &dblsqd::Feed::loadError, this, [this](const QString& error) {

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -182,7 +182,10 @@ void Updater::manuallyCheckUpdates()
     msparkleUpdater->checkForUpdates();
 #else
     feed->load();
-    connect(feed, &dblsqd::Feed::ready, this, &Updater::showDialogManually);
+    KDToolBox::connectSingleShot(feed, &dblsqd::Feed::ready, this, &Updater::showDialogManually);
+    KDToolBox::connectSingleShot(feed, &dblsqd::Feed::loadError, this, [this](const QString& error) {
+        emit signal_updateCheckFailed(error);
+    });
 #endif
 }
 

--- a/src/updater.h
+++ b/src/updater.h
@@ -52,6 +52,7 @@ private:
     dblsqd::UpdateDialog* updateDialog{nullptr};
     QPushButton* mpInstallOrRestart;
     bool mUpdateInstalled;
+    bool mManualCheckInProgress{false};
     QSettings* settings;
     std::unique_ptr<QTimer> mDailyCheck;
 

--- a/src/updater.h
+++ b/src/updater.h
@@ -22,7 +22,7 @@
 
 // FreeBSD does not support the updater and these missing files upset
 // clang-tidy / Clazy when they are run in an environment without them:
-#if defined (INCLUDE_UPDATER)
+#if defined(INCLUDE_UPDATER)
 #include "dblsqd/feed.h"
 #include "dblsqd/update_dialog.h"
 #include "sparkleupdater.h"
@@ -86,6 +86,7 @@ signals:
     // Argument is a count of updates available
     void signal_updateAvailable(const int);
     void signal_automaticUpdatesChanged(const bool);
+    void signal_updateCheckFailed(const QString& error);
 
 public slots:
     void slot_installOrRestartClicked(QAbstractButton* button, const QString& filePath);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Show feedback when manually checking for updates fails
#### Motivation for adding to Mudlet
So players aren't in the dark when their explicit action to check for updates doesn't actually follow through.

Fix https://github.com/Mudlet/Mudlet/issues/8997


#### Other info (issues closed, discussion etc)
<img width="3481" height="963" alt="image" src="https://github.com/user-attachments/assets/c17576ba-3a71-4e7a-91b1-b34b852a3f88" />
