### PR TITLE
infrastructure: skip duplicate PTB builds when no new commits exist

### DIFF
--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -180,21 +180,13 @@ else
   # Check if it's a Public Test Build
   if [[ "${GITHUB_SCHEDULED_BUILD}" == "true" ]]; then
 
-    # Skip commit check if this is a manually forced build
+    # Skip duplicate check if this is a manually forced build
     if [[ "${GITHUB_FORCE_BUILD}" == "true" ]]; then
-      echo "=== Forced build requested, skipping commit date check ==="
-    else
-      # Get the commit date of the last commit
-      COMMIT_DATE=$(git show -s --format="%cs")
-      # Get yesterday's date in the same format
-      YESTERDAY_DATE=$(date --date="yesterday" +%Y-%m-%d)
-
-      if [[ "${COMMIT_DATE}" < "${YESTERDAY_DATE}" ]]; then
-        echo "=== No new commits, aborting public test build generation ==="
-        exit 0
-      else
-        echo "=== New commits, continuing to create a public test build ==="
-      fi
+      echo "=== Forced build requested, skipping duplicate PTB check ==="
+    elif gh release list --repo "${GITHUB_REPOSITORY}" --limit 20 --json tagName \
+            --jq '.[].tagName' 2>/dev/null | grep -qF -- "${BUILD_COMMIT}"; then
+      echo "=== PTB already exists for commit ${BUILD_COMMIT}, aborting public test build generation ==="
+      exit 0
     fi
 
     # Squirrel uses the name of the binary for the Start menu, so need to rename

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -21,7 +21,8 @@
 
 set -x
 
-# Version: 2.4.0    Switch from MINGW64 to CLANG64
+# Version: 2.5.0    Replace date-based PTB skip with commit-hash check against GitHub releases
+#          2.4.0    Switch from MINGW64 to CLANG64
 #          2.3.0    Add build counter suffix for multiple builds from same commit
 #          2.2.0    Skip commit date check when build is manually forced
 #          2.1.0    Remove MINGW32 since upstream no longer supports it

--- a/CI/linux.after_success.sh
+++ b/CI/linux.after_success.sh
@@ -39,8 +39,6 @@ then
 #  fi
 
   # We refer to $BUILD_COMMIT in the environment to get the commit data now
-  COMMIT_DATE=$(git show -s --format="%cs" | tr -d '-')
-  YESTERDAY_DATE=$(date -d "yesterday" '+%F' | tr -d '-')
 
   git clone https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
 
@@ -73,11 +71,12 @@ then
   else # ptb/release build
     if [ "${public_test_build}" == "true" ]; then
 
-      # Skip commit check if this is a manually forced build
+      # Skip duplicate check if this is a manually forced build
       if [[ "${GITHUB_FORCE_BUILD}" == "true" ]]; then
-        echo "== Forced build requested, skipping commit date check =="
-      elif [[ "${COMMIT_DATE}" -lt "${YESTERDAY_DATE}" ]]; then
-        echo "== No new commits, aborting public test build generation =="
+        echo "== Forced build requested, skipping duplicate PTB check =="
+      elif gh release list --repo "${GITHUB_REPOSITORY}" --limit 20 --json tagName \
+              --jq '.[].tagName' 2>/dev/null | grep -qF -- "${BUILD_COMMIT}"; then
+        echo "== PTB already exists for commit ${BUILD_COMMIT}, aborting public test build generation =="
         exit 0
       fi
 

--- a/CI/osx.after_success.sh
+++ b/CI/osx.after_success.sh
@@ -45,10 +45,6 @@ fi
 
 if [ "${DEPLOY}" = "deploy" ]; then
 
-  # get commit date now before we check out an change into another git repository
-  COMMIT_DATE=$(git show -s --pretty="tformat:%cI" | cut -d'T' -f1 | tr -d '-')
-  YESTERDAY_DATE=$(date -v-1d '+%F' | tr -d '-')
-
   git clone https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
 
   cd "${BUILD_DIR}/../installers/osx"
@@ -96,11 +92,12 @@ if [ "${DEPLOY}" = "deploy" ]; then
     app="${BUILD_DIR}/build/mudlet.app"
     if [ "${public_test_build}" == "true" ]; then
 
-      # Skip commit check if this is a manually forced build
+      # Skip duplicate check if this is a manually forced build
       if [[ "${GITHUB_FORCE_BUILD}" == "true" ]]; then
-        echo "== Forced build requested, skipping commit date check =="
-      elif [[ "${COMMIT_DATE}" -lt "${YESTERDAY_DATE}" ]]; then
-        echo "== No new commits, aborting public test build generation =="
+        echo "== Forced build requested, skipping duplicate PTB check =="
+      elif gh release list --repo "${GITHUB_REPOSITORY}" --limit 20 --json tagName \
+              --jq '.[].tagName' 2>/dev/null | grep -qF -- "${BUILD_COMMIT}"; then
+        echo "== PTB already exists for commit ${BUILD_COMMIT}, aborting public test build generation =="
         exit 0
       fi
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Replace date-based PTB skip logic with a check against existing GitHub releases
- If a release tag already contains the current commit hash, skip packaging
- Forced builds (`workflow_dispatch`) bypass the check as before

#### Motivation for adding to Mudlet
The old date comparison had an off-by-one that allowed duplicate PTBs on consecutive days with no new commits (e.g. [April 9](https://github.com/Mudlet/Mudlet/releases/tag/Mudlet-4.20.1-ptb-2026-04-09-f52d9867) and [April 10](https://github.com/Mudlet/Mudlet/releases/tag/Mudlet-4.20.1-ptb-2026-04-10-f52d9867) both built `f52d9867`).

#### Other info (issues closed, discussion etc)
https://github.com/Mudlet/Mudlet/releases/tag/Mudlet-4.20.1-ptb-2026-04-10-f52d9867 was empty