### PR TITLE
infrastructure: fix DangerJS workflow vulnerability to malicious PRs

### DIFF
--- a/.github/workflows/dangerjs.yml
+++ b/.github/workflows/dangerjs.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, edited]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: ${{github.workflow}}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -11,25 +15,12 @@ concurrency:
 jobs:
   danger:
     runs-on: ubuntu-latest
-    #if: github.event_name  == 'pull_request' # only run pull requests, no really
     steps:
-    - name: Checkout develop branch for danger config
+    - name: Checkout base branch for danger config
       uses: actions/checkout@v6
       with:
-        path: danger-config
         fetch-depth: 1
-    - name: Checkout PR head for file analysis
-      uses: actions/checkout@v6
-      with:
-        ref: ${{github.event.pull_request.head.sha}}
-        path: pr-files
-        fetch-depth: 0
-    - name: Copy danger config to PR workspace
-      run: |
-        cp danger-config/dangerfile.js pr-files/
-        cp danger-config/package.json pr-files/ 2>/dev/null || true
-    - name: Install yarn dependencies and run danger
-      working-directory: pr-files
+    - name: Install dependencies and run danger
       run: |
         yarn add danger --dev
         yarn danger ci


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Remove PR head checkout from DangerJS workflow - it only uses GitHub API-based features, not local files
- Add explicit permissions block to limit GITHUB_TOKEN to contents:read and pull-requests:write
- Eliminates "pwn request" attack vector where a malicious PR could execute arbitrary code via npm preinstall scripts

#### Motivation for adding to Mudlet
The current workflow checks out untrusted PR code and runs yarn install on it with a fully-privileged GITHUB_TOKEN, allowing any external contributor to exfiltrate secrets by opening a PR.

#### Other info (issues closed, discussion etc)
Discovered while investigating IRE-Mudlet-Mapping/StarmournCrowdmap#122 which exploited this exact pattern.

**Test case:** Open a PR and verify DangerJS still comments with title/TODO/file count warnings as before.