### PR TITLE
fix: Variable editor misclassifies "0" as a string instead of a number

### DIFF
--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -392,7 +392,12 @@ bool LuaInterface::setValue(TVar* var)
 
 
     QList<TVar*> vars = varOrder(var);
-    QString variableChangeCode = vars[0]->getName();
+    QString variableChangeCode;
+    if (vars.size() == 1 && vars[0]->getKeyType() == LUA_TNUMBER) {
+        variableChangeCode = qsl("_G[%1]").arg(vars[0]->getName());
+    } else {
+        variableChangeCode = vars[0]->getName();
+    }
     for (int i = 1; i < vars.size(); i++) {
         if (vars[i]->isReference()) {
             return setCValue(vars);
@@ -435,7 +440,12 @@ bool LuaInterface::setValue(TVar* var)
 void LuaInterface::deleteVar(TVar* var)
 {
     QList<TVar*> vars = varOrder(var);
-    QString oldName = vars[0]->getName();
+    QString oldName;
+    if (vars.size() == 1 && vars[0]->getKeyType() == LUA_TNUMBER) {
+        oldName = qsl("_G[%1]").arg(vars[0]->getName());
+    } else {
+        oldName = vars[0]->getName();
+    }
     for (int i = 1; i < vars.size(); i++) {
         if (vars[i]->getKeyType() == LUA_TNUMBER) {
             oldName.append(qsl("[%1]").arg(vars[i]->getName()));
@@ -631,22 +641,25 @@ void LuaInterface::renameVar(TVar* var)
             if (i < vars.size() - 1) {
                 newName.append(qsl("[%1]").arg(vars[i]->getName()));
             }
-
         } else if (kType == LUA_TTABLE) {
             renameCVar(vars);
             return;
-        }
-
-        // That leaves LUA_TSTRING:
-        oldVariable.append(qsl(R"(["%1"])").arg(vars.at(i)->getName()));
-        if (i < vars.size() - 1) {
-            newName.append(qsl(R"(["%1"])").arg(vars.at(i)->getName()));
+        } else {
+            // LUA_TSTRING:
+            oldVariable.append(qsl(R"(["%1"])").arg(vars.at(i)->getName()));
+            if (i < vars.size() - 1) {
+                newName.append(qsl(R"(["%1"])").arg(vars.at(i)->getName()));
+            }
         }
     }
 
     if (vars.size() <= 1) {
         // this variable is at root level on _G
-        newName.append(qsl("_G[\"%1\"]").arg(vars.last()->getNewName()));
+        if (var->getNewKeyType() == LUA_TNUMBER) {
+            newName.append(qsl("_G[%1]").arg(vars.last()->getNewName()));
+        } else {
+            newName.append(qsl("_G[\"%1\"]").arg(vars.last()->getNewName()));
+        }
     } else {
         // this variable is nested in a table
         if (var->getNewKeyType() == LUA_TNUMBER) {

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6740,9 +6740,6 @@ void dlgTriggerEditor::saveVar()
     mChangingVar = true;
     int uiNameType = mpVarsMainArea->comboBox_variable_key_type->itemData(mpVarsMainArea->comboBox_variable_key_type->currentIndex(), Qt::UserRole).toInt();
     int uiValueType = mpVarsMainArea->comboBox_variable_value_type->itemData(mpVarsMainArea->comboBox_variable_value_type->currentIndex(), Qt::UserRole).toInt();
-    if ((uiNameType == LUA_TNUMBER || uiNameType == LUA_TSTRING) && newVar) {
-        uiNameType = LUA_TNONE;
-    }
     //check variable recasting
     const int varRecast = canRecast(pItem, uiNameType, uiValueType);
     if ((uiNameType == -1) || (variable && uiNameType != variable->getKeyType())) {

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6746,14 +6746,18 @@ void dlgTriggerEditor::saveVar()
     //check variable recasting
     const int varRecast = canRecast(pItem, uiNameType, uiValueType);
     if ((uiNameType == -1) || (variable && uiNameType != variable->getKeyType())) {
-        if (QString(newName).toInt()) {
+        bool nameIsNumber = false;
+        QString(newName).toInt(&nameIsNumber);
+        if (nameIsNumber) {
             uiNameType = LUA_TNUMBER;
         } else {
             uiNameType = LUA_TSTRING;
         }
     }
     if ((uiValueType != LUA_TTABLE) && (uiValueType == -1)) {
-        if (newValue.toInt()) {
+        bool valueIsNumber = false;
+        newValue.toInt(&valueIsNumber);
+        if (valueIsNumber) {
             uiValueType = LUA_TNUMBER;
         } else if (newValue.toLower() == "true" || newValue.toLower() == "false") {
             uiValueType = LUA_TBOOLEAN;
@@ -6786,7 +6790,9 @@ void dlgTriggerEditor::saveVar()
                 int change = 0;
                 if (newName != variable->getName() || uiNameType != variable->getKeyType()) {
                     //let's make sure the nametype works
-                    if (variable->getKeyType() == LUA_TNUMBER && newName.toInt()) {
+                    bool nameIsNumber = false;
+                    newName.toInt(&nameIsNumber);
+                    if (variable->getKeyType() == LUA_TNUMBER && nameIsNumber) {
                         uiNameType = LUA_TNUMBER;
                     } else {
                         uiNameType = LUA_TSTRING;
@@ -6796,10 +6802,12 @@ void dlgTriggerEditor::saveVar()
                 variable->setNewName(newName, uiNameType);
                 if (variable->getValueType() != LUA_TTABLE && (newValue != variable->getValue() || uiValueType != variable->getValueType())) {
                     //let's check again
+                    bool valueIsNumber = false;
+                    newValue.toInt(&valueIsNumber);
                     if (variable->getValueType() == LUA_TTABLE) {
                         //HEIKO: obvious logic error used to be valueType == LUA_TABLE
                         uiValueType = LUA_TTABLE;
-                    } else if (uiValueType == LUA_TNUMBER && newValue.toInt()) {
+                    } else if (uiValueType == LUA_TNUMBER && valueIsNumber) {
                         uiValueType = LUA_TNUMBER;
                     } else if (uiValueType == LUA_TBOOLEAN && (newValue.toLower() == "true" || newValue.toLower() == "false")) {
                         uiValueType = LUA_TBOOLEAN;
@@ -6840,9 +6848,11 @@ void dlgTriggerEditor::saveVar()
             int change = 0;
             if (newName != var->getName() || uiNameType != var->getKeyType()) {
                 //let's make sure the nametype works
+                bool nameIsNumber = false;
+                newName.toInt(&nameIsNumber);
                 if (uiNameType == LUA_TSTRING) {
                     //do nothing, we can always make key to string
-                } else if (var->getKeyType() == LUA_TNUMBER && newName.toInt()) {
+                } else if (var->getKeyType() == LUA_TNUMBER && nameIsNumber) {
                     uiNameType = LUA_TNUMBER;
                 } else {
                     uiNameType = LUA_TSTRING;
@@ -6852,9 +6862,11 @@ void dlgTriggerEditor::saveVar()
             }
             if (newValue != var->getValue() || uiValueType != var->getValueType()) {
                 //let's check again
+                bool valueIsNumber = false;
+                newValue.toInt(&valueIsNumber);
                 if (uiValueType == LUA_TTABLE) {
                     newValue = "{}";
-                } else if (uiValueType == LUA_TNUMBER && newValue.toInt()) {
+                } else if (uiValueType == LUA_TNUMBER && valueIsNumber) {
                     uiValueType = LUA_TNUMBER;
                 } else if (uiValueType == LUA_TBOOLEAN && (newValue.toLower() == QLatin1String("true") || newValue.toLower() == QLatin1String("false"))) {
                     uiValueType = LUA_TBOOLEAN;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `QString::toInt()` returns 0 for both `"0"` (valid number) and non-numeric strings, so using its return value as a boolean misclassifies `"0"` as `LUA_TSTRING`
- Switched all 6 instances in `saveVar()` to use the `bool* ok` out-parameter pattern, matching `TVar.cpp`'s `TVarLessThan` comparator which already fixed this

#### Motivation for adding to Mudlet
Lua tables with numeric key `0` or value `0` get their type silently corrupted when edited in the variable viewer.

#### Other info (issues closed, discussion etc)

**Test case:** Create `myTable = {[0] = "test"}` in Lua, open the variable editor, edit/save the `0` key — it should remain typed as `LUA_TNUMBER`, not become `LUA_TSTRING`.