### PR TITLE
Fix: Module Manager shortcut uses wrong key sequence when menu bar hidden

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3617,7 +3617,7 @@ void mudlet::assignKeySequences()
         dactionPackageManager->setShortcut(QKeySequence());
 
         delete mpShortcutModules.data();
-        mpShortcutModules = new QShortcut(mKeySequencePackages, this);
+        mpShortcutModules = new QShortcut(mKeySequenceModules, this);
         connect(mpShortcutModules.data(), &QShortcut::activated, this, &mudlet::slot_moduleManager);
         dactionModuleManager->setShortcut(QKeySequence());
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
The Module Manager QShortcut was created with mKeySequencePackages (Alt+O) instead of mKeySequenceModules (Alt+I), making both Package Manager and Module Manager share the same shortcut key.

#### Motivation for adding to Mudlet
Bugfix
#### Other info (issues closed, discussion etc)
