### PR TITLE
Infrastructure: show changelogs both from last release and last PTB

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -244,22 +244,28 @@ jobs:
           else
             # For PTB: short changelog since last PTB (prominent) + full changelog since last stable release (collapsed)
             STABLE_TAG=$(git tag --sort=-version:refname | grep '^Mudlet-' | grep -v -- '-ptb' | head -1)
-            PTB_TAG=$(git tag --sort=-version:refname | grep '^Mudlet-' | grep -- '-ptb' | head -1)
+            PTB_TAG=$(git tag --sort=-version:refname | grep '^Mudlet-' | grep -- '-ptb' | grep -v "^${RELEASE_TAG}$" | head -1)
+
+            # Verify the PTB tag is an ancestor of HEAD
+            if [ -n "${PTB_TAG}" ] && ! git merge-base --is-ancestor "${PTB_TAG}" HEAD 2>/dev/null; then
+              echo "::warning::Latest PTB tag ${PTB_TAG} is not an ancestor of HEAD, skipping PTB diff"
+              PTB_TAG=""
+            fi
 
             # Generate the full changelog since last stable release
             FULL_CHANGELOG=""
             if [ -n "${STABLE_TAG}" ]; then
               echo "Generating full changelog from ${STABLE_TAG} to HEAD"
               FULL_CHANGELOG=$(lua CI/generate-changelog.lua -f md -m release \
-                   --start-commit "${STABLE_TAG}" --end-commit HEAD 2>/dev/null || true)
+                   --start-commit "${STABLE_TAG}" --end-commit HEAD || true)
             fi
 
-            # Generate the short changelog since last PTB
+            # Generate the incremental changelog since last PTB
             PTB_CHANGELOG=""
             if [ -n "${PTB_TAG}" ] && [ "${PTB_TAG}" != "${STABLE_TAG}" ]; then
               echo "Generating PTB changelog from ${PTB_TAG} to HEAD"
               PTB_CHANGELOG=$(lua CI/generate-changelog.lua -f md -m release \
-                   --start-commit "${PTB_TAG}" --end-commit HEAD 2>/dev/null || true)
+                   --start-commit "${PTB_TAG}" --end-commit HEAD || true)
             fi
 
             # Assemble the combined changelog

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -229,31 +229,60 @@ jobs:
           if [[ "${RELEASE_TYPE}" == "release" ]]; then
             # For release: changelog from previous stable release tag to this tag
             PREV_TAG=$(git tag --sort=-version:refname | grep '^Mudlet-' | grep -v -- '-ptb' | grep -v "^${RELEASE_TAG}$" | head -1)
-            END_TAG="${RELEASE_TAG}"
-          else
-            # For PTB: changelog from latest stable release tag to HEAD
-            PREV_TAG=$(git tag --sort=-version:refname | grep '^Mudlet-' | grep -v -- '-ptb' | head -1)
-            END_TAG="HEAD"
-          fi
 
-          echo "Generating changelog from ${PREV_TAG} to ${END_TAG}"
-          # Use 'release' mode for both since we have explicit commit ranges (ptb mode requires a dblsqd feed file)
-          if [ -n "${PREV_TAG}" ]; then
-            if ! lua CI/generate-changelog.lua -f md -m release \
-                 --start-commit "${PREV_TAG}" --end-commit "${END_TAG}" > changelog.md; then
-              if [[ "${RELEASE_TYPE}" == "release" ]]; then
+            echo "Generating changelog from ${PREV_TAG} to ${RELEASE_TAG}"
+            if [ -n "${PREV_TAG}" ]; then
+              if ! lua CI/generate-changelog.lua -f md -m release \
+                   --start-commit "${PREV_TAG}" --end-commit "${RELEASE_TAG}" > changelog.md; then
                 echo "::error::Changelog generation failed for stable release"
                 exit 1
               fi
-              echo "::warning::Changelog generation failed, using placeholder"
-              echo "See commit history for changes." > changelog.md
-            fi
-          else
-            if [[ "${RELEASE_TYPE}" == "release" ]]; then
+            else
               echo "::error::No previous release tag found - cannot generate changelog for stable release"
               exit 1
             fi
-            echo "See commit history for changes." > changelog.md
+          else
+            # For PTB: short changelog since last PTB (prominent) + full changelog since last stable release (collapsed)
+            STABLE_TAG=$(git tag --sort=-version:refname | grep '^Mudlet-' | grep -v -- '-ptb' | head -1)
+            PTB_TAG=$(git tag --sort=-version:refname | grep '^Mudlet-' | grep -- '-ptb' | head -1)
+
+            # Generate the full changelog since last stable release
+            FULL_CHANGELOG=""
+            if [ -n "${STABLE_TAG}" ]; then
+              echo "Generating full changelog from ${STABLE_TAG} to HEAD"
+              FULL_CHANGELOG=$(lua CI/generate-changelog.lua -f md -m release \
+                   --start-commit "${STABLE_TAG}" --end-commit HEAD 2>/dev/null || true)
+            fi
+
+            # Generate the short changelog since last PTB
+            PTB_CHANGELOG=""
+            if [ -n "${PTB_TAG}" ] && [ "${PTB_TAG}" != "${STABLE_TAG}" ]; then
+              echo "Generating PTB changelog from ${PTB_TAG} to HEAD"
+              PTB_CHANGELOG=$(lua CI/generate-changelog.lua -f md -m release \
+                   --start-commit "${PTB_TAG}" --end-commit HEAD 2>/dev/null || true)
+            fi
+
+            # Assemble the combined changelog
+            if [ -n "${PTB_CHANGELOG}" ] && [ -n "${FULL_CHANGELOG}" ]; then
+              {
+                echo "#### Changes since last PTB (${PTB_TAG})"
+                echo ""
+                echo "${PTB_CHANGELOG}"
+                echo ""
+                echo "<details>"
+                echo "<summary>Full changelog since last release (${STABLE_TAG})</summary>"
+                echo ""
+                echo "${FULL_CHANGELOG}"
+                echo ""
+                echo "</details>"
+              } > changelog.md
+            elif [ -n "${FULL_CHANGELOG}" ]; then
+              # No previous PTB or first PTB after a release - just show full changelog
+              echo "${FULL_CHANGELOG}" > changelog.md
+            else
+              echo "::warning::Changelog generation failed, using placeholder"
+              echo "See commit history for changes." > changelog.md
+            fi
           fi
 
           echo "Changelog preview:"

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -265,7 +265,7 @@ jobs:
 
             # Generate the incremental changelog since last PTB
             PTB_CHANGELOG=""
-            if [ -n "${PTB_TAG}" ] && [ "${PTB_TAG}" != "${STABLE_TAG}" ]; then
+            if [ -n "${PTB_TAG}" ]; then
               echo "Generating PTB changelog from ${PTB_TAG} to HEAD"
               if ! PTB_CHANGELOG=$(lua CI/generate-changelog.lua -f md -m release \
                    --start-commit "${PTB_TAG}" --end-commit HEAD); then

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -247,7 +247,7 @@ jobs:
             PTB_TAG=$(git tag --sort=-version:refname | grep '^Mudlet-' | grep -- '-ptb' | grep -v "^${RELEASE_TAG}$" | head -1)
 
             # Verify the PTB tag is an ancestor of HEAD
-            if [ -n "${PTB_TAG}" ] && ! git merge-base --is-ancestor "${PTB_TAG}" HEAD 2>/dev/null; then
+            if [ -n "${PTB_TAG}" ] && ! git merge-base --is-ancestor "${PTB_TAG}" HEAD; then
               echo "::warning::Latest PTB tag ${PTB_TAG} is not an ancestor of HEAD, skipping PTB diff"
               PTB_TAG=""
             fi
@@ -256,16 +256,22 @@ jobs:
             FULL_CHANGELOG=""
             if [ -n "${STABLE_TAG}" ]; then
               echo "Generating full changelog from ${STABLE_TAG} to HEAD"
-              FULL_CHANGELOG=$(lua CI/generate-changelog.lua -f md -m release \
-                   --start-commit "${STABLE_TAG}" --end-commit HEAD || true)
+              if ! FULL_CHANGELOG=$(lua CI/generate-changelog.lua -f md -m release \
+                   --start-commit "${STABLE_TAG}" --end-commit HEAD); then
+                echo "::warning::Full changelog generation failed (from ${STABLE_TAG} to HEAD)"
+                FULL_CHANGELOG=""
+              fi
             fi
 
             # Generate the incremental changelog since last PTB
             PTB_CHANGELOG=""
             if [ -n "${PTB_TAG}" ] && [ "${PTB_TAG}" != "${STABLE_TAG}" ]; then
               echo "Generating PTB changelog from ${PTB_TAG} to HEAD"
-              PTB_CHANGELOG=$(lua CI/generate-changelog.lua -f md -m release \
-                   --start-commit "${PTB_TAG}" --end-commit HEAD || true)
+              if ! PTB_CHANGELOG=$(lua CI/generate-changelog.lua -f md -m release \
+                   --start-commit "${PTB_TAG}" --end-commit HEAD); then
+                echo "::warning::PTB changelog generation failed (from ${PTB_TAG} to HEAD)"
+                PTB_CHANGELOG=""
+              fi
             fi
 
             # Assemble the combined changelog


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Show changelogs both from last release and last PTB. Only last 2 PTBs are ever kept (to reduce flooding our [releases page](https://github.com/Mudlet/Mudlet/releases) in github), so being able to see the delta between the PTBs and last release is quite useful.
#### Motivation for adding to Mudlet
More clarity in PTB changelogs
#### Other info (issues closed, discussion etc)
