### PR TITLE
Fix: increase TelnetTextDisplayedTest timeouts for CI

### DIFF
--- a/test/functional_tests/TelnetTextDisplayedTest.cpp
+++ b/test/functional_tests/TelnetTextDisplayedTest.cpp
@@ -101,7 +101,7 @@ private slots:
         });
 
         QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
-        if (!spy.wait(1000)) {
+        if (!spy.wait(5000)) {
             QFAIL("Profile took too long to load.");
         }
         auto host = mudlet::self()->getActiveHost();
@@ -110,7 +110,7 @@ private slots:
         }
 
         QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
-        if (!spy2.wait(500)) {
+        if (!spy2.wait(2000)) {
             QFAIL("Could not connect with the host.");
         }
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Increased test timeouts in TelnetTextDisplayedTest - profile load from 1s to 5s, telnet connect from 500ms to 2s.

#### Motivation for adding to Mudlet
CI runners are slower than local machines, causing the test to consistently time out and segfault (the QPointer access after timeout triggers a crash). This was blocking PR #9169 and likely other PRs touching the same CI jobs.

#### Other info (issues closed, discussion etc)
Fixes flaky TelnetTextDisplayedTest failures seen across all CI platforms (Linux, macOS, Windows).

Ideally the root cause (crash on timeout) would be fixed, but since the cost here is just a few extra seconds of wait time, increasing the timeouts is a proportionate fix.