### PR TITLE
Improve: Remove debug print from deleteAll function

### DIFF
--- a/src/mudlet-lua/lua/IDManager.lua
+++ b/src/mudlet-lua/lua/IDManager.lua
@@ -76,7 +76,6 @@ end
 
 -- internal function, not documented
 function IDMgr:deleteAll(typ)
-  print("Deleting all " .. typ .. "...")
   if table.size(self[typ]) > 0 then
     for name,_ in pairs(self[typ]) do
       self:delete(name, typ)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove unnecessary print statement from deleteAll function.  We do not show these types of informational messages in other similar functions.  Assuming leftover debug message.

#### Motivation for adding to Mudlet
Tidier scripts.

#### Other info (issues closed, discussion etc)
