### PR TITLE
Fix: avoid bogus "new Toolbar" and "new Menu" items creation on profile load

### DIFF
--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -2070,7 +2070,6 @@ int TLuaInterpreter::tempButton(lua_State* L)
     pT->setScript(script);
     pT->setIsFolder(false);
     pT->setIsActive(true);
-    pT->setTemporary(true);
 
 
     //    pT->setIsPushDownButton( isChecked );
@@ -2135,7 +2134,6 @@ int TLuaInterpreter::tempButtonToolbar(lua_State* L)
     pT->setScript(script);
     pT->setIsFolder(true);
     pT->setIsActive(true);
-    pT->setTemporary(true);
     pT->registerAction();
     // N/U:     int childID = pT->getID();
     host.getActionUnit()->updateToolbar();

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -2070,6 +2070,7 @@ int TLuaInterpreter::tempButton(lua_State* L)
     pT->setScript(script);
     pT->setIsFolder(false);
     pT->setIsActive(true);
+    pT->setTemporary(true);
 
 
     //    pT->setIsPushDownButton( isChecked );
@@ -2134,6 +2135,7 @@ int TLuaInterpreter::tempButtonToolbar(lua_State* L)
     pT->setScript(script);
     pT->setIsFolder(true);
     pT->setIsActive(true);
+    pT->setTemporary(true);
     pT->registerAction();
     // N/U:     int childID = pT->getID();
     host.getActionUnit()->updateToolbar();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -449,14 +449,20 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mpUndoAction->setShortcut(QKeySequence(QKeySequence::Undo)); // Ctrl+Z
     mpUndoAction->setShortcutContext(Qt::WindowShortcut);
     mpUndoAction->setEnabled(false);
-    this->addAction(mpUndoAction);
+    /* In this and the next addAction(...) call we want to use the
+     * QMainWindow::addAction(...) method and NOT the
+     * dlgTriggerEditor::addAction(...) - without specifying this the derived
+     * method is used. Calling the second one causes a bogus "new Toolbar"
+     * containing a "new Menu" to be created each time the profile is opened
+     * - which persist with a new pair added to the pile each time.*/
+    QMainWindow::addAction(mpUndoAction);
     connect(mpUndoAction, &QAction::triggered, this, &dlgTriggerEditor::slot_smartUndo);
 
     mpRedoAction = new QAction(QIcon::fromTheme(qsl("edit-redo"), QIcon(qsl(":/icons/edit-redo.png"))), tr("Redo"), this);
     mpRedoAction->setShortcut(QKeySequence(QKeySequence::Redo)); // Ctrl+Y or Ctrl+Shift+Z
     mpRedoAction->setShortcutContext(Qt::WindowShortcut);
     mpRedoAction->setEnabled(false);
-    this->addAction(mpRedoAction);
+    QMainWindow::addAction(mpRedoAction);
     connect(mpRedoAction, &QAction::triggered, this, &dlgTriggerEditor::slot_smartRedo);
 
     connect(mpUndoStack, &QUndoStack::canUndoChanged, this, &dlgTriggerEditor::slot_updateUndoRedoButtonStates);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Discord user **Bob (bodega)** reported 2026/04/15 11:28 UTC:
https://canary.discord.com/channels/283581582550237184/427919962561052673/1493936125004222524
> good day, can anyone replicate - Each time I open a profile,  a new
button group and button is created.  No other packages/scripts loaded for this test:
<img width="605" height="347" alt="Screen shot showing several locked 'New toolbar' each with a locked 'New menu' in the 'Buttons' view in the editor" src="https://github.com/user-attachments/assets/b17d9145-b94d-411f-89d1-4db0c378a649" />

> This happens each time the profile is loaded.  Close/reopen and a new
button group appears.

It was happening for him on Windows and I've just discovered it was affecting the latest PTB on Linux as well.

This was a bug tracked down by **Humera (humera1295)** and myself to two calls to `addAction(...)` in the `dlgTriggerEditor` class constructor. Unfortunately these were calling the `dlgTriggerEditor::addAction(...)` method which is used to construct permanent Toolbars/Menus/Buttons and NOT the `QMainWindows::addAction(...)` that was expected/wanted in this case. This seemed to be introduced by #8469.

#### Motivation for adding to Mudlet
Prevent bogus items being created. The bug was probably also preventing the ability to perform undo/redo actions with the `<Ctrl>+Z` and `<Ctrl>+Y` keystrokes - which should be restored by this PR.

#### Other info (issues closed, discussion etc)
An announcement will probably be useful as this PR does not attempt to remove such bogus entries already created (although since they are disabled they will not show in the application window and they will just clog up the "Buttons" view in the editor).

A second defect was also noted in that the `tempButton(...)` and `tempButtonToolbar(...)` Lua API functions do NOT mark the items they create as being **temporary** so they persist longer than intended (the end of the session). We do not currently provide either `permButton(...)` or `permButtonToolbar(...)` functions. An initial attempt to do so proved ineffective as the underlying codebase is not set up to consider this flag for Buttons/Menus/Toolbars - fixing that will required a more extensive later PR.