### PR TITLE
infrastructure: fix partial PTB releases not triggering when push build exists at same SHA

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -46,6 +46,7 @@ jobs:
                 workflow_id: filename,
                 head_sha: sha,
                 status: 'success',
+                event: triggeringRun.event,
                 per_page: 1
               });
               if (data.total_count === 0) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add `event` filter to the workflow run query in `create-github-release.yml` so scheduled PTB builds only match other scheduled builds, not push builds at the same SHA

#### Motivation for adding to Mudlet
When a push build and a scheduled build exist at the same commit, the release workflow could find the push build (which has no release metadata) instead of the failed scheduled build, silently skipping the release and preventing the partial-PTB logic from #9163 from ever kicking in.

#### Other info (issues closed, discussion etc)
On 2026-04-15 no PTB was created despite only macOS failing a flaky test - the Windows and Linux builds succeeded but no release was made because the platform check matched a push build from #9191 instead of the failed scheduled build.

**Test case:** Next scheduled PTB build where one platform fails should still create a partial release with the successful platforms' assets.