### PR TITLE
Infrastructure: install `libspeechd-dev` for Linux CI to fix AppImage creation

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -68,7 +68,7 @@ jobs:
         version: ${{matrix.qt}}
         dir: ${{runner.workspace}}
         cache: true
-        modules: qt5compat qtmultimedia
+        modules: qt5compat qtmultimedia qtspeech
 
     - name: Use CMake 3.30.3
       uses: lukka/get-cmake@v4.2.3
@@ -164,6 +164,7 @@ jobs:
           libpulse-dev \
           libpugixml-dev \
           libsecret-1-dev \
+          libspeechd-dev \
           libsqlite3-dev \
           qtkeychain-qt6-dev \
           libxkbcommon-x11-0 \

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -170,6 +170,7 @@ jobs:
           libpulse-dev \
           libpugixml-dev \
           libsecret-1-dev \
+          libspeechd-dev \
           libsqlite3-dev \
           qtkeychain-qt6-dev \
           libxkbcommon-x11-0 \


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Install system native library needed for TTS capabilities to be bundled with Linux AppImages.
#### Motivation for adding to Mudlet
Fix Linux CI builds.
#### Other info (issues closed, discussion etc)
Adding qtspeech to Qt modules (86bf665) caused linuxdeployqt to find the speechd TTS plugin but fail to resolve its libspeechd.so.2 dependency, aborting AppImage creation. This resulted in empty/broken PTB artifacts (261 bytes) since March 10.