### PR TITLE
Fix: selectCaptureGroup() selecting wrong capture

### DIFF
--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -154,9 +154,10 @@ bool TAlias::match(const QString& haystack)
             posList.push_back(-1);
             continue;
         }
+        const int utf16_pos = QString::fromUtf8(haystackC, ovector[2 * i]).length();
         match.append(substring_start, substring_length);
         captureList.push_back(match);
-        posList.push_back(ovector[2 * i]);
+        posList.push_back(utf16_pos);
         if (mudlet::smDebugMode) {
             TDebug(Qt::darkCyan, Qt::black) << "Alias: capture group #" << (i + 1) << " = " >> mpHost;
             TDebug(Qt::darkMagenta, Qt::black) << TDebug::csmContinue << "<" << match.c_str() << ">\n" >> mpHost;
@@ -173,11 +174,11 @@ bool TAlias::match(const QString& haystack)
             auto name = QString::fromUtf8(reinterpret_cast<const char*>(&tabptr[2])).trimmed();
             auto* substring_start = haystackC + ovector[2 * n];
             auto substring_length = ovector[2 * n + 1] - ovector[2 * n];
-            auto utf16_pos = haystack.indexOf(QString::fromUtf8(substring_start, substring_length));
+            auto utf16_pos = QString::fromUtf8(haystackC, ovector[2 * n]).length();
             auto capture = QString::fromUtf8(substring_start, substring_length);
             nameGroups << qMakePair(name, capture);
             tabptr += name_entry_size;
-            namePositions.insert(name, qMakePair(utf16_pos, static_cast<int>(substring_length)));
+            namePositions.insert(name, qMakePair(utf16_pos, static_cast<int>(capture.length())));
         }
     }
 
@@ -212,9 +213,10 @@ bool TAlias::match(const QString& haystack)
                 posList.push_back(-1);
                 continue;
             }
+            const int utf16_pos = QString::fromUtf8(haystackC, ovector[2 * i]).length();
             match.append(substring_start, substring_length);
             captureList.push_back(match);
-            posList.push_back(ovector[2 * i]);
+            posList.push_back(utf16_pos);
             if (mudlet::smDebugMode) {
                 TDebug(Qt::darkCyan, Qt::black) << "capture group #" << (i + 1) << " = " >> mpHost;
                 TDebug(Qt::darkMagenta, Qt::black) << TDebug::csmContinue << "<" << match.c_str() << ">\n" >> mpHost;

--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -172,12 +172,15 @@ bool TAlias::match(const QString& haystack)
         for (uint32_t j = 0; j < namecount; ++j) {
             const int n = (tabptr[0] << 8) | tabptr[1];
             auto name = QString::fromUtf8(reinterpret_cast<const char*>(&tabptr[2])).trimmed();
+            tabptr += name_entry_size;
+            if (ovector[2 * n] == PCRE2_UNSET) {
+                continue;
+            }
             auto* substring_start = haystackC + ovector[2 * n];
             auto substring_length = ovector[2 * n + 1] - ovector[2 * n];
             auto utf16_pos = QString::fromUtf8(haystackC, ovector[2 * n]).length();
             auto capture = QString::fromUtf8(substring_start, substring_length);
             nameGroups << qMakePair(name, capture);
-            tabptr += name_entry_size;
             namePositions.insert(name, qMakePair(utf16_pos, static_cast<int>(capture.length())));
         }
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3377,9 +3377,9 @@ void TLuaInterpreter::adjustCaptureGroups(int x, int a)
         }
     }
 
-    for (auto& [name, posRange] : mCapturedNameGroupsPosList) {
-        if (posRange.first >= x) {
-            posRange.first += a;
+    for (auto& [pos, length] : mCapturedNameGroupsPosList) {
+        if (pos >= x) {
+            pos += a;
         }
     }
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3377,10 +3377,10 @@ void TLuaInterpreter::adjustCaptureGroups(int x, int a)
         }
     }
 
-    NamedMatchesRanges::iterator i;
-    for (i = mCapturedNameGroupsPosList.begin(); i != mCapturedNameGroupsPosList.cend(); ++i) {
-        i.value().first += a;
-        i.value().second += a;
+    for (auto& [name, posRange] : mCapturedNameGroupsPosList) {
+        if (posRange.first >= x) {
+            posRange.first += a;
+        }
     }
 }
 

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -2279,6 +2279,9 @@ int TLuaInterpreter::scaleMovie(lua_State* L)
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#selectCaptureGroup
+// Note: numeric argument uses matches[] indexing, i.e. selectCaptureGroup(1)
+// selects matches[1] (full match), selectCaptureGroup(2) selects matches[2]
+// (first capture group), etc. Named arguments select the named group directly.
 int TLuaInterpreter::selectCaptureGroup(lua_State* L)
 {
     if (!(lua_isnumber(L, 1) || lua_isstring(L, 1))) {

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -296,7 +296,6 @@ void TTrigger::processRegexMatch(
     for (i = 0; i < rc; i++) {
         const char* substring_start = haystackC + ovector[2 * i];
         const int substring_length = ovector[2 * i + 1] - ovector[2 * i];
-        const int utf16_pos = haystack.indexOf(QString::fromUtf8(substring_start, substring_length));
         std::string match;
         if (substring_length < 1) {
             captureList.push_back(match);
@@ -304,6 +303,7 @@ void TTrigger::processRegexMatch(
             continue;
         }
 
+        const int utf16_pos = QString::fromUtf8(haystackC, ovector[2 * i]).length();
         match.append(substring_start, substring_length);
         captureList.push_back(match);
         posList.push_back(utf16_pos + posOffset);
@@ -329,11 +329,11 @@ void TTrigger::processRegexMatch(
                     QString::fromUtf8(reinterpret_cast<const char*>(&tabptr[2])).trimmed(); //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)
             auto* substring_start = haystackC + ovector[2 * n];                             //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)
             auto substring_length = ovector[2 * n + 1] - ovector[2 * n];                    //NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
-            auto utf16_pos = haystack.indexOf(QString::fromUtf8(substring_start, substring_length));
+            auto utf16_pos = QString::fromUtf8(haystackC, ovector[2 * n]).length();         //NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
             auto capture = QString::fromUtf8(substring_start, substring_length);
             nameGroups << qMakePair(name, capture);
             tabptr += name_entry_size;
-            namePositions.insert(name, qMakePair(utf16_pos + posOffset, static_cast<int>(substring_length)));
+            namePositions.insert(name, qMakePair(utf16_pos + posOffset, static_cast<int>(capture.length())));
         }
     }
     if (mIsColorizerTrigger || mFilterTrigger) {
@@ -365,7 +365,6 @@ void TTrigger::processRegexMatch(
         for (i = 0; i < rc; i++) {
             const char* substring_start = haystackC + ovector[2 * i];
             const int substring_length = ovector[2 * i + 1] - ovector[2 * i];
-            const int utf16_pos = haystack.indexOf(QString::fromUtf8(substring_start, substring_length));
 
             std::string match;
             if (substring_length < 1) {
@@ -373,6 +372,7 @@ void TTrigger::processRegexMatch(
                 posList.push_back(-1);
                 continue;
             }
+            const int utf16_pos = QString::fromUtf8(haystackC, ovector[2 * i]).length();
             match.append(substring_start, substring_length);
             captureList.push_back(match);
             posList.push_back(utf16_pos + posOffset);

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -327,12 +327,15 @@ void TTrigger::processRegexMatch(
             const int n = (tabptr[0] << 8) | tabptr[1];
             auto name =
                     QString::fromUtf8(reinterpret_cast<const char*>(&tabptr[2])).trimmed(); //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)
-            auto* substring_start = haystackC + ovector[2 * n];                             //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)
-            auto substring_length = ovector[2 * n + 1] - ovector[2 * n];                    //NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
-            auto utf16_pos = QString::fromUtf8(haystackC, ovector[2 * n]).length();         //NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+            tabptr += name_entry_size;
+            if (ovector[2 * n] == PCRE2_UNSET) { //NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+                continue;
+            }
+            auto* substring_start = haystackC + ovector[2 * n];                     //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)
+            auto substring_length = ovector[2 * n + 1] - ovector[2 * n];            //NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+            auto utf16_pos = QString::fromUtf8(haystackC, ovector[2 * n]).length(); //NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
             auto capture = QString::fromUtf8(substring_start, substring_length);
             nameGroups << qMakePair(name, capture);
-            tabptr += name_entry_size;
             namePositions.insert(name, qMakePair(utf16_pos + posOffset, static_cast<int>(capture.length())));
         }
     }

--- a/src/mudlet-lua/tests/Regex_spec.lua
+++ b/src/mudlet-lua/tests/Regex_spec.lua
@@ -333,6 +333,27 @@ describe("PCRE regex cases with tempRegexTrigger", function()
         killTrigger(id)
     end)
 
+    -- named groups in alternation: non-participating group must not crash
+    it("named groups in alternation don't crash when one group doesn't participate", function()
+        local result_a, result_b
+        local snapshot = {}
+        local pattern = "^(?<a>cat)|(?<b>dog)$"
+
+        local id = tempRegexTrigger(pattern, function()
+            snapshot = matches
+            result_a = selectCaptureGroup("a")
+            result_b = selectCaptureGroup("b")
+        end, 1)
+
+        feedTriggers("\ncat\n")
+
+        assert.are.equal("cat", snapshot["a"])
+        assert.is_nil(snapshot["b"])
+        assert.are_not.equal(-1, result_a)
+        assert.are.equal(-1, result_b)
+        killTrigger(id)
+    end)
+
     -- named groups with repeated captured text elsewhere in the line
     it("selectCaptureGroup selects correct position when same word appears multiple times", function()
         local selection

--- a/src/mudlet-lua/tests/Regex_spec.lua
+++ b/src/mudlet-lua/tests/Regex_spec.lua
@@ -255,6 +255,25 @@ describe("PCRE regex cases with tempRegexTrigger", function()
         killTrigger(id)
     end)
 
+    -- https://github.com/Mudlet/Mudlet/issues/8912
+    -- selectCaptureGroup with named groups should select the actual capture position,
+    -- not the first occurrence of the captured text in the line
+    it("selectCaptureGroup selects correct position for named groups when captured text appears earlier in line", function()
+        local selection
+        local pattern = "^Hp: (?<chp>[0-9\\-]+)/(?<mhp>[0-9]+) Sp: (?<csp>[0-9\\-]+)/(?<msp>[0-9]+) Ep: (?<cep>[0-9\\-]+)/(?<mep>[0-9]+) Wght: (?<pwt>[0-9\\.]+)% Gold: (?<gld>[0-9]+) Algn: (?<align>[A-Za-z]+) Wpn: (?<wpn>W|H|N)$"
+
+        local id = tempRegexTrigger(pattern, function()
+            selectCaptureGroup("wpn")
+            selection = getSelection()
+            deselect()
+        end, 1)
+
+        feedTriggers("\nHp: 1451/1451 Sp: 6625/6625 Ep: 971/971 Wght: 14.1% Gold: 0 Algn: Angelic Wpn: H\n")
+
+        assert.are.equal("H", selection)
+        killTrigger(id)
+    end)
+
     -- no match
     it("doesnt falsely match a non matching line", function()
         local send = spy.on(_G, "send")

--- a/src/mudlet-lua/tests/Regex_spec.lua
+++ b/src/mudlet-lua/tests/Regex_spec.lua
@@ -374,8 +374,11 @@ describe("PCRE regex cases with tempRegexTrigger", function()
         killTrigger(id)
     end)
 
-    -- selectCaptureGroup works with both number and name for the same group
-    it("selectCaptureGroup by number and by name select the same text for named groups", function()
+    -- selectCaptureGroup with a number uses matches[] indexing:
+    -- selectCaptureGroup(1) = matches[1] = full match
+    -- selectCaptureGroup(2) = matches[2] = first capture group
+    -- selectCaptureGroup by name selects the named group directly
+    it("selectCaptureGroup by number uses matches[] indexing, by name selects named group", function()
         local sel_by_name, sel_by_number
         local pattern = "^Score: (?<score>\\d+) Level: (?<level>\\d+)$"
 
@@ -383,7 +386,8 @@ describe("PCRE regex cases with tempRegexTrigger", function()
             selectCaptureGroup("level")
             sel_by_name = getSelection()
             deselect()
-            selectCaptureGroup(2)
+            -- "level" is the 2nd capture group, so it's matches[3]
+            selectCaptureGroup(3)
             sel_by_number = getSelection()
             deselect()
         end, 1)

--- a/src/mudlet-lua/tests/Regex_spec.lua
+++ b/src/mudlet-lua/tests/Regex_spec.lua
@@ -274,6 +274,127 @@ describe("PCRE regex cases with tempRegexTrigger", function()
         killTrigger(id)
     end)
 
+    -- named capture groups populate matches table with both numeric and named keys
+    it("named capture groups are accessible by name in matches table", function()
+        local send = spy.on(_G, "send")
+        local snapshot = {}
+        local pattern = "^(?<first>\\w+) (?<second>\\w+)$"
+
+        local id = tempRegexTrigger(pattern, function()
+            send("match")
+            snapshot = matches
+        end, 1)
+
+        feedTriggers("\nHello World\n")
+
+        assert.spy(send).was.called(1)
+        assert.are.equal("Hello World", snapshot[1])
+        assert.are.equal("Hello", snapshot[2])
+        assert.are.equal("World", snapshot[3])
+        assert.are.equal("Hello", snapshot["first"])
+        assert.are.equal("World", snapshot["second"])
+        assert.is_nil(snapshot[4])
+        killTrigger(id)
+    end)
+
+    -- selectCaptureGroup by name selects correct text
+    it("selectCaptureGroup by name selects the right text", function()
+        local selection_first, selection_second
+        local pattern = "^(?<first>\\w+) (?<second>\\w+)$"
+
+        local id = tempRegexTrigger(pattern, function()
+            selectCaptureGroup("first")
+            selection_first = getSelection()
+            deselect()
+            selectCaptureGroup("second")
+            selection_second = getSelection()
+            deselect()
+        end, 1)
+
+        feedTriggers("\nHello World\n")
+
+        assert.are.equal("Hello", selection_first)
+        assert.are.equal("World", selection_second)
+        killTrigger(id)
+    end)
+
+    -- selectCaptureGroup returns -1 for non-existent named group
+    it("selectCaptureGroup returns -1 for non-existent named group", function()
+        local result
+        local pattern = "^(?<name>\\w+)$"
+
+        local id = tempRegexTrigger(pattern, function()
+            result = selectCaptureGroup("nonexistent")
+        end, 1)
+
+        feedTriggers("\nMudlet\n")
+
+        assert.are.equal(-1, result)
+        killTrigger(id)
+    end)
+
+    -- named groups with repeated captured text elsewhere in the line
+    it("selectCaptureGroup selects correct position when same word appears multiple times", function()
+        local selection
+        local pattern = "^(\\w+) said (?<last_word>\\w+)$"
+
+        local id = tempRegexTrigger(pattern, function()
+            selectCaptureGroup("last_word")
+            selection = getSelection()
+            deselect()
+        end, 1)
+
+        -- "hello" appears twice - selectCaptureGroup should pick the captured one (at the end)
+        feedTriggers("\nhello said hello\n")
+
+        assert.are.equal("hello", selection)
+        killTrigger(id)
+    end)
+
+    -- mixed named and unnamed capture groups
+    it("mixed named and unnamed groups both work in matches table", function()
+        local send = spy.on(_G, "send")
+        local snapshot = {}
+        local pattern = "^(\\d+) (?<word>\\w+) (\\d+)$"
+
+        local id = tempRegexTrigger(pattern, function()
+            send("match")
+            snapshot = matches
+        end, 1)
+
+        feedTriggers("\n42 hello 99\n")
+
+        assert.spy(send).was.called(1)
+        assert.are.equal("42 hello 99", snapshot[1])
+        assert.are.equal("42", snapshot[2])
+        assert.are.equal("hello", snapshot[3])
+        assert.are.equal("99", snapshot[4])
+        assert.are.equal("hello", snapshot["word"])
+        assert.is_nil(snapshot[5])
+        killTrigger(id)
+    end)
+
+    -- selectCaptureGroup works with both number and name for the same group
+    it("selectCaptureGroup by number and by name select the same text for named groups", function()
+        local sel_by_name, sel_by_number
+        local pattern = "^Score: (?<score>\\d+) Level: (?<level>\\d+)$"
+
+        local id = tempRegexTrigger(pattern, function()
+            selectCaptureGroup("level")
+            sel_by_name = getSelection()
+            deselect()
+            selectCaptureGroup(2)
+            sel_by_number = getSelection()
+            deselect()
+        end, 1)
+
+        feedTriggers("\nScore: 100 Level: 50\n")
+
+        assert.are.equal("50", sel_by_name)
+        assert.are.equal("50", sel_by_number)
+        killTrigger(id)
+    end)
+
     -- no match
     it("doesnt falsely match a non matching line", function()
         local send = spy.on(_G, "send")


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
selectCaptureGroup used indexOf to find capture group positions, which returned the
  first occurrence of the captured text in the line instead of the actual match position. Replace with
  direct byte-offset-to-UTF-16 conversion from the PCRE2 ovector.
#### Motivation for adding to Mudlet
Fix: https://github.com/Mudlet/Mudlet/issues/8912, fix https://github.com/Mudlet/Mudlet/issues/3016
#### Other info (issues closed, discussion etc)
