### PR TITLE
fix typo in mPlayerRoomColorGradentStops member name

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2123,7 +2123,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
             painter.setPen(transparentPen);
             myPath.addEllipse(playerRoomOnWidgetCoordinates, roomRadius, roomRadius);
         } else {
-            gradient.setStops(mPlayerRoomColorGradentStops);
+            gradient.setStops(mPlayerRoomColorGradientStops);
             painter.setBrush(gradient);
             painter.setPen(transparentPen);
             myPath.addEllipse(playerRoomOnWidgetCoordinates, roomRadius, roomRadius);
@@ -5151,77 +5151,77 @@ void T2DMap::setPlayerRoomStyle(const int type)
     }
 
     // From Qt 5.6 does not deallocate any memory previously used:
-    mPlayerRoomColorGradentStops.clear();
+    mPlayerRoomColorGradientStops.clear();
     // Indicate the LARGEST size we will need
-    mPlayerRoomColorGradentStops.reserve(5);
+    mPlayerRoomColorGradientStops.reserve(5);
 
     const double factor = mpMap->mPlayerRoomInnerDiameterPercentage / 100.0;
     const bool solid = (mpMap->mPlayerRoomInnerDiameterPercentage == 0);
     switch (type) {
     case 1: // Simple(?) shaded red ring:
         if (solid) {
-            mPlayerRoomColorGradentStops.resize(3);
-            mPlayerRoomColorGradentStops[0] = QGradientStop(0.000, QColor(255, 0, 0, 255));
-            mPlayerRoomColorGradentStops[1] = QGradientStop(0.990, QColor(255, 0, 0, 255));
-            mPlayerRoomColorGradentStops[2] = QGradientStop(1.000, QColor(255, 0, 0, 0));
+            mPlayerRoomColorGradientStops.resize(3);
+            mPlayerRoomColorGradientStops[0] = QGradientStop(0.000, QColor(255, 0, 0, 255));
+            mPlayerRoomColorGradientStops[1] = QGradientStop(0.990, QColor(255, 0, 0, 255));
+            mPlayerRoomColorGradientStops[2] = QGradientStop(1.000, QColor(255, 0, 0, 0));
         } else {
-            mPlayerRoomColorGradentStops.resize(5);
-            mPlayerRoomColorGradentStops[0] = QGradientStop(0.000, QColor(255, 0, 0, 0));
-            mPlayerRoomColorGradentStops[1] = QGradientStop(factor * 0.950, QColor(255, 0, 0, 0));
-            mPlayerRoomColorGradentStops[2] = QGradientStop(factor * 1.050, QColor(255, 0, 0, 255));
-            mPlayerRoomColorGradentStops[3] = QGradientStop(1.000 - (factor * 0.100), QColor(255, 0, 0, 255));
-            mPlayerRoomColorGradentStops[4] = QGradientStop(1.000, QColor(255, 0, 0, 0));
+            mPlayerRoomColorGradientStops.resize(5);
+            mPlayerRoomColorGradientStops[0] = QGradientStop(0.000, QColor(255, 0, 0, 0));
+            mPlayerRoomColorGradientStops[1] = QGradientStop(factor * 0.950, QColor(255, 0, 0, 0));
+            mPlayerRoomColorGradientStops[2] = QGradientStop(factor * 1.050, QColor(255, 0, 0, 255));
+            mPlayerRoomColorGradientStops[3] = QGradientStop(1.000 - (factor * 0.100), QColor(255, 0, 0, 255));
+            mPlayerRoomColorGradientStops[4] = QGradientStop(1.000, QColor(255, 0, 0, 0));
         }
         break;
         // End of case 1:
 
     case 2: // Shaded bicolor (blue-yellow - so it ALWAYS contrasts with underlying room color) Ring:
         if (solid) {
-            mPlayerRoomColorGradentStops.resize(3);
-            mPlayerRoomColorGradentStops[0] = QGradientStop(0.000, QColor(255, 255, 0, 255));
-            mPlayerRoomColorGradentStops[1] = QGradientStop(0.990, QColor(0, 0, 255, 255));
-            mPlayerRoomColorGradentStops[2] = QGradientStop(1.000, QColor(0, 0, 255, 0));
+            mPlayerRoomColorGradientStops.resize(3);
+            mPlayerRoomColorGradientStops[0] = QGradientStop(0.000, QColor(255, 255, 0, 255));
+            mPlayerRoomColorGradientStops[1] = QGradientStop(0.990, QColor(0, 0, 255, 255));
+            mPlayerRoomColorGradientStops[2] = QGradientStop(1.000, QColor(0, 0, 255, 0));
         } else {
-            mPlayerRoomColorGradentStops.resize(5);
-            mPlayerRoomColorGradentStops[0] = QGradientStop(0.000, QColor(255, 255, 0, 0));
-            mPlayerRoomColorGradentStops[1] = QGradientStop(factor * 0.950, QColor(255, 255, 0, 0));
-            mPlayerRoomColorGradentStops[2] = QGradientStop(factor * 1.050, QColor(255, 255, 0, 255));
-            mPlayerRoomColorGradentStops[3] = QGradientStop(1.000 - (factor * 0.100), QColor(0, 0, 255, 255));
-            mPlayerRoomColorGradentStops[4] = QGradientStop(1.000, QColor(0, 0, 255, 0));
+            mPlayerRoomColorGradientStops.resize(5);
+            mPlayerRoomColorGradientStops[0] = QGradientStop(0.000, QColor(255, 255, 0, 0));
+            mPlayerRoomColorGradientStops[1] = QGradientStop(factor * 0.950, QColor(255, 255, 0, 0));
+            mPlayerRoomColorGradientStops[2] = QGradientStop(factor * 1.050, QColor(255, 255, 0, 255));
+            mPlayerRoomColorGradientStops[3] = QGradientStop(1.000 - (factor * 0.100), QColor(0, 0, 255, 255));
+            mPlayerRoomColorGradientStops[4] = QGradientStop(1.000, QColor(0, 0, 255, 0));
         }
         break;
         // End of case 2:
 
     case 3: { // User set ring:
         if (solid) {
-            mPlayerRoomColorGradentStops.resize(3);
-            mPlayerRoomColorGradentStops[0] = QGradientStop(0.000, mpMap->mPlayerRoomInnerColor);
-            mPlayerRoomColorGradentStops[1] = QGradientStop(0.990, mpMap->mPlayerRoomOuterColor);
+            mPlayerRoomColorGradientStops.resize(3);
+            mPlayerRoomColorGradientStops[0] = QGradientStop(0.000, mpMap->mPlayerRoomInnerColor);
+            mPlayerRoomColorGradientStops[1] = QGradientStop(0.990, mpMap->mPlayerRoomOuterColor);
             QColor transparentColor(mpMap->mPlayerRoomOuterColor);
             transparentColor.setAlpha(0);
-            mPlayerRoomColorGradentStops[2] = QGradientStop(1.000, transparentColor);
+            mPlayerRoomColorGradientStops[2] = QGradientStop(1.000, transparentColor);
         } else {
-            mPlayerRoomColorGradentStops.resize(5);
+            mPlayerRoomColorGradientStops.resize(5);
             QColor transparentColor(mpMap->mPlayerRoomInnerColor);
             transparentColor.setAlpha(0);
-            mPlayerRoomColorGradentStops[0] = QGradientStop(1.000, transparentColor);
-            mPlayerRoomColorGradentStops[1] = QGradientStop(factor * 0.950, transparentColor);
-            mPlayerRoomColorGradentStops[2] = QGradientStop(factor * 1.050, mpMap->mPlayerRoomInnerColor);
-            mPlayerRoomColorGradentStops[3] = QGradientStop(1.000 - (factor * 0.100), mpMap->mPlayerRoomOuterColor);
+            mPlayerRoomColorGradientStops[0] = QGradientStop(1.000, transparentColor);
+            mPlayerRoomColorGradientStops[1] = QGradientStop(factor * 0.950, transparentColor);
+            mPlayerRoomColorGradientStops[2] = QGradientStop(factor * 1.050, mpMap->mPlayerRoomInnerColor);
+            mPlayerRoomColorGradientStops[3] = QGradientStop(1.000 - (factor * 0.100), mpMap->mPlayerRoomOuterColor);
             transparentColor = mpMap->mPlayerRoomOuterColor;
             transparentColor.setAlpha(0);
-            mPlayerRoomColorGradentStops[4] = QGradientStop(1.000, transparentColor);
+            mPlayerRoomColorGradientStops[4] = QGradientStop(1.000, transparentColor);
         }
         break;
     } // End of case 3:
 
     default: // Sort of emulates the original code:
-        mPlayerRoomColorGradentStops.resize(5);
-        mPlayerRoomColorGradentStops[0] = QGradientStop(0, Qt::white);
-        mPlayerRoomColorGradentStops[1] = QGradientStop(0.7, QColor(255, 0, 0, 200));
-        mPlayerRoomColorGradentStops[2] = QGradientStop(0.799, QColor(150, 100, 100, 100));
-        mPlayerRoomColorGradentStops[3] = QGradientStop(0.80, QColor(150, 100, 100, 150));
-        mPlayerRoomColorGradentStops[4] = QGradientStop(0.95, QColor(255, 0, 0, 150));
+        mPlayerRoomColorGradientStops.resize(5);
+        mPlayerRoomColorGradientStops[0] = QGradientStop(0, Qt::white);
+        mPlayerRoomColorGradientStops[1] = QGradientStop(0.7, QColor(255, 0, 0, 200));
+        mPlayerRoomColorGradientStops[2] = QGradientStop(0.799, QColor(150, 100, 100, 100));
+        mPlayerRoomColorGradientStops[3] = QGradientStop(0.80, QColor(150, 100, 100, 150));
+        mPlayerRoomColorGradientStops[4] = QGradientStop(0.95, QColor(255, 0, 0, 150));
     } // End of switch ()
 }
 

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -435,7 +435,7 @@ private:
     quint8 mMaxRoomIdDigits = 0;
 
     // Holds the QRadialGradient details to use for the player room:
-    QGradientStops mPlayerRoomColorGradentStops;
+    QGradientStops mPlayerRoomColorGradientStops;
 
     QPointer<dlgRoomProperties> mpDlgRoomProperties;
     QPointer<dlgMapLabel> mpDlgMapLabel;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Rename `mPlayerRoomColorGradentStops` to `mPlayerRoomColorGradientStops` (missing 'i' in Gradient) across T2DMap.h and T2DMap.cpp

#### Motivation for adding to Mudlet
Fixes a typo in a member variable name for code clarity and consistency with the correctly-spelled `buildPlayerRoomGradientStops` method coming in PR #8975.

#### Other info (issues closed, discussion etc)
Spotted during review of #8975.

**Test case:** Build succeeds, player room marker renders identically to before (pure rename, no logic changes).