### PR TITLE
Infrastructure: Remove unnecessary null checks after new

### DIFF
--- a/src/TMxpFrameManager.cpp
+++ b/src/TMxpFrameManager.cpp
@@ -585,11 +585,6 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
         // Create console directly with tabPage as parent to avoid flash on mpMainFrame
         // (createMiniConsole parents to mpMainFrame and calls show() before we can intervene)
         console = new TConsole(mpHost, frame->name, TConsole::SubConsole, tabPage);
-        if (!console) {
-            qWarning() << "TMxpFrameManager::layoutInternalFrame: Failed to create console for" << frame->name;
-            delete containerWidget;
-            return;
-        }
 
         // Setup console properties (mirroring what createMiniConsole does)
         console->setObjectName(frame->name);
@@ -615,12 +610,6 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
         // Floating/borderless: console directly in container, no tab header
         // Create console directly with containerWidget as parent to avoid flash
         console = new TConsole(mpHost, frame->name, TConsole::SubConsole, containerWidget);
-
-        if (!console) {
-            qWarning() << "TMxpFrameManager::layoutInternalFrame: Failed to create console for" << frame->name;
-            delete containerWidget;
-            return;
-        }
 
         // Setup console properties (mirroring what createMiniConsole does)
         console->setObjectName(frame->name);
@@ -783,12 +772,6 @@ void TMxpFrameManager::layoutTabFrame(TMxpFrame* frame)
 
     // Create console directly with tabPage as parent
     auto* console = new TConsole(mpHost, frame->name, TConsole::SubConsole, tabPage);
-
-    if (!console) {
-        qWarning() << "TMxpFrameManager::layoutTabFrame: Failed to create console";
-        delete tabPage;
-        return;
-    }
 
     // Setup console properties
     TMainConsole* mainConsole = mpHost->mpConsole;


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
C++ new throws on allocation failure, never returns nullptr, making these checks dead code - and CodeQL was warning about it.
#### Motivation for adding to Mudlet
<img width="2587" height="1855" alt="image" src="https://github.com/user-attachments/assets/a402bac4-3a64-4175-8bd8-243f7b2f5567" />

#### Other info (issues closed, discussion etc)
In a practical scenario, should this happen, applications will be crashing at this point anyhow due to lack of memory.