### PR TITLE
Fix: unify and translate some Map Errors

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4430,7 +4430,7 @@ void T2DMap::slot_setArea()
                 mpMap->postMessage(tr("[ ERROR ] - Unable to add \"%1\" as an area to the map.\n"
                                       "See the \"[MAP ERROR:]\" message for the reason.",
                                       // Intentional separator between argument
-                                      "The '[MAP ERROR:]' text should be the same as that used for the translation of \"[MAP ERROR:]%1\n\" in the 'TMAP::logerror(...)' function.")
+                                      "The '[MAP ERROR:]' text here should be the same as that used for the translation of \"[MAP ERROR:] %1\" in the 'TMap::logError(...)' function.")
                                            .arg(newAreaName));
                 return;
             }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -154,7 +154,7 @@ void TMap::mapClear()
 void TMap::logError(const QString& msg)
 {
     if (mpHost->mpEditorDialog) {
-        /*:Used to print a map error in the Errors console in the Editor, %1 is the
+        /*: Used to print a map error in the Errors console in the Editor, %1 is the
  message text and a line-feed is also appended.*/
         mpHost->mpEditorDialog->mpErrorConsole->print(tr("[MAP ERROR:] %1")
                                                               .arg(msg)

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -150,10 +150,17 @@ void TMap::mapClear()
     }
 }
 
-void TMap::logError(QString& msg)
+// The supplied message should contain a localised message and no "WARNING:" or other prefixes:
+void TMap::logError(const QString& msg)
 {
     if (mpHost->mpEditorDialog) {
-        mpHost->mpEditorDialog->mpErrorConsole->print(qsl("%1\n").arg(tr("[MAP ERROR:]%1").arg(msg)), QColor(255, 128, 0), QColor(Qt::black));
+        /*:Used to print a map error in the Errors console in the Editor, %1 is the
+ message text and a line-feed is also appended.*/
+        mpHost->mpEditorDialog->mpErrorConsole->print(tr("[MAP ERROR:] %1")
+                                                              .arg(msg)
+                                                              .append(QChar::LineFeed),
+                                                      QColor(255, 128, 0),
+                                                      QColor(Qt::black));
     }
 }
 
@@ -176,8 +183,8 @@ bool TMap::setRoomArea(int id, int area, bool deferAreaRecalculations)
 {
     TRoom* pR = mpRoomDB->getRoom(id);
     if (!pR) {
-        QString msg = tr("RoomID=%1 does not exist, can not set AreaID=%2 for non-existing room!").arg(id).arg(area);
-        logError(msg);
+        logError(tr("Can not set room with RoomID %1 to AreaID %2. Room does not exist!")
+                         .arg(QString::number(id), QString::number(area)));
         return false;
     }
 
@@ -187,8 +194,8 @@ bool TMap::setRoomArea(int id, int area, bool deferAreaRecalculations)
         // to see if it exists as a name only:
         if (!mpRoomDB->getAreaNamesMap().contains(area)) {
             // Ah, no it doesn't so moan:
-            QString msg = tr("AreaID=%2 does not exist, can not set RoomID=%1 to non-existing area!").arg(id).arg(area);
-            logError(msg);
+            logError(tr("Can not set room with RoomID %1 to AreaID %2. Area does not exist!")
+                             .arg(QString::number(id), QString::number(area)));
             return false;
         }
         // If got to this point then there is NOT a TArea instance for the given

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -115,7 +115,7 @@ public:
     bool setRoomArea(int id, int area, bool deferAreaRecalculations = false);
     void deleteArea(int id);
     int createNewRoomID(int minimumId = 1);
-    void logError(QString& msg);
+    void logError(const QString&);
     bool setExit(int from, int to, int dir);
     bool setRoomCoordinates(int id, int x, int y, int z);
     void updateArea(int areaId);

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -237,11 +237,16 @@ void TRoom::setExitStub(int direction, bool status)
                 exitStubs.append(direction);
             }
         } else {
-            QString error = QString("Set exit stub in given direction in RoomID(%1) - there is already an exit there!").arg(id);
-            mpRoomDB->mpMap->logError(error);
+            mpRoomDB->mpMap->logError(tr("Cannot set exit stub in given direction in RoomID %1. There is already an exit there!")
+                                              .arg(QString::number(id)));
+            // Since there is no change don't proceed to mark map as needing saving
+            return;
         }
     } else {
-        exitStubs.removeAll(direction);
+        if (!exitStubs.removeAll(direction)) {
+            // Since there is no change don't proceed to mark map as needing saving
+            return;
+        }
     }
     mpRoomDB->mpMap->setUnsaved(__func__);
 }
@@ -351,8 +356,8 @@ bool TRoom::setArea(int areaID, bool deferAreaRecalculations)
         mpRoomDB->addArea(areaID);
         pA = mpRoomDB->getArea(areaID);
         if (!pA) { // Oh dear, THAT didn't work
-            QString error = qApp->translate("TRoom", "No area created!  Requested area ID=%1. Note: Area IDs must be > 0").arg(areaID);
-            mpRoomDB->mpMap->logError(error);
+            mpRoomDB->mpMap->logError(tr("Requested AreaID %1 did not exist and could not be created. Note: Area numbers must be greater than zero!")
+                                              .arg(QString::number(areaID)));
             return false;
         }
     }
@@ -373,8 +378,9 @@ bool TRoom::setArea(int areaID, bool deferAreaRecalculations)
         // wrong on last room in a series
         pA2->mIsDirty = true;
     } else {
-        QString error = qApp->translate("TRoom", "Warning: When setting the Area for Room (Id: %1) it did not have a current area!").arg(id);
-        mpRoomDB->mpMap->logError(error);
+        //: Although this is reported as an error it is not a problem
+        mpRoomDB->mpMap->logError(tr("When setting the Area for RoomID %1 it did not have a current area, this is unexpected but not a problem!")
+                                          .arg(QString::number(id)));
     }
 
     area = areaID;

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -93,8 +93,8 @@ bool TRoomDB::addRoom(int id)
         return true;
     }
     if (id <= 0) {
-        QString error = qsl("addRoom: illegal room id=%1. roomID must be > 0").arg(id);
-        mpMap->logError(error);
+        mpMap->logError(tr("Room not created. RoomID %1 is not allowed as room numbers must be greater than zero!")
+                                .arg(QString::number(id)));
     }
     return false;
 }
@@ -540,11 +540,11 @@ bool TRoomDB::addArea(int id)
             areaNamesMap.insert(id, newAreaName);
         }
         return true;
-    } else {
-        QString error = tr("Area with ID %1 already exists!").arg(id);
-        mpMap->logError(error);
-        return false;
     }
+
+    mpMap->logError(tr("Area not added. An area with AreaID %1 already exists!")
+                            .arg(QString::number(id)));
+    return false;
 }
 
 int TRoomDB::createNewAreaID()
@@ -560,12 +560,11 @@ int TRoomDB::addArea(QString name)
 {
     // reject it if area name already exists or is empty
     if (name.isEmpty()) {
-        QString error = tr("An Unnamed Area is (no longer) permitted!");
-        mpMap->logError(error);
+        mpMap->logError(tr("Area not added. An unnamed area (empty area name) is (no longer) permitted!"));
         return 0;
-    } else if (areaNamesMap.values().contains(name)) {
-        QString error = tr("An area called %1 already exists!").arg(name);
-        mpMap->logError(error);
+    }
+    if (areaNamesMap.values().contains(name)) {
+        mpMap->logError(tr("Area not added. An area called \"%1\" already exists!").arg(name));
         return 0;
     }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Revise the text of some map related error messages that get shown in the Editor's error window. Including marking one of them for translation when it wasn't before. Also make translatable the `"[MAP ERROR:] "` text prepended to such texts and put in a space that was missing in the Engineering English for that.

#### Motivation for adding to Mudlet
Better constructed (and more localised) map error messages.

#### Other info (issues closed, discussion etc)
`(void) TMap::logError(const QString& msg)` uses the `TConsole::print(const QString&, const QColor, const QColor)` method to put error messages into the "Errors" window in the editor and that is also used in other places to insert other messages however many of them are constructed from fragments of text in different colours such that some parts are NOT put through the translation system but others are - and that isn't even consistent for different messages in the same form. Whilst it might look colourful and pretty - it makes things virtually impossible to translate them properly IMHO.

IIRC it is considered that text to be translated should not be broken up into anything less than whole sentences.
