### PR TITLE
fix: Fix QFutureWatcher memory leaks across the codebase

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -959,6 +959,7 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
             reloadModules();
         }
         mWritingHostAndModules = false;
+        watcher->deleteLater();
     });
     watcher->setFuture(mModuleFuture);
     return {true, filename_xml, QString()};

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4830,6 +4830,7 @@ int TLuaInterpreter::unzipAsync(lua_State* L)
         event.mArgumentList.append(extractLocation);
         event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         host.raiseEvent(event);
+        watcher->deleteLater();
     });
     watcher->setFuture(future);
 

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1653,6 +1653,7 @@ void dlgConnectionProfiles::slot_copyProfile()
         mpCopyProfile->setEnabled(true);
         QApplication::restoreOverrideCursor();
         validateProfile();
+        watcher->deleteLater();
     });
     watcher->setFuture(future);
 }

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1241,7 +1241,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
                         break;
                     default: {
                     } // There are a significant number of other errors
-                    // that are not handled here!
+                        // that are not handled here!
                     }
                 }
             }
@@ -3549,6 +3549,7 @@ void dlgProfilePreferences::slot_tabChanged(int tabIndex)
 
                             theme_download_label->hide();
                             tempThemesArchive->deleteLater();
+                            watcher->deleteLater();
                         });
                         watcher->setFuture(future);
                         reply->deleteLater();

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -305,6 +305,7 @@ void Updater::setupOnWindows()
         // replace current binary with the unzipped one
         auto watcher = new QFutureWatcher<void>;
         connect(watcher, &QFutureWatcher<void>::finished, this, &Updater::finishSetup);
+        connect(watcher, &QFutureWatcher<void>::finished, watcher, &QObject::deleteLater);
         watcher->setFuture(future);
     });
 
@@ -370,6 +371,7 @@ void Updater::setupOnLinux()
         // replace current binary with the unzipped one
         auto watcher = new QFutureWatcher<void>;
         connect(watcher, &QFutureWatcher<void>::finished, this, &Updater::slot_updateLinuxBinary);
+        connect(watcher, &QFutureWatcher<void>::finished, watcher, &QObject::deleteLater);
         watcher->setFuture(future);
     });
 
@@ -540,6 +542,7 @@ void Updater::slot_installOrRestartClicked(QAbstractButton* button, const QStrin
 #endif
         mpInstallOrRestart->setText(tr("Restart to apply update"));
         mpInstallOrRestart->setEnabled(true);
+        watcher->deleteLater();
     });
     watcher->setFuture(future);
 #endif // !Q_OS_MACOS


### PR DESCRIPTION
#### Brief overview of PR changes/additions
A few places allocate a QFutureWatcher with new but don't clean it up afterwards. Added deleteLater() to all of them: Host::saveProfile, dlgConnectionProfiles::slot_copyProfile, dlgProfilePreferences theme download handler, TLuaInterpreter::unzipAsync, and Updater (3 sites).

#### Motivation for adding to Mudlet
Small housekeeping fix. Each leaked watcher is ~230 bytes so the practical impact is minimal, but it's good practice to clean up after ourselves. The Host::saveProfile one is the most frequent since autosave runs every 2 minutes.

#### Other info (issues closed, discussion etc)
Test case: review the one-line diffs, confirm deleteLater() is called after the watcher's finished signal work is done.