### PR TITLE
infrastructure: set CCACHE_COMPRESS_LEVEL to 5

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -91,6 +91,7 @@ jobs:
     - name: (Windows) Build
       shell: msys2 {0}
       env:
+        CCACHE_COMPRESSLEVEL: 5
         GITHUB_REPO_TAG: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
         GITHUB_SCHEDULED_BUILD: ${{ github.event_name == 'schedule' || github.event.inputs.scheduled == 'true' }}
         GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -92,6 +92,7 @@ jobs:
       shell: msys2 {0}
       env:
         CCACHE_COMPRESSLEVEL: 5
+        CCACHE_MAXSIZE: "80M"
         GITHUB_REPO_TAG: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
         GITHUB_SCHEDULED_BUILD: ${{ github.event_name == 'schedule' || github.event.inputs.scheduled == 'true' }}
         GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -295,6 +295,7 @@ jobs:
           -DSENTRY_DSN=${{ secrets.SENTRY_DSN }}
       env:
         CCACHE_COMPRESSLEVEL: 5
+        CCACHE_MAXSIZE: "80M"
         NINJA_STATUS: '[%f/%t %o/sec] '
         MUDLET_SANITIZERS: ${{ github.event_name == 'pull_request' && 'address' || '' }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -294,6 +294,7 @@ jobs:
           -DSENTRY_SEND_DEBUG=${{ (startsWith(github.ref, 'refs/tags/') || github.event_name == 'schedule' || github.event.inputs.scheduled == 'true') && '1' || '0' }}
           -DSENTRY_DSN=${{ secrets.SENTRY_DSN }}
       env:
+        CCACHE_COMPRESSLEVEL: 5
         NINJA_STATUS: '[%f/%t %o/sec] '
         MUDLET_SANITIZERS: ${{ github.event_name == 'pull_request' && 'address' || '' }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
### Brief overview of PR changes/additions
Set the ccache compression level to 5.

### Motivation for adding to Mudlet
Right now, a single PR can use ~2GB of the action cache through the ccache.

### Other info (issues closed, discussion etc)
<img width="975" height="516" alt="image" src="https://github.com/user-attachments/assets/db56f690-8d07-4db2-af39-2fc66291c7c9" />

