### PR TITLE
Add an option to let user choose whether use display scale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ qrc_*.cpp
 mudlet
 app-build.txt
 src/crash_reporter/build/
+package-CLANG64-release/*
+portable-CLANG64-release/*
+build-CLANG64/*
+*.zip
 
 # Qt creator's clangd cache
 .cache

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -724,6 +724,11 @@ void mudlet::init()
     // The previous line will set an option used in the slot method:
     connect(mpMainToolBar, &QToolBar::visibilityChanged, this, &mudlet::slot_handleToolbarVisibilityChanged);
     connect(mpMainToolBar->toggleViewAction(), &QAction::triggered, this, &mudlet::slot_toolbarToggleActionTriggered);
+#ifdef Q_OS_WIN32
+    if (mNotUseDisplayScale) {
+        QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::Round);
+    }
+#endif
 
     dactionToggleFullScreen->setToolTip(utils::richText(tr("Toggle Full Screen View")));
 
@@ -2944,6 +2949,7 @@ void mudlet::readLateSettings(const QSettings& settings)
 
     mMinLengthForSpellCheck = settings.value("minLengthForSpellCheck", 3).toInt();
     mDrawUpperLowerLevels = settings.value("drawUpperLowerLevels", QVariant(true)).toBool();
+    mNotUseDisplayScale = settings.value("notUseDisplayScale", QVariant(true)).toBool();
     // Make a local version of the value so that we can update the real one
     // by calling the slot method that does that and ALSO carry out the
     // other things needed for it:
@@ -3139,6 +3145,7 @@ void mudlet::writeSettings()
     settings.setValue(qsl("enableMuteAPI"), mMuteAPI);
     settings.setValue(qsl("enableMuteGame"), mMuteGame);
     settings.setValue(qsl("drawUpperLowerLevels"), mDrawUpperLowerLevels);
+    settings.setValue(qsl("notUseDisplayScale"), mNotUseDisplayScale);
     settings.sync();
     switch (settings.status()) {
     case QSettings::NoError:

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -401,6 +401,7 @@ public:
     // How many graphemes do we need before we run the spell checker on a "word" in the command line:
     int mMinLengthForSpellCheck = 3;
     bool mDrawUpperLowerLevels = true;
+    bool mNotUseDisplayScale = false;
     bool mShowTabConnectionIndicators = true; // Global preference for showing connection status indicators on tabs
 
     qreal blinkPulseOpacity(bool isFastBlink) const;


### PR DESCRIPTION
Add an option (notUseDisplayScale, default is false) in Mudlet.ini to let user choose whether use display scale in Windows

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add an option (notUseDisplayScale, default is false) in Mudlet.ini to let user choose whether use display scale in Windows

#### Motivation for adding to Mudlet
Mudlet 4.19 was compiled by QT5, which by default not use display scale in Windows.
After upgraded to 4.20, it forces to use the display scale. This caused the display issues of the Widgets developed in 4.19

#### Other info (issues closed, discussion etc)
