### PR TITLE
Fix: small memory leaks when closing/reopening profiles

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -431,6 +431,8 @@ Host::~Host()
     qDeleteAll(mStopWatchMap);
     mStopWatchMap.clear();
 
+    delete mMMCPServer;
+
     if (mpDockableMapWidget) {
         mpDockableMapWidget->deleteLater();
     }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -428,6 +428,9 @@ Host::~Host()
     qDeleteAll(profileShortcuts);
     profileShortcuts.clear();
 
+    qDeleteAll(mStopWatchMap);
+    mStopWatchMap.clear();
+
     if (mpDockableMapWidget) {
         mpDockableMapWidget->deleteLater();
     }

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -593,7 +593,7 @@ void Discord::resetData(Host* pHost)
 {
     mStartTimes.remove(pHost);
     mEndTimes.remove(pHost);
-    mDetailTexts[pHost] = qsl("www.mudlet.org");
+    mDetailTexts.remove(pHost);
     mStateTexts.remove(pHost);
     mLargeImages.remove(pHost);
     mLargeImageTexts.remove(pHost);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2014,6 +2014,7 @@ void mudlet::closeHost(const QString& name)
 
     mpTabBar->removeTab(name);
     // PLACEMARKER: Host destruction (1) - from all sources
+    mDiscord.resetData(pH);
     int hostCount = mHostManager.getHostCount();
     emit signal_hostDestroyed(pH, --hostCount);
     // This is what kills the Host instance:


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

  1. Host::mStopWatchMap not cleaned in destructor

```
  createStopWatch() [TLuaInterpreterMudletObjects.cpp:256]
    → Host::createStopWatch() [Host.cpp:1410]
      → new stopWatch() [Host.cpp:1433] → mStopWatchMap.insert() [Host.cpp:1439]

  mudlet::closeHost() [mudlet.cpp:1970]
    → HostManager::deleteHost() [HostManager.cpp:31] → mHostPool.remove() [HostManager.cpp:42]
      → ~Host() [Host.cpp:418]
        → qDeleteAll(profileShortcuts)  ← PRESENT [Host.cpp:428]
        → qDeleteAll(mStopWatchMap)     ← MISSING
```

  2. Discord stale Host* map entries (dangling pointers)
```
  setDiscord*() functions → insert into QMap<Host*, ...> [discord.h:251-260] (10 maps)
  Profile close → mudlet::closeHost() [mudlet.cpp:1970]
    → mHostManager.deleteHost() [mudlet.cpp:2020] → Host destroyed
    ← Discord::resetData() NEVER called (not connected to signal_hostDestroyed)
    ← 10 maps retain entries keyed by dangling Host*
```
  3. MMCPServer + MMCPClient leak
```
  chatStartServer() → Host::initMMCPServer() [Host.cpp:3050]
    → mMMCPServer = new MMCPServer(this) [Host.cpp:3056]
      ← 'this' passed as arg only, NOT as QObject parent [MMCPServer.cpp:38]
      ← mMMCPServer is QPointer (non-owning) [Host.h:789]
  Profile close → ~Host() [Host.cpp:418] ← NEVER deletes mMMCPServer
    ← MMCPServer leaked with all connected MMCPClients
```
#### Motivation for adding to Mudlet
Addressing memory leaks
#### Other info (issues closed, discussion etc)
