### PR TITLE
fix: changelog rendering in PTB update dialog

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -297,13 +297,6 @@ jobs:
             fi
           fi
 
-          # Prepend a note for PTB changelogs so readers know the scope
-          if [[ "${RELEASE_TYPE}" == "ptb" && -n "${STABLE_TAG}" ]]; then
-            RELEASE_VERSION="${STABLE_TAG#Mudlet-}"
-            { echo "Changes since ${RELEASE_VERSION}:"; echo; cat changelog.md; } > changelog.tmp
-            mv changelog.tmp changelog.md
-          fi
-
           echo "Changelog preview:"
           head -20 changelog.md
 

--- a/CI/generate-changelog.lua
+++ b/CI/generate-changelog.lua
@@ -72,7 +72,6 @@ local mdBuilder = {
     local t = {}
     text = text.."\n"
     for s in string.gmatch(text, "(.-)\n") do
-      s = escape_for_html(s)
       s = s:gsub("%(#(.-)%)", "[#%1](https://github.com/Mudlet/Mudlet/pull/%1)")
       s = link_functions_md(s)
       t[#t+1] = string.format("\\%s\n", s)
@@ -244,7 +243,7 @@ function print_sorted_changelog(changelog)
     elseif line:match(autoPattern) then --"(autocommit)" to catch bot PRs which may not start with "infra"
       trimmedLine = prefix .. line:match(autoPattern)
       infra[#infra+1] = trimmedLine
-    else
+    elseif line:trim() ~= "" then
       other[#other+1] = prefix .. line
     end
   end

--- a/src/updater/UpdateDialog.cpp
+++ b/src/updater/UpdateDialog.cpp
@@ -543,11 +543,14 @@ QString UpdateDialog::generateChangelogDocument()
             }
         }
     }
+    static const QRegularExpression summaryTag(qsl("<details>\\s*<summary>(.*?)</summary>"));
     for (const auto& release : changelogReleases) {
+        if (!changelog.isEmpty()) {
+            changelog.append(qsl("---\n\n"));
+        }
         QString body = release.getChangelog();
         // Convert <details>/<summary> to plain markdown - Qt's markdown
         // renderer can't handle these HTML5 tags, causing garbled output
-        static const QRegularExpression summaryTag(qsl("<details>\\s*<summary>(.*?)</summary>"));
         body.replace(summaryTag, qsl("#### \\1"));
         body.remove(qsl("</details>"));
 

--- a/src/updater/UpdateDialog.cpp
+++ b/src/updater/UpdateDialog.cpp
@@ -33,6 +33,7 @@
 #include <QGuiApplication>
 #include <QMessageBox>
 #include <QPixmap>
+#include <QRegularExpression>
 #include <QSettings>
 #include <QTextBrowser>
 #include <QToolButton>
@@ -543,8 +544,14 @@ QString UpdateDialog::generateChangelogDocument()
         }
     }
     for (const auto& release : changelogReleases) {
-        changelog.append(qsl("## ") + release.getVersion() + qsl("\n\n"));
-        changelog.append(release.getChangelog() + qsl("\n\n"));
+        QString body = release.getChangelog();
+        // Convert <details>/<summary> to plain markdown - Qt's markdown
+        // renderer can't handle these HTML5 tags, causing garbled output
+        static const QRegularExpression summaryTag(qsl("<details>\\s*<summary>(.*?)</summary>"));
+        body.replace(summaryTag, qsl("#### \\1"));
+        body.remove(qsl("</details>"));
+
+        changelog.append(body + qsl("\n\n"));
     }
     return changelog;
 }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fix the in-app PTB changelog dialog which was showing garbled text (random commit hashes, file paths, broken formatting) by converting unsupported `<details>` HTML to plain markdown and fixing several changelog generation bugs.

#### Motivation for adding to Mudlet
The PTB changelog was unreadable for users - Qt's markdown renderer can't handle `<details>/<summary>` HTML tags, causing backtick content to leak out as random strings. Additionally, the markdown changelog builder was incorrectly HTML-escaping text, and empty changelog sections appeared when consecutive PTBs had no changes.

#### Other info (issues closed, discussion etc)