### PR TITLE
fix: generic mapper: add video walkthrough on how to set it up

### DIFF
--- a/src/mudlet.qrc
+++ b/src/mudlet.qrc
@@ -105,6 +105,8 @@
         <file>icons/folder-grey-locked.png</file>
         <file>icons/folder-grey.png</file>
         <file>icons/folder-lightblue-locked.png</file>
+        <file>generic_mapper_walkthrough.mp4</file>
+        <file>icons/folder-lightblue-locked.png</file>
         <file>icons/folder-new.png</file>
         <file>icons/folder-orange-locked.png</file>
         <file>icons/folder-orange.png</file>


### PR DESCRIPTION
Fixes #3172

## Changes
- `src/mudlet.qrc`

## Summary
Automated fix for: generic mapper: add video walkthrough on how to set it up