### PR TITLE
Fix: small memory leaks in package/object management

### DIFF
--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -67,7 +67,7 @@ void AliasUnit::uninstall(const QString& packageName)
         }
     }
     for (auto& alias : uninstallList) {
-        unregisterAlias(alias);
+        delete alias;
     }
     uninstallList.clear();
 }

--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -85,7 +85,7 @@ void KeyUnit::uninstall(const QString& packageName)
         }
     }
     for (auto& key : uninstallList) {
-        unregisterKey(key);
+        delete key;
     }
     uninstallList.clear();
 }

--- a/src/ScriptUnit.cpp
+++ b/src/ScriptUnit.cpp
@@ -71,7 +71,7 @@ void ScriptUnit::uninstall(const QString& packageName)
         }
     }
     for (auto& script : uninstallList) {
-        unregisterScript(script);
+        delete script;
     }
     uninstallList.clear();
 }

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -2321,6 +2321,7 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
     if (pP) {
         patterns = pP->getPatternsList();
         propertyList = pP->getRegexCodePropertyList();
+        host.getTriggerUnit()->killTrigger(triggerName);
     }
     patterns << pattern;
     if (colorTrigger) {

--- a/src/TimerUnit.cpp
+++ b/src/TimerUnit.cpp
@@ -77,7 +77,7 @@ void TimerUnit::uninstall(const QString& packageName)
         }
     }
     for (auto& timer : uninstallList) {
-        unregisterTimer(timer);
+        delete timer;
     }
     uninstallList.clear();
 }

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -78,7 +78,7 @@ void TriggerUnit::uninstall(const QString& packageName)
         }
     }
     for (auto& trigger : uninstallList) {
-        unregisterTrigger(trigger);
+        delete trigger;
     }
     uninstallList.clear();
 }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
 1. Five Unit::uninstall() methods never delete items

```
  dlgPackageManager::slot_removePackages() [dlgPackageManager.cpp:613]
    → Host::uninstallPackage() [Host.cpp:2312-2317]
      → TriggerUnit::uninstall(packageName) [TriggerUnit.cpp:72]
          for (trigger : uninstallList) { unregisterTrigger(trigger); }  ← LEAK (no delete)
        AliasUnit::uninstall()   [AliasUnit.cpp:69]   — same bug
        KeyUnit::uninstall()     [KeyUnit.cpp:87]     — same bug
        ScriptUnit::uninstall()  [ScriptUnit.cpp:73]  — same bug
        TimerUnit::uninstall()   [TimerUnit.cpp:79]   — same bug
      → ActionUnit::uninstall()  [ActionUnit.cpp:70]  — CORRECT: uses `delete action`
```

  2. tempComplexRegexTrigger accumulates old triggers

```
  tempComplexRegexTrigger("name", pattern, ...) [TLuaInterpreterMudletObjects.cpp:2224]
    → findTrigger("name") [line 2320] → finds existing trigger A
    → copies A's patterns [line 2322-2323], appends new pattern [line 2325]
    → new TTrigger("a", patterns, ...) [line 2332]  ← trigger B created
    → pT->registerTrigger() [line 2336] → addTriggerRootNode [TriggerUnit.cpp:96]
    → pT->setName("name") [line 2337] → mLookupTable.insert("name", B) [TTrigger.cpp:105]
    ← trigger A NEVER removed/killed — both A and B active in mTriggerRootNodeList

  killTrigger("name") [TriggerUnit.cpp:393]
    → finds first temp match → markCleanup → return true [line 402] ← ONLY KILLS ONE
    → cleanup → ~TTrigger → removeTriggerRootNode → mLookupTable.remove("name") ← REMOVES ALL
    ← surviving triggers lose lookup entries but stay in mTriggerRootNodeList (unkillable)
```
#### Motivation for adding to Mudlet
Addressing memory leaks.
#### Other info (issues closed, discussion etc)
