### PR TITLE
Fix: use correct variable for Discord starttime string parsing

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2940,8 +2940,8 @@ void Host::processGMCPDiscordStatus(const QJsonObject& discordInfo)
         if (startTimeStamp.isDouble()) {
             timeStamp = static_cast<int64_t>(startTimeStamp.toDouble());
             pMudlet->mDiscord.setStartTimeStamp(this, timeStamp);
-        } else if (endTimeStamp.isString()) {
-            timeStamp = endTimeStamp.toString().toLongLong();
+        } else if (startTimeStamp.isString()) {
+            timeStamp = startTimeStamp.toString().toLongLong();
             pMudlet->mDiscord.setStartTimeStamp(this, timeStamp);
         }
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fix Discord Rich Presence not showing the "Playing for..." elapsed time when the MUD server sends the start timestamp as a string instead of a number.

#### Motivation for adding to Mudlet

A copy-paste bug in `processGMCPDiscordStatus()` checked `endTimeStamp.isString()` instead of `startTimeStamp.isString()`, making the string-typed starttime path dead code. MUD servers sending starttime as a string had the value silently dropped.

#### Other info (issues closed, discussion etc)

One-line fix: two variable name corrections on Host.cpp line 2943-2944.