### PR TITLE
Infrastructure: update edbee-lib submodule & use system oniguruma if present

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends build-essential git libglu1-mesa-dev \
         libgl1-mesa-dev liblua5.1-0-dev zlib1g-dev libhunspell-dev libpcre3-dev libpcre2-dev \
         libzip-dev libboost-dev libyajl-dev libpulse-dev libsecret-1-dev lua-rex-pcre2 \
-        lua-filesystem lua-zip lua-sql-sqlite3 libxkbcommon-dev liboniguruma-dev qmake6-bin \
+        lua-filesystem lua-zip lua-sql-sqlite3 libxkbcommon-dev libonig-dev qmake6-bin \
         qt6-base-dev libqt6opengl6-dev qt6-multimedia-dev qt6-tools-dev qtkeychain-qt6-dev \
         luarocks ccache libpugixml-dev libqt6core5compat6-dev qt6-speech-dev ninja-build cmake \
         libzstd-dev libsqlite3-dev libassimp-dev firefox-esr \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,10 +16,10 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends build-essential git libglu1-mesa-dev \
         libgl1-mesa-dev liblua5.1-0-dev zlib1g-dev libhunspell-dev libpcre3-dev libpcre2-dev \
         libzip-dev libboost-dev libyajl-dev libpulse-dev libsecret-1-dev lua-rex-pcre2 \
-        lua-filesystem lua-zip lua-sql-sqlite3 libxkbcommon-dev qmake6-bin qt6-base-dev \
-        libqt6opengl6-dev qt6-multimedia-dev qt6-tools-dev qtkeychain-qt6-dev luarocks ccache \
-        libpugixml-dev libqt6core5compat6-dev qt6-speech-dev ninja-build cmake libzstd-dev \
-        libsqlite3-dev libassimp-dev firefox-esr \
+        lua-filesystem lua-zip lua-sql-sqlite3 libxkbcommon-dev liboniguruma-dev qmake6-bin \
+        qt6-base-dev libqt6opengl6-dev qt6-multimedia-dev qt6-tools-dev qtkeychain-qt6-dev \
+        luarocks ccache libpugixml-dev libqt6core5compat6-dev qt6-speech-dev ninja-build cmake \
+        libzstd-dev libsqlite3-dev libassimp-dev firefox-esr \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -102,7 +102,7 @@ jobs:
         # Install all required dependencies
         # brew install can hang indefinitely during bottle pouring, so timeout and retry
         for attempt in 1 2 3; do
-          brew install libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost &
+          brew install libzzip libzip ccache expect assimp hunspell oniguruma pcre2 pugixml sqlite yajl boost &
           brew_pid=$!
           ( sleep 120 && kill $brew_pid 2>/dev/null ) &
           watcher_pid=$!
@@ -179,21 +179,22 @@ jobs:
           libglu1-mesa-dev \
           libhunspell-dev \
           liblua5.1-0-dev \
+          libonig-dev \
           libpcre2-dev \
           libpulse-dev \
           libpugixml-dev \
           libsecret-1-dev \
           libspeechd-dev \
           libsqlite3-dev \
-          qtkeychain-qt6-dev \
+          libssl-dev \
           libxkbcommon-x11-0 \
           libxcb-render-util0-dev \
           libxcb-image0-dev \
           libyajl-dev \
           libzip-dev \
+          qtkeychain-qt6-dev \
           pcre2-utils \
           pkg-config \
-          libssl-dev \
           openssl \
           ca-certificates \
           -y

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -108,7 +108,7 @@ jobs:
         # Install all required dependencies
         # brew install can hang indefinitely during bottle pouring, so timeout and retry
         for attempt in 1 2 3; do
-          brew install libzzip libzip ccache expect assimp hunspell pcre2 pugixml sqlite yajl boost &
+          brew install libzzip libzip ccache expect assimp hunspell oniguruma pcre2 pugixml sqlite yajl boost &
           brew_pid=$!
           ( sleep 120 && kill $brew_pid 2>/dev/null ) &
           watcher_pid=$!
@@ -185,21 +185,22 @@ jobs:
           libglu1-mesa-dev \
           libhunspell-dev \
           liblua5.1-0-dev \
+          libonig-dev \
           libpcre2-dev \
           libpulse-dev \
           libpugixml-dev \
           libsecret-1-dev \
           libspeechd-dev \
           libsqlite3-dev \
-          qtkeychain-qt6-dev \
+          libssl-dev \
           libxkbcommon-x11-0 \
           libxcb-render-util0-dev \
           libxcb-image0-dev \
           libyajl-dev \
           libzip-dev \
+          qtkeychain-qt6-dev \
           pcre2-utils \
           pkg-config \
-          libssl-dev \
           openssl \
           ca-certificates \
           -y

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -119,7 +119,7 @@ jobs:
         # Install all required dependencies
         # liblua5.1-0-dev is needed for CMake to find Lua headers/library
         sudo apt-get install libsecret-1-dev ccache pkg-config pcre2-utils expect libzip-dev libglu1-mesa-dev libpulse-dev g++-${{matrix.gcc_compiler_version}} \
-          libassimp-dev libpcre2-dev libpugixml-dev libsqlite3-dev libyajl-dev libhunspell-dev liblua5.1-0-dev libboost-dev qtkeychain-qt6-dev -y
+          libassimp-dev libpcre2-dev libpugixml-dev libsqlite3-dev libyajl-dev libhunspell-dev liblua5.1-0-dev libonig-dev libboost-dev qtkeychain-qt6-dev -y
 
         # switch to GCC that supports C++20 while retaining support for older OS's
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{matrix.gcc_compiler_version}} ${{matrix.gcc_compiler_version}}

--- a/.github/workflows/performance-analysis.yml
+++ b/.github/workflows/performance-analysis.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install build-essential git liblua5.1-dev zlib1g-dev libhunspell-dev libpcre2-dev \
-          libzip-dev libboost-graph-dev libyajl-dev libpulse-dev lua-filesystem lua-zip \
+          libzip-dev libboost-graph-dev libonig-dev libyajl-dev libpulse-dev lua-filesystem lua-zip \
           lua-sql-sqlite3 qt6-multimedia-dev qt6-tools-dev luarocks ccache libpugixml-dev cmake ninja-build \
           xvfb libassimp-dev qtkeychain-qt6-dev -y
 

--- a/CI/osx.install.sh
+++ b/CI/osx.install.sh
@@ -4,7 +4,7 @@ set +e
 shopt -s expand_aliases
 #Removed boost as first item as a temporary workaround to prevent trying to
 #upgrade to boost version 1.68.0 which has not been bottled yet...
-BREWS="luarocks cmake hunspell libzip mudlet/dependencies/lua@5.1 pcre2 pkg-config yajl ccache pugixml qt6 assimp"
+BREWS="luarocks cmake hunspell libzip mudlet/dependencies/lua@5.1 pcre2 oniguruma pkg-config yajl ccache pugixml qt6 assimp"
 OUTDATED_BREWS=$(brew outdated)
 
 for i in $BREWS; do

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ###########################################################################
 #   Copyright (C) 2024-2026  by John McKisson - john.mckisson@gmail.com   #
-#   Copyright (C) 2023-2025  by Stephen Lyons - slysven@virginmedia.com   #
+#   Copyright (C) 2023-2026  by Stephen Lyons - slysven@virginmedia.com   #
 #                                                                         #
 #   This program is free software; you can redistribute it and/or modify  #
 #   it under the terms of the GNU General Public License as published by  #
@@ -120,6 +120,7 @@ while true; do
     "${MINGW_PACKAGE_PREFIX}-zlib" \
     "${MINGW_PACKAGE_PREFIX}-boost" \
     "${MINGW_PACKAGE_PREFIX}-yajl" \
+    "${MINGW_PACKAGE_PREFIX}-oniguruma" \
     "${MINGW_PACKAGE_PREFIX}-lua-luarocks" \
     "${MINGW_PACKAGE_PREFIX}-ffmpeg" \
     "${MINGW_PACKAGE_PREFIX}-cmake" \

--- a/cmake/FindONIGURUMA.cmake
+++ b/cmake/FindONIGURUMA.cmake
@@ -30,7 +30,7 @@ find_path(ONIGURUMA_INCLUDE_DIR
   oniguruma.h
   HINTS
     ${ONIGURUMA_DIR}
-    $ENV{ONIGURUMAL_DIR}
+    $ENV{ONIGURUMA_DIR}
     ${PC_ONIGURUMA_INCLUDE_DIRS}
   PATHS
     ${ONIGURUMA_HOME}/include
@@ -62,7 +62,7 @@ else()
 endif()
 
 include(FindPackageHandleStandardArgs)
-# Support the REQUIRED and QUIET arguments, and set PUGIXML_FOUND if found.
+# Support the REQUIRED and QUIET arguments, and set ONIGURUMA_FOUND if found.
 find_package_handle_standard_args(ONIGURUMA REQUIRED_VARS ONIGURUMA_LIBRARY
                                   ONIGURUMA_INCLUDE_DIR VERSION_VAR ONIGURUMA_VER)
 

--- a/cmake/FindONIGURUMA.cmake
+++ b/cmake/FindONIGURUMA.cmake
@@ -1,0 +1,77 @@
+# FindONIGURUMA.cmake by:
+#                      Vadim Peretokin - vperetokin@gmail.com 2018, 2020
+#                      Florian Scheel - keneanung@googlemail.com 2019
+#                      Stephen Lyons - slysven@virginmedia.com 2020
+#
+# To the extent possible under law, the person(s) above who associated CC0
+# with this file have waived all copyright and related or neighboring rights
+# to it.
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+# Find the Oniguruma regular expression library.
+#
+# This module exports the following targets that should be used to link against:
+# ONIGURUMA::ONIGURUMA
+#
+# Sets the usual variables expected for find_package scripts:
+#
+# ONIGURUMA_INCLUDE_DIR - header location
+# ONIGURUMA_LIBRARIES - library to link against
+# ONIGURUMA_FOUND - true if Oniguruma was found.
+
+find_package(PkgConfig)
+
+pkg_search_module(PC_ONIGURUMA onig libonig oniguruma liboniguruma)
+
+find_path(ONIGURUMA_INCLUDE_DIR
+  oniguruma.hpp
+  oniguruma.h
+  HINTS
+    ${ONIGURUMA_DIR}
+    $ENV{ONIGURUMAL_DIR}
+    ${PC_ONIGURUMA_INCLUDE_DIRS}
+  PATHS
+    ${ONIGURUMA_HOME}/include
+    /usr/local/include
+    /usr/local/include/oniguruma
+  )
+
+find_library(
+  ONIGURUMA_LIBRARY
+  NAMES oniguruma onig
+  HINTS
+    ${ONIGURUMA_DIR}
+    $ENV{ONIGURUMA_DIR}
+    ${PC_ONIGURUMA_LIBRARY_DIRS}
+        ${PC_ONIGURUMA_LIBRARY_DIR}
+  PATHS
+    ${ONIGURUMA_HOME}/lib
+    /usr/local/lib
+    /usr/local/lib/onig
+    /usr/local/lib/oniguruma
+  )
+
+if(PC_ONIGURUMA_oniguruma_FOUND)
+  set(ONIGURUMA_VER ${PC_ONIGURUMA_oniguruma_VERSION})
+elseif(PC_ONIGURUMA_liboniguruma_FOUND)
+  set(ONIGURUMA_VER ${PC_ONIGURUMA_liboniguruma_VERSION})
+else()
+  set(ONIGURUMA_VER ${PC_ONIGURUMA_VERSION})
+endif()
+
+include(FindPackageHandleStandardArgs)
+# Support the REQUIRED and QUIET arguments, and set PUGIXML_FOUND if found.
+find_package_handle_standard_args(ONIGURUMA REQUIRED_VARS ONIGURUMA_LIBRARY
+                                  ONIGURUMA_INCLUDE_DIR VERSION_VAR ONIGURUMA_VER)
+
+if(ONIGURUMA_FOUND AND NOT TARGET ONIGURUMA::ONIGURUMA)
+  add_library(ONIGURUMA::ONIGURUMA UNKNOWN IMPORTED)
+  set_target_properties(
+    ONIGURUMA::ONIGURUMA
+    PROPERTIES IMPORTED_LOCATION "${ONIGURUMA_LIBRARY}"
+               INTERFACE_INCLUDE_DIRECTORIES "${ONIGURUMA_INCLUDE_DIR}")
+endif()
+
+mark_as_advanced(ONIGURUMA_LIBRARY ONIGURUMA_INCLUDE_DIR)

--- a/cmake/FindPUGIXML.cmake
+++ b/cmake/FindPUGIXML.cmake
@@ -1,3 +1,15 @@
+# FindPUGIXML.cmake by:
+#                      Vadim Peretokin - vperetokin@gmail.com 2018, 2020
+#                      Florian Scheel - keneanung@googlemail.com 2019
+#                      Stephen Lyons - slysven@virginmedia.com 2020
+#
+# To the extent possible under law, the person(s) above who associated CC0
+# with this file have waived all copyright and related or neighboring rights
+# to it.
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
 # Find the pugixml XML parsing library.
 #
 # This module exports the following targets that should be used to link against:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
With edbee-lib being revised to use a system oniguruma library instead of compiling it from bundled source code (a change suggested by myself) update our build processes to install the required dependency in order for the CMake build process to make use of this change.

#### Motivation for adding to Mudlet
To make edbee-lib, and thus Mudlet, use a system provided library if it is available rather than building it from source. This should decrease the time to compile the application a little and to improve the situation for packagers of the Mudlet application.

#### Other info (issues closed, discussion etc)
The change required a `FindONIGURUMA.cmake` file and I created one from our `FindPUGIXML.cmake` file to suggest upstream to the `edbee-lib` project, so that it could use the file when its license is MIT whereas the Mudlet one is GPU 2.0 or later and not compatible in that direction I have negotiated with our creators of the latter file to release it with a public domain (a.k.a. Creative Commons Zero) waiver and I have added suitable header text to both files.