### PR TITLE
Improve: add control of blinking to HTML logs

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -4581,7 +4581,7 @@ void TBuffer::log(int fromLine, int toLine)
 
     QStringList linesToLog;
     if (mpHost->mIsCurrentLogFileInHtmlFormat
-            && ! mpHost->mpConsole->doesHTMLFileNeedBlinkingTextControl()
+            && !mpHost->mpConsole->doesHTMLFileNeedBlinkingTextControl()
             && pB->blinkingTextInSelection(fromLine, toLine)) {
         mpHost->mpConsole->setHTMLFileNeedsBlinkingTextControl();
     }

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -4580,6 +4580,12 @@ void TBuffer::log(int fromLine, int toLine)
     }
 
     QStringList linesToLog;
+    if (mpHost->mIsCurrentLogFileInHtmlFormat
+            && ! mpHost->mpConsole->doesHTMLFileNeedBlinkingTextControl()
+            && pB->blinkingTextInSelection(fromLine, toLine)) {
+        mpHost->mpConsole->setHTMLFileNeedsBlinkingTextControl();
+    }
+
     for (int i = fromLine; i <= toLine; ++i) {
         if (mpHost->mIsCurrentLogFileInHtmlFormat) {
             // This only handles a single line of logged text at a time:
@@ -5260,46 +5266,49 @@ QString TBuffer::bufferToHtml(const bool showTimeStamp /*= false*/, const int ro
 
     for (auto cookedPos = static_cast<size_t>(pos); pos < lastPos; ++cookedPos, ++pos) {
         // Do we need to start a new span?
-        if (firstSpan || buffer.at(cookedRow).at(cookedPos).mFgColor != currentFgColor || buffer.at(cookedRow).at(cookedPos).mBgColor != currentBgColor
-            || (buffer.at(cookedRow).at(cookedPos).mFlags & TChar::TestMask) != currentFlags) {
+        const auto currentAttributes = buffer.at(cookedRow).at(cookedPos);
+        if (firstSpan
+                || currentAttributes.mFgColor != currentFgColor
+                || currentAttributes.mBgColor != currentBgColor
+                || currentAttributes.allDisplayAttributes() != currentFlags) {
+
             if (firstSpan) {
                 firstSpan = false; // The first span - won't need to close the previous one
             } else {
                 s.append(QLatin1String("</span>"));
             }
-            currentFgColor = buffer.at(cookedRow).at(cookedPos).mFgColor;
-            currentBgColor = buffer.at(cookedRow).at(cookedPos).mBgColor;
-            currentFlags = buffer.at(cookedRow).at(cookedPos).mFlags & TChar::TestMask;
+            currentFgColor = currentAttributes.mFgColor;
+            currentBgColor = currentAttributes.mBgColor;
+            currentFlags = currentAttributes.allDisplayAttributes();
 
             // clang-format off
-            // Determine blink class if any (only when blink is enabled in settings)
-            QString blinkClass;
-            const bool enableBlink = (mpHost != nullptr) && mpHost->getEnableBlinkText();
-
-            if (enableBlink) {
-                if (currentFlags & TChar::FastBlink) {
-                    blinkClass = qsl(" class='blink-fast'");
-                } else if (currentFlags & TChar::Blink) {
-                    blinkClass = qsl(" class='blink-slow'");
-                }
+            QString blinkAttribute;
+            if (currentFlags & TChar::FastBlink) {
+                blinkAttribute = qsl(" blink='fast'");
+            } else if (currentFlags & TChar::Blink) {
+                blinkAttribute = qsl(" blink='slow'");
             }
 
+            // In the following we have to nest the foreground (and text
+            // formatting effects) inside a separate background <span> otherwise
+            // the background also turns black (or to the body background color)
+            // when the foreground blinks "off":
             if (currentFlags & TChar::Reverse) {
                 // Swap the fore and background colours:
-                s.append(qsl("<span%10 style=\"color: rgb(%1,%2,%3); background: rgb(%4,%5,%6); %7%8%9\">")
+                s.append(qsl("<span style='background: rgb(%4,%5,%6);'><span style='color: rgb(%1,%2,%3); %7%8%9'%10>")
                          .arg(QString::number(currentBgColor.red()), QString::number(currentBgColor.green()), QString::number(currentBgColor.blue()), // args 1 to 3
                               QString::number(currentFgColor.red()), QString::number(currentFgColor.green()), QString::number(currentFgColor.blue()), // args 4 to 6
                               currentFlags & TChar::Bold ? QLatin1String(" font-weight: bold;") : QString(), // arg 7
                               currentFlags & TChar::Italic ? QLatin1String(" font-style: italic;") : QString(), // arg 8
-                              currentFlags & (TChar::Underline | TChar::StrikeOut | TChar::Overline ) // remainder is arg 9
+                              currentFlags & (TChar::Underline | TChar::StrikeOut | TChar::Overline )
                               ? qsl(" text-decoration:%1%2%3")
                                 .arg(currentFlags & TChar::Underline ? QLatin1String(" underline") : QString(),
                                      currentFlags & TChar::StrikeOut ? QLatin1String(" line-through") : QString(),
-                                     currentFlags & TChar::Overline ? QLatin1String(" overline") : QString())
-                              : QString(),
-                              blinkClass)); // arg 10
+                                     currentFlags & TChar::Overline ? QLatin1String(" overline") : QString()) // arg 9
+                              : QString())
+                         .arg(blinkAttribute)); // arg 10 - No more than 9 args per QString::arg(...)
             } else {
-                s.append(qsl("<span%10 style=\"color: rgb(%1,%2,%3); background: rgb(%4,%5,%6); %7%8%9\">")
+                s.append(qsl("<span style='background: rgb(%4,%5,%6);'><span style='color: rgb(%1,%2,%3); %7%8%9'%10>")
                          .arg(QString::number(currentFgColor.red()), QString::number(currentFgColor.green()), QString::number(currentFgColor.blue()), // args 1 to 3
                               QString::number(currentBgColor.red()), QString::number(currentBgColor.green()), QString::number(currentBgColor.blue()), // args 4 to 6
                               currentFlags & TChar::Bold ? QLatin1String(" font-weight: bold;") : QString(), // arg 7
@@ -5309,8 +5318,8 @@ QString TBuffer::bufferToHtml(const bool showTimeStamp /*= false*/, const int ro
                                 .arg(currentFlags & TChar::Underline ? QLatin1String(" underline") : QString(),
                                      currentFlags & TChar::StrikeOut ? QLatin1String(" line-through") : QString(),
                                      currentFlags & TChar::Overline ? QLatin1String(" overline") : QString())
-                              : QString(),
-                              blinkClass)); // arg 10
+                              : QString())
+                         .arg(blinkAttribute)); // arg 10
             }
             // clang-format on
         }
@@ -5323,10 +5332,9 @@ QString TBuffer::bufferToHtml(const bool showTimeStamp /*= false*/, const int ro
         }
     }
     if (!s.isEmpty()) {
-        s.append(QLatin1String("</span>"));
-        // Needed to balance the very first open <span>, but only if we have
-        // included anything. the previously appearing <br /> is an XML tag, NOT
-        // a (strict) HTML 4 one
+        // We now need two spans to format the background colour separately from
+        // the foreground and text formatting effects:
+        s.append(QLatin1String("</span></span>"));
     }
 
     s.append(QLatin1String("<br>\n"));
@@ -7147,4 +7155,31 @@ void TBuffer::updateLinkCharacters(int linkIndex)
         mpConsole->mLowerPane->updateScreenView();
         mpConsole->mLowerPane->repaint();
     }
+}
+
+bool TBuffer::blinkingTextInSelection(const std::size_t startRow, const std::size_t endRow) const
+{
+    if (startRow > endRow || buffer.empty() || endRow >= buffer.size()) {
+        return false;
+    }
+    for (std::size_t row = startRow; row <= endRow; ++row) {
+        if (blinkingTextInLine(row)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool TBuffer::blinkingTextInLine(const std::size_t row) const
+{
+    if (row >= buffer.size() || buffer.empty() || buffer.at(row).empty()) {
+        return false;
+    }
+    static const TChar::AttributeFlags blinkFlags = TChar::AttributeFlag::FastBlink | TChar::AttributeFlag::FastBlink;
+    for (std::size_t col = 0, lastCol = buffer.at(row).size(); col < lastCol; ++col) {
+        if (buffer.at(row).at(col).allDisplayAttributes() & blinkFlags) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -171,6 +171,7 @@ public:
     bool isReversed() const { return mFlags & Reverse; }
     bool isConcealed() const { return mFlags & Concealed; }
     bool isFound() const { return mFlags & Found; }
+    bool hasBlinking() const { return mFlags & BlinkMask; }
     // Extended underline style accessors for enhanced OSC 8 hyperlink support
     bool isUnderlineWavy() const { return mFlags & UnderlineWavy; }
     bool isUnderlineDotted() const { return mFlags & UnderlineDotted; }
@@ -360,6 +361,8 @@ public:
     // is apparently incompatible with using a default constructor - sigh!
     void encodingChanged(const QByteArray &);
     void clearSearchHighlights();
+    bool blinkingTextInSelection(const std::size_t startRow, const std::size_t endRow) const;
+    bool blinkingTextInLine(const std::size_t row) const;
 
     static int lengthInGraphemes(const QString& text);
 

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -327,7 +327,7 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
             bool foundBody = false;
             while (!mLogStream.atEnd()) {
                 QString line = mLogStream.readLine();
-                if (! hasOldBlinkingText && (line.contains(qsl(" class='blink-fast' ")) || line.contains(qsl(" class='blink-slow' ")))) {
+                if (!hasOldBlinkingText && (line.contains(qsl(" class='blink-fast' ")) || line.contains(qsl(" class='blink-slow' ")))) {
                     // Will need to convert the prior blinking text entries:
                     hasOldBlinkingText = true;
                     mHTMLLogFileAlreadyHasBlinkingText = true;

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -48,6 +48,36 @@
 #include <QTextStream>
 #include <QPainter>
 
+/*static*/ const QString TMainConsole::csmHeaderStart = qsl("<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01//EN' 'http://www.w3.org/TR/html4/strict.dtd'>\n"
+                                                            "<html>\n"
+                                                            " <head>\n"
+                                                            "  <meta http-equiv='content-type' content='text/html; charset=utf-8'>\n"
+                                                            // put the charset as early as possible as the
+                                                            // parser MUST restart when it switches away
+                                                            // from the ASCII default
+                                                            // Nice to identify what made the file,
+                                                            "  <meta name='generator' content='%1%2'>\n"
+                                                            // Web-page title:
+                                                            "  <title>%3</title>\n"
+                                                            "  <style type='text/css'>\n"
+                                                            "   <!-- \n"
+                                                            "    body { font-family: '%4'; font-size: 100%; line-height: 1.125em; white-space: nowrap; color:rgb(%5, %6, %7); background-color:rgb(%8, %9, %10); }\n"
+                                                            "    span { white-space: pre-wrap; }\n");
+
+/*static*/ const QString TMainConsole::csmBlinkingHeader = qsl("    /* The following is required to allow blinking text to be enabled/disabled by the viewer of the HTML. */ \n"
+                                                               "    [blink='slow'] { font-style: italic; } \n"
+                                                               "    [blink='fast'] { font-style: italic; } \n"
+                                                               "    @keyframes blink { 50% { opacity: 0; } } \n"
+                                                               "    /* Select all siblings of blink-toggle (when it is checked) that have the attribute 'blink' set to 'slow':*/ \n"
+                                                               "    #blink-toggle:checked ~ * [blink='slow'] { font-style: normal; animation: blink 0.8s step-end infinite; } \n"
+                                                               "    /* Select all siblings of blink-toggle (when it is checked) that have the attribute 'blink' set to 'fast':*/ \n"
+                                                               "    #blink-toggle:checked ~ * [blink='fast'] { font-style: normal; animation: blink 0.4s step-end infinite; } \n");
+
+/*static*/ const QString TMainConsole::csmHeaderEnd = qsl("   -->\n"
+                                                          "  </style>\n"
+                                                          "  </head>\n");
+
+/*static*/ const QString TMainConsole::csmBlinkingBody = qsl("<input type=\"checkbox\" id=\"blink-toggle\" /><label for=\"blink-toggle\"> X / <span style=\"opacity: 20%;\">X</span> / X / <span style=\"opacity: 20%;\">X</span></label><br><hr>");
 
 TMainConsole::TMainConsole(Host* pH, QWidget* parent)
 : TConsole(pH, qsl("main"), TConsole::MainConsole, parent)
@@ -158,6 +188,12 @@ std::pair<bool, QString> TMainConsole::setCmdLineStyleSheet(const QString& name,
 
 void TMainConsole::toggleLogging(bool isMessageEnabled)
 {
+    // Capture the background colour separately in prior blinking text sections
+    // so we can split it out into a preceding span:
+    //                            Capture groups                                                           |-----------1-------------|  |-------------2---------------|  ||-3  ||-4
+    static const auto oldSlowBlinkRegexp = QRegularExpression(qsl(R"REGEX(<span class='blink-slow' style="(color: rgb\(\d+,\d+,\d+\); )(background: rgb\(\d+,\d+,\d+\);)(.*)">(.*)</span>)REGEX"));
+    static const auto oldFastBlinkRegexp = QRegularExpression(qsl(R"REGEX(<span class='blink-fast' style="(color: rgb\(\d+,\d+,\d+\); )(background: rgb\(\d+,\d+,\d+\);)(.*)">(.*)</span>)REGEX"));
+
     const auto loggingPath = mudlet::getMudletPath(enums::profileDataItemPath, mpHost->getName(), qsl("autolog"));
     QFile file(loggingPath);
     const QDateTime logDateTime = QDateTime::currentDateTime();
@@ -213,12 +249,16 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
         // implies Truncate."
         if (mpHost->mIsCurrentLogFileInHtmlFormat) {
             if (!mLogFile.open(QIODevice::ReadWrite)) {
-                qWarning() << "TMainConsole: failed to open log file for reading/writing:" << mLogFile.errorString();
+                //: Failure to open HTML log file, as the message %1 could be long it is placed on the next line:
+                mpHost->postMessage(tr("[ WARN ]  - Failed to open HTML log file for reading or writing, reason:\n"
+                                       "%1").arg(mLogFile.errorString()));
                 return;
             }
         } else {
             if (!mLogFile.open(QIODevice::Append)) {
-                qWarning() << "TMainConsole: failed to open log file for appending:" << mLogFile.errorString();
+                //: Failure to open text log file, as the message %1 could be long it is placed on the next line:
+                mpHost->postMessage(tr("[ WARN ]  - Failed to open text log file for appending, reason:\n"
+                                       "%1").arg(mLogFile.errorString()));
                 return;
             }
         }
@@ -245,8 +285,17 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
     if (mLogToLogFile) {
         // Logging is being turned on
         if (mpHost->mIsCurrentLogFileInHtmlFormat) {
-            QString log;
-            QTextStream logStream(&log);
+            // Unfortunately this process can take bit of time (for a large
+            // existing log file in debug builds):
+            qApp->setOverrideCursor(Qt::WaitCursor);
+            // This forms the temporary store for the existing log file whilst
+            // we scan it:
+            QStringList logLines;
+            // We alos need to build the header to prepend onto the above:
+            QStringList headerLines;
+
+            mHTMLLogFileAlreadyHasBlinkingText = false;
+            mHTMLLogFileNeedsBlinkingTextControl = false;
             // No setting a QTextCodec here, they don't work on QString based QTextStreams
             QStringList fontsList;                  // List of fonts to become the font-family entry for
                                                     // the master css in the header
@@ -259,69 +308,108 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
             fontsList << qsl("Courier");
             fontsList.removeDuplicates(); // In case the actual one is one of the defaults here
 
-            logStream << "<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01//EN' 'http://www.w3.org/TR/html4/strict.dtd'>\n";
-            logStream << "<html>\n";
-            logStream << " <head>\n";
-            logStream << "  <meta http-equiv='content-type' content='text/html; charset=utf-8'>";
-            // put the charset as early as possible as the parser MUST restart when it
-            // switches away from the ASCII default
-            logStream << "  <meta name='generator' content='" << tr("Mudlet MUD Client version: %1%2").arg(APP_VERSION, mudlet::self()->mAppBuild) << "'>\n";
-            // Nice to identify what made the file!
-            logStream << "  <title>" << tr("Mudlet, log from %1 profile").arg(mProfileName) << "</title>\n";
-            // Web-page title
-            logStream << "  <style type='text/css'>\n";
-            logStream << "   <!-- body { font-family: '" << fontsList.join("', '") << "'; font-size: 100%; line-height: 1.125em; white-space: nowrap; color:rgb(" << mpHost->mFgColor.red() << ","
-                      << mpHost->mFgColor.green() << "," << mpHost->mFgColor.blue() << "); background-color:rgb(" << mpHost->mBgColor.red() << "," << mpHost->mBgColor.green() << ","
-                      << mpHost->mBgColor.blue() << ");}\n";
-            logStream << "        span { white-space: pre-wrap; }\n";
+            headerLines << csmHeaderStart.arg(APP_VERSION, // %1 = Mudlet main version number
+                                              mudlet::self()->mAppBuild, // %2 = build suffix
+                                              //: Title for the HTML file - translatable text including %1 the profile name
+                                              tr("Mudlet, log from %1 profile").arg(mProfileName), // Whole thing is %3 = HTML <TITLE> element text
+                                              fontsList.join(qsl("', '")), // %4 = Fonts for HTML
+                                              QString::number(mpHost->mFgColor.red()), // %5 = Default Foreground Red component
+                                              QString::number(mpHost->mFgColor.green()), // %6 = Default Foreground Green component
+                                              QString::number(mpHost->mFgColor.blue())) // %7 = Default Foreground Blue component
+                                   .arg(QString::number(mpHost->mBgColor.red()), // %8 = Default Background Red component
+                                        QString::number(mpHost->mBgColor.green()), // %9 = Default Background Greencomponent
+                                        QString::number(mpHost->mBgColor.blue())); // %10 = Default Background Blue component
 
-            if (mpHost->getEnableBlinkText()) {
-                logStream << "        @keyframes blink-slow { 50% { opacity: 0; } }\n";
-                logStream << "        @keyframes blink-fast { 50% { opacity: 0; } }\n";
-                logStream << "        .blink-slow { animation: blink-slow 0.8s step-end infinite; }\n";
-                logStream << "        .blink-fast { animation: blink-fast 0.4s step-end infinite; }\n";
-            }
-
-            logStream << "     -->\n";
-            logStream << "  </style>\n";
-            logStream << "  </head>\n";
-            bool isAtBody = false;
+            // Look for evidence of blinking text in the existing log file,
+            // If we have the old format ones we'll have to convert them.
+            bool hasOldBlinkingText = false;
+            bool isInBody = false;
             bool foundBody = false;
             while (!mLogStream.atEnd()) {
-                const QString line = mLogStream.readLine();
-                if (line.contains("<body><div>")) {
-                    // Begin writing old log to the current log when the body is
-                    // found.
-                    isAtBody = true;
-                    foundBody = true;
-                } else if (line.contains("</div></body>")) {
-                    // Stop writing to current log once the end of the old log's
-                    // <body> is reached.
-                    isAtBody = false;
+                QString line = mLogStream.readLine();
+                if (! hasOldBlinkingText && (line.contains(qsl(" class='blink-fast' ")) || line.contains(qsl(" class='blink-slow' ")))) {
+                    // Will need to convert the prior blinking text entries:
+                    hasOldBlinkingText = true;
+                    mHTMLLogFileAlreadyHasBlinkingText = true;
                 }
 
-                if (isAtBody) {
-                    logStream << line << "\n";
+                if (!mHTMLLogFileAlreadyHasBlinkingText && (line.contains(qsl(" blink='fast'")) || line.contains(qsl(" blink='slow'")))) {
+                    // Has text with newer style blinking text "attribute":
+                    mHTMLLogFileAlreadyHasBlinkingText = true;
+                }
+
+                if (line.contains(QLatin1String("<body>"))) {
+                    // Begin writing old log to the current log when the body is
+                    // found - this line could already have the checkbox for
+                    // controlling blinking!
+                    isInBody = true;
+                    foundBody = true;
+                    // We don't won't THIS line to be copied so go to the next
+                    // interation:
+                    continue;
+                }
+
+                if (line.contains(qsl("</div></body>"))) {
+                    // Stop writing to current log once the end of the old log's
+                    // <body> is reached.
+                    isInBody = false;
+                }
+
+                if (isInBody && hasOldBlinkingText) {
+                    if (line.contains(qsl(" class='blink-fast' "))) {
+                        line = line.replace(oldFastBlinkRegexp, qsl(R"REGEX(<span style='\2'><span style='\1\3' blink='fast'>\4</span></span>)REGEX"));
+                    }
+                    if (line.contains(qsl(" class='blink-slow' "))) {
+                        line = line.replace(oldSlowBlinkRegexp, qsl(R"REGEX(<span style='\2'><span style='\1\3' blink='slow'>\4</span></span>)REGEX"));
+                    }
+                }
+
+                if (isInBody) {
+                    logLines << line;
                 }
             }
-            if (!foundBody) {
-                logStream << "  <body><div>\n";
-            } else {
-                // Put a horizontal line between separate log sessions
-                logStream << "  </div><hr><div>\n";
+
+            if (mHTMLLogFileAlreadyHasBlinkingText) {
+                headerLines << csmBlinkingHeader;
             }
-            logStream
-                    << qsl("<p>%1</p>\n")
-                               //: This is the format argument to QDateTime::toString(...) and needs to follow the rules for that function {literal text must be single quoted} as well as being suitable for the translation locale
-                               .arg(logDateTime.toString(tr("'Log session starting at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'.")));
+
+            headerLines << csmHeaderEnd;
+
+            // May need to insert the control for blinking:
+            headerLines << qsl("  <body>%1<div>\n").arg(mHTMLLogFileAlreadyHasBlinkingText ? csmBlinkingBody : QString());
+
+            if (foundBody) {
+                // Put a horizontal line between separate log sessions, i.e.
+                // what has already been recorded and what we are about to start
+                // to log - but only if we have some prior log:
+                logLines << "</div><hr><div>";
+            }
+
+            logLines  << qsl("<p>%1</p>")
+                                /*: This is the format argument to QDateTime::toString(...) and needs to follow
+                                    the rules for that function {literal text must be single quoted} as well as
+                                    being suitable for the translation locale.*/
+                                   .arg(logDateTime.toString(tr("'Log session starting at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'.")));
             // <div></div> tags required around outside of the body <span></spans> for
             // strict HTML 4 as we do not use <p></p>s or anything else
 
             if (!mLogFile.resize(0)) {
-                qWarning() << "TConsole::toggleLogging(...) ERROR - Failed to resize HTML Logfile - it may now be corrupted...!";
+                /*: An error has occurred whilst doing some manipulation of a HTML type log
+                    - the error message maybe long so is displayed on a new line.*/
+                mpHost->postMessage(tr("[ WARN ]  - Unable to resize the LogFile to refresh the beginning, reason:\n"
+                                       "%1\n"
+                                       "it may now be corrupted.")
+                                            .arg(mLogFile.errorString()));
             }
-            mLogStream << log;
+
+            // Now we overwrite the existing file with modified content ready
+            // for the appending of new data:
+            mLogStream << headerLines.join(QString());
+            mLogStream << logLines.join(QChar::LineFeed);
             mLogFile.flush();
+
+            qApp->restoreOverrideCursor();
+
         } else {
             // File is NOT an HTML one but pure text:
             // Put a horizontal line between separate log sessions
@@ -333,26 +421,34 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
                 // file to not trigger the insertion of this line:
                 mLogStream << qsl("⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯").repeated(8).append(QChar::LineFeed);
             }
-            mLogStream
-                    << qsl("%1\n")
-                               //: This is the format argument to QDateTime::toString(...) and needs to follow the rules for that function {literal text must be single quoted} as well as being suitable for the translation locale
-                               .arg(logDateTime.toString(tr("'Log session starting at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'.")));
+
+            mLogStream << qsl("%1\n")
+                                /*: This is the format argument to QDateTime::toString(...) and needs to follow
+                                    the rules for that function {literal text must be single quoted} as well as
+                                    being suitable for the translation locale.*/
+                                  .arg(logDateTime.toString(tr("'Log session starting at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'.")));
         }
         logButton->setToolTip(utils::richText(tr("Stop logging game output to log file.")));
     } else {
-        // Logging is being turned off
+        // Logging is being turned off - this does also do a mLogFile.flush():
         buffer.logRemainingOutput();
-        //: This is the format argument to QDateTime::toString(...) and needs to follow the rules for that function {literal text must be single quoted} as well as being suitable for the translation locale
+        /*: This is the format argument to QDateTime::toString(...) and needs to follow
+            the rules for that function {literal text must be single quoted} as well as
+            being suitable for the translation locale.*/
         const QString endDateTimeLine = logDateTime.toString(tr("'Log session ending at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'."));
         if (mpHost->mIsCurrentLogFileInHtmlFormat) {
             mLogStream << qsl("<p>%1</p>\n").arg(endDateTimeLine);
             mLogStream << "  </div></body>\n";
             mLogStream << "</html>\n";
+            mLogStream.flush();
+            if (mHTMLLogFileNeedsBlinkingTextControl) {
+                insertBlinkingTextFeaturesIntoExisitingLog();
+            }
         } else {
             // File is NOT an HTML one but pure text:
             mLogStream << endDateTimeLine << "\n";
+            mLogStream.flush();
         }
-        mLogFile.flush();
         mLogFile.close();
         logButton->setToolTip(utils::richText(tr("Start logging game output to log file.")));
     }
@@ -1760,4 +1856,74 @@ bool TMainConsole::clear(const QString& name)
     }
 
     return false;
+}
+
+void TMainConsole::insertBlinkingTextFeaturesIntoExisitingLog()
+{
+    // Unfortunately this process can take bit of time (for a large
+    // existing log file in debug builds):
+    qApp->setOverrideCursor(Qt::WaitCursor);
+    // Rewind to start of file:
+    mLogStream.seek(0);
+
+    // This forms the temporary store for the existing log file whilst
+    // we rescan it:
+    QString log;
+    QTextStream logStream(&log);
+    QStringList fontsList; // List of fonts to become the font-family entry for
+    // the master css in the header
+    fontsList << this->fontInfo().family(); // Seems to be the best way to get the
+    // font in use, as different TConsole
+    // instances within the same profile
+    // might have different fonts
+    fontsList << qsl("Courier New");
+    fontsList << qsl("Monospace");
+    fontsList << qsl("Courier");
+    fontsList.removeDuplicates(); // In case the actual one is one of the defaults here
+
+    logStream << csmHeaderStart.arg(APP_VERSION, // %1 = Mudlet main version number
+                                    mudlet::self()->mAppBuild, // %2 = build suffix
+                                    //: Title for the HTML file - translatable text including %1 the profile name
+                                    tr("Mudlet, log from %1 profile").arg(mProfileName), // %3 = HTML <TITLE> element text
+                                    fontsList.join(qsl("', '")), // %4 = Fonts for HTML
+                                    QString::number(mpHost->mFgColor.red()), // %5 = Default Foreground Red component
+                                    QString::number(mpHost->mFgColor.green()), // %6 = Default Foreground Green component
+                                    QString::number(mpHost->mFgColor.blue())) // %7 = Default Foreground Blue component
+                         .arg(QString::number(mpHost->mBgColor.red()), // %8 = Default Background Red component
+                              QString::number(mpHost->mBgColor.green()), // %9 = Default Background Greencomponent
+                              QString::number(mpHost->mBgColor.blue())); // %10 = Default Background Blue component
+    logStream << csmBlinkingHeader;
+    logStream << csmHeaderEnd;
+    logStream << qsl("  <body>%1<div>\n").arg(csmBlinkingBody);
+
+    bool foundBody = false;
+    while (!mLogStream.atEnd()) {
+        const QString line = mLogStream.readLine();
+        if (line.contains(QLatin1String("<body>"))) {
+            // Begin copying existing log to the temporary log when the body
+            // is found.
+            foundBody = true;
+            // Don't include this line, as it is to be replaced with the one
+            // already inserted into "logstream" with the checkbox for blinking
+            continue;
+        }
+
+        if (foundBody) {
+            // Copy this line verbatum
+            logStream << line << QLatin1Char(QChar::LineFeed);
+        }
+    }
+
+    // Clear the underlying log file:
+    mLogFile.resize(0);
+    // Also reset the position of the associated QTextStream:
+    mLogStream.seek(0);
+    // Store the revised content back into the log file:
+    mLogStream << log;
+    mLogStream.flush();
+
+    // Reset the flag that caused this method to have been called:
+    mHTMLLogFileNeedsBlinkingTextControl = false;
+
+    qApp->restoreOverrideCursor();
 }

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -109,6 +109,8 @@ public:
     bool saveMap(const QString&, int saveVersion = 0);
     bool loadMap(const QString&);
     bool importMap(const QString&, QString* errMsg = nullptr);
+    void setHTMLFileNeedsBlinkingTextControl() { mHTMLLogFileNeedsBlinkingTextControl = true; }
+    bool doesHTMLFileNeedBlinkingTextControl() const { return mHTMLLogFileNeedsBlinkingTextControl; }
 
 
     QMap<QString, TConsole*> mSubConsoleMap;
@@ -122,6 +124,10 @@ public:
     QTextStream mLogStream;
     bool mLogToLogFile = false;
 
+    const static QString csmHeaderStart;
+    const static QString csmBlinkingHeader;
+    const static QString csmHeaderEnd;
+    const static QString csmBlinkingBody;
 
 public slots:
     // Used by mudlet class as told by "Profile Preferences"
@@ -138,10 +144,20 @@ signals:
 
 
 private:
+    void insertBlinkingTextFeaturesIntoExisitingLog();
+
     // Was public in Host class but made private there and cloned to here
     // (for main TConsole) to prevent it being changed without going through the
     // process to load in the changed dictionary:
     QString mSpellDic;
+
+    // Track whether we need to/or have added the blinking control "header" to
+    // the HTML log file:
+    bool mHTMLLogFileAlreadyHasBlinkingText = false;
+    // Set as soon as blinking text is added to the HTML log - if the prior
+    // flag is NOT set - to note that we need to rewrite the file when it is
+    // closed to put the "header" back in at the beginning:
+    bool mHTMLLogFileNeedsBlinkingTextControl = false;
 
     // Cloned from Host
     bool mEnableUserDictionary = true;

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -124,10 +124,10 @@ public:
     QTextStream mLogStream;
     bool mLogToLogFile = false;
 
-    const static QString csmHeaderStart;
-    const static QString csmBlinkingHeader;
-    const static QString csmHeaderEnd;
-    const static QString csmBlinkingBody;
+    static const QString csmHeaderStart;
+    static const QString csmBlinkingHeader;
+    static const QString csmHeaderEnd;
+    static const QString csmBlinkingBody;
 
 public slots:
     // Used by mudlet class as told by "Profile Preferences"

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1945,6 +1945,12 @@ void TTextEdit::slot_copySelectionToClipboardHTML()
         return;
     }
 
+    // Is this a single line then we do NOT need to pad the first (and thus
+    // only) line to the right:
+    // CHECKME: how come we are using mDragStart.y() and mDragSelectionEnd.y()
+    // here - yet the rest of the method uses mPA.y() and mPB.y()?
+    bool isSingleLine = (mDragStart.y() == mDragSelectionEnd.y());
+
     QString title;
     if (mpConsole->getType() == TConsole::CentralDebugConsole) {
         title = tr("Mudlet, debug console extract");
@@ -1955,6 +1961,9 @@ void TTextEdit::slot_copySelectionToClipboardHTML()
     } else {
         title = tr("Mudlet, main console extract from %1 profile").arg(mpHost->getName());
     }
+
+    // Does this selection include blinking text?
+    bool hasBlinkingText = mpBuffer->blinkingTextInSelection(static_cast<std::size_t>(mPA.y()), static_cast<std::size_t>(mPB.y()));
 
     QStringList fontsList;                  // List of fonts to become the font-family entry for
                                             // the master css in the header
@@ -1970,55 +1979,29 @@ void TTextEdit::slot_copySelectionToClipboardHTML()
     fontsList << qsl("Courier");
     fontsList.removeDuplicates(); // In case the actual one is one of the defaults here
 
-    QString text = "<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01//EN' 'http://www.w3.org/TR/html4/strict.dtd'>\n";
-    text.append("<html>\n");
-    text.append(" <head>\n");
-    text.append("  <meta http-equiv='content-type' content='text/html; charset=utf-8'>");
-    // put the charset as early as possible as the parser MUST restart when it
-    // switches away from the ASCII default
-    text.append("  <meta name='generator' content='Mudlet MUD Client version: ");
-    text.append(APP_VERSION);
-    text.append(mudlet::self()->mAppBuild);
-    text.append("'>\n");
-    // Nice to identify what made the file!
-    text.append("  <title>");
-    text.append(title);
-    text.append("</title>\n");
-    // Web-page title
-    text.append("  <style type='text/css'>\n");
-    text.append("   <!-- body { font-family: '");
-    text.append(fontsList.join("', '"));
-    text.append("'; font-size: 100%; line-height: 1.125em; white-space: nowrap; color:rgb(255,255,255); background-color:rgb(");
-    // Line height, I think, should be equal to 18 point for a 16 point default
-    // font size by default but this seems to work even when the size is not 16
-    // Use a "%age" for a IE compatible font size, 16 point is the default for
-    // web-pages, but 14 seems to produce a more reasonable size but that could
-    // just be the browsers I tested it on! - Slysven
-    text.append(QString::number(mpHost->mBgColor.red()));
-    text.append(",");
-    text.append(QString::number(mpHost->mBgColor.green()));
-    text.append(",");
-    text.append(QString::number(mpHost->mBgColor.blue()));
-    text.append(");}\n");
-    text.append("        span { white-space: pre-wrap; }\n");
+    QString text = TMainConsole::csmHeaderStart
+                           .arg(APP_VERSION,
+                                mudlet::self()->mAppBuild,
+                                title,
+                                fontsList.join(qsl("', '")),
+                                QString::number(255),
+                                QString::number(255),
+                                QString::number(255))
+                           .arg(QString::number(mpHost->mBgColor.red()),
+                                QString::number(mpHost->mBgColor.green()),
+                                QString::number(mpHost->mBgColor.blue()));
 
-    if (mEnableBlinkText) {
-        text.append("        @keyframes blink-slow { 50% { opacity: 0; } }\n");
-        text.append("        @keyframes blink-fast { 50% { opacity: 0; } }\n");
-        text.append("        .blink-slow { animation: blink-slow 0.8s step-end infinite; }\n");
-        text.append("        .blink-fast { animation: blink-fast 0.4s step-end infinite; }\n");
+    if (hasBlinkingText) {
+        text.append(TMainConsole::csmBlinkingHeader);
     }
 
-    text.append("     -->\n");
-    text.append("  </style>\n");
-    text.append("  </head>\n");
-    text.append("  <body><div>");
+    text.append(TMainConsole::csmHeaderEnd);
+
+    text.append(qsl("  <body>%1<div>\n").arg(hasBlinkingText ? TMainConsole::csmBlinkingBody : QString()));
+
     // <div></div> tags required around outside of the body <span></spans> for
     // strict HTML 4 as we do not use <p></p>s or anything else
 
-    // Is this a single line then we do NOT need to pad the first (and thus
-    // only) line to the right:
-    bool isSingleLine = (mDragStart.y() == mDragSelectionEnd.y());
     for (int y = mPA.y(), total = mPB.y(); y <= total; ++y) {
         if (y >= static_cast<int>(mpBuffer->buffer.size())) {
             return;
@@ -2037,7 +2020,6 @@ void TTextEdit::slot_copySelectionToClipboardHTML()
     }
     text.append(qsl(" </div></body>\n"
                     "</html>"));
-    // The last two of these tags were missing and meant the HTML was not terminated properly
     QClipboard* clipboard = QApplication::clipboard();
     clipboard->setText(text);
     mSelectedRegion = QRegion(0, 0, 0, 0);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a checkbox control to the top of any HTML produced by Mudlet (from "Copy to HTML" or a main console logging to file when the latter is in HTML format AND it contains blinking or fast-blinking text) that needs to be checked in order for HTML to blink/fast-blink.

With the control unchecked the previous *italic* text effect is applied as per internal display of such text. Importantly it does not modify any actually italicised text. This is done via CSS that modifies any text with a `blink='fast'` or `blink='slow'` **attribute** - rather than the prior code that used a `class='blink-fast'` or `class='blink-slow'` to distinguish such texts.

Furthermore this PR examines any previously re-opened log file and retrofits the HTML/CSS needed to make the blinking/fast-blinking effect; it also updates any previous format blinking text to the new methodology. This means that HTML files that Mudlet produces going forward will NOT blink/ fast-blink until the effect is enabled by the viewer (and not the generator). This is a better view-experience - especially if the viewer has photo-sensitive epilepsy. So as to avoid issues with translation the label along side the checkbox shows a sequence of four `X` alternating in intensity between 100% and 20% to suggest the blinking effect of the control.

#### Motivation for adding to Mudlet
A health and safety issue to prevent viewers of HTML files from Mudlet from experiencing flashing text if it is hazardous for them.

Extension of the blinking effect so that blinking text can be added to existing log files without having to start a new one from scratch if the user is appending to existing log files.

#### Other info (issues closed, discussion etc)
This PR also converts some long bits of `QString` assembly from fragments of raw C-string literals into properly `qsl(`...`)` wrapped pieces, with some of them made into `static const` ones defined in only one place.

The rewriting of HTML files can take a noticeable time (though it should be better in "release" {optimised} code - when this is happening Mudlet changes the cursor to the "Busy" one to give a little feedback on this.

Whilst working on this on Windows I discovered that toggling the "Log" button whilst the log file concerned was a file selected in the Windows explorer window would fail to open the log file with a warning only visible on the OS "Command line". So as to make it more visible I have revised the code to produce an "in-main-console" `[ WARN ]  - ...` message. However this does not prevent the button from staying clicked and giving the mistaken impression that a log is being written when it is NOT. Further work on handling this error is needed in a separate PR.

:warning: This PR will modify existing HTML log files, if you do not want this to permanently change them then please back up such files before you try the test build of this PR. :warning: