### PR TITLE
infrastructure: fix PTB registration by reverting installer filename convention

### DIFF
--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -267,13 +267,15 @@ else
     # appended the short commit SHA1 - and just not worry about any sort of
     # sorting:
     INSTALLER_VERSION="${VERSION}-ptb-${BUILD_COMMIT,,}${BUILD_COUNTER_SUFFIX}"
-    # The name we want to use for the installer;
-    # Typically of form: 'Mudlet-4.19.1-ptb-2025-01-01-012345678-windows-64-installer.exe'
-    # Or with build counter: 'Mudlet-4.19.1-ptb-2025-01-01-012345678rebuild2-windows-64-installer.exe'
-    INSTALLER_EXE="Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}${BUILD_COUNTER_SUFFIX}-windows-64-installer.exe"
+    # The actual installer filename. Must NOT include '-installer' for PTBs —
+    # make.mudlet.org's gha_queue processor matches the extracted filename from
+    # the GHA artifact ZIP, and it expects this convention.
+    # Typically of form: 'Mudlet-4.19.1-ptb-2025-01-01-012345678-windows-64.exe'
+    # Or with build counter: 'Mudlet-4.19.1-ptb-2025-01-01-012345678rebuild2-windows-64.exe'
+    INSTALLER_EXE="Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}${BUILD_COUNTER_SUFFIX}-windows-64.exe"
     DBLSQD_VERSION_STRING="${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT,,}${BUILD_COUNTER_SUFFIX}"
-    # The name that has to be passed as the artifact so that the Mudlet website
-    # will accept it as a PTB:
+    # The GHA artifact name — includes '-installer' so make.mudlet.org
+    # recognises it as a PTB installer (distinct from the snapshot .zip):
     ARTIFACT_NAME="Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}${BUILD_COUNTER_SUFFIX}-windows-64-installer.exe"
   else
     NAME_SUFFIX='_64_'


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Revert PTB installer filename from `*-windows-64-installer.exe` back to `*-windows-64.exe`
- The GHA artifact name keeps `-installer` — these are intentionally different
- Document why INSTALLER_EXE and ARTIFACT_NAME must differ for PTBs

#### Motivation for adding to Mudlet
make.mudlet.org's gha_queue processor matches the extracted filename inside the GHA artifact ZIP. PR #9127 changed the actual filename to include `-installer`, which broke processing — PTB artifacts stopped appearing in the JSON feed, causing `register-windows-release.sh` to loop for an hour and fail. This has been broken since the April 5 nightly.

#### Other info (issues closed, discussion etc)
Regression from #9127. Follow-up to #9154.

The root cause was discovered by comparing the working April 4 nightly (commit `e58fe038`) with the broken April 5 nightly (commit `6b2de48d`): the GHA artifact name always had `-installer`, but the actual file inside the ZIP did not until #9127 changed it.

**Test case:** Trigger a PTB build via `workflow_dispatch` with `scheduled=true` and verify the "Register PTB Release" step completes successfully (finds the URL in the make.mudlet.org JSON feed).