### PR TITLE
Fix: crash when resetProfile() is called while downloads are in-progress

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -850,6 +850,7 @@ void Host::resetProfile_phase2()
     mpConsole->resetMainConsole();
     mEventHandlerMap.clear();
     mEventMap.clear();
+    mLuaInterpreter.abortAllDownloads();
     mLuaInterpreter.initLuaGlobals();
     mLuaInterpreter.loadGlobal();
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -521,28 +521,6 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
 }
 
 // No documentation available in wiki - internal function
-void TLuaInterpreter::raiseDownloadProgressEvent(lua_State* L, QString fileUrl, qint64 bytesDownloaded, qint64 totalBytes)
-{
-    Host& host = getHostFromLua(L);
-
-    TEvent event{};
-    event.mArgumentList << qsl("sysDownloadFileProgress");
-    event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-    event.mArgumentList << fileUrl;
-    event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-    event.mArgumentList << QString::number(bytesDownloaded);
-    event.mArgumentTypeList << ARGUMENT_TYPE_NUMBER;
-    if (totalBytes >= 0) {
-        event.mArgumentList << QString::number(totalBytes);
-        event.mArgumentTypeList << ARGUMENT_TYPE_NUMBER;
-    } else {
-        event.mArgumentList << QString();
-        event.mArgumentTypeList << ARGUMENT_TYPE_NIL;
-    }
-
-    host.raiseEvent(event);
-}
-
 // No documentation available in wiki - internal function
 void TLuaInterpreter::slot_pathChanged(const QString& path)
 {
@@ -4993,6 +4971,18 @@ void TLuaInterpreter::insertNativeSeparatorsFunction(lua_State* L)
   return string.gsub(rawPath, '\\', '/')
 end)LUA");
     // clang-format on
+}
+
+// Abort all in-flight network downloads. Must be called before lua_close()
+// because downloadFile() connects a progress lambda that captures the
+// lua_State* by value - closing the state turns that into a dangling pointer.
+void TLuaInterpreter::abortAllDownloads()
+{
+    for (auto* reply : downloadMap.keys()) {
+        reply->abort();
+        reply->deleteLater();
+    }
+    downloadMap.clear();
 }
 
 // No documentation available in wiki - internal function

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4973,14 +4973,13 @@ end)LUA");
     // clang-format on
 }
 
-// Abort all in-flight network downloads. Must be called before lua_close()
-// because downloadFile() connects a progress lambda that captures the
-// lua_State* by value - closing the state turns that into a dangling pointer.
+// Abort all in-flight network downloads during resetProfile so that
+// stale completion/error events from the old Lua state are not
+// delivered to the new state's event handlers.
 void TLuaInterpreter::abortAllDownloads()
 {
     for (auto* reply : downloadMap.keys()) {
         reply->abort();
-        reply->deleteLater();
     }
     downloadMap.clear();
 }

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -94,6 +94,7 @@ public:
     void handleIreComposerEdit(const QString& jsonData);
     void msdp2Lua(const char*);
     void initLuaGlobals();
+    void abortAllDownloads();
     void initIndenterGlobals();
     lua_State* getLuaGlobalState();
 
@@ -816,7 +817,6 @@ private:
     static std::pair<bool, QString> discordApiEnabled(lua_State*, bool writeAccess = false);
     static void setRequestDefaults(const QUrl& url, QNetworkRequest& request);
     static int performHttpRequest(lua_State*, const char* functionName, const int pos, QNetworkAccessManager::Operation operation, const QString& verb);
-    static void raiseDownloadProgressEvent(lua_State*, QString, qint64, qint64);
     // The last argument is only needed if the third one is true:
     static void generateElapsedTimeTable(lua_State*, const QStringList&, const bool, const qint64 elapsedTimeMilliSeconds = 0);
     static std::tuple<bool, int> getWatchId(lua_State*, Host&);

--- a/src/TLuaInterpreterNetworking.cpp
+++ b/src/TLuaInterpreterNetworking.cpp
@@ -139,12 +139,22 @@ int TLuaInterpreter::downloadFile(lua_State* L)
 
     host.updateProxySettings(host.mLuaInterpreter.mpFileDownloader);
     QNetworkReply* reply = host.mLuaInterpreter.mpFileDownloader->get(request);
+    Host* pHost = &host;
     host.mLuaInterpreter.downloadMap.insert(reply, localFile);
-    connect(reply, &QNetworkReply::downloadProgress, reply, [=](qint64 bytesDownloaded, qint64 totalBytes) {
-        raiseDownloadProgressEvent(L, urlString, bytesDownloaded, totalBytes);
+    connect(reply, &QNetworkReply::downloadProgress, reply, [pHost, urlString, reply](qint64 bytesDownloaded, qint64 totalBytes) {
+        TEvent event{};
+        event.mArgumentList << qsl("sysDownloadFileProgress") << urlString << QString::number(bytesDownloaded);
+        event.mArgumentTypeList << ARGUMENT_TYPE_STRING << ARGUMENT_TYPE_STRING << ARGUMENT_TYPE_NUMBER;
+        if (totalBytes >= 0) {
+            event.mArgumentList << QString::number(totalBytes);
+            event.mArgumentTypeList << ARGUMENT_TYPE_NUMBER;
+        } else {
+            event.mArgumentList << QString();
+            event.mArgumentTypeList << ARGUMENT_TYPE_NIL;
+        }
+        pHost->raiseEvent(event);
         if (mudlet::smDebugMode) {
-            auto& lHost = getHostFromLua(L);
-            TDebug(Qt::white, Qt::blue) << "downloadFile: " << bytesDownloaded << "/" << totalBytes << " bytes ready for " << reply->url().toString() << "\n" >> &lHost;
+            TDebug(Qt::white, Qt::blue) << "downloadFile: " << bytesDownloaded << "/" << totalBytes << " bytes ready for " << reply->url().toString() << "\n" >> pHost;
         }
     });
 

--- a/test/functional_tests/ResetProfileTest.cpp
+++ b/test/functional_tests/ResetProfileTest.cpp
@@ -403,16 +403,18 @@ private slots:
   }
 
   void test_luaStateIsNewAfterReset() {
-    lua_State *oldL = mpHost->mLuaInterpreter.getLuaGlobalState();
-    QVERIFY(oldL);
+    lua_State *L = mpHost->mLuaInterpreter.getLuaGlobalState();
+    QVERIFY(L);
+    luaL_dostring(L, "resetTestSentinel = 42");
 
     performReset();
 
     lua_State *newL = mpHost->mLuaInterpreter.getLuaGlobalState();
     QVERIFY(newL);
-    QVERIFY2(
-        oldL != newL,
-        "Lua state pointer should change after reset (new state allocated)");
+    lua_getglobal(newL, "resetTestSentinel");
+    QVERIFY2(lua_isnil(newL, -1),
+             "Lua state should be fresh after reset");
+    lua_pop(newL, 1);
   }
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
esetProfile() now properly destoys the old Lua state, but it never cancelled in-flight downloads. When a download was finished, it would try and use the old Lua state that wasn't there anymore. Fix - cancel downloads on resetProfile()


#### Motivation for adding to Mudlet
Fix crash introduced into development.
#### Other info (issues closed, discussion etc)
The new tests genuinely found a crashing issue!