### PR TITLE
improve: show version scope in PTB release changelogs

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -103,7 +103,7 @@ jobs:
         id: release-type
         run: |
           META_FILE=$(find metadata/ -name 'release-metadata.json' -type f | head -1)
-          if [ -z "${META_FILE}" ]; then
+          if [[ -z "${META_FILE}" ]]; then
             echo "No release metadata found - this is likely a snapshot or PR build"
             echo "type=skip" >> "$GITHUB_OUTPUT"
             exit 0
@@ -115,11 +115,11 @@ jobs:
           VERSION=$(echo "$META" | jq -r '.version')
           BUILD_SUFFIX=$(echo "$META" | jq -r '.build_suffix')
 
-          if [ -z "${VERSION}" ] || [ "${VERSION}" == "null" ]; then
+          if [[ -z "${VERSION}" || "${VERSION}" == "null" ]]; then
             echo "::error::VERSION field is empty or missing in release metadata"
             exit 1
           fi
-          if [ -z "${REF}" ] || [ "${REF}" == "null" ]; then
+          if [[ -z "${REF}" || "${REF}" == "null" ]]; then
             echo "::error::REF field is empty or missing in release metadata"
             exit 1
           fi
@@ -132,7 +132,7 @@ jobs:
             echo "title=Mudlet ${VERSION}" >> "$GITHUB_OUTPUT"
             echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           elif [[ "$EVENT" == "schedule" ]] || [[ "$BUILD_SUFFIX" == -ptb* ]]; then
-            if [ -z "${COMMIT}" ] || [ "${COMMIT}" == "null" ]; then
+            if [[ -z "${COMMIT}" || "${COMMIT}" == "null" ]]; then
               echo "::error::COMMIT field is empty or missing in release metadata for PTB"
               exit 1
             fi
@@ -188,17 +188,17 @@ jobs:
             MISSING+=("Windows (.exe)")
           fi
 
-          if [ ${#MISSING[@]} -gt 0 ]; then
+          if [[ ${#MISSING[@]} -gt 0 ]]; then
             echo "::warning::Missing release assets for: ${MISSING[*]}"
           fi
 
           # Stable releases must have all platforms; PTB tolerates partial
-          if [[ "${RELEASE_TYPE}" == "release" ]] && [ ${#MISSING[@]} -gt 0 ]; then
+          if [[ "${RELEASE_TYPE}" == "release" && ${#MISSING[@]} -gt 0 ]]; then
             echo "::error::Stable release is missing assets for: ${MISSING[*]}"
             exit 1
           fi
 
-          if [ ${#MISSING[@]} -eq 3 ]; then
+          if [[ ${#MISSING[@]} -eq 3 ]]; then
             echo "::error::No release assets found for any platform"
             exit 1
           fi
@@ -211,7 +211,7 @@ jobs:
           SHA_FILES=(assets/*/*.sha256)
           shopt -u nullglob
 
-          if [ ${#SHA_FILES[@]} -eq 0 ]; then
+          if [[ ${#SHA_FILES[@]} -eq 0 ]]; then
             echo "::error::No .sha256 checksum files found in assets/"
             exit 1
           fi
@@ -238,7 +238,7 @@ jobs:
 
           echo "Generating changelog from ${PREV_TAG} to ${END_TAG}"
           # Use 'release' mode for both since we have explicit commit ranges (ptb mode requires a dblsqd feed file)
-          if [ -n "${PREV_TAG}" ]; then
+          if [[ -n "${PREV_TAG}" ]]; then
             if ! lua CI/generate-changelog.lua -f md -m release \
                  --start-commit "${PREV_TAG}" --end-commit "${END_TAG}" > changelog.md; then
               if [[ "${RELEASE_TYPE}" == "release" ]]; then
@@ -257,7 +257,7 @@ jobs:
           fi
 
           # Prepend a note for PTB changelogs so readers know the scope
-          if [[ "${RELEASE_TYPE}" == "ptb" ]] && [ -n "${PREV_TAG}" ]; then
+          if [[ "${RELEASE_TYPE}" == "ptb" && -n "${PREV_TAG}" ]]; then
             RELEASE_VERSION="${PREV_TAG#Mudlet-}"
             { echo "Changes since ${RELEASE_VERSION}:"; echo; cat changelog.md; } > changelog.tmp
             mv changelog.tmp changelog.md
@@ -305,7 +305,7 @@ jobs:
           mapfile -t FILES < <(find assets/ -type f \
             \( -name '*.AppImage.tar' -o -name '*.exe' -o -name '*.dmg' -o -name 'SHA256SUMS.txt' \))
 
-          if [ ${#FILES[@]} -eq 0 ]; then
+          if [[ ${#FILES[@]} -eq 0 ]]; then
             echo "::error::No release files found to upload"
             exit 1
           fi
@@ -348,10 +348,10 @@ jobs:
 
           # Convert changelog to HTML for Sparkle's description field
           export CHANGELOG_HTML=""
-          if [ -f changelog.md ]; then
+          if [[ -f changelog.md ]]; then
             CHANGELOG_HTML=$(pandoc changelog.md -f markdown -t html --no-highlight 2>/dev/null || true)
           fi
-          if [ -z "${CHANGELOG_HTML}" ]; then
+          if [[ -z "${CHANGELOG_HTML}" ]]; then
             CHANGELOG_HTML="<p>See <a href='https://github.com/Mudlet/Mudlet/releases/tag/${RELEASE_TAG}'>release notes</a> for details.</p>"
           fi
 
@@ -367,7 +367,7 @@ jobs:
 
           for ARCH in arm64 x86_64; do
             DMG_FILE=$(find assets/ -name "*-${ARCH}.dmg" -type f | head -1)
-            if [ -z "${DMG_FILE}" ]; then
+            if [[ -z "${DMG_FILE}" ]]; then
               echo "No macOS DMG found for ${ARCH} - skipping appcast"
               continue
             fi
@@ -376,7 +376,7 @@ jobs:
             DMG_NAME=$(basename "${DMG_FILE}")
             export DOWNLOAD_URL=$(echo "${RELEASE_JSON}" | jq -r --arg name "${DMG_NAME}" '.assets[] | select(.name == $name) | .url')
 
-            if [ -z "${DOWNLOAD_URL}" ] || [ "${DOWNLOAD_URL}" == "null" ]; then
+            if [[ -z "${DOWNLOAD_URL}" || "${DOWNLOAD_URL}" == "null" ]]; then
               echo "::warning::Could not find download URL for ${DMG_NAME}"
               continue
             fi
@@ -421,7 +421,7 @@ jobs:
           APPCAST_FILES=(appcast/*.xml)
           shopt -u nullglob
 
-          if [ ${#APPCAST_FILES[@]} -eq 0 ]; then
+          if [[ ${#APPCAST_FILES[@]} -eq 0 ]]; then
             echo "::warning::No appcast files to upload"
             exit 0
           fi

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -297,6 +297,13 @@ jobs:
             fi
           fi
 
+          # Prepend a note for PTB changelogs so readers know the scope
+          if [[ "${RELEASE_TYPE}" == "ptb" && -n "${STABLE_TAG}" ]]; then
+            RELEASE_VERSION="${STABLE_TAG#Mudlet-}"
+            { echo "Changes since ${RELEASE_VERSION}:"; echo; cat changelog.md; } > changelog.tmp
+            mv changelog.tmp changelog.md
+          fi
+
           echo "Changelog preview:"
           head -20 changelog.md
 

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -256,6 +256,13 @@ jobs:
             echo "See commit history for changes." > changelog.md
           fi
 
+          # Prepend a note for PTB changelogs so readers know the scope
+          if [[ "${RELEASE_TYPE}" == "ptb" ]] && [ -n "${PREV_TAG}" ]; then
+            RELEASE_VERSION="${PREV_TAG#Mudlet-}"
+            { echo "Changes since ${RELEASE_VERSION}:"; echo; cat changelog.md; } > changelog.tmp
+            mv changelog.tmp changelog.md
+          fi
+
           echo "Changelog preview:"
           head -20 changelog.md
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Prepend a "Changes since X.Y.Z:" header to PTB release changelogs.

#### Motivation for adding to Mudlet
PTB changelogs cover all changes since the last release, which can be hundreds of entries. The header makes the scope immediately clear.

#### Other info (issues closed, discussion etc)
Follow-up to #9145.

**Test case:** Run a PTB build via workflow_dispatch and verify the GitHub Release body starts with "Changes since X.Y.Z:".