### PR TITLE
Fix: handle CMake aliasing problems when PCRE2::8BIT is itself an alias

### DIFF
--- a/cmake/FindPCRE2.cmake
+++ b/cmake/FindPCRE2.cmake
@@ -13,14 +13,26 @@
 find_package(PCRE2 CONFIG QUIET COMPONENTS 8BIT)
 
 if(PCRE2_FOUND)
+  message(STATUS "Found PCRE2 via CMake config")
   # PCRE2's config file typically creates targets like PCRE2::8BIT or PCRE2::PCRE2-8
   if(TARGET PCRE2::8BIT AND NOT TARGET PCRE2::PCRE2)
-    add_library(PCRE2::PCRE2 ALIAS PCRE2::8BIT)
+    # On FreeBSD PCRE2::8BIT exists but it is already an alias so cannot itself
+    # be made the target of another alias:
+    # From: https://stackoverflow.com/a/76554700/4805858
+    get_property(aliased_target TARGET PCRE2::8BIT PROPERTY ALIASED_TARGET)
+    if("${aliased_target}" STREQUAL "")
+      # is not an alias - so we can use it to make the alias
+      add_library(PCRE2::PCRE2 ALIAS PCRE2::8BIT)
+      message(STATUS "Aliasing PCRE2::PCRE2 to PCRE2::8BIT")
+    else()
+      # is an alias - so we have to use what it is aliased to
+      add_library(PCRE2::PCRE2 ALIAS ${aliased_target})
+      message(STATUS "Aliasing PCRE2::PCRE2 to ${aliased_target}")
+    endif()
   elseif(TARGET PCRE2::PCRE2-8 AND NOT TARGET PCRE2::PCRE2)
     add_library(PCRE2::PCRE2 ALIAS PCRE2::PCRE2-8)
+    message(STATUS "Aliasing PCRE2::PCRE2 to PCRE2::PCRE2-8")
   endif()
-  set(PCRE2_FOUND TRUE)
-  message(STATUS "Found PCRE2 via CMake config")
   return()
 endif()
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Detect when the library target `PCRE2::8BIT` is an alias and in that case assign the `PCRE2::PCRE2` alias to the target of that alias. This is required because CMake does not allow an alias to an alias. This happens for the FreeBSD OS.

#### Motivation for adding to Mudlet
Solve CMake error of the form:
> add_library cannot create ALIAS target "PCRE2::PCRE2" because target "PCRE2::8BIT" is itself an ALIAS.

for FreeBSD.

#### Other info (issues closed, discussion etc)
The issue hasn't arise for any other OS so far but it could!