### PR TITLE
infrastructure: release workflow failing due to PR build triggers and checkout wiping assets

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -3,6 +3,7 @@ on:
   workflow_run:
     workflows: ["🔨 Build Mudlet", "🔨 Build Mudlet (windows)"]
     types: [completed]
+    branches: [master, development, release-*, Mudlet-*]
 
 permissions:
   contents: write
@@ -26,7 +27,14 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const sha = context.payload.workflow_run.head_sha;
+            const triggeringRun = context.payload.workflow_run;
+            // Skip PR builds - they use a different head_sha and have no release artifacts
+            if (triggeringRun.event === 'pull_request') {
+              core.info(`Skipping: triggered by a pull_request build`);
+              core.setOutput('ready', 'false');
+              return;
+            }
+            const sha = triggeringRun.head_sha;
             const required = {
               'linux_macos': 'build-mudlet.yml',
               'windows': 'build-mudlet-win.yml'
@@ -51,6 +59,28 @@ jobs:
             core.setOutput('ready', 'true');
             core.setOutput('linux_macos_run_id', runIds['linux_macos']);
             core.setOutput('windows_run_id', runIds['windows']);
+
+      # Checkout early so .git exists before artifact downloads — actions/checkout
+      # wipes the workspace when no .git directory is present, even with clean: false
+      - uses: actions/checkout@v6
+        if: steps.check.outputs.ready == 'true'
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - uses: leafo/gh-actions-lua@v12
+        if: steps.check.outputs.ready == 'true'
+        with:
+          luaVersion: "5.1.5"
+
+      - uses: leafo/gh-actions-luarocks@v6
+        if: steps.check.outputs.ready == 'true'
+
+      - name: Install changelog dependencies
+        if: steps.check.outputs.ready == 'true'
+        run: |
+          luarocks install argparse
+          luarocks install lunajson
 
       # Download build metadata to determine if this is a release or PTB build (not present for snapshot/PR builds)
       - name: Download metadata to determine release type
@@ -190,28 +220,6 @@ jobs:
           cat "${SHA_FILES[@]}" > assets/SHA256SUMS.txt
           echo "Generated SHA256SUMS.txt (${#SHA_FILES[@]} entries):"
           cat assets/SHA256SUMS.txt
-
-      # Generate changelog
-      - uses: actions/checkout@v6
-        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-          fetch-depth: 0
-          clean: false
-
-      - uses: leafo/gh-actions-lua@v12
-        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
-        with:
-          luaVersion: "5.1.5"
-
-      - uses: leafo/gh-actions-luarocks@v6
-        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
-
-      - name: Install changelog dependencies
-        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
-        run: |
-          luarocks install argparse
-          luarocks install lunajson
 
       - name: Generate changelog
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -167,7 +167,6 @@ jobs:
           run-id: ${{ steps.check.outputs.windows_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: assets/
-          merge-multiple: false
 
       - name: Verify release assets
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fix two bugs in create-github-release.yml: PR builds triggering the release workflow with wrong SHA, and actions/checkout wiping downloaded artifacts.

#### Motivation for adding to Mudlet
Without this fix, the release workflow silently skips creating releases or fails with missing assets.

#### Other info (issues closed, discussion etc)
Root causes found by investigating failed runs from #9127.

**Test case:** Run workflow_dispatch on build-mudlet.yml with "Imitate a PTB" set to true; verify the release workflow picks up the correct build run and creates a GitHub pre-release with all available platform assets.