### PR TITLE
Infrastructure: disable CodeQL poorly-documented-function query

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,2 +1,6 @@
 paths-ignore:
   - 3rdparty
+
+query-filters:
+  - exclude:
+      id: cpp/poorly-documented-function


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Disable the "Poorly documented large function" warning, since it mostly triggers on our LuaInterface functions, which are documented externally.
#### Motivation for adding to Mudlet
Too high of a rate for false positives.
#### Other info (issues closed, discussion etc)
