### PR TITLE
Improve: change label highlight from overlay to outline

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2043,8 +2043,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
         }
 
         if (mapLabel.highlight) {
-            labelPaintRectangle.setSize(mapLabel.clickSize);
-            painter.fillRect(labelPaintRectangle, QColor(255, 155, 55, 190));
+            paintLabelHighlight(painter, labelPaintRectangle, mapLabel.clickSize);
         }
     }
 
@@ -2176,8 +2175,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
             pDrawnArea->mMapLabels[itMapLabel.key()] = mapLabel;
         }
         if (mapLabel.highlight) {
-            labelPaintRectangle.setSize(mapLabel.clickSize);
-            painter.fillRect(labelPaintRectangle, QColor(255, 155, 55, 190));
+            paintLabelHighlight(painter, labelPaintRectangle, mapLabel.clickSize);
         }
     }
 
@@ -3071,6 +3069,16 @@ void T2DMap::createLabel(QRectF labelRectangle)
     mpDlgMapLabel->show();
     mpDlgMapLabel->raise();
     mpDlgMapLabel->updated();
+}
+
+void T2DMap::paintLabelHighlight(QPainter& painter, QRectF labelPaintRectangle, const QSizeF& clickSize)
+{
+    labelPaintRectangle.setSize(clickSize);
+    painter.save();
+    painter.setPen(QPen(QColor(255, 155, 55), 2));
+    painter.setBrush(Qt::NoBrush);
+    painter.drawRect(labelPaintRectangle);
+    painter.restore();
 }
 
 void T2DMap::updateMapLabel(QRectF labelRectangle, int labelId, TArea* pArea)
@@ -5164,8 +5172,7 @@ void T2DMap::setPlayerRoomStyle(const int type)
         return;
     }
 
-    mPlayerRoomColorGradientStops = buildPlayerRoomGradientStops(
-            type, mpMap->mPlayerRoomInnerDiameterPercentage, mpMap->mPlayerRoomInnerColor, mpMap->mPlayerRoomOuterColor);
+    mPlayerRoomColorGradientStops = buildPlayerRoomGradientStops(type, mpMap->mPlayerRoomInnerDiameterPercentage, mpMap->mPlayerRoomInnerColor, mpMap->mPlayerRoomOuterColor);
 }
 
 QGradientStops T2DMap::buildPlayerRoomGradientStops(const int style, const quint8 innerDiameterPercentage, const QColor& innerColor, const QColor& outerColor)
@@ -5176,53 +5183,31 @@ QGradientStops T2DMap::buildPlayerRoomGradientStops(const int style, const quint
     switch (style) {
     case 1: // Simple(?) shaded red ring:
         if (solid) {
-            return {{0.000, QColor(255, 0, 0, 255)},
-                    {0.990, QColor(255, 0, 0, 255)},
-                    {1.000, QColor(255, 0, 0, 0)}};
+            return {{0.000, QColor(255, 0, 0, 255)}, {0.990, QColor(255, 0, 0, 255)}, {1.000, QColor(255, 0, 0, 0)}};
         }
-        return {{0.000, QColor(255, 0, 0, 0)},
-                {factor * 0.980, QColor(255, 0, 0, 0)},
-                {factor * 1.020, QColor(255, 0, 0, 255)},
-                {0.980, QColor(255, 0, 0, 255)},
-                {1.000, QColor(255, 0, 0, 0)}};
+        return {{0.000, QColor(255, 0, 0, 0)}, {factor * 0.980, QColor(255, 0, 0, 0)}, {factor * 1.020, QColor(255, 0, 0, 255)}, {0.980, QColor(255, 0, 0, 255)}, {1.000, QColor(255, 0, 0, 0)}};
 
     case 2: // Shaded bicolor (blue-yellow - so it ALWAYS contrasts with underlying room color) Ring:
         if (solid) {
-            return {{0.000, QColor(255, 255, 0, 255)},
-                    {0.990, QColor(0, 0, 255, 255)},
-                    {1.000, QColor(0, 0, 255, 0)}};
+            return {{0.000, QColor(255, 255, 0, 255)}, {0.990, QColor(0, 0, 255, 255)}, {1.000, QColor(0, 0, 255, 0)}};
         }
-        return {{0.000, QColor(255, 255, 0, 0)},
-                {factor * 0.980, QColor(255, 255, 0, 0)},
-                {factor * 1.020, QColor(255, 255, 0, 255)},
-                {0.980, QColor(0, 0, 255, 255)},
-                {1.000, QColor(0, 0, 255, 0)}};
+        return {{0.000, QColor(255, 255, 0, 0)}, {factor * 0.980, QColor(255, 255, 0, 0)}, {factor * 1.020, QColor(255, 255, 0, 255)}, {0.980, QColor(0, 0, 255, 255)}, {1.000, QColor(0, 0, 255, 0)}};
 
     case 3: { // User set ring:
         if (solid) {
             QColor transparentOuter(outerColor);
             transparentOuter.setAlpha(0);
-            return {{0.000, innerColor},
-                    {0.990, outerColor},
-                    {1.000, transparentOuter}};
+            return {{0.000, innerColor}, {0.990, outerColor}, {1.000, transparentOuter}};
         }
         QColor transparentInner(innerColor);
         transparentInner.setAlpha(0);
         QColor transparentOuter(outerColor);
         transparentOuter.setAlpha(0);
-        return {{0.000, transparentInner},
-                {factor * 0.980, transparentInner},
-                {factor * 1.020, innerColor},
-                {0.980, outerColor},
-                {1.000, transparentOuter}};
+        return {{0.000, transparentInner}, {factor * 0.980, transparentInner}, {factor * 1.020, innerColor}, {0.980, outerColor}, {1.000, transparentOuter}};
     }
 
     default: // Sort of emulates the original code:
-        return {{0, Qt::white},
-                {0.7, QColor(255, 0, 0, 200)},
-                {0.799, QColor(150, 100, 100, 100)},
-                {0.80, QColor(150, 100, 100, 150)},
-                {0.95, QColor(255, 0, 0, 150)}};
+        return {{0, Qt::white}, {0.7, QColor(255, 0, 0, 200)}, {0.799, QColor(150, 100, 100, 100)}, {0.80, QColor(150, 100, 100, 150)}, {0.95, QColor(255, 0, 0, 150)}};
     }
 }
 
@@ -5421,8 +5406,7 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
         }
 
         if (mapLabel.highlight) {
-            labelPaintRectangle.setSize(mapLabel.clickSize);
-            painter.fillRect(labelPaintRectangle, QColor(255, 155, 55, 190));
+            paintLabelHighlight(painter, labelPaintRectangle, mapLabel.clickSize);
         }
     }
 
@@ -5964,8 +5948,7 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
             pArea->mMapLabels[itMapLabel.key()] = mapLabel;
         }
         if (mapLabel.highlight) {
-            labelPaintRectangle.setSize(mapLabel.clickSize);
-            painter.fillRect(labelPaintRectangle, QColor(255, 155, 55, 190));
+            paintLabelHighlight(painter, labelPaintRectangle, mapLabel.clickSize);
         }
     }
 

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -101,7 +101,8 @@ public:
     friend class PanInteractionHandler;
     friend class MiddleMousePanHandler;
 
-    struct MapInteractionContext {
+    struct MapInteractionContext
+    {
         QMouseEvent* event = nullptr;
         Qt::MouseButtons buttons = Qt::NoButton;
         Qt::MouseButton button = Qt::NoButton;
@@ -169,9 +170,9 @@ public:
     void setBorderSize(double);
     void createLabel(QRectF labelRectangle);
     // Clears cache so new symbols are built at next paintEvent():
-    void flushSymbolPixmapCache() {mSymbolPixmapCache.clear();}
+    void flushSymbolPixmapCache() { mSymbolPixmapCache.clear(); }
     void addSymbolToPixmapCache(const QString, const QString, const QColor, const bool);
-    void flushTextLabelPixmapCache() {mTextLabelPixmapCache.clear();}
+    void flushTextLabelPixmapCache() { mTextLabelPixmapCache.clear(); }
     void addTextLabelToCache(const QString& key, const TMapLabel& label, const QSize& targetSize);
     void drawScaledLabel(QPainter& painter, const QPointF& position, TMapLabel& label, int labelKey, const QRectF& paintRect);
     void setPlayerRoomStyle(const int style);
@@ -193,7 +194,6 @@ public:
     // Center view on a room. For secondary views, skips raising sysMapAreaChanged events.
     std::pair<bool, QString> centerview(int roomId);
     std::pair<bool, QString> exportAreaToImage(int areaId, const QString& filePath, std::optional<int> zLevel = std::nullopt, qreal zoom = 2.0, bool exportAllZLevels = false);
-
 
 
     // default 2D zoom level
@@ -327,17 +327,25 @@ public slots:
     void slot_shiftLeft();
     void slot_shiftRight();
     void slot_showPropertiesDialog();
-    void slot_setRoomProperties(
-        bool changeName, QString newName,
-        bool changeRoomColor, int newRoomColor,
-        bool changeSymbol, QString newSymbol,
-        bool changeSymbolColor, QColor newSymbolColor,
-        bool changeWeight, int newWeight,
-        bool changeLockStatus, std::optional<bool> newLockStatus,
-        bool changeHiddenStatus, std::optional<bool> newHiddenStatus,
-        bool changeBorderColor, QColor newBorderColor,
-        bool changeBorderThickness, int newBorderThickness,
-        QSet<TRoom*> rooms);
+    void slot_setRoomProperties(bool changeName,
+                                QString newName,
+                                bool changeRoomColor,
+                                int newRoomColor,
+                                bool changeSymbol,
+                                QString newSymbol,
+                                bool changeSymbolColor,
+                                QColor newSymbolColor,
+                                bool changeWeight,
+                                int newWeight,
+                                bool changeLockStatus,
+                                std::optional<bool> newLockStatus,
+                                bool changeHiddenStatus,
+                                std::optional<bool> newHiddenStatus,
+                                bool changeBorderColor,
+                                QColor newBorderColor,
+                                bool changeBorderThickness,
+                                int newBorderThickness,
+                                QSet<TRoom*> rooms);
     void slot_previewBorderProperties(QSet<TRoom*> rooms);
     void slot_setImage();
     void slot_movePosition();
@@ -374,7 +382,8 @@ private:
         bool dispatch(MapInteractionContext& context) const;
 
     private:
-        struct HandlerEntry {
+        struct HandlerEntry
+        {
             int priority = 0;
             IInteractionHandler* handler = nullptr;
         };
@@ -406,14 +415,28 @@ private:
     QPointF snapPointToGrid(const QPointF& point) const;
     bool checkButtonIsForGivenDirection(const QPushButton*, const QString&, const int&);
     bool sizeFontToFitTextInRect(QFont&, const QRectF&, const QString&, const quint8 percentageMargin = 10, const qreal minFontSize = 7.0);
-    inline void drawRoom(QPainter&, QFont&, QFont&, QPen&, TRoom*, const bool isGridMode, const bool areRoomIdsLegible, const bool showRoomNames, const int, const float, const float, const QMap<int, QPointF>&, const bool showRoomCollision);
+    inline void drawRoom(QPainter&,
+                         QFont&,
+                         QFont&,
+                         QPen&,
+                         TRoom*,
+                         const bool isGridMode,
+                         const bool areRoomIdsLegible,
+                         const bool showRoomNames,
+                         const int,
+                         const float,
+                         const float,
+                         const QMap<int, QPointF>&,
+                         const bool showRoomCollision);
     void paintRoomExits(QPainter&, QPen&, QList<int>& exitList, QList<int>& oneWayExits, const TArea*, int, float, QMap<int, QPointF>&);
     void initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWalkTargetRoomId);
     inline void drawDoor(QPainter&, const TRoom&, const QString&, const QLineF&);
     void updateMapLabel(QRectF labelRectangle, int labelId, TArea* pArea);
+    static void paintLabelHighlight(QPainter& painter, QRectF labelPaintRectangle, const QSizeF& clickSize);
 
     bool mDialogLock = false;
-    struct ClickPosition {
+    struct ClickPosition
+    {
         int x;
         int y;
     } mContextMenuClickPosition;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Replace orange semi-transparent overlay with an orange outline instead, so label content is visible when selected.
#### Motivation for adding to Mudlet
Better visual for the mapper
#### Other info (issues closed, discussion etc)

Here is how it looks like now:
[Screencast from 2026-04-01 14-16-49.webm](https://github.com/user-attachments/assets/0a750429-7c67-469d-8b53-4abcd97ab530)

Previously:

[Screencast from 2026-04-01 14-24-03.webm](https://github.com/user-attachments/assets/e7b63d89-2369-4376-90cf-69347ec0f2f6)
