### PR TITLE
Fix: memory leaks in sound player, dialogs

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -437,6 +437,8 @@ Host::~Host()
         mpDockableMapWidget->deleteLater();
     }
 
+    delete mMMCPServer;
+
     mErrorLogStream.flush();
     mErrorLogFile.close();
     // Since this is a destructor, it's risky to rely on member variables within the destructor itself.

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -437,7 +437,6 @@ Host::~Host()
         mpDockableMapWidget->deleteLater();
     }
 
-    delete mMMCPServer;
 
     mErrorLogStream.flush();
     mErrorLogFile.close();

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -31,7 +31,7 @@
 #include "TMediaData.h"
 #include "TMediaPlaylist.h"
 
-#include <memory> // std::shared_ptr
+#include <memory>
 #include <QAudioOutput>
 #include <QMediaPlayer>
 
@@ -44,12 +44,19 @@ public:
     : mpHost(pHost)
     , mMediaData(mediaData)
     , mMediaPlayer(new QMediaPlayer(pHost))
-    , mPlaylist(new TMediaPlaylist)
+    , mPlaylist(std::make_unique<TMediaPlaylist>())
     , initialized(true)
     {
         mMediaPlayer->setAudioOutput(new QAudioOutput());
     }
-    ~TMediaPlayer() = default;
+    ~TMediaPlayer()
+    {
+        if (mMediaPlayer) {
+            auto* output = mMediaPlayer->audioOutput();
+            mMediaPlayer->setAudioOutput(nullptr);
+            delete output;
+        }
+    }
 
     TMediaData mediaData() const { return mMediaData; }
     void setMediaData(TMediaData& mediaData) { mMediaData = mediaData; }
@@ -71,13 +78,11 @@ public:
         }
         mMediaPlayer->audioOutput()->setVolume(volume / 100.0f);
     }
-    TMediaPlaylist* playlist() const { return mPlaylist; }
+    TMediaPlaylist* playlist() const { return mPlaylist.get(); }
     void setPlaylist(TMediaPlaylist* playlist)
     {
-        if (mPlaylist != playlist) {
-            if (mPlaylist)
-                delete mPlaylist;
-            mPlaylist = playlist;
+        if (mPlaylist.get() != playlist) {
+            mPlaylist.reset(playlist);
         }
     }
     void refreshAudioOutput()
@@ -102,7 +107,7 @@ private:
     QPointer<Host> mpHost;
     TMediaData mMediaData;
     QMediaPlayer* mMediaPlayer = nullptr;
-    TMediaPlaylist* mPlaylist = nullptr;
+    std::unique_ptr<TMediaPlaylist> mPlaylist;
     bool initialized = false;
 };
 

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2408,7 +2408,11 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
         mIsCommandPopup = false;
 
 
-        QAction* action = new QAction(tr("Copy"), this);
+        auto popup = new QMenu(this);
+        popup->setAttribute(Qt::WA_DeleteOnClose);
+        popup->setToolTipsVisible(true); // Not the default...
+
+        QAction* action = new QAction(tr("Copy"), popup);
         // According to the Qt Documentation:
         // "This text is used for the tooltip."
         // "If no tooltip is specified, the action's text is used."
@@ -2419,19 +2423,19 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
         // in the QAction constructor:
         action->setToolTip(QString());
         connect(action, &QAction::triggered, this, &TTextEdit::slot_copySelectionToClipboard);
-        QAction* action2 = new QAction(tr("Copy HTML"), this);
+        QAction* action2 = new QAction(tr("Copy HTML"), popup);
         action2->setToolTip(QString());
         connect(action2, &QAction::triggered, this, &TTextEdit::slot_copySelectionToClipboardHTML);
 
-        auto* actionCopyImage = new QAction(tr("Copy as image"), this);
+        auto* actionCopyImage = new QAction(tr("Copy as image"), popup);
         connect(actionCopyImage, &QAction::triggered, this, &TTextEdit::slot_copySelectionToClipboardImage);
 
-        QAction* action3 = new QAction(tr("Select all"), this);
+        QAction* action3 = new QAction(tr("Select all"), popup);
         action3->setToolTip(QString());
         connect(action3, &QAction::triggered, this, &TTextEdit::slot_selectAll);
 
         QString selectedEngine = mpHost ? mpHost->getSearchEngine().first : tr("Unknown");
-        QAction* action4 = new QAction(tr("Search on %1").arg(selectedEngine), this);
+        QAction* action4 = new QAction(tr("Search on %1").arg(selectedEngine), popup);
         action4->setToolTip(QString());
         connect(action4, &QAction::triggered, this, &TTextEdit::slot_searchSelectionOnline);
         if (!qApp->testAttribute(Qt::AA_DontShowIconsInMenus)) {
@@ -2439,10 +2443,6 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
             action3->setIcon(QIcon::fromTheme(qsl("edit-select-all"), QIcon(qsl(":/icons/edit-select-all.png"))));
             action4->setIcon(QIcon::fromTheme(qsl("edit-web-search"), QIcon(qsl(":/icons/edit-web-search.png"))));
         }
-
-        auto popup = new QMenu(this);
-        popup->setAttribute(Qt::WA_DeleteOnClose);
-        popup->setToolTipsVisible(true); // Not the default...
         popup->addAction(action);
         popup->addAction(action2);
         popup->addAction(actionCopyImage);
@@ -2450,7 +2450,7 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
         popup->addAction(action3);
 
         if (mDragStart != mDragSelectionEnd && mpHost->mEnableTextAnalyzer) {
-            mpContextMenuAnalyser = new QAction(tr("Analyse characters"), this);
+            mpContextMenuAnalyser = new QAction(tr("Analyse characters"), popup);
             // NOTE: If running inside the Qt Creator IDE using the debugger with
             // the hovered() signal can be *problematic* - as hitting a
             // breakpoint - or getting an OS signal (like a Segment Violation)
@@ -2468,11 +2468,11 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
         popup->addAction(action4);
 
         if (!mudlet::self()->isControlsVisible()) {
-            QAction* actionRestoreMainMenu = new QAction(tr("restore Main menu"), this);
+            QAction* actionRestoreMainMenu = new QAction(tr("restore Main menu"), popup);
             connect(actionRestoreMainMenu, &QAction::triggered, mudlet::self(), &mudlet::slot_restoreMainMenu);
             actionRestoreMainMenu->setToolTip(utils::richText(tr("Use this to restore the Main menu to get access to controls.")));
 
-            QAction* actionRestoreMainToolBar = new QAction(tr("restore Main Toolbar"), this);
+            QAction* actionRestoreMainToolBar = new QAction(tr("restore Main Toolbar"), popup);
             connect(actionRestoreMainToolBar, &QAction::triggered, mudlet::self(), &mudlet::slot_restoreMainToolBar);
             actionRestoreMainToolBar->setToolTip(utils::richText(tr("Use this to restore the Main Toolbar to get access to controls.")));
 
@@ -2482,7 +2482,7 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
         }
 
         if (mpConsole->getType() == TConsole::ErrorConsole) {
-            QAction* clearErrorConsole = new QAction(tr("Clear console"), this);
+            QAction* clearErrorConsole = new QAction(tr("Clear console"), popup);
             connect(clearErrorConsole, &QAction::triggered, this, [=, this]() {
                 mpConsole->buffer.clear();
                 mpConsole->print(qsl("%1\n").arg(tr("*** starting new session ***")));
@@ -2499,7 +2499,7 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
                 QStringList actionInfo = it.value();
                 const QString& uniqueName = it.key();
                 const QString& actionName = actionInfo.at(1);
-                QAction* mouseAction = new QAction(actionName, this);
+                QAction* mouseAction = new QAction(actionName, popup);
                 mouseAction->setToolTip(actionInfo.at(2));
                 popup->addAction(mouseAction);
                 connect(mouseAction, &QAction::triggered, this, [this, uniqueName] {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -171,6 +171,11 @@ cTelnet::~cTelnet()
         mpPostingTimer->stop();
     }
 
+    // Release zlib resources if MCCP compression was still active
+    if (mNeedDecompression) {
+        inflateEnd(&mZstream);
+    }
+
     // Aggressively disconnect the sockets to prevent signals during destruction
     if (mpSocket && mpSocket->state() != QAbstractSocket::UnconnectedState) {
         // Block all signals from the socket first
@@ -660,6 +665,9 @@ void cTelnet::slot_socketDisconnected()
  the rules of the "QDateTime::toString(...)" function and may need
  modification for some locales, e.g. France, Spain.*/
                                              .toString(tr("hh:mm:ss.zzz")));
+    if (mNeedDecompression) {
+        inflateEnd(&mZstream);
+    }
     mNeedDecompression = false;
     reset();
 
@@ -1401,6 +1409,8 @@ void cTelnet::slot_replyFinished(QNetworkReply* reply)
             //: %1 is the file path, %2 is the error message
             postMessage(tr("[ WARN ]  - Package download failed: could not open file '%1' for writing, reason: %2").arg(mServerPackage, file.errorString()));
             qWarning() << "ctelnet: failed to open file for writing:" << file.errorString();
+            reply->deleteLater();
+            mpPackageDownloadReply = nullptr;
             return;
         }
 
@@ -1410,6 +1420,8 @@ void cTelnet::slot_replyFinished(QNetworkReply* reply)
             //: %1 is the error message
             postMessage(tr("[ WARN ]  - Package download failed: could not save file, reason: %1").arg(file.errorString()));
             qDebug() << "cTelnet::slot_replyFinished: error downloading package: " << file.errorString();
+            reply->deleteLater();
+            mpPackageDownloadReply = nullptr;
             return;
         }
 

--- a/src/dlgComposer.cpp
+++ b/src/dlgComposer.cpp
@@ -226,6 +226,7 @@ void dlgComposer::recheckWholeLine()
 void dlgComposer::slot_contextMenu(const QPoint& pos)
 {
     auto* popup = edit->createStandardContextMenu();
+    popup->setAttribute(Qt::WA_DeleteOnClose);
     if (mpHost && mpHost->mEnableSpellCheck) {
         // Convert from widget coordinates to viewport coordinates
         QPoint viewportPos = edit->viewport()->mapFromParent(pos);

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1285,7 +1285,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
                         break;
                     default: {
                     } // There are a significant number of other errors
-                    // that are not handled here!
+                        // that are not handled here!
                     }
                 }
             }
@@ -3092,7 +3092,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         pHost->mLogFileNameFormat = comboBox_logFileNameFormat->currentData().toString();
         pHost->mNoAntiAlias = !checkBox_antiAlias->isChecked();
         pHost->mAlertOnNewData = mAlertOnNewData->isChecked();
-        
+
         QSettings* settings = mudlet::getQSettings();
         if (settings->value("telnetHandlerEnabled", false).toBool() != telnetHandlerEnabled->isChecked()) {
             settings->setValue("telnetHandlerEnabled", telnetHandlerEnabled->isChecked());
@@ -3201,7 +3201,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         bool ok;
         quint16 port = lineEdit_mmcpPort->text().toUShort(&ok);
         pHost->mMMCPChatPort = ok ? port : csDefaultMMCPHostPort;
-        
+
         /* Possible inclusion in 4.21
         pHost->mMMCPAutostartServer = checkBox_mmcpAutostartServer->isChecked();
         pHost->mMMCPAutoAcceptCalls = checkBox_mmcpAutoAcceptCalls->isChecked();

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1285,7 +1285,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
                         break;
                     default: {
                     } // There are a significant number of other errors
-                        // that are not handled here!
+                    // that are not handled here!
                     }
                 }
             }
@@ -1439,29 +1439,24 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     int shortcutsRow = 0;
     while (shortcutKeys.hasNext()) {
         auto key = shortcutKeys.next();
-        QKeySequence* sequence = new QKeySequence(*pHost->profileShortcuts.value(key));
-        currentShortcuts.insert(key, sequence);
-        auto sequenceEdit = new QKeySequenceEdit(*sequence);
+        currentShortcuts.insert(key, QKeySequence(*pHost->profileShortcuts.value(key)));
+        auto sequenceEdit = new QKeySequenceEdit(currentShortcuts.value(key));
 
         gridLayout_groupBox_shortcuts->addWidget(new QLabel(mudlet::self()->mpShortcutsManager->getLabel(key)), floor(shortcutsRow / 2), (shortcutsRow % 2) * 2 + 1);
         gridLayout_groupBox_shortcuts->addWidget(sequenceEdit, floor(shortcutsRow / 2), (shortcutsRow % 2) * 2 + 2);
         shortcutsRow++;
         connect(sequenceEdit, &QKeySequenceEdit::editingFinished, this, [=]() {
-            QKeySequence* newSequence = nullptr;
-            if (sequenceEdit->keySequence().isEmpty() || sequenceEdit->keySequence().matches(QKeySequence(Qt::Key_Escape))) {
-                newSequence = new QKeySequence();
-            } else {
-                newSequence = new QKeySequence(sequenceEdit->keySequence());
+            QKeySequence newSequence;
+            if (!sequenceEdit->keySequence().isEmpty() && !sequenceEdit->keySequence().matches(QKeySequence(Qt::Key_Escape))) {
+                newSequence = sequenceEdit->keySequence();
             }
-            sequenceEdit->setKeySequence(*newSequence);
-            sequence->swap(*newSequence);
-            delete newSequence;
+            sequenceEdit->setKeySequence(newSequence);
+            currentShortcuts[key] = newSequence;
         });
         connect(this, &dlgProfilePreferences::signal_resetMainWindowShortcutsToDefaults, sequenceEdit, [=]() {
-            sequenceEdit->setKeySequence(*mudlet::self()->mpShortcutsManager->getDefault(key));
-            QKeySequence* newSequence = new QKeySequence(*mudlet::self()->mpShortcutsManager->getDefault(key));
-            sequence->swap(*newSequence);
-            delete newSequence;
+            const auto defaultSequence = *mudlet::self()->mpShortcutsManager->getDefault(key);
+            sequenceEdit->setKeySequence(defaultSequence);
+            currentShortcuts[key] = defaultSequence;
         });
     }
 }
@@ -3249,7 +3244,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         auto iterator = mudlet::self()->mpShortcutsManager->iterator();
         while (iterator.hasNext()) {
             auto key = iterator.next();
-            QKeySequence sequence = QKeySequence(*currentShortcuts.value(key));
+            QKeySequence sequence = currentShortcuts.value(key);
             pHost->profileShortcuts.value(key)->swap(sequence);
         }
     }

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -230,7 +230,7 @@ private:
     QPointer<QDialog> mpDialogMapGlyphUsage;
     QPointer<QDoubleSpinBox> mpDoubleSpinBox_mapSymbolFontFudge;
     std::unique_ptr<QTimer> hidePasswordMigrationLabelTimer;
-    QMap<QString, QKeySequence*> currentShortcuts;
+    QMap<QString, QKeySequence> currentShortcuts;
     QPointer<QMenu> protocolMenu;
     QPointer<QAction> mEnableGMCP;
     QPointer<QAction> mEnableMSDP;

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -287,6 +287,10 @@ dlgRoomExits::~dlgRoomExits()
     // QActions are children of this dialog (created with 'this' as parent),
     // so Qt's parent-child system handles their deletion automatically.
     // Manual deletion here would cause double-delete crashes.
+
+    // TExit objects are heap-allocated and not Qt-parented, so we must free them
+    qDeleteAll(originalExits);
+    qDeleteAll(originalSpecialExits);
 }
 
 void dlgRoomExits::slot_endEditSpecialExits()

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -12474,6 +12474,7 @@ void dlgTriggerEditor::slot_colorTriggerFg()
     // while we get a colour setting:
     pD->setWindowModality(Qt::ApplicationModal);
     pD->exec();
+    delete pD;
 
     const QColor color = pT->mColorTriggerFgColor;
     // The above will be an invalid colour if the colour has been reset/ignored
@@ -12537,6 +12538,7 @@ void dlgTriggerEditor::slot_colorTriggerBg()
     // while we get a colour setting:
     pD->setWindowModality(Qt::ApplicationModal);
     pD->exec();
+    delete pD;
 
     const QColor color = pT->mColorTriggerBgColor;
     // The above will be an invalid colour if the colour has been reset/ignored

--- a/src/exitstreewidget.cpp
+++ b/src/exitstreewidget.cpp
@@ -42,7 +42,7 @@ void ExitsTreeWidget::keyPressEvent(QKeyEvent* event)
     if (event->key() == Qt::Key_Delete && hasFocus()) {
         QList<QTreeWidgetItem*> const selection = selectedItems();
         for (auto pItem : selection) {
-            takeTopLevelItem(indexOfTopLevelItem(pItem));
+            delete takeTopLevelItem(indexOfTopLevelItem(pItem));
         }
     }
 }

--- a/src/modern_glwidget.cpp
+++ b/src/modern_glwidget.cpp
@@ -80,6 +80,7 @@ void ModernGLWidget::cleanup()
     mNormalBuffer.destroy();
     mIndexBuffer.destroy();
     mInstanceBuffer.destroy();
+    mTexCoordBuffer.destroy();
     mVAO.destroy();
     doneCurrent();
 }
@@ -1604,16 +1605,18 @@ void ModernGLWidget::renderBackgroundLabels()
         float centerZ = label.pos.z();
 
         // Create render command for this label
-        auto command = std::make_unique<RenderLabelCommand>(
-            centerX, centerY, centerZ,
-            labelWidth, labelHeight,
-            textureId,
-            mCameraController.getRightVector(),
-            mCameraController.getUpVector(),
-            label.highlight,
-            mCameraController.getProjectionMatrix(),
-            mCameraController.getViewMatrix(),
-            mCameraController.getModelMatrix());
+        auto command = std::make_unique<RenderLabelCommand>(centerX,
+                                                            centerY,
+                                                            centerZ,
+                                                            labelWidth,
+                                                            labelHeight,
+                                                            textureId,
+                                                            mCameraController.getRightVector(),
+                                                            mCameraController.getUpVector(),
+                                                            label.highlight,
+                                                            mCameraController.getProjectionMatrix(),
+                                                            mCameraController.getViewMatrix(),
+                                                            mCameraController.getModelMatrix());
 
         mRenderCommandQueue.addCommand(std::move(command));
     }
@@ -1682,16 +1685,18 @@ void ModernGLWidget::renderForegroundLabels()
         float centerZ = label.pos.z();
 
         // Create render command for this label
-        auto command = std::make_unique<RenderLabelCommand>(
-            centerX, centerY, centerZ,
-            labelWidth, labelHeight,
-            textureId,
-            mCameraController.getRightVector(),
-            mCameraController.getUpVector(),
-            label.highlight,
-            mCameraController.getProjectionMatrix(),
-            mCameraController.getViewMatrix(),
-            mCameraController.getModelMatrix());
+        auto command = std::make_unique<RenderLabelCommand>(centerX,
+                                                            centerY,
+                                                            centerZ,
+                                                            labelWidth,
+                                                            labelHeight,
+                                                            textureId,
+                                                            mCameraController.getRightVector(),
+                                                            mCameraController.getUpVector(),
+                                                            label.highlight,
+                                                            mCameraController.getProjectionMatrix(),
+                                                            mCameraController.getViewMatrix(),
+                                                            mCameraController.getModelMatrix());
 
         mRenderCommandQueue.addCommand(std::move(command));
     }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4985,6 +4985,7 @@ mudlet::~mudlet()
 
     if (mpHunspell_sharedDictionary) {
         saveDictionary(getMudletPath(enums::mainDataItemPath, qsl("mudlet")), mWordSet_shared);
+        Hunspell_destroy(mpHunspell_sharedDictionary);
         mpHunspell_sharedDictionary = nullptr;
     }
     if (!mTranslatorsLoadedList.isEmpty()) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2905,8 +2905,7 @@ void mudlet::readLateSettings(const QSettings& settings)
     // Prevent a lockout where both menu bar and toolbar are hidden, leaving
     // the user with no way to access settings on startup
     if (mMenuBarVisibility == enums::visibleNever && mToolbarVisibility == enums::visibleNever) {
-        qWarning() << "mudlet::readLateSettings() - both menu bar and toolbar were configured"
-                   << "to never show; correcting toolbar to visibleOnlyWithoutLoadedProfile"
+        qWarning() << "mudlet::readLateSettings() - both menu bar and toolbar were configured" << "to never show; correcting toolbar to visibleOnlyWithoutLoadedProfile"
                    << "to prevent lockout. Persisting correction now.";
         setToolBarVisibility(enums::visibleOnlyWithoutLoadedProfile);
         // Write only the corrected value — calling writeSettings() here would
@@ -2915,8 +2914,8 @@ void mudlet::readLateSettings(const QSettings& settings)
         correctionSettings.setValue("toolBarVisibility", static_cast<int>(mToolbarVisibility));
         correctionSettings.sync();
         if (correctionSettings.status() != QSettings::NoError) {
-            qWarning() << "mudlet::readLateSettings() - failed to persist toolbar lockout correction to disk."
-                       << "QSettings status:" << correctionSettings.status() << "File:" << correctionSettings.fileName();
+            qWarning() << "mudlet::readLateSettings() - failed to persist toolbar lockout correction to disk." << "QSettings status:" << correctionSettings.status()
+                       << "File:" << correctionSettings.fileName();
         }
     }
 

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -200,6 +200,7 @@ void Updater::showDialogManually() const
 void Updater::showChangelog() const
 {
     auto changelogDialog = new dblsqd::UpdateDialog(feed, dblsqd::UpdateDialog::ManualChangelog);
+    changelogDialog->setAttribute(Qt::WA_DeleteOnClose);
     changelogDialog->setPreviousVersion(getPreviousVersion());
     changelogDialog->show();
 }
@@ -216,6 +217,7 @@ void Updater::showFullChangelog() const
     }
 
     auto changelogDialog = new dblsqd::UpdateDialog(feed, dblsqd::UpdateDialog::ManualChangelog);
+    changelogDialog->setAttribute(Qt::WA_DeleteOnClose);
     auto releases = feed->getReleases();
     const auto firstVersion = releases.constLast().getVersion();
     changelogDialog->setMinVersion(firstVersion);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fixes memory leaks from playing sounds, opening the room exits dialog, opening Preferences, right-clicking the console, connecting to MUDs with compression, and viewing changelogs 
#### Motivation for adding to Mudlet
Better memory management.
#### Other info (issues closed, discussion etc)

##### 3. TMediaPlayer destructor leaks TMediaPlaylist + QAudioOutput

```
playSoundFile() [TLuaInterpreterMedia.cpp:703]
  → TMedia::playMedia() [TMedia.cpp:47] → play() [TMedia.cpp:1485]
    → getMediaPlayer() [TMedia.cpp:1150]
      → make_shared<TMediaPlayer>(mpHost, mediaData) [TMedia.cpp:1193]
        → constructor: mPlaylist(new TMediaPlaylist)       ← LEAK #1 [TMedia.h:47]
        → constructor: setAudioOutput(new QAudioOutput())  ← LEAK #2 [TMedia.h:50]
    → updateMediaPlayerList() [TMedia.cpp:1102]
      → purgeStoppedMediaPlayers() [TMedia.cpp:1056] (when list > 25)
        → shared_ptr destroyed → ~TMediaPlayer() = default  ← NEVER DELETES [TMedia.h:52]
```

##### 6. dlgRoomExits TExit objects never freed

```
Right-click room → "Set exits..." [RoomContextMenuHandler.cpp:196]
  → T2DMap::slot_setExits() [T2DMap.cpp:4271]
    → new dlgRoomExits(...) [T2DMap.cpp:4278] + setAttribute(WA_DeleteOnClose) [T2DMap.cpp:4280]
      → init() [dlgRoomExits.cpp:279]
        → initExit() x12 [dlgRoomExits.cpp:1633-1775]
          → originalExits[dir] = makeExitFromControls(dir) [dlgRoomExits.cpp:1599]
            → new TExit() [dlgRoomExits.cpp:1968]  ← ALLOCATED
        → new TExit() per special exit [dlgRoomExits.cpp:1782] → originalSpecialExits[dir] [line 1848]
  User closes → ~dlgRoomExits() [dlgRoomExits.cpp:285] ← EMPTY, never deletes TExit objects
```

##### 7. dlgProfilePreferences QKeySequence* leak (no destructor)

```
mudlet::showOptionsDialog() [mudlet.cpp:3578]
  → new dlgProfilePreferences(this, pHost) [mudlet.cpp:3585]
  → setAttribute(WA_DeleteOnClose) [mudlet.cpp:3603]
    → constructor loop [dlgProfilePreferences.cpp:1394-1399]:
        new QKeySequence(*pHost->profileShortcuts.value(key)) [line 1398]
        currentShortcuts.insert(key, sequence) [line 1399]  ← 17 raw pointers stored
  User closes → WA_DeleteOnClose triggers delete
    → implicit ~dlgProfilePreferences() ← NO DESTRUCTOR EXISTS
      → QMap destroyed, pointer values NOT deleted
```

##### 10. ctelnet missing inflateEnd in destructor

```
Server sends WILL COMPRESS2 → processSocketData [ctelnet.cpp:4876-4880]
  → mNeedDecompression = true → initStreamDecompressor()
    → inflateInit(&mZstream) [ctelnet.cpp:4514]  ← allocates ~256KB

Connection drops → slot_socketDisconnected() [ctelnet.cpp:627]
  → mNeedDecompression = false [line 663]  ← NO inflateEnd()
  → reset() [line 664] ← NO inflateEnd()
  → ~cTelnet() [line 158] ← NO inflateEnd()
  (only inflateEnd is in decompressBuffer:4532, on Z_STREAM_END from server)
```

##### 11. ctelnet QNetworkReply leak on file error paths

```
slot_replyFinished() [ctelnet.cpp:1365]
  → reply->error() == NoError [line 1398]
    → file.open() fails [line 1400] → return ← LEAK (no reply->deleteLater())
    → file.commit() fails [line 1409] → return ← LEAK (no reply->deleteLater())
  (compare: error path at line 1393 correctly calls reply->deleteLater())
```

##### 15. TTextEdit QAction accumulation (5-10 per right-click)

```
Right-click on console → mouseReleaseEvent [TTextEdit.cpp:2287]
  → new QAction(tr("Copy"), this) [line 2374]      ← parented to TTextEdit, not QMenu
  → new QAction(tr("Copy HTML"), this) [line 2385]
  → new QAction(tr("Copy as image"), this) [line 2389]
  → new QAction(tr("Select all"), this) [line 2392]
  → new QAction(tr("Search on %1"), this) [line 2397]
  → (+ conditional actions at 2416, 2434, 2438, 2448, 2465)
  → popup = new QMenu(this) + WA_DeleteOnClose [line 2406-2407]
  → Menu closes → QMenu deleted, but QActions survive as TTextEdit children ← ACCUMULATE
```

##### 17. Updater changelog dialogs leaked

```
Help → Show changelog → Updater::showChangelog() [updater.cpp:202]
  → new dblsqd::UpdateDialog(feed, ...) ← no parent [line 202]
  → changelogDialog->show() [line 204] ← non-blocking, pointer lost at scope end
  (no WA_DeleteOnClose set; same at showFullChangelog:218)
```

##### 20. ModernGLWidget mTexCoordBuffer.destroy() missing

```
initializeGL() → setupBuffers() [modern_glwidget.cpp:146]
  → mTexCoordBuffer.create() [line 183]
~ModernGLWidget() → cleanup() [line 70]
  → mVertexBuffer.destroy()  [line 78] ✓
  → mColorBuffer.destroy()   [line 79] ✓
  → mNormalBuffer.destroy()  [line 80] ✓
  → mIndexBuffer.destroy()   [line 81] ✓
  → mInstanceBuffer.destroy() [line 82] ✓
  → mTexCoordBuffer.destroy() ← MISSING between lines 82 and 83
  → mVAO.destroy()           [line 83] ✓
```

##### 21. dlgComposer context menu + Hunspell suggestions

```
Right-click in composer → slot_contextMenu() [dlgComposer.cpp:226]
  → createStandardContextMenu() [line 228] ← returns new QMenu*, no parent
  → fillSpellCheckList() [line 233] → Hunspell_suggest() [line 331,335] ← allocates lists
  → popup->popup() [line 237] ← non-blocking, pointer lost
  ← QMenu leaked (no WA_DeleteOnClose, no deleteLater)
  ← If dismissed without selection: Hunspell_free_list() never called [only at line 468,472]
```

##### 22-24. Lower-impact (also in this branch)

```
dlgColorTrigger after exec() [dlgTriggerEditor.cpp:12469,12532]:
  → new dlgColorTrigger(this, ...) → exec() → no delete pD

Hunspell shared dictionary [mudlet.cpp:4768]:
  → mpHunspell_sharedDictionary = nullptr ← missing Hunspell_destroy() before

ExitsTreeWidget takeTopLevelItem [exitstreewidget.cpp:45]:
  → takeTopLevelItem(indexOfTopLevelItem(pItem)) ← return value discarded, never deleted
```