### PR TITLE
infra: enable set -e in Linux CI deploy script to catch failures

### DIFF
--- a/CI/linux.after_success.sh
+++ b/CI/linux.after_success.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# set -e
+set -e
 set -x
 
 BUILD_DIR="${BUILD_FOLDER}"


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
The macOS deploy script already uses set -e, but the Linux one had it commented out. This allowed failures like a broken AppImage creation to be silently ignored, resulting in empty artifacts being uploaded. The only intentionally-fallible command (dblsqd release) already has || true protection.
#### Motivation for adding to Mudlet
More clarity from Linux builds instead of silent failures.
#### Other info (issues closed, discussion etc)
