### PR TITLE
Improve: adjust getTime() table size hint to match 7 entries

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2552,7 +2552,7 @@ int TLuaInterpreter::getTime(lua_State* L)
     } else {
         const QDate dt = time.date();
         const QTime tm = time.time();
-        lua_createtable(L, 0, 4);
+        lua_createtable(L, 0, 7);
         lua_pushstring(L, "hour");
         lua_pushinteger(L, tm.hour());
         lua_rawset(L, n + 1);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
We told Lua we'd be creating 4 entries in a table in the getTime() function, but we actually create 7. Lua compensates for this just fine, but it's a minor error that we can fix.
#### Motivation for adding to Mudlet
More rational code.
#### Other info (issues closed, discussion etc)
