### PR TITLE
fix: Miniconsole adds extra columns at screen edge

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -4331,7 +4331,7 @@ QSize Host::calcFontSize(const QString& windowName)
 
     if (windowName.isEmpty() || windowName.compare(qsl("main"), Qt::CaseSensitive) == 0) {
         QFontMetrics fontMetrics(mpConsole->mUpperPane->fontMetrics());
-        return QSize(fontMetrics.horizontalAdvance(QChar('W')), fontMetrics.height());
+        return QSize(fontMetrics.averageCharWidth(), fontMetrics.height());
     }
 
     auto pC = mpConsole->mSubConsoleMap.value(windowName);
@@ -4341,7 +4341,7 @@ QSize Host::calcFontSize(const QString& windowName)
 
     Q_ASSERT_X(pC->mUpperPane, "calcFontSize", "located console does not have the upper pane available");
     QFontMetrics fontMetrics(pC->mUpperPane->fontMetrics());
-    return QSize(fontMetrics.horizontalAdvance(QChar('W')), fontMetrics.height());
+    return QSize(fontMetrics.averageCharWidth(), fontMetrics.height());
 }
 
 bool Host::setProfileStyleSheet(const QString& styleSheet)

--- a/src/TMxpFrameManager.cpp
+++ b/src/TMxpFrameManager.cpp
@@ -839,9 +839,9 @@ QSize TMxpFrameManager::calculateFrameSize(const QString& spec, const QSize& con
             int result = chars * fm.height();
             return QSize(0, result);
         } else {
-            // Use horizontalAdvance('W') instead of averageCharWidth() for consistency
-            // with Host::calcFontSize() which uses this for more accurate character width
-            int result = chars * fm.horizontalAdvance(QChar('W'));
+            // Use averageCharWidth() for consistency with Host::calcFontSize() and
+            // TTextEdit::mFontWidth which both use this metric for character width
+            int result = chars * fm.averageCharWidth();
             return QSize(result, 0);
         }
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Changed `calcFontSize()` to return `averageCharWidth()` instead of `horizontalAdvance('W')`
- Updated MXP frame size calculation to match

#### Motivation for adding to Mudlet
Miniconsoles sized via `calcFontSize()` had a pixel width inconsistent with the rendering grid, causing phantom horizontal scrolling into empty space.

#### Other info (issues closed, discussion etc)
Fixes #8856

**Test case:** Run the POC from the issue - create a miniconsole sized with `calcFontSize("main")`, echo dots to fill it, then try selecting and dragging right. Content should no longer scroll into empty space.