### PR TITLE
infrastructure: update sentry-native to 0.13.5

### DIFF
--- a/src/cmake/WithSentry.cmake
+++ b/src/cmake/WithSentry.cmake
@@ -118,9 +118,10 @@ elseif(WIN32)
     target_link_libraries(${LIB_MUDLET_TARGET}
         dbghelp
         version
+        synchronization
     )
 else()
-    target_link_libraries(${LIB_MUDLET_TARGET} crashpad_compat)
+    target_link_libraries(${LIB_MUDLET_TARGET} crashpad_compat unwind)
 endif()
 
 set(SENTRY_BINARIES "${SENTRY_PATH}/install_without_transport/bin")

--- a/src/crash_reporter/CMakeLists.txt
+++ b/src/crash_reporter/CMakeLists.txt
@@ -63,6 +63,7 @@ if(WIN32)
         winhttp
         version
         dbghelp
+        synchronization
     )
 elseif(APPLE)
     list(APPEND MUDLET_CRASH_REPORTER_LIBS
@@ -75,6 +76,7 @@ elseif(APPLE)
 elseif(UNIX)
     list(APPEND MUDLET_CRASH_REPORTER_LIBS
         crashpad_compat
+        unwind
         pthread
         dl
         z


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Updates sentry-native from 0.12.3 to 0.13.5, which replaces Google-hosted git submodule URLs with GitHub mirrors to fix CI build failures caused by chromium.googlesource.com returning 403.

#### Motivation for adding to Mudlet
CI builds are broken because an upstream Google-hosted git dependency is inaccessible.

#### Other info (issues closed, discussion etc)
Upstream fix: https://github.com/getsentry/sentry-native/pull/1628

**Test case:** CI builds complete successfully with recursive submodule checkout.