### PR TITLE
fix: prevent update download from being canceled when checking for updates

### DIFF
--- a/src/updater/Feed.cpp
+++ b/src/updater/Feed.cpp
@@ -110,6 +110,11 @@ bool Feed::isReady() const
     return mReady;
 }
 
+bool Feed::isDownloading() const
+{
+    return mDownloadReply != nullptr && !mDownloadReply->isFinished();
+}
+
 void Feed::load()
 {
     if (mFeedReply != nullptr) {
@@ -136,6 +141,11 @@ void Feed::load()
 
 void Feed::downloadRelease(const Release& release, bool requireChecksums)
 {
+    if (isDownloading()) {
+        qWarning() << "Download already in progress, ignoring duplicate request";
+        return;
+    }
+
     const QUrl downloadUrl = release.getDownloadUrl();
     if (!downloadUrl.isValid() || downloadUrl.isEmpty()) {
         //: Error shown when the GitHub release has no binary matching the user's operating system

--- a/src/updater/Feed.h
+++ b/src/updater/Feed.h
@@ -52,6 +52,7 @@ public:
     QList<Release> getReleases() const;
     QString getDownloadFilePath() const;
     bool isReady() const;
+    bool isDownloading() const;
 
 signals:
     void ready();

--- a/src/updater/UpdateDialog.cpp
+++ b/src/updater/UpdateDialog.cpp
@@ -610,7 +610,7 @@ void UpdateDialog::handleFeedReady()
     QString latestVersion = mLatestRelease.getVersion();
     bool skipRelease = (settingsValue(qsl("skipRelease"), "", mSettings).toString() == latestVersion);
     bool autoDownload = autoDownloadEnabled(mSettings) && (!skipRelease);
-    if (autoDownload && !mIsDownloadFinished) {
+    if (autoDownload && !mIsDownloadFinished && !mFeed->isDownloading()) {
         startDownload();
     }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Guard against duplicate download requests so that manually checking for updates while an auto-download is in progress no longer aborts the existing download.

#### Motivation for adding to Mudlet
Manually checking for updates while an auto-download was in progress would re-trigger the download, aborting the existing one with "Operation canceled".

#### Other info (issues closed, discussion etc)
**Test case:** Enable auto-download, let it start downloading an update, then manually check for updates - the download should continue without being canceled.