### PR TITLE
add: Mudlet.ini option to control high DPI scale factor rounding policy

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -190,7 +190,7 @@ static void applyHighDpiRoundingPolicyFromConfig(int argc, char* argv[])
     const QString markerExecDir = qsl("%1/portable.txt").arg(execDir);
     const QString markerHomeDir = qsl("%1/portable.txt").arg(confDirDefault);
 
-    if (QFileInfo::exists(markerExecDir)) {
+    if (QFileInfo(markerExecDir).isFile()) {
         QFile file(markerExecDir);
         QString portPath;
         if (file.open(QIODevice::ReadOnly)) {
@@ -200,7 +200,7 @@ static void applyHighDpiRoundingPolicyFromConfig(int argc, char* argv[])
             portPath = qsl("./portable");
         }
         confPath = utils::pathResolveRelative(QDir::cleanPath(portPath), execDir);
-    } else if (QFileInfo::exists(markerHomeDir)) {
+    } else if (QFileInfo(markerHomeDir).isFile()) {
         QFile file(markerHomeDir);
         QString portPath;
         if (file.open(QIODevice::ReadOnly)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,6 +44,11 @@
 #include "TAccessibleTextEdit.h"
 #include "FileOpenHandler.h"
 #include "SentryWrapper.h"
+#include "utils.h"
+#include <QFileInfo>
+#include <QGuiApplication>
+#include <QProcessEnvironment>
+#include <QTextStream>
 
 #if defined(Q_OS_WINDOWS) && defined(INCLUDE_UPDATER)
 #include <windows.h>
@@ -158,6 +163,87 @@ void msys2QtMessageHandler(QtMsgType type, const QMessageLogContext& context, co
 }
 #endif
 
+#if !defined(Q_OS_MACOS)
+// Reads highDpiScaleFactorRoundingPolicy from Mudlet.ini before QApplication
+// creation, since Qt requires this to be set before the application is constructed.
+// Replicates setupConfig() config path detection using argv[0] instead of
+// QCoreApplication::applicationDirPath() which isn't available yet.
+static void applyHighDpiRoundingPolicyFromConfig(int argc, char* argv[])
+{
+    if (!qEnvironmentVariableIsEmpty("QT_SCALE_FACTOR_ROUNDING_POLICY")) {
+        return;
+    }
+
+    QString execDir;
+    const QProcessEnvironment sysEnv = QProcessEnvironment::systemEnvironment();
+    if (sysEnv.contains(qsl("APPIMAGE"))) {
+        execDir = QFileInfo(sysEnv.value(qsl("APPIMAGE"))).absolutePath();
+    } else if (argc > 0) {
+        execDir = QFileInfo(QString::fromLocal8Bit(argv[0])).absolutePath();
+    } else {
+        return;
+    }
+
+    const QString confDirDefault = qsl("%1/.config/mudlet").arg(QDir::homePath());
+    QString confPath;
+
+    const QString markerExecDir = qsl("%1/portable.txt").arg(execDir);
+    const QString markerHomeDir = qsl("%1/portable.txt").arg(confDirDefault);
+
+    if (QFileInfo::exists(markerExecDir)) {
+        QFile file(markerExecDir);
+        QString portPath;
+        if (file.open(QIODevice::ReadOnly)) {
+            QTextStream(&file).readLineInto(&portPath);
+        }
+        if (portPath.isEmpty()) {
+            portPath = qsl("./portable");
+        }
+        confPath = utils::pathResolveRelative(QDir::cleanPath(portPath), execDir);
+    } else if (QFileInfo::exists(markerHomeDir)) {
+        QFile file(markerHomeDir);
+        QString portPath;
+        if (file.open(QIODevice::ReadOnly)) {
+            QTextStream(&file).readLineInto(&portPath);
+        }
+        confPath = utils::pathResolveRelative(QDir::cleanPath(portPath), execDir);
+    } else {
+        confPath = confDirDefault;
+    }
+
+    if (confPath.isEmpty()) {
+        return;
+    }
+
+    const QString iniPath = qsl("%1/Mudlet.ini").arg(confPath);
+    if (!QFileInfo::exists(iniPath)) {
+        return;
+    }
+
+    const QSettings settings(iniPath, QSettings::IniFormat);
+    const QString value = settings.value(qsl("highDpiScaleFactorRoundingPolicy")).toString();
+    if (value.isEmpty()) {
+        return;
+    }
+
+    static const QMap<QString, Qt::HighDpiScaleFactorRoundingPolicy> policies = {
+            {qsl("round"), Qt::HighDpiScaleFactorRoundingPolicy::Round},
+            {qsl("ceil"), Qt::HighDpiScaleFactorRoundingPolicy::Ceil},
+            {qsl("floor"), Qt::HighDpiScaleFactorRoundingPolicy::Floor},
+            {qsl("roundpreferfloor"), Qt::HighDpiScaleFactorRoundingPolicy::RoundPreferFloor},
+            {qsl("passthrough"), Qt::HighDpiScaleFactorRoundingPolicy::PassThrough},
+    };
+
+    const auto it = policies.find(value.toLower());
+    if (it == policies.end()) {
+        qWarning().noquote() << qsl("main: ignoring invalid highDpiScaleFactorRoundingPolicy value in Mudlet.ini: \"%1\"").arg(value);
+        return;
+    }
+
+    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(it.value());
+}
+#endif // !defined(Q_OS_MACOS)
+
 int main(int argc, char* argv[])
 {
     initializeQRCResources();
@@ -202,6 +288,10 @@ int main(int argc, char* argv[])
             qInstallMessageHandler(msys2QtMessageHandler);
         }
     }
+#endif
+
+#if !defined(Q_OS_MACOS)
+    applyHighDpiRoundingPolicyFromConfig(argc, argv);
 #endif
 
 #if defined(Q_OS_MACOS)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2897,8 +2897,7 @@ void mudlet::readLateSettings(const QSettings& settings)
     // Prevent a lockout where both menu bar and toolbar are hidden, leaving
     // the user with no way to access settings on startup
     if (mMenuBarVisibility == enums::visibleNever && mToolbarVisibility == enums::visibleNever) {
-        qWarning() << "mudlet::readLateSettings() - both menu bar and toolbar were configured"
-                   << "to never show; correcting toolbar to visibleOnlyWithoutLoadedProfile"
+        qWarning() << "mudlet::readLateSettings() - both menu bar and toolbar were configured" << "to never show; correcting toolbar to visibleOnlyWithoutLoadedProfile"
                    << "to prevent lockout. Persisting correction now.";
         setToolBarVisibility(enums::visibleOnlyWithoutLoadedProfile);
         // Write only the corrected value — calling writeSettings() here would
@@ -2907,8 +2906,8 @@ void mudlet::readLateSettings(const QSettings& settings)
         correctionSettings.setValue("toolBarVisibility", static_cast<int>(mToolbarVisibility));
         correctionSettings.sync();
         if (correctionSettings.status() != QSettings::NoError) {
-            qWarning() << "mudlet::readLateSettings() - failed to persist toolbar lockout correction to disk."
-                       << "QSettings status:" << correctionSettings.status() << "File:" << correctionSettings.fileName();
+            qWarning() << "mudlet::readLateSettings() - failed to persist toolbar lockout correction to disk." << "QSettings status:" << correctionSettings.status()
+                       << "File:" << correctionSettings.fileName();
         }
     }
 
@@ -3131,6 +3130,11 @@ void mudlet::writeSettings()
     settings.setValue(qsl("enableMuteAPI"), mMuteAPI);
     settings.setValue(qsl("enableMuteGame"), mMuteGame);
     settings.setValue(qsl("drawUpperLowerLevels"), mDrawUpperLowerLevels);
+#if !defined(Q_OS_MACOS)
+    if (!settings.contains(qsl("highDpiScaleFactorRoundingPolicy"))) {
+        settings.setValue(qsl("highDpiScaleFactorRoundingPolicy"), qsl("PassThrough"));
+    }
+#endif
     settings.sync();
     switch (settings.status()) {
     case QSettings::NoError:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add `highDpiScaleFactorRoundingPolicy` setting in Mudlet.ini (read before QApplication creation) to control Qt's DPI scale factor rounding, defaulting to PassThrough (current behavior).

#### Motivation for adding to Mudlet
Qt6 changed the default DPI rounding from Round to PassThrough, causing widgets sized in 4.19 (Qt5) to appear larger on Windows with non-100% display scaling - this gives affected users a config-file fix without changing behavior for everyone else.

#### Other info (issues closed, discussion etc)
Related to #8652 and #9160. PR #9160 attempts the same fix but calls the API after QApplication creation, which Qt docs say is too late. This implementation follows the same pattern as Qt Creator: reading the setting before QApplication construction.

Valid values and their effect at common Windows scaling levels:
| Value | 125% (1.25x) | 150% (1.5x) | 175% (1.75x) |
|---|---|---|---|
| `PassThrough` (default) | 1.25x | 1.5x | 1.75x |
| `Round` | 1x | 2x | 2x |
| `RoundPreferFloor` | 1x | 1x | 2x |
| `Ceil` | 2x | 2x | 2x |
| `Floor` | 1x | 1x | 1x |

**Test case:** Add `highDpiScaleFactorRoundingPolicy=Round` to Mudlet.ini, restart Mudlet on Windows with 125% display scaling, verify widgets render at 100% scale (matching 4.19 behavior). Verify omitting the key preserves current behavior.