### PR TITLE
infrastructure: increase functional test timeout to fix CI failures

### DIFF
--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -22,6 +22,6 @@ foreach(test_file ${FUNCTIONAL_TEST_SOURCES})
     set_tests_properties(${test_name} PROPERTIES
         ENVIRONMENT "QT_QPA_PLATFORM=offscreen;ASAN_OPTIONS=detect_leaks=0"
         LABELS "functional"
-        TIMEOUT 60  # seconds
+        TIMEOUT 120  # seconds
     )
 endforeach()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Increase functional test timeout from 60s to 120s in `test/functional_tests/CMakeLists.txt`

#### Motivation for adding to Mudlet
The OSC 8 title tests added in #8910 grew the TOscTest suite to 36+ test cases, which takes ~54s on arm64 but exceeds the 60s timeout on the slower x86_64 macOS runner, causing CI failures on unrelated PRs.

#### Other info (issues closed, discussion etc)
Discovered via CI failure on #8975.

**Test case:** CI should pass on macOS x86_64 without TOscTest timing out.