### PR TITLE
Fix: small leak in resetProfile() for the Lua state, label, and scrollbox

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5000,6 +5000,10 @@ end)LUA");
 // on initialization of a new session *or* in case of an interpreter reset by the user.
 void TLuaInterpreter::initLuaGlobals()
 {
+    if (pGlobalLua) {
+        lua_close(pGlobalLua);
+    }
+
     pGlobalLua = newstate();
     storeHostInLua(pGlobalLua, mpHost);
 

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -458,7 +458,7 @@ void TMainConsole::resetMainConsole()
     QMutableMapIterator<QString, TDockWidget*> itDockWidget(mDockWidgetMap);
     while (itDockWidget.hasNext()) {
         itDockWidget.next();
-        itDockWidget.value()->close();
+        itDockWidget.value()->deleteLater();
         itDockWidget.remove();
     }
 
@@ -480,14 +480,14 @@ void TMainConsole::resetMainConsole()
     QMutableMapIterator<QString, TLabel*> itLabel(mLabelMap);
     while (itLabel.hasNext()) {
         itLabel.next();
-        itLabel.value()->close();
+        itLabel.value()->deleteLater();
         itLabel.remove();
     }
 
     QMutableMapIterator<QString, TScrollBox*> itScrollBox(mScrollBoxMap);
     while (itScrollBox.hasNext()) {
         itScrollBox.next();
-        itScrollBox.value()->close();
+        itScrollBox.value()->deleteLater();
         itScrollBox.remove();
     }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fixes a couple of leaks -

1. Lua state on resetProfile is not properly closed:
```
  resetProfile() [TLuaInterpreter.cpp:753]
    → Host::resetProfile_phase1() [Host.cpp:820]
      → QTimer::singleShot(0, ...) [Host.cpp:828]
        → Host::resetProfile_phase2() [Host.cpp:833]
          → mLuaInterpreter.initLuaGlobals() [Host.cpp:848]
            → pGlobalLua = newstate()  ← LEAK [TLuaInterpreter.cpp:5003]
              (old pGlobalLua never lua_close()'d; only close is in ~TLuaInterpreter:153)
```
3. TMainConsole::resetMainConsole() leaks TLabel, TScrollBox, TDockWidget

  Impact: Widgets become untracked orphans on every reset; TDockWidgets are true leaks (no parent)
  resetProfile() 
  ```
  → Host::resetProfile_phase2() [Host.cpp:845]
    → TMainConsole::resetMainConsole() [TMainConsole.cpp:455]
      → TDockWidget:  close() [line 461] ← LEAK (closeEvent ignores, no WA_DeleteOnClose)
      → TConsole:     close() [line 476] ← OK (has WA_DeleteOnClose)
      → TLabel:       close() [line 483] ← LEAK (no WA_DeleteOnClose)
      → TScrollBox:   close() [line 490] ← LEAK (no WA_DeleteOnClose)
      → TCommandLine: deleteLater() [line 468] ← CORRECT
      → TTextBox:     deleteLater() [line 497] ← CORRECT
```

#### Motivation for adding to Mudlet
Addressing memory leaks
#### Other info (issues closed, discussion etc)
