### PR TITLE
infrastructure: ccache key should be per pr/branch

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -65,8 +65,8 @@ jobs:
       uses: actions/cache/restore@v5
       with:
         path: ${{runner.workspace}}/ccache
-        key: ccache-${{matrix.os}}-${{matrix.buildname}}-${{ github.sha }}
-        restore-keys: ccache-${{matrix.os}}-${{matrix.buildname}}
+        key: ccache-${{matrix.os}}-${{matrix.buildname}}-${{ github.ref_name }}
+        restore-keys: ccache-${{matrix.os}}-${{matrix.buildname}}-development
 
     - name: check ccache stats prior to build
       shell: msys2 {0}
@@ -146,7 +146,7 @@ jobs:
         fi
 
     - name: Save ccache
-      if: always() && steps.restore-ccache.outputs.cache-hit != 'true'
+      if: always()
       uses: actions/cache/save@v5
       with:
         path: ${{runner.workspace}}/ccache

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -239,8 +239,8 @@ jobs:
       uses: actions/cache/restore@v5
       with:
         path: ${{runner.workspace}}/ccache
-        key: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version) || ''}}-${{matrix.qt}}-${{ github.sha }}
-        restore-keys: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version) || ''}}-${{matrix.qt}}
+        key: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version) || ''}}-${{matrix.qt}}-${{ github.ref_name }}
+        restore-keys: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version) || ''}}-${{matrix.qt}}-development
 
     - name: (Linux) Set build info
       if: runner.os == 'Linux'
@@ -299,7 +299,7 @@ jobs:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
     - name: Save ccache
-      if: always() && steps.restore-ccache.outputs.cache-hit != 'true'
+      if: always()
       uses: actions/cache/save@v5
       with:
         path: ${{runner.workspace}}/ccache


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Updates ccache save key to differentiate between branchs/PRs.

#### Motivation for adding to Mudlet

As is, PRs can and will save to the ccache in the case of a cache miss.  This is problematic because then every other PR will use the ccache from that PR since the sha for the key uses the base branch's commit sha rather than their own commit sha.

Additionally, as the key uses the latest commit's sha, this makes it difficult for a build on the base branch to have a cache hit.

#### Other info (issues closed, discussion etc)

Briefly mentioned this in [discord](https://discordapp.com/channels/283581582550237184/283582439002210305/1478852221855731822).
<img width="1024" height="202" alt="image" src="https://github.com/user-attachments/assets/4d0effd6-75fc-47cd-8b4c-91ef082d9638" />
