### PR TITLE
fix: Copy Map to inactive profiles losing player room position

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2017,6 +2017,14 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
         // userMapData
         QMap<QString, QString> _dummyQMapQStringQString;
         ifs >> _dummyQMapQStringQString;
+        if (otherProfileVersion >= 19) {
+            QFont _dummyQFont;
+            ifs >> _dummyQFont;
+            double _dummyDouble;
+            ifs >> _dummyDouble;
+            bool _dummyBool;
+            ifs >> _dummyBool;
+        }
     }
 
     if (otherProfileVersion >= 14) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add missing reads for mMapSymbolFont, mMapSymbolFontFudgeFactor, and mIsOnlyMapSymbolFontToBeUsed in retrieveMapFileStats() for map format v>=19, matching what restore() already does correctly

#### Motivation for adding to Mudlet
Copying a map to inactive profiles via Preferences silently corrupts the player's saved room position in those profiles because retrieveMapFileStats() reads garbage data from a desynchronized QDataStream.

#### Other info (issues closed, discussion etc)
The bug was introduced in 2016 (94dd41bfb7) when retrieveMapFileStats was written, and became active when map format v19 added three new fields (mMapSymbolFont, mMapSymbolFontFudgeFactor, mIsOnlyMapSymbolFontToBeUsed) to the serialization in serialize()/restore() but retrieveMapFileStats was never updated to match.

The serialize() function writes in this order for v>=19:
1. mUserData
2. mMapSymbolFont (QFont)
3. mMapSymbolFontFudgeFactor (double)
4. mIsOnlyMapSymbolFontToBeUsed (bool)
5. area count + area data
6. room data
7. userRoomHash (contains the player room ID per profile)

The restore() function reads all of these correctly (lines 1664-1677). But retrieveMapFileStats() read mUserData and then jumped straight to reading area count, interpreting the QFont bytes as an int. This desynchronized the entire QDataStream, causing all subsequent reads (area count, room count, player room ID) to return garbage.

The only caller is dlgProfilePreferences.cpp:2741, the Copy Map feature for inactive profiles. It uses the returned roomId to update mRoomIdHash for the target profile. With the desync, this was either a garbage room ID (silently teleporting the player to a wrong room) or 0 (losing their position entirely).

Since the default map save version is 20, this affected every map file written by current Mudlet. Active profiles were unaffected because their room ID is read from memory, not from disk.

**Test case:** Create two profiles (A and B) each with a map. Close profile B. In profile A, go to Preferences, Mapper tab, click Copy Map. Check the debug output for profile B's stats -- area count and room count should now show correct values instead of garbage numbers. Reopen profile B and verify the player is in the correct room.