### PR TITLE
Fix: memory leaks in map info contributors, deleting labels

### DIFF
--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -52,6 +52,15 @@ TLabel::TLabel(Host* pH, const QString& name, QWidget* pW)
 
 TLabel::~TLabel()
 {
+    if (mpHost) {
+        auto* interpreter = mpHost->getLuaInterpreter();
+        for (const int funcRef : {mClickFunction, mDoubleClickFunction, mReleaseFunction, mMoveFunction, mWheelFunction, mEnterFunction, mLeaveFunction}) {
+            if (funcRef) {
+                interpreter->freeLuaRegistryIndex(funcRef);
+            }
+        }
+    }
+
     if (mpMovie) {
         mpMovie->deleteLater();
         mpMovie = nullptr;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -232,8 +232,11 @@ int TLuaInterpreter::getVerifiedInt(lua_State* L, const char* functionName, cons
     // std::optional<int>...
     auto const result = lua_tointeger(L, pos);
     if (result < std::numeric_limits<int>::min() || result > std::numeric_limits<int>::max()) {
-        lua_pushfstring(L, "%s: integer over/under-flow in argument #%d (%s as an integer, provided value %s is outside of valid range %d to %d!)",
-                        functionName, pos, publicName,
+        lua_pushfstring(L,
+                        "%s: integer over/under-flow in argument #%d (%s as an integer, provided value %s is outside of valid range %d to %d!)",
+                        functionName,
+                        pos,
+                        publicName,
                         lua_tostring(L, pos),
                         std::numeric_limits<int>::min(),
                         std::numeric_limits<int>::max());

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1530,10 +1530,12 @@ int TLuaInterpreter::setLabelCallback(lua_State* L, const QString& funcName)
     } else if (funcName == qsl("setLabelOnLeave")) {
         lua_result = host.setLabelOnLeave(labelName, func);
     } else {
+        luaL_unref(L, LUA_REGISTRYINDEX, func);
         return warnArgumentValue(L, __func__, qsl("'%1' is not a known function name - bug in Mudlet, please report it").arg(funcName));
     }
 
     if (!lua_result) {
+        luaL_unref(L, LUA_REGISTRYINDEX, func);
         return warnArgumentValue(L, __func__, qsl("label name '%1' not found").arg(labelName));
     }
     lua_pushboolean(L, true);

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -2801,57 +2801,61 @@ int TLuaInterpreter::registerMapInfo(lua_State* L)
     const int callback = luaL_ref(L, LUA_REGISTRYINDEX);
 
     auto& host = getHostFromLua(L);
-    host.mpMap->mMapInfoContributorManager->registerContributor(name, [=](int roomID, int selectionSize, int areaId, int displayAreaId, QColor& infoColor) {
-        Q_UNUSED(infoColor)
-        lua_rawgeti(L, LUA_REGISTRYINDEX, callback);
-        if (roomID > 0) {
-            lua_pushinteger(L, roomID);
-        } else {
-            lua_pushnil(L);
-        }
-        lua_pushinteger(L, selectionSize);
-        lua_pushinteger(L, areaId);
-        lua_pushinteger(L, displayAreaId);
-
-        const int error = lua_pcall(L, 4, 6, 0);
-        if (error) {
-            const int errorCount = lua_gettop(L);
-            if (mudlet::smDebugMode) {
-                for (int i = 1; i <= errorCount; i++) {
-                    if (lua_isstring(L, i)) {
-                        auto errorMessage = lua_tostring(L, i);
-                        TDebug(QColor(Qt::white), QColor(Qt::red)) << "LUA ERROR: when running map info callback for '" << name << "\nreason: " << errorMessage << "\n" >> 0;
-                    }
+    host.mpMap->mMapInfoContributorManager->registerContributor(
+            name,
+            [=](int roomID, int selectionSize, int areaId, int displayAreaId, QColor& infoColor) {
+                Q_UNUSED(infoColor)
+                lua_rawgeti(L, LUA_REGISTRYINDEX, callback);
+                if (roomID > 0) {
+                    lua_pushinteger(L, roomID);
+                } else {
+                    lua_pushnil(L);
                 }
-            }
-            lua_pop(L, errorCount);
-            return MapInfoProperties{};
-        }
+                lua_pushinteger(L, selectionSize);
+                lua_pushinteger(L, areaId);
+                lua_pushinteger(L, displayAreaId);
 
-        auto nResult = lua_gettop(L);
-        auto index = -nResult;
-        const QString text = lua_tostring(L, index);
-        const bool isBold = lua_toboolean(L, ++index);
-        const bool isItalic = lua_toboolean(L, ++index);
-        int r = -1;
-        int g = -1;
-        int b = -1;
-        if (!lua_isnil(L, ++index)) {
-            r = static_cast<int>(lua_tonumber(L, index));
-        }
-        if (!lua_isnil(L, ++index)) {
-            g = static_cast<int>(lua_tonumber(L, index));
-        }
-        if (!lua_isnil(L, ++index)) {
-            b = static_cast<int>(lua_tonumber(L, index));
-        }
-        QColor color;
-        if (r >= 0 && r <= 255 && g >= 0 && g <= 255 && b >= 0 && b <= 255) {
-            color = QColor(r, g, b);
-        }
-        lua_pop(L, nResult);
-        return MapInfoProperties{isBold, isItalic, text, color};
-    });
+                const int error = lua_pcall(L, 4, 6, 0);
+                if (error) {
+                    const int errorCount = lua_gettop(L);
+                    if (mudlet::smDebugMode) {
+                        for (int i = 1; i <= errorCount; i++) {
+                            if (lua_isstring(L, i)) {
+                                auto errorMessage = lua_tostring(L, i);
+                                TDebug(QColor(Qt::white), QColor(Qt::red)) << "LUA ERROR: when running map info callback for '" << name << "\nreason: " << errorMessage << "\n" >> 0;
+                            }
+                        }
+                    }
+                    lua_pop(L, errorCount);
+                    return MapInfoProperties{};
+                }
+
+                auto nResult = lua_gettop(L);
+                auto index = -nResult;
+                const QString text = lua_tostring(L, index);
+                const bool isBold = lua_toboolean(L, ++index);
+                const bool isItalic = lua_toboolean(L, ++index);
+                int r = -1;
+                int g = -1;
+                int b = -1;
+                if (!lua_isnil(L, ++index)) {
+                    r = static_cast<int>(lua_tonumber(L, index));
+                }
+                if (!lua_isnil(L, ++index)) {
+                    g = static_cast<int>(lua_tonumber(L, index));
+                }
+                if (!lua_isnil(L, ++index)) {
+                    b = static_cast<int>(lua_tonumber(L, index));
+                }
+                QColor color;
+                if (r >= 0 && r <= 255 && g >= 0 && g <= 255 && b >= 0 && b <= 255) {
+                    color = QColor(r, g, b);
+                }
+                lua_pop(L, nResult);
+                return MapInfoProperties{isBold, isItalic, text, color};
+            },
+            L,
+            callback);
 
     host.mpMap->updateArea(-1);
     lua_pushboolean(L, true);

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -2790,6 +2790,7 @@ int TLuaInterpreter::setCmdLineAction(lua_State* L)
     const int func = luaL_ref(L, LUA_REGISTRYINDEX);
 
     if (!host.setCmdLineAction(name, func)) {
+        luaL_unref(L, LUA_REGISTRYINDEX, func);
         return warnArgumentValue(L, __func__, qsl("command line name '%1' not found").arg(name));
     }
 

--- a/src/mapInfoContributorManager.cpp
+++ b/src/mapInfoContributorManager.cpp
@@ -39,6 +39,13 @@ MapInfoContributorManager::MapInfoContributorManager(QObject* parent, Host* pH)
     });
 }
 
+MapInfoContributorManager::~MapInfoContributorManager()
+{
+    for (auto it = mLuaCallbackRefs.begin(); it != mLuaCallbackRefs.end(); ++it) {
+        luaL_unref(it->L, LUA_REGISTRYINDEX, it->ref);
+    }
+}
+
 void MapInfoContributorManager::registerContributor(const QString& name, MapInfoCallback callback)
 {
     releaseLuaCallbackRef(name);

--- a/src/mapInfoContributorManager.cpp
+++ b/src/mapInfoContributorManager.cpp
@@ -23,6 +23,10 @@
 #include "TRoomDB.h"
 #include "dlgMapper.h"
 
+extern "C" {
+#include <lauxlib.h>
+}
+
 MapInfoContributorManager::MapInfoContributorManager(QObject* parent, Host* pH)
 : QObject(parent)
 , mpHost(pH)
@@ -37,6 +41,19 @@ MapInfoContributorManager::MapInfoContributorManager(QObject* parent, Host* pH)
 
 void MapInfoContributorManager::registerContributor(const QString& name, MapInfoCallback callback)
 {
+    releaseLuaCallbackRef(name);
+    if (contributors.contains(name)) {
+        ordering.removeOne(name);
+    }
+    ordering.append(name);
+    contributors.insert(name, callback);
+    emit signal_contributorsUpdated();
+}
+
+void MapInfoContributorManager::registerContributor(const QString& name, MapInfoCallback callback, lua_State* L, int callbackRef)
+{
+    releaseLuaCallbackRef(name);
+    mLuaCallbackRefs.insert(name, {L, callbackRef});
     if (contributors.contains(name)) {
         ordering.removeOne(name);
     }
@@ -47,10 +64,19 @@ void MapInfoContributorManager::registerContributor(const QString& name, MapInfo
 
 bool MapInfoContributorManager::removeContributor(const QString& name)
 {
+    releaseLuaCallbackRef(name);
     mpHost->mMapInfoContributors.remove(name);
     ordering.removeOne(name);
     emit signal_contributorsUpdated();
     return contributors.remove(name) > 0;
+}
+
+void MapInfoContributorManager::releaseLuaCallbackRef(const QString& name)
+{
+    if (auto it = mLuaCallbackRefs.find(name); it != mLuaCallbackRefs.end()) {
+        luaL_unref(it->L, LUA_REGISTRYINDEX, it->ref);
+        mLuaCallbackRefs.erase(it);
+    }
 }
 
 bool MapInfoContributorManager::enableContributor(const QString& name)

--- a/src/mapInfoContributorManager.h
+++ b/src/mapInfoContributorManager.h
@@ -29,12 +29,20 @@
 
 #include "Host.h"
 
+struct lua_State;
+
 struct MapInfoProperties
 {
     bool isBold;
     bool isItalic;
     QString text;
     QColor color;
+};
+
+struct LuaCallbackRef
+{
+    lua_State* L;
+    int ref;
 };
 
 using MapInfoCallback = std::function<MapInfoProperties(int roomID, int selectionSize, int areaId, int displayAreaId, QColor& infoColor)>;
@@ -47,11 +55,12 @@ public:
     MapInfoContributorManager(QObject* parent, Host* ph);
 
     void registerContributor(const QString& name, MapInfoCallback callback);
+    void registerContributor(const QString& name, MapInfoCallback callback, lua_State* L, int callbackRef);
     bool removeContributor(const QString& name);
     bool enableContributor(const QString& name);
     bool disableContributor(const QString& name);
     MapInfoCallback getContributor(const QString& name);
-    QList<QString> &getContributorKeys();
+    QList<QString>& getContributorKeys();
     MapInfoProperties fullInfo(int roomID, int selectionSize, int areaId, int displayAreaId, QColor& infoColor);
     MapInfoProperties shortInfo(int roomID, int selectionSize, int areaId, int displayAreaId, QColor& infoColor);
 
@@ -59,8 +68,11 @@ signals:
     void signal_contributorsUpdated();
 
 private:
+    void releaseLuaCallbackRef(const QString& name);
+
     QList<QString> ordering;
     QMap<QString, MapInfoCallback> contributors;
+    QMap<QString, LuaCallbackRef> mLuaCallbackRefs;
     Host* mpHost;
 };
 #endif

--- a/src/mapInfoContributorManager.h
+++ b/src/mapInfoContributorManager.h
@@ -53,6 +53,7 @@ class MapInfoContributorManager : public QObject
 
 public:
     MapInfoContributorManager(QObject* parent, Host* ph);
+    ~MapInfoContributorManager();
 
     void registerContributor(const QString& name, MapInfoCallback callback);
     void registerContributor(const QString& name, MapInfoCallback callback, lua_State* L, int callbackRef);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fixes Lua memory that was never freed when setting callbacks on labels or command lines that don't exist, when registering/unregistering map info contributors, and when deleting labels.
#### Motivation for adding to Mudlet
Better memory management.
#### Other info (issues closed, discussion etc)
```
  1. Lua registry ref leaks (setCmdLineAction, setLabelCallback, registerMapInfo)

  setCmdLineAction [TLuaInterpreterUI.cpp:2790]:
    luaL_ref(L, LUA_REGISTRYINDEX) → host.setCmdLineAction() fails → return ← NO luaL_unref

  setLabelCallback [TLuaInterpreter.cpp:1517]:
    luaL_ref(L, LUA_REGISTRYINDEX) → host.setLabel*Callback() fails → return ← NO luaL_unref
    (affects 7 functions: Click, DoubleClick, Release, Move, Wheel, OnEnter, OnLeave)

  registerMapInfo [TLuaInterpreterMapper.cpp:2801]:
    luaL_ref(L, LUA_REGISTRYINDEX) → captured in lambda by value (int)
    → registerContributor() overwrites old entry [mapInfoContributorManager.cpp:44] ← old ref leaked
    → removeContributor() removes entry [mapInfoContributorManager.cpp:53] ← ref leaked
    (leaks on SUCCESS path, not just errors)

  2. TLabel destructor leaks 7 Lua callback registry indexes

  deleteLabel("x") [TLuaInterpreterUI.cpp:461]
    → TMainConsole::deleteLabel() [TMainConsole.cpp:601] → pL->deleteLater() [line 610]
      → ~TLabel() [TLabel.cpp:53-59]
        → deletes mpMovie ← OK
        → mClickFunction, mDoubleClickFunction, mReleaseFunction,
          mMoveFunction, mWheelFunction, mEnterFunction, mLeaveFunction
          ← NEVER freed via freeLuaRegistryIndex() [TLabel.h:72-78]
```