### PR TITLE
infrastructure: fix flaky TelnetTextDisplayedTest in CI

### DIFF
--- a/test/functional_tests/TelnetTextDisplayedTest.cpp
+++ b/test/functional_tests/TelnetTextDisplayedTest.cpp
@@ -32,131 +32,131 @@ extern void qInitResources_mudlet_fonts_common();
 extern void qInitResources_mudlet_fonts_posix();
 void initializeQRCResources();
 
-class TelnetTextDisplayedTest : public QObject {
-  Q_OBJECT
+class TelnetTextDisplayedTest : public QObject
+{
+    Q_OBJECT
 
 private:
-  TelnetServerStub *mpServer = nullptr;
-  const QString mpHostname = "Test-Telnet";
-  const QString mpPort = "4000";
-  const QString mpLocalhost = "localhost";
+    TelnetServerStub* mpServer = nullptr;
+    const QString mpHostname = "Test-Telnet";
+    const QString mpPort = "4000";
+    const QString mpLocalhost = "localhost";
 
 private slots:
-  void initTestCase() { initializeQRCResources(); }
+    void initTestCase() { initializeQRCResources(); }
 
-  void init() {
-    mpServer = new TelnetServerStub(qApp);
-    mpServer->start(mpLocalhost, mpPort.toUShort());
-    mudlet::start();
-    mudlet::self()->setupConfig();
-    mudlet::self()->takeOwnershipOfInstanceCoordinator(
-        std::make_unique<MudletInstanceCoordinator>(
-            "MudletInstanceCoordinator"));
-    mudlet::self()->init();
-    mudlet::self()->setStorePasswordsSecurely(false);
-    deleteProfileDirectory(mpHostname);
-  }
-
-  void test_TelnetTextDisplayed() {
-    QString messageFromTheMud(
-        "\x1B[1z<B>Greetings < hunters & sorcerers</B>\x1B[7z");
-    QString messageToExpect("Greetings < hunters & sorcerers");
-
-    mpServer->setWelcomeMessage(messageFromTheMud);
-    startProfile(mpHostname, mpLocalhost, mpPort);
-
-    QVERIFY2(waitForTextInBuffer(messageToExpect),
-             qPrintable(qsl("Expected text '%1' not found in console buffer")
-                            .arg(messageToExpect)));
-  }
-
-  void cleanup() {
-    delete mpServer;
-    mpServer = nullptr;
-    deleteProfileDirectory(mpHostname);
-    delete mudlet::self();
-  }
-
-  // Utility function to manually start a profile like a user would do via the
-  // GUI
-  void startProfile(const QString &hostname, const QString &address,
-                    const QString &port) {
-    QTimer::singleShot(0, qApp, [hostname, address, port]() {
-      mudlet::self()->startAutoLogin({});
-      QTest::qWait(100);
-      QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button,
-                        Qt::LeftButton);
-      QTest::qWait(100);
-      QTest::keyClicks(QApplication::focusWidget(), hostname);
-      QTest::qWait(100);
-      QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-      QTest::qWait(100);
-      QTest::keyClicks(QApplication::focusWidget(), address);
-      QTest::qWait(100);
-      QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-      QTest::qWait(100);
-      QTest::keyClicks(QApplication::focusWidget(), port);
-      QTest::qWait(100);
-      QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
-    });
-
-    QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
-    if (!spy.wait(5000)) {
-      QFAIL("Profile took too long to load.");
-    }
-    auto host = mudlet::self()->getActiveHost();
-    if (!host) {
-      QFAIL("No active host available for the test.");
+    void init()
+    {
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mpLocalhost, mpPort.toUShort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mpHostname);
     }
 
-    QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
-    if (!spy2.wait(2000)) {
-      QFAIL("Could not connect with the host.");
+    void test_TelnetTextDisplayed()
+    {
+        QString messageFromTheMud("\x1B[1z<B>Greetings < hunters & sorcerers</B>\x1B[7z");
+        QString messageToExpect("Greetings < hunters & sorcerers");
+
+        mpServer->setWelcomeMessage(messageFromTheMud);
+        startProfile(mpHostname, mpLocalhost, mpPort);
+
+        QVERIFY2(waitForTextInBuffer(messageToExpect), qPrintable(qsl("Expected text '%1' not found in console buffer").arg(messageToExpect)));
     }
-  }
 
-  // Polls the console buffer until the expected text appears on any line, with
-  // a timeout
-  bool waitForTextInBuffer(const QString &text, int timeoutMs = 5000) {
-    auto *console = mudlet::self()->getActiveHost()->mpConsole;
-    return QTest::qWaitFor(
-        [&]() {
-          for (int i = 0; i <= console->buffer.getLastLineNumber(); ++i) {
-            if (console->buffer.line(i) == text) {
-              return true;
-            }
-          }
-          return false;
-        },
-        timeoutMs);
-  }
-
-  // Utility function
-  void deleteProfileDirectory(const QString &profileName) {
-    const QString path =
-        mudlet::getMudletPath(enums::profileHomePath, profileName);
-    QDir dir(path);
-
-    if (!dir.exists()) {
-      qInfo() << "Profile directory does not exist:" << path;
-      return;
+    void cleanup()
+    {
+        delete mpServer;
+        mpServer = nullptr;
+        deleteProfileDirectory(mpHostname);
+        delete mudlet::self();
     }
-    dir.removeRecursively();
-  }
+
+    // Utility function to manually start a profile like a user would do via the
+    // GUI
+    void startProfile(const QString& hostname, const QString& address, const QString& port)
+    {
+        QTimer::singleShot(0, qApp, [hostname, address, port]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), hostname);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), address);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), port);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(5000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        auto host = mudlet::self()->getActiveHost();
+        if (!host) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(2000)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    // Polls the console buffer until the expected text appears on any line, with
+    // a timeout
+    bool waitForTextInBuffer(const QString& text, int timeoutMs = 5000)
+    {
+        auto console = mudlet::self()->getActiveHost()->mpConsole;
+        return QTest::qWaitFor(
+                [&]() {
+                    for (int i = 0; i <= console->buffer.getLastLineNumber(); ++i) {
+                        if (console->buffer.line(i) == text) {
+                            return true;
+                        }
+                    }
+                    return false;
+                },
+                timeoutMs);
+    }
+
+    // Utility function
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, profileName);
+        QDir dir(path);
+
+        if (!dir.exists()) {
+            qInfo() << "Profile directory does not exist:" << path;
+            return;
+        }
+        dir.removeRecursively();
+    }
 };
 
-void initializeQRCResources() {
+void initializeQRCResources()
+{
 #ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-  qInitResources_additional_splash_screens();
+    qInitResources_additional_splash_screens();
 #endif
 #ifdef INCLUDE_FONTS
-  qInitResources_mudlet_fonts_common();
+    qInitResources_mudlet_fonts_common();
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-  qInitResources_mudlet_fonts_posix();
+    qInitResources_mudlet_fonts_posix();
 #endif
 #endif
-  qInitResources_mudlet();
-  qInitResources_qm();
+    qInitResources_mudlet();
+    qInitResources_qm();
 }
 
 #include "TelnetTextDisplayedTest.moc"

--- a/test/functional_tests/TelnetTextDisplayedTest.cpp
+++ b/test/functional_tests/TelnetTextDisplayedTest.cpp
@@ -21,126 +21,142 @@
 #include <cstdlib>
 
 #include "TelnetServerStub.h"
-#include "mudlet.h"
 #include "ctelnet.h"
 #include "dlgConnectionProfiles.h"
+#include "mudlet.h"
 
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
 extern void qInitResources_additional_splash_screens();
 extern void qInitResources_mudlet_fonts_common();
 extern void qInitResources_mudlet_fonts_posix();
-void        initializeQRCResources();
+void initializeQRCResources();
 
 class TelnetTextDisplayedTest : public QObject {
-    Q_OBJECT
+  Q_OBJECT
 
 private:
-    TelnetServerStub* mpServer = nullptr;
-    const QString mpHostname = "Test-Telnet";
-    const QString mpPort = "4000";
-    const QString mpLocalhost = "localhost";
+  TelnetServerStub *mpServer = nullptr;
+  const QString mpHostname = "Test-Telnet";
+  const QString mpPort = "4000";
+  const QString mpLocalhost = "localhost";
 
 private slots:
-    void initTestCase()
-    {
-        initializeQRCResources();
+  void initTestCase() { initializeQRCResources(); }
+
+  void init() {
+    mpServer = new TelnetServerStub(qApp);
+    mpServer->start(mpLocalhost, mpPort.toUShort());
+    mudlet::start();
+    mudlet::self()->setupConfig();
+    mudlet::self()->takeOwnershipOfInstanceCoordinator(
+        std::make_unique<MudletInstanceCoordinator>(
+            "MudletInstanceCoordinator"));
+    mudlet::self()->init();
+    mudlet::self()->setStorePasswordsSecurely(false);
+    deleteProfileDirectory(mpHostname);
+  }
+
+  void test_TelnetTextDisplayed() {
+    QString messageFromTheMud(
+        "\x1B[1z<B>Greetings < hunters & sorcerers</B>\x1B[7z");
+    QString messageToExpect("Greetings < hunters & sorcerers");
+
+    mpServer->setWelcomeMessage(messageFromTheMud);
+    startProfile(mpHostname, mpLocalhost, mpPort);
+
+    QVERIFY2(waitForTextInBuffer(messageToExpect),
+             qPrintable(qsl("Expected text '%1' not found in console buffer")
+                            .arg(messageToExpect)));
+  }
+
+  void cleanup() {
+    delete mpServer;
+    mpServer = nullptr;
+    deleteProfileDirectory(mpHostname);
+    delete mudlet::self();
+  }
+
+  // Utility function to manually start a profile like a user would do via the
+  // GUI
+  void startProfile(const QString &hostname, const QString &address,
+                    const QString &port) {
+    QTimer::singleShot(0, qApp, [hostname, address, port]() {
+      mudlet::self()->startAutoLogin({});
+      QTest::qWait(100);
+      QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button,
+                        Qt::LeftButton);
+      QTest::qWait(100);
+      QTest::keyClicks(QApplication::focusWidget(), hostname);
+      QTest::qWait(100);
+      QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+      QTest::qWait(100);
+      QTest::keyClicks(QApplication::focusWidget(), address);
+      QTest::qWait(100);
+      QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+      QTest::qWait(100);
+      QTest::keyClicks(QApplication::focusWidget(), port);
+      QTest::qWait(100);
+      QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+    });
+
+    QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+    if (!spy.wait(5000)) {
+      QFAIL("Profile took too long to load.");
+    }
+    auto host = mudlet::self()->getActiveHost();
+    if (!host) {
+      QFAIL("No active host available for the test.");
     }
 
-    void init()
-    {
-        mpServer = new TelnetServerStub(qApp);
-        mpServer->start(mpLocalhost, mpPort.toUShort());
-        mudlet::start();
-        mudlet::self()->setupConfig();
-        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
-        mudlet::self()->init();
-        mudlet::self()->setStorePasswordsSecurely(false);
-        deleteProfileDirectory(mpHostname);
+    QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
+    if (!spy2.wait(2000)) {
+      QFAIL("Could not connect with the host.");
     }
+  }
 
-    void test_TelnetTextDisplayed()
-    {
-        QString messageFromTheMud("\x1B[1z<B>Greetings < hunters & sorcerers</B>\x1B[7z");
-        QString messageToExpect("Greetings < hunters & sorcerers");
+  // Polls the console buffer until the expected text appears on any line, with
+  // a timeout
+  bool waitForTextInBuffer(const QString &text, int timeoutMs = 5000) {
+    auto *console = mudlet::self()->getActiveHost()->mpConsole;
+    return QTest::qWaitFor(
+        [&]() {
+          for (int i = 0; i <= console->buffer.getLastLineNumber(); ++i) {
+            if (console->buffer.line(i) == text) {
+              return true;
+            }
+          }
+          return false;
+        },
+        timeoutMs);
+  }
 
-        mpServer->setWelcomeMessage(messageFromTheMud);
-        startProfile(mpHostname, mpLocalhost, mpPort);
-        QSignalSpy(mudlet::self()->getActiveHost()->mpConsole, &TMainConsole::signal_newDataAlert).wait(200);
+  // Utility function
+  void deleteProfileDirectory(const QString &profileName) {
+    const QString path =
+        mudlet::getMudletPath(enums::profileHomePath, profileName);
+    QDir dir(path);
 
-        QCOMPARE(mudlet::self()->getActiveHost()->mpConsole->getCurrentLine(""), messageToExpect);
+    if (!dir.exists()) {
+      qInfo() << "Profile directory does not exist:" << path;
+      return;
     }
-
-    void cleanup()
-    {
-        delete mpServer;
-        mpServer = nullptr;
-        deleteProfileDirectory(mpHostname);
-        delete mudlet::self();
-    }
-
-    // Utility function to manually start a profile like a user would do via the GUI
-    void startProfile(const QString& hostname, const QString& address, const QString& port)
-    {
-        QTimer::singleShot(0, qApp, [hostname, address, port]() {
-            mudlet::self()->startAutoLogin({});
-            QTest::qWait(100);
-            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
-            QTest::qWait(100);
-            QTest::keyClicks(QApplication::focusWidget(), hostname);
-            QTest::qWait(100);
-            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
-            QTest::keyClicks(QApplication::focusWidget(), address);
-            QTest::qWait(100);
-            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
-            QTest::keyClicks(QApplication::focusWidget(), port);
-            QTest::qWait(100);
-            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
-        });
-
-        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
-        if (!spy.wait(5000)) {
-            QFAIL("Profile took too long to load.");
-        }
-        auto host = mudlet::self()->getActiveHost();
-        if (!host) {
-            QFAIL("No active host available for the test.");
-        }
-
-        QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
-        if (!spy2.wait(2000)) {
-            QFAIL("Could not connect with the host.");
-        }
-    }
-
-    // Utility function
-    void deleteProfileDirectory(const QString& profileName)
-    {
-        const QString path = mudlet::getMudletPath(enums::profileHomePath, profileName);
-        QDir dir(path);
-
-        if (!dir.exists()) {
-            qInfo() << "Profile directory does not exist:" << path;
-            return;
-        }
-        dir.removeRecursively();
-    }
+    dir.removeRecursively();
+  }
 };
 
 void initializeQRCResources() {
 #ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
+  qInitResources_additional_splash_screens();
 #endif
 #ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
+  qInitResources_mudlet_fonts_common();
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
+  qInitResources_mudlet_fonts_posix();
 #endif
 #endif
-    qInitResources_mudlet();
-    qInitResources_qm();
+  qInitResources_mudlet();
+  qInitResources_qm();
 }
 
 #include "TelnetTextDisplayedTest.moc"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Replace `getCurrentLine()` assertion with a `waitForTextInBuffer()` helper that polls the entire console buffer via `qWaitFor` with a 5s timeout.

#### Motivation for adding to Mudlet
The test fails intermittently in CI due to two issues: in PTB (scheduled) builds the cursor lands on the PTB banner line instead of the server's message, and in regular builds data sometimes hasn't arrived within the 200ms signal wait.

#### Other info (issues closed, discussion etc)
Failures seen in:
- https://github.com/Mudlet/Mudlet/actions/runs/24436883460 (PTB, macOS x86_64 - cursor on PTB banner)
- https://github.com/Mudlet/Mudlet/actions/runs/24310433046 (push, ubuntu/clang - cursor on connection info line)
- https://github.com/Mudlet/Mudlet/actions/runs/24310465007 (PR, ubuntu/clang - same race condition)