### PR TITLE
Fix: Separate user and MXP borders so reconnect doesn't reset user borders

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1001,8 +1001,8 @@ void Host::waitForProfileSave()
     int iterations = 0;
     while (currentlySavingProfile()) {
         if (++iterations > 1000) {
-            qWarning().nospace() << "Host::waitForProfileSave() WARNING - save did not complete after 1000 event loop iterations. "
-                                 << "State: mWritingHostAndModules=" << mWritingHostAndModules << ", writers pending=" << writers.size() << ". Continuing without waiting.";
+            qWarning().nospace() << "Host::waitForProfileSave() WARNING - save did not complete after 1000 event loop iterations. " << "State: mWritingHostAndModules=" << mWritingHostAndModules
+                                 << ", writers pending=" << writers.size() << ". Continuing without waiting.";
             break;
         }
         qApp->processEvents();
@@ -4827,6 +4827,18 @@ void Host::setBorders(QMargins borders)
     QResizeEvent event(s, s);
     QApplication::sendEvent(mpConsole, &event);
     mpConsole->raiseMudletSysWindowResizeEvent(x, y);
+}
+
+void Host::setUserBorders(const QMargins borders)
+{
+    mUserBorders = borders;
+    setBorders(mUserBorders + mMxpBorders);
+}
+
+void Host::setMxpBorders(const QMargins borders)
+{
+    mMxpBorders = borders;
+    setBorders(mUserBorders + mMxpBorders);
 }
 
 void Host::setCommandLineHistorySaveSize(const int lines)

--- a/src/Host.h
+++ b/src/Host.h
@@ -452,7 +452,9 @@ public:
     void forgetCommandLine(TCommandLine*);
     QPointer<TConsole> parentTConsole(QObject*) const;
     QMargins borders() const { return mBorders; }
-    void setBorders(const QMargins);
+    QMargins userBorders() const { return mUserBorders; }
+    void setUserBorders(const QMargins);
+    void setMxpBorders(const QMargins);
     void loadMap();
     std::tuple<QString, bool> getCmdLineSettings(const TCommandLine::CommandLineType, const QString&);
     void setCmdLineSettings(const TCommandLine::CommandLineType, const bool, const QString&);
@@ -839,6 +841,7 @@ private slots:
     void slot_purgeTemps();
 
 private:
+    void setBorders(const QMargins);
     void installPackageFonts(const QString& packageName);
     void processGMCPDiscordStatus(const QJsonObject& discordInfo);
     void processGMCPDiscordInfo(const QJsonObject& discordInfo);
@@ -944,7 +947,7 @@ private:
     // we won't use Discord functions.
     QString mRequiredDiscordUserName;
     QString mRequiredDiscordUserDiscriminator;
-    
+
     QString mMMCPChatName;
     QString mMMCPChatPrefix;
     quint16 mMMCPChatPort;
@@ -1030,6 +1033,8 @@ private:
     bool mFocusTimerRunning = false;
 
     QMargins mBorders;
+    QMargins mUserBorders;
+    QMargins mMxpBorders;
 
     // The range - applied to ALL command lines - is 0 to 10000, with the knob
     // on the profile preferences having a log-step action with multiples

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -924,7 +924,7 @@ int TLuaInterpreter::getBgColor(lua_State* L)
 int TLuaInterpreter::getBorderBottom(lua_State* L)
 {
     const Host& host = getHostFromLua(L);
-    lua_pushnumber(L, host.borders().bottom());
+    lua_pushnumber(L, host.userBorders().bottom());
     return 1;
 }
 
@@ -932,7 +932,7 @@ int TLuaInterpreter::getBorderBottom(lua_State* L)
 int TLuaInterpreter::getBorderLeft(lua_State* L)
 {
     const Host& host = getHostFromLua(L);
-    lua_pushnumber(L, host.borders().left());
+    lua_pushnumber(L, host.userBorders().left());
     return 1;
 }
 
@@ -940,7 +940,7 @@ int TLuaInterpreter::getBorderLeft(lua_State* L)
 int TLuaInterpreter::getBorderRight(lua_State* L)
 {
     const Host& host = getHostFromLua(L);
-    lua_pushnumber(L, host.borders().right());
+    lua_pushnumber(L, host.userBorders().right());
     return 1;
 }
 
@@ -948,7 +948,7 @@ int TLuaInterpreter::getBorderRight(lua_State* L)
 int TLuaInterpreter::getBorderSizes(lua_State* L)
 {
     const Host& host = getHostFromLua(L);
-    auto sizes = host.borders();
+    auto sizes = host.userBorders();
     lua_createtable(L, 0, 4);
     lua_pushinteger(L, sizes.top());
     lua_setfield(L, -2, "top");
@@ -965,7 +965,7 @@ int TLuaInterpreter::getBorderSizes(lua_State* L)
 int TLuaInterpreter::getBorderTop(lua_State* L)
 {
     const Host& host = getHostFromLua(L);
-    lua_pushnumber(L, host.borders().top());
+    lua_pushnumber(L, host.userBorders().top());
     return 1;
 }
 
@@ -2406,9 +2406,9 @@ int TLuaInterpreter::setBold(lua_State* L)
 int TLuaInterpreter::setBorderBottom(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    auto sizes = host.borders();
+    auto sizes = host.userBorders();
     sizes.setBottom(getVerifiedInt(L, __func__, 1, "new size"));
-    host.setBorders(sizes);
+    host.setUserBorders(sizes);
     return 0;
 }
 
@@ -2431,9 +2431,9 @@ int TLuaInterpreter::setBorderColor(lua_State* L)
 int TLuaInterpreter::setBorderLeft(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    auto sizes = host.borders();
+    auto sizes = host.userBorders();
     sizes.setLeft(getVerifiedInt(L, __func__, 1, "new size"));
-    host.setBorders(sizes);
+    host.setUserBorders(sizes);
     return 0;
 }
 
@@ -2441,9 +2441,9 @@ int TLuaInterpreter::setBorderLeft(lua_State* L)
 int TLuaInterpreter::setBorderRight(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    auto sizes = host.borders();
+    auto sizes = host.userBorders();
     sizes.setRight(getVerifiedInt(L, __func__, 1, "new size"));
-    host.setBorders(sizes);
+    host.setUserBorders(sizes);
     return 0;
 }
 
@@ -2457,20 +2457,20 @@ int TLuaInterpreter::setBorderSizes(lua_State* L)
         break;
     case 1: {
         auto value = getVerifiedInt(L, __func__, 1, "new size");
-        host.setBorders({value, value, value, value});
+        host.setUserBorders({value, value, value, value});
         break;
     }
     case 2: {
         auto height = getVerifiedInt(L, __func__, 1, "new height");
         auto width = getVerifiedInt(L, __func__, 2, "new width");
-        host.setBorders({width, height, width, height});
+        host.setUserBorders({width, height, width, height});
         break;
     }
     case 3: {
         auto top = getVerifiedInt(L, __func__, 1, "new top size");
         auto width = getVerifiedInt(L, __func__, 2, "new width");
         auto bottom = getVerifiedInt(L, __func__, 3, "new bottom size");
-        host.setBorders({width, top, width, bottom});
+        host.setUserBorders({width, top, width, bottom});
         break;
     }
     default: {
@@ -2478,7 +2478,7 @@ int TLuaInterpreter::setBorderSizes(lua_State* L)
         auto right = getVerifiedInt(L, __func__, 2, "new right size");
         auto bottom = getVerifiedInt(L, __func__, 3, "new bottom size");
         auto left = getVerifiedInt(L, __func__, 4, "new left size");
-        host.setBorders({left, top, right, bottom});
+        host.setUserBorders({left, top, right, bottom});
         break;
     }
     }
@@ -2489,9 +2489,9 @@ int TLuaInterpreter::setBorderSizes(lua_State* L)
 int TLuaInterpreter::setBorderTop(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    auto sizes = host.borders();
+    auto sizes = host.userBorders();
     sizes.setTop(getVerifiedInt(L, __func__, 1, "new size"));
-    host.setBorders(sizes);
+    host.setUserBorders(sizes);
     return 0;
 }
 

--- a/src/TMxpFrameManager.cpp
+++ b/src/TMxpFrameManager.cpp
@@ -259,7 +259,7 @@ void TMxpFrameManager::resetAllFrames()
     mMxpBorders = QMargins();
 
     if (mpHost) {
-        mpHost->setBorders(QMargins());
+        mpHost->setMxpBorders(QMargins());
     }
 
     clearDestination();
@@ -525,7 +525,7 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
             y = containerY;
         }
 
-        mpHost->setBorders(mMxpBorders);
+        mpHost->setMxpBorders(mMxpBorders);
     }
 
     // FLOATING attribute, no explicit title, or very small height = borderless frame without header
@@ -1029,7 +1029,7 @@ void TMxpFrameManager::recalculateBorders()
     mMxpBorders = QMargins();
 
     if (!mpHost->mpConsole) {
-        mpHost->setBorders(mMxpBorders);
+        mpHost->setMxpBorders(mMxpBorders);
         return;
     }
 
@@ -1065,5 +1065,5 @@ void TMxpFrameManager::recalculateBorders()
     }
 
     // Apply the recalculated borders
-    mpHost->setBorders(mMxpBorders);
+    mpHost->setMxpBorders(mMxpBorders);
 }

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -585,7 +585,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
         host.append_child("serverPackageName").text().set(pHost->mServerGUI_Package_name.toUtf8().constData());
         host.append_child("serverPackageVersion").text().set(pHost->mServerGUI_Package_version.toUtf8().constData());
         host.append_child("port").text().set(QString::number(pHost->getPort()).toUtf8().constData());
-        auto borders = pHost->borders();
+        auto borders = pHost->userBorders();
         host.append_child("borderTopHeight").text().set(QString::number(borders.top()).toUtf8().constData());
         host.append_child("borderBottomHeight").text().set(QString::number(borders.bottom()).toUtf8().constData());
         host.append_child("borderLeftWidth").text().set(QString::number(borders.left()).toUtf8().constData());

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1176,7 +1176,7 @@ void XMLimport::readHost(Host* pHost)
         }
     }
 
-    pHost->setBorders(borders);
+    pHost->setUserBorders(borders);
     pHost->loadPackageInfo();
 }
 
@@ -2055,8 +2055,8 @@ void XMLimport::readStopWatchMap()
     }
 }
 
-void XMLimport::readMMCPOptions() {
-
+void XMLimport::readMMCPOptions()
+{
     mpHost->mMMCPChatName = attributes().value(qsl("chatName")).toString();
     mpHost->mMMCPChatPort = attributes().value(qsl("chatPort")).toUShort();
     mpHost->mMMCPChatPrefix = attributes().value(qsl("chatPrefix")).toString();

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -258,7 +258,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
 
     // Add validator for MMCP Chatname, disallow ~ and , characters
     QRegularExpression rx("^[^~,]*$");
-    QValidator *validator = new QRegularExpressionValidator(rx, this);
+    QValidator* validator = new QRegularExpressionValidator(rx, this);
     lineEdit_mmcpChatName->setValidator(validator);
 
     connect(checkBox_showSpacesAndTabs, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_changeShowSpacesAndTabs);
@@ -873,7 +873,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         lineEdit_discordUserName->setText(pHost->mRequiredDiscordUserName);
         lineEdit_discordUserDiscriminator->setText(pHost->mRequiredDiscordUserDiscriminator);
     }
-    
+
     lineEdit_mmcpChatName->setText(pHost->getMMCPChatName());
     lineEdit_mmcpPort->setText(QString::number(pHost->getMMCPPort()));
     lineEdit_mmcpChatMessagePrefix->setText(pHost->getMMCPChatPrefix());
@@ -883,13 +883,13 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     checkBox_mmcpAllowPeekReq->setChecked(pHost->mMMCPAllowPeekRequests);
     checkBox_mmcpAutoAcceptCalls->setChecked(pHost->getMMCPAutoAcceptCalls());
     */
-    
+
     checkBox_mmcpAddChatMessageNewline->setChecked(pHost->getMMCPAddChatMessageNewline());
     checkBox_mmcpPrefixEmotes->setChecked(pHost->getMMCPPrefixEmotes());
     checkBox_mmcpSnoopInMainConsole->setChecked(pHost->getMMCPShowSnoopInMainConsole());
     checkBox_runAllKeyBindings->setChecked(pHost->getKeyUnit()->mRunAllKeyMatches);
 
-    auto originalBorders = pHost->borders();
+    auto originalBorders = pHost->userBorders();
     topBorderHeight->setValue(originalBorders.top());
     bottomBorderHeight->setValue(originalBorders.bottom());
     leftBorderWidth->setValue(originalBorders.left());
@@ -1241,7 +1241,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
                         break;
                     default: {
                     } // There are a significant number of other errors
-                        // that are not handled here!
+                    // that are not handled here!
                     }
                 }
             }
@@ -1614,7 +1614,7 @@ void dlgProfilePreferences::clearHostDetails()
     checkBox_discordServerAccessToTimerInfo->setChecked(false);
     lineEdit_discordUserName->clear();
     lineEdit_discordUserDiscriminator->clear();
-    
+
     lineEdit_mmcpChatName->clear();
 
     checkBox_debugShowAllCodepointProblems->setChecked(false);
@@ -3030,7 +3030,7 @@ void dlgProfilePreferences::slot_saveAndClose()
             }
         }
         const QMargins newBorders{leftBorderWidth->value(), topBorderHeight->value(), rightBorderWidth->value(), bottomBorderHeight->value()};
-        pHost->setBorders(newBorders);
+        pHost->setUserBorders(newBorders);
         pHost->commandLineMinimumHeight = commandLineMinimumHeight->value();
         pHost->mVersionInTTYPE = checkBox_mVersionInTTYPE->isChecked();
         pHost->setForceMXPProcessorOn(checkBox_mForceMXPProcessorOn->isChecked());
@@ -3138,14 +3138,14 @@ void dlgProfilePreferences::slot_saveAndClose()
         } else {
             pHost->mRequiredDiscordUserDiscriminator.clear();
         }
-        
+
         // Save chat options so they are written to XML upon export
         pHost->mMMCPChatName = lineEdit_mmcpChatName->text().trimmed();
         pHost->mMMCPChatPrefix = lineEdit_mmcpChatMessagePrefix->text().trimmed();
         bool ok;
         quint16 port = lineEdit_mmcpPort->text().toUShort(&ok);
         pHost->mMMCPChatPort = ok ? port : csDefaultMMCPHostPort;
-        
+
         /* Possible inclusion in 4020.1
         pHost->mMMCPAutostartServer = checkBox_mmcpAutostartServer->isChecked();
         pHost->mMMCPAutoAcceptCalls = checkBox_mmcpAutoAcceptCalls->isChecked();
@@ -3155,10 +3155,10 @@ void dlgProfilePreferences::slot_saveAndClose()
         pHost->mMMCPAutostartServer = false;
         pHost->mMMCPAutoAcceptCalls = false;
         pHost->mMMCPAllowPeekRequests = false;
-        
+
         pHost->mMMCPPrefixEmotes = checkBox_mmcpPrefixEmotes->isChecked();
         pHost->mMMCPAddChatMessageNewline = checkBox_mmcpAddChatMessageNewline->isChecked();
-        
+
         pHost->mMMCPShowSnoopInMainConsole = checkBox_mmcpSnoopInMainConsole->isChecked();
         pHost->mAnnounceIncomingText = checkBox_announceIncomingText->isChecked();
         pHost->mAdvertiseScreenReader = checkBox_advertiseScreenReader->isChecked();
@@ -4107,7 +4107,8 @@ void dlgProfilePreferences::slot_changeLogFileAsHtml(const bool isHtml)
  * Update the chatname lineEdit if the user changes their chat name while
  * the preferences dialog is open
  */
-void dlgProfilePreferences::slot_setMMCPChatName(const QString& name) {
+void dlgProfilePreferences::slot_setMMCPChatName(const QString& name)
+{
     lineEdit_mmcpChatName->setText(name);
 }
 
@@ -4115,7 +4116,8 @@ void dlgProfilePreferences::slot_setMMCPChatName(const QString& name) {
  * Notify connected clients that our chatname has been changed (via GUI)
  * 
  */
-void dlgProfilePreferences::slot_mmcpChatNameChanged() {
+void dlgProfilePreferences::slot_mmcpChatNameChanged()
+{
     const QString& chatName = lineEdit_mmcpChatName->text();
 
     if (mpHost) {


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
TMxpFrameManager::resetAllFrames() was zeroing Host::mBorders on reconnect, wiping user-configured borders. Split into mUserBorders and mMxpBorders with additive effective borders. MXP callers use setMxpBorders(), all others use setUserBorders(). setBorders() is now private.
#### Motivation for adding to Mudlet


Fixes #8871
#### Other info (issues closed, discussion etc)
