### PR TITLE
Improve: error message when saving MMP-downloaded map

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2765,7 +2765,10 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
         return;
     }
     if (!writeFile.commit()) {
-        qDebug() << "TMap::slot_replyFinished: error saving downloaded map: " << writeFile.errorString();
+        const QString alertMsg = tr("[ ALERT ] - Map download failed, unable to save destination file:\n%1\nreason: %2").arg(mLocalMapFileName, writeFile.errorString());
+        postMessage(alertMsg);
+        cleanup();
+        return;
     }
 
     Host* pHost = mpHost;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
If there was an error in saving the downloaded map, the player would have had no idea.
#### Motivation for adding to Mudlet
A bit better error reporting.
#### Other info (issues closed, discussion etc)
