### PR TITLE
Fix: resolve CodeQL stack-address-escape warnings

### DIFF
--- a/src/TMxpClient.h
+++ b/src/TMxpClient.h
@@ -87,9 +87,9 @@ public:
         return true;
     }
 
-    virtual bool endTagReceived(MxpEndTag* startTag)
+    virtual bool endTagReceived(MxpEndTag* endTag)
     {
-        Q_UNUSED(startTag)
+        Q_UNUSED(endTag)
         return true;
     }
 

--- a/src/TMxpClient.h
+++ b/src/TMxpClient.h
@@ -29,13 +29,8 @@ class TMediaData;
 
 class TMxpClient
 {
-protected:
-    TMxpContext* mpContext = nullptr;
-
 public:
     TMxpClient() = default;
-
-    virtual void initialize(TMxpContext* context) { mpContext = context; }
 
     // Declaring the next functions as virtual = 0 makes this an abstract class:
     // That is, a derived class can only be instantiated when it actually
@@ -86,57 +81,64 @@ public:
 
     virtual bool tagReceived(MxpTag* tag) { return tag->isStartTag() ? startTagReceived(tag->asStartTag()) : endTagReceived(tag->asEndTag()); }
 
-    virtual bool startTagReceived(MxpStartTag* startTag) {
+    virtual bool startTagReceived(MxpStartTag* startTag)
+    {
         Q_UNUSED(startTag)
         return true;
     }
 
-    virtual bool endTagReceived(MxpEndTag* startTag) {
+    virtual bool endTagReceived(MxpEndTag* startTag)
+    {
         Q_UNUSED(startTag)
         return true;
     }
 
-    virtual TMxpTagHandlerResult tagHandled(MxpTag* tag, TMxpTagHandlerResult result) {
+    virtual TMxpTagHandlerResult tagHandled(MxpTag* tag, TMxpTagHandlerResult result, TMxpContext& context)
+    {
         Q_UNUSED(tag)
+        Q_UNUSED(context)
         return result;
     }
 
     virtual void setCaptionForSendEvent(const QString& caption) { Q_UNUSED(caption) }
-    
+
     // Get the encoding used by the connection (for proper decoding of MXP tags)
     // Default implementation returns UTF-8 for test clients
     virtual QByteArray getEncoding() const { return QByteArrayLiteral("UTF-8"); }
 
     // Get the console wrap width for layout purposes (e.g., HR tag)
     virtual int getWrapWidth() const { return 80; } // Default fallback
-    
+
     // Insert text directly into the output (e.g., for HR tag)
     virtual void insertText(const QString& text) { Q_UNUSED(text) }
-    
+
     // Check if force MXP should prevent server from changing default mode
     virtual bool shouldLockModeToSecure() const { return false; }
-    
+
     // MXP Frame management (FRAME and DEST tag support)
-    virtual bool createMxpFrame(const QString& name, const QMap<QString, QString>& attributes) {
+    virtual bool createMxpFrame(const QString& name, const QMap<QString, QString>& attributes)
+    {
         Q_UNUSED(name)
         Q_UNUSED(attributes)
         return false;
     }
-    
-    virtual bool closeMxpFrame(const QString& name) {
+
+    virtual bool closeMxpFrame(const QString& name)
+    {
         Q_UNUSED(name)
         return false;
     }
-    
-    virtual bool setMxpDestination(const QString& frameName, bool eol, bool eof) {
+
+    virtual bool setMxpDestination(const QString& frameName, bool eol, bool eof)
+    {
         Q_UNUSED(frameName)
         Q_UNUSED(eol)
         Q_UNUSED(eof)
         return false;
     }
-    
+
     virtual void clearMxpDestination() {}
-    
+
     virtual QString getMxpCurrentDestination() const { return QString(); }
 };
 

--- a/src/TMxpMudlet.cpp
+++ b/src/TMxpMudlet.cpp
@@ -101,10 +101,10 @@ void TMxpMudlet::stopMedia(TMediaData& mediaData)
     mpHost->mpMedia->stopMedia(mediaData);
 }
 
-TMxpTagHandlerResult TMxpMudlet::tagHandled(MxpTag* tag, TMxpTagHandlerResult result)
+TMxpTagHandlerResult TMxpMudlet::tagHandled(MxpTag* tag, TMxpTagHandlerResult result, TMxpContext& context)
 {
     if (tag->isStartTag()) {
-        if (mpContext->getElementRegistry().containsElement(tag->getName())) {
+        if (context.getElementRegistry().containsElement(tag->getName())) {
             enqueueMxpEvent(tag->asStartTag());
         } else if (tag->isNamed("SEND")) {
             // send events are queued on closing tag so the caption is available

--- a/src/TMxpMudlet.h
+++ b/src/TMxpMudlet.h
@@ -47,7 +47,8 @@ public:
     explicit TMxpMudlet(Host* pHost)
     : mpHost(pHost)
     , mLinkMode(false)
-    {}
+    {
+    }
 
     QString getVersion() override;
 
@@ -72,7 +73,8 @@ public:
     const QColor& getBgColor() { return bgColors.last(); }
 
     // TODO: implement support for fonts?
-    void pushFont(const QString& fontFace, const QString& fontSize) override {
+    void pushFont(const QString& fontFace, const QString& fontSize) override
+    {
         Q_UNUSED(fontFace)
         Q_UNUSED(fontSize)
     }
@@ -103,28 +105,31 @@ public:
     void resetTextProperties() override;
 
     void setStyle(const QString& val) override { mxpStyle = val; }
-    QString getStyle() override { return mxpStyle;}
+    QString getStyle() override { return mxpStyle; }
 
-    void setFlag(const QString& elementName, const QMap<QString, QString>& values, const QString& content) override {
+    void setFlag(const QString& elementName, const QMap<QString, QString>& values, const QString& content) override
+    {
         Q_UNUSED(elementName)
         Q_UNUSED(values)
         Q_UNUSED(content)
         // TODO: raise mxp event
     }
 
-    void publishEntity(const QString& name, const QString& value) override {
+    void publishEntity(const QString& name, const QString& value) override
+    {
         Q_UNUSED(name)
         Q_UNUSED(value)
     }
 
-    void setVariable(const QString& name, const QString& value) override {
+    void setVariable(const QString& name, const QString& value) override
+    {
         Q_UNUSED(name)
         Q_UNUSED(value)
     }
 
     bool startTagReceived(MxpStartTag* startTag) override;
-    
-    TMxpTagHandlerResult tagHandled(MxpTag* tag, TMxpTagHandlerResult result) override;
+
+    TMxpTagHandlerResult tagHandled(MxpTag* tag, TMxpTagHandlerResult result, TMxpContext& context) override;
 
     void enqueueMxpEvent(MxpStartTag* tag);
     TLinkStore& getLinkStore();
@@ -142,11 +147,11 @@ public:
     void insertText(const QString& text) override;
 
     QStack<TMxpEvent> mPendingSendEvents;
-    
+
     // Get the encoding used by the connection
     QByteArray getEncoding() const override;
     bool shouldLockModeToSecure() const override;
-    
+
     // MXP Frame management (FRAME and DEST tag support)
     bool createMxpFrame(const QString& name, const QMap<QString, QString>& attributes) override;
     bool closeMxpFrame(const QString& name) override;
@@ -156,7 +161,7 @@ public:
 
 private:
     bool isTagAllowedInMode(const QString& tagName, TMXPMode mode) const;
-    
+
     Host* mpHost;
     bool mLinkMode;
 };

--- a/src/TMxpProcessor.h
+++ b/src/TMxpProcessor.h
@@ -62,7 +62,6 @@ public:
     , mEntityHandler(mMxpTagProcessor.getEntityResolver())
     , mpMxpClient(pMxpClient)
     {
-        mpMxpClient->initialize(&mMxpTagProcessor);
     }
 
     bool setMode(const QString& code);

--- a/src/TMxpTagProcessor.cpp
+++ b/src/TMxpTagProcessor.cpp
@@ -77,7 +77,7 @@ TMxpTagHandlerResult TMxpTagProcessor::handleTag(TMxpContext& ctx, TMxpClient& c
 #ifdef DEBUG_MXP_PROCESSING
             qDebug() << "  Handler handled tag, result:" << result;
 #endif
-            result = client.tagHandled(tag, result);
+            result = client.tagHandled(tag, result, ctx);
             if (result != MXP_TAG_NOT_HANDLED) {
                 return result;
             }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -4519,6 +4519,9 @@ int cTelnet::decompressBuffer(char*& in_buffer, int& length, char* out_buffer)
     length = mZstream.avail_in;
     in_buffer = (char*)mZstream.next_in;
 
+    mZstream.next_in = Z_NULL;
+    mZstream.next_out = Z_NULL;
+
     if (zval == Z_STREAM_END) {
         inflateEnd(&mZstream);
         qDebug() << "recv Z_STREAM_END, ending compression";

--- a/test/TMxpEdgeCasesTest.cpp
+++ b/test/TMxpEdgeCasesTest.cpp
@@ -41,8 +41,9 @@ private:
       return true;
     }
 
-    TMxpTagHandlerResult tagHandled(MxpTag *tag,
-                                    TMxpTagHandlerResult result) override {
+    TMxpTagHandlerResult tagHandled(MxpTag *tag, TMxpTagHandlerResult result,
+                                    TMxpContext &context) override {
+      Q_UNUSED(context)
       if (result == MXP_TAG_NOT_HANDLED) {
         unhandledTagNames.append(tag->getName());
       }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Pass TMxpContext by reference to tagHandled() instead of storing it as a member pointer via initialize(). Null out zlib stream pointers after use in decompressBuffer().
#### Motivation for adding to Mudlet
Resolve CodeQL warnings about a potential issue.
#### Other info (issues closed, discussion etc)
