### PR TITLE
fix: setSaveCommandHistory inverting the boolean when a command line name is given

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -8252,7 +8252,7 @@ int TLuaInterpreter::setSaveCommandHistory(lua_State* L)
             // First argument is a string so is presumably a command line name
             name = CMDLINE_NAME(L, 1);
             if (n > 1) {
-                saveCommands = !getVerifiedBool(L, __func__, 2, "save command history", true);
+                saveCommands = getVerifiedBool(L, __func__, 2, "save command history", true);
             }
 
         } else {
@@ -8261,7 +8261,7 @@ int TLuaInterpreter::setSaveCommandHistory(lua_State* L)
                 return lua_error(L); // Dummy return!
             }
 
-            saveCommands = !getVerifiedBool(L, __func__, 1, "save command history", true);
+            saveCommands = getVerifiedBool(L, __func__, 1, "save command history", true);
         }
     }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Remove erroneous ! negation on the getVerifiedBool result in the 2-arg paths of setSaveCommandHistory (lines 8255 and 8264)

#### Motivation for adding to Mudlet
setSaveCommandHistory("main", true) was disabling command history instead of enabling it, while setSaveCommandHistory(true) worked correctly - the 1-arg and 2-arg forms had opposite behavior for the same boolean value.

#### Other info (issues closed, discussion etc)
Bug has been present since the function was introduced in PR #6767.

**Test case:** Run setSaveCommandHistory("main", true) then getSaveCommandHistory("main") - should return true (previously returned false).