### PR TITLE
Infrastructure: fix Windows SHA256 missing from PTB releases

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -229,9 +229,7 @@ jobs:
       - name: Assemble SHA256SUMS.txt
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
         run: |
-          shopt -s nullglob
-          SHA_FILES=(assets/*/*.sha256)
-          shopt -u nullglob
+          mapfile -t SHA_FILES < <(find assets/ -name '*.sha256' -type f)
 
           if [[ ${#SHA_FILES[@]} -eq 0 ]]; then
             echo "::error::No .sha256 checksum files found in assets/"


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
fix Windows SHA256 missing from PTB releases
#### Motivation for adding to Mudlet
necessary for updates' download to have validated integrity
#### Other info (issues closed, discussion etc)
download-artifact@v8 doesn't create a subdirectory when only one artifact matches the pattern. The Windows build produces a single release-asset-* artifact, so its files end up flat in assets/ instead of assets/release-asset-Windows-X64/. The glob assets/*/*.sha256 missed it. Use find instead, matching the pattern already used elsewhere in the workflow.