### PR TITLE
Infrastructure: add CI workflow to create GitHub Releases for updater

### DIFF
--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -284,6 +284,34 @@ jobs:
           echo "Warning: No signed installer found in ${SIGNED_DIR}"
         fi
 
+    - name: (Windows) Update release asset to signed installer
+      if: steps.sign-installer.outcome == 'success' && env.RELEASE_ASSET_PATH
+      shell: msys2 {0}
+      run: |
+        # The signed installer replaced the file at ARTIFACT_WINPATHORFILE,
+        # which may differ from RELEASE_ASSET_PATH (e.g. PTB copies to upload dir).
+        # Find the signed installer and update the release asset paths.
+        SIGNED_PATH=$(cygpath -au "${ARTIFACT_WINPATHORFILE}")
+        if [ -d "${SIGNED_PATH}" ]; then
+          SIGNED_EXE=$(find "${SIGNED_PATH}" -name "*.exe" -type f | head -1)
+        else
+          SIGNED_EXE="${SIGNED_PATH}"
+        fi
+
+        if [ -n "${SIGNED_EXE}" ] && [ -f "${SIGNED_EXE}" ]; then
+          SHA256_FILE="${SIGNED_EXE}.sha256"
+          sha256sum "${SIGNED_EXE}" > "${SHA256_FILE}"
+          {
+            echo "RELEASE_ASSET_PATH=${SIGNED_EXE}"
+            echo "RELEASE_ASSET_SHA256_PATH=${SHA256_FILE}"
+          } >> "$GITHUB_ENV"
+          echo "Recomputed SHA256 for signed installer:"
+          cat "${SHA256_FILE}"
+        else
+          echo "Warning: Could not find signed installer, using original"
+          sha256sum "${RELEASE_ASSET_PATH}" > "${RELEASE_ASSET_SHA256_PATH}"
+        fi
+
     - name: Create intermediate artifact for debugging
       uses: actions/upload-artifact@v7
       if: env.INTERMEDIATE_ARTIFACT_NAME
@@ -308,6 +336,32 @@ jobs:
       shell: msys2 {0}
       if: env.ARTIFACT_NAME
       run: curl --retry 5 -X POST "https://make.mudlet.org/snapshots/gha_queue.php?artifact_name=${{env.ARTIFACT_NAME}}&unzip=${{env.ARTIFACT_UNZIP}}"
+
+    - name: Upload release asset for GitHub Release
+      uses: actions/upload-artifact@v7
+      if: env.RELEASE_ASSET_PATH
+      with:
+        name: release-asset-Windows-X64
+        path: |
+          ${{ env.RELEASE_ASSET_PATH }}
+          ${{ env.RELEASE_ASSET_SHA256_PATH }}
+        retention-days: 3
+
+    - name: Export release metadata
+      if: env.RELEASE_ASSET_PATH
+      shell: msys2 {0}
+      run: |
+        cat > release-metadata.json << METAEOF
+        {"version":"${VERSION}","build_suffix":"${MUDLET_VERSION_BUILD}","commit":"${BUILD_COMMIT}","ref":"${{ github.ref }}","event":"${{ github.event_name }}"}
+        METAEOF
+
+    - name: Upload release metadata
+      uses: actions/upload-artifact@v7
+      if: env.RELEASE_ASSET_PATH
+      with:
+        name: release-metadata-Windows-X64
+        path: release-metadata.json
+        retention-days: 3
 
     - name: Register PTB Release
       shell: msys2 {0}

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -351,7 +351,14 @@ jobs:
       if: env.RELEASE_ASSET_PATH
       shell: msys2 {0}
       run: |
-        echo "{\"version\":\"${VERSION}\",\"build_suffix\":\"${MUDLET_VERSION_BUILD}\",\"commit\":\"${BUILD_COMMIT}\",\"ref\":\"${{ github.ref }}\",\"event\":\"${{ github.event_name }}\"}" > release-metadata.json
+        jq -n \
+          --arg version "${VERSION}" \
+          --arg build_suffix "${MUDLET_VERSION_BUILD}" \
+          --arg commit "${BUILD_COMMIT}" \
+          --arg ref "${{ github.ref }}" \
+          --arg event "${{ github.event_name }}" \
+          '{version: $version, build_suffix: $build_suffix, commit: $commit, ref: $ref, event: $event}' \
+          > release-metadata.json
 
     - name: Upload release metadata
       uses: actions/upload-artifact@v7

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -288,9 +288,9 @@ jobs:
       if: steps.sign-installer.outcome == 'success' && env.RELEASE_ASSET_PATH
       shell: msys2 {0}
       run: |
-        # The signed installer replaced the file at ARTIFACT_WINPATHORFILE,
-        # which may differ from RELEASE_ASSET_PATH (e.g. PTB copies to upload dir).
-        # Find the signed installer and update the release asset paths.
+        # After signing, the signed binary lives at ARTIFACT_WINPATHORFILE.
+        # Update RELEASE_ASSET_PATH (set earlier, before signing) to point to
+        # the signed binary and recompute the SHA256.
         SIGNED_PATH=$(cygpath -au "${ARTIFACT_WINPATHORFILE}")
         if [ -d "${SIGNED_PATH}" ]; then
           SIGNED_EXE=$(find "${SIGNED_PATH}" -name "*.exe" -type f | head -1)
@@ -308,8 +308,8 @@ jobs:
           echo "Recomputed SHA256 for signed installer:"
           cat "${SHA256_FILE}"
         else
-          echo "Warning: Could not find signed installer, using original"
-          (cd "$(dirname "${RELEASE_ASSET_PATH}")" && sha256sum "$(basename "${RELEASE_ASSET_PATH}")") > "${RELEASE_ASSET_SHA256_PATH}"
+          echo "::error::Signing step reported success but signed installer not found at ${SIGNED_PATH}"
+          exit 1
         fi
 
     - name: Create intermediate artifact for debugging
@@ -351,9 +351,7 @@ jobs:
       if: env.RELEASE_ASSET_PATH
       shell: msys2 {0}
       run: |
-        cat > release-metadata.json << METAEOF
-        {"version":"${VERSION}","build_suffix":"${MUDLET_VERSION_BUILD}","commit":"${BUILD_COMMIT}","ref":"${{ github.ref }}","event":"${{ github.event_name }}"}
-        METAEOF
+        echo "{\"version\":\"${VERSION}\",\"build_suffix\":\"${MUDLET_VERSION_BUILD}\",\"commit\":\"${BUILD_COMMIT}\",\"ref\":\"${{ github.ref }}\",\"event\":\"${{ github.event_name }}\"}" > release-metadata.json
 
     - name: Upload release metadata
       uses: actions/upload-artifact@v7

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -300,7 +300,7 @@ jobs:
 
         if [ -n "${SIGNED_EXE}" ] && [ -f "${SIGNED_EXE}" ]; then
           SHA256_FILE="${SIGNED_EXE}.sha256"
-          sha256sum "${SIGNED_EXE}" > "${SHA256_FILE}"
+          (cd "$(dirname "${SIGNED_EXE}")" && sha256sum "$(basename "${SIGNED_EXE}")") > "${SHA256_FILE}"
           {
             echo "RELEASE_ASSET_PATH=${SIGNED_EXE}"
             echo "RELEASE_ASSET_SHA256_PATH=${SHA256_FILE}"
@@ -309,7 +309,7 @@ jobs:
           cat "${SHA256_FILE}"
         else
           echo "Warning: Could not find signed installer, using original"
-          sha256sum "${RELEASE_ASSET_PATH}" > "${RELEASE_ASSET_SHA256_PATH}"
+          (cd "$(dirname "${RELEASE_ASSET_PATH}")" && sha256sum "$(basename "${RELEASE_ASSET_PATH}")") > "${RELEASE_ASSET_SHA256_PATH}"
         fi
 
     - name: Create intermediate artifact for debugging

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -436,7 +436,14 @@ jobs:
       if: env.RELEASE_ASSET_PATH
       shell: bash
       run: |
-        echo "{\"version\":\"${VERSION}\",\"build_suffix\":\"${MUDLET_VERSION_BUILD}\",\"commit\":\"${BUILD_COMMIT}\",\"ref\":\"${{ github.ref }}\",\"event\":\"${{ github.event_name }}\"}" > release-metadata.json
+        jq -n \
+          --arg version "${VERSION}" \
+          --arg build_suffix "${MUDLET_VERSION_BUILD}" \
+          --arg commit "${BUILD_COMMIT}" \
+          --arg ref "${{ github.ref }}" \
+          --arg event "${{ github.event_name }}" \
+          '{version: $version, build_suffix: $build_suffix, commit: $commit, ref: $ref, event: $event}' \
+          > release-metadata.json
 
     - name: Upload release metadata
       uses: actions/upload-artifact@v7

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -422,6 +422,31 @@ jobs:
       run: curl --retry 5 -X POST "https://make.mudlet.org/snapshots/gha_queue.php?artifact_name=${{env.UPLOAD_FILENAME}}&unzip=1"
       shell: bash
 
+    - name: Upload release asset for GitHub Release
+      uses: actions/upload-artifact@v7
+      if: env.RELEASE_ASSET_PATH
+      with:
+        name: release-asset-${{ runner.os }}-${{ runner.arch }}
+        path: |
+          ${{ env.RELEASE_ASSET_PATH }}
+          ${{ env.RELEASE_ASSET_SHA256_PATH }}
+        retention-days: 3
+
+    - name: Export release metadata
+      if: env.RELEASE_ASSET_PATH
+      shell: bash
+      run: |
+        cat > release-metadata.json << METAEOF
+        {"version":"${VERSION}","build_suffix":"${MUDLET_VERSION_BUILD}","commit":"${BUILD_COMMIT}","ref":"${{ github.ref }}","event":"${{ github.event_name }}"}
+        METAEOF
+
+    - name: Upload release metadata
+      uses: actions/upload-artifact@v7
+      if: env.RELEASE_ASSET_PATH
+      with:
+        name: release-metadata-${{ runner.os }}-${{ runner.arch }}
+        path: release-metadata.json
+        retention-days: 3
 
     # we need to be in the right place for LuaGlobals.lua to load
     - name: (Linux) Prep binary for running tests

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -436,9 +436,7 @@ jobs:
       if: env.RELEASE_ASSET_PATH
       shell: bash
       run: |
-        cat > release-metadata.json << METAEOF
-        {"version":"${VERSION}","build_suffix":"${MUDLET_VERSION_BUILD}","commit":"${BUILD_COMMIT}","ref":"${{ github.ref }}","event":"${{ github.event_name }}"}
-        METAEOF
+        echo "{\"version\":\"${VERSION}\",\"build_suffix\":\"${MUDLET_VERSION_BUILD}\",\"commit\":\"${BUILD_COMMIT}\",\"ref\":\"${{ github.ref }}\",\"event\":\"${{ github.event_name }}\"}" > release-metadata.json
 
     - name: Upload release metadata
       uses: actions/upload-artifact@v7

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -8,6 +8,10 @@ permissions:
   contents: write
   actions: read
 
+concurrency:
+  group: create-github-release-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
 jobs:
   create-release:
     runs-on: ubuntu-latest
@@ -137,6 +141,7 @@ jobs:
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
         with:
           fetch-depth: 0
+          clean: false
 
       - uses: leafo/gh-actions-lua@v12
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
@@ -178,9 +183,16 @@ jobs:
           head -20 changelog.md
 
       # Create the GitHub Release
-      - name: Delete existing PTB release (rolling tag)
-        if: steps.release-type.outputs.type == 'ptb'
-        run: gh release delete public-test-build --yes --cleanup-tag 2>/dev/null || true
+      # For PTB: delete old rolling release and its tag (will be recreated)
+      # For stable: delete release only (keep the human-created git tag)
+      - name: Delete existing release if re-running
+        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        run: |
+          if [[ "${{ steps.release-type.outputs.type }}" == "ptb" ]]; then
+            gh release delete "${{ steps.release-type.outputs.tag }}" --yes --cleanup-tag 2>/dev/null || true
+          else
+            gh release delete "${{ steps.release-type.outputs.tag }}" --yes 2>/dev/null || true
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -261,9 +261,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ "${RELEASE_TYPE}" == "ptb" ]]; then
-            # Keep only the latest PTB release; after creating the new one there will be 2 total
-            gh release list --json tagName,isPrerelease,createdAt \
-                --jq '[.[] | select(.isPrerelease)] | sort_by(.createdAt) | reverse | .[1:] | .[].tagName' | \
+            # Delete the target tag first in case a duplicate workflow run already created it
+            gh release delete "${RELEASE_TAG}" --yes --cleanup-tag 2>/dev/null || true
+
+            # Clean up old PTB releases, keeping only the latest 1 (+ the new one = 2 total).
+            # Filter by -ptb in tag name to avoid deleting non-PTB prereleases (e.g. release candidates).
+            gh release list --limit 100 --json tagName,isPrerelease,createdAt \
+                --jq '[.[] | select(.isPrerelease and (.tagName | contains("-ptb")))] | sort_by(.createdAt) | reverse | .[1:] | .[].tagName' | \
                 while IFS= read -r old_tag; do
                     echo "Cleaning up old PTB release: ${old_tag}"
                     gh release delete "${old_tag}" --yes --cleanup-tag 2>/dev/null || true

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -8,6 +8,7 @@ permissions:
   contents: write
   actions: read
 
+# Both build workflows trigger this; don't cancel the first - the second trigger completes the release
 concurrency:
   group: create-github-release-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: false
@@ -51,13 +52,7 @@ jobs:
             core.setOutput('linux_macos_run_id', runIds['linux_macos']);
             core.setOutput('windows_run_id', runIds['windows']);
 
-      - name: Exit if not all builds done
-        if: steps.check.outputs.ready != 'true'
-        run: |
-          echo "Not all platform builds completed yet — exiting. The other workflow's completion will trigger another attempt."
-          exit 0
-
-      # Check if any release assets were actually produced (skips PR/snapshot builds)
+      # Download build metadata to determine if this is a release or PTB build (not present for snapshot/PR builds)
       - name: Download metadata to determine release type
         if: steps.check.outputs.ready == 'true'
         id: download-metadata
@@ -75,7 +70,7 @@ jobs:
         run: |
           META_FILE=$(find metadata/ -name 'release-metadata.json' -type f | head -1)
           if [ -z "${META_FILE}" ]; then
-            echo "No release metadata found — this is likely a snapshot/PR build"
+            echo "No release metadata found - this is likely a snapshot or PR build"
             echo "type=skip" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -85,6 +80,15 @@ jobs:
           EVENT=$(echo "$META" | jq -r '.event')
           VERSION=$(echo "$META" | jq -r '.version')
           BUILD_SUFFIX=$(echo "$META" | jq -r '.build_suffix')
+
+          if [ -z "${VERSION}" ] || [ "${VERSION}" == "null" ]; then
+            echo "::error::VERSION field is empty or missing in release metadata"
+            exit 1
+          fi
+          if [ -z "${REF}" ] || [ "${REF}" == "null" ]; then
+            echo "::error::REF field is empty or missing in release metadata"
+            exit 1
+          fi
 
           if [[ "$REF" == refs/tags/Mudlet-* ]]; then
             echo "type=release" >> "$GITHUB_OUTPUT"
@@ -98,15 +102,11 @@ jobs:
             echo "type=skip" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Exit if not a release or PTB build
-        if: steps.check.outputs.ready == 'true' && (steps.download-metadata.outcome != 'success' || steps.release-type.outputs.type == 'skip')
-        run: |
-          echo "Not a release or PTB build — skipping GitHub Release creation."
-          exit 0
-
       # Download all release assets from both workflow runs
       - name: Download Linux/macOS release assets
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        id: download-linux-macos
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           pattern: release-asset-*
@@ -116,6 +116,8 @@ jobs:
 
       - name: Download Windows release assets
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        id: download-windows
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           pattern: release-asset-*
@@ -124,22 +126,61 @@ jobs:
           path: assets/
           merge-multiple: false
 
-      - name: List collected assets
+      - name: Verify release assets
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
-        run: find assets/ -type f | sort
+        run: |
+          mkdir -p assets/
+          echo "Downloaded assets:"
+          find assets/ -type f | sort
+
+          MISSING=()
+          if ! find assets/ -name '*.AppImage.tar' -type f | grep -q .; then
+            MISSING+=("Linux (.AppImage.tar)")
+          fi
+          if ! find assets/ -name '*.dmg' -type f | grep -q .; then
+            MISSING+=("macOS (.dmg)")
+          fi
+          if ! find assets/ -name '*.exe' -type f | grep -q .; then
+            MISSING+=("Windows (.exe)")
+          fi
+
+          if [ ${#MISSING[@]} -gt 0 ]; then
+            echo "::warning::Missing release assets for: ${MISSING[*]}"
+          fi
+
+          # Stable releases must have all platforms; PTB tolerates partial
+          if [[ "${{ steps.release-type.outputs.type }}" == "release" ]] && [ ${#MISSING[@]} -gt 0 ]; then
+            echo "::error::Stable release is missing assets for: ${MISSING[*]}"
+            exit 1
+          fi
+
+          if [ ${#MISSING[@]} -eq 3 ]; then
+            echo "::error::No release assets found for any platform"
+            exit 1
+          fi
 
       # Assemble SHA256SUMS.txt from per-platform .sha256 sidecar files
       - name: Assemble SHA256SUMS.txt
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
         run: |
-          cat assets/*/*.sha256 > assets/SHA256SUMS.txt
-          echo "Generated SHA256SUMS.txt:"
+          shopt -s nullglob
+          SHA_FILES=(assets/*/*.sha256)
+          shopt -u nullglob
+
+          if [ ${#SHA_FILES[@]} -eq 0 ]; then
+            echo "::error::No .sha256 checksum files found in assets/"
+            exit 1
+          fi
+
+          cat "${SHA_FILES[@]}" > assets/SHA256SUMS.txt
+          echo "Generated SHA256SUMS.txt (${#SHA_FILES[@]} entries):"
           cat assets/SHA256SUMS.txt
 
       # Generate changelog
       - uses: actions/checkout@v6
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
           clean: false
 
@@ -171,10 +212,13 @@ jobs:
           fi
 
           echo "Generating changelog from ${PREV_TAG} to ${END_TAG}"
+          # Use 'release' mode for both since we have explicit commit ranges (ptb mode requires a dblsqd feed file)
           if [ -n "${PREV_TAG}" ]; then
-            lua CI/generate-changelog.lua -f md -m release \
-              --start-commit "${PREV_TAG}" --end-commit "${END_TAG}" > changelog.md || \
+            if ! lua CI/generate-changelog.lua -f md -m release \
+                 --start-commit "${PREV_TAG}" --end-commit "${END_TAG}" > changelog.md; then
+              echo "::warning::Changelog generation failed, using placeholder"
               echo "See commit history for changes." > changelog.md
+            fi
           else
             echo "See commit history for changes." > changelog.md
           fi
@@ -200,11 +244,16 @@ jobs:
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
         run: |
           # Collect release files (not .sha256 sidecars)
-          FILES=$(find assets/ -type f \
+          mapfile -t FILES < <(find assets/ -type f \
             \( -name '*.AppImage.tar' -o -name '*.exe' -o -name '*.dmg' -o -name 'SHA256SUMS.txt' \))
 
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "::error::No release files found to upload"
+            exit 1
+          fi
+
           echo "Files to upload:"
-          echo "$FILES"
+          printf '%s\n' "${FILES[@]}"
 
           ARGS=(
             "${{ steps.release-type.outputs.tag }}"
@@ -216,7 +265,6 @@ jobs:
             ARGS+=(--prerelease --target "${{ github.event.workflow_run.head_sha }}")
           fi
 
-          # shellcheck disable=SC2086
-          gh release create "${ARGS[@]}" $FILES
+          gh release create "${ARGS[@]}" "${FILES[@]}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -94,13 +94,20 @@ jobs:
             exit 1
           fi
 
+          COMMIT=$(echo "$META" | jq -r '.commit')
+
           if [[ "$REF" == refs/tags/Mudlet-* ]]; then
             echo "type=release" >> "$GITHUB_OUTPUT"
             echo "tag=${REF#refs/tags/}" >> "$GITHUB_OUTPUT"
             echo "title=Mudlet ${VERSION}" >> "$GITHUB_OUTPUT"
           elif [[ "$EVENT" == "schedule" ]] || [[ "$BUILD_SUFFIX" == -ptb* ]]; then
+            if [ -z "${COMMIT}" ] || [ "${COMMIT}" == "null" ]; then
+              echo "::error::COMMIT field is empty or missing in release metadata for PTB"
+              exit 1
+            fi
+            PTB_TAG="Mudlet-${VERSION}${BUILD_SUFFIX}-${COMMIT}"
             echo "type=ptb" >> "$GITHUB_OUTPUT"
-            echo "tag=public-test-build" >> "$GITHUB_OUTPUT"
+            echo "tag=${PTB_TAG}" >> "$GITHUB_OUTPUT"
             echo "title=Public Test Build" >> "$GITHUB_OUTPUT"
           else
             echo "type=skip" >> "$GITHUB_OUTPUT"
@@ -211,12 +218,12 @@ jobs:
           RELEASE_TAG: ${{ steps.release-type.outputs.tag }}
         run: |
           if [[ "${RELEASE_TYPE}" == "release" ]]; then
-            # For release: changelog from previous release tag to this tag
-            PREV_TAG=$(git tag --sort=-version:refname | grep '^Mudlet-' | grep -v "^${RELEASE_TAG}$" | head -1)
+            # For release: changelog from previous stable release tag to this tag
+            PREV_TAG=$(git tag --sort=-version:refname | grep '^Mudlet-' | grep -v -- '-ptb' | grep -v "^${RELEASE_TAG}$" | head -1)
             END_TAG="${RELEASE_TAG}"
           else
-            # For PTB: changelog from latest release tag to HEAD
-            PREV_TAG=$(git tag --sort=-version:refname | grep '^Mudlet-' | head -1)
+            # For PTB: changelog from latest stable release tag to HEAD
+            PREV_TAG=$(git tag --sort=-version:refname | grep '^Mudlet-' | grep -v -- '-ptb' | head -1)
             END_TAG="HEAD"
           fi
 
@@ -244,9 +251,9 @@ jobs:
           head -20 changelog.md
 
       # Create the GitHub Release
-      # For PTB: delete old rolling release and its tag (gh release create will recreate both)
-      # For stable: delete release only (keep the human-created git tag)
-      - name: Delete existing release if re-running
+      # For PTB: clean up old PTB releases, keeping only the latest 1 (+ the new one = 2 total)
+      # For stable: delete release only if re-running (keep the human-created git tag)
+      - name: Clean up old releases
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
         env:
           RELEASE_TYPE: ${{ steps.release-type.outputs.type }}
@@ -254,7 +261,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ "${RELEASE_TYPE}" == "ptb" ]]; then
-            gh release delete "${RELEASE_TAG}" --yes --cleanup-tag 2>/dev/null || true
+            # Keep only the latest PTB release; after creating the new one there will be 2 total
+            gh release list --json tagName,isPrerelease,createdAt \
+                --jq '[.[] | select(.isPrerelease)] | sort_by(.createdAt) | reverse | .[1:] | .[].tagName' | \
+                while IFS= read -r old_tag; do
+                    echo "Cleaning up old PTB release: ${old_tag}"
+                    gh release delete "${old_tag}" --yes --cleanup-tag 2>/dev/null || true
+                done
           else
             gh release delete "${RELEASE_TAG}" --yes 2>/dev/null || true
           fi

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -100,6 +100,7 @@ jobs:
             echo "type=release" >> "$GITHUB_OUTPUT"
             echo "tag=${REF#refs/tags/}" >> "$GITHUB_OUTPUT"
             echo "title=Mudlet ${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           elif [[ "$EVENT" == "schedule" ]] || [[ "$BUILD_SUFFIX" == -ptb* ]]; then
             if [ -z "${COMMIT}" ] || [ "${COMMIT}" == "null" ]; then
               echo "::error::COMMIT field is empty or missing in release metadata for PTB"
@@ -109,6 +110,7 @@ jobs:
             echo "type=ptb" >> "$GITHUB_OUTPUT"
             echo "tag=${PTB_TAG}" >> "$GITHUB_OUTPUT"
             echo "title=Public Test Build" >> "$GITHUB_OUTPUT"
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           else
             echo "type=skip" >> "$GITHUB_OUTPUT"
           fi
@@ -308,3 +310,130 @@ jobs:
           fi
 
           gh release create "${ARGS[@]}" "${FILES[@]}"
+
+      # Generate and upload Sparkle appcast XML for macOS updates
+      - name: Add SSH agent for appcast upload
+        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        uses: webfactory/ssh-agent@v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.UPLOAD_PRIVATEKEY }}
+
+      - name: Generate Sparkle appcast XML
+        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        env:
+          RELEASE_TYPE: ${{ steps.release-type.outputs.type }}
+          RELEASE_TAG: ${{ steps.release-type.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.release-type.outputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p appcast
+
+          # sparkle:version must match CFBundleVersion in the built app
+          export BUNDLE_VERSION="${RELEASE_TAG#Mudlet-}"
+          export RELEASE_VERSION
+
+          # Convert changelog to HTML for Sparkle's description field
+          export CHANGELOG_HTML=""
+          if [ -f changelog.md ]; then
+            CHANGELOG_HTML=$(pandoc changelog.md -f markdown -t html --no-highlight 2>/dev/null || true)
+          fi
+          if [ -z "${CHANGELOG_HTML}" ]; then
+            CHANGELOG_HTML="<p>See <a href='https://github.com/Mudlet/Mudlet/releases/tag/${RELEASE_TAG}'>release notes</a> for details.</p>"
+          fi
+
+          CHANNEL="release"
+          if [[ "${RELEASE_TYPE}" == "ptb" ]]; then
+            CHANNEL="ptb"
+          fi
+
+          export PUB_DATE=$(date -R)
+
+          # Get asset download URLs from the GitHub Release
+          RELEASE_JSON=$(gh release view "${RELEASE_TAG}" --json assets)
+
+          for ARCH in arm64 x86_64; do
+            DMG_FILE=$(find assets/ -name "*-${ARCH}.dmg" -type f | head -1)
+            if [ -z "${DMG_FILE}" ]; then
+              echo "No macOS DMG found for ${ARCH} - skipping appcast"
+              continue
+            fi
+
+            export FILE_SIZE=$(stat --printf="%s" "${DMG_FILE}")
+            DMG_NAME=$(basename "${DMG_FILE}")
+            export DOWNLOAD_URL=$(echo "${RELEASE_JSON}" | jq -r --arg name "${DMG_NAME}" '.assets[] | select(.name == $name) | .url')
+
+            if [ -z "${DOWNLOAD_URL}" ] || [ "${DOWNLOAD_URL}" == "null" ]; then
+              echo "::warning::Could not find download URL for ${DMG_NAME}"
+              continue
+            fi
+
+            # Use envsubst with quoted heredoc to safely handle special characters in changelog HTML
+            envsubst '$RELEASE_VERSION $BUNDLE_VERSION $PUB_DATE $DOWNLOAD_URL $FILE_SIZE $CHANGELOG_HTML' \
+              > "appcast/${CHANNEL}-${ARCH}.xml" << 'APPCAST_EOF'
+          <?xml version="1.0" encoding="utf-8"?>
+          <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <channel>
+              <title>Mudlet Updates</title>
+              <description>Updates for Mudlet</description>
+              <language>en</language>
+              <item>
+                <title>Mudlet $RELEASE_VERSION</title>
+                <pubDate>$PUB_DATE</pubDate>
+                <sparkle:version>$BUNDLE_VERSION</sparkle:version>
+                <sparkle:shortVersionString>$RELEASE_VERSION</sparkle:shortVersionString>
+                <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+                <description><![CDATA[$CHANGELOG_HTML]]></description>
+                <enclosure
+                  url="$DOWNLOAD_URL"
+                  length="$FILE_SIZE"
+                  type="application/octet-stream"/>
+              </item>
+            </channel>
+          </rss>
+          APPCAST_EOF
+
+            echo "Generated appcast/${CHANNEL}-${ARCH}.xml (version=${BUNDLE_VERSION}, size=${FILE_SIZE})"
+          done
+
+          echo "Generated appcast files:"
+          ls -la appcast/ 2>/dev/null || echo "No appcast files generated"
+
+      - name: Upload appcast to mudlet.org
+        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        env:
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+        run: |
+          shopt -s nullglob
+          APPCAST_FILES=(appcast/*.xml)
+          shopt -u nullglob
+
+          if [ ${#APPCAST_FILES[@]} -eq 0 ]; then
+            echo "::warning::No appcast files to upload"
+            exit 0
+          fi
+
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            mudmachine@make.mudlet.org "mkdir -p '${DEPLOY_PATH}/appcast'"
+
+          for f in "${APPCAST_FILES[@]}"; do
+            scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+              "$f" "mudmachine@make.mudlet.org:'${DEPLOY_PATH}/appcast/'"
+            echo "Uploaded $(basename "$f")"
+          done
+
+      - name: Verify appcast upload
+        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        run: |
+          shopt -s nullglob
+          APPCAST_FILES=(appcast/*.xml)
+          shopt -u nullglob
+
+          for f in "${APPCAST_FILES[@]}"; do
+            basename=$(basename "$f")
+            url="https://www.mudlet.org/wp-content/files/appcast/${basename}"
+            if curl --output /dev/null --silent --head --fail "$url"; then
+              echo "Verified: ${url}"
+            else
+              echo "::warning::Appcast not yet accessible at ${url}"
+            fi
+          done

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -64,6 +64,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: metadata/
 
+      - name: Report skipped release
+        if: steps.check.outputs.ready == 'true' && steps.download-metadata.outcome == 'failure'
+        run: echo "::warning::Release metadata download failed - cannot determine release type"
+
       - name: Determine release type
         if: steps.check.outputs.ready == 'true' && steps.download-metadata.outcome == 'success'
         id: release-type
@@ -128,6 +132,8 @@ jobs:
 
       - name: Verify release assets
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        env:
+          RELEASE_TYPE: ${{ steps.release-type.outputs.type }}
         run: |
           mkdir -p assets/
           echo "Downloaded assets:"
@@ -149,7 +155,7 @@ jobs:
           fi
 
           # Stable releases must have all platforms; PTB tolerates partial
-          if [[ "${{ steps.release-type.outputs.type }}" == "release" ]] && [ ${#MISSING[@]} -gt 0 ]; then
+          if [[ "${RELEASE_TYPE}" == "release" ]] && [ ${#MISSING[@]} -gt 0 ]; then
             echo "::error::Stable release is missing assets for: ${MISSING[*]}"
             exit 1
           fi
@@ -200,11 +206,14 @@ jobs:
 
       - name: Generate changelog
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        env:
+          RELEASE_TYPE: ${{ steps.release-type.outputs.type }}
+          RELEASE_TAG: ${{ steps.release-type.outputs.tag }}
         run: |
-          if [[ "${{ steps.release-type.outputs.type }}" == "release" ]]; then
+          if [[ "${RELEASE_TYPE}" == "release" ]]; then
             # For release: changelog from previous release tag to this tag
-            PREV_TAG=$(git tag --sort=-version:refname | grep '^Mudlet-' | sed -n '2p')
-            END_TAG="${{ steps.release-type.outputs.tag }}"
+            PREV_TAG=$(git tag --sort=-version:refname | grep '^Mudlet-' | grep -v "^${RELEASE_TAG}$" | head -1)
+            END_TAG="${RELEASE_TAG}"
           else
             # For PTB: changelog from latest release tag to HEAD
             PREV_TAG=$(git tag --sort=-version:refname | grep '^Mudlet-' | head -1)
@@ -216,10 +225,18 @@ jobs:
           if [ -n "${PREV_TAG}" ]; then
             if ! lua CI/generate-changelog.lua -f md -m release \
                  --start-commit "${PREV_TAG}" --end-commit "${END_TAG}" > changelog.md; then
+              if [[ "${RELEASE_TYPE}" == "release" ]]; then
+                echo "::error::Changelog generation failed for stable release"
+                exit 1
+              fi
               echo "::warning::Changelog generation failed, using placeholder"
               echo "See commit history for changes." > changelog.md
             fi
           else
+            if [[ "${RELEASE_TYPE}" == "release" ]]; then
+              echo "::error::No previous release tag found - cannot generate changelog for stable release"
+              exit 1
+            fi
             echo "See commit history for changes." > changelog.md
           fi
 
@@ -227,23 +244,31 @@ jobs:
           head -20 changelog.md
 
       # Create the GitHub Release
-      # For PTB: delete old rolling release and its tag (will be recreated)
+      # For PTB: delete old rolling release and its tag (gh release create will recreate both)
       # For stable: delete release only (keep the human-created git tag)
       - name: Delete existing release if re-running
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
-        run: |
-          if [[ "${{ steps.release-type.outputs.type }}" == "ptb" ]]; then
-            gh release delete "${{ steps.release-type.outputs.tag }}" --yes --cleanup-tag 2>/dev/null || true
-          else
-            gh release delete "${{ steps.release-type.outputs.tag }}" --yes 2>/dev/null || true
-          fi
         env:
+          RELEASE_TYPE: ${{ steps.release-type.outputs.type }}
+          RELEASE_TAG: ${{ steps.release-type.outputs.tag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ "${RELEASE_TYPE}" == "ptb" ]]; then
+            gh release delete "${RELEASE_TAG}" --yes --cleanup-tag 2>/dev/null || true
+          else
+            gh release delete "${RELEASE_TAG}" --yes 2>/dev/null || true
+          fi
 
       - name: Create GitHub Release
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        env:
+          RELEASE_TYPE: ${{ steps.release-type.outputs.type }}
+          RELEASE_TAG: ${{ steps.release-type.outputs.tag }}
+          RELEASE_TITLE: ${{ steps.release-type.outputs.title }}
+          TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Collect release files (not .sha256 sidecars)
+          # Collect release files and combined checksums (exclude per-platform .sha256 sidecars)
           mapfile -t FILES < <(find assets/ -type f \
             \( -name '*.AppImage.tar' -o -name '*.exe' -o -name '*.dmg' -o -name 'SHA256SUMS.txt' \))
 
@@ -256,15 +281,13 @@ jobs:
           printf '%s\n' "${FILES[@]}"
 
           ARGS=(
-            "${{ steps.release-type.outputs.tag }}"
-            --title "${{ steps.release-type.outputs.title }}"
+            "${RELEASE_TAG}"
+            --title "${RELEASE_TITLE}"
             --notes-file changelog.md
           )
 
-          if [[ "${{ steps.release-type.outputs.type }}" == "ptb" ]]; then
-            ARGS+=(--prerelease --target "${{ github.event.workflow_run.head_sha }}")
+          if [[ "${RELEASE_TYPE}" == "ptb" ]]; then
+            ARGS+=(--prerelease --target "${TARGET_SHA}")
           fi
 
           gh release create "${ARGS[@]}" "${FILES[@]}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -1,0 +1,210 @@
+name: 📦 Create GitHub Release
+on:
+  workflow_run:
+    workflows: ["🔨 Build Mudlet", "🔨 Build Mudlet (windows)"]
+    types: [completed]
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    if: >
+      github.repository_owner == 'Mudlet' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Check if all platform builds completed
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.payload.workflow_run.head_sha;
+            const required = {
+              'linux_macos': 'build-mudlet.yml',
+              'windows': 'build-mudlet-win.yml'
+            };
+            const runIds = {};
+            for (const [key, filename] of Object.entries(required)) {
+              const {data} = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: filename,
+                head_sha: sha,
+                status: 'success',
+                per_page: 1
+              });
+              if (data.total_count === 0) {
+                core.info(`Workflow "${filename}" has not completed successfully yet for ${sha}`);
+                core.setOutput('ready', 'false');
+                return;
+              }
+              runIds[key] = data.workflow_runs[0].id;
+            }
+            core.setOutput('ready', 'true');
+            core.setOutput('linux_macos_run_id', runIds['linux_macos']);
+            core.setOutput('windows_run_id', runIds['windows']);
+
+      - name: Exit if not all builds done
+        if: steps.check.outputs.ready != 'true'
+        run: |
+          echo "Not all platform builds completed yet — exiting. The other workflow's completion will trigger another attempt."
+          exit 0
+
+      # Check if any release assets were actually produced (skips PR/snapshot builds)
+      - name: Download metadata to determine release type
+        if: steps.check.outputs.ready == 'true'
+        id: download-metadata
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: release-metadata-*
+          run-id: ${{ steps.check.outputs.linux_macos_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: metadata/
+
+      - name: Determine release type
+        if: steps.check.outputs.ready == 'true' && steps.download-metadata.outcome == 'success'
+        id: release-type
+        run: |
+          META_FILE=$(find metadata/ -name 'release-metadata.json' -type f | head -1)
+          if [ -z "${META_FILE}" ]; then
+            echo "No release metadata found — this is likely a snapshot/PR build"
+            echo "type=skip" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          META=$(cat "${META_FILE}")
+          REF=$(echo "$META" | jq -r '.ref')
+          EVENT=$(echo "$META" | jq -r '.event')
+          VERSION=$(echo "$META" | jq -r '.version')
+          BUILD_SUFFIX=$(echo "$META" | jq -r '.build_suffix')
+
+          if [[ "$REF" == refs/tags/Mudlet-* ]]; then
+            echo "type=release" >> "$GITHUB_OUTPUT"
+            echo "tag=${REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+            echo "title=Mudlet ${VERSION}" >> "$GITHUB_OUTPUT"
+          elif [[ "$EVENT" == "schedule" ]] || [[ "$BUILD_SUFFIX" == -ptb* ]]; then
+            echo "type=ptb" >> "$GITHUB_OUTPUT"
+            echo "tag=public-test-build" >> "$GITHUB_OUTPUT"
+            echo "title=Public Test Build" >> "$GITHUB_OUTPUT"
+          else
+            echo "type=skip" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Exit if not a release or PTB build
+        if: steps.check.outputs.ready == 'true' && (steps.download-metadata.outcome != 'success' || steps.release-type.outputs.type == 'skip')
+        run: |
+          echo "Not a release or PTB build — skipping GitHub Release creation."
+          exit 0
+
+      # Download all release assets from both workflow runs
+      - name: Download Linux/macOS release assets
+        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-asset-*
+          run-id: ${{ steps.check.outputs.linux_macos_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: assets/
+
+      - name: Download Windows release assets
+        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-asset-*
+          run-id: ${{ steps.check.outputs.windows_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: assets/
+          merge-multiple: false
+
+      - name: List collected assets
+        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        run: find assets/ -type f | sort
+
+      # Assemble SHA256SUMS.txt from per-platform .sha256 sidecar files
+      - name: Assemble SHA256SUMS.txt
+        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        run: |
+          cat assets/*/*.sha256 > assets/SHA256SUMS.txt
+          echo "Generated SHA256SUMS.txt:"
+          cat assets/SHA256SUMS.txt
+
+      # Generate changelog
+      - uses: actions/checkout@v6
+        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        with:
+          fetch-depth: 0
+
+      - uses: leafo/gh-actions-lua@v12
+        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        with:
+          luaVersion: "5.1.5"
+
+      - uses: leafo/gh-actions-luarocks@v6
+        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+
+      - name: Install changelog dependencies
+        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        run: |
+          luarocks install argparse
+          luarocks install lunajson
+
+      - name: Generate changelog
+        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        run: |
+          if [[ "${{ steps.release-type.outputs.type }}" == "release" ]]; then
+            # For release: changelog from previous release tag to this tag
+            PREV_TAG=$(git tag --sort=-version:refname | grep '^Mudlet-' | sed -n '2p')
+            END_TAG="${{ steps.release-type.outputs.tag }}"
+          else
+            # For PTB: changelog from latest release tag to HEAD
+            PREV_TAG=$(git tag --sort=-version:refname | grep '^Mudlet-' | head -1)
+            END_TAG="HEAD"
+          fi
+
+          echo "Generating changelog from ${PREV_TAG} to ${END_TAG}"
+          if [ -n "${PREV_TAG}" ]; then
+            lua CI/generate-changelog.lua -f md -m release \
+              --start-commit "${PREV_TAG}" --end-commit "${END_TAG}" > changelog.md || \
+              echo "See commit history for changes." > changelog.md
+          else
+            echo "See commit history for changes." > changelog.md
+          fi
+
+          echo "Changelog preview:"
+          head -20 changelog.md
+
+      # Create the GitHub Release
+      - name: Delete existing PTB release (rolling tag)
+        if: steps.release-type.outputs.type == 'ptb'
+        run: gh release delete public-test-build --yes --cleanup-tag 2>/dev/null || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub Release
+        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        run: |
+          # Collect release files (not .sha256 sidecars)
+          FILES=$(find assets/ -type f \
+            \( -name '*.AppImage.tar' -o -name '*.exe' -o -name '*.dmg' -o -name 'SHA256SUMS.txt' \))
+
+          echo "Files to upload:"
+          echo "$FILES"
+
+          ARGS=(
+            "${{ steps.release-type.outputs.tag }}"
+            --title "${{ steps.release-type.outputs.title }}"
+            --notes-file changelog.md
+          )
+
+          if [[ "${{ steps.release-type.outputs.type }}" == "ptb" ]]; then
+            ARGS+=(--prerelease --target "${{ github.event.workflow_run.head_sha }}")
+          fi
+
+          # shellcheck disable=SC2086
+          gh release create "${ARGS[@]}" $FILES
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -326,6 +326,16 @@ else
   echo "Renaming \"Mudlet${NAME_SUFFIX}Setup.exe\" to \"${INSTALLER_EXE}\""
   mv "${RELEASE_DIR}/Mudlet${NAME_SUFFIX}Setup.exe" "${INSTALLER_EXE_PATHFILE}"
 
+  echo "=== Generating SHA256 checksum for GitHub Release ==="
+  sha256sum "${INSTALLER_EXE_PATHFILE}" > "${INSTALLER_EXE_PATHFILE}.sha256"
+  {
+    echo "RELEASE_ASSET_PATH=${INSTALLER_EXE_PATHFILE}"
+    echo "RELEASE_ASSET_SHA256_PATH=${INSTALLER_EXE_PATHFILE}.sha256"
+    echo "VERSION=${VERSION}"
+    echo "MUDLET_VERSION_BUILD=${MUDLET_VERSION_BUILD}"
+    echo "BUILD_COMMIT=${BUILD_COMMIT}"
+  } >> "${GITHUB_ENV}"
+
   if [[ "${GITHUB_SCHEDULED_BUILD}" == "true" ]]; then
     echo "=== Preparing artifact for PTB for upload to make.mudlet.org ==="
     # Copy the signed installer to a separate directory - as ${RELEASE_WINDIR}

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -268,9 +268,9 @@ else
     # sorting:
     INSTALLER_VERSION="${VERSION}-ptb-${BUILD_COMMIT,,}${BUILD_COUNTER_SUFFIX}"
     # The name we want to use for the installer;
-    # Typically of form: 'Mudlet-4.19.1-ptb-2025-01-01-012345678-windows-64.exe'
-    # Or with build counter: 'Mudlet-4.19.1-ptb-2025-01-01-012345678rebuild2-windows-64.exe'
-    INSTALLER_EXE="Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}${BUILD_COUNTER_SUFFIX}-windows-64.exe"
+    # Typically of form: 'Mudlet-4.19.1-ptb-2025-01-01-012345678-windows-64-installer.exe'
+    # Or with build counter: 'Mudlet-4.19.1-ptb-2025-01-01-012345678rebuild2-windows-64-installer.exe'
+    INSTALLER_EXE="Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}${BUILD_COUNTER_SUFFIX}-windows-64-installer.exe"
     DBLSQD_VERSION_STRING="${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT,,}${BUILD_COUNTER_SUFFIX}"
     # The name that has to be passed as the artifact so that the Mudlet website
     # will accept it as a PTB:

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -327,7 +327,7 @@ else
   mv "${RELEASE_DIR}/Mudlet${NAME_SUFFIX}Setup.exe" "${INSTALLER_EXE_PATHFILE}"
 
   echo "=== Generating SHA256 checksum for GitHub Release ==="
-  sha256sum "${INSTALLER_EXE_PATHFILE}" > "${INSTALLER_EXE_PATHFILE}.sha256"
+  (cd "$(dirname "${INSTALLER_EXE_PATHFILE}")" && sha256sum "$(basename "${INSTALLER_EXE_PATHFILE}")") > "${INSTALLER_EXE_PATHFILE}.sha256"
   {
     echo "RELEASE_ASSET_PATH=${INSTALLER_EXE_PATHFILE}"
     echo "RELEASE_ASSET_SHA256_PATH=${INSTALLER_EXE_PATHFILE}.sha256"

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -328,6 +328,10 @@ else
 
   echo "=== Generating SHA256 checksum for GitHub Release ==="
   (cd "$(dirname "${INSTALLER_EXE_PATHFILE}")" && sha256sum "$(basename "${INSTALLER_EXE_PATHFILE}")") > "${INSTALLER_EXE_PATHFILE}.sha256"
+  if [ ! -s "${INSTALLER_EXE_PATHFILE}.sha256" ]; then
+    echo "Error: SHA256 checksum generation failed for ${INSTALLER_EXE_PATHFILE}"
+    exit 1
+  fi
   {
     echo "RELEASE_ASSET_PATH=${INSTALLER_EXE_PATHFILE}"
     echo "RELEASE_ASSET_SHA256_PATH=${INSTALLER_EXE_PATHFILE}.sha256"

--- a/CI/linux.after_success.sh
+++ b/CI/linux.after_success.sh
@@ -119,11 +119,12 @@ then
       echo "=== Setting up for Github upload ==="
       mkdir "upload/"
       mv "${RELEASE_ARTIFACT}" "upload/"
+      mv "${RELEASE_ARTIFACT}.sha256" "upload/"
       {
         echo "FOLDER_TO_UPLOAD=$(pwd)/upload"
         echo "UPLOAD_FILENAME=Mudlet-$VERSION$MUDLET_VERSION_BUILD-${BUILD_COMMIT}-linux-x64"
         echo "RELEASE_ASSET_PATH=$(pwd)/upload/${RELEASE_ARTIFACT}"
-        echo "RELEASE_ASSET_SHA256_PATH=$(pwd)/${RELEASE_ARTIFACT}.sha256"
+        echo "RELEASE_ASSET_SHA256_PATH=$(pwd)/upload/${RELEASE_ARTIFACT}.sha256"
       } >> "$GITHUB_ENV"
       DEPLOY_URL="Github artifact, see https://github.com/$GITHUB_REPOSITORY/runs/$GITHUB_RUN_ID"
     else

--- a/CI/linux.after_success.sh
+++ b/CI/linux.after_success.sh
@@ -125,12 +125,18 @@ then
         echo "UPLOAD_FILENAME=Mudlet-$VERSION$MUDLET_VERSION_BUILD-${BUILD_COMMIT}-linux-x64"
         echo "RELEASE_ASSET_PATH=$(pwd)/upload/${RELEASE_ARTIFACT}"
         echo "RELEASE_ASSET_SHA256_PATH=$(pwd)/upload/${RELEASE_ARTIFACT}.sha256"
+        echo "VERSION=${VERSION}"
+        echo "MUDLET_VERSION_BUILD=${MUDLET_VERSION_BUILD}"
+        echo "BUILD_COMMIT=${BUILD_COMMIT}"
       } >> "$GITHUB_ENV"
       DEPLOY_URL="Github artifact, see https://github.com/$GITHUB_REPOSITORY/runs/$GITHUB_RUN_ID"
     else
       {
         echo "RELEASE_ASSET_PATH=$(pwd)/${RELEASE_ARTIFACT}"
         echo "RELEASE_ASSET_SHA256_PATH=$(pwd)/${RELEASE_ARTIFACT}.sha256"
+        echo "VERSION=${VERSION}"
+        echo "MUDLET_VERSION_BUILD=${MUDLET_VERSION_BUILD}"
+        echo "BUILD_COMMIT=${BUILD_COMMIT}"
       } >> "$GITHUB_ENV"
 
       echo "=== Uploading installer to https://www.mudlet.org/wp-content/files/?C=M;O=D ==="

--- a/CI/linux.after_success.sh
+++ b/CI/linux.after_success.sh
@@ -99,9 +99,11 @@ then
     fi
 
     if [ "${public_test_build}" == "true" ]; then
-      tar -cvf "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-linux-x64.AppImage.tar" "Mudlet PTB.AppImage"
+      RELEASE_ARTIFACT="Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-linux-x64.AppImage.tar"
+      tar -cvf "${RELEASE_ARTIFACT}" "Mudlet PTB.AppImage"
     else
-      tar -cvf "Mudlet-${VERSION}-linux-x64.AppImage.tar" "Mudlet.AppImage"
+      RELEASE_ARTIFACT="Mudlet-${VERSION}-linux-x64.AppImage.tar"
+      tar -cvf "${RELEASE_ARTIFACT}" "Mudlet.AppImage"
       echo "=== Creating portable version for Linux ==="
       PORTABLE_NAME="Mudlet-${VERSION}-linux-x64-portable"
       touch "portable.txt"
@@ -110,16 +112,26 @@ then
       rm -f "portable.txt"
     fi
 
+    echo "=== Generating SHA256 checksum for GitHub Release ==="
+    sha256sum "${RELEASE_ARTIFACT}" > "${RELEASE_ARTIFACT}.sha256"
+
     if [ "${public_test_build}" == "true" ]; then
       echo "=== Setting up for Github upload ==="
       mkdir "upload/"
-      mv "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-linux-x64.AppImage.tar" "upload/"
+      mv "${RELEASE_ARTIFACT}" "upload/"
       {
         echo "FOLDER_TO_UPLOAD=$(pwd)/upload"
         echo "UPLOAD_FILENAME=Mudlet-$VERSION$MUDLET_VERSION_BUILD-${BUILD_COMMIT}-linux-x64"
+        echo "RELEASE_ASSET_PATH=$(pwd)/upload/${RELEASE_ARTIFACT}"
+        echo "RELEASE_ASSET_SHA256_PATH=$(pwd)/${RELEASE_ARTIFACT}.sha256"
       } >> "$GITHUB_ENV"
       DEPLOY_URL="Github artifact, see https://github.com/$GITHUB_REPOSITORY/runs/$GITHUB_RUN_ID"
     else
+      {
+        echo "RELEASE_ASSET_PATH=$(pwd)/${RELEASE_ARTIFACT}"
+        echo "RELEASE_ASSET_SHA256_PATH=$(pwd)/${RELEASE_ARTIFACT}.sha256"
+      } >> "$GITHUB_ENV"
+
       echo "=== Uploading installer to https://www.mudlet.org/wp-content/files/?C=M;O=D ==="
       scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "Mudlet-${VERSION}-linux-x64.AppImage.tar" "mudmachine@make.mudlet.org:${DEPLOY_PATH}"
 

--- a/CI/osx.after_success.sh
+++ b/CI/osx.after_success.sh
@@ -152,12 +152,18 @@ if [ "${DEPLOY}" = "deploy" ]; then
         echo "UPLOAD_FILENAME=Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-${ARCH}"
         echo "RELEASE_ASSET_PATH=${BUILD_DIR}/upload/$(basename "${RELEASE_ARTIFACT}")"
         echo "RELEASE_ASSET_SHA256_PATH=${BUILD_DIR}/upload/$(basename "${RELEASE_ARTIFACT}").sha256"
+        echo "VERSION=${VERSION}"
+        echo "MUDLET_VERSION_BUILD=${MUDLET_VERSION_BUILD}"
+        echo "BUILD_COMMIT=${BUILD_COMMIT}"
       } >> "$GITHUB_ENV"
       DEPLOY_URL="Github artifact, see https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
     else
       {
         echo "RELEASE_ASSET_PATH=${RELEASE_ARTIFACT}"
         echo "RELEASE_ASSET_SHA256_PATH=${RELEASE_ARTIFACT}.sha256"
+        echo "VERSION=${VERSION}"
+        echo "MUDLET_VERSION_BUILD=${MUDLET_VERSION_BUILD}"
+        echo "BUILD_COMMIT=${BUILD_COMMIT}"
       } >> "$GITHUB_ENV"
 
       echo "=== Uploading installer to https://www.mudlet.org/wp-content/files/?C=M;O=D ==="

--- a/CI/osx.after_success.sh
+++ b/CI/osx.after_success.sh
@@ -131,21 +131,33 @@ if [ "${DEPLOY}" = "deploy" ]; then
     fi
 
     if [ "${public_test_build}" == "true" ]; then
-      mv "${HOME}/Desktop/Mudlet PTB.dmg" "${HOME}/Desktop/Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-${ARCH}.dmg"
+      RELEASE_ARTIFACT="${HOME}/Desktop/Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-${ARCH}.dmg"
+      mv "${HOME}/Desktop/Mudlet PTB.dmg" "${RELEASE_ARTIFACT}"
     else
-      mv "${HOME}/Desktop/Mudlet.dmg" "${HOME}/Desktop/Mudlet-${VERSION}-${ARCH}.dmg"
+      RELEASE_ARTIFACT="${HOME}/Desktop/Mudlet-${VERSION}-${ARCH}.dmg"
+      mv "${HOME}/Desktop/Mudlet.dmg" "${RELEASE_ARTIFACT}"
     fi
+
+    echo "=== Generating SHA256 checksum for GitHub Release ==="
+    shasum -a 256 "${RELEASE_ARTIFACT}" > "${RELEASE_ARTIFACT}.sha256"
 
     if [ "${public_test_build}" == "true" ]; then
       echo "=== Setting up for Github upload ==="
       mkdir -p "${BUILD_DIR}/upload/"
-      mv "${HOME}/Desktop/Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-${ARCH}.dmg" "${BUILD_DIR}/upload/"
+      mv "${RELEASE_ARTIFACT}" "${BUILD_DIR}/upload/"
       {
         echo "FOLDER_TO_UPLOAD=${BUILD_DIR}/upload"
         echo "UPLOAD_FILENAME=Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-${ARCH}"
+        echo "RELEASE_ASSET_PATH=${BUILD_DIR}/upload/$(basename "${RELEASE_ARTIFACT}")"
+        echo "RELEASE_ASSET_SHA256_PATH=${RELEASE_ARTIFACT}.sha256"
       } >> "$GITHUB_ENV"
       DEPLOY_URL="Github artifact, see https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
     else
+      {
+        echo "RELEASE_ASSET_PATH=${RELEASE_ARTIFACT}"
+        echo "RELEASE_ASSET_SHA256_PATH=${RELEASE_ARTIFACT}.sha256"
+      } >> "$GITHUB_ENV"
+
       echo "=== Uploading installer to https://www.mudlet.org/wp-content/files/?C=M;O=D ==="
       scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "${HOME}/Desktop/Mudlet-${VERSION}-${ARCH}.dmg" "mudmachine@make.mudlet.org:${DEPLOY_PATH}"
       DEPLOY_URL="https://www.mudlet.org/wp-content/files/Mudlet-${VERSION}-${ARCH}.dmg"

--- a/CI/osx.after_success.sh
+++ b/CI/osx.after_success.sh
@@ -139,17 +139,19 @@ if [ "${DEPLOY}" = "deploy" ]; then
     fi
 
     echo "=== Generating SHA256 checksum for GitHub Release ==="
-    shasum -a 256 "${RELEASE_ARTIFACT}" > "${RELEASE_ARTIFACT}.sha256"
+    RELEASE_ARTIFACT_BASENAME=$(basename "${RELEASE_ARTIFACT}")
+    (cd "$(dirname "${RELEASE_ARTIFACT}")" && shasum -a 256 "${RELEASE_ARTIFACT_BASENAME}") > "${RELEASE_ARTIFACT}.sha256"
 
     if [ "${public_test_build}" == "true" ]; then
       echo "=== Setting up for Github upload ==="
       mkdir -p "${BUILD_DIR}/upload/"
       mv "${RELEASE_ARTIFACT}" "${BUILD_DIR}/upload/"
+      mv "${RELEASE_ARTIFACT}.sha256" "${BUILD_DIR}/upload/"
       {
         echo "FOLDER_TO_UPLOAD=${BUILD_DIR}/upload"
         echo "UPLOAD_FILENAME=Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-${ARCH}"
         echo "RELEASE_ASSET_PATH=${BUILD_DIR}/upload/$(basename "${RELEASE_ARTIFACT}")"
-        echo "RELEASE_ASSET_SHA256_PATH=${RELEASE_ARTIFACT}.sha256"
+        echo "RELEASE_ASSET_SHA256_PATH=${BUILD_DIR}/upload/$(basename "${RELEASE_ARTIFACT}").sha256"
       } >> "$GITHUB_ENV"
       DEPLOY_URL="Github artifact, see https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
     else


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add a new create-github-release.yml workflow that coordinates cross-platform build artifacts and creates GitHub Releases compatible with the new GitHub Releases-based updater.
#### Motivation for adding to Mudlet
Replace dblsqd as the updater backend as it is no longer working.
#### Other info (issues closed, discussion etc)
Stable releases use Mudlet-X.Y.Z tags, PTB uses a rolling public-test-build tag. Existing dblsqd integration is preserved for transition.

Meant to go in tandem with https://github.com/Mudlet/Mudlet/pull/9125.