### PR TITLE
Fix: add missing statuses:write permission to DangerJS workflow

### DIFF
--- a/.github/workflows/dangerjs.yml
+++ b/.github/workflows/dangerjs.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  statuses: write
 
 concurrency:
   group: ${{github.workflow}}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add `statuses: write` to the DangerJS workflow permissions block so DangerJS can set commit status checks.

#### Motivation for adding to Mudlet
#9143 added an explicit `permissions` block to lock down the GITHUB_TOKEN, but this caused all unlisted permissions to default to `none`. DangerJS uses the Commit Statuses API to set its pass/fail check, so without `statuses: write` the "Danger" status stays permanently pending.

#### Other info (issues closed, discussion etc)
Reported by SlySven in https://github.com/Mudlet/Mudlet/pull/9066#issuecomment-4211444054