### PR TITLE
Improve: saving a key with no binding set shows an error

### DIFF
--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -393,6 +393,11 @@ QString KeyUnit::getKeyName(const Qt::Key keyCode, const Qt::KeyboardModifiers m
            % ((modifierCode & Qt::GroupSwitchModifier) ? "groupswitch + " : QString());
 
 
+    if (keyCode == Qt::Key_unknown) {
+        //: Displayed when no key binding has been set
+        return tr("no key chosen");
+    }
+
     if (mKeys.contains(keyCode)) {
         return name % mKeys.value(keyCode);
     }

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -188,7 +188,7 @@ bool TKey::compileScript()
 
 void TKey::validateKeyBinding()
 {
-    if (!isFolder() && mKeyCode == Qt::Key(0)) {
+    if (!isFolder() && (mKeyCode == Qt::Key_unknown || mKeyCode == Qt::Key(0))) {
         mOK_init = false;
         setError(QObject::tr("No key binding set. Click \"Grab New Key\" to assign one."));
     } else {

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -186,6 +186,16 @@ bool TKey::compileScript()
     }
 }
 
+void TKey::validateKeyBinding()
+{
+    if (!isFolder() && mKeyCode == Qt::Key(0)) {
+        mOK_init = false;
+        setError(QObject::tr("No key binding set. Click \"Grab New Key\" to assign one."));
+    } else {
+        mOK_init = true;
+    }
+}
+
 void TKey::execute()
 {
     if (!mCommand.isEmpty()) {

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -190,6 +190,7 @@ void TKey::validateKeyBinding()
 {
     if (!isFolder() && (mKeyCode == Qt::Key_unknown || mKeyCode == Qt::Key(0))) {
         mOK_init = false;
+        //: Error shown in the editor when a key item has no key binding assigned
         setError(QObject::tr("No key binding set. Click \"Grab New Key\" to assign one."));
     } else {
         mOK_init = true;

--- a/src/TKey.h
+++ b/src/TKey.h
@@ -87,9 +87,7 @@ private:
      * Qt::KeypadModifier  0x20000000 A keypad button is pressed.
      */
 
-    // Have to use brace default initiliaser here as there is not a null enum
-    // value declared:
-    Qt::Key mKeyCode = {};
+    Qt::Key mKeyCode = Qt::Key_unknown;
     Qt::KeyboardModifiers mKeyModifier = Qt::NoModifier;
 
     QString mScript;

--- a/src/TKey.h
+++ b/src/TKey.h
@@ -43,7 +43,7 @@ public:
     TKey(QString name, Host* pHost);
     void compileAll();
     QString getName() const { return mName; }
-    void setName(const QString & name);
+    void setName(const QString& name);
     Qt::Key getKeyCode() const { return mKeyCode; }
     void setKeyCode(const Qt::Key code) { mKeyCode = code; }
     void setKeyCode(const int codeNumber) { setKeyCode(static_cast<Qt::Key>(codeNumber)); }
@@ -65,6 +65,7 @@ public:
 
     bool match(const Qt::Key, const Qt::KeyboardModifiers, const bool);
     bool registerKey();
+    void validateKeyBinding();
 
     bool exportItem = true;
     bool mModuleMasterFolder = false;

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6939,6 +6939,8 @@ void dlgTriggerEditor::saveKey()
         pT->setCommand(command);
         pT->setScript(script);
 
+        pT->validateKeyBinding();
+
         QIcon icon;
         QString itemDescription;
         const bool itemActive = pT->isActive();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Saving a key with no binding set now shows an error:

<img width="1433" height="949" alt="Screenshot from 2026-03-24 21-55-47" src="https://github.com/user-attachments/assets/e37899ad-3f66-4e50-a55d-88d797b7309b" />

#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/8102, tackle 5.0 milestone goal
#### Other info (issues closed, discussion etc)
