### PR TITLE
Infrastructure: Fix windows builds in `development`

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -16,7 +16,7 @@ on:
 permissions:
   id-token: write
   contents: read
-  actions: read
+  actions: write
 
 jobs:
   compile-mudlet:
@@ -57,7 +57,7 @@ jobs:
         $GITHUB_WORKSPACE/CI/validate-deployment-for-windows.sh
   
     - name: Acquire ccache lock
-      uses: guibranco/github-artifact-lock-action@v2.0.5
+      uses: guibranco/github-artifact-lock-action@v3.0.9
       with:
         lock-name: ccache-${{matrix.os}}-${{matrix.buildname}}-${{ github.ref_name }}-lock
 
@@ -71,7 +71,7 @@ jobs:
 
     - name: Release ccache lock
       if: always()
-      uses: guibranco/github-artifact-lock-action/release-lock@v2.0.5
+      uses: guibranco/github-artifact-lock-action/release-lock@v3.0.9
       with:
         lock-name: ${{ steps.restore-ccache.outputs.cache-primary-key }}-lock
 
@@ -153,7 +153,7 @@ jobs:
         fi
   
     - name: Acquire ccache lock
-      uses: guibranco/github-artifact-lock-action@v2.0.5
+      uses: guibranco/github-artifact-lock-action@v3.0.9
       with:
         lock-name: ${{ steps.restore-ccache.outputs.cache-primary-key }}-lock
 
@@ -166,7 +166,7 @@ jobs:
   
     - name: Release ccache lock
       if: always()
-      uses: guibranco/github-artifact-lock-action/release-lock@v2.0.5
+      uses: guibranco/github-artifact-lock-action/release-lock@v3.0.9
       with:
         lock-name: ${{ steps.restore-ccache.outputs.cache-primary-key }}-lock
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -231,7 +231,7 @@ jobs:
          echo "WITH_FONTS=no" >> $GITHUB_ENV
   
     - name: Acquire ccache lock
-      uses: guibranco/github-artifact-lock-action@v2.0.5
+      uses: guibranco/github-artifact-lock-action@v3.0.9
       with:
         lock-name: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version) || ''}}-${{matrix.qt}}-${{ github.ref_name }}-lock
 
@@ -245,7 +245,7 @@ jobs:
 
     - name: Release ccache lock
       if: always()
-      uses: guibranco/github-artifact-lock-action/release-lock@v2.0.5
+      uses: guibranco/github-artifact-lock-action/release-lock@v3.0.9
       with:
         lock-name: ${{ steps.restore-ccache.outputs.cache-primary-key }}-lock
 
@@ -306,7 +306,7 @@ jobs:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
   
     - name: Acquire ccache lock
-      uses: guibranco/github-artifact-lock-action@v2.0.5
+      uses: guibranco/github-artifact-lock-action@v3.0.9
       with:
         lock-name: ${{ steps.restore-ccache.outputs.cache-primary-key }}-lock
 
@@ -319,7 +319,7 @@ jobs:
   
     - name: Release ccache lock
       if: always()
-      uses: guibranco/github-artifact-lock-action/release-lock@v2.0.5
+      uses: guibranco/github-artifact-lock-action/release-lock@v3.0.9
       with:
         lock-name: ${{ steps.restore-ccache.outputs.cache-primary-key }}-lock
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Change actions: read to actions: write in the Windows workflow so the lock action can actually delete lock artifacts - right now it just creates the lock, and never releases it.

Also update to the latest version of the lock action, which checks if it can write to the cache and fails loudly.
#### Motivation for adding to Mudlet
Fix windows builds in `development` to run again.
#### Other info (issues closed, discussion etc)
<img width="1315" height="1342" alt="image" src="https://github.com/user-attachments/assets/ea62cad8-505f-488f-ac39-9ad099c08b25" />
