### PR TITLE
infrastructure: fix Windows PTB registration failing after installer rename

### DIFF
--- a/CI/register-windows-release.sh
+++ b/CI/register-windows-release.sh
@@ -63,7 +63,7 @@ FetchAndCheckURL() {
     # The processing of this variable by the jq tool means that converting this
     # variable name to SCREAMING_SNAKE_CASE was too hard to do and get correct
     # so leave it alone in a form that "works":
-    search_pattern="windows-64.exe"
+    search_pattern="windows-64-installer\\.exe"
     echo "Searching for ${search_pattern}"
 
     # Use jq to filter the JSON data


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Updates search pattern in `register-windows-release.sh` to match the installer filename renamed in #9127 from `*-windows-64.exe` to `*-windows-64-installer.exe`
- Without this fix, the PTB registration step loops for 1 hour then fails

#### Motivation for adding to Mudlet
The "Register PTB Release" CI step is broken on `development` — it can never find the uploaded installer.

#### Other info (issues closed, discussion etc)
Regression from #9127.

**Test case:** Trigger a scheduled/manual PTB Windows build and verify the "Register PTB Release" step completes successfully.