### PR TITLE
Fix: review fixes for font handling rework

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1051,7 +1051,7 @@ QString Host::getMmpMapLocation() const
 void Host::updateConsolesFont()
 {
     if (!mpConsole) {
-        qWarning().nospace().noquote() << "Host::updateConsolesFont() WARNING - no TMainConsole to deal with font releated operations.";
+        qWarning().nospace().noquote() << "Host::updateConsolesFont() WARNING - no TMainConsole to deal with font related operations.";
         return;
     }
 
@@ -4949,6 +4949,12 @@ QFont Host::getDisplayFont()
 
 QFont Host::getAndClearTempDisplayFont()
 {
+    if (!mTempDisplayFontAttributes.has_value() || !mTempDisplayFont.has_value()) {
+        qWarning() << "Host::getAndClearTempDisplayFont() WARNING - no temp font was set, using default";
+        mTempDisplayFontAttributes = TFontAttributes(!mNoAntiAlias);
+        mTempDisplayFont = mTempDisplayFontAttributes.value().makeFont();
+    }
+
     QFont tempFont = mTempDisplayFont.value();
     mTempDisplayFont.reset();
     mTempDisplayFontAttributes.reset();

--- a/src/Host.h
+++ b/src/Host.h
@@ -354,7 +354,7 @@ public:
     QString mediaLocationGMCP() const;
     void setMediaLocationMSP(const QString& mediaUrl);
     QString mediaLocationMSP() const;
-    // Use this rather than accessng the TMainConsole::font() as the latter
+    // Use this rather than accessing the TMainConsole::font() as the latter
     // isn't always around during profile start-up:
     QFont getDisplayFont();
     QFont getAndClearTempDisplayFont();
@@ -502,7 +502,7 @@ public:
     // Make this the first public member instantiated so we can use ITS font
     // as the "reference" or "master" font for whole profile - and so we don't
     // have to maintain a separate one here in this class which does not, as
-    // something derived from a QOject, have one:
+    // something derived from a QObject, have one:
     QPointer<TMainConsole> mpConsole;
     cTelnet mTelnet;
     QPointer<dlgPackageManager> mpPackageManager;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -955,7 +955,7 @@ QString getColorCode(QColor color)
 void TConsole::changeColors()
 {
     if (mType == CentralDebugConsole) {
-        // No-op now?
+        // Font is managed via QWidget::font() inheritance, no font operations needed here
     } else if (mType & (ErrorConsole | SubConsole | UserWindow | Buffer)) {
         if (!mBgImageMode) {
             auto styleSheet = qsl("QWidget#MainDisplay{background-color: rgba(%1);}").arg(getColorCode(mBgColor));
@@ -1581,7 +1581,7 @@ void TConsole::setFont(const QFont& newFont, const bool forceChange)
         QWidget::setFont(newFont);
         // Update associated TCommandLine's:
         if (mType & (MainConsole | SubConsole | UserWindow)) {
-            if (mpHost->mpConsole) {
+            if (mpHost && mpHost->mpConsole) {
                 for (auto& commandLine : mpHost->mpConsole->mSubCommandLineMap) {
                     auto pConsole = commandLine->console();
                     if (pConsole && (pConsole == this)) {
@@ -1604,7 +1604,6 @@ void TConsole::setFontName(const QString& fontName)
 {
     mDisplayFontDetails.mName = fontName;
     setFont(mDisplayFontDetails.makeFont(), true);
-    refreshView();
 }
 
 QString TConsole::getCurrentLine()

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -49,12 +49,12 @@
 struct TFontAttributes
 {
     explicit TFontAttributes(const bool isAntiAliased = false)
-    : mStyleStrategy(isAntiAliased
-                             ? static_cast<QFont::StyleStrategy>(QFont::PreferAntialias | QFont::PreferQuality)
-                             : static_cast<QFont::StyleStrategy>(QFont::NoAntialias | QFont::PreferQuality))
-    {}
+    : mStyleStrategy(isAntiAliased ? static_cast<QFont::StyleStrategy>(QFont::PreferAntialias | QFont::PreferQuality) : static_cast<QFont::StyleStrategy>(QFont::NoAntialias | QFont::PreferQuality))
+    {
+    }
 
-    explicit TFontAttributes(const QFont& font) {
+    explicit TFontAttributes(const QFont& font)
+    {
         mName = font.family();
         mPointSize = font.pointSize();
         mStyleHint = font.styleHint();
@@ -78,7 +78,8 @@ struct TFontAttributes
 
     TFontAttributes& operator=(const TFontAttributes& other) = default;
 
-    QFont makeFont() const {
+    QFont makeFont() const
+    {
         QFont font = QFont(mName, mPointSize, mWeight, mItalic);
         font.setFixedPitch(mFixedPitch);
         font.setStyleHint(mStyleHint, mStyleStrategy);
@@ -90,10 +91,10 @@ struct TFontAttributes
         return font;
     }
 
-    void setAntiAliasOption(const bool isAntiAliased) {
-        mStyleStrategy = isAntiAliased
-                                 ? static_cast<QFont::StyleStrategy>(QFont::PreferAntialias | QFont::PreferQuality)
-                                 : static_cast<QFont::StyleStrategy>(QFont::NoAntialias | QFont::PreferQuality);
+    void setAntiAliasOption(const bool isAntiAliased)
+    {
+        mStyleStrategy =
+                isAntiAliased ? static_cast<QFont::StyleStrategy>(QFont::PreferAntialias | QFont::PreferQuality) : static_cast<QFont::StyleStrategy>(QFont::NoAntialias | QFont::PreferQuality);
     }
 
     // enums to consider:
@@ -114,14 +115,14 @@ struct TFontAttributes
     QFont::StyleHint mStyleHint = QFont::AnyStyle;
     // We use either: (QFont::NoAntialias | QFont::PreferQuality) for all
     // TConsoles but the main one can be set to (QFont::PreferAntialias |
-    // QFont::PreferQuality) instead - see constuctor:
-    QFont::StyleStrategy mStyleStrategy;
+    // QFont::PreferQuality) instead - see constructor:
+    QFont::StyleStrategy mStyleStrategy = static_cast<QFont::StyleStrategy>(QFont::NoAntialias | QFont::PreferQuality);
     // qreal mLetterSpacing = 0.0;
     // QFont::SpacingType mSpacingType = QFont::AbsoluteSpacing;
     // We use but don't set "Line Spacing" - so don't worry about it.
     QFont::Weight mWeight = QFont::Normal;
     bool mFixedPitch = true; // We always set this
-    bool mKerning = false; // We haven't been resetting this but we ought to
+    bool mKerning = false;   // Kerning is disabled for console fonts
     // we don't set these on "base" fonts for TConsole's but we can set them for
     // bits of text:
     bool mUnderline = false;
@@ -130,11 +131,7 @@ struct TFontAttributes
     bool mItalic = false;
 };
 
-enum class ControlCharacterMode {
-    AsIs = 0x0,
-    Picture = 0x1,
-    OEM = 0x2
-};
+enum class ControlCharacterMode { AsIs = 0x0, Picture = 0x1, OEM = 0x2 };
 
 // Needed so it can be handled as a QVariant
 Q_DECLARE_METATYPE(ControlCharacterMode)
@@ -168,13 +165,13 @@ class TConsole : public QWidget
 
 public:
     enum ConsoleTypeFlag {
-        UnknownType = 0x0, // Should not be encountered but left as a trap value
+        UnknownType = 0x0,         // Should not be encountered but left as a trap value
         CentralDebugConsole = 0x1, // One of these for whole application
-        ErrorConsole = 0x2, // The bottom right corner of the Editor, one per profile
-        MainConsole = 0x4, // One per profile
-        SubConsole = 0x8, // Overlaid on top of MainConsole instance, should be uniquely named in pool of SubConsole/UserWindow/Buffers AND Labels
-        UserWindow = 0x10, // Floatable/Dockable console, should be uniquely named in pool of SubConsole/UserWindow/Buffers AND Labels
-        Buffer = 0x20 // Non-visible store for data that can be copied to/from other per profile TConsoles, should be uniquely named in pool of SubConsole/UserWindow/Buffers AND Labels
+        ErrorConsole = 0x2,        // The bottom right corner of the Editor, one per profile
+        MainConsole = 0x4,         // One per profile
+        SubConsole = 0x8,          // Overlaid on top of MainConsole instance, should be uniquely named in pool of SubConsole/UserWindow/Buffers AND Labels
+        UserWindow = 0x10,         // Floatable/Dockable console, should be uniquely named in pool of SubConsole/UserWindow/Buffers AND Labels
+        Buffer = 0x20              // Non-visible store for data that can be copied to/from other per profile TConsoles, should be uniquely named in pool of SubConsole/UserWindow/Buffers AND Labels
     };
     Q_DECLARE_FLAGS(ConsoleType, ConsoleTypeFlag)
 
@@ -236,7 +233,7 @@ public:
         buffer.setWrapHangingIndent(count);
     }
 
-    TLinkStore &getLinkStore() { return buffer.mLinkStore; }
+    TLinkStore& getLinkStore() { return buffer.mLinkStore; }
     void echo(const QString&);
     bool moveCursor(int x, int y);
     int select(const QString&, int numOfMatch = 1);
@@ -256,11 +253,23 @@ public:
     void setHorizontalScrollBar(bool);
     void setScrolling(const bool state);
     bool getScrolling() const { return mScrollingEnabled; }
-    
-    THyperlinkCompactManager& getHyperlinkCompactManager() { Q_ASSERT(mpHyperlinkCompactManager); return *mpHyperlinkCompactManager; }
-    THyperlinkSelectionManager& getHyperlinkSelectionManager() { Q_ASSERT(mpHyperlinkSelectionManager); return *mpHyperlinkSelectionManager; }
-    THyperlinkVisibilityManager& getHyperlinkVisibilityManager() { Q_ASSERT(mpHyperlinkVisibilityManager); return *mpHyperlinkVisibilityManager; }
-    
+
+    THyperlinkCompactManager& getHyperlinkCompactManager()
+    {
+        Q_ASSERT(mpHyperlinkCompactManager);
+        return *mpHyperlinkCompactManager;
+    }
+    THyperlinkSelectionManager& getHyperlinkSelectionManager()
+    {
+        Q_ASSERT(mpHyperlinkSelectionManager);
+        return *mpHyperlinkSelectionManager;
+    }
+    THyperlinkVisibilityManager& getHyperlinkVisibilityManager()
+    {
+        Q_ASSERT(mpHyperlinkVisibilityManager);
+        return *mpHyperlinkVisibilityManager;
+    }
+
     void setCmdVisible(bool);
     void changeColors();
     void scrollDown(int lines);
@@ -288,7 +297,7 @@ public:
     void hideEvent(QHideEvent* event) override;
     void setConsoleBgColor(int, int, int, int);
     QColor getConsoleBgColor() const { return mBgColor; }
-// Not used:    void setConsoleFgColor(int, int, int);
+    // Not used:    void setConsoleFgColor(int, int, int);
     std::list<int> getFgColor();
     std::list<int> getBgColor();
     void luaWrapLine(int line);
@@ -316,12 +325,11 @@ public:
     void clearSplit();
     bool showTimeStamps() const { return mShowTimeStamps; }
     void raiseMudletResizeEvent();
-    // This *should* be overridding the (void) QWidget::setFont(const QFont&)
-    // method but doesn't seem to be...!
-    // The forceChange option is required when using this method within
-    // setFontName(...) or setFontSize(...) so that the changes made
-    // on the TFontDetails class are forced into play, as otherwise
-    // it looks that they haven't inside this method:
+    // This hides QWidget::setFont(const QFont&) rather than overriding it
+    // (QWidget::setFont is non-virtual). The forceChange parameter is needed
+    // when calling from setFontName(...) or setFontSize(...) because those
+    // modify mDisplayFontDetails before calling this, and the TFontAttributes
+    // comparison would otherwise see no change:
     void setFont(const QFont&, const bool forceChange = false);
 
 
@@ -488,13 +496,27 @@ inline QDebug& operator<<(QDebug& debug, const TConsole::ConsoleType& type)
     QString text;
     const QDebugStateSaver saver(debug);
     switch (type) {
-    case TConsole::UnknownType:           text = qsl("Unknown"); break;
-    case TConsole::CentralDebugConsole:   text = qsl("Central Debug Console"); break;
-    case TConsole::ErrorConsole:          text = qsl("Profile Error Console"); break;
-    case TConsole::MainConsole:           text = qsl("Profile Main Console"); break;
-    case TConsole::SubConsole:            text = qsl("Mini Console"); break;
-    case TConsole::UserWindow:            text = qsl("User Window"); break;
-    case TConsole::Buffer:                text = qsl("Buffer"); break;
+    case TConsole::UnknownType:
+        text = qsl("Unknown");
+        break;
+    case TConsole::CentralDebugConsole:
+        text = qsl("Central Debug Console");
+        break;
+    case TConsole::ErrorConsole:
+        text = qsl("Profile Error Console");
+        break;
+    case TConsole::MainConsole:
+        text = qsl("Profile Main Console");
+        break;
+    case TConsole::SubConsole:
+        text = qsl("Mini Console");
+        break;
+    case TConsole::UserWindow:
+        text = qsl("User Window");
+        break;
+    case TConsole::Buffer:
+        text = qsl("Buffer");
+        break;
     default:
         text = qsl("Non-coded Type");
     }

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -103,7 +103,7 @@ dlgMapper::dlgMapper(QWidget* parent, Host* pH, TMap* pM)
     // the game save file, apparently) so it was actually the initial value
     // specified in the Host class. Revising the code to make it use the
     // selected font for the main console meant that all the controls at the
-    // bottom took on that font which was glaringly inconsistant with the
+    // bottom took on that font which was glaringly inconsistent with the
     // overall GUI appearance - instead now it adopts the "default" application
     // font:
     setFont(qApp->font());

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -656,7 +656,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     loadEditorTab();
 
     fontComboBox_displayFont->setCurrentFont(pHost->getDisplayFont());
-    // Accomodate an initial font size being larger than expected - and ensure
+    // Accommodate an initial font size being larger than expected - and ensure
     // it is a positive value:
     spinBox_displayFontSize->setMaximum(std::max(pHost->getDisplayFont().pointSize(), 40));
     spinBox_displayFontSize->setValue(std::max(1, pHost->getDisplayFont().pointSize()));
@@ -1284,7 +1284,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
                         break;
                     default: {
                     } // There are a significant number of other errors
-                        // that are not handled here!
+                    // that are not handled here!
                     }
                 }
             }
@@ -3200,7 +3200,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         bool ok;
         quint16 port = lineEdit_mmcpPort->text().toUShort(&ok);
         pHost->mMMCPChatPort = ok ? port : csDefaultMMCPHostPort;
-        
+
         /* Possible inclusion in 4.21
         pHost->mMMCPAutostartServer = checkBox_mmcpAutostartServer->isChecked();
         pHost->mMMCPAutoAcceptCalls = checkBox_mmcpAutoAcceptCalls->isChecked();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix a few things from https://github.com/Mudlet/Mudlet/commit/4c0e4b764e0747578df08802fb8bf26c2cbe317d, see below for details.
#### Motivation for adding to Mudlet
QA improvements.
#### Other info (issues closed, discussion etc)

1. getAndClearTempDisplayFont() called .value() without checking if the optional was populated. The only caller is TMainConsole::TMainConsole() at line 57. If setDisplayFont() in the Host constructor returns early at line 1129 (because averageCharWidth() == 0 for the font), mTempDisplayFont is never set. Calling .value() on an empty optional is UB - in a no-exceptions build (which Mudlet uses), this is a crash with no error message. The sibling method getDisplayFont() at line 4942 already had the correct guard pattern. We replicated it.

2. setFont(mDisplayFontDetails.makeFont(), true) at line 1606 calls refreshView() internally (line 1598). Then setFontName() called refreshView() again at line 1607. Each refreshView() sets fonts on both TTextEdit panes, recalculates screen dimensions (updateScreenView()), and forces a full repaint (forceUpdate()). Every font name change was doing all of this twice.

3. mpHost is a QPointer<Host> that becomes null when the Host is destroyed. The code dereferenced mpHost->mpConsole without checking mpHost first. During profile teardown, TConsole can outlive Host briefly. Other methods in the same class (e.g. raiseFontChangeEvent() at line 1555) correctly guard with if (!mpHost).

4. Every other field in TFontAttributes had a default member initializer except mStyleStrategy. Both existing constructors set it, so it's safe today. But if anyone adds a third constructor (or a default constructor) without remembering to set this field, it's an uninitialized read - UB. Now defaults to static_cast<QFont::StyleStrategy>(QFont::NoAntialias | QFont::PreferQuality), matching the bool constructor's false-case behavior.

5. The CentralDebugConsole branch in changeColors() previously set font properties and applied them to both panes. After the font rework it became empty, but the comment "// No-op now?" with a question mark signals the author wasn't sure if this was correct. It is correct - font is now managed via QWidget::font() inheritance and propagated through updateConsolesFont(). Replaced with a definitive explanation.

6. The setFont() comment said "This *should* be overridding the (void) QWidget::setFont(const QFont&) method but doesn't seem to be...!" - implying the intent was to override and something is broken. In reality, QWidget::setFont is non-virtual so it can never be overridden. The extra bool forceChange parameter also gives it a different signature. This is intentional method hiding, not a failed override. The confused comment could mislead someone into "fixing" it. Replaced with an accurate explanation of why the hiding is needed.

7. Various typos fixed: overridding, constuctor, QOject, accessng, releated, inconsistant, Accomodate, TFontDetails, and a stale mKerning comment.