### PR TITLE
infrastructure: fix CI bugs in PTB registration, macOS updater linking, and portable ZIP upload

### DIFF
--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -79,8 +79,8 @@ jobs:
 
         echo "Linking ${bold}Linux PTB${normal} ${PTB_VERSION}..."
         dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach linux:x86_64 "${LINUX_PTB_URL}" || EXIT_CODE_LINUX=$?
-        echo "Linking ${bold}macOS x84 PTB${normal} ${PTB_VERSION}..."
-        dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach mac:x86_64 "${MACOS_ARM64_PTB_URL}" || EXIT_CODE_MACOS_x64=$?
+        echo "Linking ${bold}macOS x86 PTB${normal} ${PTB_VERSION}..."
+        dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach mac:x86_64 "${MACOS_X64_PTB_URL}" || EXIT_CODE_MACOS_x64=$?
         echo "Linking ${bold}macOS arm64 PTB${normal} ${PTB_VERSION}..."
         dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach mac:arm "${MACOS_ARM64_PTB_URL}" || EXIT_CODE_MACOS_ARM64=$?
 

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -79,7 +79,7 @@ jobs:
 
         echo "Linking ${bold}Linux PTB${normal} ${PTB_VERSION}..."
         dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach linux:x86_64 "${LINUX_PTB_URL}" || EXIT_CODE_LINUX=$?
-        echo "Linking ${bold}macOS x86 PTB${normal} ${PTB_VERSION}..."
+        echo "Linking ${bold}macOS x64 PTB${normal} ${PTB_VERSION}..."
         dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach mac:x86_64 "${MACOS_X64_PTB_URL}" || EXIT_CODE_MACOS_x64=$?
         echo "Linking ${bold}macOS arm64 PTB${normal} ${PTB_VERSION}..."
         dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach mac:arm "${MACOS_ARM64_PTB_URL}" || EXIT_CODE_MACOS_ARM64=$?

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -422,6 +422,7 @@ EOF
     # Define portable ZIP paths
     PORTABLE_ZIP_NAME="Mudlet-portable-${MSYSTEM,,}.zip"
     PORTABLE_ZIP_PATH="$(cygpath -au "${GITHUB_WORKSPACE}")/${PORTABLE_ZIP_NAME}"
+    PORTABLE_ZIP_WINPATH="$(cygpath -aw "${PORTABLE_ZIP_PATH}")"
 
     # Check if portable ZIP exists
     if [[ -f "${PORTABLE_ZIP_PATH}" ]]; then
@@ -434,7 +435,7 @@ EOF
       # Upload portable ZIP via SCP with proper naming
       PORTABLE_REMOTE_NAME="Mudlet-${VERSION}-windows-64-portable.zip"
       powershell.exe <<EOF
-\$portableZipPath = "${PORTABLE_ZIP_PATH}"
+\$portableZipPath = "${PORTABLE_ZIP_WINPATH}"
 \$DEPLOY_PATH = "${DEPLOY_PATH}"
 \$remoteFileName = "${PORTABLE_REMOTE_NAME}"
 scp.exe -i temp_key_file_portable -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \$portableZipPath mudmachine@mudlet.org:\${DEPLOY_PATH}/\$remoteFileName

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -421,7 +421,7 @@ EOF
     echo "=== Uploading portable ZIP to mudlet.org ==="
     # Define portable ZIP paths
     PORTABLE_ZIP_NAME="Mudlet-portable-${MSYSTEM,,}.zip"
-    PORTABLE_ZIP_PATH="${GITHUB_WORKSPACE_UNIX_PATH}/${PORTABLE_ZIP_NAME}"
+    PORTABLE_ZIP_PATH="$(cygpath -au "${GITHUB_WORKSPACE}")/${PORTABLE_ZIP_NAME}"
 
     # Check if portable ZIP exists
     if [[ -f "${PORTABLE_ZIP_PATH}" ]]; then

--- a/CI/register-windows-release.sh
+++ b/CI/register-windows-release.sh
@@ -49,21 +49,16 @@ start_time=$(date +%s)
 # Return Codes:
 # 0 - Success!
 # 1 - curl failure
-# 2 - json parse failure
 # 3 - no matching URL found
 FetchAndCheckURL() {
-    json_data=$(curl -s "$json_url")
-
-    # Check if curl succeeded
-    if ! curl -s "$json_url" -o /dev/null; then
+    # Fetch JSON feed and check if curl succeeded
+    if ! json_data=$(curl -s "$json_url"); then
       echo "Failed to download JSON feed."
       return 1
     fi
 
-    # The processing of this variable by the jq tool means that converting this
-    # variable name to SCREAMING_SNAKE_CASE was too hard to do and get correct
-    # so leave it alone in a form that "works":
-    search_pattern="windows-64-installer\\.exe"
+    # Match both old (*-windows-64.exe) and new (*-windows-64-installer.exe) naming
+    search_pattern="windows-64(-installer)?\\.exe"
     echo "Searching for ${search_pattern}"
 
     # Use jq to filter the JSON data
@@ -102,7 +97,7 @@ done
 
 
 echo "=== Registering release with Dblsqd ==="
-echo "dblsqd push -a mudlet -c public-test-build -r \"${VERSION_STRING}\" -s mudlet --type 'standalone' --attach win:x86_64} \"${matching_url}\""
+echo "dblsqd push -a mudlet -c public-test-build -r \"${VERSION_STRING}\" -s mudlet --type 'standalone' --attach win:x86_64 \"${matching_url}\""
 
 PATH="/c/Program Files/nodejs/:/c/npm/prefix/:${PATH}"
 export PATH


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Fix macOS Intel PTB updater serving the ARM64 binary instead of x64 (wrong variable in `link-ptbs-to-dblsqd.yml` since PR #7488)
- Fix PTB registration search pattern to match both old (`*-windows-64.exe`) and new (`*-windows-64-installer.exe`) naming from make.mudlet.org
- Fix portable ZIP upload silently failing on release builds due to undefined `GITHUB_WORKSPACE_UNIX_PATH` in `deploy-mudlet-for-windows.sh`
- Fix double curl call per retry in `register-windows-release.sh` and stray `}` in debug echo

#### Motivation for adding to Mudlet
Multiple CI bugs affecting PTB delivery: Intel Mac users get ARM64 binaries via the updater, Windows PTB registration fails when make.mudlet.org uses the old naming, and portable ZIP never uploads for releases.

#### Other info (issues closed, discussion etc)
The macOS x64/ARM64 mixup was introduced in #7488. The register pattern issue is a follow-up to #9150.

**Test case:** Trigger a PTB build and verify: (1) `register-windows-release.sh` finds the URL regardless of naming, (2) `link-ptbs-to-dblsqd.yml` links the correct macOS x64 URL, (3) a tagged release build attempts the portable ZIP upload.