### PR TITLE
Fix: use right format type for errors in playSoundFileAsOrderedArguments

### DIFF
--- a/src/TLuaInterpreterMedia.cpp
+++ b/src/TLuaInterpreterMedia.cpp
@@ -491,7 +491,7 @@ int TLuaInterpreter::playSoundFileAsOrderedArguments(lua_State* L, const char* f
             intValue = getVerifiedInt(L, func, i, "fadein");
 
             if (intValue < 0) {
-                lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %s)", "fadein", intValue);
+                lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "fadein", intValue);
                 return lua_error(L);
             }
 
@@ -501,7 +501,7 @@ int TLuaInterpreter::playSoundFileAsOrderedArguments(lua_State* L, const char* f
             intValue = getVerifiedInt(L, func, i, "fadeout");
 
             if (intValue < 0) {
-                lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %s)", "fadeout", intValue);
+                lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "fadeout", intValue);
                 return lua_error(L);
             }
 
@@ -511,7 +511,7 @@ int TLuaInterpreter::playSoundFileAsOrderedArguments(lua_State* L, const char* f
             intValue = getVerifiedInt(L, func, i, "start");
 
             if (intValue < 0) {
-                lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %s)", "start", intValue);
+                lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "start", intValue);
                 return lua_error(L);
             }
 
@@ -553,7 +553,7 @@ int TLuaInterpreter::playSoundFileAsOrderedArguments(lua_State* L, const char* f
             intValue = getVerifiedInt(L, func, i, "finish");
 
             if (intValue < 0) {
-                lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %s)", "finish", intValue);
+                lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "finish", intValue);
                 return lua_error(L);
             }
 

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2717,8 +2717,10 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
         // We don't delete the progress dialog until here as we now use it to inform
         // about post-download operations
 
-        mpProgressDialog->deleteLater();
-        mpProgressDialog = nullptr; // Must reset this so it can be reused
+        if (mpProgressDialog) {
+            mpProgressDialog->deleteLater();
+            mpProgressDialog = nullptr; // Must reset this so it can be reused
+        }
 
         mLocalMapFileName.clear();
         mExpectedFileSize = 0;
@@ -2771,7 +2773,9 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
     // Since the download is complete but we do not offer to
     // cancel the required post-processing we should now hide
     // the cancel/abort button:
-    mpProgressDialog->setCancelButton(nullptr);
+    if (mpProgressDialog) {
+        mpProgressDialog->setCancelButton(nullptr);
+    }
 
     bool parsingWasSuccessful;
     QString parsingFileName;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
%d should be used [for int](https://www.lua.org/manual/5.1/manual.html#lua_pushfstring), 
#### Motivation for adding to Mudlet
Small bugfix.
#### Other info (issues closed, discussion etc)
