### PR TITLE
infrastructure: always run build ci in core branches

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -26,7 +26,7 @@ jobs:
     if: ${{ github.repository_owner == 'Mudlet' }}
     concurrency:
       group: ${{github.workflow}}-${{matrix.buildname}}-${{ github.event.pull_request.number || github.ref }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     env:
       SIGNPATH_SIGNING_ENABLED: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
     strategy:

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ github.repository_owner == 'Mudlet' }}
     concurrency:
       group: ${{github.workflow}}-${{matrix.buildname}}-${{ github.event.pull_request.number || github.ref }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     env:
       LUA_VERSION: '5.1.5'
     strategy:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Updated build workflows so only build jobs in pull requests are cancelled due to concurrency.

#### Motivation for adding to Mudlet
We need to build every commit added to `development` so we know if it breaks something.

#### Other info (issues closed, discussion etc)
@vadi2 mentioned the problem on [Discord](https://discordapp.com/channels/283581582550237184/283582439002210305/1478849792401604752).
<img width="1009" height="396" alt="image" src="https://github.com/user-attachments/assets/9311b3a1-6025-464f-82eb-b76219627443" />
