### PR TITLE
Infra: re-introduce path stripping in geyser-docs.yaml

### DIFF
--- a/.github/workflows/update-geyser-docs.yml
+++ b/.github/workflows/update-geyser-docs.yml
@@ -37,6 +37,7 @@ jobs:
         host: 45.33.14.76
         username: ${{secrets.UPLOAD_USERNAME}}
         key: ${{secrets.UPLOAD_PRIVATEKEY}}
-        source: "${{github.workspace}}/src/mudlet-lua/mudlet-lua-doc/files/*"
-        target: "/home/${{secrets.UPLOAD_USERNAME}}/geyser/files/"
+        source: "${{github.workspace}}/src/mudlet-lua/mudlet-lua-doc/files/"
+        target: "/home/${{secrets.UPLOAD_USERNAME}}/geyser/"
+        strip_components: 9
         rm: true


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add in correct strip length for untarred directories.

#### Motivation for adding to Mudlet
Action tars up the full directory structure regardless, so resort to stripping upper directories.

#### Other info (issues closed, discussion etc)
