### PR TITLE
Fix: Changing one profile's password no longer affects others

### DIFF
--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -424,7 +424,6 @@ void CredentialManager::attemptOldFormatMigration(const QString& service, const 
                 if (migrateJob->error() == QKeychain::NoError) {
                     qDebug() << "CredentialManager: Migration to new format successful, cleaning up old entry";
 
-                    // Delete old format entry
                     auto* cleanupJob = new QKeychain::DeletePasswordJob(service);
                     cleanupJob->setKey(account); // Old format key
                     cleanupJob->setAutoDelete(true);
@@ -447,7 +446,8 @@ void CredentialManager::attemptOldFormatMigration(const QString& service, const 
         } else {
             qDebug() << "CredentialManager: Old format not found, trying other fallbacks";
             // Continue with existing legacy format checks
-            if (account == "character") {
+            // The legacy "Mudlet profile" keychain format was only used for character and password keys
+            if (account == "character" || account == "password") {
                 attemptLegacyKeychainMigration(profileName, account, callback);
             } else {
                 fallbackFileRetrieval(profileName, account, callback);
@@ -711,9 +711,10 @@ void CredentialManager::retrieveCredential(const QString& service, const QString
                     qDebug() << "CredentialManager:" << errorContext << ", trying fallback storage";
 
                     // Try old format first (before Windows keychain fix), then legacy formats
-                    // Clear callback to prevent it being called twice (the migration function will call it)
+                    // Clear state to prevent callback being called twice and keep member state consistent
                     auto originalCallback = mCurrentRetrievalCallback;
                     mCurrentRetrievalCallback = nullptr;
+                    mCurrentJob = nullptr;
                     attemptOldFormatMigration(service, account, profileName, originalCallback);
                     readJob->deleteLater();
                     return;

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -320,8 +320,19 @@ void CredentialManager::attemptCollidingMigration(const QString& profileName, co
             // Preserving the entry allows users to switch back to those versions
 #ifdef APP_VERSION
             const QString currentVersion = QString(APP_VERSION);
-            const QVersionNumber appVersion = QVersionNumber::fromString(currentVersion);
+            QVersionNumber appVersion = QVersionNumber::fromString(currentVersion);
             const QVersionNumber collidingFormatVersion = QVersionNumber(4, 20, 1);
+
+            // Dev/test/PTB builds represent the "next release", so bump version for comparison
+            QFile buildFile(qsl(":/app-build.txt"));
+
+            if (buildFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+                const QString buildSuffix = QString::fromUtf8(buildFile.readAll()).trimmed();
+
+                if (buildSuffix.startsWith(qsl("-dev")) || buildSuffix.startsWith(qsl("-test")) || buildSuffix.startsWith(qsl("-ptb"))) {
+                    appVersion = QVersionNumber(appVersion.majorVersion(), appVersion.minorVersion(), appVersion.microVersion() + 1);
+                }
+            }
 
             if (appVersion > collidingFormatVersion) {
                 removeCredential(legacyService, key, profileName, [](bool, const QString&) {});

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -396,6 +396,70 @@ void CredentialManager::fallbackFileRetrieval(const QString& profileName, const 
     }
 }
 
+void CredentialManager::attemptOldFormatMigration(const QString& service, const QString& account, const QString& profileName, CredentialRetrievalCallback callback)
+{
+    // Before the Windows keychain fix, credentials were stored with key=account instead of key=service
+    // On Windows, only setKey() value is used as the TargetName, causing all profiles to share "character"
+    // This function tries to read from the old format and migrate to the new format
+    qDebug() << "CredentialManager: Checking for old format (key=account) for service:" << service;
+
+    auto* oldFormatJob = new QKeychain::ReadPasswordJob(service, this);
+    oldFormatJob->setKey(account); // Old format used account as key
+    oldFormatJob->setAutoDelete(false);
+
+    connect(oldFormatJob, &QKeychain::ReadPasswordJob::finished, this, [this, oldFormatJob, service, account, profileName, callback]() {
+        bool found = (oldFormatJob->error() == QKeychain::NoError);
+        QString password = found ? oldFormatJob->textData() : QString();
+
+        if (found && !password.isEmpty()) {
+            qDebug() << "CredentialManager: Found password in old format, migrating to new format";
+
+            // Store in new format (key=service) for future use
+            auto* migrateJob = new QKeychain::WritePasswordJob(service, this);
+            migrateJob->setKey(service); // New format
+            migrateJob->setTextData(password);
+            migrateJob->setAutoDelete(false);
+
+            connect(migrateJob, &QKeychain::WritePasswordJob::finished, this, [migrateJob, service, account, password, callback]() {
+                if (migrateJob->error() == QKeychain::NoError) {
+                    qDebug() << "CredentialManager: Migration to new format successful, cleaning up old entry";
+
+                    // Delete old format entry
+                    auto* cleanupJob = new QKeychain::DeletePasswordJob(service);
+                    cleanupJob->setKey(account); // Old format key
+                    cleanupJob->setAutoDelete(true);
+                    connect(cleanupJob, &QKeychain::DeletePasswordJob::finished, cleanupJob, [service]() {
+                        qDebug() << "CredentialManager: Old format entry cleaned up for service:" << service;
+                    });
+                    cleanupJob->start();
+                } else {
+                    qWarning() << "CredentialManager: Migration to new format failed:" << migrateJob->errorString();
+                }
+
+                // Return password regardless of migration success
+                if (callback) {
+                    callback(true, password, QString());
+                }
+                migrateJob->deleteLater();
+            });
+
+            migrateJob->start();
+        } else {
+            qDebug() << "CredentialManager: Old format not found, trying other fallbacks";
+            // Continue with existing legacy format checks
+            if (account == "character") {
+                attemptLegacyKeychainMigration(profileName, account, callback);
+            } else {
+                fallbackFileRetrieval(profileName, account, callback);
+            }
+        }
+
+        oldFormatJob->deleteLater();
+    });
+
+    oldFormatJob->start();
+}
+
 void CredentialManager::removePassword(const QString& profileName, const QString& key, CredentialCallback callback)
 {
     if (profileName.isEmpty() || key.isEmpty()) {
@@ -496,7 +560,9 @@ void CredentialManager::storeCredential(const QString& service, const QString& a
     cleanupCurrentOperation();
 
     auto* writeJob = new QKeychain::WritePasswordJob(service, this);
-    writeJob->setKey(account);
+    // Use service as the key - on Windows, only setKey() value is used as the credential target,
+    // so using account ("character") would cause all profiles to share the same credential
+    writeJob->setKey(service);
 
     // Store password directly in keychain (keychain handles encryption)
     writeJob->setTextData(password);
@@ -584,7 +650,9 @@ void CredentialManager::retrieveCredential(const QString& service, const QString
     cleanupCurrentOperation();
 
     auto* readJob = new QKeychain::ReadPasswordJob(service, this);
-    readJob->setKey(account);
+    // Use service as the key - on Windows, only setKey() value is used as the credential target,
+    // so using account ("character") would cause all profiles to share the same credential
+    readJob->setKey(service);
     readJob->setAutoDelete(false);
 
     mCurrentJob = readJob;
@@ -642,113 +710,13 @@ void CredentialManager::retrieveCredential(const QString& service, const QString
                     }
                     qDebug() << "CredentialManager:" << errorContext << ", trying fallback storage";
 
-                    // Try legacy keychain format if this is a character password and service follows new format
-                    if (account == "character" && service.startsWith("Mudlet-") && service.endsWith("-character")) {
-                        // Extract profile name from service (format: "Mudlet-ProfileName-character")
-                        QString profileName = service.mid(7); // Remove "Mudlet-" prefix
-                        profileName.chop(10);                 // Remove "-character" suffix
-
-                        qDebug() << "CredentialManager: Checking for legacy keychain format for profile" << profileName;
-
-                        // Capture the error string now while readJob is still valid
-                        QString keychainError = readJob->errorString();
-
-                        // Check legacy keychain format asynchronously
-                        auto* legacyReadJob = new QKeychain::ReadPasswordJob("Mudlet profile", this);
-                        legacyReadJob->setKey(profileName);
-                        legacyReadJob->setAutoDelete(false);
-
-                        // Store the current callback and clear it to prevent double-calling
-                        auto originalCallback = mCurrentRetrievalCallback;
-                        mCurrentRetrievalCallback = nullptr;
-
-                        connect(legacyReadJob, &QKeychain::ReadPasswordJob::finished, this, [this, legacyReadJob, profileName, service, account, originalCallback, keychainError]() {
-                            bool legacyFound = (legacyReadJob->error() == QKeychain::NoError);
-                            QString legacyPassword = legacyFound ? legacyReadJob->textData() : QString();
-
-                            if (legacyFound && !legacyPassword.isEmpty()) {
-                                qDebug() << "CredentialManager: Found legacy password for profile" << profileName;
-
-                                // Migrate to new format asynchronously
-                                qDebug() << "CredentialManager: Migrating legacy password to new format for profile" << profileName;
-
-                                // Extract original profile name and key from service name for migration
-                                QString originalProfileName = service.mid(7); // Remove "Mudlet-" prefix
-                                originalProfileName.chop(10);                 // Remove "-character" suffix
-
-                                // Store in new format
-                                auto* migrationManager = new CredentialManager();
-                                migrationManager->storePassword(originalProfileName,
-                                                                account,
-                                                                legacyPassword,
-                                                                [migrationManager, profileName, originalCallback, legacyPassword](bool migrationSuccess, const QString& migrationError) {
-                                                                    if (migrationSuccess) {
-                                                                        qDebug() << "CredentialManager: Legacy migration successful for profile" << profileName;
-
-                                // Clean up legacy entry if migration succeeded
-#ifdef APP_VERSION
-                                                                        const QString currentVersion = QString(APP_VERSION);
-                                                                        const QVersionNumber appVersion = QVersionNumber::fromString(currentVersion);
-                                                                        const QVersionNumber secureStorageVersion = QVersionNumber(4, 20, 0);
-
-                                                                        if (appVersion >= secureStorageVersion) {
-                                                                            // Clean up legacy entry asynchronously
-                                                                            auto* cleanupManager = new CredentialManager();
-                                                                            cleanupManager->deleteLegacyKeychainEntry(profileName);
-                                                                            cleanupManager->deleteLater();
-                                                                            qDebug() << "CredentialManager: Legacy cleanup initiated for version" << currentVersion;
-                                                                        } else {
-                                                                            qDebug() << "CredentialManager: Legacy cleanup skipped for version" << currentVersion;
-                                                                        }
-#else
-                                    qDebug() << "CredentialManager: Legacy cleanup skipped (test mode)";
-#endif
-                                                                    } else {
-                                                                        qWarning() << "CredentialManager: Legacy migration failed for profile" << profileName << ":" << migrationError;
-                                                                    }
-
-                                                                    // Return the legacy password regardless of migration result
-                                                                    if (originalCallback) {
-                                                                        originalCallback(true, legacyPassword, QString());
-                                                                    }
-
-                                                                    migrationManager->deleteLater();
-                                                                });
-                            } else {
-                                qDebug() << "CredentialManager: No legacy password found for profile" << profileName;
-
-                                QString filePassword = retrieveCredentialFromFile(profileName, account);
-                                bool fileSuccess = !filePassword.isNull();
-                                QString finalError = fileSuccess ? QString() : qsl("Both keychain and encrypted file storage failed for credentials. Keychain: %1").arg(keychainError);
-
-                                if (fileSuccess) {
-                                    qDebug() << "CredentialManager: Retrieved password from encrypted file storage";
-                                }
-
-                                if (originalCallback) {
-                                    originalCallback(fileSuccess, filePassword, finalError);
-                                }
-                            }
-
-                            legacyReadJob->deleteLater();
-                        });
-
-                        legacyReadJob->start();
-
-                        // Early return to avoid the file storage check below
-                        readJob->deleteLater();
-                        return;
-                    }
-
-                    password = retrieveCredentialFromFile(profileName, account);
-
-                    if (!password.isNull()) {
-                        success = true;
-                        errorMessage = QString(); // Clear error message on successful fallback
-                        qDebug() << "CredentialManager: Retrieved password from encrypted file storage";
-                    } else {
-                        errorMessage = qsl("Both keychain and encrypted file storage failed for credentials. Keychain: %1").arg(readJob->errorString());
-                    }
+                    // Try old format first (before Windows keychain fix), then legacy formats
+                    // Clear callback to prevent it being called twice (the migration function will call it)
+                    auto originalCallback = mCurrentRetrievalCallback;
+                    mCurrentRetrievalCallback = nullptr;
+                    attemptOldFormatMigration(service, account, profileName, originalCallback);
+                    readJob->deleteLater();
+                    return;
                 }
 
                 // Final validity check before calling callback
@@ -792,7 +760,9 @@ void CredentialManager::removeCredential(const QString& service, const QString& 
     cleanupCurrentOperation();
 
     auto* deleteJob = new QKeychain::DeletePasswordJob(service, this);
-    deleteJob->setKey(account);
+    // Use service as the key - on Windows, only setKey() value is used as the credential target,
+    // so using account ("character") would cause all profiles to share the same credential
+    deleteJob->setKey(service);
     deleteJob->setAutoDelete(false);
 
     mCurrentJob = deleteJob;

--- a/src/CredentialManager.h
+++ b/src/CredentialManager.h
@@ -121,6 +121,7 @@ private:
 
     void attemptCollidingMigration(const QString& profileName, const QString& key, const QString& legacyService, const QString& password, CredentialRetrievalCallback callback);
     void attemptLegacyKeychainMigration(const QString& profileName, const QString& key, CredentialRetrievalCallback callback);
+    void attemptOldFormatMigration(const QString& service, const QString& account, const QString& profileName, CredentialRetrievalCallback callback);
     void fallbackFileRetrieval(const QString& profileName, const QString& key, CredentialRetrievalCallback callback);
 
     // Current operation state

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1095,7 +1095,18 @@ void dlgConnectionProfiles::slot_itemClicked(QListWidgetItem* pItem)
     // because there isn't one in storage yet. It'll be copied over into the widget
     // by the copy method
     if (!mCopyingProfile) {
-        character_password_entry->setText(QString());
+        // Cancel any pending password save from the previous profile to prevent
+        // cross-profile password corruption when rapidly switching profiles
+        if (mPasswordSaveTimer) {
+            mPasswordSaveTimer->stop();
+        }
+        mPendingPasswordSaveProfile.clear();
+
+        // Block signals when clearing to prevent triggering a save for the wrong profile
+        {
+            const QSignalBlocker blocker(character_password_entry);
+            character_password_entry->setText(QString());
+        }
         // Schedule password loading asynchronously to avoid event loop issues
         auto* timer = new QTimer(this);
         timer->setSingleShot(true);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2372,19 +2372,23 @@ void dlgConnectionProfiles::slot_loadPasswordAsync()
 
             // Check if profile selection has changed while we were waiting
             if (listWidget_profiles->currentItem() && listWidget_profiles->currentItem()->data(csmNameRole).toString() == profile_name) {
-                if (success && !retrievedPassword.isEmpty()) {
+                if (success) {
+                    // Keychain operation succeeded - set the password (even if empty)
+                    // Temporarily block textChanged signal to avoid triggering save on programmatic setText
                     {
                         const QSignalBlocker blocker(character_password_entry);
                         character_password_entry->setText(retrievedPassword);
                     }
-                    qDebug() << "dlgConnectionProfiles: Successfully loaded password from keychain for" << profile_name;
-                } else {
-                    loadPasswordFromSettings(profile_name);
-                    if (!success) {
-                        qDebug() << "dlgConnectionProfiles: Credential retrieval unsuccessful for" << profile_name << "-" << errorMessage;
+
+                    if (retrievedPassword.isEmpty()) {
+                        qDebug() << "dlgConnectionProfiles: Keychain returned empty password for" << profile_name;
                     } else {
-                        qDebug() << "dlgConnectionProfiles: Keychain returned empty password for" << profile_name << ", checked fallback sources";
+                        qDebug() << "dlgConnectionProfiles: Successfully loaded password from keychain for" << profile_name;
                     }
+                } else {
+                    // Fallback to QSettings only if credential retrieval failed
+                    loadPasswordFromSettings(profile_name);
+                    qDebug() << "dlgConnectionProfiles: Credential retrieval unsuccessful for" << profile_name << "-" << errorMessage;
                 }
             }
 
@@ -2446,13 +2450,7 @@ void dlgConnectionProfiles::loadPasswordFromSettings(const QString& profile_name
             settings.setValue(qsl("password"), oldPassword);
             settings.remove(qsl("login"));
         } else {
-            // Final fallback: check the portable password file on disk.
-            // This file predates the keychain/QSettings migration and may
-            // still contain a password if migration hasn't run yet (e.g.
-            // dialog opened before the deferred migration timer fires) or
-            // if migration failed.
-            const QString portablePassword = readProfileData(profile_name, qsl("password"));
-            character_password_entry->setText(portablePassword);
+            character_password_entry->setText(QString());
         }
     }
 

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -815,7 +815,11 @@ void dlgConnectionProfiles::slot_addProfile()
 {
     profile_name_entry->setReadOnly(false);
     // while normally handled by fillout_form, due to it's asynchronous nature it is better UX to reset it here
-    character_password_entry->setText(QString());
+    // Block signals to prevent triggering password save for the previously selected profile
+    {
+        const QSignalBlocker blocker(character_password_entry);
+        character_password_entry->setText(QString());
+    }
     fillout_form();
     welcome_message->hide();
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes an issue where changing the password for one profile would overwrite the passwords of other profiles. This primarily affected Windows users due to how the system credential storage works differently from macOS and Linux.

#### Motivation for adding to Mudlet

Users reported that setting a password on one profile caused all other profiles to use that same password. This made it impossible to have different passwords for different game connections. The fix ensures each profile's password is stored separately on all platforms.

#### Other info (issues closed, discussion etc)

Closes #9006