### PR TITLE
fix: package edit warning incorrectly showing for module items

### DIFF
--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -400,7 +400,7 @@ QString TAction::packageName(TAction* pAction) const
     }
 
     if (!pAction->mPackageName.isEmpty()) {
-        return !mpHost->mModuleInfo.contains(pAction->mPackageName) ? pAction->mPackageName : QString();
+        return !mpHost->mInstalledModules.contains(pAction->mPackageName) ? pAction->mPackageName : QString();
     }
 
     if (pAction->getParent()) {
@@ -417,7 +417,7 @@ QString TAction::moduleName(TAction* pAction) const
     }
 
     if (!pAction->mPackageName.isEmpty()) {
-        return mpHost->mModuleInfo.contains(pAction->mPackageName) ? pAction->mPackageName : QString();
+        return mpHost->mInstalledModules.contains(pAction->mPackageName) ? pAction->mPackageName : QString();
     }
 
     if (pAction->getParent()) {

--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -380,7 +380,7 @@ QString TAlias::packageName(TAlias* pAlias)
     }
 
     if (!pAlias->mPackageName.isEmpty()) {
-        return !mpHost->mModuleInfo.contains(pAlias->mPackageName) ? pAlias->mPackageName : QString();
+        return !mpHost->mInstalledModules.contains(pAlias->mPackageName) ? pAlias->mPackageName : QString();
     }
 
     if (pAlias->getParent()) {
@@ -397,7 +397,7 @@ QString TAlias::moduleName(TAlias* pAlias)
     }
 
     if (!pAlias->mPackageName.isEmpty()) {
-        return mpHost->mModuleInfo.contains(pAlias->mPackageName) ? pAlias->mPackageName : QString();
+        return mpHost->mInstalledModules.contains(pAlias->mPackageName) ? pAlias->mPackageName : QString();
     }
 
     if (pAlias->getParent()) {

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -227,7 +227,7 @@ QString TKey::packageName(TKey* pKey)
     }
 
     if (!pKey->mPackageName.isEmpty()) {
-        return !mpHost->mModuleInfo.contains(pKey->mPackageName) ? pKey->mPackageName : QString();
+        return !mpHost->mInstalledModules.contains(pKey->mPackageName) ? pKey->mPackageName : QString();
     }
 
     if (pKey->getParent()) {
@@ -244,7 +244,7 @@ QString TKey::moduleName(TKey* pKey)
     }
 
     if (!pKey->mPackageName.isEmpty()) {
-        return mpHost->mModuleInfo.contains(pKey->mPackageName) ? pKey->mPackageName : QString();
+        return mpHost->mInstalledModules.contains(pKey->mPackageName) ? pKey->mPackageName : QString();
     }
 
     if (pKey->getParent()) {

--- a/src/TScript.cpp
+++ b/src/TScript.cpp
@@ -184,7 +184,7 @@ QString TScript::packageName(TScript* pScript)
     }
 
     if (!pScript->mPackageName.isEmpty()) {
-        return !mpHost->mModuleInfo.contains(pScript->mPackageName) ? pScript->mPackageName : QString();
+        return !mpHost->mInstalledModules.contains(pScript->mPackageName) ? pScript->mPackageName : QString();
     }
 
     if (pScript->getParent()) {
@@ -201,7 +201,7 @@ QString TScript::moduleName(TScript* pScript)
     }
 
     if (!pScript->mPackageName.isEmpty()) {
-        return mpHost->mModuleInfo.contains(pScript->mPackageName) ? pScript->mPackageName : QString();
+        return mpHost->mInstalledModules.contains(pScript->mPackageName) ? pScript->mPackageName : QString();
     }
 
     if (pScript->getParent()) {

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -392,7 +392,7 @@ QString TTimer::packageName(TTimer* pTimer)
     }
 
     if (!pTimer->mPackageName.isEmpty()) {
-        return !mpHost->mModuleInfo.contains(pTimer->mPackageName) ? pTimer->mPackageName : QString();
+        return !mpHost->mInstalledModules.contains(pTimer->mPackageName) ? pTimer->mPackageName : QString();
     }
 
     if (pTimer->getParent()) {
@@ -409,7 +409,7 @@ QString TTimer::moduleName(TTimer* pTimer)
     }
 
     if (!pTimer->mPackageName.isEmpty()) {
-        return mpHost->mModuleInfo.contains(pTimer->mPackageName) ? pTimer->mPackageName : QString();
+        return mpHost->mInstalledModules.contains(pTimer->mPackageName) ? pTimer->mPackageName : QString();
     }
 
     if (pTimer->getParent()) {

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -1474,7 +1474,7 @@ QString TTrigger::packageName(TTrigger* pTrigger)
     }
 
     if (!pTrigger->mPackageName.isEmpty()) {
-        return !mpHost->mModuleInfo.contains(pTrigger->mPackageName) ? pTrigger->mPackageName : QString();
+        return !mpHost->mInstalledModules.contains(pTrigger->mPackageName) ? pTrigger->mPackageName : QString();
     }
 
     if (pTrigger->getParent()) {
@@ -1491,7 +1491,7 @@ QString TTrigger::moduleName(TTrigger* pTrigger)
     }
 
     if (!pTrigger->mPackageName.isEmpty()) {
-        return mpHost->mModuleInfo.contains(pTrigger->mPackageName) ? pTrigger->mPackageName : QString();
+        return mpHost->mInstalledModules.contains(pTrigger->mPackageName) ? pTrigger->mPackageName : QString();
     }
 
     if (pTrigger->getParent()) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Use `mInstalledModules` instead of `mModuleInfo` to distinguish modules from packages in `packageName()`/`moduleName()` across all 6 item types, since `mModuleInfo` is only populated for modules with a `config.lua` that sets `mpackage`.

#### Motivation for adding to Mudlet
Modules were incorrectly showing the "This item is part of a package" warning when clicking on their items in the editor.

#### Other info (issues closed, discussion etc)
Root cause traced back to PR #7411 - the PR review had suggested using `mInstalledModules` but `mModuleInfo` was used instead, which is only populated for modules that have a `config.lua` with `mpackage` set.

**Test case:** Install a module (especially a plain XML one without config.lua), click on one of its items in the script editor - the package warning banner should no longer appear.