### PR TITLE
Fix: crash when keychain operation times out

### DIFF
--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -98,16 +98,25 @@ void CredentialManager::handleTimeout()
 {
     qWarning() << "CredentialManager: Operation timed out";
 
-    // Call appropriate callback with timeout error
-    if (mCurrentCallback) {
-        mCurrentCallback(false, qsl("Operation timed out"));
-    } else if (mCurrentRetrievalCallback) {
-        mCurrentRetrievalCallback(false, QString(), qsl("Operation timed out"));
-    } else if (mCurrentAvailabilityCallback) {
-        mCurrentAvailabilityCallback(false, qsl("Operation timed out"));
-    }
+    // Move callbacks to locals before cleanup — the callback chain may call
+    // cleanupCurrentOperation() (e.g. by starting a new keychain operation),
+    // which would destroy the std::function while it's still executing,
+    // causing use-after-free of captured lambda state
+    auto callback = std::exchange(mCurrentCallback, nullptr);
+    auto retrievalCallback = std::exchange(mCurrentRetrievalCallback, nullptr);
+    auto availabilityCallback = std::exchange(mCurrentAvailabilityCallback, nullptr);
 
+    // Clean up the timed-out operation before invoking the callback,
+    // since the callback may start a new operation
     cleanupCurrentOperation();
+
+    if (callback) {
+        callback(false, qsl("Operation timed out"));
+    } else if (retrievalCallback) {
+        retrievalCallback(false, QString(), qsl("Operation timed out"));
+    } else if (availabilityCallback) {
+        availabilityCallback(false, qsl("Operation timed out"));
+    }
 }
 
 void CredentialManager::cleanupCurrentOperation()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixes a crash that occurs when a keychain password lookup takes too long and the timeout handler fires. The timeout callback could destroy its own state while still running, leading to a crash.

#### Motivation for adding to Mudlet
Mudlet crashes on startup if the system keychain is slow to respond (e.g. due to macOS Keychain prompts or system load). This makes profiles with saved passwords unusable until the keychain responds quickly enough.

#### Other info (issues closed, discussion etc)
The fix moves the callback to a local variable before cleanup, so it stays alive for the entire call chain. Detected via AddressSanitizer.

[crashlog.txt](https://github.com/user-attachments/files/26104538/crashlog.txt)
