### PR TITLE
infrastructure: remove CodeQL CI's concurrency

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,10 +17,6 @@ jobs:
     name: ${{matrix.buildname}}
     runs-on: ubuntu-latest
 
-    concurrency:
-      group: ${{github.workflow}}-${{matrix.buildname}}-${{github.ref}}
-      cancel-in-progress: true
-
     permissions:
       security-events: write
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Remove concurrency from CodeQL workflow

#### Motivation for adding to Mudlet

So the workflow runs on each commit.
