### PR TITLE
Improve: guard mudlet::self() in cTelnet destructor

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -199,7 +199,9 @@ cTelnet::~cTelnet()
         loadingReplay = false;
         replayFile.close();
         qDebug() << "cTelnet::~cTelnet() INFO - A replay was in progress on this profile but has been aborted.";
-        mudlet::self()->replayOver();
+        if (auto pMudlet = mudlet::self()) {
+            pMudlet->replayOver();
+        }
     }
 
     if (!messageStack.empty()) {
@@ -4252,8 +4254,8 @@ void cTelnet::postMessage(QString msg)
                     mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(190, 100, 50), mpHost->mBgColor); // Orange-ish
                 }
             } else if (prefix.contains(tr("CHAT")) || prefix.contains(QLatin1String("CHAT"))) {
-                mpHost->mpConsole->print(prefix, QColor(255, 255, 50), mpHost->mBgColor);                   // Bright yellow
-                mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(0, 160, 0), mpHost->mBgColor);  // Light Green
+                mpHost->mpConsole->print(prefix, QColor(255, 255, 50), mpHost->mBgColor);                  // Bright yellow
+                mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(0, 160, 0), mpHost->mBgColor); // Light Green
                 for (int _i = 0; _i < body.size(); ++_i) {
                     QString temp = body.at(_i);
                     temp.replace('\t', QLatin1String("        "));

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -193,9 +193,6 @@ cTelnet::~cTelnet()
     disconnect();
 
     if (loadingReplay) {
-        // If we are doing a replay we had better abort it so that if we are
-        // NOT the "last profile standing" the replay system gets reset for
-        // another profile to use:
         loadingReplay = false;
         replayFile.close();
         qDebug() << "cTelnet::~cTelnet() INFO - A replay was in progress on this profile but has been aborted.";

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -193,6 +193,9 @@ cTelnet::~cTelnet()
     disconnect();
 
     if (loadingReplay) {
+        // If we are doing a replay we had better abort it so that if we are
+        // NOT the "last profile standing" the replay system gets reset for
+        // another profile to use:
         loadingReplay = false;
         replayFile.close();
         qDebug() << "cTelnet::~cTelnet() INFO - A replay was in progress on this profile but has been aborted.";

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4660,9 +4660,6 @@ void mudlet::slot_compactInputLine(const bool state)
 
 mudlet::~mudlet()
 {
-    // There may be a corner case if a replay is running AND the application is
-    // closing down AND the updater on a particular platform pauses the
-    // application destruction...?
     delete (mpTimerReplay);
     mpTimerReplay = nullptr;
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4660,6 +4660,9 @@ void mudlet::slot_compactInputLine(const bool state)
 
 mudlet::~mudlet()
 {
+    // There may be a corner case if a replay is running AND the application is
+    // closing down AND the updater on a particular platform pauses the
+    // application destruction...?
     delete (mpTimerReplay);
     mpTimerReplay = nullptr;
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
guard mudlet::self() in cTelnet destructor so it doesn't crash if a profile is closed while a replay is running
#### Motivation for adding to Mudlet
Potential crash fix
#### Other info (issues closed, discussion etc)
  1. mudlet::~mudlet() body runs - at line 4690, it sets smpSelf = nullptr
  2. After the destructor body, mudlet's member variables are destroyed in reverse declaration order
  3. mHostManager (a direct member at mudlet.h:603) is destroyed, which drops the QSharedPointer<Host> references
  4. Host destructor runs, and since mTelnet is a value member (Host.h:503), cTelnet::~cTelnet() runs
  5. At ctelnet.cpp:202, if loadingReplay is true, it calls mudlet::self()->replayOver() - but self() now returns nullptr → crash
