### PR TITLE
Infrastructure: add retries to brew install to handle hangs

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -91,10 +91,20 @@ jobs:
         HOMEBREW_NO_AUTO_UPDATE: "ON"
         HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: "ON"
         HOMEBREW_NO_INSTALL_CLEANUP: "ON"
-      timeout-minutes: 3
+      timeout-minutes: 10
       run: |
         # Install all required dependencies
-        brew install libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost
+        # brew install can hang indefinitely during bottle pouring, so timeout and retry
+        for attempt in 1 2 3; do
+          if timeout 120 brew install libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost; then
+            break
+          fi
+          echo "::warning::brew install attempt $attempt failed, retrying..."
+          if [ "$attempt" -eq 3 ]; then
+            echo "::error::brew install failed after 3 attempts"
+            exit 1
+          fi
+        done
 
         echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
 

--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -96,7 +96,7 @@ jobs:
         # Install all required dependencies
         # brew install can hang indefinitely during bottle pouring, so timeout and retry
         for attempt in 1 2 3; do
-          if timeout 120 brew install libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost; then
+          if timeout 120 brew install --verbose libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost; then
             break
           fi
           echo "::warning::brew install attempt $attempt failed, retrying..."

--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -91,7 +91,7 @@ jobs:
         HOMEBREW_NO_AUTO_UPDATE: "ON"
         HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: "ON"
         HOMEBREW_NO_INSTALL_CLEANUP: "ON"
-      timeout-minutes: 10
+      timeout-minutes: 7
       run: |
         # Install all required dependencies
         # brew install can hang indefinitely during bottle pouring, so timeout and retry

--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -100,8 +100,8 @@ jobs:
           brew_pid=$!
           ( sleep 120 && kill $brew_pid 2>/dev/null ) &
           watcher_pid=$!
-          wait $brew_pid && { kill $watcher_pid 2>/dev/null; wait $watcher_pid 2>/dev/null || true; break; }
-          kill $watcher_pid 2>/dev/null; wait $watcher_pid 2>/dev/null || true
+          wait $brew_pid && { kill $watcher_pid 2>/dev/null || true; wait $watcher_pid 2>/dev/null || true; break; }
+          kill $watcher_pid 2>/dev/null || true; wait $watcher_pid 2>/dev/null || true
           echo "::warning::brew install attempt $attempt failed or timed out, retrying..."
           if [ "$attempt" -eq 3 ]; then
             echo "::error::brew install failed after 3 attempts"

--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -96,7 +96,7 @@ jobs:
         # Install all required dependencies
         # brew install can hang indefinitely during bottle pouring, so timeout and retry
         for attempt in 1 2 3; do
-          brew install --verbose libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost &
+          brew install libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost &
           brew_pid=$!
           ( sleep 120 && kill $brew_pid 2>/dev/null ) &
           watcher_pid=$!

--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -96,7 +96,7 @@ jobs:
         # Install all required dependencies
         # brew install can hang indefinitely during bottle pouring, so timeout and retry
         for attempt in 1 2 3; do
-          if timeout 120 brew install --verbose libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost; then
+          if gtimeout 120 brew install --verbose libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost; then
             break
           fi
           echo "::warning::brew install attempt $attempt failed, retrying..."

--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -96,10 +96,13 @@ jobs:
         # Install all required dependencies
         # brew install can hang indefinitely during bottle pouring, so timeout and retry
         for attempt in 1 2 3; do
-          if gtimeout 120 brew install --verbose libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost; then
-            break
-          fi
-          echo "::warning::brew install attempt $attempt failed, retrying..."
+          brew install --verbose libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost &
+          brew_pid=$!
+          ( sleep 120 && kill $brew_pid 2>/dev/null ) &
+          watcher_pid=$!
+          wait $brew_pid && { kill $watcher_pid 2>/dev/null; wait $watcher_pid 2>/dev/null; break; }
+          kill $watcher_pid 2>/dev/null; wait $watcher_pid 2>/dev/null
+          echo "::warning::brew install attempt $attempt failed or timed out, retrying..."
           if [ "$attempt" -eq 3 ]; then
             echo "::error::brew install failed after 3 attempts"
             exit 1

--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -100,8 +100,8 @@ jobs:
           brew_pid=$!
           ( sleep 120 && kill $brew_pid 2>/dev/null ) &
           watcher_pid=$!
-          wait $brew_pid && { kill $watcher_pid 2>/dev/null; wait $watcher_pid 2>/dev/null; break; }
-          kill $watcher_pid 2>/dev/null; wait $watcher_pid 2>/dev/null
+          wait $brew_pid && { kill $watcher_pid 2>/dev/null; wait $watcher_pid 2>/dev/null || true; break; }
+          kill $watcher_pid 2>/dev/null; wait $watcher_pid 2>/dev/null || true
           echo "::warning::brew install attempt $attempt failed or timed out, retrying..."
           if [ "$attempt" -eq 3 ]; then
             echo "::error::brew install failed after 3 attempts"

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -102,7 +102,7 @@ jobs:
         # Install all required dependencies
         # brew install can hang indefinitely during bottle pouring, so timeout and retry
         for attempt in 1 2 3; do
-          if timeout 120 brew install libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost; then
+          if timeout 120 brew install --verbose libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost; then
             break
           fi
           echo "::warning::brew install attempt $attempt failed, retrying..."

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -106,8 +106,8 @@ jobs:
           brew_pid=$!
           ( sleep 120 && kill $brew_pid 2>/dev/null ) &
           watcher_pid=$!
-          wait $brew_pid && { kill $watcher_pid 2>/dev/null; wait $watcher_pid 2>/dev/null || true; break; }
-          kill $watcher_pid 2>/dev/null; wait $watcher_pid 2>/dev/null || true
+          wait $brew_pid && { kill $watcher_pid 2>/dev/null || true; wait $watcher_pid 2>/dev/null || true; break; }
+          kill $watcher_pid 2>/dev/null || true; wait $watcher_pid 2>/dev/null || true
           echo "::warning::brew install attempt $attempt failed or timed out, retrying..."
           if [ "$attempt" -eq 3 ]; then
             echo "::error::brew install failed after 3 attempts"

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -102,7 +102,7 @@ jobs:
         # Install all required dependencies
         # brew install can hang indefinitely during bottle pouring, so timeout and retry
         for attempt in 1 2 3; do
-          if timeout 120 brew install --verbose libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost; then
+          if gtimeout 120 brew install --verbose libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost; then
             break
           fi
           echo "::warning::brew install attempt $attempt failed, retrying..."

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -102,10 +102,13 @@ jobs:
         # Install all required dependencies
         # brew install can hang indefinitely during bottle pouring, so timeout and retry
         for attempt in 1 2 3; do
-          if gtimeout 120 brew install --verbose libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost; then
-            break
-          fi
-          echo "::warning::brew install attempt $attempt failed, retrying..."
+          brew install --verbose libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost &
+          brew_pid=$!
+          ( sleep 120 && kill $brew_pid 2>/dev/null ) &
+          watcher_pid=$!
+          wait $brew_pid && { kill $watcher_pid 2>/dev/null; wait $watcher_pid 2>/dev/null; break; }
+          kill $watcher_pid 2>/dev/null; wait $watcher_pid 2>/dev/null
+          echo "::warning::brew install attempt $attempt failed or timed out, retrying..."
           if [ "$attempt" -eq 3 ]; then
             echo "::error::brew install failed after 3 attempts"
             exit 1

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -106,8 +106,8 @@ jobs:
           brew_pid=$!
           ( sleep 120 && kill $brew_pid 2>/dev/null ) &
           watcher_pid=$!
-          wait $brew_pid && { kill $watcher_pid 2>/dev/null; wait $watcher_pid 2>/dev/null; break; }
-          kill $watcher_pid 2>/dev/null; wait $watcher_pid 2>/dev/null
+          wait $brew_pid && { kill $watcher_pid 2>/dev/null; wait $watcher_pid 2>/dev/null || true; break; }
+          kill $watcher_pid 2>/dev/null; wait $watcher_pid 2>/dev/null || true
           echo "::warning::brew install attempt $attempt failed or timed out, retrying..."
           if [ "$attempt" -eq 3 ]; then
             echo "::error::brew install failed after 3 attempts"

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -97,10 +97,20 @@ jobs:
         HOMEBREW_NO_AUTO_UPDATE: "ON"
         HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: "ON"
         HOMEBREW_NO_INSTALL_CLEANUP: "ON"
-      timeout-minutes: 3
+      timeout-minutes: 10
       run: |
         # Install all required dependencies
-        brew install libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost
+        # brew install can hang indefinitely during bottle pouring, so timeout and retry
+        for attempt in 1 2 3; do
+          if timeout 120 brew install libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost; then
+            break
+          fi
+          echo "::warning::brew install attempt $attempt failed, retrying..."
+          if [ "$attempt" -eq 3 ]; then
+            echo "::error::brew install failed after 3 attempts"
+            exit 1
+          fi
+        done
 
         echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -97,7 +97,7 @@ jobs:
         HOMEBREW_NO_AUTO_UPDATE: "ON"
         HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: "ON"
         HOMEBREW_NO_INSTALL_CLEANUP: "ON"
-      timeout-minutes: 10
+      timeout-minutes: 7
       run: |
         # Install all required dependencies
         # brew install can hang indefinitely during bottle pouring, so timeout and retry

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -102,7 +102,7 @@ jobs:
         # Install all required dependencies
         # brew install can hang indefinitely during bottle pouring, so timeout and retry
         for attempt in 1 2 3; do
-          brew install --verbose libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost &
+          brew install libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost &
           brew_pid=$!
           ( sleep 120 && kill $brew_pid 2>/dev/null ) &
           watcher_pid=$!


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
macOS builds are [still hanging](https://github.com/Mudlet/Mudlet/actions/runs/23053096765/job/66959097245), so let's add retries to them in hope that'll bring more resiliency.
#### Motivation for adding to Mudlet
CI builds we can rely on to work.
#### Other info (issues closed, discussion etc)
