### PR TITLE
fix: stale characters during horizontal scrolling with wide fonts

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1201,7 +1201,7 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
 
     //delete non used characters.
     //needed for horizontal scrolling because there sometimes characters didn't get cleared
-    QRect deleteRect = QRect(0, from * mFontHeight, x_right * mFontHeight, (y_bottom + 1) * mFontHeight);
+    QRect deleteRect = QRect(0, from * mFontHeight, x_right * mFontWidth, (y_bottom + 1) * mFontHeight);
     p.setCompositionMode(QPainter::CompositionMode_Source);
     p.fillRect(deleteRect, Qt::transparent);
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
When using fonts where the character width exceeds the height, stale characters could remain visible during horizontal scrolling because the clear rectangle was too narrow to cover them

#### Motivation for adding to Mudlet
The `x_right` variable is a column count (pixels divided by `mFontWidth`), so converting it back to pixels for the QRect width should multiply by `mFontWidth`, not `mFontHeight`. For most monospace fonts where height > width, the clear rect was wider than necessary (harmless over-clearing). For fonts where width > height, the rect would be too narrow, leaving stale characters visible during horizontal scrolling — which is the exact problem this code was written to fix.

#### Other info (issues closed, discussion etc)

**Test case:** Use a font where the character width exceeds the height (or verify by inspection that x_right is a column count and the 3rd QRect arg is width in pixels).