### PR TITLE
infra: fix Windows and macOS nightly build failures

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -826,6 +826,7 @@ if(APPLE)
       add_custom_command(TARGET ${EXE_MUDLET_TARGET} POST_BUILD
         COMMAND bash -c
           "/usr/libexec/PlistBuddy -c 'Delete :SUFeedURL' '$<TARGET_BUNDLE_DIR:${EXE_MUDLET_TARGET}>/Contents/Info.plist' 2>/dev/null || true && /usr/libexec/PlistBuddy -c 'Add :SUFeedURL string ${SPARKLE_FEED_URL}' '$<TARGET_BUNDLE_DIR:${EXE_MUDLET_TARGET}>/Contents/Info.plist'"
+        VERBATIM
         COMMENT "Setting Sparkle feed URL for ${SPARKLE_CHANNEL}-${CMAKE_SYSTEM_PROCESSOR}"
       )
     endif()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,8 +43,9 @@
 #include <memory>
 #include <vector>
 
-#if defined(Q_OS_LINUX)
 #include <QStandardPaths>
+
+#if defined(Q_OS_LINUX)
 #include <QFile>
 #include <QTextStream>
 #include <QProcess>
@@ -735,7 +736,8 @@ int main(int argc, char* argv[])
     QSettings* appSettings = mudlet::getQSettings();
     bool shouldRegisterTelnet = false;
 
-    bool headlessMode = qEnvironmentVariableIsSet("CI") || qEnvironmentVariableIsSet("GITHUB_ACTIONS") || QCoreApplication::arguments().contains("--profile") || QCoreApplication::arguments().contains("--mirror");
+    bool headlessMode =
+            qEnvironmentVariableIsSet("CI") || qEnvironmentVariableIsSet("GITHUB_ACTIONS") || QCoreApplication::arguments().contains("--profile") || QCoreApplication::arguments().contains("--mirror");
 
     bool forceAsk = false;
 #if defined(Q_OS_MACOS)
@@ -930,7 +932,6 @@ int main(int argc, char* argv[])
         }
 #endif
     }
-
 
 
     // Pass ownership of MudletInstanceCoordinator to mudlet.


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Move `#include <QStandardPaths>` outside the `Q_OS_LINUX` guard so it's available for the Windows `runUpdate()` code, and add `VERBATIM` to the PlistBuddy `add_custom_command` to fix Ninja quoting on macOS.

#### Motivation for adding to Mudlet
Bugfix - nightly CI builds on Windows and macOS are broken since #9125.

#### Other info (issues closed, discussion etc)
Windows: removing dblsqd in #9125 dropped the transitive `<QtCore>` include that provided `QStandardPaths`.
macOS: without `VERBATIM`, Ninja mangles the `bash -c` argument quoting for the Sparkle feed URL step.

**Test case:** CI builds pass on Windows and macOS.