### PR TITLE
Improve: add defensive coding to internal code related to the TMediaPlayer

### DIFF
--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -63,7 +63,14 @@ public:
         }
         return mMediaPlayer->playbackState();
     }
-    void setVolume(int volume) const { return mMediaPlayer->audioOutput()->setVolume(volume / 100.0f); }
+    void setVolume(int volume) const
+    {
+        if (!mMediaPlayer) {
+            qWarning() << "TMediaPlayer::setVolume() - mMediaPlayer is nullptr!";
+            return;
+        }
+        mMediaPlayer->audioOutput()->setVolume(volume / 100.0f);
+    }
     TMediaPlaylist* playlist() const { return mPlaylist; }
     void setPlaylist(TMediaPlaylist* playlist)
     {
@@ -77,8 +84,8 @@ public:
 private:
     QPointer<Host> mpHost;
     TMediaData mMediaData;
-    QMediaPlayer* mMediaPlayer;
-    TMediaPlaylist* mPlaylist;
+    QMediaPlayer* mMediaPlayer = nullptr;
+    TMediaPlaylist* mPlaylist = nullptr;
     bool initialized = false;
 };
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
TMediaPlayer() = default; leaves mMediaPlayer (line 80) and mPlaylist (line 81) as uninitialized raw pointers - any method call on a default-constructed instance is undefined behavior              │
setVolume() (line 66) dereferences mMediaPlayer->audioOutput()->setVolume(...) without null checks, while getPlaybackState() (lines 60-64) properly checks for null - inconsistent safety 

These aren't real issues right now because no code path calls them like this, so this is a hypothetical issue, but it's good to cover it with defensive coding anyway
#### Motivation for adding to Mudlet
Less false positive errors when doing codebase analysis.
#### Other info (issues closed, discussion etc)
