### PR TITLE
fix: Correct call() return value so timer error handling reads correctly

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4078,7 +4078,7 @@ bool TLuaInterpreter::call(const QString& function, const QString& mName, const 
     }
     lua_pop(L, lua_gettop(L));
 
-    return (error);
+    return !error;
 }
 
 // No documentation available in wiki - internal function


### PR DESCRIPTION
#### Brief overview of PR changes/additions
`call()` now returns `!error` (true=success) instead of the raw error code, matching `callMulti()` and making TTimer's error-stop logic read as intended.

#### Motivation for adding to Mudlet
The inverted return convention made `if (!call(...)) stop()` in TTimer mean "stop on success" instead of "stop on error", harming code clarity.

#### Other info (issues closed, discussion etc)
This was not broken in practice — timers worked correctly because `slot_timerFires()` unconditionally restarts permanent timers via `checkRestart()` + `start()` after every `execute()` call, making the stop inside `execute()` a no-op regardless of the return value. This is purely a code clarity fix. Test case: create a permanent timer with a 1s interval and script `echo("tick\n")`, verify it fires repeatedly. Create one with a syntax error and verify it logs errors.