### PR TITLE
Fix: correct icon names for two recently added predefined MUDs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -352,6 +352,7 @@ set(mudlet_HDRS
     TEvent.h
     TFlipButton.h
     TForkedProcess.h
+    TGameDetails.h
     TimerUnit.h
     TKey.h
     TLabel.h

--- a/src/TGameDetails.h
+++ b/src/TGameDetails.h
@@ -741,7 +741,7 @@ qsl("<a href='https://abandonedrealms.com'>Website</a><br>"
              1999,
              false,
              qsl("<a href='https://www.dragonfiremud.com/'>https://www.dragonfiremud.com/</a>"),
-             qsl(":/icons/dragonfire_icon.jpg"),
+             qsl(":/icons/dragonfire_icon.png"),
              qsl("Dragonfire MUD is an ancient LPMUD that has been online since 1989, offering deep "
                  "lore and a classic text-based RPG experience. It features 16 distinctive guilds, "
                  "over 10,000 unique rooms, and hundreds of custom quests that you can tackle at your "
@@ -756,7 +756,7 @@ qsl("<a href='https://abandonedrealms.com'>Website</a><br>"
              2201,
              false,
              qsl("<a href='https://www.voidmud.com/'>https://www.voidmud.com/</a>"),
-             qsl(":/icons/voidmud_icon.jpg"),
+             qsl(":/icons/voidmud_icon.png"),
              qsl("Beyond the Void is an EverQuest-inspired text RPG that brings the world of Norrath "
                  "to life with a reimagined storyline touched by an ancient alien race and its rift "
                  "stones for fast travel. The Void serves as a central hub with trainers, guild "


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Make the file name used for the icons for "Dragonfire" and "Beyond the Void" in `TGameDetails,h`have the same extension as the files actually present.

Also add the `TGameDetails.h` file to the list of header files in the relevant `CMakeLists.txt` file so that it actually shows up in the Qt Creator IDE - without this it was much harder to find the problem above!

#### Motivation for adding to Mudlet
Have a icon for each of the two MUDs added by #8783 - currently the MUDs are represented by a tiny blank space in the "Select profile to connect" dialogue and are virtually invisible there - they also prompt an error message on the OS command line about a missing file!

Make it easier to access/search the contents of the predefined games in Mudlet.

#### Other info (issues closed, discussion etc)
The lists of header and source files in the `CMakeLists.txt`s files for Mudlet need to be resorted back into alphabetical order and checked that they are not missing files that are part of the Mudlet distribution. Whilst missing header files are not a problem for building as they are handled by the `#include "header.h"` lines in source code missing them from those lists makes it easy to overlook them when searching the code base and hard to edit them if required.
