### PR TITLE
Fix: memory leak when deleting areas in a map

### DIFF
--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -57,7 +57,6 @@ TArea::TArea(TMap* pMap, TRoomDB* pRDB)
 TArea::~TArea()
 {
     if (!mpRoomDB) {
-        qDebug() << "ERROR: In TArea::~TArea(), instance has no mpRoomDB";
         return;
     }
     if (!mpRoomDB->mBulkDeletionMode) {

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -385,6 +385,8 @@ bool TRoomDB::removeArea(int id)
         // This means areas.clear() is not needed during map
         // deletion
         areas.remove(id);
+        pA->mpRoomDB = nullptr;
+        delete pA;
 
         mpMap->mMapGraphNeedsUpdate = true;
         return true;

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -385,6 +385,8 @@ bool TRoomDB::removeArea(int id)
         // This means areas.clear() is not needed during map
         // deletion
         areas.remove(id);
+        // Prevent TArea::~TArea() from re-entrantly calling removeArea(this),
+        // mirroring the pattern in TRoom::~TRoom()
         pA->mpRoomDB = nullptr;
         delete pA;
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix memory leak when deleting areas in a map, which themselves were left behind as a dangling pointer
#### Motivation for adding to Mudlet
Memory leak fix
#### Other info (issues closed, discussion etc)
