### PR TITLE
Fix: OSC 8 hyperlinks strip config/preset only when features are advertised

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -5014,3 +5014,13 @@ QStringList Host::getValidExperiments() const
 {
     return QStringList(mValidExperiments.constBegin(), mValidExperiments.constEnd());
 }
+
+bool Host::shouldStripOscHyperlinkConfigParam()
+{
+    return mTelnet.isOscHyperlinkConfigFeatureEnabled();
+}
+
+bool Host::shouldStripOscHyperlinkPresetParam()
+{
+    return mTelnet.isOscHyperlinkPresetsEnabled();
+}

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -5018,10 +5018,10 @@ QStringList Host::getValidExperiments() const
 
 bool Host::shouldStripOscHyperlinkConfigParam()
 {
-    return mTelnet.isOscHyperlinkConfigFeatureEnabled();
+    return mTelnet.oscHyperlinkConfigFeatureEnabled();
 }
 
 bool Host::shouldStripOscHyperlinkPresetParam()
 {
-    return mTelnet.isOscHyperlinkPresetsEnabled();
+    return mTelnet.oscHyperlinkPresetsEnabled();
 }

--- a/src/Host.h
+++ b/src/Host.h
@@ -200,6 +200,12 @@ public:
     bool getHaveColorSpaceId() { return mSGRCodeHasColSpaceId; }
     void setMayRedefineColors(const bool state) { mServerMayRedefineColors = state; }
     bool getMayRedefineColors() { return mServerMayRedefineColors; }
+    // Check if OSC 8 config parameter should be stripped from web URLs
+    // Returns true if any config-using feature is advertised via NEW-ENVIRON
+    bool shouldStripOscHyperlinkConfigParam();
+    // Check if OSC 8 preset parameter should be stripped from web URLs
+    // Returns true if presets feature is advertised via NEW-ENVIRON
+    bool shouldStripOscHyperlinkPresetParam();
     void setDiscordApplicationID(const QString& s);
     const QString& getDiscordApplicationID();
     void setDiscordInviteURL(const QString& s);

--- a/src/Host.h
+++ b/src/Host.h
@@ -200,11 +200,7 @@ public:
     bool getHaveColorSpaceId() { return mSGRCodeHasColSpaceId; }
     void setMayRedefineColors(const bool state) { mServerMayRedefineColors = state; }
     bool getMayRedefineColors() { return mServerMayRedefineColors; }
-    // Check if OSC 8 config parameter should be stripped from web URLs
-    // Returns true if any config-using feature is advertised via NEW-ENVIRON
     bool shouldStripOscHyperlinkConfigParam();
-    // Check if OSC 8 preset parameter should be stripped from web URLs
-    // Returns true if presets feature is advertised via NEW-ENVIRON
     bool shouldStripOscHyperlinkPresetParam();
     void setDiscordApplicationID(const QString& s);
     const QString& getDiscordApplicationID();

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2968,12 +2968,13 @@ void TBuffer::decodeOSC(const QString& sequence)
             if (rawUrl.startsWith(qsl("http://")) || rawUrl.startsWith(qsl("https://")) || rawUrl.startsWith(qsl("ftp://"))) {
                 int queryStart = baseUrl.indexOf('?');
                 if (queryStart != -1) {
-                    // Only strip reserved parameters if corresponding features are advertised
+                    // Strip reserved parameters when corresponding OSC 8 features are enabled
+                    // (currently always true; will reflect NEW-ENVIRON negotiation once fully implemented)
                     const bool stripConfig = mpHost->shouldStripOscHyperlinkConfigParam();
                     const bool stripPreset = mpHost->shouldStripOscHyperlinkPresetParam();
 
-                    // Split on raw query string so percent-encoded variants of
-                    // "config"/"preset" (e.g. %63%6F%6E%66%69%67) are preserved
+                    // Compare keys against literal strings only; percent-encoded key names
+                    // (e.g. %63%6F%6E%66%69%67 for "config") are intentionally not stripped
                     const QStringList rawPairs = baseUrl.mid(queryStart + 1).split('&');
                     QStringList kept;
                     for (const auto& pair : rawPairs) {

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2973,7 +2973,18 @@ void TBuffer::decodeOSC(const QString& sequence)
                     const QStringList rawPairs = baseUrl.mid(queryStart + 1).split('&');
                     QStringList kept;
                     for (const auto& pair : rawPairs) {
-                        const auto key = pair.left(pair.indexOf('='));
+                        // Find the separator between key and value - use earliest of '=' or '%3D' (percent-encoded =)
+                        int literalEq = pair.indexOf('=');
+                        int encodedEq = pair.indexOf(qsl("%3D"), 0, Qt::CaseInsensitive);
+                        int eqPos = -1;
+                        if (literalEq >= 0 && encodedEq >= 0) {
+                            eqPos = qMin(literalEq, encodedEq);
+                        } else if (literalEq >= 0) {
+                            eqPos = literalEq;
+                        } else {
+                            eqPos = encodedEq;
+                        }
+                        const auto key = eqPos >= 0 ? pair.left(eqPos) : pair;
                         if (key != qsl("config") && key != qsl("preset")) {
                             kept.append(pair);
                         }

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2968,6 +2968,10 @@ void TBuffer::decodeOSC(const QString& sequence)
             if (rawUrl.startsWith(qsl("http://")) || rawUrl.startsWith(qsl("https://")) || rawUrl.startsWith(qsl("ftp://"))) {
                 int queryStart = baseUrl.indexOf('?');
                 if (queryStart != -1) {
+                    // Only strip reserved parameters if corresponding features are advertised
+                    const bool stripConfig = mpHost->shouldStripOscHyperlinkConfigParam();
+                    const bool stripPreset = mpHost->shouldStripOscHyperlinkPresetParam();
+
                     // Split on raw query string so percent-encoded variants of
                     // "config"/"preset" (e.g. %63%6F%6E%66%69%67) are preserved
                     const QStringList rawPairs = baseUrl.mid(queryStart + 1).split('&');
@@ -2985,9 +2989,10 @@ void TBuffer::decodeOSC(const QString& sequence)
                             eqPos = encodedEq;
                         }
                         const auto key = eqPos >= 0 ? pair.left(eqPos) : pair;
-                        if (key != qsl("config") && key != qsl("preset")) {
-                            kept.append(pair);
+                        if ((stripConfig && key == qsl("config")) || (stripPreset && key == qsl("preset"))) {
+                            continue;
                         }
+                        kept.append(pair);
                     }
 
                     baseUrl = baseUrl.left(queryStart);

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1843,6 +1843,21 @@ QString cTelnet::getNewEnvironOSCHyperlinksDisabled()
     return qsl("1");
 }
 
+bool cTelnet::isOscHyperlinkConfigFeatureEnabled()
+{
+    // Returns true if any config-using OSC 8 feature is enabled
+    // These are the features that use the ?config= parameter
+    return getNewEnvironOSCHyperlinksStyleBasic() == qsl("1") || getNewEnvironOSCHyperlinksStyleStates() == qsl("1") || getNewEnvironOSCHyperlinksTooltip() == qsl("1")
+           || getNewEnvironOSCHyperlinksMenu() == qsl("1") || getNewEnvironOSCHyperlinksCompact() == qsl("1") || getNewEnvironOSCHyperlinksVisibility() == qsl("1")
+           || getNewEnvironOSCHyperlinksSelection() == qsl("1") || getNewEnvironOSCHyperlinksSpoiler() == qsl("1") || getNewEnvironOSCHyperlinksDisabled() == qsl("1");
+}
+
+bool cTelnet::isOscHyperlinkPresetsEnabled()
+{
+    // Returns true if OSC 8 presets feature is enabled
+    return getNewEnvironOSCHyperlinksPresets() == qsl("1");
+}
+
 QString cTelnet::getNewEnvironScreenReader()
 {
     return mpHost->mAdvertiseScreenReader ? qsl("1") : qsl("0");

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1843,14 +1843,14 @@ QString cTelnet::getNewEnvironOSCHyperlinksDisabled()
     return qsl("1");
 }
 
-bool cTelnet::isOscHyperlinkConfigFeatureEnabled()
+bool cTelnet::oscHyperlinkConfigFeatureEnabled()
 {
     return getNewEnvironOSCHyperlinksStyleBasic() == qsl("1") || getNewEnvironOSCHyperlinksStyleStates() == qsl("1") || getNewEnvironOSCHyperlinksTooltip() == qsl("1")
            || getNewEnvironOSCHyperlinksMenu() == qsl("1") || getNewEnvironOSCHyperlinksCompact() == qsl("1") || getNewEnvironOSCHyperlinksVisibility() == qsl("1")
            || getNewEnvironOSCHyperlinksSelection() == qsl("1") || getNewEnvironOSCHyperlinksSpoiler() == qsl("1") || getNewEnvironOSCHyperlinksDisabled() == qsl("1");
 }
 
-bool cTelnet::isOscHyperlinkPresetsEnabled()
+bool cTelnet::oscHyperlinkPresetsEnabled()
 {
     return getNewEnvironOSCHyperlinksPresets() == qsl("1");
 }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1845,8 +1845,6 @@ QString cTelnet::getNewEnvironOSCHyperlinksDisabled()
 
 bool cTelnet::isOscHyperlinkConfigFeatureEnabled()
 {
-    // Returns true if any config-using OSC 8 feature is enabled
-    // These are the features that use the ?config= parameter
     return getNewEnvironOSCHyperlinksStyleBasic() == qsl("1") || getNewEnvironOSCHyperlinksStyleStates() == qsl("1") || getNewEnvironOSCHyperlinksTooltip() == qsl("1")
            || getNewEnvironOSCHyperlinksMenu() == qsl("1") || getNewEnvironOSCHyperlinksCompact() == qsl("1") || getNewEnvironOSCHyperlinksVisibility() == qsl("1")
            || getNewEnvironOSCHyperlinksSelection() == qsl("1") || getNewEnvironOSCHyperlinksSpoiler() == qsl("1") || getNewEnvironOSCHyperlinksDisabled() == qsl("1");
@@ -1854,7 +1852,6 @@ bool cTelnet::isOscHyperlinkConfigFeatureEnabled()
 
 bool cTelnet::isOscHyperlinkPresetsEnabled()
 {
-    // Returns true if OSC 8 presets feature is enabled
     return getNewEnvironOSCHyperlinksPresets() == qsl("1");
 }
 

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -205,8 +205,8 @@ public:
     const QByteArrayList& getEncodingsList() const { return mAcceptableEncodings; }
     std::optional<QAbstractSocket::SocketError> error() const;
     QString errorString();
-    bool isOscHyperlinkConfigFeatureEnabled();
-    bool isOscHyperlinkPresetsEnabled();
+    bool oscHyperlinkConfigFeatureEnabled();
+    bool oscHyperlinkPresetsEnabled();
 #if !defined(QT_NO_SSL)
     QSslCertificate getPeerCertificate();
     QList<QSslError> getSslErrors();

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -205,6 +205,8 @@ public:
     const QByteArrayList& getEncodingsList() const { return mAcceptableEncodings; }
     std::optional<QAbstractSocket::SocketError> error() const;
     QString errorString();
+    bool isOscHyperlinkConfigFeatureEnabled();
+    bool isOscHyperlinkPresetsEnabled();
 #if !defined(QT_NO_SSL)
     QSslCertificate getPeerCertificate();
     QList<QSslError> getSslErrors();
@@ -271,12 +273,6 @@ public slots:
     void slot_timerPosting();
     void slot_send_login();
     void slot_send_pass();
-
-public:
-    // Check if any config-using OSC 8 hyperlink feature is enabled
-    bool isOscHyperlinkConfigFeatureEnabled();
-    // Check if OSC 8 hyperlink presets feature is enabled
-    bool isOscHyperlinkPresetsEnabled();
 
 signals:
     // Intended to signal status changes for other parts of application

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -272,6 +272,12 @@ public slots:
     void slot_send_login();
     void slot_send_pass();
 
+public:
+    // Check if any config-using OSC 8 hyperlink feature is enabled
+    bool isOscHyperlinkConfigFeatureEnabled();
+    // Check if OSC 8 hyperlink presets feature is enabled
+    bool isOscHyperlinkPresetsEnabled();
+
 signals:
     // Intended to signal status changes for other parts of application
     void signal_connecting(Host*);

--- a/test/functional_tests/TOscTest.cpp
+++ b/test/functional_tests/TOscTest.cpp
@@ -266,6 +266,50 @@ private slots:
                             .arg(commands.first())));
   }
 
+  void test_Osc8WebUrl_StripsPresetWithEncodedEquals() {
+    // Tests that preset parameter is stripped even when = is percent-encoded as
+    // %3D, while preserving non-reserved parameters
+    QString messageFromMud = "\x1b]8;;https://example.com/"
+                             "?preset%3Ddefault&page=1\x1b\\Link\x1b]8;;\x1b\\";
+
+    mpServer->setWelcomeMessage(messageFromMud);
+    startProfile(mHostname, mLocalhost, mPort);
+    QSignalSpy spy(mudlet::self()->getActiveHost()->mpConsole,
+                   &TMainConsole::signal_newDataAlert);
+    QVERIFY(spy.wait(200));
+
+    QStringList commands = findFirstLinkCommands();
+    QVERIFY2(!commands.isEmpty(), "No hyperlink found in buffer");
+    QVERIFY2(!commands.first().contains("preset%3D"),
+             qPrintable(QString("Preset param with encoded = not stripped: %1")
+                            .arg(commands.first())));
+    QVERIFY2(commands.first().contains("page=1"),
+             qPrintable(QString("Non-reserved 'page' param was stripped: %1")
+                            .arg(commands.first())));
+  }
+
+  void test_Osc8WebUrl_StripsConfigWithEncodedEquals() {
+    // Tests that config parameter is stripped even when = is percent-encoded as
+    // %3d (lowercase variant of %3D), while preserving non-reserved parameters
+    QString messageFromMud = "\x1b]8;;https://example.com/"
+                             "?config%3dvalue&foo=bar\x1b\\Link\x1b]8;;\x1b\\";
+
+    mpServer->setWelcomeMessage(messageFromMud);
+    startProfile(mHostname, mLocalhost, mPort);
+    QSignalSpy spy(mudlet::self()->getActiveHost()->mpConsole,
+                   &TMainConsole::signal_newDataAlert);
+    QVERIFY(spy.wait(200));
+
+    QStringList commands = findFirstLinkCommands();
+    QVERIFY2(!commands.isEmpty(), "No hyperlink found in buffer");
+    QVERIFY2(!commands.first().contains("config%3d"),
+             qPrintable(QString("Config param with encoded = not stripped: %1")
+                            .arg(commands.first())));
+    QVERIFY2(commands.first().contains("foo=bar"),
+             qPrintable(QString("Non-reserved 'foo' param was stripped: %1")
+                            .arg(commands.first())));
+  }
+
   void test_Osc8WebUrl_PreservesPercentEncodedReservedNames() {
     // %63%6F%6E%66%69%67 is "config" percent-encoded — should NOT be stripped
     QString messageFromMud =


### PR DESCRIPTION
#### Brief overview of PR changes/additions
OSC 8 hyperlinks now only strip `config` and `preset` query parameters from web URLs when the corresponding features are actually advertised via NEW-ENVIRON. Also fixes stripping when `=` is percent-encoded as `%3D`.

#### Motivation for adding to Mudlet
Improves protocol correctness for the MUD server community. Servers using only basic `send:` and `prompt:` schemes no longer have their web URLs unexpectedly modified.

#### Other info (issues closed, discussion etc)
- Regression fix from #9073 for encoded `=` handling
- Added tests for encoded `=` variants
- `config` stripped when any config-using feature enabled (STYLE_BASIC, STYLE_STATES, TOOLTIP, MENU, COMPACT, VISIBILITY, SELECTION, SPOILER, DISABLED)
- `preset` stripped only when PRESETS feature is enabled

---

**Before**

<img width="467" height="119" alt="Screenshot 2026-03-22 at 2 07 41 AM" src="https://github.com/user-attachments/assets/5662a8c5-2c9f-415c-9a49-31b653c9ed7e" />

**After**

<img width="497" height="126" alt="Screenshot 2026-03-22 at 2 42 42 AM" src="https://github.com/user-attachments/assets/15d6afd5-a9e0-4faf-ab2f-31251ea3e633" />