### PR TITLE
fix: Ctrl+End in caret mode hides the cursor

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -3596,8 +3596,9 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
         break;
     case Qt::Key_End:
         if (QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
-            newCaretLine = mpBuffer->lineBuffer.length() - 1;
-            newCaretColumn = mpBuffer->lineBuffer[mCaretLine].length() - 1;
+            const int emptyLastLine = mpBuffer->lineBuffer.last().isEmpty() ? 1 : 0;
+            newCaretLine = mpBuffer->lineBuffer.length() - 1 - emptyLastLine;
+            newCaretColumn = std::max(0, static_cast<int>(mpBuffer->lineBuffer[newCaretLine].length()) - 1);
         } else {
             newCaretColumn = mpBuffer->lineBuffer.at(mCaretLine).length() - 1;
         }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Ctrl+End now uses the last line's length to calculate the column, instead of the current line's length

#### Motivation for adding to Mudlet
Ctrl+End in caret mode placed the cursor at the wrong column (an invalid one) when the current line had a different length than the last line in the buffer.

#### Other info (issues closed, discussion etc)

**Test case:**
1. Connect to any game and receive several lines of text with varying lengths
2. Enable caret mode (Tab or F6, see accessibility settings)
3. Position the caret on a short line (e.g. 10 characters)
4. Press Ctrl+End
5. Verify the caret moves to the end of the last line. Previously, it just hid the cursor.